### PR TITLE
ci: migrate crates.io and PyPI publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,9 @@ jobs:
     needs: [release]
     runs-on: ubuntu-latest
     environment: Publish
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -109,10 +112,14 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Authenticate with crates.io (Trusted Publishing)
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish workspace crates
         run: cargo publish --locked --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
       - name: Summary
         run: echo "✓ Workspace crates v${{ needs.release.outputs.version }} published to crates.io"
@@ -288,6 +295,8 @@ jobs:
     needs: [release, build-python-linux, build-python-windows, build-python-macos, build-python-sdist]
     runs-on: ubuntu-latest
     environment: Publish
+    permissions:
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -296,13 +305,10 @@ jobs:
           merge-multiple: true
           path: dist/
 
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+          skip-existing: true
 
       - name: Summary
         run: echo "✓ quillmark v${{ needs.release.outputs.version }} published to PyPI"

--- a/prose/designs/CI_CD.md
+++ b/prose/designs/CI_CD.md
@@ -46,9 +46,9 @@ Excluded: multi-OS matrix, MSRV, security scanners, coverage, benchmarks.
 
 | Target | Registry | Auth |
 |--------|----------|------|
-| Rust crates | crates.io | `CARGO_REGISTRY_TOKEN` secret (via `Publish` environment) |
+| Rust crates | crates.io | OIDC Trusted Publishing via `rust-lang/crates-io-auth-action` (`id-token: write`) |
 | WASM bindings | npm | OIDC Trusted Publisher (`id-token: write`) |
-| Python bindings | PyPI | `MATURIN_PYPI_TOKEN` secret (via `Publish` environment) |
+| Python bindings | PyPI | OIDC Trusted Publishing via `pypa/gh-action-pypi-publish` (`id-token: write`) |
 
 - **Crates**: `cargo publish --locked --no-verify`
 - **WASM**: builds via `./scripts/build-wasm.sh`, runs `npm test`, publishes `@quillmark/wasm` with `--provenance`


### PR DESCRIPTION
Replace static registry tokens with OIDC-based Trusted Publishing for
both crates.io and PyPI, matching the npm setup already in place:

- publish-crates: use rust-lang/crates-io-auth-action@v1 to obtain a
  short-lived token; drop secrets.CARGO_REGISTRY_TOKEN.
- publish-python: use pypa/gh-action-pypi-publish@release/v1 with
  id-token: write; drop secrets.PYPI_TOKEN / MATURIN_PYPI_TOKEN.

Both jobs keep the Publish environment gate. Update CI_CD.md to reflect
the new auth mechanism across all three registries.

Note: trusted publishers must be configured on crates.io and PyPI
(repo nibsbin/quillmark, workflow release.yml, environment Publish)
before the next release will authenticate successfully.

https://claude.ai/code/session_01UbyvKsvBBntuj2Dtk3nELC