### PR TITLE
Refactor render API: move rendering to Quill, deprecate engine.render()

### DIFF
--- a/crates/bindings/python/tests/test_render.py
+++ b/crates/bindings/python/tests/test_render.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from quillmark import OutputFormat, ParsedDocument, Quill, Quillmark
+from quillmark import OutputFormat, ParsedDocument, Quill, Quillmark, QuillmarkError
 
 
 def test_save_artifact(taro_quill_dir, taro_md, tmp_path):
@@ -19,3 +19,80 @@ def test_save_artifact(taro_quill_dir, taro_md, tmp_path):
 
     assert output_path.exists()
     assert output_path.stat().st_size > 0
+
+
+def test_quill_render_from_markdown_string(taro_quill_dir, taro_md):
+    """quill.render(str) parses internally and produces artifacts."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+
+    result = quill.render(taro_md)
+
+    assert len(result.artifacts) > 0
+    assert len(result.artifacts[0].bytes) > 0
+
+
+def test_quill_render_from_parsed_document(taro_quill_dir, taro_md):
+    """quill.render(ParsedDocument) accepts a pre-parsed document."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+    parsed = ParsedDocument.from_markdown(taro_md)
+
+    result = quill.render(parsed)
+
+    assert len(result.artifacts) > 0
+    assert len(result.artifacts[0].bytes) > 0
+
+
+def test_quill_render_with_explicit_format(taro_quill_dir, taro_md):
+    """quill.render() honours an explicit OutputFormat argument."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+
+    result = quill.render(taro_md, OutputFormat.SVG)
+
+    assert len(result.artifacts) > 0
+    assert result.output_format == OutputFormat.SVG
+
+
+def test_quill_render_ref_mismatch_warning(taro_quill_dir):
+    """Rendering a ParsedDocument with a mismatched QUILL ref emits a warning."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+
+    # Build a document that names a different quill
+    mismatch_md = (
+        "---\n"
+        "QUILL: completely_different_quill\n"
+        "author: Test Author\n"
+        "ice_cream: Chocolate\n"
+        "title: Mismatch Test\n"
+        "---\n\nContent.\n"
+    )
+    parsed = ParsedDocument.from_markdown(mismatch_md)
+    result = quill.render(parsed)
+
+    codes = [w.code for w in result.warnings]
+    assert "quill::ref_mismatch" in codes, f"expected ref_mismatch warning, got: {codes}"
+    assert len(result.artifacts) > 0, "artifact must still be produced"
+
+
+def test_quill_render_no_backend_raises(taro_quill_dir, taro_md):
+    """Quill.from_path() has no backend; calling render() on it must raise."""
+    quill = Quill.from_path(str(taro_quill_dir))
+
+    with pytest.raises(QuillmarkError):
+        quill.render(taro_md)
+
+
+def test_engine_workflow_still_works(taro_quill_dir, taro_md):
+    """engine.workflow(quill) remains the correct path for dynamic-asset renders."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+    workflow = engine.workflow(quill)
+
+    parsed = ParsedDocument.from_markdown(taro_md)
+    result = workflow.render(parsed, OutputFormat.PDF)
+
+    assert len(result.artifacts) > 0
+    assert result.output_format == OutputFormat.PDF

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1,20 +1,17 @@
 /**
- * Minimal smoke tests for quillmark-wasm
- * 
- * These tests validate the core WASM API functionality:
- * - Parse markdown with YAML frontmatter
- * - Register Quill templates
- * - Get Quill information
- * - Render documents to PDF
- * - Basic error handling
- * 
+ * Smoke tests for quillmark-wasm — new Quill.render() API
+ *
+ * These tests cover the canonical flow introduced by the render API overhaul:
+ *   engine.quillFromTree(tree) → quill.render(markdown, opts)
+ *
  * Setup: Tests use the bundler build via @quillmark-wasm alias (see vitest.config.js)
  */
 
-import { describe, it, expect } from 'vitest'
-import { Quill, Quillmark } from '@quillmark-wasm'
+import { describe, it, expect, vi } from 'vitest'
+import { Quill, Quillmark, ParsedDocument } from '@quillmark-wasm'
 import { makeQuill } from './test-helpers.js'
 
+const enc = new TextEncoder()
 const TEST_MARKDOWN = `---
 title: Test Document
 author: Test Author
@@ -25,7 +22,6 @@ QUILL: test_quill
 
 This is a test document.`
 
-const enc = new TextEncoder()
 const TEST_PLATE = `#import "@local/quillmark-helper:0.1.0": data
 #let title = data.title
 #let body = data.BODY
@@ -37,6 +33,10 @@ const TEST_PLATE = `#import "@local/quillmark-helper:0.1.0": data
 function textBytes(str) {
   return enc.encode(str)
 }
+
+// ---------------------------------------------------------------------------
+// Quill.fromTree (static, no backend)
+// ---------------------------------------------------------------------------
 
 describe('Quill.fromTree', () => {
   it('should build a Quill from a Map<string, Uint8Array>', () => {
@@ -67,23 +67,6 @@ describe('Quill.fromTree', () => {
     expect(quill).toBeDefined()
   })
 
-  it('should register a fromTree Quill with the engine', () => {
-    const engine = new Quillmark()
-    const quill = Quill.fromTree(makeQuill({ name: 'tree_quill', version: '2.0.0' }))
-    engine.registerQuill(quill)
-    expect(engine.listQuills()).toContain('tree_quill@2.0.0')
-  })
-
-  it('should allow the same Quill handle to register with multiple engines', () => {
-    const quill = Quill.fromTree(makeQuill({ name: 'shared_quill', version: '1.0.0' }))
-    const engine1 = new Quillmark()
-    const engine2 = new Quillmark()
-    engine1.registerQuill(quill)
-    engine2.registerQuill(quill)
-    expect(engine1.listQuills()).toContain('shared_quill@1.0.0')
-    expect(engine2.listQuills()).toContain('shared_quill@1.0.0')
-  })
-
   it('should throw on null/undefined input', () => {
     expect(() => Quill.fromTree(null)).toThrow()
     expect(() => Quill.fromTree(undefined)).toThrow()
@@ -102,98 +85,89 @@ describe('Quill.fromTree', () => {
     ])
     expect(() => Quill.fromTree(tree)).toThrow()
   })
+
+  it('should error on render when no backend is attached', () => {
+    // Quill.fromTree produces a quill with no backend — render must fail
+    const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    expect(() => quill.render(TEST_MARKDOWN, { format: 'pdf' })).toThrow()
+  })
 })
 
-describe('quillmark-wasm smoke tests', () => {
-  it('should parse markdown with YAML frontmatter', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
+// ---------------------------------------------------------------------------
+// engine.quillFromTree — factory path (attaches backend)
+// ---------------------------------------------------------------------------
 
-    expect(parsed).toBeDefined()
-    expect(parsed.fields).toBeDefined()
-
-    // fields should be a plain object, not a Map
-    expect(parsed.fields instanceof Map).toBe(false)
-    expect(parsed.fields instanceof Object).toBe(true)
-    expect(parsed.fields.title).toBe('Test Document')
-    expect(parsed.fields.author).toBe('Test Author')
-    expect(parsed.quillRef).toBe('test_quill')
+describe('Quillmark.quillFromTree', () => {
+  it('should return a render-ready Quill', () => {
+    const engine = new Quillmark()
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    expect(quill).toBeDefined()
   })
 
-  it('should create engine and register quill', () => {
+  it('should render markdown to PDF via quill.render(string)', () => {
     const engine = new Quillmark()
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
 
-    expect(() => {
-      engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-    }).not.toThrow()
+    const result = quill.render(TEST_MARKDOWN, { format: 'pdf' })
 
-    const quills = engine.listQuills()
-    expect(quills).toContain('test_quill@1.0.0')
-  })
-
-  it('should get quill info after registration', () => {
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    const info = engine.getQuillInfo('test_quill')
-
-    expect(info).toBeDefined()
-    expect(info.name).toBe('test_quill')
-    expect(info.backend).toBe('typst')
-    expect(info.supportedFormats).toContain('pdf')
-
-    // metadata should be a plain object and schema should be YAML text
-    expect(info.metadata instanceof Map).toBe(false)
-    expect(info.metadata instanceof Object).toBe(true)
-    expect(typeof info.schema).toBe('string')
-  })
-
-
-
-
-
-
-
-  it('should compile data to JSON', () => {
-    // Verify that we can extract the intermediate JSON data
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    const jsonData = engine.compileData(TEST_MARKDOWN)
-
-    expect(jsonData).toBeDefined()
-    expect(jsonData.title).toBe('Test Document')
-    expect(jsonData.author).toBe('Test Author')
-  })
-
-  it('should complete full workflow: parse → register → render', () => {
-    // Step 1: Parse markdown
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
-    expect(parsed).toBeDefined()
-
-    // Step 2: Create engine and register quill
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    // Step 3: Get quill info
-    const info = engine.getQuillInfo('test_quill')
-    expect(info.supportedFormats).toContain('pdf')
-
-    // Step 4: Render to PDF
-    const result = engine.render(parsed, { format: 'pdf' })
     expect(result).toBeDefined()
     expect(result.artifacts).toBeDefined()
     expect(result.artifacts.length).toBeGreaterThan(0)
-    expect(result.artifacts[0].bytes).toBeDefined()
     expect(result.artifacts[0].bytes.length).toBeGreaterThan(0)
     expect(result.artifacts[0].mimeType).toBe('application/pdf')
   })
 
-  it('should support compile + renderPages with pageCount', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
+  it('should render markdown to SVG via quill.render(string)', () => {
     const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
 
-    const compiled = engine.compile(parsed)
+    const result = quill.render(TEST_MARKDOWN, { format: 'svg' })
+
+    expect(result.artifacts.length).toBeGreaterThan(0)
+    expect(result.artifacts[0].mimeType).toBe('image/svg+xml')
+  })
+
+  it('should render a ParsedDocument via quill.render(ParsedDocument)', () => {
+    const engine = new Quillmark()
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const parsed = ParsedDocument.fromMarkdown(TEST_MARKDOWN)
+
+    const result = quill.render(parsed, { format: 'pdf' })
+
+    expect(result.artifacts.length).toBeGreaterThan(0)
+    expect(result.artifacts[0].mimeType).toBe('application/pdf')
+  })
+
+  it('should emit a quill::ref_mismatch warning when ParsedDocument QUILL differs from quill name', () => {
+    const engine = new Quillmark()
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+
+    // Document declares a different quill name
+    const otherMarkdown = `---
+title: Mismatch Test
+QUILL: other_quill
+---
+
+# Content`
+    const parsed = ParsedDocument.fromMarkdown(otherMarkdown)
+    const result = quill.render(parsed, { format: 'pdf' })
+
+    expect(result.warnings.length).toBe(1)
+    expect(result.warnings[0].code).toBe('quill::ref_mismatch')
+    expect(result.artifacts.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// compile + renderPages
+// ---------------------------------------------------------------------------
+
+describe('quill.compile + renderPages', () => {
+  it('should support compile + renderPages with pageCount', () => {
+    const engine = new Quillmark()
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+
+    const compiled = quill.compile(TEST_MARKDOWN)
     expect(typeof compiled.pageCount).toBe('number')
     expect(compiled.pageCount).toBeGreaterThan(0)
 
@@ -207,11 +181,9 @@ describe('quillmark-wasm smoke tests', () => {
   })
 
   it('should warn and skip out-of-bounds page indices', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    const compiled = engine.compile(parsed)
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const compiled = quill.compile(TEST_MARKDOWN)
     const oob = compiled.pageCount + 10
 
     const result = compiled.renderPages([0, oob], { format: 'png', ppi: 80 })
@@ -221,26 +193,34 @@ describe('quillmark-wasm smoke tests', () => {
   })
 
   it('should error when requesting page selection with PDF', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
     const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    const compiled = engine.compile(parsed)
+    const quill = engine.quillFromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const compiled = quill.compile(TEST_MARKDOWN)
 
     expect(() => {
       compiled.renderPages([0], { format: 'pdf' })
     }).toThrow()
   })
+})
 
-  it('should handle error: unregistered quill', () => {
-    const engine = new Quillmark()
+// ---------------------------------------------------------------------------
+// ParsedDocument.fromMarkdown (standalone static)
+// ---------------------------------------------------------------------------
 
-    expect(() => {
-      engine.getQuillInfo('nonexistent_quill')
-    }).toThrow()
+describe('ParsedDocument.fromMarkdown', () => {
+  it('should parse markdown with YAML frontmatter as a standalone static call', () => {
+    const parsed = ParsedDocument.fromMarkdown(TEST_MARKDOWN)
+
+    expect(parsed).toBeDefined()
+    expect(parsed.fields).toBeDefined()
+    expect(parsed.fields instanceof Map).toBe(false)
+    expect(parsed.fields instanceof Object).toBe(true)
+    expect(parsed.fields.title).toBe('Test Document')
+    expect(parsed.fields.author).toBe('Test Author')
+    expect(parsed.quillRef).toBe('test_quill')
   })
 
-  it('should handle error: invalid markdown', () => {
+  it('should throw on invalid YAML frontmatter', () => {
     const badMarkdown = `---
 title: Test
 QUILL: test_quill
@@ -250,99 +230,11 @@ this is not valid yaml
 # Content`
 
     expect(() => {
-      Quillmark.parseMarkdown(badMarkdown)
+      ParsedDocument.fromMarkdown(badMarkdown)
     }).toThrow()
   })
 
-  it('should handle error: render without quill registration', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
-    const engine = new Quillmark()
-    // Don't register the quill
-
-    expect(() => {
-      engine.render(parsed, { format: 'pdf' })
-    }).toThrow()
-  })
-
-  it('should render to SVG format', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    const result = engine.render(parsed, { format: 'svg' })
-
-    expect(result).toBeDefined()
-    expect(result.artifacts).toBeDefined()
-    expect(result.artifacts.length).toBeGreaterThan(0)
-    expect(result.artifacts[0].mimeType).toBe('image/svg+xml')
-  })
-
-  it('should unregister quill', () => {
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    expect(engine.listQuills()).toContain('test_quill@1.0.0')
-
-    engine.unregisterQuill('test_quill')
-
-    expect(engine.listQuills()).not.toContain('test_quill@1.0')
-  })
-
-  it('should accept assets as plain JavaScript objects', () => {
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-
-    // Assets should be passed as plain JavaScript objects with byte arrays
-    const assets = {
-      'logo.png': [137, 80, 78, 71],
-      'font.ttf': [0, 1, 2, 3]
-    }
-
-    // This should not throw - assets is a plain object
-    const result = engine.render(parsed, {
-      format: 'pdf',
-      assets: assets
-    })
-
-    expect(result).toBeDefined()
-    expect(result.artifacts).toBeDefined()
-  })
-
-  it('should return all data as plain objects (comprehensive test)', () => {
-    // Step 1: Parse markdown - fields should be plain object
-    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
-    expect(parsed.fields instanceof Map).toBe(false)
-    expect(parsed.fields instanceof Object).toBe(true)
-    expect(parsed.fields.title).toBe('Test Document')
-    expect(parsed.fields.author).toBe('Test Author')
-
-    // Step 2: Register and get quill info - metadata is object, schema is YAML text
-    const engine = new Quillmark()
-    engine.registerQuill(Quill.fromTree(makeQuill({ plate: TEST_PLATE })))
-    const info = engine.getQuillInfo('test_quill')
-
-    expect(info.metadata instanceof Map).toBe(false)
-    expect(info.metadata instanceof Object).toBe(true)
-    expect(info.metadata.backend).toBe('typst')
-    expect(typeof info.schema).toBe('string')
-
-    // Step 3: Render with assets as plain object
-    const result = engine.render(parsed, {
-      format: 'pdf',
-      assets: {
-        'test.txt': [72, 101, 108, 108, 111]
-      }
-    })
-
-    expect(result).toBeDefined()
-    expect(result.artifacts).toBeDefined()
-    expect(Array.isArray(result.warnings)).toBe(true)
-    expect(typeof result.renderTimeMs).toBe('number')
-  })
-
-  it('should throw when QUILL tag is not specified', () => {
-    // Markdown without QUILL: tag
+  it('should throw when QUILL field is absent', () => {
     const markdownWithoutQuill = `---
 title: Default Test
 author: Test Author
@@ -353,7 +245,28 @@ author: Test Author
 This document has no QUILL tag.`
 
     expect(() => {
-      Quillmark.parseMarkdown(markdownWithoutQuill)
+      ParsedDocument.fromMarkdown(markdownWithoutQuill)
     }).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Deprecated Quillmark.parseMarkdown wrapper
+// ---------------------------------------------------------------------------
+
+describe('Quillmark.parseMarkdown (deprecated)', () => {
+  it('should still parse markdown and emit a console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+
+    const parsed = Quillmark.parseMarkdown(TEST_MARKDOWN)
+
+    expect(parsed).toBeDefined()
+    expect(parsed.fields.title).toBe('Test Document')
+    expect(parsed.quillRef).toBe('test_quill')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('deprecated')
+    )
+
+    warnSpy.mockRestore()
   })
 })

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -10,6 +10,12 @@ use std::str::FromStr;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn console_warn(s: &str);
+}
+
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
     {
@@ -65,6 +71,9 @@ impl Quillmark {
     /// @deprecated Use `ParsedDocument.fromMarkdown()` instead.
     #[wasm_bindgen(js_name = parseMarkdown)]
     pub fn parse_markdown(markdown: &str) -> Result<ParsedDocument, JsValue> {
+        console_warn(
+            "[quillmark] Quillmark.parseMarkdown() is deprecated; use ParsedDocument.fromMarkdown() instead",
+        );
         parse_markdown_impl(markdown)
     }
 

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -1,6 +1,7 @@
+use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
-use quillmark_wasm::{Quill, Quillmark};
+use quillmark_wasm::{ParsedDocument, Quill, Quillmark, RenderOptions};
 
 mod common;
 
@@ -15,6 +16,8 @@ fn small_quill_tree() -> wasm_bindgen::JsValue {
         ("plate.typ", b"= Title\n\nThis is a test."),
     ])
 }
+
+const SIMPLE_MARKDOWN: &str = "---\nQUILL: test_quill\ntitle: Hello\n---\n\n# Hello\n";
 
 #[wasm_bindgen_test]
 fn test_parse_markdown() {
@@ -33,9 +36,7 @@ QUILL: test_quill
 
 #[wasm_bindgen_test]
 fn test_parse_markdown_static() {
-    use quillmark_wasm::ParsedDocument;
-    let markdown = "---\nQUILL: test_quill\ntitle: Hello\n---\n\n# Hello\n";
-    let parsed = ParsedDocument::from_markdown(markdown).expect("fromMarkdown failed");
+    let parsed = ParsedDocument::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     assert_eq!(parsed.quill_ref, "test_quill");
 }
 
@@ -43,7 +44,6 @@ fn test_parse_markdown_static() {
 fn test_quill_from_tree() {
     let engine = Quillmark::new();
     let quill = engine.quill_from_tree(small_quill_tree()).expect("quillFromTree failed");
-    // Quill should be render-ready after quillFromTree
     let _ = quill;
 }
 
@@ -51,4 +51,65 @@ fn test_quill_from_tree() {
 fn test_quill_from_tree_static() {
     let quill = Quill::from_tree(small_quill_tree()).expect("fromTree failed");
     let _ = quill;
+}
+
+/// A quill built via `Quill::from_tree` has no backend attached and must error on render.
+#[wasm_bindgen_test]
+fn test_render_no_backend_errors() {
+    let quill = Quill::from_tree(small_quill_tree()).expect("fromTree failed");
+    let result = quill.render(JsValue::from_str(SIMPLE_MARKDOWN), RenderOptions::default());
+    assert!(result.is_err(), "render without backend should return Err");
+}
+
+/// Rendering markdown with a QUILL ref that differs from the quill name must yield
+/// exactly one warning with code `quill::ref_mismatch` and still produce an artifact.
+#[wasm_bindgen_test]
+fn test_render_ref_mismatch_warning() {
+    let engine = Quillmark::new();
+    let quill = engine.quill_from_tree(small_quill_tree()).expect("quillFromTree failed");
+
+    // Document declares a different quill name than the loaded quill ("test_quill")
+    let mismatch_md = "---\nQUILL: other_quill\ntitle: Mismatch\n---\n\n# Content\n";
+    let result = quill
+        .render(JsValue::from_str(mismatch_md), RenderOptions::default())
+        .expect("render should succeed despite mismatch");
+
+    assert_eq!(result.warnings.len(), 1, "expected exactly one warning");
+    assert_eq!(
+        result.warnings[0].code.as_deref(),
+        Some("quill::ref_mismatch"),
+        "warning code should be quill::ref_mismatch"
+    );
+    assert!(!result.artifacts.is_empty(), "artifact must be produced");
+}
+
+/// `quill.render(markdown_string, opts)` — render via raw Markdown string input.
+#[wasm_bindgen_test]
+fn test_render_from_string() {
+    let engine = Quillmark::new();
+    let quill = engine.quill_from_tree(small_quill_tree()).expect("quillFromTree failed");
+
+    let result = quill
+        .render(JsValue::from_str(SIMPLE_MARKDOWN), RenderOptions::default())
+        .expect("render from string failed");
+
+    assert!(!result.artifacts.is_empty(), "should produce at least one artifact");
+    assert_eq!(result.warnings.len(), 0, "no warnings expected for matching quill_ref");
+}
+
+/// `quill.render(ParsedDocument, opts)` — render via pre-parsed document.
+#[wasm_bindgen_test]
+fn test_render_from_parsed_document() {
+    let engine = Quillmark::new();
+    let quill = engine.quill_from_tree(small_quill_tree()).expect("quillFromTree failed");
+
+    let parsed = ParsedDocument::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    // Convert to JsValue so the engine's input-type dispatch treats it as ParsedDocument
+    let parsed_js = serde_wasm_bindgen::to_value(&parsed).expect("ParsedDocument serialization failed");
+
+    let result = quill
+        .render(parsed_js, RenderOptions::default())
+        .expect("render from ParsedDocument failed");
+
+    assert!(!result.artifacts.is_empty(), "should produce at least one artifact");
 }


### PR DESCRIPTION
## Summary

This PR overhauls the render API to make `Quill.render()` the canonical rendering path, moving rendering responsibility from the engine to individual quill instances. The old `engine.render(ParsedDocument)` workflow is replaced with `quill.render(markdown | ParsedDocument)`, and `Quillmark.parseMarkdown()` is deprecated in favor of `ParsedDocument.fromMarkdown()`.

## Key Changes

- **New render API**: `quill.render(input, options)` now accepts either a markdown string or a `ParsedDocument` object, with the quill handling all rendering logic
- **Backend attachment**: `engine.quillFromTree()` now returns a render-ready quill with backend attached, while `Quill.fromTree()` remains a static factory with no backend
- **Deprecation**: `Quillmark.parseMarkdown()` now emits a deprecation warning and delegates to `ParsedDocument.fromMarkdown()`
- **Standalone parsing**: `ParsedDocument.fromMarkdown()` is now the canonical static entry point for parsing markdown with YAML frontmatter
- **Ref mismatch handling**: Rendering a `ParsedDocument` with a mismatched `QUILL` field now emits a `quill::ref_mismatch` warning instead of failing
- **Error handling**: Calling `render()` on a quill without a backend (from `Quill.fromTree()`) now throws an error

## Implementation Details

- Test suite reorganized into logical sections: `Quill.fromTree`, `engine.quillFromTree`, `compile + renderPages`, and `ParsedDocument.fromMarkdown`
- Python bindings updated with new `quill.render()` methods supporting both string and `ParsedDocument` inputs
- WASM bindings include new render tests covering string input, `ParsedDocument` input, and ref mismatch warnings
- Console deprecation warning added to `Quillmark.parseMarkdown()` via `console.warn()`
- Old engine-based workflow tests removed in favor of quill-centric tests

https://claude.ai/code/session_01T45h4wRsJ58jqqe3umnZUS