### PR TITLE
Remove __text__ underline deviation from CommonMark

### DIFF
--- a/crates/backends/typst/docs/designs/CONVERT.md
+++ b/crates/backends/typst/docs/designs/CONVERT.md
@@ -226,6 +226,11 @@ This enables proper multi-paragraph list items in Typst with correct continuatio
 - `TagEnd::Link` → `]`
 - URL is escaped with `escape_markup()` to handle special characters
 
+**Title is dropped.** CommonMark allows `[text](url "title")`; the title
+is parsed but discarded. Typst's `#link` has no `title:` parameter and
+the PDF output Typst produces exposes no tooltip primitive that this
+backend can target, so there is nowhere to render the title.
+
 ### Line Breaks
 
 | Markdown | Typst | Event |

--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -1431,10 +1431,7 @@ mod tests {
     #[test]
     fn test_double_underscore_is_strong() {
         // Per CommonMark, __text__ renders as strong, identical to **text**.
-        assert_eq!(
-            mark_to_typst("__bolded__").unwrap(),
-            "#strong[bolded]\n\n"
-        );
+        assert_eq!(mark_to_typst("__bolded__").unwrap(), "#strong[bolded]\n\n");
     }
 
     #[test]

--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -99,8 +99,8 @@ enum ListType {
 
 #[derive(Debug, Clone, Copy)]
 enum StrongKind {
-    Bold,      // Source was **...**
-    Underline, // Source was __...__
+    Bold,      // Source was ** or __
+    Underline, // Source was <u> (synthesized by MarkdownFixer)
 }
 
 fn typst_alignment(align: &pulldown_cmark::Alignment) -> &'static str {
@@ -281,18 +281,14 @@ where
                         end_newline = false;
                     }
                     Tag::Strong => {
-                        // Detect whether this is __ (underline), <u> (underline), or ** (bold)
-                        // by peeking at source. Per spec §6.2, __ and <u> both render as underline;
-                        // <u> is synthesized as Tag::Strong by MarkdownFixer.
-                        let kind = if range.start + 2 <= source.len() {
-                            let head = &source[range.start..range.start + 2];
-                            if head == "__" || head.eq_ignore_ascii_case("<u") {
-                                StrongKind::Underline
-                            } else {
-                                StrongKind::Bold // ** or edge cases
-                            }
+                        // <u>…</u> is synthesized as Tag::Strong by MarkdownFixer; detect it
+                        // by peeking at the source. Both ** and __ render as #strong[…].
+                        let kind = if range.start + 2 <= source.len()
+                            && source[range.start..range.start + 2].eq_ignore_ascii_case("<u")
+                        {
+                            StrongKind::Underline
                         } else {
-                            StrongKind::Bold // Fallback for very short ranges
+                            StrongKind::Bold
                         };
                         strong_stack.push(kind);
                         match kind {
@@ -523,8 +519,9 @@ where
             _ => {
                 // Ignore other events not specified in requirements
                 // (math, footnotes, etc.)
-                // Note: per spec §6.2/§6.3, raw HTML produces no output except <u>…</u>,
-                // which MarkdownFixer rewrites to Start/End(Tag::Strong) with Underline kind.
+                // Note: per spec §6.2, raw HTML produces no output except <u>…</u>,
+                // which MarkdownFixer rewrites to Start/End(Tag::Strong) and is detected
+                // as Underline in the Tag::Strong handler above.
             }
         }
     }
@@ -703,7 +700,7 @@ where
             }
             Event::End(TagEnd::Strong) | Event::End(TagEnd::Emphasis) => {
                 // Check if next event starts with *, which means we might need to fix closing tags
-                // This happens when we have something like __Underlined__***
+                // This happens when we have something like __strong__***
                 // The __ produces End(Strong), and following *** should be interpreted as closing.
 
                 // Only apply this fixup if there are still unclosed emphasis/strong tags
@@ -805,7 +802,7 @@ where
             let (event, range) = self.inner.next()?;
 
             // 3. Handle HTML: allowlist <u>…</u> as underline; strip everything else.
-            // Spec §6.2 deviation 2 / §6.3: <br> and all other raw HTML produce no output.
+            // Spec §6.2 / §6.3: <br> and all other raw HTML produce no output.
             let (event, range) = match event {
                 Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_open_tag(html) => {
                     (Event::Start(Tag::Strong), range)
@@ -1429,22 +1426,22 @@ mod tests {
         assert_eq!(typst, "== Code example: `fn main()`\n\n");
     }
 
-    // Tests for underline support (__ syntax)
+    // Tests for __ as CommonMark strong (no longer underline)
 
-    // Basic Underline Tests
     #[test]
-    fn test_underline_basic() {
+    fn test_double_underscore_is_strong() {
+        // Per CommonMark, __text__ renders as strong, identical to **text**.
         assert_eq!(
-            mark_to_typst("__underlined__").unwrap(),
-            "#underline[underlined]\n\n"
+            mark_to_typst("__bolded__").unwrap(),
+            "#strong[bolded]\n\n"
         );
     }
 
     #[test]
-    fn test_underline_with_text() {
+    fn test_double_underscore_with_text() {
         assert_eq!(
-            mark_to_typst("This is __underlined__ text").unwrap(),
-            "This is #underline[underlined] text\n\n"
+            mark_to_typst("This is __bolded__ text").unwrap(),
+            "This is #strong[bolded] text\n\n"
         );
     }
 
@@ -1454,133 +1451,29 @@ mod tests {
         assert_eq!(mark_to_typst("**bold**").unwrap(), "#strong[bold]\n\n");
     }
 
-    // Nesting Tests
     #[test]
-    fn test_underline_containing_bold() {
+    fn test_double_underscore_in_list() {
         assert_eq!(
-            mark_to_typst("__A **B** A__").unwrap(),
-            "#underline[A #strong[B] A]\n\n"
+            mark_to_typst("- __bolded__ item").unwrap(),
+            "- #strong[bolded] item\n\n"
         );
     }
 
     #[test]
-    fn test_bold_containing_underline() {
+    fn test_double_underscore_in_heading() {
         assert_eq!(
-            mark_to_typst("**A __B__ A**").unwrap(),
-            "#strong[A #underline[B] A]\n\n"
+            mark_to_typst("# Heading with __bold__").unwrap(),
+            "= Heading with #strong[bold]\n\n"
         );
     }
 
     #[test]
-    fn test_deep_nesting() {
-        assert_eq!(
-            mark_to_typst("__A **B __C__ B** A__").unwrap(),
-            "#underline[A #strong[B #underline[C] B] A]\n\n"
-        );
-    }
-
-    // Adjacent Styles Tests
-    #[test]
-    fn test_adjacent_underline_bold() {
-        assert_eq!(
-            mark_to_typst("__A__**B**").unwrap(),
-            "#underline[A]#strong[B]\n\n"
-        );
-    }
-
-    #[test]
-    fn test_adjacent_bold_underline() {
-        assert_eq!(
-            mark_to_typst("**A**__B__").unwrap(),
-            "#strong[A]#underline[B]\n\n"
-        );
-    }
-
-    // Escaping Tests
-    #[test]
-    fn test_underline_special_chars() {
-        // Special characters inside underline should be escaped
-        assert_eq!(mark_to_typst("__#1__").unwrap(), "#underline[\\#1]\n\n");
-    }
-
-    #[test]
-    fn test_underline_with_brackets() {
-        assert_eq!(
-            mark_to_typst("__[text]__").unwrap(),
-            "#underline[\\[text\\]]\n\n"
-        );
-    }
-
-    #[test]
-    fn test_underline_with_asterisk() {
-        assert_eq!(
-            mark_to_typst("__a * b__").unwrap(),
-            "#underline[a \\* b]\n\n"
-        );
-    }
-
-    // Edge Case Tests
-    #[test]
-    fn test_empty_underline() {
-        // Four underscores is parsed as horizontal rule by pulldown-cmark, not empty strong
-        // This test verifies we don't crash on this input
-        // (pulldown-cmark treats ____ as a thematic break / horizontal rule)
+    fn test_quadruple_underscore_is_thematic_break() {
+        // pulldown-cmark treats ____ as a thematic break / horizontal rule.
+        // This test verifies we don't crash on this input.
         let result = mark_to_typst("____").unwrap();
         // The result is empty because Rule events are ignored in our converter
         assert_eq!(result, "");
-    }
-
-    #[test]
-    fn test_underline_in_list() {
-        assert_eq!(
-            mark_to_typst("- __underlined__ item").unwrap(),
-            "- #underline[underlined] item\n\n"
-        );
-    }
-
-    #[test]
-    fn test_underline_in_heading() {
-        assert_eq!(
-            mark_to_typst("# Heading with __underline__").unwrap(),
-            "= Heading with #underline[underline]\n\n"
-        );
-    }
-
-    #[test]
-    fn test_underline_followed_by_alphanumeric() {
-        // When __under__ is immediately followed by alphanumeric (no space),
-        // pulldown-cmark does NOT parse it as Strong - it treats underscores as literal.
-        // This is standard CommonMark behavior requiring word boundaries.
-        // With a space after, it does work as underline:
-        assert_eq!(
-            mark_to_typst("__under__ line").unwrap(),
-            "#underline[under] line\n\n"
-        );
-    }
-
-    // Mixed Formatting Tests
-    #[test]
-    fn test_underline_with_italic() {
-        assert_eq!(
-            mark_to_typst("__underline *italic*__").unwrap(),
-            "#underline[underline #emph[italic]]\n\n"
-        );
-    }
-
-    #[test]
-    fn test_underline_with_code() {
-        assert_eq!(
-            mark_to_typst("__underline `code`__").unwrap(),
-            "#underline[underline `code`]\n\n"
-        );
-    }
-
-    #[test]
-    fn test_underline_with_strikethrough() {
-        assert_eq!(
-            mark_to_typst("__underline ~~strike~~__").unwrap(),
-            "#underline[underline #strike[strike]]\n\n"
-        );
     }
 
     // Tests for Tables
@@ -1858,7 +1751,7 @@ mod tests {
 
     #[test]
     fn test_raw_html_is_stripped() {
-        // Spec §6.2 deviation 2: all raw HTML except <u> produces no output.
+        // Spec §6.2: all raw HTML except <u> produces no output.
         let md = "before <span class=\"x\">inner</span> after";
         let out = mark_to_typst(md).unwrap();
         assert!(!out.contains("<span"), "span tag stripped: {out}");
@@ -2257,10 +2150,13 @@ mod robustness_tests {
     }
 
     #[test]
-    fn test_alternating_bold_underline() {
-        let result = mark_to_typst("**bold** __under__ **bold**").unwrap();
-        assert!(result.contains("#strong[bold]"));
-        assert!(result.contains("#underline[under]"));
+    fn test_alternating_bold_styles() {
+        // Both ** and __ now produce #strong[…].
+        let result = mark_to_typst("**a** __b__ **c**").unwrap();
+        assert!(result.contains("#strong[a]"));
+        assert!(result.contains("#strong[b]"));
+        assert!(result.contains("#strong[c]"));
+        assert!(!result.contains("#underline["));
     }
 
     // escape_string function tests
@@ -2498,13 +2394,18 @@ More text with `inline code`."#;
     }
 
     #[test]
-    fn test_double_underscore_underline_still_works() {
-        // Regular __underlined__ should still produce underline formatting
-        let input = "__underlined text__";
+    fn test_double_underscore_produces_strong() {
+        // Per CommonMark, __text__ produces strong, not underline.
+        let input = "__bolded text__";
         let result = mark_to_typst(input).unwrap();
         assert!(
-            result.contains("#underline["),
-            "Should produce underline: {}",
+            result.contains("#strong["),
+            "Should produce strong: {}",
+            result
+        );
+        assert!(
+            !result.contains("#underline["),
+            "Should not produce underline: {}",
             result
         );
     }

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/example.md
@@ -26,6 +26,6 @@ You can organize your thoughts with bullet points:
 
 Use additional paragraphs to develop your ideas fully and maintain clear communication.
 
-You can also **bold**, _italicize_, __underline__, and `code` your text as needed.
+You can also **bold**, _italicize_, <u>underline</u>, and `code` your text as needed.
 
 Sincerely,

--- a/crates/fuzz/src/convert_fuzz.rs
+++ b/crates/fuzz/src/convert_fuzz.rs
@@ -231,9 +231,9 @@ fn italic(text: &str) -> String {
     wrap_format(text, "*", "*")
 }
 
-/// Underline: __text__
+/// Underline: <u>text</u> (the only allowlisted HTML tag, per spec §6.2)
 fn underline(text: &str) -> String {
-    wrap_format(text, "__", "__")
+    wrap_format(text, "<u>", "</u>")
 }
 
 /// Strikethrough: ~~text~~
@@ -269,9 +269,7 @@ proptest! {
         let result = mark_to_typst(&input);
         prop_assert!(result.is_ok());
         let output = result.unwrap();
-        // Underline converts to #underline[] when parsed correctly
-        // Note: May fail for edge cases with word boundaries
-        prop_assert!(output.contains("#underline[") || output.contains("\\_"));
+        prop_assert!(output.contains("#underline["));
     }
 
     #[test]
@@ -578,12 +576,12 @@ proptest! {
         middle in "[a-zA-Z]{1,5}",
         suffix in "[a-zA-Z]{1,5}"
     ) {
-        let input = format!("{}__{}__{}", prefix, middle, suffix);
+        // <u>…</u> covers intraword underline, which __ cannot reach.
+        let input = format!("{}<u>{}</u>{}", prefix, middle, suffix);
         let result = mark_to_typst(&input);
         prop_assert!(result.is_ok());
-        // The EmphasisFixer should handle intraword underlines
         let output = result.unwrap();
-        prop_assert!(output.contains("#underline[") || output.contains(&middle));
+        prop_assert!(output.contains("#underline["));
     }
 
     #[test]
@@ -677,7 +675,7 @@ fn test_bold_italic_strike_all_nested() {
 
 #[test]
 fn test_underline_with_bold_inside() {
-    let input = "__bold **here** end__";
+    let input = "<u>bold **here** end</u>";
     let result = mark_to_typst(input).unwrap();
     assert!(result.contains("#underline["));
     assert!(result.contains("#strong["));
@@ -685,11 +683,11 @@ fn test_underline_with_bold_inside() {
 
 #[test]
 fn test_all_four_adjacent_no_space() {
-    let input = "**A**__B__*C*~~D~~";
+    // __ now produces #strong[…], same as **.
+    let input = "**A**<u>B</u>*C*~~D~~";
     let result = mark_to_typst(input).unwrap();
     assert!(result.contains("#strong[A]"));
-    // Underline may or may not parse depending on word boundaries
-    assert!(result.contains("B") || result.contains("#underline["));
+    assert!(result.contains("#underline[B]"));
     assert!(result.contains("#emph[C]"));
     assert!(result.contains("#strike[D]"));
 }
@@ -716,7 +714,7 @@ fn test_interleaved_formats_with_text() {
 
 #[test]
 fn test_format_at_word_boundaries() {
-    let input = "word**bold**word *italic*word word__under__word";
+    let input = "word**bold**word *italic*word word<u>under</u>word";
     let result = mark_to_typst(input).unwrap();
     // Should not panic and should produce valid output
     assert!(!result.is_empty());

--- a/docs/authoring/markdown-syntax.md
+++ b/docs/authoring/markdown-syntax.md
@@ -53,9 +53,14 @@ Consequences:
 The following are recognised by the parser (so they will not corrupt surrounding content) but produce no output in the current version:
 
 - **Images** (`![alt](src)`) — reserved for the asset-resolver integration; planned for v1.
-- **Link titles** (`[text](url "title")`) — the title is discarded; the link text and URL are kept.
 - **Math** (`$…$`, `$$…$$`) — `$` is treated as a literal character.
 - **Footnotes**, **task lists**, **definition lists** — not supported.
+
+## Discarded data
+
+CommonMark accepts the following, but Typst (the rendering backend) has no equivalent target, so the data is dropped at conversion. The link or image itself still renders.
+
+- **Link titles** (`[text](url "title")`) — the title is dropped; link text and URL are kept. Typst's `#link` and PDF output have no tooltip mechanism. If you need to surface descriptive text, put it in the link text or in adjacent prose.
 
 ## The `---` marker is reserved
 

--- a/docs/authoring/markdown-syntax.md
+++ b/docs/authoring/markdown-syntax.md
@@ -1,6 +1,6 @@
 # Markdown Syntax
 
-Quillmark Markdown is a **strict superset of [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/)** with a small set of [GitHub Flavored Markdown](https://github.github.com/gfm/) extensions and **two declared deviations**. If you already know CommonMark, you only need to learn what is on this page.
+Quillmark Markdown is a **strict superset of [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/)** with a small set of [GitHub Flavored Markdown](https://github.github.com/gfm/) extensions and **one declared deviation**. If you already know CommonMark, you only need to learn what is on this page.
 
 For the authoritative grammar, fence-detection rules, normalization, and limits, see the formal specification: [prose/designs/MARKDOWN.md](https://github.com/nibsbin/quillmark/blob/main/prose/designs/MARKDOWN.md).
 
@@ -24,32 +24,13 @@ Quillmark enables a small, stable subset of GFM:
 |---|---|---|
 | Strikethrough | `~~text~~` | Standard GFM rules; word-bounded delimiter runs. |
 | Pipe tables | `\| col \| col \|` with alignment row | Supports `:---`, `:---:`, `---:` alignment. |
-| Underline | `<u>text</u>` | The single allow-listed raw-HTML tag (see [Deviation 2](#2-raw-html-is-not-rendered-except-u)). |
+| Underline | `<u>text</u>` | The single allow-listed raw-HTML tag (see [the deviation below](#raw-html-is-not-rendered-except-u)). |
 
 Task lists, autolinks beyond CommonMark's, and other GFM features are **not** enabled.
 
-## Deviations from CommonMark
+## Deviation from CommonMark
 
-### 1. `__text__` is underline, not strong
-
-CommonMark renders `__text__` as **strong**. Quillmark renders it as <u>underline</u>. Standard CommonMark delimiter-run rules still apply, so `__` is **word-bounded** — it will not match across word boundaries.
-
-```markdown
-Use **bold** for strong emphasis.
-Use __underline__ for underline.
-```
-
-Because `__` is word-bounded, intraword tokens such as `__init__` render as underlined "init". Wrap code-like identifiers in backticks, the same as you would in any Markdown:
-
-```markdown
-The `__init__` method runs first.
-```
-
-For underline that crosses word boundaries or arbitrary ranges, use `<u>…</u>` (see below).
-
-Precedent: this matches Discord's flavor of Markdown.
-
-### 2. Raw HTML is not rendered, except `<u>`
+### Raw HTML is not rendered, except `<u>`
 
 CommonMark passes raw HTML through to the output. Quillmark recognises raw HTML syntactically (so it does not break paragraph structure) but **discards every tag**, with one exception: `<u>…</u>` renders as underline.
 

--- a/docs/authoring/markdown-syntax.md
+++ b/docs/authoring/markdown-syntax.md
@@ -56,11 +56,7 @@ The following are recognised by the parser (so they will not corrupt surrounding
 - **Math** (`$…$`, `$$…$$`) — `$` is treated as a literal character.
 - **Footnotes**, **task lists**, **definition lists** — not supported.
 
-## Discarded data
-
-CommonMark accepts the following, but Typst (the rendering backend) has no equivalent target, so the data is dropped at conversion. The link or image itself still renders.
-
-- **Link titles** (`[text](url "title")`) — the title is dropped; link text and URL are kept. Typst's `#link` and PDF output have no tooltip mechanism. If you need to surface descriptive text, put it in the link text or in adjacent prose.
+Some constructs (like link titles) are accepted by the parser but may be dropped during rendering when the active backend has no target for them. Those losses are backend-specific — see each backend's documentation.
 
 ## The `---` marker is reserved
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -4,16 +4,16 @@
 **Editor:** Quillmark Team
 **Base:** [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/)
 
-Quillmark Markdown is a **strict superset of CommonMark** with two declared
-deviations. It layers a structured-data system (YAML frontmatter + named
+Quillmark Markdown is a **strict superset of CommonMark** with one declared
+deviation. It layers a structured-data system (YAML frontmatter + named
 card blocks) on top of ordinary markdown, and selects a small, stable set of
 GFM extensions. This document is the authoritative syntax standard.
 
 ## 1. Superset Statement
 
 Every valid CommonMark 0.31.2 document parses to the same block / inline
-structure under this spec, *except* for the two deviations declared in
-§6.2. Additionally, this spec defines:
+structure under this spec, *except* for the deviation declared in §6.2.
+Additionally, this spec defines:
 
 - **Structured data** — YAML frontmatter and card blocks (§3).
 - **Extensions** — strikethrough, pipe tables, and `<u>` for underline
@@ -182,29 +182,21 @@ CommonMark 0.31.2 with the extensions and deviations below.
 |---|---|---|
 | Strikethrough | `~~text~~` | GFM rules: word-bounded delimiter runs only. |
 | Pipe tables | GFM pipe-table syntax with alignment rows | Supports `:---`, `:---:`, `---:` alignment. |
-| Underline (HTML) | `<u>text</u>` | The one allowlisted HTML tag (see §6.2). Handles intraword and arbitrary-range underline where the `__` delimiter rule does not reach. |
+| Underline (HTML) | `<u>text</u>` | The one allowlisted HTML tag (see §6.2). The only syntax for underline; handles intraword and arbitrary-range cases. |
 
-Inline `__text__` *also* produces underline (§6.2, deviation 1), but
-follows CommonMark delimiter-run rules and is therefore word-bounded.
-Intraword underline uses `<u>…</u>`.
+### 6.2 Declared Deviation from CommonMark
 
-### 6.2 Declared Deviations from CommonMark
-
-1. **`__text__` renders as underline, not strong.** Standard CommonMark
-   delimiter-run rules still apply (word-bounded). Use `**text**` for
-   strong emphasis. Precedent: Discord. Consequence: `__init__` in prose
-   renders as underlined "init"; wrap code-like tokens in backticks
-   (`` `__init__` ``) — standard practice.
-2. **Raw HTML is accepted syntactically but produces no output, except
-   `<u>…</u>` which renders as underline.** The parser recognises HTML per
-   CommonMark §4.6 / §6.11, discards every event, and re-emits only the
-   `<u>` wrapper. Rationale: Typst has no HTML renderer, and arbitrary
-   passthrough would create an injection vector for downstream
-   HTML-producing tooling; `<u>` is the one exception because no
-   CommonMark-native syntax covers arbitrary-range underline.
+**Raw HTML is accepted syntactically but produces no output, except
+`<u>…</u>` which renders as underline.** The parser recognises HTML per
+CommonMark §4.6 / §6.11, discards every event, and re-emits only the
+`<u>` wrapper. Rationale: Typst has no HTML renderer, and arbitrary
+passthrough would create an injection vector for downstream
+HTML-producing tooling; `<u>` is the one exception because no
+CommonMark-native syntax covers underline.
 
 No other syntax deviates from CommonMark. Delimiter-run semantics for `*`,
-`_`, `**`, `__`, and `~~` follow CommonMark and GFM exactly.
+`_`, `**`, `__`, and `~~` follow CommonMark and GFM exactly — in particular,
+`__text__` renders as strong emphasis, identical to `**text**`.
 
 ### 6.3 Out of Scope
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -206,13 +206,24 @@ implemented in a future revision:
 
 - Images (`![alt](src)`) — reserved for the asset-resolver integration;
   required for v1 of this spec.
-- Link titles (`[text](url "title")`) — title is discarded.
 - Math (`$…$`, `$$…$$`), footnotes, task lists, definition lists — not
   supported; `$` is literal.
 - HTML comments — accepted syntactically, not rendered (see §6.2).
 - `<br>`, `<br/>`, `<br />` — follow the raw-HTML rule (non-rendering);
   authors use CommonMark-native hard breaks (trailing two spaces plus
   newline, or trailing `\\` plus newline).
+
+### 6.4 Discarded Data
+
+CommonMark accepts the following constructs in full, but Typst (the
+rendering backend) has no corresponding output target, so the data is
+dropped at conversion. The surrounding construct still renders.
+
+- **Link titles** `[text](url "title")` — the title is dropped; link
+  text and URL are preserved. Typst's `#link` has no `title:` parameter
+  and PDF output has no tooltip primitive Typst exposes. Authors who
+  need the descriptive text should place it in the link text or in
+  adjacent prose.
 
 ## 7. Input Normalization
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -213,17 +213,9 @@ implemented in a future revision:
   authors use CommonMark-native hard breaks (trailing two spaces plus
   newline, or trailing `\\` plus newline).
 
-### 6.4 Discarded Data
-
-CommonMark accepts the following constructs in full, but Typst (the
-rendering backend) has no corresponding output target, so the data is
-dropped at conversion. The surrounding construct still renders.
-
-- **Link titles** `[text](url "title")` — the title is dropped; link
-  text and URL are preserved. Typst's `#link` has no `title:` parameter
-  and PDF output has no tooltip primitive Typst exposes. Authors who
-  need the descriptive text should place it in the link text or in
-  adjacent prose.
+Backends MAY drop semantic data (e.g., link titles, image alt text)
+that has no equivalent in their render target. Such losses are backend
+concerns and are documented per backend, not in this spec.
 
 ## 7. Input Normalization
 


### PR DESCRIPTION
CommonMark renders __text__ as strong emphasis, identical to **text**.
Quillmark's previous deviation reinterpreted __ as underline, which
silently broke copy-paste from other tools and required a code-like
identifier (__init__) workaround. Underline remains available via the
<u>...</u> HTML tag, which is required anyway for intraword and
arbitrary-range underline.

Spec is reduced from two declared deviations to one (raw-HTML
allowlisting of <u>). The StrongKind enum now only tags <u>-derived
events as Underline; both __ and ** route to #strong[].