### PR TITLE
Change out-of-bounds page validation from warning to error

### DIFF
--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -172,51 +172,44 @@ pub fn render_document_pages(
     }
 
     let page_count = document.pages.len();
-    let requested_indices: Vec<usize> = match pages {
-        Some(slice) => slice.to_vec(),
+    let selected_indices: Vec<usize> = match pages {
+        Some(slice) => {
+            let out_of_bounds: Vec<usize> =
+                slice.iter().copied().filter(|&i| i >= page_count).collect();
+            if !out_of_bounds.is_empty() {
+                return Err(RenderError::ValidationFailed {
+                    diag: Box::new(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "Page index out of bounds (page_count={}); offending indices: {:?}. Check `RenderSession.pageCount` before requesting pages.",
+                                page_count, out_of_bounds
+                            ),
+                        )
+                        .with_code("typst::page_index_out_of_bounds".to_string()),
+                    ),
+                });
+            }
+            slice.to_vec()
+        }
         None => (0..page_count).collect(),
     };
 
-    // Partition into valid and out-of-bounds indices, preserving requested order
-    let mut warnings = Vec::new();
-    let valid_indices: Vec<usize> = requested_indices
-        .into_iter()
-        .filter(|&idx| {
-            if idx >= page_count {
-                warnings.push(
-                    Diagnostic::new(
-                        Severity::Warning,
-                        format!(
-                            "Page index {} out of bounds (page_count={}), skipped",
-                            idx, page_count
-                        ),
-                    )
-                    .with_code("typst::page_index_out_of_bounds".to_string()),
-                );
-                false
-            } else {
-                true
-            }
-        })
-        .collect();
-
     match format {
         OutputFormat::Svg => {
-            let artifacts = valid_indices
+            let artifacts = selected_indices
                 .into_iter()
                 .map(|idx| Artifact {
                     bytes: typst_svg::svg(&document.pages[idx]).into_bytes(),
                     output_format: OutputFormat::Svg,
                 })
                 .collect();
-            let mut result = RenderResult::new(artifacts, OutputFormat::Svg);
-            result.warnings = warnings;
-            Ok(result)
+            Ok(RenderResult::new(artifacts, OutputFormat::Svg))
         }
         OutputFormat::Png => {
             let scale = ppi.unwrap_or(DEFAULT_PPI) / 72.0;
-            let mut artifacts = Vec::with_capacity(valid_indices.len());
-            for idx in valid_indices {
+            let mut artifacts = Vec::with_capacity(selected_indices.len());
+            for idx in selected_indices {
                 let pixmap = typst_render::render(&document.pages[idx], scale);
                 let png_data = pixmap
                     .encode_png()
@@ -232,9 +225,7 @@ pub fn render_document_pages(
                     output_format: OutputFormat::Png,
                 });
             }
-            let mut result = RenderResult::new(artifacts, OutputFormat::Png);
-            result.warnings = warnings;
-            Ok(result)
+            Ok(RenderResult::new(artifacts, OutputFormat::Png))
         }
         OutputFormat::Pdf => {
             let pdf = typst_pdf::pdf(document, &PdfOptions::default()).map_err(|e| {

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -611,17 +611,16 @@ describe('quill.open + session.render', () => {
     expect(subset.artifacts[0].mimeType).toBe('image/png')
   })
 
-  it('should warn and skip out-of-bounds page indices', () => {
+  it('should throw on out-of-bounds page indices', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const session = quill.open(doc)
     const oob = session.pageCount + 10
 
-    const result = session.render({ format: 'png', ppi: 80, pages: [0, oob] })
-    expect(result.artifacts.length).toBe(1)
-    expect(result.warnings.length).toBeGreaterThan(0)
-    expect(result.warnings[0].message).toContain('out of bounds')
+    expect(() => {
+      session.render({ format: 'png', ppi: 80, pages: [0, oob] })
+    }).toThrow(/out of bounds/)
   })
 
   it('should error when requesting page selection with PDF', () => {

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -252,9 +252,11 @@ pub struct RenderOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ppi: Option<f32>,
     /// Optional 0-based page indices to render (e.g., `[0, 2]` for the
-    /// first and third pages). `undefined` renders all pages. **Not
-    /// supported for PDF output** — passing `pages` with `format: "pdf"`
-    /// yields a `FormatNotSupported` error.
+    /// first and third pages). `undefined` renders all pages. Any index
+    /// `>= pageCount` causes the render to throw — read
+    /// `RenderSession.pageCount` first if validation is needed.
+    /// **Not supported for PDF output** — passing `pages` with
+    /// `format: "pdf"` yields a `FormatNotSupported` error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pages: Option<Vec<usize>>,
 }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -32,9 +32,11 @@ pub struct RenderOptions {
     /// Defaults to 144.0 (2x at 72pt/inch) when `None`.
     pub ppi: Option<f32>,
     /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
-    /// the first and third pages). `None` renders all pages. Backends
-    /// that do not support page selection (notably PDF) return a
-    /// `FormatNotSupported` error when this is `Some`.
+    /// the first and third pages). `None` renders all pages. Any index
+    /// `>= page_count` causes a `ValidationFailed` error — call
+    /// `RenderSession::page_count()` first if validation is needed.
+    /// Backends that do not support page selection (notably PDF) return
+    /// a `FormatNotSupported` error when this is `Some`.
     pub pages: Option<Vec<usize>>,
 }
 


### PR DESCRIPTION
## Summary
This PR changes the handling of out-of-bounds page indices in render requests from a lenient approach (warning and skipping invalid pages) to a strict approach (throwing/returning an error). This makes the API contract clearer and prevents silent failures.

## Key Changes

- **Validation behavior**: Out-of-bounds page indices now cause a `ValidationFailed` error instead of being silently skipped with a warning
  - In `render_document_pages()`, invalid indices are detected upfront and return an error immediately
  - Removed the post-processing logic that filtered out invalid indices and collected warnings

- **Error handling**: 
  - Changed from collecting warnings in `RenderResult` to returning early with a `RenderError::ValidationFailed`
  - Error message includes the page count and all offending indices for better debugging
  - Recommends checking `RenderSession.pageCount` before requesting pages

- **API documentation**: Updated comments in both `crates/core/src/types.rs` and `crates/bindings/wasm/src/types.rs` to reflect the new strict validation behavior

- **Test updates**: Updated `basic.test.js` to expect an exception instead of warnings when out-of-bounds indices are provided

## Implementation Details

The validation now happens immediately when `pages` is `Some`, before any rendering work begins. This is more efficient and provides clearer error semantics—callers must ensure their page indices are valid rather than relying on the renderer to silently handle invalid requests.

https://claude.ai/code/session_01Q2va1R6D7vVcnXDdgEHSYj