### PR TITLE
feat(wasm): canvas API ergonomics from editor integrator feedback

### DIFF
--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -25,7 +25,9 @@ console_error_panic_hook = "0.1"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "CanvasRenderingContext2d",
+    "HtmlCanvasElement",
     "ImageData",
+    "OffscreenCanvas",
     "OffscreenCanvasRenderingContext2d",
 ] }
 

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -26,6 +26,7 @@ js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "CanvasRenderingContext2d",
     "ImageData",
+    "OffscreenCanvasRenderingContext2d",
 ] }
 
 [dev-dependencies]

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -79,15 +79,29 @@ O(1) getter for the number of composable cards (excluding the main card).
 Use this to validate indices before calling card mutators (`removeCard`,
 `updateCardField`, etc.) without allocating the full `cards` array.
 
+### `quill.render(parsed, opts?)` vs. `quill.open(parsed)`
+
+Use **`Quill.render`** for one-shot exports (PDF/SVG/PNG) — compiles, emits
+artifacts, done. Use **`RenderSession`** (returned by `Quill.open`) for
+reactive previews where you'll paint or re-emit pages multiple times: the
+session retains the compiled snapshot so subsequent `paint` / `render`
+calls skip recompilation. Don't open a session per export.
+
 ### `quill.render(parsed, opts?)`
 Render with a pre-parsed `Document`.
 
 ### `quill.open(parsed)` + `session.render(opts?)`
 Open once, render all or selected pages (`opts.pages`).
 
-The session also exposes `pageCount`, `backendId`, `warnings` (snapshot of
-session-level diagnostics attached at `open` time), `pageSize(page)`, and
-`paint(ctx, page, scale)` for canvas previews. See below.
+The session also exposes `pageCount`, `backendId`, `supportsCanvas`,
+`warnings` (snapshot of session-level diagnostics attached at `open` time),
+`pageSize(page)`, and `paint(ctx, page, scale)` for canvas previews. See
+below.
+
+A document that compiles to zero pages still produces a valid session
+(`pageCount === 0`); `paint(ctx, 0, scale)` and `pageSize(0)` then throw
+`page index 0 out of range (pageCount=0)`. Branch on `pageCount === 0` to
+render a "no pages to preview" UI without relying on the throw.
 
 ### Canvas Preview (Typst only)
 
@@ -120,12 +134,19 @@ session.paint(canvas.getContext("2d"), 0, scale);
   lifetime (immutable snapshot) — cache them.
 - Setting `canvas.width` / `canvas.height` clears the backing store; if
   you reuse a canvas without resizing, call `clearRect` before `paint`.
-- Currently main-thread only: `paint` accepts `CanvasRenderingContext2D`,
-  not `OffscreenCanvasRenderingContext2D`. Worker support is on the
-  follow-up list.
-- Backend support: Typst only. Calling `paint` on a session opened by
-  any other backend throws an error that includes the resolved
-  `backendId`.
+- `paint` validates `ctx.canvas.{width,height}` against
+  `round(widthPt * scale) × round(heightPt * scale)` and throws on
+  mismatch. `putImageData` would otherwise silently clip — the throw is
+  the diagnostic.
+- `paint` accepts both `CanvasRenderingContext2D` (main thread) and
+  `OffscreenCanvasRenderingContext2D` (Workers, off-DOM rasterization,
+  `node-canvas` test setups). Note that loading the WASM module inside a
+  Worker is the host's responsibility.
+- Backend support: gated by `supportsCanvas`. Probe upfront with
+  `quill.supportsCanvas` (or `session.supportsCanvas`) before mounting a
+  canvas-based UI; the throw on `paint` / `pageSize` remains the
+  enforcement contract and includes the resolved `backendId` for
+  debugging.
 
 ### Errors
 
@@ -159,6 +180,22 @@ The wasm bindings are built with `--weak-refs`, so dropped `Document`,
 without manual `.free()` discipline. `.free()` is still emitted as an eager
 teardown hook for callers that want deterministic release. Requires
 Node 14.6+ / current evergreen browsers (all supported targets).
+
+For environments where `using` (the [explicit resource management][erm]
+proposal) hasn't landed, use an explicit `try` / `finally`:
+
+```ts
+const session = quill.open(doc);
+try {
+  for (let p = 0; p < session.pageCount; p++) {
+    session.paint(ctx, p, scale);
+  }
+} finally {
+  session.free();
+}
+```
+
+[erm]: https://github.com/tc39/proposal-explicit-resource-management
 
 ## Notes
 

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -5,6 +5,7 @@
  * minimum needed for wasm-bindgen's `instanceof` checks to pass:
  *
  *   - `globalThis.CanvasRenderingContext2D`
+ *   - `globalThis.OffscreenCanvasRenderingContext2D`
  *   - `globalThis.ImageData`
  *
  * The polyfill captures `putImageData` calls into a buffer so the test can
@@ -42,9 +43,32 @@ class FakeCanvasRenderingContext2D {
   }
 }
 
+// In real browsers, OffscreenCanvasRenderingContext2D and
+// CanvasRenderingContext2D do NOT share an inheritance chain — they're
+// siblings. Defining the polyfill as an independent class (not a subclass)
+// ensures the Rust-side `instanceof` dispatch actually exercises the
+// second branch, instead of matching `CanvasRenderingContext2D` via
+// inheritance.
+class FakeOffscreenCanvasRenderingContext2D {
+  constructor() {
+    this.calls = []
+    this.canvas = { width: 0, height: 0 }
+  }
+  putImageData(img, dx, dy) {
+    this.calls.push({
+      width: img.width,
+      height: img.height,
+      data: new Uint8ClampedArray(img.data),
+      dx,
+      dy,
+    })
+  }
+}
+
 beforeAll(() => {
   globalThis.ImageData = FakeImageData
   globalThis.CanvasRenderingContext2D = FakeCanvasRenderingContext2D
+  globalThis.OffscreenCanvasRenderingContext2D = FakeOffscreenCanvasRenderingContext2D
 })
 
 const { Quillmark, Document } = await import('@quillmark-wasm')
@@ -63,17 +87,33 @@ const TEST_PLATE = `#import "@local/quillmark-helper:0.1.0": data
 
 #data.BODY`
 
-function openSession() {
+function openQuill() {
   const engine = new Quillmark()
-  const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
-  return quill.open(Document.fromMarkdown(TEST_MARKDOWN))
+  return engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+}
+
+function openSession() {
+  return openQuill().open(Document.fromMarkdown(TEST_MARKDOWN))
+}
+
+/** Build a fake context already sized to fit page `page` at `scale`. */
+function ctxForPage(session, page, scale, CtxCtor = FakeCanvasRenderingContext2D) {
+  const { widthPt, heightPt } = session.pageSize(page)
+  const ctx = new CtxCtor()
+  ctx.canvas.width = Math.round(widthPt * scale)
+  ctx.canvas.height = Math.round(heightPt * scale)
+  return ctx
 }
 
 describe('RenderSession canvas preview', () => {
-  it('exposes pageCount, backendId, warnings, and pageSize on a Typst session', () => {
-    const session = openSession()
+  it('exposes pageCount, backendId, supportsCanvas, warnings, and pageSize on a Typst session', () => {
+    const quill = openQuill()
+    expect(quill.supportsCanvas).toBe(true)
+
+    const session = quill.open(Document.fromMarkdown(TEST_MARKDOWN))
     expect(session.pageCount).toBeGreaterThan(0)
     expect(session.backendId).toBe('typst')
+    expect(session.supportsCanvas).toBe(true)
     expect(Array.isArray(session.warnings)).toBe(true)
 
     const size = session.pageSize(0)
@@ -83,10 +123,10 @@ describe('RenderSession canvas preview', () => {
 
   it('paints a page with the expected backing-store dimensions and non-trivial pixel content', () => {
     const session = openSession()
-    const { widthPt, heightPt } = session.pageSize(0)
     const scale = 1.5
+    const ctx = ctxForPage(session, 0, scale)
+    const { widthPt, heightPt } = session.pageSize(0)
 
-    const ctx = new FakeCanvasRenderingContext2D()
     expect(() => session.paint(ctx, 0, scale)).not.toThrow()
 
     expect(ctx.calls).toHaveLength(1)
@@ -113,9 +153,32 @@ describe('RenderSession canvas preview', () => {
     expect(opaquePixels).toBeGreaterThan(0)
   })
 
+  it('also paints into an OffscreenCanvasRenderingContext2D', () => {
+    const session = openSession()
+    const scale = 1
+    const ctx = ctxForPage(session, 0, scale, FakeOffscreenCanvasRenderingContext2D)
+    expect(() => session.paint(ctx, 0, scale)).not.toThrow()
+    expect(ctx.calls).toHaveLength(1)
+  })
+
+  it('throws on canvas/scale dimension mismatch instead of silently clipping', () => {
+    const session = openSession()
+    const scale = 1
+    const ctx = ctxForPage(session, 0, scale)
+    // Sabotage the height after sizing — a common foot-gun is forgetting to
+    // resize when the user changes zoom.
+    ctx.canvas.height -= 10
+
+    expect(() => session.paint(ctx, 0, scale)).toThrow(/canvas size mismatch/)
+    expect(ctx.calls).toHaveLength(0)
+  })
+
   it('throws an out-of-range error when paint is called with a bad page index', () => {
     const session = openSession()
+    // For OOB we never reach the size validation — a 1×1 canvas is fine.
     const ctx = new FakeCanvasRenderingContext2D()
+    ctx.canvas.width = 1
+    ctx.canvas.height = 1
     expect(() => session.paint(ctx, session.pageCount + 5, 1)).toThrow(
       /out of range.*pageCount=/,
     )

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -27,6 +27,12 @@ export interface CardInput {
 }
 "#;
 
+/// Backend identifier for the only canvas-capable backend today. Both
+/// `Quill::supportsCanvas` and `RenderSession::supportsCanvas` route
+/// through this so the two APIs can't drift; if a second canvas backend
+/// ever ships, replace this with a richer check.
+const CANVAS_BACKEND_ID: &str = "typst";
+
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
     {
@@ -179,12 +185,9 @@ impl Quill {
     /// succeed for sessions opened by this quill. Use this as a precondition
     /// probe before mounting a canvas-based preview UI; the throw on `paint`
     /// remains the enforcement contract.
-    ///
-    /// Equivalent to checking `backendId === "typst"` today, but consumers
-    /// shouldn't have to hardcode our backend allowlist.
     #[wasm_bindgen(getter, js_name = supportsCanvas)]
     pub fn supports_canvas(&self) -> bool {
-        self.inner.backend_id() == "typst"
+        self.inner.backend_id() == CANVAS_BACKEND_ID
     }
 
     /// Read-only snapshot of the loaded quill's engine info and declared schema.
@@ -849,7 +852,7 @@ impl RenderSession {
     /// opened this session.
     #[wasm_bindgen(getter, js_name = supportsCanvas)]
     pub fn supports_canvas(&self) -> bool {
-        quillmark_typst::typst_session_of(&self.inner).is_some()
+        self.backend_id == CANVAS_BACKEND_ID
     }
 
     /// Session-level warnings attached at `quill.open(...)` time.
@@ -957,33 +960,37 @@ impl RenderSession {
         scale: f32,
     ) -> Result<(), JsValue> {
         let typst = self.typst_session("paint")?;
-        let (width, height, mut rgba) = typst
+        let canvas_ctx = CanvasCtx::from_js(&ctx)?;
+
+        // Compute expected dimensions from page geometry first so we can
+        // fail-fast on a mis-sized canvas without paying for rasterization.
+        let (width_pt, height_pt) = typst
+            .page_size_pt(page)
+            .ok_or_else(|| self.page_oob_error("paint", page))?;
+        let expected_w = (width_pt * scale).round() as u32;
+        let expected_h = (height_pt * scale).round() as u32;
+
+        let (actual_w, actual_h) = canvas_ctx.canvas_dims();
+        if (actual_w, actual_h) != (expected_w, expected_h) {
+            return Err(WasmError::from(format!(
+                "paint: canvas size mismatch — expected {}×{} (round(widthPt × scale) × round(heightPt × scale)), got {}×{}. Set canvas.width and canvas.height before calling paint.",
+                expected_w, expected_h, actual_w, actual_h,
+            ))
+            .to_js_value());
+        }
+
+        let (rw, rh, mut rgba) = typst
             .render_rgba(page, scale)
             .ok_or_else(|| self.page_oob_error("paint", page))?;
-
-        validate_canvas_size(&ctx, width, height)?;
-
         let img = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
             wasm_bindgen::Clamped(rgba.as_mut_slice()),
-            width,
-            height,
+            rw,
+            rh,
         )
         .map_err(|e| {
             WasmError::from(format!("paint: ImageData construction failed: {:?}", e)).to_js_value()
         })?;
-
-        if ctx.is_instance_of::<web_sys::CanvasRenderingContext2d>() {
-            let ctx_2d = ctx.unchecked_into::<web_sys::CanvasRenderingContext2d>();
-            ctx_2d.put_image_data(&img, 0.0, 0.0)
-        } else if ctx.is_instance_of::<web_sys::OffscreenCanvasRenderingContext2d>() {
-            let ctx_off = ctx.unchecked_into::<web_sys::OffscreenCanvasRenderingContext2d>();
-            ctx_off.put_image_data(&img, 0.0, 0.0)
-        } else {
-            Err(WasmError::from(
-                "paint: ctx must be CanvasRenderingContext2D or OffscreenCanvasRenderingContext2D",
-            )
-            .to_js_value())
-        }
+        canvas_ctx.put_image_data(&img)
     }
 }
 
@@ -1009,42 +1016,53 @@ impl RenderSession {
     }
 }
 
-/// Read `ctx.canvas.width` / `ctx.canvas.height` and assert they match the
-/// rasterized buffer dimensions. Uses `Reflect::get` so the same code path
-/// works for both `CanvasRenderingContext2D` (whose `canvas` is an
-/// `HTMLCanvasElement`) and `OffscreenCanvasRenderingContext2D` (whose
-/// `canvas` is an `OffscreenCanvas`); both expose numeric `width`/`height`.
-///
-/// A mismatch silently clips on `putImageData`, which produces "almost
-/// right" output that's painful to diagnose downstream — failing loudly
-/// here is the diagnostic value the consumer asked for.
-fn validate_canvas_size(ctx: &JsValue, expected_w: u32, expected_h: u32) -> Result<(), JsValue> {
-    let canvas = js_sys::Reflect::get(ctx, &JsValue::from_str("canvas")).map_err(|_| {
-        WasmError::from(
-            "paint: ctx has no 'canvas' property — ctx must be a 2D rendering context",
+/// Adapter unifying `CanvasRenderingContext2D` and
+/// `OffscreenCanvasRenderingContext2D` behind one Rust shape so `paint`
+/// can validate dimensions and emit pixels without repeating the
+/// downcast.
+enum CanvasCtx<'a> {
+    OnScreen(&'a web_sys::CanvasRenderingContext2d),
+    OffScreen(&'a web_sys::OffscreenCanvasRenderingContext2d),
+}
+
+impl<'a> CanvasCtx<'a> {
+    fn from_js(ctx: &'a JsValue) -> Result<Self, JsValue> {
+        if let Some(c) = ctx.dyn_ref::<web_sys::CanvasRenderingContext2d>() {
+            return Ok(Self::OnScreen(c));
+        }
+        if let Some(c) = ctx.dyn_ref::<web_sys::OffscreenCanvasRenderingContext2d>() {
+            return Ok(Self::OffScreen(c));
+        }
+        Err(WasmError::from(
+            "paint: ctx must be CanvasRenderingContext2D or OffscreenCanvasRenderingContext2D",
         )
-        .to_js_value()
-    })?;
-    let read_dim = |key: &str| -> Option<u32> {
-        js_sys::Reflect::get(&canvas, &JsValue::from_str(key))
-            .ok()
-            .and_then(|v| v.as_f64())
-            .map(|n| n as u32)
-    };
-    let actual_w = read_dim("width");
-    let actual_h = read_dim("height");
-    if actual_w != Some(expected_w) || actual_h != Some(expected_h) {
-        let fmt = |v: Option<u32>| v.map(|n| n.to_string()).unwrap_or_else(|| "?".into());
-        return Err(WasmError::from(format!(
-            "paint: canvas size mismatch — expected {}×{} (round(widthPt × scale) × round(heightPt × scale)), got {}×{}. Set canvas.width and canvas.height before calling paint.",
-            expected_w,
-            expected_h,
-            fmt(actual_w),
-            fmt(actual_h),
-        ))
-        .to_js_value());
+        .to_js_value())
     }
-    Ok(())
+
+    /// `(canvas.width, canvas.height)` in device pixels. Both backing
+    /// canvas types expose numeric width/height; the typed web-sys
+    /// accessors here fall back to `0` if the field is absent, which is
+    /// indistinguishable from a deliberately zero-sized canvas — fine
+    /// for our validation since either way the mismatch error fires.
+    fn canvas_dims(&self) -> (u32, u32) {
+        match self {
+            Self::OnScreen(c) => match c.canvas() {
+                Some(canvas) => (canvas.width(), canvas.height()),
+                None => (0, 0),
+            },
+            Self::OffScreen(c) => {
+                let canvas = c.canvas();
+                (canvas.width(), canvas.height())
+            }
+        }
+    }
+
+    fn put_image_data(&self, img: &web_sys::ImageData) -> Result<(), JsValue> {
+        match self {
+            Self::OnScreen(c) => c.put_image_data(img, 0.0, 0.0),
+            Self::OffScreen(c) => c.put_image_data(img, 0.0, 0.0),
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -954,7 +954,9 @@ impl RenderSession {
     #[wasm_bindgen(js_name = paint)]
     pub fn paint(
         &self,
-        #[wasm_bindgen(unchecked_param_type = "CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D")]
+        #[wasm_bindgen(
+            unchecked_param_type = "CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D"
+        )]
         ctx: JsValue,
         page: usize,
         scale: f32,

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -55,6 +55,19 @@ pub struct Quill {
     inner: quillmark::Quill,
 }
 
+/// An iterative render handle backed by an immutable compiled snapshot.
+///
+/// Created via [`Quill::open`]. Holds the compiled output so that
+/// [`RenderSession::render`], [`RenderSession::paint`], and
+/// [`RenderSession::page_size`] can be called repeatedly without
+/// recompiling.
+///
+/// **Empty documents.** A document that compiles to zero pages still
+/// produces a valid session (`pageCount === 0`). Iterating
+/// `0..pageCount` is then a no-op; calling `paint(ctx, 0, scale)` or
+/// `pageSize(0)` throws `"... page index 0 out of range
+/// (pageCount=0)"`. Hosts that surface "no pages to preview" UI should
+/// branch on `pageCount === 0` rather than on a thrown error.
 #[wasm_bindgen]
 pub struct RenderSession {
     inner: quillmark_core::RenderSession,
@@ -158,6 +171,20 @@ impl Quill {
     #[wasm_bindgen(getter, js_name = backendId)]
     pub fn backend_id(&self) -> String {
         self.inner.backend_id().to_string()
+    }
+
+    /// Whether this quill's backend supports canvas preview.
+    ///
+    /// `true` iff `RenderSession.paint` and `RenderSession.pageSize` will
+    /// succeed for sessions opened by this quill. Use this as a precondition
+    /// probe before mounting a canvas-based preview UI; the throw on `paint`
+    /// remains the enforcement contract.
+    ///
+    /// Equivalent to checking `backendId === "typst"` today, but consumers
+    /// shouldn't have to hardcode our backend allowlist.
+    #[wasm_bindgen(getter, js_name = supportsCanvas)]
+    pub fn supports_canvas(&self) -> bool {
+        self.inner.backend_id() == "typst"
     }
 
     /// Read-only snapshot of the loaded quill's engine info and declared schema.
@@ -807,9 +834,22 @@ impl RenderSession {
     }
 
     /// The backend that produced this session (e.g. `"typst"`).
+    ///
+    /// Equal to the `backendId` of the [`Quill`] that opened this session
+    /// (sessions inherit their quill's backend), so checking either is fine.
     #[wasm_bindgen(getter, js_name = backendId)]
     pub fn backend_id(&self) -> String {
         self.backend_id.clone()
+    }
+
+    /// Whether this session's backend supports canvas preview.
+    ///
+    /// `true` iff [`paint`](Self::paint) and [`page_size`](Self::page_size)
+    /// will succeed. Equal to `Quill.supportsCanvas` for the quill that
+    /// opened this session.
+    #[wasm_bindgen(getter, js_name = supportsCanvas)]
+    pub fn supports_canvas(&self) -> bool {
+        quillmark_typst::typst_session_of(&self.inner).is_some()
     }
 
     /// Session-level warnings attached at `quill.open(...)` time.
@@ -877,6 +917,11 @@ impl RenderSession {
 
     /// Paint `page` into a 2D canvas context.
     ///
+    /// Accepts either a `CanvasRenderingContext2D` (main thread) or an
+    /// `OffscreenCanvasRenderingContext2D` (Worker / off-DOM rasterization).
+    /// Both dispatch to the same Rust rasterizer; the dispatch happens at
+    /// the JS boundary so neither context type is privileged.
+    ///
     /// `scale` multiplies Typst's natural 72 ppi (1 pt → 1 device pixel at
     /// `scale = 1`). Typical usage:
     /// `scale = (window.devicePixelRatio || 1) * userZoom`.
@@ -893,13 +938,21 @@ impl RenderSession {
     /// `paint` writes into the backing store at origin `(0, 0)` and does
     /// not clear outside the rendered region.
     ///
-    /// Throws if the backend does not support canvas preview (the message
-    /// includes the resolved `backendId` for debugging), or if `page` is
-    /// out of range.
+    /// Throws when:
+    /// - the backend does not support canvas preview (message includes the
+    ///   resolved `backendId`),
+    /// - `page` is out of range,
+    /// - `ctx` is neither `CanvasRenderingContext2D` nor
+    ///   `OffscreenCanvasRenderingContext2D`,
+    /// - `ctx.canvas.width`/`height` does not match
+    ///   `round(widthPt * scale) × round(heightPt * scale)` (silent clipping
+    ///   is the surprise we'd rather throw on than ship a "almost right"
+    ///   render).
     #[wasm_bindgen(js_name = paint)]
     pub fn paint(
         &self,
-        ctx: &web_sys::CanvasRenderingContext2d,
+        #[wasm_bindgen(unchecked_param_type = "CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D")]
+        ctx: JsValue,
         page: usize,
         scale: f32,
     ) -> Result<(), JsValue> {
@@ -907,6 +960,9 @@ impl RenderSession {
         let (width, height, mut rgba) = typst
             .render_rgba(page, scale)
             .ok_or_else(|| self.page_oob_error("paint", page))?;
+
+        validate_canvas_size(&ctx, width, height)?;
+
         let img = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
             wasm_bindgen::Clamped(rgba.as_mut_slice()),
             width,
@@ -915,7 +971,19 @@ impl RenderSession {
         .map_err(|e| {
             WasmError::from(format!("paint: ImageData construction failed: {:?}", e)).to_js_value()
         })?;
-        ctx.put_image_data(&img, 0.0, 0.0)
+
+        if ctx.is_instance_of::<web_sys::CanvasRenderingContext2d>() {
+            let ctx_2d = ctx.unchecked_into::<web_sys::CanvasRenderingContext2d>();
+            ctx_2d.put_image_data(&img, 0.0, 0.0)
+        } else if ctx.is_instance_of::<web_sys::OffscreenCanvasRenderingContext2d>() {
+            let ctx_off = ctx.unchecked_into::<web_sys::OffscreenCanvasRenderingContext2d>();
+            ctx_off.put_image_data(&img, 0.0, 0.0)
+        } else {
+            Err(WasmError::from(
+                "paint: ctx must be CanvasRenderingContext2D or OffscreenCanvasRenderingContext2D",
+            )
+            .to_js_value())
+        }
     }
 }
 
@@ -939,6 +1007,44 @@ impl RenderSession {
         ))
         .to_js_value()
     }
+}
+
+/// Read `ctx.canvas.width` / `ctx.canvas.height` and assert they match the
+/// rasterized buffer dimensions. Uses `Reflect::get` so the same code path
+/// works for both `CanvasRenderingContext2D` (whose `canvas` is an
+/// `HTMLCanvasElement`) and `OffscreenCanvasRenderingContext2D` (whose
+/// `canvas` is an `OffscreenCanvas`); both expose numeric `width`/`height`.
+///
+/// A mismatch silently clips on `putImageData`, which produces "almost
+/// right" output that's painful to diagnose downstream — failing loudly
+/// here is the diagnostic value the consumer asked for.
+fn validate_canvas_size(ctx: &JsValue, expected_w: u32, expected_h: u32) -> Result<(), JsValue> {
+    let canvas = js_sys::Reflect::get(ctx, &JsValue::from_str("canvas")).map_err(|_| {
+        WasmError::from(
+            "paint: ctx has no 'canvas' property — ctx must be a 2D rendering context",
+        )
+        .to_js_value()
+    })?;
+    let read_dim = |key: &str| -> Option<u32> {
+        js_sys::Reflect::get(&canvas, &JsValue::from_str(key))
+            .ok()
+            .and_then(|v| v.as_f64())
+            .map(|n| n as u32)
+    };
+    let actual_w = read_dim("width");
+    let actual_h = read_dim("height");
+    if actual_w != Some(expected_w) || actual_h != Some(expected_h) {
+        let fmt = |v: Option<u32>| v.map(|n| n.to_string()).unwrap_or_else(|| "?".into());
+        return Err(WasmError::from(format!(
+            "paint: canvas size mismatch — expected {}×{} (round(widthPt × scale) × round(heightPt × scale)), got {}×{}. Set canvas.width and canvas.height before calling paint.",
+            expected_w,
+            expected_h,
+            fmt(actual_w),
+            fmt(actual_h),
+        ))
+        .to_js_value());
+    }
+    Ok(())
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
- Add `supportsCanvas` getter on `Quill` and `RenderSession` so consumers
  can probe canvas support without hardcoding the backend allowlist or
  wrapping each call in `try` / `catch`.
- Widen `paint()` to accept either `CanvasRenderingContext2D` or
  `OffscreenCanvasRenderingContext2D`, dispatching at the JS boundary.
  Enables Worker hosts and `node-canvas` test setups without changing
  main-thread behavior.
- Validate `ctx.canvas.{width,height}` against
  `round(widthPt × scale) × round(heightPt × scale)` inside `paint`.
  `putImageData` would otherwise silently clip into an undersized
  buffer, producing "almost right" output that's painful to diagnose.
- Document zero-page session behavior on `RenderSession`: empty docs
  produce a valid session with `pageCount === 0`; defensive callers
  branch on that instead of relying on the OOB throw.
- README: distinguish `Quill.render` (one-shot exports) from
  `RenderSession` (reactive previews); add `try` / `finally` fallback
  example for environments without explicit-resource-management.

https://claude.ai/code/session_01P7kyb3KtRB6Cg6mCkkXsPC