### PR TITLE
feat(wasm): add Document.removeCardField for card frontmatter

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -473,6 +473,23 @@ Card body.
     expect(() => doc.updateCardField(0, 'title', 'x')).toThrow(/IndexOutOfRange/)
   })
 
+  it('removeCardField returns the removed value and deletes the key', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARD)
+    const removed = doc.removeCardField(0, 'foo')
+    expect(removed).toBe('bar')
+    expect('foo' in doc.cards[0].frontmatter).toBe(false)
+  })
+
+  it('removeCardField returns undefined when field absent', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARD)
+    expect(doc.removeCardField(0, 'nonexistent')).toBeUndefined()
+  })
+
+  it('removeCardField throws IndexOutOfRange when card absent', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
+    expect(() => doc.removeCardField(0, 'foo')).toThrow(/IndexOutOfRange/)
+  })
+
   it('updateCardBody replaces card body', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
     doc.updateCardBody(0, 'New card body.')

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -518,6 +518,30 @@ impl Document {
         card.set_field(name, qv).map_err(|e| edit_error_to_js(&e))
     }
 
+    /// Remove a frontmatter field on the card at `index`, returning the
+    /// removed value or `undefined` if the field was absent.
+    ///
+    /// Throws if `index` is out of range.
+    ///
+    /// Mutators never modify `warnings`.
+    #[wasm_bindgen(js_name = removeCardField)]
+    pub fn remove_card_field(&mut self, index: usize, name: &str) -> Result<JsValue, JsValue> {
+        let len = self.inner.cards().len();
+        let card = self.inner.card_mut(index).ok_or_else(|| {
+            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+        })?;
+        Ok(match card.remove_field(name) {
+            Some(v) => {
+                let serializer =
+                    serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+                v.as_json()
+                    .serialize(&serializer)
+                    .unwrap_or(JsValue::UNDEFINED)
+            }
+            None => JsValue::UNDEFINED,
+        })
+    }
+
     /// Replace the body of the card at `index`.
     ///
     /// Throws if `index` is out of range.


### PR DESCRIPTION
Cards previously had no counterpart to the main card's `removeField`.
Consumers had to either set the field to literal null (which stored a
null value rather than removing the key) or hand-roll a remove+reinsert
of the entire card. Bridges the existing `Card::remove_field` from core
through the WASM surface so card field removal is symmetric with the
main card.