### PR TITLE
ci: switch release flow to direct commit + tag trigger

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -18,16 +18,14 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      # Use a GitHub App token so the branch push and PR creation trigger
-      # downstream workflows (CI). Events from the default GITHUB_TOKEN are
-      # suppressed by GitHub to prevent recursive runs, which leaves release
-      # PRs without checks.
+      # Use a GitHub App token so the push to main and the v* tag trigger
+      # the release workflow. Pushes signed with the default GITHUB_TOKEN
+      # don't fire downstream workflow events.
       - name: Generate tagger token
         id: tagger
         uses: actions/create-github-app-token@v1
@@ -39,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
           token: ${{ steps.tagger.outputs.token }}
 
       - name: Setup Rust toolchain
@@ -123,47 +122,31 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "New version: $VERSION"
 
-      - name: Create release branch and commit
+      - name: Commit and tag on main
         run: |
           VERSION="${{ steps.next.outputs.version }}"
-          BRANCH="release/v${VERSION}"
+          TAG="v${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
           git add -A
           git commit -m "chore: bump version to ${VERSION}"
-          git push origin "$BRANCH"
+          git tag -a "$TAG" -m "Release ${TAG}"
 
-      - name: Open pull request
-        env:
-          GH_TOKEN: ${{ steps.tagger.outputs.token }}
-        run: |
-          VERSION="${{ steps.next.outputs.version }}"
-          PREV="${{ steps.current.outputs.version }}"
-
-          PRERELEASE=${{ inputs.prerelease }}
-          if [ "$PRERELEASE" == "true" ]; then
-            TITLE="release: v${VERSION} (pre-release)"
-            LABEL="⚠️ **Pre-release** — this will be marked as a pre-release on GitHub."
-          else
-            TITLE="release: v${VERSION}"
-            LABEL=""
-          fi
-
-          gh pr create \
-            --base main \
-            --head "release/v${VERSION}" \
-            --title "$TITLE" \
-            --body "## Release v${VERSION}
-
-          Bumps workspace version from \`${PREV}\` → \`${VERSION}\` (${{ inputs.bump }}).
-
-          ${LABEL}
-
-          ### Publish targets
-          - **crates.io** — \`quillmark-core\`, \`quillmark-typst\`, \`quillmark\`
-          - **npm** — \`@quillmark/wasm\`
-          - **PyPI** — \`quillmark\`
-
-          Merging this PR will create a GitHub Release tagged \`v${VERSION}\` and publish all packages."
+          # Atomic push of the bump commit + tag. Retry once with a rebase
+          # in case main moved during the run.
+          for attempt in 1 2; do
+            if git push --atomic origin main "refs/tags/${TAG}"; then
+              echo "Pushed ${TAG} and main"
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::Failed to push release commit and tag after retry."
+              exit 1
+            fi
+            echo "Push rejected; rebasing on origin/main and retrying"
+            git fetch origin main
+            git tag -d "$TAG"
+            git rebase origin/main
+            git tag -a "$TAG" -m "Release ${TAG}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: Release
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+  push:
+    tags:
+      - 'v*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,13 +13,9 @@ env:
 
 jobs:
   # ──────────────────────────────────────────────
-  # Gate: only run when a release/* PR is merged
+  # Release: cut a GitHub Release for the pushed tag
   # ──────────────────────────────────────────────
   release:
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/') &&
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,50 +23,32 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
-      - name: Generate tagger token
-        id: tagger
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.TAGGER_APP_ID }}
-          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: main
-          token: ${{ steps.tagger.outputs.token }}
+          ref: ${{ github.ref }}
 
-      - name: Extract version from workspace
+      - name: Extract version from tag
         id: version
         run: |
-          VERSION=$(cargo metadata --format-version=1 --no-deps \
-            | jq -r '.packages[] | select(.name == "quillmark") | .version')
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 
-      - name: Validate release branch matches version
+      - name: Validate workspace version matches tag
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          EXPECTED="release/v${VERSION}"
-          ACTUAL="${{ github.event.pull_request.head.ref }}"
-
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-            echo "::error::Branch/version mismatch: expected '$EXPECTED' but got '$ACTUAL'"
+          WORKSPACE=$(cargo metadata --format-version=1 --no-deps \
+            | jq -r '.packages[] | select(.name == "quillmark") | .version')
+          if [ "$WORKSPACE" != "$VERSION" ]; then
+            echo "::error::Tag/workspace mismatch: tag is 'v$VERSION' but Cargo workspace is at 'v$WORKSPACE'"
             exit 1
           fi
 
-      - name: Create tag
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release v${VERSION}"
-          git push origin "v${VERSION}"
-
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ steps.tagger.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 

--- a/prose/designs/CI_CD.md
+++ b/prose/designs/CI_CD.md
@@ -28,19 +28,20 @@ Excluded: multi-OS matrix, MSRV, security scanners, coverage, benchmarks.
 
 ### Release Preparation (`release-prepare.yml`)
 
-**Trigger**: `workflow_dispatch` from GitHub UI with a `bump` input (`patch` or `minor`).
+**Trigger**: `workflow_dispatch` from GitHub UI with a `bump` input (`patch` or `minor`) and an optional `prerelease` flag.
 
 1. Installs `cargo-release` and runs `cargo release version <bump>` to bump all workspace `Cargo.toml` versions and intra-workspace dependencies.
-2. Pushes a `release/vX.Y.Z` branch and opens a PR targeting `main`.
-3. The PR is reviewed and merged through the normal code review process.
+2. Commits the bump directly to `main` and atomically pushes the `vX.Y.Z` tag alongside it.
+
+The push uses a GitHub App token so the resulting tag fires the release workflow (events from the default `GITHUB_TOKEN` are suppressed by GitHub).
 
 ### Release & Publish (`release.yml`)
 
-**Trigger**: merged pull request on `main` where the source branch matches `release/*`.
+**Trigger**: push of a `v*` tag.
 
 **Phase 1 — Release** (runs first):
-1. Extracts version from `Cargo.toml` and validates it matches the branch name.
-2. Creates a git tag `vX.Y.Z` and a GitHub Release.
+1. Extracts the version from the tag name and validates it matches the workspace `Cargo.toml`.
+2. Creates a GitHub Release for the tag (marked as a pre-release for `-rc` versions).
 
 **Phase 2 — Publish** (all run in parallel, after release):
 
@@ -59,6 +60,6 @@ Excluded: multi-OS matrix, MSRV, security scanners, coverage, benchmarks.
 ## 3) Versioning
 
 - SemVer across all workspace crates and bindings.
-- Version bumps are initiated via GitHub UI (`workflow_dispatch`), executed by `cargo-release` in CI, and gated by PR review before merge.
+- Version bumps are initiated via GitHub UI (`workflow_dispatch`) and executed by `cargo-release` in CI, which commits directly to `main` and pushes the `vX.Y.Z` tag.
 - WASM npm package version is derived from the workspace version at build time (`scripts/build-wasm.sh`).
 - Python package version is derived from the workspace Cargo.toml via maturin's `dynamic = ["version"]`.


### PR DESCRIPTION
release-prepare now commits the version bump directly to main and pushes
the vX.Y.Z tag in the same atomic push. release.yml triggers on `v*`
tag pushes instead of merged release/* PRs.

https://claude.ai/code/session_01DyTYLMND2maEnMT6Csk8M2