### PR TITLE
fix(wasm): emit Artifact.bytes as a real Uint8Array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde-wasm-bindgen 0.6.5",
+ "serde_bytes",
  "serde_json",
  "tsify",
  "wasm-bindgen",
@@ -2636,6 +2637,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -23,6 +23,7 @@ quillmark-core = { workspace = true }
 indexmap = { workspace = true }
 wasm-bindgen = "0.2"
 serde = { workspace = true }
+serde_bytes = "0.11"
 serde_json = { workspace = true }
 serde-saphyr = { workspace = true }
 serde-wasm-bindgen = "0.6"

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -228,6 +228,9 @@ describe('Quillmark.quill', () => {
     expect(result).toBeDefined()
     expect(result.artifacts).toBeDefined()
     expect(result.artifacts.length).toBeGreaterThan(0)
+    // The declared TS type is Uint8Array — assert the runtime matches so
+    // consumers don't need to defensively coerce `new Uint8Array(bytes)`.
+    expect(result.artifacts[0].bytes).toBeInstanceOf(Uint8Array)
     expect(result.artifacts[0].bytes.length).toBeGreaterThan(0)
     expect(result.artifacts[0].mimeType).toBe('application/pdf')
   })

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -1,6 +1,5 @@
 //! Type definitions for the WASM API
 
-
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -113,6 +113,10 @@ impl From<quillmark_core::Diagnostic> for Diagnostic {
 #[serde(rename_all = "camelCase")]
 pub struct Artifact {
     pub format: OutputFormat,
+    /// Serialized via `serde_bytes` so `serde_wasm_bindgen` emits a real
+    /// `Uint8Array` at the boundary instead of a `number[]`. Without this
+    /// annotation, the declared `Uint8Array` type would silently lie.
+    #[serde(with = "serde_bytes")]
     #[tsify(type = "Uint8Array")]
     pub bytes: Vec<u8>,
     pub mime_type: String,

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -1,5 +1,6 @@
 //! Type definitions for the WASM API
 
+
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -86,6 +86,44 @@ fn test_render_from_document() {
     );
 }
 
+/// Artifact bytes must cross the WASM boundary as a real `Uint8Array`, not a
+/// `number[]`. The declared TS type is `Uint8Array`; this guards against the
+/// type silently lying when serde's default `Vec<u8>` serializer reverts to
+/// `Array<number>`.
+#[wasm_bindgen_test]
+fn test_artifact_bytes_is_uint8array() {
+    use serde::Serialize;
+    use wasm_bindgen::{JsCast, JsValue};
+
+    let engine = Quillmark::new();
+    let quill = engine.quill(small_quill_tree()).expect("quill failed");
+    let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
+    let result = quill
+        .render(&doc, Some(RenderOptions::default()))
+        .expect("render failed");
+    assert!(!result.artifacts.is_empty(), "should produce artifacts");
+
+    // Round-trip the RenderResult through the same serializer Tsify uses for
+    // `into_wasm_abi`. The boundary representation is what JS consumers see.
+    let serializer = serde_wasm_bindgen::Serializer::new();
+    let js_result = result
+        .serialize(&serializer)
+        .expect("RenderResult serialization");
+    let artifacts = js_sys::Reflect::get(&js_result, &JsValue::from_str("artifacts"))
+        .expect("artifacts present");
+    let arr = js_sys::Array::from(&artifacts);
+    assert!(arr.length() > 0, "artifacts array non-empty");
+
+    let first = arr.get(0);
+    let bytes = js_sys::Reflect::get(&first, &JsValue::from_str("bytes")).expect("bytes present");
+    assert!(
+        bytes.is_instance_of::<js_sys::Uint8Array>(),
+        "artifact.bytes must be a Uint8Array at the WASM boundary, not a number[]"
+    );
+    let typed = bytes.unchecked_into::<js_sys::Uint8Array>();
+    assert!(typed.length() > 0, "Uint8Array has bytes");
+}
+
 /// `quill.open(Document)` returns a render session supporting page_count + render.
 #[wasm_bindgen_test]
 fn test_open_session_render() {


### PR DESCRIPTION
The TS surface declared `Artifact.bytes: Uint8Array` via tsify, but the
underlying `Vec<u8>` went through serde's default `serialize_seq` path,
which `serde_wasm_bindgen` emits as `Array<number>`. Consumers had to
defensively coerce `bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)`
because the type was lying.

Annotate the field with `#[serde(with = "serde_bytes")]` so it triggers
`serialize_bytes`, which `serde_wasm_bindgen` emits as a real
`Uint8Array`. Type and runtime now agree; consumer coercion is no
longer required.