### PR TITLE
feat(core): add dedicated parse error codes for missing-QUILL and empty input

### DIFF
--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -184,7 +184,7 @@ pub(super) fn decompose_with_warnings(
     // missing-QUILL error reads as if the user supplied a partial document
     // missing only QUILL, which is misleading when there's no document at all.
     if markdown.trim().is_empty() {
-        return Err(crate::error::ParseError::InvalidStructure(
+        return Err(crate::error::ParseError::EmptyInput(
             "Empty markdown input cannot be parsed as a Quillmark Document. \
              Provide at least a QUILL frontmatter field: `QUILL: <name>`."
                 .to_string(),
@@ -204,7 +204,7 @@ pub(super) fn decompose_with_warnings(
     let (blocks, warnings, first_fence_issue) = find_metadata_blocks(markdown)?;
 
     if blocks.is_empty() {
-        return Err(crate::error::ParseError::InvalidStructure(
+        return Err(crate::error::ParseError::MissingQuillField(
             missing_quill_message(first_fence_issue),
         ));
     }
@@ -212,7 +212,7 @@ pub(super) fn decompose_with_warnings(
     // Block 0 is always the QUILL frontmatter (F1 guarantee).
     let frontmatter_block = &blocks[0];
     let quill_tag = frontmatter_block.quill_ref.clone().ok_or_else(|| {
-        ParseError::InvalidStructure(
+        ParseError::MissingQuillField(
             "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
         )
     })?;

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -28,6 +28,45 @@ fn test_empty_input_dedicated_error() {
 }
 
 #[test]
+fn test_empty_input_diagnostic_code() {
+    // Empty / whitespace-only inputs surface a stable code consumers can
+    // pattern-match without inspecting the message text.
+    for input in ["", "   ", "\n\n\t\n"] {
+        let err = decompose(input).unwrap_err();
+        let diag = err.to_diagnostic();
+        assert_eq!(
+            diag.code.as_deref(),
+            Some("parse::empty_input"),
+            "expected parse::empty_input for {input:?}, got: {:?}",
+            diag.code
+        );
+    }
+}
+
+#[test]
+fn test_missing_quill_field_diagnostic_code() {
+    // All "missing QUILL" sub-cases — no fences, wrong-cased key, mis-ordered
+    // key, empty fence — share the dedicated `parse::missing_quill_field`
+    // code so consumers don't have to regex the message text.
+    let cases = [
+        "# Hello World\n\nNo frontmatter here.",
+        "---\nquill: foo\n---\n\nbody",
+        "---\ntitle: Foo\nQUILL: bar\n---\n\nbody",
+        "---\n   \n---\n\n# Hello",
+    ];
+    for input in cases {
+        let err = decompose(input).unwrap_err();
+        let diag = err.to_diagnostic();
+        assert_eq!(
+            diag.code.as_deref(),
+            Some("parse::missing_quill_field"),
+            "expected parse::missing_quill_field for {input:?}, got: {:?}",
+            diag.code
+        );
+    }
+}
+
+#[test]
 fn test_with_frontmatter() {
     let markdown = r#"---
 QUILL: test_quill

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -257,6 +257,20 @@ pub enum ParseError {
     #[error("Invalid YAML structure: {0}")]
     InvalidStructure(String),
 
+    /// Markdown input was empty or whitespace-only.
+    ///
+    /// Emitted as code `parse::empty_input` so consumers can pattern-match
+    /// without inspecting the message text.
+    #[error("{0}")]
+    EmptyInput(String),
+
+    /// Frontmatter is missing the required `QUILL:` field.
+    ///
+    /// Emitted as code `parse::missing_quill_field` so consumers can
+    /// pattern-match without inspecting the message text.
+    #[error("{0}")]
+    MissingQuillField(String),
+
     /// YAML parsing error with location context
     #[error("YAML error at line {line}: {message}")]
     YamlErrorWithLocation {
@@ -284,6 +298,10 @@ impl ParseError {
             .with_code("parse::input_too_large".to_string()),
             ParseError::InvalidStructure(msg) => Diagnostic::new(Severity::Error, msg.clone())
                 .with_code("parse::invalid_structure".to_string()),
+            ParseError::EmptyInput(msg) => Diagnostic::new(Severity::Error, msg.clone())
+                .with_code("parse::empty_input".to_string()),
+            ParseError::MissingQuillField(msg) => Diagnostic::new(Severity::Error, msg.clone())
+                .with_code("parse::missing_quill_field".to_string()),
             ParseError::YamlErrorWithLocation {
                 message,
                 line,


### PR DESCRIPTION
Splits ParseError::InvalidStructure into three variants so consumers can
discriminate failures by stable diagnostic code rather than regexing the
message text:

- ParseError::EmptyInput → code parse::empty_input
- ParseError::MissingQuillField → code parse::missing_quill_field
- ParseError::InvalidStructure → code parse::invalid_structure (unchanged)

The four "missing QUILL" sub-cases (no fences, wrong-cased key,
mis-ordered key, empty fence with no QUILL) all map to the new code, so
the message text remains free to evolve without breaking consumers.