### PR TITLE
Coerce scalar `examples` to arrays and emit in JSON Schema

### DIFF
--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -852,6 +852,27 @@ default: "Default value"
 }
 
 #[test]
+fn test_field_schema_scalar_examples_coerced_to_array() {
+    let yaml_str = r#"
+description: "Field schema with scalar example"
+type: "date"
+examples: "2024-01-15"
+"#;
+    let quill_value = QuillValue::from_yaml_str(yaml_str).unwrap();
+    let schema = FieldSchema::from_quill_value("effective_date".to_string(), &quill_value).unwrap();
+
+    assert_eq!(
+        schema
+            .examples
+            .as_ref()
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_str()),
+        Some("2024-01-15")
+    );
+}
+
+#[test]
 fn test_field_schema_ui_compact() {
     let yaml_str = r#"
 type: "string"

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -206,6 +206,20 @@ impl FieldSchema {
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
         let def: FieldSchemaDef = serde_json::from_value(value.clone().into_json())
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
+        let examples = match def.examples {
+            Some(examples) => {
+                if examples.is_null() {
+                    None
+                } else if examples.as_array().is_some() {
+                    Some(examples)
+                } else {
+                    Some(QuillValue::from_json(serde_json::Value::Array(vec![
+                        examples.into_json(),
+                    ])))
+                }
+            }
+            None => None,
+        };
 
         Ok(Self {
             name: key,
@@ -213,7 +227,7 @@ impl FieldSchema {
             r#type: def.r#type,
             description: def.description,
             default: def.default,
-            examples: def.examples,
+            examples,
             ui: def.ui,
             required: def.required,
             enum_values: def.enum_values,

--- a/crates/core/src/schema.rs
+++ b/crates/core/src/schema.rs
@@ -91,6 +91,11 @@ fn build_field_property(field_schema: &FieldSchema) -> Map<String, Value> {
                     Value::Array(examples_array.clone()),
                 );
             }
+        } else if !examples.is_null() {
+            property.insert(
+                field_key::EXAMPLES.to_string(),
+                Value::Array(vec![examples.as_json().clone()]),
+            );
         }
     }
 
@@ -1237,6 +1242,51 @@ mod tests {
 
         let example_value = &json_schema["properties"]["memo_for"]["examples"][0];
         assert_eq!(example_value, &json!(["ORG1/SYMBOL", "ORG2/SYMBOL"]));
+    }
+
+    #[test]
+    fn test_build_schema_with_scalar_example_wraps_as_array() {
+        let mut fields = HashMap::new();
+        let mut schema = FieldSchema::new(
+            "effective_date".to_string(),
+            FieldType::Date,
+            Some("Effective date".to_string()),
+        );
+        schema.examples = Some(QuillValue::from_json(json!("2024-01-15")));
+        fields.insert("effective_date".to_string(), schema);
+
+        let json_schema = build_schema_from_fields(&fields).unwrap().as_json().clone();
+        assert_eq!(
+            json_schema["properties"]["effective_date"]["examples"],
+            json!(["2024-01-15"])
+        );
+    }
+
+    #[test]
+    fn test_build_schema_omits_examples_for_null_or_empty_array() {
+        let mut fields = HashMap::new();
+
+        let mut null_examples_schema =
+            FieldSchema::new("null_examples".to_string(), FieldType::String, None);
+        null_examples_schema.examples = Some(QuillValue::from_json(Value::Null));
+        fields.insert("null_examples".to_string(), null_examples_schema);
+
+        let mut empty_examples_schema =
+            FieldSchema::new("empty_examples".to_string(), FieldType::String, None);
+        empty_examples_schema.examples = Some(QuillValue::from_json(json!([])));
+        fields.insert("empty_examples".to_string(), empty_examples_schema);
+
+        let json_schema = build_schema_from_fields(&fields).unwrap().as_json().clone();
+        let properties = json_schema["properties"].as_object().unwrap();
+
+        assert!(!properties["null_examples"]
+            .as_object()
+            .unwrap()
+            .contains_key("examples"));
+        assert!(!properties["empty_examples"]
+            .as_object()
+            .unwrap()
+            .contains_key("examples"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Scalar `examples` values were silently dropped during JSON Schema serialization because only non-empty arrays were emitted, which violates the JSON Schema expectation that `examples` is an array.

### Description
- Normalize `examples` during parsing in `FieldSchema::from_quill_value` by converting non-null scalar values into a one-element array and treating `null` as `None`.
- Make `build_field_property` resilient by emitting existing non-empty arrays unchanged and wrapping non-null scalar `examples` into a one-element array while still omitting `null` and empty arrays.
- Add unit tests covering parse-time coercion and schema serialization: scalar-to-array wrapping, array passthrough, and omission for `null`/empty arrays (`crates/core/src/quill/tests.rs` and `crates/core/src/schema.rs`).

### Testing
- `cargo test -p quillmark-core scalar_examples_coerced_to_array` — passed.
- `cargo test -p quillmark-core test_build_schema_with_scalar_example_wraps_as_array -- --nocapture` — passed.
- `cargo test -p quillmark-core test_build_schema_omits_examples_for_null_or_empty_array -- --nocapture` — passed.
- `cargo test -p quillmark-core test_build_schema_with_example -- --nocapture` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db043c1ee88323b1f411c9f500f849)