### PR TITLE
feat: Quill factory API (WASM)

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -31,7 +31,7 @@ impl PyQuillmark {
 
     fn register_quill(&mut self, quill: PyRef<PyQuill>) -> PyResult<()> {
         self.inner
-            .register_quill(quill.inner.clone())
+            .register_quill(&quill.inner)
             .map_err(convert_render_error)?;
         Ok(())
     }

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -49,7 +49,7 @@ The test suite includes:
 ## Usage
 
 ```typescript
-import { Quillmark } from '@quillmark-test/wasm';
+import { Quill, Quillmark } from '@quillmark-test/wasm';
 
 // Step 1: Parse markdown
 const markdown = `---
@@ -65,7 +65,7 @@ This is my document.
 
 const parsed = Quillmark.parseMarkdown(markdown);
 
-// Step 2: Create engine and register Quill
+// Step 2: Create engine and build/register Quill
 const engine = new Quillmark();
 
 const quillJson = {
@@ -79,7 +79,8 @@ const quillJson = {
   }
 };
 
-engine.registerQuill(quillJson);
+const quill = Quill.fromJson(quillJson);
+engine.registerQuill(quill);
 
 // Step 3: Get Quill info (optional)
 const info = engine.getQuillInfo('my-quill');
@@ -105,7 +106,9 @@ The `Quillmark` class provides the following methods:
 The main workflow for rendering documents:
 
 - `static parseMarkdown(markdown)` - Parse markdown into a ParsedDocument (Step 1)
-- `registerQuill(quillJson)` - Register a Quill template bundle from JSON (Step 2)
+- `Quill.fromJson(source)` - Build a Quill from JSON string/object (Step 2)
+- `Quill.fromTree(tree)` - Build a Quill from `Map<string, Uint8Array>` or plain object tree (Step 2)
+- `registerQuill(quill)` - Register a pre-built Quill handle (Step 3)
 - `render(parsedDoc, options)` - Render a ParsedDocument to final artifacts using the required `QUILL` reference parsed from the document (Step 4)
 
 ### Utility Methods

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -48,6 +48,90 @@ QUILL: test_quill
 
 This is a test document.`
 
+// Helpers for fromTree tests
+function textBytes(str) {
+  return new TextEncoder().encode(str)
+}
+
+function makeTreeQuill(name = 'tree_quill', version = '1.0.0') {
+  return new Map([
+    ['Quill.yaml', textBytes(`Quill:
+  name: ${name}
+  version: "${version}"
+  backend: typst
+  plate_file: plate.typ
+  description: Tree quill for smoke tests
+`)],
+    ['plate.typ', textBytes('#import "@local/quillmark-helper:0.1.0": data\n= Test')],
+  ])
+}
+
+describe('Quill.fromTree', () => {
+  it('should build a Quill from a Map<string, Uint8Array>', () => {
+    const quill = Quill.fromTree(makeTreeQuill())
+    expect(quill).toBeDefined()
+  })
+
+  it('should build a Quill from a plain Record<string, Uint8Array>', () => {
+    const tree = {}
+    for (const [k, v] of makeTreeQuill()) tree[k] = v
+    const quill = Quill.fromTree(tree)
+    expect(quill).toBeDefined()
+  })
+
+  it('should infer subdirectory hierarchy from path separators', () => {
+    const tree = new Map([
+      ['Quill.yaml', textBytes(`Quill:
+  name: nested_quill
+  version: "1.0.0"
+  backend: typst
+  plate_file: plate.typ
+  description: Nested tree quill
+`)],
+      ['plate.typ', textBytes('#import "@local/quillmark-helper:0.1.0": data\n= Nested')],
+      ['assets/fonts/Inter-Regular.ttf', new Uint8Array([0, 1, 2, 3])],
+    ])
+    const quill = Quill.fromTree(tree)
+    expect(quill).toBeDefined()
+  })
+
+  it('should register a fromTree Quill with the engine', () => {
+    const engine = new Quillmark()
+    const quill = Quill.fromTree(makeTreeQuill('tree_quill', '2.0.0'))
+    engine.registerQuill(quill)
+    expect(engine.listQuills()).toContain('tree_quill@2.0.0')
+  })
+
+  it('should allow the same Quill handle to register with multiple engines', () => {
+    const quill = Quill.fromTree(makeTreeQuill('shared_quill', '1.0.0'))
+    const engine1 = new Quillmark()
+    const engine2 = new Quillmark()
+    engine1.registerQuill(quill)
+    engine2.registerQuill(quill)
+    expect(engine1.listQuills()).toContain('shared_quill@1.0.0')
+    expect(engine2.listQuills()).toContain('shared_quill@1.0.0')
+  })
+
+  it('should throw on null/undefined input', () => {
+    expect(() => Quill.fromTree(null)).toThrow()
+    expect(() => Quill.fromTree(undefined)).toThrow()
+  })
+
+  it('should throw when a value is not Uint8Array', () => {
+    const bad = new Map([
+      ['Quill.yaml', 'this is a string, not Uint8Array'],
+    ])
+    expect(() => Quill.fromTree(bad)).toThrow()
+  })
+
+  it('should throw on missing Quill.yaml', () => {
+    const tree = new Map([
+      ['plate.typ', textBytes('hello')],
+    ])
+    expect(() => Quill.fromTree(tree)).toThrow()
+  })
+})
+
 describe('quillmark-wasm smoke tests', () => {
   it('should parse markdown with YAML frontmatter', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { Quillmark } from '@quillmark-wasm'
+import { Quill, Quillmark } from '@quillmark-wasm'
 
 // Minimal inline Quill for testing
 const TEST_QUILL = {
@@ -67,7 +67,7 @@ describe('quillmark-wasm smoke tests', () => {
     const engine = new Quillmark()
 
     expect(() => {
-      engine.registerQuill(TEST_QUILL)
+      engine.registerQuill(Quill.fromJson(TEST_QUILL))
     }).not.toThrow()
 
     const quills = engine.listQuills()
@@ -76,7 +76,7 @@ describe('quillmark-wasm smoke tests', () => {
 
   it('should get quill info after registration', () => {
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     const info = engine.getQuillInfo('test_quill')
 
@@ -100,7 +100,7 @@ describe('quillmark-wasm smoke tests', () => {
   it('should compile data to JSON', () => {
     // Verify that we can extract the intermediate JSON data
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     const jsonData = engine.compileData(TEST_MARKDOWN)
 
@@ -116,7 +116,7 @@ describe('quillmark-wasm smoke tests', () => {
 
     // Step 2: Create engine and register quill
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     // Step 3: Get quill info
     const info = engine.getQuillInfo('test_quill')
@@ -142,7 +142,7 @@ describe('quillmark-wasm smoke tests', () => {
   it('should support compile + renderPages with pageCount', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     const compiled = engine.compile(parsed)
     expect(typeof compiled.pageCount).toBe('number')
@@ -160,7 +160,7 @@ describe('quillmark-wasm smoke tests', () => {
   it('should warn and skip out-of-bounds page indices', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     const compiled = engine.compile(parsed)
     const oob = compiled.pageCount + 10
@@ -174,7 +174,7 @@ describe('quillmark-wasm smoke tests', () => {
   it('should error when requesting page selection with PDF', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     const compiled = engine.compile(parsed)
 
@@ -218,7 +218,7 @@ this is not valid yaml
   it('should render to SVG format', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     const result = engine.render(parsed, { format: 'svg' })
 
@@ -230,7 +230,7 @@ this is not valid yaml
 
   it('should unregister quill', () => {
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     expect(engine.listQuills()).toContain('test_quill@1.0.0')
 
@@ -242,7 +242,7 @@ this is not valid yaml
   it('should accept assets as plain JavaScript objects', () => {
     const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
 
     // Assets should be passed as plain JavaScript objects with byte arrays
     const assets = {
@@ -270,7 +270,7 @@ this is not valid yaml
 
     // Step 2: Register and get quill info - metadata is object, schema is YAML text
     const engine = new Quillmark()
-    engine.registerQuill(TEST_QUILL)
+    engine.registerQuill(Quill.fromJson(TEST_QUILL))
     const info = engine.getQuillInfo('test_quill')
 
     expect(info.metadata instanceof Map).toBe(false)

--- a/crates/bindings/wasm/resolve.js
+++ b/crates/bindings/wasm/resolve.js
@@ -1,4 +1,4 @@
-import { Quillmark } from './pkg/quillmark_wasm.js'
+import { Quill, Quillmark } from './pkg/quillmark_wasm.js'
 
 const engine = new Quillmark()
 
@@ -9,7 +9,7 @@ const quill1 = {
   schema: {},
   plate: "hello 1"
 }
-engine.registerQuill(quill1)
+engine.registerQuill(Quill.fromJson(quill1))
 
 const quill2 = {
   name: "usaf_memo",
@@ -18,7 +18,7 @@ const quill2 = {
   schema: {},
   plate: "hello 2"
 }
-engine.registerQuill(quill2)
+engine.registerQuill(Quill.fromJson(quill2))
 
 const resolved = engine.resolveQuill("usaf_memo@0.2.0")
 console.log("Resolved version:", resolved.metadata.version)

--- a/crates/bindings/wasm/resolve.test.js
+++ b/crates/bindings/wasm/resolve.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { Quillmark } from '@quillmark-wasm'
+import { Quill, Quillmark } from '@quillmark-wasm'
 
 describe('resolveQuill bug', () => {
   it('should resolve correct version', () => {
@@ -20,7 +20,7 @@ describe('resolveQuill bug', () => {
         'plate.typ': { contents: 'hello 1' }
       }
     }
-    engine.registerQuill(quill1)
+    engine.registerQuill(Quill.fromJson(quill1))
 
     // Register 0.2.0
     const quill2 = {
@@ -37,7 +37,7 @@ describe('resolveQuill bug', () => {
         'plate.typ': { contents: 'hello 2' }
       }
     }
-    engine.registerQuill(quill2)
+    engine.registerQuill(Quill.fromJson(quill2))
 
     // Verify resolveQuill returns the correct info
     const info2 = engine.resolveQuill("usaf_memo@0.2.0")

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -5,9 +5,12 @@ use crate::types::{
     CompileOptions, OutputFormat, ParsedDocument, QuillInfo, RenderOptions, RenderPagesOptions,
     RenderResult,
 };
+use js_sys::{Array, Object, Uint8Array};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 
 // Cross-platform helper to get current time in milliseconds as f64.
 fn now_ms() -> f64 {
@@ -32,6 +35,12 @@ fn now_ms() -> f64 {
 #[wasm_bindgen]
 pub struct Quillmark {
     inner: quillmark::Quillmark,
+}
+
+/// Opaque, shareable Quill handle.
+#[wasm_bindgen]
+pub struct Quill {
+    inner: Arc<quillmark_core::Quill>,
 }
 
 #[wasm_bindgen]
@@ -79,30 +88,10 @@ impl Quillmark {
         Ok(ParsedDocument { fields, quill_ref })
     }
 
-    /// Register a Quill template bundle
-    ///
-    /// Accepts either a JSON string or a JsValue object representing the Quill file tree.
-    /// Validation happens automatically on registration.
+    /// Register a pre-constructed Quill handle.
     #[wasm_bindgen(js_name = registerQuill)]
-    pub fn register_quill(&mut self, quill_json: JsValue) -> Result<QuillInfo, JsValue> {
-        // Convert JsValue to JSON string
-        let json_str = if quill_json.is_string() {
-            quill_json.as_string().ok_or_else(|| {
-                WasmError::from("Failed to convert JsValue to string").to_js_value()
-            })?
-        } else {
-            js_sys::JSON::stringify(&quill_json)
-                .map_err(|e| {
-                    WasmError::from(format!("Failed to serialize Quill JSON: {:?}", e))
-                        .to_js_value()
-                })?
-                .as_string()
-                .ok_or_else(|| WasmError::from("Failed to convert JSON to string").to_js_value())?
-        };
-
-        // Parse and validate Quill
-        let quill = quillmark_core::Quill::from_json(&json_str)
-            .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?;
+    pub fn register_quill(&mut self, quill: &Quill) -> Result<QuillInfo, JsValue> {
+        let quill = quill.inner.as_ref().clone();
         let name = quill.name.clone();
 
         // Register with backend validation
@@ -399,6 +388,124 @@ impl Quillmark {
 
         Ok(quillmark_core::ParsedDocument::new(fields, quill_ref))
     }
+}
+
+#[wasm_bindgen]
+impl Quill {
+    /// Parse and validate a Quill from JSON string or object.
+    #[wasm_bindgen(js_name = fromJson)]
+    pub fn from_json(source: JsValue) -> Result<Quill, JsValue> {
+        let json_str = if source.is_string() {
+            source.as_string().ok_or_else(|| {
+                WasmError::from("Failed to convert source to string").to_js_value()
+            })?
+        } else {
+            js_sys::JSON::stringify(&source)
+                .map_err(|e| {
+                    WasmError::from(format!("Failed to serialize Quill JSON: {:?}", e))
+                        .to_js_value()
+                })?
+                .as_string()
+                .ok_or_else(|| WasmError::from("Failed to convert JSON to string").to_js_value())?
+        };
+
+        let quill = quillmark_core::Quill::from_json(&json_str)
+            .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?;
+
+        Ok(Quill {
+            inner: Arc::new(quill),
+        })
+    }
+
+    /// Build and validate a Quill from a flat path -> bytes tree.
+    #[wasm_bindgen(js_name = fromTree)]
+    pub fn from_tree(tree: JsValue) -> Result<Quill, JsValue> {
+        let root = file_tree_from_js_tree(&tree)?;
+        let quill = quillmark_core::Quill::from_tree(root)
+            .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?;
+
+        Ok(Quill {
+            inner: Arc::new(quill),
+        })
+    }
+}
+
+fn file_tree_from_js_tree(tree: &JsValue) -> Result<quillmark_core::FileTreeNode, JsValue> {
+    let entries = js_tree_entries(tree)?;
+    let mut root = quillmark_core::FileTreeNode::Directory {
+        files: HashMap::new(),
+    };
+
+    for (path, value) in entries {
+        let bytes = js_bytes_for_tree_entry(&path, value)?;
+        root.insert(
+            path.as_str(),
+            quillmark_core::FileTreeNode::File { contents: bytes },
+        )
+        .map_err(|e| {
+            WasmError::from(format!("Invalid tree path '{}': {}", path, e)).to_js_value()
+        })?;
+    }
+
+    Ok(root)
+}
+
+fn js_tree_entries(tree: &JsValue) -> Result<Vec<(String, JsValue)>, JsValue> {
+    if tree.is_null() || tree.is_undefined() {
+        return Err(WasmError::from("fromTree requires a Map or plain object").to_js_value());
+    }
+
+    let mut entries: Vec<(String, JsValue)> = Vec::new();
+
+    if tree.is_instance_of::<js_sys::Map>() {
+        let map = tree.clone().unchecked_into::<js_sys::Map>();
+        let iter = js_sys::try_iter(&map.entries())
+            .map_err(|e| {
+                WasmError::from(format!("Failed to iterate Map entries: {:?}", e)).to_js_value()
+            })?
+            .ok_or_else(|| WasmError::from("Map entries are not iterable").to_js_value())?;
+
+        for entry in iter {
+            let pair = entry.map_err(|e| {
+                WasmError::from(format!("Failed to read Map entry: {:?}", e)).to_js_value()
+            })?;
+            let pair = Array::from(&pair);
+            let path = pair.get(0).as_string().ok_or_else(|| {
+                WasmError::from("fromTree Map key must be a string").to_js_value()
+            })?;
+            let value = pair.get(1);
+            entries.push((path, value));
+        }
+        return Ok(entries);
+    }
+
+    if tree.is_object() {
+        let obj = tree.clone().unchecked_into::<Object>();
+        for pair in Object::entries(&obj).iter() {
+            let pair = Array::from(&pair);
+            let path = pair.get(0).as_string().ok_or_else(|| {
+                WasmError::from("fromTree object key must be a string").to_js_value()
+            })?;
+            let value = pair.get(1);
+            entries.push((path, value));
+        }
+        return Ok(entries);
+    }
+
+    Err(WasmError::from("fromTree requires a Map or plain object").to_js_value())
+}
+
+fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValue> {
+    if !value.is_instance_of::<Uint8Array>() {
+        return Err(WasmError::from(format!(
+            "Invalid tree entry '{}': expected Uint8Array value",
+            path
+        ))
+        .to_js_value());
+    }
+
+    let bytes = value.unchecked_into::<Uint8Array>();
+    Ok(bytes.to_vec())
 }
 
 #[wasm_bindgen]

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -91,15 +91,12 @@ impl Quillmark {
     /// Register a pre-constructed Quill handle.
     #[wasm_bindgen(js_name = registerQuill)]
     pub fn register_quill(&mut self, quill: &Quill) -> Result<QuillInfo, JsValue> {
-        let quill = quill.inner.as_ref().clone();
-        let name = quill.name.clone();
+        let name = quill.inner.name.clone();
 
-        // Register with backend validation
         self.inner
-            .register_quill(quill)
+            .register_quill(quill.inner.as_ref())
             .map_err(|e| WasmError::from(e).to_js_value())?;
 
-        // Return full quill info
         self.get_quill_info(&name)
     }
 
@@ -392,7 +389,18 @@ impl Quillmark {
 
 #[wasm_bindgen]
 impl Quill {
-    /// Parse and validate a Quill from JSON string or object.
+    /// Parse and validate a Quill from a JSON string or plain object.
+    ///
+    /// The source must be a JSON string or a plain object with a `files` key mapping
+    /// file paths to `{ contents: string }` objects. Example:
+    /// ```js
+    /// const quill = Quill.fromJson({
+    ///   files: {
+    ///     "Quill.yaml": { contents: "Quill:\n  name: my-quill\n  ..." },
+    ///     "plate.typ": { contents: "#rect(...)" }
+    ///   }
+    /// });
+    /// ```
     #[wasm_bindgen(js_name = fromJson)]
     pub fn from_json(source: JsValue) -> Result<Quill, JsValue> {
         let json_str = if source.is_string() {
@@ -410,19 +418,29 @@ impl Quill {
         };
 
         let quill = quillmark_core::Quill::from_json(&json_str)
-            .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?;
+            .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
 
         Ok(Quill {
             inner: Arc::new(quill),
         })
     }
 
-    /// Build and validate a Quill from a flat path -> bytes tree.
+    /// Build and validate a Quill from a flat path-to-bytes tree.
+    ///
+    /// Accepts a `Map<string, Uint8Array>` or a plain `Record<string, Uint8Array>`.
+    /// Directory structure is inferred from `/` separators in paths. Example:
+    /// ```js
+    /// const quill = Quill.fromTree(new Map([
+    ///   ["Quill.yaml", yamlBytes],
+    ///   ["plate.typ", plateBytes],
+    ///   ["assets/font.ttf", fontBytes],
+    /// ]));
+    /// ```
     #[wasm_bindgen(js_name = fromTree)]
     pub fn from_tree(tree: JsValue) -> Result<Quill, JsValue> {
         let root = file_tree_from_js_tree(&tree)?;
         let quill = quillmark_core::Quill::from_tree(root)
-            .map_err(|e| WasmError::from(format!("Failed to parse Quill: {}", e)).to_js_value())?;
+            .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
 
         Ok(Quill {
             inner: Arc::new(quill),

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -9,21 +9,23 @@
 //!
 //! The WASM API provides a single class for all operations:
 //!
+//! - [`Quill`] - Opaque quill handle created by factory methods
 //! - [`Quillmark`] - Engine for registering Quills and rendering markdown
 //!
 //! ## Workflow
 //!
-//! The typical workflow consists of four steps:
+//! The typical workflow consists of five steps:
 //!
 //! 1. **Parse Markdown** - Use `Quillmark.parseMarkdown()` to parse markdown with YAML frontmatter
-//! 2. **Register Quill** - Use `registerQuill()` to load and register a Quill template bundle (JSON format)
-//! 3. **Get Quill Info** - Use `getQuillInfo()` to retrieve metadata and configuration options
-//! 4. **Render** - Use `render()` with the ParsedDocument and render options
+//! 2. **Build Quill** - Use `Quill.fromJson()` or `Quill.fromTree()` to parse and validate a quill
+//! 3. **Register Quill** - Use `registerQuill()` with a `Quill` handle
+//! 4. **Get Quill Info** - Use `getQuillInfo()` to retrieve metadata and configuration options
+//! 5. **Render** - Use `render()` with the ParsedDocument and render options
 //!
 //! ## Example (JavaScript/TypeScript)
 //!
 //! ```javascript
-//! import { Quillmark } from '@quillmark-test/wasm';
+//! import { Quill, Quillmark } from '@quillmark-test/wasm';
 //!
 //! // Step 1: Parse markdown
 //! const markdown = `---
@@ -42,7 +44,8 @@
 //! // Step 2: Load and register Quill (from JSON)
 //! const engine = new Quillmark();
 //! const quillJson = { /* Quill file tree in JSON format */ };
-//! engine.registerQuill(quillJson);
+//! const quill = Quill.fromJson(quillJson);
+//! engine.registerQuill(quill);
 //!
 //! // Step 3: Get Quill info to inspect available options
 //! const info = engine.getQuillInfo('letter-quill');
@@ -65,7 +68,7 @@ mod engine;
 mod error;
 mod types;
 
-pub use engine::{CompiledDocument, Quillmark};
+pub use engine::{CompiledDocument, Quill, Quillmark};
 pub use error::WasmError;
 pub use types::*;
 

--- a/crates/bindings/wasm/tests/metadata.rs
+++ b/crates/bindings/wasm/tests/metadata.rs
@@ -1,4 +1,4 @@
-use quillmark_wasm::Quillmark;
+use quillmark_wasm::{Quill, Quillmark};
 use serde_json::Value;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
@@ -15,8 +15,9 @@ const UI_QUILL_JSON: &str = r#"{
 #[wasm_bindgen_test]
 fn test_metadata_retrieval() {
     let mut engine = Quillmark::new();
+    let quill = Quill::from_json(JsValue::from_str(UI_QUILL_JSON)).expect("fromJson failed");
     engine
-        .register_quill(JsValue::from_str(UI_QUILL_JSON))
+        .register_quill(&quill)
         .map_err(|e| {
             let error_obj: Value = serde_wasm_bindgen::from_value(e).unwrap();
             panic!("register failed: {:#?}", error_obj);
@@ -55,8 +56,9 @@ fn test_metadata_stripping() {
     }
 
     let mut engine = Quillmark::new();
+    let quill = Quill::from_json(JsValue::from_str(UI_QUILL_JSON)).expect("fromJson failed");
     engine
-        .register_quill(JsValue::from_str(UI_QUILL_JSON))
+        .register_quill(&quill)
         .map_err(|e| {
             let error_obj: Value = serde_wasm_bindgen::from_value(e).unwrap();
             panic!("register failed: {:#?}", error_obj);

--- a/crates/bindings/wasm/tests/resolve_quill.rs
+++ b/crates/bindings/wasm/tests/resolve_quill.rs
@@ -1,4 +1,5 @@
-use quillmark_wasm::Quillmark;
+use quillmark_wasm::{Quill, Quillmark};
+use serde_json::Value;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -9,30 +10,32 @@ fn test_resolve_quill_version() {
 
     // Register 0.1.0
     let q1 = serde_json::json!({
-        "name": "usaf_memo",
-        "backend": "typst",
-        "metadata": { "version": "0.1.0" },
-        "schema": {},
-        "plate": "hello 1"
+      "files": {
+        "Quill.yaml": { "contents": "Quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.1.0\n" },
+        "plate.typ": { "contents": "hello 1" }
+      }
     });
-    engine
-        .register_quill(wasm_bindgen::JsValue::from_str(&q1.to_string()))
-        .unwrap();
+    let q1 = Quill::from_json(wasm_bindgen::JsValue::from_str(&q1.to_string())).unwrap();
+    engine.register_quill(&q1).unwrap();
 
     // Register 0.2.0
     let q2 = serde_json::json!({
-        "name": "usaf_memo",
-        "backend": "typst",
-        "metadata": { "version": "0.2.0" },
-        "schema": {},
-        "plate": "hello 2"
+      "files": {
+        "Quill.yaml": { "contents": "Quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.2.0\n" },
+        "plate.typ": { "contents": "hello 2" }
+      }
     });
-    engine
-        .register_quill(wasm_bindgen::JsValue::from_str(&q2.to_string()))
-        .unwrap();
+    let q2 = Quill::from_json(wasm_bindgen::JsValue::from_str(&q2.to_string())).unwrap();
+    engine.register_quill(&q2).unwrap();
 
     // Resolve 0.2.0
     let js_val = engine.resolve_quill("usaf_memo@0.2.0");
-    // Verify it picked 0.2.0
-    // But how to parse JsValue back?
+    let info: Value = serde_wasm_bindgen::from_value(js_val).expect("resolveQuill json");
+    assert_eq!(info.get("name").and_then(Value::as_str), Some("usaf_memo"));
+    assert_eq!(
+        info.get("metadata")
+            .and_then(|m| m.get("version"))
+            .and_then(Value::as_str),
+        Some("0.2.0")
+    );
 }

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
-use quillmark_wasm::Quillmark;
+use quillmark_wasm::{Quill, Quillmark};
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -41,9 +41,8 @@ fn test_register_and_get_quill_info() {
     let mut engine = Quillmark::new();
 
     // Register quill
-    engine
-        .register_quill(JsValue::from_str(SMALL_QUILL_JSON))
-        .expect("register failed");
+    let quill = Quill::from_json(JsValue::from_str(SMALL_QUILL_JSON)).expect("fromJson failed");
+    engine.register_quill(&quill).expect("register failed");
 
     // Get quill info
     let info = engine
@@ -73,9 +72,8 @@ This is a test.
 
     // Step 2: Create engine and register quill
     let mut engine = Quillmark::new();
-    engine
-        .register_quill(JsValue::from_str(SMALL_QUILL_JSON))
-        .expect("register failed");
+    let quill = Quill::from_json(JsValue::from_str(SMALL_QUILL_JSON)).expect("fromJson failed");
+    engine.register_quill(&quill).expect("register failed");
 
     // Step 3: Get quill info
     let info = engine

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! // Load and register a quill template
 //! let quill = Quill::from_path("path/to/quill").unwrap();
-//! engine.register_quill(quill);
+//! engine.register_quill(&quill);
 //!
 //! // Parse markdown
 //! let markdown = "---\ntitle: Hello\n---\n# Hello World";
@@ -53,7 +53,7 @@
 //! # use quillmark::{Quillmark, Quill, OutputFormat, ParsedDocument};
 //! # let mut engine = Quillmark::new();
 //! # let quill = Quill::from_path("path/to/quill").unwrap();
-//! # engine.register_quill(quill);
+//! # engine.register_quill(&quill);
 //! # let markdown = "# Report";
 //! # let parsed = ParsedDocument::from_markdown(markdown).unwrap();
 //! let mut workflow = engine.workflow("my-quill").unwrap();

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -138,7 +138,7 @@ impl Quillmark {
     /// - Version is valid semver format (MAJOR.MINOR.PATCH or MAJOR.MINOR)
     ///
     /// Multiple versions of the same quill can be registered.
-    pub fn register_quill(&mut self, quill: Quill) -> Result<(), RenderError> {
+    pub fn register_quill(&mut self, quill: &Quill) -> Result<(), RenderError> {
         let name = quill.name.clone();
 
         // Extract and validate version from quill metadata
@@ -246,7 +246,7 @@ impl Quillmark {
         self.quills
             .entry(name.clone())
             .or_insert_with(VersionedQuillSet::new)
-            .insert(version, quill);
+            .insert(version, quill.clone());
 
         Ok(())
     }

--- a/crates/quillmark/src/orchestration/mod.rs
+++ b/crates/quillmark/src/orchestration/mod.rs
@@ -38,7 +38,7 @@
 //!
 //! // Step 2: Create and register quills
 //! let quill = Quill::from_path("path/to/quill").unwrap();
-//! engine.register_quill(quill);
+//! engine.register_quill(&quill);
 //!
 //! // Step 3: Parse markdown
 //! let markdown = "# Hello";
@@ -55,7 +55,7 @@
 //! # use quillmark::{Quillmark, Quill, ParsedDocument};
 //! # let mut engine = Quillmark::new();
 //! let quill = Quill::from_path("path/to/quill").unwrap();
-//! engine.register_quill(quill.clone());
+//! engine.register_quill(&quill);
 //!
 //! // Load by name
 //! let workflow1 = engine.workflow("my-quill").unwrap();
@@ -101,7 +101,7 @@
 //! # use quillmark::{Quillmark, OutputFormat, ParsedDocument};
 //! # let mut engine = Quillmark::new();
 //! # let quill = quillmark::Quill::from_path("path/to/quill").unwrap();
-//! # engine.register_quill(quill);
+//! # engine.register_quill(&quill);
 //! let workflow = engine.workflow("my-quill").unwrap();
 //!
 //! let markdown = r#"---
@@ -124,7 +124,7 @@
 //! # use quillmark::{Quillmark, OutputFormat, ParsedDocument};
 //! # let mut engine = Quillmark::new();
 //! # let quill = quillmark::Quill::from_path("path/to/quill").unwrap();
-//! # engine.register_quill(quill);
+//! # engine.register_quill(&quill);
 //! # let markdown = "# Report";
 //! # let parsed = ParsedDocument::from_markdown(markdown).unwrap();
 //! let mut workflow = engine.workflow("my-quill").unwrap();
@@ -140,7 +140,7 @@
 //! # use quillmark::{Quillmark, OutputFormat, ParsedDocument};
 //! # let mut engine = Quillmark::new();
 //! # let quill = quillmark::Quill::from_path("path/to/quill").unwrap();
-//! # engine.register_quill(quill);
+//! # engine.register_quill(&quill);
 //! # let markdown = "# Report";
 //! # let parsed = ParsedDocument::from_markdown(markdown).unwrap();
 //! let mut workflow = engine.workflow("my-quill").unwrap();
@@ -156,7 +156,7 @@
 //! # use quillmark::Quillmark;
 //! # let mut engine = Quillmark::new();
 //! # let quill = quillmark::Quill::from_path("path/to/quill").unwrap();
-//! # engine.register_quill(quill);
+//! # engine.register_quill(&quill);
 //! let workflow = engine.workflow("my-quill").unwrap();
 //!
 //! println!("Backend: {}", workflow.backend_id());

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -138,7 +138,7 @@ fn test_workflow_with_custom_backend() {
 
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     // Load workflow using the custom backend

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -84,7 +84,7 @@ main:
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine
@@ -139,7 +139,7 @@ main:
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine
@@ -195,7 +195,7 @@ main:
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine
@@ -249,7 +249,7 @@ main:
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -58,7 +58,7 @@ fn test_dry_run_success() {
 
     let mut engine = Quillmark::new();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine
@@ -90,7 +90,7 @@ fn test_dry_run_missing_required_field() {
 
     let mut engine = Quillmark::new();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine
@@ -131,7 +131,7 @@ fn test_dry_run_no_schema() {
 
     let mut engine = Quillmark::new();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine

--- a/crates/quillmark/tests/dynamic_assets_test.rs
+++ b/crates/quillmark/tests/dynamic_assets_test.rs
@@ -33,7 +33,7 @@ fn test_with_asset_basic() {
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     let taro_picture = std::fs::read(resource_path("taro.png")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();
@@ -49,7 +49,7 @@ fn test_with_asset_collision() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();
@@ -70,7 +70,7 @@ fn test_with_assets_multiple() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let assets = vec![
@@ -92,7 +92,7 @@ fn test_clear_assets() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();

--- a/crates/quillmark/tests/dynamic_fonts_test.rs
+++ b/crates/quillmark/tests/dynamic_fonts_test.rs
@@ -39,7 +39,7 @@ fn test_with_font_basic() {
     // Create some dummy font data
     let font_data = vec![1, 2, 3, 4, 5];
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();
@@ -55,7 +55,7 @@ fn test_with_font_collision() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();
@@ -76,7 +76,7 @@ fn test_with_fonts_multiple() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let fonts = vec![
@@ -98,7 +98,7 @@ fn test_clear_fonts() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();
@@ -126,7 +126,7 @@ fn test_with_font_and_asset_together() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();
@@ -145,7 +145,7 @@ fn test_dynamic_font_names() {
     let mut engine = Quillmark::new();
     let quill = Quill::from_path(quills_path("taro")).unwrap();
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let mut workflow = engine.workflow("taro").unwrap();

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -61,7 +61,7 @@ fn test_quill_engine_register_quill() {
 
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     // Check that quill is registered
@@ -92,7 +92,7 @@ fn test_quill_engine_get_workflow() {
 
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     // Load workflow by quill name using new load() method
@@ -141,7 +141,7 @@ fn test_quill_engine_backend_not_found() {
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
 
     // Try to register quill with non-existent backend - should fail now
-    let result = engine.register_quill(quill);
+    let result = engine.register_quill(&quill);
 
     assert!(result.is_err());
     match result {
@@ -173,7 +173,7 @@ fn test_quill_engine_end_to_end() {
 
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
     engine
-        .register_quill(quill)
+        .register_quill(&quill)
         .expect("Failed to register quill");
 
     let workflow = engine

--- a/crates/quillmark/tests/versioning_test.rs
+++ b/crates/quillmark/tests/versioning_test.rs
@@ -54,13 +54,13 @@ fn test_register_multiple_versions_same_quill() {
     let quill_2_0 = create_test_quill(&temp_dir, "resume_template", "2.0");
 
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register v1.0");
     engine
-        .register_quill(quill_1_1)
+        .register_quill(&quill_1_1)
         .expect("Failed to register v1.1");
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register v2.0");
 
     // Verify quill is registered (only one name, multiple versions)
@@ -97,16 +97,16 @@ fn test_resolve_major_version_selector() {
     let quill_3_0 = create_test_quill(&temp_dir, "resume_template", "3.0");
 
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_1)
+        .register_quill(&quill_2_1)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_2)
+        .register_quill(&quill_2_2)
         .expect("Failed to register");
     engine
-        .register_quill(quill_3_0)
+        .register_quill(&quill_3_0)
         .expect("Failed to register");
 
     // Resolve @2 -> should get latest 2.x.x (2.2.0 equivalent)
@@ -137,13 +137,13 @@ fn test_resolve_exact_version_selector() {
     let quill_2_2 = create_test_quill(&temp_dir, "resume_template", "2.2.0");
 
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_1)
+        .register_quill(&quill_2_1)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_2)
+        .register_quill(&quill_2_2)
         .expect("Failed to register");
 
     // Resolve @2.1.0 -> should get exactly 2.1.0
@@ -272,13 +272,13 @@ fn test_workflow_from_versioned_document() {
     let quill_2_1 = create_test_quill(&temp_dir, "resume_template", "2.1");
 
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_1)
+        .register_quill(&quill_2_1)
         .expect("Failed to register");
 
     // Create document with version tag
@@ -311,12 +311,12 @@ fn test_version_collision_error() {
     // Register version 1.0
     let quill_1_0 = create_test_quill(&temp_dir, "resume_template", "1.0");
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register first v1.0");
 
     // Try to register same name+version again
     let quill_1_0_duplicate = create_test_quill(&temp_dir, "resume_template", "1.0");
-    let result = engine.register_quill(quill_1_0_duplicate);
+    let result = engine.register_quill(&quill_1_0_duplicate);
 
     // Should fail with version collision error
     assert!(result.is_err());
@@ -341,13 +341,13 @@ fn test_version_not_found_error_message() {
     let quill_3_0 = create_test_quill(&temp_dir, "resume_template", "3.0");
 
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_3_0)
+        .register_quill(&quill_3_0)
         .expect("Failed to register");
 
     // Request nonexistent version
@@ -401,13 +401,13 @@ fn test_latest_selector_with_multiple_versions() {
     let quill_3_0 = create_test_quill(&temp_dir, "resume_template", "3.0");
 
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_3_0)
+        .register_quill(&quill_3_0)
         .expect("Failed to register");
 
     // Resolve with no selector (implicit latest)
@@ -437,10 +437,10 @@ fn test_version_selector_with_unversioned_document() {
     let quill_2_0 = create_test_quill(&temp_dir, "resume_template", "2.0");
 
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
 
     // Document without version in QUILL tag
@@ -481,7 +481,7 @@ fn test_backward_compatibility_unversioned_quill() {
     .expect("Failed to write plate.typ");
 
     let quill = Quill::from_path(quill_path).expect("Failed to load quill");
-    engine.register_quill(quill).expect("Failed to register");
+    engine.register_quill(&quill).expect("Failed to register");
 
     // Should be accessible without version (implicit latest)
     let workflow = engine
@@ -506,10 +506,10 @@ fn test_resolve_version_with_colon_syntax() {
     let quill_2_0 = create_test_quill(&temp_dir, "usaf_memo", "2.0");
 
     engine
-        .register_quill(quill_1_0)
+        .register_quill(&quill_1_0)
         .expect("Failed to register");
     engine
-        .register_quill(quill_2_0)
+        .register_quill(&quill_2_0)
         .expect("Failed to register");
 
     // Resolve with colon syntax

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -66,16 +66,18 @@ Get started with Quillmark in Python or JavaScript.
 
     const engine = new Quillmark();
 
-    // Register a quill (JSON)
+    // Build a Quill handle from JSON, then register it
     const quill = {
       files: {
-        "Quill.yaml": { contents: "Quill:\n  name: my-quill\n  backend: typst\n  description: Demo\n" },
+        "Quill.yaml": { contents: "Quill:\n  name: my_quill\n  backend: typst\n  description: Demo\n" },
         "plate.typ": { contents: "#import \"@local/quillmark-helper:0.1.0\": data\n#data.BODY\n" }
       }
     };
-    engine.registerQuill(Quill.fromJson(quill));
+    const quillHandle = Quill.fromJson(quill);
+    engine.registerQuill(quillHandle);
 
     const markdown = `---
+    QUILL: my_quill
     title: Example Document
     ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -62,7 +62,7 @@ Get started with Quillmark in Python or JavaScript.
     ## Basic Usage
 
     ```javascript
-    import { Quillmark } from "@quillmark-test/wasm";
+    import { Quill, Quillmark } from "@quillmark-test/wasm";
 
     const engine = new Quillmark();
 
@@ -73,7 +73,7 @@ Get started with Quillmark in Python or JavaScript.
         "plate.typ": { contents: "#import \"@local/quillmark-helper:0.1.0\": data\n#data.BODY\n" }
       }
     };
-    engine.registerQuill(quill);
+    engine.registerQuill(Quill.fromJson(quill));
 
     const markdown = `---
     title: Example Document

--- a/docs/integration/dynamic-assets.md
+++ b/docs/integration/dynamic-assets.md
@@ -41,7 +41,8 @@ This is useful for:
     import { Quill, Quillmark } from "@quillmark-test/wasm";
 
     const engine = new Quillmark();
-    engine.registerQuill(Quill.fromJson(quillBundle));
+    const quill = Quill.fromJson(quillBundle);
+    engine.registerQuill(quill);
 
     const logoBytes = await fetch("logo.png").then((r) => r.arrayBuffer());
     const parsed = Quillmark.parseMarkdown(markdown);

--- a/docs/integration/dynamic-assets.md
+++ b/docs/integration/dynamic-assets.md
@@ -38,16 +38,15 @@ This is useful for:
 === "JavaScript"
 
     ```javascript
-    import { Quillmark } from "@quillmark-test/wasm";
+    import { Quill, Quillmark } from "@quillmark-test/wasm";
 
     const engine = new Quillmark();
-    engine.registerQuill(quillBundle);
+    engine.registerQuill(Quill.fromJson(quillBundle));
 
     const logoBytes = await fetch("logo.png").then((r) => r.arrayBuffer());
     const parsed = Quillmark.parseMarkdown(markdown);
     const result = engine.render(parsed, {
       format: "pdf",
-      quillName: "my-quill",
       assets: {
         "logo.png": new Uint8Array(logoBytes)
       }
@@ -85,7 +84,6 @@ workflow.add_assets(assets)
     ```javascript
     const result = engine.render(parsed, {
       format: "pdf",
-      quillName: "my-quill",
       fonts: {
         "CustomFont-Regular.ttf": regularFontBytes,
         "CustomFont-Bold.ttf": boldFontBytes

--- a/docs/integration/javascript/api.md
+++ b/docs/integration/javascript/api.md
@@ -9,10 +9,10 @@ npm install @quillmark-test/wasm
 ## Core flow
 
 ```javascript
-import { Quillmark } from "@quillmark-test/wasm";
+import { Quill, Quillmark } from "@quillmark-test/wasm";
 
 const engine = new Quillmark();
-engine.registerQuill(quillBundle);
+engine.registerQuill(Quill.fromJson(quillBundle));
 
 const parsed = Quillmark.parseMarkdown(markdown); // requires QUILL in frontmatter
 const result = engine.render(parsed, { format: "pdf" });
@@ -31,9 +31,17 @@ type ParsedDocument = {
 };
 ```
 
-### `engine.registerQuill(quillJson)`
+### `Quill.fromJson(source)`
 
-Registers a quill bundle and returns `QuillInfo`.
+Builds a `Quill` handle from a JSON string or plain object.
+
+### `Quill.fromTree(tree)`
+
+Builds a `Quill` handle from a flat `Map<string, Uint8Array>` (or plain object record) of relative paths to bytes.
+
+### `engine.registerQuill(quill)`
+
+Registers a pre-built `Quill` handle and returns `QuillInfo`.
 
 ### `engine.getQuillInfo(name)`
 

--- a/docs/integration/javascript/api.md
+++ b/docs/integration/javascript/api.md
@@ -12,7 +12,8 @@ npm install @quillmark-test/wasm
 import { Quill, Quillmark } from "@quillmark-test/wasm";
 
 const engine = new Quillmark();
-engine.registerQuill(Quill.fromJson(quillBundle));
+const quill = Quill.fromJson(quillBundle);
+engine.registerQuill(quill);
 
 const parsed = Quillmark.parseMarkdown(markdown); // requires QUILL in frontmatter
 const result = engine.render(parsed, { format: "pdf" });
@@ -41,7 +42,8 @@ Builds a `Quill` handle from a flat `Map<string, Uint8Array>` (or plain object r
 
 ### `engine.registerQuill(quill)`
 
-Registers a pre-built `Quill` handle and returns `QuillInfo`.
+Registers a pre-built `Quill` handle and returns `QuillInfo`.  
+`registerQuill` is handle-only: pass a `Quill` from `Quill.fromJson(...)` or `Quill.fromTree(...)`.
 
 ### `engine.getQuillInfo(name)`
 
@@ -77,3 +79,4 @@ Renders artifacts from a parsed document. Quill resolution always comes from `pa
 - `schema` is YAML text (not a JSON object).
 - There is no stripped-schema API.
 - `render`/`compile` do not accept quill override options; use `QUILL` in frontmatter.
+- `registerQuill` does not accept raw JSON/tree payloads directly.

--- a/docs/integration/overview.md
+++ b/docs/integration/overview.md
@@ -26,10 +26,10 @@ Most integrations follow the same three-step flow:
 === "JavaScript"
 
     ```javascript
-    import { Quillmark } from "@quillmark-test/wasm";
+    import { Quill, Quillmark } from "@quillmark-test/wasm";
 
     const engine = new Quillmark();
-    engine.registerQuill(quillBundle);
+    engine.registerQuill(Quill.fromJson(quillBundle));
 
     const parsed = Quillmark.parseMarkdown(markdownText);
     const result = engine.render(parsed, { format: "pdf" });
@@ -53,15 +53,15 @@ Most integrations follow the same three-step flow:
 === "JavaScript"
 
     ```javascript
-    import { Quillmark } from "@quillmark-test/wasm";
+    import { Quill, Quillmark } from "@quillmark-test/wasm";
 
     const engine = new Quillmark();
 
     // Register a quill bundle (JSON string or object)
-    engine.registerQuill(quillBundle);
+    engine.registerQuill(Quill.fromJson(quillBundle));
 
     const parsed = Quillmark.parseMarkdown(markdownText);
-    const result = engine.render(parsed, { format: "pdf", quillName: "my-quill" });
+    const result = engine.render(parsed, { format: "pdf" });
     ```
 
 ## Output Formats

--- a/docs/integration/overview.md
+++ b/docs/integration/overview.md
@@ -29,8 +29,10 @@ Most integrations follow the same three-step flow:
     import { Quill, Quillmark } from "@quillmark-test/wasm";
 
     const engine = new Quillmark();
-    engine.registerQuill(Quill.fromJson(quillBundle));
+    const quill = Quill.fromJson(quillBundle);
+    engine.registerQuill(quill);
 
+    // markdownText frontmatter must include: QUILL: my_quill
     const parsed = Quillmark.parseMarkdown(markdownText);
     const result = engine.render(parsed, { format: "pdf" });
     ```
@@ -57,8 +59,9 @@ Most integrations follow the same three-step flow:
 
     const engine = new Quillmark();
 
-    // Register a quill bundle (JSON string or object)
-    engine.registerQuill(Quill.fromJson(quillBundle));
+    // Build a Quill handle from JSON and register the handle
+    const quill = Quill.fromJson(quillBundle);
+    engine.registerQuill(quill);
 
     const parsed = Quillmark.parseMarkdown(markdownText);
     const result = engine.render(parsed, { format: "pdf" });

--- a/docs/integration/validation.md
+++ b/docs/integration/validation.md
@@ -31,10 +31,10 @@ except QuillmarkError as e:
 ## JavaScript/WASM
 
 ```javascript
-import { Quillmark } from "@quillmark-test/wasm";
+import { Quill, Quillmark } from "@quillmark-test/wasm";
 
 const engine = new Quillmark();
-engine.registerQuill(quillBundle);
+engine.registerQuill(Quill.fromJson(quillBundle));
 const parsed = Quillmark.parseMarkdown(markdown);
 
 // dryRun uses QUILL from parsed frontmatter

--- a/docs/integration/validation.md
+++ b/docs/integration/validation.md
@@ -34,7 +34,8 @@ except QuillmarkError as e:
 import { Quill, Quillmark } from "@quillmark-test/wasm";
 
 const engine = new Quillmark();
-engine.registerQuill(Quill.fromJson(quillBundle));
+const quill = Quill.fromJson(quillBundle);
+engine.registerQuill(quill);
 const parsed = Quillmark.parseMarkdown(markdown);
 
 // dryRun uses QUILL from parsed frontmatter

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -30,7 +30,7 @@ class Quillmark {
 ## Implementation notes
 
 - `Quill.fromTree` accepts `Map<string, Uint8Array>` or a plain `Record<string, Uint8Array>`. Directory hierarchy is inferred from `/` path separators in keys (e.g. `"assets/fonts/Inter.ttf"` inserts into `assets/fonts/`). Values must be `Uint8Array`; passing a string throws.
-- The WASM `Quill` struct holds `Arc<quillmark_core::Quill>`. The JS handle is not consumed on registration, and `registerQuill` may be called on multiple engines with the same handle. Internally, each registration deep-clones the underlying `Quill` because the core `Quillmark::register_quill` takes ownership by value — Arc sharing across engines is not achieved at the data level, only at the JS API level.
+- The WASM `Quill` struct holds `Arc<quillmark_core::Quill>`. The JS handle is not consumed on registration, and `registerQuill` may be called on multiple engines with the same handle. Each registration clones the underlying `Quill` once at storage time (the core engine stores its own copy), so the JS-level `Arc` prevents handle invalidation but does not eliminate the per-engine copy.
 
 ## Key contracts
 

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -7,10 +7,15 @@
 ## API (current)
 
 ```typescript
+class Quill {
+  static fromJson(source: string | object): Quill;
+  static fromTree(tree: Map<string, Uint8Array> | Record<string, Uint8Array>): Quill;
+}
+
 class Quillmark {
   constructor();
   static parseMarkdown(markdown: string): ParsedDocument;
-  registerQuill(quillJson: string | object): QuillInfo;
+  registerQuill(quill: Quill): QuillInfo;
   getQuillInfo(name: string): QuillInfo;
   getQuillSchema(name: string): string; // YAML
   compileData(markdown: string): object;

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -30,6 +30,7 @@ class Quillmark {
 ## Implementation notes
 
 - `Quill.fromTree` accepts `Map<string, Uint8Array>` or a plain `Record<string, Uint8Array>`. Directory hierarchy is inferred from `/` path separators in keys (e.g. `"assets/fonts/Inter.ttf"` inserts into `assets/fonts/`). Values must be `Uint8Array`; passing a string throws.
+- `registerQuill` accepts only `Quill` handles. Callers must create handles with `Quill.fromJson(...)` or `Quill.fromTree(...)` before registration.
 - The WASM `Quill` struct holds `Arc<quillmark_core::Quill>`. The JS handle is not consumed on registration, and `registerQuill` may be called on multiple engines with the same handle. Each registration clones the underlying `Quill` once at storage time (the core engine stores its own copy), so the JS-level `Arc` prevents handle invalidation but does not eliminate the per-engine copy.
 
 ## Key contracts

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -27,6 +27,11 @@ class Quillmark {
 }
 ```
 
+## Implementation notes
+
+- `Quill.fromTree` accepts `Map<string, Uint8Array>` or a plain `Record<string, Uint8Array>`. Directory hierarchy is inferred from `/` path separators in keys (e.g. `"assets/fonts/Inter.ttf"` inserts into `assets/fonts/`). Values must be `Uint8Array`; passing a string throws.
+- The WASM `Quill` struct holds `Arc<quillmark_core::Quill>`. The JS handle is not consumed on registration, and `registerQuill` may be called on multiple engines with the same handle. Internally, each registration deep-clones the underlying `Quill` because the core `Quillmark::register_quill` takes ownership by value — Arc sharing across engines is not achieved at the data level, only at the JS API level.
+
 ## Key contracts
 
 - `ParsedDocument.quillRef` is required and is sourced from `QUILL` frontmatter.

--- a/prose/proposals/quill_factory_api.md
+++ b/prose/proposals/quill_factory_api.md
@@ -1,0 +1,136 @@
+# Quill Factory API — `quillmark-wasm` Tasking
+
+## Goal
+
+Split `engine.registerQuill(json)` into two explicit steps:
+
+1. **Construct** — `Quill.from*(source)` parses and validates a bundle,
+   returning an opaque `Quill` handle.
+2. **Register** — `engine.registerQuill(quill)` stores the handle in the
+   engine.
+
+This decouples format knowledge from the engine. The engine only ever sees
+`Quill` objects; all wire-format concerns live in the factories. Adding a
+new input source (e.g. a flat path-to-bytes map for registry load path)
+requires no change to `registerQuill`.
+
+## Background
+
+The current `registerQuill(json)` API conflates parsing, validation, and
+registration into one call. It also forces every input to pass through
+JSON, which is a poor fit for binary-heavy bundles and for callers that
+already have an unpacked in-memory tree (e.g. the registry client after
+decompressing a ZIP and rehydrating fonts). The engine should accept a
+`Quill` value, not a serialization format.
+
+## Proposed API
+
+### Factories — `Quill.from*()`
+
+```typescript
+class Quill {
+  /** Parse and validate from a JSON string or plain object. */
+  static fromJson(source: string | object): Quill;
+
+  /**
+   * Build from a flat path → bytes map.
+   *
+   * Keys are file paths relative to the quill root
+   * (e.g. "Quill.yaml", "assets/fonts/Inter-Regular.ttf").
+   * This is the natural output of the registry load path after ZIP
+   * decompression and font rehydration.
+   */
+  static fromTree(tree: Map<string, Uint8Array>): Quill;
+}
+```
+
+Both factories throw on invalid input with a structured error. No other
+methods are required on `Quill` in v1 — it is an opaque handle.
+
+### Engine — `registerQuill(quill)`
+
+```typescript
+class Quillmark {
+  /** Register a pre-constructed Quill with this engine. */
+  registerQuill(quill: Quill): QuillInfo;
+}
+```
+
+`registerQuill` no longer accepts JSON or any raw format — only `Quill`
+handles. The `Quill` may be registered with more than one engine; the
+underlying data is shared rather than consumed on registration.
+
+### Registry client — calling pattern
+
+```typescript
+// Build a Quill from an in-memory tree (post-rehydration)
+const tree: Map<string, Uint8Array> = await loadAndRehydrate(ref);
+const quill = Quill.fromTree(tree);
+engine.registerQuill(quill);
+
+// Build a synthetic Quill for testing
+const quill = Quill.fromJson({ files: { 'Quill.yaml': '...', 'main.typ': '...' } });
+engine.registerQuill(quill);
+```
+
+## Decisions
+
+- **Opaque handle.** `Quill` exposes no public properties. Callers inspect
+  a registered quill through `engine.getQuillInfo(name)` as today.
+- **Shared, not consumed.** Registering a `Quill` does not invalidate the
+  JS handle. The same `Quill` may be registered with multiple engines
+  without calling a clone method. The WASM binding holds an `Arc` over the
+  inner Rust type.
+- **`fromTree` accepts `Map<string, Uint8Array>`.** Also accept a plain
+  `Record<string, Uint8Array>` for ergonomics. Directory structure is
+  inferred from path separators (`/`).
+- **No `fromZip`.** ZIP decompression stays in the registry client — it is
+  Node/browser work that happens before Quillmark is involved. Accepting
+  raw ZIP bytes would require a decompressor inside the WASM bundle.
+
+## Rust-side changes
+
+The Rust types needed already exist in `quillmark-core`:
+- `Quill::from_json(json: &str)` — backs `Quill.fromJson`
+- `Quill::from_tree(root: FileTreeNode)` — backs `Quill.fromTree`
+
+The only Rust work is in `crates/bindings/wasm/src/`:
+
+1. **Add a `Quill` WASM wrapper type** (`wasm_bindgen` struct wrapping
+   `Arc<quillmark_core::Quill>`).
+2. **Expose factory methods** as `#[wasm_bindgen(static_method_of = Quill)]`
+   — `from_json` and `from_tree`.
+3. **`from_tree` input handling**: accept a `JsValue` (Map or plain
+   object), walk entries, copy `Uint8Array` values into byte vecs, build
+   `FileTreeNode` by splitting paths on `/`.
+4. **Update `Quillmark::register_quill`** to accept `&Quill` instead of
+   `JsValue`. Clone the inner `Arc` and forward to the existing
+   `quillmark::Quillmark::register_quill`.
+5. **Remove the old `registerQuill(JsValue)` signature.** (See migration
+   below.)
+
+## Migration
+
+`Quill.fromJson` accepts the same JSON shape the old `registerQuill` did,
+so the migration at each call site is mechanical:
+
+```typescript
+// Before
+engine.registerQuill(quillJson);
+
+// After
+engine.registerQuill(Quill.fromJson(quillJson));
+```
+
+The current `registerQuill(json)` overload may be kept as a **deprecated
+shim** for one release to ease migration, but it should not persist beyond
+that — it defeats the purpose of the split.
+
+## Out of scope
+- Changes to `Quill.yaml` parsing or schema validation logic.
+- Changes to `engine.render`, `engine.compile`, or any rendering path.
+- Font rehydration — handled by the registry client before `Quill.fromTree`
+  is called.
+- A `Quill.free()` method — not needed given shared-ownership semantics.
+- TypeScript type generation changes beyond updating `registerQuill`'s
+  parameter type.


### PR DESCRIPTION
- bc89bea69 remove font cache
- f73334a88 WASM API: introduce `Quill` factories and make `registerQuill` handle-only (#418)
- a3a07fa73 validate Quill factory API: add fromTree tests and document Arc-clone caveat (#419)
- 5fb39c871 fix: register_quill takes &Quill, remove error prefix wrapping, add factory JSDoc (#422)