### PR TITLE
Remove untyped document validation and coercion APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "~1.0"
 glob = "0.3.3"
 
 # Ordered map — preserves insertion order for deterministic serialization
-indexmap = "2"
+indexmap = { version = "2", features = ["serde"] }
 
 # Unicode normalization
 unicode-normalization = "0.1"

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -151,58 +151,7 @@ impl QuillConfig {
         })
     }
 
-    /// Coerce document fields to match expected schema types.
-    ///
-    /// Returns an error when a value cannot be coerced to the declared type.
-    pub fn coerce(
-        &self,
-        fields: &HashMap<String, QuillValue>,
-    ) -> Result<HashMap<String, QuillValue>, CoercionError> {
-        let mut coerced = HashMap::new();
-
-        for (field_name, field_value) in fields {
-            if let Some(field_schema) = self.main().fields.get(field_name) {
-                let path = field_name.as_str();
-                coerced.insert(
-                    field_name.clone(),
-                    Self::coerce_value_strict(field_value, field_schema, path)?,
-                );
-            } else {
-                coerced.insert(field_name.clone(), field_value.clone());
-            }
-        }
-
-        if let Some(cards_value) = coerced.get("CARDS") {
-            if let Some(cards_array) = cards_value.as_array() {
-                let coerced_cards = self.coerce_cards_array_strict(cards_array)?;
-                coerced.insert(
-                    "CARDS".to_string(),
-                    QuillValue::from_json(serde_json::Value::Array(coerced_cards)),
-                );
-            } else {
-                return Err(CoercionError::Uncoercible {
-                    path: "CARDS".to_string(),
-                    value: cards_value.as_json().to_string(),
-                    target: "array".to_string(),
-                    reason: "CARDS must be an array".to_string(),
-                });
-            }
-        }
-
-        Ok(coerced)
-    }
-
-    /// Validate document fields against this configuration.
-    pub fn validate(
-        &self,
-        fields: &HashMap<String, QuillValue>,
-    ) -> Result<(), Vec<super::validation::ValidationError>> {
-        super::validation::validate_document(self, fields)
-    }
-
     /// Coerce typed frontmatter fields (IndexMap, no CARDS/BODY keys).
-    ///
-    /// This is the typed counterpart to [`QuillConfig::coerce`] used by the `Workflow`.
     pub fn coerce_frontmatter(
         &self,
         frontmatter: &IndexMap<String, QuillValue>,
@@ -224,8 +173,7 @@ impl QuillConfig {
 
     /// Coerce typed fields for a single card (IndexMap, no CARD/BODY keys).
     ///
-    /// This is the typed counterpart to the inner loop in [`QuillConfig::coerce`] used by
-    /// the `Workflow`. Returns the input unchanged when the card tag is unknown.
+    /// Returns the input unchanged when the card tag is unknown.
     pub fn coerce_card(
         &self,
         card_tag: &str,
@@ -250,48 +198,11 @@ impl QuillConfig {
     }
 
     /// Validate a typed [`crate::document::Document`] against this configuration.
-    ///
-    /// This is the typed counterpart to [`QuillConfig::validate`] used by the `Workflow`.
     pub fn validate_document(
         &self,
         doc: &crate::document::Document,
     ) -> Result<(), Vec<super::validation::ValidationError>> {
         super::validation::validate_typed_document(self, doc)
-    }
-
-    fn coerce_cards_array_strict(
-        &self,
-        cards_array: &[serde_json::Value],
-    ) -> Result<Vec<serde_json::Value>, CoercionError> {
-        let mut coerced_cards = Vec::new();
-
-        for (index, card) in cards_array.iter().enumerate() {
-            if let Some(card_obj) = card.as_object() {
-                if let Some(card_type) = card_obj.get("CARD").and_then(|v| v.as_str()) {
-                    if let Some(card_schema) = self.card_definition(card_type) {
-                        let mut coerced_card = serde_json::Map::new();
-                        for (k, v) in card_obj {
-                            if let Some(field_schema) = card_schema.fields.get(k) {
-                                let qv = QuillValue::from_json(v.clone());
-                                let path = format!("cards.{card_type}[{index}].{k}");
-                                coerced_card.insert(
-                                    k.clone(),
-                                    Self::coerce_value_strict(&qv, field_schema, &path)?
-                                        .into_json(),
-                                );
-                            } else {
-                                coerced_card.insert(k.clone(), v.clone());
-                            }
-                        }
-                        coerced_cards.push(serde_json::Value::Object(coerced_card));
-                        continue;
-                    }
-                }
-            }
-            coerced_cards.push(card.clone());
-        }
-
-        Ok(coerced_cards)
     }
 
     fn coerce_value_strict(

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1828,16 +1828,34 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let mut frontmatter = indexmap::IndexMap::new();
-    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("42")));
-    frontmatter.insert("active".to_string(), QuillValue::from_json(serde_json::json!("true")));
-    frontmatter.insert("signed_on".to_string(), QuillValue::from_json(serde_json::json!("2026-04-13")));
-    frontmatter.insert("created_at".to_string(), QuillValue::from_json(serde_json::json!("2026-04-13T20:00:00Z")));
+    frontmatter.insert(
+        "count".to_string(),
+        QuillValue::from_json(serde_json::json!("42")),
+    );
+    frontmatter.insert(
+        "active".to_string(),
+        QuillValue::from_json(serde_json::json!("true")),
+    );
+    frontmatter.insert(
+        "signed_on".to_string(),
+        QuillValue::from_json(serde_json::json!("2026-04-13")),
+    );
+    frontmatter.insert(
+        "created_at".to_string(),
+        QuillValue::from_json(serde_json::json!("2026-04-13T20:00:00Z")),
+    );
 
     let coerced = config.coerce_frontmatter(&frontmatter).unwrap();
     assert_eq!(coerced.get("count").unwrap().as_i64(), Some(42));
     assert_eq!(coerced.get("active").unwrap().as_bool(), Some(true));
-    assert_eq!(coerced.get("signed_on").unwrap().as_str(), Some("2026-04-13"));
-    assert_eq!(coerced.get("created_at").unwrap().as_str(), Some("2026-04-13T20:00:00Z"));
+    assert_eq!(
+        coerced.get("signed_on").unwrap().as_str(),
+        Some("2026-04-13")
+    );
+    assert_eq!(
+        coerced.get("created_at").unwrap().as_str(),
+        Some("2026-04-13T20:00:00Z")
+    );
 }
 
 #[test]
@@ -1857,7 +1875,10 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let mut frontmatter = indexmap::IndexMap::new();
-    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("42")));
+    frontmatter.insert(
+        "count".to_string(),
+        QuillValue::from_json(serde_json::json!("42")),
+    );
 
     let coerced = config.coerce_frontmatter(&frontmatter).unwrap();
     assert_eq!(coerced.get("count").unwrap().as_i64(), Some(42));
@@ -1880,7 +1901,10 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let mut frontmatter = indexmap::IndexMap::new();
-    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("42.5")));
+    frontmatter.insert(
+        "count".to_string(),
+        QuillValue::from_json(serde_json::json!("42.5")),
+    );
 
     let error = config.coerce_frontmatter(&frontmatter).unwrap_err();
     assert!(matches!(
@@ -1952,8 +1976,14 @@ cards:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let mut card_fields = indexmap::IndexMap::new();
-    card_fields.insert("score".to_string(), QuillValue::from_json(serde_json::json!("100")));
-    card_fields.insert("active".to_string(), QuillValue::from_json(serde_json::json!("false")));
+    card_fields.insert(
+        "score".to_string(),
+        QuillValue::from_json(serde_json::json!("100")),
+    );
+    card_fields.insert(
+        "active".to_string(),
+        QuillValue::from_json(serde_json::json!("false")),
+    );
 
     let coerced = config.coerce_card("indorsement", &card_fields).unwrap();
     assert_eq!(coerced.get("score").unwrap().as_i64(), Some(100));
@@ -1977,7 +2007,10 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let mut frontmatter = indexmap::IndexMap::new();
-    frontmatter.insert("signed_on".to_string(), QuillValue::from_json(serde_json::json!("13-04-2026")));
+    frontmatter.insert(
+        "signed_on".to_string(),
+        QuillValue::from_json(serde_json::json!("13-04-2026")),
+    );
 
     let error = config.coerce_frontmatter(&frontmatter).unwrap_err();
     assert!(matches!(
@@ -2004,7 +2037,10 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let mut frontmatter = indexmap::IndexMap::new();
-    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("forty-two")));
+    frontmatter.insert(
+        "count".to_string(),
+        QuillValue::from_json(serde_json::json!("forty-two")),
+    );
 
     let error = config.coerce_frontmatter(&frontmatter).unwrap_err();
     assert!(matches!(

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1782,9 +1782,8 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    // Simulate YAML parsing where numbers are represented as strings
-    let mut fields = std::collections::HashMap::new();
-    fields.insert(
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert(
         "scores".to_string(),
         crate::value::QuillValue::from_json(serde_json::json!([
             {"name": "Math", "value": "95", "active": "true"},
@@ -1792,7 +1791,7 @@ main:
         ])),
     );
 
-    let coerced = config.coerce(&fields).unwrap();
+    let coerced = config.coerce_frontmatter(&frontmatter).unwrap();
     let scores = coerced.get("scores").unwrap();
     let arr = scores.as_array().unwrap();
 
@@ -1828,35 +1827,17 @@ main:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
-        "count".to_string(),
-        QuillValue::from_json(serde_json::json!("42")),
-    );
-    fields.insert(
-        "active".to_string(),
-        QuillValue::from_json(serde_json::json!("true")),
-    );
-    fields.insert(
-        "signed_on".to_string(),
-        QuillValue::from_json(serde_json::json!("2026-04-13")),
-    );
-    fields.insert(
-        "created_at".to_string(),
-        QuillValue::from_json(serde_json::json!("2026-04-13T20:00:00Z")),
-    );
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("42")));
+    frontmatter.insert("active".to_string(), QuillValue::from_json(serde_json::json!("true")));
+    frontmatter.insert("signed_on".to_string(), QuillValue::from_json(serde_json::json!("2026-04-13")));
+    frontmatter.insert("created_at".to_string(), QuillValue::from_json(serde_json::json!("2026-04-13T20:00:00Z")));
 
-    let coerced = config.coerce(&fields).unwrap();
+    let coerced = config.coerce_frontmatter(&frontmatter).unwrap();
     assert_eq!(coerced.get("count").unwrap().as_i64(), Some(42));
     assert_eq!(coerced.get("active").unwrap().as_bool(), Some(true));
-    assert_eq!(
-        coerced.get("signed_on").unwrap().as_str(),
-        Some("2026-04-13")
-    );
-    assert_eq!(
-        coerced.get("created_at").unwrap().as_str(),
-        Some("2026-04-13T20:00:00Z")
-    );
+    assert_eq!(coerced.get("signed_on").unwrap().as_str(), Some("2026-04-13"));
+    assert_eq!(coerced.get("created_at").unwrap().as_str(), Some("2026-04-13T20:00:00Z"));
 }
 
 #[test]
@@ -1875,13 +1856,10 @@ main:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
-        "count".to_string(),
-        QuillValue::from_json(serde_json::json!("42")),
-    );
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("42")));
 
-    let coerced = config.coerce(&fields).unwrap();
+    let coerced = config.coerce_frontmatter(&frontmatter).unwrap();
     assert_eq!(coerced.get("count").unwrap().as_i64(), Some(42));
 }
 
@@ -1901,13 +1879,10 @@ main:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
-        "count".to_string(),
-        QuillValue::from_json(serde_json::json!("42.5")),
-    );
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("42.5")));
 
-    let error = config.coerce(&fields).unwrap_err();
+    let error = config.coerce_frontmatter(&frontmatter).unwrap_err();
     assert!(matches!(
         error,
         super::CoercionError::Uncoercible { ref path, ref target, .. }
@@ -1938,8 +1913,8 @@ main:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert(
         "items".to_string(),
         QuillValue::from_json(serde_json::json!([
             {"score": "90", "active": "true"},
@@ -1947,7 +1922,7 @@ main:
         ])),
     );
 
-    let coerced = config.coerce(&fields).unwrap();
+    let coerced = config.coerce_frontmatter(&frontmatter).unwrap();
     let items = coerced.get("items").unwrap().as_array().unwrap();
     let first = items[0].as_object().unwrap();
     let second = items[1].as_object().unwrap();
@@ -1976,19 +1951,13 @@ cards:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
-        "CARDS".to_string(),
-        QuillValue::from_json(serde_json::json!([
-            {"CARD": "indorsement", "score": "100", "active": "false"}
-        ])),
-    );
+    let mut card_fields = indexmap::IndexMap::new();
+    card_fields.insert("score".to_string(), QuillValue::from_json(serde_json::json!("100")));
+    card_fields.insert("active".to_string(), QuillValue::from_json(serde_json::json!("false")));
 
-    let coerced = config.coerce(&fields).unwrap();
-    let cards = coerced.get("CARDS").unwrap().as_array().unwrap();
-    let card = cards[0].as_object().unwrap();
-    assert_eq!(card["score"], serde_json::json!(100));
-    assert_eq!(card["active"], serde_json::json!(false));
+    let coerced = config.coerce_card("indorsement", &card_fields).unwrap();
+    assert_eq!(coerced.get("score").unwrap().as_i64(), Some(100));
+    assert_eq!(coerced.get("active").unwrap().as_bool(), Some(false));
 }
 
 #[test]
@@ -2007,13 +1976,10 @@ main:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
-        "signed_on".to_string(),
-        QuillValue::from_json(serde_json::json!("13-04-2026")),
-    );
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert("signed_on".to_string(), QuillValue::from_json(serde_json::json!("13-04-2026")));
 
-    let error = config.coerce(&fields).unwrap_err();
+    let error = config.coerce_frontmatter(&frontmatter).unwrap_err();
     assert!(matches!(
         error,
         super::CoercionError::Uncoercible { ref path, ref target, .. }
@@ -2037,13 +2003,10 @@ main:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let mut fields = HashMap::new();
-    fields.insert(
-        "count".to_string(),
-        QuillValue::from_json(serde_json::json!("forty-two")),
-    );
+    let mut frontmatter = indexmap::IndexMap::new();
+    frontmatter.insert("count".to_string(), QuillValue::from_json(serde_json::json!("forty-two")));
 
-    let error = config.coerce(&fields).unwrap_err();
+    let error = config.coerce_frontmatter(&frontmatter).unwrap_err();
     assert!(matches!(
         error,
         super::CoercionError::Uncoercible { ref path, ref target, .. }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -314,10 +314,7 @@ main:
         )
     }
 
-    fn doc_with_typed_cards(
-        fm: &[(&str, serde_json::Value)],
-        cards: Vec<Card>,
-    ) -> Document {
+    fn doc_with_typed_cards(fm: &[(&str, serde_json::Value)], cards: Vec<Card>) -> Document {
         let mut frontmatter = IndexMap::new();
         for (k, v) in fm {
             frontmatter.insert(k.to_string(), QuillValue::from_json(v.clone()));
@@ -559,7 +556,10 @@ main:
         );
         let doc = doc_with_typed_cards(
             &[],
-            vec![typed_card("indorsement", &[("signature_block", json!("Signed"))])],
+            vec![typed_card(
+                "indorsement",
+                &[("signature_block", json!("Signed"))],
+            )],
         );
         assert!(validate_typed_document(&config, &doc).is_ok());
     }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use indexmap::IndexMap;
 use time::format_description::well_known::Rfc3339;
 use time::{Date, OffsetDateTime};
@@ -37,80 +35,6 @@ pub enum ValidationError {
 
     #[error("card at `{path}` missing `CARD` discriminator")]
     MissingCardDiscriminator { path: String },
-}
-
-/// Validate a parsed document against the full config.
-///
-/// Validates main fields, all card instances, and enforces required fields.
-/// Collects all errors rather than short-circuiting on the first.
-pub fn validate_document(
-    config: &QuillConfig,
-    fields: &HashMap<String, QuillValue>,
-) -> Result<(), Vec<ValidationError>> {
-    let mut errors = validate_fields_for_card(config.main(), fields, "");
-
-    if let Some(cards_value) = fields.get("CARDS") {
-        match cards_value.as_array() {
-            Some(cards) => {
-                for (index, card_value) in cards.iter().enumerate() {
-                    let item_path = index_path("cards", index);
-                    let Some(card_object) = card_value.as_object() else {
-                        errors.push(ValidationError::TypeMismatch {
-                            path: item_path,
-                            expected: "object".to_string(),
-                            actual: json_type_name(card_value).to_string(),
-                        });
-                        continue;
-                    };
-
-                    let Some(card_discriminator) = card_object.get("CARD") else {
-                        errors.push(ValidationError::MissingCardDiscriminator { path: item_path });
-                        continue;
-                    };
-
-                    let Some(card_name) = card_discriminator.as_str() else {
-                        errors.push(ValidationError::TypeMismatch {
-                            path: child_path(&item_path, "CARD"),
-                            expected: "string".to_string(),
-                            actual: json_type_name(card_discriminator).to_string(),
-                        });
-                        continue;
-                    };
-
-                    let Some(card_schema) = config.card_definition(card_name) else {
-                        errors.push(ValidationError::UnknownCard {
-                            path: item_path,
-                            card: card_name.to_string(),
-                        });
-                        continue;
-                    };
-
-                    let mut card_fields = HashMap::new();
-                    for (key, value) in card_object {
-                        card_fields.insert(key.clone(), QuillValue::from_json(value.clone()));
-                    }
-
-                    let card_path = format!("cards.{card_name}[{index}]");
-                    errors.extend(validate_fields_for_card(
-                        card_schema,
-                        &card_fields,
-                        &card_path,
-                    ));
-                }
-            }
-            None => errors.push(ValidationError::TypeMismatch {
-                path: "CARDS".to_string(),
-                expected: "array".to_string(),
-                actual: json_type_name(cards_value.as_json()).to_string(),
-            }),
-        }
-    }
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors)
-    }
 }
 
 /// Validate a typed [`Document`] (with `IndexMap` frontmatter + typed `Card` list).
@@ -152,28 +76,6 @@ pub fn validate_typed_document(
 fn validate_fields_for_card_indexmap(
     card: &CardSchema,
     fields: &IndexMap<String, QuillValue>,
-    base_path: &str,
-) -> Vec<ValidationError> {
-    let mut errors = Vec::new();
-    let mut field_names: Vec<&String> = card.fields.keys().collect();
-    field_names.sort();
-
-    for field_name in field_names {
-        let schema = &card.fields[field_name];
-        let path = child_path(base_path, field_name);
-        match fields.get(field_name) {
-            Some(value) => errors.extend(validate_field(schema, value, &path)),
-            None if schema.required => errors.push(ValidationError::MissingRequired { path }),
-            None => {}
-        }
-    }
-
-    errors
-}
-
-fn validate_fields_for_card(
-    card: &CardSchema,
-    fields: &HashMap<String, QuillValue>,
     base_path: &str,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
@@ -368,7 +270,11 @@ fn index_path(parent: &str, index: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+    use crate::document::{Card, Document};
+    use crate::version::QuillReference;
     use serde_json::json;
 
     fn config_with(main_fields: &str, cards: &str) -> QuillConfig {
@@ -385,8 +291,6 @@ main:
 {cards}
 "#
         );
-        // Use _with_warnings so silently-dropped fields (e.g. unsupported
-        // standalone `type: object`) fail loudly instead of passing vacuously.
         let (config, warnings) = QuillConfig::from_yaml_with_warnings(&yaml).unwrap();
         assert!(
             warnings.is_empty(),
@@ -396,11 +300,43 @@ main:
         config
     }
 
-    fn fields(entries: &[(&str, serde_json::Value)]) -> HashMap<String, QuillValue> {
-        entries
-            .iter()
-            .map(|(k, v)| (k.to_string(), QuillValue::from_json(v.clone())))
-            .collect()
+    fn doc_from_fm(entries: &[(&str, serde_json::Value)]) -> Document {
+        let mut frontmatter = IndexMap::new();
+        for (k, v) in entries {
+            frontmatter.insert(k.to_string(), QuillValue::from_json(v.clone()));
+        }
+        Document::new_internal(
+            QuillReference::from_str("test_quill").unwrap(),
+            frontmatter,
+            String::new(),
+            vec![],
+            vec![],
+        )
+    }
+
+    fn doc_with_typed_cards(
+        fm: &[(&str, serde_json::Value)],
+        cards: Vec<Card>,
+    ) -> Document {
+        let mut frontmatter = IndexMap::new();
+        for (k, v) in fm {
+            frontmatter.insert(k.to_string(), QuillValue::from_json(v.clone()));
+        }
+        Document::new_internal(
+            QuillReference::from_str("test_quill").unwrap(),
+            frontmatter,
+            String::new(),
+            cards,
+            vec![],
+        )
+    }
+
+    fn typed_card(tag: &str, fields: &[(&str, serde_json::Value)]) -> Card {
+        let mut card_fields = IndexMap::new();
+        for (k, v) in fields {
+            card_fields.insert(k.to_string(), QuillValue::from_json(v.clone()));
+        }
+        Card::new_internal(tag.to_string(), card_fields, String::new())
     }
 
     fn has_error<F>(errors: &[ValidationError], predicate: F) -> bool
@@ -413,15 +349,15 @@ main:
     #[test]
     fn validates_simple_string_field() {
         let config = config_with("    title:\n      type: string\n      required: true", "");
-        let doc = fields(&[("title", json!("Memo"))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("title", json!("Memo"))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_simple_string_type_mismatch() {
         let config = config_with("    title:\n      type: string", "");
-        let doc = fields(&[("title", json!(9))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("title", json!(9))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
             ValidationError::TypeMismatch { path, expected, actual }
@@ -432,15 +368,15 @@ main:
     #[test]
     fn validates_integer_field_with_integer_value() {
         let config = config_with("    count:\n      type: integer", "");
-        let doc = fields(&[("count", json!(9))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("count", json!(9))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_integer_field_with_decimal_value() {
         let config = config_with("    count:\n      type: integer", "");
-        let doc = fields(&[("count", json!(9.5))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("count", json!(9.5))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
             ValidationError::TypeMismatch { path, expected, actual }
@@ -454,7 +390,8 @@ main:
             "    memo_for:\n      type: string\n      required: true",
             "",
         );
-        let errors = validate_document(&config, &HashMap::new()).unwrap_err();
+        let doc = doc_from_fm(&[]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::MissingRequired { path } if path == "memo_for")
         }));
@@ -466,8 +403,8 @@ main:
             "    memo_for:\n      type: string\n      required: true",
             "",
         );
-        let doc = fields(&[("memo_for", json!(true))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("memo_for", json!(true))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
             ValidationError::TypeMismatch { path, .. } if path == "memo_for"
@@ -480,8 +417,8 @@ main:
             "    status:\n      type: string\n      enum:\n        - draft\n        - final",
             "",
         );
-        let doc = fields(&[("status", json!("draft"))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("status", json!("draft"))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -490,8 +427,8 @@ main:
             "    status:\n      type: string\n      enum:\n        - draft\n        - final",
             "",
         );
-        let doc = fields(&[("status", json!("invalid"))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("status", json!("invalid"))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
             ValidationError::EnumViolation { path, value, .. }
@@ -502,15 +439,15 @@ main:
     #[test]
     fn validates_date_format() {
         let config = config_with("    signed_on:\n      type: date", "");
-        let doc = fields(&[("signed_on", json!("2026-04-13"))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("signed_on", json!("2026-04-13"))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_invalid_date_format() {
         let config = config_with("    signed_on:\n      type: date", "");
-        let doc = fields(&[("signed_on", json!("13-04-2026"))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("signed_on", json!("13-04-2026"))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::FormatViolation { path, format } if path == "signed_on" && format == "date")
         }));
@@ -519,15 +456,15 @@ main:
     #[test]
     fn validates_datetime_format() {
         let config = config_with("    created_at:\n      type: datetime", "");
-        let doc = fields(&[("created_at", json!("2026-04-13T19:24:55Z"))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("created_at", json!("2026-04-13T19:24:55Z"))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_invalid_datetime_format() {
         let config = config_with("    created_at:\n      type: datetime", "");
-        let doc = fields(&[("created_at", json!("2026-04-13 19:24:55"))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("created_at", json!("2026-04-13 19:24:55"))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
             ValidationError::FormatViolation { path, format }
@@ -538,8 +475,8 @@ main:
     #[test]
     fn markdown_accepts_any_string() {
         let config = config_with("    body:\n      type: markdown", "");
-        let doc = fields(&[("body", json!("# Heading\n\nBody text"))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("body", json!("# Heading\n\nBody text"))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -548,8 +485,8 @@ main:
             "    tags:\n      type: array\n      items:\n        type: string",
             "",
         );
-        let doc = fields(&[("tags", json!(["a", "b"]))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("tags", json!(["a", "b"]))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -558,8 +495,8 @@ main:
             "    tags:\n      type: array\n      items:\n        type: string",
             "",
         );
-        let doc = fields(&[("tags", json!(["a", 2]))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("tags", json!(["a", 2]))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
             ValidationError::TypeMismatch { path, .. } if path == "tags[1]"
@@ -572,8 +509,8 @@ main:
             "    recipients:\n      type: array\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n            required: true\n          org:\n            type: string",
             "",
         );
-        let doc = fields(&[("recipients", json!([{ "name": "Sam", "org": "HQ" }]))]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_from_fm(&[("recipients", json!([{ "name": "Sam", "org": "HQ" }]))]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -582,8 +519,8 @@ main:
             "    recipients:\n      type: array\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n            required: true\n          org:\n            type: string",
             "",
         );
-        let doc = fields(&[("recipients", json!([{ "org": "HQ" }]))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::MissingRequired { path } if path == "recipients[0].name")
         }));
@@ -596,29 +533,13 @@ main:
     // `reports_missing_required_field_in_array_object`.
 
     #[test]
-    fn reports_type_mismatch_for_cards_when_not_array() {
-        let config = config_with(
-            "    title:\n      type: string",
-            "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
-        );
-        let doc = fields(&[("CARDS", json!("not-an-array"))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
-        assert!(has_error(&errors, |e| {
-            matches!(
-                e,
-                ValidationError::TypeMismatch { path, expected, actual }
-                if path == "CARDS" && expected == "array" && actual == "string"
-            )
-        }));
-    }
-
-    #[test]
     fn accumulates_multiple_missing_required_errors() {
         let config = config_with(
             "    memo_for:\n      type: string\n      required: true\n    memo_from:\n      type: string\n      required: true",
             "",
         );
-        let errors = validate_document(&config, &HashMap::new()).unwrap_err();
+        let doc = doc_from_fm(&[]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         let missing_paths: Vec<&str> = errors
             .iter()
             .filter_map(|e| match e {
@@ -636,11 +557,11 @@ main:
             "    title:\n      type: string",
             "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
         );
-        let doc = fields(&[(
-            "CARDS",
-            json!([{ "CARD": "indorsement", "signature_block": "Signed" }]),
-        )]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_with_typed_cards(
+            &[],
+            vec![typed_card("indorsement", &[("signature_block", json!("Signed"))])],
+        );
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -649,23 +570,10 @@ main:
             "    title:\n      type: string",
             "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
-        let doc = fields(&[("CARDS", json!([{ "CARD": "unknown" }]))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_with_typed_cards(&[], vec![typed_card("unknown", &[])]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::UnknownCard { path, card } if path == "cards[0]" && card == "unknown")
-        }));
-    }
-
-    #[test]
-    fn reports_missing_card_discriminator() {
-        let config = config_with(
-            "    title:\n      type: string",
-            "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
-        );
-        let doc = fields(&[("CARDS", json!([{ "signature_block": "Signed" }]))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
-        assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingCardDiscriminator { path } if path == "cards[0]")
         }));
     }
 
@@ -675,14 +583,14 @@ main:
             "    title:\n      type: string",
             "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
         );
-        let doc = fields(&[(
-            "CARDS",
-            json!([
-                { "CARD": "indorsement", "signature_block": "A" },
-                { "CARD": "indorsement", "signature_block": "B" }
-            ]),
-        )]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_with_typed_cards(
+            &[],
+            vec![
+                typed_card("indorsement", &[("signature_block", json!("A"))]),
+                typed_card("indorsement", &[("signature_block", json!("B"))]),
+            ],
+        );
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -691,14 +599,14 @@ main:
             "    title:\n      type: string",
             "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true\n  routing:\n    fields:\n      office:\n        type: string\n        required: true",
         );
-        let doc = fields(&[(
-            "CARDS",
-            json!([
-                { "CARD": "indorsement", "signature_block": "A" },
-                { "CARD": "routing", "office": "HQ" }
-            ]),
-        )]);
-        assert!(validate_document(&config, &doc).is_ok());
+        let doc = doc_with_typed_cards(
+            &[],
+            vec![
+                typed_card("indorsement", &[("signature_block", json!("A"))]),
+                typed_card("routing", &[("office", json!("HQ"))]),
+            ],
+        );
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
@@ -707,8 +615,8 @@ main:
             "    title:\n      type: string",
             "cards:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
         );
-        let doc = fields(&[("CARDS", json!([{ "CARD": "indorsement" }]))]);
-        let errors = validate_document(&config, &doc).unwrap_err();
+        let doc = doc_with_typed_cards(&[], vec![typed_card("indorsement", &[])]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::MissingRequired { path } if path == "cards.indorsement[0].signature_block")
         }));


### PR DESCRIPTION
## Summary
This PR removes the untyped document validation and coercion APIs that operated on `HashMap<String, QuillValue>` and raw JSON structures. These APIs have been replaced by typed equivalents that work with the `Document` type and `IndexMap` frontmatter, simplifying the codebase and enforcing type safety.

## Key Changes

- **Removed untyped validation**: Deleted `validate_document()` function that validated documents using `HashMap` fields and raw JSON card arrays
- **Removed untyped coercion**: Deleted `QuillConfig::coerce()` method and its helper `coerce_cards_array_strict()` that operated on `HashMap` fields
- **Removed untyped config methods**: Deleted `QuillConfig::validate()` method that was the public API for untyped validation
- **Updated test infrastructure**: Refactored test helpers to use typed `Document` and `Card` structures instead of `HashMap` and raw JSON
  - Replaced `fields()` helper with `doc_from_fm()` for creating documents from frontmatter
  - Added `doc_with_typed_cards()` helper for documents with card instances
  - Added `typed_card()` helper for creating typed card instances
- **Removed obsolete tests**: Deleted tests that were specific to untyped validation (e.g., `reports_type_mismatch_for_cards_when_not_array`, `reports_missing_card_discriminator`)
- **Updated remaining tests**: Converted all validation tests to use `validate_typed_document()` with typed `Document` instances
- **Updated coercion tests**: Converted tests to use `coerce_frontmatter()` and `coerce_card()` methods with `IndexMap` instead of `HashMap`
- **Dependency update**: Added `serde` feature to `indexmap` dependency for serialization support

## Implementation Details

The typed APIs (`validate_typed_document()`, `coerce_frontmatter()`, `coerce_card()`) remain as the primary validation and coercion entry points. All tests now use these typed APIs, ensuring consistency and type safety throughout the codebase. The removal of untyped APIs eliminates the need to handle raw JSON card arrays with `CARD` discriminators and `CARDS` array keys, as the typed `Document` structure handles this internally.

https://claude.ai/code/session_017UoB9mhcaiaaW5Njw37uik