### PR TITLE
ci: skip redundant WASM rebuild in publish-wasm test step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Run WASM tests
         working-directory: crates/bindings/wasm
-        run: npm test
+        run: npx vitest run
 
       # npm 11.5.1+ required for Trusted Publishers (OIDC)
       - name: Upgrade npm for Trusted Publishers


### PR DESCRIPTION
The publish-wasm job already builds the WASM package before running
tests, but `npm test` invokes the package's test script which rebuilds
WASM via build-wasm.sh. Run vitest directly to avoid the duplicate
build.

https://claude.ai/code/session_01JETR4wQxXsSnREWU6svT2W