### PR TITLE
Bump wasm-bindgen-cli to 0.2.118 to match Cargo.lock

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         uses: taiki-e/install-action@v2
         with:
-          tool: wasm-bindgen-cli@0.2.117
+          tool: wasm-bindgen-cli@0.2.118
 
       - name: Build WASM packages
         run: ./scripts/build-wasm.sh

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 # Check for required tools
 if ! command -v wasm-bindgen &> /dev/null; then
     echo "wasm-bindgen not found. Install it with:"
-    echo "  cargo install wasm-bindgen-cli --version 0.2.117"
+    echo "  cargo install wasm-bindgen-cli --version 0.2.118"
     exit 1
 fi
 


### PR DESCRIPTION
The WASM publish workflow pinned wasm-bindgen-cli@0.2.117 while
Cargo.lock resolves wasm-bindgen to 0.2.118, causing a schema version
mismatch when generating JS bindings.