### PR TITLE
refactor(form): replace project_form with quill.form + blank constructors

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -173,7 +173,7 @@ impl PyQuill {
         self.inner.dry_run(&doc.inner).map_err(convert_render_error)
     }
 
-    /// Project a document through this quill's schema.
+    /// The schema-aware form view of `doc`.
     ///
     /// Returns a dict with keys `main`, `cards`, and `diagnostics`:
     ///
@@ -186,32 +186,69 @@ impl PyQuill {
     /// - `default`: the schema default value, or `None` if none declared
     /// - `source`: one of `"document"`, `"default"`, or `"missing"`
     ///
-    /// This is a **read-only snapshot**. Call `project_form` again after any
-    /// edits to the document to obtain an updated projection.
+    /// This is a **read-only snapshot**. Call `form` again after any edits
+    /// to the document to obtain an updated view.
     ///
     /// Cards with unknown tags are excluded from `cards`; each produces a
     /// diagnostic with code `"form::unknown_card_tag"`.
-    fn project_form<'py>(
+    fn form<'py>(
         &self,
         py: Python<'py>,
         doc: PyRef<'_, PyDocument>,
     ) -> PyResult<Bound<'py, PyDict>> {
-        let projection = quillmark::form::project_form(&self.inner, &doc.inner);
+        let form = self.inner.form(&doc.inner);
 
         // Serialise through serde_json → Python dict to avoid writing bespoke
         // conversion for every nested type (CardSchema, FormFieldValue, etc.).
-        let json_value = serde_json::to_value(&projection).map_err(|e| {
+        let json_value = serde_json::to_value(&form).map_err(|e| {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "project_form: serialization failed: {e}"
+                "form: serialization failed: {e}"
             ))
         })?;
         let py_obj = json_to_py(py, &json_value)?;
         let dict = py_obj.downcast::<PyDict>().map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "project_form: expected object at top level",
-            )
+            PyErr::new::<pyo3::exceptions::PyValueError, _>("form: expected object at top level")
         })?;
         Ok(dict.clone())
+    }
+
+    /// A blank form for the main card — no document values supplied.
+    ///
+    /// Returns a dict shaped like one entry in `form()['main']`. Every
+    /// declared field's `source` is `"default"` (when the schema declares a
+    /// default) or `"missing"`.
+    fn blank_main<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let card = self.inner.blank_main();
+        let json_value = serde_json::to_value(&card).map_err(|e| {
+            PyErr::new::<PyValueError, _>(format!("blank_main: serialization failed: {e}"))
+        })?;
+        let py_obj = json_to_py(py, &json_value)?;
+        let dict = py_obj.downcast::<PyDict>().map_err(|_| {
+            PyErr::new::<PyValueError, _>("blank_main: expected object at top level")
+        })?;
+        Ok(dict.clone())
+    }
+
+    /// A blank form for a card of the given type — no document values supplied.
+    ///
+    /// Returns `None` if `card_type` is not declared in this quill's schema.
+    /// Otherwise returns a dict shaped like a single entry in `form()['cards']`.
+    fn blank_card<'py>(
+        &self,
+        py: Python<'py>,
+        card_type: &str,
+    ) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let Some(card) = self.inner.blank_card(card_type) else {
+            return Ok(None);
+        };
+        let json_value = serde_json::to_value(&card).map_err(|e| {
+            PyErr::new::<PyValueError, _>(format!("blank_card: serialization failed: {e}"))
+        })?;
+        let py_obj = json_to_py(py, &json_value)?;
+        let dict = py_obj.downcast::<PyDict>().map_err(|_| {
+            PyErr::new::<PyValueError, _>("blank_card: expected object at top level")
+        })?;
+        Ok(Some(dict.clone()))
     }
 }
 

--- a/crates/bindings/python/tests/test_form.py
+++ b/crates/bindings/python/tests/test_form.py
@@ -1,4 +1,4 @@
-"""Smoke tests for quill.project_form (Phase 5).
+"""Smoke tests for quill.form / blank_main / blank_card.
 
 NOTE: These tests cannot run in the devcontainer because the Python binding
 is not built with `maturin develop` in this environment.  They are written
@@ -29,7 +29,7 @@ QUILL_YAML_CONTENT = """quill:
   name: py_form_smoke
   version: "1.0"
   backend: typst
-  description: Python project_form smoke test
+  description: Python form smoke test
 
 main:
   fields:
@@ -38,6 +38,15 @@ main:
       default: Untitled
     count:
       type: integer
+
+card_types:
+  note:
+    fields:
+      body:
+        type: string
+        default: TBD
+      tag:
+        type: string
 """
 
 MD_WITH_TITLE = "---\nQUILL: py_form_smoke\ntitle: \"Hello\"\n---\n"
@@ -54,84 +63,81 @@ def make_quill(tmp_path, yaml_content=QUILL_YAML_CONTENT):
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Tests: form()
 # ---------------------------------------------------------------------------
 
-def test_project_form_returns_dict(tmp_path):
-    """project_form returns a dict with main, cards, diagnostics."""
+def test_form_returns_dict(tmp_path):
+    """form returns a dict with main, cards, diagnostics."""
     quill = make_quill(tmp_path)
     doc = Document.from_markdown(MD_WITH_TITLE)
 
-    projection = quill.project_form(doc)
+    form = quill.form(doc)
 
-    assert isinstance(projection, dict)
-    assert "main" in projection
-    assert "cards" in projection
-    assert "diagnostics" in projection
-    assert isinstance(projection["cards"], list)
-    assert isinstance(projection["diagnostics"], list)
+    assert isinstance(form, dict)
+    assert "main" in form
+    assert "cards" in form
+    assert "diagnostics" in form
+    assert isinstance(form["cards"], list)
+    assert isinstance(form["diagnostics"], list)
 
 
-def test_project_form_document_source(tmp_path):
+def test_form_document_source(tmp_path):
     """Fields present in the document get source='document'."""
     quill = make_quill(tmp_path)
     doc = Document.from_markdown(MD_WITH_TITLE)
 
-    projection = quill.project_form(doc)
-    values = projection["main"]["values"]
+    form = quill.form(doc)
+    values = form["main"]["values"]
 
     assert "title" in values
     assert values["title"]["source"] == "document"
     assert values["title"]["value"] == "Hello"
 
 
-def test_project_form_missing_source(tmp_path):
+def test_form_missing_source(tmp_path):
     """Fields absent from doc with no schema default get source='missing'."""
     quill = make_quill(tmp_path)
     doc = Document.from_markdown(MD_EMPTY)
 
-    projection = quill.project_form(doc)
-    values = projection["main"]["values"]
+    form = quill.form(doc)
+    values = form["main"]["values"]
 
-    # count has no default
     assert "count" in values
     assert values["count"]["source"] == "missing"
     assert values["count"]["value"] is None
     assert values["count"]["default"] is None
 
 
-def test_project_form_default_source(tmp_path):
+def test_form_default_source(tmp_path):
     """Fields absent from doc with a schema default get source='default'."""
     quill = make_quill(tmp_path)
     doc = Document.from_markdown(MD_EMPTY)
 
-    projection = quill.project_form(doc)
-    values = projection["main"]["values"]
+    form = quill.form(doc)
+    values = form["main"]["values"]
 
-    # title has default: "Untitled"
     assert "title" in values
     assert values["title"]["source"] == "default"
     assert values["title"]["value"] is None
     assert values["title"]["default"] == "Untitled"
 
 
-def test_project_form_json_serializable(tmp_path):
-    """FormProjection is fully JSON-serializable via json.dumps."""
+def test_form_json_serializable(tmp_path):
+    """Form is fully JSON-serializable via json.dumps."""
     quill = make_quill(tmp_path)
     doc = Document.from_markdown(MD_WITH_TITLE)
 
-    projection = quill.project_form(doc)
-    dumped = json.dumps(projection)
+    form = quill.form(doc)
+    dumped = json.dumps(form)
 
     assert isinstance(dumped, str)
     assert len(dumped) > 0
 
-    # Round-trip: parsed back is structurally identical
     parsed = json.loads(dumped)
     assert parsed["main"]["values"]["title"]["source"] == "document"
 
 
-def test_project_form_unknown_card_diagnostic(tmp_path):
+def test_form_unknown_card_diagnostic(tmp_path):
     """Unknown card tags produce a diagnostic and are excluded from cards."""
     quill = make_quill(tmp_path)
     md = (
@@ -140,10 +146,52 @@ def test_project_form_unknown_card_diagnostic(tmp_path):
     )
     doc = Document.from_markdown(md)
 
-    projection = quill.project_form(doc)
+    form = quill.form(doc)
 
-    assert projection["cards"] == [], "unknown-tag card must be excluded"
-    diag_codes = [d.get("code") for d in projection["diagnostics"]]
+    assert form["cards"] == [], "unknown-tag card must be excluded"
+    diag_codes = [d.get("code") for d in form["diagnostics"]]
     assert "form::unknown_card_tag" in diag_codes, (
         f"expected form::unknown_card_tag diagnostic; got: {diag_codes}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests: blank_main / blank_card
+# ---------------------------------------------------------------------------
+
+def test_blank_main_returns_card_with_no_document_values(tmp_path):
+    """blank_main returns a card with every value at default or missing."""
+    quill = make_quill(tmp_path)
+
+    blank = quill.blank_main()
+
+    assert isinstance(blank, dict)
+    values = blank["values"]
+
+    assert values["title"]["source"] == "default"
+    assert values["title"]["value"] is None
+    assert values["title"]["default"] == "Untitled"
+
+    assert values["count"]["source"] == "missing"
+    assert values["count"]["value"] is None
+    assert values["count"]["default"] is None
+
+
+def test_blank_card_known_type(tmp_path):
+    """blank_card returns a dict for a known card type."""
+    quill = make_quill(tmp_path)
+
+    blank = quill.blank_card("note")
+
+    assert blank is not None
+    values = blank["values"]
+    assert values["body"]["source"] == "default"
+    assert values["body"]["default"] == "TBD"
+    assert values["tag"]["source"] == "missing"
+
+
+def test_blank_card_unknown_type(tmp_path):
+    """blank_card returns None for an unknown card type."""
+    quill = make_quill(tmp_path)
+
+    assert quill.blank_card("does_not_exist") is None

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -732,18 +732,18 @@ describe('Document.clone', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Phase 5: quill.projectForm — schema-aware form projection
+// quill.form / blank_main / blank_card — schema-aware form view
 // NOTE: These tests cannot run in the devcontainer (no wasm-pack / browser
 //       runtime available).  They are written to run in CI where the WASM
 //       bundle is built by wasm-pack and loaded into a vitest/jsdom context.
 // ---------------------------------------------------------------------------
 
-describe('quill.projectForm', () => {
+describe('quill.form', () => {
   const QUILL_YAML = `quill:
   name: form_smoke_test
   version: "1.0"
   backend: typst
-  description: Smoke test for projectForm
+  description: Smoke test for form
 
 main:
   fields:
@@ -752,6 +752,15 @@ main:
       default: "Untitled"
     count:
       type: integer
+
+card_types:
+  note:
+    fields:
+      body:
+        type: string
+        default: "TBD"
+      tag:
+        type: string
 `
 
   const MD_WITH_TITLE = `---
@@ -760,29 +769,29 @@ title: "Hello"
 ---
 `
 
-  it('projectForm returns a plain object with main, cards, diagnostics', () => {
+  it('form returns a plain object with main, cards, diagnostics', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'form_smoke_test', quillYaml: QUILL_YAML }))
     const doc = Document.fromMarkdown(MD_WITH_TITLE)
 
-    const projection = quill.projectForm(doc)
+    const form = quill.form(doc)
 
-    expect(typeof projection).toBe('object')
-    expect(projection).not.toBeNull()
-    expect('main' in projection).toBe(true)
-    expect('cards' in projection).toBe(true)
-    expect('diagnostics' in projection).toBe(true)
-    expect(Array.isArray(projection.cards)).toBe(true)
-    expect(Array.isArray(projection.diagnostics)).toBe(true)
+    expect(typeof form).toBe('object')
+    expect(form).not.toBeNull()
+    expect('main' in form).toBe(true)
+    expect('cards' in form).toBe(true)
+    expect('diagnostics' in form).toBe(true)
+    expect(Array.isArray(form.cards)).toBe(true)
+    expect(Array.isArray(form.diagnostics)).toBe(true)
   })
 
-  it('projectForm main.values has correct sources', () => {
+  it('form main.values has correct sources', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'form_smoke_test', quillYaml: QUILL_YAML }))
     const doc = Document.fromMarkdown(MD_WITH_TITLE)
 
-    const projection = quill.projectForm(doc)
-    const values = projection.main.values
+    const form = quill.form(doc)
+    const values = form.main.values
 
     // title is present in doc → source: document
     expect(values.title).toBeDefined()
@@ -795,17 +804,54 @@ title: "Hello"
     expect(values.count.value).toBeNull()
   })
 
-  it('projectForm result is JSON.stringify-able and round-trips', () => {
+  it('form result is JSON.stringify-able and round-trips', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'form_smoke_test', quillYaml: QUILL_YAML }))
     const doc = Document.fromMarkdown(MD_WITH_TITLE)
 
-    const projection = quill.projectForm(doc)
-    const json = JSON.stringify(projection)
+    const form = quill.form(doc)
+    const json = JSON.stringify(form)
     expect(typeof json).toBe('string')
     expect(json.length).toBeGreaterThan(0)
 
     const parsed = JSON.parse(json)
     expect(parsed.main.values.title.source).toBe('document')
+  })
+
+  it('blankMain returns a card with no document values', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(makeQuill({ name: 'form_smoke_test', quillYaml: QUILL_YAML }))
+
+    const blank = quill.blankMain()
+
+    expect(typeof blank).toBe('object')
+    expect(blank).not.toBeNull()
+    // title has a default
+    expect(blank.values.title.source).toBe('default')
+    expect(blank.values.title.value).toBeNull()
+    expect(blank.values.title.default).toBe('Untitled')
+    // count has no default
+    expect(blank.values.count.source).toBe('missing')
+    expect(blank.values.count.value).toBeNull()
+    expect(blank.values.count.default).toBeNull()
+  })
+
+  it('blankCard returns a card for a known type', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(makeQuill({ name: 'form_smoke_test', quillYaml: QUILL_YAML }))
+
+    const blank = quill.blankCard('note')
+
+    expect(blank).not.toBeNull()
+    expect(blank.values.body.source).toBe('default')
+    expect(blank.values.body.default).toBe('TBD')
+    expect(blank.values.tag.source).toBe('missing')
+  })
+
+  it('blankCard returns null for an unknown type', () => {
+    const engine = new Quillmark()
+    const quill = engine.quill(makeQuill({ name: 'form_smoke_test', quillYaml: QUILL_YAML }))
+
+    expect(quill.blankCard('does_not_exist')).toBeNull()
   })
 })

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -230,10 +230,10 @@ impl Quill {
         val.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
-    /// Project a document through this quill's schema.
+    /// The schema-aware form view of `doc`.
     ///
     /// Returns a plain JS object (not a class) that is immediately
-    /// `JSON.stringify`-able. The shape mirrors [`FormProjection`]:
+    /// `JSON.stringify`-able. The shape mirrors [`Form`]:
     ///
     /// ```json
     /// {
@@ -244,19 +244,57 @@ impl Quill {
     /// ```
     ///
     /// **Snapshot semantics.** This is a read-only snapshot of the document
-    /// at call time. Subsequent edits to `doc` require calling `projectForm`
-    /// again.
+    /// at call time. Subsequent edits to `doc` require calling `form` again.
     ///
-    /// [`FormProjection`]: quillmark::form::FormProjection
-    #[wasm_bindgen(js_name = projectForm)]
-    pub fn project_form(&self, doc: &Document) -> Result<JsValue, JsValue> {
-        let projection = quillmark::form::project_form(&self.inner, &doc.inner);
+    /// [`Form`]: quillmark::form::Form
+    #[wasm_bindgen(js_name = form)]
+    pub fn form(&self, doc: &Document) -> Result<JsValue, JsValue> {
+        let form = self.inner.form(&doc.inner);
         let serializer = serde_wasm_bindgen::Serializer::new()
             .serialize_maps_as_objects(true)
             .serialize_missing_as_null(true);
-        projection.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("projectForm: serialization failed: {e}")).to_js_value()
+        form.serialize(&serializer)
+            .map_err(|e| WasmError::from(format!("form: serialization failed: {e}")).to_js_value())
+    }
+
+    /// A blank form for the main card — no document values supplied.
+    ///
+    /// Returns a plain JS object with the same shape as one entry in
+    /// [`Form::main`]. Every declared field's `source` is `"default"` (when
+    /// the schema declares a default) or `"missing"`.
+    ///
+    /// [`Form::main`]: quillmark::form::Form::main
+    #[wasm_bindgen(js_name = blankMain)]
+    pub fn blank_main(&self) -> Result<JsValue, JsValue> {
+        let card = self.inner.blank_main();
+        let serializer = serde_wasm_bindgen::Serializer::new()
+            .serialize_maps_as_objects(true)
+            .serialize_missing_as_null(true);
+        card.serialize(&serializer).map_err(|e| {
+            WasmError::from(format!("blankMain: serialization failed: {e}")).to_js_value()
         })
+    }
+
+    /// A blank form for a card of the given type — no document values supplied.
+    ///
+    /// Returns `null` if `cardType` is not declared in this quill's schema.
+    /// Otherwise returns a plain JS object shaped like a single entry in
+    /// [`Form::cards`].
+    ///
+    /// [`Form::cards`]: quillmark::form::Form::cards
+    #[wasm_bindgen(js_name = blankCard)]
+    pub fn blank_card(&self, card_type: &str) -> Result<JsValue, JsValue> {
+        match self.inner.blank_card(card_type) {
+            Some(card) => {
+                let serializer = serde_wasm_bindgen::Serializer::new()
+                    .serialize_maps_as_objects(true)
+                    .serialize_missing_as_null(true);
+                card.serialize(&serializer).map_err(|e| {
+                    WasmError::from(format!("blankCard: serialization failed: {e}")).to_js_value()
+                })
+            }
+            None => Ok(JsValue::NULL),
+        }
     }
 }
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -180,10 +180,10 @@ impl Document {
     ///
     /// - Fields valid under both old and new schemas round-trip unchanged.
     /// - Fields only in the old schema linger in the bag (silently ignored
-    ///   by `project_form` and `validate_document`, but still emitted by
+    ///   by `Quill::form` and `validate_document`, but still emitted by
     ///   `to_markdown()`).
     /// - Fields only in the new schema are absent — surfaced as `Default`
-    ///   or `Missing` by `project_form`, and `MissingRequired` by
+    ///   or `Missing` by `Quill::form`, and `MissingRequired` by
     ///   `validate_document`.
     ///
     /// Schema-aware migration (clearing orphans, applying defaults, etc.) is

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -1,40 +1,47 @@
-//! Schema-aware form projection for form editors.
+//! Schema-aware form views for form editors.
 //!
-//! This module provides [`FormProjection`] — a read-only snapshot of a
-//! [`Document`] through its [`Quill`] schema. For each schema-declared field
-//! the projection records the current value, the schema default, and the
-//! source of the effective value.
+//! This module provides [`Form`] — a read-only snapshot of a [`Document`]
+//! viewed through its [`Quill`] schema — and [`FormCard`], the per-card view.
+//! For each schema-declared field the view records the current value, the
+//! schema default, and the source of the effective value.
 //!
-//! # Usage
+//! # Entry points
+//!
+//! Consumers reach this module through methods on [`Quill`]:
 //!
 //! ```rust,no_run
 //! # use quillmark::{Quill, Document};
-//! # use quillmark::form::{project_form, FormFieldSource};
+//! # use quillmark::form::FormFieldSource;
 //! # fn example(quill: &Quill, doc: &Document) {
-//! let projection = project_form(quill, doc);
+//! let form = quill.form(doc);
 //!
-//! for (name, fv) in &projection.main.values {
+//! for (name, fv) in &form.main.values {
 //!     match fv.source {
 //!         FormFieldSource::Document => println!("{name}: {:?}", fv.value),
 //!         FormFieldSource::Default  => println!("{name}: (default) {:?}", fv.default),
 //!         FormFieldSource::Missing  => println!("{name}: MISSING"),
 //!     }
 //! }
+//!
+//! // A blank form for a fresh card the user is about to add:
+//! if let Some(blank) = quill.blank_card("indorsement") {
+//!     // render `blank.values`...
+//!     # let _ = blank;
+//! }
 //! # }
 //! ```
 //!
-//! # Re-projection after editing
+//! # Snapshot semantics
 //!
-//! A `FormProjection` is a **read-only snapshot** of the document at the time
-//! [`project_form`] is called. Subsequent edits to `doc` (e.g. via
-//! `doc.main_mut().set_field(...)`) are not reflected in an existing
-//! `FormProjection`; call `project_form` again to obtain an updated snapshot.
+//! A [`Form`] (or [`FormCard`]) is a read-only snapshot built at the moment
+//! the call returned. Subsequent edits to the document are not reflected;
+//! call `quill.form(doc)` again to obtain an updated snapshot.
 //!
 //! # Unknown card tags
 //!
-//! Cards whose tag is not declared in the schema are **dropped** from
-//! `FormProjection.cards`. Each such card produces one [`Diagnostic`]
-//! in `FormProjection.diagnostics` with code `"form::unknown_card_tag"`.
+//! Cards whose tag is not declared in the schema are dropped from
+//! [`Form::cards`]. Each such card produces one [`Diagnostic`] in
+//! [`Form::diagnostics`] with code `"form::unknown_card_tag"`.
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -44,7 +51,7 @@ use quillmark_core::{Diagnostic, Document, QuillValue, Severity};
 
 use crate::Quill;
 
-/// Source of a field's effective value in a form projection.
+/// Source of a field's effective value in a form view.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum FormFieldSource {
@@ -56,7 +63,7 @@ pub enum FormFieldSource {
     Missing,
 }
 
-/// A single field's projection within a [`FormCard`].
+/// A single field's view within a [`FormCard`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FormFieldValue {
     /// Current value from the document, if present.
@@ -67,86 +74,79 @@ pub struct FormFieldValue {
     pub source: FormFieldSource,
 }
 
-/// A card projected through its schema — either the main document card or a
+/// A card viewed through its schema — either the main document card or a
 /// named card block.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FormCard {
     /// The schema that governs this card.
     pub schema: CardSchema,
-    /// Projection of each schema-declared field.
+    /// View of each schema-declared field.
     ///
-    /// Keys follow `IndexMap` insertion order (schema field definition order).
+    /// Keys follow `IndexMap` insertion order: schema field definition order,
+    /// stably re-sorted by `ui.order` when present.
     pub values: IndexMap<String, FormFieldValue>,
 }
 
-/// Read-only snapshot of a [`Document`] projected through a [`Quill`]'s schema.
+impl FormCard {
+    /// A blank form card for `schema` — no document values supplied. Every
+    /// declared field's source is [`FormFieldSource::Default`] (when the
+    /// schema declares a default) or [`FormFieldSource::Missing`].
+    ///
+    /// This is the "user is about to add a new card" view. Reach it through
+    /// [`Quill::blank_card`] or [`Quill::blank_main`] when you have a tag in
+    /// hand instead of a [`CardSchema`].
+    pub fn blank(schema: &CardSchema) -> Self {
+        project_card(schema, &IndexMap::new())
+    }
+}
+
+/// Read-only snapshot of a [`Document`] viewed through a [`Quill`]'s schema.
 ///
-/// Produced by [`project_form`]. Subsequent edits to the document are **not**
-/// reflected here — call `project_form` again after editing.
+/// Produced by [`Quill::form`]. Subsequent edits to the document are **not**
+/// reflected here — call `quill.form(doc)` again after editing.
 ///
 /// # Unknown cards
 ///
 /// Document cards whose tag is not declared in the schema are dropped and
 /// each produces a [`Diagnostic`] with code `"form::unknown_card_tag"` in
-/// `diagnostics`.
+/// [`Form::diagnostics`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct FormProjection {
-    /// Projection of the main document (frontmatter fields).
+pub struct Form {
+    /// View of the main document card (frontmatter fields).
     pub main: FormCard,
-    /// Projections of each recognised card, in document order.
+    /// View of each recognised card, in document order.
     ///
-    /// Cards with unknown tags are excluded; see `diagnostics`.
+    /// Cards with unknown tags are excluded; see [`Form::diagnostics`].
     pub cards: Vec<FormCard>,
     /// Diagnostics from unknown card tags and validation.
     pub diagnostics: Vec<Diagnostic>,
 }
 
-/// Project a document through a quill's schema.
-///
-/// Returns a [`FormProjection`] — a read-only snapshot of the document's
-/// fields mapped against the schema. For each schema-declared field the
-/// projection records:
-///
-/// - [`FormFieldSource::Document`] — value present in the document.
-/// - [`FormFieldSource::Default`] — value absent; schema default used.
-/// - [`FormFieldSource::Missing`] — value absent; no schema default.
-///
-/// **Snapshot semantics.** Subsequent edits to `doc` are not reflected;
-/// call `project_form` again after editing.
-///
-/// **Unknown cards.** Each card in `doc.cards()` whose tag is not declared
-/// in the quill schema is dropped from `FormProjection.cards`. A
-/// [`Diagnostic`] with code `"form::unknown_card_tag"` is appended to
-/// `FormProjection.diagnostics` for each such card.
-///
-/// **Validation.** `QuillConfig::validate_document` is run over the
-/// document and any resulting errors are converted to diagnostics and
-/// appended to `FormProjection.diagnostics`. This is purely additive —
-/// the projection itself is never modified by validation failures.
-///
-/// # Composing existing functions
-///
-/// This function composes:
-/// - `QuillConfig::main` — to obtain the main card schema.
-/// - `QuillConfig::card_definition` — to look up card schemas by tag.
+// ── Internal projection ─────────────────────────────────────────────────────
+//
+// `project_card`, `build_form`, and `blank_card_for_tag` are the internal
+// machinery used by `Quill::form`, `Quill::blank_main`, and
+// `Quill::blank_card`. They are **deliberately not public**: consumers
+// reach the form module through methods on `Quill`, never by holding a
+// `CardSchema` and a field map directly.
+
+/// Build the [`Form`] for a document. Composes:
+/// - `QuillConfig::main` — the main card schema.
+/// - `QuillConfig::card_type` — to look up card schemas by tag.
 /// - `QuillConfig::validate_document` — to gather validation diagnostics.
 ///
-/// Coercion (`coerce_frontmatter` / `coerce_card`) is **not** applied here
-/// because `project_form` is a projection of the document as-is; coercion
-/// is a lossy transformation and would change the field values visible to
-/// the form editor. Validation diagnostics already inform the consumer when
-/// values are type-mismatched.
-pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
+/// Coercion (`coerce_frontmatter` / `coerce_card`) is **not** applied here:
+/// the form view is the document as-is so the editor sees what the user typed.
+/// Validation diagnostics already inform the consumer when values are
+/// type-mismatched.
+pub(crate) fn build_form(quill: &Quill, doc: &Document) -> Form {
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
-    // ── Main card projection ──────────────────────────────────────────────
     let main_schema = &quill.source().config().main;
     let main_fields = doc.main().frontmatter().to_index_map();
     let main = project_card(main_schema, &main_fields);
 
-    // ── Per-card projections ──────────────────────────────────────────────
     let mut cards: Vec<FormCard> = Vec::new();
-
     for (index, card) in doc.cards().iter().enumerate() {
         let tag = card.tag();
         match quill.source().config().card_type(&tag) {
@@ -161,7 +161,7 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
                         format!(
                             "card at index {index} has unknown tag \"{tag}\"; \
                              it is not declared in the quill schema and has been \
-                             excluded from the form projection"
+                             excluded from the form view"
                         ),
                     )
                     .with_code("form::unknown_card_tag".to_string()),
@@ -170,7 +170,6 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
         }
     }
 
-    // ── Validation diagnostics ────────────────────────────────────────────
     if let Err(validation_errors) = quill.source().config().validate_document(doc) {
         for err in validation_errors {
             diagnostics.push(
@@ -180,14 +179,22 @@ pub fn project_form(quill: &Quill, doc: &Document) -> FormProjection {
         }
     }
 
-    FormProjection {
+    Form {
         main,
         cards,
         diagnostics,
     }
 }
 
-// ── Private helpers ───────────────────────────────────────────────────────────
+/// Build a blank [`FormCard`] for a card type by tag, or `None` if the tag
+/// isn't declared in the quill's schema.
+pub(crate) fn blank_card_for_tag(quill: &Quill, card_type: &str) -> Option<FormCard> {
+    quill
+        .source()
+        .config()
+        .card_type(card_type)
+        .map(FormCard::blank)
+}
 
 /// Build a [`FormCard`] by walking each schema-declared field and looking up
 /// its value in `fields`.

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -1,4 +1,4 @@
-//! Tests for [`project_form`].
+//! Tests for [`Quill::form`], [`Quill::blank_main`], and [`Quill::blank_card`].
 
 use std::collections::HashMap;
 
@@ -7,7 +7,7 @@ use quillmark_core::Document;
 
 use crate::{Quill, Quillmark};
 
-use super::{project_form, FormFieldSource, FormProjection};
+use super::{Form, FormFieldSource};
 
 /// Build a minimal [`Quill`] from inline YAML with no filesystem dependencies.
 fn quill_from_yaml(yaml: &str) -> Quill {
@@ -25,14 +25,14 @@ fn quill_from_yaml(yaml: &str) -> Quill {
 }
 
 #[test]
-fn project_form_all_fields_present() {
+fn form_all_fields_present() {
     let quill = quill_from_yaml(
         r#"
 quill:
   name: form_test
   version: "1.0"
   backend: typst
-  description: Form projection test
+  description: Form view test
 
 main:
   fields:
@@ -47,19 +47,19 @@ main:
     let md = "---\nQUILL: form_test\ntitle: \"My Title\"\nstatus: \"final\"\n---\n";
     let doc = Document::from_markdown(md).unwrap();
 
-    let proj = project_form(&quill, &doc);
+    let form = quill.form(&doc);
 
-    assert!(proj.diagnostics.is_empty(), "no diagnostics expected");
-    assert!(proj.cards.is_empty(), "no cards expected");
+    assert!(form.diagnostics.is_empty(), "no diagnostics expected");
+    assert!(form.cards.is_empty(), "no cards expected");
 
-    let title_fv = proj.main.values.get("title").expect("title field");
+    let title_fv = form.main.values.get("title").expect("title field");
     assert_eq!(title_fv.source, FormFieldSource::Document);
     assert_eq!(
         title_fv.value.as_ref().and_then(|v| v.as_str()),
         Some("My Title")
     );
 
-    let status_fv = proj.main.values.get("status").expect("status field");
+    let status_fv = form.main.values.get("status").expect("status field");
     assert_eq!(status_fv.source, FormFieldSource::Document);
     assert_eq!(
         status_fv.value.as_ref().and_then(|v| v.as_str()),
@@ -73,7 +73,7 @@ main:
 }
 
 #[test]
-fn project_form_missing_field_uses_default() {
+fn form_missing_field_uses_default() {
     let quill = quill_from_yaml(
         r#"
 quill:
@@ -102,16 +102,16 @@ main:
     let md = "---\nQUILL: form_defaults_test\n---\n";
     let doc = Document::from_markdown(md).unwrap();
 
-    let proj = project_form(&quill, &doc);
+    let form = quill.form(&doc);
 
     // `title` is required and missing → validation diagnostic
     assert!(
-        proj.diagnostics.iter().any(|d| d.message.contains("title")),
+        form.diagnostics.iter().any(|d| d.message.contains("title")),
         "expected validation diagnostic for required 'title'; got: {:?}",
-        proj.diagnostics
+        form.diagnostics
     );
 
-    let status_fv = proj.main.values.get("status").expect("status field");
+    let status_fv = form.main.values.get("status").expect("status field");
     assert_eq!(status_fv.source, FormFieldSource::Default);
     assert!(
         status_fv.value.is_none(),
@@ -122,14 +122,14 @@ main:
         Some("draft")
     );
 
-    let notes_fv = proj.main.values.get("notes").expect("notes field");
+    let notes_fv = form.main.values.get("notes").expect("notes field");
     assert_eq!(notes_fv.source, FormFieldSource::Missing);
     assert!(notes_fv.value.is_none());
     assert!(notes_fv.default.is_none());
 }
 
 #[test]
-fn project_form_unknown_card_tag_drops_card_and_emits_diagnostic() {
+fn form_unknown_card_tag_drops_card_and_emits_diagnostic() {
     let quill = quill_from_yaml(
         r#"
 quill:
@@ -156,14 +156,14 @@ card_types:
               ---\nCARD: ghost_card\nnote: \"B\"\n---\n";
     let doc = Document::from_markdown(md).unwrap();
 
-    let proj = project_form(&quill, &doc);
+    let form = quill.form(&doc);
 
     // Only the known card appears in cards
-    assert_eq!(proj.cards.len(), 1, "only known_card should be projected");
-    assert_eq!(proj.cards[0].schema.name, "known_card");
+    assert_eq!(form.cards.len(), 1, "only known_card should be projected");
+    assert_eq!(form.cards[0].schema.name, "known_card");
 
     // A diagnostic for ghost_card
-    let unknown_diag = proj
+    let unknown_diag = form
         .diagnostics
         .iter()
         .find(|d| d.code.as_deref() == Some("form::unknown_card_tag"))
@@ -176,7 +176,7 @@ card_types:
 }
 
 #[test]
-fn project_form_card_field_sources() {
+fn form_card_field_sources() {
     let quill = quill_from_yaml(
         r#"
 quill:
@@ -209,9 +209,9 @@ card_types:
               ---\nCARD: indorsement\nsignature_block: \"Col Smith\"\n---\n";
     let doc = Document::from_markdown(md).unwrap();
 
-    let proj = project_form(&quill, &doc);
-    assert_eq!(proj.cards.len(), 1);
-    let card = &proj.cards[0];
+    let form = quill.form(&doc);
+    assert_eq!(form.cards.len(), 1);
+    let card = &form.cards[0];
 
     let sig = card.values.get("signature_block").expect("signature_block");
     assert_eq!(sig.source, FormFieldSource::Document);
@@ -232,7 +232,7 @@ card_types:
 }
 
 #[test]
-fn project_form_validation_diagnostics_appear() {
+fn form_validation_diagnostics_appear() {
     let quill = quill_from_yaml(
         r#"
 quill:
@@ -253,9 +253,9 @@ main:
     let md = "---\nQUILL: validation_diag_test\ncount: \"not-a-number\"\n---\n";
     let doc = Document::from_markdown(md).unwrap();
 
-    let proj = project_form(&quill, &doc);
+    let form = quill.form(&doc);
 
-    let val_diag = proj
+    let val_diag = form
         .diagnostics
         .iter()
         .find(|d| d.code.as_deref() == Some("form::validation_error"))
@@ -268,8 +268,8 @@ main:
 }
 
 #[test]
-fn project_form_serializes_cleanly() {
-    // Smoke test: serde_json round-trip of FormProjection.
+fn form_serializes_cleanly() {
+    // Smoke test: serde_json round-trip of Form.
     let quill = quill_from_yaml(
         r#"
 quill:
@@ -290,20 +290,19 @@ main:
 
     let md = "---\nQUILL: serial_test\ntitle: \"Hello\"\n---\n";
     let doc = Document::from_markdown(md).unwrap();
-    let proj = project_form(&quill, &doc);
+    let form = quill.form(&doc);
 
-    let json = serde_json::to_string(&proj).expect("FormProjection must serialize");
-    let back: FormProjection =
-        serde_json::from_str(&json).expect("FormProjection must deserialize");
+    let json = serde_json::to_string(&form).expect("Form must serialize");
+    let back: Form = serde_json::from_str(&json).expect("Form must deserialize");
 
     // Name fields on CardSchema / FieldSchema are intentionally skipped on the
     // wire (the map key carries them), so round-trip identity does not hold for
     // those. Compare structural content instead.
-    assert_eq!(proj.main.values, back.main.values);
-    assert_eq!(proj.cards, back.cards);
-    assert_eq!(proj.diagnostics, back.diagnostics);
+    assert_eq!(form.main.values, back.main.values);
+    assert_eq!(form.cards, back.cards);
+    assert_eq!(form.diagnostics, back.diagnostics);
     assert_eq!(
-        proj.main.schema.fields.keys().collect::<Vec<_>>(),
+        form.main.schema.fields.keys().collect::<Vec<_>>(),
         back.main.schema.fields.keys().collect::<Vec<_>>()
     );
     assert!(
@@ -313,8 +312,8 @@ main:
 }
 
 #[test]
-fn project_form_over_usaf_memo_fixture() {
-    // Integration test: load the usaf_memo fixture quill and project the
+fn form_over_usaf_memo_fixture() {
+    // Integration test: load the usaf_memo fixture quill and view the
     // bundled example.  Checks that every required field gets a deterministic
     // FormFieldSource and no projection panics.
     let quill_path = quillmark_fixtures::resource_path("quills/usaf_memo/0.1.0");
@@ -330,16 +329,16 @@ fn project_form_over_usaf_memo_fixture() {
         Err(_) => return,
     };
 
-    let proj = project_form(&quill, &doc);
+    let form = quill.form(&doc);
 
-    // Projection must produce a FormCard for main with at least the required fields.
+    // The form must produce a FormCard for main with at least the required fields.
     assert!(
-        !proj.main.values.is_empty(),
-        "main card projection should have fields"
+        !form.main.values.is_empty(),
+        "main card view should have fields"
     );
 
     // Every field value must have a deterministic source.
-    for (name, fv) in &proj.main.values {
+    for (name, fv) in &form.main.values {
         match fv.source {
             FormFieldSource::Document => {
                 assert!(
@@ -371,6 +370,113 @@ fn project_form_over_usaf_memo_fixture() {
     }
 
     // Serialization must not panic.
-    let json = serde_json::to_string(&proj).expect("projection must serialize");
+    let json = serde_json::to_string(&form).expect("form must serialize");
     assert!(!json.is_empty());
+}
+
+// ── blank_main / blank_card ─────────────────────────────────────────────────
+
+#[test]
+fn blank_main_has_default_or_missing_sources() {
+    let quill = quill_from_yaml(
+        r#"
+quill:
+  name: blank_main_test
+  version: "1.0"
+  backend: typst
+  description: Blank main test
+
+main:
+  fields:
+    title:
+      type: string
+      default: Untitled
+    count:
+      type: integer
+"#,
+    );
+
+    let blank = quill.blank_main();
+
+    let title = blank.values.get("title").expect("title field");
+    assert_eq!(title.source, FormFieldSource::Default);
+    assert!(title.value.is_none());
+    assert_eq!(
+        title.default.as_ref().and_then(|v| v.as_str()),
+        Some("Untitled")
+    );
+
+    let count = blank.values.get("count").expect("count field");
+    assert_eq!(count.source, FormFieldSource::Missing);
+    assert!(count.value.is_none());
+    assert!(count.default.is_none());
+}
+
+#[test]
+fn blank_card_returns_form_card_for_known_type() {
+    let quill = quill_from_yaml(
+        r#"
+quill:
+  name: blank_card_test
+  version: "1.0"
+  backend: typst
+  description: Blank card test
+
+main:
+  fields:
+    title:
+      type: string
+
+card_types:
+  indorsement:
+    fields:
+      office:
+        type: string
+        default: HQ
+      from:
+        type: string
+"#,
+    );
+
+    let blank = quill
+        .blank_card("indorsement")
+        .expect("known card type should yield a FormCard");
+
+    assert_eq!(blank.schema.name, "indorsement");
+
+    let office = blank.values.get("office").expect("office field");
+    assert_eq!(office.source, FormFieldSource::Default);
+    assert!(office.value.is_none());
+    assert_eq!(office.default.as_ref().and_then(|v| v.as_str()), Some("HQ"));
+
+    let from = blank.values.get("from").expect("from field");
+    assert_eq!(from.source, FormFieldSource::Missing);
+    assert!(from.value.is_none());
+    assert!(from.default.is_none());
+}
+
+#[test]
+fn blank_card_returns_none_for_unknown_type() {
+    let quill = quill_from_yaml(
+        r#"
+quill:
+  name: blank_unknown_test
+  version: "1.0"
+  backend: typst
+  description: Blank unknown card test
+
+main:
+  fields:
+    title:
+      type: string
+
+card_types:
+  known:
+    fields:
+      x:
+        type: string
+"#,
+    );
+
+    assert!(quill.blank_card("does_not_exist").is_none());
 }

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -30,7 +30,7 @@ pub mod form;
 pub mod orchestration;
 
 // Re-export commonly-used form types at the crate root
-pub use form::{FormCard, FormFieldSource, FormFieldValue, FormProjection};
+pub use form::{Form, FormCard, FormFieldSource, FormFieldValue};
 
 // Re-export types from orchestration module
 pub use orchestration::{Quill, Quillmark};

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -10,6 +10,8 @@ use quillmark_core::{
     Severity,
 };
 
+use crate::form::{self, Form, FormCard};
+
 /// Renderable quill. Composes an [`Arc<QuillSource>`] with a resolved
 /// [`Backend`]. Constructed by the engine; immutable once created.
 #[derive(Clone)]
@@ -245,6 +247,44 @@ impl Quill {
             .plate()
             .filter(|s| !s.is_empty())
             .map(str::to_string)
+    }
+
+    /// The schema-aware form view of `doc` — the whole-document snapshot
+    /// rendered through this quill's schema.
+    ///
+    /// For each schema-declared field on the main card and on every
+    /// recognised card, the returned [`Form`] records the current value, the
+    /// schema default, and a [`form::FormFieldSource`] label.
+    ///
+    /// **Snapshot semantics.** The result is a read-only snapshot — re-call
+    /// after editing `doc`.
+    ///
+    /// **Unknown card tags** are dropped from [`Form::cards`] and surface as
+    /// `form::unknown_card_tag` diagnostics. Validation errors are appended
+    /// as `form::validation_error` diagnostics; the view itself is never
+    /// altered or filtered by validation failures.
+    pub fn form(&self, doc: &Document) -> Form {
+        form::build_form(self, doc)
+    }
+
+    /// A blank form for the main card — no document values supplied. Every
+    /// declared field's source is [`form::FormFieldSource::Default`] (when
+    /// the schema declares a default) or [`form::FormFieldSource::Missing`].
+    ///
+    /// Useful as a starting state for a fresh document, or for previewing the
+    /// main-card form without a document in hand.
+    pub fn blank_main(&self) -> FormCard {
+        FormCard::blank(&self.source.config().main)
+    }
+
+    /// A blank form for a card of the given type — no document values
+    /// supplied. Returns `None` if `card_type` is not declared in the
+    /// quill's schema.
+    ///
+    /// This is the "user is about to add a new card" view: the UI can render
+    /// the form before the card is committed to the document.
+    pub fn blank_card(&self, card_type: &str) -> Option<FormCard> {
+        form::blank_card_for_tag(self, card_type)
     }
 
     /// Perform a dry-run validation without backend compilation.


### PR DESCRIPTION
Reshapes the form-view surface around methods on `Quill`:

- `quill.form(&doc) -> Form`           (was: `project_form(quill, doc)`)
- `quill.blank_main() -> FormCard`     (new)
- `quill.blank_card(tag) -> Option<FormCard>` (new)
- `FormCard::blank(schema)`            (new)

`FormProjection` is renamed to `Form`. The free function `project_form`
and the internal `(schema, fields) -> FormCard` primitive are no longer
public — consumers reach the form module through `Quill` only.

`blank_main` / `blank_card` give form consumers a way to project schema
defaults onto a fresh, not-yet-committed card so a UI can render the
"add new card" panel before the card is inserted into the document.

WASM and Python bindings updated: `quill.projectForm` → `quill.form`,
adds `blankMain` / `blankCard` (JS) and `blank_main` / `blank_card`
(Python). Tests updated across all three layers.