### PR TITLE
Optimize WASM build with caching in CI/release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,18 +79,32 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Cache WASM build output
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/wasm32-unknown-unknown/wasm-release
+            pkg
+          key: wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
+
       - name: Install wasm-bindgen-cli
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-bindgen-cli@0.2.118
+
+      - name: Build WASM
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: ./scripts/build-wasm.sh
 
       - name: Install npm dependencies
         working-directory: crates/bindings/wasm
         run: npm install
 
-      - name: Build and test WASM
+      - name: Test WASM
         working-directory: crates/bindings/wasm
-        run: npm test
+        run: npx vitest run
 
   ci-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,17 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Restore WASM build cache
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            target/wasm32-unknown-unknown/wasm-release
+            pkg
+          key: wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
+          restore-keys: |
+            wasm-${{ runner.os }}-
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -131,11 +142,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install wasm-bindgen-cli
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-bindgen-cli@0.2.118
 
       - name: Build WASM packages
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: ./scripts/build-wasm.sh
 
       - name: Install npm test dependencies


### PR DESCRIPTION
## Summary
This PR optimizes the WASM build process by introducing caching for build artifacts in both CI and release workflows, reducing build times when source code hasn't changed.

## Key Changes
- **Added WASM build caching**: Implemented `actions/cache@v4` to cache WASM build outputs (`target/wasm32-unknown-unknown/wasm-release` and `pkg` directories) based on `Cargo.lock` and Rust source file hashes
- **Conditional tool installation**: Made `wasm-bindgen-cli` installation conditional, only running when cache miss occurs
- **Separated build and test steps**: Split the WASM build into a dedicated step that only runs on cache misses, while test steps always run
- **Updated test command**: Changed WASM test invocation from `npm test` to `npx vitest run` for more explicit test runner specification
- **Applied to both workflows**: Implemented consistent caching strategy in both `ci.yml` and `release.yml` with appropriate fallback keys in the release workflow

## Implementation Details
- Cache keys are based on `Cargo.lock` and all Rust source files (`crates/**/*.rs`), ensuring cache invalidation when dependencies or source code changes
- The release workflow includes `restore-keys` fallback to partially match cache keys if exact match isn't found
- All conditional steps use the `steps.wasm-cache.outputs.cache-hit` output to determine whether to skip expensive operations

https://claude.ai/code/session_01Eoxqb3NmqEwYu5yFZX41ns