### PR TITLE
Strip trailing newlines from body content and improve error handling

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -92,10 +92,14 @@ impl Quillmark {
 impl Quill {
     /// Render a document to final artifacts.
     #[wasm_bindgen(js_name = render)]
-    pub fn render(&self, doc: Document, opts: RenderOptions) -> Result<RenderResult, JsValue> {
+    pub fn render(
+        &self,
+        doc: Document,
+        opts: Option<RenderOptions>,
+    ) -> Result<RenderResult, JsValue> {
         let start = now_ms();
         let parse_warnings = doc.parse_warnings.clone();
-        let rust_opts: quillmark_core::RenderOptions = opts.into();
+        let rust_opts: quillmark_core::RenderOptions = opts.unwrap_or_default().into();
         let result = self
             .inner
             .render_with_options(&doc.inner, rust_opts.output_format, rust_opts.ppi)
@@ -147,7 +151,9 @@ impl Quill {
     #[wasm_bindgen(js_name = projectForm)]
     pub fn project_form(&self, doc: &Document) -> Result<JsValue, JsValue> {
         let projection = quillmark::form::project_form(&self.inner, &doc.inner);
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        let serializer = serde_wasm_bindgen::Serializer::new()
+            .serialize_maps_as_objects(true)
+            .serialize_missing_as_null(true);
         projection.serialize(&serializer).map_err(|e| {
             WasmError::from(format!("projectForm: serialization failed: {e}")).to_js_value()
         })
@@ -202,10 +208,13 @@ impl Document {
 
     /// Global Markdown body between frontmatter and the first card.
     ///
+    /// Trailing newlines are stripped — those are structural separators in
+    /// the Markdown wire format, not content the consumer wrote.
+    ///
     /// Empty string when no body is present.
     #[wasm_bindgen(getter, js_name = body)]
     pub fn body(&self) -> String {
-        self.inner.body().to_string()
+        trim_body(self.inner.body())
     }
 
     /// Ordered list of card blocks as JS objects with `tag`, `fields`, and `body`.
@@ -223,7 +232,7 @@ impl Document {
                 serde_json::json!({
                     "tag": card.tag(),
                     "fields": serde_json::Value::Object(fields_map),
-                    "body": card.body(),
+                    "body": trim_body(card.body()),
                 })
             })
             .collect();
@@ -453,10 +462,20 @@ fn card_to_js_value(card: &quillmark_core::Card) -> JsValue {
     let json = serde_json::json!({
         "tag": card.tag(),
         "fields": serde_json::Value::Object(fields_map),
-        "body": card.body(),
+        "body": trim_body(card.body()),
     });
     let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
     json.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
+}
+
+/// Strip trailing line terminators from a body string.
+///
+/// Parsed bodies include a trailing blank line when followed by a card fence
+/// (required by the MARKDOWN.md §3 F2 rule); those characters are structural
+/// separators, not part of what the document author wrote.
+fn trim_body(body: &str) -> String {
+    body.trim_end_matches(|c: char| c == '\n' || c == '\r')
+        .to_string()
 }
 
 fn file_tree_from_js_tree(tree: &JsValue) -> Result<quillmark_core::FileTreeNode, JsValue> {
@@ -530,9 +549,9 @@ impl RenderSession {
 
     /// Render all or selected pages from this session.
     #[wasm_bindgen(js_name = render)]
-    pub fn render(&self, opts: RenderOptions) -> Result<RenderResult, JsValue> {
+    pub fn render(&self, opts: Option<RenderOptions>) -> Result<RenderResult, JsValue> {
         let start = now_ms();
-        let rust_opts: quillmark_core::RenderOptions = opts.into();
+        let rust_opts: quillmark_core::RenderOptions = opts.unwrap_or_default().into();
 
         let result = self
             .inner

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -22,10 +22,26 @@ pub enum WasmError {
 }
 
 impl WasmError {
-    /// Convert to JsValue for throwing
+    /// Convert to a JS `Error` object for throwing.
+    ///
+    /// The returned value is a real `Error` instance whose `message` is the
+    /// primary diagnostic message. Structured data is attached as a `diagnostic`
+    /// property for callers that need to branch on error codes, severity, etc.
+    ///
+    /// Returning an `Error` (rather than a plain object or `Map`) ensures that
+    /// JavaScript consumers — including Vitest's `toThrow(regex)` matcher —
+    /// see `err instanceof Error === true` and `err.message` populated.
     pub fn to_js_value(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(self)
-            .unwrap_or_else(|_| JsValue::from_str(&format!("{:?}", self)))
+        let message = match self {
+            WasmError::Diagnostic { diagnostic } => diagnostic.message.clone(),
+            WasmError::MultipleDiagnostics { message, .. } => message.clone(),
+        };
+        let err = js_sys::Error::new(&message);
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        if let Ok(data) = self.serialize(&serializer) {
+            let _ = js_sys::Reflect::set(&err, &JsValue::from_str("diagnostic"), &data);
+        }
+        err.into()
     }
 
     /// Build a Diagnostic with an explicit error code.

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -43,22 +43,6 @@ impl WasmError {
         }
         err.into()
     }
-
-    /// Build a Diagnostic with an explicit error code.
-    /// Use this instead of `WasmError::from(string)` when the call site knows
-    /// a stable code that JS callers can branch on.
-    pub fn with_code(code: &str, message: impl std::fmt::Display) -> Self {
-        WasmError::Diagnostic {
-            diagnostic: SerializableDiagnostic {
-                severity: quillmark_core::Severity::Error,
-                code: Some(code.to_string()),
-                message: message.to_string(),
-                primary: None,
-                hint: None,
-                source_chain: vec![],
-            },
-        }
-    }
 }
 
 impl From<ParseError> for WasmError {

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -4,15 +4,17 @@ export function makeQuill({
   name = 'test_quill',
   version = '1.0.0',
   plate = '#import "@local/quillmark-helper:0.1.0": data\n= Test',
+  quillYaml,
 } = {}) {
-  return new Map([
-    ['Quill.yaml', enc.encode(`Quill:
+  const yaml = quillYaml ?? `Quill:
   name: ${name}
   version: "${version}"
   backend: typst
   plate_file: plate.typ
   description: Test quill for smoke tests
-`)],
+`
+  return new Map([
+    ['Quill.yaml', enc.encode(yaml)],
     ['plate.typ', enc.encode(plate)],
   ])
 }

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -27,7 +27,8 @@ fn test_parse_markdown_static() {
 #[wasm_bindgen_test]
 fn test_document_body_and_warnings() {
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
-    assert_eq!(doc.body(), "\n# Hello\n");
+    // WASM `body` getter strips trailing newlines (structural separator, not content).
+    assert_eq!(doc.body(), "\n# Hello");
     // warnings() returns JsValue (array) — just verify it's defined
     let warnings = doc.warnings();
     assert!(!warnings.is_undefined());
@@ -50,7 +51,7 @@ fn test_render_ref_mismatch_warning() {
     let mismatch_md = "---\nQUILL: other_quill\ntitle: Mismatch\n---\n\n# Content\n";
     let doc = Document::from_markdown(mismatch_md).expect("fromMarkdown failed");
     let result = quill
-        .render(doc, RenderOptions::default())
+        .render(doc, Some(RenderOptions::default()))
         .expect("render should succeed despite mismatch");
 
     assert_eq!(result.warnings.len(), 1, "expected exactly one warning");
@@ -70,7 +71,7 @@ fn test_render_from_document() {
 
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     let result = quill
-        .render(doc, RenderOptions::default())
+        .render(doc, Some(RenderOptions::default()))
         .expect("render from Document failed");
 
     assert!(
@@ -95,7 +96,7 @@ fn test_open_session_render() {
     assert!(session.page_count() > 0, "session should expose page count");
 
     let result = session
-        .render(RenderOptions::default())
+        .render(Some(RenderOptions::default()))
         .expect("session render failed");
     assert!(!result.artifacts.is_empty(), "should produce artifacts");
 }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -113,8 +113,11 @@ impl Document {
 // ── Card emission ─────────────────────────────────────────────────────────────
 
 fn emit_card(out: &mut String, card: &Card) {
-    // The preceding body (global or card) already ends with the blank line
-    // before this fence — do not add an extra `\n`.
+    // MARKDOWN.md §3 F2 requires a blank line before each metadata fence.
+    // Parsed bodies typically already end with `\n\n`, but edited bodies
+    // (e.g. `replace_body("x")` with no trailing newline) do not — normalise
+    // here so the emitted markdown round-trips through the parser.
+    ensure_blank_line_before_fence(out);
     out.push_str("---\n");
     out.push_str("CARD: ");
     out.push_str(card.tag());
@@ -129,6 +132,19 @@ fn emit_card(out: &mut String, card: &Card) {
     // Card body: emitted verbatim.  Empty body → nothing after the fence.
     if !card.body().is_empty() {
         out.push_str(card.body());
+    }
+}
+
+/// Ensures `out` ends with a blank line (`"\n\n"`) or is empty — the F2
+/// precondition for the next metadata fence marker.
+fn ensure_blank_line_before_fence(out: &mut String) {
+    if out.is_empty() || out.ends_with("\n\n") {
+        return;
+    }
+    if out.ends_with('\n') {
+        out.push('\n');
+    } else {
+        out.push_str("\n\n");
     }
 }
 

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -100,8 +100,8 @@ impl Document {
         out.push_str(&self.body);
 
         // ── Cards ─────────────────────────────────────────────────────────────
-        // Each card's body already contains the blank line before the next
-        // card fence, so no extra `\n` is injected between cards.
+        // `emit_card` normalises the separator before each fence, so edited
+        // bodies (which may lack a trailing blank line) still round-trip.
         for card in &self.cards {
             emit_card(&mut out, card);
         }


### PR DESCRIPTION
## Summary
This PR improves content handling and error reporting in the WASM bindings by stripping trailing newlines from body content (which are structural separators in the Markdown format, not user content) and enhancing error objects returned to JavaScript consumers.

## Key Changes

- **Body content trimming**: Added `trim_body()` helper function that strips trailing `\n` and `\r` characters from document and card bodies. This is applied in the `Document.body` getter and card serialization, since trailing newlines are required by the Markdown spec (§3 F2) as structural separators between content blocks, not part of the actual content.

- **Optional render options**: Made `RenderOptions` parameter optional in `Quill.render()` and `RenderSession.render()` methods, defaulting to `RenderOptions::default()` when not provided. This simplifies the JavaScript API.

- **Enhanced error objects**: Refactored `WasmError::to_js_value()` to return proper JavaScript `Error` instances with:
  - A `message` property containing the primary diagnostic message
  - A `diagnostic` property with structured error data (code, severity, etc.)
  - This ensures JavaScript consumers see `err instanceof Error === true` and enables proper error matching in test frameworks like Vitest

- **Improved markdown emission**: Added `ensure_blank_line_before_fence()` function to normalize card fence emission, ensuring edited bodies (without trailing newlines) properly round-trip through the parser by guaranteeing a blank line before metadata fences.

- **Better documentation**: Enhanced doc comments explaining the rationale for body trimming and error object structure.

- **Test updates**: Updated WASM binding tests to reflect the new optional parameter API and corrected body content assertions.

## Implementation Details

The `trim_body()` function uses `trim_end_matches()` to remove trailing line terminators, preserving internal newlines while removing only the structural separators added by the parser. The error handling changes use `js_sys::Reflect::set()` to attach diagnostic data to Error objects, maintaining compatibility with JavaScript error handling patterns.

https://claude.ai/code/session_01PnrE9B9TEkeDWT3mP4oTZ1