### PR TITLE
Fix WASM rendering panic by replacing std::time with js-sys::Date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,25 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --no-deps --all-features --locked
 
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check WASM build
+        run: cargo check --package quillmark-wasm --target wasm32-unknown-unknown --locked
+
   ci-success:
     runs-on: ubuntu-latest
-    needs: [lint, test, docs]
+    needs: [lint, test, docs, wasm]
     if: ${{ always() }}
     steps:
       - name: Fail if any dependency did not succeed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,9 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing WASM version: $VERSION"
 
+      - name: Check WASM build
+        run: cargo check --package quillmark-wasm --target wasm32-unknown-unknown --locked
+
       - name: Build WASM packages
         run: ./scripts/build-wasm.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "quillmark-core",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-core"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "minijinja",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-fixtures"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "quillmark",
  "quillmark-typst",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-fuzz"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "proptest",
  "quillmark-core",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-typst"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-wasm"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.24"
+version = "0.0.25"
 edition = "2021"
 include = ["src/**", "Cargo.toml", "README*", "LICENSE*"]
 readme = "README.md"
@@ -46,9 +46,9 @@ typst-svg = "0.13.1"
 dirs = "6.0"
 
 # Intra-project dependencies
-quillmark-core = { version = "0.0.24", path = "quillmark-core" }
-quillmark-typst = { version = "0.0.24", path = "quillmark-typst", default-features = false }
-quillmark = { version = "0.0.24", path = "quillmark", default-features = false }
+quillmark-core = { version = "0.0.25", path = "quillmark-core" }
+quillmark-typst = { version = "0.0.25", path = "quillmark-typst", default-features = false }
+quillmark = { version = "0.0.25", path = "quillmark", default-features = false }
 
 # Test and dev dependencies
 tempfile = "~3.23"

--- a/quillmark-wasm/src/workflow.rs
+++ b/quillmark-wasm/src/workflow.rs
@@ -2,7 +2,6 @@
 
 use crate::error::QuillmarkError;
 use crate::types::{OutputFormat, RenderMetadata, RenderOptions, RenderResult};
-use std::time::Instant;
 use wasm_bindgen::prelude::*;
 
 /// Rendering workflow for a specific Quill
@@ -17,7 +16,7 @@ pub struct Workflow {
 impl Workflow {
     /// Render markdown to artifacts
     pub fn render(&self, markdown: &str, options_js: JsValue) -> Result<JsValue, JsValue> {
-        let start = Instant::now();
+        let start = js_sys::Date::now();
 
         // Parse options
         let options: RenderOptions = if options_js.is_undefined() || options_js.is_null() {
@@ -38,14 +37,14 @@ impl Workflow {
             .render(markdown, output_format)
             .map_err(|e| QuillmarkError::from(e).to_js_value())?;
 
-        let elapsed = start.elapsed();
+        let elapsed_ms = js_sys::Date::now() - start;
 
         // Convert result
         let render_result = RenderResult {
             artifacts: result.artifacts.into_iter().map(|a| a.into()).collect(),
             warnings: result.warnings.into_iter().map(|d| d.into()).collect(),
             metadata: RenderMetadata {
-                render_time_ms: elapsed.as_secs_f64() * 1000.0,
+                render_time_ms: elapsed_ms,
                 backend: self.backend_id.clone(),
                 quill_name: self.quill_name.clone(),
             },
@@ -59,7 +58,7 @@ impl Workflow {
     /// Render pre-processed glue content (advanced)
     #[wasm_bindgen(js_name = renderSource)]
     pub fn render_source(&self, content: &str, options_js: JsValue) -> Result<JsValue, JsValue> {
-        let start = Instant::now();
+        let start = js_sys::Date::now();
 
         // Parse options
         let options: RenderOptions = if options_js.is_undefined() || options_js.is_null() {
@@ -80,14 +79,14 @@ impl Workflow {
             .render_source(content, output_format)
             .map_err(|e| QuillmarkError::from(e).to_js_value())?;
 
-        let elapsed = start.elapsed();
+        let elapsed_ms = js_sys::Date::now() - start;
 
         // Convert result
         let render_result = RenderResult {
             artifacts: result.artifacts.into_iter().map(|a| a.into()).collect(),
             warnings: result.warnings.into_iter().map(|d| d.into()).collect(),
             metadata: RenderMetadata {
-                render_time_ms: elapsed.as_secs_f64() * 1000.0,
+                render_time_ms: elapsed_ms,
                 backend: self.backend_id.clone(),
                 quill_name: self.quill_name.clone(),
             },


### PR DESCRIPTION
Replace std::time::Instant with js_sys::Date::now() in workflow.rs to fix "time not implemented on this platform" panic when rendering in WASM environments. The std::time API is not available in wasm32-unknown-unknown targets without special polyfills.

Changes:
- Remove std::time::Instant import
- Use js_sys::Date::now() for timing (already a dependency)
- Applies to both render() and render_source() methods

Fixes the "Rendering failed: unreachable" error in @quillmark-test/wasm v0.0.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)