### PR TITLE
Allow leading underscores for card type names across config/docs

### DIFF
--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -608,6 +608,16 @@ impl QuillConfig {
         chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
     }
 
+    fn is_valid_card_identifier(name: &str) -> bool {
+        let mut chars = name.chars();
+        match chars.next() {
+            Some(c) if c.is_ascii_lowercase() || c == '_' => {}
+            _ => return false,
+        }
+
+        chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    }
+
     fn is_valid_quill_name(name: &str) -> bool {
         name == "__default__" || Self::is_snake_case_identifier(name)
     }
@@ -790,9 +800,9 @@ impl QuillConfig {
                 .ok_or("'cards' section must be an object")?;
 
             for (card_name, card_value) in cards_table {
-                if !Self::is_snake_case_identifier(card_name) {
+                if !Self::is_valid_card_identifier(card_name) {
                     return Err(format!(
-                        "Invalid card name '{}': card names must be snake_case (lowercase letters, digits, and underscores only).",
+                        "Invalid card name '{}': card names must match [a-z_][a-z0-9_]* (lowercase letters, digits, and underscores only).",
                         card_name
                     )
                     .into());

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1000,7 +1000,27 @@ cards:
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("BadCard"));
-    assert!(err.contains("snake_case"));
+    assert!(err.contains("[a-z_][a-z0-9_]*"));
+}
+
+#[test]
+fn test_quill_config_accepts_leading_underscore_card_name() {
+    let yaml = r#"
+Quill:
+  name: good_quill
+  version: "1.0"
+  backend: typst
+  description: Leading underscore card name
+
+cards:
+  _private_card:
+    fields:
+      title:
+        type: string
+"#;
+
+    let result = QuillConfig::from_yaml(yaml);
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -41,6 +41,7 @@ All card blocks are collected into the `CARDS` array.
 - `BODY` and `CARDS` are reserved names.
 - `QUILL` cannot appear in card blocks.
 - Use `***` or `___` for horizontal rules in body content; `---` is reserved for metadata delimiters.
+- Invalid card-name examples: `BadCard`, `my-card`, `2nd_card`.
 
 ## Card Body Content
 

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -240,7 +240,7 @@ main:
 
 Cards define composable, repeatable content blocks. A document can have zero or more instances of each card type, interleaved with body content.
 
-Card type names (the keys under `cards`) must be `snake_case` (`^[a-z][a-z0-9_]*$`).
+Card type names (the keys under `cards`) must match `[a-z_][a-z0-9_]*` (leading underscore is allowed).
 
 ```yaml
 cards:
@@ -257,6 +257,12 @@ cards:
         enum: [standard, informal, separate_page]
         default: standard
 ```
+
+Invalid card names include:
+
+- `BadCard` (uppercase letters)
+- `my-card` (hyphen)
+- `2nd_card` (starts with a digit)
 
 ### Card Properties
 


### PR DESCRIPTION
### Motivation

- Card naming was inconsistent: parser and Markdown docs allowed leading `_` but `Quill.yaml` validation forbade it, which could let a document parse but then prevent defining matching card schemas. 
- Allowing a leading underscore is useful for private/internal card types and is low-risk because reserved/system keys are capitalized (e.g., `BODY`, `CARDS`). 
- The intent is to pick a single convention (`[a-z_][a-z0-9_]*`) and enforce it across config and docs to remove author confusion. 

### Description

- Added a dedicated validator `is_valid_card_identifier` that accepts names matching `[a-z_][a-z0-9_]*` and updated the `cards` validation to use it instead of the stricter `is_snake_case_identifier`. 
- Updated the validation error text to explicitly mention the allowed pattern ` [a-z_][a-z0-9_]*`. 
- Added a unit test `test_quill_config_accepts_leading_underscore_card_name` and adjusted an existing test to assert the new error message. 
- Aligned documentation in `docs/format-designer/quill-yaml-reference.md` and `docs/authoring/cards.md` to state the new pattern and added explicit invalid examples. 

### Testing

- Ran `cargo test -p quillmark-core quill_config_` which executed the quill config unit tests and completed successfully (`16 passed; 0 failed`). 
- An earlier attempt to run two named tests in one `cargo test` invocation failed due to incorrect argument usage of `cargo`, not due to code failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41b3558c08323a92f6272ad6c9b5b)