### PR TITLE
Fix unused `close_start` variable in Typst converter

### DIFF
--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -1096,7 +1096,6 @@ fn replace_intraword_marker_pairs(source: &str, marker: &str, open: &str, close:
                 while i < chars.len() {
                     if chars[i] == '`' {
                         let mut close_count = 0;
-                        let close_start = i;
                         while i < chars.len() && chars[i] == '`' {
                             close_count += 1;
                             i += 1;


### PR DESCRIPTION
### Motivation
- Remove an unused local in fenced-backtick scanning to eliminate a compiler warning and keep the codebase clean.

### Description
- Delete the unused `close_start` local in the fenced-code handling branch of `replace_intraword_marker_pairs` in `crates/backends/typst/src/convert.rs`.

### Testing
- Running `cargo check -p typst-backend` failed because that package name does not exist in this workspace.
- Running `cargo check -p quillmark-typst` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcbe2467483239178d56168dd941d)