### PR TITLE
fix(quill): decouple quill.description from main.description

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -697,6 +697,7 @@ describe('quill.metadata', () => {
   description: Metadata test
 
 main:
+  description: The main card schema
   fields:
     title:
       type: string
@@ -722,6 +723,9 @@ card_types:
     expect(meta.backend).toBe('typst')
     expect(meta.version).toBe('0.2.1')
     expect(meta.author).toBe('Unknown')
+    // The quill's own description is surfaced at the top level, distinct
+    // from any schema description authored under `main:`.
+    expect(meta.description).toBe('Metadata test')
     expect(Array.isArray(meta.supportedFormats)).toBe(true)
     expect(meta.supportedFormats.length).toBeGreaterThan(0)
 
@@ -732,7 +736,9 @@ card_types:
     expect(meta.schema).toBeDefined()
     expect(meta.schema.name).toBe('meta_test_quill')
     expect(meta.schema.main).toBeDefined()
-    expect(meta.schema.main.description).toBe('Metadata test')
+    // schema.main.description is the schema's own description, authored
+    // under `main:`, independent of meta.description above.
+    expect(meta.schema.main.description).toBe('The main card schema')
     expect(meta.schema.main.fields.title).toBeDefined()
     expect(meta.schema.card_types).toBeDefined()
     // card_types holds the OTHER composable card types — main is not duplicated here

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -165,8 +165,11 @@ impl Quill {
     ///   optional `example`. `main` and each card under `card_types` share
     ///   the same shape: `fields` (map keyed by field name), optional
     ///   `title`, `description`, `ui`.
-    /// - `backend`, `version`, `author` — quill identity declared in
-    ///   `Quill.yaml`'s `quill:` section.
+    /// - `backend`, `version`, `author`, `description` — quill identity
+    ///   declared in `Quill.yaml`'s `quill:` section. `description` describes
+    ///   the quill itself; if the author also declared `main.description` (the
+    ///   schema description of the entry-point card), it lives at
+    ///   `schema.main.description` and is independent.
     /// - `supportedFormats` — output formats the backend produces, as
     ///   lowercase strings.
     /// - Any additional unstructured keys declared under `quill:`.
@@ -194,6 +197,10 @@ impl Quill {
         obj.insert(
             "author".to_string(),
             serde_json::Value::String(config.author.clone()),
+        );
+        obj.insert(
+            "description".to_string(),
+            serde_json::Value::String(config.description.clone()),
         );
 
         let formats: Vec<serde_json::Value> = self

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -208,7 +208,7 @@ fn test_quill_metadata_snapshot() {
         .quill(common::tree(&[
             (
                 "Quill.yaml",
-                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  fields:\n    title:\n      type: string\n      description: The title\n\ncard_types:\n  indorsement:\n    title: Indorsement\n    fields:\n      signature_block:\n        type: string\n",
+                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\n\nmain:\n  description: The main card schema\n  fields:\n    title:\n      type: string\n      description: The title\n\ncard_types:\n  indorsement:\n    title: Indorsement\n    fields:\n      signature_block:\n        type: string\n",
             ),
             ("plate.typ", b"= Title"),
         ]))
@@ -224,6 +224,12 @@ fn test_quill_metadata_snapshot() {
     assert_eq!(get("version").as_string().as_deref(), Some("0.2.1"));
     // `author` defaults to "Unknown" when the YAML omits it.
     assert_eq!(get("author").as_string().as_deref(), Some("Unknown"));
+    // The quill's own description is surfaced at the top level, distinct from
+    // any schema description authored under `main:`.
+    assert_eq!(
+        get("description").as_string().as_deref(),
+        Some("Metadata quill")
+    );
 
     let formats = get("supportedFormats");
     assert!(
@@ -252,12 +258,14 @@ fn test_quill_metadata_snapshot() {
 
     let main = schema_get("main");
     assert!(main.is_object(), "schema.main must be present");
+    // `schema.main.description` is the schema description authored under
+    // `main:`; it is independent of the quill's own description above.
     assert_eq!(
         Reflect::get(&main, &JsValue::from_str("description"))
             .unwrap()
             .as_string()
             .as_deref(),
-        Some("Metadata quill")
+        Some("The main card schema")
     );
     let main_fields = Reflect::get(&main, &JsValue::from_str("fields")).unwrap();
     assert!(

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -19,6 +19,10 @@ use super::{CardSchema, FieldSchema, FieldType, UiContainerSchema, UiFieldSchema
 pub struct QuillConfig {
     /// Quill package name
     pub name: String,
+    /// Human-readable description of the quill itself (parsed from
+    /// `quill.description`). Distinct from `main.description`, which describes
+    /// the main card's schema.
+    pub description: String,
     /// The entry-point card schema (parsed from the Quill.yaml `main:` section).
     pub main: CardSchema,
     /// Named, composable card-type schemas (parsed from the Quill.yaml
@@ -713,11 +717,25 @@ impl QuillConfig {
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());
 
+        // Extract main.title (optional, authored under `main:` like any other card type).
+        let main_title = main_obj_opt
+            .and_then(|main_obj| main_obj.get("title"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| Some("main".to_string()));
+
+        // Extract main.description (optional, authored under `main:` like any
+        // other card type). This is independent of `quill.description`.
+        let main_description = main_obj_opt
+            .and_then(|main_obj| main_obj.get("description"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
         // The main entry-point card.
         let main = CardSchema {
             name: "main".to_string(),
-            title: Some("main".to_string()),
-            description: Some(description),
+            title: main_title,
+            description: main_description,
             fields,
             ui: main_ui.or(ui_section),
         };
@@ -775,6 +793,7 @@ impl QuillConfig {
         Ok((
             QuillConfig {
                 name,
+                description,
                 main,
                 card_types,
                 backend,

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -56,9 +56,7 @@ impl QuillSource {
 
         metadata.insert(
             "description".to_string(),
-            QuillValue::from_json(serde_json::Value::String(
-                config.main.description.clone().unwrap_or_default(),
-            )),
+            QuillValue::from_json(serde_json::Value::String(config.description.clone())),
         );
 
         // Add author

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -821,10 +821,10 @@ main:
     assert_eq!(config.name, "test_config");
     assert_eq!(config.main.name, "main");
     assert_eq!(config.backend, "typst");
-    assert_eq!(
-        config.main.description,
-        Some("Test configuration parsing".to_string())
-    );
+    assert_eq!(config.description, "Test configuration parsing");
+    // `main.description` is independent of `quill.description`; this fixture
+    // does not declare one under `main:`, so it stays absent.
+    assert_eq!(config.main.description, None);
 
     // Verify optional fields
     assert_eq!(config.version, "1.0");

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/public_schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/public_schema.yaml
@@ -1,7 +1,6 @@
 name: usaf_memo
 main:
   title: main
-  description: Typesetted USAF Official Memorandum
   fields:
     attachments:
       title: List of attachments

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -36,7 +36,7 @@ Every Quill.yaml must have a `quill` section with format metadata.
 |------------------|--------|----------|-------------|
 | `name`           | string | yes      | Unique identifier for the Quill |
 | `backend`        | string | yes      | Rendering backend (e.g. `typst`) |
-| `description`    | string | yes      | Human-readable description (non-empty) |
+| `description`    | string | yes      | Human-readable description of the quill itself (non-empty). Independent of `main.description`, which is the optional schema description authored under `main:`. |
 | `version`        | string | yes      | Semantic version (`MAJOR.MINOR` or `MAJOR.MINOR.PATCH`) |
 | `author`         | string | no       | Creator of the Quill (defaults to `"Unknown"`) |
 | `plate_file`     | string | no       | Path to the plate file |
@@ -71,7 +71,7 @@ quill:
 
 ## `main` Section
 
-The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
+The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.title` and `main.description` describe the schema itself (independent of `quill.description`, which describes the quill package). Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
 
 Field order under `main.fields` determines display order in UIs — the first field gets `order: 0`, the second gets `order: 1`, and so on.
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -99,7 +99,7 @@ typst:
 Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`) are reserved by the engine. Standalone `object` fields are not supported; use `array` with `items: {type: object, properties: {...}}` instead.
 
 Metadata resolution:
-- `name`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`; `description` is stored in `QuillConfig.main.description` (required non-empty in the `quill:` section)
+- `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card type.
 - `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, any extra `Quill.*` keys, and `typst_*` keys from the `[typst]` section
 - `example_file` also accepts the alias `example` in YAML
 


### PR DESCRIPTION
Previously, `quill.description` from Quill.yaml was silently copied into
`main.description` (the schema description of the entry-point card),
making them indistinguishable. Catalog consumers asking for "what is
this quill?" had to dig into `metadata.schema.main.description` while
the wasm metadata getter actively excluded `description` from the
top-level passthrough — at odds with the documented "additional
unstructured keys become metadata.<key>" contract.

Now `quill.description` is a top-level field on QuillConfig that
describes the quill itself, and `main.description` is authored under
`main:` like every other card type's description. Both flow through
to their natural homes: `metadata.description` for the quill,
`metadata.schema.main.description` for the schema (only when authored).