### PR TITLE
Drop experimental-nodejs-module WASM build, target Node >=24

### DIFF
--- a/crates/bindings/wasm/package.template.json
+++ b/crates/bindings/wasm/package.template.json
@@ -4,6 +4,9 @@
   "description": "WebAssembly bindings for quillmark",
   "type": "module",
   "license": "MIT OR Apache-2.0",
+  "engines": {
+    "node": ">=24"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nibsbin/quillmark.git"
@@ -13,20 +16,14 @@
     "bundler/wasm_bg.js",
     "bundler/wasm_bg.wasm.d.ts",
     "bundler/wasm.js",
-    "bundler/wasm.d.ts",
-    "node-esm/wasm_bg.wasm",
-    "node-esm/wasm_bg.js",
-    "node-esm/wasm_bg.wasm.d.ts",
-    "node-esm/wasm.js",
-    "node-esm/wasm.d.ts"
+    "bundler/wasm.d.ts"
   ],
-  "main": "./node-esm/wasm.js",
+  "main": "./bundler/wasm.js",
   "module": "./bundler/wasm.js",
   "types": "./bundler/wasm.d.ts",
   "exports": {
     ".": {
       "types": "./bundler/wasm.d.ts",
-      "node": "./node-esm/wasm.js",
       "import": "./bundler/wasm.js",
       "default": "./bundler/wasm.js"
     }

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -13,7 +13,7 @@ if ! command -v wasm-bindgen &> /dev/null; then
 fi
 
 echo ""
-echo "Building for targets: bundler, nodejs (optimized for size)"
+echo "Building for target: bundler (optimized for size)"
 
 # Step 1: Build WASM binary with cargo
 echo "Building WASM binary..."
@@ -36,15 +36,6 @@ wasm-bindgen \
     --out-dir pkg/bundler \
     --out-name wasm \
     --target bundler \
-    --weak-refs
-
-echo "Generating JS bindings for nodejs..."
-mkdir -p pkg/node-esm
-wasm-bindgen \
-    target/wasm32-unknown-unknown/wasm-release/quillmark_wasm.wasm \
-    --out-dir pkg/node-esm \
-    --out-name wasm \
-    --target experimental-nodejs-module \
     --weak-refs
 
 # Note: a wasm-opt -Oz pass was tried and removed. With the current
@@ -98,4 +89,3 @@ report_size() {
     fi
 }
 report_size "bundler" pkg/bundler/wasm_bg.wasm
-report_size "nodejs"  pkg/node-esm/wasm_bg.wasm


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the `experimental-nodejs-module` wasm-bindgen target and the `pkg/node-esm/` output directory entirely
- Points the `"main"` field and all export conditions at the single `bundler/` build
- Adds `"engines": { "node": ">=24" }` to document the minimum Node requirement
- Halves the number of shipped files (10 → 5) and eliminates the duplicate `wasm.d.ts`

**Trade-off accepted:** raw Node.js consumers (no bundler) will see an `ExperimentalWarning` for the WASM ESM import. Browser/bundler consumers (webpack, Vite, etc.) are unaffected. The existing test suite already ran exclusively against the bundler output via `vite-plugin-wasm`.

## Test plan

- [ ] CI WASM job passes with Node 24 (single `wasm-bindgen` run, bundler target only)
- [ ] `pkg/` contains only `bundler/` files after build
- [ ] TypeScript consumers resolve types correctly from `bundler/wasm.d.ts`

https://claude.ai/code/session_014q91bzoQpWRufezR6YvAoQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014q91bzoQpWRufezR6YvAoQ)_