### PR TITLE
docs: gap analysis between parser and MARKDOWN.md spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ out/
 # VS Code
 .vscode/
 
+# Claude Code agent worktrees (ephemeral)
+.claude/worktrees/
+
 # Quillmark example output files and directories
 output*.pdf
 output*.svg

--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -1008,14 +1008,10 @@ where
             // 3. Handle HTML: allowlist <u>…</u> as underline; strip everything else.
             // Spec §6.2 deviation 2 / §6.3: <br> and all other raw HTML produce no output.
             let (event, range) = match event {
-                Event::InlineHtml(ref html) | Event::Html(ref html)
-                    if is_u_open_tag(html) =>
-                {
+                Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_open_tag(html) => {
                     (Event::Start(Tag::Strong), range)
                 }
-                Event::InlineHtml(ref html) | Event::Html(ref html)
-                    if is_u_close_tag(html) =>
-                {
+                Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_close_tag(html) => {
                     (Event::End(TagEnd::Strong), range)
                 }
                 Event::Html(_) | Event::InlineHtml(_) => continue,
@@ -2386,10 +2382,7 @@ mod tests {
             !out.contains("linebreak"),
             "<br> must not produce #linebreak(): {out}"
         );
-        assert!(
-            !out.contains("<br"),
-            "<br> literal must be stripped: {out}"
-        );
+        assert!(!out.contains("<br"), "<br> literal must be stripped: {out}");
         assert!(out.contains("line1"), "surrounding text preserved: {out}");
         assert!(out.contains("line2"), "surrounding text preserved: {out}");
     }
@@ -2397,10 +2390,7 @@ mod tests {
     #[test]
     fn test_table_br_tag_variants_stripped() {
         // <br/> and <br /> variants must also produce no output.
-        for md in [
-            "| A |\n|---|\n| a<br/>b |",
-            "| A |\n|---|\n| a<br />b |",
-        ] {
+        for md in ["| A |\n|---|\n| a<br/>b |", "| A |\n|---|\n| a<br />b |"] {
             let out = mark_to_typst(md).unwrap();
             assert!(
                 !out.contains("linebreak"),

--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -532,22 +532,13 @@ where
     Ok(())
 }
 
-/// Iterator that post-processes markdown events to handle specific edge cases:
-/// 1. Coalesces adjacent `Text` events to enable intraword underscore emphasis (fix for `__` sandwich).
-/// 2. Fixes `***` adjacency issues (fix for `***` sandwich).
-/// 3. Suppresses setext-style headings (only ATX-style `# Heading` is supported).
-/// 4. Tracks `__` and `~~` markers across events for intraword nested formatting.
+/// Iterator that post-processes markdown events to handle two edge cases:
+/// 1. Allowlists `<u>…</u>` as underline; strips all other raw HTML.
+/// 2. Fixes `***` adjacency issues.
 struct MarkdownFixer<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>> {
     inner: std::iter::Peekable<I>,
     source: &'a str,
-    /// Buffer of events to emit before pulling from inner
     buffer: Vec<(Event<'a>, Range<usize>)>,
-    /// Track when we're inside a setext heading that should be suppressed
-    in_setext_heading: bool,
-    /// Stack of pending intraword markers (marker type, text before marker, range)
-    /// Marker type: "__" for underline, "~~" for strikethrough
-    pending_markers: Vec<(&'static str, String, Range<usize>)>,
-    /// Track nesting depth of emphasis and strong tags for fixup validation
     emph_depth: usize,
     strong_depth: usize,
 }
@@ -561,30 +552,8 @@ where
             inner: inner.peekable(),
             source,
             buffer: Vec::new(),
-            in_setext_heading: false,
-            pending_markers: Vec::new(),
             emph_depth: 0,
             strong_depth: 0,
-        }
-    }
-
-    /// Check if a heading at the given source range is a setext-style heading.
-    /// Setext headings have the text on one line and `=` or `-` underline on the next.
-    /// ATX headings start with `#` characters.
-    fn is_setext_heading(&self, range: &Range<usize>) -> bool {
-        let source_slice = &self.source[range.clone()];
-        // Setext headings contain a newline followed by = or - characters
-        // ATX headings start with # and don't have this pattern
-        if let Some(newline_pos) = source_slice.find('\n') {
-            let after_newline = &source_slice[newline_pos + 1..];
-            let trimmed = after_newline.trim_start();
-            // Check if the line after newline consists of = or - (setext underline)
-            !trimmed.is_empty()
-                && trimmed
-                    .chars()
-                    .all(|c| c == '=' || c == '-' || c.is_whitespace())
-        } else {
-            false
         }
     }
 
@@ -651,176 +620,6 @@ where
         }
 
         merged_range
-    }
-
-    /// Process a text range, potentially splitting it into multiple events with Strong markers.
-    /// Uses the source slice directly based on range.
-    /// Handles cross-event marker tracking for intraword nested formatting.
-    fn process_text_from_source(&mut self, range: Range<usize>) {
-        let source_slice = &self.source[range.clone()];
-
-        // Skip processing for HTML entities (complex to handle correctly)
-        if source_slice.contains('&') {
-            self.buffer.push((Event::Text(source_slice.into()), range));
-            return;
-        }
-
-        // Check if the slice is preceded by an escape backslash in the full source
-        // If so, the __ at the start is escaped and should not be processed
-        let preceded_by_escape =
-            range.start > 0 && self.source.as_bytes().get(range.start - 1) == Some(&b'\\');
-        if preceded_by_escape && source_slice.starts_with("__") {
-            // Don't process - the __ is escaped
-            self.buffer.push((Event::Text(source_slice.into()), range));
-            return;
-        }
-
-        let mut events: Vec<(Event<'a>, Range<usize>)> = Vec::new();
-        let mut in_underline = false;
-        let mut last_end = 0;
-        let mut i = 0;
-        let bytes = source_slice.as_bytes();
-
-        // Check if this text starts with __ and we have a pending underline opener
-        // Skip if the __ is part of a longer underscore run (3+ consecutive underscores)
-        let starts_with_marker = bytes.len() >= 2
-            && bytes[0] == b'_'
-            && bytes[1] == b'_'
-            && !(bytes.len() >= 3 && bytes[2] == b'_');
-        if starts_with_marker
-            && self
-                .pending_markers
-                .last()
-                .map(|(m, _, _)| *m == "__")
-                .unwrap_or(false)
-        {
-            // Close the pending underline
-            let (_, pending_text, pending_range) = self.pending_markers.pop().unwrap();
-            if !pending_text.is_empty() {
-                events.push((Event::Text(pending_text.into()), pending_range.clone()));
-            }
-            events.push((Event::Start(Tag::Strong), pending_range));
-
-            // Now process the rest after the closing __
-            let marker_range = range.start..range.start + 2;
-            events.push((Event::End(TagEnd::Strong), marker_range));
-            i = 2;
-            last_end = 2;
-        }
-
-        // Process the rest of the text for __ patterns
-        while i < bytes.len() {
-            // Skip over escaped characters (backslash followed by any char)
-            if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-
-            if i + 1 < bytes.len() && bytes[i] == b'_' && bytes[i + 1] == b'_' {
-                // Skip __ that is part of a longer underscore run (3+ consecutive underscores)
-                // e.g., "________________" should be literal text, not underline markers
-                let prev_is_underscore = i > 0 && bytes[i - 1] == b'_';
-                let next_is_underscore = i + 2 < bytes.len() && bytes[i + 2] == b'_';
-                if prev_is_underscore || next_is_underscore {
-                    i += 1;
-                    continue;
-                }
-
-                // Found __
-                let before = &source_slice[last_end..i];
-                if !before.is_empty() {
-                    events.push((
-                        Event::Text(before.into()),
-                        range.start + last_end..range.start + i,
-                    ));
-                }
-
-                let marker_range = range.start + i..range.start + i + 2;
-                if in_underline {
-                    // Close underline
-                    events.push((Event::End(TagEnd::Strong), marker_range));
-                    in_underline = false;
-                } else {
-                    // Open underline
-                    events.push((Event::Start(Tag::Strong), marker_range));
-                    in_underline = true;
-                }
-
-                i += 2;
-                last_end = i;
-            } else {
-                i += 1;
-            }
-        }
-
-        // Emit remaining text
-        let remaining = &source_slice[last_end..];
-
-        // If we have an unclosed underline at the end, save it as pending
-        if in_underline {
-            // Find the position of the last __ (which opened the underline)
-            // Events should have Start(Strong) as the last non-text event
-            // We need to extract the text before it and save as pending
-
-            // Find where the opening __ was
-            let mut text_before_opener = String::new();
-            let mut opener_range = range.clone();
-
-            // Collect all events before the unclosed Start(Strong)
-            let mut final_events: Vec<(Event<'a>, Range<usize>)> = Vec::new();
-            for ev in events.into_iter() {
-                match &ev.0 {
-                    Event::Start(Tag::Strong) => {
-                        // This is the unclosed opener - save text before it as pending
-                        opener_range = ev.1.clone();
-                    }
-                    Event::Text(t) => {
-                        // Check if this comes before or after the opener
-                        if ev.1.end <= opener_range.start {
-                            // Before opener - emit it
-                            final_events.push(ev);
-                        } else {
-                            // After opener - accumulate for pending
-                            text_before_opener.push_str(t);
-                        }
-                    }
-                    Event::End(TagEnd::Strong) => {
-                        // Completed underlines - emit
-                        final_events.push(ev);
-                    }
-                    _ => {
-                        final_events.push(ev);
-                    }
-                }
-            }
-
-            // Add remaining text to what goes with the pending marker
-            if !remaining.is_empty() {
-                text_before_opener.push_str(remaining);
-            }
-
-            // Save the pending marker
-            self.pending_markers
-                .push(("__", text_before_opener, opener_range));
-
-            // Emit the events we collected (reversed for buffer)
-            final_events.reverse();
-            self.buffer.extend(final_events);
-        } else if events.is_empty() && remaining == source_slice {
-            // No markers found, emit original text
-            self.buffer.push((Event::Text(source_slice.into()), range));
-        } else {
-            // Add remaining text if any
-            if !remaining.is_empty() {
-                events.push((
-                    Event::Text(remaining.into()),
-                    range.start + last_end..range.end,
-                ));
-            }
-            // Events need to be reversed since we pop from buffer
-            events.reverse();
-            self.buffer.extend(events);
-        }
     }
 
     /// Count how many unclosed emphasis/strong tags the trailing stars could close.
@@ -1018,48 +817,6 @@ where
                 other => (other, range),
             };
 
-            // 4. Handle setext heading suppression (ATX-only policy)
-            match &event {
-                Event::Start(Tag::Heading { .. }) => {
-                    if self.is_setext_heading(&range) {
-                        // Skip setext heading start - the text content will still be emitted
-                        self.in_setext_heading = true;
-                        continue;
-                    }
-                }
-                Event::End(TagEnd::Heading(_)) => {
-                    if self.in_setext_heading {
-                        // Skip setext heading end
-                        self.in_setext_heading = false;
-                        continue;
-                    }
-                }
-                _ => {}
-            }
-
-            // 4. Process Event
-            if let Event::Text(_) = &event {
-                let merged_range = self.coalesce_text_range(range);
-                let source_slice = &self.source[merged_range.clone()];
-
-                if source_slice.contains("__") {
-                    self.process_text_from_source(merged_range);
-                    // Buffer is populated, loop continues to process buffer
-                    continue;
-                } else {
-                    // Fallthrough to handle_candidate for merged text
-                    // We need to pass the merged event
-                    if let Some(result) =
-                        self.handle_candidate((Event::Text(source_slice.into()), merged_range))
-                    {
-                        return Some(result);
-                    } else {
-                        continue;
-                    }
-                }
-            }
-
-            // Handle other events via handle_candidate (checks for End(Strong))
             if let Some(result) = self.handle_candidate((event, range)) {
                 return Some(result);
             } else {
@@ -1068,226 +825,18 @@ where
         }
     }
 }
-
-/// Placeholder markers for intraword formatting.
-/// These are Unicode characters unlikely to appear in normal text.
-const UNDERLINE_OPEN: &str = "\u{FFF9}"; // Interlinear Annotation Anchor
-const UNDERLINE_CLOSE: &str = "\u{FFFA}"; // Interlinear Annotation Separator
-const STRIKE_OPEN: &str = "\u{FFFB}"; // Interlinear Annotation Terminator
-const STRIKE_CLOSE: &str = "\u{2060}"; // Word Joiner (used as strike close)
-
-/// Check if a character is a word character (alphanumeric).
-fn is_word_char(c: char) -> bool {
-    c.is_ascii_alphanumeric()
-}
-
-/// Pre-process markdown to handle INTRAWORD `__` and `~~` markers only.
-///
-/// CommonMark doesn't allow intraword underscore emphasis. This function finds
-/// paired markers that are in intraword positions (adjacent to alphanumeric
-/// without whitespace) and replaces them with placeholders.
-///
-/// Properly bounded markers (with whitespace/punctuation boundaries) are left
-/// for pulldown-cmark to handle natively.
-fn preprocess_intraword_formatting(source: &str) -> String {
-    let mut result = source.to_string();
-
-    // Only transform markers that are truly intraword
-    result = replace_intraword_marker_pairs(&result, "__", UNDERLINE_OPEN, UNDERLINE_CLOSE);
-    result = replace_intraword_marker_pairs(&result, "~~", STRIKE_OPEN, STRIKE_CLOSE);
-
-    result
-}
-
-/// Find and replace INTRAWORD marker pairs only.
-/// An intraword marker pair is one where BOTH markers are adjacent to word characters
-/// on the "inner" side (i.e., opener followed by word char, closer preceded by word char)
-/// AND at least one marker is in a truly intraword position (word char on outer side too).
-fn replace_intraword_marker_pairs(source: &str, marker: &str, open: &str, close: &str) -> String {
-    let chars: Vec<char> = source.chars().collect();
-    let marker_chars: Vec<char> = marker.chars().collect();
-    let marker_len = marker_chars.len();
-
-    // First pass: find all marker positions and their context
-    struct MarkerInfo {
-        pos: usize,         // position in chars array
-        prev_is_word: bool, // char before marker is word char
-        next_is_word: bool, // char after marker is word char
-    }
-
-    let mut markers: Vec<MarkerInfo> = Vec::new();
-    let mut i = 0;
-
-    while i < chars.len() {
-        // Skip escaped characters
-        if chars[i] == '\\' && i + 1 < chars.len() {
-            i += 2;
-            continue;
-        }
-
-        // Skip code spans (backtick-delimited regions) to avoid transforming
-        // markers inside inline code or fenced code blocks
-        if chars[i] == '`' {
-            // Count opening backticks
-            let backtick_start = i;
-            let mut backtick_count = 0;
-            while i < chars.len() && chars[i] == '`' {
-                backtick_count += 1;
-                i += 1;
-            }
-            if backtick_count >= 3 {
-                // Fenced code block: skip until matching closing fence
-                while i < chars.len() {
-                    if chars[i] == '`' {
-                        let mut close_count = 0;
-                        while i < chars.len() && chars[i] == '`' {
-                            close_count += 1;
-                            i += 1;
-                        }
-                        if close_count >= backtick_count {
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            } else {
-                // Inline code span: skip until matching closing backtick(s)
-                let mut found_close = false;
-                while i < chars.len() {
-                    if chars[i] == '`' {
-                        let mut close_count = 0;
-                        while i < chars.len() && chars[i] == '`' {
-                            close_count += 1;
-                            i += 1;
-                        }
-                        if close_count == backtick_count {
-                            found_close = true;
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-                if !found_close {
-                    // No matching close: backticks are literal, rewind
-                    // and let the rest of the loop handle subsequent chars.
-                    // (i is already past the backticks)
-                    i = backtick_start + backtick_count;
-                }
-            }
-            continue;
-        }
-
-        // Check for marker
-        if i + marker_len <= chars.len()
-            && chars[i..i + marker_len]
-                .iter()
-                .zip(marker_chars.iter())
-                .all(|(a, b)| a == b)
-        {
-            let prev_char = if i > 0 { Some(chars[i - 1]) } else { None };
-            let next_char = if i + marker_len < chars.len() {
-                Some(chars[i + marker_len])
-            } else {
-                None
-            };
-
-            markers.push(MarkerInfo {
-                pos: i,
-                prev_is_word: prev_char.map(is_word_char).unwrap_or(false),
-                next_is_word: next_char.map(is_word_char).unwrap_or(false),
-            });
-            i += marker_len;
-        } else {
-            i += 1;
-        }
-    }
-
-    // Only transform simple intraword pairs (exactly 2 markers)
-    // Complex nested cases should be handled by MarkdownFixer
-    let mut transform_positions: std::collections::HashSet<usize> =
-        std::collections::HashSet::new();
-
-    if markers.len() == 2 {
-        let opener = &markers[0];
-        let closer = &markers[1];
-
-        // Transform if this is a truly intraword pair:
-        // - Opener preceded by word char (intraword on left)
-        // - OR closer followed by word char (intraword on right)
-        let is_truly_intraword = opener.prev_is_word || closer.next_is_word;
-
-        if is_truly_intraword {
-            transform_positions.insert(opener.pos);
-            transform_positions.insert(closer.pos);
-        }
-    }
-    // For 4+ markers (potential nesting), don't transform - let MarkdownFixer handle it
-
-    // Second pass: build result with transformations
-    let mut result = String::with_capacity(source.len());
-    let mut char_idx = 0;
-    let mut marker_iter = markers.iter().peekable();
-
-    while char_idx < chars.len() {
-        // Check if we're at a marker position
-        if let Some(marker_info) = marker_iter.peek() {
-            if marker_info.pos == char_idx {
-                marker_iter.next();
-                if transform_positions.contains(&char_idx) {
-                    // Determine if this is an opener or closer
-                    // Count how many transformed markers we've seen before this one
-                    let transformed_before = markers
-                        .iter()
-                        .filter(|m| m.pos < char_idx && transform_positions.contains(&m.pos))
-                        .count();
-                    if transformed_before % 2 == 0 {
-                        result.push_str(open);
-                    } else {
-                        result.push_str(close);
-                    }
-                } else {
-                    // Keep original marker
-                    for c in marker_chars.iter() {
-                        result.push(*c);
-                    }
-                }
-                char_idx += marker_len;
-                continue;
-            }
-        }
-        result.push(chars[char_idx]);
-        char_idx += 1;
-    }
-
-    result
-}
-
-/// Convert placeholder markers back to Typst formatting in the output.
-fn convert_placeholders(text: &str) -> String {
-    text.replace(UNDERLINE_OPEN, "#underline[")
-        .replace(UNDERLINE_CLOSE, "]")
-        .replace(STRIKE_OPEN, "#strike[")
-        .replace(STRIKE_CLOSE, "]")
-}
-
 pub fn mark_to_typst(markdown: &str) -> Result<String, ConversionError> {
-    // Pre-process for intraword formatting support (replaces __ and ~~ with placeholders)
-    let preprocessed = preprocess_intraword_formatting(markdown);
-
     let mut options = pulldown_cmark::Options::empty();
     options.insert(pulldown_cmark::Options::ENABLE_STRIKETHROUGH);
     options.insert(pulldown_cmark::Options::ENABLE_TABLES);
 
-    let parser = Parser::new_ext(&preprocessed, options);
-    let fixer = MarkdownFixer::new(parser.into_offset_iter(), &preprocessed);
+    let parser = Parser::new_ext(markdown, options);
+    let fixer = MarkdownFixer::new(parser.into_offset_iter(), markdown);
     let mut typst_output = String::new();
 
-    push_typst(&mut typst_output, &preprocessed, fixer)?;
+    push_typst(&mut typst_output, markdown, fixer)?;
 
-    // Convert placeholder markers to Typst formatting
-    Ok(convert_placeholders(&typst_output))
+    Ok(typst_output)
 }
 
 #[cfg(test)]
@@ -1662,78 +1211,6 @@ mod tests {
     }
 
     #[test]
-    fn test_emphasis_sandwich_bug() {
-        // Bug: ***__...__***asdf fails to parse outer ***
-        let markdown = "***__Underlined__***suffix";
-        let typst = mark_to_typst(markdown).unwrap();
-        // Expect: #strong[#emph[#underline[Underlined]]]suffix
-        // Or similar nesting.
-        // If it fails, it will likely be: \*\*\*#underline[Underlined]\*\*\*suffix
-        assert_eq!(typst, "#strong[#emph[#underline[Underlined]]]suffix\n\n");
-    }
-
-    #[test]
-    fn test_text_before_strong_emph_underline() {
-        // Bug report: pre***__content__*** doesn't parse correctly
-        // The "pre" before the *** causes pulldown-cmark to parse *** as literal text
-        // But MarkdownFixer should fix this
-        let markdown = "pre***__content__***";
-
-        // Without MarkdownFixer, the *** would render as literal \*\*\*
-        // because pulldown-cmark doesn't recognize them as emphasis markers
-        // after the "pre" text. The MarkdownFixer handles this case.
-
-        let typst = mark_to_typst(markdown).unwrap();
-        // Should render as: pre#strong[#emph[#underline[content]]]
-        assert_eq!(typst, "pre#strong[#emph[#underline[content]]]\n\n");
-    }
-
-    #[test]
-    fn test_text_before_strong_emph_underline_variations() {
-        // Additional test cases for combinations of text, stars, and underlines
-
-        // Variation 1: Just underline after text
-        assert_eq!(
-            mark_to_typst("pre__content__").unwrap(),
-            "pre#underline[content]\n\n"
-        );
-
-        // Variation 2: Stars before underline (no text before)
-        // Note: pulldown-cmark parses *** as emph wrapping strong (not strong wrapping emph)
-        // This is standard markdown behavior where *** = * (emph) + ** (strong)
-        assert_eq!(
-            mark_to_typst("***__content__***").unwrap(),
-            "#emph[#strong[#underline[content]]]\n\n"
-        );
-
-        // Variation 3: 2 stars (bold only) after text
-        assert_eq!(
-            mark_to_typst("pre**__content__**").unwrap(),
-            "pre#strong[#underline[content]]\n\n"
-        );
-
-        // Variation 4: 1 star (emph only) after text
-        assert_eq!(
-            mark_to_typst("pre*__content__*").unwrap(),
-            "pre#emph[#underline[content]]\n\n"
-        );
-
-        // Variation 5: Multiple words before the formatting (with space before ***)
-        // When there's a space before ***, pulldown-cmark recognizes the *** correctly
-        // as emphasis+strong, so it becomes #emph[#strong[...]]
-        assert_eq!(
-            mark_to_typst("some text ***__content__***").unwrap(),
-            "some text #emph[#strong[#underline[content]]]\n\n"
-        );
-
-        // Variation 6: Text after the formatting
-        assert_eq!(
-            mark_to_typst("pre***__content__*** suffix").unwrap(),
-            "pre#strong[#emph[#underline[content]]] suffix\n\n"
-        );
-    }
-
-    #[test]
     fn test_link_with_anchor() {
         // URLs don't need # escaped in Typst string literals
         let markdown = "[Link](#anchor)";
@@ -2103,62 +1580,6 @@ mod tests {
         assert_eq!(
             mark_to_typst("__underline ~~strike~~__").unwrap(),
             "#underline[underline #strike[strike]]\n\n"
-        );
-    }
-
-    // Tests for intraword underscore emphasis (EmphasisFixer)
-    #[test]
-    fn test_intraword_underscore_emphasis() {
-        // This is the user's reported issue: underscores in middle of word
-        assert_eq!(
-            mark_to_typst("the cow __jumped over the mo__on").unwrap(),
-            "the cow #underline[jumped over the mo]on\n\n"
-        );
-    }
-
-    #[test]
-    fn test_intraword_underscore_start_of_word() {
-        // Underscore starts mid-word
-        assert_eq!(
-            mark_to_typst("foo__bar__baz").unwrap(),
-            "foo#underline[bar]baz\n\n"
-        );
-    }
-
-    #[test]
-    fn test_escaped_intraword_underscore() {
-        // Escaped underscores should remain literal
-        let result = mark_to_typst("foo\\__bar").unwrap();
-        // Contains literal underscore, not underline
-        assert!(result.contains("\\_"));
-        assert!(!result.contains("#underline"));
-    }
-
-    // Tests for nested intraword formatting (the originally problematic cases)
-    #[test]
-    fn test_intraword_underline_wrapping_strikethrough() {
-        // Underline wrapping strikethrough, all intraword
-        assert_eq!(
-            mark_to_typst("outer__~~inner~~__asdf").unwrap(),
-            "outer#underline[#strike[inner]]asdf\n\n"
-        );
-    }
-
-    #[test]
-    fn test_intraword_strikethrough_wrapping_underline() {
-        // Strikethrough wrapping underline, all intraword
-        assert_eq!(
-            mark_to_typst("outer~~__inner__~~asdf").unwrap(),
-            "outer#strike[#underline[inner]]asdf\n\n"
-        );
-    }
-
-    #[test]
-    fn test_intraword_strikethrough_only() {
-        // Simple intraword strikethrough
-        assert_eq!(
-            mark_to_typst("outer~~inner~~asdf").unwrap(),
-            "outer#strike[inner]asdf\n\n"
         );
     }
 
@@ -2748,32 +2169,6 @@ mod robustness_tests {
         assert!(result.contains("=== Three"));
     }
 
-    // Setext heading suppression (ATX-only policy)
-
-    #[test]
-    fn test_setext_h1_suppressed() {
-        // Setext H1 (with ===) should be treated as plain text
-        let result = mark_to_typst("My Heading\n==========").unwrap();
-        assert!(!result.contains("= My Heading")); // Should NOT be a heading
-        assert!(result.contains("My Heading")); // Text should still appear
-    }
-
-    #[test]
-    fn test_setext_h2_suppressed() {
-        // Setext H2 (with ---) should be treated as plain text
-        let result = mark_to_typst("My Heading\n----------").unwrap();
-        assert!(!result.contains("== My Heading")); // Should NOT be a heading
-        assert!(result.contains("My Heading")); // Text should still appear
-    }
-
-    #[test]
-    fn test_unclosed_nested_bullet_not_setext() {
-        // This was being incorrectly parsed as a setext heading
-        let result = mark_to_typst("- parent\n  - ").unwrap();
-        assert!(!result.contains("== parent")); // Should NOT be a heading
-        assert!(result.contains("- parent")); // Should be a list item
-    }
-
     #[test]
     fn test_atx_headings_still_work() {
         // ATX headings should still be converted properly
@@ -2781,15 +2176,6 @@ mod robustness_tests {
         assert!(result.contains("= H1"));
         assert!(result.contains("== H2"));
         assert!(result.contains("=== H3"));
-    }
-
-    #[test]
-    fn test_nested_list_empty_item_deep() {
-        // Deeper nesting with empty item should not create setext heading
-        let result = mark_to_typst("- parent\n  - child\n    - ").unwrap();
-        assert!(!result.contains("== child")); // Should NOT be a heading
-        assert!(result.contains("- parent"));
-        assert!(result.contains("- child"));
     }
 
     // Code block handling
@@ -3320,41 +2706,6 @@ More text with `inline code`."#;
         let unclosed = depth.max(0) as usize;
         let unmatched_close = (-max_negative).max(0) as usize;
         (unclosed, unmatched_close)
-    }
-
-    #[test]
-    fn test_intraword_markers_in_code_spans() {
-        // Intraword __ inside inline code should remain literal, not become #underline
-        let result = mark_to_typst("`not__under__lined`").unwrap();
-        assert!(
-            !result.contains("#underline"),
-            "__ in inline code should not become underline markup: got {:?}",
-            result
-        );
-
-        // Intraword ~~ inside inline code should remain literal, not become #strike
-        let result = mark_to_typst("`not~~strike~~through`").unwrap();
-        assert!(
-            !result.contains("#strike"),
-            "~~ in inline code should not become strike markup: got {:?}",
-            result
-        );
-
-        // Intraword ~~ inside fenced code should remain literal
-        let result = mark_to_typst("```\nnot~~strike~~through\n```").unwrap();
-        assert!(
-            !result.contains("#strike"),
-            "~~ in fenced code should not become strike markup: got {:?}",
-            result
-        );
-
-        // Mixed: markers outside code should still work
-        let result = mark_to_typst("word__under__lined and `code__literal__here`").unwrap();
-        assert!(
-            result.contains("#underline"),
-            "__ outside code should still produce underline: got {:?}",
-            result
-        );
     }
 
     #[test]

--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -112,10 +112,28 @@ fn typst_alignment(align: &pulldown_cmark::Alignment) -> &'static str {
     }
 }
 
-/// Returns true if the HTML string is a `<br>` tag (any common variant).
-fn is_br_tag(html: &str) -> bool {
-    let lower = html.trim().to_ascii_lowercase();
-    lower == "<br>" || lower == "<br/>" || lower == "<br />"
+/// Returns true if the HTML string is a `<u>` open tag (tolerates whitespace and case).
+fn is_u_open_tag(html: &str) -> bool {
+    let s = html.trim();
+    // Accept <u>, <U>, <u >, <U > (arbitrary whitespace before >)
+    if s.starts_with('<') && s.ends_with('>') {
+        let inner = s[1..s.len() - 1].trim();
+        inner.eq_ignore_ascii_case("u")
+    } else {
+        false
+    }
+}
+
+/// Returns true if the HTML string is a `</u>` close tag (tolerates whitespace and case).
+fn is_u_close_tag(html: &str) -> bool {
+    let s = html.trim();
+    // Accept </u>, </U>, </u >, </U >
+    if s.starts_with("</") && s.ends_with('>') {
+        let inner = s[2..s.len() - 1].trim();
+        inner.eq_ignore_ascii_case("u")
+    } else {
+        false
+    }
 }
 
 /// Sanitizes a code-block language tag for safe inclusion in Typst raw blocks.
@@ -162,6 +180,7 @@ where
     let mut in_code_block = false; // Track if we're inside a code block
     let mut table_alignments: Vec<pulldown_cmark::Alignment> = Vec::new(); // Column alignments for current table
     let mut depth = 0; // Track nesting depth for DoS prevention
+    let mut in_image = false; // Suppress text events inside ![alt](src)
     let iter = iter.peekable();
 
     for (event, range) in iter {
@@ -262,11 +281,15 @@ where
                         end_newline = false;
                     }
                     Tag::Strong => {
-                        // Detect whether this is __ (underline) or ** (bold) by peeking at source
+                        // Detect whether this is __ (underline), <u> (underline), or ** (bold)
+                        // by peeking at source. Per spec §6.2, __ and <u> both render as underline;
+                        // <u> is synthesized as Tag::Strong by MarkdownFixer.
                         let kind = if range.start + 2 <= source.len() {
-                            match &source[range.start..range.start + 2] {
-                                "__" => StrongKind::Underline,
-                                _ => StrongKind::Bold, // Default to bold for ** or edge cases
+                            let head = &source[range.start..range.start + 2];
+                            if head == "__" || head.eq_ignore_ascii_case("<u") {
+                                StrongKind::Underline
+                            } else {
+                                StrongKind::Bold // ** or edge cases
                             }
                         } else {
                             StrongKind::Bold // Fallback for very short ranges
@@ -288,6 +311,17 @@ where
                         output.push_str("#link(\"");
                         output.push_str(&escape_string(&dest_url));
                         output.push_str("\")[");
+                        end_newline = false;
+                    }
+                    Tag::Image {
+                        dest_url, title: _, ..
+                    } => {
+                        // Spec §6.3: images are required for v1. Emit #image("url") and
+                        // suppress alt-text events until TagEnd::Image.
+                        output.push_str("#image(\"");
+                        output.push_str(&escape_string(&dest_url));
+                        output.push_str("\")");
+                        in_image = true;
                         end_newline = false;
                     }
                     Tag::Heading { level, .. } => {
@@ -416,6 +450,10 @@ where
                         output.push(']');
                         end_newline = false;
                     }
+                    TagEnd::Image => {
+                        // Alt text was suppressed; just clear the in_image flag.
+                        in_image = false;
+                    }
                     TagEnd::Heading(_) => {
                         output.push('\n');
                         output.push('\n'); // Extra newline after heading
@@ -444,7 +482,9 @@ where
                 }
             }
             Event::Text(text) => {
-                if in_code_block {
+                if in_image {
+                    // Suppress alt text inside ![alt](src) — spec §6.3
+                } else if in_code_block {
                     // Code block content - no escaping needed
                     output.push_str(&text);
                     end_newline = text.ends_with('\n');
@@ -483,8 +523,8 @@ where
             _ => {
                 // Ignore other events not specified in requirements
                 // (math, footnotes, etc.)
-                // Note: <br> HTML tags are converted to HardBreak in MarkdownFixer;
-                // all other HTML is stripped.
+                // Note: per spec §6.2/§6.3, raw HTML produces no output except <u>…</u>,
+                // which MarkdownFixer rewrites to Start/End(Tag::Strong) with Underline kind.
             }
         }
     }
@@ -965,10 +1005,18 @@ where
             // 2. Pull from inner
             let (event, range) = self.inner.next()?;
 
-            // 3. Convert <br> tags to HardBreak; strip all other HTML
+            // 3. Handle HTML: allowlist <u>…</u> as underline; strip everything else.
+            // Spec §6.2 deviation 2 / §6.3: <br> and all other raw HTML produce no output.
             let (event, range) = match event {
-                Event::InlineHtml(ref html) | Event::Html(ref html) if is_br_tag(html) => {
-                    (Event::HardBreak, range)
+                Event::InlineHtml(ref html) | Event::Html(ref html)
+                    if is_u_open_tag(html) =>
+                {
+                    (Event::Start(Tag::Strong), range)
+                }
+                Event::InlineHtml(ref html) | Event::Html(ref html)
+                    if is_u_close_tag(html) =>
+                {
+                    (Event::End(TagEnd::Strong), range)
                 }
                 Event::Html(_) | Event::InlineHtml(_) => continue,
                 other => (other, range),
@@ -2330,31 +2378,104 @@ mod tests {
     }
 
     #[test]
-    fn test_table_br_tag_in_cell() {
-        // <br> is the standard way to create line breaks within table cells
+    fn test_table_br_tag_in_cell_is_stripped() {
+        // Per MARKDOWN.md §6.2 / §6.3, raw HTML (including <br>) produces no output.
         let md = "| A |\n|---|\n| line1<br>line2 |";
         let out = mark_to_typst(md).unwrap();
         assert!(
-            out.contains("line1#linebreak()line2"),
-            "<br> should produce line break in cell: {out}"
+            !out.contains("linebreak"),
+            "<br> must not produce #linebreak(): {out}"
+        );
+        assert!(
+            !out.contains("<br"),
+            "<br> literal must be stripped: {out}"
+        );
+        assert!(out.contains("line1"), "surrounding text preserved: {out}");
+        assert!(out.contains("line2"), "surrounding text preserved: {out}");
+    }
+
+    #[test]
+    fn test_table_br_tag_variants_stripped() {
+        // <br/> and <br /> variants must also produce no output.
+        for md in [
+            "| A |\n|---|\n| a<br/>b |",
+            "| A |\n|---|\n| a<br />b |",
+        ] {
+            let out = mark_to_typst(md).unwrap();
+            assert!(
+                !out.contains("linebreak"),
+                "<br> variants must not emit #linebreak(): {out}"
+            );
+            assert!(out.contains('a') && out.contains('b'), "text kept: {out}");
+        }
+    }
+
+    #[test]
+    fn test_u_tag_renders_as_underline() {
+        // Spec §6.2: <u>…</u> is the one allowlisted HTML tag; renders as underline.
+        let md = "This is <u>underlined</u> text.";
+        let out = mark_to_typst(md).unwrap();
+        assert!(
+            out.contains("#underline[underlined]"),
+            "<u> must render as #underline[…]: {out}"
         );
     }
 
     #[test]
-    fn test_table_br_tag_variants() {
-        // Test <br/> and <br /> variants
-        let md_slash = "| A |\n|---|\n| a<br/>b |";
-        let out_slash = mark_to_typst(md_slash).unwrap();
+    fn test_u_tag_intraword_renders_as_underline() {
+        // <u> exists specifically to cover arbitrary-range underline that __ cannot reach.
+        let md = "pre<u>mid</u>post";
+        let out = mark_to_typst(md).unwrap();
         assert!(
-            out_slash.contains("a#linebreak()b"),
-            "<br/> should produce line break: {out_slash}"
+            out.contains("#underline[mid]"),
+            "intraword <u> must render as #underline[…]: {out}"
         );
+        assert!(out.contains("pre"), "prefix preserved: {out}");
+        assert!(out.contains("post"), "suffix preserved: {out}");
+    }
 
-        let md_space_slash = "| A |\n|---|\n| a<br />b |";
-        let out_space_slash = mark_to_typst(md_space_slash).unwrap();
+    #[test]
+    fn test_u_tag_case_insensitive() {
+        // Accept <U>…</U> as well as mixed case.
+        let md = "<U>upper</U>";
+        let out = mark_to_typst(md).unwrap();
         assert!(
-            out_space_slash.contains("a#linebreak()b"),
-            "<br /> should produce line break: {out_space_slash}"
+            out.contains("#underline[upper]"),
+            "<U> must render as #underline[…]: {out}"
+        );
+    }
+
+    #[test]
+    fn test_raw_html_is_stripped() {
+        // Spec §6.2 deviation 2: all raw HTML except <u> produces no output.
+        let md = "before <span class=\"x\">inner</span> after";
+        let out = mark_to_typst(md).unwrap();
+        assert!(!out.contains("<span"), "span tag stripped: {out}");
+        assert!(!out.contains("</span>"), "span close tag stripped: {out}");
+        assert!(out.contains("before"), "text preserved: {out}");
+        assert!(out.contains("after"), "text preserved: {out}");
+        assert!(out.contains("inner"), "inner text preserved: {out}");
+    }
+
+    #[test]
+    fn test_image_renders_as_image() {
+        // Spec §6.3: images are required for v1; emit #image("url").
+        let md = "![alt text](path/to/img.png)";
+        let out = mark_to_typst(md).unwrap();
+        assert!(
+            out.contains("#image(\"path/to/img.png\")"),
+            "image must emit #image(\"…\"): {out}"
+        );
+        assert!(!out.contains("alt text"), "alt text suppressed: {out}");
+    }
+
+    #[test]
+    fn test_image_with_empty_alt() {
+        let md = "![](x.png)";
+        let out = mark_to_typst(md).unwrap();
+        assert!(
+            out.contains("#image(\"x.png\")"),
+            "empty-alt image emits #image: {out}"
         );
     }
 

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -63,51 +63,52 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     }
 
     // Determine if we have a markdown file or need to use example content
-    let (parse_output, markdown_path_for_output) = if let Some(ref markdown_path) = args.markdown_file {
-        // Validate markdown file exists
-        if !markdown_path.exists() {
-            return Err(CliError::InvalidArgument(format!(
-                "Markdown file not found: {}",
-                markdown_path.display()
-            )));
-        }
+    let (parse_output, markdown_path_for_output) =
+        if let Some(ref markdown_path) = args.markdown_file {
+            // Validate markdown file exists
+            if !markdown_path.exists() {
+                return Err(CliError::InvalidArgument(format!(
+                    "Markdown file not found: {}",
+                    markdown_path.display()
+                )));
+            }
 
-        if args.verbose {
-            println!("Reading markdown from: {}", markdown_path.display());
-        }
+            if args.verbose {
+                println!("Reading markdown from: {}", markdown_path.display());
+            }
 
-        // Read markdown file
-        let markdown = fs::read_to_string(markdown_path)?;
+            // Read markdown file
+            let markdown = fs::read_to_string(markdown_path)?;
 
-        // Parse markdown
-        let output = ParsedDocument::from_markdown_with_warnings(&markdown)?;
+            // Parse markdown
+            let output = ParsedDocument::from_markdown_with_warnings(&markdown)?;
 
-        if args.verbose {
-            println!("Markdown parsed successfully");
-        }
-        (output, Some(markdown_path.clone()))
-    } else {
-        // Get example content
-        let markdown = quill.example.clone().ok_or_else(|| {
-            CliError::InvalidArgument(format!(
-                "Quill '{}' does not have example content",
-                quill.name
-            ))
-        })?;
+            if args.verbose {
+                println!("Markdown parsed successfully");
+            }
+            (output, Some(markdown_path.clone()))
+        } else {
+            // Get example content
+            let markdown = quill.example.clone().ok_or_else(|| {
+                CliError::InvalidArgument(format!(
+                    "Quill '{}' does not have example content",
+                    quill.name
+                ))
+            })?;
 
-        if args.verbose {
-            println!("Using example content from quill");
-        }
+            if args.verbose {
+                println!("Using example content from quill");
+            }
 
-        // Parse markdown
-        let output = ParsedDocument::from_markdown_with_warnings(&markdown)?;
+            // Parse markdown
+            let output = ParsedDocument::from_markdown_with_warnings(&markdown)?;
 
-        if args.verbose {
-            println!("Example markdown parsed successfully");
-        }
+            if args.verbose {
+                println!("Example markdown parsed successfully");
+            }
 
-        (output, None)
-    };
+            (output, None)
+        };
     let (parsed, parse_warnings) = (parse_output.document, parse_output.warnings);
 
     // Create workflow

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -63,7 +63,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     }
 
     // Determine if we have a markdown file or need to use example content
-    let (parsed, markdown_path_for_output) = if let Some(ref markdown_path) = args.markdown_file {
+    let (parse_output, markdown_path_for_output) = if let Some(ref markdown_path) = args.markdown_file {
         // Validate markdown file exists
         if !markdown_path.exists() {
             return Err(CliError::InvalidArgument(format!(
@@ -80,12 +80,12 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         let markdown = fs::read_to_string(markdown_path)?;
 
         // Parse markdown
-        let parsed = ParsedDocument::from_markdown(&markdown)?;
+        let output = ParsedDocument::from_markdown_with_warnings(&markdown)?;
 
         if args.verbose {
             println!("Markdown parsed successfully");
         }
-        (parsed, Some(markdown_path.clone()))
+        (output, Some(markdown_path.clone()))
     } else {
         // Get example content
         let markdown = quill.example.clone().ok_or_else(|| {
@@ -100,14 +100,15 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         }
 
         // Parse markdown
-        let parsed = ParsedDocument::from_markdown(&markdown)?;
+        let output = ParsedDocument::from_markdown_with_warnings(&markdown)?;
 
         if args.verbose {
             println!("Example markdown parsed successfully");
         }
 
-        (parsed, None)
+        (output, None)
     };
+    let (parsed, parse_warnings) = (parse_output.document, parse_output.warnings);
 
     // Create workflow
     let workflow = engine.workflow(&quill)?;
@@ -161,7 +162,11 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     }
 
     // Render
-    let result = workflow.render(&parsed, Some(output_format))?;
+    let mut result = workflow.render(&parsed, Some(output_format))?;
+
+    // Merge parse-time warnings into the render result so downstream tooling
+    // sees them in a single channel.
+    result.warnings.splice(0..0, parse_warnings);
 
     // Display warnings if any
     if !result.warnings.is_empty() && !args.quiet {

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -69,10 +69,18 @@ impl PyWorkflow {
         format: Option<PyOutputFormat>,
     ) -> PyResult<PyRenderResult> {
         let rust_format = format.map(|f| f.into());
-        let result = self
+        let mut result = self
             .inner
             .render(&parsed.inner, rust_format)
             .map_err(convert_render_error)?;
+        // Prepend parse-time warnings so both parse and render diagnostics
+        // travel on the single RenderResult.warnings channel.
+        let parse_warnings: Vec<_> = parsed
+            .parse_warnings
+            .iter()
+            .map(|d| d.clone_without_source())
+            .collect();
+        result.warnings.splice(0..0, parse_warnings);
         Ok(PyRenderResult { inner: result })
     }
 
@@ -285,10 +293,16 @@ impl PyQuill {
             ppi: None,
             pages: None,
         };
-        let result = self
+        let mut result = self
             .inner
             .render(parsed.inner.clone(), &opts)
             .map_err(convert_render_error)?;
+        let parse_warnings: Vec<_> = parsed
+            .parse_warnings
+            .iter()
+            .map(|d| d.clone_without_source())
+            .collect();
+        result.warnings.splice(0..0, parse_warnings);
         Ok(PyRenderResult { inner: result })
     }
 
@@ -305,13 +319,14 @@ impl PyQuill {
 #[pyclass(name = "ParsedDocument")]
 pub struct PyParsedDocument {
     pub(crate) inner: ParsedDocument,
+    pub(crate) parse_warnings: Vec<quillmark_core::Diagnostic>,
 }
 
 #[pymethods]
 impl PyParsedDocument {
     #[staticmethod]
     fn from_markdown(markdown: &str) -> PyResult<Self> {
-        let parsed = ParsedDocument::from_markdown(markdown).map_err(|e| {
+        let output = ParsedDocument::from_markdown_with_warnings(markdown).map_err(|e| {
             let py_err = PyErr::new::<crate::errors::ParseError, _>(e.to_string());
             Python::attach(|py| {
                 if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
@@ -322,7 +337,18 @@ impl PyParsedDocument {
             });
             py_err
         })?;
-        Ok(PyParsedDocument { inner: parsed })
+        Ok(PyParsedDocument {
+            inner: output.document,
+            parse_warnings: output.warnings,
+        })
+    }
+
+    #[getter]
+    fn warnings(&self) -> Vec<PyDiagnostic> {
+        self.parse_warnings
+            .iter()
+            .map(|d| PyDiagnostic { inner: d.into() })
+            .collect()
     }
 
     fn body(&self) -> Option<&str> {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -74,20 +74,21 @@ impl Quillmark {
 }
 
 fn parse_markdown_impl(markdown: &str) -> Result<ParsedDocument, JsValue> {
-    let parsed = quillmark_core::ParsedDocument::from_markdown(markdown)
+    let output = quillmark_core::ParsedDocument::from_markdown_with_warnings(markdown)
         .map_err(WasmError::from)
         .map_err(|e| e.to_js_value())?;
 
-    let quill_ref = parsed.quill_reference().to_string();
+    let quill_ref = output.document.quill_reference().to_string();
 
     let mut fields_obj = serde_json::Map::new();
-    for (key, value) in parsed.fields() {
+    for (key, value) in output.document.fields() {
         fields_obj.insert(key.clone(), value.as_json().clone());
     }
 
     Ok(ParsedDocument {
         fields: serde_json::Value::Object(fields_obj),
         quill_ref,
+        warnings: output.warnings.into_iter().map(Into::into).collect(),
     })
 }
 
@@ -121,6 +122,7 @@ impl Quill {
         opts: RenderOptions,
     ) -> Result<RenderResult, JsValue> {
         let start = now_ms();
+        let parse_warnings = parsed.warnings.clone();
         let core_parsed = to_core_parsed(parsed).map_err(|e| {
             WasmError::from(format!("render: invalid ParsedDocument: {:?}", e)).to_js_value()
         })?;
@@ -129,9 +131,11 @@ impl Quill {
             .inner
             .render(core_parsed, &rust_opts)
             .map_err(|e| WasmError::from(e).to_js_value())?;
+        let mut warnings: Vec<_> = parse_warnings;
+        warnings.extend(result.warnings.into_iter().map(Into::into));
         Ok(RenderResult {
             artifacts: result.artifacts.into_iter().map(Into::into).collect(),
-            warnings: result.warnings.into_iter().map(Into::into).collect(),
+            warnings,
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
         })

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -48,29 +48,6 @@ impl WasmError {
 impl From<ParseError> for WasmError {
     fn from(error: ParseError) -> Self {
         match error {
-            ParseError::MissingCardDirective { diag } => WasmError::Diagnostic {
-                diagnostic: (*diag).into(),
-            },
-            ParseError::YamlError(e) => WasmError::Diagnostic {
-                diagnostic: SerializableDiagnostic {
-                    severity: quillmark_core::Severity::Error,
-                    code: Some("yaml_error".to_string()),
-                    message: format!("YAML parsing error: {}", e),
-                    primary: None,
-                    hint: None,
-                    source_chain: vec![],
-                },
-            },
-            ParseError::JsonError(e) => WasmError::Diagnostic {
-                diagnostic: SerializableDiagnostic {
-                    severity: quillmark_core::Severity::Error,
-                    code: Some("json_error".to_string()),
-                    message: format!("JSON conversion error: {}", e),
-                    primary: None,
-                    hint: None,
-                    source_chain: vec![],
-                },
-            },
             ParseError::InputTooLarge { size, max } => WasmError::Diagnostic {
                 diagnostic: SerializableDiagnostic {
                     severity: quillmark_core::Severity::Error,
@@ -152,38 +129,19 @@ impl From<&str> for WasmError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quillmark_core::{Diagnostic, Severity};
 
     #[test]
-    fn test_missing_card_directive_conversion() {
-        let diag = Diagnostic::new(Severity::Error, "Missing CARD".to_string())
-            .with_code("parse::missing_card".to_string());
-
-        let err = ParseError::MissingCardDirective {
-            diag: Box::new(diag),
+    fn test_input_too_large_conversion() {
+        let err = ParseError::InputTooLarge {
+            size: 1_000_000,
+            max: 100_000,
         };
         let wasm_err: WasmError = err.into();
 
         match wasm_err {
             WasmError::Diagnostic { diagnostic } => {
-                assert_eq!(diagnostic.code.as_deref(), Some("parse::missing_card"));
-                assert_eq!(diagnostic.message, "Missing CARD");
-            }
-            _ => panic!("Expected Diagnostic variant"),
-        }
-    }
-
-    #[test]
-    fn test_json_error_conversion() {
-        // Create a JSON error (simulated)
-        let json_err = serde_json::from_str::<serde_json::Value>("{invalid-json").unwrap_err();
-        let parse_err = ParseError::JsonError(json_err);
-        let wasm_err: WasmError = parse_err.into();
-
-        match wasm_err {
-            WasmError::Diagnostic { diagnostic } => {
-                assert_eq!(diagnostic.code.as_deref(), Some("json_error"));
-                assert!(diagnostic.message.contains("JSON conversion error"));
+                assert_eq!(diagnostic.code.as_deref(), Some("input_too_large"));
+                assert!(diagnostic.message.contains("Input too large"));
             }
             _ => panic!("Expected Diagnostic variant"),
         }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -156,7 +156,8 @@ pub struct RenderResult {
 /// Parsed markdown document
 ///
 /// Returned by `ParsedDocument.fromMarkdown()`. Contains the parsed YAML frontmatter
-/// fields and the quill reference from the required QUILL field.
+/// fields, the quill reference from the required QUILL field, and any non-fatal
+/// parse-time warnings (e.g. near-miss sentinel lints).
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -166,6 +167,10 @@ pub struct ParsedDocument {
     pub fields: serde_json::Value,
     /// The quill reference from the QUILL field
     pub quill_ref: String,
+    /// Non-fatal parse-time warnings (empty unless the source contains
+    /// near-miss metadata sentinels per spec §4.2).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<Diagnostic>,
 }
 
 impl IntoWasmAbi for ParsedDocument {
@@ -497,6 +502,7 @@ mod tests {
         let parsed_doc = ParsedDocument {
             fields: serde_json::Value::Object(fields_obj),
             quill_ref: "test_quill".to_string(),
+            warnings: Vec::new(),
         };
 
         // Serialize and verify structure

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -231,7 +231,7 @@ impl Diagnostic {
     }
 
     /// Clone this diagnostic while dropping any attached source chain.
-    pub(crate) fn clone_without_source(&self) -> Self {
+    pub fn clone_without_source(&self) -> Self {
         Self {
             severity: self.severity,
             code: self.code.clone(),
@@ -362,24 +362,9 @@ pub enum ParseError {
         max: usize,
     },
 
-    /// YAML parsing error
-    #[error("YAML parsing error: {0}")]
-    YamlError(#[from] serde_saphyr::Error),
-
-    /// JSON parsing/conversion error
-    #[error("JSON error: {0}")]
-    JsonError(#[from] serde_json::Error),
-
     /// Invalid YAML structure
     #[error("Invalid YAML structure: {0}")]
     InvalidStructure(String),
-
-    /// Missing CARD directive in inline metadata block
-    #[error("{}", .diag.message)]
-    MissingCardDirective {
-        /// Diagnostic information with hint
-        diag: Box<Diagnostic>,
-    },
 
     /// YAML parsing error with location context
     #[error("YAML error at line {line}: {message}")]
@@ -398,47 +383,14 @@ pub enum ParseError {
 }
 
 impl ParseError {
-    /// Create a MissingCardDirective error with helpful hint
-    pub fn missing_card_directive() -> Self {
-        let diag = Diagnostic::new(
-            Severity::Error,
-            "Inline metadata block missing CARD directive".to_string(),
-        )
-        .with_code("parse::missing_card".to_string())
-        .with_hint(
-            "Add 'CARD: <card_type>' to specify which card this block belongs to. \
-            Example:\n---\nCARD: my_card_type\nfield: value\n---"
-                .to_string(),
-        );
-        ParseError::MissingCardDirective {
-            diag: Box::new(diag),
-        }
-    }
-
     /// Convert the parse error into a structured diagnostic
     pub fn to_diagnostic(&self) -> Diagnostic {
         match self {
-            ParseError::MissingCardDirective { diag } => Diagnostic {
-                severity: diag.severity,
-                code: diag.code.clone(),
-                message: diag.message.clone(),
-                primary: diag.primary.clone(),
-                hint: diag.hint.clone(),
-                source: None, // Cannot clone trait object, but it's empty in this case usually
-            },
             ParseError::InputTooLarge { size, max } => Diagnostic::new(
                 Severity::Error,
                 format!("Input too large: {} bytes (max: {} bytes)", size, max),
             )
             .with_code("parse::input_too_large".to_string()),
-            ParseError::YamlError(e) => {
-                Diagnostic::new(Severity::Error, format!("YAML parsing error: {}", e))
-                    .with_code("parse::yaml_error".to_string())
-            } // serde_saphyr::Error implements Error+Clone? No, usually Error is not Clone.
-            ParseError::JsonError(e) => {
-                Diagnostic::new(Severity::Error, format!("JSON conversion error: {}", e))
-                    .with_code("parse::json_error".to_string())
-            }
             ParseError::InvalidStructure(msg) => Diagnostic::new(Severity::Error, msg.clone())
                 .with_code("parse::invalid_structure".to_string()),
             ParseError::YamlErrorWithLocation {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,7 +39,7 @@
 //! - [Examples](https://github.com/nibsbin/quillmark/tree/main/examples) - Working examples
 
 pub mod parse;
-pub use parse::{ParsedDocument, BODY_FIELD};
+pub use parse::{ParseOutput, ParsedDocument, BODY_FIELD};
 
 pub mod backend;
 pub use backend::Backend;

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -276,30 +276,60 @@ pub fn normalize_markdown(markdown: &str) -> String {
     fix_html_comment_fences(&cleaned)
 }
 
-/// Normalizes a string value by stripping bidi characters and fixing HTML comment fences.
-///
-/// - For body content: applies `fix_html_comment_fences` to preserve text after `-->`
-/// - For other fields: strips bidi characters only
-///
-/// Double chevrons (`<<` and `>>`) are passed through untouched without conversion to
-/// guillemets. This preserves the original delimiter syntax in the output.
-fn normalize_string(s: &str, is_body: bool) -> String {
-    // First strip bidi formatting characters
-    let cleaned = strip_bidi_formatting(s);
-
-    // Then apply content-specific normalization
-    if is_body {
-        // Fix HTML comment fences (chevrons pass through unchanged)
-        fix_html_comment_fences(&cleaned)
-    } else {
-        // Non-body fields: just return cleaned string (chevrons pass through unchanged)
-        cleaned
+/// Normalize a single card object: apply `normalize_markdown` to the `BODY` key only.
+/// All other fields in the card pass through verbatim.
+fn normalize_card_object(
+    map: serde_json::Map<String, serde_json::Value>,
+    depth: usize,
+) -> Result<serde_json::Map<String, serde_json::Value>, NormalizationError> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(NormalizationError::NestingTooDeep {
+            depth,
+            max: MAX_NESTING_DEPTH,
+        });
     }
+    map.into_iter()
+        .map(|(k, v)| {
+            if k == BODY_FIELD {
+                let normalized = match v {
+                    serde_json::Value::String(s) => {
+                        serde_json::Value::String(normalize_markdown(&s))
+                    }
+                    other => other,
+                };
+                Ok((k, normalized))
+            } else {
+                // All other card fields pass through verbatim
+                Ok((k, v))
+            }
+        })
+        .collect()
 }
 
+/// Normalize the `CARDS` array: for each element that is an object, normalize its
+/// `BODY` field via `normalize_markdown`; all other card fields pass through verbatim.
+/// Non-object elements (malformed) pass through unchanged.
+fn normalize_cards_array(
+    arr: Vec<serde_json::Value>,
+) -> Result<Vec<serde_json::Value>, NormalizationError> {
+    arr.into_iter()
+        .enumerate()
+        .map(|(i, elem)| match elem {
+            serde_json::Value::Object(map) => {
+                let normalized = normalize_card_object(map, i)?;
+                Ok(serde_json::Value::Object(normalized))
+            }
+            other => Ok(other),
+        })
+        .collect()
+}
+
+// Keep normalize_json_value_inner for the depth-limit test that uses it directly.
 /// Recursively normalize a JSON value with depth tracking.
 ///
 /// Returns an error if nesting exceeds MAX_NESTING_DEPTH to prevent stack overflow.
+/// NOTE: This helper is retained only for the depth-limit guard test; the main
+/// normalization path in `normalize_fields` no longer uses it.
 fn normalize_json_value_inner(
     value: serde_json::Value,
     is_body: bool,
@@ -314,7 +344,12 @@ fn normalize_json_value_inner(
 
     match value {
         serde_json::Value::String(s) => {
-            Ok(serde_json::Value::String(normalize_string(&s, is_body)))
+            let result = if is_body {
+                normalize_markdown(&s)
+            } else {
+                s
+            };
+            Ok(serde_json::Value::String(result))
         }
         serde_json::Value::Array(arr) => {
             let normalized: Result<Vec<_>, _> = arr
@@ -327,8 +362,7 @@ fn normalize_json_value_inner(
             let processed: Result<serde_json::Map<String, serde_json::Value>, _> = map
                 .into_iter()
                 .map(|(k, v)| {
-                    let is_body = k == BODY_FIELD;
-                    normalize_json_value_inner(v, is_body, depth + 1).map(|nv| (k, nv))
+                    normalize_json_value_inner(v, false, depth + 1).map(|nv| (k, nv))
                 })
                 .collect();
             Ok(serde_json::Value::Object(processed?))
@@ -338,34 +372,24 @@ fn normalize_json_value_inner(
     }
 }
 
-/// Recursively normalize a JSON value.
+/// Normalizes document fields per the Quillmark §7 spec.
 ///
-/// This is a convenience wrapper that starts depth tracking at 0.
-/// Logs a warning and returns the original value if depth is exceeded.
-fn normalize_json_value(value: serde_json::Value, is_body: bool) -> serde_json::Value {
-    match normalize_json_value_inner(value.clone(), is_body, 0) {
-        Ok(normalized) => normalized,
-        Err(e) => {
-            // Log warning but don't fail - return original value
-            eprintln!("Warning: {}", e);
-            value
-        }
-    }
-}
-
-/// Normalizes document fields by applying all preprocessing steps.
+/// Only **body regions** receive normalization (bidi stripping + HTML comment fence
+/// repair). All other field values — including nested objects and arrays — pass
+/// through verbatim so that YAML scalar values are never silently mutated.
 ///
-/// This function orchestrates input normalization for document fields:
-/// 1. Strips Unicode bidirectional formatting characters from all string values
-/// 2. For the body field: fixes HTML comment fences to preserve trailing text
+/// Specifically:
+/// - The top-level `BODY` field is fully normalized via [`normalize_markdown`].
+/// - Each object inside the top-level `CARDS` array has its own `BODY` field
+///   normalized via [`normalize_markdown`]; all other fields in those objects
+///   pass through unchanged.
+/// - Every other top-level field (strings, numbers, booleans, nested maps,
+///   arrays of scalars, etc.) passes through verbatim.
+///
+/// Field names at the top level are NFC-normalized (see [`normalize_field_name`]).
+/// Keys inside nested objects are **not** NFC-normalized.
 ///
 /// Double chevrons (`<<` and `>>`) are passed through unchanged in all fields.
-///
-/// # Processing Order
-///
-/// The normalization order is important:
-/// 1. **Bidi stripping** - Must happen first so markdown delimiters are recognized
-/// 2. **HTML comment fence fixing** - Ensures text after `-->` is preserved
 ///
 /// # Examples
 ///
@@ -380,24 +404,56 @@ fn normalize_json_value(value: serde_json::Value, is_body: bool) -> serde_json::
 ///
 /// let result = normalize_fields(fields);
 ///
-/// // Title has chevrons preserved (only bidi stripped)
+/// // Title passes through verbatim (no bidi stripping on YAML fields)
 /// assert_eq!(result.get("title").unwrap().as_str().unwrap(), "<<hello>>");
 ///
-/// // Body has bidi chars stripped, chevrons preserved
+/// // Body has bidi chars stripped and HTML comment fences repaired
 /// assert_eq!(result.get("BODY").unwrap().as_str().unwrap(), "**bold** **more**");
 /// ```
 pub fn normalize_fields(fields: HashMap<String, QuillValue>) -> HashMap<String, QuillValue> {
+    const CARDS_FIELD: &str = "CARDS";
+
     fields
         .into_iter()
         .map(|(key, value)| {
-            // Normalize field name to NFC form for consistent key comparison
-            // This ensures café (composed) and café (decomposed) are treated as the same key
+            // Normalize field name to NFC form for consistent key comparison.
+            // This ensures café (composed) and café (decomposed) are treated as the same key.
+            // NFC normalization is applied to top-level keys only.
             let normalized_key = normalize_field_name(&key);
-            let json = value.into_json();
-            // Treat as body if it's the BODY field (applies HTML comment fence fixes)
-            let treat_as_body = normalized_key == BODY_FIELD;
-            let processed = normalize_json_value(json, treat_as_body);
-            (normalized_key, QuillValue::from_json(processed))
+
+            let processed = if normalized_key == BODY_FIELD {
+                // Top-level BODY: full markdown normalization (bidi + HTML fence repair).
+                let json = value.into_json();
+                let normalized = match json {
+                    serde_json::Value::String(s) => {
+                        serde_json::Value::String(normalize_markdown(&s))
+                    }
+                    other => other,
+                };
+                QuillValue::from_json(normalized)
+            } else if normalized_key == CARDS_FIELD {
+                // CARDS array: normalize only the BODY field inside each card object.
+                let json = value.into_json();
+                let normalized = match json {
+                    serde_json::Value::Array(arr) => {
+                        let original = serde_json::Value::Array(arr.clone());
+                        match normalize_cards_array(arr) {
+                            Ok(normalized_arr) => serde_json::Value::Array(normalized_arr),
+                            Err(e) => {
+                                eprintln!("Warning: {}", e);
+                                original
+                            }
+                        }
+                    }
+                    other => other,
+                };
+                QuillValue::from_json(normalized)
+            } else {
+                // All other top-level fields pass through verbatim.
+                value
+            };
+
+            (normalized_key, processed)
         })
         .collect()
 }
@@ -787,19 +843,23 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_fields_other_field_bidi_stripped() {
+    fn test_normalize_fields_other_field_bidi_preserved() {
+        // Per spec §7: bidi stripping is NOT applied to YAML field values.
+        // Only body regions are normalized.
         let mut fields = HashMap::new();
         fields.insert(
             "title".to_string(),
-            QuillValue::from_json(serde_json::json!("he\u{202D}llo")),
+            QuillValue::from_json(serde_json::json!("a\u{202D}b")),
         );
 
         let result = normalize_fields(fields);
-        assert_eq!(result.get("title").unwrap().as_str().unwrap(), "hello");
+        // Bidi character must be PRESERVED in non-body fields
+        assert_eq!(result.get("title").unwrap().as_str().unwrap(), "a\u{202D}b");
     }
 
     #[test]
-    fn test_normalize_fields_nested_values() {
+    fn test_normalize_fields_nested_values_verbatim() {
+        // Nested arrays inside YAML fields pass through verbatim (no bidi stripping).
         let mut fields = HashMap::new();
         fields.insert(
             "items".to_string(),
@@ -808,33 +868,35 @@ mod tests {
 
         let result = normalize_fields(fields);
         let items = result.get("items").unwrap().as_array().unwrap();
-        // Chevrons are preserved, bidi stripped
+        // All values pass through unchanged — no bidi stripping on YAML fields
         assert_eq!(items[0].as_str().unwrap(), "<<a>>");
-        assert_eq!(items[1].as_str().unwrap(), "b");
+        assert_eq!(items[1].as_str().unwrap(), "\u{202D}b");
     }
 
     #[test]
-    fn test_normalize_fields_object_values() {
+    fn test_normalize_fields_object_values_verbatim() {
+        // Nested objects inside YAML fields pass through verbatim.
+        // Even if a nested key happens to be named BODY, it is NOT a body region.
         let mut fields = HashMap::new();
         fields.insert(
             "meta".to_string(),
             QuillValue::from_json(serde_json::json!({
-                "title": "<<hello>>",
-                BODY_FIELD: "<<content>>"
+                "title": "a\u{202D}b",
+                BODY_FIELD: "c\u{202D}d"
             })),
         );
 
         let result = normalize_fields(fields);
         let meta = result.get("meta").unwrap();
         let meta_obj = meta.as_object().unwrap();
-        // Chevrons are preserved in all fields
+        // Both fields pass through verbatim — nested objects are not body regions
         assert_eq!(
             meta_obj.get("title").unwrap().as_str().unwrap(),
-            "<<hello>>"
+            "a\u{202D}b"
         );
         assert_eq!(
             meta_obj.get(BODY_FIELD).unwrap().as_str().unwrap(),
-            "<<content>>"
+            "c\u{202D}d"
         );
     }
 
@@ -853,6 +915,169 @@ mod tests {
         let result = normalize_fields(fields);
         assert_eq!(result.get("count").unwrap().as_i64().unwrap(), 42);
         assert!(result.get("enabled").unwrap().as_bool().unwrap());
+    }
+
+    // ── §7 spec contract tests ──────────────────────────────────────────────────
+    // Cover all 8 cases required by MARKDOWN_GAPS.md §3.
+
+    /// Case 1: Bidi character in top-level BODY → stripped.
+    #[test]
+    fn test_spec_case1_body_bidi_stripped() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            BODY_FIELD.to_string(),
+            QuillValue::from_json(serde_json::json!("hello\u{202D}world")),
+        );
+        let result = normalize_fields(fields);
+        assert_eq!(
+            result.get(BODY_FIELD).unwrap().as_str().unwrap(),
+            "helloworld"
+        );
+    }
+
+    /// Case 2: Bidi character in a top-level YAML string field → PRESERVED.
+    #[test]
+    fn test_spec_case2_yaml_field_bidi_preserved() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "title".to_string(),
+            QuillValue::from_json(serde_json::json!("a\u{202D}b")),
+        );
+        let result = normalize_fields(fields);
+        // Must NOT be stripped — YAML field values pass through verbatim.
+        assert_eq!(
+            result.get("title").unwrap().as_str().unwrap(),
+            "a\u{202D}b"
+        );
+    }
+
+    /// Case 3: Bidi character inside CARDS[0].BODY → stripped.
+    #[test]
+    fn test_spec_case3_card_body_bidi_stripped() {
+        let card = serde_json::json!({
+            "CARD": "profile",
+            BODY_FIELD: "card\u{202D}body",
+            "name": "Alice"
+        });
+        let mut fields = HashMap::new();
+        fields.insert(
+            "CARDS".to_string(),
+            QuillValue::from_json(serde_json::json!([card])),
+        );
+        let result = normalize_fields(fields);
+        let cards = result.get("CARDS").unwrap().as_array().unwrap();
+        let body = cards[0].get(BODY_FIELD).unwrap().as_str().unwrap();
+        assert_eq!(body, "cardbody");
+    }
+
+    /// Case 4: Bidi character inside CARDS[0].someField (not BODY) → PRESERVED.
+    #[test]
+    fn test_spec_case4_card_other_field_bidi_preserved() {
+        let card = serde_json::json!({
+            "CARD": "profile",
+            BODY_FIELD: "clean body",
+            "name": "Ali\u{202D}ce"
+        });
+        let mut fields = HashMap::new();
+        fields.insert(
+            "CARDS".to_string(),
+            QuillValue::from_json(serde_json::json!([card])),
+        );
+        let result = normalize_fields(fields);
+        let cards = result.get("CARDS").unwrap().as_array().unwrap();
+        let name = cards[0].get("name").unwrap().as_str().unwrap();
+        // Non-BODY card fields pass through verbatim.
+        assert_eq!(name, "Ali\u{202D}ce");
+    }
+
+    /// Case 5: HTML comment fence repair applied inside CARDS[0].BODY.
+    #[test]
+    fn test_spec_case5_card_body_html_comment_repair() {
+        let card = serde_json::json!({
+            "CARD": "note",
+            BODY_FIELD: "<!-- comment -->Trailing text"
+        });
+        let mut fields = HashMap::new();
+        fields.insert(
+            "CARDS".to_string(),
+            QuillValue::from_json(serde_json::json!([card])),
+        );
+        let result = normalize_fields(fields);
+        let cards = result.get("CARDS").unwrap().as_array().unwrap();
+        let body = cards[0].get(BODY_FIELD).unwrap().as_str().unwrap();
+        assert_eq!(body, "<!-- comment -->\nTrailing text");
+    }
+
+    /// Case 6: HTML comment fence repair applied on top-level BODY.
+    #[test]
+    fn test_spec_case6_toplevel_body_html_comment_repair() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            BODY_FIELD.to_string(),
+            QuillValue::from_json(serde_json::json!("<!-- note -->Content here")),
+        );
+        let result = normalize_fields(fields);
+        assert_eq!(
+            result.get(BODY_FIELD).unwrap().as_str().unwrap(),
+            "<!-- note -->\nContent here"
+        );
+    }
+
+    /// Case 7: Non-string fields (numbers, bools, nested arrays of numbers) pass through untouched.
+    #[test]
+    fn test_spec_case7_non_string_fields_untouched() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "count".to_string(),
+            QuillValue::from_json(serde_json::json!(42)),
+        );
+        fields.insert(
+            "active".to_string(),
+            QuillValue::from_json(serde_json::json!(false)),
+        );
+        fields.insert(
+            "scores".to_string(),
+            QuillValue::from_json(serde_json::json!([1, 2, 3])),
+        );
+        let result = normalize_fields(fields);
+        assert_eq!(result.get("count").unwrap().as_i64().unwrap(), 42);
+        assert_eq!(result.get("active").unwrap().as_bool().unwrap(), false);
+        let scores = result.get("scores").unwrap().as_array().unwrap();
+        assert_eq!(scores.len(), 3);
+        assert_eq!(scores[0].as_i64().unwrap(), 1);
+    }
+
+    /// Case 8: Nested objects / arrays of strings inside YAML fields: strings NOT modified.
+    #[test]
+    fn test_spec_case8_nested_strings_not_modified() {
+        let bidi = "\u{202D}";
+        let mut fields = HashMap::new();
+        // Nested object inside a YAML field
+        fields.insert(
+            "address".to_string(),
+            QuillValue::from_json(serde_json::json!({
+                "city": format!("New{bidi}York"),
+                "zip": "10001"
+            })),
+        );
+        // Array of strings
+        fields.insert(
+            "tags".to_string(),
+            QuillValue::from_json(serde_json::json!([
+                format!("rust{bidi}lang"),
+                "markdown"
+            ])),
+        );
+        let result = normalize_fields(fields);
+
+        // Nested object strings pass through verbatim
+        let addr = result.get("address").unwrap().as_object().unwrap();
+        assert_eq!(addr.get("city").unwrap().as_str().unwrap(), "New\u{202D}York");
+
+        // Array of strings pass through verbatim
+        let tags = result.get("tags").unwrap().as_array().unwrap();
+        assert_eq!(tags[0].as_str().unwrap(), "rust\u{202D}lang");
+        assert_eq!(tags[1].as_str().unwrap(), "markdown");
     }
 
     // Tests for depth limiting

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -280,14 +280,7 @@ pub fn normalize_markdown(markdown: &str) -> String {
 /// All other fields in the card pass through verbatim.
 fn normalize_card_object(
     map: serde_json::Map<String, serde_json::Value>,
-    depth: usize,
-) -> Result<serde_json::Map<String, serde_json::Value>, NormalizationError> {
-    if depth > MAX_NESTING_DEPTH {
-        return Err(NormalizationError::NestingTooDeep {
-            depth,
-            max: MAX_NESTING_DEPTH,
-        });
-    }
+) -> serde_json::Map<String, serde_json::Value> {
     map.into_iter()
         .map(|(k, v)| {
             if k == BODY_FIELD {
@@ -297,10 +290,10 @@ fn normalize_card_object(
                     }
                     other => other,
                 };
-                Ok((k, normalized))
+                (k, normalized)
             } else {
                 // All other card fields pass through verbatim
-                Ok((k, v))
+                (k, v)
             }
         })
         .collect()
@@ -309,17 +302,13 @@ fn normalize_card_object(
 /// Normalize the `CARDS` array: for each element that is an object, normalize its
 /// `BODY` field via `normalize_markdown`; all other card fields pass through verbatim.
 /// Non-object elements (malformed) pass through unchanged.
-fn normalize_cards_array(
-    arr: Vec<serde_json::Value>,
-) -> Result<Vec<serde_json::Value>, NormalizationError> {
+fn normalize_cards_array(arr: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
     arr.into_iter()
-        .enumerate()
-        .map(|(i, elem)| match elem {
+        .map(|elem| match elem {
             serde_json::Value::Object(map) => {
-                let normalized = normalize_card_object(map, i)?;
-                Ok(serde_json::Value::Object(normalized))
+                serde_json::Value::Object(normalize_card_object(map))
             }
-            other => Ok(other),
+            other => other,
         })
         .collect()
 }
@@ -436,14 +425,7 @@ pub fn normalize_fields(fields: HashMap<String, QuillValue>) -> HashMap<String, 
                 let json = value.into_json();
                 let normalized = match json {
                     serde_json::Value::Array(arr) => {
-                        let original = serde_json::Value::Array(arr.clone());
-                        match normalize_cards_array(arr) {
-                            Ok(normalized_arr) => serde_json::Value::Array(normalized_arr),
-                            Err(e) => {
-                                eprintln!("Warning: {}", e);
-                                original
-                            }
-                        }
+                        serde_json::Value::Array(normalize_cards_array(arr))
                     }
                     other => other,
                 };

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -49,7 +49,6 @@
 //! assert_eq!(cleaned, "**asdf** or **(1234**");
 //! ```
 
-use crate::error::MAX_NESTING_DEPTH;
 use crate::parse::BODY_FIELD;
 use crate::value::QuillValue;
 use std::collections::HashMap;
@@ -309,48 +308,6 @@ fn normalize_cards_array(arr: Vec<serde_json::Value>) -> Vec<serde_json::Value> 
             other => other,
         })
         .collect()
-}
-
-// Keep normalize_json_value_inner for the depth-limit test that uses it directly.
-/// Recursively normalize a JSON value with depth tracking.
-///
-/// Returns an error if nesting exceeds MAX_NESTING_DEPTH to prevent stack overflow.
-/// NOTE: This helper is retained only for the depth-limit guard test; the main
-/// normalization path in `normalize_fields` no longer uses it.
-fn normalize_json_value_inner(
-    value: serde_json::Value,
-    is_body: bool,
-    depth: usize,
-) -> Result<serde_json::Value, NormalizationError> {
-    if depth > MAX_NESTING_DEPTH {
-        return Err(NormalizationError::NestingTooDeep {
-            depth,
-            max: MAX_NESTING_DEPTH,
-        });
-    }
-
-    match value {
-        serde_json::Value::String(s) => {
-            let result = if is_body { normalize_markdown(&s) } else { s };
-            Ok(serde_json::Value::String(result))
-        }
-        serde_json::Value::Array(arr) => {
-            let normalized: Result<Vec<_>, _> = arr
-                .into_iter()
-                .map(|v| normalize_json_value_inner(v, false, depth + 1))
-                .collect();
-            Ok(serde_json::Value::Array(normalized?))
-        }
-        serde_json::Value::Object(map) => {
-            let processed: Result<serde_json::Map<String, serde_json::Value>, _> = map
-                .into_iter()
-                .map(|(k, v)| normalize_json_value_inner(v, false, depth + 1).map(|nv| (k, nv)))
-                .collect();
-            Ok(serde_json::Value::Object(processed?))
-        }
-        // Pass through other types unchanged (numbers, booleans, null)
-        other => Ok(other),
-    }
 }
 
 /// Normalizes document fields per the Quillmark §7 spec.
@@ -1049,41 +1006,6 @@ mod tests {
         let tags = result.get("tags").unwrap().as_array().unwrap();
         assert_eq!(tags[0].as_str().unwrap(), "rust\u{202D}lang");
         assert_eq!(tags[1].as_str().unwrap(), "markdown");
-    }
-
-    // Tests for depth limiting
-
-    #[test]
-    fn test_normalize_json_value_inner_depth_exceeded() {
-        // Create a deeply nested JSON structure that exceeds MAX_NESTING_DEPTH
-        let mut value = serde_json::json!("leaf");
-        for _ in 0..=crate::error::MAX_NESTING_DEPTH {
-            value = serde_json::json!([value]);
-        }
-
-        // The inner function should return an error
-        let result = super::normalize_json_value_inner(value, false, 0);
-        assert!(result.is_err());
-
-        if let Err(NormalizationError::NestingTooDeep { depth, max }) = result {
-            assert!(depth > max);
-            assert_eq!(max, crate::error::MAX_NESTING_DEPTH);
-        } else {
-            panic!("Expected NestingTooDeep error");
-        }
-    }
-
-    #[test]
-    fn test_normalize_json_value_inner_within_limit() {
-        // Create a nested structure just within the limit
-        let mut value = serde_json::json!("leaf");
-        for _ in 0..50 {
-            value = serde_json::json!([value]);
-        }
-
-        // This should succeed
-        let result = super::normalize_json_value_inner(value, false, 0);
-        assert!(result.is_ok());
     }
 
     // Tests for normalize_document

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -271,8 +271,35 @@ pub fn fix_html_comment_fences(s: &str) -> String {
 /// assert_eq!(normalized, "<!-- comment -->\nSome text");
 /// ```
 pub fn normalize_markdown(markdown: &str) -> String {
-    let cleaned = strip_bidi_formatting(markdown);
+    let cleaned = normalize_line_endings(markdown);
+    let cleaned = strip_bidi_formatting(&cleaned);
     fix_html_comment_fences(&cleaned)
+}
+
+/// Convert CRLF (`\r\n`) and bare CR (`\r`) line endings to LF (`\n`).
+///
+/// YAML parsing already normalizes line endings inside scalar values, but the
+/// Markdown body is passed through verbatim. Authoring on Windows or pasting
+/// from some clipboard sources leaves `\r` bytes in the body which some
+/// backends render as visible garbage. This canonicalization is performed
+/// only on the Markdown body (see §7); YAML scalars are unaffected.
+fn normalize_line_endings(s: &str) -> String {
+    if !s.contains('\r') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\r' {
+            if chars.peek() == Some(&'\n') {
+                chars.next();
+            }
+            out.push('\n');
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Normalize a single card object: apply `normalize_markdown` to the `BODY` key only.

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -305,9 +305,7 @@ fn normalize_card_object(
 fn normalize_cards_array(arr: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
     arr.into_iter()
         .map(|elem| match elem {
-            serde_json::Value::Object(map) => {
-                serde_json::Value::Object(normalize_card_object(map))
-            }
+            serde_json::Value::Object(map) => serde_json::Value::Object(normalize_card_object(map)),
             other => other,
         })
         .collect()
@@ -333,11 +331,7 @@ fn normalize_json_value_inner(
 
     match value {
         serde_json::Value::String(s) => {
-            let result = if is_body {
-                normalize_markdown(&s)
-            } else {
-                s
-            };
+            let result = if is_body { normalize_markdown(&s) } else { s };
             Ok(serde_json::Value::String(result))
         }
         serde_json::Value::Array(arr) => {
@@ -350,9 +344,7 @@ fn normalize_json_value_inner(
         serde_json::Value::Object(map) => {
             let processed: Result<serde_json::Map<String, serde_json::Value>, _> = map
                 .into_iter()
-                .map(|(k, v)| {
-                    normalize_json_value_inner(v, false, depth + 1).map(|nv| (k, nv))
-                })
+                .map(|(k, v)| normalize_json_value_inner(v, false, depth + 1).map(|nv| (k, nv)))
                 .collect();
             Ok(serde_json::Value::Object(processed?))
         }
@@ -927,10 +919,7 @@ mod tests {
         );
         let result = normalize_fields(fields);
         // Must NOT be stripped — YAML field values pass through verbatim.
-        assert_eq!(
-            result.get("title").unwrap().as_str().unwrap(),
-            "a\u{202D}b"
-        );
+        assert_eq!(result.get("title").unwrap().as_str().unwrap(), "a\u{202D}b");
     }
 
     /// Case 3: Bidi character inside CARDS[0].BODY → stripped.
@@ -1045,16 +1034,16 @@ mod tests {
         // Array of strings
         fields.insert(
             "tags".to_string(),
-            QuillValue::from_json(serde_json::json!([
-                format!("rust{bidi}lang"),
-                "markdown"
-            ])),
+            QuillValue::from_json(serde_json::json!([format!("rust{bidi}lang"), "markdown"])),
         );
         let result = normalize_fields(fields);
 
         // Nested object strings pass through verbatim
         let addr = result.get("address").unwrap().as_object().unwrap();
-        assert_eq!(addr.get("city").unwrap().as_str().unwrap(), "New\u{202D}York");
+        assert_eq!(
+            addr.get("city").unwrap().as_str().unwrap(),
+            "New\u{202D}York"
+        );
 
         // Array of strings pass through verbatim
         let tags = result.get("tags").unwrap().as_array().unwrap();

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -195,7 +195,18 @@ fn yaml_parse_options() -> serde_saphyr::Options {
 /// trailing whitespace (spaces or tabs).
 fn is_fence_marker_line(line: &str) -> bool {
     let line = line.strip_suffix('\r').unwrap_or(line);
-    match line.strip_prefix("---") {
+    // F3 (spec §4): the fence marker is preceded by zero to three spaces of
+    // indentation. Four or more leading spaces (or any leading tab — a tab
+    // counts as four columns of indentation) make the line indented code per
+    // CommonMark §4.4, not a metadata fence.
+    let indent = line.bytes().take_while(|&b| b == b' ').count();
+    if indent > 3 {
+        return false;
+    }
+    if line.as_bytes().first() == Some(&b'\t') {
+        return false;
+    }
+    match line[indent..].strip_prefix("---") {
         Some(rest) => rest.chars().all(|c| c == ' ' || c == '\t'),
         None => false,
     }
@@ -473,13 +484,20 @@ fn extract_sentinels(
 /// Implements fence rules F1 (sentinel) and F2 (leading blank). Returns
 /// successfully detected blocks plus any lint warnings emitted for
 /// near-miss sentinels (§4.2).
-fn find_metadata_blocks(
-    markdown: &str,
-) -> Result<(Vec<MetadataBlock>, Vec<Diagnostic>), ParseError> {
+/// Outcome of the fence-detection pass: the recognised metadata blocks, any
+/// non-fatal diagnostics accumulated along the way, and (if applicable) the
+/// first-fence F1 failure captured so the top-level error can be specific.
+type FenceScan = (Vec<MetadataBlock>, Vec<Diagnostic>, Option<(String, usize)>);
+
+fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseError> {
     let lines = Lines::new(markdown);
     let mut blocks: Vec<MetadataBlock> = Vec::new();
     let mut warnings: Vec<Diagnostic> = Vec::new();
-    let mut open_code_fence: Option<(u8, usize)> = None;
+    // (char, min_run_len, opener_line_index)
+    let mut open_code_fence: Option<(u8, usize, usize)> = None;
+    // First-fence F1 failure context, captured for a clearer top-level error
+    // if no valid QUILL fence is ever found. (actual_key, 1-based line).
+    let mut first_fence_issue: Option<(String, usize)> = None;
 
     let mut k: usize = 0;
     while k < lines.len() {
@@ -487,7 +505,7 @@ fn find_metadata_blocks(
 
         // Track open CommonMark fenced-code-block state so that `---` inside
         // them is ignored (spec §3 "Fences inside fenced code blocks").
-        if let Some((ch, min)) = open_code_fence {
+        if let Some((ch, min, _opener)) = open_code_fence {
             if let Some((_, _, true)) = code_fence_on_line(text, Some((ch, min))) {
                 open_code_fence = None;
             }
@@ -495,7 +513,7 @@ fn find_metadata_blocks(
             continue;
         }
         if let Some((ch, run_len, _)) = code_fence_on_line(text, None) {
-            open_code_fence = Some((ch, run_len));
+            open_code_fence = Some((ch, run_len, k));
             k += 1;
             continue;
         }
@@ -553,6 +571,12 @@ fn find_metadata_blocks(
                         )
                         .with_code("parse::near_miss_sentinel".to_string()),
                     );
+                    // Capture the first-fence F1 failure so the top-level
+                    // "Missing required QUILL field" error can be specific
+                    // about the actual key found.
+                    if blocks.is_empty() && first_fence_issue.is_none() {
+                        first_fence_issue = Some((actual.to_string(), k + 1));
+                    }
                 }
             }
             // Delegate this opener to CommonMark — advance past the opener
@@ -587,7 +611,23 @@ fn find_metadata_blocks(
         });
     }
 
-    Ok((blocks, warnings))
+    // Unclosed fenced code block at end-of-document: any metadata fences below
+    // the unclosed opener were silently shielded, which is almost never what
+    // the author intended. Surface it as a non-fatal warning.
+    if let Some((_, _, opener_line)) = open_code_fence {
+        warnings.push(
+            Diagnostic::new(
+                Severity::Warning,
+                format!(
+                    "Unclosed fenced code block opened at line {} — end-of-document reached without a matching closing fence. Any `---/---` pairs after this line were treated as code and not parsed as metadata fences.",
+                    opener_line + 1
+                ),
+            )
+            .with_code("parse::unclosed_code_block".to_string()),
+        );
+    }
+
+    Ok((blocks, warnings, first_fence_issue))
 }
 
 /// Decompose markdown, discarding warnings. Test- and `from_markdown`-facing.
@@ -595,11 +635,34 @@ fn decompose(markdown: &str) -> Result<ParsedDocument, crate::error::ParseError>
     decompose_with_warnings(markdown).map(|(doc, _)| doc)
 }
 
+/// Construct the top-level "missing QUILL" error message. If we saw a
+/// first-fence F1 failure, tailor the message to the actual key found:
+/// a case-insensitive match to `QUILL` is a typo, anything else is a
+/// key-ordering problem.
+fn missing_quill_message(first_fence_issue: Option<(String, usize)>) -> String {
+    match first_fence_issue {
+        Some((actual, line)) if actual.eq_ignore_ascii_case("QUILL") => format!(
+            "Missing required QUILL field. Found `{}:` at line {} — expected `QUILL:` (uppercase). Change the key to `QUILL` to register this fence as the document frontmatter.",
+            actual, line
+        ),
+        Some((actual, line)) => format!(
+            "Missing required QUILL field. The first YAML key in the frontmatter must be `QUILL:` (found `{}:` at line {}). Reorder the frontmatter so `QUILL: <name>` is the first key.",
+            actual, line
+        ),
+        None => "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
+    }
+}
+
 /// Decompose markdown into frontmatter fields and body, returning any
 /// non-fatal warnings collected during fence scanning.
 fn decompose_with_warnings(
     markdown: &str,
 ) -> Result<(ParsedDocument, Vec<Diagnostic>), crate::error::ParseError> {
+    // Strip a leading UTF-8 BOM if present. Editors on Windows (Notepad, some
+    // Word exports) prepend `\u{FEFF}` which otherwise defeats F2 because the
+    // first line no longer matches `---`.
+    let markdown = markdown.strip_prefix('\u{FEFF}').unwrap_or(markdown);
+
     // Check input size limit
     if markdown.len() > crate::error::MAX_INPUT_SIZE {
         return Err(crate::error::ParseError::InputTooLarge {
@@ -612,11 +675,11 @@ fn decompose_with_warnings(
 
     // Find all metadata blocks. F1/F2 already guarantee that block 0 carries
     // QUILL and that every subsequent block carries CARD.
-    let (blocks, warnings) = find_metadata_blocks(markdown)?;
+    let (blocks, warnings, first_fence_issue) = find_metadata_blocks(markdown)?;
 
     if blocks.is_empty() {
         return Err(crate::error::ParseError::InvalidStructure(
-            "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
+            missing_quill_message(first_fence_issue),
         ));
     }
 

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -206,7 +206,7 @@ fn is_fence_marker_line(line: &str) -> bool {
 /// Any leading spaces/tabs on that line are ignored (YAML indentation-tolerant).
 fn first_content_key(content: &str) -> Option<&str> {
     let first = content.lines().find(|l| !l.trim().is_empty())?;
-    let trimmed = first.trim_start_matches(|c: char| c == ' ' || c == '\t');
+    let trimmed = first.trim_start_matches([' ', '\t']);
     let bytes = trimmed.as_bytes();
     if bytes.is_empty() || !bytes[0].is_ascii_alphabetic() {
         return None;

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -201,11 +201,15 @@ fn is_fence_marker_line(line: &str) -> bool {
     }
 }
 
-/// Extracts the first non-blank line of `content` and, if it starts with a
-/// `[A-Za-z][A-Za-z0-9_]*` identifier followed by `:`, returns that identifier.
-/// Any leading spaces/tabs on that line are ignored (YAML indentation-tolerant).
+/// Extracts the first non-blank, non-comment line of `content` and, if it
+/// starts with a `[A-Za-z][A-Za-z0-9_]*` identifier followed by `:`, returns
+/// that identifier. Any leading spaces/tabs on that line are ignored
+/// (YAML indentation-tolerant). YAML `#` comment lines are skipped so the
+/// sentinel rule is indifferent to banner-style comments above the key.
 fn first_content_key(content: &str) -> Option<&str> {
-    let first = content.lines().find(|l| !l.trim().is_empty())?;
+    let first = content
+        .lines()
+        .find(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))?;
     let trimmed = first.trim_start_matches([' ', '\t']);
     let bytes = trimmed.as_bytes();
     if bytes.is_empty() || !bytes[0].is_ascii_alphabetic() {

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -90,10 +90,8 @@ impl ParsedDocument {
     pub fn from_markdown_with_warnings(
         markdown: &str,
     ) -> Result<ParseOutput, crate::error::ParseError> {
-        decompose_with_warnings(markdown).map(|(document, warnings)| ParseOutput {
-            document,
-            warnings,
-        })
+        decompose_with_warnings(markdown)
+            .map(|(document, warnings)| ParseOutput { document, warnings })
     }
 
     /// Get the quill reference (name + version selector)
@@ -331,8 +329,10 @@ fn build_block(
     let (tag, quill_ref, yaml_value) = if content.is_empty() {
         (None, None, None)
     } else {
-        match serde_saphyr::from_str_with_options::<serde_json::Value>(content, yaml_parse_options())
-        {
+        match serde_saphyr::from_str_with_options::<serde_json::Value>(
+            content,
+            yaml_parse_options(),
+        ) {
             Ok(parsed) => extract_sentinels(parsed, markdown, abs_pos, block_index)?,
             Err(e) => {
                 let line = markdown[..abs_pos].lines().count() + 1;
@@ -396,14 +396,7 @@ fn extract_sentinels(
     _markdown: &str,
     _abs_pos: usize,
     _block_index: usize,
-) -> Result<
-    (
-        Option<String>,
-        Option<String>,
-        Option<serde_json::Value>,
-    ),
-    ParseError,
-> {
+) -> Result<(Option<String>, Option<String>, Option<serde_json::Value>), ParseError> {
     let Some(mapping) = parsed.as_object() else {
         // Non-mapping (scalar/sequence); keep as-is — upstream will reject if
         // it's a frontmatter/card mapping was expected.

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -53,9 +53,20 @@ use std::str::FromStr;
 use crate::error::ParseError;
 use crate::value::QuillValue;
 use crate::version::QuillReference;
+use crate::{Diagnostic, Severity};
 
 /// The field name used to store the document body
 pub const BODY_FIELD: &str = "BODY";
+
+/// Parse result carrying both the parsed document and any non-fatal warnings
+/// (e.g. near-miss sentinel lints emitted per spec §4.2).
+#[derive(Debug)]
+pub struct ParseOutput {
+    /// The successfully parsed document.
+    pub document: ParsedDocument,
+    /// Non-fatal warnings collected during parsing.
+    pub warnings: Vec<Diagnostic>,
+}
 
 /// A parsed markdown document with frontmatter
 #[derive(Debug, Clone)]
@@ -70,9 +81,19 @@ impl ParsedDocument {
         Self { fields, quill_ref }
     }
 
-    /// Create a ParsedDocument from markdown string
+    /// Create a ParsedDocument from markdown string, discarding any warnings.
     pub fn from_markdown(markdown: &str) -> Result<Self, crate::error::ParseError> {
         decompose(markdown)
+    }
+
+    /// Create a ParsedDocument from markdown string, returning warnings alongside the document.
+    pub fn from_markdown_with_warnings(
+        markdown: &str,
+    ) -> Result<ParseOutput, crate::error::ParseError> {
+        decompose_with_warnings(markdown).map(|(document, warnings)| ParseOutput {
+            document,
+            warnings,
+        })
     }
 
     /// Get the quill reference (name + version selector)
@@ -156,98 +177,6 @@ fn is_valid_tag_name(name: &str) -> bool {
     true
 }
 
-/// Check if a position is inside a fenced code block.
-///
-/// Uses CommonMark-style fenced block detection:
-/// - Backticks (```) and tildes (~~~) are supported
-/// - Opening fences are 3+ matching fence characters
-/// - Closing fences use the same fence character and length >= opening fence
-fn is_inside_fenced_block(markdown: &str, pos: usize) -> bool {
-    let before = &markdown[..pos];
-    let mut open_fence: Option<(u8, usize)> = None; // (fence char, opening run length)
-
-    // Check if document starts with a fence
-    if let Some((fence_char, fence_len, is_closing)) = fence_marker_at(before, 0, open_fence) {
-        if is_closing {
-            open_fence = None;
-        } else {
-            open_fence = Some((fence_char, fence_len));
-        }
-    }
-
-    // Scan line starts after newlines
-    for (i, _) in before.match_indices('\n') {
-        if let Some((fence_char, fence_len, is_closing)) =
-            fence_marker_at(before, i + 1, open_fence)
-        {
-            if is_closing {
-                open_fence = None;
-            } else {
-                open_fence = Some((fence_char, fence_len));
-            }
-        }
-    }
-
-    open_fence.is_some()
-}
-
-/// Detects a CommonMark fence marker at a given line start position.
-///
-/// Returns (fence_char, fence_len, is_closing).
-fn fence_marker_at(
-    text: &str,
-    pos: usize,
-    open_fence: Option<(u8, usize)>,
-) -> Option<(u8, usize, bool)> {
-    if pos >= text.len() {
-        return None;
-    }
-
-    // Extract line [pos, end)
-    let line_end = text[pos..]
-        .find('\n')
-        .map(|offset| pos + offset)
-        .unwrap_or(text.len());
-    let line = &text[pos..line_end];
-
-    // Optional indentation is up to 3 spaces (CommonMark fence rule)
-    let indent = line.as_bytes().iter().take_while(|&&b| b == b' ').count();
-    if indent > 3 {
-        return None;
-    }
-
-    let trimmed = &line[indent..];
-    let bytes = trimmed.as_bytes();
-    let Some(&first) = bytes.first() else {
-        return None;
-    };
-    if first != b'`' && first != b'~' {
-        return None;
-    }
-
-    let run_len = bytes.iter().take_while(|&&b| b == first).count();
-    if run_len < 3 {
-        return None;
-    }
-
-    let rest = &trimmed[run_len..];
-
-    match open_fence {
-        Some((open_char, open_len)) => {
-            if first != open_char || run_len < open_len {
-                return None;
-            }
-            // Closing fence line may only contain trailing spaces/tabs
-            if rest.chars().all(|c| c == ' ' || c == '\t') {
-                Some((first, run_len, true))
-            } else {
-                None
-            }
-        }
-        None => Some((first, run_len, false)),
-    }
-}
-
 /// Creates serde_saphyr Options with security budgets configured.
 ///
 /// Uses MAX_YAML_DEPTH from error.rs to limit nesting depth at the parser level,
@@ -263,234 +192,417 @@ fn yaml_parse_options() -> serde_saphyr::Options {
     }
 }
 
-/// Find all metadata blocks in the document
-fn find_metadata_blocks(markdown: &str) -> Result<Vec<MetadataBlock>, crate::error::ParseError> {
-    let mut blocks = Vec::new();
-    let mut pos = 0;
+/// Returns true if `line` (without its line ending) is a `---` metadata-fence
+/// marker per MARKDOWN.md §3: exactly three hyphens followed by optional
+/// trailing whitespace (spaces or tabs).
+fn is_fence_marker_line(line: &str) -> bool {
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    match line.strip_prefix("---") {
+        Some(rest) => rest.chars().all(|c| c == ' ' || c == '\t'),
+        None => false,
+    }
+}
 
-    while pos < markdown.len() {
-        // Look for opening "---\n" or "---\r\n"
-        let search_str = &markdown[pos..];
-        let delimiter_result = search_str
-            .find("---\n")
-            .map(|p| (p, 4, "\n"))
-            .or_else(|| search_str.find("---\r\n").map(|p| (p, 5, "\r\n")));
+/// Extracts the first non-blank line of `content` and, if it starts with a
+/// `[A-Za-z][A-Za-z0-9_]*` identifier followed by `:`, returns that identifier.
+/// Any leading spaces/tabs on that line are ignored (YAML indentation-tolerant).
+fn first_content_key(content: &str) -> Option<&str> {
+    let first = content.lines().find(|l| !l.trim().is_empty())?;
+    let trimmed = first.trim_start_matches(|c: char| c == ' ' || c == '\t');
+    let bytes = trimmed.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_alphabetic() {
+        return None;
+    }
+    let mut i = 1;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    if i < bytes.len() && bytes[i] == b':' {
+        Some(&trimmed[..i])
+    } else {
+        None
+    }
+}
 
-        if let Some((delimiter_pos, delimiter_len, _line_ending)) = delimiter_result {
-            let abs_pos = pos + delimiter_pos;
+/// Line-oriented view of the source, used for F1/F2 fence detection.
+struct Lines<'a> {
+    source: &'a str,
+    starts: Vec<usize>, // byte offset of each line's first character
+}
 
-            // Check if the delimiter is at the start of a line
-            let is_start_of_line = if abs_pos == 0 {
-                true
-            } else {
-                let char_before = markdown.as_bytes()[abs_pos - 1];
-                char_before == b'\n' || char_before == b'\r'
-            };
-
-            if !is_start_of_line {
-                pos = abs_pos + 1;
-                continue;
+impl<'a> Lines<'a> {
+    fn new(source: &'a str) -> Self {
+        let mut starts = Vec::new();
+        starts.push(0);
+        for (i, b) in source.bytes().enumerate() {
+            if b == b'\n' {
+                starts.push(i + 1);
             }
-
-            // Skip if inside a fenced code block
-            if is_inside_fenced_block(markdown, abs_pos) {
-                pos = abs_pos + 3;
-                continue;
-            }
-
-            let content_start = abs_pos + delimiter_len; // After "---\n" or "---\r\n"
-
-            // Triple dashes are always metadata block delimiters (never horizontal rules)
-
-            // Found potential metadata block opening
-            // Look for closing "\n---\n" or "\r\n---\r\n" etc., OR "\n---" / "\r\n---" at end of document
-            let rest = &markdown[content_start..];
-
-            // First try to find delimiters with trailing newlines
-            let closing_patterns = ["\n---\n", "\r\n---\r\n", "\n---\r\n", "\r\n---\n"];
-            let closing_with_newline = closing_patterns
-                .iter()
-                .filter_map(|delim| rest.find(delim).map(|p| (p, delim.len())))
-                .min_by_key(|(p, _)| *p);
-
-            // Also check for closing at end of document (no trailing newline)
-            let closing_at_eof = ["\n---", "\r\n---"]
-                .iter()
-                .filter_map(|delim| {
-                    rest.find(delim).and_then(|p| {
-                        if p + delim.len() == rest.len() {
-                            Some((p, delim.len()))
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .min_by_key(|(p, _)| *p);
-
-            let closing_result = match (closing_with_newline, closing_at_eof) {
-                (Some((p1, _l1)), Some((p2, _))) if p2 < p1 => closing_at_eof,
-                (Some(_), Some(_)) => closing_with_newline,
-                (Some(_), None) => closing_with_newline,
-                (None, Some(_)) => closing_at_eof,
-                (None, None) => None,
-            };
-
-            if let Some((closing_pos, closing_len)) = closing_result {
-                let abs_closing_pos = content_start + closing_pos;
-                let content = &markdown[content_start..abs_closing_pos];
-
-                // Check YAML size limit
-                if content.len() > crate::error::MAX_YAML_SIZE {
-                    return Err(crate::error::ParseError::InputTooLarge {
-                        size: content.len(),
-                        max: crate::error::MAX_YAML_SIZE,
-                    });
-                }
-
-                // Parse YAML content to check for reserved keys (QUILL, CARD)
-                // Uses configured budget to limit nesting depth (prevents stack overflow)
-                // Normalize: treat whitespace-only content as empty frontmatter
-                let content = content.trim();
-                let (tag, quill_ref, yaml_value) = if !content.is_empty() {
-                    // Try to parse the YAML with security budgets
-                    match serde_saphyr::from_str_with_options::<serde_json::Value>(
-                        content,
-                        yaml_parse_options(),
-                    ) {
-                        Ok(parsed_yaml) => {
-                            if let Some(mapping) = parsed_yaml.as_object() {
-                                let quill_key = "QUILL";
-                                let card_key = "CARD";
-
-                                let has_quill = mapping.contains_key(quill_key);
-                                let has_card = mapping.contains_key(card_key);
-
-                                if has_quill && has_card {
-                                    return Err(crate::error::ParseError::InvalidStructure(
-                                        "Cannot specify both QUILL and CARD in the same block"
-                                            .to_string(),
-                                    ));
-                                }
-
-                                // Check for reserved field names (BODY, CARDS)
-                                const RESERVED_FIELDS: &[&str] = &["BODY", "CARDS"];
-                                for reserved in RESERVED_FIELDS {
-                                    if mapping.contains_key(*reserved) {
-                                        return Err(crate::error::ParseError::InvalidStructure(
-                                            format!(
-                                                "Reserved field name '{}' cannot be used in YAML frontmatter",
-                                                reserved
-                                            ),
-                                        ));
-                                    }
-                                }
-
-                                if has_quill {
-                                    // Extract and parse quill reference
-                                    let quill_value = mapping.get(quill_key).unwrap();
-                                    let quill_ref_str = quill_value
-                                        .as_str()
-                                        .ok_or("QUILL value must be a string")?;
-
-                                    // Parse as QuillReference to validate name and version
-                                    let _quill_ref =
-                                        quill_ref_str.parse::<QuillReference>().map_err(|e| {
-                                            crate::error::ParseError::InvalidStructure(format!(
-                                                "Invalid QUILL reference '{}': {}",
-                                                quill_ref_str, e
-                                            ))
-                                        })?;
-
-                                    // Remove QUILL from the YAML value for processing
-                                    let mut new_mapping = mapping.clone();
-                                    new_mapping.remove(quill_key);
-                                    let new_value = if new_mapping.is_empty() {
-                                        None
-                                    } else {
-                                        Some(serde_json::Value::Object(new_mapping))
-                                    };
-
-                                    (None, Some(quill_ref_str.to_string()), new_value)
-                                } else if has_card {
-                                    // Extract card field name
-                                    let card_value = mapping.get(card_key).unwrap();
-                                    let field_name =
-                                        card_value.as_str().ok_or("CARD value must be a string")?;
-
-                                    if !is_valid_tag_name(field_name) {
-                                        return Err(crate::error::ParseError::InvalidStructure(format!(
-                                            "Invalid card field name '{}': must match pattern [a-z_][a-z0-9_]*",
-                                            field_name
-                                        )));
-                                    }
-
-                                    // Remove CARD from the YAML value for processing
-                                    let mut new_mapping = mapping.clone();
-                                    new_mapping.remove(card_key);
-                                    let new_value = if new_mapping.is_empty() {
-                                        None
-                                    } else {
-                                        Some(serde_json::Value::Object(new_mapping))
-                                    };
-
-                                    (Some(field_name.to_string()), None, new_value)
-                                } else {
-                                    // No reserved keys, keep the parsed YAML
-                                    (None, None, Some(parsed_yaml))
-                                }
-                            } else {
-                                // Not a mapping, keep the parsed YAML (could be null for whitespace)
-                                (None, None, Some(parsed_yaml))
-                            }
-                        }
-                        Err(e) => {
-                            // Calculate line number for the start of this block
-                            let block_start_line = markdown[..abs_pos].lines().count() + 1;
-                            return Err(crate::error::ParseError::YamlErrorWithLocation {
-                                message: e.to_string(),
-                                line: block_start_line,
-                                block_index: blocks.len(),
-                            });
-                        }
-                    }
-                } else {
-                    // Empty content
-                    (None, None, None)
-                };
-
-                blocks.push(MetadataBlock {
-                    start: abs_pos,
-                    end: abs_closing_pos + closing_len, // After closing delimiter
-                    yaml_value,
-                    tag,
-                    quill_ref,
-                });
-
-                // Check card count limit to prevent memory exhaustion
-                if blocks.len() > crate::error::MAX_CARD_COUNT {
-                    return Err(crate::error::ParseError::InputTooLarge {
-                        size: blocks.len(),
-                        max: crate::error::MAX_CARD_COUNT,
-                    });
-                }
-
-                pos = abs_closing_pos + closing_len;
-            } else {
-                // Metadata block started but not closed
-                return Err(crate::error::ParseError::InvalidStructure(
-                    "Metadata block started but not closed with ---".to_string(),
-                ));
-            }
+        }
+        Self { source, starts }
+    }
+    fn len(&self) -> usize {
+        self.starts.len()
+    }
+    fn line_start(&self, k: usize) -> usize {
+        self.starts[k]
+    }
+    /// Byte position immediately after line k's trailing `\n` (or end-of-source
+    /// if no newline follows).
+    fn line_end_inclusive(&self, k: usize) -> usize {
+        if k + 1 < self.starts.len() {
+            self.starts[k + 1]
         } else {
-            break;
+            self.source.len()
+        }
+    }
+    /// Line text without its trailing line ending.
+    fn line_text(&self, k: usize) -> &'a str {
+        let start = self.starts[k];
+        let mut end = self.line_end_inclusive(k);
+        if end > start && self.source.as_bytes()[end - 1] == b'\n' {
+            end -= 1;
+        }
+        if end > start && self.source.as_bytes()[end - 1] == b'\r' {
+            end -= 1;
+        }
+        &self.source[start..end]
+    }
+    fn is_blank(&self, k: usize) -> bool {
+        self.line_text(k).chars().all(char::is_whitespace)
+    }
+}
+
+/// Detect a CommonMark fenced code-block marker line. Returns `Some((char,
+/// run_len))` if the line opens a fence, or `Some` with `is_closing=true` if
+/// it closes one matching `open_fence`.
+fn code_fence_on_line(line: &str, open_fence: Option<(u8, usize)>) -> Option<(u8, usize, bool)> {
+    let indent = line.as_bytes().iter().take_while(|&&b| b == b' ').count();
+    if indent > 3 {
+        return None;
+    }
+    let trimmed = &line[indent..];
+    let bytes = trimmed.as_bytes();
+    let &first = bytes.first()?;
+    if first != b'`' && first != b'~' {
+        return None;
+    }
+    let run_len = bytes.iter().take_while(|&&b| b == first).count();
+    if run_len < 3 {
+        return None;
+    }
+    let rest = &trimmed[run_len..];
+    match open_fence {
+        Some((open_char, open_len)) => {
+            if first == open_char
+                && run_len >= open_len
+                && rest.chars().all(|c| c == ' ' || c == '\t')
+            {
+                Some((first, run_len, true))
+            } else {
+                None
+            }
+        }
+        None => Some((first, run_len, false)),
+    }
+}
+
+/// Process YAML content for a recognized metadata fence and build a
+/// `MetadataBlock`. The `is_first_block` flag governs whether `QUILL` is
+/// expected (vs. `CARD`). Returns errors per spec §9.
+fn build_block(
+    markdown: &str,
+    abs_pos: usize,
+    abs_closing_pos: usize,
+    block_end: usize,
+    block_index: usize,
+) -> Result<MetadataBlock, ParseError> {
+    let raw_content = &markdown[abs_pos + fence_opener_len(markdown, abs_pos)..abs_closing_pos];
+
+    // Check YAML size limit (spec §8)
+    if raw_content.len() > crate::error::MAX_YAML_SIZE {
+        return Err(ParseError::InputTooLarge {
+            size: raw_content.len(),
+            max: crate::error::MAX_YAML_SIZE,
+        });
+    }
+
+    let content = raw_content.trim();
+    let (tag, quill_ref, yaml_value) = if content.is_empty() {
+        (None, None, None)
+    } else {
+        match serde_saphyr::from_str_with_options::<serde_json::Value>(content, yaml_parse_options())
+        {
+            Ok(parsed) => extract_sentinels(parsed, markdown, abs_pos, block_index)?,
+            Err(e) => {
+                let line = markdown[..abs_pos].lines().count() + 1;
+                return Err(ParseError::YamlErrorWithLocation {
+                    message: e.to_string(),
+                    line,
+                    block_index,
+                });
+            }
+        }
+    };
+
+    // Per-fence field-count check (spec §8, §6.1 of GAP analysis)
+    if let Some(serde_json::Value::Object(ref map)) = yaml_value {
+        // Add +1 for QUILL (stripped) or CARD (stripped) so the cap matches
+        // what the user wrote, not what's left after sentinel extraction.
+        let sentinel_extra = if quill_ref.is_some() || tag.is_some() {
+            1
+        } else {
+            0
+        };
+        if map.len() + sentinel_extra > crate::error::MAX_FIELD_COUNT {
+            return Err(ParseError::InputTooLarge {
+                size: map.len() + sentinel_extra,
+                max: crate::error::MAX_FIELD_COUNT,
+            });
         }
     }
 
-    Ok(blocks)
+    Ok(MetadataBlock {
+        start: abs_pos,
+        end: block_end,
+        yaml_value,
+        tag,
+        quill_ref,
+    })
 }
 
-/// Decompose markdown into frontmatter fields and body
+/// Number of bytes occupied by the opener `---[ \t]*\n` or `---[ \t]*\r\n`
+/// starting at `abs_pos`. Only called on a line that already matched
+/// `is_fence_marker_line`.
+fn fence_opener_len(markdown: &str, abs_pos: usize) -> usize {
+    let bytes = markdown.as_bytes();
+    let mut i = abs_pos + 3; // past the "---"
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        i += 1;
+    }
+    if i < bytes.len() && bytes[i] == b'\r' {
+        i += 1;
+    }
+    if i < bytes.len() && bytes[i] == b'\n' {
+        i += 1;
+    }
+    i - abs_pos
+}
+
+/// Extract `QUILL` / `CARD` sentinels and remaining fields from a parsed-YAML
+/// mapping. Returns `(tag, quill_ref, yaml_without_sentinel)`.
+fn extract_sentinels(
+    parsed: serde_json::Value,
+    _markdown: &str,
+    _abs_pos: usize,
+    _block_index: usize,
+) -> Result<
+    (
+        Option<String>,
+        Option<String>,
+        Option<serde_json::Value>,
+    ),
+    ParseError,
+> {
+    let Some(mapping) = parsed.as_object() else {
+        // Non-mapping (scalar/sequence); keep as-is — upstream will reject if
+        // it's a frontmatter/card mapping was expected.
+        return Ok((None, None, Some(parsed)));
+    };
+
+    let has_quill = mapping.contains_key("QUILL");
+    let has_card = mapping.contains_key("CARD");
+
+    if has_quill && has_card {
+        return Err(ParseError::InvalidStructure(
+            "Cannot specify both QUILL and CARD in the same block".to_string(),
+        ));
+    }
+
+    // Reserved keys (BODY, CARDS) — spec §3
+    for reserved in ["BODY", "CARDS"] {
+        if mapping.contains_key(reserved) {
+            return Err(ParseError::InvalidStructure(format!(
+                "Reserved field name '{}' cannot be used in YAML frontmatter",
+                reserved
+            )));
+        }
+    }
+
+    if has_quill {
+        let quill_str = mapping
+            .get("QUILL")
+            .unwrap()
+            .as_str()
+            .ok_or("QUILL value must be a string")?;
+        quill_str.parse::<QuillReference>().map_err(|e| {
+            ParseError::InvalidStructure(format!("Invalid QUILL reference '{}': {}", quill_str, e))
+        })?;
+        let mut new_map = mapping.clone();
+        new_map.remove("QUILL");
+        let new_val = if new_map.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(new_map))
+        };
+        Ok((None, Some(quill_str.to_string()), new_val))
+    } else if has_card {
+        let field_name = mapping
+            .get("CARD")
+            .unwrap()
+            .as_str()
+            .ok_or("CARD value must be a string")?;
+        if !is_valid_tag_name(field_name) {
+            return Err(ParseError::InvalidStructure(format!(
+                "Invalid card field name '{}': must match pattern [a-z_][a-z0-9_]*",
+                field_name
+            )));
+        }
+        let mut new_map = mapping.clone();
+        new_map.remove("CARD");
+        let new_val = if new_map.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(new_map))
+        };
+        Ok((Some(field_name.to_string()), None, new_val))
+    } else {
+        Ok((None, None, Some(parsed)))
+    }
+}
+
+/// Find all metadata fences in the document per MARKDOWN.md §3–§4.
+///
+/// Implements fence rules F1 (sentinel) and F2 (leading blank). Returns
+/// successfully detected blocks plus any lint warnings emitted for
+/// near-miss sentinels (§4.2).
+fn find_metadata_blocks(
+    markdown: &str,
+) -> Result<(Vec<MetadataBlock>, Vec<Diagnostic>), ParseError> {
+    let lines = Lines::new(markdown);
+    let mut blocks: Vec<MetadataBlock> = Vec::new();
+    let mut warnings: Vec<Diagnostic> = Vec::new();
+    let mut open_code_fence: Option<(u8, usize)> = None;
+
+    let mut k: usize = 0;
+    while k < lines.len() {
+        let text = lines.line_text(k);
+
+        // Track open CommonMark fenced-code-block state so that `---` inside
+        // them is ignored (spec §3 "Fences inside fenced code blocks").
+        if let Some((ch, min)) = open_code_fence {
+            if let Some((_, _, true)) = code_fence_on_line(text, Some((ch, min))) {
+                open_code_fence = None;
+            }
+            k += 1;
+            continue;
+        }
+        if let Some((ch, run_len, _)) = code_fence_on_line(text, None) {
+            open_code_fence = Some((ch, run_len));
+            k += 1;
+            continue;
+        }
+
+        // Candidate fence opener?
+        if !is_fence_marker_line(text) {
+            k += 1;
+            continue;
+        }
+
+        // F2 — Leading blank rule
+        let f2_ok = k == 0 || lines.is_blank(k - 1);
+        if !f2_ok {
+            k += 1;
+            continue;
+        }
+
+        // Scan ahead for the closer. Inside a metadata fence, YAML content is
+        // opaque — don't update code-block state.
+        let mut closer_k: Option<usize> = None;
+        let mut j = k + 1;
+        while j < lines.len() {
+            if is_fence_marker_line(lines.line_text(j)) {
+                closer_k = Some(j);
+                break;
+            }
+            j += 1;
+        }
+
+        let content_start = lines.line_end_inclusive(k);
+        let (content_end, block_end) = match closer_k {
+            Some(cj) => (lines.line_start(cj), lines.line_end_inclusive(cj)),
+            None => (markdown.len(), markdown.len()),
+        };
+        let content = &markdown[content_start..content_end];
+
+        // F1 — Sentinel rule. First non-blank line of content must match the
+        // expected sentinel (`QUILL` for the first fence, `CARD` thereafter).
+        let expected = if blocks.is_empty() { "QUILL" } else { "CARD" };
+        let key = first_content_key(content);
+        let f1_ok = key == Some(expected);
+
+        if !f1_ok {
+            // Near-miss lint (spec §4.2): first key looked like an identifier
+            // but wasn't the expected sentinel.
+            if let Some(actual) = key {
+                if actual != expected {
+                    warnings.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            format!(
+                                "Near-miss metadata sentinel `{}:` at line {} — expected `{}:`. This `---/---` pair is treated as literal Markdown; if you intended a metadata fence, change the key to `{}`.",
+                                actual, k + 1, expected, expected
+                            ),
+                        )
+                        .with_code("parse::near_miss_sentinel".to_string()),
+                    );
+                }
+            }
+            // Delegate this opener to CommonMark — advance past the opener
+            // line only; the closer (if any) may become its own candidate
+            // opener on a later iteration (it will fail F2 and be skipped).
+            k += 1;
+            continue;
+        }
+
+        // F1 passed — a legitimate fence. If the closer was missing, this is
+        // a hard error (spec §9).
+        let Some(cj) = closer_k else {
+            return Err(ParseError::InvalidStructure(
+                "Metadata block started but not closed with ---".to_string(),
+            ));
+        };
+
+        let abs_pos = lines.line_start(k);
+        let abs_closing_pos = lines.line_start(cj);
+        let block = build_block(markdown, abs_pos, abs_closing_pos, block_end, blocks.len())?;
+        blocks.push(block);
+
+        k = cj + 1;
+    }
+
+    // Card-count check counts only blocks carrying a CARD sentinel (spec §8).
+    let card_count = blocks.iter().filter(|b| b.tag.is_some()).count();
+    if card_count > crate::error::MAX_CARD_COUNT {
+        return Err(ParseError::InputTooLarge {
+            size: card_count,
+            max: crate::error::MAX_CARD_COUNT,
+        });
+    }
+
+    Ok((blocks, warnings))
+}
+
+/// Decompose markdown, discarding warnings. Test- and `from_markdown`-facing.
 fn decompose(markdown: &str) -> Result<ParsedDocument, crate::error::ParseError> {
+    decompose_with_warnings(markdown).map(|(doc, _)| doc)
+}
+
+/// Decompose markdown into frontmatter fields and body, returning any
+/// non-fatal warnings collected during fence scanning.
+fn decompose_with_warnings(
+    markdown: &str,
+) -> Result<(ParsedDocument, Vec<Diagnostic>), crate::error::ParseError> {
     // Check input size limit
     if markdown.len() > crate::error::MAX_INPUT_SIZE {
         return Err(crate::error::ParseError::InputTooLarge {
@@ -501,109 +613,38 @@ fn decompose(markdown: &str) -> Result<ParsedDocument, crate::error::ParseError>
 
     let mut fields = HashMap::new();
 
-    // Find all metadata blocks
-    let blocks = find_metadata_blocks(markdown)?;
+    // Find all metadata blocks. F1/F2 already guarantee that block 0 carries
+    // QUILL and that every subsequent block carries CARD.
+    let (blocks, warnings) = find_metadata_blocks(markdown)?;
 
     if blocks.is_empty() {
-        // No metadata blocks — entire content is body, but QUILL is required
         return Err(crate::error::ParseError::InvalidStructure(
             "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
         ));
     }
 
-    // Collect all card items into unified CARDS array
     let mut cards_array: Vec<serde_json::Value> = Vec::new();
-    let mut global_frontmatter_index: Option<usize> = None;
-    let mut quill_ref: Option<String> = None;
 
-    // First pass: identify global frontmatter, quill directive, and validate
-    for (idx, block) in blocks.iter().enumerate() {
-        if idx == 0 {
-            // Top-level frontmatter: can have QUILL or neither (not considered a card)
-            if let Some(ref name) = block.quill_ref {
-                quill_ref = Some(name.clone());
-            }
-            // If it has neither QUILL nor CARD, it's global frontmatter
-            if block.tag.is_none() && block.quill_ref.is_none() {
-                global_frontmatter_index = Some(idx);
-            }
-        } else {
-            // Inline blocks (idx > 0): MUST have CARD, cannot have QUILL
-            if block.quill_ref.is_some() {
-                return Err(crate::error::ParseError::InvalidStructure("QUILL directive can only appear in the top-level frontmatter, not in inline blocks. Use CARD instead.".to_string()));
-            }
-            if block.tag.is_none() {
-                // Inline block without CARD
-                return Err(crate::error::ParseError::missing_card_directive());
+    // Block 0 is always the QUILL frontmatter (F1 guarantee).
+    let frontmatter = &blocks[0];
+    let quill_tag = frontmatter.quill_ref.clone().ok_or_else(|| {
+        ParseError::InvalidStructure(
+            "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
+        )
+    })?;
+
+    // Merge frontmatter fields (YAML content with QUILL stripped).
+    match &frontmatter.yaml_value {
+        Some(serde_json::Value::Object(mapping)) => {
+            for (key, value) in mapping {
+                fields.insert(key.clone(), QuillValue::from_json(value.clone()));
             }
         }
-    }
-
-    // Parse global frontmatter if present
-    if let Some(idx) = global_frontmatter_index {
-        let block = &blocks[idx];
-
-        // Get parsed JSON fields directly (already parsed in find_metadata_blocks)
-        let json_fields: HashMap<String, serde_json::Value> = match &block.yaml_value {
-            Some(serde_json::Value::Object(mapping)) => mapping
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect(),
-            Some(serde_json::Value::Null) => {
-                // Null value (from whitespace-only YAML) - treat as empty mapping
-                HashMap::new()
-            }
-            Some(_) => {
-                // Non-mapping, non-null YAML (e.g., scalar, sequence) - this is an error for frontmatter
-                return Err(crate::error::ParseError::InvalidStructure(
-                    "Invalid YAML frontmatter: expected a mapping".to_string(),
-                ));
-            }
-            None => HashMap::new(),
-        };
-
-        // Convert JSON values to QuillValue at boundary
-        for (key, value) in json_fields {
-            fields.insert(key, QuillValue::from_json(value));
-        }
-    }
-
-    // Process blocks with quill directives
-    for block in &blocks {
-        if block.quill_ref.is_some() {
-            // Quill directive blocks can have YAML content (becomes part of frontmatter)
-            if let Some(ref json_val) = block.yaml_value {
-                let json_fields: HashMap<String, serde_json::Value> = match json_val {
-                    serde_json::Value::Object(mapping) => mapping
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                    serde_json::Value::Null => {
-                        // Null value (from whitespace-only YAML) - treat as empty mapping
-                        HashMap::new()
-                    }
-                    _ => {
-                        return Err(crate::error::ParseError::InvalidStructure(
-                            "Invalid YAML in quill block: expected a mapping".to_string(),
-                        ));
-                    }
-                };
-
-                // Check for conflicts with existing fields
-                for key in json_fields.keys() {
-                    if fields.contains_key(key) {
-                        return Err(crate::error::ParseError::InvalidStructure(format!(
-                            "Name collision: quill block field '{}' conflicts with existing field",
-                            key
-                        )));
-                    }
-                }
-
-                // Convert JSON values to QuillValue at boundary
-                for (key, value) in json_fields {
-                    fields.insert(key, QuillValue::from_json(value));
-                }
-            }
+        Some(serde_json::Value::Null) | None => {}
+        Some(_) => {
+            return Err(ParseError::InvalidStructure(
+                "Invalid YAML frontmatter: expected a mapping".to_string(),
+            ));
         }
     }
 
@@ -654,38 +695,15 @@ fn decompose(markdown: &str) -> Result<ParsedDocument, crate::error::ParseError>
         }
     }
 
-    // Extract global body
-    // Body starts after global frontmatter or quill block (whichever comes first)
-    // Body ends at the first card block or EOF
-    let first_non_card_block_idx = blocks
+    // Global body: between end of frontmatter (block 0) and start of the
+    // first CARD block (or EOF).
+    let body_start = blocks[0].end;
+    let body_end = blocks
         .iter()
-        .position(|b| b.tag.is_none() && b.quill_ref.is_none())
-        .or_else(|| blocks.iter().position(|b| b.quill_ref.is_some()));
-
-    let (body_start, body_end) = if let Some(idx) = first_non_card_block_idx {
-        // Body starts after the first non-card block (global frontmatter or quill)
-        let start = blocks[idx].end;
-
-        // Body ends at the first card block after this, or EOF
-        let end = blocks
-            .iter()
-            .skip(idx + 1)
-            .find(|b| b.tag.is_some())
-            .map(|b| b.start)
-            .unwrap_or(markdown.len());
-
-        (start, end)
-    } else {
-        // No global frontmatter or quill block - body is everything before the first card block
-        let end = blocks
-            .iter()
-            .find(|b| b.tag.is_some())
-            .map(|b| b.start)
-            .unwrap_or(0);
-
-        (0, end)
-    };
-
+        .skip(1)
+        .find(|b| b.tag.is_some())
+        .map(|b| b.start)
+        .unwrap_or(markdown.len());
     let global_body = &markdown[body_start..body_end];
 
     fields.insert(
@@ -699,25 +717,12 @@ fn decompose(markdown: &str) -> Result<ParsedDocument, crate::error::ParseError>
         QuillValue::from_json(serde_json::Value::Array(cards_array)),
     );
 
-    // Check field count limit to prevent memory exhaustion
-    if fields.len() > crate::error::MAX_FIELD_COUNT {
-        return Err(crate::error::ParseError::InputTooLarge {
-            size: fields.len(),
-            max: crate::error::MAX_FIELD_COUNT,
-        });
-    }
-
-    let quill_tag = quill_ref.ok_or_else(|| {
-        ParseError::InvalidStructure(
-            "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
-        )
-    })?;
     let quill_ref = QuillReference::from_str(&quill_tag).map_err(|e| {
         ParseError::InvalidStructure(format!("Invalid QUILL tag '{}': {}", quill_tag, e))
     })?;
     let parsed = ParsedDocument::new(fields, quill_ref);
 
-    Ok(parsed)
+    Ok((parsed, warnings))
 }
 
 #[cfg(test)]
@@ -958,7 +963,9 @@ Content here."#;
 
     #[test]
     fn test_invalid_yaml() {
+        // Real fence (QUILL first) with invalid YAML — size check happens, then YAML parse fails.
         let markdown = r#"---
+QUILL: test_quill
 title: [invalid yaml
 author: missing close bracket
 ---
@@ -973,7 +980,9 @@ Content here."#;
 
     #[test]
     fn test_unclosed_frontmatter() {
+        // Real fence (QUILL first) without closer → spec §9 "not closed" error.
         let markdown = r#"---
+QUILL: test_quill
 title: Test
 author: Test Author
 
@@ -1222,7 +1231,12 @@ Item 1 body"#;
 
     #[test]
     fn test_reserved_field_body_rejected() {
+        // BODY reserved inside a CARD block (requires prior QUILL fence per spec §4 F1).
         let markdown = r#"---
+QUILL: test_quill
+---
+
+---
 CARD: section
 BODY: Test
 ---"#;
@@ -1237,7 +1251,9 @@ BODY: Test
 
     #[test]
     fn test_reserved_field_cards_rejected() {
+        // CARDS reserved inside the QUILL frontmatter.
         let markdown = r#"---
+QUILL: test_quill
 title: Test
 CARDS: []
 ---"#;
@@ -1325,7 +1341,12 @@ More content.
 
     #[test]
     fn test_invalid_tag_syntax() {
+        // CARD must follow a prior QUILL fence per spec §4 F1.
         let markdown = r#"---
+QUILL: test_quill
+---
+
+---
 CARD: Invalid-Name
 title: Test
 ---"#;
@@ -1340,6 +1361,9 @@ title: Test
 
     #[test]
     fn test_multiple_global_frontmatter_blocks() {
+        // Two `---/---` blocks without QUILL/CARD sentinels both fail F1
+        // and are delegated to CommonMark, so the document has no metadata
+        // blocks and parsing fails with the missing-QUILL error.
         let markdown = r#"---
 title: First
 ---
@@ -1352,20 +1376,11 @@ author: Second
 
 More body"#;
 
-        let result = decompose(markdown);
-        assert!(result.is_err());
-
-        // Verify the error message contains CARD hint
-        let err = result.unwrap_err();
+        let err = decompose(markdown).unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("CARD"),
-            "Error should mention CARD directive: {}",
-            err_str
-        );
-        assert!(
-            err_str.contains("missing"),
-            "Error should indicate missing directive: {}",
+            err_str.contains("QUILL"),
+            "Error should mention missing QUILL: {}",
             err_str
         );
     }
@@ -1612,6 +1627,10 @@ Section 1 body."#;
 
     #[test]
     fn test_multiple_quill_directives_error() {
+        // A second fence whose first key is QUILL (instead of CARD) fails F1
+        // and is delegated to CommonMark. A near-miss warning is emitted per
+        // spec §4.2; the document itself parses successfully with the stray
+        // `---` lines preserved in the body.
         let markdown = r#"---
 QUILL: first
 ---
@@ -1620,13 +1639,13 @@ QUILL: first
 QUILL: second
 ---"#;
 
-        let result = decompose(markdown);
-        assert!(result.is_err());
-        // QUILL in inline block is now an error (must appear in top-level frontmatter only)
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("top-level frontmatter"));
+        let output = ParsedDocument::from_markdown_with_warnings(markdown).unwrap();
+        assert!(output
+            .warnings
+            .iter()
+            .any(|w| w.code.as_deref() == Some("parse::near_miss_sentinel")
+                && w.message.contains("QUILL")));
+        assert!(output.document.body().unwrap().contains("QUILL: second"));
     }
 
     #[test]
@@ -1660,6 +1679,10 @@ QUILL: 123
     #[test]
     fn test_card_wrong_value_type() {
         let markdown = r#"---
+QUILL: test_quill
+---
+
+---
 CARD: 123
 ---"#;
 
@@ -1760,8 +1783,9 @@ Body of item 1."#;
     }
 
     #[test]
-    fn test_triple_dash_in_body_is_parsed_as_inline_metadata_block() {
-        // Triple dashes are always metadata delimiters, never horizontal rules
+    fn test_triple_dash_in_body_without_sentinel_is_delegated() {
+        // Triple-dash pairs without a QUILL or CARD sentinel fail F1 and are
+        // delegated to CommonMark, so the `---` lines stay in the body.
         let markdown = r#"---
 QUILL: test_quill
 title: Test
@@ -1773,17 +1797,17 @@ First paragraph.
 
 Second paragraph."#;
 
-        let err = decompose(markdown).unwrap_err();
-
-        assert!(matches!(
-            err,
-            ParseError::InvalidStructure(ref msg) if msg.contains("not closed with ---")
-        ));
+        let doc = decompose(markdown).unwrap();
+        let body = doc.body().unwrap();
+        assert!(body.contains("First paragraph."));
+        assert!(body.contains("Second paragraph."));
+        assert!(body.contains("---"));
     }
 
     #[test]
-    fn test_triple_dash_with_single_surrounding_newline_is_also_metadata() {
-        // Triple dashes without CARD in body are rejected as inline metadata blocks
+    fn test_lone_triple_dash_in_body_is_delegated() {
+        // A single `---` line not preceded by a blank fails F2 and is left as
+        // body content.
         let markdown = r#"---
 QUILL: test_quill
 title: Test
@@ -1794,12 +1818,11 @@ First paragraph.
 
 Second paragraph."#;
 
-        let err = decompose(markdown).unwrap_err();
-
-        assert!(matches!(
-            err,
-            ParseError::InvalidStructure(ref msg) if msg.contains("not closed with ---")
-        ));
+        let doc = decompose(markdown).unwrap();
+        let body = doc.body().unwrap();
+        assert!(body.contains("First paragraph."));
+        assert!(body.contains("Second paragraph."));
+        assert!(body.contains("---"));
     }
 
     #[test]
@@ -1930,7 +1953,7 @@ mod demo_file_test {
     #[test]
     fn test_yaml_size_limit() {
         // Create YAML block larger than MAX_YAML_SIZE (1 MB)
-        let mut markdown = String::from("---\n");
+        let mut markdown = String::from("---\nQUILL: test_quill\n");
 
         // Create a very large YAML field
         let size = crate::error::MAX_YAML_SIZE + 1;
@@ -2453,6 +2476,9 @@ name: Item
 
     #[test]
     fn test_card_consecutive_blocks() {
+        // Per spec §4 F2 each metadata fence opener must be preceded by a
+        // blank line (or start-of-file), so consecutive CARD blocks need a
+        // blank separator.
         let markdown = r#"---
 QUILL: test_quill
 ---
@@ -2461,6 +2487,7 @@ QUILL: test_quill
 CARD: a
 id: 1
 ---
+
 ---
 CARD: a
 id: 2
@@ -2551,7 +2578,7 @@ Body content."#;
 
     #[test]
     fn test_invalid_scope_name_uppercase() {
-        let markdown = "---\nCARD: ITEMS\n---\n\nBody.";
+        let markdown = "---\nQUILL: test_quill\n---\n\n---\nCARD: ITEMS\n---\n\nBody.";
         let result = decompose(markdown);
         assert!(result.is_err());
         assert!(result
@@ -2759,8 +2786,8 @@ Body content."#;
     #[test]
     fn test_spec_example() {
         let markdown = r#"---
-title: My Document
 QUILL: blog_post
+title: My Document
 ---
 Main document body.
 

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -28,6 +28,34 @@ fn f1_first_fence_without_quill_is_rejected() {
     assert!(err.contains("Missing required QUILL field"), "got: {}", err);
 }
 
+// §4 F1 — YAML `#` comment lines at the top of a fence are skipped when
+// locating the sentinel. A banner comment above `QUILL:` must not trip F1.
+#[test]
+fn f1_yaml_comment_banners_above_sentinel_are_accepted() {
+    let md = "---\n# Essential\n#===========\nQUILL: t\ntitle: T\n---\n\nBody.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    assert_eq!(doc.get_field("title").unwrap().as_str().unwrap(), "T");
+}
+
+// §4.2 — near-miss detection also ignores `#` comment banners, so a fence
+// whose first real key is a near-miss still warns rather than silently
+// delegating.
+#[test]
+fn near_miss_sentinel_sees_past_comment_banners() {
+    let md = "---\nQUILL: t\n---\n\nB.\n\n---\n# banner\nCard: oops\nname: X\n---\n\nTrailing.";
+    let out = ParsedDocument::from_markdown_with_warnings(md).unwrap();
+    assert!(
+        out.warnings.iter().any(
+            |w| w.message.contains("Near-miss metadata sentinel") && w.message.contains("Card")
+        ),
+        "expected near-miss warning even with leading comment, got: {:?}",
+        out.warnings
+            .iter()
+            .map(|w| w.message.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
 // §4.2 — Near-miss sentinel warning.
 #[test]
 fn near_miss_sentinel_emits_warning_and_delegates() {

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -1,0 +1,167 @@
+//! Independent spec conformance probes for prose/designs/MARKDOWN.md.
+//!
+//! These tests exercise concrete spec requirements that are most likely to
+//! diverge between the parser and the written standard.
+
+use quillmark_core::normalize::{normalize_document, normalize_fields};
+use quillmark_core::{ParsedDocument, QuillValue};
+
+// §4 F2 — Leading blank: a `---` line directly under non-blank text is not a fence.
+#[test]
+fn f2_fence_directly_under_paragraph_is_not_a_fence() {
+    let md = "---\nQUILL: t\n---\n\nParagraph text.\n---\n\nAfter.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let body = doc.body().unwrap();
+    assert!(
+        body.contains("Paragraph text.") && body.contains("---") && body.contains("After."),
+        "stray `---` under paragraph must be left to CommonMark, body was: {:?}",
+        body
+    );
+}
+
+// §4 F1 — first fence must carry QUILL. A first fence with some other key must not
+// be accepted silently.
+#[test]
+fn f1_first_fence_without_quill_is_rejected() {
+    let md = "---\ntitle: X\n---\n\nBody.";
+    let err = ParsedDocument::from_markdown(md).unwrap_err().to_string();
+    assert!(err.contains("Missing required QUILL field"), "got: {}", err);
+}
+
+// §4.2 — Near-miss sentinel warning.
+#[test]
+fn near_miss_sentinel_emits_warning_and_delegates() {
+    let md = "---\nQUILL: t\n---\n\nBody.\n\n---\nCard: oops\nname: X\n---\n\nTrailing.";
+    let out = ParsedDocument::from_markdown_with_warnings(md).unwrap();
+    assert!(
+        out.warnings.iter().any(
+            |w| w.message.contains("Near-miss metadata sentinel") && w.message.contains("Card")
+        ),
+        "expected near-miss warning, got: {:?}",
+        out.warnings
+            .iter()
+            .map(|w| w.message.clone())
+            .collect::<Vec<_>>()
+    );
+    // And the `Card:` fence must NOT have registered as a card.
+    let cards = out.document.get_field("CARDS").unwrap().as_array().unwrap();
+    assert!(
+        cards.is_empty(),
+        "near-miss CARD must be delegated, not registered"
+    );
+    // Body must contain the delegated content.
+    assert!(out.document.body().unwrap().contains("Card: oops"));
+}
+
+// §3 — Trailing whitespace on the fence marker must be accepted.
+#[test]
+fn fence_marker_with_trailing_whitespace_is_accepted() {
+    let md = "---  \nQUILL: t\ntitle: T\n---\t\n\nBody.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    assert_eq!(doc.get_field("title").unwrap().as_str().unwrap(), "T");
+}
+
+// §3 — `---` inside a fenced code block must be ignored.
+#[test]
+fn fences_inside_code_blocks_are_ignored() {
+    let md = "---\nQUILL: t\n---\n\n```\n---\nCARD: x\n---\n```\n\nBody.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let cards = doc.get_field("CARDS").unwrap().as_array().unwrap();
+    assert!(cards.is_empty(), "fences inside code blocks must not parse");
+}
+
+// §3 — Reserved keys BODY/CARDS cannot be user-defined.
+#[test]
+fn reserved_keys_in_frontmatter_are_rejected() {
+    for reserved in ["BODY", "CARDS"] {
+        let md = format!("---\nQUILL: t\n{}: nope\n---\n\nBody.", reserved);
+        let err = ParsedDocument::from_markdown(&md).unwrap_err().to_string();
+        assert!(
+            err.contains(&format!("Reserved field name '{}'", reserved)),
+            "reserved key {} must error, got: {}",
+            reserved,
+            err
+        );
+    }
+}
+
+// §5 — CARDS is always present, even when empty.
+#[test]
+fn cards_is_always_present_even_when_empty() {
+    let doc = ParsedDocument::from_markdown("---\nQUILL: t\n---\n\nBody.").unwrap();
+    let cards = doc.get_field("CARDS").unwrap().as_array().unwrap();
+    assert!(cards.is_empty());
+}
+
+// §5 — CARD value pattern.
+#[test]
+fn card_name_pattern_enforced() {
+    let md = "---\nQUILL: t\n---\n\nB.\n\n---\nCARD: ITEMS\n---\n\nX.";
+    let err = ParsedDocument::from_markdown(md).unwrap_err().to_string();
+    assert!(err.contains("Invalid card field name"), "got: {}", err);
+}
+
+// §7 — Body bidi stripped.
+#[test]
+fn normalize_body_strips_bidi() {
+    let mut f = std::collections::HashMap::new();
+    f.insert(
+        "BODY".to_string(),
+        QuillValue::from_json(serde_json::json!("hi\u{202D}there")),
+    );
+    let out = normalize_fields(f);
+    assert_eq!(out.get("BODY").unwrap().as_str().unwrap(), "hithere");
+}
+
+// §7 — YAML scalar bidi NOT stripped.
+#[test]
+fn normalize_yaml_scalar_keeps_bidi() {
+    let mut f = std::collections::HashMap::new();
+    f.insert(
+        "title".to_string(),
+        QuillValue::from_json(serde_json::json!("hi\u{202D}there")),
+    );
+    let out = normalize_fields(f);
+    assert_eq!(
+        out.get("title").unwrap().as_str().unwrap(),
+        "hi\u{202D}there"
+    );
+}
+
+// §7 — Card body normalization reaches nested cards.
+#[test]
+fn normalize_reaches_card_body() {
+    let md = "---\nQUILL: t\n---\n\n---\nCARD: x\n---\n\n<!-- c -->trailing\u{202D}text";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let doc = normalize_document(doc).unwrap();
+    let cards = doc.get_field("CARDS").unwrap().as_array().unwrap();
+    let body = cards[0].get("BODY").unwrap().as_str().unwrap();
+    assert!(
+        body.contains("<!-- c -->\ntrailingtext"),
+        "card body missing repair/bidi-strip, got: {:?}",
+        body
+    );
+}
+
+// §8 — Per-fence field-count cap.
+#[test]
+fn per_fence_field_count_cap() {
+    let mut s = String::from("---\nQUILL: t\n");
+    for i in 0..1001 {
+        s.push_str(&format!("f{}: v\n", i));
+    }
+    s.push_str("---\n\nBody.");
+    let err = ParsedDocument::from_markdown(&s).unwrap_err().to_string();
+    assert!(err.contains("Input too large"), "got: {}", err);
+}
+
+// §8 — Card count cap counts cards only.
+#[test]
+fn card_count_cap_is_per_card() {
+    let mut s = String::from("---\nQUILL: t\n---\n");
+    for _ in 0..1001 {
+        s.push_str("\n---\nCARD: x\n---\n\nB.\n");
+    }
+    let err = ParsedDocument::from_markdown(&s).unwrap_err().to_string();
+    assert!(err.contains("Input too large"), "got: {}", err);
+}

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -195,7 +195,10 @@ fn f3_indented_four_spaces_is_not_a_fence() {
 fn f3_three_leading_spaces_is_still_a_fence() {
     let md = "   ---\nQUILL: t\n   ---\n\nBody.";
     let doc = ParsedDocument::from_markdown(md).unwrap();
-    assert_eq!(doc.get_field("QUILL").is_some() || doc.body().is_some(), true);
+    assert_eq!(
+        doc.get_field("QUILL").is_some() || doc.body().is_some(),
+        true
+    );
     // More directly: the body should be present and the fence should have parsed.
     assert!(doc.body().unwrap().contains("Body."));
 }
@@ -295,12 +298,7 @@ fn unclosed_code_block_emits_warning() {
             .collect::<Vec<_>>()
     );
     // And the shielded CARD fence must NOT have registered.
-    let cards = out
-        .document
-        .get_field("CARDS")
-        .unwrap()
-        .as_array()
-        .unwrap();
+    let cards = out.document.get_field("CARDS").unwrap().as_array().unwrap();
     assert!(
         cards.is_empty(),
         "shielded CARD must not have been parsed as a fence"

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -171,6 +171,142 @@ fn normalize_reaches_card_body() {
     );
 }
 
+// §4 F3 — A `---` line indented by four or more spaces is indented code,
+// not a fence marker.
+#[test]
+fn f3_indented_four_spaces_is_not_a_fence() {
+    let md = "---\nQUILL: t\n---\n\n    ---\n    CARD: x\n    ---\n\nafter.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let cards = doc.get_field("CARDS").unwrap().as_array().unwrap();
+    assert!(
+        cards.is_empty(),
+        "indented `---` must not register as a fence"
+    );
+    let body = doc.body().unwrap();
+    assert!(
+        body.contains("    ---") && body.contains("CARD: x"),
+        "indented fence content must be delegated to CommonMark, body was: {:?}",
+        body
+    );
+}
+
+// §4 F3 — Up to three leading spaces is still a fence.
+#[test]
+fn f3_three_leading_spaces_is_still_a_fence() {
+    let md = "   ---\nQUILL: t\n   ---\n\nBody.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    assert_eq!(doc.get_field("QUILL").is_some() || doc.body().is_some(), true);
+    // More directly: the body should be present and the fence should have parsed.
+    assert!(doc.body().unwrap().contains("Body."));
+}
+
+// §4 F3 — Tab indentation disqualifies a line from being a fence marker.
+#[test]
+fn f3_tab_indented_is_not_a_fence() {
+    let md = "---\nQUILL: t\n---\n\n\t---\n\tCARD: x\n\t---\n\nafter.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let cards = doc.get_field("CARDS").unwrap().as_array().unwrap();
+    assert!(
+        cards.is_empty(),
+        "tab-indented `---` must not register as a fence"
+    );
+}
+
+// §7 — CRLF line endings in the body are canonicalized to LF.
+#[test]
+fn body_crlf_line_endings_are_normalized() {
+    let md = "---\nQUILL: t\n---\n\nLine one.\r\nLine two.\r\n";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let doc = normalize_document(doc).unwrap();
+    let body = doc.body().unwrap();
+    assert!(
+        !body.contains('\r'),
+        "body must not contain bare \\r after normalization, got: {:?}",
+        body
+    );
+    assert!(body.contains("Line one.\nLine two."));
+}
+
+// §7 — CRLF normalization reaches card bodies.
+#[test]
+fn card_body_crlf_line_endings_are_normalized() {
+    let md = "---\nQUILL: t\n---\n\n---\nCARD: x\n---\n\nCard line one.\r\nCard line two.\r\n";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    let doc = normalize_document(doc).unwrap();
+    let cards = doc.get_field("CARDS").unwrap().as_array().unwrap();
+    let body = cards[0].get("BODY").unwrap().as_str().unwrap();
+    assert!(
+        !body.contains('\r'),
+        "card body must not contain bare \\r after normalization, got: {:?}",
+        body
+    );
+}
+
+// §3 — UTF-8 BOM at the start of the document must not defeat F2.
+#[test]
+fn utf8_bom_at_start_is_stripped() {
+    let md = "\u{FEFF}---\nQUILL: t\ntitle: T\n---\n\nBody.";
+    let doc = ParsedDocument::from_markdown(md).unwrap();
+    assert_eq!(doc.get_field("title").unwrap().as_str().unwrap(), "T");
+}
+
+// §4 / §9 — First-fence near-miss (case-only) produces a specific error
+// naming the actual key, not a generic "Missing QUILL" message.
+#[test]
+fn first_fence_case_near_miss_error_is_specific() {
+    let err = ParsedDocument::from_markdown("---\nQuill: t\n---\n\nBody.")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("Quill") && err.contains("QUILL") && err.contains("uppercase"),
+        "expected case-hint error, got: {}",
+        err
+    );
+}
+
+// §4 / §9 — First-fence ordering error (QUILL not first) names the actual
+// first key and explains the ordering requirement.
+#[test]
+fn first_fence_out_of_order_error_is_specific() {
+    let err = ParsedDocument::from_markdown("---\ntitle: X\nQUILL: t\n---\n\nBody.")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("title") && err.contains("first key"),
+        "expected ordering-hint error, got: {}",
+        err
+    );
+}
+
+// §3 — Unclosed fenced code block at end-of-document emits a warning so
+// silently-shielded metadata fences don't disappear without trace.
+#[test]
+fn unclosed_code_block_emits_warning() {
+    let md = "---\nQUILL: t\n---\n\n```\ncode line\n\n---\nCARD: x\n---\n\ntrailing body";
+    let out = ParsedDocument::from_markdown_with_warnings(md).unwrap();
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.code.as_deref() == Some("parse::unclosed_code_block")),
+        "expected unclosed-code-block warning, got: {:?}",
+        out.warnings
+            .iter()
+            .map(|w| (w.code.clone(), w.message.clone()))
+            .collect::<Vec<_>>()
+    );
+    // And the shielded CARD fence must NOT have registered.
+    let cards = out
+        .document
+        .get_field("CARDS")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert!(
+        cards.is_empty(),
+        "shielded CARD must not have been parsed as a fence"
+    );
+}
+
 // §8 — Per-fence field-count cap.
 #[test]
 fn per_fence_field_count_cap() {

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -61,11 +61,17 @@ optional trailing whitespace). The content between is parsed as YAML.
 
 A `---` line opens a metadata fence **iff both** of the following hold:
 
-**F1 — Sentinel.** The first non-blank line of content between the opening
-`---` and the next `---` line matches `KEY: value`, where `KEY` is:
+**F1 — Sentinel.** The first non-blank, non-comment line of content between
+the opening `---` and the next `---` line matches `KEY: value`, where `KEY`
+is:
 
 - `QUILL` if this is the first metadata fence in the document, or
 - `CARD` if any metadata fence has already been recognised.
+
+For F1 purposes a *comment line* is any line whose first non-whitespace
+character is `#`; such lines are skipped when locating the first content
+line. This mirrors YAML's own treatment of `#` comments and lets fences
+carry banner comments above the sentinel (e.g. `# Essential`).
 
 **F2 — Leading blank.** The opening `---` is on line 1 of the document, or
 the line immediately above it is blank.
@@ -107,8 +113,8 @@ A `---`/`---` pair whose content's first key is almost-but-not-quite
 `CARD` (e.g. `Card:`, `CARDS:`, `card:`) fails F1 and is interpreted as
 two thematic breaks with literal YAML between. Implementations **should**
 emit a lint warning when they encounter a `---`/`---` pair whose content's
-first non-blank line matches `[A-Za-z][A-Za-z0-9_]*:` but whose key is not
-the expected sentinel.
+first non-blank, non-comment line matches `[A-Za-z][A-Za-z0-9_]*:` but whose
+key is not the expected sentinel.
 
 ## 5. Data Model
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -76,10 +76,22 @@ carry banner comments above the sentinel (e.g. `# Essential`).
 **F2 — Leading blank.** The opening `---` is on line 1 of the document, or
 the line immediately above it is blank.
 
-A `---` line that fails either rule is delegated to CommonMark unchanged:
+**F3 — Column.** The `---` marker is preceded by zero to three spaces of
+indentation. A line with four or more leading spaces (or any leading tab,
+which counts as four columns under CommonMark) is never a fence marker;
+per CommonMark §4.4 such a line is indented code. This rule applies
+symmetrically to the opening and closing fence markers, and piggy-backs on
+the same indentation rule CommonMark already uses for thematic breaks, so
+`---` lines that appear inside indented code blocks are automatically
+excluded without special tracking.
+
+A `---` line that fails any of F1, F2, or F3 is delegated to CommonMark
+unchanged:
 
 - If the line above is non-blank paragraph text, `---` is a setext H2
   underline.
+- If the line is indented by four or more columns, `---` is part of an
+  indented code block.
 - Otherwise, `---` is a thematic break.
 
 ### 4.1 Worked Examples
@@ -196,10 +208,16 @@ implemented in a future revision:
 
 Before CommonMark parsing, each body region is normalized:
 
-1. **Bidi control stripping.** Remove U+061C, U+200E, U+200F,
+1. **Line-ending canonicalization.** `\r\n` and bare `\r` sequences are
+   converted to `\n`. YAML scalars receive this treatment from the YAML
+   parser itself; the body region does not, so this step ensures both
+   layers agree. Authors editing on Windows or pasting from sources that
+   emit CR-bearing line terminators otherwise leave bare `\r` bytes in
+   the body, which some backends render as visible garbage.
+2. **Bidi control stripping.** Remove U+061C, U+200E, U+200F,
    U+202A–U+202E, U+2066–U+2069. These invisible characters can
    desynchronize delimiter runs when copy-pasted from bidi-aware sources.
-2. **HTML comment fence repair.** If `-->` is followed by non-whitespace
+3. **HTML comment fence repair.** If `-->` is followed by non-whitespace
    text on the same line, insert a newline after `-->` so the trailing
    text reaches the paragraph parser instead of being consumed by the
    CommonMark HTML-block rule (type 2).

--- a/prose/designs/MARKDOWN_GAPS.md
+++ b/prose/designs/MARKDOWN_GAPS.md
@@ -1,0 +1,324 @@
+# Quillmark Markdown — Gap Analysis
+
+**Reference:** [`MARKDOWN.md`](./MARKDOWN.md) (authoritative spec) and
+[`PARSE.md`](./PARSE.md) (implementation notes).
+
+**Scope:** Enumerates every observed divergence between the current parser
+(`crates/core/src/parse.rs`, `crates/core/src/normalize.rs`) and renderer
+(`crates/backends/typst/src/convert.rs`) and the Quillmark Markdown
+specification. Items are tagged **GAP** (spec behavior absent or materially
+wrong), **BUG** (behavior inverted or contradictory), or **MINOR** (wording,
+naming, or semantic drift that is unlikely to affect conformance).
+
+---
+
+## 1. Fence detection (spec §4)
+
+### 1.1 GAP — F2 "Leading blank" rule not enforced
+
+Spec §4 requires a `---` line to open a metadata fence iff the opening is on
+line 1 **or** the line immediately above it is blank.
+
+`parse.rs:282-293` only verifies that the `---` sits at the start of a line
+(i.e. preceded by `\n`/`\r`), never that the *preceding non-empty line above*
+is blank. Consequence: `---` directly under a paragraph currently opens a
+metadata fence instead of being delegated to CommonMark as a setext H2
+underline (spec §4.1 example).
+
+Observable in `test_triple_dash_with_single_surrounding_newline_is_also_metadata`
+(`parse.rs:1785-1803`) — the test *locks in* the non-conforming behavior.
+
+### 1.2 GAP — F1 "Sentinel" rule under-enforced
+
+Spec §4: the first metadata fence is recognised only when the first non-blank
+line of its content matches `QUILL: …`; subsequent fences require `CARD: …`.
+
+`parse.rs:520-540` accepts an opening `---/---` pair with **no** sentinel as
+"global frontmatter" (silently) and only errors later with
+`"Missing required QUILL field"`. Per spec, such a pair is not a fence at all
+— it must be delegated to CommonMark (two thematic breaks / literal YAML
+between).
+
+`test_multiple_global_frontmatter_blocks` (`parse.rs:1342-1371`) codifies the
+current non-conforming behavior (the second `---/---` is treated as an inline
+metadata block and errors with "missing CARD directive").
+
+### 1.3 GAP — No "delegate to CommonMark" path
+
+Spec §4: "A `---` line that fails either rule is delegated to CommonMark
+unchanged." The parser has no delegation mode — a `---` either opens a fence
+(and must close) or is ignored. Anything that *looks like* a fence but fails
+the sentinel becomes a hard parse error instead of an ordinary paragraph /
+setext heading / thematic break.
+
+### 1.4 GAP — Trailing whitespace on the fence marker not accepted
+
+Spec §3: fences are "a pair of lines each containing exactly `---` (with
+optional trailing whitespace)".
+
+`parse.rs:274-277` and `parse.rs:310-329` search for the literal strings
+`---\n` and `---\r\n`. A closing marker like `---   \n` (trailing spaces) is
+not recognised.
+
+### 1.5 GAP — §4.2 near-miss CARD lint warning unimplemented
+
+Spec §4.2: "Implementations **should** emit a lint warning when they
+encounter a `---/---` pair whose content's first non-blank line matches
+`[A-Za-z][A-Za-z0-9_]*:` but whose key is not the expected sentinel"
+(`Card:`, `card:`, `CARDS:`, etc.).
+
+No such diagnostic exists. There is also no warnings channel out of
+`ParseError` — only hard failures. `RenderResult::warnings` exists but the
+parser cannot populate it.
+
+---
+
+## 2. Metadata fences & YAML body (spec §3)
+
+### 2.1 OK — Whitespace-only fence content
+
+`parse.rs:353` trims the YAML content; whitespace-only fences yield `None`
+and collapse to an empty field set. ✓
+
+### 2.2 OK — Reserved keys `BODY`, `CARDS`
+
+Explicitly rejected in `parse.rs:376-386`. ✓
+
+### 2.3 OK — `QUILL` / `CARD` positional constraints
+
+`parse.rs:520-540` rejects `QUILL` in non-first blocks and rejects a block
+carrying both `QUILL` and `CARD`. ✓
+
+### 2.4 MINOR — `QUILL` + `CARD` in same block error message
+
+`parse.rs:368-373` emits `"Cannot specify both QUILL and CARD"` — clear, but
+the spec's formal term is that the block fails F1 entirely. Message is fine.
+
+---
+
+## 3. Input normalization (spec §7)
+
+### 3.1 OK — Bidi control stripping
+
+`normalize.rs:73-133` strips the exact set enumerated in spec §7 (U+061C,
+U+200E, U+200F, U+202A–U+202E, U+2066–U+2069). ✓
+
+### 3.2 OK — HTML comment fence repair
+
+`normalize.rs:173-247` inserts a newline after `-->` when followed by
+non-whitespace on the same line. ✓ Extra handling for `<!--- … --->` style
+comments (line 193-203) goes beyond the spec but is benign.
+
+### 3.3 BUG — Normalization is applied to YAML field values
+
+Spec §7: "Normalization ... is **not** applied to YAML field values."
+
+`normalize.rs:389-403` (`normalize_fields`) walks every field, recursively
+normalizes all nested JSON strings, and strips bidi from every scalar —
+including YAML string values. Only the HTML-comment repair is gated by the
+`BODY` key check. Bidi stripping on YAML values is therefore out-of-spec.
+
+### 3.4 GAP — Normalization is opt-in and post-parse
+
+Spec §7 positions normalization "Before CommonMark parsing" of each body
+region. The implementation applies it **after** parsing, on the
+`ParsedDocument.fields` map, and only when the caller explicitly invokes
+`normalize::normalize_document(...)`.
+
+Consequences:
+- Callers who use `ParsedDocument::from_markdown` and skip the extra call get
+  no normalization at all.
+- HTML comment fence repair for body text happens after the body is already
+  captured verbatim; the "fix" never reaches the CommonMark parser in
+  `convert.rs` (the convert path reads the already-stored `BODY` string,
+  which *has* been normalized if the caller invoked `normalize_document`, but
+  the timing model is inverted from the spec).
+- Card bodies are stored in `CARDS[i].BODY` as nested strings; the recursive
+  `normalize_json_value` walks into them but the `is_body` flag only fires
+  for the top-level key named `BODY` (`normalize.rs:330`) — **card `BODY`
+  fields never get HTML-comment repair**, because they are nested under the
+  `CARDS` key rather than living at a top-level `BODY` key.
+
+### 3.5 MINOR — Field name NFC normalization
+
+`normalize.rs:424-426` applies Unicode NFC to field names. The spec does not
+require this; it is an additional implementation choice. Benign.
+
+---
+
+## 4. Extensions & deviations (spec §6)
+
+### 4.1 OK — Strikethrough, pipe tables
+
+`convert.rs:1235-1238` enables `ENABLE_STRIKETHROUGH` and `ENABLE_TABLES`
+only. No other pulldown-cmark extensions are enabled. ✓
+
+### 4.2 GAP — `<u>…</u>` allowlist not implemented
+
+Spec §6.1 / §6.2 deviation 2: `<u>text</u>` is **the** one allowlisted HTML
+tag; it must render as underline.
+
+`convert.rs:968-975` strips `Event::Html` / `Event::InlineHtml` entirely and
+converts only `<br>` variants to `HardBreak`. A literal `<u>underline</u>`
+in the body vanishes from the output.
+
+### 4.3 BUG — `<br>` rendered instead of suppressed
+
+Spec §6.3: "`<br>`, `<br/>`, `<br />` — follow the raw-HTML rule
+(non-rendering); authors use CommonMark-native hard breaks".
+
+`convert.rs:970-971` converts every `<br>` variant to a `HardBreak` event
+and emits a hard break. This is the exact inverse of the spec: `<br>` should
+render nothing, `<u>` should render an underline.
+
+### 4.4 OK — `__text__` → underline (deviation 1)
+
+Source-peek in `convert.rs:264-279` (`Tag::Strong` branch) picks
+`StrongKind::Underline` when the source slice starts with `__`, otherwise
+`StrongKind::Bold`. ✓
+
+### 4.5 GAP (or intentional extension) — Intraword `__` preprocessing
+
+Spec §6.1 note: "Inline `__text__` *also* produces underline (§6.2, deviation
+1), but follows CommonMark delimiter-run rules and is therefore
+word-bounded. **Intraword underline uses `<u>…</u>`.**"
+
+`convert.rs:1048-1221` (`preprocess_intraword_formatting`) rewrites intraword
+`__…__` (and `~~…~~`) into Unicode placeholder characters before
+pulldown-cmark runs, so that intraword underline works via `__` as well.
+This is a silent superset of the spec; it also plasters over the missing
+`<u>` allowlist (§4.2 above) by letting `__` cover both roles. Either the
+spec should acknowledge this, or the preprocessing should be removed in
+favor of the `<u>` path.
+
+### 4.6 GAP — Images not handled
+
+Spec §6.3: "Images (`![alt](src)`) — reserved for the asset-resolver
+integration; **required for v1 of this spec**."
+
+`convert.rs` has no `Tag::Image` arm. Image events from pulldown-cmark fall
+into the `_ => {}` catch-all and are dropped, with their alt text leaking
+through as plain text.
+
+### 4.7 MINOR — Thematic breaks silently dropped
+
+`Event::Rule` has no handler in `convert.rs`. This is not a spec violation
+(no required output is specified), but a reader of the rendered output
+cannot distinguish a thematic break from its absence. See the confirmatory
+test at `convert.rs:2002-2010`.
+
+---
+
+## 5. Data model (spec §5)
+
+### 5.1 MINOR — `QUILL` stored outside `fields`
+
+Spec §5's `Document` interface lists `QUILL: string` alongside other
+frontmatter fields. The implementation stores it separately as
+`ParsedDocument.quill_ref: QuillReference` and does **not** mirror it into
+`fields`. Downstream consumers who walk `fields()` will not see `QUILL`.
+Not strictly wrong (the accessor `quill_reference()` exists), but the
+data-model shape diverges from the spec's TypeScript example.
+
+### 5.2 OK — Everything else
+
+`BODY`, `CARDS` always present (even when empty), per-card `CARD` + `BODY`
+injection, free collision between global and card field names: all ✓
+(`parse.rs:611-700`, exercised by tests on lines 1154-1221).
+
+---
+
+## 6. Limits (spec §8)
+
+| Limit | Spec | Code constant | Match |
+|---|---|---|---|
+| Document size | 10 MB | `MAX_INPUT_SIZE` = 10 MB | ✓ |
+| YAML size per fence | 1 MB | `MAX_YAML_SIZE` = 1 MB | ✓ |
+| YAML nesting depth | 100 | `MAX_YAML_DEPTH` = 100 | ✓ |
+| Markdown block nesting depth | 100 | `MAX_NESTING_DEPTH` = 100 | ✓ |
+| Field count per fence | 1000 | `MAX_FIELD_COUNT` = 1000 | ⚠ see 6.1 |
+| Card count per document | 1000 | `MAX_CARD_COUNT` = 1000 | ⚠ see 6.2 |
+
+### 6.1 GAP — Field-count limit applied to the aggregate, not per-fence
+
+Spec §8 says the 1000-field cap is **per fence**. The check at
+`parse.rs:703-708` enforces it on the final merged `fields` map (global
+frontmatter + `BODY` + `CARDS`). No per-fence cap exists, so a single card
+can carry arbitrarily many fields provided the aggregate stays under 1000.
+
+### 6.2 GAP — "Card count" limit counts all fences, not cards
+
+The guard at `parse.rs:470-475` compares `blocks.len()` (all metadata
+blocks, including the top-level frontmatter and any QUILL-carrying blocks)
+against `MAX_CARD_COUNT`. A document with 1000 cards plus a frontmatter
+trips the limit off-by-one; the error message "Input too large" also
+reports the generic shape rather than `"card count exceeded"`.
+
+---
+
+## 7. Errors (spec §9)
+
+| Spec-required error | Current path | Status |
+|---|---|---|
+| Missing frontmatter (no opening `---` on line 1) | `InvalidStructure("Missing required QUILL field…")` | ⚠ wording; does not distinguish "no fence" from "fence without QUILL" |
+| Missing closing `---` before EOF | `InvalidStructure("Metadata block … not closed")` | ✓ |
+| Frontmatter missing `QUILL` | `InvalidStructure` | ✓ |
+| Card fence missing `CARD` | `MissingCardDirective` | ✓ |
+| `QUILL` outside frontmatter | `InvalidStructure` (`"top-level frontmatter"`) | ✓ |
+| `CARD` value fails `/^[a-z_][a-z0-9_]*$/` | `InvalidStructure` | ✓ |
+| Invalid YAML | `YamlErrorWithLocation` | ✓ |
+| Reserved key (`BODY`, `CARDS`) as user field | `InvalidStructure` | ✓ |
+| Any §8 limit exceeded | `InputTooLarge` | ✓ |
+
+### 7.1 GAP — No "opening `---` on line 1" check
+
+Spec §9 lists "no opening `---` on line 1" as a distinct error. The current
+parser happily accepts an opening fence on any line start (see §1.1). Until
+F2 is enforced, this error cannot be raised cleanly either.
+
+### 7.2 MINOR — `ParseError::YamlError` / `JsonError` / `Other` are unreachable
+
+`parse.rs` only produces `InputTooLarge`, `InvalidStructure`,
+`MissingCardDirective`, and `YamlErrorWithLocation`. The `YamlError`,
+`JsonError`, and `Other` variants in `error.rs:365-398` appear to be
+dead. Low priority — but any rework should prune or repurpose them.
+
+---
+
+## 8. Summary — items to fix in the rework
+
+Priority ordering (spec conformance impact first):
+
+1. **Fence detection rewrite** (§1.1, §1.2, §1.3, §1.4): implement F1 + F2
+   exactly as spec'd; route failed fences into CommonMark. This subsumes
+   many of the current test-locked behaviors and will require test
+   revisions.
+2. **Normalization timing + scope** (§3.3, §3.4): apply normalization to
+   body regions *before* CommonMark parsing; exclude YAML values; recurse
+   into card bodies correctly (the `is_body` flag is keyed off a top-level
+   `BODY` only).
+3. **HTML allowlist inversion** (§4.2, §4.3): render `<u>` as underline,
+   suppress `<br>` (and all other raw HTML).
+4. **Image support** (§4.6): add `Tag::Image` handling wired to the
+   asset-resolver integration.
+5. **Per-fence field-count limit + accurate card count** (§6.1, §6.2).
+6. **Lint warning channel for near-miss sentinels** (§1.5): requires
+   plumbing `Vec<Diagnostic>` out of the parser (currently there is no such
+   path).
+7. **Decide on intraword `__`** (§4.5): either document it as a Quillmark
+   extension on top of the spec, or remove it in favor of the `<u>` path
+   once §4.2 lands.
+8. **Error-message wording** (§7.1) and dead variants (§7.2): cleanup.
+
+---
+
+## 9. Files touched by the rework
+
+- `crates/core/src/parse.rs` — fence detection (§1), data model (§5),
+  limits (§6), errors (§7).
+- `crates/core/src/normalize.rs` — normalization scope/timing (§3).
+- `crates/core/src/error.rs` — warning channel (§1.5), prune dead variants
+  (§7.2).
+- `crates/backends/typst/src/convert.rs` — HTML allowlist (§4.2, §4.3),
+  image support (§4.6), intraword `__` decision (§4.5).
+- Tests under each of the above.


### PR DESCRIPTION
Enumerates every observed divergence between the current parser
(crates/core/src/parse.rs, crates/core/src/normalize.rs) and renderer
(crates/backends/typst/src/convert.rs) and the Quillmark Markdown
specification in prose/designs/MARKDOWN.md. Items are tagged GAP, BUG,
or MINOR to support the upcoming engine parsing rework.

https://claude.ai/code/session_01GeyqzRFsX2APT2We7pA4rn