### PR TITLE
docs: warn frontmatter authors about object field schema limits

### DIFF
--- a/docs/authoring/yaml-frontmatter.md
+++ b/docs/authoring/yaml-frontmatter.md
@@ -66,7 +66,7 @@ document:
 ```
 
 > [!WARNING]
-> YAML objects and nested structures are syntactically valid in frontmatter. However, when using schema-driven fields from `Quill.yaml`, Quill currently only supports `type: object` inside `array.items` (typed array rows). Top-level fields declared as `type: object` are not supported. See [Quill.yaml Reference: Field Types](../format-designer/quill-yaml-reference.md#field-types).
+> YAML objects and nested structures are syntactically valid in frontmatter. However, Quill’s schema system does not yet provide a general-purpose deep-nesting field type. As a current product-scoping decision, `type: object` is only supported for structured rows inside `array.items` (not as standalone top-level fields). See [Quill.yaml Reference: Field Types](../format-designer/quill-yaml-reference.md#field-types).
 
 ## QUILL Key
 

--- a/docs/authoring/yaml-frontmatter.md
+++ b/docs/authoring/yaml-frontmatter.md
@@ -65,6 +65,9 @@ document:
     margins: [1, 1, 1, 1]
 ```
 
+> [!WARNING]
+> YAML objects and nested structures are syntactically valid in frontmatter. However, when using schema-driven fields from `Quill.yaml`, Quill currently only supports `type: object` inside `array.items` (typed array rows). Top-level fields declared as `type: object` are not supported. See [Quill.yaml Reference: Field Types](../format-designer/quill-yaml-reference.md#field-types).
+
 ## QUILL Key
 
 The `QUILL` key specifies which Quill format to use for rendering:

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -115,7 +115,7 @@ main:
 | `markdown` | Rich text; backends convert to target format |
 | `object` or `dict` | Supported for typed table rows inside `array.items` |
 
-Use `type: array` with `items: { type: object, properties: {...} }` when you need a **list** of structured rows. Top-level `type: object` fields are not supported.
+Use `type: array` with `items: { type: object, properties: {...} }` when you need a **list** of structured rows. Quill does not yet provide a general-purpose deep-nesting field type, so `type: object` is currently scoped to `array.items` rather than standalone top-level fields.
 
 ### Enum Constraints
 


### PR DESCRIPTION
### Motivation
- Align the frontmatter authoring guide with the actual `Quill.yaml` behavior so authors are not misled into modeling top-level `object` fields that the schema system does not support.

### Description
- Add a warning callout to `docs/authoring/yaml-frontmatter.md` immediately after the object/nested examples that states YAML objects are syntactically valid but that Quill currently only supports `type: object` inside `array.items`, and link to `docs/format-designer/quill-yaml-reference.md#field-types` for the authoritative restriction.

### Testing
- Docs-only change; no automated tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41aebbd1483238dbc9674a28dcff6)