### PR TITLE
Add tasking doc for 0.54 → 0.58 consumer feedback followups

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -50,14 +50,25 @@ jobs:
         run: |
           CURRENT="${{ steps.current.outputs.version }}"
 
+          # A `patch` rc has patch != 0 (e.g. 0.58.2-rc.*), a `minor` rc has
+          # patch == 0 (e.g. 0.59.0-rc.*). This lets us detect when the user's
+          # `bump` input conflicts with the base of the current RC.
           if [ "${{ inputs.prerelease }}" == "true" ]; then
             # cargo-release has no "minor-rc" compound bump, so we compute the
             # target version ourselves.
             if [[ "$CURRENT" == *-rc.* ]]; then
-              # Already on an RC — increment the RC number (e.g. 0.59.0-rc.1 → 0.59.0-rc.2)
               RC_NUM="${CURRENT##*-rc.}"
-              BASE_WITH_RC="${CURRENT%-rc.*}"
-              NEXT="${BASE_WITH_RC}-rc.$((RC_NUM + 1))"
+              BASE="${CURRENT%-rc.*}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+              if [ "${{ inputs.bump }}" == "minor" ] && [ "$PATCH" != "0" ]; then
+                # Escalating from a patch-rc to a new minor-rc
+                # (e.g. 0.58.2-rc.5 → 0.59.0-rc.1).
+                NEXT="${MAJOR}.$((MINOR + 1)).0-rc.1"
+              else
+                # Continuing the current RC cycle
+                # (e.g. 0.59.0-rc.1 → 0.59.0-rc.2).
+                NEXT="${BASE}-rc.$((RC_NUM + 1))"
+              fi
             else
               # Stable version — bump and start at rc.1
               IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
@@ -68,7 +79,23 @@ jobs:
               fi
             fi
           else
-            NEXT="${{ inputs.bump }}"
+            if [[ "$CURRENT" == *-rc.* ]]; then
+              # Finalizing an RC — strip the -rc.N suffix so the release tag
+              # matches the RC base (e.g. 0.58.2-rc.5 → 0.58.2).
+              BASE="${CURRENT%-rc.*}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+              if [ "${{ inputs.bump }}" == "minor" ] && [ "$PATCH" != "0" ]; then
+                echo "::error::Cannot finalize patch-rc $CURRENT with bump=minor. Re-run with bump=patch to finalize, or open a new minor rc first."
+                exit 1
+              fi
+              if [ "${{ inputs.bump }}" == "patch" ] && [ "$PATCH" == "0" ]; then
+                echo "::error::Cannot finalize minor-rc $CURRENT with bump=patch. Re-run with bump=minor to finalize, or open a new patch rc first."
+                exit 1
+              fi
+              NEXT="$BASE"
+            else
+              NEXT="${{ inputs.bump }}"
+            fi
           fi
 
           echo "Bumping workspace to: $NEXT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-cli"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-core"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "glob",
  "indexmap",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-fixtures"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "quillmark",
  "quillmark-typst",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-fuzz"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "proptest",
  "quillmark-core",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-python"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-typst"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-wasm"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 edition = "2021"
 include = ["src/**", "Cargo.toml", "README*", "LICENSE*"]
 readme = "README.md"
@@ -55,9 +55,9 @@ typst-svg = "0.14.2"
 dirs = "6.0"
 
 # Intra-project dependencies
-quillmark-core = { version = "0.58.2-rc.5", path = "crates/core" }
-quillmark-typst = { version = "0.58.2-rc.5", path = "crates/backends/typst", default-features = false }
-quillmark = { version = "0.58.2-rc.5", path = "crates/quillmark" }
+quillmark-core = { version = "0.58.2-rc.6", path = "crates/core" }
+quillmark-typst = { version = "0.58.2-rc.6", path = "crates/backends/typst", default-features = false }
+quillmark = { version = "0.58.2-rc.6", path = "crates/quillmark" }
 
 # Test and dev dependencies
 tempfile = "~3.23"

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -281,7 +281,7 @@ mod compile_helper_tests {
         root_files.insert(
             "Quill.yaml".to_string(),
             FileTreeNode::File {
-                contents: br#"Quill:
+                contents: br#"quill:
   name: "test_helper_compile"
   version: "1.0"
   backend: "typst"

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -59,7 +59,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     let quill = engine.quill_from_path(args.quill.clone())?;
 
     if args.verbose {
-        println!("Quill loaded: {}", quill.source().name);
+        println!("Quill loaded: {}", quill.source().name());
     }
 
     // Determine if we have a markdown file or need to use example content
@@ -89,12 +89,16 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             (output, Some(markdown_path.clone()))
         } else {
             // Get example content
-            let markdown = quill.source().example.clone().ok_or_else(|| {
-                CliError::InvalidArgument(format!(
-                    "Quill '{}' does not have example content",
-                    quill.source().name
-                ))
-            })?;
+            let markdown = quill
+                .source()
+                .example()
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    CliError::InvalidArgument(format!(
+                        "Quill '{}' does not have example content",
+                        quill.source().name()
+                    ))
+                })?;
 
             if args.verbose {
                 println!("Using example content from quill");

--- a/crates/bindings/cli/src/commands/schema.rs
+++ b/crates/bindings/cli/src/commands/schema.rs
@@ -31,7 +31,7 @@ pub fn execute(args: SchemaArgs) -> Result<()> {
     // Emit public schema contract as YAML
     let schema_yaml = quill
         .source()
-        .config
+        .config()
         .public_schema_yaml()
         .map_err(|e| CliError::InvalidArgument(format!("Failed to serialize schema: {}", e)))?;
 

--- a/crates/bindings/python/tests/test_project_form.py
+++ b/crates/bindings/python/tests/test_project_form.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
 # Helpers
 # ---------------------------------------------------------------------------
 
-QUILL_YAML_CONTENT = """Quill:
+QUILL_YAML_CONTENT = """quill:
   name: py_form_smoke
   version: "1.0"
   backend: typst

--- a/crates/bindings/python/tests/test_versioning.py
+++ b/crates/bindings/python/tests/test_versioning.py
@@ -18,7 +18,7 @@ def test_quill_from_path_bad_backend(tmp_path):
     quill_dir = tmp_path / "test_quill"
     quill_dir.mkdir()
     (quill_dir / "Quill.yaml").write_text(
-        'Quill:\n  name: "test"\n  version: "1.0"\n  backend: "nonexistent"\n  description: "Test"\n'
+        'quill:\n  name: "test"\n  version: "1.0"\n  backend: "nonexistent"\n  description: "Test"\n'
     )
     engine = Quillmark()
     with pytest.raises(QuillmarkError):

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -141,10 +141,16 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
     expect(typeof emitted).toBe('string')
     expect(emitted.length).toBeGreaterThan(0)
 
-    // Re-parse and assert structure survives
+    // Re-parse and assert structure survives.
+    //
+    // Note on trailing newlines: the global body is followed by a card fence,
+    // so the wire format inserts a line terminator + F2 blank line between
+    // them (`Updated body\n\n---`). On re-parse the F2 blank is stripped but
+    // the terminator stays, so `doc2.body === 'Updated body\n'`. The card
+    // body is at EOF and has no F2 separator, so it survives byte-for-byte.
     const doc2 = Document.fromMarkdown(emitted)
     expect(doc2.frontmatter.title).toBe('New Title')
-    expect(doc2.body).toBe('Updated body')
+    expect(doc2.body).toBe('Updated body\n')
     expect(doc2.cards.length).toBe(originalCardCount + 1)
     expect(doc2.cards[0].tag).toBe('note')
     expect(doc2.cards[0].fields.author).toBe('Alice')

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -558,7 +558,7 @@ describe('quill.open + session.render', () => {
 })
 
 describe('quill.metadata', () => {
-  const META_QUILL_YAML = `Quill:
+  const META_QUILL_YAML = `quill:
   name: meta_test_quill
   version: "0.2.1"
   backend: typst
@@ -641,7 +641,7 @@ describe('Document.clone', () => {
 // ---------------------------------------------------------------------------
 
 describe('quill.projectForm', () => {
-  const QUILL_YAML = `Quill:
+  const QUILL_YAML = `quill:
   name: form_smoke_test
   version: "1.0"
   backend: typst

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -189,6 +189,29 @@ describe('Quillmark.quill', () => {
     expect(quill).toBeDefined()
   })
 
+  it('should accept a plain object tree (Record<string, Uint8Array>)', () => {
+    const engine = new Quillmark()
+    const mapTree = makeQuill({ name: 'test_quill', plate: TEST_PLATE })
+    const objectTree = Object.fromEntries(mapTree)
+
+    const fromMap = engine.quill(mapTree)
+    const fromObject = engine.quill(objectTree)
+
+    expect(fromMap.backendId).toBe(fromObject.backendId)
+
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const r1 = fromMap.render(doc, { format: 'svg' })
+    const r2 = fromObject.render(doc, { format: 'svg' })
+    expect(r1.artifacts.length).toBe(r2.artifacts.length)
+  })
+
+  it('should reject non-object trees with a clear error', () => {
+    const engine = new Quillmark()
+    expect(() => engine.quill(42)).toThrow()
+    expect(() => engine.quill('string')).toThrow()
+    expect(() => engine.quill(null)).toThrow()
+  })
+
   it('should render markdown to PDF via quill.render(doc) with default opts', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
@@ -531,6 +554,82 @@ describe('quill.open + session.render', () => {
     expect(() => {
       session.render({ format: 'pdf', pages: [0] })
     }).toThrow()
+  })
+})
+
+describe('quill.metadata', () => {
+  const META_QUILL_YAML = `Quill:
+  name: meta_test_quill
+  version: "0.2.1"
+  backend: typst
+  plate_file: plate.typ
+  description: Metadata test
+
+main:
+  fields:
+    title:
+      type: string
+      description: The title
+`
+
+  it('exposes name, backend, description, version, author, supportedFormats, schema', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(
+      makeQuill({ name: 'meta_test_quill', plate: TEST_PLATE, quillYaml: META_QUILL_YAML }),
+    )
+
+    const meta = quill.metadata
+    expect(meta).toBeDefined()
+    expect(meta.name).toBe('meta_test_quill')
+    expect(meta.backend).toBe('typst')
+    expect(meta.description).toBe('Metadata test')
+    expect(meta.version).toBe('0.2.1')
+    expect(meta.author).toBe('Unknown')
+    expect(Array.isArray(meta.supportedFormats)).toBe(true)
+    expect(meta.supportedFormats.length).toBeGreaterThan(0)
+    expect(meta.schema).toBeDefined()
+    expect(meta.schema.title).toBeDefined()
+  })
+
+  it('is JSON.stringify-able (plain object, not a class)', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(
+      makeQuill({ name: 'meta_test_quill', plate: TEST_PLATE, quillYaml: META_QUILL_YAML }),
+    )
+    const json = JSON.stringify(quill.metadata)
+    expect(typeof json).toBe('string')
+    const parsed = JSON.parse(json)
+    expect(parsed.name).toBe('meta_test_quill')
+  })
+})
+
+describe('Document.clone', () => {
+  it('returns an independent handle', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const clone = doc.clone()
+
+    clone.setField('title', 'Changed')
+
+    expect(doc.frontmatter.title).toBe('Test Document')
+    expect(clone.frontmatter.title).toBe('Changed')
+  })
+
+  it('preserves parse-time warnings on the clone', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const clone = doc.clone()
+
+    expect(clone.warnings.length).toBe(doc.warnings.length)
+  })
+
+  it('produces a clone that renders equivalently to the original', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const clone = doc.clone()
+
+    const r1 = quill.render(doc, { format: 'svg' })
+    const r2 = quill.render(clone, { format: 'svg' })
+    expect(r1.artifacts.length).toBe(r2.artifacts.length)
   })
 })
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -76,7 +76,10 @@ impl Quillmark {
 
     /// Load a quill from a file tree and attach the appropriate backend.
     ///
-    /// The tree must be a `Map<string, Uint8Array>`.
+    /// Accepts either a `Map<string, Uint8Array>` or a plain object
+    /// (`Record<string, Uint8Array>`). Plain objects are walked via
+    /// `Object.entries` at the boundary; the Rust side sees a single
+    /// canonical shape.
     #[wasm_bindgen(js_name = quill)]
     pub fn quill(&self, tree: JsValue) -> Result<Quill, JsValue> {
         let root = file_tree_from_js_tree(&tree)?;
@@ -128,6 +131,94 @@ impl Quill {
     #[wasm_bindgen(getter, js_name = backendId)]
     pub fn backend_id(&self) -> String {
         self.inner.backend_id().to_string()
+    }
+
+    /// Read-only snapshot of the loaded `Quill.yaml`.
+    ///
+    /// Returns a plain JS object with `name`, `backend`, `description`,
+    /// `version`, `author`, optional `example` (content of the example
+    /// markdown, when the quill ships one), `supportedFormats` (backend's
+    /// output formats as lowercase strings), `schema` (the raw main-card
+    /// field schema as parsed from YAML — consumers that need validation
+    /// run their own validator against this), and any additional
+    /// unstructured keys declared inside the `Quill:` section.
+    ///
+    /// Equivalent by value for the lifetime of the handle; the quill is
+    /// immutable once constructed.
+    #[wasm_bindgen(getter, js_name = metadata)]
+    pub fn metadata(&self) -> JsValue {
+        let source = self.inner.source();
+        let config = source.config();
+
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "name".to_string(),
+            serde_json::Value::String(config.name.clone()),
+        );
+        obj.insert(
+            "backend".to_string(),
+            serde_json::Value::String(config.backend.clone()),
+        );
+        obj.insert(
+            "description".to_string(),
+            serde_json::Value::String(config.main().description.clone().unwrap_or_default()),
+        );
+        obj.insert(
+            "version".to_string(),
+            serde_json::Value::String(config.version.clone()),
+        );
+        obj.insert(
+            "author".to_string(),
+            serde_json::Value::String(config.author.clone()),
+        );
+        if let Some(example) = source.example() {
+            obj.insert(
+                "example".to_string(),
+                serde_json::Value::String(example.to_string()),
+            );
+        }
+
+        let formats: Vec<serde_json::Value> = self
+            .inner
+            .supported_formats()
+            .iter()
+            .map(|f| {
+                let wasm_format: crate::types::OutputFormat = (*f).into();
+                serde_json::to_value(wasm_format).unwrap_or(serde_json::Value::Null)
+            })
+            .collect();
+        obj.insert(
+            "supportedFormats".to_string(),
+            serde_json::Value::Array(formats),
+        );
+
+        let mut schema = serde_json::Map::new();
+        for (name, field) in &config.main().fields {
+            schema.insert(
+                name.clone(),
+                serde_json::to_value(field).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        obj.insert("schema".to_string(), serde_json::Value::Object(schema));
+
+        // Unstructured keys declared under `Quill:` (excluding fields already
+        // surfaced above).
+        for (key, value) in source.metadata() {
+            if matches!(
+                key.as_str(),
+                "name" | "backend" | "description" | "version" | "author"
+            ) {
+                continue;
+            }
+            if obj.contains_key(key) {
+                continue;
+            }
+            obj.insert(key.clone(), value.as_json().clone());
+        }
+
+        let val = serde_json::Value::Object(obj);
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        val.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
     /// Project a document through this quill's schema.
@@ -188,6 +279,20 @@ impl Document {
         self.inner.to_markdown()
     }
 
+    /// Return a fresh `Document` handle with the same parse state.
+    ///
+    /// Mutations on the returned handle do not affect the original and
+    /// vice versa. Parse-time warnings are snapshotted alongside the
+    /// document — they describe the original parse, not the edit
+    /// history of either handle.
+    #[wasm_bindgen(js_name = clone)]
+    pub fn clone_doc(&self) -> Document {
+        Document {
+            inner: self.inner.clone(),
+            parse_warnings: self.parse_warnings.clone(),
+        }
+    }
+
     /// The QUILL reference string (e.g. `"usaf_memo@0.1"`).
     #[wasm_bindgen(getter, js_name = quillRef)]
     pub fn quill_ref(&self) -> String {
@@ -195,6 +300,8 @@ impl Document {
     }
 
     /// Typed YAML frontmatter fields as a JS object (no QUILL, BODY, or CARDS keys).
+    ///
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = frontmatter)]
     pub fn frontmatter(&self) -> JsValue {
         let mut map = serde_json::Map::new();
@@ -218,6 +325,8 @@ impl Document {
     }
 
     /// Ordered list of card blocks as JS objects with `tag`, `fields`, and `body`.
+    ///
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = cards)]
     pub fn cards(&self) -> JsValue {
         let cards: Vec<serde_json::Value> = self
@@ -242,6 +351,8 @@ impl Document {
     }
 
     /// Non-fatal parse-time warnings as a JS array of Diagnostic objects.
+    ///
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = warnings)]
     pub fn warnings(&self) -> JsValue {
         let diags: Vec<Diagnostic> = self
@@ -499,31 +610,49 @@ fn file_tree_from_js_tree(tree: &JsValue) -> Result<quillmark_core::FileTreeNode
 }
 
 fn js_tree_entries(tree: &JsValue) -> Result<Vec<(String, JsValue)>, JsValue> {
-    if !tree.is_instance_of::<js_sys::Map>() {
-        return Err(WasmError::from("quill requires a Map<string, Uint8Array>").to_js_value());
+    if tree.is_instance_of::<js_sys::Map>() {
+        let map = tree.clone().unchecked_into::<js_sys::Map>();
+        let iter = js_sys::try_iter(&map.entries())
+            .map_err(|e| {
+                WasmError::from(format!("Failed to iterate Map entries: {:?}", e)).to_js_value()
+            })?
+            .ok_or_else(|| WasmError::from("Map entries are not iterable").to_js_value())?;
+
+        let mut entries: Vec<(String, JsValue)> = Vec::new();
+        for entry in iter {
+            let pair = entry.map_err(|e| {
+                WasmError::from(format!("Failed to read Map entry: {:?}", e)).to_js_value()
+            })?;
+            let pair = Array::from(&pair);
+            let path = pair
+                .get(0)
+                .as_string()
+                .ok_or_else(|| WasmError::from("quill Map key must be a string").to_js_value())?;
+            let value = pair.get(1);
+            entries.push((path, value));
+        }
+        return Ok(entries);
     }
 
-    let map = tree.clone().unchecked_into::<js_sys::Map>();
-    let iter = js_sys::try_iter(&map.entries())
-        .map_err(|e| {
-            WasmError::from(format!("Failed to iterate Map entries: {:?}", e)).to_js_value()
-        })?
-        .ok_or_else(|| WasmError::from("Map entries are not iterable").to_js_value())?;
-
-    let mut entries: Vec<(String, JsValue)> = Vec::new();
-    for entry in iter {
-        let pair = entry.map_err(|e| {
-            WasmError::from(format!("Failed to read Map entry: {:?}", e)).to_js_value()
-        })?;
-        let pair = Array::from(&pair);
-        let path = pair
-            .get(0)
-            .as_string()
-            .ok_or_else(|| WasmError::from("quill Map key must be a string").to_js_value())?;
-        let value = pair.get(1);
-        entries.push((path, value));
+    // Plain object: walk via `Object.entries`.
+    if tree.is_object() && !tree.is_null() {
+        let obj = tree.clone().unchecked_into::<js_sys::Object>();
+        let pairs = js_sys::Object::entries(&obj);
+        let mut entries: Vec<(String, JsValue)> = Vec::with_capacity(pairs.length() as usize);
+        for i in 0..pairs.length() {
+            let pair = Array::from(&pairs.get(i));
+            let path = pair.get(0).as_string().ok_or_else(|| {
+                WasmError::from("quill object key must be a string").to_js_value()
+            })?;
+            entries.push((path, pair.get(1)));
+        }
+        return Ok(entries);
     }
-    Ok(entries)
+
+    Err(WasmError::from(
+        "quill requires a Map<string, Uint8Array> or Record<string, Uint8Array>",
+    )
+    .to_js_value())
 }
 
 fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValue> {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -141,7 +141,7 @@ impl Quill {
     /// output formats as lowercase strings), `schema` (the raw main-card
     /// field schema as parsed from YAML — consumers that need validation
     /// run their own validator against this), and any additional
-    /// unstructured keys declared inside the `Quill:` section.
+    /// unstructured keys declared inside the `quill:` section.
     ///
     /// Equivalent by value for the lifetime of the handle; the quill is
     /// immutable once constructed.
@@ -201,7 +201,7 @@ impl Quill {
         }
         obj.insert("schema".to_string(), serde_json::Value::Object(schema));
 
-        // Unstructured keys declared under `Quill:` (excluding fields already
+        // Unstructured keys declared under `quill:` (excluding fields already
         // surfaced above).
         for (key, value) in source.metadata() {
             if matches!(

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1,11 +1,31 @@
 //! Quillmark WASM Engine - Simplified API
 
 use crate::error::WasmError;
-use crate::types::{Diagnostic, RenderOptions, RenderResult};
+use crate::types::{Card, Diagnostic, RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
+
+/// TypeScript declaration for the `pushCard` / `insertCard` input shape.
+///
+/// `tag` is required; `fields` and `body` are optional (defaulted by serde).
+/// Emitted via `typescript_custom_section` so it lands in the generated
+/// `.d.ts` without forcing consumers to import a nominal type — the
+/// `unchecked_param_type` attribute on each method references it by name.
+#[wasm_bindgen(typescript_custom_section)]
+const CARD_INPUT_TS: &'static str = r#"
+/**
+ * Input shape for `Document.pushCard` and `Document.insertCard`.
+ *
+ * Only `tag` is required. `fields` defaults to `{}`, `body` to `""`.
+ */
+export interface CardInput {
+    tag: string;
+    fields?: Record<string, unknown>;
+    body?: string;
+}
+"#;
 
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
@@ -81,7 +101,10 @@ impl Quillmark {
     /// `Object.entries` at the boundary; the Rust side sees a single
     /// canonical shape.
     #[wasm_bindgen(js_name = quill)]
-    pub fn quill(&self, tree: JsValue) -> Result<Quill, JsValue> {
+    pub fn quill(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Map<string, Uint8Array>")] tree: JsValue,
+    ) -> Result<Quill, JsValue> {
         let root = file_tree_from_js_tree(&tree)?;
         let quill = self
             .inner
@@ -302,7 +325,7 @@ impl Document {
     /// Typed YAML frontmatter fields as a JS object (no QUILL, BODY, or CARDS keys).
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = frontmatter)]
+    #[wasm_bindgen(getter, js_name = frontmatter, unchecked_return_type = "Record<string, unknown>")]
     pub fn frontmatter(&self) -> JsValue {
         let mut map = serde_json::Map::new();
         for (k, v) in self.inner.frontmatter() {
@@ -315,50 +338,37 @@ impl Document {
 
     /// Global Markdown body between frontmatter and the first card.
     ///
-    /// Trailing newlines are stripped — those are structural separators in
-    /// the Markdown wire format, not content the consumer wrote.
+    /// Returned verbatim from core — the F2 structural separator is stripped
+    /// at parse time (see `quillmark_core::document::assemble::strip_f2_separator`),
+    /// so the string here is exactly what the author wrote (or what was set
+    /// via `replaceBody`).
     ///
     /// Empty string when no body is present.
     #[wasm_bindgen(getter, js_name = body)]
     pub fn body(&self) -> String {
-        trim_body(self.inner.body())
+        self.inner.body().to_string()
     }
 
-    /// Ordered list of card blocks as JS objects with `tag`, `fields`, and `body`.
+    /// Ordered list of card blocks as typed `Card` objects.
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = cards)]
+    #[wasm_bindgen(getter, js_name = cards, unchecked_return_type = "Card[]")]
     pub fn cards(&self) -> JsValue {
-        let cards: Vec<serde_json::Value> = self
-            .inner
-            .cards()
-            .iter()
-            .map(|card| {
-                let mut fields_map = serde_json::Map::new();
-                for (k, v) in card.fields() {
-                    fields_map.insert(k.clone(), v.as_json().clone());
-                }
-                serde_json::json!({
-                    "tag": card.tag(),
-                    "fields": serde_json::Value::Object(fields_map),
-                    "body": trim_body(card.body()),
-                })
-            })
-            .collect();
-        let val = serde_json::Value::Array(cards);
+        let cards: Vec<Card> = self.inner.cards().iter().map(Card::from).collect();
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        val.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
+        cards.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
-    /// Non-fatal parse-time warnings as a JS array of Diagnostic objects.
+    /// Non-fatal parse-time warnings as an array of typed `Diagnostic` objects.
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = warnings)]
+    #[wasm_bindgen(getter, js_name = warnings, unchecked_return_type = "Diagnostic[]")]
     pub fn warnings(&self) -> JsValue {
         let diags: Vec<Diagnostic> = self
             .parse_warnings
             .iter()
-            .map(|d| d.clone().into())
+            .cloned()
+            .map(Into::into)
             .collect();
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         diags.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
@@ -436,7 +446,10 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = pushCard)]
-    pub fn push_card(&mut self, card: JsValue) -> Result<(), JsValue> {
+    pub fn push_card(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
+    ) -> Result<(), JsValue> {
         let core_card = js_value_to_card(&card)?;
         self.inner
             .push_card(core_card)
@@ -449,7 +462,11 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = insertCard)]
-    pub fn insert_card(&mut self, index: usize, card: JsValue) -> Result<(), JsValue> {
+    pub fn insert_card(
+        &mut self,
+        index: usize,
+        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
+    ) -> Result<(), JsValue> {
         let core_card = js_value_to_card(&card)?;
         self.inner
             .insert_card(index, core_card)
@@ -459,10 +476,15 @@ impl Document {
     /// Remove the card at `index` and return it, or `undefined` if out of range.
     ///
     /// Mutators never modify `warnings`.
-    #[wasm_bindgen(js_name = removeCard)]
+    #[wasm_bindgen(js_name = removeCard, unchecked_return_type = "Card | undefined")]
     pub fn remove_card(&mut self, index: usize) -> JsValue {
         match self.inner.remove_card(index) {
-            Some(card) => card_to_js_value(&card),
+            Some(core_card) => {
+                let card = Card::from(&core_card);
+                let serializer =
+                    serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+                card.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
+            }
             None => JsValue::UNDEFINED,
         }
     }
@@ -561,32 +583,6 @@ fn js_value_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
     }
     card.set_body(input.body);
     Ok(card)
-}
-
-/// Serialise a [`quillmark_core::Card`] to a JS value
-/// `{ tag: string, fields: object, body: string }`.
-fn card_to_js_value(card: &quillmark_core::Card) -> JsValue {
-    let mut fields_map = serde_json::Map::new();
-    for (k, v) in card.fields() {
-        fields_map.insert(k.clone(), v.as_json().clone());
-    }
-    let json = serde_json::json!({
-        "tag": card.tag(),
-        "fields": serde_json::Value::Object(fields_map),
-        "body": trim_body(card.body()),
-    });
-    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-    json.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
-}
-
-/// Strip trailing line terminators from a body string.
-///
-/// Parsed bodies include a trailing blank line when followed by a card fence
-/// (required by the MARKDOWN.md §3 F2 rule); those characters are structural
-/// separators, not part of what the document author wrote.
-fn trim_body(body: &str) -> String {
-    body.trim_end_matches(|c: char| c == '\n' || c == '\r')
-        .to_string()
 }
 
 fn file_tree_from_js_tree(tree: &JsValue) -> Result<quillmark_core::FileTreeNode, JsValue> {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -649,10 +649,10 @@ fn js_tree_entries(tree: &JsValue) -> Result<Vec<(String, JsValue)>, JsValue> {
         return Ok(entries);
     }
 
-    Err(WasmError::from(
-        "quill requires a Map<string, Uint8Array> or Record<string, Uint8Array>",
+    Err(
+        WasmError::from("quill requires a Map<string, Uint8Array> or Record<string, Uint8Array>")
+            .to_js_value(),
     )
-    .to_js_value())
 }
 
 fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValue> {

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -167,6 +167,20 @@ pub struct Card {
     pub body: String,
 }
 
+impl From<&quillmark_core::Card> for Card {
+    fn from(card: &quillmark_core::Card) -> Self {
+        let mut fields_map = serde_json::Map::new();
+        for (k, v) in card.fields() {
+            fields_map.insert(k.clone(), v.as_json().clone());
+        }
+        Card {
+            tag: card.tag().to_string(),
+            fields: serde_json::Value::Object(fields_map),
+            body: card.body().to_string(),
+        }
+    }
+}
+
 /// Options for rendering
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -179,7 +179,10 @@ pub struct RenderOptions {
     /// Defaults to 144.0 (2x at 72pt/inch) when omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ppi: Option<f32>,
-    /// Optional page indices to render (`undefined` means all pages).
+    /// Optional 0-based page indices to render (e.g., `[0, 2]` for the
+    /// first and third pages). `undefined` renders all pages. **Not
+    /// supported for PDF output** — passing `pages` with `format: "pdf"`
+    /// yields a `FormatNotSupported` error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pages: Option<Vec<usize>>,
 }

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -6,7 +6,7 @@ export function makeQuill({
   plate = '#import "@local/quillmark-helper:0.1.0": data\n= Test',
   quillYaml,
 } = {}) {
-  const yaml = quillYaml ?? `Quill:
+  const yaml = quillYaml ?? `quill:
   name: ${name}
   version: "${version}"
   backend: typst

--- a/crates/bindings/wasm/tests/common.rs
+++ b/crates/bindings/wasm/tests/common.rs
@@ -1,4 +1,4 @@
-use js_sys::{Map, Uint8Array};
+use js_sys::{Map, Object, Reflect, Uint8Array};
 use wasm_bindgen::JsValue;
 
 pub fn tree(entries: &[(&str, &[u8])]) -> JsValue {
@@ -9,4 +9,16 @@ pub fn tree(entries: &[(&str, &[u8])]) -> JsValue {
         map.set(&JsValue::from_str(path), &array.into());
     }
     map.into()
+}
+
+/// Build a plain-object file tree (`Record<string, Uint8Array>`).
+#[allow(dead_code)]
+pub fn tree_object(entries: &[(&str, &[u8])]) -> JsValue {
+    let obj = Object::new();
+    for (path, bytes) in entries {
+        let array = Uint8Array::new_with_length(bytes.len() as u32);
+        array.copy_from(bytes);
+        Reflect::set(&obj, &JsValue::from_str(path), &array.into()).unwrap();
+    }
+    obj.into()
 }

--- a/crates/bindings/wasm/tests/metadata.rs
+++ b/crates/bindings/wasm/tests/metadata.rs
@@ -8,7 +8,7 @@ fn test_quill_from_tree_with_ui_metadata() {
     let tree = common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: ui_test_quill\n  version: \"0.1\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for UI metadata\n\nmain:\n  fields:\n    my_field:\n      type: string\n      ui:\n        group: Personal Info\n",
+            b"quill:\n  name: ui_test_quill\n  version: \"0.1\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for UI metadata\n\nmain:\n  fields:\n    my_field:\n      type: string\n      ui:\n        group: Personal Info\n",
         ),
         ("plate.typ", b"= Title"),
     ]);

--- a/crates/bindings/wasm/tests/resolve_quill.rs
+++ b/crates/bindings/wasm/tests/resolve_quill.rs
@@ -12,7 +12,7 @@ fn test_quill_from_tree_versioned() {
     let q1 = engine.quill(common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.1.0\n",
+            b"quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.1.0\n",
         ),
         ("plate.typ", b"hello 1"),
     ])).unwrap();
@@ -20,7 +20,7 @@ fn test_quill_from_tree_versioned() {
     let q2 = engine.quill(common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.2.0\n",
+            b"quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.2.0\n",
         ),
         ("plate.typ", b"hello 2"),
     ])).unwrap();

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -133,7 +133,9 @@ fn test_quill_from_object_tree() {
     ];
 
     let engine = Quillmark::new();
-    let from_map = engine.quill(common::tree(entries)).expect("Map form failed");
+    let from_map = engine
+        .quill(common::tree(entries))
+        .expect("Map form failed");
     let from_obj = engine
         .quill(common::tree_object(entries))
         .expect("Object form failed");

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -119,3 +119,135 @@ fn test_to_markdown_round_trip() {
         "quill_ref must survive round-trip"
     );
 }
+
+/// Plain object (`Record<string, Uint8Array>`) must be accepted by
+/// `engine.quill` equivalently to `Map<string, Uint8Array>`.
+#[wasm_bindgen_test]
+fn test_quill_from_object_tree() {
+    let entries: &[(&str, &[u8])] = &[
+        (
+            "Quill.yaml",
+            b"Quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+        ),
+        ("plate.typ", b"= Title\n\nThis is a test."),
+    ];
+
+    let engine = Quillmark::new();
+    let from_map = engine.quill(common::tree(entries)).expect("Map form failed");
+    let from_obj = engine
+        .quill(common::tree_object(entries))
+        .expect("Object form failed");
+
+    assert_eq!(from_map.backend_id(), from_obj.backend_id());
+
+    // Both handles render the same document to the same artifact count/format.
+    let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let doc2 = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let r_map = from_map
+        .render(&doc, Some(RenderOptions::default()))
+        .expect("render from Map form");
+    let r_obj = from_obj
+        .render(&doc2, Some(RenderOptions::default()))
+        .expect("render from object form");
+    assert_eq!(r_map.artifacts.len(), r_obj.artifacts.len());
+}
+
+/// `quill.metadata` exposes the snapshot of `Quill.yaml` expected by
+/// downstream consumers: `name`, `backend`, `description`, `version`,
+/// `supportedFormats`, and the raw `schema`.
+#[wasm_bindgen_test]
+fn test_quill_metadata_snapshot() {
+    use js_sys::Reflect;
+    use wasm_bindgen::JsValue;
+
+    let engine = Quillmark::new();
+    let quill = engine
+        .quill(common::tree(&[
+            (
+                "Quill.yaml",
+                b"Quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n",
+            ),
+            ("plate.typ", b"= Title"),
+        ]))
+        .expect("quill failed");
+
+    let meta: JsValue = quill.metadata();
+    assert!(meta.is_object(), "metadata must be a plain JS object");
+
+    let get = |key: &str| -> JsValue { Reflect::get(&meta, &JsValue::from_str(key)).unwrap() };
+
+    assert_eq!(get("name").as_string().as_deref(), Some("meta_quill"));
+    assert_eq!(get("backend").as_string().as_deref(), Some("typst"));
+    assert_eq!(
+        get("description").as_string().as_deref(),
+        Some("Metadata quill")
+    );
+    assert_eq!(get("version").as_string().as_deref(), Some("0.2.1"));
+    // `author` defaults to "Unknown" when the YAML omits it.
+    assert_eq!(get("author").as_string().as_deref(), Some("Unknown"));
+
+    let formats = get("supportedFormats");
+    assert!(
+        js_sys::Array::is_array(&formats),
+        "supportedFormats must be an array"
+    );
+    let formats_arr = js_sys::Array::from(&formats);
+    assert!(
+        formats_arr.length() > 0,
+        "supportedFormats must be non-empty"
+    );
+
+    let schema = get("schema");
+    assert!(schema.is_object(), "schema must be an object");
+    let title_field = Reflect::get(&schema, &JsValue::from_str("title")).unwrap();
+    assert!(
+        title_field.is_object(),
+        "schema.title must be present from Quill.yaml"
+    );
+}
+
+/// `doc.clone()` returns an independent handle: mutations on the clone
+/// must not affect the original, and parse-time warnings must survive.
+#[wasm_bindgen_test]
+fn test_document_clone_independence() {
+    use js_sys::Reflect;
+    use wasm_bindgen::JsValue;
+
+    let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let mut clone = doc.clone_doc();
+
+    // Mutate the clone; the original must keep its original title.
+    clone
+        .set_field("title", JsValue::from_str("Changed"))
+        .expect("setField on clone");
+
+    let original_fm = doc.frontmatter();
+    let clone_fm = clone.frontmatter();
+
+    assert_eq!(
+        Reflect::get(&original_fm, &JsValue::from_str("title"))
+            .unwrap()
+            .as_string()
+            .as_deref(),
+        Some("Hello"),
+        "original frontmatter must be untouched after clone mutation"
+    );
+    assert_eq!(
+        Reflect::get(&clone_fm, &JsValue::from_str("title"))
+            .unwrap()
+            .as_string()
+            .as_deref(),
+        Some("Changed"),
+        "clone frontmatter must reflect the mutation"
+    );
+
+    // Warnings are a JS array on both handles. Length-equality is the
+    // observable guarantee for parse-warning preservation.
+    let orig_warns = js_sys::Array::from(&doc.warnings());
+    let clone_warns = js_sys::Array::from(&clone.warnings());
+    assert_eq!(
+        orig_warns.length(),
+        clone_warns.length(),
+        "clone must preserve parse-time warnings"
+    );
+}

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -27,8 +27,9 @@ fn test_parse_markdown_static() {
 #[wasm_bindgen_test]
 fn test_document_body_and_warnings() {
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
-    // WASM `body` getter strips trailing newlines (structural separator, not content).
-    assert_eq!(doc.body(), "\n# Hello");
+    // Body at EOF: no F2 separator to strip, so trailing content newlines are
+    // preserved verbatim. The WASM binding forwards core's body unchanged.
+    assert_eq!(doc.body(), "\n# Hello\n");
     // warnings() returns JsValue (array) — just verify it's defined
     let warnings = doc.warnings();
     assert!(!warnings.is_undefined());

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -10,7 +10,7 @@ fn small_quill_tree() -> wasm_bindgen::JsValue {
     common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+            b"quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
         ),
         ("plate.typ", b"= Title\n\nThis is a test."),
     ])
@@ -127,7 +127,7 @@ fn test_quill_from_object_tree() {
     let entries: &[(&str, &[u8])] = &[
         (
             "Quill.yaml",
-            b"Quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+            b"quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
         ),
         ("plate.typ", b"= Title\n\nThis is a test."),
     ];
@@ -167,7 +167,7 @@ fn test_quill_metadata_snapshot() {
         .quill(common::tree(&[
             (
                 "Quill.yaml",
-                b"Quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n",
+                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n",
             ),
             ("plate.typ", b"= Title"),
         ]))

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -16,6 +16,29 @@ use super::fences::{fence_opener_len, find_metadata_blocks};
 use super::sentinel::extract_sentinels;
 use super::{Card, Document};
 
+/// Strip exactly one F2 structural separator from the tail of a body slice.
+///
+/// The F2 rule (`MARKDOWN.md §3`) requires a blank line immediately above
+/// every metadata fence. When a body is followed by another fence, the raw
+/// slice ends with that blank line's terminator — exactly one `\n` or
+/// `\r\n`. This helper strips that single line ending so stored bodies
+/// contain only authored content. The emitter re-adds the separator on
+/// output via `ensure_blank_line_before_fence`.
+///
+/// Stripping more than one line ending (as the WASM binding's former
+/// `trim_body` did) would silently drop content-meaningful trailing
+/// newlines — e.g. a body that ends with a fenced code block's closing
+/// newline.
+fn strip_f2_separator(body: &str) -> &str {
+    if let Some(rest) = body.strip_suffix("\r\n") {
+        rest
+    } else if let Some(rest) = body.strip_suffix('\n') {
+        rest
+    } else {
+        body
+    }
+}
+
 /// An intermediate representation of one `---…---` metadata block.
 #[derive(Debug)]
 pub(super) struct MetadataBlock {
@@ -184,14 +207,23 @@ pub(super) fn decompose_with_warnings(
 
     // Global body: between end of frontmatter (block 0) and start of the
     // first CARD block (or EOF).
+    //
+    // When a fence follows, the body slice ends with the F2 blank-line
+    // terminator — strip it so stored bodies contain only authored content.
+    // The emitter re-derives the separator on output (see `emit.rs`'s
+    // `ensure_blank_line_before_fence`).
     let body_start = blocks[0].end;
-    let body_end = blocks
-        .iter()
-        .skip(1)
-        .find(|b| b.tag.is_some())
-        .map(|b| b.start)
-        .unwrap_or(markdown.len());
-    let global_body = markdown[body_start..body_end].to_string();
+    let first_card_block = blocks.iter().skip(1).find(|b| b.tag.is_some());
+    let (body_end, body_is_followed_by_fence) = match first_card_block {
+        Some(b) => (b.start, true),
+        None => (markdown.len(), false),
+    };
+    let global_body_raw = &markdown[body_start..body_end];
+    let global_body = if body_is_followed_by_fence {
+        strip_f2_separator(global_body_raw).to_string()
+    } else {
+        global_body_raw.to_string()
+    };
 
     // Parse tagged blocks (CARD blocks) into typed Cards.
     let mut cards: Vec<Card> = Vec::new();
@@ -216,12 +248,18 @@ pub(super) fn decompose_with_warnings(
 
             // Card body: between this block's end and the next block's start (or EOF).
             let card_body_start = block.end;
-            let card_body_end = if idx + 1 < blocks.len() {
+            let has_next_block = idx + 1 < blocks.len();
+            let card_body_end = if has_next_block {
                 blocks[idx + 1].start
             } else {
                 markdown.len()
             };
-            let card_body = markdown[card_body_start..card_body_end].to_string();
+            let card_body_raw = &markdown[card_body_start..card_body_end];
+            let card_body = if has_next_block {
+                strip_f2_separator(card_body_raw).to_string()
+            } else {
+                card_body_raw.to_string()
+            };
 
             cards.push(Card::new_internal(tag_name.clone(), card_fields, card_body));
         }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -113,11 +113,12 @@ impl Document {
 // ── Card emission ─────────────────────────────────────────────────────────────
 
 fn emit_card(out: &mut String, card: &Card) {
-    // MARKDOWN.md §3 F2 requires a blank line before each metadata fence.
-    // Parsed bodies typically already end with `\n\n`, but edited bodies
-    // (e.g. `replace_body("x")` with no trailing newline) do not — normalise
-    // here so the emitted markdown round-trips through the parser.
-    ensure_blank_line_before_fence(out);
+    // MARKDOWN.md §3 F2 requires a blank line immediately above each metadata
+    // fence. Stored bodies never contain the F2 separator (see `assemble.rs`'s
+    // `strip_f2_separator`), so we always add exactly one `\n` as the F2 blank
+    // before emitting the fence, plus a content line terminator if the body
+    // didn't end in `\n`.
+    ensure_f2_before_fence(out);
     out.push_str("---\n");
     out.push_str("CARD: ");
     out.push_str(card.tag());
@@ -135,17 +136,26 @@ fn emit_card(out: &mut String, card: &Card) {
     }
 }
 
-/// Ensures `out` ends with a blank line (`"\n\n"`) or is empty — the F2
-/// precondition for the next metadata fence marker.
-fn ensure_blank_line_before_fence(out: &mut String) {
-    if out.is_empty() || out.ends_with("\n\n") {
+/// Ensures `out` ends with a `\n\n` suffix suitable for the F2 precondition
+/// of the next metadata fence.
+///
+/// Under the F2-separator-never-stored invariant, stored bodies may end with
+/// their content (no newline), a content line terminator (`\n`), or an
+/// author-intended blank line (`\n\n`, `\n\n\n`, …). In every case we append
+/// exactly one `\n` to produce the F2 blank line. If the body doesn't already
+/// end in `\n`, we also append a line terminator first so content lines are
+/// terminated in the emitted markdown.
+///
+/// Empty `out` satisfies F2 via the "line 1" clause (MARKDOWN.md §3 F2) and
+/// needs no separator.
+fn ensure_f2_before_fence(out: &mut String) {
+    if out.is_empty() {
         return;
     }
-    if out.ends_with('\n') {
+    if !out.ends_with('\n') {
         out.push('\n');
-    } else {
-        out.push_str("\n\n");
     }
+    out.push('\n');
 }
 
 // ── YAML value emission ───────────────────────────────────────────────────────

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -135,7 +135,10 @@ Body of item 1."#;
 
     let doc = decompose(markdown).unwrap();
 
-    assert_eq!(doc.body(), "\nMain body content.\n\n");
+    // Global body is followed by a CARD fence: F2 separator stripped, so the
+    // trailing `\n\n` from the source becomes a single `\n` (content's line
+    // terminator preserved).
+    assert_eq!(doc.body(), "\nMain body content.\n");
     assert_eq!(
         doc.frontmatter().get("title").unwrap().as_str().unwrap(),
         "Main Document"
@@ -148,6 +151,7 @@ Body of item 1."#;
         card.fields().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
+    // Last card body at EOF: no F2 separator to strip.
     assert_eq!(card.body(), "\nBody of item 1.");
 }
 
@@ -221,7 +225,7 @@ Section 2 content."#;
         doc.frontmatter().get("title").unwrap().as_str().unwrap(),
         "Global"
     );
-    assert_eq!(doc.body(), "\nGlobal body.\n\n");
+    assert_eq!(doc.body(), "\nGlobal body.\n");
     assert_eq!(doc.cards().len(), 2);
     assert_eq!(doc.cards()[0].tag(), "sections");
 }
@@ -733,7 +737,7 @@ Section 1 body."#;
     );
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].tag(), "sections");
-    assert_eq!(doc.body(), "\nMain body.\n\n");
+    assert_eq!(doc.body(), "\nMain body.\n");
 }
 
 #[test]
@@ -1570,9 +1574,73 @@ fn test_body_with_leading_newlines() {
 
 #[test]
 fn test_body_with_trailing_newlines() {
+    // Body at EOF: no F2 separator to strip, source's trailing newlines
+    // are preserved verbatim as authored content.
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---\n\nBody.\n\n\n";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.body().ends_with('\n'));
+    assert_eq!(doc.body(), "\nBody.\n\n\n");
+}
+
+// ── F2 separator stripping: parse-side normalisation ─────────────────────────
+// See `assemble.rs::strip_f2_separator` and `MARKDOWN.md §3 F2`.
+
+#[test]
+fn test_f2_strip_global_body_followed_by_card_lf() {
+    // Global body followed by a CARD fence: the source's tail `\n\n` is
+    // (content line terminator) + (F2 blank line). Strip exactly the F2 `\n`,
+    // leaving `\n` as the content terminator.
+    let markdown = "---\nQUILL: q\n---\n\nbody\n\n---\nCARD: x\n---\n";
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(doc.body(), "\nbody\n");
+}
+
+#[test]
+fn test_f2_strip_global_body_followed_by_card_crlf() {
+    // CRLF line endings: strip exactly one `\r\n` as the F2 separator.
+    let markdown = "---\r\nQUILL: q\r\n---\r\n\r\nbody\r\n\r\n---\r\nCARD: x\r\n---\r\n";
+    let doc = decompose(markdown).unwrap();
+    assert!(
+        doc.body().ends_with('\n') && !doc.body().ends_with("\n\n"),
+        "expected exactly one trailing line ending, got {:?}",
+        doc.body()
+    );
+}
+
+#[test]
+fn test_f2_strip_card_body_followed_by_card() {
+    // First card body is followed by another fence → F2 stripped.
+    // Last card body is at EOF → preserved verbatim.
+    let markdown = "---\nQUILL: q\n---\n\n---\nCARD: a\n---\nfirst\n\n---\nCARD: b\n---\nsecond\n";
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(doc.cards()[0].body(), "first\n");
+    assert_eq!(doc.cards()[1].body(), "second\n");
+}
+
+#[test]
+fn test_f2_strip_preserves_author_blank_lines() {
+    // Author wrote two blank lines after the body. Only the F2 blank (last
+    // `\n`) is stripped; the author's blank line is preserved.
+    let markdown = "---\nQUILL: q\n---\n\nbody\n\n\n---\nCARD: x\n---\n";
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(doc.body(), "\nbody\n\n");
+}
+
+#[test]
+fn test_f2_strip_does_not_overstrip_content_newlines() {
+    // Content-fidelity: a body whose authored content ends with multiple
+    // newlines (e.g. a code block with trailing blank lines) must survive
+    // round-trip. The previous WASM-binding `trim_body` over-stripped this.
+    let markdown = "---\nQUILL: q\n---\n\n```\ncode\n```\n\n\n---\nCARD: x\n---\n";
+    let doc = decompose(markdown).unwrap();
+    let emitted = doc.to_markdown();
+    let reparsed = Document::from_markdown(&emitted).unwrap();
+    assert_eq!(doc.body(), reparsed.body());
+    // Author's blank line after the code block survives.
+    assert!(
+        doc.body().ends_with("```\n\n"),
+        "expected code block + blank line, got {:?}",
+        doc.body()
+    );
 }
 
 #[test]
@@ -1744,7 +1812,7 @@ Conclusion content.
             .unwrap(),
         "Introduction"
     );
-    assert_eq!(doc.cards()[0].body(), "Introduction content.\n\n");
+    assert_eq!(doc.cards()[0].body(), "Introduction content.\n");
     assert_eq!(doc.cards()[1].tag(), "section");
     assert_eq!(
         doc.cards()[1]
@@ -1807,7 +1875,9 @@ Card body here.
 
     assert_eq!(json["QUILL"], "usaf_memo");
     assert_eq!(json["title"], "Test");
-    assert_eq!(json["BODY"], "\nGlobal body.\n\n");
+    // F2 separator stripped on parse; plate `BODY` reflects the same
+    // content-only string as `Document::body()`.
+    assert_eq!(json["BODY"], "\nGlobal body.\n");
 
     let cards = json["CARDS"].as_array().unwrap();
     assert_eq!(cards.len(), 1);

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -611,20 +611,20 @@ impl QuillConfig {
         let quill_yaml_val: serde_json::Value = serde_saphyr::from_str(yaml_content)
             .map_err(|e| format!("Failed to parse Quill.yaml: {}", e))?;
 
-        // Extract [Quill] section (required)
+        // Extract [quill] section (required)
         let quill_section = quill_yaml_val
-            .get("Quill")
-            .ok_or("Missing required 'Quill' section in Quill.yaml")?;
+            .get("quill")
+            .ok_or("Missing required 'quill' section in Quill.yaml")?;
 
         // Extract required fields
         let name = quill_section
             .get("name")
             .and_then(|v| v.as_str())
-            .ok_or("Missing required 'name' field in 'Quill' section")?
+            .ok_or("Missing required 'name' field in 'quill' section")?
             .to_string();
         if !Self::is_valid_quill_name(&name) {
             return Err(format!(
-                "Invalid Quill name '{}': Quill.name must be snake_case (lowercase letters, digits, and underscores only).",
+                "Invalid Quill name '{}': quill.name must be snake_case (lowercase letters, digits, and underscores only).",
                 name
             )
             .into());
@@ -633,23 +633,23 @@ impl QuillConfig {
         let backend = quill_section
             .get("backend")
             .and_then(|v| v.as_str())
-            .ok_or("Missing required 'backend' field in 'Quill' section")?
+            .ok_or("Missing required 'backend' field in 'quill' section")?
             .to_string();
 
         let description = quill_section
             .get("description")
             .and_then(|v| v.as_str())
-            .ok_or("Missing required 'description' field in 'Quill' section")?;
+            .ok_or("Missing required 'description' field in 'quill' section")?;
 
         if description.trim().is_empty() {
-            return Err("'description' field in 'Quill' section cannot be empty".into());
+            return Err("'description' field in 'quill' section cannot be empty".into());
         }
         let description = description.to_string();
 
         // Extract optional fields (now version is required)
         let version_val = quill_section
             .get("version")
-            .ok_or("Missing required 'version' field in 'Quill' section")?;
+            .ok_or("Missing required 'version' field in 'quill' section")?;
 
         // Handle version as string or number (YAML might parse 1.0 as number)
         let version = if let Some(s) = version_val.as_str() {
@@ -692,7 +692,7 @@ impl QuillConfig {
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());
 
-        // Extract additional metadata from [Quill] section (excluding standard fields)
+        // Extract additional metadata from [quill] section (excluding standard fields)
         let mut metadata = HashMap::new();
         if let Some(table) = quill_section.as_object() {
             for (key, value) in table {

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -168,7 +168,7 @@ mod tests {
     fn emits_minimal_public_schema() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: test_schema
   version: "1.0"
   backend: typst
@@ -193,7 +193,7 @@ main:
     fn omits_cards_when_absent() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: no_cards
   version: "1.0"
   backend: typst
@@ -214,7 +214,7 @@ main:
     fn emits_integer_field_type() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: integer_schema
   version: "1.0"
   backend: typst
@@ -247,7 +247,7 @@ main:
 
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: card_schema
   version: "1.0"
   backend: typst
@@ -284,7 +284,7 @@ cards:
     fn includes_example_when_present() {
         let mut config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: with_example
   version: "1.0"
   backend: typst
@@ -307,7 +307,7 @@ main:
     fn round_trips_as_json_value() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: round_trip
   version: "1.0"
   backend: typst

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -118,7 +118,7 @@ fn test_in_memory_file_system() {
     // Create test files
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "Quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "test plate").unwrap();
@@ -161,7 +161,7 @@ fn test_quillignore_integration() {
     // Create test files
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "Quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "test template").unwrap();
@@ -188,7 +188,7 @@ fn test_find_files_pattern() {
     // Create test directory structure
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "Quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "template").unwrap();
@@ -221,7 +221,7 @@ fn test_new_standardized_yaml_format() {
 
     // Create test files using new standardized format
     let yaml_content = r#"
-Quill:
+quill:
   name: my_custom_quill
   version: "1.0"
   backend: typst
@@ -272,7 +272,7 @@ fn test_template_loading() {
     let quill_dir = temp_dir.path();
 
     // Create test files with example specified
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: "test_with_template"
   version: "1.0"
   backend: "typst"
@@ -312,7 +312,7 @@ fn test_template_smart_default() {
     let quill_dir = temp_dir.path();
 
     // Create test files without example specified
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: "test_smart_default"
   version: "1.0"
   backend: "typst"
@@ -344,7 +344,7 @@ fn test_template_optional() {
     let quill_dir = temp_dir.path();
 
     // Create test files without example specified
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: "test_without_template"
   version: "1.0"
   backend: "typst"
@@ -370,7 +370,7 @@ fn test_from_tree() {
     let mut root_files = HashMap::new();
 
     // Add Quill.yaml
-    let quill_yaml = r#"Quill:
+    let quill_yaml = r#"quill:
   name: "test_from_tree"
   version: "1.0"
   backend: "typst"
@@ -412,7 +412,7 @@ fn test_from_tree_with_template() {
     // Add Quill.yaml with example specified
     // Add Quill.yaml with example specified
     let quill_yaml = r#"
-Quill:
+quill:
   name: test_tree_template
   version: "1.0"
   backend: typst
@@ -462,7 +462,7 @@ fn test_from_tree_structure_direct() {
             "Quill.yaml".to_string(),
             FileTreeNode::File {
                 contents:
-                    b"Quill:\n  name: direct_tree\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Direct tree test\n"
+                    b"quill:\n  name: direct_tree\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Direct tree test\n"
                         .to_vec(),
             },
         );
@@ -505,7 +505,7 @@ fn test_dir_exists_and_list_apis() {
     root_files.insert(
             "Quill.yaml".to_string(),
             FileTreeNode::File {
-                contents: b"Quill:\n  name: test\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill\n"
+                contents: b"quill:\n  name: test\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill\n"
                     .to_vec(),
             },
         );
@@ -607,7 +607,7 @@ fn test_field_schemas_parsing() {
     let mut root_files = HashMap::new();
 
     // Add Quill.yaml with field schemas
-    let quill_yaml = r#"Quill:
+    let quill_yaml = r#"quill:
   name: "taro"
   version: "1.0"
   backend: "typst"
@@ -765,7 +765,7 @@ fn test_quill_without_plate_file() {
     let mut root_files = HashMap::new();
 
     // Add Quill.yaml without plate field
-    let quill_yaml = r#"Quill:
+    let quill_yaml = r#"quill:
   name: "test_no_plate"
   version: "1.0"
   backend: "typst"
@@ -792,7 +792,7 @@ fn test_quill_without_plate_file() {
 fn test_quill_config_from_yaml() {
     // Test parsing QuillConfig from YAML content
     let yaml_content = r#"
-Quill:
+quill:
   name: test_config
   version: "1.0"
   backend: typst
@@ -848,7 +848,7 @@ main:
 #[test]
 fn test_quill_config_parses_example_alias() {
     let yaml_content = r#"
-Quill:
+quill:
   name: test_example_alias
   version: "1.0"
   backend: typst
@@ -865,7 +865,7 @@ fn test_quill_from_path_rejects_example_traversal() {
     let temp_dir = TempDir::new().unwrap();
     let quill_dir = temp_dir.path();
 
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: traversal_test
   version: "1.0"
   backend: typst
@@ -887,7 +887,7 @@ fn test_quill_from_path_errors_when_explicit_example_missing() {
     let temp_dir = TempDir::new().unwrap();
     let quill_dir = temp_dir.path();
 
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: missing_example_test
   version: "1.0"
   backend: typst
@@ -908,7 +908,7 @@ fn test_quill_from_path_errors_when_explicit_example_missing() {
 fn test_quill_config_missing_required_fields() {
     // Test that missing required fields result in error
     let yaml_missing_name = r#"
-Quill:
+quill:
   backend: typst
   description: Missing name
 "#;
@@ -920,7 +920,7 @@ Quill:
         .contains("Missing required 'name'"));
 
     let yaml_missing_backend = r#"
-Quill:
+quill:
   name: test
   description: Missing backend
 "#;
@@ -932,7 +932,7 @@ Quill:
         .contains("Missing required 'backend'"));
 
     let yaml_missing_description = r#"
-Quill:
+quill:
   name: test
   version: "1.0"
   backend: typst
@@ -949,7 +949,7 @@ Quill:
 fn test_quill_config_empty_description() {
     // Test that empty description results in error
     let yaml_empty_description = r#"
-Quill:
+quill:
   name: test
   version: "1.0"
   backend: typst
@@ -960,12 +960,12 @@ Quill:
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("description' field in 'Quill' section cannot be empty"));
+        .contains("description' field in 'quill' section cannot be empty"));
 }
 
 #[test]
 fn test_quill_config_missing_quill_section() {
-    // Test that missing [Quill] section results in error
+    // Test that missing [quill] section results in error
     let yaml_no_section = r#"
 fields:
   title:
@@ -976,13 +976,13 @@ fields:
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Missing required 'Quill' section"));
+        .contains("Missing required 'quill' section"));
 }
 
 #[test]
 fn test_quill_config_rejects_root_level_fields() {
     let yaml = r#"
-Quill:
+quill:
   name: root_fields_test
   version: "1.0"
   backend: typst
@@ -1000,7 +1000,7 @@ fields:
 #[test]
 fn test_quill_config_rejects_non_snake_case_quill_name() {
     let yaml = r#"
-Quill:
+quill:
   name: BadQuill
   version: "1.0"
   backend: typst
@@ -1017,7 +1017,7 @@ Quill:
 #[test]
 fn test_quill_config_rejects_non_snake_case_card_name() {
     let yaml = r#"
-Quill:
+quill:
   name: good_quill
   version: "1.0"
   backend: typst
@@ -1040,7 +1040,7 @@ cards:
 #[test]
 fn test_quill_config_accepts_leading_underscore_card_name() {
     let yaml = r#"
-Quill:
+quill:
   name: good_quill
   version: "1.0"
   backend: typst
@@ -1060,7 +1060,7 @@ cards:
 #[test]
 fn test_quill_config_rejects_non_snake_case_main_field_keys() {
     let yaml = r#"
-Quill:
+quill:
   name: bad_field_key
   version: "1.0"
   backend: typst
@@ -1082,7 +1082,7 @@ main:
 #[test]
 fn test_quill_config_rejects_non_snake_case_card_field_keys() {
     let yaml = r#"
-Quill:
+quill:
   name: bad_card_field_key
   version: "1.0"
   backend: typst
@@ -1108,7 +1108,7 @@ fn test_quill_from_config_metadata() {
     let mut root_files = HashMap::new();
 
     let quill_yaml = r#"
-Quill:
+quill:
   name: metadata_test
   version: "1.0"
   backend: typst
@@ -1152,7 +1152,7 @@ fn test_config_defaults() {
     let mut root_files = HashMap::new();
 
     let quill_yaml = r#"
-Quill:
+quill:
   name: metadata_test_yaml
   version: "1.0"
   backend: typst
@@ -1202,7 +1202,7 @@ main:
 #[test]
 fn test_config_defaults_and_examples_methods() {
     let yaml_content = r#"
-Quill:
+quill:
   name: defaults_examples_test
   version: "1.0"
   backend: typst
@@ -1242,7 +1242,7 @@ main:
 #[test]
 fn test_card_defaults_and_examples_methods() {
     let yaml_content = r#"
-Quill:
+quill:
   name: card_defaults_examples_test
   version: "1.0"
   backend: typst
@@ -1282,7 +1282,7 @@ cards:
 #[test]
 fn test_field_order_preservation() {
     let yaml_content = r#"
-Quill:
+quill:
   name: order_test
   version: "1.0"
   backend: typst
@@ -1331,7 +1331,7 @@ main:
 #[test]
 fn test_quill_with_all_ui_properties() {
     let yaml_content = r#"
-Quill:
+quill:
   name: full_ui_test
   version: "1.0"
   backend: typst
@@ -1412,7 +1412,7 @@ description: "A simple string field"
 fn test_parse_card_with_fields_in_yaml() {
     // Test parsing [cards] section with [cards.X.fields.Y] syntax
     let yaml_content = r#"
-Quill:
+quill:
   name: cards_fields_test
   version: "1.0"
   backend: typst
@@ -1490,7 +1490,7 @@ invalid_key:
 #[test]
 fn test_quill_config_with_cards_section() {
     let yaml_content = r#"
-Quill:
+quill:
   name: cards_test
   version: "1.0"
   backend: typst
@@ -1532,7 +1532,7 @@ cards:
 fn test_quill_config_cards_empty_fields() {
     // Test that cards with no fields section are valid
     let yaml_content = r#"
-Quill:
+quill:
   name: cards_empty_fields_test
   version: "1.0"
   backend: typst
@@ -1554,7 +1554,7 @@ cards:
 fn test_quill_config_allows_card_collision() {
     // Test that scope name colliding with field name is ALLOWED
     let yaml_content = r#"
-Quill:
+quill:
   name: collision_test
   version: "1.0"
   backend: typst
@@ -1589,7 +1589,7 @@ cards:
 fn test_quill_config_ordering_with_cards() {
     // Test that fields have proper UI ordering (cards no longer have card-level ordering)
     let yaml_content = r#"
-Quill:
+quill:
   name: ordering_test
   version: "1.0"
   backend: typst
@@ -1639,7 +1639,7 @@ fn test_card_field_order_preservation() {
     // defined: z_first, then a_second
     // alphabetical: a_second, then z_first
     let yaml_content = r#"
-Quill:
+quill:
   name: card_order_test
   version: "1.0"
   backend: typst
@@ -1675,7 +1675,7 @@ cards:
 #[test]
 fn test_nested_schema_parsing() {
     let yaml_content = r#"
-Quill:
+quill:
   name: nested_test
   version: "1.0"
   backend: typst
@@ -1718,7 +1718,7 @@ main:
 #[test]
 fn test_standalone_object_field_rejected_with_warning() {
     let yaml_content = r#"
-Quill:
+quill:
   name: obj_test
   version: "1.0"
   backend: typst
@@ -1756,7 +1756,7 @@ main:
 #[test]
 fn test_nested_object_in_typed_table_rejected_with_warning() {
     let yaml_content = r#"
-Quill:
+quill:
   name: nested_obj_test
   version: "1.0"
   backend: typst
@@ -1793,7 +1793,7 @@ main:
 #[test]
 fn test_array_items_recursive_coercion() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_test
   version: "1.0"
   backend: typst
@@ -1842,7 +1842,7 @@ main:
 #[test]
 fn test_config_coerce_number_boolean_date_datetime_success() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_success_test
   version: "1.0"
   backend: typst
@@ -1895,7 +1895,7 @@ main:
 #[test]
 fn test_config_coerce_integer_success() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_integer_success_test
   version: "1.0"
   backend: typst
@@ -1921,7 +1921,7 @@ main:
 #[test]
 fn test_config_coerce_integer_rejects_decimal() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_integer_error_test
   version: "1.0"
   backend: typst
@@ -1951,7 +1951,7 @@ main:
 #[test]
 fn test_config_coerce_array_item_wise() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_array_items_test
   version: "1.0"
   backend: typst
@@ -1993,7 +1993,7 @@ main:
 #[test]
 fn test_config_coerce_cards_item_wise() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_cards_items_test
   version: "1.0"
   backend: typst
@@ -2027,7 +2027,7 @@ cards:
 #[test]
 fn test_config_coerce_error_unparseable_date() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_date_error_test
   version: "1.0"
   backend: typst
@@ -2057,7 +2057,7 @@ main:
 #[test]
 fn test_config_coerce_error_unparseable_number() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_number_error_test
   version: "1.0"
   backend: typst
@@ -2087,7 +2087,7 @@ main:
 #[test]
 fn test_multiline_ui_field_parses() {
     let yaml_content = r#"
-Quill:
+quill:
   name: multiline_test
   version: "1.0"
   backend: typst
@@ -2119,7 +2119,7 @@ main:
 #[test]
 fn test_multiline_ui_field_on_string_type() {
     let yaml_content = r#"
-Quill:
+quill:
   name: multiline_string_test
   version: "1.0"
   backend: typst
@@ -2151,7 +2151,7 @@ main:
 #[test]
 fn test_quill_config_from_yaml_collects_non_fatal_field_warnings() {
     let yaml_content = r#"
-Quill:
+quill:
   name: warning_config
   version: "1.0"
   backend: typst

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -280,7 +280,7 @@ mod tests {
     fn config_with(main_fields: &str, cards: &str) -> QuillConfig {
         let yaml = format!(
             r#"
-Quill:
+quill:
   name: native_validation
   backend: typst
   description: Native validator tests

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -31,7 +31,10 @@ pub struct RenderOptions {
     /// Ignored for vector/document formats (PDF, SVG, TXT).
     /// Defaults to 144.0 (2x at 72pt/inch) when `None`.
     pub ppi: Option<f32>,
-    /// Optional page indices to render (`None` = all pages).
+    /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
+    /// the first and third pages). `None` renders all pages. Backends
+    /// that do not support page selection (notably PDF) return a
+    /// `FormatNotSupported` error when this is `Some`.
     pub pages: Option<Vec<usize>>,
 }
 

--- a/crates/core/tests/markdown_field_test.rs
+++ b/crates/core/tests/markdown_field_test.rs
@@ -4,7 +4,7 @@ use quillmark_core::{normalize::normalize_document, quill::QuillConfig, Document
 fn test_markdown_field_public_schema_emission() {
     let config = QuillConfig::from_yaml(
         r#"
-Quill:
+quill:
   name: markdown_schema
   version: "1.0"
   backend: typst

--- a/crates/fixtures/resources/appreciated_letter/Quill.yaml
+++ b/crates/fixtures/resources/appreciated_letter/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: appreciated_letter
   version: "0.1"
   backend: typst

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: classic_resume
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: cmu_letter
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: taro
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: usaf_memo
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: usaf_memo
   version: 0.2.0
   backend: typst

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -28,7 +28,7 @@ fn quill_from_yaml(yaml: &str) -> Quill {
 fn project_form_all_fields_present() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: form_test
   version: "1.0"
   backend: typst
@@ -76,7 +76,7 @@ main:
 fn project_form_missing_field_uses_default() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: form_defaults_test
   version: "1.0"
   backend: typst
@@ -132,7 +132,7 @@ main:
 fn project_form_unknown_card_tag_drops_card_and_emits_diagnostic() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: unknown_card_test
   version: "1.0"
   backend: typst
@@ -179,7 +179,7 @@ cards:
 fn project_form_card_field_sources() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: card_fields_test
   version: "1.0"
   backend: typst
@@ -235,7 +235,7 @@ cards:
 fn project_form_validation_diagnostics_appear() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: validation_diag_test
   version: "1.0"
   backend: typst
@@ -272,7 +272,7 @@ fn project_form_serializes_cleanly() {
     // Smoke test: serde_json round-trip of FormProjection.
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: serial_test
   version: "1.0"
   backend: typst

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -89,7 +89,7 @@ fn test_render_with_custom_backend() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        "Quill:\n  name: \"custom_backend_quill\"\n  version: \"1.0\"\n  backend: \"mock-txt\"\n  plate_file: \"plate.txt\"\n  description: \"Test\"\n",
+        "quill:\n  name: \"custom_backend_quill\"\n  version: \"1.0\"\n  backend: \"mock-txt\"\n  plate_file: \"plate.txt\"\n  description: \"Test\"\n",
     ).unwrap();
     fs::write(quill_path.join("plate.txt"), "Test template: {{ title }}").unwrap();
 

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -21,7 +21,7 @@ fn test_default_values_applied_via_dry_run() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -61,7 +61,7 @@ fn test_default_values_not_overriding_existing_fields() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -99,7 +99,7 @@ fn test_validation_with_defaults() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -137,7 +137,7 @@ fn test_validation_fails_without_defaults() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -183,7 +183,7 @@ fn test_extract_defaults_from_quill() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -17,7 +17,7 @@ fn make_test_quill_path(temp_dir: &TempDir, with_required_field: bool) -> std::p
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "Quill:\n  name: \"test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n\n{}",
+            "quill:\n  name: \"test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n\n{}",
             fields_section
         ),
     ).unwrap();

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -11,7 +11,7 @@ fn make_quill_dir(temp_dir: &TempDir, name: &str, backend: &str) -> std::path::P
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "Quill:\n  name: \"{}\"\n  version: \"1.0\"\n  backend: \"{}\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
+            "quill:\n  name: \"{}\"\n  version: \"1.0\"\n  backend: \"{}\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
             name, backend
         ),
     )
@@ -68,7 +68,7 @@ fn test_quill_engine_end_to_end() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        "Quill:\n  name: \"my_test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
+        "quill:\n  name: \"my_test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
     ).unwrap();
     fs::write(
         quill_path.join("plate.typ"),

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -18,7 +18,7 @@ my-quill/
 Create a minimal but complete config:
 
 ```yaml
-Quill:
+quill:
   name: my_quill
   backend: typst
   version: "1.0.0"

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -7,7 +7,7 @@ Complete reference for authoring `Quill.yaml` configuration files. For a hands-o
 A `Quill.yaml` has these top-level sections:
 
 ```yaml
-Quill:        # Required — format metadata
+quill:        # Required — format metadata
   ...
 
 main:         # Optional — document main card: field schemas and optional ui
@@ -26,11 +26,11 @@ Root-level `fields:` is not supported; define the main document’s field schema
 
 ---
 
-## `Quill` Section
+## `quill` Section
 
-Every Quill.yaml must have a `Quill` section with format metadata.
+Every Quill.yaml must have a `quill` section with format metadata.
 
-`Quill.name` must be `snake_case` (`^[a-z][a-z0-9_]*$`).
+`quill.name` must be `snake_case` (`^[a-z][a-z0-9_]*$`).
 
 | Key              | Type   | Required | Description |
 |------------------|--------|----------|-------------|
@@ -45,7 +45,7 @@ Every Quill.yaml must have a `Quill` section with format metadata.
 | `ui`             | object | no       | Document-level UI metadata |
 
 ```yaml
-Quill:
+quill:
   name: usaf_memo
   version: "0.1"
   backend: typst
@@ -60,7 +60,7 @@ Quill:
 Controls UI behavior for the document root:
 
 ```yaml
-Quill:
+quill:
   name: metadata-only-doc
   # ...
   ui:
@@ -71,7 +71,7 @@ Quill:
 
 ## `main` Section
 
-The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `Quill.ui` is merged with `main.ui` when building the main card.
+The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
 
 Field order under `main.fields` determines display order in UIs — the first field gets `order: 0`, the second gets `order: 1`, and so on.
 
@@ -397,7 +397,7 @@ Quillmark emits a public schema YAML contract from `QuillConfig`. The output kee
 ## Complete Example
 
 ```yaml
-Quill:
+quill:
   name: project_report
   version: "1.0"
   backend: typst

--- a/docs/format-designer/typst-backend.md
+++ b/docs/format-designer/typst-backend.md
@@ -17,7 +17,7 @@ Typst is a modern typesetting system designed as a better alternative to LaTeX. 
 Specify `backend: typst` in your `Quill.yaml`:
 
 ```yaml
-Quill:
+quill:
   name: my-typst-quill
   backend: typst
   description: Document format using Typst

--- a/docs/format-designer/versioning.md
+++ b/docs/format-designer/versioning.md
@@ -7,7 +7,7 @@ Versioning helps format designers evolve Quills safely while keeping document re
 Each Quill must declare a semantic version. Both `version` and `description` are required fields:
 
 ```yaml
-Quill:
+quill:
   name: my_quill
   backend: typst
   description: A professional document format

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -50,7 +50,7 @@ Get started with Quillmark in Python or JavaScript.
     const enc = new TextEncoder();
 
     const quill = engine.quill(new Map([
-      ["Quill.yaml", enc.encode("Quill:\n  name: my_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Demo\n")],
+      ["Quill.yaml", enc.encode("quill:\n  name: my_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Demo\n")],
       ["plate.typ", enc.encode("#import \"@local/quillmark-helper:0.1.0\": data\n#data.BODY\n")],
     ]));
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -66,7 +66,7 @@ Validation rules:
 Required top-level sections: `Quill` (bundle metadata). Optional: `main` (document fields), `cards` (card type definitions), `typst` (backend config).
 
 ```yaml
-Quill:
+quill:
   name: my_quill          # required; snake_case
   backend: typst          # required
   version: "1.0.0"        # required; semver (MAJOR.MINOR.PATCH or MAJOR.MINOR)

--- a/prose/designs/VERSIONING.md
+++ b/prose/designs/VERSIONING.md
@@ -41,7 +41,7 @@ Given versions `[1.0.0, 1.0.1, 1.1.0, 2.0.0, 2.1.0, 2.1.1, 3.0.0]`:
 `version` and `description` are both required:
 
 ```yaml
-Quill:
+quill:
   name: my_format
   version: "2.1.0"
   backend: typst

--- a/prose/document-rework/01-frontmatter-comments.md
+++ b/prose/document-rework/01-frontmatter-comments.md
@@ -1,0 +1,114 @@
+# 01 — Frontmatter Comments as First-Class Items
+
+**Status:** Draft
+**Depends on:** 03 (unified Card type)
+**Blocks:** 02
+
+## Background
+
+YAML comments are stripped at parse today (`crates/core/src/document/tests/lossiness_tests.rs::yaml_comments_disappear_on_round_trip`). The frontmatter is an `IndexMap<String, QuillValue>` — key-value pairs in insertion order, nothing else. A round-trip of
+
+```markdown
+---
+QUILL: q
+# recipient's full name
+recipient: Jane
+---
+```
+
+loses the comment. Downstream editors that want to preserve author intent
+ship a second YAML parser (`parseBlocks`) to keep a comment-aware AST
+alongside our parsed values.
+
+## Change
+
+Replace the map-shaped frontmatter inside `Card` with an ordered list of
+typed items.
+
+```rust
+pub enum FrontmatterItem {
+    Field { key: String, value: QuillValue },
+    Comment(String), // text excludes the leading `#` and one optional space.
+}
+
+pub struct Frontmatter {
+    items: Vec<FrontmatterItem>,
+}
+```
+
+`Frontmatter` is the `frontmatter` field on every `Card` — main and
+composable alike, courtesy of tasking 03.
+
+`Frontmatter` provides both ordered iteration and map-keyed access
+(`get`, `contains_key`, `insert`, `remove`) so existing callers that
+treat the frontmatter as a map keep working. Internally the map-keyed
+accessors walk the item vec; field count is small enough that linear
+scan is fine.
+
+### Parser
+
+- Standalone comment lines (first non-whitespace char is `#`) between
+  the opening `---` and the closing `---` become `Comment(text)` items
+  in source order.
+- Trailing comments on value lines (`key: value  # note`) are normalized
+  to standalone `Comment` items on the next line on round-trip. This is
+  a deliberate canonical-formatting choice (opinionated layout beats two
+  code paths). The parser produces a `Field` followed by a `Comment`
+  item.
+- Comments *inside* nested values (arrays, maps) are dropped silently.
+  Emit one `comments_in_nested_yaml_dropped` warning per document the
+  first time this is encountered.
+- Banner comments above the F1 sentinel line (already tolerated by
+  MARKDOWN.md §4 F1) land in the item list in source order.
+
+### Emitter
+
+Walk `items` in order, one per line. For `Field`: emit `key: value`
+(canonical quoting). For `Comment`: emit `# <text>`. No blank-line
+inference; blank lines are not modeled.
+
+### Mutator behaviour
+
+On `Card` (per tasking 03):
+
+- `set_field(key, value)` — updates the existing `Field` entry in place;
+  or appends a new `Field` at the end if the key is absent. Adjacent
+  comments are untouched.
+- `remove_field(key)` — drops the `Field` entry. Adjacent comments stay.
+  Orphaned comments are the caller's problem; we don't infer attachment.
+
+### WASM surface
+
+On `Card`:
+
+- `Card.frontmatter` (getter) — `Record<string, unknown>`, map-keyed
+  view of values only. Comments invisible here. Covers the common case.
+- `Card.frontmatterItems` (getter) — `FrontmatterItem[]`, ordered,
+  revealing comments. For consumers that care.
+
+Both accessors are available on `doc.main` and on each element of
+`doc.cards`, uniformly.
+
+## Non-goals
+
+- Nested-value comments.
+- Blank-line preservation.
+- Trailing-comment round-trip as trailing (they become own-line).
+- Comment-editing mutators.
+- Attachment inference ("this comment belongs to this key").
+
+## Done when
+
+- Round-tripping a document with top-level comments (in main or any
+  composable card) produces output where all such comments appear as
+  own-line comments, in source order, with their original text.
+- `lossiness_tests.rs::yaml_comments_disappear_on_round_trip` is
+  rewritten to assert the opposite and passes.
+- `set_field` / `remove_field` on a commented frontmatter leave
+  comments in place (new tests).
+- `Card.frontmatterItems` is exposed in WASM; basic test in
+  `basic.test.js` covers the round-trip across main and a composable
+  card.
+- `MARKDOWN.md` §3 gains a one-paragraph note that top-level comments
+  round-trip (as own-line), trailing comments are normalized to
+  own-line, and nested comments are dropped with a warning.

--- a/prose/document-rework/02-fill-typed-marker.md
+++ b/prose/document-rework/02-fill-typed-marker.md
@@ -1,0 +1,125 @@
+# 02 — `!fill` as a Typed Marker
+
+**Status:** Draft
+**Depends on:** 01 (FrontmatterItem model), 03 (unified Card)
+**Blocks:** nothing
+
+## Background
+
+`!fill` is a YAML tag authors use to mark placeholder values in example
+documents (see `crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md`).
+Today the parser accepts the tag and drops it
+(`crates/core/src/value.rs::test_yaml_custom_tags_ignored`), so a round
+trip turns `recipient: !fill` into `recipient: ""` with no trace of the
+author's intent. Downstream wizards re-scan the source to recover fill
+markers.
+
+## Change
+
+Promote `!fill` to a first-class typed marker on fields; round-trip it
+on emit.
+
+```rust
+// Extends the FrontmatterItem::Field variant from tasking 01.
+pub enum FrontmatterItem {
+    Field {
+        key: String,
+        value: QuillValue,
+        fill: bool,
+    },
+    Comment(String),
+}
+```
+
+`fill: bool` is sufficient — a field is either fill-tagged or not. The
+value lives in `value` with its natural YAML type. No separate enum.
+
+### Parser
+
+`!fill` tags **any** scalar. The tagged scalar keeps its parsed YAML
+type:
+
+- `key: !fill "2d lt example"` → `Field { value: String("2d lt example"), fill: true }`.
+- `key: !fill 42`              → `Field { value: Integer(42),            fill: true }`.
+- `key: !fill 3.14`            → `Field { value: Float(3.14),            fill: true }`.
+- `key: !fill true`            → `Field { value: Bool(true),             fill: true }`.
+- `key: !fill`  (no value)     → `Field { value: Null,                   fill: true }`.
+
+Non-scalar `!fill` (tagged map or sequence) is rejected at parse with
+`unsupported_fill_target` — `!fill` on structured values is YAGNI until
+a use case exists.
+
+Any **other** custom tag (`!include`, `!env`, `!anything`) → reject with
+a parse warning (`unsupported_yaml_tag`) and drop the tag, keeping the
+raw scalar value.
+
+### Emitter
+
+- `Field { fill: true, value: Null, … }` → `key: !fill`.
+- `Field { fill: true, value: scalar, … }` → `key: !fill <canonical-scalar>`.
+- `Field { fill: false, … }` → unchanged canonical emission.
+
+### Data-model surface
+
+- `card.frontmatter` (the map-keyed getter from tasking 01) continues to
+  return values only. A fill-tagged null field appears as `null` there.
+- `card.frontmatterItems` exposes `fill: boolean` per item so consumers
+  drive wizard UI off the data model.
+
+### Mutators — two explicit methods on `Card`
+
+```rust
+impl Card {
+    /// Set a field's value. Always clears the fill marker.
+    /// This is the "user filled this in" path.
+    pub fn set_field<V: Into<QuillValue>>(&mut self, key: &str, value: V);
+
+    /// Set a field's value AND mark it as fill.
+    /// This is the "reset to placeholder" path. `Null` value = `key: !fill`.
+    pub fn set_fill<V: Into<QuillValue>>(&mut self, key: &str, value: V);
+}
+```
+
+Two methods, two intents. The common wizard flow ("user typed something,
+clear the placeholder") is the default `set_field`; the rarer reset is
+the explicit `set_fill`. No options struct, no boolean parameter to
+forget in JS.
+
+`Document` has no top-level shortcut — callers write
+`doc.main_mut().set_field(…)` per tasking 03.
+
+### WASM surface
+
+- `FrontmatterItem` TS type gains `fill: boolean`.
+- `Card.setField(key, value)` — clears fill.
+- `Card.setFill(key, value)` — sets fill=true with the given value.
+- `frontmatter` record getter unchanged.
+
+## Validation
+
+Required-field-is-filled validation is **out of scope** for this tasking.
+A `!fill` on a required field will not error at parse or at `projectForm`
+time here. Follow-on tasking may gate render on it.
+
+## Non-goals
+
+- Generic custom-tag preservation (`!include`, etc.). Rejected with a
+  warning.
+- `!fill` on maps / sequences. Rejected with a warning.
+- Render-time enforcement of fill state.
+- Document-level mutator shortcuts.
+
+## Done when
+
+- `!fill` round-trips through `fromMarkdown → toMarkdown` for all scalar
+  types (string, int, float, bool, null), on main and on composable
+  cards.
+- `lossiness_tests.rs::custom_tags_lose_tag_but_keep_value` is rewritten
+  to assert preservation for `!fill` and rejection-with-warning for
+  other tags.
+- `cmu_letter` example markdown round-trips byte-identically (modulo
+  canonical quoting normalization from unrelated fields).
+- `frontmatterItems` exposes `fill: boolean`; a WASM test exercises
+  `setField` clearing fill and `setFill` setting it.
+- `MARKDOWN.md` gains a short section documenting `!fill` as the one
+  supported custom tag.

--- a/prose/document-rework/03-unify-cards.md
+++ b/prose/document-rework/03-unify-cards.md
@@ -1,0 +1,143 @@
+# 03 — Unify Entry and Composable Cards
+
+**Status:** Draft
+**Depends on:** nothing
+**Blocks:** 01, 02 (they operate on Card's frontmatter)
+**Recommended implementation order:** land first.
+
+## Background
+
+MARKDOWN.md §2 defines every Quillmark document as a sequence of
+(sentinel, frontmatter, body) triples:
+
+```
+Document = Frontmatter Body (CardFence CardBody)*
+```
+
+The first triple is the entry — its sentinel is `QUILL:` and it carries
+the document-level fields plus the global body. Subsequent triples are
+composable cards — their sentinel is `CARD:` and each carries a typed
+record.
+
+The data model today splits these: `Document { frontmatter, body, … }`
+plus a separate `Vec<Card>`. The split is historical; grammatically,
+all three regions are the same shape. Unifying them collapses the
+parser, emitter, and mutator surface, and matches how `Quill.yaml`
+already describes the model (a `main:` section alongside `cards:`
+entries).
+
+## Change
+
+One `Card` type for all fences. `Document` holds one `main` plus a
+`Vec<Card>` of composable cards.
+
+```rust
+pub struct Card {
+    sentinel: Sentinel,
+    frontmatter: Frontmatter,  // shape per tasking 01
+    body: String,
+}
+
+pub enum Sentinel {
+    Main(QuillReference),
+    Card(String),
+}
+
+pub struct Document {
+    main: Card,
+    cards: Vec<Card>,
+    // Invariants, enforced via private fields + smart constructors:
+    //   main.sentinel matches Sentinel::Main(_)
+    //   every card in cards matches Sentinel::Card(_)
+}
+```
+
+### Parser
+
+- First fence: sentinel `QUILL:` → `Sentinel::Main(ref)`; build a `Card`
+  with the global body between the fence and the first card fence (or
+  EOF). Store as `Document.main`.
+- Subsequent fences: sentinel `CARD:` → `Sentinel::Card(tag)`; build a
+  `Card`; push onto `Document.cards`.
+- One code path for "parse a fence"; sentinel kind is determined by
+  position.
+
+### Emitter
+
+Walk `once(&main).chain(&cards)`. Emit each card's fence + body
+uniformly; `sentinel` drives the first content line (`QUILL: …` or
+`CARD: …`). No separate "emit document body" path.
+
+### Mutators
+
+Frontmatter and body mutators live on `Card`:
+
+```rust
+impl Card {
+    pub fn set_field(&mut self, key: &str, value: impl Into<QuillValue>);
+    pub fn remove_field(&mut self, key: &str);
+    pub fn replace_body(&mut self, body: impl Into<String>);
+    // …plus set_fill from tasking 02.
+}
+```
+
+`Document` keeps only document-level concerns:
+
+```rust
+impl Document {
+    pub fn main(&self) -> &Card;
+    pub fn main_mut(&mut self) -> &mut Card;
+    pub fn cards(&self) -> &[Card];
+    pub fn cards_mut(&mut self) -> &mut [Card];
+
+    pub fn push_card(&mut self, tag: impl Into<String>, …);
+    pub fn insert_card(&mut self, idx: usize, …);
+    pub fn remove_card(&mut self, idx: usize) -> Option<Card>;
+    pub fn move_card(&mut self, from: usize, to: usize);
+
+    pub fn quill_reference(&self) -> &QuillReference; // reads main.sentinel
+    pub fn set_quill_ref(&mut self, r: QuillReference);
+}
+```
+
+No top-level shortcuts for frontmatter / body mutators. Callers write
+`doc.main_mut().set_field(…)` explicitly. KISS: one place for each
+operation; no parallel APIs to keep in sync.
+
+### WASM surface
+
+- `Document.main` (getter) → `Card` handle.
+- `Document.cards` (getter) → `Card[]`.
+- `Document.quillRef` unchanged — convenience reader over
+  `doc.main.sentinel`.
+- `Document.frontmatter`, `Document.body`, `Document.frontmatterItems`,
+  `Document.setField`, `Document.setFill`, `Document.replaceBody`, etc.
+  are **removed**. Consumers migrate to `doc.main.frontmatter`,
+  `doc.main.body`, `doc.main.setField`, etc.
+- `Card` gains the full mutator surface (`setField`, `setFill`,
+  `removeField`, `replaceBody`) plus the read accessors (`frontmatter`,
+  `frontmatterItems`, `body`).
+- `Card.tag` exposes the string tag for composable cards. For main
+  cards, it returns the quill reference's string form (or callers can
+  read `doc.quillRef` directly).
+
+## Non-goals
+
+- Document-level shortcuts for card operations. The rework is a
+  breaking change; don't also ship a parallel API we'd need to keep
+  in sync forever.
+- Changes to `QuillReference` typing or parsing. Structure only.
+- A third sentinel kind. Two is sufficient for the grammar.
+
+## Done when
+
+- `Document::main()` returns a `Card` whose sentinel matches
+  `Sentinel::Main(_)`.
+- `once(&doc.main()).chain(doc.cards())` covers every fence in the
+  source.
+- One emit code path serves both main and composable cards.
+- Frontmatter / body mutators live on `Card`, not on `Document`.
+- Existing tests migrate to the new access pattern; no
+  `Document::frontmatter` / `Document::body` callers remain.
+- `WASM_MIGRATION.md` gains a section describing the access-pattern
+  change.

--- a/prose/document-rework/README.md
+++ b/prose/document-rework/README.md
@@ -1,0 +1,60 @@
+# Document Rework
+
+**Umbrella goal:** make markdown the single contract between quillmark and
+its consumers. `Document.fromMarkdown → Document.toMarkdown` must be
+faithful enough that consumers never need to reparse source or splice
+bytes to preserve author intent.
+
+Today `Document.to_markdown()` is a canonical emitter that drops YAML
+comments and custom tags, which forces downstream consumers (registry
+editors, wizards) to ship their own comment-preserving YAML AST and
+byte-range splicers. The rework closes that gap inside quillmark so
+consumers can delete that code.
+
+## Taskings
+
+1. [03-unify-cards.md](03-unify-cards.md) — one `Card` type for both
+   the document entry (QUILL sentinel) and composable cards (CARD
+   sentinel). `Document { main: Card, cards: Vec<Card> }`.
+2. [01-frontmatter-comments.md](01-frontmatter-comments.md) — preserve
+   YAML comments in `Card.frontmatter` as first-class ordered items.
+3. [02-fill-typed-marker.md](02-fill-typed-marker.md) — promote `!fill`
+   to a typed marker on `Field`. Reject other custom tags.
+
+**Implementation order:** 03 → 01 → 02. Numeric prefixes reflect the
+order decisions were made, not the order to implement. 03 restructures
+the data model; 01 rebuilds the frontmatter representation on the
+unified model; 02 layers `!fill` semantics onto the item model from 01.
+
+## Explicit non-goals
+
+- **No byte offsets in the public API.** Considered and rejected. Markdown
+  is the serialization contract; exposing source locations would introduce
+  a second contract and undo the offload.
+- **No source-preserving mode.** Canonical emission stays canonical. The
+  items above make canonical *faithful* for the parts consumers care
+  about (comments, `!fill`); string quoting, flow vs block style, and
+  similar formatting are normalized by design.
+- **No general custom-tag round-trip.** Only `!fill` is integrated. Other
+  tags are rejected at parse with a warning.
+- **No comments inside nested YAML values.** Only top-level comments
+  round-trip. Nested comments are dropped silently; a parse warning is
+  emitted on the first occurrence per document.
+- **No markdown body AST, and no content-level transformations of the
+  body.** The body stays an opaque string between the frontmatter and
+  the first card fence. We do not walk its markdown structure, and we
+  do not ship utilities (comment strippers, link rewriters, etc.) that
+  would imply partial parsing. Downstream editors own their body
+  pipeline; when we commit to a markdown AST it will be a separate
+  design, not something smuggled in through helpers.
+- **No bare-YAML parse entry point.** Every Quillmark markdown document
+  carries `QUILL`; there is no supported authoring format that lacks
+  it. Consumers with a full document call `Document.fromMarkdown`;
+  consumers with something that isn't a Quillmark document should use a
+  general YAML library, not us. Speculative fragment-parse use cases
+  are YAGNI until a concrete consumer need is named.
+- **No document-level shortcuts for card mutators.** After 03,
+  frontmatter and body mutations live on `Card`. `Document.setField`
+  and friends are removed; callers write `doc.main_mut().set_field(…)`
+  (or hold a `&mut Card` reference). One surface, no parallel API to
+  keep in sync.

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -263,12 +263,51 @@ const rPng = session.render({ format: "png", ppi: 300, pages: [0, 2] });
 
 ---
 
+## Parse-time requirements that bite silently
+
+These are intentional behaviors but surface as errors consumers did not see in
+0.54. Listed here so migrators do not re-discover them from stack traces.
+
+### `Document.fromMarkdown` now requires `QUILL:` in frontmatter
+
+A top-level `QUILL: <name>` is a **parse-time** requirement on every input
+document. In 0.54, missing-QUILL surfaced at render time; in 0.58+ it fails
+inside `Document.fromMarkdown` with an `InvalidStructure` diagnostic whose
+message is `Missing required QUILL field. Add `QUILL: <name>` to the
+frontmatter`.
+
+Fix: add `QUILL: <name>` to the frontmatter of every document you parse. Test
+fixtures in particular rot silently — a fixture that used to render will now
+throw on parse.
+
+### `Quill.yaml` requires a nested `Quill:` section
+
+Flat top-level keys (`name:`, `backend:`, `description:` at the root) are not
+supported and will not be. Every field lives under the top-level `Quill:`
+mapping:
+
+```yaml
+Quill:
+  name: my_quill           # required, snake_case
+  backend: typst           # required
+  description: My quill    # required, non-empty
+  version: 0.1.0           # required, semver
+  author: Alice            # optional, defaults to "Unknown"
+```
+
+`name`, `backend`, `description`, and `version` are all required — only
+`author` has a default (`"Unknown"`). See
+`crates/core/src/quill/config.rs:615-672` for the full parse.
+
+---
+
 ## Unchanged
 
 The following are behaviorally unchanged by this refactor:
 
 - `new Quillmark()` constructor.
-- `engine.quill(tree)` where `tree` is `Map<string, Uint8Array>`.
+- `engine.quill(tree)` where `tree` is `Map<string, Uint8Array>` or
+  `Record<string, Uint8Array>` (plain object — normalized at the boundary).
 - `quill.open(doc)` → `session.pageCount` + `session.render(opts)`.
 - `quill.backendId` getter.
 - `RenderResult` shape: `{ artifacts, warnings, outputFormat, renderTimeMs }`.

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -280,14 +280,14 @@ Fix: add `QUILL: <name>` to the frontmatter of every document you parse. Test
 fixtures in particular rot silently — a fixture that used to render will now
 throw on parse.
 
-### `Quill.yaml` requires a nested `Quill:` section
+### `Quill.yaml` requires a nested `quill:` section
 
 Flat top-level keys (`name:`, `backend:`, `description:` at the root) are not
-supported and will not be. Every field lives under the top-level `Quill:`
-mapping:
+supported and will not be. Every field lives under the top-level `quill:`
+mapping (lowercase — previously capitalized `Quill:`, see note below):
 
 ```yaml
-Quill:
+quill:
   name: my_quill           # required, snake_case
   backend: typst           # required
   description: My quill    # required, non-empty
@@ -298,6 +298,11 @@ Quill:
 `name`, `backend`, `description`, and `version` are all required — only
 `author` has a default (`"Unknown"`). See
 `crates/core/src/quill/config.rs:615-672` for the full parse.
+
+> **Key name is `quill:` (lowercase).** Pre-0.58 drafts used `Quill:` with a
+> capital Q to match the filename; the published 0.58 line uses lowercase
+> `quill:` for YAML-idiom consistency. Capitalized `Quill:` is not accepted —
+> rename the section key in each `Quill.yaml` on migration.
 
 ---
 

--- a/prose/taskings/consumer_feedback_followups.md
+++ b/prose/taskings/consumer_feedback_followups.md
@@ -39,7 +39,7 @@ readonly metadata: {
   example?: string;          // example_file contents (if present)
   supportedFormats: string[];
   schema: unknown;           // raw schema from Quill.yaml; consumer validates
-  // ...other unstructured metadata from the Quill: section
+  // ...other unstructured metadata from the quill: section
 };
 ```
 
@@ -90,7 +90,7 @@ No memoization, no `toJSON()`. Deferred until more consumers hit this.
 The following are intentional behaviors being called out by consumers. No code change; add to the migration guide.
 
 - **`Document.fromMarkdown` now requires `QUILL:` in frontmatter.** Parse-time failure, not render-time. Fix: add `QUILL: <name>` to frontmatter. Note the shift from render-time to parse-time explicitly (test fixtures rot silently).
-- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-672`.
+- **`Quill.yaml` requires a nested `quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-672`.
 
 ## Out of scope
 

--- a/prose/taskings/consumer_feedback_followups.md
+++ b/prose/taskings/consumer_feedback_followups.md
@@ -1,0 +1,128 @@
+# Quillmark WASM: Downstream Consumer Feedback Followups
+
+**Audience:** Quillmark WASM binding maintainer
+**Source:** Consumer feedback from a 0.54 → 0.58 migration (registry-side)
+
+## Background
+
+A downstream consumer migrating from 0.54 to 0.58 surfaced a set of friction points in the WASM binding. Most are narrow fixes (doc comments, small API additions). Two are deliberate behaviors we will keep but document more clearly. One (the `init()` footgun) is inherent to `wasm-bindgen --target web` and needs a JS-side mitigation.
+
+Tasks are ordered by consumer impact × implementation cost. Items marked **docs-only** need no code changes beyond comments and the migration guide.
+
+## Tasks
+
+### 1. Accept `Record<string, Uint8Array>` in `engine.quill(tree)`
+
+Today `engine.quill()` rejects plain objects with `quill requires a Map<string, Uint8Array>`. The README advertises both shapes. Every consumer whose source of truth is a `Record` (most of them) has to write `new Map(Object.entries(files))` at the call site.
+
+**Change:** at the NAPI/WASM boundary in `crates/bindings/wasm/src/engine.rs`, normalize the input:
+
+```
+input instanceof Map ? input : new Map(Object.entries(input))
+```
+
+Update the TS signature to `Map<string, Uint8Array> | Record<string, Uint8Array>`. The Rust side keeps taking a single canonical shape — normalization stays at the boundary.
+
+### 2. Expose `Quill.metadata` (read-only snapshot of Quill.yaml)
+
+Consumers that used `engine.resolveQuill(name).example` / `.supportedFormats` in 0.54 have no replacement. They are re-parsing `Quill.yaml` with regexes to recover the data the engine already owns.
+
+**Change:** add a `metadata` getter on the `Quill` handle returning a plain JS object projection of the loaded `Quill.yaml`:
+
+```ts
+readonly metadata: {
+  name: string;
+  backend: string;
+  description: string;
+  version: string;
+  author: string;
+  example?: string;          // example_file contents (if present)
+  supportedFormats: string[];
+  schema: unknown;           // raw schema from Quill.yaml; consumer validates
+  // ...other unstructured metadata from the Quill: section
+};
+```
+
+Snapshot at `Quill` construction time, not live. One marshalling hop.
+
+The `schema` field ships raw (as parsed from YAML). The engine deliberately no longer owns schema validation in WASM; consumers that need it run their own validator against `metadata.schema`. This is consistent with the "schema APIs are no longer engine-level in WASM" note and gives consumers a supported path forward instead of regex-parsing the bytes themselves.
+
+### 3. Add `Document.clone()`
+
+`Document` has ~10 in-place mutators (`set_field`, `remove_field`, `push_card`, `insert_card`, `remove_card`, `move_card`, `update_card_field`, `update_card_body`, `replace_body`, `set_quill_ref` at `crates/bindings/wasm/src/engine.rs:266-408`). Once a consumer mutates, they cannot cheaply recover the pristine parse without holding the original markdown and re-calling `Document.fromMarkdown`.
+
+**Change:** add a `clone()` method on `Document`:
+
+```rust
+#[wasm_bindgen(js_name = clone)]
+pub fn clone_doc(&self) -> Document {
+    Document {
+        inner: self.inner.clone(),
+        parse_warnings: self.parse_warnings.clone(),
+    }
+}
+```
+
+Doc comment must state explicitly: parse-time warnings are snapshotted (they describe the document, not the edit history).
+
+### 4. Ship a JS shim that lazy-inits the WASM module
+
+Forgetting `await init()` still produces cryptic panics deep inside the wasm module. This is inherent to `wasm-bindgen --target web` and cannot be fixed on the Rust side.
+
+**Change:** ship a thin JS wrapper around the generated bindings. The wrapper exports lazy-initialized proxies for `Quillmark`, `Document`, etc.; first access awaits the generated `init()` once and caches the promise. Subsequent calls are zero-cost.
+
+Done well this turns the landmine into a non-issue. The consumer's complaint that this was "unchanged from 0.54" implies they expect it to stay broken — fixing it is a real DX upgrade with no Rust-side cost.
+
+If the shim approach is rejected, fall back to:
+- A prominent "You must `await init()` first" block at the top of the README.
+- A custom panic hook that detects "accessed before init" and throws a legible error rather than a wasm trap.
+
+### 5. Document `RenderOptions.pages` indexing **(docs-only)**
+
+The pages array is 0-indexed (confirmed: `crates/backends/typst/src/compile.rs:175-178` uses the values as direct indices into `document.pages`, default is `(0..page_count).collect()`). The TS type has no JSDoc, so the convention is not self-evident and 0.54 callers migrating may assume 1-indexed.
+
+**Change:** update the doc comment on `pages` in both `crates/bindings/wasm/src/types.rs:182` and `crates/core/src/types.rs:34`:
+
+> Optional 0-based page indices to render (e.g., `[0, 2]` for first and third pages). `undefined` renders all pages. **Not supported for PDF output** — see `FormatNotSupported`.
+
+wasm-bindgen propagates Rust doc comments to the generated `.d.ts`, so IDE hover picks this up automatically.
+
+### 6. Document `Document` getter allocation cost **(docs-only)**
+
+`frontmatter`, `cards`, and `warnings` each build a fresh `serde_json::Value` and call `serialize_maps_as_objects` on every access (`crates/bindings/wasm/src/engine.rs:199-256`). `body` allocates a `String` but is much cheaper; `quillRef` is trivial.
+
+**Change:** add a one-line cost note to the three serializing getters' doc comments, e.g.:
+
+> Allocates and serializes on each call — cache locally if read in a hot loop.
+
+No memoization, no `toJSON()`. Deferred until more consumers hit this.
+
+### 7. Migration guide updates **(docs-only)**
+
+The following are intentional behaviors being called out by consumers. No code change; add to the migration guide.
+
+- **`Document.fromMarkdown` now requires `QUILL:` in frontmatter.** Parse-time failure, not render-time. Fix: add `QUILL: <name>` to frontmatter. Note the shift from render-time to parse-time explicitly (test fixtures rot silently).
+- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-666`.
+
+## Out of scope
+
+- Flattening `Quill.yaml` back to top-level keys. The nested shape is deliberate (room for sibling sections like `typst:`, `cards:`, `main:`).
+- Making `description` optional. It is required by design.
+- `Document.toJSON()` — deferred. No clear need from the current feedback.
+- A `Document.fromMarkdown(md, { quill: name })` overload that injects `QUILL:` — deferred. Possible future ergonomic win; not required by the current feedback.
+- Replacing the Document handle with a plain JSON object. `toMarkdown()` needs Rust state, and a JSON-only API would force awkward statics.
+
+## Test updates
+
+- `crates/bindings/wasm/tests/` — add a test that `engine.quill({ "Quill.yaml": ..., ... })` (plain object) succeeds with the same result as the `Map` form.
+- `crates/bindings/wasm/tests/metadata.rs` — extend to assert `quill.metadata` exposes `name`, `backend`, `description`, `version`, `supportedFormats`, and the raw `schema` field.
+- `crates/bindings/wasm/tests/` — add a test that `doc.clone()` returns a fresh handle, mutations on the clone do not affect the original, and parse warnings are preserved on the clone.
+
+## Done when
+
+- Consumers can pass a `Record<string, Uint8Array>` to `engine.quill()` without a helper.
+- `quill.metadata` returns the data consumers used to get from `engine.resolveQuill(name)` — no regex-parsing of `Quill.yaml` required.
+- `doc.clone()` produces a mutable copy without re-parsing markdown.
+- The JS shim (or the documented fallback) eliminates the `init()` footgun for common integration paths.
+- `RenderOptions.pages` and the three serializing Document getters carry doc comments that make their behavior obvious from IDE hover.
+- The migration guide explicitly calls out the `QUILL:` parse-time requirement and the `Quill.yaml` required-field list.

--- a/prose/taskings/consumer_feedback_followups.md
+++ b/prose/taskings/consumer_feedback_followups.md
@@ -5,7 +5,7 @@
 
 ## Background
 
-A downstream consumer migrating from 0.54 to 0.58 surfaced a set of friction points in the WASM binding. Most are narrow fixes (doc comments, small API additions). Two are deliberate behaviors we will keep but document more clearly. One (the `init()` footgun) is inherent to `wasm-bindgen --target web` and needs a JS-side mitigation.
+A downstream consumer migrating from 0.54 to 0.58 surfaced a set of friction points in the WASM binding. Most are narrow fixes (doc comments, small API additions). Two are deliberate behaviors we will keep but document more clearly.
 
 Tasks are ordered by consumer impact × implementation cost. Items marked **docs-only** need no code changes beyond comments and the migration guide.
 
@@ -49,7 +49,7 @@ The `schema` field ships raw (as parsed from YAML). The engine deliberately no l
 
 ### 3. Add `Document.clone()`
 
-`Document` has ~10 in-place mutators (`set_field`, `remove_field`, `push_card`, `insert_card`, `remove_card`, `move_card`, `update_card_field`, `update_card_body`, `replace_body`, `set_quill_ref` at `crates/bindings/wasm/src/engine.rs:266-408`). Once a consumer mutates, they cannot cheaply recover the pristine parse without holding the original markdown and re-calling `Document.fromMarkdown`.
+`Document` has ~10 in-place mutators (`set_field`, `remove_field`, `push_card`, `insert_card`, `remove_card`, `move_card`, `update_card_field`, `update_card_body`, `replace_body`, `set_quill_ref` at `crates/bindings/wasm/src/engine.rs:265-410`). Once a consumer mutates, they cannot cheaply recover the pristine parse without holding the original markdown and re-calling `Document.fromMarkdown`.
 
 **Change:** add a `clone()` method on `Document`:
 
@@ -65,19 +65,7 @@ pub fn clone_doc(&self) -> Document {
 
 Doc comment must state explicitly: parse-time warnings are snapshotted (they describe the document, not the edit history).
 
-### 4. Ship a JS shim that lazy-inits the WASM module
-
-Forgetting `await init()` still produces cryptic panics deep inside the wasm module. This is inherent to `wasm-bindgen --target web` and cannot be fixed on the Rust side.
-
-**Change:** ship a thin JS wrapper around the generated bindings. The wrapper exports lazy-initialized proxies for `Quillmark`, `Document`, etc.; first access awaits the generated `init()` once and caches the promise. Subsequent calls are zero-cost.
-
-Done well this turns the landmine into a non-issue. The consumer's complaint that this was "unchanged from 0.54" implies they expect it to stay broken — fixing it is a real DX upgrade with no Rust-side cost.
-
-If the shim approach is rejected, fall back to:
-- A prominent "You must `await init()` first" block at the top of the README.
-- A custom panic hook that detects "accessed before init" and throws a legible error rather than a wasm trap.
-
-### 5. Document `RenderOptions.pages` indexing **(docs-only)**
+### 4. Document `RenderOptions.pages` indexing **(docs-only)**
 
 The pages array is 0-indexed (confirmed: `crates/backends/typst/src/compile.rs:175-178` uses the values as direct indices into `document.pages`, default is `(0..page_count).collect()`). The TS type has no JSDoc, so the convention is not self-evident and 0.54 callers migrating may assume 1-indexed.
 
@@ -87,7 +75,7 @@ The pages array is 0-indexed (confirmed: `crates/backends/typst/src/compile.rs:1
 
 wasm-bindgen propagates Rust doc comments to the generated `.d.ts`, so IDE hover picks this up automatically.
 
-### 6. Document `Document` getter allocation cost **(docs-only)**
+### 5. Document `Document` getter allocation cost **(docs-only)**
 
 `frontmatter`, `cards`, and `warnings` each build a fresh `serde_json::Value` and call `serialize_maps_as_objects` on every access (`crates/bindings/wasm/src/engine.rs:199-256`). `body` allocates a `String` but is much cheaper; `quillRef` is trivial.
 
@@ -97,12 +85,12 @@ wasm-bindgen propagates Rust doc comments to the generated `.d.ts`, so IDE hover
 
 No memoization, no `toJSON()`. Deferred until more consumers hit this.
 
-### 7. Migration guide updates **(docs-only)**
+### 6. Migration guide updates **(docs-only)**
 
 The following are intentional behaviors being called out by consumers. No code change; add to the migration guide.
 
 - **`Document.fromMarkdown` now requires `QUILL:` in frontmatter.** Parse-time failure, not render-time. Fix: add `QUILL: <name>` to frontmatter. Note the shift from render-time to parse-time explicitly (test fixtures rot silently).
-- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-666`.
+- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-672`.
 
 ## Out of scope
 
@@ -123,6 +111,5 @@ The following are intentional behaviors being called out by consumers. No code c
 - Consumers can pass a `Record<string, Uint8Array>` to `engine.quill()` without a helper.
 - `quill.metadata` returns the data consumers used to get from `engine.resolveQuill(name)` — no regex-parsing of `Quill.yaml` required.
 - `doc.clone()` produces a mutable copy without re-parsing markdown.
-- The JS shim (or the documented fallback) eliminates the `init()` footgun for common integration paths.
 - `RenderOptions.pages` and the three serializing Document getters carry doc comments that make their behavior obvious from IDE hover.
 - The migration guide explicitly calls out the `QUILL:` parse-time requirement and the `Quill.yaml` required-field list.

--- a/prose/taskings/wasm_type_surface.md
+++ b/prose/taskings/wasm_type_surface.md
@@ -1,0 +1,255 @@
+# WASM Type Surface & Body-Separator Refactor Tasking
+
+**Audience:** Quillmark engine + WASM binding maintainer
+**Consumer feedback source:** `@quillmark/quiver` authors (post-integration review)
+**Branch:** `claude/review-consumer-feedback-TRloK`
+**wasm-bindgen version:** 0.2.118 (supports `unchecked_param_type` /
+`unchecked_return_type`; added in 0.2.95).
+
+## Background
+
+A downstream consumer reviewed the generated `.d.ts` for `@quillmark/wasm` and
+flagged four friction points where the binding forces runtime assertions that
+should be compile-time checks. Three are binding-level typing fixes. The
+fourth, initially framed as a binding concern (`trim_body` scattered across
+output paths), turned out to be a symptom of a core storage decision and is
+promoted to a core refactor.
+
+Scope is bounded: no change to `render`, `parseMarkdown`, selector resolution,
+or plate wire format. No new public surface area beyond what's listed.
+
+## Tasks
+
+### 1a. `Quillmark.quill(tree)` — narrow the declared input type
+
+Today `quill(tree: any): Quill` in the generated `.d.ts`. The runtime strictly
+requires `js_sys::Map` (`crates/bindings/wasm/src/engine.rs:502`). Narrow the
+declared type to match runtime truth:
+
+```rust
+#[wasm_bindgen(js_name = quill, unchecked_param_type = "Map<string, Uint8Array>")]
+pub fn quill(&self, tree: JsValue) -> Result<Quill, JsValue>
+```
+
+Zero runtime change. Anyone currently passing a `Map` keeps compiling.
+
+### 1b. `Quillmark.quill(tree)` — also accept `Record` (deferred)
+
+Accepting `Record<string, Uint8Array>` is a separate *runtime* change that adds
+a code path for consumer convenience (`new Map(Object.entries(x))` is the
+current workaround). The ergonomic win is small relative to the maintenance
+cost, and it would be a silent behaviour change for callers who used to get
+a clear error on plain-object input.
+
+**Deferred.** Revisit only if concrete consumer friction demands it.
+
+### 2. `pushCard` / `insertCard` — typed input via TS-only `CardInput`
+
+Today both methods accept `card: any`. The runtime shape is already defined by
+the function-local `CardInput` struct in `js_value_to_card`
+(`crates/bindings/wasm/src/engine.rs:430`): `tag` required, `fields` and
+`body` optional with serde defaults.
+
+**Deliberately rejected:** promoting the local `CardInput` to a public
+tsify-derived binding struct. That would export a nominal type consumers must
+import, add a `TryFrom` indirection, and is overkill for two call sites. The
+function-local struct stays.
+
+**Change:**
+
+1. Add a `typescript_custom_section`:
+
+   ```rust
+   #[wasm_bindgen(typescript_custom_section)]
+   const CARD_INPUT_TS: &'static str = r#"
+   export interface CardInput {
+     tag: string;
+     fields?: Record<string, unknown>;
+     body?: string;
+   }
+   "#;
+   ```
+
+2. Annotate the two methods:
+
+   ```rust
+   #[wasm_bindgen(js_name = pushCard, unchecked_param_type = "CardInput")]
+   pub fn push_card(&mut self, card: JsValue) -> Result<(), JsValue>
+
+   #[wasm_bindgen(js_name = insertCard, unchecked_param_type = "CardInput")]
+   pub fn insert_card(&mut self, index: usize, card: JsValue) -> Result<(), JsValue>
+   ```
+
+`js_value_to_card` stays unchanged. TS-only type, no Rust-side plumbing.
+
+### 3. Typed output getters — `cards`, `frontmatter`, `warnings`
+
+Today all three return `JsValue` (emitted as `any`). Each method rebuilds a
+`serde_json::Value` and hands it to `serde_wasm_bindgen` manually — a
+hand-rolled reimplementation of what the tsify-derived `Card` and `Diagnostic`
+types in `crates/bindings/wasm/src/types.rs` already do automatically.
+
+**Change:** return typed values and delete the JSON scaffolding.
+
+1. `cards()` returns `Vec<Card>`:
+
+   ```rust
+   #[wasm_bindgen(getter, js_name = cards)]
+   pub fn cards(&self) -> Vec<Card> {
+       self.inner.cards().iter().map(Card::from).collect()
+   }
+   ```
+
+   Add a `From<&quillmark_core::Card> for Card` impl in `types.rs` that
+   constructs the tsify struct from core fields.
+
+2. `warnings()` returns `Vec<Diagnostic>`:
+
+   ```rust
+   #[wasm_bindgen(getter, js_name = warnings)]
+   pub fn warnings(&self) -> Vec<Diagnostic> {
+       self.parse_warnings.iter().cloned().map(Into::into).collect()
+   }
+   ```
+
+3. `frontmatter()` returns a tsify newtype wrapping `serde_json::Value` with
+   `#[tsify(type = "Record<string, unknown>")]`, matching the convention
+   already used on `Card.fields` (`types.rs:164`).
+
+4. **Delete** `card_to_js_value` (`engine.rs:457`). This also changes
+   `removeCard`: today it returns `JsValue` (typed as `any`, semantically
+   `Card | undefined`). Change the return type to `Option<Card>` so the
+   generated `.d.ts` declares `Card | undefined` explicitly.
+
+   **This is a public API change** — the runtime shape is unchanged (object
+   or `undefined`), but the declared TS type narrows. Consumers who relied
+   on `any` lose the implicit-any escape hatch.
+
+### 4. Remove F2 separator storage from core (deeper fix)
+
+The binding-level `trim_body` helper (`engine.rs:476`) is applied in three
+output paths (`body`, `cards`, `card_to_js_value`). Its own doc comment
+(`engine.rs:471-479`) names the issue: the trailing newline characters are
+"structural separators, not part of what the document author wrote" — yet
+they live in `Card.body` and `Document.body` storage and every consumer-facing
+read has to strip them.
+
+**Semantic correction from initial draft.** `trim_body`'s current
+implementation (`trim_end_matches(|c| c == '\n' || c == '\r')`) strips **all**
+trailing newlines, conflating two distinct things:
+
+- The F2 *blank line* required before the next fence (exactly one line ending
+  at the tail of a body that's followed by another block). This is structural.
+- Any line-ending or trailing whitespace that's part of the author's content
+  (e.g. a code block that ends with `\n`). This is content.
+
+Moving `trim_body`-as-written into core would propagate the conflation — every
+reader would see content-ending newlines silently dropped. The correct model
+is narrower.
+
+**Correct model.**
+
+- **F2 separator = exactly one line ending at the tail of a body slice that is
+  followed by another metadata block.** For `\n` line endings, that's one
+  `\n`. For `\r\n`, that's one `\r\n`.
+- Bodies at end-of-document have no F2 separator to strip.
+- Author content after the strip is preserved verbatim, including its own line
+  terminators.
+
+Worked example: `...---\nalpha\n\n---\nCARD: x...`
+- Raw body slice = `"alpha\n\n"` (seven bytes).
+- The tail `\n` is the F2 blank line; the first `\n` terminates the `alpha`
+  line — that's content.
+- Stored body = `"alpha\n"`.
+- Emit side already ensures `\n\n` before the next fence (`emit.rs:140`), so
+  round-trip byte equality holds.
+
+**Change:**
+
+1. **Parse side** (`crates/core/src/document/assemble.rs`): when extracting a
+   body segment that is followed by another block (i.e. `idx + 1 < blocks.len()`
+   for card bodies, or a CARD block exists for the global body), strip exactly
+   one trailing line ending. Bodies at EOF are stored as-is.
+
+   Implement as a private helper in `assemble.rs`:
+
+   ```rust
+   fn strip_f2_separator(body: &str) -> &str {
+       if let Some(rest) = body.strip_suffix("\r\n") { rest }
+       else if let Some(rest) = body.strip_suffix('\n') { rest }
+       else { body }
+   }
+   ```
+
+2. **Edit side** (`crates/core/src/document/edit.rs:158`, `:315`): no change.
+   `set_body` / `replace_body` continue to accept arbitrary strings as-is; the
+   emitter already adds the F2 separator on output, so a consumer setting
+   `replace_body("x")` still round-trips correctly. **Not** normalising on
+   input means `get_body` returns what was set.
+
+3. **Emit side** (`crates/core/src/document/emit.rs:140`): no change needed.
+   `ensure_blank_line_before_fence` already handles bodies ending in `\n`,
+   `\n\n`, or no newline. Verify with tests; adjust only if a round-trip case
+   fails.
+
+4. **Binding side**: delete `trim_body` entirely. `Document.body` getter
+   forwards `self.inner.body().to_string()`. The `From<&core::Card> for Card`
+   impl from Task 3 copies the body without trimming.
+
+**Load-bearing tests.**
+
+- Round-trip byte equality: for every fixture in
+  `crates/core/src/document/tests/fixtures/`, `emit(decompose(src)) == src`
+  (modulo documented canonicalisation).
+- **Content fidelity:** a body ending in `\n` as author content survives
+  round-trip. Construct a case: `---\nCARD: x\n---\ncode line\n\n---\nCARD: y\n---\n`
+  — the first card's body should be `"code line\n"` (not `"code line"`), and
+  re-emitting should restore `\n\n` before the next fence.
+
+**Scope estimate:** medium. Touches parser + emitter audit + test fixtures +
+binding cleanup. ~4 distinct commits: parse-side strip, binding trim removal,
+test updates, cross-crate verification.
+
+## Out of scope
+
+- Changes to plate wire format or `to_plate_json`. That format is a backend
+  contract separate from the Document representation.
+- Any new public API beyond `CardInput` (TS-only) and the return-type
+  changes on existing getters.
+- Reworking `updateCardField` / `setField` — those take a `JsValue` value
+  because field values are genuinely dynamic (`unknown` on the TS side).
+  They're already typed reasonably; a future pass can tighten to `unknown`
+  if `any` is still showing through.
+
+## Test updates
+
+- **Task 1a:** `tsc --noEmit` fixture that rejects `quill({})` at compile
+  time and accepts `quill(new Map<string, Uint8Array>())`.
+- **Task 2:** no runtime test change. Add a `.d.ts` snapshot or `tsc`
+  fixture importing `CardInput` and calling `pushCard({ tag: "foo" })`.
+- **Task 3:** existing tests that assert shape of `cards` / `warnings` /
+  `frontmatter` should keep passing. Add a TS fixture that relies on the
+  narrowed types (e.g. `doc.cards[0].tag` type-checks without a cast).
+- **Task 4:**
+  - Update `test_body_with_trailing_newlines`
+    (`assemble_tests.rs:1572`) to match the new model — at EOF, trailing
+    content newlines are preserved; followed by a fence, exactly one line
+    ending is stripped.
+  - Add an explicit F2-strip test covering `\n`, `\r\n`, and multi-newline
+    cases for bodies followed by a fence.
+  - Add a content-fidelity test asserting that a body ending in `\n` as
+    content survives round-trip.
+
+## Done when
+
+- `.d.ts` for `@quillmark/wasm` contains no `any` on `quill`, `pushCard`,
+  `insertCard`, `removeCard`, `cards`, `frontmatter`, or `warnings`.
+- `CardInput` is exported from the `.d.ts` and accepts object literals
+  without a nominal import.
+- `trim_body` is deleted from `crates/bindings/wasm/src/engine.rs`.
+- Core `Card::body()` / `Document::body()` return exactly what was authored
+  (or set), with the F2 structural separator removed on parse and re-added
+  on emit.
+- Markdown round-trip byte equality holds for all existing fixtures.
+- Content-fidelity test (body ending in `\n`) passes.
+- No existing wasm or core tests regress.


### PR DESCRIPTION
Captures the decisions from iterating on downstream feedback: accept
Record<string, Uint8Array> in engine.quill(), expose Quill.metadata,
add Document.clone(), ship a JS shim for the init() footgun, plus
doc-only fixes for pages indexing, getter allocation cost, and
migration notes.