### PR TITLE
Refactor WASM engine: simplify API, improve error handling, add validation

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -116,18 +116,38 @@ The main workflow for rendering documents:
 Additional methods for managing the engine and debugging:
 
 - `new Quillmark()` - Create a new engine instance
-- `renderQuill(RenderOptions, markdown)` - Load markdown and map it onto an internally fetched Quill, resolving to `RenderResult` including output format, the artifact byte slice buffer, and time to render
-- `processPlate(quillRef, markdown)` - Debug helper that processes markdown through the template engine and returns the intermediate template source code (e.g., Typst, LaTeX) without compiling to final artifacts. Useful for inspecting template output during development.
-- `fetchQuillInfo(quillRef)` - Fetches metadata and schema about an available Quill from the configured registry without loading the full filesystem or rendering context.
-- `listQuills()` - List all registered Quill names
-- `unregisterQuill(name)` - Unregister a Quill to free memory
+- `getQuillInfo(name)` - Get metadata, schema, and supported formats for a registered Quill
+- `getQuillSchema(name)` - Get the public YAML schema for a registered Quill
+- `resolveQuill(ref)` - Return `QuillInfo` if the ref is already registered, or `null`
+- `listQuills()` - List all registered Quills as `"name@version"` strings
+- `unregisterQuill(name)` - Unregister a Quill by name or `"name@version"`
+- `dryRun(markdown)` - Validate without backend compilation (fast feedback)
+- `compile(parsed, opts?)` - Compile to an opaque `CompiledDocument` handle
+- `compileData(markdown)` - Return the intermediate JSON data structure for debugging
+
+### Quill handle lifetime
+
+`Quill.fromJson` and `Quill.fromTree` return a handle backed by an `Arc`. The same handle can be registered with multiple engines. Once all `registerQuill` calls are done you may call `quill.free()` to release the WASM-side reference; do not use the handle again after calling `free()`.
+
+### Factory types
+
+```typescript
+// fromJson — source must have a `files` key mapping paths to { contents: string }
+Quill.fromJson(source: string | object): Quill
+
+// fromTree — flat path → bytes map; paths must be relative with no .. or .
+Quill.fromTree(tree: Map<string, Uint8Array> | Record<string, Uint8Array>): Quill
+```
+
+Both factories throw a `WasmError` with `code: "quill::invalid_bundle"` on invalid input.
 
 ### Render Options
 
 ```typescript
 type RenderOptions = {
   format?: 'pdf' | 'svg' | 'txt'
-  assets?: Record<string, Uint8Array | number[]> 
+  // Assets are plain arrays of byte values, not Uint8Array
+  assets?: Record<string, number[]>
 }
 ```
 
@@ -165,7 +185,7 @@ Data crossing the JavaScript ↔ WebAssembly boundary:
 - **Binary data**: `Vec<u8>` maps to `Uint8Array`
 - **Collections**: `Vec<T>` maps to JS arrays; object types use plain JS objects `{}`
 - **Option**: `Option<T>` maps to `T | null`
-- **Errors**: Thrown as exceptions using `SerializableDiagnostic` from core, containing structured diagnostic information (severity, message, location, hint, source chain)
+- **Errors**: Thrown as `WasmError` objects with `type`, `severity`, `message`, and (where available) `code` fields. Factory errors use `code: "quill::invalid_bundle"`; registration and render errors carry codes from core diagnostics
 
 ## Design Principles
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -387,6 +387,33 @@ impl Quillmark {
     }
 }
 
+// Namespace merges with the wasm-bindgen-generated `Quill` class declaration,
+// adding the two factory methods with precise types in place of the `any`-typed
+// signatures that wasm-bindgen would otherwise emit (suppressed via skip_typescript).
+#[wasm_bindgen(typescript_custom_section)]
+const QUILL_FACTORY_TS: &str = r#"
+export namespace Quill {
+  /**
+   * Parse and validate a Quill from a JSON string or plain object.
+   * The root object must have a `files` key mapping paths to
+   * `{ contents: string }` objects.
+   * Throws a structured `WasmError` (code `"quill::invalid_bundle"`) on failure.
+   */
+  export function fromJson(source: string | object): Quill;
+
+  /**
+   * Build and validate a Quill from a flat path-to-bytes tree.
+   * Paths may include `/`-separated subdirectory components.
+   * Only relative paths with normal components are accepted —
+   * `..`, `.`, and absolute paths are rejected with an error.
+   * Throws a structured `WasmError` (code `"quill::invalid_bundle"`) on failure.
+   */
+  export function fromTree(
+    tree: Map<string, Uint8Array> | Record<string, Uint8Array>
+  ): Quill;
+}
+"#;
+
 #[wasm_bindgen]
 impl Quill {
     /// Parse and validate a Quill from a JSON string or plain object.
@@ -401,7 +428,7 @@ impl Quill {
     ///   }
     /// });
     /// ```
-    #[wasm_bindgen(js_name = fromJson)]
+    #[wasm_bindgen(js_name = fromJson, skip_typescript)]
     pub fn from_json(source: JsValue) -> Result<Quill, JsValue> {
         let json_str = if source.is_string() {
             source.as_string().ok_or_else(|| {
@@ -418,7 +445,7 @@ impl Quill {
         };
 
         let quill = quillmark_core::Quill::from_json(&json_str)
-            .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
+            .map_err(|e| WasmError::with_code("quill::invalid_bundle", e).to_js_value())?;
 
         Ok(Quill {
             inner: Arc::new(quill),
@@ -436,11 +463,11 @@ impl Quill {
     ///   ["assets/font.ttf", fontBytes],
     /// ]));
     /// ```
-    #[wasm_bindgen(js_name = fromTree)]
+    #[wasm_bindgen(js_name = fromTree, skip_typescript)]
     pub fn from_tree(tree: JsValue) -> Result<Quill, JsValue> {
         let root = file_tree_from_js_tree(&tree)?;
         let quill = quillmark_core::Quill::from_tree(root)
-            .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
+            .map_err(|e| WasmError::with_code("quill::invalid_bundle", e).to_js_value())?;
 
         Ok(Quill {
             inner: Arc::new(quill),
@@ -495,6 +522,24 @@ fn js_tree_entries(tree: &JsValue) -> Result<Vec<(String, JsValue)>, JsValue> {
             entries.push((path, value));
         }
         return Ok(entries);
+    }
+
+    // Reject Array and typed arrays before the generic is_object() check.
+    // Arrays are objects in JS, so without this they'd silently produce
+    // numeric-string paths ("0", "1", ...) and give a misleading error later.
+    if tree.is_instance_of::<js_sys::Array>() {
+        return Err(
+            WasmError::from("fromTree requires a Map or plain object, not an Array").to_js_value(),
+        );
+    }
+    if tree.is_instance_of::<Uint8Array>() {
+        return Err(
+            WasmError::from(
+                "fromTree requires a Map or plain object, not a Uint8Array; \
+                 did you mean to pass a Map<string, Uint8Array>?",
+            )
+            .to_js_value(),
+        );
     }
 
     if tree.is_object() {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2,8 +2,7 @@
 
 use crate::error::WasmError;
 use crate::types::{
-    CompileOptions, OutputFormat, ParsedDocument, QuillInfo, RenderOptions, RenderPagesOptions,
-    RenderResult,
+    OutputFormat, ParsedDocument, QuillInfo, RenderOptions, RenderPagesOptions, RenderResult,
 };
 use js_sys::{Array, Object, Uint8Array};
 use std::collections::HashMap;
@@ -75,49 +74,36 @@ impl Quillmark {
             .map_err(WasmError::from)
             .map_err(|e| e.to_js_value())?;
 
-        // Convert to WASM type
         let quill_ref = parsed.quill_reference().to_string();
 
-        // Convert fields HashMap to JSON
         let mut fields_obj = serde_json::Map::new();
         for (key, value) in parsed.fields() {
             fields_obj.insert(key.clone(), value.as_json().clone());
         }
-        let fields = serde_json::Value::Object(fields_obj);
 
-        Ok(ParsedDocument { fields, quill_ref })
+        Ok(ParsedDocument {
+            fields: serde_json::Value::Object(fields_obj),
+            quill_ref,
+        })
     }
 
     /// Register a pre-constructed Quill handle.
     #[wasm_bindgen(js_name = registerQuill)]
     pub fn register_quill(&mut self, quill: &Quill) -> Result<QuillInfo, JsValue> {
         let name = quill.inner.name.clone();
-
         self.inner
             .register_quill(quill.inner.as_ref())
             .map_err(|e| WasmError::from(e).to_js_value())?;
-
         self.get_quill_info(&name)
     }
 
-    /// Get shallow information about a registered Quill
-    ///
-    /// This returns metadata, backend info, field schemas, and supported formats
-    /// that consumers need to configure render options for the next step.
+    /// Get metadata, backend info, field schemas, and supported formats for a registered Quill.
     #[wasm_bindgen(js_name = getQuillInfo)]
     pub fn get_quill_info(&self, name: &str) -> Result<QuillInfo, JsValue> {
-        self.fetch_quill_info(name)
-    }
-
-    fn fetch_quill_info(&self, name: &str) -> Result<QuillInfo, JsValue> {
         let quill = self.inner.get_quill(name).ok_or_else(|| {
             WasmError::from(format!("Quill '{}' not registered", name)).to_js_value()
         })?;
 
-        // Get backend ID
-        let backend_id = &quill.backend;
-
-        // Create workflow to get supported formats
         let workflow = self.inner.workflow(name).map_err(|e| {
             WasmError::from(format!(
                 "Failed to create workflow for quill '{}': {}",
@@ -132,28 +118,18 @@ impl Quillmark {
             .map(|&f| f.into())
             .collect();
 
-        // Convert metadata to serde_json::Value (plain JavaScript object)
-        let mut metadata_obj = serde_json::Map::new();
-        for (key, value) in &quill.metadata {
-            metadata_obj.insert(key.clone(), value.as_json().clone());
-        }
-        let metadata_json = serde_json::Value::Object(metadata_obj);
-
-        // Convert defaults to serde_json::Value (plain JavaScript object)
-        let mut defaults_obj = serde_json::Map::new();
-        for (key, value) in quill.config.defaults() {
-            defaults_obj.insert(key.clone(), value.as_json().clone());
-        }
-        let defaults_json = serde_json::Value::Object(defaults_obj);
-
-        // Convert examples to serde_json::Value (plain JavaScript object with arrays)
-        let mut examples_obj = serde_json::Map::new();
-        for (key, values) in quill.config.examples() {
-            let examples_array: Vec<serde_json::Value> =
-                values.iter().map(|v| v.as_json().clone()).collect();
-            examples_obj.insert(key.clone(), serde_json::Value::Array(examples_array));
-        }
-        let examples_json = serde_json::Value::Object(examples_obj);
+        let metadata_json = quill_map_to_json(&quill.metadata);
+        let defaults_json = quill_map_to_json(&quill.config.defaults());
+        let examples_json = serde_json::Value::Object(
+            quill.config
+                .examples()
+                .into_iter()
+                .map(|(k, vs)| {
+                    let arr = vs.into_iter().map(|v| v.as_json().clone()).collect();
+                    (k, serde_json::Value::Array(arr))
+                })
+                .collect(),
+        );
 
         let schema_yaml = quill.config.public_schema_yaml().map_err(|e| {
             WasmError::from(format!("Failed to serialize schema: {}", e)).to_js_value()
@@ -161,7 +137,7 @@ impl Quillmark {
 
         Ok(QuillInfo {
             name: quill.name.clone(),
-            backend: backend_id.clone(),
+            backend: quill.backend.clone(),
             metadata: metadata_json,
             example: quill.example.clone(),
             schema: schema_yaml,
@@ -194,12 +170,10 @@ impl Quillmark {
     /// This is useful for fast feedback loops in LLM-driven document generation.
     #[wasm_bindgen(js_name = dryRun)]
     pub fn dry_run(&mut self, markdown: &str) -> Result<(), JsValue> {
-        // Parse markdown first
         let parsed = quillmark_core::ParsedDocument::from_markdown(markdown)
             .map_err(WasmError::from)
             .map_err(|e| e.to_js_value())?;
 
-        // Read quill reference from parsed document
         let quill_ref = parsed.quill_reference().to_string();
 
         let workflow = self.inner.workflow(quill_ref.as_str()).map_err(|e| {
@@ -217,12 +191,10 @@ impl Quillmark {
     /// Useful for debugging and validation.
     #[wasm_bindgen(js_name = compileData)]
     pub fn compile_data(&mut self, markdown: &str) -> Result<JsValue, JsValue> {
-        // Parse markdown first
         let parsed = quillmark_core::ParsedDocument::from_markdown(markdown)
             .map_err(WasmError::from)
             .map_err(|e| e.to_js_value())?;
 
-        // Read quill reference from parsed document
         let quill_ref = parsed.quill_reference().to_string();
 
         let workflow = self.inner.workflow(quill_ref.as_str()).map_err(|e| {
@@ -233,19 +205,11 @@ impl Quillmark {
             .compile_data(&parsed)
             .map_err(|e| WasmError::from(e).to_js_value())?;
 
-        // Convert serde_json::Value to JsValue
-        // We can stringify and parse, or use serde-wasm-bindgen (if available).
-        // For simplicity/compatibility, let's use the JSON string approach via js_sys
-        let json_str = serde_json::to_string(&json_data).map_err(|e| {
-            WasmError::from(format!("Failed to serialize data: {}", e)).to_js_value()
-        })?;
-
-        js_sys::JSON::parse(&json_str).map_err(|e| {
-            WasmError::from(format!("Failed to parse JSON data: {:?}", e)).to_js_value()
-        })
+        serde_wasm_bindgen::to_value(&json_data)
+            .map_err(|e| WasmError::from(format!("Failed to serialize data: {}", e)).to_js_value())
     }
 
-    /// Render a ParsedDocument to final artifacts (PDF, SVG, TXT)
+    /// Render a ParsedDocument to final artifacts (PDF, SVG, PNG, TXT)
     ///
     /// Uses the Quill specified in the ParsedDocument's quill_ref field.
     #[wasm_bindgen]
@@ -257,20 +221,13 @@ impl Quillmark {
         let quill_ref_to_use = parsed.quill_ref.clone();
         let parsed = Self::to_core_parsed(parsed)?;
 
-        // Load the workflow
         let mut workflow = self.inner.workflow(&quill_ref_to_use).map_err(|e| {
             WasmError::from(format!("Quill '{}' not found: {}", quill_ref_to_use, e)).to_js_value()
         })?;
 
-        // Add assets if provided
         if let Some(serde_json::Value::Object(assets_map)) = opts.assets {
-            // assets is now a serde_json::Value representing a plain JavaScript object
-            // We need to convert it to an iterator of (filename, bytes)
             for (filename, value) in assets_map {
-                // Extract bytes from the value
-                // Bytes can be either an array of numbers or a Uint8Array
                 let bytes = if let Some(arr) = value.as_array() {
-                    // Array of numbers [0, 1, 2, ...]
                     arr.iter()
                         .filter_map(|v| v.as_u64().map(|n| n as u8))
                         .collect::<Vec<u8>>()
@@ -281,7 +238,6 @@ impl Quillmark {
                     ))
                     .to_js_value());
                 };
-
                 workflow.add_asset(filename, bytes).map_err(|e| {
                     WasmError::from(format!("Failed to add asset: {}", e)).to_js_value()
                 })?;
@@ -289,7 +245,6 @@ impl Quillmark {
         }
 
         let start = now_ms();
-
         let output_format = opts.format.map(|f| f.into());
         let result = workflow
             .render_with_options(&parsed, output_format, opts.ppi)
@@ -305,12 +260,7 @@ impl Quillmark {
 
     /// Compile a parsed document into an opaque compiled document handle.
     #[wasm_bindgen]
-    pub fn compile(
-        &mut self,
-        parsed: ParsedDocument,
-        opts: Option<CompileOptions>,
-    ) -> Result<CompiledDocument, JsValue> {
-        let _opts = opts.unwrap_or_default();
+    pub fn compile(&mut self, parsed: ParsedDocument) -> Result<CompiledDocument, JsValue> {
         let quill_ref_to_use = parsed.quill_ref.clone();
         let parsed = Self::to_core_parsed(parsed)?;
 
@@ -319,7 +269,6 @@ impl Quillmark {
         })?;
 
         let backend = workflow.backend();
-
         let compiled = workflow
             .compile(&parsed)
             .map_err(|e| WasmError::from(e).to_js_value())?;
@@ -330,22 +279,22 @@ impl Quillmark {
         })
     }
 
-    /// Resolve a Quill reference to a registered Quill, or null if not available
+    /// Resolve a Quill reference to a registered Quill, or null if not available.
     ///
     /// Accepts a quill reference string like "resume-template", "resume-template@2",
     /// or "resume-template@2.1.0". Returns QuillInfo if the engine can resolve it
     /// locally, or null if an external fetch is needed.
     #[wasm_bindgen(js_name = resolveQuill)]
     pub fn resolve_quill(&self, quill_ref: &str) -> JsValue {
-        match self.fetch_quill_info(quill_ref) {
-            Ok(info) => {
+        use serde::Serialize;
+        self.get_quill_info(quill_ref)
+            .ok()
+            .and_then(|info| {
                 let serializer =
                     serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-                use serde::Serialize;
-                info.serialize(&serializer).unwrap_or(JsValue::NULL)
-            }
-            Err(_) => JsValue::NULL,
-        }
+                info.serialize(&serializer).ok()
+            })
+            .unwrap_or(JsValue::NULL)
     }
 
     /// List registered Quills with their exact versions
@@ -356,7 +305,7 @@ impl Quillmark {
         self.inner.registered_quill_versions()
     }
 
-    /// Unregister a Quill by name or specific version
+    /// Unregister a Quill by name or specific version.
     ///
     /// If a base name is provided (e.g., "my-quill"), all versions of that quill are freed.
     /// If a versioned name is provided (e.g., "my-quill@2.1.0"), only that specific version is freed.
@@ -385,6 +334,16 @@ impl Quillmark {
 
         Ok(quillmark_core::ParsedDocument::new(fields, quill_ref))
     }
+}
+
+fn quill_map_to_json(
+    map: &std::collections::HashMap<String, quillmark_core::value::QuillValue>,
+) -> serde_json::Value {
+    serde_json::Value::Object(
+        map.iter()
+            .map(|(k, v)| (k.clone(), v.as_json().clone()))
+            .collect(),
+    )
 }
 
 // Namespace merges with the wasm-bindgen-generated `Quill` class declaration,

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -27,6 +27,22 @@ impl WasmError {
         serde_wasm_bindgen::to_value(self)
             .unwrap_or_else(|_| JsValue::from_str(&format!("{:?}", self)))
     }
+
+    /// Build a Diagnostic with an explicit error code.
+    /// Use this instead of `WasmError::from(string)` when the call site knows
+    /// a stable code that JS callers can branch on.
+    pub fn with_code(code: &str, message: impl std::fmt::Display) -> Self {
+        WasmError::Diagnostic {
+            diagnostic: SerializableDiagnostic {
+                severity: quillmark_core::Severity::Error,
+                code: Some(code.to_string()),
+                message: message.to_string(),
+                primary: None,
+                hint: None,
+                source_chain: vec![],
+            },
+        }
+    }
 }
 
 impl From<ParseError> for WasmError {

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -237,12 +237,6 @@ pub struct RenderOptions {
     pub ppi: Option<f32>,
 }
 
-/// Options for compile() phase in the split compile/render pipeline.
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify, Default)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-#[serde(rename_all = "camelCase")]
-pub struct CompileOptions {}
-
 /// Options for rendering pages from a previously compiled document.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]

--- a/crates/core/src/quill/tree.rs
+++ b/crates/core/src/quill/tree.rs
@@ -119,17 +119,29 @@ impl FileTreeNode {
     ) -> Result<(), Box<dyn StdError + Send + Sync>> {
         let path = path.as_ref();
 
-        // Split path into components
-        let components: Vec<_> = path
-            .components()
-            .filter_map(|c| {
-                if let std::path::Component::Normal(s) = c {
-                    s.to_str().map(|s| s.to_string())
-                } else {
-                    None
+        // Validate and collect path components, rejecting any non-Normal component
+        // so that `..`, `.`, and absolute roots are errors rather than silent no-ops.
+        let mut components: Vec<String> = Vec::new();
+        for c in path.components() {
+            match c {
+                std::path::Component::Normal(s) => {
+                    components.push(
+                        s.to_str()
+                            .ok_or("Path component is not valid UTF-8")?
+                            .to_string(),
+                    );
                 }
-            })
-            .collect();
+                std::path::Component::ParentDir => {
+                    return Err("Path traversal ('..') is not allowed".into());
+                }
+                std::path::Component::CurDir => {
+                    return Err("Current-directory ('.') components are not allowed".into());
+                }
+                std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                    return Err("Absolute paths are not allowed; use a relative path".into());
+                }
+            }
+        }
 
         if components.is_empty() {
             return Err("Cannot insert at root path".into());

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -21,9 +21,9 @@ class Quillmark {
   compileData(markdown: string): object;
   dryRun(markdown: string): void;
   render(parsed: ParsedDocument, options?: RenderOptions): RenderResult;
-  compile(parsed: ParsedDocument, options?: CompileOptions): CompiledDocument;
+  compile(parsed: ParsedDocument): CompiledDocument;
   listQuills(): string[];
-  unregisterQuill(name: string): void;
+  unregisterQuill(name: string): boolean;
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR refactors the WASM bindings to simplify the public API, improve error handling with structured error codes, and add stricter path validation for Quill file trees. The changes reduce API surface area, eliminate redundant code paths, and provide better diagnostics for JavaScript consumers.

## Key Changes

- **Simplified Quillmark API**: Removed `CompileOptions` (unused), eliminated `fetch_quill_info()` private method in favor of direct `get_quill_info()` implementation, and removed `CompileOptions` parameter from `compile()`
- **Improved error handling**: Added `WasmError::with_code()` to attach stable error codes (e.g., `"quill::invalid_bundle"`) that JavaScript can branch on; updated `Quill::fromJson()` and `Quill::fromTree()` to use structured error codes
- **Better JSON serialization**: Replaced manual `js_sys::JSON::parse()` round-trip with `serde_wasm_bindgen::to_value()` in `compile_data()` for cleaner, more efficient conversion
- **Path validation**: Enhanced `FileTreeNode::insert()` to explicitly reject `..`, `.`, and absolute paths with clear error messages instead of silently filtering them out
- **Code cleanup**: Removed unnecessary comments, consolidated variable assignments, extracted `quill_map_to_json()` helper to reduce duplication, and improved formatting
- **TypeScript definitions**: Added `QUILL_FACTORY_TS` custom section with precise factory method signatures and `skip_typescript` attributes to suppress auto-generated `any` types
- **Documentation**: Updated README with clearer method descriptions, factory type signatures, and error code documentation; improved docstring clarity throughout

## Notable Implementation Details

- The `resolve_quill()` method now uses functional composition (`ok()`, `and_then()`, `unwrap_or()`) for cleaner error handling
- `quill_map_to_json()` helper eliminates repeated HashMap-to-JSON conversion logic
- Path validation now uses explicit pattern matching on `std::path::Component` variants for exhaustive checking
- Factory methods now throw `WasmError` with `code: "quill::invalid_bundle"` for consistent error handling in JavaScript

https://claude.ai/code/session_01SFfWPCri8CFQpvkAD2Nbks