### PR TITLE
feat(wasm): painter-owned canvas dims; structured PaintOptions/PaintResult

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -95,53 +95,56 @@ Open once, render all or selected pages (`opts.pages`).
 
 The session also exposes `pageCount`, `backendId`, `supportsCanvas`,
 `warnings` (snapshot of session-level diagnostics attached at `open` time),
-`pageSize(page)`, and `paint(ctx, page, scale)` for canvas previews. See
+`pageSize(page)`, and `paint(ctx, page, opts?)` for canvas previews. See
 below.
 
 A document that compiles to zero pages still produces a valid session
-(`pageCount === 0`); `paint(ctx, 0, scale)` and `pageSize(0)` then throw
+(`pageCount === 0`); `paint(ctx, 0)` and `pageSize(0)` then throw
 `page index 0 out of range (pageCount=0)`. Branch on `pageCount === 0` to
 render a "no pages to preview" UI without relying on the throw.
 
 ### Canvas Preview (Typst only)
 
-`session.paint(ctx, page, scale)` rasterizes a page directly into a
-`CanvasRenderingContext2D`, skipping PNG/SVG byte round-trips. Pair with
-`session.pageSize(page)` to size the canvas:
+`session.paint(ctx, page, opts?)` rasterizes a page directly into a
+`CanvasRenderingContext2D` (main thread) or
+`OffscreenCanvasRenderingContext2D` (Worker), skipping PNG/SVG byte
+round-trips.
+
+The painter owns `canvas.width` / `canvas.height` — it sizes the backing
+store itself. Consumers own `canvas.style.*` (or the layout system that
+sets them) and read `layoutWidth` / `layoutHeight` from the returned
+`PaintResult`.
 
 ```ts
-const dpr = window.devicePixelRatio || 1;
-const userZoom = 1;                              // your zoom UI
-const scale = dpr * userZoom;                    // multiplier on 72 ppi
+const result = session.paint(canvas.getContext("2d"), 0, {
+  layoutScale: 1,                            // layout px per Typst pt
+  densityScale: window.devicePixelRatio,     // backing-store density
+});
 
-const { widthPt, heightPt } = session.pageSize(0);
-// Reassigning canvas.width/height clears the backing store, which is what
-// you want between pages. If you reuse the same canvas at the same size
-// (e.g. repaint after a zoom that didn't change scale), call
-// ctx.clearRect(0, 0, canvas.width, canvas.height) before paint instead.
-canvas.width  = Math.round(widthPt  * scale);    // device px
-canvas.height = Math.round(heightPt * scale);
-canvas.style.width  = `${widthPt  * userZoom}px`;
-canvas.style.height = `${heightPt * userZoom}px`;
-
-session.paint(canvas.getContext("2d"), 0, scale);
+canvas.style.width  = `${result.layoutWidth}px`;
+canvas.style.height = `${result.layoutHeight}px`;
 ```
 
-- `scale` is a multiplier on Typst's natural 72 ppi (1 pt → 1 device
-  pixel at `scale = 1`). Always include `devicePixelRatio` for crisp
-  output.
+- `layoutScale` (default 1) sets the canvas's display-box size:
+  `layoutWidth = widthPt * layoutScale`. For on-screen canvases this is
+  CSS pixels per Typst point. Defaults to 1 (one CSS pixel per pt).
+- `densityScale` (default 1) is the backing-store density multiplier.
+  Fold `window.devicePixelRatio`, in-app zoom, and `visualViewport.scale`
+  (pinch-zoom) into a single value here. Pass `devicePixelRatio` for
+  crisp output on high-DPI displays.
+- The effective rasterization scale is `layoutScale * densityScale`. If
+  that would exceed the safe maximum (16384 px per side), `densityScale`
+  is clamped proportionally; compare `result.pixelWidth` against
+  `Math.round(result.layoutWidth * densityScale)` to detect.
+- `paint` is always a full repaint — setting the backing-store width /
+  height clears it. No `clearRect` required.
 - `pageCount` and `pageSize(page)` are stable for the session's
   lifetime (immutable snapshot) — cache them.
-- Setting `canvas.width` / `canvas.height` clears the backing store; if
-  you reuse a canvas without resizing, call `clearRect` before `paint`.
-- `paint` validates `ctx.canvas.{width,height}` against
-  `round(widthPt * scale) × round(heightPt * scale)` and throws on
-  mismatch. `putImageData` would otherwise silently clip — the throw is
-  the diagnostic.
-- `paint` accepts both `CanvasRenderingContext2D` (main thread) and
-  `OffscreenCanvasRenderingContext2D` (Workers, off-DOM rasterization,
-  `node-canvas` test setups). Note that loading the WASM module inside a
-  Worker is the host's responsibility.
+- Worker support: pass an `OffscreenCanvasRenderingContext2D` and the
+  same call signature works. `layoutWidth` / `layoutHeight` are
+  informational in that mode (no CSS layout box); fold everything into
+  `densityScale`. Loading the WASM module inside a Worker is the host's
+  responsibility.
 - Backend support: gated by `supportsCanvas`. Probe upfront with
   `quill.supportsCanvas` (or `session.supportsCanvas`) before mounting a
   canvas-based UI; the throw on `paint` / `pageSize` remains the

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -191,7 +191,7 @@ proposal) hasn't landed, use an explicit `try` / `finally`:
 const session = quill.open(doc);
 try {
   for (let p = 0; p < session.pageCount; p++) {
-    session.paint(ctx, p, scale);
+    session.paint(ctx, p);
   }
 } finally {
   session.free();

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -96,15 +96,6 @@ function openSession() {
   return openQuill().open(Document.fromMarkdown(TEST_MARKDOWN))
 }
 
-/** Build a fake context already sized to fit page `page` at `scale`. */
-function ctxForPage(session, page, scale, CtxCtor = FakeCanvasRenderingContext2D) {
-  const { widthPt, heightPt } = session.pageSize(page)
-  const ctx = new CtxCtor()
-  ctx.canvas.width = Math.round(widthPt * scale)
-  ctx.canvas.height = Math.round(heightPt * scale)
-  return ctx
-}
-
 describe('RenderSession canvas preview', () => {
   it('exposes pageCount, backendId, supportsCanvas, warnings, and pageSize on a Typst session', () => {
     const quill = openQuill()
@@ -121,20 +112,34 @@ describe('RenderSession canvas preview', () => {
     expect(size.heightPt).toBeGreaterThan(0)
   })
 
-  it('paints a page with the expected backing-store dimensions and non-trivial pixel content', () => {
+  it('paint sizes the canvas backing store and returns layout + pixel dimensions', () => {
     const session = openSession()
-    const scale = 1.5
-    const ctx = ctxForPage(session, 0, scale)
     const { widthPt, heightPt } = session.pageSize(0)
+    const layoutScale = 1
+    const densityScale = 1.5
 
-    expect(() => session.paint(ctx, 0, scale)).not.toThrow()
+    const ctx = new FakeCanvasRenderingContext2D()
+    const result = session.paint(ctx, 0, { layoutScale, densityScale })
+
+    // Layout dimensions reflect layoutScale only — independent of density.
+    expect(result.layoutWidth).toBeCloseTo(widthPt * layoutScale, 4)
+    expect(result.layoutHeight).toBeCloseTo(heightPt * layoutScale, 4)
+
+    // Pixel dimensions reflect layoutScale * densityScale, rounded.
+    expect(result.pixelWidth).toBe(Math.round(widthPt * layoutScale * densityScale))
+    expect(result.pixelHeight).toBe(Math.round(heightPt * layoutScale * densityScale))
+
+    // Painter owns canvas.width/height — they must equal the reported
+    // pixel dimensions.
+    expect(ctx.canvas.width).toBe(result.pixelWidth)
+    expect(ctx.canvas.height).toBe(result.pixelHeight)
 
     expect(ctx.calls).toHaveLength(1)
     const call = ctx.calls[0]
     expect(call.dx).toBe(0)
     expect(call.dy).toBe(0)
-    expect(call.width).toBe(Math.round(widthPt * scale))
-    expect(call.height).toBe(Math.round(heightPt * scale))
+    expect(call.width).toBe(result.pixelWidth)
+    expect(call.height).toBe(result.pixelHeight)
     expect(call.data.length).toBe(call.width * call.height * 4)
 
     // Pixel-content sanity. The test plate renders a title heading, so the
@@ -153,33 +158,65 @@ describe('RenderSession canvas preview', () => {
     expect(opaquePixels).toBeGreaterThan(0)
   })
 
-  it('also paints into an OffscreenCanvasRenderingContext2D', () => {
+  it('paint defaults layoutScale and densityScale to 1 when opts are omitted', () => {
     const session = openSession()
-    const scale = 1
-    const ctx = ctxForPage(session, 0, scale, FakeOffscreenCanvasRenderingContext2D)
-    expect(() => session.paint(ctx, 0, scale)).not.toThrow()
-    expect(ctx.calls).toHaveLength(1)
+    const { widthPt, heightPt } = session.pageSize(0)
+
+    const ctx = new FakeCanvasRenderingContext2D()
+    const result = session.paint(ctx, 0)
+
+    expect(result.layoutWidth).toBeCloseTo(widthPt, 4)
+    expect(result.layoutHeight).toBeCloseTo(heightPt, 4)
+    expect(result.pixelWidth).toBe(Math.round(widthPt))
+    expect(result.pixelHeight).toBe(Math.round(heightPt))
   })
 
-  it('throws on canvas/scale dimension mismatch instead of silently clipping', () => {
+  it('also paints into an OffscreenCanvasRenderingContext2D', () => {
     const session = openSession()
-    const scale = 1
-    const ctx = ctxForPage(session, 0, scale)
-    // Sabotage the height after sizing — a common foot-gun is forgetting to
-    // resize when the user changes zoom.
-    ctx.canvas.height -= 10
+    const ctx = new FakeOffscreenCanvasRenderingContext2D()
+    const result = session.paint(ctx, 0, { densityScale: 2 })
 
-    expect(() => session.paint(ctx, 0, scale)).toThrow(/canvas size mismatch/)
-    expect(ctx.calls).toHaveLength(0)
+    expect(ctx.calls).toHaveLength(1)
+    expect(ctx.canvas.width).toBe(result.pixelWidth)
+    expect(ctx.canvas.height).toBe(result.pixelHeight)
+  })
+
+  it('paint clamps backing-store dimensions to the safe maximum', () => {
+    const session = openSession()
+    const { widthPt, heightPt } = session.pageSize(0)
+    const longest = Math.max(widthPt, heightPt)
+    // Pick a densityScale that drives the longest backing dimension well
+    // past the 16384-px clamp threshold.
+    const densityScale = (16384 / longest) * 4
+
+    const ctx = new FakeCanvasRenderingContext2D()
+    const result = session.paint(ctx, 0, { densityScale })
+
+    // Backing dimensions clamp at 16384 on the longer side.
+    expect(Math.max(result.pixelWidth, result.pixelHeight)).toBeLessThanOrEqual(16384)
+    // Layout dimensions are independent of the clamp.
+    expect(result.layoutWidth).toBeCloseTo(widthPt, 4)
+    expect(result.layoutHeight).toBeCloseTo(heightPt, 4)
+    // Detect-clamp contract: pixelWidth < round(layoutWidth * densityScale).
+    expect(result.pixelWidth).toBeLessThan(Math.round(result.layoutWidth * densityScale))
+  })
+
+  it('paint throws on non-finite or non-positive layoutScale / densityScale', () => {
+    const session = openSession()
+    const ctx = new FakeCanvasRenderingContext2D()
+    expect(() => session.paint(ctx, 0, { layoutScale: 0 })).toThrow(/layoutScale/)
+    expect(() => session.paint(ctx, 0, { layoutScale: -1 })).toThrow(/layoutScale/)
+    expect(() => session.paint(ctx, 0, { layoutScale: Number.NaN })).toThrow(/layoutScale/)
+    expect(() => session.paint(ctx, 0, { densityScale: 0 })).toThrow(/densityScale/)
+    expect(() =>
+      session.paint(ctx, 0, { densityScale: Number.POSITIVE_INFINITY }),
+    ).toThrow(/densityScale/)
   })
 
   it('throws an out-of-range error when paint is called with a bad page index', () => {
     const session = openSession()
-    // For OOB we never reach the size validation — a 1×1 canvas is fine.
     const ctx = new FakeCanvasRenderingContext2D()
-    ctx.canvas.width = 1
-    ctx.canvas.height = 1
-    expect(() => session.paint(ctx, session.pageCount + 5, 1)).toThrow(
+    expect(() => session.paint(ctx, session.pageCount + 5)).toThrow(
       /out of range.*pageCount=/,
     )
   })

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -33,6 +33,16 @@ export interface CardInput {
 /// ever ships, replace this with a richer check.
 const CANVAS_BACKEND_ID: &str = "typst";
 
+/// Maximum backing-store dimension the painter will produce, in device
+/// pixels per side. Real browser limits vary (~32k on Chrome/Firefox,
+/// 16k on Safari, lower on memory-constrained devices); 16384 is the
+/// floor that works everywhere we ship to. When a requested
+/// `layoutScale * densityScale` would exceed this, the painter clamps
+/// `densityScale` proportionally and surfaces the actual backing
+/// dimensions in the returned `PaintResult` so consumers can detect the
+/// clamp.
+const MAX_BACKING_DIMENSION: u32 = 16384;
+
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
     {
@@ -70,7 +80,7 @@ pub struct Quill {
 ///
 /// **Empty documents.** A document that compiles to zero pages still
 /// produces a valid session (`pageCount === 0`). Iterating
-/// `0..pageCount` is then a no-op; calling `paint(ctx, 0, scale)` or
+/// `0..pageCount` is then a no-op; calling `paint(ctx, 0)` or
 /// `pageSize(0)` throws `"... page index 0 out of range
 /// (pageCount=0)"`. Hosts that surface "no pages to preview" UI should
 /// branch on `pageCount === 0` rather than on a thrown error.
@@ -809,19 +819,83 @@ fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValu
     Ok(bytes.to_vec())
 }
 
-/// TypeScript declaration for the page-size record returned by
-/// `RenderSession.pageSize`.
+/// TypeScript declarations for the canvas-preview surface.
+///
+/// `paint` is the single source of truth for canvas backing-store sizing —
+/// consumers do not multiply by `devicePixelRatio` themselves and do not
+/// write to `canvas.width` / `canvas.height` directly. They supply layout
+/// (`layoutScale`) and density (`densityScale`) inputs separately; the
+/// painter folds them into the rasterization scale, sizes the backing
+/// store, and reports what it picked.
 #[wasm_bindgen(typescript_custom_section)]
-const PAGE_SIZE_TS: &'static str = r#"
+const CANVAS_PREVIEW_TS: &'static str = r#"
 /**
  * Page dimensions in Typst points (1 pt = 1/72 inch).
  *
- * Returned by `RenderSession.pageSize`. Use these to size a canvas backing
- * store (`widthPt * scale × heightPt * scale`) before calling `paint`.
+ * Report-only: the painter sizes the canvas itself based on
+ * `PaintOptions`. `pageSize` is exposed for callers that need page
+ * geometry up-front (e.g. to lay out a scrollable list of canvases
+ * before any pixels are rendered).
  */
 export interface PageSize {
     widthPt: number;
     heightPt: number;
+}
+
+/**
+ * Inputs to `RenderSession.paint`. Both fields are optional and default
+ * to `1`.
+ *
+ * - `layoutScale` — layout-space pixels per Typst point. For on-screen
+ *   canvases this is CSS pixels per pt; the page's layout-pixel size is
+ *   `widthPt * layoutScale × heightPt * layoutScale`. The painter
+ *   surfaces these dimensions as `layoutWidth` / `layoutHeight` so
+ *   consumers can drive `canvas.style.*` (or any layout system).
+ * - `densityScale` — backing-store density multiplier. Fold
+ *   `window.devicePixelRatio`, in-app zoom, and `visualViewport.scale`
+ *   (pinch-zoom) into a single value here. Defaults to `1`, which
+ *   produces a non-retina backing store — pass `window.devicePixelRatio`
+ *   for crisp output on high-DPI displays.
+ *
+ * The effective rasterization scale is `layoutScale * densityScale`.
+ * Both must be finite and `> 0`. For `OffscreenCanvasRenderingContext2D`
+ * the two collapse to a single scalar; folding everything into
+ * `densityScale` is the simplest convention.
+ */
+export interface PaintOptions {
+    layoutScale?: number;
+    densityScale?: number;
+}
+
+/**
+ * Returned by `RenderSession.paint`.
+ *
+ * - `layoutWidth` / `layoutHeight` — layout-pixel dimensions of the
+ *   canvas's display box. For on-screen canvases this is CSS pixels:
+ *   set `canvas.style.width = layoutWidth + "px"` and
+ *   `canvas.style.height = layoutHeight + "px"` (or feed these into
+ *   your layout system). Independent of `densityScale`.
+ * - `pixelWidth` / `pixelHeight` — integer backing-store pixel
+ *   dimensions the painter wrote to `canvas.width` / `canvas.height`.
+ *   Equal to `round(layoutWidth * densityScale)` ×
+ *   `round(layoutHeight * densityScale)` *unless* the requested backing
+ *   exceeded the painter's safe maximum (16384 px per side), in which
+ *   case `densityScale` was clamped to fit. Detect clamping via
+ *   `pixelWidth < round(layoutWidth * densityScale)`.
+ *
+ * The painter owns `canvas.width` / `canvas.height`; consumers must not
+ * write to them. The painter does **not** touch `canvas.style.*`;
+ * consumers own layout.
+ *
+ * For `OffscreenCanvasRenderingContext2D` (Worker rasterization, no
+ * DOM), `layoutWidth` / `layoutHeight` are informational — there's no
+ * CSS layout box to apply them to.
+ */
+export interface PaintResult {
+    layoutWidth: number;
+    layoutHeight: number;
+    pixelWidth: number;
+    pixelHeight: number;
 }
 "#;
 
@@ -897,6 +971,11 @@ impl RenderSession {
 
     /// Page dimensions in Typst points (1 pt = 1/72 inch).
     ///
+    /// Report-only: the painter sizes the canvas itself based on
+    /// `PaintOptions`. Exposed for consumers that need page geometry
+    /// up-front (e.g. to lay out a scrollable list of canvases before
+    /// any pixels are rendered).
+    ///
     /// Stable for a given `page` across the session's lifetime — the
     /// compiled document is an immutable snapshot, so callers can cache
     /// results.
@@ -925,21 +1004,27 @@ impl RenderSession {
     /// Both dispatch to the same Rust rasterizer; the dispatch happens at
     /// the JS boundary so neither context type is privileged.
     ///
-    /// `scale` multiplies Typst's natural 72 ppi (1 pt → 1 device pixel at
-    /// `scale = 1`). Typical usage:
-    /// `scale = (window.devicePixelRatio || 1) * userZoom`.
+    /// The painter owns `canvas.width` / `canvas.height` and writes them
+    /// itself; consumers must not. The painter does not touch
+    /// `canvas.style.*` — that's layout, owned by the consumer (see
+    /// `PaintResult.layoutWidth` / `layoutHeight`).
     ///
-    /// The caller must size `ctx.canvas` so that
-    /// `canvas.width === round(widthPt * scale)` and `canvas.height ===
-    /// round(heightPt * scale)` *before* calling `paint`. Setting
-    /// `canvas.width` / `canvas.height` clears the backing store, which is
-    /// the recommended way to handle page-to-page transitions; if you
-    /// reuse a canvas without resizing, call
-    /// `ctx.clearRect(0, 0, canvas.width, canvas.height)` first to avoid
-    /// stale pixels showing through transparent regions.
+    /// `opts.layoutScale` (default 1.0) is layout-space pixels per Typst
+    /// point and determines the canvas's display-box size. `opts.densityScale`
+    /// (default 1.0) is the rasterization density multiplier the consumer
+    /// folds `window.devicePixelRatio`, in-app zoom, and
+    /// `visualViewport.scale` (pinch-zoom) into. The effective
+    /// rasterization scale is `layoutScale * densityScale`.
     ///
-    /// `paint` writes into the backing store at origin `(0, 0)` and does
-    /// not clear outside the rendered region.
+    /// If `layoutScale * densityScale` would exceed the safe backing-store
+    /// maximum (16384 px per side), `densityScale` is clamped
+    /// proportionally so the largest dimension fits. The actual
+    /// backing-store dimensions are reported in the returned
+    /// `PaintResult` — compare against
+    /// `round(layoutWidth * densityScale)` to detect clamping.
+    ///
+    /// Each call resets the backing store (`paint` is always a full
+    /// repaint). Consumers do not need to call `clearRect`.
     ///
     /// Throws when:
     /// - the backend does not support canvas preview (message includes the
@@ -947,11 +1032,8 @@ impl RenderSession {
     /// - `page` is out of range,
     /// - `ctx` is neither `CanvasRenderingContext2D` nor
     ///   `OffscreenCanvasRenderingContext2D`,
-    /// - `ctx.canvas.width`/`height` does not match
-    ///   `round(widthPt * scale) × round(heightPt * scale)` (silent clipping
-    ///   is the surprise we'd rather throw on than ship a "almost right"
-    ///   render).
-    #[wasm_bindgen(js_name = paint)]
+    /// - `opts.layoutScale` or `opts.densityScale` is non-finite or `<= 0`.
+    #[wasm_bindgen(js_name = paint, unchecked_return_type = "PaintResult")]
     pub fn paint(
         &self,
         #[wasm_bindgen(
@@ -959,40 +1041,82 @@ impl RenderSession {
         )]
         ctx: JsValue,
         page: usize,
-        scale: f32,
-    ) -> Result<(), JsValue> {
+        #[wasm_bindgen(unchecked_param_type = "PaintOptions | undefined")] opts: JsValue,
+    ) -> Result<JsValue, JsValue> {
         let typst = self.typst_session("paint")?;
         let canvas_ctx = CanvasCtx::from_js(&ctx)?;
 
-        // Compute expected dimensions from page geometry first so we can
-        // fail-fast on a mis-sized canvas without paying for rasterization.
         let (width_pt, height_pt) = typst
             .page_size_pt(page)
             .ok_or_else(|| self.page_oob_error("paint", page))?;
-        let expected_w = (width_pt * scale).round() as u32;
-        let expected_h = (height_pt * scale).round() as u32;
 
-        let (actual_w, actual_h) = canvas_ctx.canvas_dims();
-        if (actual_w, actual_h) != (expected_w, expected_h) {
-            return Err(WasmError::from(format!(
-                "paint: canvas size mismatch — expected {}×{} (round(widthPt × scale) × round(heightPt × scale)), got {}×{}. Set canvas.width and canvas.height before calling paint.",
-                expected_w, expected_h, actual_w, actual_h,
-            ))
+        let opts: PaintOptions = if opts.is_undefined() || opts.is_null() {
+            PaintOptions::default()
+        } else {
+            serde_wasm_bindgen::from_value(opts).map_err(|e| {
+                WasmError::from(format!("paint: invalid options: {e}")).to_js_value()
+            })?
+        };
+
+        let layout_scale = opts.layout_scale.unwrap_or(1.0);
+        let requested_density = opts.density_scale.unwrap_or(1.0);
+
+        if !layout_scale.is_finite() || layout_scale <= 0.0 {
+            return Err(WasmError::from(
+                "paint: layoutScale must be a finite number greater than 0",
+            )
+            .to_js_value());
+        }
+        if !requested_density.is_finite() || requested_density <= 0.0 {
+            return Err(WasmError::from(
+                "paint: densityScale must be a finite number greater than 0",
+            )
             .to_js_value());
         }
 
-        let (rw, rh, mut rgba) = typst
-            .render_rgba(page, scale)
+        let layout_width = (width_pt as f64) * (layout_scale as f64);
+        let layout_height = (height_pt as f64) * (layout_scale as f64);
+
+        let desired_w = (layout_width * requested_density as f64).round();
+        let desired_h = (layout_height * requested_density as f64).round();
+        let max_dim = desired_w.max(desired_h);
+
+        let effective_density = if max_dim > MAX_BACKING_DIMENSION as f64 {
+            (requested_density as f64) * (MAX_BACKING_DIMENSION as f64 / max_dim)
+        } else {
+            requested_density as f64
+        };
+
+        let render_scale = (layout_scale as f64) * effective_density;
+
+        let (pixel_w, pixel_h, mut rgba) = typst
+            .render_rgba(page, render_scale as f32)
             .ok_or_else(|| self.page_oob_error("paint", page))?;
+
+        // The painter owns canvas.width/height. Setting these clears the
+        // backing store automatically — no clearRect needed.
+        canvas_ctx.set_canvas_dims(pixel_w, pixel_h)?;
+
         let img = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
             wasm_bindgen::Clamped(rgba.as_mut_slice()),
-            rw,
-            rh,
+            pixel_w,
+            pixel_h,
         )
         .map_err(|e| {
             WasmError::from(format!("paint: ImageData construction failed: {:?}", e)).to_js_value()
         })?;
-        canvas_ctx.put_image_data(&img)
+        canvas_ctx.put_image_data(&img)?;
+
+        let result = PaintResult {
+            layout_width,
+            layout_height,
+            pixel_width: pixel_w,
+            pixel_height: pixel_h,
+        };
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        result
+            .serialize(&serializer)
+            .map_err(|e| WasmError::from(format!("paint: serialization failed: {e}")).to_js_value())
     }
 }
 
@@ -1020,7 +1144,7 @@ impl RenderSession {
 
 /// Adapter unifying `CanvasRenderingContext2D` and
 /// `OffscreenCanvasRenderingContext2D` behind one Rust shape so `paint`
-/// can validate dimensions and emit pixels without repeating the
+/// can size the backing store and emit pixels without repeating the
 /// downcast.
 enum CanvasCtx<'a> {
     OnScreen(&'a web_sys::CanvasRenderingContext2d),
@@ -1041,22 +1165,27 @@ impl<'a> CanvasCtx<'a> {
         .to_js_value())
     }
 
-    /// `(canvas.width, canvas.height)` in device pixels. Both backing
-    /// canvas types expose numeric width/height; the typed web-sys
-    /// accessors here fall back to `0` if the field is absent, which is
-    /// indistinguishable from a deliberately zero-sized canvas — fine
-    /// for our validation since either way the mismatch error fires.
-    fn canvas_dims(&self) -> (u32, u32) {
+    /// Set `canvas.width` and `canvas.height`. Writing to either is
+    /// specified to clear the backing store, which is exactly the
+    /// contract `paint` wants on each call (full repaint, no stale
+    /// pixels in transparent regions).
+    fn set_canvas_dims(&self, width: u32, height: u32) -> Result<(), JsValue> {
         match self {
-            Self::OnScreen(c) => match c.canvas() {
-                Some(canvas) => (canvas.width(), canvas.height()),
-                None => (0, 0),
-            },
+            Self::OnScreen(c) => {
+                let canvas = c.canvas().ok_or_else(|| {
+                    WasmError::from("paint: rendering context has no associated <canvas> element")
+                        .to_js_value()
+                })?;
+                canvas.set_width(width);
+                canvas.set_height(height);
+            }
             Self::OffScreen(c) => {
                 let canvas = c.canvas();
-                (canvas.width(), canvas.height())
+                canvas.set_width(width);
+                canvas.set_height(height);
             }
         }
+        Ok(())
     }
 
     fn put_image_data(&self, img: &web_sys::ImageData) -> Result<(), JsValue> {
@@ -1073,4 +1202,22 @@ struct PageSize {
     width_pt: f32,
     #[serde(rename = "heightPt")]
     height_pt: f32,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PaintOptions {
+    #[serde(default)]
+    layout_scale: Option<f32>,
+    #[serde(default)]
+    density_scale: Option<f32>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PaintResult {
+    layout_width: f64,
+    layout_height: f64,
+    pixel_width: u32,
+    pixel_height: u32,
 }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -88,22 +88,17 @@ Get started with Quillmark in Python or JavaScript.
     for (const w of session.warnings) console.warn(w.message);
 
     function renderPage(canvas, page, userZoom = 1) {
-      const dpr = window.devicePixelRatio || 1;
-      const scale = dpr * userZoom;                    // multiplier on 72 ppi
+      const densityScale = (window.devicePixelRatio || 1) * userZoom;
 
-      const { widthPt, heightPt } = session.pageSize(page);
+      // Painter sizes canvas.width/height itself; consumer reads back the
+      // layout dimensions to drive layout.
+      const result = session.paint(canvas.getContext("2d"), page, {
+        layoutScale: 1,
+        densityScale,
+      });
 
-      // Backing store (device pixels). Reassigning width/height clears the
-      // canvas. If you ever reuse the same canvas at the same size (e.g.
-      // repaint without a scale change), call clearRect before paint instead.
-      canvas.width  = Math.round(widthPt  * scale);
-      canvas.height = Math.round(heightPt * scale);
-
-      // CSS box (layout pixels) — independent of DPR.
-      canvas.style.width  = `${widthPt  * userZoom}px`;
-      canvas.style.height = `${heightPt * userZoom}px`;
-
-      session.paint(canvas.getContext("2d"), page, scale);
+      canvas.style.width  = `${result.layoutWidth}px`;
+      canvas.style.height = `${result.layoutHeight}px`;
     }
 
     for (let p = 0; p < session.pageCount; p++) {
@@ -116,22 +111,28 @@ Get started with Quillmark in Python or JavaScript.
 
     ### Notes
 
-    - **`scale` is a multiplier on 72 ppi**, not a ppi value. `scale = 1`
-      gives 1 device pixel per Typst point. Always include
-      `devicePixelRatio` so retina displays are crisp.
+    - **`layoutScale` vs `densityScale`.** `layoutScale` is layout-space
+      pixels per Typst point — a layout decision (how big does the page
+      look on screen). `densityScale` is the backing-store density
+      multiplier — a sharpness decision. Fold `window.devicePixelRatio`,
+      any in-app zoom level, and `visualViewport.scale` (pinch-zoom) into
+      one `densityScale` value. Both default to `1`.
+    - **Painter owns backing store.** Don't write to `canvas.width` /
+      `canvas.height` yourself — the painter does it on every call. Don't
+      call `clearRect` either; setting the backing-store size clears it.
+    - **Consumer owns layout.** The painter doesn't touch
+      `canvas.style.*`. Use `result.layoutWidth` / `result.layoutHeight`
+      to size the canvas's display box.
+    - **Backing-store clamp.** If `layoutScale * densityScale` would push
+      either dimension past 16384 px, the painter clamps `densityScale`
+      to fit and the result reflects what it actually wrote. Detect via
+      `result.pixelWidth < Math.round(result.layoutWidth * densityScale)`.
     - **`pageCount` and `pageSize(page)` are stable** for the lifetime of a
       session — the underlying compiled document is an immutable snapshot.
       Cache them.
-    - **Canvas reuse.** Setting `canvas.width` / `canvas.height` clears the
-      backing store. If you reuse a canvas without resizing (same page,
-      same scale, repaint), call
-      `ctx.clearRect(0, 0, canvas.width, canvas.height)` before `paint` to
-      avoid stale pixels in transparent regions.
-    - **Worker rendering.** The painter currently accepts only
-      `CanvasRenderingContext2D` and runs on the main thread. For
-      multi-page documents this can jank typing in an editor; route the
-      paint loop through `requestIdleCallback` or coalesce to the visible
-      viewport.
+    - **Worker rendering.** Pass an `OffscreenCanvasRenderingContext2D`
+      to the same `paint` call to rasterize off the main thread. Loading
+      the WASM module inside the Worker is the host's responsibility.
     - **No text selection / find-in-page.** Canvas pixels are opaque to the
       DOM. If you need accessibility or text selection in the preview,
       keep an SVG/PDF export path alongside.

--- a/prose/designs/ARCHITECTURE.md
+++ b/prose/designs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ PyO3 bindings published as `quillmark` on PyPI.
 
 wasm-bindgen bindings published as `@quillmark/wasm`. Supports bundler and Node.js targets. Builds with `--weak-refs` so wasm-bindgen handles are reclaimed by `FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires Node 14.6+ / current evergreen browsers.
 
-In addition to the byte-output verbs (`Quill.render`, `RenderSession.render`), exposes a Typst-only **canvas preview** path on `RenderSession`: `pageCount`, `pageSize(page)`, `paint(ctx, page, scale)`, plus `backendId` and `warnings`. The painter rasterizes pages directly from the cached `PagedDocument` into a `CanvasRenderingContext2d`, skipping PNG/SVG round-trips. See [PREVIEW.md](PREVIEW.md).
+In addition to the byte-output verbs (`Quill.render`, `RenderSession.render`), exposes a Typst-only **canvas preview** path on `RenderSession`: `pageCount`, `pageSize(page)`, `paint(ctx, page, opts?)`, plus `backendId`, `supportsCanvas`, and `warnings`. The painter rasterizes pages directly from the cached `PagedDocument` into a `CanvasRenderingContext2D` or `OffscreenCanvasRenderingContext2D`, sizes the canvas backing store itself, and returns the chosen layout/pixel dimensions. Skips PNG/SVG round-trips. See [PREVIEW.md](PREVIEW.md).
 
 ### `bindings/quillmark-cli`
 

--- a/prose/designs/PREVIEW.md
+++ b/prose/designs/PREVIEW.md
@@ -180,13 +180,6 @@ reports the actual backing dimensions in the result.
   off-screen previews); the cost of the silent default is one missed
   `densityScale` ⇒ blurry retina, the benefit is a usable
   `paint(ctx, page)` for the simple case.
-- **Names are context-neutral, not CSS-specific.** Earlier drafts used
-  `cssScale` / `dpr` / `cssWidth` / `cssHeight`. `dpr` was misleading —
-  consumers fold zoom + pinch into it, not just `devicePixelRatio`. And
-  `cssWidth` lies for `OffscreenCanvasRenderingContext2D`, which has no
-  CSS layout box. `layoutScale` / `densityScale` / `layoutWidth` /
-  `layoutHeight` / `pixelWidth` / `pixelHeight` are honest in both
-  contexts and symmetric in style.
 - **Painter owns `canvas.width` / `canvas.height`; consumer owns
   `canvas.style.*`.** Earlier API pushed backing-store math onto every
   consumer ("size your canvas like X before calling paint"). That made

--- a/prose/designs/PREVIEW.md
+++ b/prose/designs/PREVIEW.md
@@ -218,22 +218,21 @@ crates/
 └── bindings/wasm/
     ├── Cargo.toml                   extended  — web-sys features
     │                                            (CanvasRenderingContext2d,
-    │                                             ImageData)
+    │                                             HtmlCanvasElement,
+    │                                             ImageData,
+    │                                             OffscreenCanvas,
+    │                                             OffscreenCanvasRenderingContext2d)
     └── src/engine.rs                extended  — paint, pageSize,
-                                                  backendId, warnings
-                                                  (calls typst_session_of
-                                                  directly; no separate
-                                                  adapter file)
+                                                  backendId, supportsCanvas,
+                                                  warnings; CanvasCtx enum
+                                                  dispatches OnScreen vs
+                                                  OffScreen contexts (calls
+                                                  typst_session_of directly;
+                                                  no separate adapter file)
 ```
 
 ## Future work (not in V1)
 
-- **OffscreenCanvas / Worker support.** The current painter accepts only
-  `CanvasRenderingContext2d`. Multi-page documents will jank typing on
-  the host thread. Add `OffscreenCanvas` features and an overload taking
-  `OffscreenCanvasRenderingContext2d`, or document the main-thread-only
-  constraint loudly so consumers route pixels through `postMessage` if
-  they want a worker.
 - **Direct `CanvasRenderingContext2d` adapter.** V1 allocates an RGBA
   `Vec<u8>` per repaint. A direct path that hands tiny_skia's pixmap to
   the canvas (or a typed-array view backed by linear memory) would

--- a/prose/designs/PREVIEW.md
+++ b/prose/designs/PREVIEW.md
@@ -81,17 +81,36 @@ pub fn typst_session_of(s: &RenderSession) -> Option<&TypstSession>;
 class RenderSession {
   readonly pageCount: number;
   readonly backendId: string;
+  readonly supportsCanvas: boolean;
   readonly warnings: Diagnostic[];
 
   render(opts?: RenderOptions): RenderResult;
-  pageSize(page: number): PageSize;     // { widthPt, heightPt } in pt
-  paint(ctx: CanvasRenderingContext2D, page: number, scale: number): void;
+  pageSize(page: number): PageSize;     // { widthPt, heightPt } in pt; report-only
+  paint(
+    ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    page: number,
+    opts?: PaintOptions,
+  ): PaintResult;
+}
+
+interface PaintOptions {
+  layoutScale?: number;   // layout px per Typst pt; layout decision; default 1
+  densityScale?: number;  // backing-store density multiplier; default 1
+}
+
+interface PaintResult {
+  layoutWidth: number;    // canvas.style.width target; independent of densityScale
+  layoutHeight: number;
+  pixelWidth: number;     // canvas.width the painter wrote (clamped at 16384)
+  pixelHeight: number;
 }
 ```
 
-`scale` multiplies Typst's natural 72 ppi (1 pt → 1 device pixel at
-`scale = 1`). Caller computes `scale = devicePixelRatio * userZoom` and
-sizes the canvas before calling `paint`.
+The painter owns `canvas.width` / `canvas.height` — it sizes the backing
+store on every call. Consumers own `canvas.style.*` (or layout) and read
+`layoutWidth` / `layoutHeight` from the result. `layoutScale * densityScale`
+is the effective rasterization scale; the painter clamps `densityScale`
+if the largest backing dimension would exceed 16384 px.
 
 ## Architecture
 
@@ -117,21 +136,22 @@ byte-identical.
 
 ```js
 const session = quill.open(doc);              // compiles once, caches PagedDocument
-const dpr = window.devicePixelRatio || 1;
-const scale = dpr * userZoom;                 // userZoom is a UI control
-const { widthPt, heightPt } = session.pageSize(page);
+const densityScale = (window.devicePixelRatio || 1) * userZoom;  // userZoom is a UI control
 
-canvas.width  = Math.round(widthPt  * scale); // backing store, device px
-canvas.height = Math.round(heightPt * scale);
-canvas.style.width  = `${widthPt  * userZoom}px`;  // CSS box, layout px
-canvas.style.height = `${heightPt * userZoom}px`;
+const result = session.paint(canvas.getContext('2d'), page, {
+  layoutScale: 1,                             // layout px per Typst pt
+  densityScale,                               // includes devicePixelRatio + zoom
+});
 
-session.paint(canvas.getContext('2d'), page, scale);
+canvas.style.width  = `${result.layoutWidth}px`;   // CSS box, layout px
+canvas.style.height = `${result.layoutHeight}px`;
 ```
 
-Setting `canvas.width` / `canvas.height` clears the backing store, which
-is the recommended way to handle page-to-page transitions. If a consumer
-reuses a canvas without resizing, `clearRect` first.
+Each `paint` call resets the backing store (writing `canvas.width`
+clears it), so paint is always a full repaint. Consumers don't call
+`clearRect`. If `layoutScale * densityScale` would push either dimension
+past 16384 px, the painter clamps `densityScale` proportionally and
+reports the actual backing dimensions in the result.
 
 ## Decisions and rationale
 
@@ -150,12 +170,35 @@ reuses a canvas without resizing, `clearRect` first.
   Typst-only and WASM-only; pushing it through a generic core trait would
   force every backend to implement or stub it and would drag `web-sys`
   toward `core`. The downcast is the standard escape hatch.
-- **`scale` is a multiplier on 72 ppi, not a ppi value.** Matches how
-  canvas/DPR consumers think (`scale = dpr * zoom`), and makes
-  `scale = 1` the natural "1 pt = 1 device pixel" baseline.
-- **Required `scale` (not optional).** Real consumers always compute it
-  from `devicePixelRatio`. A default of `1.0` would produce non-retina
-  output by accident. Forcing the parameter is better DX.
+- **`layoutScale` and `densityScale` separated, both optional.** A
+  single scalar conflated layout (how big on screen) with sharpness
+  (how many backing pixels). The split mirrors how editor consumers
+  think about it — `layoutScale` is a layout decision, `densityScale`
+  is a sharpness decision they fold `devicePixelRatio` + zoom +
+  `visualViewport.scale` into. Both default to 1 because the painter
+  alone cannot know the consumer's DPR (e.g. SSR contexts, tests,
+  off-screen previews); the cost of the silent default is one missed
+  `densityScale` ⇒ blurry retina, the benefit is a usable
+  `paint(ctx, page)` for the simple case.
+- **Names are context-neutral, not CSS-specific.** Earlier drafts used
+  `cssScale` / `dpr` / `cssWidth` / `cssHeight`. `dpr` was misleading —
+  consumers fold zoom + pinch into it, not just `devicePixelRatio`. And
+  `cssWidth` lies for `OffscreenCanvasRenderingContext2D`, which has no
+  CSS layout box. `layoutScale` / `densityScale` / `layoutWidth` /
+  `layoutHeight` / `pixelWidth` / `pixelHeight` are honest in both
+  contexts and symmetric in style.
+- **Painter owns `canvas.width` / `canvas.height`; consumer owns
+  `canvas.style.*`.** Earlier API pushed backing-store math onto every
+  consumer ("size your canvas like X before calling paint"). That made
+  `devicePixelRatio` and the rounding rule callable-side state, which
+  means every consumer has to get them right. Folding the math into the
+  painter eliminates a class of "blurry on retina" bugs and lets the
+  painter clamp at the 16384-px browser limit centrally.
+- **Hard 16384-px backing-store clamp.** Real browser limits vary
+  (Chrome/Firefox ~32k, Safari 16k, lower on memory-constrained mobile);
+  16384 is the floor that works everywhere. `PaintResult` reports the
+  actual backing dimensions, so a consumer that cares can detect the
+  clamp and surface "max zoom reached" UI.
 - **Unpremultiplied RGBA on the wire.** `tiny_skia` produces premultiplied
   alpha; `ImageData` expects non-premultiplied. We unpremultiply pixel-by-
   pixel before constructing `ImageData`. One allocation per repaint;


### PR DESCRIPTION
Replace `paint(ctx, page, scale)` with `paint(ctx, page, opts?): PaintResult`.
The painter now writes `canvas.width` / `canvas.height` itself based on a
structured `{ layoutScale?, densityScale? }` opts shape, returning the
chosen `{ layoutWidth, layoutHeight, pixelWidth, pixelHeight }`. Consumers
own `canvas.style.*` and read the layout dims off the result.

Backing-store math (rounding, DPR, the whole "size your canvas before
calling paint" dance) moves from every call-site into the painter, which
also clamps at 16384 px per side to stay under Safari's canvas limit.
Names are context-neutral (layoutScale/densityScale, not cssScale/dpr) so
they read honestly for OffscreenCanvasRenderingContext2D too — `dpr` was
misleading once consumers fold zoom + visualViewport.scale into it, and
`cssWidth` lies when there's no DOM.

Hard break by intent: the only first-party consumer is @quillmark/editor,
which is being designed against this contract. Keeps main's PR #508
additions (supportsCanvas getters, CanvasCtx OffscreenCanvas dispatch,
empty-doc note); replaces its caller-sized validation with painter
ownership, since the foot-gun motivating validation ("forgot to resize
on zoom") is structurally impossible once the painter owns the dims.

https://claude.ai/code/session_018E4JgyajBjEbNPpTF8QeUT