### PR TITLE
refactor(core): generalize backend config in QuillConfig

### DIFF
--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -43,9 +43,10 @@ pub struct QuillConfig {
     /// Additional unstructured metadata
     #[serde(flatten)]
     pub metadata: HashMap<String, QuillValue>,
-    /// Typst specific configuration
+    /// Backend-specific configuration parsed from the top-level YAML section
+    /// whose key matches `backend` (e.g. `[typst]`, `[html]`).
     #[serde(default)]
-    pub typst_config: HashMap<String, QuillValue>,
+    pub backend_config: HashMap<String, QuillValue>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -673,12 +674,12 @@ impl QuillConfig {
             }
         }
 
-        // Extract [typst] section (optional)
-        let mut typst_config = HashMap::new();
-        if let Some(typst_val) = quill_yaml_val.get("typst") {
-            if let Some(table) = typst_val.as_object() {
+        // Extract optional backend-specific section (keyed by `quill.backend`).
+        let mut backend_config = HashMap::new();
+        if let Some(section_val) = quill_yaml_val.get(&backend) {
+            if let Some(table) = section_val.as_object() {
                 for (key, value) in table {
-                    typst_config.insert(key.clone(), QuillValue::from_json(value.clone()));
+                    backend_config.insert(key.clone(), QuillValue::from_json(value.clone()));
                 }
             }
         }
@@ -803,7 +804,7 @@ impl QuillConfig {
                 example_markdown: None,
                 plate_file,
                 metadata,
-                typst_config,
+                backend_config,
             },
             warnings,
         ))

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -71,9 +71,9 @@ impl QuillSource {
             QuillValue::from_json(serde_json::Value::String(config.version.clone())),
         );
 
-        // Add typst config to metadata with typst_ prefix
-        for (key, value) in &config.typst_config {
-            metadata.insert(format!("typst_{}", key), value.clone());
+        // Expose backend-specific config to metadata under `<backend>_<key>`.
+        for (key, value) in &config.backend_config {
+            metadata.insert(format!("{}_{}", config.backend, key), value.clone());
         }
 
         // Read the plate content from plate file (if specified)

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -832,8 +832,8 @@ main:
     assert_eq!(config.plate_file, Some("plate.typ".to_string()));
     assert_eq!(config.example_file, Some("example.md".to_string()));
 
-    // Verify typst config
-    assert!(config.typst_config.contains_key("packages"));
+    // Verify backend-specific config (parsed from the [typst] section).
+    assert!(config.backend_config.contains_key("packages"));
 
     // Verify field schemas
     assert_eq!(config.main.fields.len(), 2);

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -32,9 +32,8 @@ impl RenderSession {
     /// Borrow the underlying [`SessionHandle`] for typed-side-channel access.
     ///
     /// Bindings call this and downcast via [`SessionHandle::as_any`] to reach
-    /// backend-specific surfaces (e.g. `quillmark_typst::typst_session_of`
-    /// for canvas preview). Intentionally `#[doc(hidden)]` — the shape of
-    /// this accessor is not part of the stable public API.
+    /// backend-specific surfaces. Intentionally `#[doc(hidden)]` — the shape
+    /// of this accessor is not part of the stable public API.
     #[doc(hidden)]
     pub fn handle(&self) -> &dyn SessionHandle {
         &*self.inner


### PR DESCRIPTION
Replace the Typst-named `typst_config` field on `QuillConfig` with a
neutral `backend_config: HashMap<String, QuillValue>`. The optional
top-level YAML section is now keyed by `quill.backend` (e.g. `[typst]`,
`[html]`) instead of being hard-coded to `typst`. Metadata exposed to
the loader is prefixed `<backend>_<key>` so the existing Typst plate
contract (`typst_packages`, ...) is preserved without naming the
backend in the core crate.

Also drop the stray `quillmark_typst::typst_session_of` example from
the `RenderSession::handle` rustdoc so core no longer references a
specific backend.