### PR TITLE
Add font dehydration/rehydration for published bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecow"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2200,7 @@ version = "0.54.1"
 dependencies = [
  "glob",
  "quillmark-fixtures",
+ "schemars",
  "serde",
  "serde-saphyr",
  "serde_json",
@@ -2557,6 +2564,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.29.1",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2693,17 @@ name = "serde_derive_internals"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3149,7 +3191,7 @@ checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.28.0",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ anyhow = "~1.0"
 # File globbing
 glob = "0.3.3"
 
+# JSON Schema generation
+schemars = "~0.8"
+
 # Unicode normalization
 unicode-normalization = "0.1"
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -83,13 +83,46 @@ impl Quillmark {
     ///
     /// Accepts either a JSON string or a JsValue object representing the Quill file tree.
     /// Validation happens automatically on registration.
+    ///
+    /// `font_map` is an optional `Map<string, Uint8Array>` (or plain JS object)
+    /// mapping MD5 hex strings to font bytes.  Pass it when registering a
+    /// dehydrated (published) bundle — Node fetches the bytes from the store and
+    /// hands them here so Rust can rehydrate the file tree before loading.
+    /// If the bundle is not dehydrated (no `fonts.json`) the argument is ignored.
     #[wasm_bindgen(js_name = registerQuill)]
-    pub fn register_quill(&mut self, quill_json: JsValue) -> Result<QuillInfo, JsValue> {
-        // Convert JsValue to JSON string
-        let json_str = if quill_json.is_string() {
-            quill_json.as_string().ok_or_else(|| {
-                WasmError::from("Failed to convert JsValue to string").to_js_value()
-            })?
+    pub fn register_quill(
+        &mut self,
+        quill_json: JsValue,
+        font_map: Option<JsValue>,
+    ) -> Result<QuillInfo, JsValue> {
+        let json_str = Self::quill_json_to_str(quill_json)?;
+
+        let quill = match font_map {
+            Some(map) if !map.is_null() && !map.is_undefined() => {
+                let provider = js_font_map_to_provider(map)?;
+                quillmark_core::Quill::from_json_with_fonts(&json_str, &provider)
+                    .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?
+            }
+            _ => {
+                quillmark_core::Quill::from_json(&json_str)
+                    .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?
+            }
+        };
+
+        let name = quill.name.clone();
+        self.inner
+            .register_quill(quill)
+            .map_err(|e| WasmError::from(e).to_js_value())?;
+
+        self.get_quill_info(&name)
+    }
+
+    /// Shared helper: coerce the quill_json JsValue to a JSON string.
+    fn quill_json_to_str(quill_json: JsValue) -> Result<String, JsValue> {
+        if quill_json.is_string() {
+            quill_json
+                .as_string()
+                .ok_or_else(|| WasmError::from("Failed to convert JsValue to string").to_js_value())
         } else {
             js_sys::JSON::stringify(&quill_json)
                 .map_err(|e| {
@@ -97,21 +130,8 @@ impl Quillmark {
                         .to_js_value()
                 })?
                 .as_string()
-                .ok_or_else(|| WasmError::from("Failed to convert JSON to string").to_js_value())?
-        };
-
-        // Parse and validate Quill
-        let quill = quillmark_core::Quill::from_json(&json_str)
-            .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?;
-        let name = quill.name.clone();
-
-        // Register with backend validation
-        self.inner
-            .register_quill(quill)
-            .map_err(|e| WasmError::from(e).to_js_value())?;
-
-        // Return full quill info
-        self.get_quill_info(&name)
+                .ok_or_else(|| WasmError::from("Failed to convert JSON to string").to_js_value())
+        }
     }
 
     /// Get shallow information about a registered Quill
@@ -380,7 +400,9 @@ impl Quillmark {
         self.inner.unregister_quill(name_or_ref)
     }
 
-    fn to_core_parsed(parsed: ParsedDocument) -> Result<quillmark_core::ParsedDocument, JsValue> {
+    fn to_core_parsed(
+        parsed: ParsedDocument,
+    ) -> Result<quillmark_core::ParsedDocument, JsValue> {
         let mut fields = std::collections::HashMap::new();
 
         if let serde_json::Value::Object(obj) = parsed.fields {
@@ -436,4 +458,50 @@ impl CompiledDocument {
             render_time_ms: now_ms() - start,
         })
     }
+}
+
+// ── font-map helper ───────────────────────────────────────────────────────────
+
+/// Convert a JS `Map<string, Uint8Array>` or plain object into a [`MapProvider`].
+///
+/// Both a JS `Map` and a plain JS object are accepted.  Values must be
+/// `Uint8Array` instances; the bytes are copied into Rust-owned `Vec<u8>`.
+fn js_font_map_to_provider(
+    font_map: JsValue,
+) -> Result<quillmark_core::MapProvider, JsValue> {
+    let mut map: std::collections::HashMap<String, Vec<u8>> = std::collections::HashMap::new();
+
+    if js_sys::Map::<JsValue, JsValue>::instanceof(&font_map) {
+        // JS Map — iterate with .entries()
+        let js_map = js_sys::Map::from(font_map);
+        let iter = js_map.entries();
+        loop {
+            let next = iter.next().map_err(|e| {
+                WasmError::from(format!("Failed to iterate font map: {:?}", e)).to_js_value()
+            })?;
+            if next.done() {
+                break;
+            }
+            let pair = js_sys::Array::from(&next.value());
+            let key = pair.get(0).as_string().ok_or_else(|| {
+                WasmError::from("Font map key must be a string").to_js_value()
+            })?;
+            let bytes = js_sys::Uint8Array::new(&pair.get(1)).to_vec();
+            map.insert(key, bytes);
+        }
+    } else {
+        // Plain JS object — iterate with Object.entries()
+        let obj = js_sys::Object::from(font_map);
+        let entries = js_sys::Object::entries(&obj);
+        for entry in entries.iter() {
+            let pair = js_sys::Array::from(&entry);
+            let key = pair.get(0).as_string().ok_or_else(|| {
+                WasmError::from("Font map key must be a string").to_js_value()
+            })?;
+            let bytes = js_sys::Uint8Array::new(&pair.get(1)).to_vec();
+            map.insert(key, bytes);
+        }
+    }
+
+    Ok(quillmark_core::MapProvider::new(map))
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde-saphyr = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+schemars = { workspace = true }
 thiserror = { workspace = true }
 glob = { workspace = true }
 unicode-normalization = { workspace = true }

--- a/crates/core/schemas/fonts-manifest.schema.json
+++ b/crates/core/schemas/fonts-manifest.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FontManifest",
+  "description": "Dehydration record written to `fonts.json` at the ZIP root by the publisher.\n\nMaps every stripped font path to the MD5 hex of its bytes.  Multiple paths may share the same hash when byte-identical fonts are embedded more than once (e.g. under both `assets/fonts/` and `packages/*/fonts/`).\n\nRust is the canonical schema owner.  The JSON Schema at `crates/core/schemas/fonts-manifest.schema.json` is derived from this type via `schemars` and committed to the repository; CI fails on drift.",
+  "type": "object",
+  "required": [
+    "files",
+    "version"
+  ],
+  "properties": {
+    "files": {
+      "description": "Map from file path (relative to ZIP root) to lowercase MD5 hex.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "version": {
+      "description": "Schema version.  Must be `1`.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    }
+  }
+}

--- a/crates/core/src/fonts.rs
+++ b/crates/core/src/fonts.rs
@@ -1,0 +1,151 @@
+//! Font manifest and provider types for centralized font storage.
+//!
+//! Quill bundles are published in a **dehydrated** form: font files are stripped
+//! from the ZIP and replaced by a `fonts.json` sidecar that records each
+//! removed path together with the MD5 hex of its bytes.  Loading a published
+//! Quill **rehydrates** the bundle: the manifest drives fetches from a
+//! [`FontProvider`] and the bytes are written back to their original tree paths
+//! before the backend ever sees the [`FileTreeNode`].
+//!
+//! After rehydration the in-memory [`crate::Quill`] is indistinguishable from
+//! the pre-strip source.  The Typst backend therefore requires no changes.
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error as StdError;
+
+use serde::{Deserialize, Serialize};
+
+use crate::quill::FileTreeNode;
+
+// ── FontManifest ─────────────────────────────────────────────────────────────
+
+/// Dehydration record written to `fonts.json` at the ZIP root by the publisher.
+///
+/// Maps every stripped font path to the MD5 hex of its bytes.  Multiple paths
+/// may share the same hash when byte-identical fonts are embedded more than once
+/// (e.g. under both `assets/fonts/` and `packages/*/fonts/`).
+///
+/// Rust is the canonical schema owner.  The JSON Schema at
+/// `crates/core/schemas/fonts-manifest.schema.json` is derived from this type
+/// via `schemars` and committed to the repository; CI fails on drift.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FontManifest {
+    /// Schema version.  Must be `1`.
+    pub version: u32,
+    /// Map from file path (relative to ZIP root) to lowercase MD5 hex.
+    pub files: HashMap<String, String>,
+}
+
+// ── FontProvider ─────────────────────────────────────────────────────────────
+
+/// Supplies raw font bytes by MD5 content hash during rehydration.
+///
+/// Implementations are called **at most once per unique hash** in a single
+/// [`rehydrate_tree`] call.  The trait is intentionally sync so it remains
+/// usable inside Typst's sync font-loading path and in WASM without async.
+pub trait FontProvider {
+    /// Return the raw font bytes for `md5` (lowercase hex), or `None` if the
+    /// hash is not available.
+    ///
+    /// Returning `None` for any hash that appears in a manifest causes
+    /// [`rehydrate_tree`] to fail.
+    fn fetch(&self, md5: &str) -> Option<Vec<u8>>;
+}
+
+// ── MapProvider ──────────────────────────────────────────────────────────────
+
+/// A [`FontProvider`] backed by an in-memory `md5 → bytes` map.
+///
+/// Used by the WASM binding: Node reads `fonts.json`, fetches every unique hash
+/// from the store, builds a `Map<string, Uint8Array>`, and hands it to Rust as
+/// a `MapProvider`.  From Rust's perspective fonts are already present when
+/// [`rehydrate_tree`] runs.
+pub struct MapProvider {
+    map: HashMap<String, Vec<u8>>,
+}
+
+impl MapProvider {
+    /// Create a `MapProvider` from a pre-populated `md5-hex → bytes` map.
+    pub fn new(map: HashMap<String, Vec<u8>>) -> Self {
+        Self { map }
+    }
+}
+
+impl FontProvider for MapProvider {
+    fn fetch(&self, md5: &str) -> Option<Vec<u8>> {
+        self.map.get(md5).cloned()
+    }
+}
+
+// ── rehydrate_tree ────────────────────────────────────────────────────────────
+
+/// Rehydrate `root` in-place using `provider`.
+///
+/// # Algorithm
+///
+/// 1. Look for `fonts.json` at the tree root.  If absent, return `Ok(())` — the
+///    tree is either a local dev tree (fonts already present) or a bundle that
+///    pre-dates centralization.
+/// 2. Parse the [`FontManifest`] and reject unknown schema versions.
+/// 3. Collect the unique set of MD5 hashes from `manifest.files`.
+/// 4. Call `provider.fetch(md5)` once per unique hash.  **Fail immediately** if
+///    any hash is not available.
+/// 5. Insert font bytes at every path listed in the manifest.
+///
+/// After this call the tree is indistinguishable from the pre-strip source.
+///
+/// # Errors
+///
+/// - `fonts.json` is present but cannot be parsed as a [`FontManifest`].
+/// - `manifest.version` is not `1`.
+/// - Any hash in the manifest cannot be resolved by `provider`.
+/// - A path in the manifest cannot be inserted into the tree.
+pub fn rehydrate_tree(
+    root: &mut FileTreeNode,
+    provider: &dyn FontProvider,
+) -> Result<(), Box<dyn StdError + Send + Sync>> {
+    let manifest_bytes = match root.get_file("fonts.json") {
+        Some(b) => b.to_vec(),
+        None => return Ok(()),
+    };
+
+    let manifest: FontManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| format!("Failed to parse fonts.json: {}", e))?;
+
+    if manifest.version != 1 {
+        return Err(format!(
+            "Unsupported fonts.json version {} (expected 1)",
+            manifest.version
+        )
+        .into());
+    }
+
+    // Fetch each unique hash exactly once.
+    let unique_hashes: HashSet<&str> = manifest.files.values().map(String::as_str).collect();
+
+    let mut resolved: HashMap<&str, Vec<u8>> = HashMap::with_capacity(unique_hashes.len());
+    for hash in &unique_hashes {
+        match provider.fetch(hash) {
+            Some(bytes) => {
+                resolved.insert(hash, bytes);
+            }
+            None => {
+                return Err(
+                    format!("Font provider could not resolve hash: {}", hash).into(),
+                );
+            }
+        }
+    }
+
+    // Write bytes back to their original paths.
+    for (path, hash) in &manifest.files {
+        let bytes = resolved
+            .get(hash.as_str())
+            .expect("invariant: all hashes were resolved above")
+            .clone();
+        root.insert(path, FileTreeNode::File { contents: bytes })
+            .map_err(|e| format!("Failed to insert rehydrated font at '{}': {}", path, e))?;
+    }
+
+    Ok(())
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -57,6 +57,9 @@ pub use types::{Artifact, CompiledDocument, OutputFormat, RenderOptions};
 pub mod quill;
 pub use quill::{FileTreeNode, Quill, QuillIgnore};
 
+pub mod fonts;
+pub use fonts::{FontManifest, FontProvider, MapProvider};
+
 pub mod value;
 pub use value::QuillValue;
 

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -71,6 +71,21 @@ impl Quill {
         Self::from_config(config, root)
     }
 
+    /// Create a Quill from a tree, rehydrating fonts via `provider`.
+    ///
+    /// If `fonts.json` is present at the root of `root`, the provider is called
+    /// for each unique hash listed in the manifest and the bytes are written back
+    /// to their original paths before loading proceeds.  If `fonts.json` is
+    /// absent (local dev trees, pre-centralization bundles) the provider is
+    /// never called and this method is identical to [`from_tree`].
+    pub fn from_tree_with_fonts(
+        mut root: FileTreeNode,
+        provider: &dyn crate::fonts::FontProvider,
+    ) -> Result<Self, Box<dyn StdError + Send + Sync>> {
+        crate::fonts::rehydrate_tree(&mut root, provider)?;
+        Self::from_tree(root)
+    }
+
     /// Create a Quill from a QuillConfig and file tree
     ///
     /// This method constructs a Quill from a parsed QuillConfig and validates
@@ -209,6 +224,29 @@ impl Quill {
     /// The JSON format MUST have a root object with a `files` key. The optional
     /// `metadata` key provides additional metadata that overrides defaults.
     pub fn from_json(json_str: &str) -> Result<Self, Box<dyn StdError + Send + Sync>> {
+        let root = Self::parse_json_to_tree(json_str)?;
+        Self::from_tree(root)
+    }
+
+    /// Create a Quill from a JSON representation, rehydrating fonts via `provider`.
+    ///
+    /// Identical to [`from_json`] except that if `fonts.json` is present in the
+    /// tree (i.e. the bundle was published in dehydrated form), font bytes are
+    /// fetched from `provider` and written back to their original paths before
+    /// loading proceeds.
+    ///
+    /// This is the entry point used by the WASM binding when Node supplies a
+    /// pre-fetched `Map<string, Uint8Array>` alongside the Quill JSON.
+    pub fn from_json_with_fonts(
+        json_str: &str,
+        provider: &dyn crate::fonts::FontProvider,
+    ) -> Result<Self, Box<dyn StdError + Send + Sync>> {
+        let root = Self::parse_json_to_tree(json_str)?;
+        Self::from_tree_with_fonts(root, provider)
+    }
+
+    /// Shared JSON-to-tree parsing used by both `from_json` variants.
+    fn parse_json_to_tree(json_str: &str) -> Result<FileTreeNode, Box<dyn StdError + Send + Sync>> {
         use serde_json::Value as JsonValue;
 
         let json: JsonValue =
@@ -228,10 +266,7 @@ impl Quill {
             root_files.insert(key.clone(), FileTreeNode::from_json_value(value)?);
         }
 
-        let root = FileTreeNode::Directory { files: root_files };
-
-        // Create Quill from tree
-        Self::from_tree(root)
+        Ok(FileTreeNode::Directory { files: root_files })
     }
 
     /// Recursively load all files from a directory into a tree structure

--- a/crates/core/tests/fixtures/fonts-manifest/valid-dedup.json
+++ b/crates/core/tests/fixtures/fonts-manifest/valid-dedup.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "files": {
+    "assets/fonts/Inter-Regular.ttf": "3f2a8c1d9e4b5a7f0c8d6e3a1b4f9c2d",
+    "packages/ttq-classic-resume/fonts/Inter-Regular.ttf": "3f2a8c1d9e4b5a7f0c8d6e3a1b4f9c2d",
+    "assets/fonts/Inter-Bold.ttf": "a7e3b2d5f0c8e1a4b7d2f5c9e0a3b6d1"
+  }
+}

--- a/crates/core/tests/fixtures/fonts-manifest/valid-simple.json
+++ b/crates/core/tests/fixtures/fonts-manifest/valid-simple.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "files": {
+    "assets/fonts/Inter-Regular.ttf": "3f2a8c1d9e4b5a7f0c8d6e3a1b4f9c2d",
+    "assets/fonts/Inter-Bold.ttf": "a7e3b2d5f0c8e1a4b7d2f5c9e0a3b6d1"
+  }
+}

--- a/crates/core/tests/fonts.rs
+++ b/crates/core/tests/fonts.rs
@@ -1,0 +1,206 @@
+//! Tests for FontManifest parsing, rehydration, and schema drift detection.
+
+use std::collections::HashMap;
+
+use quillmark_core::fonts::{rehydrate_tree, FontManifest, FontProvider, MapProvider};
+use quillmark_core::FileTreeNode;
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+fn fixture(name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/fonts-manifest")
+        .join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("fixture not found: {}", path.display()))
+}
+
+// ── FontManifest parsing ──────────────────────────────────────────────────────
+
+#[test]
+fn parse_valid_simple_fixture() {
+    let json = fixture("valid-simple.json");
+    let manifest: FontManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(manifest.version, 1);
+    assert_eq!(manifest.files.len(), 2);
+    assert_eq!(
+        manifest.files["assets/fonts/Inter-Regular.ttf"],
+        "3f2a8c1d9e4b5a7f0c8d6e3a1b4f9c2d"
+    );
+}
+
+#[test]
+fn parse_valid_dedup_fixture() {
+    let json = fixture("valid-dedup.json");
+    let manifest: FontManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(manifest.version, 1);
+    assert_eq!(manifest.files.len(), 3);
+    // Two paths share the same hash — the dedup case.
+    let hash = &manifest.files["assets/fonts/Inter-Regular.ttf"];
+    assert_eq!(
+        &manifest.files["packages/ttq-classic-resume/fonts/Inter-Regular.ttf"],
+        hash
+    );
+}
+
+#[test]
+fn roundtrip_serialization() {
+    let mut files = HashMap::new();
+    files.insert(
+        "assets/fonts/Foo.ttf".to_string(),
+        "aabbccdd".to_string(),
+    );
+    let original = FontManifest { version: 1, files };
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: FontManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, decoded);
+}
+
+// ── rehydrate_tree ────────────────────────────────────────────────────────────
+
+/// Builds a minimal dehydrated tree: Quill.yaml + fonts.json, no font files.
+fn dehydrated_tree(manifest_json: &str) -> FileTreeNode {
+    let mut root = FileTreeNode::Directory {
+        files: HashMap::new(),
+    };
+    root.insert(
+        "Quill.yaml",
+        FileTreeNode::File {
+            contents: b"name: test\nbackend: typst\nversion: '0.1.0'\nauthor: Test\ncards: []\n"
+                .to_vec(),
+        },
+    )
+    .unwrap();
+    root.insert(
+        "fonts.json",
+        FileTreeNode::File {
+            contents: manifest_json.as_bytes().to_vec(),
+        },
+    )
+    .unwrap();
+    root
+}
+
+/// A [`FontProvider`] that serves synthetic font bytes keyed by md5.
+struct FakeProvider(HashMap<String, Vec<u8>>);
+
+impl FontProvider for FakeProvider {
+    fn fetch(&self, md5: &str) -> Option<Vec<u8>> {
+        self.0.get(md5).cloned()
+    }
+}
+
+#[test]
+fn rehydrate_inserts_font_at_correct_path() {
+    let manifest_json = r#"{"version":1,"files":{"assets/fonts/Inter-Regular.ttf":"aabbccdd"}}"#;
+    let mut tree = dehydrated_tree(manifest_json);
+
+    let provider = FakeProvider({
+        let mut m = HashMap::new();
+        m.insert("aabbccdd".to_string(), b"FAKE_FONT_BYTES".to_vec());
+        m
+    });
+
+    rehydrate_tree(&mut tree, &provider).unwrap();
+
+    assert_eq!(
+        tree.get_file("assets/fonts/Inter-Regular.ttf").unwrap(),
+        b"FAKE_FONT_BYTES"
+    );
+}
+
+#[test]
+fn rehydrate_dedup_calls_provider_once_per_unique_hash() {
+    let manifest_json = r#"{
+      "version": 1,
+      "files": {
+        "assets/fonts/Inter-Regular.ttf": "aabbccdd",
+        "packages/pkg/fonts/Inter-Regular.ttf": "aabbccdd"
+      }
+    }"#;
+    let mut tree = dehydrated_tree(manifest_json);
+
+    // Track how many times fetch is called.
+    struct CountingProvider {
+        bytes: Vec<u8>,
+        calls: std::cell::Cell<usize>,
+    }
+    impl FontProvider for CountingProvider {
+        fn fetch(&self, _md5: &str) -> Option<Vec<u8>> {
+            self.calls.set(self.calls.get() + 1);
+            Some(self.bytes.clone())
+        }
+    }
+
+    let provider = CountingProvider {
+        bytes: b"FONT".to_vec(),
+        calls: std::cell::Cell::new(0),
+    };
+    rehydrate_tree(&mut tree, &provider).unwrap();
+
+    // Both paths should now have font bytes.
+    assert!(tree
+        .get_file("assets/fonts/Inter-Regular.ttf")
+        .is_some());
+    assert!(tree
+        .get_file("packages/pkg/fonts/Inter-Regular.ttf")
+        .is_some());
+    // Provider was called exactly once for the single unique hash.
+    assert_eq!(provider.calls.get(), 1);
+}
+
+#[test]
+fn rehydrate_no_op_when_fonts_json_absent() {
+    let mut tree = FileTreeNode::Directory {
+        files: HashMap::new(),
+    };
+    // No fonts.json — should succeed silently.
+    let provider = MapProvider::new(HashMap::new());
+    rehydrate_tree(&mut tree, &provider).unwrap();
+}
+
+#[test]
+fn rehydrate_fails_on_missing_hash() {
+    let manifest_json =
+        r#"{"version":1,"files":{"assets/fonts/Missing.ttf":"deadbeef"}}"#;
+    let mut tree = dehydrated_tree(manifest_json);
+
+    // Provider has nothing.
+    let provider = MapProvider::new(HashMap::new());
+    let err = rehydrate_tree(&mut tree, &provider).unwrap_err();
+    assert!(err.to_string().contains("deadbeef"), "{}", err);
+}
+
+#[test]
+fn rehydrate_fails_on_unsupported_version() {
+    let manifest_json = r#"{"version":99,"files":{}}"#;
+    let mut tree = dehydrated_tree(manifest_json);
+
+    let provider = MapProvider::new(HashMap::new());
+    let err = rehydrate_tree(&mut tree, &provider).unwrap_err();
+    assert!(err.to_string().contains("99"), "{}", err);
+}
+
+// ── Schema drift guard ────────────────────────────────────────────────────────
+
+#[test]
+fn fonts_manifest_schema_matches_committed_file() {
+    let schema = schemars::schema_for!(FontManifest);
+    let generated = serde_json::to_string_pretty(&schema).unwrap();
+
+    let committed_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("schemas/fonts-manifest.schema.json");
+    let committed = std::fs::read_to_string(&committed_path).unwrap_or_else(|_| {
+        panic!(
+            "schemas/fonts-manifest.schema.json not found at {}",
+            committed_path.display()
+        )
+    });
+
+    assert_eq!(
+        committed.trim(),
+        generated.trim(),
+        "schemas/fonts-manifest.schema.json is out of date — \
+         update the file to match the generated schema above"
+    );
+}

--- a/prose/proposals/dehydrate-fonts.md
+++ b/prose/proposals/dehydrate-fonts.md
@@ -1,13 +1,5 @@
 # Font Dehydration — `@quillmark/registry` Tasking
 
-## Supersedes
-
-`prose/proposals/centralize_fonts.md`. The goal and store model are
-unchanged. This document revises the responsibility split: rehydration
-moves entirely into the `@quillmark/registry` Node layer so that
-`quillmark` (Rust/WASM) receives only complete, hydrated bundles and
-requires no API changes.
-
 ## Goal
 
 Move font bytes out of published Quill bundles into a shared,
@@ -19,9 +11,16 @@ is fetched and cached once regardless of how many quills embed it.
 
 ## Scope
 
-**Fonts only.** Non-font assets stay inline. Typst packages stay inline —
-after font stripping, remaining source (`.typ` files + `typst.toml`) is
-negligible. The store URL shape is file-type-agnostic if this changes later.
+**Fonts only.** Non-font assets stay inline (templates reference them by
+path, making content-addressed substitution awkward). Typst packages stay
+inline — after font stripping, remaining source (`.typ` files +
+`typst.toml`) is negligible. The store URL shape is file-type-agnostic if
+this changes later.
+
+**The registry owns the full lifecycle.** `@quillmark/registry` dehydrates
+at publish, serves the store, and rehydrates at load before handing a
+complete bundle to Quillmark. Quillmark's rendering path sees no
+centralization.
 
 ## Model: dehydrate at publish, rehydrate at load
 
@@ -29,11 +28,12 @@ A published Quill is a **dehydration** of its source tree: font files are
 stripped, their bytes moved to the content-addressed store, and a sidecar
 manifest records what was removed and where.
 
-Loading a published Quill **rehydrates** the tree: the registry client reads
-the manifest, fetches missing bytes from the store (parallel, cache-first),
-reconstructs a complete in-memory file tree, and passes it to
-`registerQuill`. Quillmark receives a hydrated bundle identical to the
-pre-strip source. The Typst backend never sees centralization.
+Loading a published Quill **rehydrates** the tree: the registry client
+reads the manifest, fetches missing bytes from the store (parallel,
+cache-first), reconstructs a complete in-memory file tree, and passes it
+to Quillmark for compilation. The rehydrated bundle is indistinguishable
+from the pre-strip source — the Typst backend sees a normal file tree and
+requires no changes.
 
 ## Core decisions
 
@@ -51,8 +51,13 @@ pre-strip source. The Typst backend never sees centralization.
 - **Manifest is a sidecar inside the ZIP** — `fonts.json` at the ZIP root.
 - **No font metadata sniffing.** Hash bytes, record paths. No font-parsing
   dependency required.
+- **No store URL pinned in the manifest.** Consumers prepend their
+  configured base URL so bundles remain portable across mirrors.
 
 ## Manifest: `fonts.json`
+
+A dehydration record — nothing more. Maps each stripped path to its
+content hash:
 
 ```json
 {
@@ -68,21 +73,21 @@ pre-strip source. The Typst backend never sees centralization.
 - **`files`**: path → md5-hex. One entry per stripped file. Identical bytes
   at multiple source paths produce multiple entries with the same hash;
   rehydration faithfully reproduces the tree.
-- No store URL pinned in the manifest; consumers prepend their configured
-  base URL so bundles remain portable across mirrors.
 
-## Schema ownership
+## Schema
 
-**Rust is canonical.** `quillmark-core` owns the `FontManifest` type (serde
-+ `schemars` derives). This is already shipped:
+The `FontManifest` type is defined in Rust and is the canonical contract.
+The registry validates `fonts.json` against the generated JSON Schema both
+when writing it at publish time and when reading it at load time — drift
+in either direction fails CI.
 
-- Type: `crates/core/src/fonts.rs`
-- Generated JSON Schema: `crates/core/schemas/fonts-manifest.schema.json`
-- Shared fixtures: `crates/core/tests/fixtures/fonts-manifest/`
+- **Type definition**: `crates/core/src/fonts.rs` (`quillmark-core`)
+- **JSON Schema**: `crates/core/schemas/fonts-manifest.schema.json`
+- **Shared test fixtures**: `crates/core/tests/fixtures/fonts-manifest/`
 
-**Node validates against the committed schema** (ajv or equivalent) before
-writing `fonts.json` at publish time and before reading it at load time. CI
-fails on schema drift in either direction.
+Node validates with `ajv` (or equivalent). The fixtures are parsed by
+Rust CI and validated by Node CI against the schema; both sides regress
+against the same inputs.
 
 ## Publish flow
 
@@ -94,7 +99,8 @@ Triggered when a Quill source tree is packaged for the registry.
    `<store-base>/store/<md5-hex>` (PUT, idempotent — skip if already
    present).
 3. Build the `files` map: `{ [path]: md5-hex }` for every matched file.
-4. Build the ZIP — include `fonts.json` at the root, exclude every matched
+4. Validate the manifest against `fonts-manifest.schema.json`.
+5. Build the ZIP — include `fonts.json` at the root, exclude every matched
    font file.
 
 Print a dedup summary after publish (counts are a local walk — no store
@@ -112,58 +118,60 @@ bundle: stripped 47 MB across 22 quills
 ## Load flow
 
 Triggered when the registry client fetches a Quill bundle to hand to
-`quillmark-wasm`.
+Quillmark.
 
 1. Fetch and unpack the Quill ZIP in memory.
 2. Check for `fonts.json` at the ZIP root.
-   - **Absent** (non-dehydrated bundle or pre-centralization): proceed
-     directly to step 6.
-3. Validate `fonts.json` against `fonts-manifest.schema.json`.
+   - **Absent** (non-dehydrated bundle): skip to step 6.
+3. Parse `fonts.json` and validate against `fonts-manifest.schema.json`.
 4. Collect the unique set of MD5 hashes from `files` values.
 5. Fetch each hash from `<store-base>/store/<md5-hex>` in **parallel**.
-   Cache fetched bytes for the duration of the session (cross-quill dedup).
+   Cache fetched bytes in a session-level `Map<md5, Uint8Array>` so the
+   same bytes aren't re-fetched when loading additional quills.
    **Fail the load if any hash cannot be resolved.**
-6. Reconstruct the complete file tree: for every `[path, md5]` entry in
-   `files`, write the resolved bytes at `path`.
-7. Serialize the hydrated tree as Quill JSON and call
-   `engine.registerQuill(quillJson)` — unchanged API, no font map argument.
+6. Reconstruct the complete in-memory file tree: for every `[path, md5]`
+   entry in `files`, insert the resolved bytes at `path`.
+7. Hand the hydrated tree to Quillmark via the registration API. The
+   bundle is a complete Quill — no font manifest, no missing files.
+
+## Cross-quill caching
+
+The session-level `Map<md5, Uint8Array>` is the main performance payoff.
+Without it, each quill load re-fetches every font; with it, Inter-Regular
+is fetched exactly once per session regardless of how many quills use it.
+Keep the cache keyed by raw md5 hex and scoped to a single registry client
+instance. Eviction policy: none in v1 (processes are short-lived in
+practice).
 
 ## Responsibility split
 
 **`@quillmark/registry` owns everything.**
 
-- Publish: walk, hash, upload, strip, emit `fonts.json`, build ZIP.
+- Publish: walk, hash, upload, strip, emit `fonts.json`, validate, build ZIP.
 - Store: serve font bytes as static files at `/store/<md5-hex>`.
 - Load: fetch ZIP, validate manifest, fetch font bytes in parallel,
-  rehydrate file tree, hand hydrated JSON to `quillmark-wasm`.
-- Cross-quill font cache: in-process `Map<md5, Uint8Array>` for the
-  duration of a registry session (prevents re-fetching the same bytes when
-  loading multiple quills).
+  rehydrate file tree, hand hydrated bundle to Quillmark.
+- Caching: session-level cross-quill font cache.
 
-**`quillmark` (Rust/WASM) — no changes required.**
+**Quillmark receives complete, hydrated bundles.** The rendering path is
+unchanged. Dehydration is invisible to Quillmark consumers (WASM or
+native).
 
-The `FontManifest` type and JSON Schema are already shipped in
-`quillmark-core` for schema validation use by Node. The `registerQuill` API
-is unchanged. The Rust `FontProvider` / `rehydrate_tree` machinery from the
-initial implementation (`crates/core/src/fonts.rs`) can be removed in a
-follow-up — it is no longer part of the load path.
+## Key references
 
-## Key existing code
-
+- Canonical schema: `crates/core/schemas/fonts-manifest.schema.json`
+- Shared test fixtures: `crates/core/tests/fixtures/fonts-manifest/`
 - ZIP packager:
   `references/quillmark-registry/src/sources/file-system-source.ts:206-233`
-- Schema to validate against:
-  `crates/core/schemas/fonts-manifest.schema.json`
-- Shared test fixtures:
-  `crates/core/tests/fixtures/fonts-manifest/`
 
 ## Deferred
 
-- Same-family conflicts within one Quill: v1 sorts discovery paths
-  deterministically. Real conflict detection is later.
-- Fonts inside downloaded `@preview/…` packages are not registered today
-  (file-scan only walks the Quill tree). Unchanged.
-- GC, license metadata, HTML/LaTeX backends.
-- Generic dehydration (non-font large assets): not in scope. If added, the
-  store URL shape and manifest structure extend naturally; fonts remain the
-  only dehydrated type until a second use case is validated.
+- **Same-family conflicts** within one Quill: v1 sorts discovery paths
+  deterministically so whichever wins is reproducible. Real conflict
+  detection is later.
+- **Fonts inside downloaded `@preview/...` packages** are not registered
+  today (file-scan only walks the Quill tree). Unchanged.
+- License metadata, garbage collection, HTML/LaTeX backends.
+- Generic dehydration (non-font large assets). The store URL shape and
+  manifest structure extend naturally if a second use case is validated,
+  but fonts remain the only dehydrated type in v1.

--- a/prose/proposals/dehydrate-fonts.md
+++ b/prose/proposals/dehydrate-fonts.md
@@ -1,0 +1,169 @@
+# Font Dehydration — `@quillmark/registry` Tasking
+
+## Supersedes
+
+`prose/proposals/centralize_fonts.md`. The goal and store model are
+unchanged. This document revises the responsibility split: rehydration
+moves entirely into the `@quillmark/registry` Node layer so that
+`quillmark` (Rust/WASM) receives only complete, hydrated bundles and
+requires no API changes.
+
+## Goal
+
+Move font bytes out of published Quill bundles into a shared,
+content-addressed store. Fonts are 60–95% of bundle size today
+(`classic_resume@0.1.0`: 2.1 MB total, 2.1 MB fonts; `usaf_memo@0.1.0`
+and `0.2.0` ship byte-identical 551 KB font sets). Wire savings compound
+across quills because the store deduplicates by content hash: Inter-Regular
+is fetched and cached once regardless of how many quills embed it.
+
+## Scope
+
+**Fonts only.** Non-font assets stay inline. Typst packages stay inline —
+after font stripping, remaining source (`.typ` files + `typst.toml`) is
+negligible. The store URL shape is file-type-agnostic if this changes later.
+
+## Model: dehydrate at publish, rehydrate at load
+
+A published Quill is a **dehydration** of its source tree: font files are
+stripped, their bytes moved to the content-addressed store, and a sidecar
+manifest records what was removed and where.
+
+Loading a published Quill **rehydrates** the tree: the registry client reads
+the manifest, fetches missing bytes from the store (parallel, cache-first),
+reconstructs a complete in-memory file tree, and passes it to
+`registerQuill`. Quillmark receives a hydrated bundle identical to the
+pre-strip source. The Typst backend never sees centralization.
+
+## Core decisions
+
+- **Identity = MD5 of raw font bytes.** Dedup, not integrity.
+- **Store is flat and content-addressed.** URL: `<base>/store/<md5-hex>`.
+  Raw bytes, lowercase hex, no extension. Publisher filesystem mirrors
+  the URL.
+- **Persisted, write-open, idempotent uploads.** No GC in v1. No zipping,
+  no format conversion (Typst does not support WOFF2). Transport
+  compression is the CDN's job.
+- **Strip everywhere at publish.** `*.ttf`, `*.otf`, `*.woff`, `*.woff2`
+  are removed from the ZIP wherever they appear, including under
+  `packages/**`.
+- **`Quill.yaml` is never modified.** Author source stays clean.
+- **Manifest is a sidecar inside the ZIP** — `fonts.json` at the ZIP root.
+- **No font metadata sniffing.** Hash bytes, record paths. No font-parsing
+  dependency required.
+
+## Manifest: `fonts.json`
+
+```json
+{
+  "version": 1,
+  "files": {
+    "assets/fonts/Inter-Regular.ttf": "3f2a8c1d9e4b5a7f0c8d6e3a1b4f9c2d",
+    "packages/ttq-classic-resume/fonts/Inter-Regular.ttf": "3f2a8c1d9e4b5a7f0c8d6e3a1b4f9c2d",
+    "assets/fonts/Inter-Bold.ttf": "a7e3b2d5f0c8e1a4b7d2f5c9e0a3b6d1"
+  }
+}
+```
+
+- **`files`**: path → md5-hex. One entry per stripped file. Identical bytes
+  at multiple source paths produce multiple entries with the same hash;
+  rehydration faithfully reproduces the tree.
+- No store URL pinned in the manifest; consumers prepend their configured
+  base URL so bundles remain portable across mirrors.
+
+## Schema ownership
+
+**Rust is canonical.** `quillmark-core` owns the `FontManifest` type (serde
++ `schemars` derives). This is already shipped:
+
+- Type: `crates/core/src/fonts.rs`
+- Generated JSON Schema: `crates/core/schemas/fonts-manifest.schema.json`
+- Shared fixtures: `crates/core/tests/fixtures/fonts-manifest/`
+
+**Node validates against the committed schema** (ajv or equivalent) before
+writing `fonts.json` at publish time and before reading it at load time. CI
+fails on schema drift in either direction.
+
+## Publish flow
+
+Triggered when a Quill source tree is packaged for the registry.
+
+1. Walk the source tree. For every file whose extension is `ttf`, `otf`,
+   `woff`, or `woff2`, compute the MD5 of its raw bytes.
+2. Collect the unique set of hashes. For each, upload bytes to
+   `<store-base>/store/<md5-hex>` (PUT, idempotent — skip if already
+   present).
+3. Build the `files` map: `{ [path]: md5-hex }` for every matched file.
+4. Build the ZIP — include `fonts.json` at the root, exclude every matched
+   font file.
+
+Print a dedup summary after publish (counts are a local walk — no store
+query required):
+
+```
+fonts:
+  Inter-Regular.ttf   3f2a8c…  used by 14 quills
+  Inter-Bold.ttf      a7e3b2…  used by 12 quills
+  EBGaramond.ttf      789abc…  used by 1 quill
+
+bundle: stripped 47 MB across 22 quills
+```
+
+## Load flow
+
+Triggered when the registry client fetches a Quill bundle to hand to
+`quillmark-wasm`.
+
+1. Fetch and unpack the Quill ZIP in memory.
+2. Check for `fonts.json` at the ZIP root.
+   - **Absent** (non-dehydrated bundle or pre-centralization): proceed
+     directly to step 6.
+3. Validate `fonts.json` against `fonts-manifest.schema.json`.
+4. Collect the unique set of MD5 hashes from `files` values.
+5. Fetch each hash from `<store-base>/store/<md5-hex>` in **parallel**.
+   Cache fetched bytes for the duration of the session (cross-quill dedup).
+   **Fail the load if any hash cannot be resolved.**
+6. Reconstruct the complete file tree: for every `[path, md5]` entry in
+   `files`, write the resolved bytes at `path`.
+7. Serialize the hydrated tree as Quill JSON and call
+   `engine.registerQuill(quillJson)` — unchanged API, no font map argument.
+
+## Responsibility split
+
+**`@quillmark/registry` owns everything.**
+
+- Publish: walk, hash, upload, strip, emit `fonts.json`, build ZIP.
+- Store: serve font bytes as static files at `/store/<md5-hex>`.
+- Load: fetch ZIP, validate manifest, fetch font bytes in parallel,
+  rehydrate file tree, hand hydrated JSON to `quillmark-wasm`.
+- Cross-quill font cache: in-process `Map<md5, Uint8Array>` for the
+  duration of a registry session (prevents re-fetching the same bytes when
+  loading multiple quills).
+
+**`quillmark` (Rust/WASM) — no changes required.**
+
+The `FontManifest` type and JSON Schema are already shipped in
+`quillmark-core` for schema validation use by Node. The `registerQuill` API
+is unchanged. The Rust `FontProvider` / `rehydrate_tree` machinery from the
+initial implementation (`crates/core/src/fonts.rs`) can be removed in a
+follow-up — it is no longer part of the load path.
+
+## Key existing code
+
+- ZIP packager:
+  `references/quillmark-registry/src/sources/file-system-source.ts:206-233`
+- Schema to validate against:
+  `crates/core/schemas/fonts-manifest.schema.json`
+- Shared test fixtures:
+  `crates/core/tests/fixtures/fonts-manifest/`
+
+## Deferred
+
+- Same-family conflicts within one Quill: v1 sorts discovery paths
+  deterministically. Real conflict detection is later.
+- Fonts inside downloaded `@preview/…` packages are not registered today
+  (file-scan only walks the Quill tree). Unchanged.
+- GC, license metadata, HTML/LaTeX backends.
+- Generic dehydration (non-font large assets): not in scope. If added, the
+  store URL shape and manifest structure extend naturally; fonts remain the
+  only dehydrated type until a second use case is validated.

--- a/prose/proposals/quill-factory-api.md
+++ b/prose/proposals/quill-factory-api.md
@@ -1,0 +1,137 @@
+# Quill Factory API — `quillmark-wasm` Tasking
+
+## Goal
+
+Split `engine.registerQuill(json)` into two explicit steps:
+
+1. **Construct** — `Quill.from*(source)` parses and validates a bundle,
+   returning an opaque `Quill` handle.
+2. **Register** — `engine.registerQuill(quill)` stores the handle in the
+   engine.
+
+This decouples format knowledge from the engine. The engine only ever sees
+`Quill` objects; all wire-format concerns live in the factories. Adding a
+new input source (e.g. a flat path-to-bytes map for registry load path)
+requires no change to `registerQuill`.
+
+## Background
+
+The current `registerQuill(json)` API conflates parsing, validation, and
+registration into one call. It also forces every input to pass through
+JSON, which is a poor fit for binary-heavy bundles and for callers that
+already have an unpacked in-memory tree (e.g. the registry client after
+decompressing a ZIP and rehydrating fonts). The engine should accept a
+`Quill` value, not a serialization format.
+
+## Proposed API
+
+### Factories — `Quill.from*()`
+
+```typescript
+class Quill {
+  /** Parse and validate from a JSON string or plain object. */
+  static fromJson(source: string | object): Quill;
+
+  /**
+   * Build from a flat path → bytes map.
+   *
+   * Keys are file paths relative to the quill root
+   * (e.g. "Quill.yaml", "assets/fonts/Inter-Regular.ttf").
+   * This is the natural output of the registry load path after ZIP
+   * decompression and font rehydration.
+   */
+  static fromTree(tree: Map<string, Uint8Array>): Quill;
+}
+```
+
+Both factories throw on invalid input with a structured error. No other
+methods are required on `Quill` in v1 — it is an opaque handle.
+
+### Engine — `registerQuill(quill)`
+
+```typescript
+class Quillmark {
+  /** Register a pre-constructed Quill with this engine. */
+  registerQuill(quill: Quill): QuillInfo;
+}
+```
+
+`registerQuill` no longer accepts JSON or any raw format — only `Quill`
+handles. The `Quill` may be registered with more than one engine; the
+underlying data is shared rather than consumed on registration.
+
+### Registry client — calling pattern
+
+```typescript
+// Build a Quill from an in-memory tree (post-rehydration)
+const tree: Map<string, Uint8Array> = await loadAndRehydrate(ref, fontCache);
+const quill = Quill.fromTree(tree);
+engine.registerQuill(quill);
+
+// Build a synthetic Quill for testing
+const quill = Quill.fromJson({ files: { 'Quill.yaml': '...', 'main.typ': '...' } });
+engine.registerQuill(quill);
+```
+
+## Decisions
+
+- **Opaque handle.** `Quill` exposes no public properties. Callers inspect
+  a registered quill through `engine.getQuillInfo(name)` as today.
+- **Shared, not consumed.** Registering a `Quill` does not invalidate the
+  JS handle. The same `Quill` may be registered with multiple engines
+  without calling a clone method. The WASM binding holds an `Arc` over the
+  inner Rust type.
+- **`fromTree` accepts `Map<string, Uint8Array>`.** Also accept a plain
+  `Record<string, Uint8Array>` for ergonomics. Directory structure is
+  inferred from path separators (`/`).
+- **No `fromZip`.** ZIP decompression stays in the registry client — it is
+  Node/browser work that happens before Quillmark is involved. Accepting
+  raw ZIP bytes would require a decompressor inside the WASM bundle.
+
+## Rust-side changes
+
+The Rust types needed already exist in `quillmark-core`:
+- `Quill::from_json(json: &str)` — backs `Quill.fromJson`
+- `Quill::from_tree(root: FileTreeNode)` — backs `Quill.fromTree`
+
+The only Rust work is in `crates/bindings/wasm/src/`:
+
+1. **Add a `Quill` WASM wrapper type** (`wasm_bindgen` struct wrapping
+   `Arc<quillmark_core::Quill>`).
+2. **Expose factory methods** as `#[wasm_bindgen(static_method_of = Quill)]`
+   — `from_json` and `from_tree`.
+3. **`from_tree` input handling**: accept a `JsValue` (Map or plain
+   object), walk entries, copy `Uint8Array` values into byte vecs, build
+   `FileTreeNode` by splitting paths on `/`.
+4. **Update `Quillmark::register_quill`** to accept `&Quill` instead of
+   `JsValue`. Clone the inner `Arc` and forward to the existing
+   `quillmark::Quillmark::register_quill`.
+5. **Remove the old `registerQuill(JsValue)` signature.** (See migration
+   below.)
+
+## Migration
+
+`Quill.fromJson` accepts the same JSON shape the old `registerQuill` did,
+so the migration at each call site is mechanical:
+
+```typescript
+// Before
+engine.registerQuill(quillJson);
+
+// After
+engine.registerQuill(Quill.fromJson(quillJson));
+```
+
+The current `registerQuill(json)` overload may be kept as a **deprecated
+shim** for one release to ease migration, but it should not persist beyond
+that — it defeats the purpose of the split.
+
+## Out of scope
+
+- Changes to `Quill.yaml` parsing or schema validation logic.
+- Changes to `engine.render`, `engine.compile`, or any rendering path.
+- Font rehydration — handled by the registry client before `Quill.fromTree`
+  is called.
+- A `Quill.free()` method — not needed given shared-ownership semantics.
+- TypeScript type generation changes beyond updating `registerQuill`'s
+  parameter type.


### PR DESCRIPTION
## Summary

Implements a font manifest and provider system to support dehydrated (published) Quill bundles. Published bundles strip font files and replace them with a `fonts.json` sidecar that maps file paths to MD5 content hashes. When loading a published bundle, the system rehydrates it by fetching font bytes from a provider and writing them back to their original tree paths.

## Key Changes

- **New `fonts` module** (`crates/core/src/fonts.rs`):
  - `FontManifest`: Struct representing the dehydration record with version and path-to-hash mappings
  - `FontProvider` trait: Sync interface for supplying font bytes by MD5 hash
  - `MapProvider`: In-memory implementation backed by a HashMap
  - `rehydrate_tree()`: Algorithm that parses `fonts.json`, fetches unique hashes once each, and writes bytes back to original paths
  - Comprehensive error handling for missing hashes, unsupported versions, and parse failures

- **Extended Quill loading** (`crates/core/src/quill/load.rs`):
  - `from_tree_with_fonts()`: Load from tree with font rehydration via provider
  - `from_json_with_fonts()`: Load from JSON with font rehydration
  - Shared `parse_json_to_tree()` helper to reduce duplication

- **WASM binding updates** (`crates/bindings/wasm/src/engine.rs`):
  - `registerQuill()` now accepts optional `font_map` parameter (JS `Map<string, Uint8Array>` or plain object)
  - New `js_font_map_to_provider()` helper converts JS maps/objects to `MapProvider`
  - Extracted `quill_json_to_str()` helper for cleaner code reuse

- **JSON Schema** (`crates/core/schemas/fonts-manifest.schema.json`):
  - Auto-generated from `FontManifest` via `schemars`
  - Committed to repo with CI guard to detect schema drift

- **Comprehensive test suite** (`crates/core/tests/fonts.rs`):
  - Parsing tests for valid manifests (simple and dedup cases)
  - Roundtrip serialization verification
  - Rehydration tests: correct path insertion, dedup optimization (single fetch per unique hash), missing hashes, unsupported versions
  - No-op behavior when `fonts.json` absent
  - Schema drift detection test

- **Test fixtures** (`crates/core/tests/fixtures/fonts-manifest/`):
  - `valid-simple.json`: Two distinct fonts
  - `valid-dedup.json`: Two paths sharing the same hash

## Notable Implementation Details

- Rehydration is a no-op if `fonts.json` is absent, making the system backward-compatible with local dev trees and pre-centralization bundles
- Provider is called exactly once per unique hash, even if multiple paths reference the same hash (dedup optimization)
- All errors are propagated with context to aid debugging
- The system is sync-only to remain compatible with Typst's font-loading path and WASM environments
- After rehydration, the in-memory tree is indistinguishable from the pre-strip source, requiring no backend changes

https://claude.ai/code/session_01Y5xveo85KPK6KcBmkixxYg