### PR TITLE
Refactor Diagnostic to be Clone+Deserializable; remove SerializableDiagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cargo add quillmark
 ## Quick Start (Rust)
 
 ```rust
-use quillmark::{Document, OutputFormat, Quillmark};
+use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
 
 let engine = Quillmark::new();
 let quill = engine.quill_from_path("path/to/quill")?;
@@ -47,7 +47,13 @@ title: Example
 "#;
 
 let doc = Document::from_markdown(markdown)?;
-let result = quill.render(&doc, Some(OutputFormat::Pdf))?;
+let result = quill.render(
+    &doc,
+    &RenderOptions {
+        output_format: Some(OutputFormat::Pdf),
+        ..Default::default()
+    },
+)?;
 
 let pdf_bytes = &result.artifacts[0].bytes;
 # Ok::<(), quillmark::RenderError>(())

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cargo add quillmark
 ## Quick Start (Rust)
 
 ```rust
-use quillmark::{OutputFormat, Quillmark, RenderOptions};
+use quillmark::{Document, OutputFormat, Quillmark};
 
 let engine = Quillmark::new();
 let quill = engine.quill_from_path("path/to/quill")?;
@@ -46,13 +46,8 @@ title: Example
 # Hello World
 "#;
 
-let result = quill.render(
-    markdown,
-    &RenderOptions {
-        output_format: Some(OutputFormat::Pdf),
-        ppi: None,
-    },
-)?;
+let doc = Document::from_markdown(markdown)?;
+let result = quill.render(&doc, Some(OutputFormat::Pdf))?;
 
 let pdf_bytes = &result.artifacts[0].bytes;
 # Ok::<(), quillmark::RenderError>(())

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -58,7 +58,7 @@ pub fn compile_to_document(
                     format!("Failed to create Typst compilation environment: {}", e),
                 )
                 .with_code("typst::world_creation".to_string())
-                .with_source(e),
+                .with_source(e.as_ref()),
             ),
         }
     })?;

--- a/crates/backends/typst/src/error_mapping.rs
+++ b/crates/backends/typst/src/error_mapping.rs
@@ -36,9 +36,9 @@ fn map_single_diagnostic(error: &SourceDiagnostic, world: &QuillWorld) -> Diagno
         severity,
         code,
         message: error.message.to_string(),
-        primary: location,
+        location,
         hint,
-        source: None,
+        source_chain: Vec::new(),
     }
 }
 
@@ -52,12 +52,12 @@ fn resolve_span_to_location(span: &typst::syntax::Span, world: &QuillWorld) -> O
 
     let text = source.text();
     let line = text[..range.start].matches('\n').count() + 1;
-    let col = range.start - text[..range.start].rfind('\n').map_or(0, |pos| pos + 1) + 1;
+    let column = range.start - text[..range.start].rfind('\n').map_or(0, |pos| pos + 1) + 1;
 
     Some(Location {
         file: source.id().vpath().as_rootless_path().display().to_string(),
         line: line as u32,
-        col: col as u32,
+        column: column as u32,
     })
 }
 

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -52,7 +52,7 @@ use std::collections::HashMap;
 #[cfg(feature = "native")]
 pub(crate) fn typst_packages(source: &QuillSource) -> Vec<String> {
     source
-        .metadata
+        .metadata()
         .get("typst_packages")
         .and_then(|v| v.as_array())
         .map(|arr| {
@@ -123,7 +123,7 @@ impl Backend for TypstBackend {
         });
 
         let transformed_fields =
-            transform_markdown_fields(&fields, &build_transform_schema(&source.config));
+            transform_markdown_fields(&fields, &build_transform_schema(source.config()));
         let transformed_json = serde_json::Value::Object(
             transformed_fields
                 .into_iter()

--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -46,7 +46,7 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
     let mut info = serde_json::Map::new();
     info.insert(
         "name".to_string(),
-        serde_json::Value::String(source.name.clone()),
+        serde_json::Value::String(source.name().to_string()),
     );
     info.insert(
         "backend".to_string(),
@@ -54,22 +54,23 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
     );
 
     // Extract metadata fields: version, author, description
-    if let Some(version) = source.metadata.get("version") {
+    let metadata = source.metadata();
+    if let Some(version) = metadata.get("version") {
         info.insert("version".to_string(), version.as_json().clone());
     }
-    if let Some(author) = source.metadata.get("author") {
+    if let Some(author) = metadata.get("author") {
         info.insert("author".to_string(), author.as_json().clone());
     }
-    if let Some(description) = source.metadata.get("description") {
+    if let Some(description) = metadata.get("description") {
         info.insert("description".to_string(), description.as_json().clone());
     }
 
     // Add counts
     info.insert(
         "field_count".to_string(),
-        serde_json::Value::Number(source.config.main().fields.len().into()),
+        serde_json::Value::Number(source.config().main().fields.len().into()),
     );
-    let card_count = source.config.card_definitions().len();
+    let card_count = source.config().card_definitions().len();
     if card_count > 0 {
         info.insert(
             "card_count".to_string(),
@@ -78,16 +79,16 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
     }
     info.insert(
         "has_plate".to_string(),
-        serde_json::Value::Bool(source.plate.is_some()),
+        serde_json::Value::Bool(source.plate().is_some()),
     );
     info.insert(
         "has_example".to_string(),
-        serde_json::Value::Bool(source.example.is_some()),
+        serde_json::Value::Bool(source.example().is_some()),
     );
 
     // Add any additional metadata (excluding the standard fields already included)
     let mut extra_metadata = serde_json::Map::new();
-    for (key, value) in &source.metadata {
+    for (key, value) in metadata {
         if !STANDARD_METADATA_KEYS.contains(&key.as_str()) {
             extra_metadata.insert(key.clone(), value.as_json().clone());
         }
@@ -108,9 +109,11 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
 
 fn print_human_readable(quill: &quillmark::Quill) {
     let source = quill.source();
-    println!("Quill: {}", source.name);
+    let metadata = source.metadata();
+    let config = source.config();
+    println!("Quill: {}", source.name());
 
-    if let Some(description) = source.metadata.get("description") {
+    if let Some(description) = metadata.get("description") {
         if let Some(desc_str) = description.as_str() {
             if !desc_str.is_empty() {
                 println!("  Description: {}", desc_str);
@@ -118,13 +121,13 @@ fn print_human_readable(quill: &quillmark::Quill) {
         }
     }
 
-    if let Some(version) = source.metadata.get("version") {
+    if let Some(version) = metadata.get("version") {
         if let Some(ver_str) = version.as_str() {
             println!("  Version:     {}", ver_str);
         }
     }
 
-    if let Some(author) = source.metadata.get("author") {
+    if let Some(author) = metadata.get("author") {
         if let Some(auth_str) = author.as_str() {
             println!("  Author:      {}", auth_str);
         }
@@ -133,22 +136,22 @@ fn print_human_readable(quill: &quillmark::Quill) {
     println!("  Backend:     {}", quill.backend_id());
 
     // Field count from schema properties
-    let field_count = source.config.main().fields.len();
+    let field_count = config.main().fields.len();
     println!("  Fields:      {}", field_count);
 
     // Card count from schema $defs
-    let card_count = source.config.card_definitions().len();
+    let card_count = config.card_definitions().len();
     if card_count > 0 {
         println!("  Cards:       {}", card_count);
     }
 
     // Defaults and examples
-    let defaults_count = source.config.defaults().len();
+    let defaults_count = config.defaults().len();
     if defaults_count > 0 {
         println!("  Defaults:    {}", defaults_count);
     }
 
-    let examples_count = source.config.examples().len();
+    let examples_count = config.examples().len();
     if examples_count > 0 {
         println!("  Examples:    {}", examples_count);
     }
@@ -156,11 +159,11 @@ fn print_human_readable(quill: &quillmark::Quill) {
     // Plate and example
     println!(
         "  Has plate:   {}",
-        if source.plate.is_some() { "yes" } else { "no" }
+        if source.plate().is_some() { "yes" } else { "no" }
     );
     println!(
         "  Has example: {}",
-        if source.example.is_some() {
+        if source.example().is_some() {
             "yes"
         } else {
             "no"
@@ -168,15 +171,14 @@ fn print_human_readable(quill: &quillmark::Quill) {
     );
 
     // Additional metadata
-    let extra_keys: Vec<&String> = source
-        .metadata
+    let extra_keys: Vec<&String> = metadata
         .keys()
         .filter(|k| !STANDARD_METADATA_KEYS.contains(&k.as_str()))
         .collect();
     if !extra_keys.is_empty() {
         println!("  Metadata:");
         for key in extra_keys {
-            if let Some(value) = source.metadata.get(key) {
+            if let Some(value) = metadata.get(key) {
                 println!("    {}: {}", key, format_metadata_value(value));
             }
         }

--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -159,7 +159,11 @@ fn print_human_readable(quill: &quillmark::Quill) {
     // Plate and example
     println!(
         "  Has plate:   {}",
-        if source.plate().is_some() { "yes" } else { "no" }
+        if source.plate().is_some() {
+            "yes"
+        } else {
+            "no"
+        }
     );
     println!(
         "  Has example: {}",

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -2,7 +2,7 @@ use crate::errors::{CliError, Result};
 use crate::output::{derive_output_path, OutputWriter};
 use clap::Parser;
 use quillmark::{Document, Quillmark};
-use quillmark_core::OutputFormat;
+use quillmark_core::{OutputFormat, RenderOptions};
 use std::fs;
 use std::path::PathBuf;
 
@@ -160,7 +160,13 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     }
 
     // Render
-    let mut result = quill.render(&parsed, Some(output_format))?;
+    let mut result = quill.render(
+        &parsed,
+        &RenderOptions {
+            output_format: Some(output_format),
+            ..Default::default()
+        },
+    )?;
 
     // Merge parse-time warnings into the render result so downstream tooling
     // sees them in a single channel.

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -149,7 +149,7 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
                 println!("  Schema generated successfully");
                 println!(
                     "  Defaults extracted: {}",
-                    quill.source().config.defaults().len()
+                    quill.source().config().defaults().len()
                 );
             }
 
@@ -373,7 +373,7 @@ fn validate_defaults_against_schema(
     config: &QuillConfig,
     result: &mut ValidationResult,
 ) {
-    let defaults = quill.source().config.defaults();
+    let defaults = quill.source().config().defaults();
 
     for (field_name, default_value) in &defaults {
         // Look up field type in config

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -149,7 +149,7 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
                 println!("  Schema generated successfully");
                 println!(
                     "  Defaults extracted: {}",
-                    quill.source().extract_defaults().len()
+                    quill.source().config.defaults().len()
                 );
             }
 
@@ -373,9 +373,9 @@ fn validate_defaults_against_schema(
     config: &QuillConfig,
     result: &mut ValidationResult,
 ) {
-    let defaults = quill.source().extract_defaults();
+    let defaults = quill.source().config.defaults();
 
-    for (field_name, default_value) in defaults {
+    for (field_name, default_value) in &defaults {
         // Look up field type in config
         if let Some(field_schema) = config.main().fields.get(field_name) {
             if let Some(type_mismatch) = check_type_mismatch(&field_schema.r#type, default_value) {

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -82,7 +82,13 @@ impl PyQuill {
 
     #[getter]
     fn quill_ref(&self) -> String {
-        self.inner.quill_ref()
+        let source = self.inner.source();
+        let version = source
+            .metadata
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0.0.0");
+        format!("{}@{}", source.name, version)
     }
 
     #[getter]

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -57,12 +57,12 @@ pub struct PyQuill {
 impl PyQuill {
     #[getter]
     fn print_tree(&self) -> String {
-        self.inner.source().files.print_tree().clone()
+        self.inner.source().files().print_tree().clone()
     }
 
     #[getter]
     fn name(&self) -> String {
-        self.inner.source().name.clone()
+        self.inner.source().name().to_string()
     }
 
     #[getter]
@@ -72,29 +72,29 @@ impl PyQuill {
 
     #[getter]
     fn plate(&self) -> Option<String> {
-        self.inner.source().plate.clone()
+        self.inner.source().plate().map(str::to_string)
     }
 
     #[getter]
     fn example(&self) -> Option<String> {
-        self.inner.source().example.clone()
+        self.inner.source().example().map(str::to_string)
     }
 
     #[getter]
     fn quill_ref(&self) -> String {
         let source = self.inner.source();
         let version = source
-            .metadata
+            .metadata()
             .get("version")
             .and_then(|v| v.as_str())
             .unwrap_or("0.0.0");
-        format!("{}@{}", source.name, version)
+        format!("{}@{}", source.name(), version)
     }
 
     #[getter]
     fn metadata<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        for (key, value) in &self.inner.source().metadata {
+        for (key, value) in self.inner.source().metadata() {
             dict.set_item(key, quillvalue_to_py(py, value)?)?;
         }
         Ok(dict)
@@ -105,7 +105,7 @@ impl PyQuill {
         let yaml = self
             .inner
             .source()
-            .config
+            .config()
             .public_schema_yaml()
             .map_err(|e| PyValueError::new_err(format!("schema: {}", e)))?;
         Ok(yaml.into_pyobject(py)?.into_any())
@@ -114,7 +114,7 @@ impl PyQuill {
     #[getter]
     fn defaults<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        for (key, value) in self.inner.source().config.defaults() {
+        for (key, value) in self.inner.source().config().defaults() {
             dict.set_item(key, quillvalue_to_py(py, &value)?)?;
         }
         Ok(dict)
@@ -123,7 +123,7 @@ impl PyQuill {
     #[getter]
     fn examples<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        for (key, values) in self.inner.source().config.examples() {
+        for (key, values) in self.inner.source().config().examples() {
             let py_list = pyo3::types::PyList::empty(py);
             for value in values {
                 py_list.append(quillvalue_to_py(py, &value)?)?;

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -6,8 +6,7 @@ use pyo3::types::PyDict; // PyDict
 use pyo3::Bound; // Bound
 
 use quillmark::{
-    Document, Location, OutputFormat, Quill, Quillmark, RenderResult, RenderSession,
-    SerializableDiagnostic,
+    Diagnostic, Document, Location, OutputFormat, Quill, Quillmark, RenderResult, RenderSession,
 };
 use std::path::PathBuf;
 
@@ -156,12 +155,9 @@ impl PyQuill {
             .inner
             .render(&doc.inner, &opts)
             .map_err(convert_render_error)?;
-        let parse_warnings: Vec<_> = doc
-            .parse_warnings
-            .iter()
-            .map(|d| d.clone_without_source())
-            .collect();
-        result.warnings.splice(0..0, parse_warnings);
+        result
+            .warnings
+            .splice(0..0, doc.parse_warnings.iter().cloned());
         Ok(PyRenderResult { inner: result })
     }
 
@@ -243,8 +239,9 @@ impl PyDocument {
             let py_err = PyErr::new::<crate::errors::ParseError, _>(e.to_string());
             Python::attach(|py| {
                 if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
-                    let diag = e.to_diagnostic();
-                    let py_diag = crate::types::PyDiagnostic { inner: diag.into() };
+                    let py_diag = crate::types::PyDiagnostic {
+                        inner: e.to_diagnostic(),
+                    };
                     let _ = exc.setattr("diagnostic", py_diag);
                 }
             });
@@ -275,7 +272,7 @@ impl PyDocument {
     fn warnings(&self) -> Vec<PyDiagnostic> {
         self.parse_warnings
             .iter()
-            .map(|d| PyDiagnostic { inner: d.into() })
+            .map(|d| PyDiagnostic { inner: d.clone() })
             .collect()
     }
 
@@ -508,7 +505,7 @@ impl PyRenderResult {
         self.inner
             .warnings
             .iter()
-            .map(|d| PyDiagnostic { inner: d.into() })
+            .map(|d| PyDiagnostic { inner: d.clone() })
             .collect()
     }
 
@@ -562,7 +559,7 @@ impl PyArtifact {
 #[pyclass(name = "Diagnostic")]
 #[derive(Clone)]
 pub struct PyDiagnostic {
-    pub(crate) inner: SerializableDiagnostic,
+    pub(crate) inner: Diagnostic,
 }
 
 #[pymethods]
@@ -583,9 +580,9 @@ impl PyDiagnostic {
     }
 
     #[getter]
-    fn primary(&self) -> Option<PyLocation> {
+    fn location(&self) -> Option<PyLocation> {
         self.inner
-            .primary
+            .location
             .as_ref()
             .map(|l| PyLocation { inner: l.clone() })
     }
@@ -621,8 +618,8 @@ impl PyLocation {
     }
 
     #[getter]
-    fn col(&self) -> usize {
-        self.inner.col as usize
+    fn column(&self) -> usize {
+        self.inner.column as usize
     }
 }
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -148,10 +148,13 @@ impl PyQuill {
         doc: PyRef<'_, PyDocument>,
         format: Option<PyOutputFormat>,
     ) -> PyResult<PyRenderResult> {
-        let rust_format = format.map(OutputFormat::from);
+        let opts = quillmark_core::RenderOptions {
+            output_format: format.map(OutputFormat::from),
+            ..Default::default()
+        };
         let mut result = self
             .inner
-            .render(&doc.inner, rust_format)
+            .render(&doc.inner, &opts)
             .map_err(convert_render_error)?;
         let parse_warnings: Vec<_> = doc
             .parse_warnings

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -228,6 +228,18 @@ describe('Quillmark.quill', () => {
     expect(result.artifacts[0].mimeType).toBe('image/svg+xml')
   })
 
+  it('should allow rendering the same Document multiple times', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+
+    const pdf = quill.render(doc, { format: 'pdf' })
+    const svg = quill.render(doc, { format: 'svg' })
+
+    expect(pdf.artifacts[0].mimeType).toBe('application/pdf')
+    expect(svg.artifacts[0].mimeType).toBe('image/svg+xml')
+  })
+
   it('should emit a quill::ref_mismatch warning when Document QUILL differs from quill name', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -100,9 +100,12 @@ impl Quill {
         let start = now_ms();
         let parse_warnings = doc.parse_warnings.clone();
         let rust_opts: quillmark_core::RenderOptions = opts.unwrap_or_default().into();
-        let result = self
+        let session = self
             .inner
-            .render_with_options(&doc.inner, rust_opts.output_format, rust_opts.ppi)
+            .open(&doc.inner)
+            .map_err(|e| WasmError::from(e).to_js_value())?;
+        let result = session
+            .render(&rust_opts)
             .map_err(|e| WasmError::from(e).to_js_value())?;
         let mut warnings: Vec<Diagnostic> = parse_warnings.into_iter().map(Into::into).collect();
         warnings.extend(result.warnings.into_iter().map(Into::into));

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -94,20 +94,17 @@ impl Quill {
     #[wasm_bindgen(js_name = render)]
     pub fn render(
         &self,
-        doc: Document,
+        doc: &Document,
         opts: Option<RenderOptions>,
     ) -> Result<RenderResult, JsValue> {
         let start = now_ms();
-        let parse_warnings = doc.parse_warnings.clone();
         let rust_opts: quillmark_core::RenderOptions = opts.unwrap_or_default().into();
-        let session = self
+        let result = self
             .inner
-            .open(&doc.inner)
+            .render(&doc.inner, &rust_opts)
             .map_err(|e| WasmError::from(e).to_js_value())?;
-        let result = session
-            .render(&rust_opts)
-            .map_err(|e| WasmError::from(e).to_js_value())?;
-        let mut warnings: Vec<Diagnostic> = parse_warnings.into_iter().map(Into::into).collect();
+        let mut warnings: Vec<Diagnostic> =
+            doc.parse_warnings.iter().cloned().map(Into::into).collect();
         warnings.extend(result.warnings.into_iter().map(Into::into));
         Ok(RenderResult {
             artifacts: result.artifacts.into_iter().map(Into::into).collect(),
@@ -119,7 +116,7 @@ impl Quill {
 
     /// Open an iterative render session for page-selective rendering.
     #[wasm_bindgen(js_name = open)]
-    pub fn open(&self, doc: Document) -> Result<RenderSession, JsValue> {
+    pub fn open(&self, doc: &Document) -> Result<RenderSession, JsValue> {
         let session = self
             .inner
             .open(&doc.inner)

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -1,36 +1,36 @@
 //! Error handling utilities for WASM bindings
 
-use quillmark_core::{ParseError, RenderError, SerializableDiagnostic};
+use quillmark_core::{Diagnostic, ParseError, RenderError, Severity};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-/// Serializable error for JavaScript consumption
+/// Serializable error for JavaScript consumption.
+///
+/// Shape matches the success-path [`quillmark_core::Diagnostic`] so JS
+/// consumers can use a single renderer for both thrown errors and warnings
+/// in `RenderResult.warnings`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(tag = "type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 pub enum WasmError {
     /// Single diagnostic error
     Diagnostic {
         #[serde(flatten)]
-        diagnostic: SerializableDiagnostic,
+        diagnostic: Diagnostic,
     },
     /// Multiple diagnostics (e.g., compilation errors)
     MultipleDiagnostics {
         message: String,
-        diagnostics: Vec<SerializableDiagnostic>,
+        diagnostics: Vec<Diagnostic>,
     },
 }
 
 impl WasmError {
     /// Convert to a JS `Error` object for throwing.
     ///
-    /// The returned value is a real `Error` instance whose `message` is the
-    /// primary diagnostic message. Structured data is attached as a `diagnostic`
-    /// property for callers that need to branch on error codes, severity, etc.
-    ///
-    /// Returning an `Error` (rather than a plain object or `Map`) ensures that
-    /// JavaScript consumers — including Vitest's `toThrow(regex)` matcher —
-    /// see `err instanceof Error === true` and `err.message` populated.
+    /// Returns a real `Error` whose `.message` is the primary diagnostic
+    /// message. Structured data is attached as a `.diagnostic` property for
+    /// callers that need to branch on codes, severity, etc. The shape
+    /// mirrors the diagnostics in `result.warnings`.
     pub fn to_js_value(&self) -> JsValue {
         let message = match self {
             WasmError::Diagnostic { diagnostic } => diagnostic.message.clone(),
@@ -47,28 +47,8 @@ impl WasmError {
 
 impl From<ParseError> for WasmError {
     fn from(error: ParseError) -> Self {
-        match error {
-            ParseError::InputTooLarge { size, max } => WasmError::Diagnostic {
-                diagnostic: SerializableDiagnostic {
-                    severity: quillmark_core::Severity::Error,
-                    code: Some("input_too_large".to_string()),
-                    message: format!("Input too large: {} bytes (max: {} bytes)", size, max),
-                    primary: None,
-                    hint: None,
-                    source_chain: vec![],
-                },
-            },
-            // Fallback for other errors to basic diagnostic
-            _ => WasmError::Diagnostic {
-                diagnostic: SerializableDiagnostic {
-                    severity: quillmark_core::Severity::Error,
-                    code: None,
-                    message: error.to_string(),
-                    primary: None,
-                    hint: None,
-                    source_chain: vec![],
-                },
-            },
+        WasmError::Diagnostic {
+            diagnostic: error.to_diagnostic(),
         }
     }
 }
@@ -78,28 +58,15 @@ impl From<RenderError> for WasmError {
         match error {
             RenderError::CompilationFailed { diags } => WasmError::MultipleDiagnostics {
                 message: format!("Compilation failed with {} error(s)", diags.len()),
-                diagnostics: diags.into_iter().map(|d| d.into()).collect(),
+                diagnostics: diags,
             },
-            // All other variants contain a single Diagnostic
             _ => {
-                let diags = error.diagnostics();
-                if let Some(diag) = diags.first() {
-                    WasmError::Diagnostic {
-                        diagnostic: (*diag).into(),
-                    }
-                } else {
-                    // Fallback for edge cases
-                    WasmError::Diagnostic {
-                        diagnostic: SerializableDiagnostic {
-                            severity: quillmark_core::Severity::Error,
-                            code: None,
-                            message: error.to_string(),
-                            primary: None,
-                            hint: None,
-                            source_chain: vec![],
-                        },
-                    }
-                }
+                let diagnostic = error
+                    .diagnostics()
+                    .first()
+                    .map(|d| (*d).clone())
+                    .unwrap_or_else(|| Diagnostic::new(Severity::Error, error.to_string()));
+                WasmError::Diagnostic { diagnostic }
             }
         }
     }
@@ -108,14 +75,7 @@ impl From<RenderError> for WasmError {
 impl From<String> for WasmError {
     fn from(message: String) -> Self {
         WasmError::Diagnostic {
-            diagnostic: SerializableDiagnostic {
-                severity: quillmark_core::Severity::Error,
-                code: None,
-                message,
-                primary: None,
-                hint: None,
-                source_chain: vec![],
-            },
+            diagnostic: Diagnostic::new(Severity::Error, message),
         }
     }
 }
@@ -140,7 +100,7 @@ mod tests {
 
         match wasm_err {
             WasmError::Diagnostic { diagnostic } => {
-                assert_eq!(diagnostic.code.as_deref(), Some("input_too_large"));
+                assert_eq!(diagnostic.code.as_deref(), Some("parse::input_too_large"));
                 assert!(diagnostic.message.contains("Input too large"));
             }
             _ => panic!("Expected Diagnostic variant"),

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -72,7 +72,7 @@ impl From<quillmark_core::Location> for Location {
         Location {
             file: loc.file,
             line: loc.line as usize,
-            column: loc.col as usize,
+            column: loc.column as usize,
         }
     }
 }
@@ -96,14 +96,13 @@ pub struct Diagnostic {
 
 impl From<quillmark_core::Diagnostic> for Diagnostic {
     fn from(diag: quillmark_core::Diagnostic) -> Self {
-        let source_chain = diag.source_chain();
         Diagnostic {
             severity: diag.severity.into(),
             code: diag.code,
             message: diag.message,
-            location: diag.primary.map(|loc| loc.into()),
+            location: diag.location.map(Into::into),
             hint: diag.hint,
-            source_chain,
+            source_chain: diag.source_chain,
         }
     }
 }
@@ -273,7 +272,7 @@ mod tests {
         .with_location(quillmark_core::Location {
             file: "test.typ".to_string(),
             line: 10,
-            col: 5,
+            column: 5,
         })
         .with_hint("This is a hint".to_string());
 
@@ -297,7 +296,7 @@ mod tests {
             "Failed to load template".to_string(),
         )
         .with_code("E002".to_string())
-        .with_source(Box::new(root_error));
+        .with_source(&root_error);
 
         let wasm_diag: Diagnostic = diag.into();
         let json = serde_json::to_string(&wasm_diag).unwrap();
@@ -333,7 +332,7 @@ mod tests {
             .with_location(Location {
                 file: "test.typ".to_string(),
                 line: 10,
-                col: 5,
+                column: 5,
             })
             .with_hint("This is a hint".to_string());
 
@@ -347,7 +346,7 @@ mod tests {
 
         let obj = json.as_object().unwrap();
         assert_eq!(obj.get("type").unwrap().as_str().unwrap(), "diagnostic");
-        assert_eq!(obj.get("severity").unwrap().as_str().unwrap(), "Error");
+        assert_eq!(obj.get("severity").unwrap().as_str().unwrap(), "error");
         assert_eq!(obj.get("code").unwrap().as_str().unwrap(), "E001");
         assert_eq!(
             obj.get("message").unwrap().as_str().unwrap(),
@@ -355,10 +354,10 @@ mod tests {
         );
         assert_eq!(obj.get("hint").unwrap().as_str().unwrap(), "This is a hint");
 
-        let primary = obj.get("primary").unwrap().as_object().unwrap();
-        assert_eq!(primary.get("file").unwrap().as_str().unwrap(), "test.typ");
-        assert_eq!(primary.get("line").unwrap().as_u64().unwrap(), 10);
-        assert_eq!(primary.get("col").unwrap().as_u64().unwrap(), 5);
+        let location = obj.get("location").unwrap().as_object().unwrap();
+        assert_eq!(location.get("file").unwrap().as_str().unwrap(), "test.typ");
+        assert_eq!(location.get("line").unwrap().as_u64().unwrap(), 10);
+        assert_eq!(location.get("column").unwrap().as_u64().unwrap(), 5);
     }
 
     #[test]
@@ -409,7 +408,7 @@ mod tests {
             obj.get("message").unwrap().as_str().unwrap(),
             "Simple error message"
         );
-        assert_eq!(obj.get("severity").unwrap().as_str().unwrap(), "Error");
+        assert_eq!(obj.get("severity").unwrap().as_str().unwrap(), "error");
     }
 
     #[test]

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -51,7 +51,7 @@ fn test_render_ref_mismatch_warning() {
     let mismatch_md = "---\nQUILL: other_quill\ntitle: Mismatch\n---\n\n# Content\n";
     let doc = Document::from_markdown(mismatch_md).expect("fromMarkdown failed");
     let result = quill
-        .render(doc, Some(RenderOptions::default()))
+        .render(&doc, Some(RenderOptions::default()))
         .expect("render should succeed despite mismatch");
 
     assert_eq!(result.warnings.len(), 1, "expected exactly one warning");
@@ -71,7 +71,7 @@ fn test_render_from_document() {
 
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     let result = quill
-        .render(doc, Some(RenderOptions::default()))
+        .render(&doc, Some(RenderOptions::default()))
         .expect("render from Document failed");
 
     assert!(
@@ -92,7 +92,7 @@ fn test_open_session_render() {
     let quill = engine.quill(small_quill_tree()).expect("quill failed");
 
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
-    let session = quill.open(doc).expect("open failed");
+    let session = quill.open(&doc).expect("open failed");
     assert!(session.page_count() > 0, "session should expose page count");
 
     let result = session

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -40,7 +40,7 @@
 //!     .with_location(Location {
 //!         file: "template.typ".to_string(),
 //!         line: 10,
-//!         col: 5,
+//!         column: 5,
 //!     })
 //!     .with_hint("Check variable spelling".to_string());
 //!
@@ -106,6 +106,7 @@ pub const MAX_FIELD_COUNT: usize = 1000;
 
 /// Error severity levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     /// Fatal error that prevents completion
     Error,
@@ -117,33 +118,41 @@ pub enum Severity {
 
 /// Location information for diagnostics
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Location {
     /// Source file name (e.g., "plate.typ", "template.typ", "input.md")
     pub file: String,
     /// Line number (1-indexed)
     pub line: u32,
     /// Column number (1-indexed)
-    pub col: u32,
+    pub column: u32,
 }
 
-/// Structured diagnostic information
-#[derive(Debug, serde::Serialize)]
+/// Structured diagnostic information.
+///
+/// `source_chain` is a flat list of error messages from any attached
+/// `std::error::Error` cause chain, eagerly walked at construction time so
+/// the diagnostic remains trivially `Clone` and fully serializable across
+/// every binding boundary.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
     /// Error severity level
     pub severity: Severity,
     /// Optional error code (e.g., "E001", "typst::syntax")
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub code: Option<String>,
     /// Human-readable error message
     pub message: String,
     /// Primary source location
-    pub primary: Option<Location>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub location: Option<Location>,
     /// Optional hint for fixing the error
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
-    /// Source error that caused this diagnostic (for error chaining)
-    /// Note: This field is excluded from serialization as Error trait
-    /// objects cannot be serialized
-    #[serde(skip)]
-    pub source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    /// Flattened cause chain (outermost first).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub source_chain: Vec<String>,
 }
 
 impl Diagnostic {
@@ -153,9 +162,9 @@ impl Diagnostic {
             severity,
             code: None,
             message,
-            primary: None,
+            location: None,
             hint: None,
-            source: None,
+            source_chain: Vec::new(),
         }
     }
 
@@ -167,7 +176,7 @@ impl Diagnostic {
 
     /// Set the primary location
     pub fn with_location(mut self, location: Location) -> Self {
-        self.primary = Some(location);
+        self.location = Some(location);
         self
     }
 
@@ -177,60 +186,14 @@ impl Diagnostic {
         self
     }
 
-    /// Set error source (chainable)
-    pub fn with_source(mut self, source: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        self.source = Some(source);
+    /// Attach an error cause chain, walked eagerly into `source_chain`.
+    pub fn with_source(mut self, source: &(dyn std::error::Error + 'static)) -> Self {
+        let mut current: Option<&(dyn std::error::Error + 'static)> = Some(source);
+        while let Some(err) = current {
+            self.source_chain.push(err.to_string());
+            current = err.source();
+        }
         self
-    }
-
-    /// Clone this diagnostic while dropping any attached source chain.
-    pub fn clone_without_source(&self) -> Self {
-        Self {
-            severity: self.severity,
-            code: self.code.clone(),
-            message: self.message.clone(),
-            primary: self.primary.clone(),
-            hint: self.hint.clone(),
-            source: None,
-        }
-    }
-}
-
-impl Clone for Diagnostic {
-    /// Clone a `Diagnostic`, dropping the source error chain.
-    ///
-    /// The `source` field holds a boxed `dyn Error` which is not `Clone`;
-    /// the cloned value will have `source: None`. Use `clone_without_source()`
-    /// explicitly if you want to be clear about this loss.
-    fn clone(&self) -> Self {
-        self.clone_without_source()
-    }
-}
-
-impl PartialEq for Diagnostic {
-    /// Two `Diagnostic`s are equal when all fields except `source` are equal.
-    fn eq(&self, other: &Self) -> bool {
-        self.severity == other.severity
-            && self.code == other.code
-            && self.message == other.message
-            && self.primary == other.primary
-            && self.hint == other.hint
-    }
-}
-
-impl Diagnostic {
-    /// Get the source chain as a list of error messages
-    pub fn source_chain(&self) -> Vec<String> {
-        let mut chain = Vec::new();
-        let mut current_source = self
-            .source
-            .as_ref()
-            .map(|b| b.as_ref() as &dyn std::error::Error);
-        while let Some(err) = current_source {
-            chain.push(err.to_string());
-            current_source = err.source();
-        }
-        chain
     }
 
     /// Format diagnostic for pretty printing
@@ -249,8 +212,8 @@ impl Diagnostic {
             result.push_str(&format!(" ({})", code));
         }
 
-        if let Some(ref loc) = self.primary {
-            result.push_str(&format!("\n  --> {}:{}:{}", loc.file, loc.line, loc.col));
+        if let Some(ref loc) = self.location {
+            result.push_str(&format!("\n  --> {}:{}:{}", loc.file, loc.line, loc.column));
         }
 
         if let Some(ref hint) = self.hint {
@@ -264,7 +227,7 @@ impl Diagnostic {
     pub fn fmt_pretty_with_source(&self) -> String {
         let mut result = self.fmt_pretty();
 
-        for (i, cause) in self.source_chain().iter().enumerate() {
+        for (i, cause) in self.source_chain.iter().enumerate() {
             result.push_str(&format!("\n  cause {}: {}", i + 1, cause));
         }
 
@@ -275,55 +238,6 @@ impl Diagnostic {
 impl std::fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)
-    }
-}
-
-/// Serializable diagnostic for cross-language boundaries
-///
-/// This type is used when diagnostics need to be serialized and sent across
-/// FFI boundaries (e.g., Python, WASM). Unlike `Diagnostic`, it does not
-/// contain the non-serializable `source` field, but instead includes a
-/// flattened `source_chain` for display purposes.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct SerializableDiagnostic {
-    /// Error severity level
-    pub severity: Severity,
-    /// Optional error code (e.g., "E001", "typst::syntax")
-    pub code: Option<String>,
-    /// Human-readable error message
-    pub message: String,
-    /// Primary source location
-    pub primary: Option<Location>,
-    /// Optional hint for fixing the error
-    pub hint: Option<String>,
-    /// Source chain as list of strings (for display purposes)
-    pub source_chain: Vec<String>,
-}
-
-impl From<Diagnostic> for SerializableDiagnostic {
-    fn from(diag: Diagnostic) -> Self {
-        let source_chain = diag.source_chain();
-        Self {
-            severity: diag.severity,
-            code: diag.code,
-            message: diag.message,
-            primary: diag.primary,
-            hint: diag.hint,
-            source_chain,
-        }
-    }
-}
-
-impl From<&Diagnostic> for SerializableDiagnostic {
-    fn from(diag: &Diagnostic) -> Self {
-        Self {
-            severity: diag.severity,
-            code: diag.code.clone(),
-            message: diag.message.clone(),
-            primary: diag.primary.clone(),
-            hint: diag.hint.clone(),
-            source_chain: diag.source_chain(),
-        }
     }
 }
 
@@ -528,11 +442,10 @@ mod tests {
     fn test_diagnostic_with_source_chain() {
         let root_err = std::io::Error::new(std::io::ErrorKind::NotFound, "File not found");
         let diag = Diagnostic::new(Severity::Error, "Rendering failed".to_string())
-            .with_source(Box::new(root_err));
+            .with_source(&root_err);
 
-        let chain = diag.source_chain();
-        assert_eq!(chain.len(), 1);
-        assert!(chain[0].contains("File not found"));
+        assert_eq!(diag.source_chain.len(), 1);
+        assert!(diag.source_chain[0].contains("File not found"));
     }
 
     #[test]
@@ -542,13 +455,14 @@ mod tests {
             .with_location(Location {
                 file: "test.typ".to_string(),
                 line: 10,
-                col: 5,
+                column: 5,
             });
 
-        let serializable: SerializableDiagnostic = diag.into();
-        let json = serde_json::to_string(&serializable).unwrap();
+        let json = serde_json::to_string(&diag).unwrap();
         assert!(json.contains("Test error"));
         assert!(json.contains("E001"));
+        assert!(json.contains("\"severity\":\"error\""));
+        assert!(json.contains("\"column\":5"));
     }
 
     #[test]
@@ -571,7 +485,7 @@ mod tests {
             .with_location(Location {
                 file: "input.md".to_string(),
                 line: 5,
-                col: 10,
+                column: 10,
             })
             .with_hint("Use the new field name instead".to_string());
 
@@ -588,7 +502,7 @@ mod tests {
         let root_err = std::io::Error::other("Underlying error");
         let diag = Diagnostic::new(Severity::Error, "Top-level error".to_string())
             .with_code("E002".to_string())
-            .with_source(Box::new(root_err));
+            .with_source(&root_err);
 
         let output = diag.fmt_pretty_with_source();
         assert!(output.contains("[ERROR]"));

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -441,8 +441,8 @@ mod tests {
     #[test]
     fn test_diagnostic_with_source_chain() {
         let root_err = std::io::Error::new(std::io::ErrorKind::NotFound, "File not found");
-        let diag = Diagnostic::new(Severity::Error, "Rendering failed".to_string())
-            .with_source(&root_err);
+        let diag =
+            Diagnostic::new(Severity::Error, "Rendering failed".to_string()).with_source(&root_err);
 
         assert_eq!(diag.source_chain.len(), 1);
         assert!(diag.source_chain[0].contains("File not found"));

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -49,9 +49,7 @@ pub mod backend;
 pub use backend::Backend;
 
 pub mod error;
-pub use error::{
-    Diagnostic, Location, ParseError, RenderError, RenderResult, SerializableDiagnostic, Severity,
-};
+pub use error::{Diagnostic, Location, ParseError, RenderError, RenderResult, Severity};
 
 pub mod types;
 pub use types::{Artifact, OutputFormat, RenderOptions};

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -30,20 +30,50 @@ use crate::value::QuillValue;
 /// renderable `Quill` (see `quillmark::Quill`).
 #[derive(Clone)]
 pub struct QuillSource {
-    /// Quill-specific metadata
-    pub metadata: HashMap<String, QuillValue>,
-    /// Name of the quill
-    pub name: String,
-    /// Backend identifier (e.g., "typst")
-    pub backend_id: String,
-    /// Plate template content (optional)
-    pub plate: Option<String>,
-    /// Markdown template content (optional)
-    pub example: Option<String>,
-    /// Parsed configuration — the authoritative schema model.
-    pub config: QuillConfig,
-    /// In-memory file system (tree structure)
-    pub files: FileTreeNode,
+    pub(crate) metadata: HashMap<String, QuillValue>,
+    pub(crate) name: String,
+    pub(crate) backend_id: String,
+    pub(crate) plate: Option<String>,
+    pub(crate) example: Option<String>,
+    pub(crate) config: QuillConfig,
+    pub(crate) files: FileTreeNode,
+}
+
+impl QuillSource {
+    /// The quill's declared name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The backend identifier declared in Quill.yaml (e.g. `"typst"`).
+    pub fn backend_id(&self) -> &str {
+        &self.backend_id
+    }
+
+    /// Quill-specific metadata parsed from Quill.yaml.
+    pub fn metadata(&self) -> &HashMap<String, QuillValue> {
+        &self.metadata
+    }
+
+    /// The plate template content, if the quill declares one.
+    pub fn plate(&self) -> Option<&str> {
+        self.plate.as_deref()
+    }
+
+    /// The example Markdown content, if the quill ships one.
+    pub fn example(&self) -> Option<&str> {
+        self.example.as_deref()
+    }
+
+    /// The parsed schema configuration.
+    pub fn config(&self) -> &QuillConfig {
+        &self.config
+    }
+
+    /// The in-memory file tree for this quill.
+    pub fn files(&self) -> &FileTreeNode {
+        &self.files
+    }
 }
 
 impl std::fmt::Debug for QuillSource {

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -42,10 +42,6 @@ pub struct QuillSource {
     pub example: Option<String>,
     /// Parsed configuration — the authoritative schema model.
     pub config: QuillConfig,
-    /// Cached default values extracted from config (for performance)
-    pub defaults: HashMap<String, QuillValue>,
-    /// Cached example values extracted from config (for performance)
-    pub examples: HashMap<String, Vec<QuillValue>>,
     /// In-memory file system (tree structure)
     pub files: FileTreeNode,
 }

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -137,10 +137,6 @@ impl QuillSource {
 
         config.example_markdown = example_content.clone();
 
-        // Extract and cache defaults and examples from config directly
-        let defaults = config.defaults();
-        let examples = config.examples();
-
         let source = QuillSource {
             metadata,
             name: config.name.clone(),
@@ -148,8 +144,6 @@ impl QuillSource {
             plate: plate_content,
             example: example_content,
             config,
-            defaults,
-            examples,
             files: root,
         };
 

--- a/crates/core/src/quill/query.rs
+++ b/crates/core/src/quill/query.rs
@@ -1,25 +1,9 @@
 //! QuillSource file/query convenience methods.
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-
-use crate::value::QuillValue;
 
 use super::{FileTreeNode, QuillSource};
 
 impl QuillSource {
-    /// Get default values from cached config-derived defaults.
-    ///
-    /// Returns a reference to the pre-computed defaults HashMap that was extracted
-    /// during construction.
-    pub fn extract_defaults(&self) -> &HashMap<String, QuillValue> {
-        &self.defaults
-    }
-
-    /// Get example values from cached config-derived examples.
-    pub fn extract_examples(&self) -> &HashMap<String, Vec<QuillValue>> {
-        &self.examples
-    }
-
     /// Get file contents by path (relative to quill root)
     pub fn get_file<P: AsRef<Path>>(&self, path: P) -> Option<&[u8]> {
         self.files.get_file(path)

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1147,8 +1147,8 @@ typst:
 }
 
 #[test]
-fn test_extract_defaults_method() {
-    // Test the extract_defaults method on Quill
+fn test_config_defaults() {
+    // Test defaults extraction via QuillConfig
     let mut root_files = HashMap::new();
 
     let quill_yaml = r#"
@@ -1186,7 +1186,7 @@ main:
     let quill = QuillSource::from_tree(root).unwrap();
 
     // Extract defaults
-    let defaults = quill.extract_defaults();
+    let defaults = quill.config.defaults();
 
     // Verify only fields with defaults are returned
     assert_eq!(defaults.len(), 2);

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -35,7 +35,7 @@ impl RenderSession {
     pub fn render(&self, opts: &RenderOptions) -> Result<RenderResult, RenderError> {
         let mut result = self.inner.render(opts)?;
         if let Some(warning) = &self.warning {
-            result.warnings.push(warning.clone_without_source());
+            result.warnings.push(warning.clone());
         }
         Ok(result)
     }

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -33,16 +33,14 @@
 //! # Unknown card tags
 //!
 //! Cards whose tag is not declared in the schema are **dropped** from
-//! `FormProjection.cards`. Each such card produces one [`SerializableDiagnostic`]
+//! `FormProjection.cards`. Each such card produces one [`Diagnostic`]
 //! in `FormProjection.diagnostics` with code `"form::unknown_card_tag"`.
-//!
-//! [`SerializableDiagnostic`]: quillmark_core::SerializableDiagnostic
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use quillmark_core::quill::CardSchema;
-use quillmark_core::{Diagnostic, Document, QuillValue, SerializableDiagnostic, Severity};
+use quillmark_core::{Diagnostic, Document, QuillValue, Severity};
 
 use crate::Quill;
 
@@ -89,10 +87,8 @@ pub struct FormCard {
 /// # Unknown cards
 ///
 /// Document cards whose tag is not declared in the schema are dropped and
-/// each produces a [`SerializableDiagnostic`] with code `"form::unknown_card_tag"` in
+/// each produces a [`Diagnostic`] with code `"form::unknown_card_tag"` in
 /// `diagnostics`.
-///
-/// [`SerializableDiagnostic`]: quillmark_core::SerializableDiagnostic
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FormProjection {
     /// Projection of the main document (frontmatter fields).
@@ -102,15 +98,7 @@ pub struct FormProjection {
     /// Cards with unknown tags are excluded; see `diagnostics`.
     pub cards: Vec<FormCard>,
     /// Diagnostics from unknown card tags and validation.
-    ///
-    /// Uses [`SerializableDiagnostic`] (fully serializable) rather than
-    /// [`Diagnostic`] (non-deserializable due to boxed source chain) so that
-    /// `FormProjection` can be fully round-tripped via `serde_json`,
-    /// `serde_wasm_bindgen`, and `pyo3`.
-    ///
-    /// [`SerializableDiagnostic`]: quillmark_core::SerializableDiagnostic
-    /// [`Diagnostic`]: quillmark_core::Diagnostic
-    pub diagnostics: Vec<SerializableDiagnostic>,
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 /// Project a document through a quill's schema.
@@ -128,8 +116,8 @@ pub struct FormProjection {
 ///
 /// **Unknown cards.** Each card in `doc.cards()` whose tag is not declared
 /// in the quill schema is dropped from `FormProjection.cards`. A
-/// [`SerializableDiagnostic`] with code `"form::unknown_card_tag"` is
-/// appended to `FormProjection.diagnostics` for each such card.
+/// [`Diagnostic`] with code `"form::unknown_card_tag"` is appended to
+/// `FormProjection.diagnostics` for each such card.
 ///
 /// **Validation.** `QuillConfig::validate_document` is run over the
 /// document and any resulting errors are converted to diagnostics and
@@ -148,10 +136,8 @@ pub struct FormProjection {
 /// is a lossy transformation and would change the field values visible to
 /// the form editor. Validation diagnostics already inform the consumer when
 /// values are type-mismatched.
-///
-/// [`SerializableDiagnostic`]: quillmark_core::SerializableDiagnostic
 pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
-    let mut diagnostics: Vec<SerializableDiagnostic> = Vec::new();
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
     // ── Main card projection ──────────────────────────────────────────────
     let main_schema = quill.source().config().main();
@@ -167,16 +153,17 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
                 cards.push(project_card(card_schema, card.fields()));
             }
             None => {
-                let diag = Diagnostic::new(
-                    Severity::Warning,
-                    format!(
-                        "card at index {index} has unknown tag \"{tag}\"; \
-                         it is not declared in the quill schema and has been \
-                         excluded from the form projection"
-                    ),
-                )
-                .with_code("form::unknown_card_tag".to_string());
-                diagnostics.push(SerializableDiagnostic::from(diag));
+                diagnostics.push(
+                    Diagnostic::new(
+                        Severity::Warning,
+                        format!(
+                            "card at index {index} has unknown tag \"{tag}\"; \
+                             it is not declared in the quill schema and has been \
+                             excluded from the form projection"
+                        ),
+                    )
+                    .with_code("form::unknown_card_tag".to_string()),
+                );
             }
         }
     }
@@ -184,9 +171,10 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
     // ── Validation diagnostics ────────────────────────────────────────────
     if let Err(validation_errors) = quill.source().config().validate_document(doc) {
         for err in validation_errors {
-            let diag = Diagnostic::new(Severity::Error, err.to_string())
-                .with_code("form::validation_error".to_string());
-            diagnostics.push(SerializableDiagnostic::from(diag));
+            diagnostics.push(
+                Diagnostic::new(Severity::Error, err.to_string())
+                    .with_code("form::validation_error".to_string()),
+            );
         }
     }
 

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -154,7 +154,7 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
     let mut diagnostics: Vec<SerializableDiagnostic> = Vec::new();
 
     // ── Main card projection ──────────────────────────────────────────────
-    let main_schema = quill.source().config.main();
+    let main_schema = quill.source().config().main();
     let main = project_card(main_schema, doc.frontmatter());
 
     // ── Per-card projections ──────────────────────────────────────────────
@@ -162,7 +162,7 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
 
     for (index, card) in doc.cards().iter().enumerate() {
         let tag = card.tag();
-        match quill.source().config.card_definition(tag) {
+        match quill.source().config().card_definition(tag) {
             Some(card_schema) => {
                 cards.push(project_card(card_schema, card.fields()));
             }
@@ -182,7 +182,7 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
     }
 
     // ── Validation diagnostics ────────────────────────────────────────────
-    if let Err(validation_errors) = quill.source().config.validate_document(doc) {
+    if let Err(validation_errors) = quill.source().config().validate_document(doc) {
         for err in validation_errors {
             let diag = Diagnostic::new(Severity::Error, err.to_string())
                 .with_code("form::validation_error".to_string());

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -313,7 +313,7 @@ fn project_form_over_usaf_memo_fixture() {
         .quill_from_path(quill_path)
         .expect("failed to load usaf_memo fixture");
 
-    let example_md = quill.source().example.as_deref().unwrap_or("");
+    let example_md = quill.source().example().unwrap_or("");
     // If the example can't parse, skip gracefully (it uses YAML comments that
     // are valid but the field values may not match the schema exactly).
     let doc = match Document::from_markdown(example_md) {

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -30,4 +30,4 @@ pub mod orchestration;
 pub use form::{FormCard, FormFieldSource, FormFieldValue, FormProjection};
 
 // Re-export types from orchestration module
-pub use orchestration::{Quill, QuillRef, Quillmark};
+pub use orchestration::{Quill, Quillmark};

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -6,13 +6,16 @@
 //! ## Quick Start
 //!
 //! ```no_run
-//! use quillmark::{Quillmark, OutputFormat, Document};
+//! use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
 //!
 //! let engine = Quillmark::new();
 //! let quill = engine.quill_from_path("path/to/quill").unwrap();
 //!
 //! let parsed = Document::from_markdown("---\nQUILL: my_quill\ntitle: Hello\n---\n# Hello World").unwrap();
-//! let result = quill.render(&parsed, Some(OutputFormat::Pdf)).unwrap();
+//! let result = quill.render(&parsed, &RenderOptions {
+//!     output_format: Some(OutputFormat::Pdf),
+//!     ..Default::default()
+//! }).unwrap();
 //! ```
 
 // Re-export core types for convenience. Note: `QuillSource` is not re-exported

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -22,7 +22,7 @@
 // at the crate root — Quillmark consumers work with the renderable `Quill`.
 pub use quillmark_core::{
     Artifact, Backend, Card, Diagnostic, Document, Location, OutputFormat, ParseError, ParseOutput,
-    RenderError, RenderOptions, RenderResult, RenderSession, SerializableDiagnostic, Severity,
+    RenderError, RenderOptions, RenderResult, RenderSession, Severity,
 };
 
 // Declare modules

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -11,7 +11,6 @@ use super::Quill;
 /// High-level engine for orchestrating backends and quills.
 pub struct Quillmark {
     backends: HashMap<String, Arc<dyn Backend>>,
-    warnings: Vec<Diagnostic>,
 }
 
 impl Quillmark {
@@ -19,7 +18,6 @@ impl Quillmark {
     pub fn new() -> Self {
         let mut engine = Self {
             backends: HashMap::new(),
-            warnings: Vec::new(),
         };
 
         #[cfg(feature = "typst")]
@@ -34,16 +32,6 @@ impl Quillmark {
     pub fn register_backend(&mut self, backend: Box<dyn Backend>) {
         let id = backend.id().to_string();
         self.backends.insert(id, Arc::from(backend));
-    }
-
-    /// Returns all currently accumulated non-fatal engine warnings.
-    pub fn warnings(&self) -> &[Diagnostic] {
-        &self.warnings
-    }
-
-    /// Drains and returns all currently accumulated non-fatal engine warnings.
-    pub fn take_warnings(&mut self) -> Vec<Diagnostic> {
-        std::mem::take(&mut self.warnings)
     }
 
     /// Build and return a render-ready quill from an in-memory file tree.

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -60,7 +60,7 @@ impl Quillmark {
     }
 
     fn assemble(&self, source: QuillSource) -> Result<Quill, RenderError> {
-        let backend_id = source.backend_id.as_str();
+        let backend_id = source.backend_id();
         let backend =
             self.backends
                 .get(backend_id)

--- a/crates/quillmark/src/orchestration/mod.rs
+++ b/crates/quillmark/src/orchestration/mod.rs
@@ -13,15 +13,3 @@ mod quill;
 
 pub use engine::Quillmark;
 pub use quill::Quill;
-
-/// Ergonomic reference to a [`Quill`] object.
-pub enum QuillRef<'a> {
-    /// Reference to a borrowed Quill object
-    Object(&'a Quill),
-}
-
-impl<'a> From<&'a Quill> for QuillRef<'a> {
-    fn from(quill: &'a Quill) -> Self {
-        QuillRef::Object(quill)
-    }
-}

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -52,48 +52,17 @@ impl Quill {
     }
 
     /// Render a document to final artifacts.
+    ///
+    /// Pass `&RenderOptions::default()` for backend defaults (first supported
+    /// format, backend-chosen ppi, all pages).
     pub fn render(
         &self,
         doc: &Document,
-        format: Option<OutputFormat>,
+        opts: &RenderOptions,
     ) -> Result<RenderResult, RenderError> {
-        self.render_with_options(doc, format, None)
-    }
-
-    /// Render with explicit pixels-per-inch for raster formats (PNG).
-    ///
-    /// `ppi` is ignored for vector/document formats (PDF, SVG, TXT).
-    /// When `None`, the backend's default is used.
-    pub fn render_with_options(
-        &self,
-        doc: &Document,
-        format: Option<OutputFormat>,
-        ppi: Option<f32>,
-    ) -> Result<RenderResult, RenderError> {
-        let context = self.prepare_render_context(doc)?;
-        let format = if format.is_some() {
-            format
-        } else {
-            let supported = self.backend.supported_formats();
-            if !supported.is_empty() {
-                Some(supported[0])
-            } else {
-                None
-            }
-        };
-
-        let render_opts = RenderOptions {
-            output_format: format,
-            ppi,
-            pages: None,
-        };
-
-        let warning = self.ref_mismatch_warning(doc);
-        let session =
-            self.backend
-                .open(&context.plate_content, &self.source, &context.json_data)?;
-        let session = session.with_warning(warning);
-        session.render(&render_opts)
+        let session = self.open(doc)?;
+        let resolved = self.resolve_options(opts);
+        session.render(&resolved)
     }
 
     /// Open an iterative render session for this document.
@@ -104,6 +73,20 @@ impl Quill {
             self.backend
                 .open(&context.plate_content, &self.source, &context.json_data)?;
         Ok(session.with_warning(warning))
+    }
+
+    fn resolve_options(&self, opts: &RenderOptions) -> RenderOptions {
+        let output_format = opts.output_format.or_else(|| {
+            self.backend
+                .supported_formats()
+                .first()
+                .copied()
+        });
+        RenderOptions {
+            output_format,
+            ppi: opts.ppi,
+            pages: opts.pages.clone(),
+        }
     }
 
     /// Compile a Document to JSON data suitable for the backend.

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -48,7 +48,7 @@ impl Quill {
 
     /// The quill's declared name.
     pub fn name(&self) -> &str {
-        &self.source.name
+        self.source.name()
     }
 
     /// Render a document to final artifacts.
@@ -76,12 +76,9 @@ impl Quill {
     }
 
     fn resolve_options(&self, opts: &RenderOptions) -> RenderOptions {
-        let output_format = opts.output_format.or_else(|| {
-            self.backend
-                .supported_formats()
-                .first()
-                .copied()
-        });
+        let output_format = opts
+            .output_format
+            .or_else(|| self.backend.supported_formats().first().copied());
         RenderOptions {
             output_format,
             ppi: opts.ppi,
@@ -97,7 +94,7 @@ impl Quill {
         // Coerce frontmatter fields against the schema.
         let coerced_frontmatter = self
             .source
-            .config
+            .config()
             .coerce_frontmatter(doc.frontmatter())
             .map_err(|e| RenderError::ValidationFailed {
                 diag: Box::new(
@@ -114,7 +111,7 @@ impl Quill {
         for card in doc.cards() {
             let coerced_fields = self
                 .source
-                .config
+                .config()
                 .coerce_card(card.tag(), card.fields())
                 .map_err(|e| RenderError::ValidationFailed {
                     diag: Box::new(
@@ -185,13 +182,14 @@ impl Quill {
 
     fn ref_mismatch_warning(&self, doc: &Document) -> Option<Diagnostic> {
         let doc_ref = doc.quill_reference().name.as_str();
-        if doc_ref != self.source.name {
+        if doc_ref != self.source.name() {
             Some(
                 Diagnostic::new(
                     Severity::Warning,
                     format!(
                         "document declares QUILL '{}' but was rendered with '{}'",
-                        doc_ref, self.source.name
+                        doc_ref,
+                        self.source.name()
                     ),
                 )
                 .with_code("quill::ref_mismatch".to_string())
@@ -210,7 +208,7 @@ impl Quill {
         frontmatter: &IndexMap<String, QuillValue>,
     ) -> IndexMap<String, QuillValue> {
         let mut result = frontmatter.clone();
-        for (field_name, default_value) in self.source.config.defaults() {
+        for (field_name, default_value) in self.source.config().defaults() {
             if !result.contains_key(&field_name) {
                 result.insert(field_name, default_value);
             }
@@ -224,7 +222,7 @@ impl Quill {
         fields: &IndexMap<String, QuillValue>,
     ) -> IndexMap<String, QuillValue> {
         let mut result = fields.clone();
-        if let Some(card_defaults) = self.source.config.card_defaults(card_tag) {
+        if let Some(card_defaults) = self.source.config().card_defaults(card_tag) {
             for (field_name, default_value) in card_defaults {
                 if !result.contains_key(&field_name) {
                     result.insert(field_name, default_value);
@@ -235,17 +233,17 @@ impl Quill {
     }
 
     fn plate_content(&self) -> Option<String> {
-        match &self.source.plate {
-            Some(s) if !s.is_empty() => Some(s.clone()),
-            _ => None,
-        }
+        self.source
+            .plate()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
     }
 
     /// Perform a dry-run validation without backend compilation.
     pub fn dry_run(&self, doc: &Document) -> Result<(), RenderError> {
         let coerced_frontmatter = self
             .source
-            .config
+            .config()
             .coerce_frontmatter(doc.frontmatter())
             .map_err(|e| RenderError::ValidationFailed {
                 diag: Box::new(
@@ -261,7 +259,7 @@ impl Quill {
         for card in doc.cards() {
             let coerced_fields = self
                 .source
-                .config
+                .config()
                 .coerce_card(card.tag(), card.fields())
                 .map_err(|e| RenderError::ValidationFailed {
                     diag: Box::new(
@@ -291,7 +289,7 @@ impl Quill {
     }
 
     fn validate_document(&self, doc: &Document) -> Result<(), RenderError> {
-        match self.source.config.validate_document(doc) {
+        match self.source.config().validate_document(doc) {
             Ok(_) => Ok(()),
             Err(errors) => {
                 let error_message = errors
@@ -317,7 +315,7 @@ impl Quill {
 impl std::fmt::Debug for Quill {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Quill")
-            .field("name", &self.source.name)
+            .field("name", &self.source.name())
             .field("backend", &self.backend.id())
             .finish()
     }

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -36,19 +36,9 @@ impl Quill {
         &self.source
     }
 
-    /// Shared handle to the underlying source.
-    pub fn source_arc(&self) -> Arc<QuillSource> {
-        Arc::clone(&self.source)
-    }
-
     /// The resolved backend identifier (e.g. `"typst"`).
     pub fn backend_id(&self) -> &str {
         self.backend.id()
-    }
-
-    /// A shared handle to the resolved backend.
-    pub fn backend(&self) -> Arc<dyn Backend> {
-        Arc::clone(&self.backend)
     }
 
     /// Supported output formats for this quill's backend.
@@ -59,17 +49,6 @@ impl Quill {
     /// The quill's declared name.
     pub fn name(&self) -> &str {
         &self.source.name
-    }
-
-    /// Quill reference string (`name@version`) for diagnostics.
-    pub fn quill_ref(&self) -> String {
-        let version = self
-            .source
-            .metadata
-            .get("version")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0.0.0");
-        format!("{}@{}", self.source.name, version)
     }
 
     /// Render a document to final artifacts.
@@ -326,11 +305,6 @@ impl Quill {
         );
         self.validate_document(&coerced_doc)?;
         Ok(())
-    }
-
-    /// Validate a Document against this quill's schema.
-    pub fn validate_schema(&self, doc: &Document) -> Result<(), RenderError> {
-        self.validate_document(doc)
     }
 
     fn validate_document(&self, doc: &Document) -> Result<(), RenderError> {

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -104,7 +104,13 @@ fn test_render_with_custom_backend() {
     let markdown = "---\nQUILL: custom_backend_quill\ntitle: Hello Custom Backend\n---\n\n# Test\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
     let result = quill
-        .render(&parsed, Some(OutputFormat::Txt))
+        .render(
+            &parsed,
+            &RenderOptions {
+                output_format: Some(OutputFormat::Txt),
+                ..Default::default()
+            },
+        )
         .expect("render failed");
 
     assert!(!result.artifacts.is_empty());
@@ -120,4 +126,3 @@ fn test_register_backend_after_new() {
     assert_eq!(backends.len(), initial_count + 1);
     assert!(backends.contains(&"added-later"));
 }
-

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -98,7 +98,7 @@ fn test_render_with_custom_backend() {
         .expect("quill_from_path failed");
 
     assert_eq!(quill.backend_id(), "mock-txt");
-    assert!(quill.quill_ref().starts_with("custom_backend_quill@"));
+    assert_eq!(quill.name(), "custom_backend_quill");
     assert!(quill.supported_formats().contains(&OutputFormat::Txt));
 
     let markdown = "---\nQUILL: custom_backend_quill\ntitle: Hello Custom Backend\n---\n\n# Test\n";
@@ -121,10 +121,3 @@ fn test_register_backend_after_new() {
     assert!(backends.contains(&"added-later"));
 }
 
-#[test]
-fn test_register_backend_emits_no_warnings() {
-    let mut engine = Quillmark::new();
-    engine.register_backend(Box::new(MockBackend { id: "no-warning" }));
-    assert!(engine.warnings().is_empty());
-    assert!(engine.take_warnings().is_empty());
-}

--- a/crates/quillmark/tests/common.rs
+++ b/crates/quillmark/tests/common.rs
@@ -41,10 +41,9 @@ pub fn demo(
     // Load the markdown template from the quill
     let markdown = quill
         .source()
-        .example
-        .as_ref()
+        .example()
         .ok_or("Quill does not have a markdown template")?
-        .clone();
+        .to_string();
 
     // Parse the markdown once
     let parsed = quillmark::Document::from_markdown(&markdown)?;

--- a/crates/quillmark/tests/common.rs
+++ b/crates/quillmark/tests/common.rs
@@ -50,7 +50,13 @@ pub fn demo(
     let parsed = quillmark::Document::from_markdown(&markdown)?;
 
     // render output
-    let rendered = quill.render(&parsed, Some(quillmark_core::OutputFormat::Pdf))?;
+    let rendered = quill.render(
+        &parsed,
+        &quillmark_core::RenderOptions {
+            output_format: Some(quillmark_core::OutputFormat::Pdf),
+            ..Default::default()
+        },
+    )?;
     let output_bytes = rendered.artifacts[0].bytes.clone();
 
     write_example_output(render_output, &output_bytes)?;

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -208,7 +208,7 @@ main:
     let quill = engine
         .quill_from_path(quill_path)
         .expect("quill_from_path failed");
-    let defaults = quill.source().extract_defaults();
+    let defaults = quill.source().config.defaults();
 
     assert!(defaults.contains_key("author"));
     assert_eq!(defaults.get("author").unwrap().as_str(), Some("Anonymous"));

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -208,7 +208,7 @@ main:
     let quill = engine
         .quill_from_path(quill_path)
         .expect("quill_from_path failed");
-    let defaults = quill.source().config.defaults();
+    let defaults = quill.source().config().defaults();
 
     assert!(defaults.contains_key("author"));
     assert_eq!(defaults.get("author").unwrap().as_str(), Some("Anonymous"));

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -40,7 +40,7 @@ fn test_quill_from_path_engine_metadata() {
         .quill_from_path(quill_path)
         .expect("quill_from_path failed");
 
-    assert!(quill.quill_ref().starts_with("my_test_quill@"));
+    assert_eq!(quill.name(), "my_test_quill");
     assert_eq!(quill.backend_id(), "typst");
     assert!(quill.supported_formats().contains(&OutputFormat::Pdf));
 }

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use tempfile::TempDir;
 
-use quillmark::{Document, OutputFormat, Quillmark};
+use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
 
 fn make_quill_dir(temp_dir: &TempDir, name: &str, backend: &str) -> std::path::PathBuf {
     let quill_path = temp_dir.path().join(name);
@@ -99,7 +99,13 @@ fn test_quill_render_succeeds_with_engine_loaded_quill() {
         .quill_from_path(quill_path)
         .expect("quill_from_path failed");
     let parsed = Document::from_markdown("---\nQUILL: my_quill\n---\n").expect("parse failed");
-    let result = quill.render(&parsed, Some(OutputFormat::Pdf));
+    let result = quill.render(
+        &parsed,
+        &RenderOptions {
+            output_format: Some(OutputFormat::Pdf),
+            ..Default::default()
+        },
+    );
 
     if let Err(quillmark::RenderError::EngineCreation { diag }) = &result {
         if diag.message.contains("No fonts found") {

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -13,7 +13,7 @@ Get started with Quillmark in Python or JavaScript.
     ## Basic Usage
 
     ```python
-    from quillmark import Quillmark, OutputFormat
+    from quillmark import Document, Quillmark, OutputFormat
 
     engine = Quillmark()
     quill = engine.quill_from_path("path/to/quill")
@@ -26,7 +26,8 @@ Get started with Quillmark in Python or JavaScript.
     # Hello World
     """
 
-    result = quill.render(markdown, OutputFormat.PDF)
+    doc = Document.from_markdown(markdown)
+    result = quill.render(doc, OutputFormat.PDF)
 
     with open("output.pdf", "wb") as f:
         f.write(result.artifacts[0].bytes)

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -95,6 +95,12 @@ object — you could spread it, `JSON.stringify` it, and pass the same value to
    const svg = quill.render(parsed, { format: "svg" });
    ```
 
+   The `opts` argument is optional. Omitting it uses the quill's default
+   output format (as declared in `Quill.yaml`):
+   ```js
+   const result = quill.render(parsed);  // default format
+   ```
+
    Use `quill.open(doc)` when you want a single compilation that serves
    multiple page-selective renders:
    ```js
@@ -189,11 +195,15 @@ This takes `&Document`, so the handle survives the call.
 
 ## 5. Render options — `assets` field removed
 
-`RenderOptions` shape on the wire:
+`RenderOptions` shape on the wire (all fields optional):
 
 ```ts
 { format?: "pdf"|"svg"|"png"|"txt", ppi?: number, pages?: number[] }
 ```
+
+The entire options object is optional. `quill.render(doc)` and
+`session.render()` both accept `undefined` and fall back to the quill's
+default output format.
 
 Dynamic asset injection was removed from the pipeline in this refactor.
 `RenderOptions.assets` was **deleted** from the WASM surface — it is no longer
@@ -262,7 +272,9 @@ The following are behaviorally unchanged by this refactor:
 - `quill.open(doc)` → `session.pageCount` + `session.render(opts)`.
 - `quill.backendId` getter.
 - `RenderResult` shape: `{ artifacts, warnings, outputFormat, renderTimeMs }`.
-- `Diagnostic` shape: `{ severity, code?, message, location?, hint?, sourceChain }`.
+- `Diagnostic` shape: `{ severity, code?, message, location?, hint?, sourceChain? }`.
+  `severity` is a lowercase string: `"error"`, `"warning"`, or `"note"`.
+  `sourceChain` is absent (not serialised) when empty.
 - QUILL-ref mismatch behaviour: `quill.render(doc)` with a mismatched
   `doc.quillRef` still emits a `quill::ref_mismatch` warning, not an error.
 - npm package name and import path.
@@ -276,6 +288,10 @@ This migration pass also resolved stale references to the removed APIs:
 - **`RenderOptions.assets`** — deleted from `crates/bindings/wasm/src/types.rs`.
   The TypeScript type no longer exposes it. Inject assets through the quill
   tree.
+- **`quill.renderWithOptions`** — this overload never existed on the WASM
+  surface; the Rust `render_with_options` helper it mirrored was collapsed into
+  `render`. `quill.render(doc, opts?)` is the single entry point for both
+  default and custom render options.
 - **`docs/format-designer/typst-backend.md`** — Python and JS code snippets
   rerouted from `workflow.render(parsed, …)` to `quill.render(doc, …)`.
 - **`prose/schema-rework/`** — deleted. The plan's success criteria (delete

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -86,37 +86,22 @@ object — you could spread it, `JSON.stringify` it, and pass the same value to
    and deserialize on every access. If you read them in hot loops, cache the
    value locally.
 
-**b. `quill.render(doc)` and `quill.open(doc)` *consume* the handle.**
-   Both take `Document` by value (`engine.rs:95`, `engine.rs:115`). After the
-   call, the JS reference is moved into Rust and freed; any further access on
-   the old reference throws *"null pointer passed to rust"*. In contrast,
-   `quill.projectForm(doc)` takes `&Document` and leaves the handle usable.
-
-   Old pattern that **stops working**:
+**b. `quill.render(doc)` and `quill.open(doc)` borrow the handle.**
+   Both take `&Document`, so the JS reference remains usable after the call.
+   Render the same parse as many times and as many formats as you like:
    ```js
    const parsed = Document.fromMarkdown(md);
    const pdf = quill.render(parsed, { format: "pdf" });
-   const svg = quill.render(parsed, { format: "svg" }); // ❌ throws
+   const svg = quill.render(parsed, { format: "svg" });
    ```
 
-   Workarounds (pick one):
+   Use `quill.open(doc)` when you want a single compilation that serves
+   multiple page-selective renders:
    ```js
-   // (a) Parse once per render.
-   const pdf = quill.render(Document.fromMarkdown(md), { format: "pdf" });
-   const svg = quill.render(Document.fromMarkdown(md), { format: "svg" });
-
-   // (b) Use quill.open() for multi-format / multi-page output from one parse.
-   const session = quill.open(Document.fromMarkdown(md));
-   const pdf = session.render({ format: "pdf" });
-   const svg = session.render({ format: "svg" });
-   const png = session.render({ format: "png", ppi: 300 });
-
-   // (c) Emit → re-parse if you need a separate handle for a different call.
-   const doc2 = Document.fromMarkdown(doc.toMarkdown());
+   const session = quill.open(parsed);
+   const page1 = session.render({ format: "png", pages: [0], ppi: 300 });
+   const all   = session.render({ format: "pdf" });
    ```
-
-   `quill.open(doc)` itself consumes the handle — the session owns the parse.
-   The session is also the right entrypoint for page-selective rendering.
 
 ---
 
@@ -256,15 +241,14 @@ const quill  = engine.quill(tree);
 const doc = Document.fromMarkdown(md);
 console.log(doc.frontmatter.title, doc.body);
 
-// Option A: one parse per render
-const r1 = quill.render(Document.fromMarkdown(md), { format: "pdf" });
-const r2 = quill.render(Document.fromMarkdown(md), { format: "svg" });
+// Render the same document multiple times
+const r1 = quill.render(doc, { format: "pdf" });
+const r2 = quill.render(doc, { format: "svg" });
 
-// Option B: open a session
-const session = quill.open(Document.fromMarkdown(md));
-const rA = session.render({ format: "pdf" });
-const rB = session.render({ format: "svg" });
-const rC = session.render({ format: "png", ppi: 300, pages: [0, 2] });
+// Or open a session for page-selective output
+const session = quill.open(doc);
+const rPdf = session.render({ format: "pdf" });
+const rPng = session.render({ format: "png", ppi: 300, pages: [0, 2] });
 ```
 
 ---


### PR DESCRIPTION
## Summary

This PR makes `Diagnostic` fully serializable and cloneable by replacing the non-serializable `source: Box<dyn Error>` field with an eagerly-walked `source_chain: Vec<String>`. This eliminates the need for the separate `SerializableDiagnostic` type and simplifies the error handling API across all bindings.

## Key Changes

- **Diagnostic struct refactoring:**
  - Removed `source: Option<Box<dyn std::error::Error + Send + Sync>>` field
  - Added `source_chain: Vec<String>` to store flattened error cause chains
  - Changed `primary: Option<Location>` to `location: Option<Location>` for consistency
  - Derived `Clone, PartialEq, Deserialize` directly on `Diagnostic`
  - Added `#[serde(rename_all = "camelCase")]` for JSON field naming

- **API simplification:**
  - `with_source()` now takes `&dyn Error` and eagerly walks the cause chain at construction time
  - Removed `clone_without_source()` and manual `Clone`/`PartialEq` implementations
  - Removed `source_chain()` method (now a direct field)
  - Deleted `SerializableDiagnostic` type entirely

- **Location struct:**
  - Renamed field `col` → `column` for consistency
  - Added `#[serde(rename_all = "camelCase")]`

- **QuillSource encapsulation:**
  - Made all fields `pub(crate)` and added accessor methods (`name()`, `config()`, `metadata()`, `plate()`, `example()`, `files()`)
  - Updated all call sites to use the new accessor methods

- **Quill API simplification:**
  - Removed `source_arc()` and `backend()` methods (callers use `source()` and `backend_id()`)
  - Consolidated `render()` and `render_with_options()` into a single `render(&self, doc: &Document, opts: &RenderOptions)` method
  - Removed `quill_ref()` method (callers compute it directly)

- **Bindings updates:**
  - WASM: Updated error handling to use `Diagnostic` directly instead of `SerializableDiagnostic`
  - Python: Updated to use accessor methods on `QuillSource`
  - CLI: Updated to use new `RenderOptions` API

- **Documentation:**
  - Updated WASM migration guide to reflect that `render()` now borrows the document (allowing multiple renders of the same parse)
  - Updated examples and tests throughout

## Implementation Details

The key insight is that error cause chains are walked eagerly at `Diagnostic` construction time (in `with_source()`), converting each error to a string. This makes the diagnostic trivially `Clone` and fully serializable across every binding boundary (WASM, Python, FFI), while preserving the full error context for debugging.

The `RenderOptions` struct now centralizes all rendering parameters (format, ppi, pages), replacing the previous multi-method approach and making the API more discoverable.

https://claude.ai/code/session_01UWFou4bWbYairjJqRQ7HzJ