### PR TITLE
Comprehensive API documentation and design specification updates

### DIFF
--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -8,6 +8,7 @@ Use metadata blocks with a `CARD` key:
 
 ```markdown
 ---
+QUILL: my_quill@1.0
 title: Main Document
 ---
 

--- a/docs/authoring/markdown-syntax.md
+++ b/docs/authoring/markdown-syntax.md
@@ -1,6 +1,6 @@
 # Markdown Syntax
 
-Quillmark supports standard CommonMark syntax for document content.
+Quillmark supports a subset of CommonMark for document body content. The sections below cover what is supported; anything not listed (blockquotes, images, thematic breaks, raw HTML, math) is silently dropped.
 
 ## Your First Document
 
@@ -40,6 +40,7 @@ Use this as a base, then layer in the syntax patterns below.
 *Italic text*
 ***Bold and italic***
 ~~Strikethrough~~
+__Underline__
 `Inline code`
 ```
 
@@ -78,28 +79,36 @@ can be placed inside fenced blocks.
 ```
 ````
 
-## Blockquotes
+## Tables
 
 ```markdown
-> This is a blockquote
-> It can span multiple lines
+| Name    | Role      |
+| ------- | --------- |
+| Alice   | Engineer  |
+| Bob     | Designer  |
 ```
 
-## Horizontal Rules
+Column alignment is supported with `:` in the separator row.
 
-Use either:
+## Line Breaks
+
+Use `<br>` for a hard line break within a paragraph or table cell:
 
 ```markdown
-***
+First line<br>Second line
 ```
 
-or:
+## Not Supported
 
-```markdown
-___
-```
+The following are silently dropped and will not appear in rendered output:
 
-The `---` syntax is reserved for metadata delimiters, so it cannot be used as a horizontal rule in Quillmark documents.
+- Blockquotes (`>`)
+- Images (`![alt](src)`)
+- Thematic breaks (`***`, `___`)
+- Raw HTML (other than `<br>`)
+- Math and footnotes
+
+The `---` syntax is always reserved for metadata delimiters and cannot be used as a thematic break.
 
 ## Next Steps
 

--- a/docs/authoring/yaml-frontmatter.md
+++ b/docs/authoring/yaml-frontmatter.md
@@ -1,11 +1,12 @@
 # YAML Frontmatter
 
-Quillmark documents begin with YAML frontmatter delimited by `---` markers:
+Quillmark documents begin with a YAML frontmatter block delimited by `---` markers. The `QUILL` key is required and names the format used to render the document.
 
 ```markdown
 ---
+QUILL: my_format
 title: My Document
-author: John Doe
+author: Jane Doe
 date: 2025-01-15
 tags: ["important", "draft"]
 ---
@@ -13,9 +14,39 @@ tags: ["important", "draft"]
 # Document content starts here
 ```
 
-## Frontmatter Data Types
+## QUILL Key
 
-YAML supports various data types:
+`QUILL` must appear in the first (global) frontmatter block. If it is missing, parsing fails.
+
+```markdown
+---
+QUILL: my_format
+title: Document Title
+---
+```
+
+### Version Selectors
+
+Pin a specific version with `@version` syntax:
+
+```markdown
+---
+QUILL: my_format@2.1
+title: Document Title
+---
+```
+
+| Syntax | Meaning |
+|--------|---------|
+| `format` | Latest version (default) |
+| `format@latest` | Latest version (explicit) |
+| `format@2` | Latest 2.x.x |
+| `format@2.1` | Latest 2.1.x |
+| `format@2.1.0` | Exact version 2.1.0 |
+
+Quill names must match `[a-z_][a-z0-9_]*` (lowercase letters, digits, and underscores; starts with a letter or underscore).
+
+## Frontmatter Data Types
 
 **Strings:**
 ```yaml
@@ -54,67 +85,39 @@ author:
   email: john@example.com
 ```
 
-**Nested Structures:**
-```yaml
-document:
-  metadata:
-    title: Complex Doc
-    version: 1.0
-  settings:
-    page_size: A4
-    margins: [1, 1, 1, 1]
-```
-
 > [!WARNING]
-> YAML objects and nested structures are syntactically valid in frontmatter. However, Quill’s schema system does not yet provide a general-purpose deep-nesting field type. As a current product-scoping decision, `type: object` is only supported for structured rows inside `array.items` (not as standalone top-level fields). See [Quill.yaml Reference: Field Types](../format-designer/quill-yaml-reference.md#field-types).
+> YAML objects and nested structures are syntactically valid in frontmatter. However, Quill's schema system does not yet provide a general-purpose deep-nesting field type. As a current product-scoping decision, `type: object` is only supported for structured rows inside `array.items` (not as standalone top-level fields). See [Quill.yaml Reference: Field Types](../format-designer/quill-yaml-reference.md#field-types).
 
-## QUILL Key
+## Reserved Field Names
 
-The `QUILL` key specifies which Quill format to use for rendering:
+`BODY` and `CARDS` are reserved and cannot be used in frontmatter — the parser rejects documents that include them. `BODY` holds the document's Markdown body; `CARDS` holds the array of card blocks.
 
-```markdown
----
-QUILL: my-custom-format
-title: Document Title
-author: Jane Doe
----
-
-# Content
-```
-
-`QUILL` is required in top-level frontmatter. If it is missing, parsing fails with an invalid-structure error.
-
-### Version Selectors
-
-You can pin a specific version of a Quill format using `@version` syntax:
-
-```markdown
----
-QUILL: my-format@2.1
-title: Document Title
----
-```
-
-Supported version selectors:
-
-| Syntax | Meaning |
-|--------|---------|
-| `format` | Latest version (default) |
-| `format@latest` | Latest version (explicit) |
-| `format@2` | Latest 2.x.x |
-| `format@2.1` | Latest 2.1.x |
-| `format@2.1.0` | Exact version 2.1.0 |
-
-## Frontmatter Rules
+## Rules Summary
 
 - `QUILL` can only appear in the first (global) metadata block.
-- `BODY` and `CARDS` are reserved field names and cannot be used in frontmatter.
-- A document can only have one global metadata block.
-- The body content is stored in the special `BODY` field.
+- `QUILL` and `CARD` cannot both appear in the same block.
+- A document can have only one global metadata block.
+- All metadata blocks after the first must carry a `CARD` directive (see below).
+
+## Card Blocks
+
+Additional `---`-delimited blocks embedded in the document body are **card blocks**. Each must declare `CARD: <type>`, where `<type>` matches `[a-z_][a-z0-9_]*`. All card blocks are collected into the `CARDS` array available to templates.
+
+```markdown
+---
+CARD: indorsement
+from: ORG/SYMBOL
+for: ORG2/SYMBOL
+---
+
+Indorsement body text here.
+```
+
+See [CARDS.md](../../prose/designs/CARDS.md) for the full card architecture.
 
 ## Validation
 
-Frontmatter is validated against native schema rules defined in your Quill's `Quill.yaml`:
+Frontmatter is validated against the schema defined in your Quill's `Quill.yaml`:
 
 ```yaml
 main:
@@ -131,7 +134,4 @@ main:
       type: string
 ```
 
-When validation is enabled, the parser checks:
-- Required fields are present
-- Field types match the schema
-- Values meet constraints
+When validation runs, the parser checks that required fields are present, field types match the schema, and values meet any constraints.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -29,7 +29,7 @@ quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
 
 - `-o <PATH>` / `--output <PATH>`: Output file path (default: derived from input filename, e.g. `input.pdf`)
 - `-f <FORMAT>` / `--format <FORMAT>`: Output format: `pdf`, `svg`, `png`, `txt` (default: `pdf`)
-- `--output-data <DATA_FILE>`: Write compiled JSON data (after coercion/defaults/transform_fields) to a file
+- `--output-data <DATA_FILE>`: Write compiled JSON data to a file
 - `-v` / `--verbose`: Show detailed processing information
 - `--quiet`: Suppress all non-error output
 - `--stdout`: Write output to stdout instead of file

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -19,12 +19,12 @@ Create a minimal but complete config:
 
 ```yaml
 Quill:
-  name: my-quill
+  name: my_quill
   backend: typst
+  version: "1.0.0"
   description: A simple letter format
   plate_file: plate.typ
   example_file: example.md
-  version: "1.0.0"
 
 main:
   fields:
@@ -39,7 +39,7 @@ main:
       description: Letter date
 ```
 
-Define your document's expected frontmatter fields under `main.fields`. Each field has a `type`, optional `default`, `description`, and validation constraints. Use `integer` for whole numbers only and `number` for values that may include decimals. For the full list of field types, UI hints, typed arrays, and enum constraints, see the [Quill.yaml Reference](quill-yaml-reference.md).
+`name`, `backend`, `version`, and `description` are all required. `name` must be `snake_case`. Define your document's expected frontmatter fields under `main.fields`. Each field has a `type`, optional `default`, `description`, and validation constraints. Use `integer` for whole numbers only and `number` for values that may include decimals. For the full list of field types, UI hints, typed arrays, and enum constraints, see the [Quill.yaml Reference](quill-yaml-reference.md).
 
 ## 3. Write `plate.typ`
 
@@ -88,6 +88,8 @@ For command options and output controls, see the [CLI Reference](../cli/referenc
 
 ## 6. Next steps
 
-- [Quill.yaml Reference](quill-yaml-reference.md)
-- [Typst Backend](typst-backend.md)
+- [Quill.yaml Reference](quill-yaml-reference.md) — full field types, UI hints, `cards`, `typst` section
+- [Typst Backend](typst-backend.md) — data access patterns, CARDS iteration, helper package
 - [Quill Versioning](versioning.md)
+
+**Tip:** To exclude files (fonts, build artifacts) from the bundle when loading from disk, add a `.quillignore` file at the bundle root using gitignore syntax.

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -105,7 +105,7 @@ main:
 
 | Type       | Notes |
 |------------|-------|
-| `string`   | Also accepts `str` as alias |
+| `string`   | UTF-8 text |
 | `number`   | Numeric scalar (integers and decimals) |
 | `integer`  | Integer-only numeric scalar |
 | `boolean`  | `true` or `false` |
@@ -113,7 +113,7 @@ main:
 | `date`     | YYYY-MM-DD |
 | `datetime`  | ISO 8601 |
 | `markdown` | Rich text; backends convert to target format |
-| `object` or `dict` | Supported for typed table rows inside `array.items` |
+| `object`   | Structured map; valid only inside `array.items` (not as a standalone field) |
 
 Use `type: array` with `items: { type: object, properties: {...} }` when you need a **list** of structured rows. Quill does not yet provide a general-purpose deep-nesting field type, so `type: object` is currently scoped to `array.items` rather than standalone top-level fields.
 
@@ -213,9 +213,22 @@ main:
         order: 5
 ```
 
+### `compact`
+
+When `true`, the UI renders this field in a compact style (smaller vertical footprint). UI hint only — no effect on validation or rendering.
+
+```yaml
+main:
+  fields:
+    tag:
+      type: string
+      ui:
+        compact: true
+```
+
 ### `multiline`
 
-Controls the initial size of the text input for `markdown` fields. When `true`, the UI starts with a larger text box instead of a single-line input:
+Controls the initial size of the text input for `string` and `markdown` fields. When `true`, the UI starts with a larger text box instead of a single-line input:
 
 ```yaml
 main:
@@ -226,13 +239,19 @@ main:
       ui:
         multiline: true   # start as a larger text box
 
+    notes:
+      type: string
+      description: Free-form notes
+      ui:
+        multiline: true
+
     tagline:
       type: markdown
       description: One-sentence tagline
       # no multiline — single-line input that expands on demand
 ```
 
-`multiline` is a UI hint only — it has no effect on validation or backend processing. It is only meaningful on `markdown` fields and is ignored on other types.
+`multiline` is a UI hint only — it has no effect on validation or backend processing. It is meaningful on `string` and `markdown` fields; ignored on other types.
 
 ---
 

--- a/docs/format-designer/typst-backend.md
+++ b/docs/format-designer/typst-backend.md
@@ -90,7 +90,7 @@ Use Typst's `in` operator to check for optional fields:
 
 ### Rendering Body Content
 
-The document body (Markdown content after frontmatter) is stored in `data.BODY` (and accessible via `data.body`). Markdown fields are automatically converted to Typst content objects by the helper package, so you can use them directly:
+The document body (Markdown content after frontmatter) is stored in `data.BODY`. Markdown fields are automatically converted to Typst content objects by the helper package, so you can use them directly:
 
 ```typst
 #data.at("body", default: "")

--- a/docs/format-designer/versioning.md
+++ b/docs/format-designer/versioning.md
@@ -4,15 +4,17 @@ Versioning helps format designers evolve Quills safely while keeping document re
 
 ## Version Field in `Quill.yaml`
 
-Each Quill should declare a semantic version:
+Each Quill must declare a semantic version. Both `version` and `description` are required fields:
 
 ```yaml
 Quill:
-  name: my-quill
+  name: my_quill
   backend: typst
   description: A professional document format
   version: "1.2.0"
 ```
+
+Quill names must be `snake_case` (lowercase letters, digits, and underscores only — hyphens are not allowed).
 
 Use semantic versioning (`MAJOR.MINOR.PATCH`) to communicate compatibility:
 
@@ -26,7 +28,7 @@ Authors can target versions through the `QUILL` key in frontmatter:
 
 ```markdown
 ---
-QUILL: my-quill@1.2
+QUILL: my_quill@1.2
 title: Quarterly Report
 ---
 ```
@@ -35,11 +37,11 @@ Supported selectors:
 
 | Selector | Meaning |
 |---|---|
-| `my-quill` | Latest available version |
-| `my-quill@latest` | Latest available version (explicit) |
-| `my-quill@1` | Latest 1.x.x |
-| `my-quill@1.2` | Latest 1.2.x |
-| `my-quill@1.2.0` | Exact version |
+| `my_quill` | Latest available version |
+| `my_quill@latest` | Latest available version (explicit) |
+| `my_quill@1` | Latest 1.x.x |
+| `my_quill@1.2` | Latest 1.2.x |
+| `my_quill@1.2.0` | Exact version |
 
 ## Practical Guidelines
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -45,9 +45,9 @@ This metadata is accessible in formats and is validated against native schema ru
 
 ### Backends
 
-Backends compile raw plate content with injected JSON data into final artifacts:
+Backends compile plate content with injected JSON data into final artifacts:
 
-- **Typst Backend** - Generates PDF and SVG files using the Typst typesetting system. It transforms markdown fields (annotated with `contentMediaType = "text/markdown"`) into Typst markup before serialization.
+- **Typst Backend** - Generates PDF, SVG, and PNG files using the Typst typesetting system. Markdown fields (annotated with `contentMediaType = "text/markdown"`) are converted to Typst markup during compilation.
 
 Each backend has its own compilation process and error mapping.
 
@@ -67,15 +67,14 @@ If `QUILL` is missing, parsing fails with `ParseError::InvalidStructure`.
 
 ## The Rendering Pipeline
 
-Quillmark follows a multi-stage pipeline:
+Quillmark follows a three-stage pipeline:
 
-1. **Parse & Normalize** - Extract YAML frontmatter/body, apply schema coercion/defaults, normalize bidi/HTML fences
-2. **Transform Fields** - Backend-specific shaping (e.g., markdown→Typst markup) before JSON serialization
-3. **Compile** - Backend processes plate with injected JSON data into final artifacts (PDF, SVG, etc.)
-4. **Output** - Return artifacts with metadata
+1. **Parse & Normalize** - Extract YAML frontmatter/body, apply schema coercion/defaults, strip bidi characters, fix HTML fences
+2. **Compile** - Backend receives plate content + JSON data and converts them into final artifacts (PDF, SVG, PNG, etc.)
+3. **Output** - Return artifacts with metadata
 
 ```
-Markdown + YAML → Parse/Normalize → Transform Fields → Compile (Backend) → Artifacts
+Markdown + YAML → Parse/Normalize → Compile (Backend) → Artifacts
 ```
 
 ## Mental Model

--- a/docs/integration/javascript/api.md
+++ b/docs/integration/javascript/api.md
@@ -50,8 +50,20 @@ Renders artifacts from a `ParsedDocument`.
 ```ts
 type RenderOptions = {
   format?: "pdf" | "svg" | "txt" | "png";
-  ppi?: number;
+  assets?: Record<string, Uint8Array | number[]>;
+  ppi?: number;    // PNG only; defaults to 144 (2× at 72 pt/inch)
   pages?: number[];
+};
+```
+
+Returns:
+
+```ts
+type RenderResult = {
+  artifacts: Array<{ format: string; bytes: Uint8Array; mimeType: string }>;
+  warnings: Diagnostic[];
+  outputFormat: "pdf" | "svg" | "txt" | "png";
+  renderTimeMs: number;
 };
 ```
 
@@ -65,20 +77,10 @@ Returns the number of pages in the opened session.
 
 ### `session.render(options?)`
 
-Renders all pages or selected pages from the session.
-
-`options`:
-
-```ts
-type RenderOptions = {
-  format?: "pdf" | "svg" | "txt" | "png";
-  ppi?: number;
-  pages?: number[];
-};
-```
+Renders all or selected pages from the session. Accepts the same `RenderOptions` as `quill.render()`.
 
 ## Notes
 
 - `QUILL` in frontmatter is required when parsing markdown.
 - `quill.render(parsed)` emits a warning (not error) if `parsed.quillRef` does not match the quill name.
-- `pages` selection is intended for page-addressable outputs (for example SVG/PNG), not PDF.
+- `pages` selection is intended for page-addressable outputs (SVG/PNG), not PDF.

--- a/docs/integration/overview.md
+++ b/docs/integration/overview.md
@@ -51,7 +51,8 @@ Quillmark can produce one or more artifacts depending on backend + format:
 
 - `pdf` for documents and print workflows
 - `svg` for vector output
-- `png` for raster output
+- `png` for raster output (use `render_with_options` / `ppi` to control resolution)
+- `txt` for plain-text output
 
 ## Error Handling Philosophy
 

--- a/docs/integration/python/api.md
+++ b/docs/integration/python/api.md
@@ -47,21 +47,35 @@ class Quillmark:
 
 ### `Quill`
 
+Obtained via `engine.quill_from_path(path)`.
+
 ```python
 class Quill:
+    name: str
+    backend: str
+    plate: str | None
+    metadata: dict
+    schema: str           # public schema as YAML text
+    defaults: dict        # field default values
+    examples: dict        # field example value lists
+    example: str | None   # raw example document string
+    print_tree: str       # quill file tree
+
+    def supported_formats(self) -> list[OutputFormat]: ...
+
     def render(
         self,
-        input: str | ParsedDocument,
+        parsed: ParsedDocument,
         format: OutputFormat | None = None,
-    ) -> RenderResult:
-        """Render directly with this quill."""
-```
+    ) -> RenderResult: ...
 
-Obtain a `Quill` via `engine.quill_from_path(path)`.
+    def open(self, parsed: ParsedDocument) -> RenderSession:
+        """Open a render session for page inspection before rendering."""
+```
 
 ### `Workflow`
 
-Use when you need runtime assets/fonts:
+Use when you need runtime assets or fonts:
 
 ```python
 workflow = engine.workflow(quill)
@@ -71,26 +85,107 @@ workflow.dry_run(parsed)
 result = workflow.render(parsed, OutputFormat.PDF)
 ```
 
+```python
+class Workflow:
+    backend_id: str       # property
+    supported_formats: list[OutputFormat]  # property
+    quill_ref: str        # property
+
+    def render(self, parsed: ParsedDocument, format: OutputFormat | None = None) -> RenderResult: ...
+    def open(self, parsed: ParsedDocument) -> RenderSession: ...
+    def dry_run(self, parsed: ParsedDocument) -> None:
+        """Validate without compiling. Raises QuillmarkError on failure."""
+
+    def add_asset(self, filename: str, contents: bytes) -> None: ...
+    def add_assets(self, assets: list[tuple[str, bytes]]) -> None: ...
+    def clear_assets(self) -> None: ...
+    def dynamic_asset_names(self) -> list[str]: ...
+
+    def add_font(self, filename: str, contents: bytes) -> None: ...
+    def add_fonts(self, fonts: list[tuple[str, bytes]]) -> None: ...
+    def clear_fonts(self) -> None: ...
+    def dynamic_font_names(self) -> list[str]: ...
+```
+
+### `RenderSession`
+
+Obtained via `quill.open(parsed)` or `workflow.open(parsed)`. Useful for page-range rendering.
+
+```python
+session = quill.open(parsed)
+print(session.page_count)
+result = session.render(OutputFormat.PDF, pages=[0, 1])
+```
+
+```python
+class RenderSession:
+    page_count: int  # property
+
+    def render(
+        self,
+        format: OutputFormat | None = None,
+        pages: list[int] | None = None,
+    ) -> RenderResult: ...
+```
+
 ### `ParsedDocument`
 
 ```python
-parsed = ParsedDocument.from_markdown(markdown)
-parsed.quill_ref()
-parsed.fields
-parsed.body()
+parsed = ParsedDocument.from_markdown(markdown)  # raises ParseError on failure
+parsed.quill_ref()     # → str
+parsed.fields          # property → dict
+parsed.body()          # → str | None
+parsed.get_field(key)  # → value | None
 ```
 
-## Diagnostics and Errors
-
-- `ParseError`: markdown/frontmatter parsing failures
-- `QuillmarkError`: validation/rendering/workflow failures
-- `RenderResult.warnings`: non-fatal diagnostics (including QUILL ref mismatch warnings)
-
-## Schema Access
-
-Python exposes schema as YAML text:
+### `RenderResult` and `Artifact`
 
 ```python
-schema_yaml = quill.schema
+result.artifacts       # list[Artifact]
+result.warnings        # list[Diagnostic]
+result.output_format   # OutputFormat
+
+artifact.bytes         # bytes
+artifact.output_format # OutputFormat
+artifact.mime_type     # str (e.g. "application/pdf")
+artifact.save(path)    # write bytes to file
 ```
 
+### `Diagnostic` and `Location`
+
+```python
+diag.severity      # Severity
+diag.message       # str
+diag.code          # str | None
+diag.primary       # Location | None
+diag.hint          # str | None
+diag.source_chain  # list[str]
+
+loc.file  # str
+loc.line  # int
+loc.col   # int
+```
+
+## Enums
+
+```python
+OutputFormat.PDF   # application/pdf
+OutputFormat.SVG   # image/svg+xml
+OutputFormat.PNG   # image/png
+OutputFormat.TXT   # text/plain
+OutputFormat.all() # → list[OutputFormat]
+
+Severity.ERROR
+Severity.WARNING
+Severity.NOTE
+Severity.all()     # → list[Severity]
+```
+
+## Errors
+
+| Exception | Raised when |
+|---|---|
+| `QuillmarkError` | Base class; validation, engine, or workflow failures |
+| `ParseError` | Markdown/frontmatter parse failure; has `.diagnostic` |
+| `TemplateError` | Template processing failure |
+| `CompilationError` | Backend compilation failure; has `.diagnostics` (list) |

--- a/docs/integration/validation.md
+++ b/docs/integration/validation.md
@@ -4,11 +4,10 @@ Validate documents before full rendering for faster feedback loops.
 
 ## Overview
 
-Validation runs against native `QuillConfig` schema rules (no JSON Schema runtime).
+Validation runs against native `QuillConfig` schema rules (no JSON Schema runtime). Two levels are available:
 
-- Parse markdown to `ParsedDocument`
-- Render-ready quill via `engine.quill_from_path(...)` / `engine.quill(...)`
-- Optional `workflow.dry_run()` for fast validation without compilation (Python)
+- **Dry run** (Rust/Python): coercion + schema validation only, no compilation cost
+- **render()** (all bindings): validation runs as part of the full render pipeline
 
 ## Python
 
@@ -23,12 +22,14 @@ parsed = ParsedDocument.from_markdown(markdown)
 
 try:
     workflow.dry_run(parsed)
-    print("✓ Document valid")
+    print("Document valid")
 except QuillmarkError as e:
-    print(f"✗ Validation error: {e}")
+    print(f"Validation error: {e}")
 ```
 
 ## JavaScript/WASM
+
+WASM has no separate dry-run method. Call `render()` — validation runs before compilation and errors are thrown before any output is produced.
 
 ```javascript
 import { ParsedDocument, Quillmark } from "@quillmark-test/wasm";
@@ -37,8 +38,21 @@ const engine = new Quillmark();
 const quill = engine.quill(tree);
 const parsed = ParsedDocument.fromMarkdown(markdown);
 
-// render() performs validation + compilation
-const result = quill.render(parsed, { format: "pdf" });
+try {
+    const result = quill.render(parsed, { format: "pdf" });
+} catch (e) {
+    // e is a WasmError object with diagnostic payload
+    console.error(e.message, e.code);
+}
+```
+
+## CLI
+
+Validate a quill's configuration (not a document):
+
+```sh
+quillmark validate ./my-quill
+quillmark validate --verbose ./my-quill
 ```
 
 ## Passing schema to LLMs
@@ -52,9 +66,11 @@ prompt = f"""Use this schema YAML to generate valid frontmatter:\n\n{schema_yaml
 
 ## Error shape
 
-Validation errors are path-aware and include field-level context, for example:
+Validation errors include field-level context, for example:
 
 - `missing required field 'memo_for'`
 - `field 'format' value 'weird' not in allowed set ["standard", "informal", "separate_page"]`
 
 These errors are intended to be fed back into retry loops directly.
+
+> For the full diagnostic type hierarchy and FFI shape, see [prose/designs/ERROR.md](../../prose/designs/ERROR.md).

--- a/prose/designs/ARCHITECTURE.md
+++ b/prose/designs/ARCHITECTURE.md
@@ -1,28 +1,30 @@
 # Quillmark Architecture
 
-## System Overview
+## TL;DR
 
-Quillmark converts Markdown with YAML frontmatter into output artifacts (PDF, SVG, TXT). Data flow:
+Quillmark converts Markdown with YAML frontmatter into output artifacts (PDF, SVG, PNG, TXT). A `Workflow` orchestrates the pipeline; backends do the heavy compilation.
 
-1. **Parse** — YAML/frontmatter extraction, CARD aggregation, bidi stripping, HTML fence normalization
-2. **Normalize** — Type coercion, defaults from Quill schema, backend `transform_fields`
-3. **Compile** — Backend processes plate content with injected JSON data
+## Data Flow
+
+1. **Parse** — YAML frontmatter extraction, bidi stripping, HTML fence normalization
+2. **Normalize** — Type coercion, schema defaults, field validation
+3. **Compile** — Backend's `open()` receives plate + JSON data and returns a `RenderSession`; `RenderSession::render()` produces artifacts
 
 ## Crate Structure
 
 ### `quillmark-core`
 
-Types: `Backend`, `Artifact`, `OutputFormat`, `ParsedDocument`, `Quill`, `RenderError`, `Diagnostic`, `Severity`, `Location`, `QuillValue`.
+Foundation types and traits. No backend dependencies; backends depend on this crate.
 
-No external backend dependencies; backends depend on core.
+Key exports: `Backend`, `Artifact`, `OutputFormat`, `RenderOptions`, `RenderSession`, `ParsedDocument`, `Quill`, `FileTreeNode`, `QuillIgnore`, `RenderError`, `Diagnostic`, `Severity`, `Location`, `RenderResult`, `QuillValue`, `QuillReference`, `Version`, `VersionSelector`, `BODY_FIELD`.
 
 ### `quillmark` (orchestration)
 
-High-level API: `Quillmark` (engine), `Workflow` (pipeline). Handles parse → compose → compile, schema coercion, backend auto-registration, and default Quill registration.
+High-level API: `Quillmark` (engine), `Workflow` (pipeline), `QuillRef`. Handles parse → normalize → compile, schema coercion, and backend auto-registration.
 
 ### `backends/quillmark-typst`
 
-Implements `Backend` for PDF/SVG. Markdown→Typst via `transform_fields`. Injects JSON as `@local/quillmark-helper` package. Resolves fonts and assets. See [GLUE_METADATA.md](GLUE_METADATA.md).
+Implements `Backend` for PDF, SVG, and PNG. Converts Markdown fields to Typst markup inside `open()`. Resolves fonts and assets. See [GLUE_METADATA.md](GLUE_METADATA.md).
 
 ### `bindings/quillmark-python`
 
@@ -46,25 +48,26 @@ Fuzz tests for parsing, templating, and rendering.
 
 ## Core Interfaces
 
-- **`Quillmark`** — Engine managing backends and quills
-- **`Workflow`** — Rendering pipeline (parse → template → compile)
-- **`Backend`** — Trait for output formats (`Send + Sync`)
-- **`Quill`** — Template bundle (plate + assets/packages)
-- **`ParsedDocument`** — Frontmatter + body from markdown
+- **`Quillmark`** — Engine managing registered backends; auto-registers `TypstBackend` when the `typst` feature is enabled
+- **`Workflow`** — Rendering pipeline (parse → normalize → compile); supports dynamic asset/font injection and `dry_run` validation
+- **`Backend`** — Trait for output formats (`Send + Sync`): `id()`, `supported_formats()`, `open()`
+- **`RenderSession`** — Opaque handle returned by `Backend::open()`; call `render(opts)` to produce artifacts
+- **`Quill`** — Format bundle (plate + assets/packages/metadata)
+- **`ParsedDocument`** — Frontmatter fields + body from Markdown
 - **`Diagnostic`** — Structured error with severity, code, message, location, hint, source chain
-- **`RenderResult`** — Output artifacts + warnings
+- **`RenderResult`** — Output artifacts + accumulated warnings
 
 ## Data Injection
 
-Backends receive:
-- `plate_content` — raw plate from `Quill.plate` (empty for plate-less backends)
-- `json_data` — JSON after coercion, defaults, normalization, and `transform_fields`
-- `quill` — bundle with assets, packages, and any dynamic assets/fonts injected
+`Backend::open()` receives:
+- `plate_content` — raw plate string from `Quill.plate` (empty string for plate-less backends)
+- `json_data` — JSON object after coercion, defaults, normalization
+- `quill` — bundle with static assets/packages plus any dynamic assets/fonts injected via `Workflow::add_asset` / `add_font`
 
 See [GLUE_METADATA.md](GLUE_METADATA.md) for the Typst helper package.
 
 ## Backend Implementation
 
-Implement the `Backend` trait: `id()`, `supported_formats()`, `plate_extension_types()`, `transform_fields()`, `compile()`. Optionally provide `default_quill()`.
+Implement three methods of the `Backend` trait: `id()`, `supported_formats()`, `open()`. Return a `RenderSession` wrapping a `SessionHandle` that handles format-specific rendering.
 
-See `backends/quillmark-typst` for reference implementation.
+See `backends/quillmark-typst` for the reference implementation.

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -16,35 +16,38 @@ pub struct CardSchema {
     pub title: Option<String>,
     pub description: Option<String>,
     pub fields: HashMap<String, FieldSchema>,
+    pub ui: Option<UiContainerSchema>,
 }
 ```
 
-`QuillConfig` has a `cards: HashMap<String, CardSchema>` field alongside `fields`.
+`QuillConfig` stores `cards: Vec<CardSchema>` where index 0 is always the **main** card (document-level fields). Named card definitions start at index 1 and are accessed via `card_definitions()` / `card_definition(name)`.
 
 ## Quill.yaml Configuration
 
 ```yaml
+main:
+  fields:
+    # ... document-level fields ...
+
 cards:
-  indorsements:
-    title: Routing Indorsements
+  indorsement:
+    title: Routing Indorsement
     description: Chain of routing endorsements for multi-level correspondence.
     fields:
       from:
         title: From office/symbol
         type: string
-        required: true
         description: Office symbol of the endorsing official.
       for:
         title: To office/symbol
         type: string
-        required: true
         description: Office symbol receiving the endorsed memo.
       signature_block:
         title: Signature block lines
         type: array
         required: true
         ui:
-          group: Signature
+          group: Addressing
         description: Name, grade, and duty title.
 ```
 
@@ -52,8 +55,8 @@ cards:
 
 ```yaml
 cards:
-  indorsements:
-    title: Routing Indorsements
+  indorsement:
+    title: Routing Indorsement
     description: Chain of routing endorsements for multi-level correspondence.
     fields:
       from:
@@ -62,17 +65,16 @@ cards:
         type: string
       signature_block:
         type: array
-        items:
-          type: string
+        required: true
 ```
 
-Public schema is emitted from `QuillConfig::public_schema_yaml()` and keeps the same `cards.<name>.fields` shape as `Quill.yaml`.
+Public schema is emitted from `QuillConfig::public_schema_yaml()` and keeps the same `cards.<name>.fields` shape as `Quill.yaml`. The `cards` key is omitted entirely when no named cards are defined.
 
 ## Markdown Syntax
 
 ```markdown
 ---
-CARD: indorsements
+CARD: indorsement
 from: ORG1/SYMBOL
 for: ORG2/SYMBOL
 signature_block:
@@ -85,5 +87,5 @@ Indorsement body content.
 
 ## Backend Consumption
 
-- **Typst**: cards at `data.CARDS`; markdown fields pre-converted to Typst markup
-- **Bindings**: `Workflow::compile_data()` exposes the exact JSON
+- **All backends**: cards are delivered as `data.CARDS`, an array of objects each containing a `CARD` discriminator field, the card's metadata fields, and a `BODY` field with the card's body Markdown.
+- **`Workflow::compile_data()`** returns the fully coerced and validated JSON, including `CARDS`.

--- a/prose/designs/CI_CD.md
+++ b/prose/designs/CI_CD.md
@@ -10,47 +10,51 @@ Not published: `quillmark-fixtures`, `quillmark-fuzz`, `bindings/quillmark-pytho
 
 ## 1) Continuous Integration (CI)
 
-**Trigger**: pull requests and pushes to `main`.
-**Environment**: single Linux runner.
+**Trigger**: pull requests and pushes to any branch except version tags.
+**Jobs** (all Linux, run in parallel; `ci-success` gate aggregates results):
 
-Steps:
-1. Checkout & stable Rust toolchain
-2. Cache Cargo artifacts
-3. `cargo check` (all features, then no-default-features)
-4. `cargo test` (workspace, all features; doctests included)
-5. `cargo fmt -- --check`
-6. `cargo doc --no-deps`
+| Job | What it does |
+|-----|-------------|
+| `lint` | `cargo fmt --all -- --check` (Clippy commented out, not yet enforced) |
+| `test` | `cargo test --locked` in a matrix: default features and `--all-features` |
+| `docs` | `cargo doc --no-deps --locked` with `-Dwarnings` |
+| `wasm` | `cargo check --package quillmark-wasm --target wasm32-unknown-unknown --locked` |
 
-Excluded: Clippy, multi-OS matrix, MSRV, security scanners, coverage, benchmarks.
+Excluded: multi-OS matrix, MSRV, security scanners, coverage, benchmarks.
 
 ---
 
 ## 2) Continuous Delivery (CD)
 
-### Rust Crates
+### Rust Crates (`publish.yml`)
 
-**Trigger**: manual dispatch (`workflow_dispatch`) or pushed tag `vX.Y.Z`.
-**Auth**: `CARGO_REGISTRY_TOKEN` repository secret.
+**Trigger**: tag `vX.Y.Z` or manual dispatch.
 
-Publish sequence (via `cargo publish`): `quillmark-core` → `backends/quillmark-typst` → `quillmark`.
+1. Runs `cargo test` matrix (same as CI, fail-fast enabled).
+2. Runs `cargo publish --locked --no-verify` to publish all publishable workspace crates.
+**Auth**: `CARGO_REGISTRY_TOKEN` secret (via `Publish` environment).
 
-### Python Bindings
+### Python Bindings (`publish-python.yml`)
 
-**Workflow**: `.github/workflows/publish-python.yml`
-**Trigger**: tag push `vX.Y.Z` or manual dispatch
-**Publish**: PyPI via `maturin publish` (Linux, macOS, Windows wheels)
+**Trigger**: tag `vX.Y.Z` or `py-vX.Y.Z`, or manual dispatch.
 
-### WASM Bindings
+1. Runs pytest via `uv`.
+2. Builds wheels via `maturin-action` for Linux (x86_64, aarch64), Windows (x64), macOS (aarch64) — Python 3.10–3.12 — plus sdist.
+3. Publishes all artifacts to PyPI via `maturin upload`.
+**Auth**: `MATURIN_PYPI_TOKEN` secret (via `Publish` environment).
 
-**Workflow**: `.github/workflows/publish-wasm.yml`
-**Trigger**: tag push `vX.Y.Z` or manual dispatch
-**Publish**: npm via `wasm-pack publish` (bundler, nodejs, web targets)
+### WASM Bindings (`publish-wasm.yml`)
+
+**Trigger**: tag `vX.Y.Z` or `wasm-vX.Y.Z`, or manual dispatch.
+
+1. Builds via `./scripts/build-wasm.sh` and runs `npm test`.
+2. Publishes `@quillmark/wasm` to npm via `npm publish --provenance` (OIDC Trusted Publisher).
+**Auth**: OIDC `id-token: write` permission; no token secret needed.
 
 ---
 
 ## 3) Versioning
 
-- SemVer across all workspace crates and bindings
-- Bump `quillmark-core`, `backends/quillmark-typst`, and `quillmark` together
-- Python and WASM bindings follow the same version as the Rust workspace
-- Tag `vX.Y.Z` required for publishing
+- SemVer across all workspace crates and bindings.
+- Version bumps managed locally via `cargo-release` (`release.toml`): bumps, commits (`chore: release X.Y.Z`), and pushes tag `vX.Y.Z`; publishing is delegated entirely to CI.
+- Python and WASM bindings can also be released independently via `py-vX.Y.Z` / `wasm-vX.Y.Z` tags.

--- a/prose/designs/CLI.md
+++ b/prose/designs/CLI.md
@@ -19,7 +19,7 @@ Options:
 - `-f, --format <FORMAT>` — `pdf`, `svg`, `png`, or `txt` (default: `pdf`)
 - `--stdout` — write output to stdout
 - `--output-data <FILE>` — write compiled JSON data to file
-- `--verbose` — detailed processing output
+- `-v, --verbose` — detailed processing output
 - `--quiet` — suppress non-error output
 
 ### `schema`
@@ -33,10 +33,13 @@ Outputs the Quill's public schema contract as YAML to stdout or file.
 ### `validate`
 
 ```
-quillmark validate <QUILL_PATH>
+quillmark validate [OPTIONS] <QUILL_PATH>
 ```
 
 Validates quill configuration.
+
+Options:
+- `-v, --verbose` — show all validation details including warnings
 
 ### `info`
 
@@ -66,5 +69,4 @@ crates/bindings/cli/src/
 - `clap` — argument parsing
 - `quillmark` — rendering engine
 - `quillmark-core` — types
-- `anyhow` — error handling
 - `serde_json` — JSON output

--- a/prose/designs/ERROR.md
+++ b/prose/designs/ERROR.md
@@ -1,6 +1,6 @@
 # Error Handling System
 
-> **Implementation**: `quillmark-core/src/error.rs`
+> **Implementation**: `crates/core/src/error.rs`
 
 ## Types
 
@@ -8,18 +8,32 @@
 
 **`Location`**: file name, line (1-indexed), column (1-indexed)
 
-**`Diagnostic`**: severity, optional error code, message, primary location, optional hint, source error chain
+**`Diagnostic`**: severity, optional error code, message, primary location, optional hint, source error chain (skipped from serialization)
 
-**`RenderError`**: main error enum — engine creation, invalid frontmatter, template rendering, backend compilation (may contain multiple diagnostics), format/backend support, resource collision, size limits, schema validation, invalid schema, quill configuration
+**`SerializableDiagnostic`**: flattened `Diagnostic` for Python and WASM FFI — replaces the non-serializable `source` field with a `source_chain: Vec<String>`
 
-**`SerializableDiagnostic`**: flattened `Diagnostic` for Python and WASM FFI boundaries
+**`ParseError`**: parsing-stage error enum — input too large, YAML errors (with and without location), JSON conversion, invalid structure, missing CARD directive; converts to `Diagnostic` via `to_diagnostic()`
+
+**`RenderError`**: main rendering error enum with variants:
+- `EngineCreation` — failed to create engine
+- `InvalidFrontmatter` — malformed YAML frontmatter (also wraps `ParseError`)
+- `CompilationFailed` — backend compilation failed; carries `Vec<Diagnostic>`
+- `FormatNotSupported` — requested output format not supported
+- `UnsupportedBackend` — backend not registered
+- `DynamicAssetCollision` — asset filename collision
+- `DynamicFontCollision` — font filename collision
+- `ValidationFailed` — field coercion/schema validation failure
+- `QuillConfig` — quill configuration error
+- `NoBackend` — quill has no backend attached
+
+**`RenderResult`**: successful result carrying artifacts, output format, and non-fatal `Vec<Diagnostic>` warnings
 
 ## Bindings Error Delegation
 
 Python and WASM bindings delegate to core types:
 
-- **Python**: `PyDiagnostic` wraps `SerializableDiagnostic`, converting `RenderError` to Python exceptions with attached diagnostic payloads
-- **WASM**: `WasmError` wraps `SerializableDiagnostic` (single or multiple), serialized to JSON via `serde_wasm_bindgen`
+- **Python**: `PyDiagnostic` wraps `SerializableDiagnostic`. `RenderError` is mapped to typed Python exceptions: `CompilationError` (carries a `diagnostics` list), `ParseError` (frontmatter errors), and `QuillmarkError` (all other variants) — each with an attached `diagnostic` attribute. Base hierarchy: `QuillmarkError → PyException`.
+- **WASM**: `WasmError` wraps `SerializableDiagnostic` as either `Diagnostic` (single) or `MultipleDiagnostics` (compilation errors), serialized to JSON via `serde_wasm_bindgen`. Also handles `ParseError` conversions directly.
 
 ## Backend Error Mapping
 
@@ -30,15 +44,18 @@ Typst diagnostics mapped via `map_typst_errors()`:
 - Spans resolved to file/line/column
 - Error codes: `"typst::<error_type>"`
 
-See `backends/quillmark-typst/src/error_mapping.rs`.
+See `crates/backends/typst/src/error_mapping.rs`.
 
 ## Error Presentation
 
 **Pretty printing** (`Diagnostic::fmt_pretty()`):
 ```
-[ERROR] Undefined variable (E001) at template.typ:10:5
+[ERROR] Undefined variable (E001)
+  --> template.typ:10:5
   hint: Check variable spelling
 ```
+
+**Extended printing** (`Diagnostic::fmt_pretty_with_source()`): appends each cause in the source chain as `cause N: <message>`.
 
 **Consolidated printing**: `print_errors()` handles all `RenderError` variants.
 

--- a/prose/designs/EXTENDED_MARKDOWN.md
+++ b/prose/designs/EXTENDED_MARKDOWN.md
@@ -7,7 +7,7 @@ This document describes the **Quillmark Extended Markdown** format. It is a stri
 
 ## Document Structure
 
-A Extended Markdown file is composed of **Segments**. A segment is either a **Metadata Block** followed by **Body Content**, or (in the case of the first segment only) just Body Content.
+A Quillmark document is composed of one required **Global Block** (with the `QUILL` key), optional additional **Card Blocks**, and **Body Content** sections between them.
 
 ### 1. Metadata Blocks
 
@@ -15,23 +15,22 @@ A metadata block is delimited by lines containing exactly three hyphens (`---`).
 
 ```markdown
 ---
+QUILL: my_quill
 key: value
 ---
 ```
 
 **Key Rules:**
-*   **Delimiters:** The `---` marker must form its own line with no leading/trailing whitespace.
+*   **Delimiters:** The `---` marker must appear on its own line with no leading or trailing whitespace.
 *   **Line Endings:** Both Unix (`\n`) and Windows (`\r\n`) line endings are supported.
-*   **Exclusivity:** `---` is reserved for metadata and is never treated as a setext header underline.
-*   **Horizontal Rule Exception:** A `---` line preceded by a blank line AND followed by a blank line is treated as a horizontal rule in the body content (not a metadata delimiter).
+*   **Always a delimiter:** `---` is always treated as a metadata block delimiter — never as a setext heading underline or thematic break, regardless of surrounding blank lines.
 *   **Context:** `---` markers inside fenced code blocks are ignored.
 
 **Content:**
-The content inside the block is standard YAML 1.2.
+The content inside the block is parsed as YAML.
 *   **Whitespace Normalization:** Content that contains only whitespace (spaces, tabs, newlines) is treated as empty.
-*   **Custom Tags:** Custom YAML tags (like `!fill`) are silently stripped during parsing. For example, `key: !fill value` becomes `key: "value"`. This ensures the data model remains simple JSON.
-*   **Recursion Limit:** Nesting is limited to 100 levels to prevent stack overflows.
-*   **Reserved Keys:** `BODY` and `CARDS` are reserved system keys and cannot be used in the YAML.
+*   **Recursion Limit:** YAML nesting is limited to 100 levels to prevent stack overflows.
+*   **Reserved Keys:** `BODY`, `CARDS`, `QUILL`, and `CARD` are reserved system keys and cannot be used as user-defined YAML fields.
 
 ### 2. Body Content
 
@@ -41,31 +40,32 @@ The text following a metadata block is the "Body". It captures everything up to 
 
 ## Data Model
 
-The parsed document results in a flat JSON structure:
+The parsed document results in a flat field map:
 
 ```typescript
 interface Document {
-  // Global fields from the first block (if it's not a card)
+  // User-defined global fields from the first block
   [key: string]: any;
 
   // Reserved fields filled by the parser
   BODY: string;       // The content of the main/global body
-  CARDS: Card[];      // List of all named card blocks
+  CARDS: Card[];      // List of all card blocks (always present, may be empty)
 }
 
 interface Card {
-  CARD: string;       // The type of card (e.g. "section", "profile")
-  BODY: string;       // The content associated with this card
-  [key: string]: any; // Other fields defined in the block
+  CARD: string;       // The card type value (e.g. "section", "profile")
+  BODY: string;       // The body content associated with this card
+  [key: string]: any; // Other fields defined in the card block
 }
 ```
 
 **Block Logic:**
-*   **Global Block:** The first block in the file is the "Global" block, unless it contains a `CARD` key.
-*   **Card Blocks:** Any block containing a `CARD` key is added to the `CARDS` array.
-*   **Validity:** Any block after the first one *must* have a `CARD` key.
-*   **CARDS Array:** The `CARDS` field is always present in the parsed document, even if empty (as an empty array `[]`).
-*   **Name Collisions:** Field names in the global block and `CARD` type names can overlap without error. For example, a global field `items` and a card type `CARD: items` can coexist.
+*   **Global Block:** The first block must contain the `QUILL` key (specifying the template). Any other fields in that block become global document fields.
+*   **Card Blocks:** Any subsequent block must contain a `CARD` key whose value names the card type. These are collected into the `CARDS` array.
+*   **Validity:** Any block after the first one *must* have a `CARD` key. Using `QUILL` in a non-first block is an error.
+*   **CARDS Array:** Always present in the parsed document, even if empty (`[]`).
+*   **Card name pattern:** `CARD` values must match `[a-z_][a-z0-9_]*`.
+*   **Name Collisions:** Global field names and `CARD` type values can overlap without error.
 
 ## Markdown Support
 
@@ -76,20 +76,24 @@ Quillmark supports a specific subset of CommonMark to ensure security and consis
 *   **Text:** Paragraphs, Bold (`**`), Italic (`*`), Strike (`~~`), Underline (`__`).
 *   **Lists:** Ordered and unordered.
 *   **Links:** Standard `[text](url)`.
+*   **Line breaks:** `<br>`, `<br/>`, and `<br />` are converted to hard line breaks.
 *   **Code:** Inline code and Fenced Code Blocks.
     *   **Fenced blocks:** CommonMark rules apply: lines of three or more matching backticks or tildes open and close a fence; the closing run must be at least as long as the opening run. Metadata `---` delimiters inside a fenced block are ignored (see **Context** under Metadata Blocks).
 *   **Tables:** GFM-style pipe tables with optional column alignment.
 
 ### Unsupported Features
-These features are intentionally ignored or rendered as plain text:
-*   **Setext Headings:** Underline-style headings using `===` or `---` are NOT supported. Only ATX-style headings (`# Heading`) are recognized. This prevents ambiguity with list items and horizontal rules.
-*   **Thematic Breaks:** `***`, `___`, `---` (ignored).
-*   **Images:** `![alt](src)` (ignored).
-*   **HTML:** Raw HTML tags are ignored, except for comments.
-*   **Complex formatting:** Math, Footnotes, Blockquotes.
+These features are intentionally ignored (silently dropped) during rendering:
+*   **Setext Headings:** Underline-style headings using `===` or `---` are NOT supported. Only ATX-style headings (`# Heading`) are recognized.
+*   **Thematic Breaks:** `***`, `___`, `---` are dropped.
+*   **Images:** `![alt](src)` is dropped.
+*   **Blockquotes:** `>` quoted blocks are dropped.
+*   **Raw HTML:** HTML tags other than `<br>` are stripped. HTML comments (`<!-- -->`) pass through as non-rendering content.
+*   **Complex formatting:** Math, Footnotes.
 
-### HTML Comments
-Standard `<!-- comments -->` are supported as non-rendering content. Nested comments are handled safely.
+### Input Normalization
+Before parsing, the body content is normalized:
+*   **Bidi stripping:** Unicode bidirectional control characters (U+061C, U+200E–U+200F, U+202A–U+202E, U+2066–U+2069) are removed to prevent delimiter-recognition attacks.
+*   **HTML comment fences:** Text immediately following `-->` on the same line is moved to the next line to prevent content loss.
 
 ## System Limits
 
@@ -98,4 +102,5 @@ To ensure performance and stability, the system enforces the following hard limi
 *   **Max Input Size:** 10 MB
 *   **Max YAML Size:** 1 MB per block
 *   **Max YAML Depth:** 100 levels
+*   **Max Nesting Depth:** 100 levels (markdown rendering)
 *   **Max Item Count:** 1000 fields or cards

--- a/prose/designs/GLUE_METADATA.md
+++ b/prose/designs/GLUE_METADATA.md
@@ -5,13 +5,16 @@
 
 ## Overview
 
-Quillmark no longer runs a template engine for plates. Instead, `Workflow::compile_data()` produces JSON after coercion, defaults, normalization, and backend `transform_fields`, then passes it alongside the raw plate content to the backend `compile` call.
+Quillmark does not use a template engine for plates. Data flows in two stages:
+
+1. `Workflow::compile_data()` coerces, validates, normalizes, and applies schema defaults to frontmatter, producing a plain JSON object.
+2. `Backend::open()` receives that JSON and performs any backend-specific field transformations (e.g., converting markdown strings to Typst markup) before compilation.
 
 ### Data Shape
 
 - Keys mirror normalized frontmatter fields (including `BODY` and `CARDS`)
-- Defaults from the Quill schema are applied before serialization
-- Backend `transform_fields` may reshape values (e.g., Typst markdown → Typst markup strings)
+- Defaults from the Quill schema are applied before serialization in stage 1
+- Markdown-to-Typst conversion and date parsing happen in stage 2, inside the backend
 
 ## Typst Helper Package
 
@@ -25,11 +28,12 @@ The Typst backend injects a virtual package `@local/quillmark-helper:<version>` 
 #data.date           // date fields are auto-converted to datetime
 ```
 
-Helper contents (generated in `backends/typst/helper.rs`):
-- `data`: parsed JSON dictionary of all fields, with markdown fields converted to Typst content objects and date fields (`format: date`) converted to Typst `datetime`
+Helper contents (generated in `backends/typst/helper.rs` from `lib.typ.template`):
+- `data`: parsed JSON dictionary of all fields; a `__meta__` key injected by the backend carries the list of markdown and date fields to process, then is consumed by the helper before `data` is exposed to plates — plates never see `__meta__`
+- Markdown fields (`contentMediaType: text/markdown`) are auto-evaluated into Typst content; date fields (`format: date`) are converted to Typst `datetime`
 
 ## Guarantees
 
-- No `__metadata__` shadow fields; JSON matches normalized document keys
+- Plates see no internal shadow keys; `__meta__` is injected by the backend and consumed by the helper package before `data` is exposed
 - Dynamic assets/fonts are injected into the quill file tree before compilation
-- Backends receive the exact JSON used for compilation (also exposed via `Workflow::compile_data`)
+- `Workflow::compile_data` returns the pre-transformation JSON (coerced + normalized + defaults); markdown/date conversion occurs inside `Backend::open` and is not separately observable

--- a/prose/designs/INDEX.md
+++ b/prose/designs/INDEX.md
@@ -10,7 +10,7 @@
 - **[PARSE.md](PARSE.md)** - Markdown parsing and Extended YAML Metadata Standard
 - **[EXTENDED_MARKDOWN.md](EXTENDED_MARKDOWN.md)** - Extended Markdown format specification
 - **[QUILL.md](QUILL.md)** - Quill bundle structure and file tree API
-- **[QUILL_VALUE.md](QUILL_VALUE.md)** - Unified value type for TOML/YAML/JSON conversions
+- **[QUILL_VALUE.md](QUILL_VALUE.md)** - Unified value type for YAML/JSON conversions
 - **[VERSIONING.md](VERSIONING.md)** - Quill version resolution
 - **[SCHEMAS.md](SCHEMAS.md)** - `QuillConfig` schema model, native validation, and emission overview
 - **[PUBLIC_SCHEMA.md](PUBLIC_SCHEMA.md)** - External YAML schema contract consumed by bindings/integrations

--- a/prose/designs/PARSE.md
+++ b/prose/designs/PARSE.md
@@ -3,31 +3,66 @@
 Implementation notes for `quillmark-core/src/parse.rs`.
 
 > **Specification**: See [EXTENDED_MARKDOWN.md](./EXTENDED_MARKDOWN.md) for the authoritative syntax standard.
+> **Cards**: See [CARDS.md](./CARDS.md) for card block semantics.
 
 ## Architecture
 
 ### ParsedDocument
 
-Stores fields and body in a single `HashMap<String, QuillValue>`.
+```rust
+pub struct ParsedDocument {
+    fields: HashMap<String, QuillValue>,
+    quill_ref: QuillReference,
+}
+```
 
-- Body stored under `BODY_FIELD = "BODY"`
-- Quill reference is required from top-level `QUILL` frontmatter
-- Access via `body()`, `get_field()`, `fields()`, `quill_reference()`
+- `fields` holds all frontmatter key/value pairs plus two reserved entries: `BODY` (global document body as a string) and `CARDS` (array of card objects, always present, may be empty).
+- `quill_ref` is stored separately as a `QuillReference` (name + `VersionSelector`); it is never included in `fields`.
+- Access via `body()`, `get_field()`, `fields()`, `quill_reference()`.
+- `with_defaults()` returns a new `ParsedDocument` with default values applied for missing fields; existing fields are preserved.
 
 ### Parsing Flow
 
-1. Scan for `---` delimiters
-2. Classify as metadata block or horizontal rule (per disambiguation rules)
-3. Parse YAML, extract CARD/QUILL keys
-4. Extract body content between blocks
-5. Aggregate card blocks into `CARDS` array
-6. Validate and assemble result
+1. Check input size (max 10 MB; each YAML block max 1 MB).
+2. Scan for `---\n` / `---\r\n` delimiters that are at the start of a line and not inside a fenced code block (backtick or tilde, CommonMark rules).
+3. For each found block, parse YAML content via `serde-saphyr` with a depth budget (max 100 levels) and extract special keys:
+   - `QUILL` — Quill name + optional version selector; valid only in the first block.
+   - `CARD` — card type discriminator; required in all blocks after the first.
+   - `BODY` and `CARDS` are reserved and rejected if found in any YAML block.
+4. Validate block roles:
+   - Block 0: may carry `QUILL` (and optional other fields), or be plain global frontmatter (no `QUILL`, no `CARD`). Cannot have both `QUILL` and `CARD`.
+   - Blocks 1+: must carry `CARD`. `QUILL` is forbidden here.
+5. Assemble global frontmatter fields from block 0 (or the `QUILL` block if they overlap).
+6. For each `CARD` block, build an item object with its YAML fields, a `CARD` discriminator, and a `BODY` field containing the Markdown between this block's closing `---` and the next block's opening `---` (or EOF). Append to `cards_array`.
+7. Extract global body: text between the end of the first non-card block and the start of the first card block (or EOF).
+8. Insert `BODY` and `CARDS` into `fields`; check total field count (max 1 000).
+9. Require `QUILL` to have been found; parse it as `QuillReference`; return `ParsedDocument`.
+
+### CARD name validation
+
+CARD field names must match `[a-z_][a-z0-9_]*`.
+
+### QUILL name validation
+
+Quill names must match `[a-z_][a-z0-9_]*`. Version selectors follow `@MAJOR`, `@MAJOR.MINOR`, `@MAJOR.MINOR.PATCH`, or `@latest`.
 
 ## Design Decisions
 
 ### Error Handling
 
-Fail-fast on malformed YAML. Top-level frontmatter must include `QUILL`; missing `QUILL` returns `ParseError::InvalidStructure`.
+The parser returns `ParseError` variants; these are converted to `RenderError::InvalidFrontmatter` upstream.
+
+| Situation | Error |
+|---|---|
+| Missing `QUILL` | `InvalidStructure` |
+| Malformed YAML | `YamlErrorWithLocation` (includes line + block index) |
+| `QUILL` + `CARD` in same block | `InvalidStructure` |
+| `QUILL` in non-first block | `InvalidStructure` |
+| Inline block without `CARD` | `MissingCardDirective` (with hint) |
+| Reserved field name used | `InvalidStructure` |
+| Field name collision | `InvalidStructure` |
+| Input/block too large | `InputTooLarge` |
+| Invalid card name | `InvalidStructure` |
 
 ### Line Endings
 
@@ -35,4 +70,14 @@ Supports both `\n` and `\r\n`.
 
 ### YAML Parsing
 
-Uses `serde-saphyr` for YAML → `serde_json::Value` conversion, then converts to `QuillValue`.
+Uses `serde-saphyr` for YAML → `serde_json::Value` conversion, then wraps in `QuillValue`. A `serde_saphyr::Budget` limits nesting depth at the parser level to prevent stack overflow.
+
+### Security Limits
+
+| Limit | Value |
+|---|---|
+| Max document size | 10 MB |
+| Max single YAML block | 1 MB |
+| Max YAML nesting depth | 100 |
+| Max CARD blocks | 1 000 |
+| Max field count | 1 000 |

--- a/prose/designs/PUBLIC_SCHEMA.md
+++ b/prose/designs/PUBLIC_SCHEMA.md
@@ -14,13 +14,19 @@ A YAML subset projection of `Quill.yaml`:
 - `fields`
 - `cards`
 
-## Who consumes it
+## Intended consumers
 
 - LLM generation/repair loops
 - form/UI builders
 - third-party integrations that need field contracts without internal runtime details
 
 ## Shape
+
+Top-level keys: `name`, `description` (optional), `example` (optional), `fields`, `cards` (omitted when empty).
+
+Each field includes: `type`, `title` (optional), `description` (optional), `required` (omitted when false), `default` (optional), `examples` (optional list), `enum` (optional), `properties` (optional, for `object` fields), `items` (optional, for `array` fields), `ui` (optional).
+
+Each card includes: `title` (optional), `description` (optional), `fields`, `ui` (optional).
 
 ```yaml
 name: usaf_memo
@@ -40,6 +46,10 @@ fields:
     ui:
       group: Addressing
       order: 0
+  status:
+    type: string
+    enum: [draft, final]
+    default: draft
 cards:
   indorsement:
     title: Routing Indorsement
@@ -48,6 +58,9 @@ cards:
       from:
         type: string
         required: true
+    ui:
+      hide_body: false
+      default_title: Indorsement
 ```
 
 ## Relationship to `Quill.yaml`
@@ -59,11 +72,17 @@ Projection is by exclusion:
 
 `QuillConfig` remains the source of truth for both runtime and emitted contract.
 
+## Who exposes it
+
+- **Python** (`crates/bindings/python/`): `quill.schema` property returns YAML string. See PYTHON.md.
+- **CLI** (`crates/bindings/cli/`): `quillmark schema <path>` subcommand prints or writes the YAML.
+- **WASM** (`crates/bindings/wasm/`): the WASM `Quill` class does **not** currently expose a schema getter. See WASM.md.
+
 ## Why YAML text (not JSON object)
 
 - Matches authoring format (`Quill.yaml`) and docs/examples
 - Avoids maintaining parallel object schemas/projections in bindings
-- Keeps binding contracts simple (`quill.schema` / `quillInfo.schema` are plain strings)
+- Keeps binding contracts simple — callers receive a plain YAML string
 
 ## Contract ownership
 

--- a/prose/designs/PYTHON.md
+++ b/prose/designs/PYTHON.md
@@ -10,38 +10,53 @@
 
 ```python
 engine = Quillmark()
-engine.register_quill(quill)
-engine.workflow(name)             # by quill name
-engine.workflow(parsed)           # from ParsedDocument with QUILL field
-engine.workflow_from_quill(quill) # from Quill object
-engine.registered_backends()     # list[str]
-engine.registered_quills()       # list[str]
+engine.quill_from_path(path)      # → Quill (load quill, attach backend)
+engine.workflow(quill)            # → Workflow (for dynamic asset/font injection)
+engine.registered_backends()     # → list[str]
+```
+
+### `Quill`
+
+Obtained via `engine.quill_from_path(path)`.
+
+```python
+quill.name, quill.backend, quill.plate, quill.metadata, quill.schema
+quill.defaults          # dict of field defaults
+quill.examples          # dict of field example lists
+quill.example           # optional raw example string
+quill.print_tree        # file tree string
+quill.supported_formats()         # → list[OutputFormat]
+quill.render(parsed, format=None) # → RenderResult
+quill.open(parsed)                # → RenderSession
 ```
 
 ### `Workflow`
 
 ```python
 workflow.render(parsed, format=None)  # → RenderResult
+workflow.open(parsed)                 # → RenderSession
 workflow.dry_run(parsed)              # raises on validation failure
 workflow.backend_id                   # property
 workflow.supported_formats            # property
 workflow.quill_ref                    # property
 # Dynamic assets/fonts:
 workflow.add_asset(filename, contents)
-workflow.add_assets(assets)
+workflow.add_assets(assets)           # assets: list[tuple[str, bytes]]
 workflow.clear_assets()
 workflow.dynamic_asset_names()
 workflow.add_font(filename, contents)
-workflow.add_fonts(fonts)
+workflow.add_fonts(fonts)             # fonts: list[tuple[str, bytes]]
 workflow.clear_fonts()
 workflow.dynamic_font_names()
 ```
 
-### `Quill`
+### `RenderSession`
+
+Obtained via `quill.open(parsed)` or `workflow.open(parsed)`. Allows inspecting before rendering.
 
 ```python
-quill = Quill.from_path("path/to/quill")
-quill.name, quill.backend, quill.plate, quill.metadata, quill.schema, quill.example
+session.page_count                          # property
+session.render(format=None, pages=None)     # → RenderResult
 ```
 
 ### `ParsedDocument`
@@ -50,7 +65,7 @@ quill.name, quill.backend, quill.plate, quill.metadata, quill.schema, quill.exam
 parsed = ParsedDocument.from_markdown(markdown)
 parsed.body()
 parsed.get_field("key")
-parsed.fields()
+parsed.fields           # property → dict
 parsed.quill_ref()
 ```
 
@@ -66,25 +81,38 @@ artifact.mime_type
 artifact.save(path)
 ```
 
+### `Diagnostic`, `Location`
+
+```python
+diag.severity        # Severity enum
+diag.message         # str
+diag.code            # optional str
+diag.primary         # optional Location
+diag.hint            # optional str
+diag.source_chain    # list[str]
+
+loc.file, loc.line, loc.col
+```
+
 ### Enums
 
-- `OutputFormat.PDF`, `.SVG`, `.TXT`
+- `OutputFormat.PDF`, `.SVG`, `.TXT`, `.PNG`
 - `Severity.ERROR`, `.WARNING`, `.NOTE`
+- Both enums expose `.name` property and `.all()` static method.
 
 ### Exceptions
 
 - `QuillmarkError` (base) → `ParseError`, `TemplateError`, `CompilationError`
-- `CompilationError.diagnostics` — list of `SerializableDiagnostic`
+- `CompilationError.diagnostics` — list of `Diagnostic`
+- `ParseError.diagnostic` — single `Diagnostic`
 
 ## Module Structure
 
 ```
 crates/bindings/python/src/
-├── lib.rs       # PyO3 module entry point
-├── engine.rs
-├── workflow.rs
-├── quill.rs
-├── types.rs     # RenderResult, Artifact, Diagnostic
+├── lib.rs       # PyO3 module entry point; registers all classes/enums/exceptions
+├── types.rs     # All pyclass wrappers: Quillmark, Workflow, Quill, ParsedDocument,
+│                #   RenderResult, RenderSession, Artifact, Diagnostic, Location
 ├── enums.rs     # OutputFormat, Severity
 └── errors.rs    # Exception definitions and error mapping
 ```

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -1,7 +1,7 @@
 # Quill Resource File Structure and API
 
 > **Status**: Final Design - Opinionated, No Backward Compatibility
-> **Implementation**: `quillmark-core/src/quill.rs`
+> **Implementation**: `crates/core/src/quill.rs`
 
 ## Internal File Structure
 
@@ -14,7 +14,7 @@ pub enum FileTreeNode {
 pub struct Quill {
     pub metadata: HashMap<String, QuillValue>,
     pub name: String,
-    pub backend: String,
+    pub backend_id: String,
     pub plate: Option<String>,
     pub example: Option<String>,
     pub config: QuillConfig,
@@ -24,6 +24,8 @@ pub struct Quill {
 }
 ```
 
+`metadata` is populated from `Quill.yaml` fields plus computed entries: `backend`, `description`, `version`, `author`, and any `typst_*` keys from the `[typst]` section.
+
 ## In-memory Tree Contract (`engine.quill(tree)`)
 
 In-memory construction routes through the engine as `engine.quill(tree)`. The
@@ -31,39 +33,63 @@ core `Quill::from_tree` constructor is internal to `quillmark-core`. Input is
 a `FileTreeNode` directory tree with UTF-8 and binary file contents represented
 as bytes.
 
-For JS/WASM consumers this is exposed as `engine.quill(...)` with a flat
-`Map<string, Uint8Array>` (or plain object) path→bytes shape.
+For JS/WASM consumers this is exposed as `engine.quill(...)` accepting a
+`Map<string, Uint8Array>` (path→bytes). Plain objects are not accepted; only
+`Map` instances are supported.
 
 Validation rules:
 1. Root MUST be a directory node
-2. `Quill.yaml` MUST exist and be valid
-3. The `plate_file` referenced in `Quill.yaml` MUST exist
+2. `Quill.yaml` MUST exist and be valid YAML
+3. The `plate_file` referenced in `Quill.yaml`, if specified, MUST exist
 4. File paths use `/` separators and are resolved relative to root
 
 ## `Quill.yaml` Structure
 
+Required top-level sections: `Quill` (bundle metadata). Optional: `main` (document fields), `cards` (card type definitions), `typst` (backend config).
+
 ```yaml
 Quill:
-  name: my_quill
-  backend: typst
-  version: "1.0.0"
-  description: A beautiful format
-  plate_file: plate.typ
-  example_file: example.md
+  name: my_quill          # required; snake_case
+  backend: typst          # required
+  version: "1.0.0"        # required; semver (MAJOR.MINOR.PATCH or MAJOR.MINOR)
+  description: A beautiful format  # required; non-empty
+  author: Jane Doe        # optional; defaults to "Unknown"
+  plate_file: plate.typ   # optional; path to Typst template
+  example_file: example.md  # optional; example document for preview
 
 main:
   fields:
-    author:
-      type: string
-      description: Author of document
     title:
       type: string
       description: Document title
+    count:
+      type: integer
+      description: Whole-number count
+
+cards:
+  quote:
+    title: Quote block
+    description: A single pull quote
+    fields:
+      author:
+        type: string
+        description: Quote author
+
+typst:
+  packages:
+    - "@preview/some-package:1.0.0"
 ```
 
+Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`) are reserved by the engine. Standalone `object` fields are not supported; use `array` with `items: {type: object, properties: {...}}` instead.
+
 Metadata resolution:
-- `name` always read from `Quill.yaml` `Quill.name` (required)
-- `metadata` includes `backend`, `description`, `version`, and other Quill-level keys
+- `name`, `backend`, `version`, `description`, `author` are required/defaulted struct fields in `QuillConfig`
+- `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, any extra `Quill.*` keys, and `typst_*` keys from the `[typst]` section
+- `example_file` also accepts the alias `example` in YAML
+
+## File Ignore Rules
+
+When loading from disk, `Quill::from_path` respects a `.quillignore` file at the bundle root. If absent, default patterns apply: `.git/`, `.gitignore`, `.quillignore`, `target/`, `node_modules/`.
 
 ## API
 
@@ -71,14 +97,13 @@ Construction:
 - `Quillmark::quill_from_path(path)` — load render-ready quill from filesystem directory
 - `Quillmark::quill(tree)` — load render-ready quill from in-memory file tree
 
-Note: `Quill::from_json` is removed from the public API.
+Note: `Quill::from_json` is not part of the public API.
 
-File access:
+File access on `FileTreeNode`:
 - `file_exists(path)` / `get_file(path)` — check/read file
 - `dir_exists(path)` / `list_files(path)` / `list_subdirectories(path)` — directory navigation
 
 Path rules:
-- Always use forward slashes (`/`)
-- Directory paths must end with `/` for `list_files()` and `list_subdirectories()`
-- Root: use `""` or `"/"`
-- `get_file()` returns `Vec<u8>` for all files
+- Use forward slashes (`/`); absolute paths and `..` traversal are rejected
+- Root: use `""` (empty string)
+- `get_file()` returns `&[u8]` for all files

--- a/prose/designs/QUILL_VALUE.md
+++ b/prose/designs/QUILL_VALUE.md
@@ -1,16 +1,16 @@
 # QuillValue - Centralized Value Type
 
 > **Status**: Implemented  
-> **Implementation**: `quillmark-core/src/value.rs`
+> **Implementation**: `crates/core/src/value.rs`
 
 ## Overview
 
-`QuillValue` is a unified value type centralizing TOML/YAML/JSON conversions. Backed by `serde_json::Value`, it provides a single canonical representation for metadata and fields.
+`QuillValue` is a unified value type backed by `serde_json::Value`. It provides a single canonical representation for metadata and fields, with YAML and JSON as the supported input formats.
 
 ## Design Principles
 
 1. **JSON Foundation** - Use `serde_json::Value` for simplicity and broad ecosystem support
-2. **Conversion Boundaries** - Convert TOML/YAML to `QuillValue` at system boundaries
+2. **Conversion Boundaries** - Convert YAML/JSON to `QuillValue` at system boundaries
 3. **Newtype Pattern** - Wrap JSON to add domain-specific methods and control API
 
 ## Implementation
@@ -19,9 +19,9 @@
 pub struct QuillValue(serde_json::Value);
 ```
 
-**Conversion methods:** `from_toml()`, `from_yaml_str()`, `from_json()`, `as_json()`, `into_json()`
+**Conversion methods:** `from_yaml_str()`, `from_json()`, `as_json()`, `into_json()`
 
-**Delegating methods:** `is_null()`, `as_str()`, `as_bool()`, `as_i64()`, `as_array()`, `as_object()`, `get(key)`
+**Delegating methods:** `is_null()`, `as_str()`, `as_bool()`, `as_i64()`, `as_u64()`, `as_f64()`, `as_array()`, `as_object()`, `get(key)`
 - `get(key)` - Field access with `QuillValue` wrapping
 
 ### Deref Implementation

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -26,14 +26,24 @@ Supported field types:
 | `datetime` | ISO 8601 |
 | `markdown` | Rich text; backends handle conversion |
 
+## Type coercion
+
+`QuillConfig::coerce(&HashMap<String, QuillValue>)` runs before validation.
+
+- Returns `Result<HashMap<String, QuillValue>, CoercionError>`
+- Coerces top-level fields and card fields in `CARDS` to their declared types
+- Fails fast (`Err`) on the first value that cannot be coerced
+- Coercion rules per type: array wrapping, boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
+
 ## Native validation
 
 Validation is implemented by a native walker over `QuillConfig` in `quill/validation.rs`.
 
-- Entry point: `QuillConfig::validate(&HashMap<String, QuillValue>)`
+- Entry point: `QuillConfig::validate(&HashMap<String, QuillValue>)` (dispatches to `validate_document`)
 - Returns `Result<(), Vec<ValidationError>>`
 - Collects all errors (does not short-circuit)
 - Emits path-aware errors for top-level fields and card fields
+- Validates `CARDS` array: each element must have a `CARD` discriminator matching a known card type
 
 ## Public schema emission
 

--- a/prose/designs/TEMPLATE_DRY_RUN.md
+++ b/prose/designs/TEMPLATE_DRY_RUN.md
@@ -2,15 +2,14 @@
 
 **Status:** Implemented
 
-Dry run provides a lightweight validation path that stops before backend compilation. It is exposed as `Workflow::dry_run(&ParsedDocument)` and mirrored in the WASM bindings (`dryRun(markdown)`).
+Dry run provides a lightweight validation path that stops before backend compilation. It is exposed as `Workflow::dry_run(&ParsedDocument)` on the Rust/Python side. WASM does not expose a separate dry-run entry point; WASM callers use `quill.render()` which includes full validation.
 
 ## What Runs
 
 1. Type coercion via `QuillConfig::coerce`
 2. Native validation via `QuillConfig::validate`
-3. Normalization (bidi stripping, HTML fence fixes)
 
-No plate composition or backend compilation occurs; errors are limited to parsing/validation/normalization.
+No normalization, plate composition, or backend compilation occurs. Errors are limited to field coercion and schema validation.
 
 ## Error Surfacing
 
@@ -20,11 +19,13 @@ No plate composition or backend compilation occurs; errors are limited to parsin
 ## Usage
 
 ```rust
-let workflow = engine.workflow("my-quill")?;
+let quill = engine.quill_from_path("./my-quill")?;
+let workflow = engine.workflow(&quill)?;
 let parsed = ParsedDocument::from_markdown(markdown)?;
 workflow.dry_run(&parsed)?; // Ok(()) on success
 ```
 
 Bindings:
 - **Python**: `workflow.dry_run(parsed)` raises `QuillmarkError` on failure
-- **WASM**: `engine.dryRun(markdown)` throws a `WasmError` with diagnostic payload
+- **WASM**: no `dryRun` method; use `quill.render()` which validates before compiling
+- **CLI**: `quillmark validate <quill-path>` validates a quill's configuration (not a document)

--- a/prose/designs/VERSIONING.md
+++ b/prose/designs/VERSIONING.md
@@ -38,26 +38,21 @@ Given versions `[1.0.0, 1.0.1, 1.1.0, 2.0.0, 2.1.0, 2.1.1, 3.0.0]`:
 
 ## Quill.yaml
 
-`version` is required:
+`version` and `description` are both required:
 
 ```yaml
 Quill:
   name: my_format
   version: "2.1.0"
   backend: typst
-  description: "..."
+  description: "Short description of this format"
 ```
+
+`version` must parse as `MAJOR.MINOR.PATCH` (or `MAJOR.MINOR`); an invalid or missing value is a hard error at load time.
 
 ## Error Handling
 
-```
-Error: Version not found
-  Quill: resume_format
-  Requested: @2.3
-  Available: 3.0.0, 2.2.0, 2.1.0, 2.0.0, 1.0.0
-
-  Suggestion: Use @2 for latest 2.x.x (currently 2.2.0)
-```
+Version parse errors surface as `RenderError::QuillConfig` with a descriptive message. There is no runtime version-registry lookup — each Quill is loaded directly from a path or in-memory file tree.
 
 See [ERROR.md](ERROR.md) for error handling patterns.
 

--- a/prose/designs/WASM.md
+++ b/prose/designs/WASM.md
@@ -7,41 +7,66 @@
 ## API (current)
 
 ```typescript
-class Quill {
-}
-
 class Quillmark {
   constructor();
-  static parseMarkdown(markdown: string): ParsedDocument;
-  quill(tree: Map<string, Uint8Array> | Record<string, Uint8Array>): Quill;
+  quill(tree: Map<string, Uint8Array>): Quill;
+}
+
+class Quill {
+  render(parsed: ParsedDocument, opts?: RenderOptions): RenderResult;
+  open(parsed: ParsedDocument): RenderSession;
+}
+
+class RenderSession {
+  readonly pageCount: number;
+  render(opts?: RenderOptions): RenderResult;
+}
+
+class ParsedDocument {
+  static fromMarkdown(markdown: string): ParsedDocument;
+  fields: Record<string, any>;
+  quillRef: string;
+}
+
+interface RenderOptions {
+  format?: "pdf" | "svg" | "txt" | "png";
+  assets?: Record<string, Uint8Array | number[]>;
+  ppi?: number;
+  pages?: number[];
+}
+
+interface RenderResult {
+  artifacts: Artifact[];
+  warnings: Diagnostic[];
+  outputFormat: "pdf" | "svg" | "txt" | "png";
+  renderTimeMs: number;
+}
+
+interface Artifact {
+  format: "pdf" | "svg" | "txt" | "png";
+  bytes: Uint8Array;
+  mimeType: string;
+}
+
+interface Diagnostic {
+  severity: "error" | "warning" | "note";
+  code?: string;
+  message: string;
+  location?: { file: string; line: number; column: number };
+  hint?: string;
+  sourceChain?: string[];
 }
 ```
 
 ## Implementation notes
 
-- `engine.quill(...)` accepts `Map<string, Uint8Array>` or a plain `Record<string, Uint8Array>`. Directory hierarchy is inferred from `/` path separators in keys (e.g. `"assets/fonts/Inter.ttf"` inserts into `assets/fonts/`). Values must be `Uint8Array`; passing a string throws.
+- `engine.quill(tree)` requires a `Map<string, Uint8Array>`; plain objects are rejected with an error. Directory hierarchy is inferred from `/` separators in keys (e.g. `"assets/fonts/Inter.ttf"` inserts into `assets/fonts/`). Values must be `Uint8Array`; anything else throws.
+- `RenderOptions.ppi` defaults to 144.0 (2× at 72 pt/inch) and is only applied to PNG output.
+- `RenderOptions.pages` is intended for page-addressable outputs (SVG, PNG), not PDF.
 
 ## Key contracts
 
-- `ParsedDocument.quillRef` is required and is sourced from `QUILL` frontmatter.
-- `QuillInfo.schema` is YAML text.
+- `ParsedDocument.quillRef` is required and sourced from `QUILL` frontmatter; parsing fails without it.
+- `quill.render()` emits a warning (not an error) if `parsed.quillRef` does not match the quill name.
 - No schema projection API is exposed.
-- Render/compile options do not include quill override fields.
-
-```typescript
-interface ParsedDocument {
-  fields: Record<string, any>;
-  quillRef: string;
-}
-
-interface QuillInfo {
-  name: string;
-  backend: string;
-  metadata: Record<string, any>;
-  example?: string;
-  schema: string; // YAML
-  defaults: Record<string, any>;
-  examples: Record<string, any[]>;
-  supportedFormats: Array<"pdf" | "svg" | "png" | "txt">;
-}
-```
+- Render options do not include quill override fields.


### PR DESCRIPTION
This PR updates documentation and design specifications across the Quillmark project to reflect current API contracts, implementation details, and user-facing interfaces.

## Summary

Extensive documentation refresh covering Python/JavaScript/WASM API contracts, design specifications, and user-facing guides. Changes clarify API signatures, add missing type information, improve examples, and align documentation with actual implementation.

## Key Changes

**API Documentation**
- Python API (`docs/integration/python/api.md`): Added complete class definitions for `Quill`, `Workflow`, `RenderSession`, `RenderResult`, `Artifact`, `Diagnostic`, and `Location` with full method signatures and property types
- JavaScript/WASM API (`prose/designs/WASM.md`, `docs/integration/javascript/api.md`): Clarified `RenderOptions`, `RenderResult`, and `RenderSession` interfaces; documented `ppi` parameter behavior and page selection semantics
- Removed ambiguous method overloads; clarified that `ParsedDocument` requires `QUILL` frontmatter and parsing fails without it

**Design Specifications**
- `PARSE.md`: Detailed parsing flow with validation rules, CARD name validation, QUILL name validation, and field count limits
- `QUILL.md`: Updated struct field names (`backend_id` instead of `backend`), clarified metadata resolution, and documented `Quill.yaml` structure with required/optional sections
- `EXTENDED_MARKDOWN.md`: Clarified that `---` is always a metadata delimiter (never a thematic break), documented reserved keys (`BODY`, `CARDS`, `QUILL`, `CARD`), and added card block semantics
- `ERROR.md`: Documented error type hierarchy (`ParseError`, `RenderError`, `TemplateError`, `CompilationError`) and `SerializableDiagnostic` for FFI boundaries
- `CARDS.md`: Updated `QuillConfig` structure to use `Vec<CardSchema>` with index 0 as main card; documented card field schema and UI hints
- `ARCHITECTURE.md`: Simplified overview; clarified data flow through parse → normalize → compile stages with `RenderSession` abstraction

**Authoring Guides**
- `yaml-frontmatter.md`: Reorganized with dedicated QUILL key section, version selector syntax table, reserved field names, and card block examples
- `markdown-syntax.md`: Added underline support (`__text__`), documented table syntax, clarified `<br>` for line breaks, and listed unsupported features (blockquotes, images, thematic breaks)
- `cards.md`: Added example with `QUILL` key in frontmatter

**Format Designer Guides**
- `creating-quills.md`: Updated naming convention from kebab-case to snake_case for Quill names
- `quill-yaml-reference.md`: Clarified field types, added `compact` UI hint, and noted `object` type scoping to `array.items`
- `versioning.md`: Enforced snake_case naming, made `version` and `description` required fields
- `PUBLIC_SCHEMA.md`: Documented top-level keys and field/card shape in schema output

**Integration & CI/CD**
- `validation.md`: Clarified two validation levels (dry run vs. full render) and WASM behavior
- `CI_CD.md`: Restructured CI jobs table, documented publish workflows for Rust crates, Python wheels, and WASM packages
- `PYTHON.md`: Updated engine API to use `quill_from_path()` and `workflow()` methods with clearer signatures

**Other Updates**
- `GLUE_METADATA.md`: Clarified two-stage data flow (coercion/validation, then backend transformation)
- `TEMPLATE_DRY_RUN.md`: Noted WASM does not expose separate dry-run entry point
- `CLI.md`: Minor formatting fix (`-v` flag for verbose)
- `concepts.md`: Updated backend description to include PNG output

## Notable Implementation Details

- `RenderSession` abstraction enables page-selective rendering for page-addressable formats (SVG, PNG)
- `ParsedDocument` stores `BODY` and `CARDS` as reserved fields

https://claude.ai/code/session_01VmrkHTmC7TyTDP7PVrDhoN