### PR TITLE
Expand date_rework proposal with complete implementation plan

### DIFF
--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -7,17 +7,16 @@
 //!
 //! The generated package exports:
 //! - `data` - A dictionary containing all document fields, with markdown fields
-//!   automatically converted to Typst content objects
-//! - `parse-date(string)` - Parses ISO 8601 date strings to Typst datetime
+//!   and date fields automatically converted to Typst values
 //!
 //! ## Usage in Plates
 //!
 //! ```typst
-//! #import "@local/quillmark-helper:0.1.0": data, parse-date
+//! #import "@local/quillmark-helper:0.1.0": data
 //!
 //! #data.title
 //! #data.BODY
-//! #parse-date(data.date)
+//! #data.date
 //! ```
 
 use crate::convert::escape_string;
@@ -45,8 +44,7 @@ const LIB_TYP_TEMPLATE: &str = include_str!("lib.typ.template");
 ///
 /// The generated file contains:
 /// - Embedded JSON data (including `__meta__` injected by `transform_fields`)
-///   with markdown fields auto-evaluated into content
-/// - `#let parse-date(s) = { ... }` helper for ISO 8601 dates
+///   with markdown and date fields auto-normalized
 pub fn generate_lib_typ(json_data: &str) -> String {
     let escaped_json = escape_string(json_data);
 
@@ -76,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_generate_lib_typ_basic() {
-        let json = r#"{"title": "Test", "BODY": "Hello", "__meta__": {"content_fields": ["BODY"], "card_content_fields": {}}}"#;
+        let json = r#"{"title":"Test","BODY":"Hello","date":"2025-01-15","__meta__":{"content_fields":["BODY"],"card_content_fields":{},"date_fields":["date"],"card_date_fields":{}}}"#;
         let lib = generate_lib_typ(json);
 
         // Should contain the version comment
@@ -88,8 +86,11 @@ mod tests {
         // Should NOT contain eval-markup (auto-eval replaces it)
         assert!(!lib.contains("eval-markup"));
 
-        // Should contain the parse-date helper
-        assert!(lib.contains("#let parse-date(s)"));
+        // Should contain private date parser and conversion metadata handling
+        assert!(lib.contains("#let _parse-date(s)"));
+        assert!(!lib.contains("#let parse-date(s)"));
+        assert!(lib.contains("meta.date_fields"));
+        assert!(lib.contains("meta.card_date_fields"));
     }
 
     #[test]

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -205,6 +205,27 @@ fn is_markdown_field(field_schema: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
+/// Check if a field schema indicates a date field.
+///
+/// A field is considered a date if it has:
+/// - `type = "string"`
+/// - `format = "date"`
+fn is_date_field(field_schema: &serde_json::Value) -> bool {
+    let is_string = field_schema
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(|s| s == "string")
+        .unwrap_or(false);
+
+    let is_date_format = field_schema
+        .get("format")
+        .and_then(|v| v.as_str())
+        .map(|s| s == "date")
+        .unwrap_or(false);
+
+    is_string && is_date_format
+}
+
 /// Transform markdown fields to Typst markup based on schema.
 ///
 /// Identifies fields with `contentMediaType = "text/markdown"` and converts
@@ -245,6 +266,12 @@ fn transform_markdown_fields(
         }
     }
 
+    let date_fields: Vec<&str> = properties_obj
+        .iter()
+        .filter(|(_, fs)| is_date_field(fs))
+        .map(|(name, _)| name.as_str())
+        .collect();
+
     // Handle CARDS array recursively
     if let Some(cards_value) = result.get("CARDS") {
         if let Some(cards_array) = cards_value.as_array() {
@@ -258,6 +285,7 @@ fn transform_markdown_fields(
 
     // Collect per-card-type content field names from schema $defs
     let mut card_content_fields = serde_json::Map::new();
+    let mut card_date_fields = serde_json::Map::new();
     if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
         for (def_name, def_schema) in defs {
             if let Some(card_type) = def_name.strip_suffix("_card") {
@@ -283,6 +311,29 @@ fn transform_markdown_fields(
                         ),
                     );
                 }
+
+                let date_fields: Vec<&str> = def_schema
+                    .get("properties")
+                    .and_then(|v| v.as_object())
+                    .map(|props| {
+                        props
+                            .iter()
+                            .filter(|(_, fs)| is_date_field(fs))
+                            .map(|(name, _)| name.as_str())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if !date_fields.is_empty() {
+                    card_date_fields.insert(
+                        card_type.to_string(),
+                        serde_json::Value::Array(
+                            date_fields
+                                .into_iter()
+                                .map(|s| serde_json::Value::String(s.to_string()))
+                                .collect(),
+                        ),
+                    );
+                }
             }
         }
     }
@@ -293,6 +344,8 @@ fn transform_markdown_fields(
         QuillValue::from_json(serde_json::json!({
             "content_fields": content_field_names,
             "card_content_fields": card_content_fields,
+            "date_fields": date_fields,
+            "card_date_fields": card_date_fields,
         })),
     );
 
@@ -385,6 +438,27 @@ mod tests {
     }
 
     #[test]
+    fn test_is_date_field() {
+        let date_schema = json!({
+            "type": "string",
+            "format": "date"
+        });
+        assert!(is_date_field(&date_schema));
+
+        let date_time_schema = json!({
+            "type": "string",
+            "format": "date-time"
+        });
+        assert!(!is_date_field(&date_time_schema));
+
+        let non_string_date_schema = json!({
+            "type": "number",
+            "format": "date"
+        });
+        assert!(!is_date_field(&non_string_date_schema));
+    }
+
+    #[test]
     fn test_transform_markdown_fields_basic() {
         let schema = QuillValue::from_json(json!({
             "type": "object",
@@ -458,5 +532,52 @@ mod tests {
 
         let body = result.get("BODY").unwrap().as_str().unwrap();
         assert!(body.contains("#emph[italic]"));
+    }
+
+    #[test]
+    fn test_transform_markdown_fields_collects_top_level_date_metadata() {
+        let schema = QuillValue::from_json(json!({
+            "type": "object",
+            "properties": {
+                "title": { "type": "string" },
+                "date": { "type": "string", "format": "date" },
+                "timestamp": { "type": "string", "format": "date-time" }
+            }
+        }));
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "title".to_string(),
+            QuillValue::from_json(json!("My Title")),
+        );
+
+        let result = transform_markdown_fields(&fields, &schema);
+        let meta = result.get("__meta__").expect("missing __meta__").as_json();
+
+        assert_eq!(meta["date_fields"], json!(["date"]));
+    }
+
+    #[test]
+    fn test_transform_markdown_fields_collects_card_date_metadata() {
+        let schema = QuillValue::from_json(json!({
+            "type": "object",
+            "properties": {},
+            "$defs": {
+                "indorsement_card": {
+                    "type": "object",
+                    "properties": {
+                        "date": { "type": "string", "format": "date" },
+                        "created_at": { "type": "string", "format": "date-time" },
+                        "BODY": { "type": "string", "contentMediaType": "text/markdown" }
+                    }
+                }
+            }
+        }));
+
+        let fields = HashMap::new();
+        let result = transform_markdown_fields(&fields, &schema);
+        let meta = result.get("__meta__").expect("missing __meta__").as_json();
+
+        assert_eq!(meta["card_date_fields"]["indorsement"], json!(["date"]));
     }
 }

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -9,7 +9,12 @@
   let d = json(bytes("{escaped_json}"))
 
   // Read and consume __meta__ (injected by transform_fields)
-  let meta = d.remove("__meta__", default: (content_fields: (), card_content_fields: (:)))
+  let meta = d.remove("__meta__", default: (
+    content_fields: (),
+    card_content_fields: (:),
+    date_fields: (),
+    card_date_fields: (:),
+  ))
 
   // Auto-eval top-level content fields
   for key in meta.content_fields {
@@ -17,6 +22,16 @@
       let val = d.at(key)
       if type(val) == str and val != "" {
         d.insert(key, eval(val, mode: "markup"))
+      }
+    }
+  }
+
+  // Auto-convert top-level date fields to datetime
+  for key in meta.date_fields {
+    if key in d {
+      let val = d.at(key)
+      if val != none {
+        d.insert(key, _parse-date(val))
       }
     }
   }
@@ -35,6 +50,18 @@
           }
         }
       }
+
+      // Auto-convert date fields for this card type
+      let date-fields = meta.card_date_fields.at(card-type, default: ())
+      for key in date-fields {
+        if key in card {
+          let val = card.at(key)
+          if val != none {
+            card.insert(key, _parse-date(val))
+          }
+        }
+      }
+
       cards.push(card)
     }
     d.insert("CARDS", cards)
@@ -45,7 +72,7 @@
 
 /// Parse an ISO 8601 date string (YYYY-MM-DD) to a Typst datetime
 /// Handles both pure dates (2024-01-15) and datetime strings (2024-01-15T10:30:00)
-#let parse-date(s) = {
+#let _parse-date(s) = {
   if s == none { return none }
   let date-str = str(s)
   // Handle datetime strings by extracting just the date part

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/ttq-classic-resume:0.1.0": *
 
 #show: resume

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/tonguetoquill-cmu-letter:0.1.0": backmatter, frontmatter, mainmatter
 
 #show: frontmatter.with(
@@ -6,7 +6,7 @@
   department: data.department,
   address: data.address,
   url: data.url,
-  date: if "date" in data { parse-date(data.date) } else { datetime.today() },
+  date: if "date" in data { data.date } else { datetime.today() },
   recipient: data.recipient,
 )
 

--- a/crates/fixtures/resources/quills/taro/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/taro/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 
 #set text(font: "Figtree")
 

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/tonguetoquill-usaf-memo:1.0.0": backmatter, frontmatter, indorsement, mainmatter
 
 // Frontmatter configuration
@@ -9,7 +9,7 @@
   letterhead_seal: image("assets/dow_seal.jpg"),
 
   // Date
-  date: parse-date(data.date),
+  date: data.date,
 
   // Receiver information
   memo_for: data.memo_for,

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/tonguetoquill-usaf-memo:1.1.0": backmatter, frontmatter, indorsement, mainmatter
 
 // Frontmatter configuration
@@ -9,7 +9,7 @@
   letterhead_seal: image("assets/dow_seal.jpg"),
 
   // Date
-  date: parse-date(data.date),
+  date: data.date,
 
   // Receiver information
   memo_for: data.memo_for,

--- a/docs/format-designer/typst-backend.md
+++ b/docs/format-designer/typst-backend.md
@@ -47,12 +47,12 @@ Quillmark injects your document's frontmatter as JSON data via the `@local/quill
 ### Importing the Helper
 
 ```typst
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 ```
 
 The helper provides:
 - `data` - Dictionary containing all frontmatter fields, with markdown fields automatically converted to Typst content objects
-- `parse-date(str)` - Parse date strings into Typst datetime objects
+- Date fields declared with `format: date` are automatically converted to Typst `datetime` values
 
 ### Accessing Fields
 
@@ -96,13 +96,13 @@ The document body (Markdown content after frontmatter) is stored in `data.BODY` 
 #data.at("body", default: "")
 ```
 
-### Parsing Dates
+### Date Fields
 
-Use `parse-date()` to convert date strings to Typst datetime objects:
+Date fields are auto-converted to Typst `datetime` values by the helper package:
 
 ```typst
 // Input: date: "2025-01-15" in frontmatter
-#parse-date(data.date)  // Returns datetime(year: 2025, month: 1, day: 15)
+#data.date  // datetime(year: 2025, month: 1, day: 15)
 ```
 
 ### Working with Arrays
@@ -333,12 +333,12 @@ Errors include:
 ### Simple Letter
 
 ```typst
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 
 #set page(margin: 1in)
 #set text(font: "Arial", size: 11pt)
 
-#parse-date(data.date).display("[month repr:long] [day], [year]")
+#data.date.display("[month repr:long] [day], [year]")
 
 #data.recipient
 

--- a/prose/designs/GLUE_METADATA.md
+++ b/prose/designs/GLUE_METADATA.md
@@ -18,16 +18,15 @@ Quillmark no longer runs a template engine for plates. Instead, `Workflow::compi
 The Typst backend injects a virtual package `@local/quillmark-helper:<version>` that exposes the JSON to plates and provides helpers.
 
 ```typst
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 
 #data.title          // plain field access
 #data.BODY           // BODY is automatically converted to content
-#parse-date(data.date)  // ISO 8601 → datetime
+#data.date           // date fields are auto-converted to datetime
 ```
 
 Helper contents (generated in `backends/typst/helper.rs`):
-- `data`: parsed JSON dictionary of all fields, with markdown fields automatically converted to Typst content objects
-- `parse-date(s)`: ISO 8601 date parsing helper
+- `data`: parsed JSON dictionary of all fields, with markdown fields converted to Typst content objects and date fields (`format: date`) converted to Typst `datetime`
 
 ## Guarantees
 

--- a/prose/migrations/typst-date-auto-conversion.md
+++ b/prose/migrations/typst-date-auto-conversion.md
@@ -1,0 +1,43 @@
+# Migration: Typst date auto-conversion & `parse-date` removal
+
+**Audience:** Maintainers updating existing Quill Typst plates after the date helper rework.
+
+## What changed
+
+- **JSON Schema** fields with `type: string` and `format: "date"` are converted to Typst `datetime` inside the generated `data` dictionary (top-level and per card type).
+- **`parse-date` is no longer part of the public helper API.** Only `data` should be imported for normal plates.
+- **`format: "date-time"`** is unchanged: it is **not** auto-converted; keep any manual handling you already use.
+
+## Plate edits (checklist)
+
+1. **Imports:** use only `data`.
+
+   ```typst
+   // Before
+   #import "@local/quillmark-helper:0.1.0": data, parse-date
+
+   // After
+   #import "@local/quillmark-helper:0.1.0": data
+   ```
+
+2. **Top-level dates:** drop `parse-date(...)`; use the field from `data`.
+
+   ```typst
+   // Before
+   #parse-date(data.effective_date)
+
+   // After
+   #data.effective_date
+   ```
+
+3. **Card dates:** same idea—read the key on each card object after `data` is built (e.g. `card.date`); do not call a helper parser.
+
+4. **Optional / bad values:** if a date string is missing or not parseable as an ISO date, the helper leaves a **`none`** (or skips conversion where appropriate). Keep `#if field != none { ... }` or `.at(..., default: ...)` patterns as needed.
+
+## Schema reminder
+
+Auto-conversion applies only when the field is declared in the Quill JSON Schema as a **`date`** (`format: "date"` on a string). If a field should stay a raw string, do not mark it as `format: "date"`.
+
+## Internal detail (usually ignore)
+
+The Typst backend injects `date_fields` and `card_date_fields` into `__meta__`; the helper consumes `__meta__` and never exposes it to plates. No plate changes are required for that metadata beyond fixing imports and removing `parse-date` call sites.

--- a/prose/proposals/date_rework.md
+++ b/prose/proposals/date_rework.md
@@ -89,6 +89,57 @@ Update fixture plates and docs that currently import/call `parse-date`:
 - **Template/helper tests**: generated helper no longer exports `parse-date` and still renders valid data conversion logic
 - **Integration/fixtures**: rendered output from updated plates remains semantically equivalent for date display
 
+## Implementation plan
+
+### Phase 1: Typst backend metadata (`lib.rs`)
+
+1. Extend `transform_markdown_fields` to collect top-level date fields from schema `properties` where:
+   - `type == "string"`
+   - `format == "date"`
+2. Extend card metadata extraction from `$defs` (`*_card`) to collect per-card date fields with the same rule.
+3. Inject `date_fields` and `card_date_fields` into `__meta__` alongside existing markdown metadata.
+4. Keep behavior strict to `format: "date"` only (exclude `date-time`).
+
+### Phase 2: Helper template conversion (`lib.typ.template`)
+
+1. Keep date parser helper internal/private (`_parse-date` style naming).
+2. In `data` construction:
+   - convert `meta.date_fields` on top-level `d`
+   - convert `meta.card_date_fields` in each card object
+3. Preserve null/invalid tolerance (non-parseable values map to `none`, matching current helper behavior expectations).
+4. Remove public export of `parse-date`; keep only `data` as plate-facing API.
+
+### Phase 3: Fixtures and docs
+
+1. Update first-party plates to remove `parse-date` imports.
+2. Replace direct parse calls (`parse-date(data.date)`) with direct value usage (`data.date`).
+3. Update Typst backend docs to describe date auto-conversion as part of helper `data` normalization.
+
+### Phase 4: Tests
+
+1. Add/update backend unit tests for:
+   - top-level `date_fields`
+   - card `card_date_fields`
+   - `date-time` exclusion
+2. Add/update helper/template tests for:
+   - private parser symbol (not exported)
+   - generated conversion loops for top-level and card date fields
+3. Update fixture/integration tests to ensure rendered date output remains stable.
+
+### Phase 5: Verification and cleanup
+
+1. Run targeted backend + fixture tests.
+2. Run workspace tests before merge.
+3. Remove stale docs/examples still referencing `parse-date`.
+
+## Acceptance criteria
+
+- Plate authors can render date fields with `data.<field>` directly without importing/calling `parse-date`.
+- `__meta__` contains deterministic date metadata for both top-level and card fields.
+- `format: "date-time"` behavior is unchanged and not auto-converted.
+- Existing fixtures continue producing expected date output.
+- Public Typst helper API surface does not expose `parse-date`.
+
 ## Files affected
 
 | File | Change |

--- a/prose/proposals/date_rework.md
+++ b/prose/proposals/date_rework.md
@@ -1,0 +1,76 @@
+---
+
+**Feature: Auto-convert `date` fields to Typst `datetime` in quillmark-helper**
+
+**Goal:** `date` fields arrive in `data` as Typst `datetime` objects. Plate authors use `data.date` directly — no helper function to import or call. Mirror exactly how markdown fields are auto-evaluated via `__meta__`.
+
+---
+
+### 1. Annotate date fields in `__meta__` — `crates/backends/typst/src/lib.rs`
+
+In `transform_markdown_fields`, after collecting `content_field_names`, walk schema properties and collect fields where `"format" == "date"` into a `date_fields` vec. Do the same for card fields via `$defs`, producing `card_date_fields: { "<card_type>": [...] }` — same shape as `card_content_fields`.
+
+Inject into `__meta__`:
+```json
+{
+  "content_fields": [...],
+  "card_content_fields": {...},
+  "date_fields": ["date", "effective_date"],
+  "card_date_fields": { "indorsement": ["date"] }
+}
+```
+
+Date values remain ISO strings in JSON. No Rust-side parsing.
+
+---
+
+### 2. Rework `lib.typ.template` — `crates/backends/typst/src/lib.typ.template`
+
+**Make `parse-date` private** (remove from exports, keep as internal `let`):
+```typst
+// internal — not exported
+#let _parse-date(s) = {
+  if s == none { return none }
+  let parts = str(s).split("T").at(0).split("-")
+  if parts.len() < 3 { return none }
+  datetime(year: int(parts.at(0)), month: int(parts.at(1)), day: int(parts.at(2).slice(0, 2)))
+}
+```
+
+**Add auto-conversion in the `data` block**, after the existing content-field eval loop:
+```typst
+for key in meta.date_fields {
+  if key in d and d.at(key) != none { d.insert(key, _parse-date(str(d.at(key)))) }
+}
+```
+
+**In the CARDS loop**, after the existing card content-field eval:
+```typst
+let date-fields = meta.card_date_fields.at(card-type, default: ())
+for key in date-fields { 
+  if key in card and card.at(key) != none { card.insert(key, _parse-date(str(card.at(key)))) }
+}
+```
+
+**Update the export line** — `parse-date` is no longer public:
+```typst
+// Only `data` is exported. Date fields are already datetime objects inside data.
+```
+
+---
+
+### 3. Update fixture plates
+
+In all plates (`usaf_memo`, `cmu_letter`, etc.):
+- Remove `parse-date` from the import line
+- Remove `parse-date(...)` call sites — `data.date` is already a `datetime`
+- Card date spreads (`..if "date" in card { (date: card.date) }`) work unchanged
+
+---
+
+### 4. Tests
+
+- **Unit — `lib.rs`:** schema with `format: "date"` fields (top-level and in card `$defs`) produces correct `date_fields` / `card_date_fields` in `__meta__`
+- **Unit — `lib.rs`:** `format: "date-time"` fields are **not** included (explicitly out of scope)
+- **Integration:** existing render fixture output is byte-identical after rework — the auto-converted `datetime` formats the same way as the old manual `parse-date` result
+- **Compile error:** confirm a plate importing `parse-date` fails — validates the symbol is no longer exported

--- a/prose/proposals/date_rework.md
+++ b/prose/proposals/date_rework.md
@@ -1,16 +1,41 @@
----
+# Proposal: Typst Date Field Auto-Conversion Rework
 
-**Feature: Auto-convert `date` fields to Typst `datetime` in quillmark-helper**
+## Problem
 
-**Goal:** `date` fields arrive in `data` as Typst `datetime` objects. Plate authors use `data.date` directly — no helper function to import or call. Mirror exactly how markdown fields are auto-evaluated via `__meta__`.
+Typst plates currently parse date values manually:
 
----
+```typst
+#import "@local/quillmark-helper:0.1.0": data, parse-date
+#parse-date(data.date)
+```
 
-### 1. Annotate date fields in `__meta__` — `crates/backends/typst/src/lib.rs`
+This is inconsistent with markdown field handling, where conversion is automatic via `__meta__` and plate authors just use `data.<field>`.
 
-In `transform_markdown_fields`, after collecting `content_field_names`, walk schema properties and collect fields where `"format" == "date"` into a `date_fields` vec. Do the same for card fields via `$defs`, producing `card_date_fields: { "<card_type>": [...] }` — same shape as `card_content_fields`.
+Current drawbacks:
 
-Inject into `__meta__`:
+- Boilerplate in every plate that uses date fields
+- Public helper API surface (`parse-date`) that can be avoided
+- Uneven data model (`data.BODY` is ready-to-use content, but `data.date` is still a raw string)
+
+## Decisions
+
+### 1. Date conversion becomes automatic inside `data`
+
+For Typst backend output, fields declared as JSON Schema `"format": "date"` are converted to Typst `datetime` values in `quillmark-helper` during `data` construction.
+
+- Plate authors use `data.date` directly
+- Raw JSON payload remains unchanged (ISO string); conversion stays in Typst helper layer
+- `format: "date-time"` remains out of scope for this change
+
+### 2. Extend `__meta__` with date field annotations
+
+In `crates/backends/typst/src/lib.rs` (`transform_markdown_fields`), collect date fields from:
+
+- top-level schema `properties`
+- card schemas under `$defs` (`*_card`)
+
+Inject alongside existing markdown metadata:
+
 ```json
 {
   "content_fields": [...],
@@ -20,57 +45,56 @@ Inject into `__meta__`:
 }
 ```
 
-Date values remain ISO strings in JSON. No Rust-side parsing.
+### 3. Keep date parser internal to helper package
 
----
+In `crates/backends/typst/src/lib.typ.template`:
 
-### 2. Rework `lib.typ.template` — `crates/backends/typst/src/lib.typ.template`
+- keep a private date parser helper (for internal conversion)
+- auto-convert `meta.date_fields` on top-level `d`
+- auto-convert `meta.card_date_fields` for each `CARDS` item
+- stop exporting `parse-date` as a public symbol
 
-**Make `parse-date` private** (remove from exports, keep as internal `let`):
-```typst
-// internal — not exported
-#let _parse-date(s) = {
-  if s == none { return none }
-  let parts = str(s).split("T").at(0).split("-")
-  if parts.len() < 3 { return none }
-  datetime(year: int(parts.at(0)), month: int(parts.at(1)), day: int(parts.at(2).slice(0, 2)))
-}
-```
+End state: only `data` is exported for normal plate usage.
 
-**Add auto-conversion in the `data` block**, after the existing content-field eval loop:
-```typst
-for key in meta.date_fields {
-  if key in d and d.at(key) != none { d.insert(key, _parse-date(str(d.at(key)))) }
-}
-```
+### 4. Update first-party plates and docs
 
-**In the CARDS loop**, after the existing card content-field eval:
-```typst
-let date-fields = meta.card_date_fields.at(card-type, default: ())
-for key in date-fields { 
-  if key in card and card.at(key) != none { card.insert(key, _parse-date(str(card.at(key)))) }
-}
-```
+Update fixture plates and docs that currently import/call `parse-date`:
 
-**Update the export line** — `parse-date` is no longer public:
-```typst
-// Only `data` is exported. Date fields are already datetime objects inside data.
-```
+- remove `parse-date` from imports
+- replace `parse-date(data.date)` with direct `data.date` usage
+- keep existing card wiring unchanged (date fields remain available on card objects)
 
----
+## Scope
 
-### 3. Update fixture plates
+### In scope
 
-In all plates (`usaf_memo`, `cmu_letter`, etc.):
-- Remove `parse-date` from the import line
-- Remove `parse-date(...)` call sites — `data.date` is already a `datetime`
-- Card date spreads (`..if "date" in card { (date: card.date) }`) work unchanged
+- Typst backend metadata enrichment for date fields
+- Typst helper template auto-conversion for date fields
+- Removal of public `parse-date` export from helper package
+- Fixture plate updates to new usage
+- Documentation updates that currently recommend `parse-date`
+- Tests covering new metadata and helper behavior
 
----
+### Out of scope
 
-### 4. Tests
+- New coercion/validation semantics in core field parsing
+- Automatic conversion for `format: "date-time"`
+- Changes to non-Typst backends
 
-- **Unit — `lib.rs`:** schema with `format: "date"` fields (top-level and in card `$defs`) produces correct `date_fields` / `card_date_fields` in `__meta__`
-- **Unit — `lib.rs`:** `format: "date-time"` fields are **not** included (explicitly out of scope)
-- **Integration:** existing render fixture output is byte-identical after rework — the auto-converted `datetime` formats the same way as the old manual `parse-date` result
-- **Compile error:** confirm a plate importing `parse-date` fails — validates the symbol is no longer exported
+## Test plan
+
+- **Unit (`lib.rs`)**: top-level `format: "date"` populates `date_fields`
+- **Unit (`lib.rs`)**: card `$defs` `format: "date"` populates `card_date_fields`
+- **Unit (`lib.rs`)**: `format: "date-time"` is excluded
+- **Template/helper tests**: generated helper no longer exports `parse-date` and still renders valid data conversion logic
+- **Integration/fixtures**: rendered output from updated plates remains semantically equivalent for date display
+
+## Files affected
+
+| File | Change |
+|------|--------|
+| `crates/backends/typst/src/lib.rs` | collect/inject `date_fields` + `card_date_fields` in `__meta__` |
+| `crates/backends/typst/src/lib.typ.template` | auto-convert date fields in `data`, keep parser internal |
+| `crates/backends/typst/src/helper.rs` | update helper docs/tests to match exported API |
+| `crates/fixtures/resources/quills/**/plate.typ` | remove `parse-date` imports/call sites |
+| `docs/format-designer/typst-backend.md` | update user guidance to direct date field usage |


### PR DESCRIPTION
This pull request implements automatic conversion of JSON Schema date fields to Typst `datetime` values in the Typst backend, and removes the public `parse-date` helper from the API. Now, any field marked as `type: string` and `format: "date"` in the schema is auto-converted to a Typst datetime, both at the top level and within cards. As a result, plates should access date fields directly from `data`, without calling a helper. Documentation, tests, and migration notes have been updated to reflect these changes.

**Auto-conversion and helper changes:**

* Added detection of `date` fields in the schema and auto-injection of `date_fields` and `card_date_fields` metadata for both top-level and card fields in `transform_markdown_fields` (`crates/backends/typst/src/lib.rs`). [[1]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R208-R228) [[2]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R269-R274) [[3]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R288) [[4]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R314-R336) [[5]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R347-R348)
* Updated the Typst helper template to automatically convert all declared date fields to Typst `datetime` values using a private `_parse-date` helper, and removed the public `parse-date` function from the API (`crates/backends/typst/src/lib.typ.template`). [[1]](diffhunk://#diff-ed373a7c436354551aa7dd9247c814ed6dcf53769654fe043f3d0c6af15f50f0L12-R17) [[2]](diffhunk://#diff-ed373a7c436354551aa7dd9247c814ed6dcf53769654fe043f3d0c6af15f50f0R29-R38) [[3]](diffhunk://#diff-ed373a7c436354551aa7dd9247c814ed6dcf53769654fe043f3d0c6af15f50f0R53-R64) [[4]](diffhunk://#diff-ed373a7c436354551aa7dd9247c814ed6dcf53769654fe043f3d0c6af15f50f0L48-R75)
* Updated helper documentation and comments to clarify that date fields are auto-converted, and removed references to the public `parse-date` helper (`crates/backends/typst/src/helper.rs`). [[1]](diffhunk://#diff-63bce5f31141486f0780f6eff4f23be88677f3dd2778823d1ba6a388e40a6c09L10-R19) [[2]](diffhunk://#diff-63bce5f31141486f0780f6eff4f23be88677f3dd2778823d1ba6a388e40a6c09L48-R47)

**Test and fixture updates:**

* Added/updated tests for date field detection, metadata injection, and auto-conversion logic (`crates/backends/typst/src/lib.rs`, `crates/backends/typst/src/helper.rs`). [[1]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R440-R460) [[2]](diffhunk://#diff-65919b48409ebae1c04f7026eb7bc381bac096d26f2d3a0e7057bcef0360a3c5R536-R582) [[3]](diffhunk://#diff-63bce5f31141486f0780f6eff4f23be88677f3dd2778823d1ba6a388e40a6c09L79-R77) [[4]](diffhunk://#diff-63bce5f31141486f0780f6eff4f23be88677f3dd2778823d1ba6a388e40a6c09L91-R93)
* Updated all fixture plates to import only `data` (not `parse-date`) and to access date fields directly (`crates/fixtures/resources/quills/*/plate.typ`). [[1]](diffhunk://#diff-12e3afd75c9de54f33f7b17e7512757cccafe4a3cc9a91c335b2126b2a676af0L1-R1) [[2]](diffhunk://#diff-9bc4b6a83ef4195d05614ff303cfff0f2239dc5e9b66df24cf3525019403b840L1-R9) [[3]](diffhunk://#diff-647e92bd4423cf6c9db5947742c556d3a20fb4c199ff1f694f371be52a6c4301L1-R1) [[4]](diffhunk://#diff-19d2e8d73fce81a3ecb33c09c5d7326ac50c71401d19b8568400862fcbee29bfL1-R1) [[5]](diffhunk://#diff-19d2e8d73fce81a3ecb33c09c5d7326ac50c71401d19b8568400862fcbee29bfL12-R12) [[6]](diffhunk://#diff-a5e890fee85d5763c3b171657993823fc6c2f1b0ffc2612c6e7aef8be4b406a5L1-R1) [[7]](diffhunk://#diff-a5e890fee85d5763c3b171657993823fc6c2f1b0ffc2612c6e7aef8be4b406a5L12-R12)

**Documentation and migration:**

* Updated documentation to describe the new auto-conversion behavior and removed instructions for using `parse-date` (`docs/format-designer/typst-backend.md`, `prose/designs/GLUE_METADATA.md`). [[1]](diffhunk://#diff-c39dc8d4a6fca2fd329c8c8513102b7d6609f21f57a7097b855a3f28d91b985bL50-R55) [[2]](diffhunk://#diff-c39dc8d4a6fca2fd329c8c8513102b7d6609f21f57a7097b855a3f28d91b985bL99-R105) [[3]](diffhunk://#diff-c39dc8d4a6fca2fd329c8c8513102b7d6609f21f57a7097b855a3f28d91b985bL336-R341) [[4]](diffhunk://#diff-c5e59d5c1ad05504afc14a5a1f6ed6ef15c8e34a2ff8e9c1346cab2213f3667cL21-R29)
* Added a migration guide for maintainers explaining the required changes to plates and how the new auto-conversion works (`prose/migrations/typst-date-auto-conversion.md`).