### PR TITLE
feat(wasm): add cardCount + equals, drop WasmError.message duplicate, enable --weak-refs

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -11,8 +11,11 @@ Use Quillmark in browsers/Node.js with explicit in-memory trees (`Map<string, Ui
 ## Build
 
 ```bash
-wasm-pack build --target bundler --scope quillmark
+bash scripts/build-wasm.sh
 ```
+
+The script builds for `bundler` and `experimental-nodejs-module` targets with
+`--weak-refs` enabled (see [Lifecycle](#lifecycle)).
 
 ## Test
 
@@ -51,11 +54,30 @@ Create engine.
 Build + validate + attach backend. Returns a render-ready `Quill`.
 
 ### `Document.fromMarkdown(markdown)`
-Parse markdown to parsed document.
+Parse markdown to a parsed document. Throws a JS `Error` (with `.diagnostics`
+attached, see [Errors](#errors)) on any parse failure, including missing
+`QUILL`, malformed YAML, and inputs over the 10 MB `parse::input_too_large`
+limit.
 
 ### `doc.toMarkdown()`
 Emit canonical Quillmark Markdown. Type-fidelity round-trip safe:
-`Document.fromMarkdown(doc.toMarkdown())` returns a document equal to `doc`.
+`Document.fromMarkdown(doc.toMarkdown())` returns a document equal to `doc`
+under [`doc.equals`](#docequalsother). The output is **not** guaranteed
+byte-equal to the original source — YAML quoting, key ordering, and
+whitespace are normalised. Use `equals` (not string comparison) to test
+semantic equality.
+
+### `doc.equals(other)`
+Structural equality between two `Document` handles. Compares `main` and
+`cards` by value; parse-time `warnings` are intentionally excluded.
+
+Use this to debounce upstream prop updates: keep the last parsed `Document`
+and compare instead of re-parsing on every keystroke.
+
+### `doc.cardCount`
+O(1) getter for the number of composable cards (excluding the main card).
+Use this to validate indices before calling card mutators (`removeCard`,
+`updateCardField`, etc.) without allocating the full `cards` array.
 
 ### `quill.render(parsed, opts?)`
 Render with a pre-parsed `Document`.
@@ -65,15 +87,36 @@ Open once, render all or selected pages (`opts.pages`).
 
 ### Errors
 
-Every method that can fail throws a JS `Error` with a flat shape:
+Every method that can fail throws a JS `Error` with `.diagnostics` attached:
 
 ```ts
 { message: string, diagnostics: Diagnostic[] }
 ```
 
 `diagnostics` is always non-empty — length 1 for most failures, length N for
-backend compilation errors. Read `err.diagnostics[0]` for the primary
-diagnostic; iterate the array for compilation failures.
+backend compilation errors. `message` is derived from `diagnostics`
+(`diagnostics[0].message` for single-diagnostic errors; an aggregate
+`"<N> error(s): <first.message>"` summary for compilation failures).
+
+Read `err.diagnostics[0]` for the primary diagnostic; iterate the array for
+compilation failures. The same shape applies to every throw site:
+
+- `Document.fromMarkdown` — parse errors (missing `QUILL`, YAML errors,
+  `parse::input_too_large` for inputs > 10 MB).
+- `Document` mutators (`setField`, `updateCardField`, etc.) — `EditError`
+  variants (`ReservedName`, `InvalidFieldName`, `InvalidTagName`,
+  `IndexOutOfRange`) appear in `diagnostics[0].message` with the
+  `[EditError::<Variant>]` prefix.
+- `quill.render` / `session.render` — backend compilation failures and
+  validation errors.
+
+### Lifecycle
+
+The wasm bindings are built with `--weak-refs`, so dropped `Document`,
+`Quill`, and `RenderSession` handles are reclaimed by `FinalizationRegistry`
+without manual `.free()` discipline. `.free()` is still emitted as an eager
+teardown hook for callers that want deterministic release. Requires
+Node 14.6+ / current evergreen browsers (all supported targets).
 
 ## Notes
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -496,6 +496,59 @@ Card two.
     const doc = Document.fromMarkdown(MD_WITH_CARDS) // 2 cards
     expect(() => doc.setCardTag(5, 'annotation')).toThrow(/IndexOutOfRange/)
   })
+
+  it('cardCount reports composable card count without allocating', () => {
+    const empty = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(empty.cardCount).toBe(0)
+
+    const two = Document.fromMarkdown(MD_WITH_CARDS)
+    expect(two.cardCount).toBe(2)
+    two.pushCard({ tag: 'extra' })
+    expect(two.cardCount).toBe(3)
+    two.removeCard(0)
+    expect(two.cardCount).toBe(2)
+  })
+})
+
+describe('Document.equals', () => {
+  it('returns true for identical documents', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(a.equals(b)).toBe(true)
+  })
+
+  it('returns true for clones', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = a.clone()
+    expect(a.equals(b)).toBe(true)
+  })
+
+  it('returns false after a frontmatter mutation', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = Document.fromMarkdown(TEST_MARKDOWN)
+    b.setField('title', 'Different')
+    expect(a.equals(b)).toBe(false)
+  })
+
+  it('returns false after a body mutation', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = Document.fromMarkdown(TEST_MARKDOWN)
+    b.replaceBody('Different body')
+    expect(a.equals(b)).toBe(false)
+  })
+
+  it('returns false after pushing a card', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = Document.fromMarkdown(TEST_MARKDOWN)
+    b.pushCard({ tag: 'note' })
+    expect(a.equals(b)).toBe(false)
+  })
+
+  it('survives round-trip through toMarkdown / fromMarkdown', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = Document.fromMarkdown(a.toMarkdown())
+    expect(a.equals(b)).toBe(true)
+  })
 })
 
 describe('Document editor surface — updateCardField / updateCardBody', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -368,6 +368,28 @@ impl Document {
         cards.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
     }
 
+    /// Number of composable cards (excludes the main card).
+    ///
+    /// O(1). Use this to validate indices before calling card mutators
+    /// instead of allocating the full `cards` array.
+    #[wasm_bindgen(getter, js_name = cardCount)]
+    pub fn card_count(&self) -> usize {
+        self.inner.cards().len()
+    }
+
+    /// Structural equality against another `Document`.
+    ///
+    /// Compares `main` and `cards` by value (matching core's [`PartialEq`]).
+    /// Parse-time `warnings` are intentionally excluded — they describe the
+    /// source text, not the document's content.
+    ///
+    /// Use this to debounce upstream prop updates: keep the last parsed
+    /// `Document` and compare instead of re-parsing on every keystroke.
+    #[wasm_bindgen(js_name = equals)]
+    pub fn equals(&self, other: &Document) -> bool {
+        self.inner == other.inner
+    }
+
     /// Non-fatal parse-time warnings as an array of typed `Diagnostic` objects.
     #[wasm_bindgen(getter, js_name = warnings, unchecked_return_type = "Diagnostic[]")]
     pub fn warnings(&self) -> JsValue {

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -7,31 +7,41 @@ use wasm_bindgen::prelude::*;
 
 /// Serializable error for JavaScript consumption.
 ///
-/// Single uniform shape regardless of underlying error variant:
+/// Single uniform shape regardless of underlying error variant: a non-empty
+/// list of [`Diagnostic`]s. The thrown JS `Error`'s `.message` is derived
+/// from `diagnostics` (`diagnostics[0].message` for single-diagnostic
+/// errors, an aggregate `"… N error(s)"` summary for compilation failures),
+/// and a `.diagnostics` property carries the full array.
 ///
-/// ```text
-/// { message: string, diagnostics: Diagnostic[] }
-/// ```
-///
-/// `diagnostics` is always a non-empty array — length 1 for
-/// single-diagnostic errors, length N for compilation failures. The thrown
-/// JS `Error` has its `.message` set to `message` and a `.diagnostics`
-/// property attached carrying the array. Read `err.diagnostics[0]` for the
-/// primary diagnostic.
+/// Read `err.diagnostics[0]` for the primary diagnostic; iterate the array
+/// for backend compilation failures.
 #[derive(Debug, Clone)]
 pub struct WasmError {
-    pub message: String,
     pub diagnostics: Vec<Diagnostic>,
 }
 
 impl WasmError {
+    /// Display message for the JS `Error` constructor.
+    ///
+    /// For single-diagnostic errors this is the diagnostic's `message`. For
+    /// multi-diagnostic errors (backend compilation) this is an aggregate
+    /// `"… N error(s)"` summary; callers should iterate `diagnostics` for
+    /// the per-error details.
+    pub fn message(&self) -> String {
+        match self.diagnostics.len() {
+            0 => "Unknown error".to_string(),
+            1 => self.diagnostics[0].message.clone(),
+            n => format!("{} error(s): {}", n, self.diagnostics[0].message),
+        }
+    }
+
     /// Convert to a JS `Error` object for throwing.
     ///
-    /// Returns a real `Error` whose `.message` is `self.message` and whose
-    /// `.diagnostics` property is an array of diagnostic objects matching
-    /// the shape used in `RenderResult.warnings`.
+    /// Returns a real `Error` whose `.message` is [`WasmError::message`] and
+    /// whose `.diagnostics` property is an array of diagnostic objects
+    /// matching the shape used in `RenderResult.warnings`.
     pub fn to_js_value(&self) -> JsValue {
-        let err = js_sys::Error::new(&self.message);
+        let err = js_sys::Error::new(&self.message());
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         let wasm_diags: Vec<WasmDiagnostic> =
             self.diagnostics.iter().cloned().map(Into::into).collect();
@@ -44,10 +54,8 @@ impl WasmError {
 
 impl From<ParseError> for WasmError {
     fn from(error: ParseError) -> Self {
-        let diag = error.to_diagnostic();
         WasmError {
-            message: diag.message.clone(),
-            diagnostics: vec![diag],
+            diagnostics: vec![error.to_diagnostic()],
         }
     }
 }
@@ -55,10 +63,7 @@ impl From<ParseError> for WasmError {
 impl From<RenderError> for WasmError {
     fn from(error: RenderError) -> Self {
         match error {
-            RenderError::CompilationFailed { diags } => WasmError {
-                message: format!("Compilation failed with {} error(s)", diags.len()),
-                diagnostics: diags,
-            },
+            RenderError::CompilationFailed { diags } => WasmError { diagnostics: diags },
             _ => {
                 let diagnostic = error
                     .diagnostics()
@@ -66,7 +71,6 @@ impl From<RenderError> for WasmError {
                     .map(|d| (*d).clone())
                     .unwrap_or_else(|| Diagnostic::new(Severity::Error, error.to_string()));
                 WasmError {
-                    message: diagnostic.message.clone(),
                     diagnostics: vec![diagnostic],
                 }
             }
@@ -77,7 +81,6 @@ impl From<RenderError> for WasmError {
 impl From<String> for WasmError {
     fn from(message: String) -> Self {
         WasmError {
-            message: message.clone(),
             diagnostics: vec![Diagnostic::new(Severity::Error, message)],
         }
     }
@@ -105,7 +108,7 @@ mod tests {
         let diag = &wasm_err.diagnostics[0];
         assert_eq!(diag.code.as_deref(), Some("parse::input_too_large"));
         assert!(diag.message.contains("Input too large"));
-        assert_eq!(wasm_err.message, diag.message);
+        assert_eq!(wasm_err.message(), diag.message);
     }
 
     #[test]
@@ -120,13 +123,15 @@ mod tests {
         assert_eq!(wasm_err.diagnostics.len(), 2);
         assert_eq!(wasm_err.diagnostics[0].message, "Error 1");
         assert_eq!(wasm_err.diagnostics[1].message, "Error 2");
-        assert!(wasm_err.message.contains("2"));
+        let summary = wasm_err.message();
+        assert!(summary.contains("2"));
+        assert!(summary.contains("Error 1"));
     }
 
     #[test]
     fn test_string_conversion_yields_single_diagnostic() {
         let wasm_err: WasmError = "Simple error".into();
-        assert_eq!(wasm_err.message, "Simple error");
+        assert_eq!(wasm_err.message(), "Simple error");
         assert_eq!(wasm_err.diagnostics.len(), 1);
         assert_eq!(wasm_err.diagnostics[0].message, "Simple error");
     }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -418,7 +418,7 @@ mod tests {
         };
         let wasm_err: WasmError = render_err.into();
 
-        assert_eq!(wasm_err.message, "Test error message");
+        assert_eq!(wasm_err.message(), "Test error message");
         assert_eq!(wasm_err.diagnostics.len(), 1);
         let d = &wasm_err.diagnostics[0];
         assert_eq!(d.code.as_deref(), Some("E001"));
@@ -446,7 +446,7 @@ mod tests {
         assert_eq!(wasm_err.diagnostics.len(), 2);
         assert_eq!(wasm_err.diagnostics[0].message, "Error 1");
         assert_eq!(wasm_err.diagnostics[1].message, "Error 2");
-        assert!(wasm_err.message.contains("2"));
+        assert!(wasm_err.message().contains("2"));
     }
 
     #[test]
@@ -454,7 +454,7 @@ mod tests {
         use crate::error::WasmError;
 
         let wasm_err: WasmError = "Simple error message".into();
-        assert_eq!(wasm_err.message, "Simple error message");
+        assert_eq!(wasm_err.message(), "Simple error message");
         assert_eq!(wasm_err.diagnostics.len(), 1);
         assert_eq!(wasm_err.diagnostics[0].message, "Simple error message");
     }

--- a/prose/designs/ARCHITECTURE.md
+++ b/prose/designs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ PyO3 bindings published as `quillmark` on PyPI.
 
 ### `bindings/quillmark-wasm`
 
-wasm-bindgen bindings published as `@quillmark/wasm`. Supports bundler and Node.js targets.
+wasm-bindgen bindings published as `@quillmark/wasm`. Supports bundler and Node.js targets. Builds with `--weak-refs` so wasm-bindgen handles are reclaimed by `FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires Node 14.6+ / current evergreen browsers.
 
 ### `bindings/quillmark-cli`
 

--- a/prose/designs/ERROR.md
+++ b/prose/designs/ERROR.md
@@ -28,7 +28,7 @@
 Python and WASM bindings delegate to core types:
 
 - **Python**: `PyDiagnostic` wraps `Diagnostic`. `RenderError` is mapped to typed Python exceptions: `CompilationError` (carries a `diagnostics` list), `ParseError` (frontmatter errors), and `QuillmarkError` (all other variants) — each with an attached `diagnostic` attribute. Base hierarchy: `QuillmarkError → PyException`.
-- **WASM**: `WasmError` is a flat `{ message, diagnostics: Vec<Diagnostic> }`. The thrown JS `Error` has `.message` and a `.diagnostics` array attached (always non-empty — length 1 for single-diagnostic errors, length N for compilation failures). Same shape regardless of underlying variant; consumers read `err.diagnostics[0]` for the primary diagnostic.
+- **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics`: `diagnostics[0].message` for single-diagnostic errors, an aggregate `"<N> error(s): <first.message>"` summary for backend compilation failures. Same shape regardless of underlying variant; consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for compilation errors. Parse failures (`Document.fromMarkdown`) carry the same shape — including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MB) and the various `EditError::*` variants for post-parse mutators.
 
 ## Backend Error Mapping
 

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -23,13 +23,20 @@ cargo build \
     --manifest-path crates/bindings/wasm/Cargo.toml
 
 # Step 2: Generate JS bindings with wasm-bindgen
+#
+# `--weak-refs` opts into FinalizationRegistry-based auto-free for
+# wasm-bindgen handles. `.free()` is still emitted as an eager hook for
+# callers that want deterministic teardown; opting in just ensures dropped
+# handles eventually get reclaimed without manual `.free()` discipline.
+# Requires Node 14.6+ / all current evergreen browsers.
 echo "Generating JS bindings for bundler..."
 mkdir -p pkg/bundler
 wasm-bindgen \
     target/wasm32-unknown-unknown/wasm-release/quillmark_wasm.wasm \
     --out-dir pkg/bundler \
     --out-name wasm \
-    --target bundler
+    --target bundler \
+    --weak-refs
 
 echo "Generating JS bindings for nodejs..."
 mkdir -p pkg/node-esm
@@ -37,7 +44,8 @@ wasm-bindgen \
     target/wasm32-unknown-unknown/wasm-release/quillmark_wasm.wasm \
     --out-dir pkg/node-esm \
     --out-name wasm \
-    --target experimental-nodejs-module
+    --target experimental-nodejs-module \
+    --weak-refs
 
 # Step 3: Extract version from Cargo.toml
 VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "quillmark-wasm") | .version')


### PR DESCRIPTION
Addresses consumer feedback on the wasm API surface:

- `Document.cardCount` (getter): O(1) length without allocating the
  `cards` array, so callers can validate indices before mutators
  (`updateCardField`, `removeCard`, etc.) without mirroring bounds logic.

- `Document.equals(other)`: structural equality through core's `PartialEq`
  (`main` + `cards`, ignoring parse-time `warnings`). Lets editor flows
  debounce upstream prop updates with one parse per change instead of one
  per keystroke. Replaces the rejected ask for byte-stable round-trip
  serialisation; `toMarkdown` keeps its type-fidelity (not byte-stable)
  contract, now documented explicitly.

- `WasmError`: drop the redundant `message: String` field; derive the JS
  `Error`'s `.message` from `diagnostics` (`diagnostics[0].message` for
  single-diagnostic, aggregate `"<N> error(s): <first.message>"` for
  compilation failures). Eliminates a duplicate-state foot-gun where
  `message` and `diagnostics[0].message` could drift.

- `scripts/build-wasm.sh`: add `--weak-refs` to both wasm-bindgen
  invocations so dropped handles are reclaimed by `FinalizationRegistry`.
  `.free()` stays as the eager teardown hook. Requires Node 14.6+ /
  current evergreen browsers (already our supported targets).

Docs:

- `crates/bindings/wasm/README.md`: document `cardCount`, `equals`, the
  `--weak-refs` lifecycle contract, and a clearer Errors section that
  lists the specific throw sites (`fromMarkdown`, mutators, render) and
  diagnostic codes (`parse::input_too_large`, `EditError::*`). Update
  Build section to match the actual `scripts/build-wasm.sh` invocation.
- `prose/designs/ARCHITECTURE.md`: note `--weak-refs` build flag.
- `prose/designs/ERROR.md`: update WASM bindings paragraph to reflect
  the derived-message shape and call out the parse-time diagnostics
  (input size, EditError) that flow through the same envelope.

Tests:

- 7 new vitest cases in `basic.test.js` covering `cardCount` (incl.
  through push/remove) and `equals` (identity, clone, mutation,
  round-trip).
- Existing 13 Rust unit tests pass; updated assertions to use
  `WasmError::message()` accessor instead of the removed field.

Validated: `cargo test -p quillmark-wasm --lib` (13/13 pass),
`cargo check --target wasm32-unknown-unknown -p quillmark-wasm`,
`cargo test --workspace --exclude quillmark-wasm` (no regressions).
The vitest suite requires `wasm-bindgen-cli` and runs in CI.

QUILL-mandatory tightening was investigated and found to already be
enforced at parse time (`crates/core/src/document/assemble.rs:214`) —
no code change needed; the README now states this explicitly.

https://claude.ai/code/session_01MMg1L78QHypzcWZBuyWew6