### PR TITLE
Remove unused dependencies across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,12 +269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
-name = "cargo-husky"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,8 +2158,6 @@ dependencies = [
 name = "quillmark"
 version = "0.64.0"
 dependencies = [
- "anyhow",
- "cargo-husky",
  "indexmap",
  "quillmark-core",
  "quillmark-fixtures",
@@ -2180,7 +2172,6 @@ dependencies = [
 name = "quillmark-cli"
 version = "0.64.0"
 dependencies = [
- "anyhow",
  "clap",
  "quillmark",
  "quillmark-core",
@@ -2209,7 +2200,6 @@ name = "quillmark-fixtures"
 version = "0.64.0"
 dependencies = [
  "quillmark",
- "quillmark-typst",
 ]
 
 [[package]]
@@ -2225,8 +2215,6 @@ dependencies = [
 name = "quillmark-python"
 version = "0.64.0"
 dependencies = [
- "anyhow",
- "indexmap",
  "pyo3",
  "quillmark",
  "quillmark-core",
@@ -2261,21 +2249,17 @@ name = "quillmark-wasm"
 version = "0.64.0"
 dependencies = [
  "console_error_panic_hook",
- "getrandom 0.3.4",
- "indexmap",
  "js-sys",
  "quillmark",
  "quillmark-core",
  "quillmark-typst",
  "serde",
- "serde-saphyr",
  "serde-wasm-bindgen 0.6.5",
  "serde_bytes",
  "serde_json",
  "tsify",
  "wasm-bindgen",
  "wasm-bindgen-test",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,6 @@ tempfile = "~3.23"
 proptest = "~1.5"
 quillmark-fixtures = { path = "crates/fixtures" }
 
-cargo-husky = { version = "~1", default-features = false, features = [
-    "user-hooks",
-] }
-
 [workspace.metadata.workspaces]
 # Exclude fixtures from publishing since it's dev-only
 no_individual_tags = true

--- a/crates/bindings/cli/Cargo.toml
+++ b/crates/bindings/cli/Cargo.toml
@@ -22,6 +22,5 @@ clap = { version = "~4.5", features = ["derive"] }
 quillmark = { workspace = true }
 quillmark-typst = { workspace = true, default-features = false, features = ["embed-default-font"] }
 quillmark-core = { workspace = true }
-anyhow = { workspace = true}
 serde_json = { workspace = true }
 

--- a/crates/bindings/python/Cargo.toml
+++ b/crates/bindings/python/Cargo.toml
@@ -14,7 +14,5 @@ crate-type = ["cdylib"]
 pyo3 = { version = "~0.26", features = ["extension-module", "abi3-py310"] }
 quillmark = { workspace = true, default-features = true }
 quillmark-core = { workspace = true }
-indexmap = { workspace = true }
 quillmark-typst = { workspace = true, default-features = false, features = ["embed-default-font"] }
-anyhow = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -20,21 +20,14 @@ quillmark-typst = { workspace = true, default-features = false, features = [
     "embed-default-font",
 ] }
 quillmark-core = { workspace = true }
-indexmap = { workspace = true }
 wasm-bindgen = "0.2"
 serde = { workspace = true }
 serde_bytes = "0.11"
 serde_json = { workspace = true }
-serde-saphyr = { workspace = true }
 serde-wasm-bindgen = "0.6"
 tsify = { version = "0.4.5", features = ["js"] }
 console_error_panic_hook = "0.1"
 js-sys = "0.3"
-getrandom = { version = "0.3", features = ["wasm_js"] }
-
-[dependencies.web-sys]
-version = "0.3"
-features = ["console"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/fixtures/Cargo.toml
+++ b/crates/fixtures/Cargo.toml
@@ -10,4 +10,3 @@ publish = false  # Don't publish test fixtures to crates.io
 
 [dependencies]
 quillmark = { workspace = true }
-quillmark-typst = { workspace = true }

--- a/crates/quillmark/Cargo.toml
+++ b/crates/quillmark/Cargo.toml
@@ -16,7 +16,6 @@ quillmark-typst = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-anyhow = { workspace = true }
 indexmap = { workspace = true }
 
 [dev-dependencies]
@@ -24,8 +23,6 @@ tempfile = { workspace = true }
 quillmark-typst = { workspace = true }
 quillmark-fixtures = { workspace = true }
 serde_json = { workspace = true }
-# host cargo husky dev dep
-cargo-husky = { workspace = true }
 
 [features]
 default = ["typst"]


### PR DESCRIPTION
## Summary
This PR removes unused dependencies that were declared but not actively used across the workspace crates.

## Key Changes
- **crates/bindings/wasm**: Removed `indexmap`, `serde-saphyr`, `getrandom`, and `web-sys` dependencies
- **crates/bindings/python**: Removed `indexmap` and `anyhow` dependencies
- **crates/bindings/cli**: Removed `anyhow` dependency
- **crates/quillmark**: Removed `anyhow` dependency from main dependencies and `cargo-husky` from dev dependencies
- **crates/fixtures**: Removed `quillmark-typst` dependency
- **Root workspace**: Removed `cargo-husky` dev dependency

## Notes
These dependencies were likely added during development or for future use but are no longer required by the current codebase. Removing them reduces the dependency tree and improves build times.

https://claude.ai/code/session_01Meu4LqTfgoWe58mao7YcmL