### PR TITLE
Add tasking doc for 0.54 → 0.58 consumer feedback followups

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -50,14 +50,25 @@ jobs:
         run: |
           CURRENT="${{ steps.current.outputs.version }}"
 
+          # A `patch` rc has patch != 0 (e.g. 0.58.2-rc.*), a `minor` rc has
+          # patch == 0 (e.g. 0.59.0-rc.*). This lets us detect when the user's
+          # `bump` input conflicts with the base of the current RC.
           if [ "${{ inputs.prerelease }}" == "true" ]; then
             # cargo-release has no "minor-rc" compound bump, so we compute the
             # target version ourselves.
             if [[ "$CURRENT" == *-rc.* ]]; then
-              # Already on an RC — increment the RC number (e.g. 0.59.0-rc.1 → 0.59.0-rc.2)
               RC_NUM="${CURRENT##*-rc.}"
-              BASE_WITH_RC="${CURRENT%-rc.*}"
-              NEXT="${BASE_WITH_RC}-rc.$((RC_NUM + 1))"
+              BASE="${CURRENT%-rc.*}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+              if [ "${{ inputs.bump }}" == "minor" ] && [ "$PATCH" != "0" ]; then
+                # Escalating from a patch-rc to a new minor-rc
+                # (e.g. 0.58.2-rc.5 → 0.59.0-rc.1).
+                NEXT="${MAJOR}.$((MINOR + 1)).0-rc.1"
+              else
+                # Continuing the current RC cycle
+                # (e.g. 0.59.0-rc.1 → 0.59.0-rc.2).
+                NEXT="${BASE}-rc.$((RC_NUM + 1))"
+              fi
             else
               # Stable version — bump and start at rc.1
               IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
@@ -68,7 +79,23 @@ jobs:
               fi
             fi
           else
-            NEXT="${{ inputs.bump }}"
+            if [[ "$CURRENT" == *-rc.* ]]; then
+              # Finalizing an RC — strip the -rc.N suffix so the release tag
+              # matches the RC base (e.g. 0.58.2-rc.5 → 0.58.2).
+              BASE="${CURRENT%-rc.*}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+              if [ "${{ inputs.bump }}" == "minor" ] && [ "$PATCH" != "0" ]; then
+                echo "::error::Cannot finalize patch-rc $CURRENT with bump=minor. Re-run with bump=patch to finalize, or open a new minor rc first."
+                exit 1
+              fi
+              if [ "${{ inputs.bump }}" == "patch" ] && [ "$PATCH" == "0" ]; then
+                echo "::error::Cannot finalize minor-rc $CURRENT with bump=patch. Re-run with bump=minor to finalize, or open a new patch rc first."
+                exit 1
+              fi
+              NEXT="$BASE"
+            else
+              NEXT="${{ inputs.bump }}"
+            fi
           fi
 
           echo "Bumping workspace to: $NEXT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-cli"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-core"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "glob",
  "indexmap",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-fixtures"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "quillmark",
  "quillmark-typst",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-fuzz"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "proptest",
  "quillmark-core",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-python"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-typst"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "quillmark-wasm"
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.58.2-rc.5"
+version = "0.58.2-rc.6"
 edition = "2021"
 include = ["src/**", "Cargo.toml", "README*", "LICENSE*"]
 readme = "README.md"
@@ -55,9 +55,9 @@ typst-svg = "0.14.2"
 dirs = "6.0"
 
 # Intra-project dependencies
-quillmark-core = { version = "0.58.2-rc.5", path = "crates/core" }
-quillmark-typst = { version = "0.58.2-rc.5", path = "crates/backends/typst", default-features = false }
-quillmark = { version = "0.58.2-rc.5", path = "crates/quillmark" }
+quillmark-core = { version = "0.58.2-rc.6", path = "crates/core" }
+quillmark-typst = { version = "0.58.2-rc.6", path = "crates/backends/typst", default-features = false }
+quillmark = { version = "0.58.2-rc.6", path = "crates/quillmark" }
 
 # Test and dev dependencies
 tempfile = "~3.23"

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -281,7 +281,7 @@ mod compile_helper_tests {
         root_files.insert(
             "Quill.yaml".to_string(),
             FileTreeNode::File {
-                contents: br#"Quill:
+                contents: br#"quill:
   name: "test_helper_compile"
   version: "1.0"
   backend: "typst"

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -59,7 +59,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     let quill = engine.quill_from_path(args.quill.clone())?;
 
     if args.verbose {
-        println!("Quill loaded: {}", quill.source().name);
+        println!("Quill loaded: {}", quill.source().name());
     }
 
     // Determine if we have a markdown file or need to use example content
@@ -89,12 +89,16 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             (output, Some(markdown_path.clone()))
         } else {
             // Get example content
-            let markdown = quill.source().example.clone().ok_or_else(|| {
-                CliError::InvalidArgument(format!(
-                    "Quill '{}' does not have example content",
-                    quill.source().name
-                ))
-            })?;
+            let markdown = quill
+                .source()
+                .example()
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    CliError::InvalidArgument(format!(
+                        "Quill '{}' does not have example content",
+                        quill.source().name()
+                    ))
+                })?;
 
             if args.verbose {
                 println!("Using example content from quill");

--- a/crates/bindings/cli/src/commands/schema.rs
+++ b/crates/bindings/cli/src/commands/schema.rs
@@ -31,7 +31,7 @@ pub fn execute(args: SchemaArgs) -> Result<()> {
     // Emit public schema contract as YAML
     let schema_yaml = quill
         .source()
-        .config
+        .config()
         .public_schema_yaml()
         .map_err(|e| CliError::InvalidArgument(format!("Failed to serialize schema: {}", e)))?;
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -276,45 +276,54 @@ impl PyDocument {
             .collect()
     }
 
-    /// Global Markdown body (str, never None).
+    /// Main card's global Markdown body (str, never None).
+    ///
+    /// Convenience accessor equivalent to `doc.main['body']`.
     #[getter]
     fn body(&self) -> &str {
-        self.inner.body()
+        self.inner.main().body()
     }
 
-    /// Typed YAML frontmatter fields (no QUILL, BODY, or CARDS keys).
+    /// Typed YAML frontmatter fields on the main card (no QUILL, BODY, or CARDS keys).
+    ///
+    /// Convenience accessor equivalent to `doc.main['frontmatter']`.
     #[getter]
     fn frontmatter<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
-        for (key, value) in self.inner.frontmatter() {
+        for (key, value) in self.inner.main().frontmatter().iter() {
             dict.set_item(key, quillvalue_to_py(py, value)?)?;
         }
         Ok(dict)
     }
 
-    /// Ordered list of card blocks.
+    /// The document's main (entry) card as a dict.
     ///
-    /// Each card is a dict with keys: `tag` (str), `fields` (dict), `body` (str).
+    /// Keys: `tag` (str), `frontmatter` (dict), `frontmatter_items` (list),
+    /// `fields` (dict — alias of `frontmatter`), `body` (str).
+    #[getter]
+    fn main<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        card_to_pydict(py, self.inner.main())
+    }
+
+    /// Ordered list of composable card blocks.
+    ///
+    /// Each card is a dict with keys: `tag` (str), `frontmatter` (dict),
+    /// `frontmatter_items` (list), `fields` (dict), `body` (str).
     #[getter]
     fn cards<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
         let mut result = Vec::new();
         for card in self.inner.cards() {
-            let d = PyDict::new(py);
-            d.set_item("tag", card.tag())?;
-            let fields_dict = PyDict::new(py);
-            for (k, v) in card.fields() {
-                fields_dict.set_item(k, quillvalue_to_py(py, v)?)?;
-            }
-            d.set_item("fields", fields_dict)?;
-            d.set_item("body", card.body())?;
-            result.push(d);
+            result.push(card_to_pydict(py, card)?);
         }
         Ok(result)
     }
 
     // ── Mutators ──────────────────────────────────────────────────────────────
 
-    /// Set a frontmatter field by name.
+    /// Set a frontmatter field by name on the main card.
+    ///
+    /// Convenience method equivalent to `doc.main_mut().set_field(name, value)`.
+    /// Clears any `!fill` marker on the field.
     ///
     /// Raises `quillmark.EditError` if `name` is a reserved sentinel
     /// (`BODY`, `CARDS`, `QUILL`, `CARD`) or does not match `[a-z_][a-z0-9_]*`.
@@ -322,14 +331,28 @@ impl PyDocument {
     /// This method never modifies `warnings`.
     fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
-        self.inner.set_field(name, qv).map_err(convert_edit_error)
+        self.inner
+            .main_mut()
+            .set_field(name, qv)
+            .map_err(convert_edit_error)
     }
 
-    /// Remove a frontmatter field by name, returning the value or `None`.
+    /// Set a frontmatter field on the main card AND mark it as `!fill`.
+    ///
+    /// Convenience method equivalent to `doc.main_mut().set_fill(name, value)`.
+    fn set_fill(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let qv = py_to_quillvalue(&value)?;
+        self.inner
+            .main_mut()
+            .set_fill(name, qv)
+            .map_err(convert_edit_error)
+    }
+
+    /// Remove a frontmatter field from the main card, returning the value or `None`.
     ///
     /// This method never modifies `warnings`.
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-        match self.inner.remove_field(name) {
+        match self.inner.main_mut().remove_field(name) {
             Some(v) => quillvalue_to_py(py, &v),
             None => py.None().into_bound_py_any(py),
         }
@@ -348,11 +371,11 @@ impl PyDocument {
         Ok(())
     }
 
-    /// Replace the global Markdown body.
+    /// Replace the main card's body (the global Markdown body).
     ///
     /// This method never modifies `warnings`.
     fn replace_body(&mut self, body: &str) {
-        self.inner.replace_body(body);
+        self.inner.main_mut().replace_body(body);
     }
 
     /// Append a card to the card list.
@@ -390,17 +413,7 @@ impl PyDocument {
         index: usize,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
         match self.inner.remove_card(index) {
-            Some(card) => {
-                let d = PyDict::new(py);
-                d.set_item("tag", card.tag())?;
-                let fields_dict = PyDict::new(py);
-                for (k, v) in card.fields() {
-                    fields_dict.set_item(k, quillvalue_to_py(py, v)?)?;
-                }
-                d.set_item("fields", fields_dict)?;
-                d.set_item("body", card.body())?;
-                Ok(Some(d))
-            }
+            Some(card) => Ok(Some(card_to_pydict(py, &card)?)),
             None => Ok(None),
         }
     }
@@ -629,6 +642,50 @@ fn quillvalue_to_py<'py>(
     value: &quillmark_core::QuillValue,
 ) -> PyResult<Bound<'py, PyAny>> {
     json_to_py(py, value.as_json())
+}
+
+// Helper: convert a typed Card into the Python dict shape exposed to callers.
+fn card_to_pydict<'py>(
+    py: Python<'py>,
+    card: &quillmark_core::Card,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item(
+        "sentinel",
+        if card.is_main() { "main" } else { "card" },
+    )?;
+    d.set_item("tag", card.tag())?;
+
+    // Map-keyed frontmatter view (values only, no comments).
+    let fm = PyDict::new(py);
+    for (k, v) in card.frontmatter().iter() {
+        fm.set_item(k, quillvalue_to_py(py, v)?)?;
+    }
+    d.set_item("frontmatter", fm.clone())?;
+    d.set_item("fields", fm)?;
+
+    // Ordered item list with comments and fill flags.
+    let items = pyo3::types::PyList::empty(py);
+    for item in card.frontmatter().items() {
+        let entry = PyDict::new(py);
+        match item {
+            quillmark_core::FrontmatterItem::Field { key, value, fill } => {
+                entry.set_item("kind", "field")?;
+                entry.set_item("key", key)?;
+                entry.set_item("value", quillvalue_to_py(py, value)?)?;
+                entry.set_item("fill", *fill)?;
+            }
+            quillmark_core::FrontmatterItem::Comment { text } => {
+                entry.set_item("kind", "comment")?;
+                entry.set_item("text", text)?;
+            }
+        }
+        items.append(entry)?;
+    }
+    d.set_item("frontmatter_items", items)?;
+
+    d.set_item("body", card.body())?;
+    Ok(d)
 }
 
 // Helper function to convert JSON values to Python objects

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -460,7 +460,7 @@ impl PyDocument {
         let card = self.inner.card_mut(index).ok_or_else(|| {
             convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
         })?;
-        card.set_body(body);
+        card.replace_body(body);
         Ok(())
     }
 }
@@ -801,7 +801,7 @@ fn py_dict_to_card(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::Card> {
 
     if let Some(body_val) = dict.get_item("body")? {
         let body: String = body_val.extract()?;
-        card.set_body(body);
+        card.replace_body(body);
     }
 
     Ok(card)

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -650,10 +650,7 @@ fn card_to_pydict<'py>(
     card: &quillmark_core::Card,
 ) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
-    d.set_item(
-        "sentinel",
-        if card.is_main() { "main" } else { "card" },
-    )?;
+    d.set_item("sentinel", if card.is_main() { "main" } else { "card" })?;
     d.set_item("tag", card.tag())?;
 
     // Map-keyed frontmatter view (values only, no comments).

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -389,7 +389,8 @@ impl PyDocument {
     /// This method never modifies `warnings`.
     fn push_card(&mut self, card: Bound<'_, PyAny>) -> PyResult<()> {
         let core_card = py_dict_to_card(&card)?;
-        self.inner.push_card(core_card).map_err(convert_edit_error)
+        self.inner.push_card(core_card);
+        Ok(())
     }
 
     /// Insert a card at the given index.

--- a/crates/bindings/python/tests/test_project_form.py
+++ b/crates/bindings/python/tests/test_project_form.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
 # Helpers
 # ---------------------------------------------------------------------------
 
-QUILL_YAML_CONTENT = """Quill:
+QUILL_YAML_CONTENT = """quill:
   name: py_form_smoke
   version: "1.0"
   backend: typst

--- a/crates/bindings/python/tests/test_versioning.py
+++ b/crates/bindings/python/tests/test_versioning.py
@@ -18,7 +18,7 @@ def test_quill_from_path_bad_backend(tmp_path):
     quill_dir = tmp_path / "test_quill"
     quill_dir.mkdir()
     (quill_dir / "Quill.yaml").write_text(
-        'Quill:\n  name: "test"\n  version: "1.0"\n  backend: "nonexistent"\n  description: "Test"\n'
+        'quill:\n  name: "test"\n  version: "1.0"\n  backend: "nonexistent"\n  description: "Test"\n'
     )
     engine = Quillmark()
     with pytest.raises(QuillmarkError):

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -141,10 +141,16 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
     expect(typeof emitted).toBe('string')
     expect(emitted.length).toBeGreaterThan(0)
 
-    // Re-parse and assert structure survives
+    // Re-parse and assert structure survives.
+    //
+    // Note on trailing newlines: the global body is followed by a card fence,
+    // so the wire format inserts a line terminator + F2 blank line between
+    // them (`Updated body\n\n---`). On re-parse the F2 blank is stripped but
+    // the terminator stays, so `doc2.body === 'Updated body\n'`. The card
+    // body is at EOF and has no F2 separator, so it survives byte-for-byte.
     const doc2 = Document.fromMarkdown(emitted)
     expect(doc2.frontmatter.title).toBe('New Title')
-    expect(doc2.body).toBe('Updated body')
+    expect(doc2.body).toBe('Updated body\n')
     expect(doc2.cards.length).toBe(originalCardCount + 1)
     expect(doc2.cards[0].tag).toBe('note')
     expect(doc2.cards[0].fields.author).toBe('Alice')

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -558,7 +558,7 @@ describe('quill.open + session.render', () => {
 })
 
 describe('quill.metadata', () => {
-  const META_QUILL_YAML = `Quill:
+  const META_QUILL_YAML = `quill:
   name: meta_test_quill
   version: "0.2.1"
   backend: typst
@@ -641,7 +641,7 @@ describe('Document.clone', () => {
 // ---------------------------------------------------------------------------
 
 describe('quill.projectForm', () => {
-  const QUILL_YAML = `Quill:
+  const QUILL_YAML = `quill:
   name: form_smoke_test
   version: "1.0"
   backend: typst

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -189,6 +189,29 @@ describe('Quillmark.quill', () => {
     expect(quill).toBeDefined()
   })
 
+  it('should accept a plain object tree (Record<string, Uint8Array>)', () => {
+    const engine = new Quillmark()
+    const mapTree = makeQuill({ name: 'test_quill', plate: TEST_PLATE })
+    const objectTree = Object.fromEntries(mapTree)
+
+    const fromMap = engine.quill(mapTree)
+    const fromObject = engine.quill(objectTree)
+
+    expect(fromMap.backendId).toBe(fromObject.backendId)
+
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const r1 = fromMap.render(doc, { format: 'svg' })
+    const r2 = fromObject.render(doc, { format: 'svg' })
+    expect(r1.artifacts.length).toBe(r2.artifacts.length)
+  })
+
+  it('should reject non-object trees with a clear error', () => {
+    const engine = new Quillmark()
+    expect(() => engine.quill(42)).toThrow()
+    expect(() => engine.quill('string')).toThrow()
+    expect(() => engine.quill(null)).toThrow()
+  })
+
   it('should render markdown to PDF via quill.render(doc) with default opts', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
@@ -531,6 +554,82 @@ describe('quill.open + session.render', () => {
     expect(() => {
       session.render({ format: 'pdf', pages: [0] })
     }).toThrow()
+  })
+})
+
+describe('quill.metadata', () => {
+  const META_QUILL_YAML = `Quill:
+  name: meta_test_quill
+  version: "0.2.1"
+  backend: typst
+  plate_file: plate.typ
+  description: Metadata test
+
+main:
+  fields:
+    title:
+      type: string
+      description: The title
+`
+
+  it('exposes name, backend, description, version, author, supportedFormats, schema', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(
+      makeQuill({ name: 'meta_test_quill', plate: TEST_PLATE, quillYaml: META_QUILL_YAML }),
+    )
+
+    const meta = quill.metadata
+    expect(meta).toBeDefined()
+    expect(meta.name).toBe('meta_test_quill')
+    expect(meta.backend).toBe('typst')
+    expect(meta.description).toBe('Metadata test')
+    expect(meta.version).toBe('0.2.1')
+    expect(meta.author).toBe('Unknown')
+    expect(Array.isArray(meta.supportedFormats)).toBe(true)
+    expect(meta.supportedFormats.length).toBeGreaterThan(0)
+    expect(meta.schema).toBeDefined()
+    expect(meta.schema.title).toBeDefined()
+  })
+
+  it('is JSON.stringify-able (plain object, not a class)', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(
+      makeQuill({ name: 'meta_test_quill', plate: TEST_PLATE, quillYaml: META_QUILL_YAML }),
+    )
+    const json = JSON.stringify(quill.metadata)
+    expect(typeof json).toBe('string')
+    const parsed = JSON.parse(json)
+    expect(parsed.name).toBe('meta_test_quill')
+  })
+})
+
+describe('Document.clone', () => {
+  it('returns an independent handle', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const clone = doc.clone()
+
+    clone.setField('title', 'Changed')
+
+    expect(doc.frontmatter.title).toBe('Test Document')
+    expect(clone.frontmatter.title).toBe('Changed')
+  })
+
+  it('preserves parse-time warnings on the clone', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const clone = doc.clone()
+
+    expect(clone.warnings.length).toBe(doc.warnings.length)
+  })
+
+  it('produces a clone that renders equivalently to the original', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const clone = doc.clone()
+
+    const r1 = quill.render(doc, { format: 'svg' })
+    const r2 = quill.render(clone, { format: 'svg' })
+    expect(r1.artifacts.length).toBe(r2.artifacts.length)
   })
 })
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -76,7 +76,10 @@ impl Quillmark {
 
     /// Load a quill from a file tree and attach the appropriate backend.
     ///
-    /// The tree must be a `Map<string, Uint8Array>`.
+    /// Accepts either a `Map<string, Uint8Array>` or a plain object
+    /// (`Record<string, Uint8Array>`). Plain objects are walked via
+    /// `Object.entries` at the boundary; the Rust side sees a single
+    /// canonical shape.
     #[wasm_bindgen(js_name = quill)]
     pub fn quill(&self, tree: JsValue) -> Result<Quill, JsValue> {
         let root = file_tree_from_js_tree(&tree)?;
@@ -128,6 +131,94 @@ impl Quill {
     #[wasm_bindgen(getter, js_name = backendId)]
     pub fn backend_id(&self) -> String {
         self.inner.backend_id().to_string()
+    }
+
+    /// Read-only snapshot of the loaded `Quill.yaml`.
+    ///
+    /// Returns a plain JS object with `name`, `backend`, `description`,
+    /// `version`, `author`, optional `example` (content of the example
+    /// markdown, when the quill ships one), `supportedFormats` (backend's
+    /// output formats as lowercase strings), `schema` (the raw main-card
+    /// field schema as parsed from YAML — consumers that need validation
+    /// run their own validator against this), and any additional
+    /// unstructured keys declared inside the `Quill:` section.
+    ///
+    /// Equivalent by value for the lifetime of the handle; the quill is
+    /// immutable once constructed.
+    #[wasm_bindgen(getter, js_name = metadata)]
+    pub fn metadata(&self) -> JsValue {
+        let source = self.inner.source();
+        let config = source.config();
+
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "name".to_string(),
+            serde_json::Value::String(config.name.clone()),
+        );
+        obj.insert(
+            "backend".to_string(),
+            serde_json::Value::String(config.backend.clone()),
+        );
+        obj.insert(
+            "description".to_string(),
+            serde_json::Value::String(config.main().description.clone().unwrap_or_default()),
+        );
+        obj.insert(
+            "version".to_string(),
+            serde_json::Value::String(config.version.clone()),
+        );
+        obj.insert(
+            "author".to_string(),
+            serde_json::Value::String(config.author.clone()),
+        );
+        if let Some(example) = source.example() {
+            obj.insert(
+                "example".to_string(),
+                serde_json::Value::String(example.to_string()),
+            );
+        }
+
+        let formats: Vec<serde_json::Value> = self
+            .inner
+            .supported_formats()
+            .iter()
+            .map(|f| {
+                let wasm_format: crate::types::OutputFormat = (*f).into();
+                serde_json::to_value(wasm_format).unwrap_or(serde_json::Value::Null)
+            })
+            .collect();
+        obj.insert(
+            "supportedFormats".to_string(),
+            serde_json::Value::Array(formats),
+        );
+
+        let mut schema = serde_json::Map::new();
+        for (name, field) in &config.main().fields {
+            schema.insert(
+                name.clone(),
+                serde_json::to_value(field).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        obj.insert("schema".to_string(), serde_json::Value::Object(schema));
+
+        // Unstructured keys declared under `Quill:` (excluding fields already
+        // surfaced above).
+        for (key, value) in source.metadata() {
+            if matches!(
+                key.as_str(),
+                "name" | "backend" | "description" | "version" | "author"
+            ) {
+                continue;
+            }
+            if obj.contains_key(key) {
+                continue;
+            }
+            obj.insert(key.clone(), value.as_json().clone());
+        }
+
+        let val = serde_json::Value::Object(obj);
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        val.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
     /// Project a document through this quill's schema.
@@ -188,6 +279,20 @@ impl Document {
         self.inner.to_markdown()
     }
 
+    /// Return a fresh `Document` handle with the same parse state.
+    ///
+    /// Mutations on the returned handle do not affect the original and
+    /// vice versa. Parse-time warnings are snapshotted alongside the
+    /// document — they describe the original parse, not the edit
+    /// history of either handle.
+    #[wasm_bindgen(js_name = clone)]
+    pub fn clone_doc(&self) -> Document {
+        Document {
+            inner: self.inner.clone(),
+            parse_warnings: self.parse_warnings.clone(),
+        }
+    }
+
     /// The QUILL reference string (e.g. `"usaf_memo@0.1"`).
     #[wasm_bindgen(getter, js_name = quillRef)]
     pub fn quill_ref(&self) -> String {
@@ -195,6 +300,8 @@ impl Document {
     }
 
     /// Typed YAML frontmatter fields as a JS object (no QUILL, BODY, or CARDS keys).
+    ///
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = frontmatter)]
     pub fn frontmatter(&self) -> JsValue {
         let mut map = serde_json::Map::new();
@@ -218,6 +325,8 @@ impl Document {
     }
 
     /// Ordered list of card blocks as JS objects with `tag`, `fields`, and `body`.
+    ///
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = cards)]
     pub fn cards(&self) -> JsValue {
         let cards: Vec<serde_json::Value> = self
@@ -242,6 +351,8 @@ impl Document {
     }
 
     /// Non-fatal parse-time warnings as a JS array of Diagnostic objects.
+    ///
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = warnings)]
     pub fn warnings(&self) -> JsValue {
         let diags: Vec<Diagnostic> = self
@@ -499,31 +610,49 @@ fn file_tree_from_js_tree(tree: &JsValue) -> Result<quillmark_core::FileTreeNode
 }
 
 fn js_tree_entries(tree: &JsValue) -> Result<Vec<(String, JsValue)>, JsValue> {
-    if !tree.is_instance_of::<js_sys::Map>() {
-        return Err(WasmError::from("quill requires a Map<string, Uint8Array>").to_js_value());
+    if tree.is_instance_of::<js_sys::Map>() {
+        let map = tree.clone().unchecked_into::<js_sys::Map>();
+        let iter = js_sys::try_iter(&map.entries())
+            .map_err(|e| {
+                WasmError::from(format!("Failed to iterate Map entries: {:?}", e)).to_js_value()
+            })?
+            .ok_or_else(|| WasmError::from("Map entries are not iterable").to_js_value())?;
+
+        let mut entries: Vec<(String, JsValue)> = Vec::new();
+        for entry in iter {
+            let pair = entry.map_err(|e| {
+                WasmError::from(format!("Failed to read Map entry: {:?}", e)).to_js_value()
+            })?;
+            let pair = Array::from(&pair);
+            let path = pair
+                .get(0)
+                .as_string()
+                .ok_or_else(|| WasmError::from("quill Map key must be a string").to_js_value())?;
+            let value = pair.get(1);
+            entries.push((path, value));
+        }
+        return Ok(entries);
     }
 
-    let map = tree.clone().unchecked_into::<js_sys::Map>();
-    let iter = js_sys::try_iter(&map.entries())
-        .map_err(|e| {
-            WasmError::from(format!("Failed to iterate Map entries: {:?}", e)).to_js_value()
-        })?
-        .ok_or_else(|| WasmError::from("Map entries are not iterable").to_js_value())?;
-
-    let mut entries: Vec<(String, JsValue)> = Vec::new();
-    for entry in iter {
-        let pair = entry.map_err(|e| {
-            WasmError::from(format!("Failed to read Map entry: {:?}", e)).to_js_value()
-        })?;
-        let pair = Array::from(&pair);
-        let path = pair
-            .get(0)
-            .as_string()
-            .ok_or_else(|| WasmError::from("quill Map key must be a string").to_js_value())?;
-        let value = pair.get(1);
-        entries.push((path, value));
+    // Plain object: walk via `Object.entries`.
+    if tree.is_object() && !tree.is_null() {
+        let obj = tree.clone().unchecked_into::<js_sys::Object>();
+        let pairs = js_sys::Object::entries(&obj);
+        let mut entries: Vec<(String, JsValue)> = Vec::with_capacity(pairs.length() as usize);
+        for i in 0..pairs.length() {
+            let pair = Array::from(&pairs.get(i));
+            let path = pair.get(0).as_string().ok_or_else(|| {
+                WasmError::from("quill object key must be a string").to_js_value()
+            })?;
+            entries.push((path, pair.get(1)));
+        }
+        return Ok(entries);
     }
-    Ok(entries)
+
+    Err(WasmError::from(
+        "quill requires a Map<string, Uint8Array> or Record<string, Uint8Array>",
+    )
+    .to_js_value())
 }
 
 fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValue> {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -141,7 +141,7 @@ impl Quill {
     /// output formats as lowercase strings), `schema` (the raw main-card
     /// field schema as parsed from YAML — consumers that need validation
     /// run their own validator against this), and any additional
-    /// unstructured keys declared inside the `Quill:` section.
+    /// unstructured keys declared inside the `quill:` section.
     ///
     /// Equivalent by value for the lifetime of the handle; the quill is
     /// immutable once constructed.
@@ -201,7 +201,7 @@ impl Quill {
         }
         obj.insert("schema".to_string(), serde_json::Value::Object(schema));
 
-        // Unstructured keys declared under `Quill:` (excluding fields already
+        // Unstructured keys declared under `quill:` (excluding fields already
         // surfaced above).
         for (key, value) in source.metadata() {
             if matches!(

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -546,7 +546,7 @@ impl Document {
         let card = self.inner.card_mut(index).ok_or_else(|| {
             edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
         })?;
-        card.set_body(body);
+        card.replace_body(body);
         Ok(())
     }
 }
@@ -588,7 +588,7 @@ fn js_value_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
         let qv = quillmark_core::QuillValue::from_json(v);
         card.set_field(&k, qv).map_err(|e| edit_error_to_js(&e))?;
     }
-    card.set_body(input.body);
+    card.replace_body(input.body);
     Ok(card)
 }
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -328,10 +328,12 @@ impl Document {
     /// global body. Frontmatter/body reads and mutations go through this
     /// handle — there are no document-level shortcuts after the rework.
     ///
-    /// Allocates on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = main)]
-    pub fn main(&self) -> Card {
-        Card::from(self.inner.main())
+    /// Allocates and serializes on each call — cache locally if read in a hot loop.
+    #[wasm_bindgen(getter, js_name = main, unchecked_return_type = "Card")]
+    pub fn main(&self) -> JsValue {
+        let card = Card::from(self.inner.main());
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        card.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
     /// Ordered list of composable card blocks as typed `Card` objects.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1,11 +1,31 @@
 //! Quillmark WASM Engine - Simplified API
 
 use crate::error::WasmError;
-use crate::types::{Diagnostic, RenderOptions, RenderResult};
+use crate::types::{Card, Diagnostic, RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
+
+/// TypeScript declaration for the `pushCard` / `insertCard` input shape.
+///
+/// `tag` is required; `fields` and `body` are optional (defaulted by serde).
+/// Emitted via `typescript_custom_section` so it lands in the generated
+/// `.d.ts` without forcing consumers to import a nominal type — the
+/// `unchecked_param_type` attribute on each method references it by name.
+#[wasm_bindgen(typescript_custom_section)]
+const CARD_INPUT_TS: &'static str = r#"
+/**
+ * Input shape for `Document.pushCard` and `Document.insertCard`.
+ *
+ * Only `tag` is required. `fields` defaults to `{}`, `body` to `""`.
+ */
+export interface CardInput {
+    tag: string;
+    fields?: Record<string, unknown>;
+    body?: string;
+}
+"#;
 
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
@@ -81,7 +101,10 @@ impl Quillmark {
     /// `Object.entries` at the boundary; the Rust side sees a single
     /// canonical shape.
     #[wasm_bindgen(js_name = quill)]
-    pub fn quill(&self, tree: JsValue) -> Result<Quill, JsValue> {
+    pub fn quill(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Map<string, Uint8Array>")] tree: JsValue,
+    ) -> Result<Quill, JsValue> {
         let root = file_tree_from_js_tree(&tree)?;
         let quill = self
             .inner
@@ -302,7 +325,7 @@ impl Document {
     /// Typed YAML frontmatter fields as a JS object (no QUILL, BODY, or CARDS keys).
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = frontmatter)]
+    #[wasm_bindgen(getter, js_name = frontmatter, unchecked_return_type = "Record<string, unknown>")]
     pub fn frontmatter(&self) -> JsValue {
         let mut map = serde_json::Map::new();
         for (k, v) in self.inner.frontmatter() {
@@ -315,50 +338,37 @@ impl Document {
 
     /// Global Markdown body between frontmatter and the first card.
     ///
-    /// Trailing newlines are stripped — those are structural separators in
-    /// the Markdown wire format, not content the consumer wrote.
+    /// Returned verbatim from core — the F2 structural separator is stripped
+    /// at parse time (see `quillmark_core::document::assemble::strip_f2_separator`),
+    /// so the string here is exactly what the author wrote (or what was set
+    /// via `replaceBody`).
     ///
     /// Empty string when no body is present.
     #[wasm_bindgen(getter, js_name = body)]
     pub fn body(&self) -> String {
-        trim_body(self.inner.body())
+        self.inner.body().to_string()
     }
 
-    /// Ordered list of card blocks as JS objects with `tag`, `fields`, and `body`.
+    /// Ordered list of card blocks as typed `Card` objects.
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = cards)]
+    #[wasm_bindgen(getter, js_name = cards, unchecked_return_type = "Card[]")]
     pub fn cards(&self) -> JsValue {
-        let cards: Vec<serde_json::Value> = self
-            .inner
-            .cards()
-            .iter()
-            .map(|card| {
-                let mut fields_map = serde_json::Map::new();
-                for (k, v) in card.fields() {
-                    fields_map.insert(k.clone(), v.as_json().clone());
-                }
-                serde_json::json!({
-                    "tag": card.tag(),
-                    "fields": serde_json::Value::Object(fields_map),
-                    "body": trim_body(card.body()),
-                })
-            })
-            .collect();
-        let val = serde_json::Value::Array(cards);
+        let cards: Vec<Card> = self.inner.cards().iter().map(Card::from).collect();
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        val.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
+        cards.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
-    /// Non-fatal parse-time warnings as a JS array of Diagnostic objects.
+    /// Non-fatal parse-time warnings as an array of typed `Diagnostic` objects.
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = warnings)]
+    #[wasm_bindgen(getter, js_name = warnings, unchecked_return_type = "Diagnostic[]")]
     pub fn warnings(&self) -> JsValue {
         let diags: Vec<Diagnostic> = self
             .parse_warnings
             .iter()
-            .map(|d| d.clone().into())
+            .cloned()
+            .map(Into::into)
             .collect();
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         diags.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
@@ -436,7 +446,10 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = pushCard)]
-    pub fn push_card(&mut self, card: JsValue) -> Result<(), JsValue> {
+    pub fn push_card(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
+    ) -> Result<(), JsValue> {
         let core_card = js_value_to_card(&card)?;
         self.inner
             .push_card(core_card)
@@ -449,7 +462,11 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = insertCard)]
-    pub fn insert_card(&mut self, index: usize, card: JsValue) -> Result<(), JsValue> {
+    pub fn insert_card(
+        &mut self,
+        index: usize,
+        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
+    ) -> Result<(), JsValue> {
         let core_card = js_value_to_card(&card)?;
         self.inner
             .insert_card(index, core_card)
@@ -459,10 +476,15 @@ impl Document {
     /// Remove the card at `index` and return it, or `undefined` if out of range.
     ///
     /// Mutators never modify `warnings`.
-    #[wasm_bindgen(js_name = removeCard)]
+    #[wasm_bindgen(js_name = removeCard, unchecked_return_type = "Card | undefined")]
     pub fn remove_card(&mut self, index: usize) -> JsValue {
         match self.inner.remove_card(index) {
-            Some(card) => card_to_js_value(&card),
+            Some(core_card) => {
+                let card = Card::from(&core_card);
+                let serializer =
+                    serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+                card.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
+            }
             None => JsValue::UNDEFINED,
         }
     }
@@ -561,32 +583,6 @@ fn js_value_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
     }
     card.set_body(input.body);
     Ok(card)
-}
-
-/// Serialise a [`quillmark_core::Card`] to a JS value
-/// `{ tag: string, fields: object, body: string }`.
-fn card_to_js_value(card: &quillmark_core::Card) -> JsValue {
-    let mut fields_map = serde_json::Map::new();
-    for (k, v) in card.fields() {
-        fields_map.insert(k.clone(), v.as_json().clone());
-    }
-    let json = serde_json::json!({
-        "tag": card.tag(),
-        "fields": serde_json::Value::Object(fields_map),
-        "body": trim_body(card.body()),
-    });
-    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-    json.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
-}
-
-/// Strip trailing line terminators from a body string.
-///
-/// Parsed bodies include a trailing blank line when followed by a card fence
-/// (required by the MARKDOWN.md §3 F2 rule); those characters are structural
-/// separators, not part of what the document author wrote.
-fn trim_body(body: &str) -> String {
-    body.trim_end_matches(|c: char| c == '\n' || c == '\r')
-        .to_string()
 }
 
 fn file_tree_from_js_tree(tree: &JsValue) -> Result<quillmark_core::FileTreeNode, JsValue> {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -458,9 +458,8 @@ impl Document {
         #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
     ) -> Result<(), JsValue> {
         let core_card = js_value_to_card(&card)?;
-        self.inner
-            .push_card(core_card)
-            .map_err(|e| edit_error_to_js(&e))
+        self.inner.push_card(core_card);
+        Ok(())
     }
 
     /// Insert a card at the given index.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -649,10 +649,10 @@ fn js_tree_entries(tree: &JsValue) -> Result<Vec<(String, JsValue)>, JsValue> {
         return Ok(entries);
     }
 
-    Err(WasmError::from(
-        "quill requires a Map<string, Uint8Array> or Record<string, Uint8Array>",
+    Err(
+        WasmError::from("quill requires a Map<string, Uint8Array> or Record<string, Uint8Array>")
+            .to_js_value(),
     )
-    .to_js_value())
 }
 
 fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValue> {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -322,34 +322,19 @@ impl Document {
         self.inner.quill_reference().to_string()
     }
 
-    /// Typed YAML frontmatter fields as a JS object (no QUILL, BODY, or CARDS keys).
+    /// The document's main (entry) card.
     ///
-    /// Allocates and serializes on each call — cache locally if read in a hot loop.
-    #[wasm_bindgen(getter, js_name = frontmatter, unchecked_return_type = "Record<string, unknown>")]
-    pub fn frontmatter(&self) -> JsValue {
-        let mut map = serde_json::Map::new();
-        for (k, v) in self.inner.frontmatter() {
-            map.insert(k.clone(), v.as_json().clone());
-        }
-        let val = serde_json::Value::Object(map);
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        val.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
+    /// Carries the QUILL sentinel, the document-level frontmatter, and the
+    /// global body. Frontmatter/body reads and mutations go through this
+    /// handle — there are no document-level shortcuts after the rework.
+    ///
+    /// Allocates on each call — cache locally if read in a hot loop.
+    #[wasm_bindgen(getter, js_name = main)]
+    pub fn main(&self) -> Card {
+        Card::from(self.inner.main())
     }
 
-    /// Global Markdown body between frontmatter and the first card.
-    ///
-    /// Returned verbatim from core — the F2 structural separator is stripped
-    /// at parse time (see `quillmark_core::document::assemble::strip_f2_separator`),
-    /// so the string here is exactly what the author wrote (or what was set
-    /// via `replaceBody`).
-    ///
-    /// Empty string when no body is present.
-    #[wasm_bindgen(getter, js_name = body)]
-    pub fn body(&self) -> String {
-        self.inner.body().to_string()
-    }
-
-    /// Ordered list of card blocks as typed `Card` objects.
+    /// Ordered list of composable card blocks as typed `Card` objects.
     ///
     /// Allocates and serializes on each call — cache locally if read in a hot loop.
     #[wasm_bindgen(getter, js_name = cards, unchecked_return_type = "Card[]")]
@@ -376,7 +361,10 @@ impl Document {
 
     // ── Mutators ──────────────────────────────────────────────────────────────
 
-    /// Set a frontmatter field.
+    /// Update a frontmatter field on the main card.
+    ///
+    /// Convenience method: equivalent to `doc.mainMut().setField(name, value)`.
+    /// Clears any existing `!fill` marker on the field.
     ///
     /// Throws an `Error` whose message includes the `EditError` variant name and
     /// details if `name` is reserved (`BODY`, `CARDS`, `QUILL`, `CARD`) or does
@@ -390,16 +378,36 @@ impl Document {
         })?;
         let qv = quillmark_core::QuillValue::from_json(json);
         self.inner
+            .main_mut()
             .set_field(name, qv)
             .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Remove a frontmatter field, returning the removed value or `undefined`.
+    /// Update a frontmatter field on the main card AND mark it as `!fill`.
+    ///
+    /// Convenience method: equivalent to `doc.mainMut().setFill(name, value)`.
+    ///
+    /// Throws on invalid name (see [`setField`](Document::set_field)).
+    ///
+    /// Mutators never modify `warnings`.
+    #[wasm_bindgen(js_name = setFill)]
+    pub fn set_fill(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
+        let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
+            WasmError::from(format!("setFill: invalid value: {}", e)).to_js_value()
+        })?;
+        let qv = quillmark_core::QuillValue::from_json(json);
+        self.inner
+            .main_mut()
+            .set_fill(name, qv)
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// Remove a frontmatter field on the main card, returning the removed value or `undefined`.
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = removeField)]
     pub fn remove_field(&mut self, name: &str) -> JsValue {
-        match self.inner.remove_field(name) {
+        match self.inner.main_mut().remove_field(name) {
             Some(v) => {
                 let serializer =
                     serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
@@ -429,12 +437,12 @@ impl Document {
         Ok(())
     }
 
-    /// Replace the global Markdown body.
+    /// Replace the main card's body (the global Markdown body).
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = replaceBody)]
     pub fn replace_body(&mut self, body: &str) {
-        self.inner.replace_body(body);
+        self.inner.main_mut().replace_body(body);
     }
 
     /// Append a card to the end of the card list.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -392,9 +392,8 @@ impl Document {
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = setFill)]
     pub fn set_fill(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
-        let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
-            WasmError::from(format!("setFill: invalid value: {}", e)).to_js_value()
-        })?;
+        let json: serde_json::Value = serde_wasm_bindgen::from_value(value)
+            .map_err(|e| WasmError::from(format!("setFill: invalid value: {}", e)).to_js_value())?;
         let qv = quillmark_core::QuillValue::from_json(json);
         self.inner
             .main_mut()

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -167,6 +167,20 @@ pub struct Card {
     pub body: String,
 }
 
+impl From<&quillmark_core::Card> for Card {
+    fn from(card: &quillmark_core::Card) -> Self {
+        let mut fields_map = serde_json::Map::new();
+        for (k, v) in card.fields() {
+            fields_map.insert(k.clone(), v.as_json().clone());
+        }
+        Card {
+            tag: card.tag().to_string(),
+            fields: serde_json::Value::Object(fields_map),
+            body: card.body().to_string(),
+        }
+    }
+}
+
 /// Options for rendering
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -151,18 +151,52 @@ pub struct RenderResult {
     pub render_time_ms: f64,
 }
 
+/// A single frontmatter item — either a field or an own-line comment.
+///
+/// Exposed via `Card.frontmatterItems`.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum FrontmatterItem {
+    Field {
+        key: String,
+        #[tsify(type = "unknown")]
+        value: serde_json::Value,
+        /// `true` when the field was written as `key: !fill <value>` in
+        /// source or was marked via `Card.setFill()`.
+        #[serde(default)]
+        fill: bool,
+    },
+    Comment {
+        text: String,
+    },
+}
+
 /// A single card block parsed from a Quillmark Markdown document.
 ///
-/// Exposed as a plain JS object via the `Document.cards` getter.
+/// Exposed as a plain JS object via `Document.main`, `Document.cards`, etc.
+/// Carries a sentinel that distinguishes the document entry (main) card from
+/// composable cards, a `tag` string (the QUILL reference or CARD tag), typed
+/// frontmatter (map view under `frontmatter`, ordered item list under
+/// `frontmatterItems`), and the body.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct Card {
-    /// The CARD sentinel value (e.g. `"indorsement"`).
+    /// `"main"` for the document entry (QUILL) card; `"card"` for composable cards.
+    pub sentinel: String,
+    /// The CARD sentinel value (e.g. `"indorsement"`) or the QUILL reference
+    /// string for the main card.
     pub tag: String,
-    /// Typed YAML fields from the card fence (no `CARD` key).
+    /// Map-keyed view of frontmatter values (no `CARD`/`QUILL` key, comments invisible).
+    #[tsify(type = "Record<string, unknown>")]
+    pub frontmatter: serde_json::Value,
+    /// Back-compat alias for `frontmatter`. Will be removed in a future release.
     #[tsify(type = "Record<string, unknown>")]
     pub fields: serde_json::Value,
+    /// Ordered frontmatter item list — fields and comments, in source order.
+    #[tsify(type = "FrontmatterItem[]")]
+    pub frontmatter_items: Vec<FrontmatterItem>,
     /// Markdown body after the card's closing `---`. Empty string when absent.
     pub body: String,
 }
@@ -170,12 +204,38 @@ pub struct Card {
 impl From<&quillmark_core::Card> for Card {
     fn from(card: &quillmark_core::Card) -> Self {
         let mut fields_map = serde_json::Map::new();
-        for (k, v) in card.fields() {
+        for (k, v) in card.frontmatter().iter() {
             fields_map.insert(k.clone(), v.as_json().clone());
         }
+
+        let frontmatter_value = serde_json::Value::Object(fields_map);
+
+        let items: Vec<FrontmatterItem> = card
+            .frontmatter()
+            .items()
+            .iter()
+            .map(|item| match item {
+                quillmark_core::FrontmatterItem::Field { key, value, fill } => {
+                    FrontmatterItem::Field {
+                        key: key.clone(),
+                        value: value.as_json().clone(),
+                        fill: *fill,
+                    }
+                }
+                quillmark_core::FrontmatterItem::Comment { text } => {
+                    FrontmatterItem::Comment { text: text.clone() }
+                }
+            })
+            .collect();
+
+        let sentinel = if card.is_main() { "main" } else { "card" };
+
         Card {
-            tag: card.tag().to_string(),
-            fields: serde_json::Value::Object(fields_map),
+            sentinel: sentinel.to_string(),
+            tag: card.tag(),
+            frontmatter: frontmatter_value.clone(),
+            fields: frontmatter_value,
+            frontmatter_items: items,
             body: card.body().to_string(),
         }
     }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -179,7 +179,10 @@ pub struct RenderOptions {
     /// Defaults to 144.0 (2x at 72pt/inch) when omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ppi: Option<f32>,
-    /// Optional page indices to render (`undefined` means all pages).
+    /// Optional 0-based page indices to render (e.g., `[0, 2]` for the
+    /// first and third pages). `undefined` renders all pages. **Not
+    /// supported for PDF output** — passing `pages` with `format: "pdf"`
+    /// yields a `FormatNotSupported` error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pages: Option<Vec<usize>>,
 }

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -6,7 +6,7 @@ export function makeQuill({
   plate = '#import "@local/quillmark-helper:0.1.0": data\n= Test',
   quillYaml,
 } = {}) {
-  const yaml = quillYaml ?? `Quill:
+  const yaml = quillYaml ?? `quill:
   name: ${name}
   version: "${version}"
   backend: typst

--- a/crates/bindings/wasm/tests/common.rs
+++ b/crates/bindings/wasm/tests/common.rs
@@ -1,4 +1,4 @@
-use js_sys::{Map, Uint8Array};
+use js_sys::{Map, Object, Reflect, Uint8Array};
 use wasm_bindgen::JsValue;
 
 pub fn tree(entries: &[(&str, &[u8])]) -> JsValue {
@@ -9,4 +9,16 @@ pub fn tree(entries: &[(&str, &[u8])]) -> JsValue {
         map.set(&JsValue::from_str(path), &array.into());
     }
     map.into()
+}
+
+/// Build a plain-object file tree (`Record<string, Uint8Array>`).
+#[allow(dead_code)]
+pub fn tree_object(entries: &[(&str, &[u8])]) -> JsValue {
+    let obj = Object::new();
+    for (path, bytes) in entries {
+        let array = Uint8Array::new_with_length(bytes.len() as u32);
+        array.copy_from(bytes);
+        Reflect::set(&obj, &JsValue::from_str(path), &array.into()).unwrap();
+    }
+    obj.into()
 }

--- a/crates/bindings/wasm/tests/metadata.rs
+++ b/crates/bindings/wasm/tests/metadata.rs
@@ -8,7 +8,7 @@ fn test_quill_from_tree_with_ui_metadata() {
     let tree = common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: ui_test_quill\n  version: \"0.1\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for UI metadata\n\nmain:\n  fields:\n    my_field:\n      type: string\n      ui:\n        group: Personal Info\n",
+            b"quill:\n  name: ui_test_quill\n  version: \"0.1\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for UI metadata\n\nmain:\n  fields:\n    my_field:\n      type: string\n      ui:\n        group: Personal Info\n",
         ),
         ("plate.typ", b"= Title"),
     ]);

--- a/crates/bindings/wasm/tests/resolve_quill.rs
+++ b/crates/bindings/wasm/tests/resolve_quill.rs
@@ -12,7 +12,7 @@ fn test_quill_from_tree_versioned() {
     let q1 = engine.quill(common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.1.0\n",
+            b"quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.1.0\n",
         ),
         ("plate.typ", b"hello 1"),
     ])).unwrap();
@@ -20,7 +20,7 @@ fn test_quill_from_tree_versioned() {
     let q2 = engine.quill(common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.2.0\n",
+            b"quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.2.0\n",
         ),
         ("plate.typ", b"hello 2"),
     ])).unwrap();

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -28,8 +28,8 @@ fn test_parse_markdown_static() {
 fn test_document_body_and_warnings() {
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     // Body at EOF: no F2 separator to strip, so trailing content newlines are
-    // preserved verbatim. The WASM binding forwards core's body unchanged.
-    assert_eq!(doc.main().body, "\n# Hello\n");
+    // preserved verbatim. `toMarkdown` carries the body through unchanged.
+    assert!(doc.to_markdown().contains("# Hello\n"));
     // warnings() returns JsValue (array) — just verify it's defined
     let warnings = doc.warnings();
     assert!(!warnings.is_undefined());
@@ -223,18 +223,19 @@ fn test_document_clone_independence() {
         .set_field("title", JsValue::from_str("Changed"))
         .expect("setField on clone");
 
-    let original_fm = doc.main().frontmatter;
-    let clone_fm = clone.main().frontmatter;
+    // Emit both and check the title survived on each side independently.
+    let original_md = doc.to_markdown();
+    let clone_md = clone.to_markdown();
 
-    assert_eq!(
-        original_fm.get("title").and_then(|v| v.as_str()),
-        Some("Hello"),
-        "original frontmatter must be untouched after clone mutation"
+    assert!(
+        original_md.contains("title: \"Hello\""),
+        "original frontmatter must be untouched after clone mutation\nGot:\n{}",
+        original_md
     );
-    assert_eq!(
-        clone_fm.get("title").and_then(|v| v.as_str()),
-        Some("Changed"),
-        "clone frontmatter must reflect the mutation"
+    assert!(
+        clone_md.contains("title: \"Changed\""),
+        "clone frontmatter must reflect the mutation\nGot:\n{}",
+        clone_md
     );
 
     // Warnings are a JS array on both handles. Length-equality is the

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -133,7 +133,9 @@ fn test_quill_from_object_tree() {
     ];
 
     let engine = Quillmark::new();
-    let from_map = engine.quill(common::tree(entries)).expect("Map form failed");
+    let from_map = engine
+        .quill(common::tree(entries))
+        .expect("Map form failed");
     let from_obj = engine
         .quill(common::tree_object(entries))
         .expect("Object form failed");

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -119,3 +119,135 @@ fn test_to_markdown_round_trip() {
         "quill_ref must survive round-trip"
     );
 }
+
+/// Plain object (`Record<string, Uint8Array>`) must be accepted by
+/// `engine.quill` equivalently to `Map<string, Uint8Array>`.
+#[wasm_bindgen_test]
+fn test_quill_from_object_tree() {
+    let entries: &[(&str, &[u8])] = &[
+        (
+            "Quill.yaml",
+            b"Quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+        ),
+        ("plate.typ", b"= Title\n\nThis is a test."),
+    ];
+
+    let engine = Quillmark::new();
+    let from_map = engine.quill(common::tree(entries)).expect("Map form failed");
+    let from_obj = engine
+        .quill(common::tree_object(entries))
+        .expect("Object form failed");
+
+    assert_eq!(from_map.backend_id(), from_obj.backend_id());
+
+    // Both handles render the same document to the same artifact count/format.
+    let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let doc2 = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let r_map = from_map
+        .render(&doc, Some(RenderOptions::default()))
+        .expect("render from Map form");
+    let r_obj = from_obj
+        .render(&doc2, Some(RenderOptions::default()))
+        .expect("render from object form");
+    assert_eq!(r_map.artifacts.len(), r_obj.artifacts.len());
+}
+
+/// `quill.metadata` exposes the snapshot of `Quill.yaml` expected by
+/// downstream consumers: `name`, `backend`, `description`, `version`,
+/// `supportedFormats`, and the raw `schema`.
+#[wasm_bindgen_test]
+fn test_quill_metadata_snapshot() {
+    use js_sys::Reflect;
+    use wasm_bindgen::JsValue;
+
+    let engine = Quillmark::new();
+    let quill = engine
+        .quill(common::tree(&[
+            (
+                "Quill.yaml",
+                b"Quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n",
+            ),
+            ("plate.typ", b"= Title"),
+        ]))
+        .expect("quill failed");
+
+    let meta: JsValue = quill.metadata();
+    assert!(meta.is_object(), "metadata must be a plain JS object");
+
+    let get = |key: &str| -> JsValue { Reflect::get(&meta, &JsValue::from_str(key)).unwrap() };
+
+    assert_eq!(get("name").as_string().as_deref(), Some("meta_quill"));
+    assert_eq!(get("backend").as_string().as_deref(), Some("typst"));
+    assert_eq!(
+        get("description").as_string().as_deref(),
+        Some("Metadata quill")
+    );
+    assert_eq!(get("version").as_string().as_deref(), Some("0.2.1"));
+    // `author` defaults to "Unknown" when the YAML omits it.
+    assert_eq!(get("author").as_string().as_deref(), Some("Unknown"));
+
+    let formats = get("supportedFormats");
+    assert!(
+        js_sys::Array::is_array(&formats),
+        "supportedFormats must be an array"
+    );
+    let formats_arr = js_sys::Array::from(&formats);
+    assert!(
+        formats_arr.length() > 0,
+        "supportedFormats must be non-empty"
+    );
+
+    let schema = get("schema");
+    assert!(schema.is_object(), "schema must be an object");
+    let title_field = Reflect::get(&schema, &JsValue::from_str("title")).unwrap();
+    assert!(
+        title_field.is_object(),
+        "schema.title must be present from Quill.yaml"
+    );
+}
+
+/// `doc.clone()` returns an independent handle: mutations on the clone
+/// must not affect the original, and parse-time warnings must survive.
+#[wasm_bindgen_test]
+fn test_document_clone_independence() {
+    use js_sys::Reflect;
+    use wasm_bindgen::JsValue;
+
+    let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let mut clone = doc.clone_doc();
+
+    // Mutate the clone; the original must keep its original title.
+    clone
+        .set_field("title", JsValue::from_str("Changed"))
+        .expect("setField on clone");
+
+    let original_fm = doc.frontmatter();
+    let clone_fm = clone.frontmatter();
+
+    assert_eq!(
+        Reflect::get(&original_fm, &JsValue::from_str("title"))
+            .unwrap()
+            .as_string()
+            .as_deref(),
+        Some("Hello"),
+        "original frontmatter must be untouched after clone mutation"
+    );
+    assert_eq!(
+        Reflect::get(&clone_fm, &JsValue::from_str("title"))
+            .unwrap()
+            .as_string()
+            .as_deref(),
+        Some("Changed"),
+        "clone frontmatter must reflect the mutation"
+    );
+
+    // Warnings are a JS array on both handles. Length-equality is the
+    // observable guarantee for parse-warning preservation.
+    let orig_warns = js_sys::Array::from(&doc.warnings());
+    let clone_warns = js_sys::Array::from(&clone.warnings());
+    assert_eq!(
+        orig_warns.length(),
+        clone_warns.length(),
+        "clone must preserve parse-time warnings"
+    );
+}

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -27,8 +27,9 @@ fn test_parse_markdown_static() {
 #[wasm_bindgen_test]
 fn test_document_body_and_warnings() {
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
-    // WASM `body` getter strips trailing newlines (structural separator, not content).
-    assert_eq!(doc.body(), "\n# Hello");
+    // Body at EOF: no F2 separator to strip, so trailing content newlines are
+    // preserved verbatim. The WASM binding forwards core's body unchanged.
+    assert_eq!(doc.body(), "\n# Hello\n");
     // warnings() returns JsValue (array) — just verify it's defined
     let warnings = doc.warnings();
     assert!(!warnings.is_undefined());

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -29,7 +29,7 @@ fn test_document_body_and_warnings() {
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     // Body at EOF: no F2 separator to strip, so trailing content newlines are
     // preserved verbatim. The WASM binding forwards core's body unchanged.
-    assert_eq!(doc.body(), "\n# Hello\n");
+    assert_eq!(doc.main().body, "\n# Hello\n");
     // warnings() returns JsValue (array) — just verify it's defined
     let warnings = doc.warnings();
     assert!(!warnings.is_undefined());
@@ -224,22 +224,16 @@ fn test_document_clone_independence() {
         .set_field("title", JsValue::from_str("Changed"))
         .expect("setField on clone");
 
-    let original_fm = doc.frontmatter();
-    let clone_fm = clone.frontmatter();
+    let original_fm = doc.main().frontmatter;
+    let clone_fm = clone.main().frontmatter;
 
     assert_eq!(
-        Reflect::get(&original_fm, &JsValue::from_str("title"))
-            .unwrap()
-            .as_string()
-            .as_deref(),
+        original_fm.get("title").and_then(|v| v.as_str()),
         Some("Hello"),
         "original frontmatter must be untouched after clone mutation"
     );
     assert_eq!(
-        Reflect::get(&clone_fm, &JsValue::from_str("title"))
-            .unwrap()
-            .as_string()
-            .as_deref(),
+        clone_fm.get("title").and_then(|v| v.as_str()),
         Some("Changed"),
         "clone frontmatter must reflect the mutation"
     );

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -213,7 +213,6 @@ fn test_quill_metadata_snapshot() {
 /// must not affect the original, and parse-time warnings must survive.
 #[wasm_bindgen_test]
 fn test_document_clone_independence() {
-    use js_sys::Reflect;
     use wasm_bindgen::JsValue;
 
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -10,7 +10,7 @@ fn small_quill_tree() -> wasm_bindgen::JsValue {
     common::tree(&[
         (
             "Quill.yaml",
-            b"Quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+            b"quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
         ),
         ("plate.typ", b"= Title\n\nThis is a test."),
     ])
@@ -127,7 +127,7 @@ fn test_quill_from_object_tree() {
     let entries: &[(&str, &[u8])] = &[
         (
             "Quill.yaml",
-            b"Quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+            b"quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
         ),
         ("plate.typ", b"= Title\n\nThis is a test."),
     ];
@@ -167,7 +167,7 @@ fn test_quill_metadata_snapshot() {
         .quill(common::tree(&[
             (
                 "Quill.yaml",
-                b"Quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n",
+                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n",
             ),
             ("plate.typ", b"= Title"),
         ]))

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -325,12 +325,12 @@ fn build_frontmatter_from_pre_and_parsed(
                     continue;
                 }
                 if let Some(value) = mapping.get(key).cloned() {
-                    // `!fill` only applies to scalars (string/int/float/
-                    // bool/null). Reject tagged maps or sequences per
-                    // tasking 02 (`unsupported_fill_target`).
-                    if *fill && (value.is_array() || value.is_object()) {
+                    // `!fill` applies to scalars and sequences. Mappings
+                    // are rejected because top-level `type: object` is
+                    // unsupported by Quillmark's schema.
+                    if *fill && value.is_object() {
                         return Err(ParseError::InvalidStructure(format!(
-                            "`!fill` on key `{}` targets a non-scalar value; only scalars (string, int, float, bool, null) may be tagged `!fill`",
+                            "`!fill` on key `{}` targets a mapping; `!fill` is supported on scalars and sequences only",
                             key
                         )));
                     }

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -5,16 +5,16 @@
 
 use std::str::FromStr;
 
-use indexmap::IndexMap;
-
 use crate::error::ParseError;
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 use crate::Diagnostic;
 
 use super::fences::{fence_opener_len, find_metadata_blocks};
+use super::frontmatter::{Frontmatter, FrontmatterItem};
+use super::prescan::{prescan_fence_content, PreItem};
 use super::sentinel::extract_sentinels;
-use super::{Card, Document};
+use super::{Card, Document, Sentinel};
 
 /// Strip exactly one F2 structural separator from the tail of a body slice.
 ///
@@ -47,6 +47,10 @@ pub(super) struct MetadataBlock {
     pub(super) yaml_value: Option<serde_json::Value>, // Parsed YAML as JSON (None if empty or parse failed)
     pub(super) tag: Option<String>,                   // Field name from CARD key
     pub(super) quill_ref: Option<String>,             // Quill reference from QUILL key
+    /// Pre-scan items (comments + fill-tagged field keys) in source order.
+    pub(super) pre_items: Vec<PreItem>,
+    /// Pre-scan warnings (nested-comment drops, unknown-tag strips, ...).
+    pub(super) pre_warnings: Vec<Diagnostic>,
 }
 
 /// Creates serde_saphyr Options with security budgets configured.
@@ -84,12 +88,20 @@ pub(super) fn build_block(
         });
     }
 
-    let content = raw_content.trim();
+    // Run the pre-scan to extract top-level comments, `!fill` markers,
+    // and warn on unsupported tags / nested comments.
+    let pre = prescan_fence_content(raw_content);
+
+    if let Some(err) = pre.fill_target_errors.first() {
+        return Err(ParseError::InvalidStructure(err.clone()));
+    }
+
+    let content = pre.cleaned_yaml.trim().to_string();
     let (tag, quill_ref, yaml_value) = if content.is_empty() {
         (None, None, None)
     } else {
         match serde_saphyr::from_str_with_options::<serde_json::Value>(
-            content,
+            &content,
             yaml_parse_options(),
         ) {
             Ok(parsed) => extract_sentinels(parsed, markdown, abs_pos, block_index)?,
@@ -127,6 +139,8 @@ pub(super) fn build_block(
         yaml_value,
         tag,
         quill_ref,
+        pre_items: pre.items,
+        pre_warnings: pre.warnings,
     })
 }
 
@@ -189,20 +203,19 @@ pub(super) fn decompose_with_warnings(
         )
     })?;
 
-    // Build frontmatter IndexMap (YAML content with QUILL stripped).
-    let mut frontmatter: IndexMap<String, QuillValue> = IndexMap::new();
-    match &frontmatter_block.yaml_value {
-        Some(serde_json::Value::Object(mapping)) => {
-            for (key, value) in mapping {
-                frontmatter.insert(key.clone(), QuillValue::from_json(value.clone()));
-            }
-        }
-        Some(serde_json::Value::Null) | None => {}
-        Some(_) => {
-            return Err(ParseError::InvalidStructure(
-                "Invalid YAML frontmatter: expected a mapping".to_string(),
-            ));
-        }
+    // Build frontmatter item list (YAML content with QUILL stripped).
+    //
+    // The pre-scan captured top-level comments and `!fill` markers in source
+    // order; serde_saphyr produced the parsed values. We iterate the pre-scan
+    // order and pull each field's value from the parsed map.
+    let frontmatter = build_frontmatter_from_pre_and_parsed(
+        &frontmatter_block.pre_items,
+        &frontmatter_block.yaml_value,
+    )?;
+    // Surface pre-scan warnings (nested-comment drops, unsupported tags).
+    let mut warnings = warnings;
+    for w in &frontmatter_block.pre_warnings {
+        warnings.push(w.clone());
     }
 
     // Global body: between end of frontmatter (block 0) and start of the
@@ -229,21 +242,20 @@ pub(super) fn decompose_with_warnings(
     let mut cards: Vec<Card> = Vec::new();
     for (idx, block) in blocks.iter().enumerate() {
         if let Some(ref tag_name) = block.tag {
-            // Build the card's typed fields.
-            let mut card_fields: IndexMap<String, QuillValue> = IndexMap::new();
-            match &block.yaml_value {
-                Some(serde_json::Value::Object(mapping)) => {
-                    for (key, value) in mapping {
-                        card_fields.insert(key.clone(), QuillValue::from_json(value.clone()));
-                    }
-                }
-                Some(serde_json::Value::Null) | None => {}
-                Some(_) => {
-                    return Err(crate::error::ParseError::InvalidStructure(format!(
-                        "Invalid YAML in card block '{}': expected a mapping",
-                        tag_name
-                    )));
-                }
+            // Build the card's typed frontmatter from pre-scan + parsed YAML.
+            let card_frontmatter = build_frontmatter_from_pre_and_parsed(
+                &block.pre_items,
+                &block.yaml_value,
+            )
+            .map_err(|e| match e {
+                ParseError::InvalidStructure(msg) => ParseError::InvalidStructure(format!(
+                    "Invalid YAML in card block '{}': {}",
+                    tag_name, msg
+                )),
+                other => other,
+            })?;
+            for w in &block.pre_warnings {
+                warnings.push(w.clone());
             }
 
             // Card body: between this block's end and the next block's start (or EOF).
@@ -261,7 +273,11 @@ pub(super) fn decompose_with_warnings(
                 card_body_raw.to_string()
             };
 
-            cards.push(Card::new_internal(tag_name.clone(), card_fields, card_body));
+            cards.push(Card::new_with_sentinel(
+                Sentinel::Card(tag_name.clone()),
+                card_frontmatter,
+                card_body,
+            ));
         }
     }
 
@@ -269,7 +285,84 @@ pub(super) fn decompose_with_warnings(
         ParseError::InvalidStructure(format!("Invalid QUILL tag '{}': {}", quill_tag, e))
     })?;
 
-    let doc = Document::new_internal(quill_ref, frontmatter, global_body, cards, warnings.clone());
+    let main = Card::new_with_sentinel(Sentinel::Main(quill_ref), frontmatter, global_body);
+    let doc = Document::from_main_and_cards(main, cards, warnings.clone());
 
     Ok((doc, warnings))
+}
+
+/// Build a [`Frontmatter`] from the pre-scan items and the parsed YAML
+/// mapping (with sentinel keys already stripped).
+///
+/// The pre-scan defined source order for fields and comments; the parsed
+/// YAML defined the typed value for each key. We walk pre-scan order,
+/// pulling each field's value from `parsed`. Any field that the pre-scan
+/// didn't catch (e.g. it used a YAML key form the pre-scan doesn't
+/// recognise — exotic identifier, flow-mapping syntax, etc.) is appended at
+/// the end of the item list in parsed-map order so we never drop values.
+fn build_frontmatter_from_pre_and_parsed(
+    pre_items: &[PreItem],
+    yaml_value: &Option<serde_json::Value>,
+) -> Result<Frontmatter, ParseError> {
+    let mapping = match yaml_value {
+        Some(serde_json::Value::Object(map)) => map.clone(),
+        Some(serde_json::Value::Null) | None => serde_json::Map::new(),
+        Some(_) => {
+            return Err(ParseError::InvalidStructure(
+                "expected a mapping".to_string(),
+            ));
+        }
+    };
+
+    let mut items: Vec<FrontmatterItem> = Vec::new();
+    let mut consumed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for pre in pre_items {
+        match pre {
+            PreItem::Comment(text) => items.push(FrontmatterItem::comment(text.clone())),
+            PreItem::Field { key, fill } => {
+                // QUILL / CARD sentinel keys are stripped from the parsed
+                // map by `extract_sentinels`; skip them in the item list.
+                if key == "QUILL" || key == "CARD" {
+                    continue;
+                }
+                if let Some(value) = mapping.get(key).cloned() {
+                    // `!fill` only applies to scalars (string/int/float/
+                    // bool/null). Reject tagged maps or sequences per
+                    // tasking 02 (`unsupported_fill_target`).
+                    if *fill
+                        && (value.is_array() || value.is_object())
+                    {
+                        return Err(ParseError::InvalidStructure(format!(
+                            "`!fill` on key `{}` targets a non-scalar value; only scalars (string, int, float, bool, null) may be tagged `!fill`",
+                            key
+                        )));
+                    }
+                    items.push(FrontmatterItem::Field {
+                        key: key.clone(),
+                        value: QuillValue::from_json(value),
+                        fill: *fill,
+                    });
+                    consumed.insert(key.clone());
+                }
+                // If the key isn't in the parsed map, it was dropped by
+                // YAML parsing (shouldn't happen for well-formed input);
+                // silently skip.
+            }
+        }
+    }
+
+    // Append any parsed-map keys that the pre-scan didn't capture.
+    for (key, value) in &mapping {
+        if consumed.contains(key) {
+            continue;
+        }
+        items.push(FrontmatterItem::Field {
+            key: key.clone(),
+            value: QuillValue::from_json(value.clone()),
+            fill: false,
+        });
+    }
+
+    Ok(Frontmatter::from_items(items))
 }

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -243,17 +243,15 @@ pub(super) fn decompose_with_warnings(
     for (idx, block) in blocks.iter().enumerate() {
         if let Some(ref tag_name) = block.tag {
             // Build the card's typed frontmatter from pre-scan + parsed YAML.
-            let card_frontmatter = build_frontmatter_from_pre_and_parsed(
-                &block.pre_items,
-                &block.yaml_value,
-            )
-            .map_err(|e| match e {
-                ParseError::InvalidStructure(msg) => ParseError::InvalidStructure(format!(
-                    "Invalid YAML in card block '{}': {}",
-                    tag_name, msg
-                )),
-                other => other,
-            })?;
+            let card_frontmatter =
+                build_frontmatter_from_pre_and_parsed(&block.pre_items, &block.yaml_value)
+                    .map_err(|e| match e {
+                        ParseError::InvalidStructure(msg) => ParseError::InvalidStructure(format!(
+                            "Invalid YAML in card block '{}': {}",
+                            tag_name, msg
+                        )),
+                        other => other,
+                    })?;
             for w in &block.pre_warnings {
                 warnings.push(w.clone());
             }
@@ -330,9 +328,7 @@ fn build_frontmatter_from_pre_and_parsed(
                     // `!fill` only applies to scalars (string/int/float/
                     // bool/null). Reject tagged maps or sequences per
                     // tasking 02 (`unsupported_fill_target`).
-                    if *fill
-                        && (value.is_array() || value.is_object())
-                    {
+                    if *fill && (value.is_array() || value.is_object()) {
                         return Err(ParseError::InvalidStructure(format!(
                             "`!fill` on key `{}` targets a non-scalar value; only scalars (string, int, float, bool, null) may be tagged `!fill`",
                             key

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -16,6 +16,29 @@ use super::fences::{fence_opener_len, find_metadata_blocks};
 use super::sentinel::extract_sentinels;
 use super::{Card, Document};
 
+/// Strip exactly one F2 structural separator from the tail of a body slice.
+///
+/// The F2 rule (`MARKDOWN.md §3`) requires a blank line immediately above
+/// every metadata fence. When a body is followed by another fence, the raw
+/// slice ends with that blank line's terminator — exactly one `\n` or
+/// `\r\n`. This helper strips that single line ending so stored bodies
+/// contain only authored content. The emitter re-adds the separator on
+/// output via `ensure_blank_line_before_fence`.
+///
+/// Stripping more than one line ending (as the WASM binding's former
+/// `trim_body` did) would silently drop content-meaningful trailing
+/// newlines — e.g. a body that ends with a fenced code block's closing
+/// newline.
+fn strip_f2_separator(body: &str) -> &str {
+    if let Some(rest) = body.strip_suffix("\r\n") {
+        rest
+    } else if let Some(rest) = body.strip_suffix('\n') {
+        rest
+    } else {
+        body
+    }
+}
+
 /// An intermediate representation of one `---…---` metadata block.
 #[derive(Debug)]
 pub(super) struct MetadataBlock {
@@ -184,14 +207,23 @@ pub(super) fn decompose_with_warnings(
 
     // Global body: between end of frontmatter (block 0) and start of the
     // first CARD block (or EOF).
+    //
+    // When a fence follows, the body slice ends with the F2 blank-line
+    // terminator — strip it so stored bodies contain only authored content.
+    // The emitter re-derives the separator on output (see `emit.rs`'s
+    // `ensure_blank_line_before_fence`).
     let body_start = blocks[0].end;
-    let body_end = blocks
-        .iter()
-        .skip(1)
-        .find(|b| b.tag.is_some())
-        .map(|b| b.start)
-        .unwrap_or(markdown.len());
-    let global_body = markdown[body_start..body_end].to_string();
+    let first_card_block = blocks.iter().skip(1).find(|b| b.tag.is_some());
+    let (body_end, body_is_followed_by_fence) = match first_card_block {
+        Some(b) => (b.start, true),
+        None => (markdown.len(), false),
+    };
+    let global_body_raw = &markdown[body_start..body_end];
+    let global_body = if body_is_followed_by_fence {
+        strip_f2_separator(global_body_raw).to_string()
+    } else {
+        global_body_raw.to_string()
+    };
 
     // Parse tagged blocks (CARD blocks) into typed Cards.
     let mut cards: Vec<Card> = Vec::new();
@@ -216,12 +248,18 @@ pub(super) fn decompose_with_warnings(
 
             // Card body: between this block's end and the next block's start (or EOF).
             let card_body_start = block.end;
-            let card_body_end = if idx + 1 < blocks.len() {
+            let has_next_block = idx + 1 < blocks.len();
+            let card_body_end = if has_next_block {
                 blocks[idx + 1].start
             } else {
                 markdown.len()
             };
-            let card_body = markdown[card_body_start..card_body_end].to_string();
+            let card_body_raw = &markdown[card_body_start..card_body_end];
+            let card_body = if has_next_block {
+                strip_f2_separator(card_body_raw).to_string()
+            } else {
+                card_body_raw.to_string()
+            };
 
             cards.push(Card::new_internal(tag_name.clone(), card_fields, card_body));
         }

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -232,7 +232,7 @@ impl Card {
     }
 
     /// Set a frontmatter field by name. Always clears the `!fill` marker for
-    /// that key (per tasking 02, this is the "user filled in" path).
+    /// that key — the "user filled in" path.
     ///
     /// # Invariants enforced
     ///
@@ -260,9 +260,9 @@ impl Card {
         Ok(())
     }
 
-    /// Set a frontmatter field AND mark it as a `!fill` placeholder (per
-    /// tasking 02, this is the "reset to placeholder" path). A `Null` value
-    /// emits as `key: !fill`; a scalar value emits as `key: !fill <value>`.
+    /// Set a frontmatter field AND mark it as a `!fill` placeholder — the
+    /// "reset to placeholder" path. A `Null` value emits as `key: !fill`;
+    /// a scalar or sequence value emits as `key: !fill <value>`.
     ///
     /// # Invariants enforced
     ///
@@ -301,11 +301,5 @@ impl Card {
     /// Card mutators never modify the parent document's `warnings`.
     pub fn replace_body(&mut self, body: impl Into<String>) {
         self.overwrite_body(body.into());
-    }
-
-    /// Deprecated alias for [`Card::replace_body`]; kept to ease migration.
-    #[doc(hidden)]
-    pub fn set_body(&mut self, body: impl Into<String>) {
-        self.replace_body(body);
     }
 }

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -122,10 +122,6 @@ impl Document {
 
     /// Append a composable card to the end of the card list.
     ///
-    /// Currently trivial — reserved for future cross-card invariant checks
-    /// (e.g. duplicate-tag detection).  The `Result` return type is API
-    /// future-proofing.
-    ///
     /// # Invariants
     ///
     /// `card.sentinel()` must be [`Sentinel::Card`]; a main card cannot be
@@ -134,14 +130,12 @@ impl Document {
     /// # Warnings
     ///
     /// This method never modifies `warnings`.
-    pub fn push_card(&mut self, card: Card) -> Result<(), EditError> {
+    pub fn push_card(&mut self, card: Card) {
         debug_assert!(
             !card.sentinel().is_main(),
             "cannot push a Main-sentinel card as a composable card"
         );
-        // Access private field via helper
         self.cards_vec_mut().push(card);
-        Ok(())
     }
 
     /// Insert a composable card at `index`.

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -5,26 +5,32 @@
 //! ## Invariants
 //!
 //! Every successful mutator call leaves the document in a state that:
-//! - Contains no reserved key in `frontmatter` (`BODY`, `CARDS`, `QUILL`, `CARD`).
-//! - Has every `card.tag` passing `sentinel::is_valid_tag_name`.
+//! - Contains no reserved key in any card's frontmatter (`BODY`, `CARDS`, `QUILL`, `CARD`).
+//! - Has every composable `card.tag()` passing `sentinel::is_valid_tag_name`.
 //! - Can be safely serialized via [`Document::to_plate_json`].
 //!
 //! **Mutators never modify `warnings`.**  Warnings are parse-time observations
 //! and remain stable for the lifetime of the document.
+//!
+//! ## Surface
+//!
+//! After the document-rework, frontmatter and body mutators live on [`Card`]:
+//! `doc.main_mut().set_field(…)`, `doc.main_mut().replace_body(…)`,
+//! `doc.cards_mut()[i].set_field(…)`. [`Document`] keeps only document-level
+//! operations (quill-ref, push/insert/remove/move card).
 
 use unicode_normalization::UnicodeNormalization;
 
 use crate::document::sentinel::is_valid_tag_name;
-use crate::document::{Card, Document};
+use crate::document::{Card, Document, Frontmatter, Sentinel};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
 // ── Reserved names ──────────────────────────────────────────────────────────
 
-/// Reserved field names that may not appear in `Document.frontmatter` or
-/// `Card.fields`.  These are the sentinel keys whose presence in user-visible
-/// fields would corrupt the plate wire format or the parser's structural
-/// invariants.
+/// Reserved field names that may not appear in any `Card`'s frontmatter.
+/// These are the sentinel keys whose presence in user-visible fields would
+/// corrupt the plate wire format or the parser's structural invariants.
 pub const RESERVED_NAMES: &[&str] = &["BODY", "CARDS", "QUILL", "CARD"];
 
 /// Returns `true` if `name` is one of the four reserved sentinel names.
@@ -88,51 +94,7 @@ pub enum EditError {
 // ── impl Document ────────────────────────────────────────────────────────────
 
 impl Document {
-    // ── Frontmatter mutators ─────────────────────────────────────────────────
-
-    /// Set a frontmatter field by name.
-    ///
-    /// # Invariants enforced
-    ///
-    /// - `name` must not be one of the reserved sentinel names
-    ///   (`BODY`, `CARDS`, `QUILL`, `CARD`).  Returns [`EditError::ReservedName`].
-    /// - `name` must match `[a-z_][a-z0-9_]*` after NFC normalisation.
-    ///   Returns [`EditError::InvalidFieldName`].
-    ///
-    /// # Validity
-    ///
-    /// After a successful call the document remains valid: `frontmatter`
-    /// contains no reserved key and the value is stored at the correct key.
-    ///
-    /// # Warnings
-    ///
-    /// This method never modifies `warnings`.
-    pub fn set_field(&mut self, name: &str, value: QuillValue) -> Result<(), EditError> {
-        if is_reserved_name(name) {
-            return Err(EditError::ReservedName(name.to_string()));
-        }
-        if !is_valid_field_name(name) {
-            return Err(EditError::InvalidFieldName(name.to_string()));
-        }
-        self.frontmatter.insert(name.to_string(), value);
-        Ok(())
-    }
-
-    /// Remove a frontmatter field by name, returning the value if it existed.
-    ///
-    /// # Invariants enforced
-    ///
-    /// None — reserved names cannot be present in `frontmatter` (the parser
-    /// guarantees this), so passing a reserved name simply returns `None`.
-    ///
-    /// # Warnings
-    ///
-    /// This method never modifies `warnings`.
-    pub fn remove_field(&mut self, name: &str) -> Option<QuillValue> {
-        self.frontmatter.shift_remove(name)
-    }
-
-    /// Replace the QUILL reference.
+    /// Replace the QUILL reference on the main card's sentinel.
     ///
     /// # Invariants enforced
     ///
@@ -143,47 +105,46 @@ impl Document {
     ///
     /// This method never modifies `warnings`.
     pub fn set_quill_ref(&mut self, reference: QuillReference) {
-        self.quill_ref = reference;
-    }
-
-    /// Replace the global Markdown body.
-    ///
-    /// The new body replaces whatever was stored; no structural validation is
-    /// applied (body content is opaque Markdown text).
-    ///
-    /// # Warnings
-    ///
-    /// This method never modifies `warnings`.
-    pub fn replace_body(&mut self, body: impl Into<String>) {
-        self.body = body.into();
+        self.main_mut().replace_sentinel(Sentinel::Main(reference));
     }
 
     // ── Card mutators ────────────────────────────────────────────────────────
 
-    /// Return a mutable reference to the card at `index`, or `None` if out of range.
+    /// Return a mutable reference to the composable card at `index`, or `None`
+    /// if out of range.
     ///
     /// # Warnings
     ///
     /// This method never modifies `warnings`.
     pub fn card_mut(&mut self, index: usize) -> Option<&mut Card> {
-        self.cards.get_mut(index)
+        self.cards_mut().get_mut(index)
     }
 
-    /// Append a card to the end of the card list.
+    /// Append a composable card to the end of the card list.
     ///
     /// Currently trivial — reserved for future cross-card invariant checks
     /// (e.g. duplicate-tag detection).  The `Result` return type is API
     /// future-proofing.
     ///
+    /// # Invariants
+    ///
+    /// `card.sentinel()` must be [`Sentinel::Card`]; a main card cannot be
+    /// appended as a composable card. Debug assert.
+    ///
     /// # Warnings
     ///
     /// This method never modifies `warnings`.
     pub fn push_card(&mut self, card: Card) -> Result<(), EditError> {
-        self.cards.push(card);
+        debug_assert!(
+            !card.sentinel().is_main(),
+            "cannot push a Main-sentinel card as a composable card"
+        );
+        // Access private field via helper
+        self.cards_vec_mut().push(card);
         Ok(())
     }
 
-    /// Insert a card at `index`.
+    /// Insert a composable card at `index`.
     ///
     /// # Invariants enforced
     ///
@@ -194,27 +155,31 @@ impl Document {
     ///
     /// This method never modifies `warnings`.
     pub fn insert_card(&mut self, index: usize, card: Card) -> Result<(), EditError> {
-        let len = self.cards.len();
+        debug_assert!(
+            !card.sentinel().is_main(),
+            "cannot insert a Main-sentinel card as a composable card"
+        );
+        let len = self.cards().len();
         if index > len {
             return Err(EditError::IndexOutOfRange { index, len });
         }
-        self.cards.insert(index, card);
+        self.cards_vec_mut().insert(index, card);
         Ok(())
     }
 
-    /// Remove and return the card at `index`, or `None` if out of range.
+    /// Remove and return the composable card at `index`, or `None` if out of range.
     ///
     /// # Warnings
     ///
     /// This method never modifies `warnings`.
     pub fn remove_card(&mut self, index: usize) -> Option<Card> {
-        if index >= self.cards.len() {
+        if index >= self.cards().len() {
             return None;
         }
-        Some(self.cards.remove(index))
+        Some(self.cards_vec_mut().remove(index))
     }
 
-    /// Move the card at `from` to position `to`.
+    /// Move the composable card at `from` to position `to`.
     ///
     /// If `from == to`, this is a no-op and returns `Ok(())`.
     ///
@@ -227,7 +192,7 @@ impl Document {
     ///
     /// This method never modifies `warnings`.
     pub fn move_card(&mut self, from: usize, to: usize) -> Result<(), EditError> {
-        let len = self.cards.len();
+        let len = self.cards().len();
         if from >= len {
             return Err(EditError::IndexOutOfRange { index: from, len });
         }
@@ -237,8 +202,8 @@ impl Document {
         if from == to {
             return Ok(());
         }
-        let card = self.cards.remove(from);
-        self.cards.insert(to, card);
+        let card = self.cards_vec_mut().remove(from);
+        self.cards_vec_mut().insert(to, card);
         Ok(())
     }
 }
@@ -246,7 +211,7 @@ impl Document {
 // ── impl Card ────────────────────────────────────────────────────────────────
 
 impl Card {
-    /// Create a new, empty card with the given tag.
+    /// Create a new, empty composable card with the given tag.
     ///
     /// # Invariants enforced
     ///
@@ -259,14 +224,15 @@ impl Card {
         if !is_valid_tag_name(&tag) {
             return Err(EditError::InvalidTagName(tag));
         }
-        Ok(Card::new_internal(
-            tag,
-            indexmap::IndexMap::new(),
+        Ok(Card::new_with_sentinel(
+            Sentinel::Card(tag),
+            Frontmatter::new(),
             String::new(),
         ))
     }
 
-    /// Set a card field by name.
+    /// Set a frontmatter field by name. Always clears the `!fill` marker for
+    /// that key (per tasking 02, this is the "user filled in" path).
     ///
     /// # Invariants enforced
     ///
@@ -277,8 +243,8 @@ impl Card {
     ///
     /// # Validity
     ///
-    /// After a successful call the card remains valid: `fields` contains no
-    /// reserved key and the value is stored at the correct key.
+    /// After a successful call the card remains valid: `frontmatter`
+    /// contains no reserved key and the value is stored at the correct key.
     ///
     /// # Warnings
     ///
@@ -290,20 +256,42 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        self.fields.insert(name.to_string(), value);
+        self.frontmatter_mut().insert(name.to_string(), value);
         Ok(())
     }
 
-    /// Remove a card field by name, returning the value if it existed.
+    /// Set a frontmatter field AND mark it as a `!fill` placeholder (per
+    /// tasking 02, this is the "reset to placeholder" path). A `Null` value
+    /// emits as `key: !fill`; a scalar value emits as `key: !fill <value>`.
     ///
-    /// Reserved names cannot be present in `fields` (the parser guarantees
-    /// this), so passing a reserved name simply returns `None`.
+    /// # Invariants enforced
+    ///
+    /// Same as [`Card::set_field`].
+    ///
+    /// # Warnings
+    ///
+    /// Card mutators never modify the parent document's `warnings`.
+    pub fn set_fill(&mut self, name: &str, value: QuillValue) -> Result<(), EditError> {
+        if is_reserved_name(name) {
+            return Err(EditError::ReservedName(name.to_string()));
+        }
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
+        }
+        self.frontmatter_mut().insert_fill(name.to_string(), value);
+        Ok(())
+    }
+
+    /// Remove a frontmatter field by name, returning the value if it existed.
+    ///
+    /// Reserved names cannot be present in the frontmatter (the parser
+    /// guarantees this), so passing a reserved name simply returns `None`.
     ///
     /// # Warnings
     ///
     /// Card mutators never modify the parent document's `warnings`.
     pub fn remove_field(&mut self, name: &str) -> Option<QuillValue> {
-        self.fields.shift_remove(name)
+        self.frontmatter_mut().remove(name)
     }
 
     /// Replace the card's Markdown body.
@@ -311,7 +299,13 @@ impl Card {
     /// # Warnings
     ///
     /// Card mutators never modify the parent document's `warnings`.
+    pub fn replace_body(&mut self, body: impl Into<String>) {
+        self.overwrite_body(body.into());
+    }
+
+    /// Deprecated alias for [`Card::replace_body`]; kept to ease migration.
+    #[doc(hidden)]
     pub fn set_body(&mut self, body: impl Into<String>) {
-        self.body = body.into();
+        self.replace_body(body);
     }
 }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -165,14 +165,12 @@ fn ensure_f2_before_fence(out: &mut String) {
 /// - Empty objects are **omitted** (caller skips them).
 /// - Empty arrays emit `key: []\n`.
 /// - All other values follow the block-style rules.
-/// - When `fill` is `true`, the emitted form is `key: !fill <value>` (scalar)
-///   or `key: !fill` (null value). `!fill` only applies to scalar fields at
-///   the top level of a card's frontmatter; nested recursion always passes
-///   `fill = false`.
+/// - When `fill` is `true`, the emitted form is `key: !fill <value>` for
+///   scalars, `key: !fill\n  - …` for non-empty sequences,
+///   `key: !fill []` for empty sequences, and `key: !fill` for null.
+///   Mappings are rejected at parse and never reach this path.
 fn emit_field(out: &mut String, key: &str, value: &JsonValue, indent: usize, fill: bool) {
     if fill {
-        // !fill applies only to scalar values (incl. null). Non-scalar fill
-        // targets are rejected at parse time (tasking 02).
         push_indent(out, indent);
         out.push_str(key);
         match value {
@@ -182,10 +180,17 @@ fn emit_field(out: &mut String, key: &str, value: &JsonValue, indent: usize, fil
                 emit_scalar(out, value);
                 out.push('\n');
             }
-            JsonValue::Array(_) | JsonValue::Object(_) => {
-                // Shouldn't happen — parser rejects !fill on non-scalars —
-                // but emit verbatim scalar recovery if someone constructs
-                // this state directly.
+            JsonValue::Array(items) if items.is_empty() => {
+                out.push_str(": !fill []\n");
+            }
+            JsonValue::Array(items) => {
+                out.push_str(": !fill\n");
+                for item in items {
+                    emit_sequence_item(out, item, indent);
+                }
+            }
+            JsonValue::Object(_) => {
+                // Parser rejects !fill on mappings; recovery path only.
                 out.push_str(": ");
                 emit_scalar(out, value);
                 out.push('\n');

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -20,7 +20,8 @@
 
 use serde_json::Value as JsonValue;
 
-use super::{Card, Document};
+use super::frontmatter::FrontmatterItem;
+use super::{Card, Document, Sentinel};
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -78,32 +79,19 @@ impl Document {
     pub fn to_markdown(&self) -> String {
         let mut out = String::new();
 
-        // ── Frontmatter fence ─────────────────────────────────────────────────
-        out.push_str("---\n");
+        // ── Main card (first fence + global body) ─────────────────────────────
+        emit_card_fence(&mut out, self.main());
+        out.push_str(self.main().body());
 
-        // QUILL first
-        out.push_str("QUILL: ");
-        out.push_str(&self.quill_ref.to_string());
-        out.push('\n');
-
-        // Remaining frontmatter in IndexMap insertion order.
-        for (key, value) in &self.frontmatter {
-            emit_field(&mut out, key, value.as_json(), 0);
-        }
-
-        out.push_str("---\n");
-
-        // ── Global body ───────────────────────────────────────────────────────
-        // The body contains the blank line(s) between the frontmatter fence and
-        // the first card (or EOF).  Emit it verbatim before any cards so the
-        // parser sees the correct document structure on re-parse.
-        out.push_str(&self.body);
-
-        // ── Cards ─────────────────────────────────────────────────────────────
+        // ── Composable cards ──────────────────────────────────────────────────
         // `emit_card` normalises the separator before each fence, so edited
         // bodies (which may lack a trailing blank line) still round-trip.
-        for card in &self.cards {
-            emit_card(&mut out, card);
+        for card in self.cards() {
+            ensure_f2_before_fence(&mut out);
+            emit_card_fence(&mut out, card);
+            if !card.body().is_empty() {
+                out.push_str(card.body());
+            }
         }
 
         out
@@ -112,28 +100,40 @@ impl Document {
 
 // ── Card emission ─────────────────────────────────────────────────────────────
 
-fn emit_card(out: &mut String, card: &Card) {
-    // MARKDOWN.md §3 F2 requires a blank line immediately above each metadata
-    // fence. Stored bodies never contain the F2 separator (see `assemble.rs`'s
-    // `strip_f2_separator`), so we always add exactly one `\n` as the F2 blank
-    // before emitting the fence, plus a content line terminator if the body
-    // didn't end in `\n`.
-    ensure_f2_before_fence(out);
+/// Emit a card's metadata fence (between `---\n` markers), including the
+/// sentinel line and every frontmatter item.
+fn emit_card_fence(out: &mut String, card: &Card) {
     out.push_str("---\n");
-    out.push_str("CARD: ");
-    out.push_str(card.tag());
-    out.push('\n');
 
-    for (key, value) in card.fields() {
-        emit_field(out, key, value.as_json(), 0);
+    // Sentinel line.
+    match card.sentinel() {
+        Sentinel::Main(r) => {
+            out.push_str("QUILL: ");
+            out.push_str(&r.to_string());
+            out.push('\n');
+        }
+        Sentinel::Card(tag) => {
+            out.push_str("CARD: ");
+            out.push_str(tag);
+            out.push('\n');
+        }
+    }
+
+    // Frontmatter items in order.
+    for item in card.frontmatter().items() {
+        match item {
+            FrontmatterItem::Field { key, value, fill } => {
+                emit_field(out, key, value.as_json(), 0, *fill);
+            }
+            FrontmatterItem::Comment { text } => {
+                out.push_str("# ");
+                out.push_str(text);
+                out.push('\n');
+            }
+        }
     }
 
     out.push_str("---\n");
-
-    // Card body: emitted verbatim.  Empty body → nothing after the fence.
-    if !card.body().is_empty() {
-        out.push_str(card.body());
-    }
 }
 
 /// Ensures `out` ends with a `\n\n` suffix suitable for the F2 precondition
@@ -165,7 +165,36 @@ fn ensure_f2_before_fence(out: &mut String) {
 /// - Empty objects are **omitted** (caller skips them).
 /// - Empty arrays emit `key: []\n`.
 /// - All other values follow the block-style rules.
-fn emit_field(out: &mut String, key: &str, value: &JsonValue, indent: usize) {
+/// - When `fill` is `true`, the emitted form is `key: !fill <value>` (scalar)
+///   or `key: !fill` (null value). `!fill` only applies to scalar fields at
+///   the top level of a card's frontmatter; nested recursion always passes
+///   `fill = false`.
+fn emit_field(out: &mut String, key: &str, value: &JsonValue, indent: usize, fill: bool) {
+    if fill {
+        // !fill applies only to scalar values (incl. null). Non-scalar fill
+        // targets are rejected at parse time (tasking 02).
+        push_indent(out, indent);
+        out.push_str(key);
+        match value {
+            JsonValue::Null => out.push_str(": !fill\n"),
+            JsonValue::Bool(_)
+            | JsonValue::Number(_)
+            | JsonValue::String(_) => {
+                out.push_str(": !fill ");
+                emit_scalar(out, value);
+                out.push('\n');
+            }
+            JsonValue::Array(_) | JsonValue::Object(_) => {
+                // Shouldn't happen — parser rejects !fill on non-scalars —
+                // but emit verbatim scalar recovery if someone constructs
+                // this state directly.
+                out.push_str(": ");
+                emit_scalar(out, value);
+                out.push('\n');
+            }
+        }
+        return;
+    }
     match value {
         JsonValue::Object(map) if map.is_empty() => {
             // Empty object → omit the key entirely.
@@ -176,7 +205,7 @@ fn emit_field(out: &mut String, key: &str, value: &JsonValue, indent: usize) {
             out.push_str(key);
             out.push_str(":\n");
             for (k, v) in map {
-                emit_field(out, k, v, indent + 2);
+                emit_field(out, k, v, indent + 2, false);
             }
         }
         JsonValue::Array(items) if items.is_empty() => {
@@ -221,7 +250,7 @@ fn emit_sequence_item(out: &mut String, value: &JsonValue, base_indent: usize) {
                     emit_field_inline(out, k, v, base_indent + 2);
                     first = false;
                 } else {
-                    emit_field(out, k, v, base_indent + 2);
+                    emit_field(out, k, v, base_indent + 2, false);
                 }
             }
         }
@@ -259,7 +288,7 @@ fn emit_field_inline(out: &mut String, key: &str, value: &JsonValue, child_inden
             out.push_str(key);
             out.push_str(":\n");
             for (k, v) in map {
-                emit_field(out, k, v, child_indent);
+                emit_field(out, k, v, child_indent, false);
             }
         }
         JsonValue::Array(items) if items.is_empty() => {
@@ -386,7 +415,7 @@ mod tests {
     fn empty_object_omitted() {
         let value = QuillValue::from_json(serde_json::json!({}));
         let mut out = String::new();
-        emit_field(&mut out, "empty_map", value.as_json(), 0);
+        emit_field(&mut out, "empty_map", value.as_json(), 0, false);
         assert_eq!(out, ""); // omitted
     }
 
@@ -394,7 +423,31 @@ mod tests {
     fn empty_array_emitted() {
         let value = QuillValue::from_json(serde_json::json!([]));
         let mut out = String::new();
-        emit_field(&mut out, "empty_seq", value.as_json(), 0);
+        emit_field(&mut out, "empty_seq", value.as_json(), 0, false);
         assert_eq!(out, "empty_seq: []\n");
+    }
+
+    #[test]
+    fn fill_null_emits_bare_tag() {
+        let value = QuillValue::from_json(serde_json::Value::Null);
+        let mut out = String::new();
+        emit_field(&mut out, "recipient", value.as_json(), 0, true);
+        assert_eq!(out, "recipient: !fill\n");
+    }
+
+    #[test]
+    fn fill_string_emits_tag_with_value() {
+        let value = QuillValue::from_json(serde_json::json!("placeholder"));
+        let mut out = String::new();
+        emit_field(&mut out, "dept", value.as_json(), 0, true);
+        assert_eq!(out, "dept: !fill \"placeholder\"\n");
+    }
+
+    #[test]
+    fn fill_integer_emits_tag_with_value() {
+        let value = QuillValue::from_json(serde_json::json!(42));
+        let mut out = String::new();
+        emit_field(&mut out, "count", value.as_json(), 0, true);
+        assert_eq!(out, "count: !fill 42\n");
     }
 }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -113,11 +113,12 @@ impl Document {
 // ── Card emission ─────────────────────────────────────────────────────────────
 
 fn emit_card(out: &mut String, card: &Card) {
-    // MARKDOWN.md §3 F2 requires a blank line before each metadata fence.
-    // Parsed bodies typically already end with `\n\n`, but edited bodies
-    // (e.g. `replace_body("x")` with no trailing newline) do not — normalise
-    // here so the emitted markdown round-trips through the parser.
-    ensure_blank_line_before_fence(out);
+    // MARKDOWN.md §3 F2 requires a blank line immediately above each metadata
+    // fence. Stored bodies never contain the F2 separator (see `assemble.rs`'s
+    // `strip_f2_separator`), so we always add exactly one `\n` as the F2 blank
+    // before emitting the fence, plus a content line terminator if the body
+    // didn't end in `\n`.
+    ensure_f2_before_fence(out);
     out.push_str("---\n");
     out.push_str("CARD: ");
     out.push_str(card.tag());
@@ -135,17 +136,26 @@ fn emit_card(out: &mut String, card: &Card) {
     }
 }
 
-/// Ensures `out` ends with a blank line (`"\n\n"`) or is empty — the F2
-/// precondition for the next metadata fence marker.
-fn ensure_blank_line_before_fence(out: &mut String) {
-    if out.is_empty() || out.ends_with("\n\n") {
+/// Ensures `out` ends with a `\n\n` suffix suitable for the F2 precondition
+/// of the next metadata fence.
+///
+/// Under the F2-separator-never-stored invariant, stored bodies may end with
+/// their content (no newline), a content line terminator (`\n`), or an
+/// author-intended blank line (`\n\n`, `\n\n\n`, …). In every case we append
+/// exactly one `\n` to produce the F2 blank line. If the body doesn't already
+/// end in `\n`, we also append a line terminator first so content lines are
+/// terminated in the emitted markdown.
+///
+/// Empty `out` satisfies F2 via the "line 1" clause (MARKDOWN.md §3 F2) and
+/// needs no separator.
+fn ensure_f2_before_fence(out: &mut String) {
+    if out.is_empty() {
         return;
     }
-    if out.ends_with('\n') {
+    if !out.ends_with('\n') {
         out.push('\n');
-    } else {
-        out.push_str("\n\n");
     }
+    out.push('\n');
 }
 
 // ── YAML value emission ───────────────────────────────────────────────────────

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -177,9 +177,7 @@ fn emit_field(out: &mut String, key: &str, value: &JsonValue, indent: usize, fil
         out.push_str(key);
         match value {
             JsonValue::Null => out.push_str(": !fill\n"),
-            JsonValue::Bool(_)
-            | JsonValue::Number(_)
-            | JsonValue::String(_) => {
+            JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
                 out.push_str(": !fill ");
                 emit_scalar(out, value);
                 out.push('\n');

--- a/crates/core/src/document/frontmatter.rs
+++ b/crates/core/src/document/frontmatter.rs
@@ -1,0 +1,353 @@
+//! Ordered frontmatter representation.
+//!
+//! A [`Frontmatter`] is the typed representation of a YAML fence body with the
+//! sentinel key already stripped. Unlike a plain `IndexMap`, it preserves
+//! YAML comments as first-class ordered items and carries a `fill: bool`
+//! marker on each field (for `!fill` tags).
+//!
+//! It provides both ordered iteration (over [`FrontmatterItem`]s) and
+//! map-keyed access (`get`, `contains_key`, `insert`, `remove`) so existing
+//! callers that treat the frontmatter as a map keep working. The map-keyed
+//! accessors walk the item vec; field count is small enough that a linear
+//! scan is fine.
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::value::QuillValue;
+
+/// One entry in a [`Frontmatter`]: a field or a comment line.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum FrontmatterItem {
+    /// A YAML field (key-value pair), optionally tagged `!fill`.
+    Field {
+        key: String,
+        value: QuillValue,
+        /// `true` when the field was written as `key: !fill <value>` or
+        /// `key: !fill` in source. See tasking 02.
+        #[serde(default)]
+        fill: bool,
+    },
+    /// An own-line YAML comment. Text excludes the leading `#` and one
+    /// optional space, per the frontmatter-comments tasking.
+    Comment { text: String },
+}
+
+impl FrontmatterItem {
+    /// Build a plain (non-fill) field entry.
+    pub fn field(key: impl Into<String>, value: QuillValue) -> Self {
+        FrontmatterItem::Field {
+            key: key.into(),
+            value,
+            fill: false,
+        }
+    }
+
+    /// Build a fill-tagged field entry.
+    pub fn fill_field(key: impl Into<String>, value: QuillValue) -> Self {
+        FrontmatterItem::Field {
+            key: key.into(),
+            value,
+            fill: true,
+        }
+    }
+
+    /// Build a comment item.
+    pub fn comment(text: impl Into<String>) -> Self {
+        FrontmatterItem::Comment { text: text.into() }
+    }
+
+    /// Returns `Some((key, value, fill))` if this is a field, else `None`.
+    pub fn as_field(&self) -> Option<(&str, &QuillValue, bool)> {
+        match self {
+            FrontmatterItem::Field { key, value, fill } => Some((key.as_str(), value, *fill)),
+            FrontmatterItem::Comment { .. } => None,
+        }
+    }
+
+    /// Returns `Some(text)` if this is a comment, else `None`.
+    pub fn as_comment(&self) -> Option<&str> {
+        match self {
+            FrontmatterItem::Comment { text } => Some(text),
+            FrontmatterItem::Field { .. } => None,
+        }
+    }
+}
+
+/// Ordered list of frontmatter items with map-keyed convenience accessors.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Frontmatter {
+    items: Vec<FrontmatterItem>,
+}
+
+impl Frontmatter {
+    /// Create an empty `Frontmatter`.
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    /// Build from an `IndexMap` of fields (no comments, no fill markers).
+    pub fn from_index_map(map: IndexMap<String, QuillValue>) -> Self {
+        let items = map
+            .into_iter()
+            .map(|(key, value)| FrontmatterItem::Field {
+                key,
+                value,
+                fill: false,
+            })
+            .collect();
+        Self { items }
+    }
+
+    /// Build from a pre-computed item list.
+    pub fn from_items(items: Vec<FrontmatterItem>) -> Self {
+        Self { items }
+    }
+
+    /// Ordered iterator over raw items (including comments).
+    pub fn items(&self) -> &[FrontmatterItem] {
+        &self.items
+    }
+
+    /// Mutable access to the ordered item list.
+    pub fn items_mut(&mut self) -> &mut Vec<FrontmatterItem> {
+        &mut self.items
+    }
+
+    /// Iterator over `(key, value)` pairs, skipping comments. Preserves order.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &QuillValue)> + '_ {
+        self.items.iter().filter_map(|item| match item {
+            FrontmatterItem::Field { key, value, .. } => Some((key, value)),
+            FrontmatterItem::Comment { .. } => None,
+        })
+    }
+
+    /// Iterator over field keys, skipping comments. Preserves order.
+    pub fn keys(&self) -> impl Iterator<Item = &String> + '_ {
+        self.items.iter().filter_map(|item| match item {
+            FrontmatterItem::Field { key, .. } => Some(key),
+            FrontmatterItem::Comment { .. } => None,
+        })
+    }
+
+    /// Number of *field* items (comments excluded).
+    pub fn len(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| matches!(item, FrontmatterItem::Field { .. }))
+            .count()
+    }
+
+    /// Returns `true` if there are no field items (comments are ignored).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Look up a field value by key.
+    pub fn get(&self, key: &str) -> Option<&QuillValue> {
+        self.items.iter().find_map(|item| match item {
+            FrontmatterItem::Field { key: k, value, .. } if k == key => Some(value),
+            _ => None,
+        })
+    }
+
+    /// Returns `true` if a field with this key is present.
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// Insert or update a field. Always clears the `fill` marker (field is no
+    /// longer a placeholder). Preserves position for existing keys; appends
+    /// new keys at the end. Adjacent comments are untouched.
+    pub fn insert(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
+        let key = key.into();
+        for item in self.items.iter_mut() {
+            if let FrontmatterItem::Field {
+                key: k,
+                value: v,
+                fill,
+            } = item
+            {
+                if k == &key {
+                    let old = std::mem::replace(v, value);
+                    *fill = false;
+                    return Some(old);
+                }
+            }
+        }
+        self.items.push(FrontmatterItem::Field {
+            key,
+            value,
+            fill: false,
+        });
+        None
+    }
+
+    /// Insert or update a field and mark it as a `!fill` placeholder. Preserves
+    /// position for existing keys; appends new keys at the end.
+    pub fn insert_fill(
+        &mut self,
+        key: impl Into<String>,
+        value: QuillValue,
+    ) -> Option<QuillValue> {
+        let key = key.into();
+        for item in self.items.iter_mut() {
+            if let FrontmatterItem::Field {
+                key: k,
+                value: v,
+                fill,
+            } = item
+            {
+                if k == &key {
+                    let old = std::mem::replace(v, value);
+                    *fill = true;
+                    return Some(old);
+                }
+            }
+        }
+        self.items.push(FrontmatterItem::Field {
+            key,
+            value,
+            fill: true,
+        });
+        None
+    }
+
+    /// Remove a field by key and return its value. Adjacent comments stay
+    /// where they are.
+    pub fn remove(&mut self, key: &str) -> Option<QuillValue> {
+        let pos = self.items.iter().position(|item| {
+            matches!(item, FrontmatterItem::Field { key: k, .. } if k == key)
+        })?;
+        match self.items.remove(pos) {
+            FrontmatterItem::Field { value, .. } => Some(value),
+            FrontmatterItem::Comment { .. } => unreachable!(),
+        }
+    }
+
+    /// Returns `true` if a field with this key is marked `!fill`.
+    pub fn is_fill(&self, key: &str) -> bool {
+        self.items.iter().any(|item| match item {
+            FrontmatterItem::Field { key: k, fill, .. } => k == key && *fill,
+            _ => false,
+        })
+    }
+
+    /// Project the field portion into an `IndexMap<String, QuillValue>`.
+    /// Comments are dropped; fill markers are lost. Preserves order.
+    pub fn to_index_map(&self) -> IndexMap<String, QuillValue> {
+        let mut map = IndexMap::new();
+        for item in &self.items {
+            if let FrontmatterItem::Field { key, value, .. } = item {
+                map.insert(key.clone(), value.clone());
+            }
+        }
+        map
+    }
+}
+
+impl<'a> IntoIterator for &'a Frontmatter {
+    type Item = (&'a String, &'a QuillValue);
+    type IntoIter = std::iter::FilterMap<
+        std::slice::Iter<'a, FrontmatterItem>,
+        fn(&'a FrontmatterItem) -> Option<(&'a String, &'a QuillValue)>,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        fn filter<'a>(
+            item: &'a FrontmatterItem,
+        ) -> Option<(&'a String, &'a QuillValue)> {
+            match item {
+                FrontmatterItem::Field { key, value, .. } => Some((key, value)),
+                FrontmatterItem::Comment { .. } => None,
+            }
+        }
+        self.items.iter().filter_map(filter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qv(s: &str) -> QuillValue {
+        QuillValue::from_json(serde_json::json!(s))
+    }
+
+    #[test]
+    fn insert_new_appends() {
+        let mut fm = Frontmatter::new();
+        fm.insert("title", qv("Hello"));
+        fm.insert("author", qv("Alice"));
+        assert_eq!(fm.len(), 2);
+        let keys: Vec<&String> = fm.keys().collect();
+        assert_eq!(keys, vec!["title", "author"]);
+    }
+
+    #[test]
+    fn insert_existing_preserves_position() {
+        let mut fm = Frontmatter::new();
+        fm.insert("a", qv("1"));
+        fm.insert("b", qv("2"));
+        fm.insert("a", qv("updated"));
+        let keys: Vec<&String> = fm.keys().collect();
+        assert_eq!(keys, vec!["a", "b"]);
+        assert_eq!(fm.get("a").unwrap().as_str(), Some("updated"));
+    }
+
+    #[test]
+    fn insert_clears_fill() {
+        let mut fm = Frontmatter::new();
+        fm.insert_fill("k", qv("placeholder"));
+        assert!(fm.is_fill("k"));
+        fm.insert("k", qv("user value"));
+        assert!(!fm.is_fill("k"));
+    }
+
+    #[test]
+    fn insert_fill_preserves_position_and_sets_flag() {
+        let mut fm = Frontmatter::new();
+        fm.insert("k", qv("v"));
+        fm.insert_fill("k", qv("placeholder"));
+        assert!(fm.is_fill("k"));
+        assert_eq!(fm.get("k").unwrap().as_str(), Some("placeholder"));
+    }
+
+    #[test]
+    fn remove_leaves_comments_alone() {
+        let items = vec![
+            FrontmatterItem::comment("header"),
+            FrontmatterItem::field("a", qv("1")),
+            FrontmatterItem::comment("mid"),
+            FrontmatterItem::field("b", qv("2")),
+        ];
+        let mut fm = Frontmatter::from_items(items);
+        let removed = fm.remove("a").unwrap();
+        assert_eq!(removed.as_str(), Some("1"));
+        let comments: Vec<&str> = fm
+            .items()
+            .iter()
+            .filter_map(FrontmatterItem::as_comment)
+            .collect();
+        assert_eq!(comments, vec!["header", "mid"]);
+    }
+
+    #[test]
+    fn map_style_iter_skips_comments() {
+        let items = vec![
+            FrontmatterItem::comment("c"),
+            FrontmatterItem::field("a", qv("1")),
+            FrontmatterItem::field("b", qv("2")),
+        ];
+        let fm = Frontmatter::from_items(items);
+        let pairs: Vec<(String, String)> = fm
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![("a".to_string(), "1".to_string()), ("b".to_string(), "2".to_string())]
+        );
+    }
+}

--- a/crates/core/src/document/frontmatter.rs
+++ b/crates/core/src/document/frontmatter.rs
@@ -25,7 +25,7 @@ pub enum FrontmatterItem {
         key: String,
         value: QuillValue,
         /// `true` when the field was written as `key: !fill <value>` or
-        /// `key: !fill` in source. See tasking 02.
+        /// `key: !fill` in source.
         #[serde(default)]
         fill: bool,
     },
@@ -44,34 +44,9 @@ impl FrontmatterItem {
         }
     }
 
-    /// Build a fill-tagged field entry.
-    pub fn fill_field(key: impl Into<String>, value: QuillValue) -> Self {
-        FrontmatterItem::Field {
-            key: key.into(),
-            value,
-            fill: true,
-        }
-    }
-
     /// Build a comment item.
     pub fn comment(text: impl Into<String>) -> Self {
         FrontmatterItem::Comment { text: text.into() }
-    }
-
-    /// Returns `Some((key, value, fill))` if this is a field, else `None`.
-    pub fn as_field(&self) -> Option<(&str, &QuillValue, bool)> {
-        match self {
-            FrontmatterItem::Field { key, value, fill } => Some((key.as_str(), value, *fill)),
-            FrontmatterItem::Comment { .. } => None,
-        }
-    }
-
-    /// Returns `Some(text)` if this is a comment, else `None`.
-    pub fn as_comment(&self) -> Option<&str> {
-        match self {
-            FrontmatterItem::Comment { text } => Some(text),
-            FrontmatterItem::Field { .. } => None,
-        }
     }
 }
 
@@ -108,11 +83,6 @@ impl Frontmatter {
     /// Ordered iterator over raw items (including comments).
     pub fn items(&self) -> &[FrontmatterItem] {
         &self.items
-    }
-
-    /// Mutable access to the ordered item list.
-    pub fn items_mut(&mut self) -> &mut Vec<FrontmatterItem> {
-        &mut self.items
     }
 
     /// Iterator over `(key, value)` pairs, skipping comments. Preserves order.
@@ -323,7 +293,10 @@ mod tests {
         let comments: Vec<&str> = fm
             .items()
             .iter()
-            .filter_map(FrontmatterItem::as_comment)
+            .filter_map(|item| match item {
+                FrontmatterItem::Comment { text } => Some(text.as_str()),
+                FrontmatterItem::Field { .. } => None,
+            })
             .collect();
         assert_eq!(comments, vec!["header", "mid"]);
     }

--- a/crates/core/src/document/frontmatter.rs
+++ b/crates/core/src/document/frontmatter.rs
@@ -186,11 +186,7 @@ impl Frontmatter {
 
     /// Insert or update a field and mark it as a `!fill` placeholder. Preserves
     /// position for existing keys; appends new keys at the end.
-    pub fn insert_fill(
-        &mut self,
-        key: impl Into<String>,
-        value: QuillValue,
-    ) -> Option<QuillValue> {
+    pub fn insert_fill(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
             if let FrontmatterItem::Field {
@@ -217,9 +213,10 @@ impl Frontmatter {
     /// Remove a field by key and return its value. Adjacent comments stay
     /// where they are.
     pub fn remove(&mut self, key: &str) -> Option<QuillValue> {
-        let pos = self.items.iter().position(|item| {
-            matches!(item, FrontmatterItem::Field { key: k, .. } if k == key)
-        })?;
+        let pos = self
+            .items
+            .iter()
+            .position(|item| matches!(item, FrontmatterItem::Field { key: k, .. } if k == key))?;
         match self.items.remove(pos) {
             FrontmatterItem::Field { value, .. } => Some(value),
             FrontmatterItem::Comment { .. } => unreachable!(),
@@ -255,9 +252,7 @@ impl<'a> IntoIterator for &'a Frontmatter {
     >;
 
     fn into_iter(self) -> Self::IntoIter {
-        fn filter<'a>(
-            item: &'a FrontmatterItem,
-        ) -> Option<(&'a String, &'a QuillValue)> {
+        fn filter<'a>(item: &'a FrontmatterItem) -> Option<(&'a String, &'a QuillValue)> {
             match item {
                 FrontmatterItem::Field { key, value, .. } => Some((key, value)),
                 FrontmatterItem::Comment { .. } => None,
@@ -347,7 +342,10 @@ mod tests {
             .collect();
         assert_eq!(
             pairs,
-            vec![("a".to_string(), "1".to_string()), ("b".to_string(), "2".to_string())]
+            vec![
+                ("a".to_string(), "1".to_string()),
+                ("b".to_string(), "2".to_string())
+            ]
         );
     }
 }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -9,8 +9,11 @@
 //!
 //! ## Key Types
 //!
-//! - [`Document`]: Typed in-memory Quillmark document — frontmatter, body, and cards.
-//! - [`Card`]: A single `CARD:` block with a tag, typed fields, and a body.
+//! - [`Document`]: Typed in-memory Quillmark document — `main` card plus composable cards.
+//! - [`Card`]: A single metadata fence block, main or composable, with a sentinel,
+//!   typed frontmatter, and a body.
+//! - [`Sentinel`]: Discriminates `QUILL:` main cards from `CARD:` composable cards.
+//! - [`Frontmatter`]: Ordered list of items (fields + comments) parsed from a YAML fence.
 //!
 //! ## Examples
 //!
@@ -31,7 +34,8 @@
 //! "#;
 //!
 //! let doc = Document::from_markdown(markdown).unwrap();
-//! let title = doc.frontmatter()
+//! let title = doc.main()
+//!     .frontmatter()
 //!     .get("title")
 //!     .and_then(|v| v.as_str())
 //!     .unwrap_or("Untitled");
@@ -78,10 +82,16 @@ pub mod assemble;
 pub mod edit;
 pub mod emit;
 pub mod fences;
+pub mod frontmatter;
 pub mod limits;
+pub mod prescan;
 pub mod sentinel;
 
 pub use edit::EditError;
+pub use frontmatter::{Frontmatter, FrontmatterItem};
+
+// Re-export the sentinel type (defined below in this module file).
+// `Sentinel` is exported at the crate root via `lib.rs`.
 
 #[cfg(test)]
 mod tests;
@@ -96,11 +106,58 @@ pub struct ParseOutput {
     pub warnings: Vec<Diagnostic>,
 }
 
-/// A single `CARD:` block parsed from a Quillmark Markdown document.
+/// Discriminator for a [`Card`]'s metadata fence.
 ///
-/// Every card has a `tag` (the value of its `CARD:` sentinel), typed `fields`
-/// (all YAML key-value pairs from the fence body, excluding the `CARD` key
-/// itself), and a `body` (the Markdown text that follows the closing `---`).
+/// The first fence in a Quillmark document carries `QUILL: <ref>` and is the
+/// document-level *main* card; every subsequent fence carries `CARD: <tag>`
+/// and is a composable card. `Sentinel` captures that distinction in the typed
+/// model so every fence is one uniform shape.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Sentinel {
+    /// `QUILL: <ref>` — the document entry card.
+    Main(QuillReference),
+    /// `CARD: <tag>` — a composable card with the given tag.
+    Card(String),
+}
+
+impl Sentinel {
+    /// Construct the `QUILL:` variant.
+    pub fn main(reference: QuillReference) -> Self {
+        Sentinel::Main(reference)
+    }
+
+    /// Construct the `CARD:` variant. The tag is not validated here; use
+    /// [`Card::new`] or the parser for validation.
+    pub fn card(tag: impl Into<String>) -> Self {
+        Sentinel::Card(tag.into())
+    }
+
+    /// String form of this sentinel's value: the quill reference for `Main`,
+    /// the tag for `Card`.
+    pub fn as_str(&self) -> String {
+        match self {
+            Sentinel::Main(r) => r.to_string(),
+            Sentinel::Card(t) => t.clone(),
+        }
+    }
+
+    /// Returns `true` if this is a `Main` sentinel.
+    pub fn is_main(&self) -> bool {
+        matches!(self, Sentinel::Main(_))
+    }
+}
+
+/// A single metadata fence parsed from a Quillmark Markdown document.
+///
+/// A `Card` is the uniform shape for both the document entry (main) fence and
+/// composable card fences. `sentinel` distinguishes the two.
+///
+/// Every card has:
+/// - `sentinel` — the `QUILL` reference (for main) or `CARD` tag (for composable).
+/// - `frontmatter` — ordered items parsed from the YAML fence body (with the
+///   sentinel key already removed).
+/// - `body` — the Markdown text that follows the closing fence, up to the next
+///   fence (or EOF).
 ///
 /// ## Card body absence
 ///
@@ -110,8 +167,8 @@ pub struct ParseOutput {
 /// should check `card.body().is_empty()`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Card {
-    tag: String,
-    fields: IndexMap<String, QuillValue>,
+    sentinel: Sentinel,
+    frontmatter: Frontmatter,
     body: String,
 }
 
@@ -123,17 +180,45 @@ impl Card {
     /// responsible for providing already-valid data.  For user-facing
     /// construction use [`Card::new`] (defined in `edit.rs`).
     pub fn new_internal(tag: String, fields: IndexMap<String, QuillValue>, body: String) -> Self {
-        Self { tag, fields, body }
+        Self {
+            sentinel: Sentinel::Card(tag),
+            frontmatter: Frontmatter::from_index_map(fields),
+            body,
+        }
     }
 
-    /// The card tag (value of the `CARD:` sentinel).
-    pub fn tag(&self) -> &str {
-        &self.tag
+    /// Create a `Card` directly from a sentinel and typed frontmatter.
+    pub fn new_with_sentinel(
+        sentinel: Sentinel,
+        frontmatter: Frontmatter,
+        body: String,
+    ) -> Self {
+        Self {
+            sentinel,
+            frontmatter,
+            body,
+        }
     }
 
-    /// Typed fields from this card's YAML fence (excluding the `CARD` key).
-    pub fn fields(&self) -> &IndexMap<String, QuillValue> {
-        &self.fields
+    /// The sentinel discriminating this card as main or composable.
+    pub fn sentinel(&self) -> &Sentinel {
+        &self.sentinel
+    }
+
+    /// The card tag — the `CARD:` value for composable cards, or the string
+    /// form of the quill reference for main cards.
+    pub fn tag(&self) -> String {
+        self.sentinel.as_str()
+    }
+
+    /// Typed frontmatter (map-keyed view and ordered item list).
+    pub fn frontmatter(&self) -> &Frontmatter {
+        &self.frontmatter
+    }
+
+    /// Mutable access to the frontmatter.
+    pub fn frontmatter_mut(&mut self) -> &mut Frontmatter {
+        &mut self.frontmatter
     }
 
     /// Markdown body that follows this card's closing fence.
@@ -141,6 +226,28 @@ impl Card {
     /// Empty string when no trailing content is present.
     pub fn body(&self) -> &str {
         &self.body
+    }
+
+    /// Returns `true` if this is the document entry (main) card.
+    pub fn is_main(&self) -> bool {
+        self.sentinel.is_main()
+    }
+
+    /// Deprecated: use `card.frontmatter()` instead.
+    #[doc(hidden)]
+    pub fn fields(&self) -> &Frontmatter {
+        &self.frontmatter
+    }
+
+    /// Replace this card's sentinel. Internal helper; public mutators
+    /// ([`Document::set_quill_ref`], the parser) call this.
+    pub(crate) fn replace_sentinel(&mut self, sentinel: Sentinel) {
+        self.sentinel = sentinel;
+    }
+
+    /// Overwrite the body string. Internal helper used by [`Card::replace_body`].
+    pub(crate) fn overwrite_body(&mut self, body: String) {
+        self.body = body;
     }
 }
 
@@ -150,23 +257,30 @@ impl Card {
 /// Markdown is one import format (and will be one export format in Phase 4);
 /// the structured data here is primary.
 ///
-/// ## Fields vs. plate wire format
+/// ## Structure
 ///
-/// `Document` stores:
-/// - `frontmatter` — user-visible YAML fields (no `CARDS`, no `BODY` sentinel keys)
-/// - `body` — global Markdown body between the frontmatter fence and the first card
-/// - `cards` — ordered list of `Card` values
+/// - `main` — the entry `Card` (sentinel is `Sentinel::Main(reference)`).
+/// - `cards` — ordered composable cards (each with `Sentinel::Card(tag)`).
 ///
 /// When a backend plate needs the legacy flat JSON shape, call
 /// [`Document::to_plate_json`]. That method is the **only** place in core that
 /// reconstructs `{"QUILL": ..., "CARDS": [...], "BODY": "..."}`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Document {
-    quill_ref: QuillReference,
-    frontmatter: IndexMap<String, QuillValue>,
-    body: String,
+    main: Card,
     cards: Vec<Card>,
     warnings: Vec<Diagnostic>,
+}
+
+// Equality is defined over the structural content only — `warnings` are
+// parse-time observations that depend on what the source text happened to
+// contain (near-miss sentinels, dropped nested comments, etc.) and so
+// differ between a source document and its round-tripped emission. Two
+// documents are equal when their `main` and `cards` match.
+impl PartialEq for Document {
+    fn eq(&self, other: &Self) -> bool {
+        self.main == other.main && self.cards == other.cards
+    }
 }
 
 impl Document {
@@ -180,10 +294,34 @@ impl Document {
         cards: Vec<Card>,
         warnings: Vec<Diagnostic>,
     ) -> Self {
-        Self {
-            quill_ref,
-            frontmatter,
+        let main = Card::new_with_sentinel(
+            Sentinel::Main(quill_ref),
+            Frontmatter::from_index_map(frontmatter),
             body,
+        );
+        Self {
+            main,
+            cards,
+            warnings,
+        }
+    }
+
+    /// Create a `Document` from a pre-built main `Card` and composable cards.
+    ///
+    /// The caller must guarantee that `main.sentinel` is `Sentinel::Main(_)`
+    /// and every card in `cards` has `sentinel` = `Sentinel::Card(_)`.
+    pub fn from_main_and_cards(
+        main: Card,
+        cards: Vec<Card>,
+        warnings: Vec<Diagnostic>,
+    ) -> Self {
+        debug_assert!(main.sentinel.is_main(), "main card must be Sentinel::Main");
+        debug_assert!(
+            cards.iter().all(|c| !c.sentinel.is_main()),
+            "composable cards must be Sentinel::Card"
+        );
+        Self {
+            main,
             cards,
             warnings,
         }
@@ -202,34 +340,70 @@ impl Document {
 
     // ── Accessors ──────────────────────────────────────────────────────────────
 
-    /// The quill reference (`name@version-selector`).
+    /// The document's main (entry) card.
+    pub fn main(&self) -> &Card {
+        &self.main
+    }
+
+    /// Mutable access to the main card.
+    pub fn main_mut(&mut self) -> &mut Card {
+        &mut self.main
+    }
+
+    /// The quill reference (`name@version-selector`) carried by the main card's
+    /// sentinel. Convenience reader over `doc.main().sentinel()`.
     pub fn quill_reference(&self) -> &QuillReference {
-        &self.quill_ref
+        match &self.main.sentinel {
+            Sentinel::Main(r) => r,
+            Sentinel::Card(_) => {
+                unreachable!("main card must carry Sentinel::Main by construction")
+            }
+        }
     }
 
-    /// User-visible YAML frontmatter fields.
-    ///
-    /// Does **not** include the `QUILL`, `CARDS`, or `BODY` sentinel keys;
-    /// those are available via [`Document::quill_reference`], [`Document::cards`], and [`Document::body`].
-    pub fn frontmatter(&self) -> &IndexMap<String, QuillValue> {
-        &self.frontmatter
-    }
-
-    /// Global Markdown body between the frontmatter fence and the first card.
-    ///
-    /// Empty string when no body is present.
-    pub fn body(&self) -> &str {
-        &self.body
-    }
-
-    /// Ordered list of card blocks.
+    /// Ordered list of composable card blocks.
     pub fn cards(&self) -> &[Card] {
         &self.cards
+    }
+
+    /// Mutable access to the composable cards slice.
+    pub fn cards_mut(&mut self) -> &mut [Card] {
+        &mut self.cards
+    }
+
+    /// Internal mutable access to the backing `Vec<Card>`. Used by edit
+    /// operations ([`Document::push_card`], etc.) that need to insert or
+    /// remove elements.
+    pub(crate) fn cards_vec_mut(&mut self) -> &mut Vec<Card> {
+        &mut self.cards
     }
 
     /// Non-fatal warnings collected during parsing.
     pub fn warnings(&self) -> &[Diagnostic] {
         &self.warnings
+    }
+
+    // ── Back-compat shims ──────────────────────────────────────────────────
+    //
+    // These `#[doc(hidden)]` shortcuts forward to `self.main()`. The typed
+    // model is now `Document { main: Card, cards: Vec<Card> }`; all
+    // frontmatter/body reads and mutations live on `Card`. These shims keep
+    // existing internal call sites compiling during migration and will be
+    // removed once every caller has been updated.
+
+    /// Deprecated: use `doc.main().frontmatter()` instead.
+    ///
+    /// Exposes the main card's [`Frontmatter`], which supports `get`,
+    /// `contains_key`, `iter`, `keys`, and item-level iteration.
+    #[doc(hidden)]
+    pub fn frontmatter(&self) -> &Frontmatter {
+        self.main.frontmatter()
+    }
+
+    /// Deprecated: use `doc.main().body()` instead.
+    #[doc(hidden)]
+    pub fn body(&self) -> &str {
+        self.main.body()
     }
 
     // ── Wire format ────────────────────────────────────────────────────────────
@@ -261,18 +435,18 @@ impl Document {
         // QUILL first — plate authors expect this at the top.
         map.insert(
             "QUILL".to_string(),
-            serde_json::Value::String(self.quill_ref.to_string()),
+            serde_json::Value::String(self.quill_reference().to_string()),
         );
 
         // Frontmatter fields in insertion order.
-        for (key, value) in &self.frontmatter {
+        for (key, value) in self.main.frontmatter.iter() {
             map.insert(key.clone(), value.as_json().clone());
         }
 
         // Global body.
         map.insert(
             "BODY".to_string(),
-            serde_json::Value::String(self.body.clone()),
+            serde_json::Value::String(self.main.body.clone()),
         );
 
         // Cards array.
@@ -283,9 +457,9 @@ impl Document {
                 let mut card_map = serde_json::Map::new();
                 card_map.insert(
                     "CARD".to_string(),
-                    serde_json::Value::String(card.tag.clone()),
+                    serde_json::Value::String(card.tag()),
                 );
-                for (key, value) in &card.fields {
+                for (key, value) in card.frontmatter.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());
                 }
                 card_map.insert(

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -188,11 +188,7 @@ impl Card {
     }
 
     /// Create a `Card` directly from a sentinel and typed frontmatter.
-    pub fn new_with_sentinel(
-        sentinel: Sentinel,
-        frontmatter: Frontmatter,
-        body: String,
-    ) -> Self {
+    pub fn new_with_sentinel(sentinel: Sentinel, frontmatter: Frontmatter, body: String) -> Self {
         Self {
             sentinel,
             frontmatter,
@@ -310,11 +306,7 @@ impl Document {
     ///
     /// The caller must guarantee that `main.sentinel` is `Sentinel::Main(_)`
     /// and every card in `cards` has `sentinel` = `Sentinel::Card(_)`.
-    pub fn from_main_and_cards(
-        main: Card,
-        cards: Vec<Card>,
-        warnings: Vec<Diagnostic>,
-    ) -> Self {
+    pub fn from_main_and_cards(main: Card, cards: Vec<Card>, warnings: Vec<Diagnostic>) -> Self {
         debug_assert!(main.sentinel.is_main(), "main card must be Sentinel::Main");
         debug_assert!(
             cards.iter().all(|c| !c.sentinel.is_main()),
@@ -455,10 +447,7 @@ impl Document {
             .iter()
             .map(|card| {
                 let mut card_map = serde_json::Map::new();
-                card_map.insert(
-                    "CARD".to_string(),
-                    serde_json::Value::String(card.tag()),
-                );
+                card_map.insert("CARD".to_string(), serde_json::Value::String(card.tag()));
                 for (key, value) in card.frontmatter.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());
                 }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -71,10 +71,7 @@
 //! See [PARSE.md](https://github.com/nibsbin/quillmark/blob/main/designs/PARSE.md) for
 //! comprehensive documentation of the Extended YAML Metadata Standard.
 
-use indexmap::IndexMap;
-
 use crate::error::ParseError;
-use crate::value::QuillValue;
 use crate::version::QuillReference;
 use crate::Diagnostic;
 
@@ -121,17 +118,6 @@ pub enum Sentinel {
 }
 
 impl Sentinel {
-    /// Construct the `QUILL:` variant.
-    pub fn main(reference: QuillReference) -> Self {
-        Sentinel::Main(reference)
-    }
-
-    /// Construct the `CARD:` variant. The tag is not validated here; use
-    /// [`Card::new`] or the parser for validation.
-    pub fn card(tag: impl Into<String>) -> Self {
-        Sentinel::Card(tag.into())
-    }
-
     /// String form of this sentinel's value: the quill reference for `Main`,
     /// the tag for `Card`.
     pub fn as_str(&self) -> String {
@@ -173,21 +159,11 @@ pub struct Card {
 }
 
 impl Card {
-    /// Create a `Card` directly from typed parts.
-    ///
-    /// Used by `assemble.rs`, `normalize.rs`, and the `Quill`.
-    /// Does **not** validate the tag name or field names — callers are
-    /// responsible for providing already-valid data.  For user-facing
-    /// construction use [`Card::new`] (defined in `edit.rs`).
-    pub fn new_internal(tag: String, fields: IndexMap<String, QuillValue>, body: String) -> Self {
-        Self {
-            sentinel: Sentinel::Card(tag),
-            frontmatter: Frontmatter::from_index_map(fields),
-            body,
-        }
-    }
-
-    /// Create a `Card` directly from a sentinel and typed frontmatter.
+    /// Create a `Card` directly from a sentinel, a typed frontmatter, and a
+    /// body. Does **not** validate the sentinel tag or any field names —
+    /// callers are responsible for providing already-valid data. For
+    /// user-facing construction of composable cards use [`Card::new`]
+    /// (defined in `edit.rs`).
     pub fn new_with_sentinel(sentinel: Sentinel, frontmatter: Frontmatter, body: String) -> Self {
         Self {
             sentinel,
@@ -229,12 +205,6 @@ impl Card {
         self.sentinel.is_main()
     }
 
-    /// Deprecated: use `card.frontmatter()` instead.
-    #[doc(hidden)]
-    pub fn fields(&self) -> &Frontmatter {
-        &self.frontmatter
-    }
-
     /// Replace this card's sentinel. Internal helper; public mutators
     /// ([`Document::set_quill_ref`], the parser) call this.
     pub(crate) fn replace_sentinel(&mut self, sentinel: Sentinel) {
@@ -250,17 +220,17 @@ impl Card {
 /// A fully-parsed, typed in-memory Quillmark document.
 ///
 /// `Document` is the canonical representation of a Quillmark Markdown file.
-/// Markdown is one import format (and will be one export format in Phase 4);
-/// the structured data here is primary.
+/// Markdown is both the import and export format; the structured data here
+/// is primary.
 ///
 /// ## Structure
 ///
 /// - `main` — the entry `Card` (sentinel is `Sentinel::Main(reference)`).
 /// - `cards` — ordered composable cards (each with `Sentinel::Card(tag)`).
 ///
-/// When a backend plate needs the legacy flat JSON shape, call
-/// [`Document::to_plate_json`]. That method is the **only** place in core that
-/// reconstructs `{"QUILL": ..., "CARDS": [...], "BODY": "..."}`.
+/// Backend plates consume the flat JSON wire shape produced by
+/// [`Document::to_plate_json`]. That method is the **only** place in core
+/// that reconstructs `{"QUILL": ..., "CARDS": [...], "BODY": "..."}`.
 #[derive(Debug, Clone)]
 pub struct Document {
     main: Card,
@@ -280,28 +250,6 @@ impl PartialEq for Document {
 }
 
 impl Document {
-    /// Create a `Document` directly from typed parts.
-    ///
-    /// This is used by `assemble.rs`, `normalize.rs`, and the `Quill`.
-    pub fn new_internal(
-        quill_ref: QuillReference,
-        frontmatter: IndexMap<String, QuillValue>,
-        body: String,
-        cards: Vec<Card>,
-        warnings: Vec<Diagnostic>,
-    ) -> Self {
-        let main = Card::new_with_sentinel(
-            Sentinel::Main(quill_ref),
-            Frontmatter::from_index_map(frontmatter),
-            body,
-        );
-        Self {
-            main,
-            cards,
-            warnings,
-        }
-    }
-
     /// Create a `Document` from a pre-built main `Card` and composable cards.
     ///
     /// The caller must guarantee that `main.sentinel` is `Sentinel::Main(_)`
@@ -373,29 +321,6 @@ impl Document {
     /// Non-fatal warnings collected during parsing.
     pub fn warnings(&self) -> &[Diagnostic] {
         &self.warnings
-    }
-
-    // ── Back-compat shims ──────────────────────────────────────────────────
-    //
-    // These `#[doc(hidden)]` shortcuts forward to `self.main()`. The typed
-    // model is now `Document { main: Card, cards: Vec<Card> }`; all
-    // frontmatter/body reads and mutations live on `Card`. These shims keep
-    // existing internal call sites compiling during migration and will be
-    // removed once every caller has been updated.
-
-    /// Deprecated: use `doc.main().frontmatter()` instead.
-    ///
-    /// Exposes the main card's [`Frontmatter`], which supports `get`,
-    /// `contains_key`, `iter`, `keys`, and item-level iteration.
-    #[doc(hidden)]
-    pub fn frontmatter(&self) -> &Frontmatter {
-        self.main.frontmatter()
-    }
-
-    /// Deprecated: use `doc.main().body()` instead.
-    #[doc(hidden)]
-    pub fn body(&self) -> &str {
-        self.main.body()
     }
 
     // ── Wire format ────────────────────────────────────────────────────────────

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -1,0 +1,411 @@
+//! Pre-scan of a metadata fence's YAML content to recover features that
+//! serde_saphyr discards.
+//!
+//! Two features are recovered here:
+//!
+//! 1. **Top-level comments.** YAML comments are dropped by the YAML parser.
+//!    To round-trip them as [`FrontmatterItem::Comment`], we extract them
+//!    before parsing.
+//!
+//! 2. **`!fill` tags.** Custom YAML tags are accepted and dropped by
+//!    serde_saphyr; the value survives but the tag annotation is lost. We
+//!    detect `!fill` on top-level scalar fields, strip the tag from the
+//!    cleaned YAML (so serde_saphyr sees a plain scalar), and record a
+//!    `fill: true` marker on the resulting `Field` item.
+//!
+//! Anything else is left to the YAML parser. Nested comments inside block
+//! mappings/sequences are silently dropped; we emit a single
+//! `parse::comments_in_nested_yaml_dropped` warning per document when we
+//! encounter the first one. Other custom tags (`!include`, `!env`, …) are
+//! stripped with a `parse::unsupported_yaml_tag` warning.
+
+use crate::Diagnostic;
+use crate::Severity;
+
+/// One ordered hint extracted from the fence body.
+///
+/// `Comment` stands alone; `Field` captures only the `fill` flag because the
+/// value is produced by serde_saphyr parsing the cleaned text. The matching
+/// YAML key is the lookup key into the parsed map.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PreItem {
+    Field { key: String, fill: bool },
+    Comment(String),
+}
+
+/// Output of [`prescan_fence_content`].
+#[derive(Debug, Clone, Default)]
+pub struct PreScan {
+    /// YAML text with `!fill` tags stripped and top-level comment lines
+    /// removed. Suitable for feeding into serde_saphyr.
+    pub cleaned_yaml: String,
+    /// Ordered items discovered in source order — fields (with fill flags)
+    /// and top-level comments.
+    pub items: Vec<PreItem>,
+    /// Warnings produced during the scan.
+    pub warnings: Vec<Diagnostic>,
+    /// Unsupported-fill-target errors. The parser turns these into
+    /// `ParseError::InvalidStructure` rejections per tasking 02.
+    pub fill_target_errors: Vec<String>,
+}
+
+/// Scan the body of a YAML metadata fence.
+///
+/// `content` is the text between the opening and closing `---` markers
+/// (exclusive), with leading/trailing whitespace preserved.
+pub fn prescan_fence_content(content: &str) -> PreScan {
+    let mut out = PreScan::default();
+    let mut saw_nested_comment = false;
+
+    // We operate on the raw text to preserve positions. `lines()` strips
+    // line endings; we rebuild with `\n` which is what serde_saphyr expects.
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut cleaned_lines: Vec<String> = Vec::with_capacity(lines.len());
+
+    for raw_line in &lines {
+        let line = *raw_line;
+
+        // Preserve the original line for any pass-through cases.
+        let trimmed = line.trim_start_matches([' ', '\t']);
+
+        // Top-level lines have no leading whitespace. That means the
+        // dedented portion equals the original line. (Serde_saphyr reads
+        // YAML relative to the leftmost column; indentation inside the
+        // fence is carried verbatim.)
+        let is_top_level = line.len() == trimmed.len();
+
+        // Case 1: own-line comment.
+        if trimmed.starts_with('#') {
+            if is_top_level {
+                // Preserve the comment text (without the leading `#` and
+                // one optional space).
+                let mut text = &trimmed[1..];
+                if text.starts_with(' ') {
+                    text = &text[1..];
+                }
+                out.items.push(PreItem::Comment(text.to_string()));
+                // Don't emit any line into the cleaned YAML — serde_saphyr
+                // ignores comments but omitting the line avoids any
+                // ambiguity.
+                continue;
+            } else {
+                // Nested comment (inside a block mapping/sequence). Drop
+                // silently and warn once per document.
+                if !saw_nested_comment {
+                    saw_nested_comment = true;
+                    out.warnings.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            "YAML comments inside nested values are dropped during parse; only top-level frontmatter comments round-trip".to_string(),
+                        )
+                        .with_code("parse::comments_in_nested_yaml_dropped".to_string()),
+                    );
+                }
+                // Keep the line out of the cleaned YAML so parsing isn't
+                // confused. (Comments are structurally transparent to YAML,
+                // so we can just drop them.)
+                continue;
+            }
+        }
+
+        // Case 2: top-level field line with possible `!fill` tag and/or
+        // trailing comment.
+        if is_top_level {
+            if let Some((key, after_colon)) = split_key(line) {
+                let (value_part, trailing_comment) = split_trailing_comment(&after_colon);
+
+                let (fill, value_without_tag, had_non_fill_tag, fill_target_err) =
+                    inspect_fill_and_tags(&value_part, &key);
+
+                if had_non_fill_tag {
+                    out.warnings.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            format!(
+                                "YAML tag on key `{}` is not supported; the tag has been dropped and the value kept",
+                                key
+                            ),
+                        )
+                        .with_code("parse::unsupported_yaml_tag".to_string()),
+                    );
+                }
+                if let Some(err) = fill_target_err {
+                    out.fill_target_errors.push(err);
+                }
+
+                out.items
+                    .push(PreItem::Field { key: key.clone(), fill });
+
+                // Rebuild the line without the `!fill` tag (and without
+                // the trailing comment, since that goes on its own
+                // line now).
+                let cleaned = format!("{}:{}", key, value_without_tag);
+                cleaned_lines.push(cleaned);
+
+                if let Some(c) = trailing_comment {
+                    let mut text = c.trim_start_matches('#');
+                    if text.starts_with(' ') {
+                        text = &text[1..];
+                    }
+                    out.items.push(PreItem::Comment(text.to_string()));
+                }
+
+                continue;
+            }
+        }
+
+        // Everything else: pass through verbatim.
+        cleaned_lines.push(line.to_string());
+    }
+
+    out.cleaned_yaml = cleaned_lines.join("\n");
+    out
+}
+
+/// Split a line into `(key, rest_after_colon)`. Returns `None` if the line
+/// does not start with a bare YAML key.
+fn split_key(line: &str) -> Option<(String, String)> {
+    // Must start at column 0.
+    let bytes = line.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    // Identifier-like keys only. YAML allows more, but Quillmark's schema
+    // restricts field names to `[a-zA-Z_][a-zA-Z0-9_]*` (and reserved
+    // uppercase sentinels). Anything more exotic falls through to the
+    // unmodified path and will be parsed (or rejected) by serde_saphyr.
+    if !(bytes[0].is_ascii_alphabetic() || bytes[0] == b'_') {
+        return None;
+    }
+    let mut i = 1;
+    while i < bytes.len()
+        && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_')
+    {
+        i += 1;
+    }
+    if i >= bytes.len() || bytes[i] != b':' {
+        return None;
+    }
+    let key = line[..i].to_string();
+    let rest = line[i + 1..].to_string();
+    Some((key, rest))
+}
+
+/// Split a value string into `(value, trailing_comment)`.
+///
+/// Trailing comments begin with ` #` or `\t#` outside of any quoted string.
+/// This is a simple scanner: it respects `"..."` and `'...'` quoting.
+fn split_trailing_comment(value: &str) -> (String, Option<String>) {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    let mut prev_was_ws = true; // allow `key:#` edge case to NOT be a comment
+    let mut in_dq = false;
+    let mut in_sq = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_dq {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                in_dq = false;
+            }
+        } else if in_sq {
+            if b == b'\'' {
+                in_sq = false;
+            }
+        } else {
+            if b == b'"' {
+                in_dq = true;
+            } else if b == b'\'' {
+                in_sq = true;
+            } else if b == b'#' && prev_was_ws {
+                let v = value[..i].trim_end().to_string();
+                let c = value[i..].to_string();
+                return (v, Some(c));
+            }
+        }
+        prev_was_ws = matches!(b, b' ' | b'\t');
+        i += 1;
+    }
+    (value.to_string(), None)
+}
+
+/// Inspect the value portion of a field line for `!fill` and other tags.
+///
+/// Returns `(fill, value_without_tag, had_other_tag, fill_target_err)`.
+///
+/// - `fill`: `true` when the value starts with `!fill`.
+/// - `value_without_tag`: the same text with the `!fill` tag stripped;
+///   leading whitespace is preserved so YAML parsing still sees a clean
+///   scalar.
+/// - `had_other_tag`: `true` when a non-`!fill` `!tag` was found at the
+///   start of the value. The tag is *not* stripped (serde_saphyr tolerates
+///   and drops unknown tags), so callers get a warning only.
+/// - `fill_target_err`: populated when `!fill` is applied to a block
+///   mapping or sequence (non-scalar). Per tasking 02 that is rejected.
+fn inspect_fill_and_tags(
+    value: &str,
+    key: &str,
+) -> (bool, String, bool, Option<String>) {
+    let trimmed = value.trim_start();
+    let leading_ws_len = value.len() - trimmed.len();
+
+    // Exactly empty / null (e.g. `key:` with nothing) — not a fill target.
+    if trimmed.is_empty() {
+        return (false, value.to_string(), false, None);
+    }
+
+    // `!fill` alone on the line (bare tag, no value) → null placeholder.
+    if trimmed == "!fill" {
+        // Replace the tag with nothing; leave the leading whitespace so the
+        // line shape is preserved (serde_saphyr treats `key: ` as null).
+        let reconstructed = value[..leading_ws_len].to_string();
+        return (true, reconstructed, false, None);
+    }
+
+    // `!fill <value>` → strip tag, record fill=true.
+    if let Some(rest) = trimmed.strip_prefix("!fill") {
+        // Must be followed by whitespace or end-of-value to count; otherwise
+        // it's `!fillwhatever` which is a non-`!fill` tag.
+        if rest.starts_with(' ') || rest.starts_with('\t') || rest.is_empty() {
+            let rest_trim = rest.trim_start();
+            // Flow-mapping / flow-sequence explicitly rejected; `!fill` only
+            // applies to plain scalars (or null).
+            let starts_block = rest_trim.starts_with('[')
+                || rest_trim.starts_with('{');
+            let err = if starts_block {
+                Some(format!(
+                    "`!fill` on key `{}` targets a non-scalar value; only scalars (string, int, float, bool, null) may be tagged `!fill`",
+                    key
+                ))
+            } else {
+                None
+            };
+            // Reconstruct: one space + the rest (trimmed) so the cleaned
+            // text reads `key: rest`.
+            let reconstructed = if rest_trim.is_empty() {
+                value[..leading_ws_len].to_string()
+            } else {
+                format!(" {}", rest_trim)
+            };
+            return (true, reconstructed, false, err);
+        }
+    }
+
+    // Any other `!tag` prefix is a non-fill custom tag. Leave the value
+    // alone; serde_saphyr will strip the tag.
+    if trimmed.starts_with('!') {
+        return (false, value.to_string(), true, None);
+    }
+
+    (false, value.to_string(), false, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_own_line_comments() {
+        let input = "# top\ntitle: foo\n# mid\nauthor: bar\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.items,
+            vec![
+                PreItem::Comment("top".to_string()),
+                PreItem::Field {
+                    key: "title".to_string(),
+                    fill: false,
+                },
+                PreItem::Comment("mid".to_string()),
+                PreItem::Field {
+                    key: "author".to_string(),
+                    fill: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn splits_trailing_comments() {
+        let input = "title: foo # inline\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.items,
+            vec![
+                PreItem::Field {
+                    key: "title".to_string(),
+                    fill: false,
+                },
+                PreItem::Comment("inline".to_string()),
+            ]
+        );
+        assert!(out.cleaned_yaml.contains("title: foo"));
+        assert!(!out.cleaned_yaml.contains("inline"));
+    }
+
+    #[test]
+    fn detects_fill_on_scalar() {
+        let input = "dept: !fill Department\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.items,
+            vec![PreItem::Field {
+                key: "dept".to_string(),
+                fill: true,
+            }]
+        );
+        assert!(out.cleaned_yaml.contains("dept: Department"));
+        assert!(!out.cleaned_yaml.contains("!fill"));
+    }
+
+    #[test]
+    fn detects_bare_fill() {
+        let input = "dept: !fill\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.items,
+            vec![PreItem::Field {
+                key: "dept".to_string(),
+                fill: true,
+            }]
+        );
+        assert!(!out.cleaned_yaml.contains("!fill"));
+    }
+
+    #[test]
+    fn unknown_tag_warns() {
+        let input = "x: !custom value\n";
+        let out = prescan_fence_content(input);
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.code.as_deref() == Some("parse::unsupported_yaml_tag")),
+            "expected unsupported_yaml_tag warning"
+        );
+    }
+
+    #[test]
+    fn nested_comment_warns_once() {
+        let input = "arr:\n  - a # inline\n  # own-line\n  - b\n";
+        let out = prescan_fence_content(input);
+        let nested = out
+            .warnings
+            .iter()
+            .filter(|w| w.code.as_deref() == Some("parse::comments_in_nested_yaml_dropped"))
+            .count();
+        assert_eq!(nested, 1, "expected exactly one nested-comment warning");
+    }
+
+    #[test]
+    fn fill_on_flow_sequence_errors() {
+        let input = "x: !fill [1, 2]\n";
+        let out = prescan_fence_content(input);
+        assert!(
+            !out.fill_target_errors.is_empty(),
+            "expected unsupported_fill_target error"
+        );
+    }
+}

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -45,7 +45,7 @@ pub struct PreScan {
     /// Warnings produced during the scan.
     pub warnings: Vec<Diagnostic>,
     /// Unsupported-fill-target errors. The parser turns these into
-    /// `ParseError::InvalidStructure` rejections per tasking 02.
+    /// `ParseError::InvalidStructure` rejections (`!fill` on mappings).
     pub fill_target_errors: Vec<String>,
 }
 
@@ -79,10 +79,8 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
             if is_top_level {
                 // Preserve the comment text (without the leading `#` and
                 // one optional space).
-                let mut text = &trimmed[1..];
-                if text.starts_with(' ') {
-                    text = &text[1..];
-                }
+                let without_hash = &trimmed[1..];
+                let text = without_hash.strip_prefix(' ').unwrap_or(without_hash);
                 out.items.push(PreItem::Comment(text.to_string()));
                 // Don't emit any line into the cleaned YAML — serde_saphyr
                 // ignores comments but omitting the line avoids any
@@ -145,10 +143,8 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
                 cleaned_lines.push(cleaned);
 
                 if let Some(c) = trailing_comment {
-                    let mut text = c.trim_start_matches('#');
-                    if text.starts_with(' ') {
-                        text = &text[1..];
-                    }
+                    let stripped = c.trim_start_matches('#');
+                    let text = stripped.strip_prefix(' ').unwrap_or(stripped);
                     out.items.push(PreItem::Comment(text.to_string()));
                 }
 
@@ -243,8 +239,10 @@ fn split_trailing_comment(value: &str) -> (String, Option<String>) {
 /// - `had_other_tag`: `true` when a non-`!fill` `!tag` was found at the
 ///   start of the value. The tag is *not* stripped (serde_saphyr tolerates
 ///   and drops unknown tags), so callers get a warning only.
-/// - `fill_target_err`: populated when `!fill` is applied to a block
-///   mapping or sequence (non-scalar). Per tasking 02 that is rejected.
+/// - `fill_target_err`: populated when `!fill` is applied to a mapping
+///   (flow `{...}` or block form). `!fill` on mappings is rejected because
+///   top-level `type: object` is not a supported schema type in Quillmark;
+///   `!fill` on scalars and sequences is allowed.
 fn inspect_fill_and_tags(value: &str, key: &str) -> (bool, String, bool, Option<String>) {
     let trimmed = value.trim_start();
     let leading_ws_len = value.len() - trimmed.len();
@@ -254,10 +252,14 @@ fn inspect_fill_and_tags(value: &str, key: &str) -> (bool, String, bool, Option<
         return (false, value.to_string(), false, None);
     }
 
-    // `!fill` alone on the line (bare tag, no value) → null placeholder.
+    // `!fill` alone on the line (bare tag, no value) → placeholder. The
+    // value may be null (no continuation) or a block sequence on the
+    // following indented lines. serde_saphyr produces the actual value.
     if trimmed == "!fill" {
         // Replace the tag with nothing; leave the leading whitespace so the
-        // line shape is preserved (serde_saphyr treats `key: ` as null).
+        // line shape is preserved (serde_saphyr treats `key: ` as null,
+        // and if a block sequence follows on indented lines, it parses as
+        // a sequence).
         let reconstructed = value[..leading_ws_len].to_string();
         return (true, reconstructed, false, None);
     }
@@ -268,12 +270,12 @@ fn inspect_fill_and_tags(value: &str, key: &str) -> (bool, String, bool, Option<
         // it's `!fillwhatever` which is a non-`!fill` tag.
         if rest.starts_with(' ') || rest.starts_with('\t') || rest.is_empty() {
             let rest_trim = rest.trim_start();
-            // Flow-mapping / flow-sequence explicitly rejected; `!fill` only
-            // applies to plain scalars (or null).
-            let starts_block = rest_trim.starts_with('[') || rest_trim.starts_with('{');
-            let err = if starts_block {
+            // Reject flow-mappings (`!fill {...}`); top-level `type: object`
+            // isn't supported by the schema. Flow sequences (`!fill [...]`)
+            // and scalars are allowed.
+            let err = if rest_trim.starts_with('{') {
                 Some(format!(
-                    "`!fill` on key `{}` targets a non-scalar value; only scalars (string, int, float, bool, null) may be tagged `!fill`",
+                    "`!fill` on key `{}` targets a mapping; `!fill` is supported on scalars and sequences only",
                     key
                 ))
             } else {
@@ -396,12 +398,29 @@ mod tests {
     }
 
     #[test]
-    fn fill_on_flow_sequence_errors() {
+    fn fill_on_flow_sequence_allowed() {
         let input = "x: !fill [1, 2]\n";
         let out = prescan_fence_content(input);
         assert!(
+            out.fill_target_errors.is_empty(),
+            "expected no error; !fill on sequences is supported"
+        );
+        assert_eq!(
+            out.items,
+            vec![PreItem::Field {
+                key: "x".to_string(),
+                fill: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn fill_on_flow_mapping_errors() {
+        let input = "x: !fill {a: 1}\n";
+        let out = prescan_fence_content(input);
+        assert!(
             !out.fill_target_errors.is_empty(),
-            "expected unsupported_fill_target error"
+            "expected error; !fill on mappings is rejected"
         );
     }
 }

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -133,8 +133,10 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
                     out.fill_target_errors.push(err);
                 }
 
-                out.items
-                    .push(PreItem::Field { key: key.clone(), fill });
+                out.items.push(PreItem::Field {
+                    key: key.clone(),
+                    fill,
+                });
 
                 // Rebuild the line without the `!fill` tag (and without
                 // the trailing comment, since that goes on its own
@@ -178,9 +180,7 @@ fn split_key(line: &str) -> Option<(String, String)> {
         return None;
     }
     let mut i = 1;
-    while i < bytes.len()
-        && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_')
-    {
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
         i += 1;
     }
     if i >= bytes.len() || bytes[i] != b':' {
@@ -245,10 +245,7 @@ fn split_trailing_comment(value: &str) -> (String, Option<String>) {
 ///   and drops unknown tags), so callers get a warning only.
 /// - `fill_target_err`: populated when `!fill` is applied to a block
 ///   mapping or sequence (non-scalar). Per tasking 02 that is rejected.
-fn inspect_fill_and_tags(
-    value: &str,
-    key: &str,
-) -> (bool, String, bool, Option<String>) {
+fn inspect_fill_and_tags(value: &str, key: &str) -> (bool, String, bool, Option<String>) {
     let trimmed = value.trim_start();
     let leading_ws_len = value.len() - trimmed.len();
 
@@ -273,8 +270,7 @@ fn inspect_fill_and_tags(
             let rest_trim = rest.trim_start();
             // Flow-mapping / flow-sequence explicitly rejected; `!fill` only
             // applies to plain scalars (or null).
-            let starts_block = rest_trim.starts_with('[')
-                || rest_trim.starts_with('{');
+            let starts_block = rest_trim.starts_with('[') || rest_trim.starts_with('{');
             let err = if starts_block {
                 Some(format!(
                     "`!fill` on key `{}` targets a non-scalar value; only scalars (string, int, float, bool, null) may be tagged `!fill`",

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -4,7 +4,7 @@
 //! Two features are recovered here:
 //!
 //! 1. **Top-level comments.** YAML comments are dropped by the YAML parser.
-//!    To round-trip them as [`FrontmatterItem::Comment`], we extract them
+//!    To round-trip them as [`super::FrontmatterItem::Comment`], we extract them
 //!    before parsing.
 //!
 //! 2. **`!fill` tags.** Custom YAML tags are accepted and dropped by

--- a/crates/core/src/document/tests/ambiguous_strings_tests.rs
+++ b/crates/core/src/document/tests/ambiguous_strings_tests.rs
@@ -9,7 +9,6 @@
 //! JSON-style escaping, which is what buys the round-trip guarantee tested
 //! here.
 //!
-//! See plan §Phase 4 test item 2.
 
 use crate::document::Document;
 
@@ -42,7 +41,7 @@ fn parse_fixture() -> Document {
 /// expected bytes, then perform a round-trip and assert byte-identical.
 fn assert_string_field_round_trips(doc: &Document, key: &str, expected: &str) {
     let value = doc
-        .frontmatter()
+        .main().frontmatter()
         .get(key)
         .unwrap_or_else(|| panic!("field '{}' not found in frontmatter", key));
 
@@ -73,7 +72,7 @@ fn assert_round_trip_strings(keys_and_values: &[(&str, &str)]) {
         assert_string_field_round_trips(&doc, key, expected);
         // Re-parsed: byte-identical.
         let v2 = doc2
-            .frontmatter()
+            .main().frontmatter()
             .get(*key)
             .unwrap_or_else(|| panic!("field '{}' missing after round-trip", key));
         assert!(
@@ -199,7 +198,7 @@ fn all_ambiguous_fields_are_strings() {
     ];
     for field in &expected_string_fields {
         let value = doc
-            .frontmatter()
+            .main().frontmatter()
             .get(*field)
             .unwrap_or_else(|| panic!("field '{}' not found", field));
         assert!(

--- a/crates/core/src/document/tests/ambiguous_strings_tests.rs
+++ b/crates/core/src/document/tests/ambiguous_strings_tests.rs
@@ -41,7 +41,8 @@ fn parse_fixture() -> Document {
 /// expected bytes, then perform a round-trip and assert byte-identical.
 fn assert_string_field_round_trips(doc: &Document, key: &str, expected: &str) {
     let value = doc
-        .main().frontmatter()
+        .main()
+        .frontmatter()
         .get(key)
         .unwrap_or_else(|| panic!("field '{}' not found in frontmatter", key));
 
@@ -72,7 +73,8 @@ fn assert_round_trip_strings(keys_and_values: &[(&str, &str)]) {
         assert_string_field_round_trips(&doc, key, expected);
         // Re-parsed: byte-identical.
         let v2 = doc2
-            .main().frontmatter()
+            .main()
+            .frontmatter()
             .get(*key)
             .unwrap_or_else(|| panic!("field '{}' missing after round-trip", key));
         assert!(
@@ -198,7 +200,8 @@ fn all_ambiguous_fields_are_strings() {
     ];
     for field in &expected_string_fields {
         let value = doc
-            .main().frontmatter()
+            .main()
+            .frontmatter()
             .get(*field)
             .unwrap_or_else(|| panic!("field '{}' not found", field));
         assert!(

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -209,14 +209,14 @@ Second item body."#;
     let card1 = &doc.cards()[0];
     assert_eq!(card1.tag(), "items");
     assert_eq!(
-        card1.fields().get("name").unwrap().as_str().unwrap(),
+        card1.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
 
     let card2 = &doc.cards()[1];
     assert_eq!(card2.tag(), "items");
     assert_eq!(
-        card2.fields().get("name").unwrap().as_str().unwrap(),
+        card2.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 2"
     );
 }
@@ -546,14 +546,14 @@ Section 1 body"#;
     let card0 = &doc.cards()[0];
     assert_eq!(card0.tag(), "items");
     assert_eq!(
-        card0.fields().get("name").unwrap().as_str().unwrap(),
+        card0.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
 
     let card1 = &doc.cards()[1];
     assert_eq!(card1.tag(), "sections");
     assert_eq!(
-        card1.fields().get("title").unwrap().as_str().unwrap(),
+        card1.frontmatter().get("title").unwrap().as_str().unwrap(),
         "Section 1"
     );
 }
@@ -681,7 +681,7 @@ rating: 4
     assert_eq!(doc.cards()[0].tag(), "products");
     assert_eq!(
         doc.cards()[0]
-            .fields()
+            .frontmatter()
             .get("name")
             .unwrap()
             .as_str()
@@ -690,7 +690,7 @@ rating: 4
     );
     assert_eq!(
         doc.cards()[0]
-            .fields()
+            .frontmatter()
             .get("price")
             .unwrap()
             .as_f64()
@@ -701,7 +701,7 @@ rating: 4
     assert_eq!(doc.cards()[1].tag(), "products");
     assert_eq!(
         doc.cards()[1]
-            .fields()
+            .frontmatter()
             .get("name")
             .unwrap()
             .as_str()
@@ -713,7 +713,7 @@ rating: 4
     assert_eq!(doc.cards()[2].tag(), "reviews");
     assert_eq!(
         doc.cards()[2]
-            .fields()
+            .frontmatter()
             .get("product")
             .unwrap()
             .as_str()
@@ -722,7 +722,7 @@ rating: 4
     );
     assert_eq!(
         doc.cards()[2]
-            .fields()
+            .frontmatter()
             .get("rating")
             .unwrap()
             .as_i64()
@@ -808,7 +808,7 @@ QUILL: second
         .iter()
         .any(|w| w.code.as_deref() == Some("parse::near_miss_sentinel")
             && w.message.contains("QUILL")));
-    assert!(output.document.body().contains("QUILL: second"));
+    assert!(output.document.main().body().contains("QUILL: second"));
 }
 
 #[test]
@@ -1120,7 +1120,7 @@ fn test_extended_metadata_demo_file() {
     assert_eq!(doc.cards()[0].tag(), "features");
     assert_eq!(
         doc.cards()[0]
-            .fields()
+            .frontmatter()
             .get("name")
             .unwrap()
             .as_str()
@@ -1265,7 +1265,7 @@ Use <<card body>> here."#;
     assert_eq!(items[0].as_str().unwrap(), "<<first>>");
     assert_eq!(items[1].as_str().unwrap(), "<<second>>");
     let metadata = doc
-        .frontmatter()
+        .main().frontmatter()
         .get("metadata")
         .unwrap()
         .as_object()
@@ -1495,7 +1495,7 @@ description: |
 Body."#;
     let doc = decompose(markdown).unwrap();
     let desc = doc
-        .frontmatter()
+        .main().frontmatter()
         .get("description")
         .unwrap()
         .as_str()
@@ -1517,7 +1517,7 @@ description: >
 Body."#;
     let doc = decompose(markdown).unwrap();
     let desc = doc
-        .frontmatter()
+        .main().frontmatter()
         .get("description")
         .unwrap()
         .as_str()
@@ -1577,7 +1577,7 @@ config:
 Body."#;
     let doc = decompose(markdown).unwrap();
     let config = doc
-        .frontmatter()
+        .main().frontmatter()
         .get("config")
         .unwrap()
         .as_object()
@@ -1810,7 +1810,7 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
     let doc = decompose(markdown).unwrap();
     let emitted = doc.to_markdown();
     let reparsed = Document::from_markdown(&emitted).unwrap();
-    assert_eq!(doc.main().body(), reparsed.body());
+    assert_eq!(doc.main().body(), reparsed.main().body());
     // Author's blank line after the code block survives.
     assert!(
         doc.main().body().ends_with("```\n\n"),
@@ -1926,7 +1926,7 @@ Body
     assert_eq!(doc.cards()[0].tag(), "my_card");
     assert_eq!(
         doc.cards()[0]
-            .fields()
+            .frontmatter()
             .get("title")
             .unwrap()
             .as_str()
@@ -2014,7 +2014,7 @@ Conclusion content.
     assert_eq!(doc.cards()[0].tag(), "section");
     assert_eq!(
         doc.cards()[0]
-            .fields()
+            .frontmatter()
             .get("heading")
             .unwrap()
             .as_str()
@@ -2025,7 +2025,7 @@ Conclusion content.
     assert_eq!(doc.cards()[1].tag(), "section");
     assert_eq!(
         doc.cards()[1]
-            .fields()
+            .frontmatter()
             .get("heading")
             .unwrap()
             .as_str()

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -29,11 +29,21 @@ This is the body."#;
 
     assert_eq!(doc.main().body(), "\n# Hello World\n\nThis is the body.");
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test Document"
     );
     assert_eq!(
-        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("author")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test Author"
     );
     assert_eq!(doc.main().frontmatter().len(), 2); // title, author
@@ -73,11 +83,22 @@ Content here."#;
 
     assert_eq!(doc.main().body(), "\nContent here.");
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Complex Document"
     );
 
-    let tags = doc.main().frontmatter().get("tags").unwrap().as_array().unwrap();
+    let tags = doc
+        .main()
+        .frontmatter()
+        .get("tags")
+        .unwrap()
+        .as_array()
+        .unwrap();
     assert_eq!(tags.len(), 2);
     assert_eq!(tags[0].as_str().unwrap(), "test");
     assert_eq!(tags[1].as_str().unwrap(), "yaml");
@@ -140,7 +161,12 @@ Body of item 1."#;
     // terminator preserved).
     assert_eq!(doc.main().body(), "\nMain body content.\n");
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Main Document"
     );
 
@@ -222,7 +248,12 @@ Section 2 content."#;
     let doc = decompose(markdown).unwrap();
 
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Global"
     );
     assert_eq!(doc.main().body(), "\nGlobal body.\n");
@@ -613,15 +644,30 @@ rating: 4
 
     // Verify global frontmatter
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Product Catalog"
     );
     assert_eq!(
-        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("author")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "John Doe"
     );
     assert_eq!(
-        doc.main().frontmatter().get("date").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("date")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "2024-01-01"
     );
 
@@ -701,7 +747,8 @@ This is the memo body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "usaf_memo");
     assert_eq!(
-        doc.main().frontmatter()
+        doc.main()
+            .frontmatter()
             .get("memo_for")
             .unwrap()
             .as_array()
@@ -732,7 +779,12 @@ Section 1 body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "document");
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test Document"
     );
     assert_eq!(doc.cards().len(), 1);
@@ -840,22 +892,39 @@ This is the body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\n# Hello World\n\nThis is the body.");
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test Document"
     );
     assert_eq!(
-        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("author")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test Author"
     );
     assert_eq!(
-        doc.main().frontmatter()
+        doc.main()
+            .frontmatter()
             .get("description")
             .unwrap()
             .as_str()
             .unwrap(),
         "This has a blank line above it"
     );
-    let tags = doc.main().frontmatter().get("tags").unwrap().as_array().unwrap();
+    let tags = doc
+        .main()
+        .frontmatter()
+        .get("tags")
+        .unwrap()
+        .as_array()
+        .unwrap();
     assert_eq!(tags.len(), 2);
 }
 
@@ -886,7 +955,10 @@ Body of item 1."#;
         card.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
-    assert_eq!(card.frontmatter().get("price").unwrap().as_f64().unwrap(), 19.99);
+    assert_eq!(
+        card.frontmatter().get("price").unwrap().as_f64().unwrap(),
+        19.99
+    );
     let tags = card.frontmatter().get("tags").unwrap().as_array().unwrap();
     assert_eq!(tags.len(), 2);
 }
@@ -947,15 +1019,30 @@ Body content."#;
 
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test"
     );
     assert_eq!(
-        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("author")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "John Doe"
     );
     assert_eq!(
-        doc.main().frontmatter().get("version").unwrap().as_f64().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("version")
+            .unwrap()
+            .as_f64()
+            .unwrap(),
         1.0
     );
 }
@@ -983,21 +1070,39 @@ fn test_extended_metadata_demo_file() {
     let doc = decompose(markdown).unwrap();
 
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Extended Metadata Demo"
     );
     assert_eq!(
-        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("author")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Quillmark Team"
     );
     // version is parsed as a number by YAML
     assert_eq!(
-        doc.main().frontmatter().get("version").unwrap().as_f64().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("version")
+            .unwrap()
+            .as_f64()
+            .unwrap(),
         1.0
     );
 
     // Verify body
-    assert!(doc.main().body().contains("extended YAML metadata standard"));
+    assert!(doc
+        .main()
+        .body()
+        .contains("extended YAML metadata standard"));
 
     // 5 cards total: 3 features + 2 use_cases
     assert_eq!(doc.cards().len(), 5);
@@ -1142,10 +1247,21 @@ Use <<card body>> here."#;
 
     // Frontmatter scalar, array, nested map.
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test <<with chevrons>>"
     );
-    let items = doc.main().frontmatter().get("items").unwrap().as_array().unwrap();
+    let items = doc
+        .main()
+        .frontmatter()
+        .get("items")
+        .unwrap()
+        .as_array()
+        .unwrap();
     assert_eq!(items[0].as_str().unwrap(), "<<first>>");
     assert_eq!(items[1].as_str().unwrap(), "<<second>>");
     let metadata = doc
@@ -1169,7 +1285,11 @@ Use <<card body>> here."#;
     // Card yaml and body.
     let card = &doc.cards()[0];
     assert_eq!(
-        card.frontmatter().get("description").unwrap().as_str().unwrap(),
+        card.frontmatter()
+            .get("description")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "<<card yaml>>"
     );
     assert!(card.body().contains("<<card body>>"));
@@ -1185,7 +1305,12 @@ count: 42
 Body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("count").unwrap().as_i64().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("count")
+            .unwrap()
+            .as_i64()
+            .unwrap(),
         42
     );
 }
@@ -1199,7 +1324,13 @@ active: true
 
 Body."#;
     let doc = decompose(markdown).unwrap();
-    assert!(doc.main().frontmatter().get("active").unwrap().as_bool().unwrap());
+    assert!(doc
+        .main()
+        .frontmatter()
+        .get("active")
+        .unwrap()
+        .as_bool()
+        .unwrap());
 }
 
 #[test]
@@ -1251,7 +1382,12 @@ fn test_line_ending_normalization() {
     ] {
         let doc = decompose(markdown).unwrap();
         assert_eq!(
-            doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+            doc.main()
+                .frontmatter()
+                .get("title")
+                .unwrap()
+                .as_str()
+                .unwrap(),
             "Test"
         );
     }
@@ -1262,7 +1398,12 @@ fn test_frontmatter_at_eof_no_trailing_newline() {
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Test"
     );
     assert_eq!(doc.main().body(), "");
@@ -1297,11 +1438,21 @@ fn test_unicode_in_yaml_keys() {
     let markdown = "---\nQUILL: test_quill\ntitre: Bonjour\nタイトル: こんにちは\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("titre").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("titre")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Bonjour"
     );
     assert_eq!(
-        doc.main().frontmatter().get("タイトル").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("タイトル")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "こんにちは"
     );
 }
@@ -1311,7 +1462,12 @@ fn test_unicode_in_yaml_values() {
     let markdown = "---\nQUILL: test_quill\ntitle: 你好世界 🎉\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "你好世界 🎉"
     );
 }
@@ -1381,7 +1537,12 @@ fn test_yaml_empty_string_value() {
     let markdown = "---\nQUILL: test_quill\nempty: \"\"\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("empty").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("empty")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         ""
     );
 }
@@ -1391,7 +1552,12 @@ fn test_yaml_special_characters_in_string() {
     let markdown = "---\nQUILL: test_quill\nspecial: \"colon: here, and [brackets]\"\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("special").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("special")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "colon: here, and [brackets]"
     );
 }
@@ -1505,11 +1671,21 @@ Body content."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "my_quill");
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Document Title"
     );
     assert_eq!(
-        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("author")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "John Doe"
     );
 }
@@ -1682,14 +1858,30 @@ items:
 Body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("count").unwrap().as_i64().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("count")
+            .unwrap()
+            .as_i64()
+            .unwrap(),
         42
     );
     assert_eq!(
-        doc.main().frontmatter().get("price").unwrap().as_f64().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("price")
+            .unwrap()
+            .as_f64()
+            .unwrap(),
         19.99
     );
-    assert!(doc.main().frontmatter().get("active").unwrap().as_bool().unwrap());
+    assert!(doc
+        .main()
+        .frontmatter()
+        .get("active")
+        .unwrap()
+        .as_bool()
+        .unwrap());
 }
 
 #[test]
@@ -1697,7 +1889,12 @@ fn test_guillemet_double_conversion_prevention() {
     let markdown = "---\nQUILL: test_quill\ntitle: Already «converted»\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Already «converted»"
     );
 }
@@ -1717,7 +1914,12 @@ Body
 "#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("my_card").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("my_card")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "some global value"
     );
     assert_eq!(doc.cards().len(), 1);
@@ -1744,7 +1946,8 @@ regular_field: normal value
 Body content."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.main().frontmatter()
+        doc.main()
+            .frontmatter()
             .get("memo_from")
             .unwrap()
             .as_str()
@@ -1752,7 +1955,8 @@ Body content."#;
         "2d lt example"
     );
     assert_eq!(
-        doc.main().frontmatter()
+        doc.main()
+            .frontmatter()
             .get("regular_field")
             .unwrap()
             .as_str()
@@ -1791,7 +1995,12 @@ Conclusion content.
     let doc = decompose(markdown).unwrap();
 
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "My Document"
     );
     assert_eq!(doc.quill_reference().name, "blog_post");
@@ -1930,7 +2139,12 @@ fn test_to_plate_json_fixture_snapshot() {
 fn frontmatter_field_order_preserved_after_quill_removal() {
     let md = "---\nQUILL: q\nsender: Alice\nrecipient: Bob\ndate: March 15\nsubject: hi\n---\n";
     let doc = Document::from_markdown(md).unwrap();
-    let keys: Vec<&str> = doc.main().frontmatter().keys().map(|s| s.as_str()).collect();
+    let keys: Vec<&str> = doc
+        .main()
+        .frontmatter()
+        .keys()
+        .map(|s| s.as_str())
+        .collect();
     // Fields must appear in YAML document order, not alphabetical or swap-order.
     assert_eq!(
         keys,

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -27,16 +27,16 @@ This is the body."#;
 
     let doc = decompose(markdown).unwrap();
 
-    assert_eq!(doc.body(), "\n# Hello World\n\nThis is the body.");
+    assert_eq!(doc.main().body(), "\n# Hello World\n\nThis is the body.");
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Test Document"
     );
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
         "Test Author"
     );
-    assert_eq!(doc.frontmatter().len(), 2); // title, author
+    assert_eq!(doc.main().frontmatter().len(), 2); // title, author
     assert_eq!(doc.cards().len(), 0);
     assert_eq!(doc.quill_reference().name, "test_quill");
 }
@@ -71,13 +71,13 @@ Content here."#;
 
     let doc = decompose(markdown).unwrap();
 
-    assert_eq!(doc.body(), "\nContent here.");
+    assert_eq!(doc.main().body(), "\nContent here.");
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Complex Document"
     );
 
-    let tags = doc.frontmatter().get("tags").unwrap().as_array().unwrap();
+    let tags = doc.main().frontmatter().get("tags").unwrap().as_array().unwrap();
     assert_eq!(tags.len(), 2);
     assert_eq!(tags[0].as_str().unwrap(), "test");
     assert_eq!(tags[1].as_str().unwrap(), "yaml");
@@ -138,9 +138,9 @@ Body of item 1."#;
     // Global body is followed by a CARD fence: F2 separator stripped, so the
     // trailing `\n\n` from the source becomes a single `\n` (content's line
     // terminator preserved).
-    assert_eq!(doc.body(), "\nMain body content.\n");
+    assert_eq!(doc.main().body(), "\nMain body content.\n");
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Main Document"
     );
 
@@ -148,7 +148,7 @@ Body of item 1."#;
     let card = &doc.cards()[0];
     assert_eq!(card.tag(), "items");
     assert_eq!(
-        card.fields().get("name").unwrap().as_str().unwrap(),
+        card.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
     // Last card body at EOF: no F2 separator to strip.
@@ -222,10 +222,10 @@ Section 2 content."#;
     let doc = decompose(markdown).unwrap();
 
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Global"
     );
-    assert_eq!(doc.body(), "\nGlobal body.\n");
+    assert_eq!(doc.main().body(), "\nGlobal body.\n");
     assert_eq!(doc.cards().len(), 2);
     assert_eq!(doc.cards()[0].tag(), "sections");
 }
@@ -246,7 +246,7 @@ Body without metadata."#;
     assert_eq!(doc.cards().len(), 1);
     let card = &doc.cards()[0];
     assert_eq!(card.tag(), "items");
-    assert!(card.fields().is_empty());
+    assert!(card.frontmatter().is_empty());
     assert_eq!(card.body(), "\nBody without metadata.");
 }
 
@@ -393,8 +393,8 @@ More content.
 
     let doc = decompose(markdown).unwrap();
     // The --- inside the code block should NOT be parsed as metadata
-    assert!(doc.body().contains("fake: frontmatter"));
-    assert!(doc.frontmatter().get("fake").is_none());
+    assert!(doc.main().body().contains("fake: frontmatter"));
+    assert!(doc.main().frontmatter().get("fake").is_none());
 }
 
 #[test]
@@ -417,8 +417,8 @@ More content.
 "#;
 
     let doc = decompose(markdown).unwrap();
-    assert!(doc.body().contains("fake: frontmatter"));
-    assert!(doc.frontmatter().get("fake").is_none());
+    assert!(doc.main().body().contains("fake: frontmatter"));
+    assert!(doc.main().frontmatter().get("fake").is_none());
 }
 
 #[test]
@@ -440,8 +440,8 @@ More content.
 "#;
 
     let doc = decompose(markdown).unwrap();
-    assert!(doc.body().contains("fake: frontmatter"));
-    assert!(doc.frontmatter().get("fake").is_none());
+    assert!(doc.main().body().contains("fake: frontmatter"));
+    assert!(doc.main().frontmatter().get("fake").is_none());
 }
 
 #[test]
@@ -559,7 +559,7 @@ Third"#;
 
     for (i, card) in doc.cards().iter().enumerate() {
         assert_eq!(card.tag(), "items");
-        let id = card.fields().get("id").unwrap().as_i64().unwrap();
+        let id = card.frontmatter().get("id").unwrap().as_i64().unwrap();
         assert_eq!(id, (i + 1) as i64);
     }
 }
@@ -613,20 +613,20 @@ rating: 4
 
     // Verify global frontmatter
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Product Catalog"
     );
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
         "John Doe"
     );
     assert_eq!(
-        doc.frontmatter().get("date").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("date").unwrap().as_str().unwrap(),
         "2024-01-01"
     );
 
     // Verify global body
-    assert!(doc.body().contains("main catalog description"));
+    assert!(doc.main().body().contains("main catalog description"));
 
     // 4 cards total
     assert_eq!(doc.cards().len(), 4);
@@ -685,7 +685,7 @@ rating: 4
     );
 
     // Frontmatter has 3 fields: title, author, date
-    assert_eq!(doc.frontmatter().len(), 3);
+    assert_eq!(doc.main().frontmatter().len(), 3);
 }
 
 #[test]
@@ -701,7 +701,7 @@ This is the memo body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "usaf_memo");
     assert_eq!(
-        doc.frontmatter()
+        doc.main().frontmatter()
             .get("memo_for")
             .unwrap()
             .as_array()
@@ -710,7 +710,7 @@ This is the memo body."#;
             .unwrap(),
         "ORG/SYMBOL"
     );
-    assert_eq!(doc.body(), "\nThis is the memo body.");
+    assert_eq!(doc.main().body(), "\nThis is the memo body.");
 }
 
 #[test]
@@ -732,12 +732,12 @@ Section 1 body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "document");
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Test Document"
     );
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].tag(), "sections");
-    assert_eq!(doc.body(), "\nMain body.\n");
+    assert_eq!(doc.main().body(), "\nMain body.\n");
 }
 
 #[test]
@@ -838,24 +838,24 @@ tags:
 This is the body."#;
 
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "\n# Hello World\n\nThis is the body.");
+    assert_eq!(doc.main().body(), "\n# Hello World\n\nThis is the body.");
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Test Document"
     );
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
         "Test Author"
     );
     assert_eq!(
-        doc.frontmatter()
+        doc.main().frontmatter()
             .get("description")
             .unwrap()
             .as_str()
             .unwrap(),
         "This has a blank line above it"
     );
-    let tags = doc.frontmatter().get("tags").unwrap().as_array().unwrap();
+    let tags = doc.main().frontmatter().get("tags").unwrap().as_array().unwrap();
     assert_eq!(tags.len(), 2);
 }
 
@@ -883,11 +883,11 @@ Body of item 1."#;
     let card = &doc.cards()[0];
     assert_eq!(card.tag(), "items");
     assert_eq!(
-        card.fields().get("name").unwrap().as_str().unwrap(),
+        card.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
-    assert_eq!(card.fields().get("price").unwrap().as_f64().unwrap(), 19.99);
-    let tags = card.fields().get("tags").unwrap().as_array().unwrap();
+    assert_eq!(card.frontmatter().get("price").unwrap().as_f64().unwrap(), 19.99);
+    let tags = card.frontmatter().get("tags").unwrap().as_array().unwrap();
     assert_eq!(tags.len(), 2);
 }
 
@@ -905,7 +905,7 @@ First paragraph.
 Second paragraph."#;
 
     let doc = decompose(markdown).unwrap();
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(body.contains("First paragraph."));
     assert!(body.contains("Second paragraph."));
     assert!(body.contains("---"));
@@ -924,7 +924,7 @@ First paragraph.
 Second paragraph."#;
 
     let doc = decompose(markdown).unwrap();
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(body.contains("First paragraph."));
     assert!(body.contains("Second paragraph."));
     assert!(body.contains("---"));
@@ -947,15 +947,15 @@ Body content."#;
 
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Test"
     );
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
         "John Doe"
     );
     assert_eq!(
-        doc.frontmatter().get("version").unwrap().as_f64().unwrap(),
+        doc.main().frontmatter().get("version").unwrap().as_f64().unwrap(),
         1.0
     );
 }
@@ -971,7 +971,7 @@ key: value
 ---
 "#;
     let doc = decompose(markdown).unwrap();
-    let key = doc.frontmatter().get("key").and_then(|v| v.as_str());
+    let key = doc.main().frontmatter().get("key").and_then(|v| v.as_str());
     assert_eq!(key, Some("value"));
 }
 
@@ -983,21 +983,21 @@ fn test_extended_metadata_demo_file() {
     let doc = decompose(markdown).unwrap();
 
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Extended Metadata Demo"
     );
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
         "Quillmark Team"
     );
     // version is parsed as a number by YAML
     assert_eq!(
-        doc.frontmatter().get("version").unwrap().as_f64().unwrap(),
+        doc.main().frontmatter().get("version").unwrap().as_f64().unwrap(),
         1.0
     );
 
     // Verify body
-    assert!(doc.body().contains("extended YAML metadata standard"));
+    assert!(doc.main().body().contains("extended YAML metadata standard"));
 
     // 5 cards total: 3 features + 2 use_cases
     assert_eq!(doc.cards().len(), 5);
@@ -1142,10 +1142,10 @@ Use <<card body>> here."#;
 
     // Frontmatter scalar, array, nested map.
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Test <<with chevrons>>"
     );
-    let items = doc.frontmatter().get("items").unwrap().as_array().unwrap();
+    let items = doc.main().frontmatter().get("items").unwrap().as_array().unwrap();
     assert_eq!(items[0].as_str().unwrap(), "<<first>>");
     assert_eq!(items[1].as_str().unwrap(), "<<second>>");
     let metadata = doc
@@ -1160,7 +1160,7 @@ Use <<card body>> here."#;
     );
 
     // Body: plain, fenced code, inline code.
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(body.contains("<<body>>"));
     assert!(body.contains("<<in code block>>"));
     assert!(body.contains("`<<inline code>>`"));
@@ -1169,7 +1169,7 @@ Use <<card body>> here."#;
     // Card yaml and body.
     let card = &doc.cards()[0];
     assert_eq!(
-        card.fields().get("description").unwrap().as_str().unwrap(),
+        card.frontmatter().get("description").unwrap().as_str().unwrap(),
         "<<card yaml>>"
     );
     assert!(card.body().contains("<<card body>>"));
@@ -1185,7 +1185,7 @@ count: 42
 Body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("count").unwrap().as_i64().unwrap(),
+        doc.main().frontmatter().get("count").unwrap().as_i64().unwrap(),
         42
     );
 }
@@ -1199,14 +1199,14 @@ active: true
 
 Body."#;
     let doc = decompose(markdown).unwrap();
-    assert!(doc.frontmatter().get("active").unwrap().as_bool().unwrap());
+    assert!(doc.main().frontmatter().get("active").unwrap().as_bool().unwrap());
 }
 
 #[test]
 fn test_multiline_chevrons_preserved() {
     let markdown = "---\nQUILL: test_quill\n---\n<<text\nacross lines>>";
     let doc = decompose(markdown).unwrap();
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(body.contains("<<text"));
     assert!(body.contains("across lines>>"));
 }
@@ -1215,7 +1215,7 @@ fn test_multiline_chevrons_preserved() {
 fn test_unmatched_chevrons_preserved() {
     let markdown = "---\nQUILL: test_quill\n---\n<<unmatched";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "<<unmatched");
+    assert_eq!(doc.main().body(), "<<unmatched");
 }
 
 // Robustness tests
@@ -1239,7 +1239,7 @@ fn test_missing_quill_field() {
 fn test_dashes_in_middle_of_line() {
     let markdown = "---\nQUILL: test_quill\n---\nsome text --- more text";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "some text --- more text");
+    assert_eq!(doc.main().body(), "some text --- more text");
 }
 
 /// CRLF and mixed line endings must parse identically to LF.
@@ -1251,7 +1251,7 @@ fn test_line_ending_normalization() {
     ] {
         let doc = decompose(markdown).unwrap();
         assert_eq!(
-            doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+            doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
             "Test"
         );
     }
@@ -1262,10 +1262,10 @@ fn test_frontmatter_at_eof_no_trailing_newline() {
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Test"
     );
-    assert_eq!(doc.body(), "");
+    assert_eq!(doc.main().body(), "");
 }
 
 #[test]
@@ -1297,11 +1297,11 @@ fn test_unicode_in_yaml_keys() {
     let markdown = "---\nQUILL: test_quill\ntitre: Bonjour\nタイトル: こんにちは\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("titre").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("titre").unwrap().as_str().unwrap(),
         "Bonjour"
     );
     assert_eq!(
-        doc.frontmatter().get("タイトル").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("タイトル").unwrap().as_str().unwrap(),
         "こんにちは"
     );
 }
@@ -1311,7 +1311,7 @@ fn test_unicode_in_yaml_values() {
     let markdown = "---\nQUILL: test_quill\ntitle: 你好世界 🎉\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "你好世界 🎉"
     );
 }
@@ -1320,8 +1320,8 @@ fn test_unicode_in_yaml_values() {
 fn test_unicode_in_body() {
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---\n\n日本語テキスト with emoji 🚀";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.body().contains("日本語テキスト"));
-    assert!(doc.body().contains("🚀"));
+    assert!(doc.main().body().contains("日本語テキスト"));
+    assert!(doc.main().body().contains("🚀"));
 }
 
 // YAML edge cases
@@ -1373,7 +1373,7 @@ Body."#;
 fn test_yaml_null_value() {
     let markdown = "---\nQUILL: test_quill\noptional: null\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.frontmatter().get("optional").unwrap().is_null());
+    assert!(doc.main().frontmatter().get("optional").unwrap().is_null());
 }
 
 #[test]
@@ -1381,7 +1381,7 @@ fn test_yaml_empty_string_value() {
     let markdown = "---\nQUILL: test_quill\nempty: \"\"\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("empty").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("empty").unwrap().as_str().unwrap(),
         ""
     );
 }
@@ -1391,7 +1391,7 @@ fn test_yaml_special_characters_in_string() {
     let markdown = "---\nQUILL: test_quill\nspecial: \"colon: here, and [brackets]\"\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("special").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("special").unwrap().as_str().unwrap(),
         "colon: here, and [brackets]"
     );
 }
@@ -1505,11 +1505,11 @@ Body content."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "my_quill");
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Document Title"
     );
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("author").unwrap().as_str().unwrap(),
         "John Doe"
     );
 }
@@ -1569,7 +1569,7 @@ fn test_yaml_syntax_error_bad_indentation() {
 fn test_body_with_leading_newlines() {
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---\n\n\n\nBody with leading newlines.";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.body().starts_with('\n'));
+    assert!(doc.main().body().starts_with('\n'));
 }
 
 #[test]
@@ -1578,7 +1578,7 @@ fn test_body_with_trailing_newlines() {
     // are preserved verbatim as authored content.
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---\n\nBody.\n\n\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "\nBody.\n\n\n");
+    assert_eq!(doc.main().body(), "\nBody.\n\n\n");
 }
 
 // ── F2 separator stripping: parse-side normalisation ─────────────────────────
@@ -1591,7 +1591,7 @@ fn test_f2_strip_global_body_followed_by_card_lf() {
     // leaving `\n` as the content terminator.
     let markdown = "---\nQUILL: q\n---\n\nbody\n\n---\nCARD: x\n---\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "\nbody\n");
+    assert_eq!(doc.main().body(), "\nbody\n");
 }
 
 #[test]
@@ -1600,9 +1600,9 @@ fn test_f2_strip_global_body_followed_by_card_crlf() {
     let markdown = "---\r\nQUILL: q\r\n---\r\n\r\nbody\r\n\r\n---\r\nCARD: x\r\n---\r\n";
     let doc = decompose(markdown).unwrap();
     assert!(
-        doc.body().ends_with('\n') && !doc.body().ends_with("\n\n"),
+        doc.main().body().ends_with('\n') && !doc.main().body().ends_with("\n\n"),
         "expected exactly one trailing line ending, got {:?}",
-        doc.body()
+        doc.main().body()
     );
 }
 
@@ -1622,7 +1622,7 @@ fn test_f2_strip_preserves_author_blank_lines() {
     // `\n`) is stripped; the author's blank line is preserved.
     let markdown = "---\nQUILL: q\n---\n\nbody\n\n\n---\nCARD: x\n---\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "\nbody\n\n");
+    assert_eq!(doc.main().body(), "\nbody\n\n");
 }
 
 #[test]
@@ -1634,12 +1634,12 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
     let doc = decompose(markdown).unwrap();
     let emitted = doc.to_markdown();
     let reparsed = Document::from_markdown(&emitted).unwrap();
-    assert_eq!(doc.body(), reparsed.body());
+    assert_eq!(doc.main().body(), reparsed.body());
     // Author's blank line after the code block survives.
     assert!(
-        doc.body().ends_with("```\n\n"),
+        doc.main().body().ends_with("```\n\n"),
         "expected code block + blank line, got {:?}",
-        doc.body()
+        doc.main().body()
     );
 }
 
@@ -1647,7 +1647,7 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
 fn test_no_body_after_frontmatter() {
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.body(), "");
+    assert_eq!(doc.main().body(), "");
 }
 
 // Tag name validation
@@ -1682,14 +1682,14 @@ items:
 Body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("count").unwrap().as_i64().unwrap(),
+        doc.main().frontmatter().get("count").unwrap().as_i64().unwrap(),
         42
     );
     assert_eq!(
-        doc.frontmatter().get("price").unwrap().as_f64().unwrap(),
+        doc.main().frontmatter().get("price").unwrap().as_f64().unwrap(),
         19.99
     );
-    assert!(doc.frontmatter().get("active").unwrap().as_bool().unwrap());
+    assert!(doc.main().frontmatter().get("active").unwrap().as_bool().unwrap());
 }
 
 #[test]
@@ -1697,7 +1697,7 @@ fn test_guillemet_double_conversion_prevention() {
     let markdown = "---\nQUILL: test_quill\ntitle: Already «converted»\n---\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "Already «converted»"
     );
 }
@@ -1717,7 +1717,7 @@ Body
 "#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter().get("my_card").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("my_card").unwrap().as_str().unwrap(),
         "some global value"
     );
     assert_eq!(doc.cards().len(), 1);
@@ -1744,7 +1744,7 @@ regular_field: normal value
 Body content."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(
-        doc.frontmatter()
+        doc.main().frontmatter()
             .get("memo_from")
             .unwrap()
             .as_str()
@@ -1752,14 +1752,14 @@ Body content."#;
         "2d lt example"
     );
     assert_eq!(
-        doc.frontmatter()
+        doc.main().frontmatter()
             .get("regular_field")
             .unwrap()
             .as_str()
             .unwrap(),
         "normal value"
     );
-    assert_eq!(doc.body(), "\nBody content.");
+    assert_eq!(doc.main().body(), "\nBody content.");
 }
 
 /// Test the exact example from EXTENDED_MARKDOWN.md
@@ -1791,12 +1791,12 @@ Conclusion content.
     let doc = decompose(markdown).unwrap();
 
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "My Document"
     );
     assert_eq!(doc.quill_reference().name, "blog_post");
 
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(body.contains("Main document body."));
     assert!(body.contains("***"));
     assert!(body.contains("More content after horizontal rule."));
@@ -1930,7 +1930,7 @@ fn test_to_plate_json_fixture_snapshot() {
 fn frontmatter_field_order_preserved_after_quill_removal() {
     let md = "---\nQUILL: q\nsender: Alice\nrecipient: Bob\ndate: March 15\nsubject: hi\n---\n";
     let doc = Document::from_markdown(md).unwrap();
-    let keys: Vec<&str> = doc.frontmatter().keys().map(|s| s.as_str()).collect();
+    let keys: Vec<&str> = doc.main().frontmatter().keys().map(|s| s.as_str()).collect();
     // Fields must appear in YAML document order, not alphabetical or swap-order.
     assert_eq!(
         keys,

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -1265,7 +1265,8 @@ Use <<card body>> here."#;
     assert_eq!(items[0].as_str().unwrap(), "<<first>>");
     assert_eq!(items[1].as_str().unwrap(), "<<second>>");
     let metadata = doc
-        .main().frontmatter()
+        .main()
+        .frontmatter()
         .get("metadata")
         .unwrap()
         .as_object()
@@ -1495,7 +1496,8 @@ description: |
 Body."#;
     let doc = decompose(markdown).unwrap();
     let desc = doc
-        .main().frontmatter()
+        .main()
+        .frontmatter()
         .get("description")
         .unwrap()
         .as_str()
@@ -1517,7 +1519,8 @@ description: >
 Body."#;
     let doc = decompose(markdown).unwrap();
     let desc = doc
-        .main().frontmatter()
+        .main()
+        .frontmatter()
         .get("description")
         .unwrap()
         .as_str()
@@ -1577,7 +1580,8 @@ config:
 Body."#;
     let doc = decompose(markdown).unwrap();
     let config = doc
-        .main().frontmatter()
+        .main()
+        .frontmatter()
         .get("config")
         .unwrap()
         .as_object()

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -135,7 +135,10 @@ Body of item 1."#;
 
     let doc = decompose(markdown).unwrap();
 
-    assert_eq!(doc.body(), "\nMain body content.\n\n");
+    // Global body is followed by a CARD fence: F2 separator stripped, so the
+    // trailing `\n\n` from the source becomes a single `\n` (content's line
+    // terminator preserved).
+    assert_eq!(doc.body(), "\nMain body content.\n");
     assert_eq!(
         doc.frontmatter().get("title").unwrap().as_str().unwrap(),
         "Main Document"
@@ -148,6 +151,7 @@ Body of item 1."#;
         card.fields().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
+    // Last card body at EOF: no F2 separator to strip.
     assert_eq!(card.body(), "\nBody of item 1.");
 }
 
@@ -221,7 +225,7 @@ Section 2 content."#;
         doc.frontmatter().get("title").unwrap().as_str().unwrap(),
         "Global"
     );
-    assert_eq!(doc.body(), "\nGlobal body.\n\n");
+    assert_eq!(doc.body(), "\nGlobal body.\n");
     assert_eq!(doc.cards().len(), 2);
     assert_eq!(doc.cards()[0].tag(), "sections");
 }
@@ -733,7 +737,7 @@ Section 1 body."#;
     );
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].tag(), "sections");
-    assert_eq!(doc.body(), "\nMain body.\n\n");
+    assert_eq!(doc.body(), "\nMain body.\n");
 }
 
 #[test]
@@ -1570,9 +1574,73 @@ fn test_body_with_leading_newlines() {
 
 #[test]
 fn test_body_with_trailing_newlines() {
+    // Body at EOF: no F2 separator to strip, source's trailing newlines
+    // are preserved verbatim as authored content.
     let markdown = "---\nQUILL: test_quill\ntitle: Test\n---\n\nBody.\n\n\n";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.body().ends_with('\n'));
+    assert_eq!(doc.body(), "\nBody.\n\n\n");
+}
+
+// ── F2 separator stripping: parse-side normalisation ─────────────────────────
+// See `assemble.rs::strip_f2_separator` and `MARKDOWN.md §3 F2`.
+
+#[test]
+fn test_f2_strip_global_body_followed_by_card_lf() {
+    // Global body followed by a CARD fence: the source's tail `\n\n` is
+    // (content line terminator) + (F2 blank line). Strip exactly the F2 `\n`,
+    // leaving `\n` as the content terminator.
+    let markdown = "---\nQUILL: q\n---\n\nbody\n\n---\nCARD: x\n---\n";
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(doc.body(), "\nbody\n");
+}
+
+#[test]
+fn test_f2_strip_global_body_followed_by_card_crlf() {
+    // CRLF line endings: strip exactly one `\r\n` as the F2 separator.
+    let markdown = "---\r\nQUILL: q\r\n---\r\n\r\nbody\r\n\r\n---\r\nCARD: x\r\n---\r\n";
+    let doc = decompose(markdown).unwrap();
+    assert!(
+        doc.body().ends_with('\n') && !doc.body().ends_with("\n\n"),
+        "expected exactly one trailing line ending, got {:?}",
+        doc.body()
+    );
+}
+
+#[test]
+fn test_f2_strip_card_body_followed_by_card() {
+    // First card body is followed by another fence → F2 stripped.
+    // Last card body is at EOF → preserved verbatim.
+    let markdown = "---\nQUILL: q\n---\n\n---\nCARD: a\n---\nfirst\n\n---\nCARD: b\n---\nsecond\n";
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(doc.cards()[0].body(), "first\n");
+    assert_eq!(doc.cards()[1].body(), "second\n");
+}
+
+#[test]
+fn test_f2_strip_preserves_author_blank_lines() {
+    // Author wrote two blank lines after the body. Only the F2 blank (last
+    // `\n`) is stripped; the author's blank line is preserved.
+    let markdown = "---\nQUILL: q\n---\n\nbody\n\n\n---\nCARD: x\n---\n";
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(doc.body(), "\nbody\n\n");
+}
+
+#[test]
+fn test_f2_strip_does_not_overstrip_content_newlines() {
+    // Content-fidelity: a body whose authored content ends with multiple
+    // newlines (e.g. a code block with trailing blank lines) must survive
+    // round-trip. The previous WASM-binding `trim_body` over-stripped this.
+    let markdown = "---\nQUILL: q\n---\n\n```\ncode\n```\n\n\n---\nCARD: x\n---\n";
+    let doc = decompose(markdown).unwrap();
+    let emitted = doc.to_markdown();
+    let reparsed = Document::from_markdown(&emitted).unwrap();
+    assert_eq!(doc.body(), reparsed.body());
+    // Author's blank line after the code block survives.
+    assert!(
+        doc.body().ends_with("```\n\n"),
+        "expected code block + blank line, got {:?}",
+        doc.body()
+    );
 }
 
 #[test]
@@ -1744,7 +1812,7 @@ Conclusion content.
             .unwrap(),
         "Introduction"
     );
-    assert_eq!(doc.cards()[0].body(), "Introduction content.\n\n");
+    assert_eq!(doc.cards()[0].body(), "Introduction content.\n");
     assert_eq!(doc.cards()[1].tag(), "section");
     assert_eq!(
         doc.cards()[1]
@@ -1807,7 +1875,9 @@ Card body here.
 
     assert_eq!(json["QUILL"], "usaf_memo");
     assert_eq!(json["title"], "Test");
-    assert_eq!(json["BODY"], "\nGlobal body.\n\n");
+    // F2 separator stripped on parse; plate `BODY` reflects the same
+    // content-only string as `Document::body()`.
+    assert_eq!(json["BODY"], "\nGlobal body.\n");
 
     let cards = json["CARDS"].as_array().unwrap();
     assert_eq!(cards.len(), 1);

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests for the document editor surface (Phase 3).
+//! Unit tests for the document editor surface.
 
 use crate::document::edit::{is_reserved_name, is_valid_field_name, EditError, RESERVED_NAMES};
 use crate::document::sentinel::is_valid_tag_name;
@@ -293,7 +293,7 @@ fn test_document_card_mut() {
     let mut doc = make_doc_with_cards();
     {
         let card = doc.card_mut(0).unwrap();
-        card.set_body("Updated card body.");
+        card.replace_body("Updated card body.");
     }
     assert_eq!(doc.cards()[0].body(), "Updated card body.");
 }
@@ -413,7 +413,7 @@ fn test_card_remove_field_absent() {
 #[test]
 fn test_card_set_body() {
     let mut card = Card::new("note").unwrap();
-    card.set_body("Card body text.");
+    card.replace_body("Card body text.");
     assert_eq!(card.body(), "Card body text.");
 }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -80,14 +80,14 @@ fn test_is_reserved_name() {
 #[test]
 fn test_edit_error_reserved_name() {
     let mut doc = make_doc();
-    let result = doc.set_field("BODY", qv("value"));
+    let result = doc.main_mut().set_field("BODY", qv("value"));
     assert_eq!(result, Err(EditError::ReservedName("BODY".to_string())));
 }
 
 #[test]
 fn test_edit_error_invalid_field_name() {
     let mut doc = make_doc();
-    let result = doc.set_field("My-Field", qv("value"));
+    let result = doc.main_mut().set_field("My-Field", qv("value"));
     assert_eq!(
         result,
         Err(EditError::InvalidFieldName("My-Field".to_string()))
@@ -135,7 +135,7 @@ fn test_edit_error_display() {
 fn test_document_set_field_rejects_all_reserved_names() {
     for &name in RESERVED_NAMES {
         let mut doc = make_doc();
-        let result = doc.set_field(name, qv("value"));
+        let result = doc.main_mut().set_field(name, qv("value"));
         assert_eq!(
             result,
             Err(EditError::ReservedName(name.to_string())),
@@ -166,9 +166,9 @@ fn test_card_set_field_rejects_all_reserved_names() {
 #[test]
 fn test_document_set_field_inserts() {
     let mut doc = make_doc();
-    doc.set_field("author", qv("Alice")).unwrap();
+    doc.main_mut().set_field("author", qv("Alice")).unwrap();
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str(),
+        doc.main().frontmatter().get("author").unwrap().as_str(),
         Some("Alice")
     );
 }
@@ -176,9 +176,9 @@ fn test_document_set_field_inserts() {
 #[test]
 fn test_document_set_field_updates_existing() {
     let mut doc = make_doc();
-    doc.set_field("title", qv("New Title")).unwrap();
+    doc.main_mut().set_field("title", qv("New Title")).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str(),
+        doc.main().frontmatter().get("title").unwrap().as_str(),
         Some("New Title")
     );
 }
@@ -188,15 +188,15 @@ fn test_document_set_field_updates_existing() {
 #[test]
 fn test_document_remove_field_existing() {
     let mut doc = make_doc();
-    let removed = doc.remove_field("title");
+    let removed = doc.main_mut().remove_field("title");
     assert_eq!(removed.unwrap().as_str(), Some("Hello"));
-    assert!(doc.frontmatter().get("title").is_none());
+    assert!(doc.main().frontmatter().get("title").is_none());
 }
 
 #[test]
 fn test_document_remove_field_absent() {
     let mut doc = make_doc();
-    let removed = doc.remove_field("nonexistent");
+    let removed = doc.main_mut().remove_field("nonexistent");
     assert!(removed.is_none());
 }
 
@@ -204,7 +204,7 @@ fn test_document_remove_field_absent() {
 fn test_document_remove_field_reserved_returns_none() {
     // Reserved names can't be in frontmatter; remove must return None.
     let mut doc = make_doc();
-    let removed = doc.remove_field("BODY");
+    let removed = doc.main_mut().remove_field("BODY");
     assert!(removed.is_none());
 }
 
@@ -223,8 +223,8 @@ fn test_document_set_quill_ref() {
 #[test]
 fn test_document_replace_body() {
     let mut doc = make_doc();
-    doc.replace_body("New body content.");
-    assert_eq!(doc.body(), "New body content.");
+    doc.main_mut().replace_body("New body content.");
+    assert_eq!(doc.main().body(), "New body content.");
 }
 
 // ── Document::push_card ──────────────────────────────────────────────────────
@@ -354,7 +354,7 @@ fn test_move_card_to_out_of_range() {
 fn test_card_new_valid() {
     let card = Card::new("note").unwrap();
     assert_eq!(card.tag(), "note");
-    assert!(card.fields().is_empty());
+    assert!(card.frontmatter().is_empty());
     assert_eq!(card.body(), "");
 }
 
@@ -375,7 +375,7 @@ fn test_card_set_field_valid() {
     let mut card = Card::new("note").unwrap();
     card.set_field("content", qv("Some text")).unwrap();
     assert_eq!(
-        card.fields().get("content").unwrap().as_str(),
+        card.frontmatter().get("content").unwrap().as_str(),
         Some("Some text")
     );
 }
@@ -399,7 +399,7 @@ fn test_card_remove_field_existing() {
     let card = doc.card_mut(0).unwrap();
     let removed = card.remove_field("foo");
     assert_eq!(removed.unwrap().as_str(), Some("bar"));
-    assert!(card.fields().get("foo").is_none());
+    assert!(card.frontmatter().get("foo").is_none());
 }
 
 #[test]
@@ -428,8 +428,8 @@ fn test_invariants_after_mutation_sequence() {
     let mut doc = make_doc();
 
     // 1. Add some frontmatter fields
-    doc.set_field("author", qv("Alice")).unwrap();
-    doc.set_field("version", qv_int(3)).unwrap();
+    doc.main_mut().set_field("author", qv("Alice")).unwrap();
+    doc.main_mut().set_field("version", qv_int(3)).unwrap();
 
     // 2. Add cards
     let c1 = Card::new("note").unwrap();
@@ -452,15 +452,15 @@ fn test_invariants_after_mutation_sequence() {
     doc.remove_card(1); // summary, appendix
 
     // 6. Replace body
-    doc.replace_body("Updated body.");
+    doc.main_mut().replace_body("Updated body.");
 
     // 7. Remove a frontmatter field
-    doc.remove_field("version");
+    doc.main_mut().remove_field("version");
 
     // --- Assertions ---
 
     // No reserved key in frontmatter
-    for key in doc.frontmatter().keys() {
+    for key in doc.main().frontmatter().keys() {
         assert!(
             !is_reserved_name(key),
             "reserved key '{}' found in frontmatter",
@@ -470,10 +470,11 @@ fn test_invariants_after_mutation_sequence() {
 
     // Every card tag is valid
     for card in doc.cards() {
+        let tag = card.tag();
         assert!(
-            is_valid_tag_name(card.tag()),
+            is_valid_tag_name(&tag),
             "invalid tag '{}' found",
-            card.tag()
+            tag
         );
     }
 
@@ -486,10 +487,10 @@ fn test_invariants_after_mutation_sequence() {
 
     // Frontmatter still has expected keys
     assert_eq!(
-        doc.frontmatter().get("author").unwrap().as_str(),
+        doc.main().frontmatter().get("author").unwrap().as_str(),
         Some("Alice")
     );
-    assert!(doc.frontmatter().get("version").is_none());
+    assert!(doc.main().frontmatter().get("version").is_none());
 }
 
 // ── Warnings never touched ───────────────────────────────────────────────────
@@ -500,8 +501,8 @@ fn test_mutators_do_not_touch_warnings() {
     let initial_warnings = doc.warnings().to_vec();
 
     let mut doc = doc;
-    doc.set_field("extra", qv("value")).unwrap();
-    doc.replace_body("New body.");
+    doc.main_mut().set_field("extra", qv("value")).unwrap();
+    doc.main_mut().replace_body("New body.");
     let card = Card::new("new_card").unwrap();
     doc.push_card(card).unwrap();
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -471,11 +471,7 @@ fn test_invariants_after_mutation_sequence() {
     // Every card tag is valid
     for card in doc.cards() {
         let tag = card.tag();
-        assert!(
-            is_valid_tag_name(&tag),
-            "invalid tag '{}' found",
-            tag
-        );
+        assert!(is_valid_tag_name(&tag), "invalid tag '{}' found", tag);
     }
 
     // Can produce plate JSON without panicking

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -233,7 +233,7 @@ fn test_document_replace_body() {
 fn test_document_push_card() {
     let mut doc = make_doc();
     let card = Card::new("note").unwrap();
-    doc.push_card(card).unwrap();
+    doc.push_card(card);
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].tag(), "note");
 }
@@ -435,8 +435,8 @@ fn test_invariants_after_mutation_sequence() {
     let c1 = Card::new("note").unwrap();
     let c2 = Card::new("summary").unwrap();
     let c3 = Card::new("appendix").unwrap();
-    doc.push_card(c1).unwrap();
-    doc.push_card(c2).unwrap();
+    doc.push_card(c1);
+    doc.push_card(c2);
     doc.insert_card(1, c3).unwrap(); // now: note, appendix, summary
 
     // 3. Mutate a card field
@@ -500,7 +500,7 @@ fn test_mutators_do_not_touch_warnings() {
     doc.main_mut().set_field("extra", qv("value")).unwrap();
     doc.main_mut().replace_body("New body.");
     let card = Card::new("new_card").unwrap();
-    doc.push_card(card).unwrap();
+    doc.push_card(card);
 
     assert_eq!(doc.warnings(), initial_warnings.as_slice());
 }

--- a/crates/core/src/document/tests/emit_idempotence_tests.rs
+++ b/crates/core/src/document/tests/emit_idempotence_tests.rs
@@ -1,10 +1,9 @@
-//! Emit-idempotence corpus tests — Phase 4b.
+//! Emit-idempotence corpus tests
 //!
 //! `doc.to_markdown()` must be a pure function of `doc`: two calls return
 //! byte-equal strings.  These tests run that invariant over the full fixture
 //! corpus.
 //!
-//! See plan §Phase 4 test item 3.
 
 use crate::document::Document;
 

--- a/crates/core/src/document/tests/emit_stability_tests.rs
+++ b/crates/core/src/document/tests/emit_stability_tests.rs
@@ -1,4 +1,4 @@
-//! Parse ∘ Emit ∘ Parse ∘ Emit stability tests — Phase 4b.
+//! Parse ∘ Emit ∘ Parse ∘ Emit stability tests
 //!
 //! Verifies that `emit1 == emit2` where:
 //!
@@ -14,7 +14,6 @@
 //! test: two distinct inputs could parse to equal `Document` values yet emit
 //! differently if there is hidden state or non-determinism in the emitter.
 //!
-//! See plan §Phase 4 test item 4.
 
 use crate::document::Document;
 

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -1,15 +1,9 @@
-//! Tests for `Document::to_markdown` — Phase 4a.
+//! Tests for `Document::to_markdown`.
 //!
-//! Coverage in this file:
+//! Coverage:
 //! - Type-fidelity round-trip over the full fixture corpus.
 //! - Stability (emit-twice byte-equal) smoke test.
 //! - Unit tests for targeted value types and edge cases.
-//!
-//! NOT in this file (deferred to 4b/4c):
-//! - Ambiguous-strings regression corpus
-//! - Full emit-idempotence corpus (parse∘emit∘parse∘emit)
-//! - Fuzz target
-//! - Binding wiring (4c)
 
 use crate::document::Document;
 
@@ -313,14 +307,17 @@ fn empty_map_omitted_from_emit() {
         QuillValue::from_json(serde_json::json!("hello")),
     );
 
+    use crate::document::{Card, Frontmatter, Sentinel};
     use crate::version::{QuillReference, VersionSelector};
-    let doc = crate::document::Document::new_internal(
-        QuillReference::new("test".to_string(), VersionSelector::Latest),
-        frontmatter,
+    let main = Card::new_with_sentinel(
+        Sentinel::Main(QuillReference::new(
+            "test".to_string(),
+            VersionSelector::Latest,
+        )),
+        Frontmatter::from_index_map(frontmatter),
         String::new(),
-        vec![],
-        vec![],
     );
+    let doc = crate::document::Document::from_main_and_cards(main, vec![], vec![]);
 
     let md = doc.to_markdown();
     assert!(

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -1,19 +1,16 @@
 //! Round-trip tests for comments, `!fill`, and custom tags.
 //!
-//! The canonical emitter preserves what taskings 01 and 02 promise:
-//! top-level YAML comments round-trip as own-line comments, `!fill` tags on
-//! scalar fields round-trip, and the original quoting style normalises to
-//! double-quoted (type-fidelity guarantee). This file pins those contracts.
+//! Top-level YAML comments round-trip as own-line comments, `!fill` on
+//! scalars and sequences round-trips, and string quoting is normalised to
+//! double-quoted (the type-fidelity guarantee).
 
 use crate::document::Document;
 
 // ── Category: YAML comments ───────────────────────────────────────────────────
 
-/// Top-level YAML comments survive a round-trip (tasking 01).
+/// Top-level YAML comments survive a round-trip.
 #[test]
-fn yaml_comments_disappear_on_round_trip() {
-    // Legacy name kept for git history; the assertion is now that comments
-    // *do* round-trip. See tasking 01.
+fn top_level_comments_round_trip() {
     let src =
         "---\nQUILL: q\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n---\n\nBody.\n";
 
@@ -42,7 +39,7 @@ fn yaml_comments_disappear_on_round_trip() {
 }
 
 /// Trailing comments on value lines normalise to own-line comments on the
-/// next line (opinionated canonical form per tasking 01).
+/// next line (canonical form).
 #[test]
 fn trailing_comments_become_own_line_on_round_trip() {
     let src = "---\nQUILL: q\ntitle: My Document # this is a comment\n---\n\nBody.\n";
@@ -140,6 +137,80 @@ fn fill_tag_bare_null_round_trip() {
     );
 }
 
+/// `!fill` on a top-level block sequence round-trips, preserving items and
+/// the fill marker.
+#[test]
+fn fill_tag_block_sequence_round_trip() {
+    let src = "---\nQUILL: q\nrecipient: !fill\n  - Dr. Who\n  - 1 TARDIS Lane\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let fm = doc.main().frontmatter();
+
+    assert!(fm.is_fill("recipient"));
+    let arr = fm.get("recipient").and_then(|v| v.as_array()).unwrap();
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0].as_str(), Some("Dr. Who"));
+    assert_eq!(arr[1].as_str(), Some("1 TARDIS Lane"));
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("recipient: !fill\n"),
+        "`!fill` on sequence must emit `key: !fill` before the block\nGot:\n{}",
+        emitted
+    );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    assert!(doc2.main().frontmatter().is_fill("recipient"));
+    assert_eq!(doc2, doc, "full round-trip must be equal");
+}
+
+/// `!fill` on a flow sequence round-trips (normalised to block form).
+#[test]
+fn fill_tag_flow_sequence_round_trip() {
+    let src = "---\nQUILL: q\ntags: !fill [a, b, c]\n---\n";
+    let doc = Document::from_markdown(src).unwrap();
+    let fm = doc.main().frontmatter();
+    assert!(fm.is_fill("tags"));
+    assert_eq!(fm.get("tags").and_then(|v| v.as_array()).map(|a| a.len()), Some(3));
+
+    let emitted = doc.to_markdown();
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    assert!(doc2.main().frontmatter().is_fill("tags"));
+    assert_eq!(doc2, doc);
+}
+
+/// `!fill` on an empty sequence round-trips as `key: !fill []`.
+#[test]
+fn fill_tag_empty_sequence_round_trip() {
+    let src = "---\nQUILL: q\nitems: !fill []\n---\n";
+    let doc = Document::from_markdown(src).unwrap();
+    let fm = doc.main().frontmatter();
+    assert!(fm.is_fill("items"));
+    assert_eq!(fm.get("items").and_then(|v| v.as_array()).map(|a| a.len()), Some(0));
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("items: !fill []\n"),
+        "empty fill-sequence must round-trip as `key: !fill []`\nGot:\n{}",
+        emitted
+    );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    assert_eq!(doc2, doc);
+}
+
+/// `!fill` on a top-level mapping is rejected at parse.
+#[test]
+fn fill_tag_mapping_rejected() {
+    let src = "---\nQUILL: q\nx: !fill {a: 1}\n---\n";
+    let err = Document::from_markdown(src).unwrap_err();
+    assert!(
+        err.to_string().contains("!fill") && err.to_string().contains("mapping"),
+        "expected mapping-rejection error; got: {}",
+        err
+    );
+}
+
 /// `!fill` on every supported scalar type round-trips with the correct type.
 #[test]
 fn fill_tag_all_scalar_types_round_trip() {
@@ -183,7 +254,7 @@ fn fill_tag_all_scalar_types_round_trip() {
 /// is not preserved.  All strings are re-emitted double-quoted with JSON-style
 /// escaping, regardless of how they were written in the source.
 ///
-/// This is intentional (proposal §5.4): normalizing to double-quoted style is
+/// This is intentional: normalizing to double-quoted style is
 /// what guarantees type fidelity for ambiguous strings like `on` and `01234`.
 #[test]
 fn original_quoting_style_is_not_preserved() {

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -14,7 +14,8 @@ use crate::document::Document;
 fn yaml_comments_disappear_on_round_trip() {
     // Legacy name kept for git history; the assertion is now that comments
     // *do* round-trip. See tasking 01.
-    let src = "---\nQUILL: q\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n---\n\nBody.\n";
+    let src =
+        "---\nQUILL: q\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n---\n\nBody.\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -63,7 +64,10 @@ fn trailing_comments_become_own_line_on_round_trip() {
     // And the value is still intact.
     let doc2 = Document::from_markdown(&emitted).unwrap();
     assert_eq!(
-        doc2.main().frontmatter().get("title").and_then(|v| v.as_str()),
+        doc2.main()
+            .frontmatter()
+            .get("title")
+            .and_then(|v| v.as_str()),
         Some("My Document"),
     );
 }
@@ -218,15 +222,24 @@ fn original_quoting_style_is_not_preserved() {
     // Values must survive round-trip.
     let doc2 = Document::from_markdown(&emitted).unwrap();
     assert_eq!(
-        doc2.main().frontmatter().get("single_q").and_then(|v| v.as_str()),
+        doc2.main()
+            .frontmatter()
+            .get("single_q")
+            .and_then(|v| v.as_str()),
         Some("hello")
     );
     assert_eq!(
-        doc2.main().frontmatter().get("unquoted").and_then(|v| v.as_str()),
+        doc2.main()
+            .frontmatter()
+            .get("unquoted")
+            .and_then(|v| v.as_str()),
         Some("world")
     );
     assert_eq!(
-        doc2.main().frontmatter().get("double_q").and_then(|v| v.as_str()),
+        doc2.main()
+            .frontmatter()
+            .get("double_q")
+            .and_then(|v| v.as_str()),
         Some("already")
     );
 }

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -1,108 +1,176 @@
-//! Lossiness documentation tests — Phase 4b.
+//! Round-trip tests for comments, `!fill`, and custom tags.
 //!
-//! The canonical emitter deliberately discards certain input features that are
-//! not representable in the `Document` typed model.  These tests assert the
-//! **expected** loss and document it explicitly.
-//!
-//! Per proposal §5.4: comments, custom tags, and original quoting style are
-//! all stripped on round-trip.  This is intentional, documented in
-//! `Document::to_markdown`'s rustdoc, and tested here so regressions are
-//! immediately visible.
-//!
-//! See plan §Phase 4 test item 5.
+//! The canonical emitter preserves what taskings 01 and 02 promise:
+//! top-level YAML comments round-trip as own-line comments, `!fill` tags on
+//! scalar fields round-trip, and the original quoting style normalises to
+//! double-quoted (type-fidelity guarantee). This file pins those contracts.
 
 use crate::document::Document;
 
 // ── Category: YAML comments ───────────────────────────────────────────────────
 
-/// YAML comments (`# …`) are not stored in the `Document` model.
-/// After a round-trip they do not appear in the emitted Markdown.
-///
-/// This is an intentional limitation (proposal §5.4 "what is lost"):
-/// preserving comments would require a layout-preserving AST, which is a v2
-/// feature.
+/// Top-level YAML comments survive a round-trip (tasking 01).
 #[test]
 fn yaml_comments_disappear_on_round_trip() {
-    // Source has a YAML comment on the title line.
-    let src =
-        "---\nQUILL: q\ntitle: My Document # this is a comment\nauthor: Alice\n---\n\nBody.\n";
+    // Legacy name kept for git history; the assertion is now that comments
+    // *do* round-trip. See tasking 01.
+    let src = "---\nQUILL: q\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n---\n\nBody.\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
 
-    // The comment must not appear in the emitted output.
     assert!(
-        !emitted.contains("# this is a comment"),
-        "YAML comment must be stripped on emit (proposal §5.4)\nGot:\n{}",
+        emitted.contains("# recipient's full name"),
+        "top-level YAML comment must survive round-trip\nGot:\n{}",
         emitted
     );
 
-    // The value itself must survive (comment is not part of the value).
-    assert!(
-        emitted.contains("My Document"),
-        "value before comment must survive emit\nGot:\n{}",
-        emitted
-    );
-
-    // Re-parse must succeed and value must be intact.
+    // Value remains intact.
     let doc2 = Document::from_markdown(&emitted).unwrap();
     assert_eq!(
-        doc2.frontmatter().get("title").and_then(|v| v.as_str()),
+        doc2.main()
+            .frontmatter()
+            .get("recipient")
+            .and_then(|v| v.as_str()),
+        Some("Jane"),
+    );
+
+    // Comment idempotent across repeated round-trips.
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Trailing comments on value lines normalise to own-line comments on the
+/// next line (opinionated canonical form per tasking 01).
+#[test]
+fn trailing_comments_become_own_line_on_round_trip() {
+    let src = "---\nQUILL: q\ntitle: My Document # this is a comment\n---\n\nBody.\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
+
+    assert!(
+        emitted.contains("# this is a comment"),
+        "trailing comment text must survive\nGot:\n{}",
+        emitted
+    );
+    assert!(
+        emitted.contains("title: \"My Document\"\n# this is a comment"),
+        "trailing comment must normalise to own-line on the next line\nGot:\n{}",
+        emitted
+    );
+
+    // And the value is still intact.
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    assert_eq!(
+        doc2.main().frontmatter().get("title").and_then(|v| v.as_str()),
         Some("My Document"),
-        "title value must survive round-trip even though comment is stripped"
     );
 }
 
 // ── Category: Custom tags ─────────────────────────────────────────────────────
 
-/// Custom YAML tags (`!fill`, `!include`, etc.) are stripped during parsing;
-/// only the scalar value is stored.  On re-emit the tag does not appear.
-///
-/// This is intentional (proposal §5.4): tags would require first-class
-/// `QuillValue::Tagged` support, which is deferred.  The value is preserved;
-/// only the tag annotation is lost.
+/// `!fill` tags round-trip; other custom tags are rejected with a warning
+/// and the tag is dropped.
 #[test]
 fn custom_tags_lose_tag_but_keep_value() {
-    // `!fill` is a real Quillmark custom tag used in USAF memo templates.
+    // `!fill` case: round-trip with fill preserved.
     let src = "---\nQUILL: q\nmemo_from: !fill 2d lt example\n---\n";
-
     let doc = Document::from_markdown(src).unwrap();
 
-    // Value must be stored as a string (tag stripped at parse time).
-    let value = doc.frontmatter().get("memo_from").unwrap();
-    assert!(
-        value.as_str().is_some(),
-        "custom-tagged value must parse as a string after tag is dropped"
-    );
+    let fm = doc.main().frontmatter();
     assert_eq!(
-        value.as_str().unwrap(),
-        "2d lt example",
-        "string value must survive tag stripping"
+        fm.get("memo_from").and_then(|v| v.as_str()),
+        Some("2d lt example"),
+        "string value must survive tag parsing"
     );
+    assert!(fm.is_fill("memo_from"), "fill marker must be recorded");
 
     let emitted = doc.to_markdown();
-
-    // Tag must not appear in the emission.
     assert!(
-        !emitted.contains("!fill"),
-        "custom tag must not reappear on emit (proposal §5.4)\nGot:\n{}",
+        emitted.contains("memo_from: !fill"),
+        "`!fill` tag must round-trip\nGot:\n{}",
         emitted
     );
 
-    // Value must appear double-quoted.
-    assert!(
-        emitted.contains("\"2d lt example\""),
-        "value must survive emit as a double-quoted string\nGot:\n{}",
-        emitted
-    );
-
-    // Round-trip: value still a string.
     let doc2 = Document::from_markdown(&emitted).unwrap();
-    assert_eq!(
-        doc2.frontmatter().get("memo_from").and_then(|v| v.as_str()),
-        Some("2d lt example"),
-        "value must survive full round-trip"
+    assert!(
+        doc2.main().frontmatter().is_fill("memo_from"),
+        "fill marker must survive a full round-trip"
     );
+
+    // Non-`!fill` tag case: warning + dropped tag.
+    let src2 = "---\nQUILL: q\nmemo_from: !include value.txt\n---\n";
+    let out = Document::from_markdown_with_warnings(src2).unwrap();
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.code.as_deref() == Some("parse::unsupported_yaml_tag")),
+        "expected unsupported_yaml_tag warning; got: {:?}",
+        out.warnings
+    );
+    let emitted2 = out.document.to_markdown();
+    assert!(
+        !emitted2.contains("!include"),
+        "unknown tag must not re-appear on emit\nGot:\n{}",
+        emitted2
+    );
+}
+
+/// `!fill` on a bare key (no value) emits `key: !fill` and preserves null.
+#[test]
+fn fill_tag_bare_null_round_trip() {
+    let src = "---\nQUILL: q\nrecipient: !fill\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let fm = doc.main().frontmatter();
+
+    assert!(fm.get("recipient").map(|v| v.is_null()).unwrap_or(false));
+    assert!(fm.is_fill("recipient"));
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("recipient: !fill\n"),
+        "bare `!fill` must round-trip as `key: !fill`\nGot:\n{}",
+        emitted
+    );
+}
+
+/// `!fill` on every supported scalar type round-trips with the correct type.
+#[test]
+fn fill_tag_all_scalar_types_round_trip() {
+    let src = concat!(
+        "---\nQUILL: q\n",
+        "s: !fill hello\n",
+        "i: !fill 42\n",
+        "f: !fill 3.14\n",
+        "b: !fill true\n",
+        "n: !fill\n",
+        "---\n",
+    );
+
+    let doc = Document::from_markdown(src).unwrap();
+    let fm = doc.main().frontmatter();
+
+    assert_eq!(fm.get("s").and_then(|v| v.as_str()), Some("hello"));
+    assert_eq!(fm.get("i").and_then(|v| v.as_i64()), Some(42));
+    assert_eq!(fm.get("f").and_then(|v| v.as_f64()), Some(3.14));
+    assert_eq!(fm.get("b").and_then(|v| v.as_bool()), Some(true));
+    assert!(fm.get("n").map(|v| v.is_null()).unwrap_or(false));
+
+    for key in ["s", "i", "f", "b", "n"] {
+        assert!(fm.is_fill(key), "{} must be fill-tagged", key);
+    }
+
+    let emitted = doc.to_markdown();
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    for key in ["s", "i", "f", "b", "n"] {
+        assert!(
+            doc2.main().frontmatter().is_fill(key),
+            "{} must remain fill-tagged after round-trip",
+            key
+        );
+    }
 }
 
 // ── Category: Original quoting style ─────────────────────────────────────────
@@ -150,15 +218,39 @@ fn original_quoting_style_is_not_preserved() {
     // Values must survive round-trip.
     let doc2 = Document::from_markdown(&emitted).unwrap();
     assert_eq!(
-        doc2.frontmatter().get("single_q").and_then(|v| v.as_str()),
+        doc2.main().frontmatter().get("single_q").and_then(|v| v.as_str()),
         Some("hello")
     );
     assert_eq!(
-        doc2.frontmatter().get("unquoted").and_then(|v| v.as_str()),
+        doc2.main().frontmatter().get("unquoted").and_then(|v| v.as_str()),
         Some("world")
     );
     assert_eq!(
-        doc2.frontmatter().get("double_q").and_then(|v| v.as_str()),
+        doc2.main().frontmatter().get("double_q").and_then(|v| v.as_str()),
         Some("already")
+    );
+}
+
+// ── Category: Nested comments dropped ────────────────────────────────────────
+
+#[test]
+fn nested_yaml_comments_dropped_with_warning() {
+    let src = "---\nQUILL: q\nitems:\n  # nested\n  - a\n  - b\n---\n";
+
+    let out = Document::from_markdown_with_warnings(src).unwrap();
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.code.as_deref() == Some("parse::comments_in_nested_yaml_dropped")),
+        "expected comments_in_nested_yaml_dropped warning; got: {:?}",
+        out.warnings
+    );
+
+    // And the nested comment must not appear on emit.
+    let emitted = out.document.to_markdown();
+    assert!(
+        !emitted.contains("# nested"),
+        "nested comments are dropped silently\nGot:\n{}",
+        emitted
     );
 }

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -171,7 +171,10 @@ fn fill_tag_flow_sequence_round_trip() {
     let doc = Document::from_markdown(src).unwrap();
     let fm = doc.main().frontmatter();
     assert!(fm.is_fill("tags"));
-    assert_eq!(fm.get("tags").and_then(|v| v.as_array()).map(|a| a.len()), Some(3));
+    assert_eq!(
+        fm.get("tags").and_then(|v| v.as_array()).map(|a| a.len()),
+        Some(3)
+    );
 
     let emitted = doc.to_markdown();
     let doc2 = Document::from_markdown(&emitted).unwrap();
@@ -186,7 +189,10 @@ fn fill_tag_empty_sequence_round_trip() {
     let doc = Document::from_markdown(src).unwrap();
     let fm = doc.main().frontmatter();
     assert!(fm.is_fill("items"));
-    assert_eq!(fm.get("items").and_then(|v| v.as_array()).map(|a| a.len()), Some(0));
+    assert_eq!(
+        fm.get("items").and_then(|v| v.as_array()).map(|a| a.len()),
+        Some(0)
+    );
 
     let emitted = doc.to_markdown();
     assert!(

--- a/crates/core/src/document/tests/number_edge_tests.rs
+++ b/crates/core/src/document/tests/number_edge_tests.rs
@@ -33,7 +33,7 @@ fn number_scientific_notation_round_trip() {
 
     // The parsed value must be a number (not a string).
     let doc = Document::from_markdown(src).unwrap();
-    let v = doc.frontmatter().get("big").unwrap();
+    let v = doc.main().frontmatter().get("big").unwrap();
     assert!(
         v.as_f64().is_some(),
         "1e10 must parse as a number, got {:?}",
@@ -48,7 +48,7 @@ fn string_that_looks_like_scientific_notation_round_trip() {
     assert_round_trip("\"1e10\" string", src);
 
     let doc = Document::from_markdown(src).unwrap();
-    let v = doc.frontmatter().get("big").unwrap();
+    let v = doc.main().frontmatter().get("big").unwrap();
     assert_eq!(
         v.as_str(),
         Some("1e10"),
@@ -67,7 +67,7 @@ fn string_hex_like_round_trip() {
     assert_round_trip("0x1F string", src);
 
     let doc = Document::from_markdown(src).unwrap();
-    let v = doc.frontmatter().get("hex").unwrap();
+    let v = doc.main().frontmatter().get("hex").unwrap();
     assert_eq!(
         v.as_str(),
         Some("0x1F"),
@@ -85,7 +85,7 @@ fn large_integer_round_trip() {
     assert_round_trip("large integer", src);
 
     let doc = Document::from_markdown(src).unwrap();
-    let v = doc.frontmatter().get("big_int").unwrap();
+    let v = doc.main().frontmatter().get("big_int").unwrap();
     assert_eq!(
         v.as_i64(),
         Some(9_999_999_999_999_i64),
@@ -138,8 +138,8 @@ fn emitted_number_representation_matches_parse() {
                 case.src_value, e, emitted
             )
         });
-        let v1 = doc.frontmatter().get(case.key).unwrap();
-        let v2 = doc2.frontmatter().get(case.key).unwrap();
+        let v1 = doc.main().frontmatter().get(case.key).unwrap();
+        let v2 = doc2.main().frontmatter().get(case.key).unwrap();
         assert_eq!(
             v1, v2,
             "number {} changed representation after emit/re-parse\nEmitted:\n{}",

--- a/crates/core/src/document/tests/number_edge_tests.rs
+++ b/crates/core/src/document/tests/number_edge_tests.rs
@@ -1,9 +1,7 @@
-//! Targeted number-edge tests — Phase 4b.
+//! Targeted number-edge tests
 //!
-//! Per plan §Phase 4 risks: `1e10`, `0x1F`, large integers — confirm
 //! `QuillValue::Number` and the emitter agree on representation.
 //!
-//! See plan §Phase 4 test item 6.
 
 use crate::document::Document;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,7 +43,9 @@
 //! - [Examples](https://github.com/nibsbin/quillmark/tree/main/examples) - Working examples
 
 pub mod document;
-pub use document::{Card, Document, EditError, Frontmatter, FrontmatterItem, ParseOutput, Sentinel};
+pub use document::{
+    Card, Document, EditError, Frontmatter, FrontmatterItem, ParseOutput, Sentinel,
+};
 
 pub mod backend;
 pub use backend::Backend;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,7 +20,8 @@
 //! // Parse markdown with frontmatter
 //! let markdown = "---\nQUILL: my_quill\ntitle: Example\n---\n\n# Content";
 //! let doc = Document::from_markdown(markdown).unwrap();
-//! let title = doc.frontmatter()
+//! let title = doc.main()
+//!     .frontmatter()
 //!     .get("title")
 //!     .and_then(|v| v.as_str())
 //!     .unwrap_or("Untitled");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,7 +43,7 @@
 //! - [Examples](https://github.com/nibsbin/quillmark/tree/main/examples) - Working examples
 
 pub mod document;
-pub use document::{Card, Document, EditError, ParseOutput};
+pub use document::{Card, Document, EditError, Frontmatter, FrontmatterItem, ParseOutput, Sentinel};
 
 pub mod backend;
 pub use backend::Backend;

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -373,8 +373,8 @@ pub fn normalize_field_name(name: &str) -> String {
 ///
 /// 1. **Unicode NFC normalization** — Frontmatter field names are normalized to NFC form.
 /// 2. **Bidi stripping** — Invisible bidirectional control characters are removed from
-///    body regions (`Document::body` and each `Card::body`). YAML field values in
-///    `frontmatter` and `Card::fields` pass through verbatim (spec §7).
+///    body regions (each `Card::body`). YAML field values in every
+///    `Card::frontmatter` pass through verbatim (spec §7).
 /// 3. **HTML comment fence fixing** — Trailing text after `-->` is preserved in body
 ///    regions only.
 ///
@@ -734,7 +734,7 @@ mod tests {
         // Title has chevrons preserved (only bidi stripped on body)
         assert_eq!(
             normalized
-                .frontmatter()
+                .main().frontmatter()
                 .get("title")
                 .unwrap()
                 .as_str()
@@ -788,7 +788,7 @@ mod tests {
         // Bidi preserved in YAML fields
         assert_eq!(
             normalized
-                .frontmatter()
+                .main().frontmatter()
                 .get("title")
                 .unwrap()
                 .as_str()
@@ -818,7 +818,7 @@ mod tests {
         let normalized = super::normalize_document(doc).unwrap();
         assert_eq!(
             normalized.cards()[0]
-                .fields()
+                .frontmatter()
                 .get("name")
                 .unwrap()
                 .as_str()

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -396,38 +396,41 @@ pub fn normalize_field_name(name: &str) -> String {
 pub fn normalize_document(
     doc: crate::document::Document,
 ) -> Result<crate::document::Document, crate::error::ParseError> {
-    use crate::document::Document;
+    use crate::document::{Document, Sentinel};
 
-    // NFC-normalize frontmatter field names; values pass through verbatim.
-    let normalized_frontmatter = normalize_fields(doc.frontmatter().clone());
+    // NFC-normalize main-card field names; values pass through verbatim.
+    let normalized_main_fm_map =
+        normalize_fields(doc.main().frontmatter().to_index_map());
+    let normalized_main_body = normalize_markdown(doc.main().body());
+    let main_sentinel = doc.main().sentinel().clone();
+    let main = Card::new_with_sentinel(
+        main_sentinel,
+        crate::document::Frontmatter::from_index_map(normalized_main_fm_map),
+        normalized_main_body,
+    );
 
-    // Normalize global body (bidi + HTML comment fence repair).
-    let normalized_body = normalize_markdown(doc.body());
-
-    // Normalize each card's body; card fields pass through verbatim.
+    // Normalize each composable card's body; NFC-normalize its field names;
+    // values pass through verbatim.
     let normalized_cards: Vec<Card> = doc
         .cards()
         .iter()
         .map(|card| {
-            // NFC-normalize card field names; values pass through verbatim.
             let normalized_card_fields: IndexMap<String, QuillValue> = card
-                .fields()
+                .frontmatter()
                 .iter()
                 .map(|(k, v)| (normalize_field_name(k), v.clone()))
                 .collect();
             let normalized_card_body = normalize_markdown(card.body());
-            Card::new_internal(
-                card.tag().to_string(),
-                normalized_card_fields,
+            Card::new_with_sentinel(
+                Sentinel::Card(card.tag()),
+                crate::document::Frontmatter::from_index_map(normalized_card_fields),
                 normalized_card_body,
             )
         })
         .collect();
 
-    Ok(Document::new_internal(
-        doc.quill_reference().clone(),
-        normalized_frontmatter,
-        normalized_body,
+    Ok(Document::from_main_and_cards(
+        main,
         normalized_cards,
         doc.warnings().to_vec(),
     ))
@@ -741,7 +744,7 @@ mod tests {
         );
 
         // Body has bidi stripped, chevrons preserved
-        assert_eq!(normalized.body(), "\n<<content>> **bold**");
+        assert_eq!(normalized.main().body(), "\n<<content>> **bold**");
     }
 
     #[test]
@@ -762,7 +765,7 @@ mod tests {
         let normalized_once = super::normalize_document(doc).unwrap();
         let normalized_twice = super::normalize_document(normalized_once.clone()).unwrap();
 
-        assert_eq!(normalized_once.body(), normalized_twice.body());
+        assert_eq!(normalized_once.main().body(), normalized_twice.main().body());
     }
 
     #[test]
@@ -771,7 +774,7 @@ mod tests {
 
         let doc = Document::from_markdown("---\nQUILL: test\n---\n\nhello\u{202D}world").unwrap();
         let normalized = super::normalize_document(doc).unwrap();
-        assert_eq!(normalized.body(), "\nhelloworld");
+        assert_eq!(normalized.main().body(), "\nhelloworld");
     }
 
     #[test]
@@ -842,6 +845,6 @@ mod tests {
         let md = "---\nQUILL: test\n---\n\n<!-- note -->Content here";
         let doc = Document::from_markdown(md).unwrap();
         let normalized = super::normalize_document(doc).unwrap();
-        assert_eq!(normalized.body(), "\n<!-- note -->\nContent here");
+        assert_eq!(normalized.main().body(), "\n<!-- note -->\nContent here");
     }
 }

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -734,7 +734,8 @@ mod tests {
         // Title has chevrons preserved (only bidi stripped on body)
         assert_eq!(
             normalized
-                .main().frontmatter()
+                .main()
+                .frontmatter()
                 .get("title")
                 .unwrap()
                 .as_str()
@@ -788,7 +789,8 @@ mod tests {
         // Bidi preserved in YAML fields
         assert_eq!(
             normalized
-                .main().frontmatter()
+                .main()
+                .frontmatter()
                 .get("title")
                 .unwrap()
                 .as_str()

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -399,8 +399,7 @@ pub fn normalize_document(
     use crate::document::{Document, Sentinel};
 
     // NFC-normalize main-card field names; values pass through verbatim.
-    let normalized_main_fm_map =
-        normalize_fields(doc.main().frontmatter().to_index_map());
+    let normalized_main_fm_map = normalize_fields(doc.main().frontmatter().to_index_map());
     let normalized_main_body = normalize_markdown(doc.main().body());
     let main_sentinel = doc.main().sentinel().clone();
     let main = Card::new_with_sentinel(
@@ -765,7 +764,10 @@ mod tests {
         let normalized_once = super::normalize_document(doc).unwrap();
         let normalized_twice = super::normalize_document(normalized_once.clone()).unwrap();
 
-        assert_eq!(normalized_once.main().body(), normalized_twice.main().body());
+        assert_eq!(
+            normalized_once.main().body(),
+            normalized_twice.main().body()
+        );
     }
 
     #[test]

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -611,20 +611,20 @@ impl QuillConfig {
         let quill_yaml_val: serde_json::Value = serde_saphyr::from_str(yaml_content)
             .map_err(|e| format!("Failed to parse Quill.yaml: {}", e))?;
 
-        // Extract [Quill] section (required)
+        // Extract [quill] section (required)
         let quill_section = quill_yaml_val
-            .get("Quill")
-            .ok_or("Missing required 'Quill' section in Quill.yaml")?;
+            .get("quill")
+            .ok_or("Missing required 'quill' section in Quill.yaml")?;
 
         // Extract required fields
         let name = quill_section
             .get("name")
             .and_then(|v| v.as_str())
-            .ok_or("Missing required 'name' field in 'Quill' section")?
+            .ok_or("Missing required 'name' field in 'quill' section")?
             .to_string();
         if !Self::is_valid_quill_name(&name) {
             return Err(format!(
-                "Invalid Quill name '{}': Quill.name must be snake_case (lowercase letters, digits, and underscores only).",
+                "Invalid Quill name '{}': quill.name must be snake_case (lowercase letters, digits, and underscores only).",
                 name
             )
             .into());
@@ -633,23 +633,23 @@ impl QuillConfig {
         let backend = quill_section
             .get("backend")
             .and_then(|v| v.as_str())
-            .ok_or("Missing required 'backend' field in 'Quill' section")?
+            .ok_or("Missing required 'backend' field in 'quill' section")?
             .to_string();
 
         let description = quill_section
             .get("description")
             .and_then(|v| v.as_str())
-            .ok_or("Missing required 'description' field in 'Quill' section")?;
+            .ok_or("Missing required 'description' field in 'quill' section")?;
 
         if description.trim().is_empty() {
-            return Err("'description' field in 'Quill' section cannot be empty".into());
+            return Err("'description' field in 'quill' section cannot be empty".into());
         }
         let description = description.to_string();
 
         // Extract optional fields (now version is required)
         let version_val = quill_section
             .get("version")
-            .ok_or("Missing required 'version' field in 'Quill' section")?;
+            .ok_or("Missing required 'version' field in 'quill' section")?;
 
         // Handle version as string or number (YAML might parse 1.0 as number)
         let version = if let Some(s) = version_val.as_str() {
@@ -692,7 +692,7 @@ impl QuillConfig {
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());
 
-        // Extract additional metadata from [Quill] section (excluding standard fields)
+        // Extract additional metadata from [quill] section (excluding standard fields)
         let mut metadata = HashMap::new();
         if let Some(table) = quill_section.as_object() {
             for (key, value) in table {

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -168,7 +168,7 @@ mod tests {
     fn emits_minimal_public_schema() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: test_schema
   version: "1.0"
   backend: typst
@@ -193,7 +193,7 @@ main:
     fn omits_cards_when_absent() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: no_cards
   version: "1.0"
   backend: typst
@@ -214,7 +214,7 @@ main:
     fn emits_integer_field_type() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: integer_schema
   version: "1.0"
   backend: typst
@@ -247,7 +247,7 @@ main:
 
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: card_schema
   version: "1.0"
   backend: typst
@@ -284,7 +284,7 @@ cards:
     fn includes_example_when_present() {
         let mut config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: with_example
   version: "1.0"
   backend: typst
@@ -307,7 +307,7 @@ main:
     fn round_trips_as_json_value() {
         let config = config_from_yaml(
             r#"
-Quill:
+quill:
   name: round_trip
   version: "1.0"
   backend: typst

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -118,7 +118,7 @@ fn test_in_memory_file_system() {
     // Create test files
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "Quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "test plate").unwrap();
@@ -161,7 +161,7 @@ fn test_quillignore_integration() {
     // Create test files
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "Quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "test template").unwrap();
@@ -188,7 +188,7 @@ fn test_find_files_pattern() {
     // Create test directory structure
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "Quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "template").unwrap();
@@ -221,7 +221,7 @@ fn test_new_standardized_yaml_format() {
 
     // Create test files using new standardized format
     let yaml_content = r#"
-Quill:
+quill:
   name: my_custom_quill
   version: "1.0"
   backend: typst
@@ -272,7 +272,7 @@ fn test_template_loading() {
     let quill_dir = temp_dir.path();
 
     // Create test files with example specified
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: "test_with_template"
   version: "1.0"
   backend: "typst"
@@ -312,7 +312,7 @@ fn test_template_smart_default() {
     let quill_dir = temp_dir.path();
 
     // Create test files without example specified
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: "test_smart_default"
   version: "1.0"
   backend: "typst"
@@ -344,7 +344,7 @@ fn test_template_optional() {
     let quill_dir = temp_dir.path();
 
     // Create test files without example specified
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: "test_without_template"
   version: "1.0"
   backend: "typst"
@@ -370,7 +370,7 @@ fn test_from_tree() {
     let mut root_files = HashMap::new();
 
     // Add Quill.yaml
-    let quill_yaml = r#"Quill:
+    let quill_yaml = r#"quill:
   name: "test_from_tree"
   version: "1.0"
   backend: "typst"
@@ -412,7 +412,7 @@ fn test_from_tree_with_template() {
     // Add Quill.yaml with example specified
     // Add Quill.yaml with example specified
     let quill_yaml = r#"
-Quill:
+quill:
   name: test_tree_template
   version: "1.0"
   backend: typst
@@ -462,7 +462,7 @@ fn test_from_tree_structure_direct() {
             "Quill.yaml".to_string(),
             FileTreeNode::File {
                 contents:
-                    b"Quill:\n  name: direct_tree\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Direct tree test\n"
+                    b"quill:\n  name: direct_tree\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Direct tree test\n"
                         .to_vec(),
             },
         );
@@ -505,7 +505,7 @@ fn test_dir_exists_and_list_apis() {
     root_files.insert(
             "Quill.yaml".to_string(),
             FileTreeNode::File {
-                contents: b"Quill:\n  name: test\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill\n"
+                contents: b"quill:\n  name: test\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill\n"
                     .to_vec(),
             },
         );
@@ -607,7 +607,7 @@ fn test_field_schemas_parsing() {
     let mut root_files = HashMap::new();
 
     // Add Quill.yaml with field schemas
-    let quill_yaml = r#"Quill:
+    let quill_yaml = r#"quill:
   name: "taro"
   version: "1.0"
   backend: "typst"
@@ -765,7 +765,7 @@ fn test_quill_without_plate_file() {
     let mut root_files = HashMap::new();
 
     // Add Quill.yaml without plate field
-    let quill_yaml = r#"Quill:
+    let quill_yaml = r#"quill:
   name: "test_no_plate"
   version: "1.0"
   backend: "typst"
@@ -792,7 +792,7 @@ fn test_quill_without_plate_file() {
 fn test_quill_config_from_yaml() {
     // Test parsing QuillConfig from YAML content
     let yaml_content = r#"
-Quill:
+quill:
   name: test_config
   version: "1.0"
   backend: typst
@@ -848,7 +848,7 @@ main:
 #[test]
 fn test_quill_config_parses_example_alias() {
     let yaml_content = r#"
-Quill:
+quill:
   name: test_example_alias
   version: "1.0"
   backend: typst
@@ -865,7 +865,7 @@ fn test_quill_from_path_rejects_example_traversal() {
     let temp_dir = TempDir::new().unwrap();
     let quill_dir = temp_dir.path();
 
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: traversal_test
   version: "1.0"
   backend: typst
@@ -887,7 +887,7 @@ fn test_quill_from_path_errors_when_explicit_example_missing() {
     let temp_dir = TempDir::new().unwrap();
     let quill_dir = temp_dir.path();
 
-    let yaml_content = r#"Quill:
+    let yaml_content = r#"quill:
   name: missing_example_test
   version: "1.0"
   backend: typst
@@ -908,7 +908,7 @@ fn test_quill_from_path_errors_when_explicit_example_missing() {
 fn test_quill_config_missing_required_fields() {
     // Test that missing required fields result in error
     let yaml_missing_name = r#"
-Quill:
+quill:
   backend: typst
   description: Missing name
 "#;
@@ -920,7 +920,7 @@ Quill:
         .contains("Missing required 'name'"));
 
     let yaml_missing_backend = r#"
-Quill:
+quill:
   name: test
   description: Missing backend
 "#;
@@ -932,7 +932,7 @@ Quill:
         .contains("Missing required 'backend'"));
 
     let yaml_missing_description = r#"
-Quill:
+quill:
   name: test
   version: "1.0"
   backend: typst
@@ -949,7 +949,7 @@ Quill:
 fn test_quill_config_empty_description() {
     // Test that empty description results in error
     let yaml_empty_description = r#"
-Quill:
+quill:
   name: test
   version: "1.0"
   backend: typst
@@ -960,12 +960,12 @@ Quill:
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("description' field in 'Quill' section cannot be empty"));
+        .contains("description' field in 'quill' section cannot be empty"));
 }
 
 #[test]
 fn test_quill_config_missing_quill_section() {
-    // Test that missing [Quill] section results in error
+    // Test that missing [quill] section results in error
     let yaml_no_section = r#"
 fields:
   title:
@@ -976,13 +976,13 @@ fields:
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Missing required 'Quill' section"));
+        .contains("Missing required 'quill' section"));
 }
 
 #[test]
 fn test_quill_config_rejects_root_level_fields() {
     let yaml = r#"
-Quill:
+quill:
   name: root_fields_test
   version: "1.0"
   backend: typst
@@ -1000,7 +1000,7 @@ fields:
 #[test]
 fn test_quill_config_rejects_non_snake_case_quill_name() {
     let yaml = r#"
-Quill:
+quill:
   name: BadQuill
   version: "1.0"
   backend: typst
@@ -1017,7 +1017,7 @@ Quill:
 #[test]
 fn test_quill_config_rejects_non_snake_case_card_name() {
     let yaml = r#"
-Quill:
+quill:
   name: good_quill
   version: "1.0"
   backend: typst
@@ -1040,7 +1040,7 @@ cards:
 #[test]
 fn test_quill_config_accepts_leading_underscore_card_name() {
     let yaml = r#"
-Quill:
+quill:
   name: good_quill
   version: "1.0"
   backend: typst
@@ -1060,7 +1060,7 @@ cards:
 #[test]
 fn test_quill_config_rejects_non_snake_case_main_field_keys() {
     let yaml = r#"
-Quill:
+quill:
   name: bad_field_key
   version: "1.0"
   backend: typst
@@ -1082,7 +1082,7 @@ main:
 #[test]
 fn test_quill_config_rejects_non_snake_case_card_field_keys() {
     let yaml = r#"
-Quill:
+quill:
   name: bad_card_field_key
   version: "1.0"
   backend: typst
@@ -1108,7 +1108,7 @@ fn test_quill_from_config_metadata() {
     let mut root_files = HashMap::new();
 
     let quill_yaml = r#"
-Quill:
+quill:
   name: metadata_test
   version: "1.0"
   backend: typst
@@ -1152,7 +1152,7 @@ fn test_config_defaults() {
     let mut root_files = HashMap::new();
 
     let quill_yaml = r#"
-Quill:
+quill:
   name: metadata_test_yaml
   version: "1.0"
   backend: typst
@@ -1202,7 +1202,7 @@ main:
 #[test]
 fn test_config_defaults_and_examples_methods() {
     let yaml_content = r#"
-Quill:
+quill:
   name: defaults_examples_test
   version: "1.0"
   backend: typst
@@ -1242,7 +1242,7 @@ main:
 #[test]
 fn test_card_defaults_and_examples_methods() {
     let yaml_content = r#"
-Quill:
+quill:
   name: card_defaults_examples_test
   version: "1.0"
   backend: typst
@@ -1282,7 +1282,7 @@ cards:
 #[test]
 fn test_field_order_preservation() {
     let yaml_content = r#"
-Quill:
+quill:
   name: order_test
   version: "1.0"
   backend: typst
@@ -1331,7 +1331,7 @@ main:
 #[test]
 fn test_quill_with_all_ui_properties() {
     let yaml_content = r#"
-Quill:
+quill:
   name: full_ui_test
   version: "1.0"
   backend: typst
@@ -1412,7 +1412,7 @@ description: "A simple string field"
 fn test_parse_card_with_fields_in_yaml() {
     // Test parsing [cards] section with [cards.X.fields.Y] syntax
     let yaml_content = r#"
-Quill:
+quill:
   name: cards_fields_test
   version: "1.0"
   backend: typst
@@ -1490,7 +1490,7 @@ invalid_key:
 #[test]
 fn test_quill_config_with_cards_section() {
     let yaml_content = r#"
-Quill:
+quill:
   name: cards_test
   version: "1.0"
   backend: typst
@@ -1532,7 +1532,7 @@ cards:
 fn test_quill_config_cards_empty_fields() {
     // Test that cards with no fields section are valid
     let yaml_content = r#"
-Quill:
+quill:
   name: cards_empty_fields_test
   version: "1.0"
   backend: typst
@@ -1554,7 +1554,7 @@ cards:
 fn test_quill_config_allows_card_collision() {
     // Test that scope name colliding with field name is ALLOWED
     let yaml_content = r#"
-Quill:
+quill:
   name: collision_test
   version: "1.0"
   backend: typst
@@ -1589,7 +1589,7 @@ cards:
 fn test_quill_config_ordering_with_cards() {
     // Test that fields have proper UI ordering (cards no longer have card-level ordering)
     let yaml_content = r#"
-Quill:
+quill:
   name: ordering_test
   version: "1.0"
   backend: typst
@@ -1639,7 +1639,7 @@ fn test_card_field_order_preservation() {
     // defined: z_first, then a_second
     // alphabetical: a_second, then z_first
     let yaml_content = r#"
-Quill:
+quill:
   name: card_order_test
   version: "1.0"
   backend: typst
@@ -1675,7 +1675,7 @@ cards:
 #[test]
 fn test_nested_schema_parsing() {
     let yaml_content = r#"
-Quill:
+quill:
   name: nested_test
   version: "1.0"
   backend: typst
@@ -1718,7 +1718,7 @@ main:
 #[test]
 fn test_standalone_object_field_rejected_with_warning() {
     let yaml_content = r#"
-Quill:
+quill:
   name: obj_test
   version: "1.0"
   backend: typst
@@ -1756,7 +1756,7 @@ main:
 #[test]
 fn test_nested_object_in_typed_table_rejected_with_warning() {
     let yaml_content = r#"
-Quill:
+quill:
   name: nested_obj_test
   version: "1.0"
   backend: typst
@@ -1793,7 +1793,7 @@ main:
 #[test]
 fn test_array_items_recursive_coercion() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_test
   version: "1.0"
   backend: typst
@@ -1842,7 +1842,7 @@ main:
 #[test]
 fn test_config_coerce_number_boolean_date_datetime_success() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_success_test
   version: "1.0"
   backend: typst
@@ -1895,7 +1895,7 @@ main:
 #[test]
 fn test_config_coerce_integer_success() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_integer_success_test
   version: "1.0"
   backend: typst
@@ -1921,7 +1921,7 @@ main:
 #[test]
 fn test_config_coerce_integer_rejects_decimal() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_integer_error_test
   version: "1.0"
   backend: typst
@@ -1951,7 +1951,7 @@ main:
 #[test]
 fn test_config_coerce_array_item_wise() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_array_items_test
   version: "1.0"
   backend: typst
@@ -1993,7 +1993,7 @@ main:
 #[test]
 fn test_config_coerce_cards_item_wise() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_cards_items_test
   version: "1.0"
   backend: typst
@@ -2027,7 +2027,7 @@ cards:
 #[test]
 fn test_config_coerce_error_unparseable_date() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_date_error_test
   version: "1.0"
   backend: typst
@@ -2057,7 +2057,7 @@ main:
 #[test]
 fn test_config_coerce_error_unparseable_number() {
     let yaml_content = r#"
-Quill:
+quill:
   name: coerce_number_error_test
   version: "1.0"
   backend: typst
@@ -2087,7 +2087,7 @@ main:
 #[test]
 fn test_multiline_ui_field_parses() {
     let yaml_content = r#"
-Quill:
+quill:
   name: multiline_test
   version: "1.0"
   backend: typst
@@ -2119,7 +2119,7 @@ main:
 #[test]
 fn test_multiline_ui_field_on_string_type() {
     let yaml_content = r#"
-Quill:
+quill:
   name: multiline_string_test
   version: "1.0"
   backend: typst
@@ -2151,7 +2151,7 @@ main:
 #[test]
 fn test_quill_config_from_yaml_collects_non_fatal_field_warnings() {
     let yaml_content = r#"
-Quill:
+quill:
   name: warning_config
   version: "1.0"
   backend: typst

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -280,7 +280,7 @@ mod tests {
     fn config_with(main_fields: &str, cards: &str) -> QuillConfig {
         let yaml = format!(
             r#"
-Quill:
+quill:
   name: native_validation
   backend: typst
   description: Native validator tests

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -44,24 +44,26 @@ pub fn validate_typed_document(
     config: &QuillConfig,
     doc: &Document,
 ) -> Result<(), Vec<ValidationError>> {
-    let mut errors = validate_fields_for_card_indexmap(config.main(), doc.frontmatter(), "");
+    let main_fields = doc.main().frontmatter().to_index_map();
+    let mut errors = validate_fields_for_card_indexmap(config.main(), &main_fields, "");
 
     for (index, card) in doc.cards().iter().enumerate() {
         let card_name = card.tag();
         let item_path = format!("cards[{index}]");
 
-        let Some(card_schema) = config.card_definition(card_name) else {
+        let Some(card_schema) = config.card_definition(card_name.as_str()) else {
             errors.push(ValidationError::UnknownCard {
                 path: item_path,
-                card: card_name.to_string(),
+                card: card_name,
             });
             continue;
         };
 
         let card_path = format!("cards.{card_name}[{index}]");
+        let card_fields = card.frontmatter().to_index_map();
         errors.extend(validate_fields_for_card_indexmap(
             card_schema,
-            card.fields(),
+            &card_fields,
             &card_path,
         ));
     }
@@ -329,11 +331,11 @@ main:
     }
 
     fn typed_card(tag: &str, fields: &[(&str, serde_json::Value)]) -> Card {
-        let mut card_fields = IndexMap::new();
+        let mut card = Card::new(tag).unwrap();
         for (k, v) in fields {
-            card_fields.insert(k.to_string(), QuillValue::from_json(v.clone()));
+            card.set_field(k, QuillValue::from_json(v.clone())).unwrap();
         }
-        Card::new_internal(tag.to_string(), card_fields, String::new())
+        card
     }
 
     fn has_error<F>(errors: &[ValidationError], predicate: F) -> bool

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -303,31 +303,21 @@ main:
     }
 
     fn doc_from_fm(entries: &[(&str, serde_json::Value)]) -> Document {
-        let mut frontmatter = IndexMap::new();
-        for (k, v) in entries {
-            frontmatter.insert(k.to_string(), QuillValue::from_json(v.clone()));
-        }
-        Document::new_internal(
-            QuillReference::from_str("test_quill").unwrap(),
-            frontmatter,
-            String::new(),
-            vec![],
-            vec![],
-        )
+        doc_with_typed_cards(entries, vec![])
     }
 
     fn doc_with_typed_cards(fm: &[(&str, serde_json::Value)], cards: Vec<Card>) -> Document {
+        use crate::document::{Frontmatter, Sentinel};
         let mut frontmatter = IndexMap::new();
         for (k, v) in fm {
             frontmatter.insert(k.to_string(), QuillValue::from_json(v.clone()));
         }
-        Document::new_internal(
-            QuillReference::from_str("test_quill").unwrap(),
-            frontmatter,
+        let main = Card::new_with_sentinel(
+            Sentinel::Main(QuillReference::from_str("test_quill").unwrap()),
+            Frontmatter::from_index_map(frontmatter),
             String::new(),
-            cards,
-            vec![],
-        )
+        );
+        Document::from_main_and_cards(main, cards, vec![])
     }
 
     fn typed_card(tag: &str, fields: &[(&str, serde_json::Value)]) -> Card {

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -31,7 +31,10 @@ pub struct RenderOptions {
     /// Ignored for vector/document formats (PDF, SVG, TXT).
     /// Defaults to 144.0 (2x at 72pt/inch) when `None`.
     pub ppi: Option<f32>,
-    /// Optional page indices to render (`None` = all pages).
+    /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
+    /// the first and third pages). `None` renders all pages. Backends
+    /// that do not support page selection (notably PDF) return a
+    /// `FormatNotSupported` error when this is `Some`.
     pub pages: Option<Vec<usize>>,
 }
 

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -206,13 +206,15 @@ mod tests {
     }
 
     #[test]
-    fn test_yaml_custom_tags_ignored() {
-        // User-defined YAML tags should be accepted and ignored
-        // The value should be parsed as if the tag were not present
+    fn test_yaml_custom_tags_ignored_at_value_level() {
+        // At the raw `QuillValue::from_yaml_str` layer, custom YAML tags
+        // (including `!fill`) pass through serde_saphyr which drops the
+        // tag and returns the underlying scalar.  The tag is recovered at
+        // the `Document` layer by `document::prescan`: see
+        // `document::tests::lossiness_tests::custom_tags_lose_tag_but_keep_value`.
         let yaml_str = "memo_from: !fill 2d lt example";
         let quill_val = QuillValue::from_yaml_str(yaml_str).unwrap();
 
-        // The tag !fill should be ignored, value parsed as string
         assert_eq!(
             quill_val.get("memo_from").as_ref().and_then(|v| v.as_str()),
             Some("2d lt example")

--- a/crates/core/tests/markdown_field_test.rs
+++ b/crates/core/tests/markdown_field_test.rs
@@ -4,7 +4,7 @@ use quillmark_core::{normalize::normalize_document, quill::QuillConfig, Document
 fn test_markdown_field_public_schema_emission() {
     let config = QuillConfig::from_yaml(
         r#"
-Quill:
+quill:
   name: markdown_schema
   version: "1.0"
   backend: typst

--- a/crates/core/tests/markdown_field_test.rs
+++ b/crates/core/tests/markdown_field_test.rs
@@ -39,7 +39,7 @@ fn test_markdown_field_normalization() {
 
     // Normalize
     let normalized = normalize_document(doc).expect("Failed to normalize document");
-    let fm = normalized.frontmatter();
+    let fm = normalized.main().frontmatter();
 
     // Both fields pass through unchanged (no stripping on YAML fields)
     assert_eq!(
@@ -57,5 +57,5 @@ fn test_normalize_document_body_is_str_not_option() {
     // body() now returns &str (not Option<&str>)
     let doc = Document::from_markdown("---\nQUILL: t\n---\n\nHello body.").unwrap();
     let normalized = normalize_document(doc).unwrap();
-    assert!(normalized.body().contains("Hello body."));
+    assert!(normalized.main().body().contains("Hello body."));
 }

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -83,7 +83,7 @@ fn near_miss_sentinel_emits_warning_and_delegates() {
         "near-miss CARD must be delegated, not registered"
     );
     // Body must contain the delegated content.
-    assert!(out.document.body().contains("Card: oops"));
+    assert!(out.document.main().body().contains("Card: oops"));
 }
 
 // §3 — Trailing whitespace on the fence marker must be accepted.

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -35,7 +35,12 @@ fn f1_yaml_comment_banners_above_sentinel_are_accepted() {
     let md = "---\n# Essential\n#===========\nQUILL: t\ntitle: T\n---\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "T"
     );
 }
@@ -87,7 +92,12 @@ fn fence_marker_with_trailing_whitespace_is_accepted() {
     let md = "---  \nQUILL: t\ntitle: T\n---\t\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "T"
     );
 }
@@ -149,7 +159,12 @@ fn normalize_yaml_scalar_keeps_bidi() {
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "hi\u{202D}there"
     );
 }
@@ -239,7 +254,12 @@ fn utf8_bom_at_start_is_stripped() {
     let md = "\u{FEFF}---\nQUILL: t\ntitle: T\n---\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
-        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main()
+            .frontmatter()
+            .get("title")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "T"
     );
 }

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -11,7 +11,7 @@ use quillmark_core::Document;
 fn f2_fence_directly_under_paragraph_is_not_a_fence() {
     let md = "---\nQUILL: t\n---\n\nParagraph text.\n---\n\nAfter.";
     let doc = Document::from_markdown(md).unwrap();
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(
         body.contains("Paragraph text.") && body.contains("---") && body.contains("After."),
         "stray `---` under paragraph must be left to CommonMark, body was: {:?}",
@@ -35,7 +35,7 @@ fn f1_yaml_comment_banners_above_sentinel_are_accepted() {
     let md = "---\n# Essential\n#===========\nQUILL: t\ntitle: T\n---\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "T"
     );
 }
@@ -87,7 +87,7 @@ fn fence_marker_with_trailing_whitespace_is_accepted() {
     let md = "---  \nQUILL: t\ntitle: T\n---\t\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "T"
     );
 }
@@ -139,7 +139,7 @@ fn normalize_body_strips_bidi() {
     let md = "---\nQUILL: t\n---\n\nhi\u{202D}there";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
-    assert_eq!(doc.body(), "\nhithere");
+    assert_eq!(doc.main().body(), "\nhithere");
 }
 
 // §7 — YAML scalar bidi NOT stripped.
@@ -149,7 +149,7 @@ fn normalize_yaml_scalar_keeps_bidi() {
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "hi\u{202D}there"
     );
 }
@@ -177,7 +177,7 @@ fn f3_indented_four_spaces_is_not_a_fence() {
         doc.cards().is_empty(),
         "indented `---` must not register as a fence"
     );
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(
         body.contains("    ---") && body.contains("CARD: x"),
         "indented fence content must be delegated to CommonMark, body was: {:?}",
@@ -190,7 +190,7 @@ fn f3_indented_four_spaces_is_not_a_fence() {
 fn f3_three_leading_spaces_is_still_a_fence() {
     let md = "   ---\nQUILL: t\n   ---\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
-    assert!(doc.body().contains("Body."));
+    assert!(doc.main().body().contains("Body."));
 }
 
 // §4 F3 — Tab indentation disqualifies a line from being a fence marker.
@@ -210,7 +210,7 @@ fn body_crlf_line_endings_are_normalized() {
     let md = "---\nQUILL: t\n---\n\nLine one.\r\nLine two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
-    let body = doc.body();
+    let body = doc.main().body();
     assert!(
         !body.contains('\r'),
         "body must not contain bare \\r after normalization, got: {:?}",
@@ -239,7 +239,7 @@ fn utf8_bom_at_start_is_stripped() {
     let md = "\u{FEFF}---\nQUILL: t\ntitle: T\n---\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
-        doc.frontmatter().get("title").unwrap().as_str().unwrap(),
+        doc.main().frontmatter().get("title").unwrap().as_str().unwrap(),
         "T"
     );
 }

--- a/crates/fixtures/resources/appreciated_letter/Quill.yaml
+++ b/crates/fixtures/resources/appreciated_letter/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: appreciated_letter
   version: "0.1"
   backend: typst

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: classic_resume
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: cmu_letter
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md
@@ -5,11 +5,11 @@ address:
   - 5000 Forbes Avenue
   - Pittsburgh, PA 15213-3890
 url: cmu.edu
-recipient: !fill
+recipient:
   - Dr. Heinz Doofenshmirtz
   - 9297 Polly Parkway
   - City, Virginia 46231
-signature_block: !fill
+signature_block:
   - Phineas Flynn
   - Masters Student
 ---

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md
@@ -5,11 +5,11 @@ address:
   - 5000 Forbes Avenue
   - Pittsburgh, PA 15213-3890
 url: cmu.edu
-recipient:
+recipient: !fill
   - Dr. Heinz Doofenshmirtz
   - 9297 Polly Parkway
   - City, Virginia 46231
-signature_block:
+signature_block: !fill
   - Phineas Flynn
   - Masters Student
 ---

--- a/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: taro
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: usaf_memo
   version: 0.1.0
   backend: typst

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -1,4 +1,4 @@
-Quill:
+quill:
   name: usaf_memo
   version: 0.2.0
   backend: typst

--- a/crates/fuzz/src/parse_fuzz.rs
+++ b/crates/fuzz/src/parse_fuzz.rs
@@ -17,8 +17,8 @@ proptest! {
         match result {
             Ok(doc) => {
                 // If it parsed, we should be able to access the document safely
-                let _ = doc.body();
-                let _ = doc.frontmatter();
+                let _ = doc.main().body();
+                let _ = doc.main().frontmatter();
                 let _ = doc.cards();
             }
             Err(_) => {
@@ -57,7 +57,7 @@ proptest! {
         if let Ok(doc) = result {
             // Tag might create a card
             let _ = doc.cards();
-            let _ = doc.frontmatter();
+            let _ = doc.main().frontmatter();
         }
     }
 
@@ -81,7 +81,7 @@ proptest! {
         let result = Document::from_markdown(&markdown);
         if let Ok(doc) = result {
             // frontmatter has exactly the fields we provided (no BODY or CARDS keys)
-            assert!(doc.frontmatter().len() <= size);
+            assert!(doc.main().frontmatter().len() <= size);
         }
     }
 
@@ -111,7 +111,7 @@ proptest! {
 
         if let Ok(doc) = result {
             // Should be able to retrieve body with special chars
-            let body = doc.body();
+            let body = doc.main().body();
             let _ = body;
         }
     }
@@ -123,7 +123,7 @@ proptest! {
         let result = Document::from_markdown(&markdown);
 
         if let Ok(doc) = result {
-            let _ = doc.body();
+            let _ = doc.main().body();
         }
     }
 
@@ -142,7 +142,7 @@ proptest! {
         let result = Document::from_markdown(&markdown);
         if let Ok(doc) = result {
             // Should handle multiple sections
-            let _ = doc.frontmatter();
+            let _ = doc.main().frontmatter();
             let _ = doc.cards();
         }
     }

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -141,16 +141,18 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
 
     // ── Main card projection ──────────────────────────────────────────────
     let main_schema = quill.source().config().main();
-    let main = project_card(main_schema, doc.frontmatter());
+    let main_fields = doc.main().frontmatter().to_index_map();
+    let main = project_card(main_schema, &main_fields);
 
     // ── Per-card projections ──────────────────────────────────────────────
     let mut cards: Vec<FormCard> = Vec::new();
 
     for (index, card) in doc.cards().iter().enumerate() {
         let tag = card.tag();
-        match quill.source().config().card_definition(tag) {
+        match quill.source().config().card_definition(&tag) {
             Some(card_schema) => {
-                cards.push(project_card(card_schema, card.fields()));
+                let card_fields = card.frontmatter().to_index_map();
+                cards.push(project_card(card_schema, &card_fields));
             }
             None => {
                 diagnostics.push(

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -27,8 +27,8 @@
 //!
 //! A `FormProjection` is a **read-only snapshot** of the document at the time
 //! [`project_form`] is called. Subsequent edits to `doc` (e.g. via
-//! [`Document::set_field`]) are not reflected in an existing `FormProjection`;
-//! call `project_form` again to obtain an updated snapshot.
+//! `doc.main_mut().set_field(...)`) are not reflected in an existing
+//! `FormProjection`; call `project_form` again to obtain an updated snapshot.
 //!
 //! # Unknown card tags
 //!

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -28,7 +28,7 @@ fn quill_from_yaml(yaml: &str) -> Quill {
 fn project_form_all_fields_present() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: form_test
   version: "1.0"
   backend: typst
@@ -76,7 +76,7 @@ main:
 fn project_form_missing_field_uses_default() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: form_defaults_test
   version: "1.0"
   backend: typst
@@ -132,7 +132,7 @@ main:
 fn project_form_unknown_card_tag_drops_card_and_emits_diagnostic() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: unknown_card_test
   version: "1.0"
   backend: typst
@@ -179,7 +179,7 @@ cards:
 fn project_form_card_field_sources() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: card_fields_test
   version: "1.0"
   backend: typst
@@ -235,7 +235,7 @@ cards:
 fn project_form_validation_diagnostics_appear() {
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: validation_diag_test
   version: "1.0"
   backend: typst
@@ -272,7 +272,7 @@ fn project_form_serializes_cleanly() {
     // Smoke test: serde_json round-trip of FormProjection.
     let quill = quill_from_yaml(
         r#"
-Quill:
+quill:
   name: serial_test
   version: "1.0"
   backend: typst

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -5,8 +5,9 @@ use indexmap::IndexMap;
 use std::sync::Arc;
 
 use quillmark_core::{
-    normalize::normalize_document, Backend, Card, Diagnostic, Document, OutputFormat, QuillSource,
-    QuillValue, RenderError, RenderOptions, RenderResult, RenderSession, Severity,
+    normalize::normalize_document, Backend, Card, Diagnostic, Document, Frontmatter, OutputFormat,
+    QuillSource, QuillValue, RenderError, RenderOptions, RenderResult, RenderSession, Sentinel,
+    Severity,
 };
 
 /// Renderable quill. Composes an [`Arc<QuillSource>`] with a resolved
@@ -125,20 +126,20 @@ impl Quill {
                             ),
                     ),
                 })?;
-            coerced_cards.push(Card::new_internal(
-                card.tag(),
-                coerced_fields,
+            coerced_cards.push(Card::new_with_sentinel(
+                Sentinel::Card(card.tag()),
+                Frontmatter::from_index_map(coerced_fields),
                 card.body().to_string(),
             ));
         }
 
-        let coerced_doc = Document::new_internal(
-            doc.quill_reference().clone(),
-            coerced_frontmatter,
+        let coerced_main = Card::new_with_sentinel(
+            Sentinel::Main(doc.quill_reference().clone()),
+            Frontmatter::from_index_map(coerced_frontmatter),
             doc.main().body().to_string(),
-            coerced_cards,
-            doc.warnings().to_vec(),
         );
+        let coerced_doc =
+            Document::from_main_and_cards(coerced_main, coerced_cards, doc.warnings().to_vec());
 
         self.validate_document(&coerced_doc)?;
 
@@ -156,15 +157,22 @@ impl Quill {
             .map(|card| {
                 let card_map = card.frontmatter().to_index_map();
                 let fields_with_defaults = self.apply_card_defaults(&card.tag(), &card_map);
-                Card::new_internal(card.tag(), fields_with_defaults, card.body().to_string())
+                Card::new_with_sentinel(
+                    Sentinel::Card(card.tag()),
+                    Frontmatter::from_index_map(fields_with_defaults),
+                    card.body().to_string(),
+                )
             })
             .collect();
 
         // Rebuild document with defaults applied.
-        let final_doc = Document::new_internal(
-            normalized.quill_reference().clone(),
-            frontmatter_with_defaults,
+        let final_main = Card::new_with_sentinel(
+            Sentinel::Main(normalized.quill_reference().clone()),
+            Frontmatter::from_index_map(frontmatter_with_defaults),
             normalized.main().body().to_string(),
+        );
+        let final_doc = Document::from_main_and_cards(
+            final_main,
             cards_with_defaults,
             normalized.warnings().to_vec(),
         );
@@ -273,19 +281,19 @@ impl Quill {
                             ),
                     ),
                 })?;
-            coerced_cards.push(Card::new_internal(
-                card.tag(),
-                coerced_fields,
+            coerced_cards.push(Card::new_with_sentinel(
+                Sentinel::Card(card.tag()),
+                Frontmatter::from_index_map(coerced_fields),
                 card.body().to_string(),
             ));
         }
-        let coerced_doc = Document::new_internal(
-            doc.quill_reference().clone(),
-            coerced_frontmatter,
+        let coerced_main = Card::new_with_sentinel(
+            Sentinel::Main(doc.quill_reference().clone()),
+            Frontmatter::from_index_map(coerced_frontmatter),
             doc.main().body().to_string(),
-            coerced_cards,
-            doc.warnings().to_vec(),
         );
+        let coerced_doc =
+            Document::from_main_and_cards(coerced_main, coerced_cards, doc.warnings().to_vec());
         self.validate_document(&coerced_doc)?;
         Ok(())
     }

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -91,11 +91,12 @@ impl Quill {
     /// Applies coercion, validation, normalization, and schema defaults, then
     /// calls [`Document::to_plate_json`] to produce the wire format.
     pub fn compile_data(&self, doc: &Document) -> Result<serde_json::Value, RenderError> {
-        // Coerce frontmatter fields against the schema.
+        // Coerce main-card frontmatter fields against the schema.
+        let main_fields_map = doc.main().frontmatter().to_index_map();
         let coerced_frontmatter = self
             .source
             .config()
-            .coerce_frontmatter(doc.frontmatter())
+            .coerce_frontmatter(&main_fields_map)
             .map_err(|e| RenderError::ValidationFailed {
                 diag: Box::new(
                     Diagnostic::new(Severity::Error, e.to_string())
@@ -109,10 +110,11 @@ impl Quill {
         // Coerce card fields against per-card schemas.
         let mut coerced_cards: Vec<Card> = Vec::new();
         for card in doc.cards() {
+            let card_fields_map = card.frontmatter().to_index_map();
             let coerced_fields = self
                 .source
                 .config()
-                .coerce_card(card.tag(), card.fields())
+                .coerce_card(&card.tag(), &card_fields_map)
                 .map_err(|e| RenderError::ValidationFailed {
                     diag: Box::new(
                         Diagnostic::new(Severity::Error, e.to_string())
@@ -124,7 +126,7 @@ impl Quill {
                     ),
                 })?;
             coerced_cards.push(Card::new_internal(
-                card.tag().to_string(),
+                card.tag(),
                 coerced_fields,
                 card.body().to_string(),
             ));
@@ -133,7 +135,7 @@ impl Quill {
         let coerced_doc = Document::new_internal(
             doc.quill_reference().clone(),
             coerced_frontmatter,
-            doc.body().to_string(),
+            doc.main().body().to_string(),
             coerced_cards,
             doc.warnings().to_vec(),
         );
@@ -144,16 +146,18 @@ impl Quill {
         let normalized = normalize_document(coerced_doc)?;
 
         // Apply schema defaults to frontmatter.
-        let frontmatter_with_defaults = self.apply_frontmatter_defaults(normalized.frontmatter());
+        let normalized_main_map = normalized.main().frontmatter().to_index_map();
+        let frontmatter_with_defaults = self.apply_frontmatter_defaults(&normalized_main_map);
 
         // Apply per-card defaults.
         let cards_with_defaults: Vec<Card> = normalized
             .cards()
             .iter()
             .map(|card| {
-                let fields_with_defaults = self.apply_card_defaults(card.tag(), card.fields());
+                let card_map = card.frontmatter().to_index_map();
+                let fields_with_defaults = self.apply_card_defaults(&card.tag(), &card_map);
                 Card::new_internal(
-                    card.tag().to_string(),
+                    card.tag(),
                     fields_with_defaults,
                     card.body().to_string(),
                 )
@@ -164,7 +168,7 @@ impl Quill {
         let final_doc = Document::new_internal(
             normalized.quill_reference().clone(),
             frontmatter_with_defaults,
-            normalized.body().to_string(),
+            normalized.main().body().to_string(),
             cards_with_defaults,
             normalized.warnings().to_vec(),
         );
@@ -241,10 +245,11 @@ impl Quill {
 
     /// Perform a dry-run validation without backend compilation.
     pub fn dry_run(&self, doc: &Document) -> Result<(), RenderError> {
+        let main_fields_map = doc.main().frontmatter().to_index_map();
         let coerced_frontmatter = self
             .source
             .config()
-            .coerce_frontmatter(doc.frontmatter())
+            .coerce_frontmatter(&main_fields_map)
             .map_err(|e| RenderError::ValidationFailed {
                 diag: Box::new(
                     Diagnostic::new(Severity::Error, e.to_string())
@@ -257,10 +262,11 @@ impl Quill {
             })?;
         let mut coerced_cards: Vec<Card> = Vec::new();
         for card in doc.cards() {
+            let card_fields_map = card.frontmatter().to_index_map();
             let coerced_fields = self
                 .source
                 .config()
-                .coerce_card(card.tag(), card.fields())
+                .coerce_card(&card.tag(), &card_fields_map)
                 .map_err(|e| RenderError::ValidationFailed {
                     diag: Box::new(
                         Diagnostic::new(Severity::Error, e.to_string())
@@ -272,7 +278,7 @@ impl Quill {
                     ),
                 })?;
             coerced_cards.push(Card::new_internal(
-                card.tag().to_string(),
+                card.tag(),
                 coerced_fields,
                 card.body().to_string(),
             ));
@@ -280,7 +286,7 @@ impl Quill {
         let coerced_doc = Document::new_internal(
             doc.quill_reference().clone(),
             coerced_frontmatter,
-            doc.body().to_string(),
+            doc.main().body().to_string(),
             coerced_cards,
             doc.warnings().to_vec(),
         );

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -156,11 +156,7 @@ impl Quill {
             .map(|card| {
                 let card_map = card.frontmatter().to_index_map();
                 let fields_with_defaults = self.apply_card_defaults(&card.tag(), &card_map);
-                Card::new_internal(
-                    card.tag(),
-                    fields_with_defaults,
-                    card.body().to_string(),
-                )
+                Card::new_internal(card.tag(), fields_with_defaults, card.body().to_string())
             })
             .collect();
 

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -89,7 +89,7 @@ fn test_render_with_custom_backend() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        "Quill:\n  name: \"custom_backend_quill\"\n  version: \"1.0\"\n  backend: \"mock-txt\"\n  plate_file: \"plate.txt\"\n  description: \"Test\"\n",
+        "quill:\n  name: \"custom_backend_quill\"\n  version: \"1.0\"\n  backend: \"mock-txt\"\n  plate_file: \"plate.txt\"\n  description: \"Test\"\n",
     ).unwrap();
     fs::write(quill_path.join("plate.txt"), "Test template: {{ title }}").unwrap();
 

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -21,7 +21,7 @@ fn test_default_values_applied_via_dry_run() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -61,7 +61,7 @@ fn test_default_values_not_overriding_existing_fields() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -99,7 +99,7 @@ fn test_validation_with_defaults() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -137,7 +137,7 @@ fn test_validation_fails_without_defaults() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"
@@ -183,7 +183,7 @@ fn test_extract_defaults_from_quill() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        r#"Quill:
+        r#"quill:
   name: "test_quill"
   version: "1.0"
   backend: "typst"

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -17,7 +17,7 @@ fn make_test_quill_path(temp_dir: &TempDir, with_required_field: bool) -> std::p
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "Quill:\n  name: \"test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n\n{}",
+            "quill:\n  name: \"test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n\n{}",
             fields_section
         ),
     ).unwrap();

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -11,7 +11,7 @@ fn make_quill_dir(temp_dir: &TempDir, name: &str, backend: &str) -> std::path::P
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "Quill:\n  name: \"{}\"\n  version: \"1.0\"\n  backend: \"{}\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
+            "quill:\n  name: \"{}\"\n  version: \"1.0\"\n  backend: \"{}\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
             name, backend
         ),
     )
@@ -68,7 +68,7 @@ fn test_quill_engine_end_to_end() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        "Quill:\n  name: \"my_test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
+        "quill:\n  name: \"my_test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
     ).unwrap();
     fs::write(
         quill_path.join("plate.typ"),

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -18,7 +18,7 @@ my-quill/
 Create a minimal but complete config:
 
 ```yaml
-Quill:
+quill:
   name: my_quill
   backend: typst
   version: "1.0.0"

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -7,7 +7,7 @@ Complete reference for authoring `Quill.yaml` configuration files. For a hands-o
 A `Quill.yaml` has these top-level sections:
 
 ```yaml
-Quill:        # Required — format metadata
+quill:        # Required — format metadata
   ...
 
 main:         # Optional — document main card: field schemas and optional ui
@@ -26,11 +26,11 @@ Root-level `fields:` is not supported; define the main document’s field schema
 
 ---
 
-## `Quill` Section
+## `quill` Section
 
-Every Quill.yaml must have a `Quill` section with format metadata.
+Every Quill.yaml must have a `quill` section with format metadata.
 
-`Quill.name` must be `snake_case` (`^[a-z][a-z0-9_]*$`).
+`quill.name` must be `snake_case` (`^[a-z][a-z0-9_]*$`).
 
 | Key              | Type   | Required | Description |
 |------------------|--------|----------|-------------|
@@ -45,7 +45,7 @@ Every Quill.yaml must have a `Quill` section with format metadata.
 | `ui`             | object | no       | Document-level UI metadata |
 
 ```yaml
-Quill:
+quill:
   name: usaf_memo
   version: "0.1"
   backend: typst
@@ -60,7 +60,7 @@ Quill:
 Controls UI behavior for the document root:
 
 ```yaml
-Quill:
+quill:
   name: metadata-only-doc
   # ...
   ui:
@@ -71,7 +71,7 @@ Quill:
 
 ## `main` Section
 
-The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `Quill.ui` is merged with `main.ui` when building the main card.
+The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
 
 Field order under `main.fields` determines display order in UIs — the first field gets `order: 0`, the second gets `order: 1`, and so on.
 
@@ -397,7 +397,7 @@ Quillmark emits a public schema YAML contract from `QuillConfig`. The output kee
 ## Complete Example
 
 ```yaml
-Quill:
+quill:
   name: project_report
   version: "1.0"
   backend: typst

--- a/docs/format-designer/typst-backend.md
+++ b/docs/format-designer/typst-backend.md
@@ -17,7 +17,7 @@ Typst is a modern typesetting system designed as a better alternative to LaTeX. 
 Specify `backend: typst` in your `Quill.yaml`:
 
 ```yaml
-Quill:
+quill:
   name: my-typst-quill
   backend: typst
   description: Document format using Typst

--- a/docs/format-designer/versioning.md
+++ b/docs/format-designer/versioning.md
@@ -7,7 +7,7 @@ Versioning helps format designers evolve Quills safely while keeping document re
 Each Quill must declare a semantic version. Both `version` and `description` are required fields:
 
 ```yaml
-Quill:
+quill:
   name: my_quill
   backend: typst
   description: A professional document format

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -50,7 +50,7 @@ Get started with Quillmark in Python or JavaScript.
     const enc = new TextEncoder();
 
     const quill = engine.quill(new Map([
-      ["Quill.yaml", enc.encode("Quill:\n  name: my_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Demo\n")],
+      ["Quill.yaml", enc.encode("quill:\n  name: my_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Demo\n")],
       ["plate.typ", enc.encode("#import \"@local/quillmark-helper:0.1.0\": data\n#data.BODY\n")],
     ]));
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -66,12 +66,13 @@ optional trailing whitespace). The content between is parsed as YAML.
   silently; a `parse::comments_in_nested_yaml_dropped` warning is emitted
   on the first occurrence per document.
 - **The `!fill` tag.** `!fill` is the single supported YAML tag; it marks
-  a top-level scalar field as a placeholder awaiting user input and
-  round-trips through emit. `!fill` may only be applied to scalars
-  (string, integer, float, bool, null); `!fill` on a block map or
-  sequence is rejected at parse. Any other custom tag (`!include`,
-  `!env`, …) is dropped with a `parse::unsupported_yaml_tag` warning;
-  the scalar value is kept but the tag does not round-trip.
+  a top-level field as a placeholder awaiting user input and round-trips
+  through emit. `!fill` may be applied to scalars (string, integer,
+  float, bool, null) and sequences; it is rejected on mappings because
+  Quillmark's schema has no top-level `type: object`. Any other custom
+  tag (`!include`, `!env`, …) is dropped with a
+  `parse::unsupported_yaml_tag` warning; the scalar value is kept but
+  the tag does not round-trip.
 
 ## 4. Fence Detection Rules
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -56,6 +56,22 @@ optional trailing whitespace). The content between is parsed as YAML.
 - **Reserved keys.** `QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and
   may not appear as user-defined field names. `QUILL` is permitted only in
   the frontmatter; `CARD` is required in every non-frontmatter fence.
+- **YAML comments.** Own-line comments (`# …`) between the fence
+  delimiters are preserved as first-class ordered items and round-trip
+  through `toMarkdown`. Trailing comments on value lines
+  (`key: value  # note`) are normalised to own-line comments on the next
+  line as a canonical-formatting choice — the parser produces a `Field`
+  followed by a `Comment` item and the emitter emits them on separate
+  lines. Comments *inside* nested YAML values (arrays, maps) are dropped
+  silently; a `parse::comments_in_nested_yaml_dropped` warning is emitted
+  on the first occurrence per document.
+- **The `!fill` tag.** `!fill` is the single supported YAML tag; it marks
+  a top-level scalar field as a placeholder awaiting user input and
+  round-trips through emit. `!fill` may only be applied to scalars
+  (string, integer, float, bool, null); `!fill` on a block map or
+  sequence is rejected at parse. Any other custom tag (`!include`,
+  `!env`, …) is dropped with a `parse::unsupported_yaml_tag` warning;
+  the scalar value is kept but the tag does not round-trip.
 
 ## 4. Fence Detection Rules
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -66,7 +66,7 @@ Validation rules:
 Required top-level sections: `Quill` (bundle metadata). Optional: `main` (document fields), `cards` (card type definitions), `typst` (backend config).
 
 ```yaml
-Quill:
+quill:
   name: my_quill          # required; snake_case
   backend: typst          # required
   version: "1.0.0"        # required; semver (MAJOR.MINOR.PATCH or MAJOR.MINOR)

--- a/prose/designs/VERSIONING.md
+++ b/prose/designs/VERSIONING.md
@@ -41,7 +41,7 @@ Given versions `[1.0.0, 1.0.1, 1.1.0, 2.0.0, 2.1.0, 2.1.1, 3.0.0]`:
 `version` and `description` are both required:
 
 ```yaml
-Quill:
+quill:
   name: my_format
   version: "2.1.0"
   backend: typst

--- a/prose/document-rework/01-frontmatter-comments.md
+++ b/prose/document-rework/01-frontmatter-comments.md
@@ -1,0 +1,114 @@
+# 01 — Frontmatter Comments as First-Class Items
+
+**Status:** Draft
+**Depends on:** 03 (unified Card type)
+**Blocks:** 02
+
+## Background
+
+YAML comments are stripped at parse today (`crates/core/src/document/tests/lossiness_tests.rs::yaml_comments_disappear_on_round_trip`). The frontmatter is an `IndexMap<String, QuillValue>` — key-value pairs in insertion order, nothing else. A round-trip of
+
+```markdown
+---
+QUILL: q
+# recipient's full name
+recipient: Jane
+---
+```
+
+loses the comment. Downstream editors that want to preserve author intent
+ship a second YAML parser (`parseBlocks`) to keep a comment-aware AST
+alongside our parsed values.
+
+## Change
+
+Replace the map-shaped frontmatter inside `Card` with an ordered list of
+typed items.
+
+```rust
+pub enum FrontmatterItem {
+    Field { key: String, value: QuillValue },
+    Comment(String), // text excludes the leading `#` and one optional space.
+}
+
+pub struct Frontmatter {
+    items: Vec<FrontmatterItem>,
+}
+```
+
+`Frontmatter` is the `frontmatter` field on every `Card` — main and
+composable alike, courtesy of tasking 03.
+
+`Frontmatter` provides both ordered iteration and map-keyed access
+(`get`, `contains_key`, `insert`, `remove`) so existing callers that
+treat the frontmatter as a map keep working. Internally the map-keyed
+accessors walk the item vec; field count is small enough that linear
+scan is fine.
+
+### Parser
+
+- Standalone comment lines (first non-whitespace char is `#`) between
+  the opening `---` and the closing `---` become `Comment(text)` items
+  in source order.
+- Trailing comments on value lines (`key: value  # note`) are normalized
+  to standalone `Comment` items on the next line on round-trip. This is
+  a deliberate canonical-formatting choice (opinionated layout beats two
+  code paths). The parser produces a `Field` followed by a `Comment`
+  item.
+- Comments *inside* nested values (arrays, maps) are dropped silently.
+  Emit one `comments_in_nested_yaml_dropped` warning per document the
+  first time this is encountered.
+- Banner comments above the F1 sentinel line (already tolerated by
+  MARKDOWN.md §4 F1) land in the item list in source order.
+
+### Emitter
+
+Walk `items` in order, one per line. For `Field`: emit `key: value`
+(canonical quoting). For `Comment`: emit `# <text>`. No blank-line
+inference; blank lines are not modeled.
+
+### Mutator behaviour
+
+On `Card` (per tasking 03):
+
+- `set_field(key, value)` — updates the existing `Field` entry in place;
+  or appends a new `Field` at the end if the key is absent. Adjacent
+  comments are untouched.
+- `remove_field(key)` — drops the `Field` entry. Adjacent comments stay.
+  Orphaned comments are the caller's problem; we don't infer attachment.
+
+### WASM surface
+
+On `Card`:
+
+- `Card.frontmatter` (getter) — `Record<string, unknown>`, map-keyed
+  view of values only. Comments invisible here. Covers the common case.
+- `Card.frontmatterItems` (getter) — `FrontmatterItem[]`, ordered,
+  revealing comments. For consumers that care.
+
+Both accessors are available on `doc.main` and on each element of
+`doc.cards`, uniformly.
+
+## Non-goals
+
+- Nested-value comments.
+- Blank-line preservation.
+- Trailing-comment round-trip as trailing (they become own-line).
+- Comment-editing mutators.
+- Attachment inference ("this comment belongs to this key").
+
+## Done when
+
+- Round-tripping a document with top-level comments (in main or any
+  composable card) produces output where all such comments appear as
+  own-line comments, in source order, with their original text.
+- `lossiness_tests.rs::yaml_comments_disappear_on_round_trip` is
+  rewritten to assert the opposite and passes.
+- `set_field` / `remove_field` on a commented frontmatter leave
+  comments in place (new tests).
+- `Card.frontmatterItems` is exposed in WASM; basic test in
+  `basic.test.js` covers the round-trip across main and a composable
+  card.
+- `MARKDOWN.md` §3 gains a one-paragraph note that top-level comments
+  round-trip (as own-line), trailing comments are normalized to
+  own-line, and nested comments are dropped with a warning.

--- a/prose/document-rework/02-fill-typed-marker.md
+++ b/prose/document-rework/02-fill-typed-marker.md
@@ -1,0 +1,125 @@
+# 02 — `!fill` as a Typed Marker
+
+**Status:** Draft
+**Depends on:** 01 (FrontmatterItem model), 03 (unified Card)
+**Blocks:** nothing
+
+## Background
+
+`!fill` is a YAML tag authors use to mark placeholder values in example
+documents (see `crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md`).
+Today the parser accepts the tag and drops it
+(`crates/core/src/value.rs::test_yaml_custom_tags_ignored`), so a round
+trip turns `recipient: !fill` into `recipient: ""` with no trace of the
+author's intent. Downstream wizards re-scan the source to recover fill
+markers.
+
+## Change
+
+Promote `!fill` to a first-class typed marker on fields; round-trip it
+on emit.
+
+```rust
+// Extends the FrontmatterItem::Field variant from tasking 01.
+pub enum FrontmatterItem {
+    Field {
+        key: String,
+        value: QuillValue,
+        fill: bool,
+    },
+    Comment(String),
+}
+```
+
+`fill: bool` is sufficient — a field is either fill-tagged or not. The
+value lives in `value` with its natural YAML type. No separate enum.
+
+### Parser
+
+`!fill` tags **any** scalar. The tagged scalar keeps its parsed YAML
+type:
+
+- `key: !fill "2d lt example"` → `Field { value: String("2d lt example"), fill: true }`.
+- `key: !fill 42`              → `Field { value: Integer(42),            fill: true }`.
+- `key: !fill 3.14`            → `Field { value: Float(3.14),            fill: true }`.
+- `key: !fill true`            → `Field { value: Bool(true),             fill: true }`.
+- `key: !fill`  (no value)     → `Field { value: Null,                   fill: true }`.
+
+Non-scalar `!fill` (tagged map or sequence) is rejected at parse with
+`unsupported_fill_target` — `!fill` on structured values is YAGNI until
+a use case exists.
+
+Any **other** custom tag (`!include`, `!env`, `!anything`) → reject with
+a parse warning (`unsupported_yaml_tag`) and drop the tag, keeping the
+raw scalar value.
+
+### Emitter
+
+- `Field { fill: true, value: Null, … }` → `key: !fill`.
+- `Field { fill: true, value: scalar, … }` → `key: !fill <canonical-scalar>`.
+- `Field { fill: false, … }` → unchanged canonical emission.
+
+### Data-model surface
+
+- `card.frontmatter` (the map-keyed getter from tasking 01) continues to
+  return values only. A fill-tagged null field appears as `null` there.
+- `card.frontmatterItems` exposes `fill: boolean` per item so consumers
+  drive wizard UI off the data model.
+
+### Mutators — two explicit methods on `Card`
+
+```rust
+impl Card {
+    /// Set a field's value. Always clears the fill marker.
+    /// This is the "user filled this in" path.
+    pub fn set_field<V: Into<QuillValue>>(&mut self, key: &str, value: V);
+
+    /// Set a field's value AND mark it as fill.
+    /// This is the "reset to placeholder" path. `Null` value = `key: !fill`.
+    pub fn set_fill<V: Into<QuillValue>>(&mut self, key: &str, value: V);
+}
+```
+
+Two methods, two intents. The common wizard flow ("user typed something,
+clear the placeholder") is the default `set_field`; the rarer reset is
+the explicit `set_fill`. No options struct, no boolean parameter to
+forget in JS.
+
+`Document` has no top-level shortcut — callers write
+`doc.main_mut().set_field(…)` per tasking 03.
+
+### WASM surface
+
+- `FrontmatterItem` TS type gains `fill: boolean`.
+- `Card.setField(key, value)` — clears fill.
+- `Card.setFill(key, value)` — sets fill=true with the given value.
+- `frontmatter` record getter unchanged.
+
+## Validation
+
+Required-field-is-filled validation is **out of scope** for this tasking.
+A `!fill` on a required field will not error at parse or at `projectForm`
+time here. Follow-on tasking may gate render on it.
+
+## Non-goals
+
+- Generic custom-tag preservation (`!include`, etc.). Rejected with a
+  warning.
+- `!fill` on maps / sequences. Rejected with a warning.
+- Render-time enforcement of fill state.
+- Document-level mutator shortcuts.
+
+## Done when
+
+- `!fill` round-trips through `fromMarkdown → toMarkdown` for all scalar
+  types (string, int, float, bool, null), on main and on composable
+  cards.
+- `lossiness_tests.rs::custom_tags_lose_tag_but_keep_value` is rewritten
+  to assert preservation for `!fill` and rejection-with-warning for
+  other tags.
+- `cmu_letter` example markdown round-trips byte-identically (modulo
+  canonical quoting normalization from unrelated fields).
+- `frontmatterItems` exposes `fill: boolean`; a WASM test exercises
+  `setField` clearing fill and `setFill` setting it.
+- `MARKDOWN.md` gains a short section documenting `!fill` as the one
+  supported custom tag.

--- a/prose/document-rework/03-unify-cards.md
+++ b/prose/document-rework/03-unify-cards.md
@@ -1,0 +1,143 @@
+# 03 — Unify Entry and Composable Cards
+
+**Status:** Draft
+**Depends on:** nothing
+**Blocks:** 01, 02 (they operate on Card's frontmatter)
+**Recommended implementation order:** land first.
+
+## Background
+
+MARKDOWN.md §2 defines every Quillmark document as a sequence of
+(sentinel, frontmatter, body) triples:
+
+```
+Document = Frontmatter Body (CardFence CardBody)*
+```
+
+The first triple is the entry — its sentinel is `QUILL:` and it carries
+the document-level fields plus the global body. Subsequent triples are
+composable cards — their sentinel is `CARD:` and each carries a typed
+record.
+
+The data model today splits these: `Document { frontmatter, body, … }`
+plus a separate `Vec<Card>`. The split is historical; grammatically,
+all three regions are the same shape. Unifying them collapses the
+parser, emitter, and mutator surface, and matches how `Quill.yaml`
+already describes the model (a `main:` section alongside `cards:`
+entries).
+
+## Change
+
+One `Card` type for all fences. `Document` holds one `main` plus a
+`Vec<Card>` of composable cards.
+
+```rust
+pub struct Card {
+    sentinel: Sentinel,
+    frontmatter: Frontmatter,  // shape per tasking 01
+    body: String,
+}
+
+pub enum Sentinel {
+    Main(QuillReference),
+    Card(String),
+}
+
+pub struct Document {
+    main: Card,
+    cards: Vec<Card>,
+    // Invariants, enforced via private fields + smart constructors:
+    //   main.sentinel matches Sentinel::Main(_)
+    //   every card in cards matches Sentinel::Card(_)
+}
+```
+
+### Parser
+
+- First fence: sentinel `QUILL:` → `Sentinel::Main(ref)`; build a `Card`
+  with the global body between the fence and the first card fence (or
+  EOF). Store as `Document.main`.
+- Subsequent fences: sentinel `CARD:` → `Sentinel::Card(tag)`; build a
+  `Card`; push onto `Document.cards`.
+- One code path for "parse a fence"; sentinel kind is determined by
+  position.
+
+### Emitter
+
+Walk `once(&main).chain(&cards)`. Emit each card's fence + body
+uniformly; `sentinel` drives the first content line (`QUILL: …` or
+`CARD: …`). No separate "emit document body" path.
+
+### Mutators
+
+Frontmatter and body mutators live on `Card`:
+
+```rust
+impl Card {
+    pub fn set_field(&mut self, key: &str, value: impl Into<QuillValue>);
+    pub fn remove_field(&mut self, key: &str);
+    pub fn replace_body(&mut self, body: impl Into<String>);
+    // …plus set_fill from tasking 02.
+}
+```
+
+`Document` keeps only document-level concerns:
+
+```rust
+impl Document {
+    pub fn main(&self) -> &Card;
+    pub fn main_mut(&mut self) -> &mut Card;
+    pub fn cards(&self) -> &[Card];
+    pub fn cards_mut(&mut self) -> &mut [Card];
+
+    pub fn push_card(&mut self, tag: impl Into<String>, …);
+    pub fn insert_card(&mut self, idx: usize, …);
+    pub fn remove_card(&mut self, idx: usize) -> Option<Card>;
+    pub fn move_card(&mut self, from: usize, to: usize);
+
+    pub fn quill_reference(&self) -> &QuillReference; // reads main.sentinel
+    pub fn set_quill_ref(&mut self, r: QuillReference);
+}
+```
+
+No top-level shortcuts for frontmatter / body mutators. Callers write
+`doc.main_mut().set_field(…)` explicitly. KISS: one place for each
+operation; no parallel APIs to keep in sync.
+
+### WASM surface
+
+- `Document.main` (getter) → `Card` handle.
+- `Document.cards` (getter) → `Card[]`.
+- `Document.quillRef` unchanged — convenience reader over
+  `doc.main.sentinel`.
+- `Document.frontmatter`, `Document.body`, `Document.frontmatterItems`,
+  `Document.setField`, `Document.setFill`, `Document.replaceBody`, etc.
+  are **removed**. Consumers migrate to `doc.main.frontmatter`,
+  `doc.main.body`, `doc.main.setField`, etc.
+- `Card` gains the full mutator surface (`setField`, `setFill`,
+  `removeField`, `replaceBody`) plus the read accessors (`frontmatter`,
+  `frontmatterItems`, `body`).
+- `Card.tag` exposes the string tag for composable cards. For main
+  cards, it returns the quill reference's string form (or callers can
+  read `doc.quillRef` directly).
+
+## Non-goals
+
+- Document-level shortcuts for card operations. The rework is a
+  breaking change; don't also ship a parallel API we'd need to keep
+  in sync forever.
+- Changes to `QuillReference` typing or parsing. Structure only.
+- A third sentinel kind. Two is sufficient for the grammar.
+
+## Done when
+
+- `Document::main()` returns a `Card` whose sentinel matches
+  `Sentinel::Main(_)`.
+- `once(&doc.main()).chain(doc.cards())` covers every fence in the
+  source.
+- One emit code path serves both main and composable cards.
+- Frontmatter / body mutators live on `Card`, not on `Document`.
+- Existing tests migrate to the new access pattern; no
+  `Document::frontmatter` / `Document::body` callers remain.
+- `WASM_MIGRATION.md` gains a section describing the access-pattern
+  change.

--- a/prose/document-rework/README.md
+++ b/prose/document-rework/README.md
@@ -1,0 +1,60 @@
+# Document Rework
+
+**Umbrella goal:** make markdown the single contract between quillmark and
+its consumers. `Document.fromMarkdown → Document.toMarkdown` must be
+faithful enough that consumers never need to reparse source or splice
+bytes to preserve author intent.
+
+Today `Document.to_markdown()` is a canonical emitter that drops YAML
+comments and custom tags, which forces downstream consumers (registry
+editors, wizards) to ship their own comment-preserving YAML AST and
+byte-range splicers. The rework closes that gap inside quillmark so
+consumers can delete that code.
+
+## Taskings
+
+1. [03-unify-cards.md](03-unify-cards.md) — one `Card` type for both
+   the document entry (QUILL sentinel) and composable cards (CARD
+   sentinel). `Document { main: Card, cards: Vec<Card> }`.
+2. [01-frontmatter-comments.md](01-frontmatter-comments.md) — preserve
+   YAML comments in `Card.frontmatter` as first-class ordered items.
+3. [02-fill-typed-marker.md](02-fill-typed-marker.md) — promote `!fill`
+   to a typed marker on `Field`. Reject other custom tags.
+
+**Implementation order:** 03 → 01 → 02. Numeric prefixes reflect the
+order decisions were made, not the order to implement. 03 restructures
+the data model; 01 rebuilds the frontmatter representation on the
+unified model; 02 layers `!fill` semantics onto the item model from 01.
+
+## Explicit non-goals
+
+- **No byte offsets in the public API.** Considered and rejected. Markdown
+  is the serialization contract; exposing source locations would introduce
+  a second contract and undo the offload.
+- **No source-preserving mode.** Canonical emission stays canonical. The
+  items above make canonical *faithful* for the parts consumers care
+  about (comments, `!fill`); string quoting, flow vs block style, and
+  similar formatting are normalized by design.
+- **No general custom-tag round-trip.** Only `!fill` is integrated. Other
+  tags are rejected at parse with a warning.
+- **No comments inside nested YAML values.** Only top-level comments
+  round-trip. Nested comments are dropped silently; a parse warning is
+  emitted on the first occurrence per document.
+- **No markdown body AST, and no content-level transformations of the
+  body.** The body stays an opaque string between the frontmatter and
+  the first card fence. We do not walk its markdown structure, and we
+  do not ship utilities (comment strippers, link rewriters, etc.) that
+  would imply partial parsing. Downstream editors own their body
+  pipeline; when we commit to a markdown AST it will be a separate
+  design, not something smuggled in through helpers.
+- **No bare-YAML parse entry point.** Every Quillmark markdown document
+  carries `QUILL`; there is no supported authoring format that lacks
+  it. Consumers with a full document call `Document.fromMarkdown`;
+  consumers with something that isn't a Quillmark document should use a
+  general YAML library, not us. Speculative fragment-parse use cases
+  are YAGNI until a concrete consumer need is named.
+- **No document-level shortcuts for card mutators.** After 03,
+  frontmatter and body mutations live on `Card`. `Document.setField`
+  and friends are removed; callers write `doc.main_mut().set_field(…)`
+  (or hold a `&mut Card` reference). One surface, no parallel API to
+  keep in sync.

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -263,12 +263,51 @@ const rPng = session.render({ format: "png", ppi: 300, pages: [0, 2] });
 
 ---
 
+## Parse-time requirements that bite silently
+
+These are intentional behaviors but surface as errors consumers did not see in
+0.54. Listed here so migrators do not re-discover them from stack traces.
+
+### `Document.fromMarkdown` now requires `QUILL:` in frontmatter
+
+A top-level `QUILL: <name>` is a **parse-time** requirement on every input
+document. In 0.54, missing-QUILL surfaced at render time; in 0.58+ it fails
+inside `Document.fromMarkdown` with an `InvalidStructure` diagnostic whose
+message is `Missing required QUILL field. Add `QUILL: <name>` to the
+frontmatter`.
+
+Fix: add `QUILL: <name>` to the frontmatter of every document you parse. Test
+fixtures in particular rot silently — a fixture that used to render will now
+throw on parse.
+
+### `Quill.yaml` requires a nested `Quill:` section
+
+Flat top-level keys (`name:`, `backend:`, `description:` at the root) are not
+supported and will not be. Every field lives under the top-level `Quill:`
+mapping:
+
+```yaml
+Quill:
+  name: my_quill           # required, snake_case
+  backend: typst           # required
+  description: My quill    # required, non-empty
+  version: 0.1.0           # required, semver
+  author: Alice            # optional, defaults to "Unknown"
+```
+
+`name`, `backend`, `description`, and `version` are all required — only
+`author` has a default (`"Unknown"`). See
+`crates/core/src/quill/config.rs:615-672` for the full parse.
+
+---
+
 ## Unchanged
 
 The following are behaviorally unchanged by this refactor:
 
 - `new Quillmark()` constructor.
-- `engine.quill(tree)` where `tree` is `Map<string, Uint8Array>`.
+- `engine.quill(tree)` where `tree` is `Map<string, Uint8Array>` or
+  `Record<string, Uint8Array>` (plain object — normalized at the boundary).
 - `quill.open(doc)` → `session.pageCount` + `session.render(opts)`.
 - `quill.backendId` getter.
 - `RenderResult` shape: `{ artifacts, warnings, outputFormat, renderTimeMs }`.

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -280,14 +280,14 @@ Fix: add `QUILL: <name>` to the frontmatter of every document you parse. Test
 fixtures in particular rot silently — a fixture that used to render will now
 throw on parse.
 
-### `Quill.yaml` requires a nested `Quill:` section
+### `Quill.yaml` requires a nested `quill:` section
 
 Flat top-level keys (`name:`, `backend:`, `description:` at the root) are not
-supported and will not be. Every field lives under the top-level `Quill:`
-mapping:
+supported and will not be. Every field lives under the top-level `quill:`
+mapping (lowercase — previously capitalized `Quill:`, see note below):
 
 ```yaml
-Quill:
+quill:
   name: my_quill           # required, snake_case
   backend: typst           # required
   description: My quill    # required, non-empty
@@ -298,6 +298,11 @@ Quill:
 `name`, `backend`, `description`, and `version` are all required — only
 `author` has a default (`"Unknown"`). See
 `crates/core/src/quill/config.rs:615-672` for the full parse.
+
+> **Key name is `quill:` (lowercase).** Pre-0.58 drafts used `Quill:` with a
+> capital Q to match the filename; the published 0.58 line uses lowercase
+> `quill:` for YAML-idiom consistency. Capitalized `Quill:` is not accepted —
+> rename the section key in each `Quill.yaml` on migration.
 
 ---
 

--- a/prose/taskings/consumer_feedback_followups.md
+++ b/prose/taskings/consumer_feedback_followups.md
@@ -39,7 +39,7 @@ readonly metadata: {
   example?: string;          // example_file contents (if present)
   supportedFormats: string[];
   schema: unknown;           // raw schema from Quill.yaml; consumer validates
-  // ...other unstructured metadata from the Quill: section
+  // ...other unstructured metadata from the quill: section
 };
 ```
 
@@ -90,7 +90,7 @@ No memoization, no `toJSON()`. Deferred until more consumers hit this.
 The following are intentional behaviors being called out by consumers. No code change; add to the migration guide.
 
 - **`Document.fromMarkdown` now requires `QUILL:` in frontmatter.** Parse-time failure, not render-time. Fix: add `QUILL: <name>` to frontmatter. Note the shift from render-time to parse-time explicitly (test fixtures rot silently).
-- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-672`.
+- **`Quill.yaml` requires a nested `quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-672`.
 
 ## Out of scope
 

--- a/prose/taskings/consumer_feedback_followups.md
+++ b/prose/taskings/consumer_feedback_followups.md
@@ -1,0 +1,128 @@
+# Quillmark WASM: Downstream Consumer Feedback Followups
+
+**Audience:** Quillmark WASM binding maintainer
+**Source:** Consumer feedback from a 0.54 → 0.58 migration (registry-side)
+
+## Background
+
+A downstream consumer migrating from 0.54 to 0.58 surfaced a set of friction points in the WASM binding. Most are narrow fixes (doc comments, small API additions). Two are deliberate behaviors we will keep but document more clearly. One (the `init()` footgun) is inherent to `wasm-bindgen --target web` and needs a JS-side mitigation.
+
+Tasks are ordered by consumer impact × implementation cost. Items marked **docs-only** need no code changes beyond comments and the migration guide.
+
+## Tasks
+
+### 1. Accept `Record<string, Uint8Array>` in `engine.quill(tree)`
+
+Today `engine.quill()` rejects plain objects with `quill requires a Map<string, Uint8Array>`. The README advertises both shapes. Every consumer whose source of truth is a `Record` (most of them) has to write `new Map(Object.entries(files))` at the call site.
+
+**Change:** at the NAPI/WASM boundary in `crates/bindings/wasm/src/engine.rs`, normalize the input:
+
+```
+input instanceof Map ? input : new Map(Object.entries(input))
+```
+
+Update the TS signature to `Map<string, Uint8Array> | Record<string, Uint8Array>`. The Rust side keeps taking a single canonical shape — normalization stays at the boundary.
+
+### 2. Expose `Quill.metadata` (read-only snapshot of Quill.yaml)
+
+Consumers that used `engine.resolveQuill(name).example` / `.supportedFormats` in 0.54 have no replacement. They are re-parsing `Quill.yaml` with regexes to recover the data the engine already owns.
+
+**Change:** add a `metadata` getter on the `Quill` handle returning a plain JS object projection of the loaded `Quill.yaml`:
+
+```ts
+readonly metadata: {
+  name: string;
+  backend: string;
+  description: string;
+  version: string;
+  author: string;
+  example?: string;          // example_file contents (if present)
+  supportedFormats: string[];
+  schema: unknown;           // raw schema from Quill.yaml; consumer validates
+  // ...other unstructured metadata from the Quill: section
+};
+```
+
+Snapshot at `Quill` construction time, not live. One marshalling hop.
+
+The `schema` field ships raw (as parsed from YAML). The engine deliberately no longer owns schema validation in WASM; consumers that need it run their own validator against `metadata.schema`. This is consistent with the "schema APIs are no longer engine-level in WASM" note and gives consumers a supported path forward instead of regex-parsing the bytes themselves.
+
+### 3. Add `Document.clone()`
+
+`Document` has ~10 in-place mutators (`set_field`, `remove_field`, `push_card`, `insert_card`, `remove_card`, `move_card`, `update_card_field`, `update_card_body`, `replace_body`, `set_quill_ref` at `crates/bindings/wasm/src/engine.rs:266-408`). Once a consumer mutates, they cannot cheaply recover the pristine parse without holding the original markdown and re-calling `Document.fromMarkdown`.
+
+**Change:** add a `clone()` method on `Document`:
+
+```rust
+#[wasm_bindgen(js_name = clone)]
+pub fn clone_doc(&self) -> Document {
+    Document {
+        inner: self.inner.clone(),
+        parse_warnings: self.parse_warnings.clone(),
+    }
+}
+```
+
+Doc comment must state explicitly: parse-time warnings are snapshotted (they describe the document, not the edit history).
+
+### 4. Ship a JS shim that lazy-inits the WASM module
+
+Forgetting `await init()` still produces cryptic panics deep inside the wasm module. This is inherent to `wasm-bindgen --target web` and cannot be fixed on the Rust side.
+
+**Change:** ship a thin JS wrapper around the generated bindings. The wrapper exports lazy-initialized proxies for `Quillmark`, `Document`, etc.; first access awaits the generated `init()` once and caches the promise. Subsequent calls are zero-cost.
+
+Done well this turns the landmine into a non-issue. The consumer's complaint that this was "unchanged from 0.54" implies they expect it to stay broken — fixing it is a real DX upgrade with no Rust-side cost.
+
+If the shim approach is rejected, fall back to:
+- A prominent "You must `await init()` first" block at the top of the README.
+- A custom panic hook that detects "accessed before init" and throws a legible error rather than a wasm trap.
+
+### 5. Document `RenderOptions.pages` indexing **(docs-only)**
+
+The pages array is 0-indexed (confirmed: `crates/backends/typst/src/compile.rs:175-178` uses the values as direct indices into `document.pages`, default is `(0..page_count).collect()`). The TS type has no JSDoc, so the convention is not self-evident and 0.54 callers migrating may assume 1-indexed.
+
+**Change:** update the doc comment on `pages` in both `crates/bindings/wasm/src/types.rs:182` and `crates/core/src/types.rs:34`:
+
+> Optional 0-based page indices to render (e.g., `[0, 2]` for first and third pages). `undefined` renders all pages. **Not supported for PDF output** — see `FormatNotSupported`.
+
+wasm-bindgen propagates Rust doc comments to the generated `.d.ts`, so IDE hover picks this up automatically.
+
+### 6. Document `Document` getter allocation cost **(docs-only)**
+
+`frontmatter`, `cards`, and `warnings` each build a fresh `serde_json::Value` and call `serialize_maps_as_objects` on every access (`crates/bindings/wasm/src/engine.rs:199-256`). `body` allocates a `String` but is much cheaper; `quillRef` is trivial.
+
+**Change:** add a one-line cost note to the three serializing getters' doc comments, e.g.:
+
+> Allocates and serializes on each call — cache locally if read in a hot loop.
+
+No memoization, no `toJSON()`. Deferred until more consumers hit this.
+
+### 7. Migration guide updates **(docs-only)**
+
+The following are intentional behaviors being called out by consumers. No code change; add to the migration guide.
+
+- **`Document.fromMarkdown` now requires `QUILL:` in frontmatter.** Parse-time failure, not render-time. Fix: add `QUILL: <name>` to frontmatter. Note the shift from render-time to parse-time explicitly (test fixtures rot silently).
+- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-666`.
+
+## Out of scope
+
+- Flattening `Quill.yaml` back to top-level keys. The nested shape is deliberate (room for sibling sections like `typst:`, `cards:`, `main:`).
+- Making `description` optional. It is required by design.
+- `Document.toJSON()` — deferred. No clear need from the current feedback.
+- A `Document.fromMarkdown(md, { quill: name })` overload that injects `QUILL:` — deferred. Possible future ergonomic win; not required by the current feedback.
+- Replacing the Document handle with a plain JSON object. `toMarkdown()` needs Rust state, and a JSON-only API would force awkward statics.
+
+## Test updates
+
+- `crates/bindings/wasm/tests/` — add a test that `engine.quill({ "Quill.yaml": ..., ... })` (plain object) succeeds with the same result as the `Map` form.
+- `crates/bindings/wasm/tests/metadata.rs` — extend to assert `quill.metadata` exposes `name`, `backend`, `description`, `version`, `supportedFormats`, and the raw `schema` field.
+- `crates/bindings/wasm/tests/` — add a test that `doc.clone()` returns a fresh handle, mutations on the clone do not affect the original, and parse warnings are preserved on the clone.
+
+## Done when
+
+- Consumers can pass a `Record<string, Uint8Array>` to `engine.quill()` without a helper.
+- `quill.metadata` returns the data consumers used to get from `engine.resolveQuill(name)` — no regex-parsing of `Quill.yaml` required.
+- `doc.clone()` produces a mutable copy without re-parsing markdown.
+- The JS shim (or the documented fallback) eliminates the `init()` footgun for common integration paths.
+- `RenderOptions.pages` and the three serializing Document getters carry doc comments that make their behavior obvious from IDE hover.
+- The migration guide explicitly calls out the `QUILL:` parse-time requirement and the `Quill.yaml` required-field list.

--- a/prose/taskings/consumer_feedback_followups.md
+++ b/prose/taskings/consumer_feedback_followups.md
@@ -5,7 +5,7 @@
 
 ## Background
 
-A downstream consumer migrating from 0.54 to 0.58 surfaced a set of friction points in the WASM binding. Most are narrow fixes (doc comments, small API additions). Two are deliberate behaviors we will keep but document more clearly. One (the `init()` footgun) is inherent to `wasm-bindgen --target web` and needs a JS-side mitigation.
+A downstream consumer migrating from 0.54 to 0.58 surfaced a set of friction points in the WASM binding. Most are narrow fixes (doc comments, small API additions). Two are deliberate behaviors we will keep but document more clearly.
 
 Tasks are ordered by consumer impact × implementation cost. Items marked **docs-only** need no code changes beyond comments and the migration guide.
 
@@ -49,7 +49,7 @@ The `schema` field ships raw (as parsed from YAML). The engine deliberately no l
 
 ### 3. Add `Document.clone()`
 
-`Document` has ~10 in-place mutators (`set_field`, `remove_field`, `push_card`, `insert_card`, `remove_card`, `move_card`, `update_card_field`, `update_card_body`, `replace_body`, `set_quill_ref` at `crates/bindings/wasm/src/engine.rs:266-408`). Once a consumer mutates, they cannot cheaply recover the pristine parse without holding the original markdown and re-calling `Document.fromMarkdown`.
+`Document` has ~10 in-place mutators (`set_field`, `remove_field`, `push_card`, `insert_card`, `remove_card`, `move_card`, `update_card_field`, `update_card_body`, `replace_body`, `set_quill_ref` at `crates/bindings/wasm/src/engine.rs:265-410`). Once a consumer mutates, they cannot cheaply recover the pristine parse without holding the original markdown and re-calling `Document.fromMarkdown`.
 
 **Change:** add a `clone()` method on `Document`:
 
@@ -65,19 +65,7 @@ pub fn clone_doc(&self) -> Document {
 
 Doc comment must state explicitly: parse-time warnings are snapshotted (they describe the document, not the edit history).
 
-### 4. Ship a JS shim that lazy-inits the WASM module
-
-Forgetting `await init()` still produces cryptic panics deep inside the wasm module. This is inherent to `wasm-bindgen --target web` and cannot be fixed on the Rust side.
-
-**Change:** ship a thin JS wrapper around the generated bindings. The wrapper exports lazy-initialized proxies for `Quillmark`, `Document`, etc.; first access awaits the generated `init()` once and caches the promise. Subsequent calls are zero-cost.
-
-Done well this turns the landmine into a non-issue. The consumer's complaint that this was "unchanged from 0.54" implies they expect it to stay broken — fixing it is a real DX upgrade with no Rust-side cost.
-
-If the shim approach is rejected, fall back to:
-- A prominent "You must `await init()` first" block at the top of the README.
-- A custom panic hook that detects "accessed before init" and throws a legible error rather than a wasm trap.
-
-### 5. Document `RenderOptions.pages` indexing **(docs-only)**
+### 4. Document `RenderOptions.pages` indexing **(docs-only)**
 
 The pages array is 0-indexed (confirmed: `crates/backends/typst/src/compile.rs:175-178` uses the values as direct indices into `document.pages`, default is `(0..page_count).collect()`). The TS type has no JSDoc, so the convention is not self-evident and 0.54 callers migrating may assume 1-indexed.
 
@@ -87,7 +75,7 @@ The pages array is 0-indexed (confirmed: `crates/backends/typst/src/compile.rs:1
 
 wasm-bindgen propagates Rust doc comments to the generated `.d.ts`, so IDE hover picks this up automatically.
 
-### 6. Document `Document` getter allocation cost **(docs-only)**
+### 5. Document `Document` getter allocation cost **(docs-only)**
 
 `frontmatter`, `cards`, and `warnings` each build a fresh `serde_json::Value` and call `serialize_maps_as_objects` on every access (`crates/bindings/wasm/src/engine.rs:199-256`). `body` allocates a `String` but is much cheaper; `quillRef` is trivial.
 
@@ -97,12 +85,12 @@ wasm-bindgen propagates Rust doc comments to the generated `.d.ts`, so IDE hover
 
 No memoization, no `toJSON()`. Deferred until more consumers hit this.
 
-### 7. Migration guide updates **(docs-only)**
+### 6. Migration guide updates **(docs-only)**
 
 The following are intentional behaviors being called out by consumers. No code change; add to the migration guide.
 
 - **`Document.fromMarkdown` now requires `QUILL:` in frontmatter.** Parse-time failure, not render-time. Fix: add `QUILL: <name>` to frontmatter. Note the shift from render-time to parse-time explicitly (test fixtures rot silently).
-- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-666`.
+- **`Quill.yaml` requires a nested `Quill:` section.** Flat top-level keys were never supported in 0.58+ and will not be. The required fields inside `Quill:` are `name`, `backend`, `description`, `version` (only `author` has a default, `"Unknown"`). See `crates/core/src/quill/config.rs:615-672`.
 
 ## Out of scope
 
@@ -123,6 +111,5 @@ The following are intentional behaviors being called out by consumers. No code c
 - Consumers can pass a `Record<string, Uint8Array>` to `engine.quill()` without a helper.
 - `quill.metadata` returns the data consumers used to get from `engine.resolveQuill(name)` — no regex-parsing of `Quill.yaml` required.
 - `doc.clone()` produces a mutable copy without re-parsing markdown.
-- The JS shim (or the documented fallback) eliminates the `init()` footgun for common integration paths.
 - `RenderOptions.pages` and the three serializing Document getters carry doc comments that make their behavior obvious from IDE hover.
 - The migration guide explicitly calls out the `QUILL:` parse-time requirement and the `Quill.yaml` required-field list.

--- a/prose/taskings/wasm_type_surface.md
+++ b/prose/taskings/wasm_type_surface.md
@@ -1,0 +1,255 @@
+# WASM Type Surface & Body-Separator Refactor Tasking
+
+**Audience:** Quillmark engine + WASM binding maintainer
+**Consumer feedback source:** `@quillmark/quiver` authors (post-integration review)
+**Branch:** `claude/review-consumer-feedback-TRloK`
+**wasm-bindgen version:** 0.2.118 (supports `unchecked_param_type` /
+`unchecked_return_type`; added in 0.2.95).
+
+## Background
+
+A downstream consumer reviewed the generated `.d.ts` for `@quillmark/wasm` and
+flagged four friction points where the binding forces runtime assertions that
+should be compile-time checks. Three are binding-level typing fixes. The
+fourth, initially framed as a binding concern (`trim_body` scattered across
+output paths), turned out to be a symptom of a core storage decision and is
+promoted to a core refactor.
+
+Scope is bounded: no change to `render`, `parseMarkdown`, selector resolution,
+or plate wire format. No new public surface area beyond what's listed.
+
+## Tasks
+
+### 1a. `Quillmark.quill(tree)` — narrow the declared input type
+
+Today `quill(tree: any): Quill` in the generated `.d.ts`. The runtime strictly
+requires `js_sys::Map` (`crates/bindings/wasm/src/engine.rs:502`). Narrow the
+declared type to match runtime truth:
+
+```rust
+#[wasm_bindgen(js_name = quill, unchecked_param_type = "Map<string, Uint8Array>")]
+pub fn quill(&self, tree: JsValue) -> Result<Quill, JsValue>
+```
+
+Zero runtime change. Anyone currently passing a `Map` keeps compiling.
+
+### 1b. `Quillmark.quill(tree)` — also accept `Record` (deferred)
+
+Accepting `Record<string, Uint8Array>` is a separate *runtime* change that adds
+a code path for consumer convenience (`new Map(Object.entries(x))` is the
+current workaround). The ergonomic win is small relative to the maintenance
+cost, and it would be a silent behaviour change for callers who used to get
+a clear error on plain-object input.
+
+**Deferred.** Revisit only if concrete consumer friction demands it.
+
+### 2. `pushCard` / `insertCard` — typed input via TS-only `CardInput`
+
+Today both methods accept `card: any`. The runtime shape is already defined by
+the function-local `CardInput` struct in `js_value_to_card`
+(`crates/bindings/wasm/src/engine.rs:430`): `tag` required, `fields` and
+`body` optional with serde defaults.
+
+**Deliberately rejected:** promoting the local `CardInput` to a public
+tsify-derived binding struct. That would export a nominal type consumers must
+import, add a `TryFrom` indirection, and is overkill for two call sites. The
+function-local struct stays.
+
+**Change:**
+
+1. Add a `typescript_custom_section`:
+
+   ```rust
+   #[wasm_bindgen(typescript_custom_section)]
+   const CARD_INPUT_TS: &'static str = r#"
+   export interface CardInput {
+     tag: string;
+     fields?: Record<string, unknown>;
+     body?: string;
+   }
+   "#;
+   ```
+
+2. Annotate the two methods:
+
+   ```rust
+   #[wasm_bindgen(js_name = pushCard, unchecked_param_type = "CardInput")]
+   pub fn push_card(&mut self, card: JsValue) -> Result<(), JsValue>
+
+   #[wasm_bindgen(js_name = insertCard, unchecked_param_type = "CardInput")]
+   pub fn insert_card(&mut self, index: usize, card: JsValue) -> Result<(), JsValue>
+   ```
+
+`js_value_to_card` stays unchanged. TS-only type, no Rust-side plumbing.
+
+### 3. Typed output getters — `cards`, `frontmatter`, `warnings`
+
+Today all three return `JsValue` (emitted as `any`). Each method rebuilds a
+`serde_json::Value` and hands it to `serde_wasm_bindgen` manually — a
+hand-rolled reimplementation of what the tsify-derived `Card` and `Diagnostic`
+types in `crates/bindings/wasm/src/types.rs` already do automatically.
+
+**Change:** return typed values and delete the JSON scaffolding.
+
+1. `cards()` returns `Vec<Card>`:
+
+   ```rust
+   #[wasm_bindgen(getter, js_name = cards)]
+   pub fn cards(&self) -> Vec<Card> {
+       self.inner.cards().iter().map(Card::from).collect()
+   }
+   ```
+
+   Add a `From<&quillmark_core::Card> for Card` impl in `types.rs` that
+   constructs the tsify struct from core fields.
+
+2. `warnings()` returns `Vec<Diagnostic>`:
+
+   ```rust
+   #[wasm_bindgen(getter, js_name = warnings)]
+   pub fn warnings(&self) -> Vec<Diagnostic> {
+       self.parse_warnings.iter().cloned().map(Into::into).collect()
+   }
+   ```
+
+3. `frontmatter()` returns a tsify newtype wrapping `serde_json::Value` with
+   `#[tsify(type = "Record<string, unknown>")]`, matching the convention
+   already used on `Card.fields` (`types.rs:164`).
+
+4. **Delete** `card_to_js_value` (`engine.rs:457`). This also changes
+   `removeCard`: today it returns `JsValue` (typed as `any`, semantically
+   `Card | undefined`). Change the return type to `Option<Card>` so the
+   generated `.d.ts` declares `Card | undefined` explicitly.
+
+   **This is a public API change** — the runtime shape is unchanged (object
+   or `undefined`), but the declared TS type narrows. Consumers who relied
+   on `any` lose the implicit-any escape hatch.
+
+### 4. Remove F2 separator storage from core (deeper fix)
+
+The binding-level `trim_body` helper (`engine.rs:476`) is applied in three
+output paths (`body`, `cards`, `card_to_js_value`). Its own doc comment
+(`engine.rs:471-479`) names the issue: the trailing newline characters are
+"structural separators, not part of what the document author wrote" — yet
+they live in `Card.body` and `Document.body` storage and every consumer-facing
+read has to strip them.
+
+**Semantic correction from initial draft.** `trim_body`'s current
+implementation (`trim_end_matches(|c| c == '\n' || c == '\r')`) strips **all**
+trailing newlines, conflating two distinct things:
+
+- The F2 *blank line* required before the next fence (exactly one line ending
+  at the tail of a body that's followed by another block). This is structural.
+- Any line-ending or trailing whitespace that's part of the author's content
+  (e.g. a code block that ends with `\n`). This is content.
+
+Moving `trim_body`-as-written into core would propagate the conflation — every
+reader would see content-ending newlines silently dropped. The correct model
+is narrower.
+
+**Correct model.**
+
+- **F2 separator = exactly one line ending at the tail of a body slice that is
+  followed by another metadata block.** For `\n` line endings, that's one
+  `\n`. For `\r\n`, that's one `\r\n`.
+- Bodies at end-of-document have no F2 separator to strip.
+- Author content after the strip is preserved verbatim, including its own line
+  terminators.
+
+Worked example: `...---\nalpha\n\n---\nCARD: x...`
+- Raw body slice = `"alpha\n\n"` (seven bytes).
+- The tail `\n` is the F2 blank line; the first `\n` terminates the `alpha`
+  line — that's content.
+- Stored body = `"alpha\n"`.
+- Emit side already ensures `\n\n` before the next fence (`emit.rs:140`), so
+  round-trip byte equality holds.
+
+**Change:**
+
+1. **Parse side** (`crates/core/src/document/assemble.rs`): when extracting a
+   body segment that is followed by another block (i.e. `idx + 1 < blocks.len()`
+   for card bodies, or a CARD block exists for the global body), strip exactly
+   one trailing line ending. Bodies at EOF are stored as-is.
+
+   Implement as a private helper in `assemble.rs`:
+
+   ```rust
+   fn strip_f2_separator(body: &str) -> &str {
+       if let Some(rest) = body.strip_suffix("\r\n") { rest }
+       else if let Some(rest) = body.strip_suffix('\n') { rest }
+       else { body }
+   }
+   ```
+
+2. **Edit side** (`crates/core/src/document/edit.rs:158`, `:315`): no change.
+   `set_body` / `replace_body` continue to accept arbitrary strings as-is; the
+   emitter already adds the F2 separator on output, so a consumer setting
+   `replace_body("x")` still round-trips correctly. **Not** normalising on
+   input means `get_body` returns what was set.
+
+3. **Emit side** (`crates/core/src/document/emit.rs:140`): no change needed.
+   `ensure_blank_line_before_fence` already handles bodies ending in `\n`,
+   `\n\n`, or no newline. Verify with tests; adjust only if a round-trip case
+   fails.
+
+4. **Binding side**: delete `trim_body` entirely. `Document.body` getter
+   forwards `self.inner.body().to_string()`. The `From<&core::Card> for Card`
+   impl from Task 3 copies the body without trimming.
+
+**Load-bearing tests.**
+
+- Round-trip byte equality: for every fixture in
+  `crates/core/src/document/tests/fixtures/`, `emit(decompose(src)) == src`
+  (modulo documented canonicalisation).
+- **Content fidelity:** a body ending in `\n` as author content survives
+  round-trip. Construct a case: `---\nCARD: x\n---\ncode line\n\n---\nCARD: y\n---\n`
+  — the first card's body should be `"code line\n"` (not `"code line"`), and
+  re-emitting should restore `\n\n` before the next fence.
+
+**Scope estimate:** medium. Touches parser + emitter audit + test fixtures +
+binding cleanup. ~4 distinct commits: parse-side strip, binding trim removal,
+test updates, cross-crate verification.
+
+## Out of scope
+
+- Changes to plate wire format or `to_plate_json`. That format is a backend
+  contract separate from the Document representation.
+- Any new public API beyond `CardInput` (TS-only) and the return-type
+  changes on existing getters.
+- Reworking `updateCardField` / `setField` — those take a `JsValue` value
+  because field values are genuinely dynamic (`unknown` on the TS side).
+  They're already typed reasonably; a future pass can tighten to `unknown`
+  if `any` is still showing through.
+
+## Test updates
+
+- **Task 1a:** `tsc --noEmit` fixture that rejects `quill({})` at compile
+  time and accepts `quill(new Map<string, Uint8Array>())`.
+- **Task 2:** no runtime test change. Add a `.d.ts` snapshot or `tsc`
+  fixture importing `CardInput` and calling `pushCard({ tag: "foo" })`.
+- **Task 3:** existing tests that assert shape of `cards` / `warnings` /
+  `frontmatter` should keep passing. Add a TS fixture that relies on the
+  narrowed types (e.g. `doc.cards[0].tag` type-checks without a cast).
+- **Task 4:**
+  - Update `test_body_with_trailing_newlines`
+    (`assemble_tests.rs:1572`) to match the new model — at EOF, trailing
+    content newlines are preserved; followed by a fence, exactly one line
+    ending is stripped.
+  - Add an explicit F2-strip test covering `\n`, `\r\n`, and multi-newline
+    cases for bodies followed by a fence.
+  - Add a content-fidelity test asserting that a body ending in `\n` as
+    content survives round-trip.
+
+## Done when
+
+- `.d.ts` for `@quillmark/wasm` contains no `any` on `quill`, `pushCard`,
+  `insertCard`, `removeCard`, `cards`, `frontmatter`, or `warnings`.
+- `CardInput` is exported from the `.d.ts` and accepts object literals
+  without a nominal import.
+- `trim_body` is deleted from `crates/bindings/wasm/src/engine.rs`.
+- Core `Card::body()` / `Document::body()` return exactly what was authored
+  (or set), with the F2 structural separator removed on parse and re-added
+  on emit.
+- Markdown round-trip byte equality holds for all existing fixtures.
+- Content-fidelity test (body ending in `\n`) passes.
+- No existing wasm or core tests regress.


### PR DESCRIPTION
Captures the decisions from iterating on downstream feedback: accept
Record<string, Uint8Array> in engine.quill(), expose Quill.metadata,
add Document.clone(), ship a JS shim for the init() footgun, plus
doc-only fixes for pages indexing, getter allocation cost, and
migration notes.