### PR TITLE
Add Quill.fromTree() method with comprehensive test coverage

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -48,6 +48,90 @@ QUILL: test_quill
 
 This is a test document.`
 
+// Helpers for fromTree tests
+function textBytes(str) {
+  return new TextEncoder().encode(str)
+}
+
+function makeTreeQuill(name = 'tree_quill', version = '1.0.0') {
+  return new Map([
+    ['Quill.yaml', textBytes(`Quill:
+  name: ${name}
+  version: "${version}"
+  backend: typst
+  plate_file: plate.typ
+  description: Tree quill for smoke tests
+`)],
+    ['plate.typ', textBytes('#import "@local/quillmark-helper:0.1.0": data\n= Test')],
+  ])
+}
+
+describe('Quill.fromTree', () => {
+  it('should build a Quill from a Map<string, Uint8Array>', () => {
+    const quill = Quill.fromTree(makeTreeQuill())
+    expect(quill).toBeDefined()
+  })
+
+  it('should build a Quill from a plain Record<string, Uint8Array>', () => {
+    const tree = {}
+    for (const [k, v] of makeTreeQuill()) tree[k] = v
+    const quill = Quill.fromTree(tree)
+    expect(quill).toBeDefined()
+  })
+
+  it('should infer subdirectory hierarchy from path separators', () => {
+    const tree = new Map([
+      ['Quill.yaml', textBytes(`Quill:
+  name: nested_quill
+  version: "1.0.0"
+  backend: typst
+  plate_file: plate.typ
+  description: Nested tree quill
+`)],
+      ['plate.typ', textBytes('#import "@local/quillmark-helper:0.1.0": data\n= Nested')],
+      ['assets/fonts/Inter-Regular.ttf', new Uint8Array([0, 1, 2, 3])],
+    ])
+    const quill = Quill.fromTree(tree)
+    expect(quill).toBeDefined()
+  })
+
+  it('should register a fromTree Quill with the engine', () => {
+    const engine = new Quillmark()
+    const quill = Quill.fromTree(makeTreeQuill('tree_quill', '2.0.0'))
+    engine.registerQuill(quill)
+    expect(engine.listQuills()).toContain('tree_quill@2.0.0')
+  })
+
+  it('should allow the same Quill handle to register with multiple engines', () => {
+    const quill = Quill.fromTree(makeTreeQuill('shared_quill', '1.0.0'))
+    const engine1 = new Quillmark()
+    const engine2 = new Quillmark()
+    engine1.registerQuill(quill)
+    engine2.registerQuill(quill)
+    expect(engine1.listQuills()).toContain('shared_quill@1.0.0')
+    expect(engine2.listQuills()).toContain('shared_quill@1.0.0')
+  })
+
+  it('should throw on null/undefined input', () => {
+    expect(() => Quill.fromTree(null)).toThrow()
+    expect(() => Quill.fromTree(undefined)).toThrow()
+  })
+
+  it('should throw when a value is not Uint8Array', () => {
+    const bad = new Map([
+      ['Quill.yaml', 'this is a string, not Uint8Array'],
+    ])
+    expect(() => Quill.fromTree(bad)).toThrow()
+  })
+
+  it('should throw on missing Quill.yaml', () => {
+    const tree = new Map([
+      ['plate.typ', textBytes('hello')],
+    ])
+    expect(() => Quill.fromTree(tree)).toThrow()
+  })
+})
+
 describe('quillmark-wasm smoke tests', () => {
   it('should parse markdown with YAML frontmatter', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -27,6 +27,11 @@ class Quillmark {
 }
 ```
 
+## Implementation notes
+
+- `Quill.fromTree` accepts `Map<string, Uint8Array>` or a plain `Record<string, Uint8Array>`. Directory hierarchy is inferred from `/` path separators in keys (e.g. `"assets/fonts/Inter.ttf"` inserts into `assets/fonts/`). Values must be `Uint8Array`; passing a string throws.
+- The WASM `Quill` struct holds `Arc<quillmark_core::Quill>`. The JS handle is not consumed on registration, and `registerQuill` may be called on multiple engines with the same handle. Internally, each registration deep-clones the underlying `Quill` because the core `Quillmark::register_quill` takes ownership by value — Arc sharing across engines is not achieved at the data level, only at the JS API level.
+
 ## Key contracts
 
 - `ParsedDocument.quillRef` is required and is sourced from `QUILL` frontmatter.


### PR DESCRIPTION
## Summary
This PR adds the `Quill.fromTree()` static method to the WASM bindings, enabling construction of Quill instances from in-memory file trees. This is useful for dynamic quill creation and testing scenarios.

## Key Changes
- **New `Quill.fromTree()` method**: Accepts either `Map<string, Uint8Array>` or plain `Record<string, Uint8Array>` objects
  - Automatically infers directory hierarchy from `/` path separators in keys
  - Validates that all values are `Uint8Array` (throws on strings or other types)
  - Requires `Quill.yaml` to be present in the tree
- **Comprehensive test suite** with 8 test cases covering:
  - Basic functionality with Map and plain Record inputs
  - Nested directory structure inference
  - Registration with single and multiple engines
  - Error handling (null/undefined input, invalid value types, missing Quill.yaml)
- **Implementation documentation** in WASM.md explaining:
  - API contract for input formats and validation
  - Internal behavior: `Arc<quillmark_core::Quill>` wrapping with deep-clone semantics on registration
  - Rationale for deep-cloning (core API takes ownership by value)

## Notable Implementation Details
- Helper function `textBytes()` converts strings to `Uint8Array` for test convenience
- The same `Quill` handle can be registered with multiple `Quillmark` engines without consuming the handle
- Each engine registration performs a deep clone of the underlying quill data due to ownership requirements in the core API

https://claude.ai/code/session_015Ms3cgy12rZFJLjZ2zNnXP