### PR TITLE
Add version and ref fields to Quill public schema

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -730,11 +730,13 @@ card_types:
     expect(meta.supportedFormats.length).toBeGreaterThan(0)
 
     // The quill's declared contract lives under metadata.schema. Its shape is
-    // identical to QuillConfig::public_schema() in Rust: { name, main,
-    // card_types, example? }. main and each card under card_types share the
-    // same shape.
+    // identical to QuillConfig::public_schema() in Rust: { name, version, ref,
+    // main, card_types, example? }. main and each card under card_types share
+    // the same shape.
     expect(meta.schema).toBeDefined()
     expect(meta.schema.name).toBe('meta_test_quill')
+    expect(meta.schema.version).toBe('0.2.1')
+    expect(meta.schema.ref).toBe('meta_test_quill@0.2.1')
     expect(meta.schema.main).toBeDefined()
     // schema.main.description is the schema's own description, authored
     // under `main:`, independent of meta.description above.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -57,6 +57,10 @@ export interface QuillCardSchema {
  */
 export interface QuillSchema {
     name: string;
+    /** Semver version of this quill. */
+    version: string;
+    /** Canonical reference string (`name@version`) — the value authors write in the `QUILL:` field. */
+    ref: string;
     main: QuillCardSchema;
     /** Present only when the quill declares at least one named card type. */
     card_types?: Record<string, QuillCardSchema>;

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -321,7 +321,8 @@ impl Quill {
     ///
     /// Returns a plain JS object with:
     /// - `schema` — the quill's public schema contract, identical to
-    ///   `QuillConfig::public_schema()`. Top-level keys: `name`, `main`,
+    ///   `QuillConfig::public_schema()`. Top-level keys: `name`, `version`,
+    ///   `ref` (`name@version` — the string authors write in `QUILL:`), `main`,
     ///   optional `card_types` (map keyed by card name, omitted when empty),
     ///   optional `example`. `main` and each card under `card_types` share
     ///   the same shape: `fields` (map keyed by field name), optional

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -78,16 +78,26 @@ impl QuillConfig {
     /// Public schema contract as a JSON value.
     ///
     /// The single source of truth for what consumers (form UIs, MCP tools,
-    /// LLM repair loops) see. Top-level keys: `name`, `main`, optional
-    /// `card_types` (map keyed by card name), and optional `example`.
-    /// `main` and each card under `card_types` serialize their `FieldSchema`
-    /// children via the structs' own serde attributes; the wire format here
-    /// is therefore pinned by those attributes plus this projection.
+    /// LLM repair loops) see. Top-level keys: `name`, `version`, `ref`
+    /// (`name@version` — the string authors write in the `QUILL:` field),
+    /// `main`, optional `card_types` (map keyed by card name), and optional
+    /// `example`. `main` and each card under `card_types` serialize their
+    /// `FieldSchema` children via the structs' own serde attributes; the wire
+    /// format here is therefore pinned by those attributes plus this
+    /// projection.
     pub fn public_schema(&self) -> serde_json::Value {
         let mut obj = serde_json::Map::new();
         obj.insert(
             "name".to_string(),
             serde_json::Value::String(self.name.clone()),
+        );
+        obj.insert(
+            "version".to_string(),
+            serde_json::Value::String(self.version.clone()),
+        );
+        obj.insert(
+            "ref".to_string(),
+            serde_json::Value::String(format!("{}@{}", self.name, self.version)),
         );
         obj.insert(
             "main".to_string(),

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/public_schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/public_schema.yaml
@@ -1,4 +1,6 @@
 name: usaf_memo
+version: 0.1.0
+ref: usaf_memo@0.1.0
 main:
   title: main
   fields:


### PR DESCRIPTION
## Summary
This PR adds `version` and `ref` fields to the Quill public schema contract, making version information explicitly available to consumers like form UIs, MCP tools, and LLM repair loops.

## Key Changes
- **Core schema generation**: Updated `QuillConfig::public_schema()` to include:
  - `version`: The semver version of the quill
  - `ref`: A canonical reference string in the format `name@version` (the value authors write in the `QUILL:` field)
- **TypeScript bindings**: Added corresponding fields to the `QuillSchema` interface with documentation
- **Test coverage**: Updated WASM binding tests to verify the new fields are present and correctly formatted
- **Documentation**: Updated comments in both Rust and JavaScript to reflect the new schema structure
- **Golden fixtures**: Updated the public schema fixture to include the new fields

## Implementation Details
The `ref` field is computed as a formatted string combining the existing `name` and `version` fields, providing a single canonical identifier for the quill that matches what authors use in configuration files. This makes it easier for consumers to reference and validate quill versions without additional parsing.

https://claude.ai/code/session_01PgKmQYP26cVcJnPw23iHAc