### PR TITLE
feat(core, wasm, python): tighten card/field editing surface

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -350,9 +350,18 @@ impl PyDocument {
 
     /// Remove a frontmatter field from the main card, returning the value or `None`.
     ///
+    /// Raises `quillmark.EditError` if `name` is reserved (`BODY`, `CARDS`,
+    /// `QUILL`, `CARD`) or does not match `[a-z_][a-z0-9_]*`. Validation is
+    /// symmetric with `set_field`.
+    ///
     /// This method never modifies `warnings`.
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-        match self.inner.main_mut().remove_field(name) {
+        match self
+            .inner
+            .main_mut()
+            .remove_field(name)
+            .map_err(convert_edit_error)?
+        {
             Some(v) => quillvalue_to_py(py, &v),
             None => py.None().into_bound_py_any(py),
         }
@@ -428,6 +437,23 @@ impl PyDocument {
     fn move_card(&mut self, from_idx: usize, to_idx: usize) -> PyResult<()> {
         self.inner
             .move_card(from_idx, to_idx)
+            .map_err(convert_edit_error)
+    }
+
+    /// Replace the tag of the composable card at `index`.
+    ///
+    /// Mutates only the sentinel — the card's frontmatter and body are
+    /// untouched. Schema-aware migration (clearing orphan fields, applying
+    /// new defaults) is the caller's responsibility; `set_card_tag` is a
+    /// structural primitive.
+    ///
+    /// Raises `quillmark.EditError` if `index` is out of range or `new_tag`
+    /// does not match `[a-z_][a-z0-9_]*`.
+    ///
+    /// This method never modifies `warnings`.
+    fn set_card_tag(&mut self, index: usize, new_tag: &str) -> PyResult<()> {
+        self.inner
+            .set_card_tag(index, new_tag)
             .map_err(convert_edit_error)
     }
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -351,8 +351,8 @@ impl PyDocument {
     /// Remove a frontmatter field from the main card, returning the value or `None`.
     ///
     /// Raises `quillmark.EditError` if `name` is reserved (`BODY`, `CARDS`,
-    /// `QUILL`, `CARD`) or does not match `[a-z_][a-z0-9_]*`. Validation is
-    /// symmetric with `set_field`.
+    /// `QUILL`, `CARD`) or does not match `[a-z_][a-z0-9_]*`. Absence of an
+    /// otherwise-valid name returns `None`.
     ///
     /// This method never modifies `warnings`.
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -63,9 +63,22 @@ Render with a pre-parsed `Document`.
 ### `quill.open(parsed)` + `session.render(opts?)`
 Open once, render all or selected pages (`opts.pages`).
 
+### Errors
+
+Every method that can fail throws a JS `Error` with a flat shape:
+
+```ts
+{ message: string, diagnostics: Diagnostic[] }
+```
+
+`diagnostics` is always non-empty — length 1 for most failures, length N for
+backend compilation errors. Read `err.diagnostics[0]` for the primary
+diagnostic; iterate the array for compilation failures.
+
 ## Notes
 
-- Parsed markdown requires top-level `QUILL` in frontmatter.
+- Parsed markdown requires top-level `QUILL` in frontmatter. Empty input
+  surfaces a dedicated "Empty markdown input cannot be parsed" message.
 - QUILL mismatch during `quill.render(parsed)` is a warning (`quill::ref_mismatch`), not an error.
 - Output schema APIs are no longer engine-level in WASM.
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -122,9 +122,9 @@ This document has no QUILL tag.`
   })
 
   it('attaches err.diagnostics as a non-empty array on thrown errors', () => {
-    // The wasm bindings normalise all thrown errors to a flat
-    // { message, diagnostics[] } shape regardless of whether the underlying
-    // failure produced one diagnostic or many.
+    // Thrown errors normalise to a flat { message, diagnostics[] } shape
+    // regardless of whether the underlying failure produced one diagnostic
+    // or many.
     try {
       Document.fromMarkdown('')
       throw new Error('fromMarkdown should have thrown')
@@ -134,8 +134,6 @@ This document has no QUILL tag.`
       expect(err.diagnostics[0]).toHaveProperty('message')
       expect(err.diagnostics[0]).toHaveProperty('severity')
       expect(err.message).toMatch(/Empty markdown input/)
-      // The pre-0.62 .diagnostic (singular) wrapper is gone.
-      expect(err.diagnostic).toBeUndefined()
     }
   })
 })

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -120,6 +120,24 @@ This document has no QUILL tag.`
       Document.fromMarkdown(markdownWithoutQuill)
     }).toThrow()
   })
+
+  it('attaches err.diagnostics as a non-empty array on thrown errors', () => {
+    // The wasm bindings normalise all thrown errors to a flat
+    // { message, diagnostics[] } shape regardless of whether the underlying
+    // failure produced one diagnostic or many.
+    try {
+      Document.fromMarkdown('')
+      throw new Error('fromMarkdown should have thrown')
+    } catch (err) {
+      expect(Array.isArray(err.diagnostics)).toBe(true)
+      expect(err.diagnostics.length).toBeGreaterThanOrEqual(1)
+      expect(err.diagnostics[0]).toHaveProperty('message')
+      expect(err.diagnostics[0]).toHaveProperty('severity')
+      expect(err.message).toMatch(/Empty markdown input/)
+      // The pre-0.62 .diagnostic (singular) wrapper is gone.
+      expect(err.diagnostic).toBeUndefined()
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -345,6 +363,23 @@ describe('Document editor surface — setField / removeField', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     expect(doc.removeField('nonexistent')).toBeUndefined()
   })
+
+  it('removeField throws EditError::ReservedName for QUILL', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(() => doc.removeField('QUILL')).toThrow(/ReservedName/)
+  })
+
+  it('removeField throws EditError::ReservedName for BODY/CARDS/CARD', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    for (const reserved of ['BODY', 'CARDS', 'CARD']) {
+      expect(() => doc.removeField(reserved)).toThrow(/ReservedName/)
+    }
+  })
+
+  it('removeField throws EditError::InvalidFieldName for uppercase name', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(() => doc.removeField('Title')).toThrow(/InvalidFieldName/)
+  })
 })
 
 describe('Document editor surface — setQuillRef / replaceBody', () => {
@@ -442,6 +477,26 @@ Card two.
   it('moveCard throws IndexOutOfRange on out-of-range index', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARDS) // 2 cards
     expect(() => doc.moveCard(5, 0)).toThrow(/IndexOutOfRange/)
+  })
+
+  it('setCardTag renames the tag in place', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARDS)
+    doc.setCardTag(0, 'annotation')
+    expect(doc.cards[0].tag).toBe('annotation')
+    // Frontmatter preserved across rename.
+    expect(doc.cards[0].frontmatter).toBeDefined()
+  })
+
+  it('setCardTag throws InvalidTagName for empty/uppercase/dashed tags', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARDS)
+    for (const bad of ['', 'BadTag', 'with-dash']) {
+      expect(() => doc.setCardTag(0, bad)).toThrow(/InvalidTagName/)
+    }
+  })
+
+  it('setCardTag throws IndexOutOfRange when index >= len', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARDS) // 2 cards
+    expect(() => doc.setCardTag(5, 'annotation')).toThrow(/IndexOutOfRange/)
   })
 })
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -387,10 +387,21 @@ impl Document {
 
     /// Remove a frontmatter field on the main card, returning the removed value or `undefined`.
     ///
+    /// Throws an `Error` whose message includes the `EditError` variant name and
+    /// details if `name` is reserved (`BODY`, `CARDS`, `QUILL`, `CARD`) or does
+    /// not match `[a-z_][a-z0-9_]*`. Validation is symmetric with `setField`:
+    /// names that could never have been stored are programmer errors and
+    /// throw, rather than silently returning `undefined`.
+    ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = removeField)]
-    pub fn remove_field(&mut self, name: &str) -> JsValue {
-        match self.inner.main_mut().remove_field(name) {
+    pub fn remove_field(&mut self, name: &str) -> Result<JsValue, JsValue> {
+        let removed = self
+            .inner
+            .main_mut()
+            .remove_field(name)
+            .map_err(|e| edit_error_to_js(&e))?;
+        Ok(match removed {
             Some(v) => {
                 let serializer =
                     serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
@@ -399,7 +410,7 @@ impl Document {
                     .unwrap_or(JsValue::UNDEFINED)
             }
             None => JsValue::UNDEFINED,
-        }
+        })
     }
 
     /// Replace the QUILL reference string.
@@ -492,6 +503,24 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
+    /// Replace the tag of the composable card at `index`.
+    ///
+    /// Mutates only the sentinel — the card's frontmatter and body are
+    /// untouched. Schema-aware migration (clearing orphan fields, applying
+    /// new defaults) is the caller's responsibility; `setCardTag` is a
+    /// structural primitive.
+    ///
+    /// Throws if `index` is out of range or if `newTag` does not match
+    /// `[a-z_][a-z0-9_]*`.
+    ///
+    /// Mutators never modify `warnings`.
+    #[wasm_bindgen(js_name = setCardTag)]
+    pub fn set_card_tag(&mut self, index: usize, new_tag: &str) -> Result<(), JsValue> {
+        self.inner
+            .set_card_tag(index, new_tag)
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
     /// Update a field on the card at `index`.
     ///
     /// Convenience method: equivalent to `doc.card_mut(index)?.set_field(name, value)`.
@@ -521,7 +550,9 @@ impl Document {
     /// Remove a frontmatter field on the card at `index`, returning the
     /// removed value or `undefined` if the field was absent.
     ///
-    /// Throws if `index` is out of range.
+    /// Throws if `index` is out of range, `name` is reserved, or `name` does
+    /// not match `[a-z_][a-z0-9_]*`. Validation is symmetric with
+    /// `updateCardField`.
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = removeCardField)]
@@ -530,7 +561,8 @@ impl Document {
         let card = self.inner.card_mut(index).ok_or_else(|| {
             edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
         })?;
-        Ok(match card.remove_field(name) {
+        let removed = card.remove_field(name).map_err(|e| edit_error_to_js(&e))?;
+        Ok(match removed {
             Some(v) => {
                 let serializer =
                     serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -387,11 +387,10 @@ impl Document {
 
     /// Remove a frontmatter field on the main card, returning the removed value or `undefined`.
     ///
-    /// Throws an `Error` whose message includes the `EditError` variant name and
-    /// details if `name` is reserved (`BODY`, `CARDS`, `QUILL`, `CARD`) or does
-    /// not match `[a-z_][a-z0-9_]*`. Validation is symmetric with `setField`:
-    /// names that could never have been stored are programmer errors and
-    /// throw, rather than silently returning `undefined`.
+    /// Throws an `Error` whose message includes the `EditError` variant name
+    /// and details if `name` is reserved (`BODY`, `CARDS`, `QUILL`, `CARD`)
+    /// or does not match `[a-z_][a-z0-9_]*`. Absence of an otherwise-valid
+    /// name returns `undefined`.
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = removeField)]
@@ -551,8 +550,7 @@ impl Document {
     /// removed value or `undefined` if the field was absent.
     ///
     /// Throws if `index` is out of range, `name` is reserved, or `name` does
-    /// not match `[a-z_][a-z0-9_]*`. Validation is symmetric with
-    /// `updateCardField`.
+    /// not match `[a-z_][a-z0-9_]*`.
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = removeCardField)]

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -13,11 +13,11 @@ use wasm_bindgen::prelude::*;
 /// { message: string, diagnostics: Diagnostic[] }
 /// ```
 ///
-/// `diagnostics` is always a non-empty array. Single-diagnostic errors
-/// produce length 1; compilation failures produce length N. The thrown JS
-/// `Error` has its `.message` set to `message` and a `.diagnostics` property
-/// attached carrying the array. The pre-0.62 `.diagnostic` (singular) shape
-/// is gone — read `err.diagnostics[0]` for the primary diagnostic instead.
+/// `diagnostics` is always a non-empty array — length 1 for
+/// single-diagnostic errors, length N for compilation failures. The thrown
+/// JS `Error` has its `.message` set to `message` and a `.diagnostics`
+/// property attached carrying the array. Read `err.diagnostics[0]` for the
+/// primary diagnostic.
 #[derive(Debug, Clone)]
 pub struct WasmError {
     pub message: String,

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -1,45 +1,42 @@
 //! Error handling utilities for WASM bindings
 
+use crate::types::Diagnostic as WasmDiagnostic;
 use quillmark_core::{Diagnostic, ParseError, RenderError, Severity};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 /// Serializable error for JavaScript consumption.
 ///
-/// Shape matches the success-path [`quillmark_core::Diagnostic`] so JS
-/// consumers can use a single renderer for both thrown errors and warnings
-/// in `RenderResult.warnings`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", tag = "type")]
-pub enum WasmError {
-    /// Single diagnostic error
-    Diagnostic {
-        #[serde(flatten)]
-        diagnostic: Diagnostic,
-    },
-    /// Multiple diagnostics (e.g., compilation errors)
-    MultipleDiagnostics {
-        message: String,
-        diagnostics: Vec<Diagnostic>,
-    },
+/// Single uniform shape regardless of underlying error variant:
+///
+/// ```text
+/// { message: string, diagnostics: Diagnostic[] }
+/// ```
+///
+/// `diagnostics` is always a non-empty array. Single-diagnostic errors
+/// produce length 1; compilation failures produce length N. The thrown JS
+/// `Error` has its `.message` set to `message` and a `.diagnostics` property
+/// attached carrying the array. The pre-0.62 `.diagnostic` (singular) shape
+/// is gone — read `err.diagnostics[0]` for the primary diagnostic instead.
+#[derive(Debug, Clone)]
+pub struct WasmError {
+    pub message: String,
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 impl WasmError {
     /// Convert to a JS `Error` object for throwing.
     ///
-    /// Returns a real `Error` whose `.message` is the primary diagnostic
-    /// message. Structured data is attached as a `.diagnostic` property for
-    /// callers that need to branch on codes, severity, etc. The shape
-    /// mirrors the diagnostics in `result.warnings`.
+    /// Returns a real `Error` whose `.message` is `self.message` and whose
+    /// `.diagnostics` property is an array of diagnostic objects matching
+    /// the shape used in `RenderResult.warnings`.
     pub fn to_js_value(&self) -> JsValue {
-        let message = match self {
-            WasmError::Diagnostic { diagnostic } => diagnostic.message.clone(),
-            WasmError::MultipleDiagnostics { message, .. } => message.clone(),
-        };
-        let err = js_sys::Error::new(&message);
+        let err = js_sys::Error::new(&self.message);
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        if let Ok(data) = self.serialize(&serializer) {
-            let _ = js_sys::Reflect::set(&err, &JsValue::from_str("diagnostic"), &data);
+        let wasm_diags: Vec<WasmDiagnostic> =
+            self.diagnostics.iter().cloned().map(Into::into).collect();
+        if let Ok(data) = wasm_diags.serialize(&serializer) {
+            let _ = js_sys::Reflect::set(&err, &JsValue::from_str("diagnostics"), &data);
         }
         err.into()
     }
@@ -47,8 +44,10 @@ impl WasmError {
 
 impl From<ParseError> for WasmError {
     fn from(error: ParseError) -> Self {
-        WasmError::Diagnostic {
-            diagnostic: error.to_diagnostic(),
+        let diag = error.to_diagnostic();
+        WasmError {
+            message: diag.message.clone(),
+            diagnostics: vec![diag],
         }
     }
 }
@@ -56,7 +55,7 @@ impl From<ParseError> for WasmError {
 impl From<RenderError> for WasmError {
     fn from(error: RenderError) -> Self {
         match error {
-            RenderError::CompilationFailed { diags } => WasmError::MultipleDiagnostics {
+            RenderError::CompilationFailed { diags } => WasmError {
                 message: format!("Compilation failed with {} error(s)", diags.len()),
                 diagnostics: diags,
             },
@@ -66,7 +65,10 @@ impl From<RenderError> for WasmError {
                     .first()
                     .map(|d| (*d).clone())
                     .unwrap_or_else(|| Diagnostic::new(Severity::Error, error.to_string()));
-                WasmError::Diagnostic { diagnostic }
+                WasmError {
+                    message: diagnostic.message.clone(),
+                    diagnostics: vec![diagnostic],
+                }
             }
         }
     }
@@ -74,8 +76,9 @@ impl From<RenderError> for WasmError {
 
 impl From<String> for WasmError {
     fn from(message: String) -> Self {
-        WasmError::Diagnostic {
-            diagnostic: Diagnostic::new(Severity::Error, message),
+        WasmError {
+            message: message.clone(),
+            diagnostics: vec![Diagnostic::new(Severity::Error, message)],
         }
     }
 }
@@ -98,12 +101,33 @@ mod tests {
         };
         let wasm_err: WasmError = err.into();
 
-        match wasm_err {
-            WasmError::Diagnostic { diagnostic } => {
-                assert_eq!(diagnostic.code.as_deref(), Some("parse::input_too_large"));
-                assert!(diagnostic.message.contains("Input too large"));
-            }
-            _ => panic!("Expected Diagnostic variant"),
-        }
+        assert_eq!(wasm_err.diagnostics.len(), 1);
+        let diag = &wasm_err.diagnostics[0];
+        assert_eq!(diag.code.as_deref(), Some("parse::input_too_large"));
+        assert!(diag.message.contains("Input too large"));
+        assert_eq!(wasm_err.message, diag.message);
+    }
+
+    #[test]
+    fn test_compilation_failed_carries_all_diagnostics() {
+        let diag1 = Diagnostic::new(Severity::Error, "Error 1".to_string());
+        let diag2 = Diagnostic::new(Severity::Error, "Error 2".to_string());
+        let render_err = RenderError::CompilationFailed {
+            diags: vec![diag1, diag2],
+        };
+        let wasm_err: WasmError = render_err.into();
+
+        assert_eq!(wasm_err.diagnostics.len(), 2);
+        assert_eq!(wasm_err.diagnostics[0].message, "Error 1");
+        assert_eq!(wasm_err.diagnostics[1].message, "Error 2");
+        assert!(wasm_err.message.contains("2"));
+    }
+
+    #[test]
+    fn test_string_conversion_yields_single_diagnostic() {
+        let wasm_err: WasmError = "Simple error".into();
+        assert_eq!(wasm_err.message, "Simple error");
+        assert_eq!(wasm_err.diagnostics.len(), 1);
+        assert_eq!(wasm_err.diagnostics[0].message, "Simple error");
     }
 }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -416,23 +416,16 @@ mod tests {
         };
         let wasm_err: WasmError = render_err.into();
 
-        let json = serde_json::to_value(&wasm_err).unwrap();
-        assert!(json.is_object());
-
-        let obj = json.as_object().unwrap();
-        assert_eq!(obj.get("type").unwrap().as_str().unwrap(), "diagnostic");
-        assert_eq!(obj.get("severity").unwrap().as_str().unwrap(), "error");
-        assert_eq!(obj.get("code").unwrap().as_str().unwrap(), "E001");
-        assert_eq!(
-            obj.get("message").unwrap().as_str().unwrap(),
-            "Test error message"
-        );
-        assert_eq!(obj.get("hint").unwrap().as_str().unwrap(), "This is a hint");
-
-        let location = obj.get("location").unwrap().as_object().unwrap();
-        assert_eq!(location.get("file").unwrap().as_str().unwrap(), "test.typ");
-        assert_eq!(location.get("line").unwrap().as_u64().unwrap(), 10);
-        assert_eq!(location.get("column").unwrap().as_u64().unwrap(), 5);
+        assert_eq!(wasm_err.message, "Test error message");
+        assert_eq!(wasm_err.diagnostics.len(), 1);
+        let d = &wasm_err.diagnostics[0];
+        assert_eq!(d.code.as_deref(), Some("E001"));
+        assert_eq!(d.message, "Test error message");
+        assert_eq!(d.hint.as_deref(), Some("This is a hint"));
+        let loc = d.location.as_ref().unwrap();
+        assert_eq!(loc.file, "test.typ");
+        assert_eq!(loc.line, 10);
+        assert_eq!(loc.column, 5);
     }
 
     #[test]
@@ -448,24 +441,10 @@ mod tests {
         };
         let wasm_err: WasmError = render_err.into();
 
-        let json = serde_json::to_value(&wasm_err).unwrap();
-        assert!(json.is_object());
-
-        let obj = json.as_object().unwrap();
-        assert_eq!(
-            obj.get("type").unwrap().as_str().unwrap(),
-            "multipleDiagnostics"
-        );
-        assert!(obj.get("message").unwrap().as_str().unwrap().contains("2"));
-
-        let diagnostics = obj.get("diagnostics").unwrap().as_array().unwrap();
-        assert_eq!(diagnostics.len(), 2);
-
-        let first_diag = diagnostics[0].as_object().unwrap();
-        assert_eq!(
-            first_diag.get("message").unwrap().as_str().unwrap(),
-            "Error 1"
-        );
+        assert_eq!(wasm_err.diagnostics.len(), 2);
+        assert_eq!(wasm_err.diagnostics[0].message, "Error 1");
+        assert_eq!(wasm_err.diagnostics[1].message, "Error 2");
+        assert!(wasm_err.message.contains("2"));
     }
 
     #[test]
@@ -473,17 +452,9 @@ mod tests {
         use crate::error::WasmError;
 
         let wasm_err: WasmError = "Simple error message".into();
-
-        let json = serde_json::to_value(&wasm_err).unwrap();
-        assert!(json.is_object());
-
-        let obj = json.as_object().unwrap();
-        assert_eq!(obj.get("type").unwrap().as_str().unwrap(), "diagnostic");
-        assert_eq!(
-            obj.get("message").unwrap().as_str().unwrap(),
-            "Simple error message"
-        );
-        assert_eq!(obj.get("severity").unwrap().as_str().unwrap(), "error");
+        assert_eq!(wasm_err.message, "Simple error message");
+        assert_eq!(wasm_err.diagnostics.len(), 1);
+        assert_eq!(wasm_err.diagnostics[0].message, "Simple error message");
     }
 
     #[test]

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -180,6 +180,17 @@ pub(super) fn decompose_with_warnings(
     // first line no longer matches `---`.
     let markdown = markdown.strip_prefix('\u{FEFF}').unwrap_or(markdown);
 
+    // Empty / whitespace-only input gets a tailored message. The default
+    // missing-QUILL error reads as if the user supplied a partial document
+    // missing only QUILL, which is misleading when there's no document at all.
+    if markdown.trim().is_empty() {
+        return Err(crate::error::ParseError::InvalidStructure(
+            "Empty markdown input cannot be parsed as a Quillmark Document. \
+             Provide at least a QUILL frontmatter field: `QUILL: <name>`."
+                .to_string(),
+        ));
+    }
+
     // Check input size limit
     if markdown.len() > crate::error::MAX_INPUT_SIZE {
         return Err(crate::error::ParseError::InputTooLarge {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -328,9 +328,6 @@ impl Card {
     /// - `name` must match `[a-z_][a-z0-9_]*` after NFC normalisation.
     ///   Returns [`EditError::InvalidFieldName`].
     ///
-    /// Validation is symmetric with [`Card::set_field`]: passing a name that
-    /// could never have been stored (reserved or invalid) is treated as a
-    /// programmer error and throws, rather than silently returning `None`.
     /// Absence of an otherwise-valid name returns `Ok(None)`.
     ///
     /// # Warnings

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -173,6 +173,49 @@ impl Document {
         Some(self.cards_vec_mut().remove(index))
     }
 
+    /// Replace the tag (sentinel) of the composable card at `index`.
+    ///
+    /// **Field-bag semantics.** This mutates only the sentinel; the card's
+    /// frontmatter and body are untouched. After the call:
+    ///
+    /// - Fields valid under both old and new schemas round-trip unchanged.
+    /// - Fields only in the old schema linger in the bag (silently ignored
+    ///   by `project_form` and `validate_document`, but still emitted by
+    ///   `to_markdown()`).
+    /// - Fields only in the new schema are absent — surfaced as `Default`
+    ///   or `Missing` by `project_form`, and `MissingRequired` by
+    ///   `validate_document`.
+    ///
+    /// Schema-aware migration (clearing orphans, applying defaults, etc.) is
+    /// the caller's responsibility — `set_card_tag` is a structural primitive.
+    ///
+    /// # Invariants enforced
+    ///
+    /// - `index` must be in `0..len`. Out of range returns
+    ///   [`EditError::IndexOutOfRange`].
+    /// - `new_tag` must match `[a-z_][a-z0-9_]*`. Invalid tags return
+    ///   [`EditError::InvalidTagName`].
+    ///
+    /// # Warnings
+    ///
+    /// This method never modifies `warnings`.
+    pub fn set_card_tag(
+        &mut self,
+        index: usize,
+        new_tag: impl Into<String>,
+    ) -> Result<(), EditError> {
+        let new_tag = new_tag.into();
+        if !is_valid_tag_name(&new_tag) {
+            return Err(EditError::InvalidTagName(new_tag));
+        }
+        let len = self.cards().len();
+        let card = self
+            .card_mut(index)
+            .ok_or(EditError::IndexOutOfRange { index, len })?;
+        card.replace_sentinel(Sentinel::Card(new_tag));
+        Ok(())
+    }
+
     /// Move the composable card at `from` to position `to`.
     ///
     /// If `from == to`, this is a no-op and returns `Ok(())`.
@@ -278,14 +321,29 @@ impl Card {
 
     /// Remove a frontmatter field by name, returning the value if it existed.
     ///
-    /// Reserved names cannot be present in the frontmatter (the parser
-    /// guarantees this), so passing a reserved name simply returns `None`.
+    /// # Invariants enforced
+    ///
+    /// - `name` must not be one of the reserved sentinel names.
+    ///   Returns [`EditError::ReservedName`].
+    /// - `name` must match `[a-z_][a-z0-9_]*` after NFC normalisation.
+    ///   Returns [`EditError::InvalidFieldName`].
+    ///
+    /// Validation is symmetric with [`Card::set_field`]: passing a name that
+    /// could never have been stored (reserved or invalid) is treated as a
+    /// programmer error and throws, rather than silently returning `None`.
+    /// Absence of an otherwise-valid name returns `Ok(None)`.
     ///
     /// # Warnings
     ///
     /// Card mutators never modify the parent document's `warnings`.
-    pub fn remove_field(&mut self, name: &str) -> Option<QuillValue> {
-        self.frontmatter_mut().remove(name)
+    pub fn remove_field(&mut self, name: &str) -> Result<Option<QuillValue>, EditError> {
+        if is_reserved_name(name) {
+            return Err(EditError::ReservedName(name.to_string()));
+        }
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
+        }
+        Ok(self.frontmatter_mut().remove(name))
     }
 
     /// Replace the card's Markdown body.

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -14,6 +14,20 @@ fn test_no_frontmatter() {
 }
 
 #[test]
+fn test_empty_input_dedicated_error() {
+    // Empty input should not surface the generic "Missing required QUILL"
+    // message — that misleadingly suggests a partial document. Both the
+    // truly-empty and whitespace-only cases get the dedicated message.
+    for input in ["", "   ", "\n\n\t\n"] {
+        let err = decompose(input).unwrap_err().to_string();
+        assert!(
+            err.contains("Empty markdown input"),
+            "expected dedicated empty-input message for {input:?}, got: {err}"
+        );
+    }
+}
+
+#[test]
 fn test_with_frontmatter() {
     let markdown = r#"---
 QUILL: test_quill
@@ -1352,11 +1366,12 @@ fn test_unmatched_chevrons_preserved() {
 
 // Robustness tests
 
-/// Inputs with no parseable QUILL frontmatter must all fail with "Missing
-/// required QUILL field". Covers empty, whitespace-only, lone/quad dashes.
+/// Inputs with no parseable QUILL frontmatter must fail with "Missing
+/// required QUILL field". Empty / whitespace-only inputs get a dedicated
+/// "Empty markdown input" message instead — see `test_empty_input_dedicated_error`.
 #[test]
 fn test_missing_quill_field() {
-    for input in ["", "   \n\n   \t", "---", "----\ntitle: Test\n----\n\nBody"] {
+    for input in ["---", "----\ntitle: Test\n----\n\nBody"] {
         let err = decompose(input).unwrap_err().to_string();
         assert!(
             err.contains("Missing required QUILL field"),

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -188,7 +188,7 @@ fn test_document_set_field_updates_existing() {
 #[test]
 fn test_document_remove_field_existing() {
     let mut doc = make_doc();
-    let removed = doc.main_mut().remove_field("title");
+    let removed = doc.main_mut().remove_field("title").unwrap();
     assert_eq!(removed.unwrap().as_str(), Some("Hello"));
     assert!(doc.main().frontmatter().get("title").is_none());
 }
@@ -196,16 +196,30 @@ fn test_document_remove_field_existing() {
 #[test]
 fn test_document_remove_field_absent() {
     let mut doc = make_doc();
-    let removed = doc.main_mut().remove_field("nonexistent");
+    let removed = doc.main_mut().remove_field("nonexistent").unwrap();
     assert!(removed.is_none());
 }
 
 #[test]
-fn test_document_remove_field_reserved_returns_none() {
-    // Reserved names can't be in frontmatter; remove must return None.
+fn test_document_remove_field_reserved_throws() {
+    // Symmetric with set_field: reserved names are programmer errors and
+    // throw, rather than silently returning None.
     let mut doc = make_doc();
-    let removed = doc.main_mut().remove_field("BODY");
-    assert!(removed.is_none());
+    for reserved in ["BODY", "CARDS", "QUILL", "CARD"] {
+        match doc.main_mut().remove_field(reserved) {
+            Err(EditError::ReservedName(name)) => assert_eq!(name, reserved),
+            other => panic!("expected ReservedName for {reserved}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_document_remove_field_invalid_name_throws() {
+    let mut doc = make_doc();
+    match doc.main_mut().remove_field("Bad-Name") {
+        Err(EditError::InvalidFieldName(name)) => assert_eq!(name, "Bad-Name"),
+        other => panic!("expected InvalidFieldName, got {other:?}"),
+    }
 }
 
 // ── Document::set_quill_ref ──────────────────────────────────────────────────
@@ -348,6 +362,55 @@ fn test_move_card_to_out_of_range() {
     assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
 }
 
+// ── Document::set_card_tag ───────────────────────────────────────────────────
+
+#[test]
+fn test_set_card_tag_renames_in_place() {
+    let mut doc = make_doc_with_cards(); // note(0) with field foo=bar, summary(1)
+    doc.set_card_tag(0, "annotation").unwrap();
+    // Sentinel changed.
+    assert_eq!(doc.cards()[0].tag(), "annotation");
+    // Frontmatter and body untouched.
+    assert_eq!(
+        doc.cards()[0].frontmatter().get("foo").unwrap().as_str(),
+        Some("bar")
+    );
+    // Other cards untouched.
+    assert_eq!(doc.cards()[1].tag(), "summary");
+}
+
+#[test]
+fn test_set_card_tag_rejects_invalid_tag() {
+    let mut doc = make_doc_with_cards();
+    for bad in ["", "Bad", "with-dash", "1leading_digit"] {
+        match doc.set_card_tag(0, bad) {
+            Err(EditError::InvalidTagName(t)) => assert_eq!(t, bad),
+            other => panic!("expected InvalidTagName for {bad:?}, got {other:?}"),
+        }
+    }
+    // Original tag preserved on failure.
+    assert_eq!(doc.cards()[0].tag(), "note");
+}
+
+#[test]
+fn test_set_card_tag_index_out_of_range() {
+    let mut doc = make_doc_with_cards();
+    let len = doc.cards().len();
+    let result = doc.set_card_tag(len, "annotation");
+    assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
+}
+
+#[test]
+fn test_set_card_tag_round_trips_via_markdown() {
+    // Verify that renaming a card and re-emitting markdown produces a doc
+    // that re-parses with the new tag.
+    let mut doc = make_doc_with_cards();
+    doc.set_card_tag(0, "annotation").unwrap();
+    let md = doc.to_markdown();
+    let reparsed = crate::Document::from_markdown(&md).unwrap();
+    assert_eq!(reparsed.cards()[0].tag(), "annotation");
+}
+
 // ── Card::new ────────────────────────────────────────────────────────────────
 
 #[test]
@@ -397,7 +460,7 @@ fn test_card_remove_field_existing() {
     let mut doc = make_doc_with_cards();
     // doc.cards()[0] is "note" with field "foo" = "bar"
     let card = doc.card_mut(0).unwrap();
-    let removed = card.remove_field("foo");
+    let removed = card.remove_field("foo").unwrap();
     assert_eq!(removed.unwrap().as_str(), Some("bar"));
     assert!(card.frontmatter().get("foo").is_none());
 }
@@ -405,7 +468,27 @@ fn test_card_remove_field_existing() {
 #[test]
 fn test_card_remove_field_absent() {
     let mut card = Card::new("note").unwrap();
-    assert!(card.remove_field("nonexistent").is_none());
+    assert!(card.remove_field("nonexistent").unwrap().is_none());
+}
+
+#[test]
+fn test_card_remove_field_reserved_throws() {
+    let mut card = Card::new("note").unwrap();
+    for reserved in ["BODY", "CARDS", "QUILL", "CARD"] {
+        match card.remove_field(reserved) {
+            Err(EditError::ReservedName(name)) => assert_eq!(name, reserved),
+            other => panic!("expected ReservedName for {reserved}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_card_remove_field_invalid_name_throws() {
+    let mut card = Card::new("note").unwrap();
+    match card.remove_field("Bad-Name") {
+        Err(EditError::InvalidFieldName(name)) => assert_eq!(name, "Bad-Name"),
+        other => panic!("expected InvalidFieldName, got {other:?}"),
+    }
 }
 
 // ── Card::set_body ───────────────────────────────────────────────────────────
@@ -455,7 +538,7 @@ fn test_invariants_after_mutation_sequence() {
     doc.main_mut().replace_body("Updated body.");
 
     // 7. Remove a frontmatter field
-    doc.main_mut().remove_field("version");
+    doc.main_mut().remove_field("version").unwrap();
 
     // --- Assertions ---
 

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -41,7 +41,7 @@ boundary.
 surface Rust variant names like `"ReservedName"`
 (`crates/bindings/wasm/src/engine.rs:571-577`). No exported enum, no
 constants, no stability guarantee. Consumers that key behavior off
-`error.diagnostic.code` are one refactor away from breaking. Ship a
+`err.diagnostics[0].code` are one refactor away from breaking. Ship a
 `DiagnosticCode` enum in the .d.ts and document the set as part of the
 public API.
 

--- a/prose/designs/ERROR.md
+++ b/prose/designs/ERROR.md
@@ -28,7 +28,7 @@
 Python and WASM bindings delegate to core types:
 
 - **Python**: `PyDiagnostic` wraps `Diagnostic`. `RenderError` is mapped to typed Python exceptions: `CompilationError` (carries a `diagnostics` list), `ParseError` (frontmatter errors), and `QuillmarkError` (all other variants) — each with an attached `diagnostic` attribute. Base hierarchy: `QuillmarkError → PyException`.
-- **WASM**: `WasmError` wraps `Diagnostic` as either `Diagnostic` (single) or `MultipleDiagnostics` (compilation errors), serialized to JSON via `serde_wasm_bindgen`. Also handles `ParseError` conversions directly.
+- **WASM**: `WasmError` is a flat `{ message, diagnostics: Vec<Diagnostic> }`. The thrown JS `Error` has `.message` and a `.diagnostics` array attached (always non-empty — length 1 for single-diagnostic errors, length N for compilation failures). Same shape regardless of underlying variant; consumers read `err.diagnostics[0]` for the primary diagnostic.
 
 ## Backend Error Mapping
 

--- a/prose/migrations/WASM_MIGRATION.md
+++ b/prose/migrations/WASM_MIGRATION.md
@@ -127,13 +127,24 @@ invariants and throws `EditError` (as a JS `Error` whose message starts with
 | `insertCard(index, { tag, fields?, body? })`  | Insert at `0..=cards.length`               |
 | `removeCard(index)`                           | Remove and return the card (or `undefined`)|
 | `moveCard(from, to)`                          | Reorder                                    |
+| `setCardTag(index, newTag)`                   | Rename a card's tag in place               |
 | `updateCardField(index, name, value)`         | Convenience: edit a card's field           |
+| `removeCardField(index, name)`                | Remove a card's frontmatter field          |
 | `updateCardBody(index, body)`                 | Convenience: replace a card's body         |
 
 `EditError` variants surfaced to JS: `ReservedName`, `InvalidFieldName`,
 `InvalidTagName`, `IndexOutOfRange`. Reserved frontmatter field names are
 `BODY`, `CARDS`, `QUILL`, `CARD`. Field names must match `[a-z_][a-z0-9_]*`
 (NFC); tag names must match the tag grammar from the parser.
+
+`removeField` and `removeCardField` validate `name` symmetrically with
+`setField` / `updateCardField`: passing a reserved or syntactically invalid
+name throws (`ReservedName` / `InvalidFieldName`) rather than silently
+returning `undefined`. Absence of an otherwise-valid name returns `undefined`.
+
+`setCardTag` is a structural primitive: it mutates only the sentinel, leaving
+the card's frontmatter and body untouched. Schema-aware migration (clearing
+orphan fields, applying new defaults) is the caller's responsibility.
 
 Mutators never modify `doc.warnings`; warnings remain a frozen record of the
 original parse.
@@ -275,6 +286,10 @@ document. In 0.54, missing-QUILL surfaced at render time; in 0.58+ it fails
 inside `Document.fromMarkdown` with an `InvalidStructure` diagnostic whose
 message is `Missing required QUILL field. Add `QUILL: <name>` to the
 frontmatter`.
+
+Empty / whitespace-only inputs surface a dedicated message instead:
+`Empty markdown input cannot be parsed as a Quillmark Document. Provide at
+least a QUILL frontmatter field: `QUILL: <name>`.`.
 
 Fix: add `QUILL: <name>` to the frontmatter of every document you parse. Test
 fixtures in particular rot silently — a fixture that used to render will now


### PR DESCRIPTION
Addresses integrator feedback against 0.62.0:

* Add `Document::set_card_tag(index, new_tag)` (core) and
  `Document.setCardTag` (wasm + python) — a structural primitive that
  renames a composable card's tag in place without disturbing the
  frontmatter or body. Resolves the "Add Card without a known type"
  flow without introducing an untagged-card concept; schema-aware
  field migration remains a caller concern.

* Make `Card::remove_field` validate the field name symmetrically with
  `set_field`: reserved names (`BODY`/`CARDS`/`QUILL`/`CARD`) and
  invalid names now throw `EditError::ReservedName` /
  `EditError::InvalidFieldName` instead of silently no-opping. Bindings
  surface the throws; tests updated.

* Normalise the wasm error shape on thrown JS errors. `WasmError`
  collapses to `{ message, diagnostics: Diagnostic[] }` — `diagnostics`
  is always a non-empty array, length 1 for single-diagnostic errors,
  N for compilation failures. The pre-0.62 nested
  `err.diagnostic.diagnostics` shape is removed; consumers should read
  `err.diagnostics[0]` for the primary diagnostic.

* Surface a dedicated "Empty markdown input cannot be parsed" message
  for empty / whitespace-only input in `assemble::decompose`, instead
  of the generic "Missing required QUILL field" — the latter
  misleadingly suggested a partial document.

JS tests updated; the wasm32 target is not available in this
environment, so `basic.test.js` was not executed end-to-end. The
host-side cargo unit tests for the wasm crate pass and the wasm crate
type-checks clean.

https://claude.ai/code/session_01MtWZ5ahyUeuGNj4VYpRLYq