### PR TITLE
Allow null and empty string values for Date and DateTime fields

### DIFF
--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -346,7 +346,13 @@ impl QuillConfig {
                 Ok(value.clone())
             }
             FieldType::Date | FieldType::DateTime => {
+                if json_value.is_null() {
+                    return Ok(QuillValue::from_json(serde_json::Value::Null));
+                }
                 let text = if let Some(s) = json_value.as_str() {
+                    if s.is_empty() {
+                        return Ok(QuillValue::from_json(serde_json::Value::Null));
+                    }
                     s.to_string()
                 } else if let Some(arr) = json_value.as_array() {
                     if arr.len() == 1 {

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -146,34 +146,48 @@ pub(crate) fn validate_field(
         FieldType::String | FieldType::Markdown => value.as_str().is_some(),
         FieldType::Number => value.as_json().is_number(),
         FieldType::Boolean => value.as_bool().is_some(),
-        FieldType::Date => match value.as_str() {
-            Some(text) => {
-                if is_valid_date(text) {
-                    true
-                } else {
-                    errors.push(ValidationError::FormatViolation {
-                        path: path.to_string(),
-                        format: "date".to_string(),
-                    });
-                    false
+        FieldType::Date => {
+            if value.as_json().is_null() {
+                true
+            } else {
+                match value.as_str() {
+                    Some(text) if text.is_empty() => true,
+                    Some(text) => {
+                        if is_valid_date(text) {
+                            true
+                        } else {
+                            errors.push(ValidationError::FormatViolation {
+                                path: path.to_string(),
+                                format: "date".to_string(),
+                            });
+                            false
+                        }
+                    }
+                    None => false,
                 }
             }
-            None => false,
-        },
-        FieldType::DateTime => match value.as_str() {
-            Some(text) => {
-                if is_valid_datetime(text) {
-                    true
-                } else {
-                    errors.push(ValidationError::FormatViolation {
-                        path: path.to_string(),
-                        format: "date-time".to_string(),
-                    });
-                    false
+        }
+        FieldType::DateTime => {
+            if value.as_json().is_null() {
+                true
+            } else {
+                match value.as_str() {
+                    Some(text) if text.is_empty() => true,
+                    Some(text) => {
+                        if is_valid_datetime(text) {
+                            true
+                        } else {
+                            errors.push(ValidationError::FormatViolation {
+                                path: path.to_string(),
+                                format: "date-time".to_string(),
+                            });
+                            false
+                        }
+                    }
+                    None => false,
                 }
             }
-            None => false,
-        },
+        }
         FieldType::Array => match value.as_array() {
             Some(items) => {
                 if let Some(item_schema) = &field.items {


### PR DESCRIPTION
## Summary
This PR updates the validation and deserialization logic for Date and DateTime fields to properly handle null values and empty strings, treating them as valid inputs rather than validation errors.

## Key Changes
- **Validation (`validation.rs`)**: Modified `FieldType::Date` and `FieldType::DateTime` validation to:
  - Accept null JSON values as valid
  - Accept empty strings as valid (in addition to properly formatted date/datetime strings)
  - Only validate format when a non-empty string is provided
  
- **Deserialization (`config.rs`)**: Updated Date and DateTime field deserialization to:
  - Return null when the input JSON value is null
  - Return null when the input string is empty
  - Preserve existing behavior for valid date/datetime strings

## Implementation Details
The changes follow a consistent pattern for both Date and DateTime fields:
1. First check if the value is null and allow it
2. Then check if it's an empty string and allow it
3. Only perform format validation on non-empty string values
4. Maintain backward compatibility with existing valid date/datetime formats

https://claude.ai/code/session_019ZStwsSWPCHktHaB8dScAY