### PR TITLE
Add quill.template and simplify examples to single example

### DIFF
--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -151,11 +151,6 @@ fn print_human_readable(quill: &quillmark::Quill) {
         println!("  Defaults:    {}", defaults_count);
     }
 
-    let examples_count = config.main.examples().len();
-    if examples_count > 0 {
-        println!("  Examples:    {}", examples_count);
-    }
-
     // Plate and example
     println!(
         "  Has plate:   {}",

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -133,8 +133,8 @@ impl PyQuill {
     }
 
     #[getter]
-    fn template(&self) -> String {
-        self.inner.source().config().template()
+    fn blueprint(&self) -> String {
+        self.inner.source().config().blueprint()
     }
 
     #[getter]

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -133,16 +133,8 @@ impl PyQuill {
     }
 
     #[getter]
-    fn examples<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let dict = PyDict::new(py);
-        for (key, values) in self.inner.source().config().main.examples() {
-            let py_list = pyo3::types::PyList::empty(py);
-            for value in values {
-                py_list.append(quillvalue_to_py(py, &value)?)?;
-            }
-            dict.set_item(key, py_list)?;
-        }
-        Ok(dict)
+    fn template(&self) -> String {
+        self.inner.source().config().template()
     }
 
     #[getter]

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -34,7 +34,7 @@ export interface QuillFieldSchema {
     title?: string;
     description?: string;
     default?: unknown;
-    examples?: unknown;
+    example?: unknown;
     required?: boolean;
     enum?: string[];
     ui?: QuillFieldUi;
@@ -314,6 +314,12 @@ impl Quill {
     #[wasm_bindgen(getter, js_name = example)]
     pub fn example(&self) -> Option<String> {
         self.inner.source().config().example_markdown.clone()
+    }
+
+    /// Auto-generated fill-in-the-blank Markdown template for LLM consumers.
+    #[wasm_bindgen(getter, js_name = template)]
+    pub fn template(&self) -> String {
+        self.inner.source().config().template()
     }
 
     /// Document schema with `ui` hints stripped — for LLM/MCP consumers.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -31,7 +31,6 @@ export interface QuillCardUi {
 /** Schema entry for a single field declared in a quill's `Quill.yaml`. */
 export interface QuillFieldSchema {
     type: "string" | "number" | "integer" | "boolean" | "array" | "object" | "date" | "datetime" | "markdown";
-    title?: string;
     description?: string;
     default?: unknown;
     example?: unknown;
@@ -44,7 +43,6 @@ export interface QuillFieldSchema {
 
 /** Schema entry for the main card or a named card type. */
 export interface QuillCardSchema {
-    title?: string;
     description?: string;
     fields: Record<string, QuillFieldSchema>;
     ui?: QuillCardUi;

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -314,10 +314,10 @@ impl Quill {
         self.inner.source().config().example_markdown.clone()
     }
 
-    /// Auto-generated fill-in-the-blank Markdown template for LLM consumers.
-    #[wasm_bindgen(getter, js_name = template)]
-    pub fn template(&self) -> String {
-        self.inner.source().config().template()
+    /// Auto-generated annotated Markdown blueprint for LLM consumers.
+    #[wasm_bindgen(getter, js_name = blueprint)]
+    pub fn blueprint(&self) -> String {
+        self.inner.source().config().blueprint()
     }
 
     /// Document schema with `ui` hints stripped — for LLM/MCP consumers.

--- a/crates/core/examples/print_blueprint.rs
+++ b/crates/core/examples/print_blueprint.rs
@@ -1,9 +1,9 @@
-//! Prints the auto-generated Markdown template for a quill fixture.
+//! Prints the auto-generated Markdown blueprint for a quill fixture.
 //!
 //! Usage:
-//!   cargo run -p quillmark-core --example print_template
-//!   cargo run -p quillmark-core --example print_template -- classic_resume
-//!   cargo run -p quillmark-core --example print_template -- usaf_memo 0.1.0
+//!   cargo run -p quillmark-core --example print_blueprint
+//!   cargo run -p quillmark-core --example print_blueprint -- classic_resume
+//!   cargo run -p quillmark-core --example print_blueprint -- usaf_memo 0.1.0
 
 use quillmark_core::quill::QuillConfig;
 use quillmark_fixtures::quills_path;
@@ -25,5 +25,5 @@ fn main() {
     let cfg = QuillConfig::from_yaml(&yaml)
         .unwrap_or_else(|e| panic!("could not parse {}: {}", yaml_path.display(), e));
 
-    print!("{}", cfg.template());
+    print!("{}", cfg.blueprint());
 }

--- a/crates/core/examples/print_template.rs
+++ b/crates/core/examples/print_template.rs
@@ -1,0 +1,29 @@
+//! Prints the auto-generated Markdown template for a quill fixture.
+//!
+//! Usage:
+//!   cargo run -p quillmark-core --example print_template
+//!   cargo run -p quillmark-core --example print_template -- classic_resume
+//!   cargo run -p quillmark-core --example print_template -- usaf_memo 0.1.0
+
+use quillmark_core::quill::QuillConfig;
+use quillmark_fixtures::quills_path;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let quill_name = args.first().map(|s| s.as_str()).unwrap_or("usaf_memo");
+
+    let quill_dir = if let Some(version) = args.get(1) {
+        quills_path(quill_name).parent().unwrap().join(version)
+    } else {
+        quills_path(quill_name)
+    };
+
+    let yaml_path = quill_dir.join("Quill.yaml");
+    let yaml = std::fs::read_to_string(&yaml_path)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", yaml_path.display(), e));
+
+    let cfg = QuillConfig::from_yaml(&yaml)
+        .unwrap_or_else(|e| panic!("could not parse {}: {}", yaml_path.display(), e));
+
+    print!("{}", cfg.template());
+}

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -7,7 +7,7 @@ mod load;
 mod query;
 mod schema;
 mod schema_yaml;
-mod template;
+mod blueprint;
 mod tree;
 mod types;
 pub(crate) mod validation;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -7,6 +7,7 @@ mod load;
 mod query;
 mod schema;
 mod schema_yaml;
+mod template;
 mod tree;
 mod types;
 pub(crate) mod validation;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -4,8 +4,11 @@
 //! for LLM consumers. The blueprint shows the document's shape — fields,
 //! constraints, examples — so a consumer can write a fresh document from it.
 //! Each field is annotated with preceding `# …` comment lines (description,
-//! `required`, `enum:`, `example:`) and a single inline type hint. No UI
-//! metadata is emitted.
+//! `required`, `enum:`, `example:`) and a single inline type hint.
+//!
+//! Most UI metadata is stripped, but two semantic-structure hints are honored:
+//! `ui.group` produces `# === <Group> ===` banners and `ui.order` controls
+//! field ordering within a group.
 
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
@@ -50,7 +53,7 @@ impl QuillConfig {
             .and_then(|u| u.hide_body)
             .unwrap_or(false);
         if !hide_body {
-            out.push_str("\n<body>\n");
+            out.push_str("\n<Markdown body>\n");
         }
         for card in &self.card_types {
             let sentinel = format!("CARD: {}", card.name);
@@ -58,7 +61,7 @@ impl QuillConfig {
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
             let hide = card.ui.as_ref().and_then(|u| u.hide_body).unwrap_or(false);
             if !hide {
-                out.push_str("\n<body>\n");
+                out.push_str("\n<Markdown body>\n");
             }
         }
         out
@@ -79,12 +82,40 @@ fn write_card_frontmatter(
     }
     out.push_str(sentinel_line);
     out.push('\n');
-    let mut fields: Vec<&FieldSchema> = card.fields.values().collect();
-    fields.sort_by_key(|f| f.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX));
-    for field in fields {
-        write_field(out, field, 0);
+    for (group, fields) in group_fields(card.fields.values()) {
+        if let Some(name) = group {
+            out.push_str(&format!("\n# === {} ===\n", name));
+        }
+        for field in fields {
+            write_field(out, field, 0);
+        }
     }
     out.push_str("---\n");
+}
+
+/// Partition fields by `ui.group`, preserving first-appearance order of groups
+/// and sorting fields within each group by `ui.order`. Ungrouped fields form
+/// the leading section (no banner).
+fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
+    fields: I,
+) -> Vec<(Option<String>, Vec<&'a FieldSchema>)> {
+    let mut sorted: Vec<&FieldSchema> = fields.into_iter().collect();
+    sorted.sort_by_key(|f| f.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX));
+    let mut groups: Vec<(Option<String>, Vec<&FieldSchema>)> = Vec::new();
+    for field in sorted {
+        let group = field
+            .ui
+            .as_ref()
+            .and_then(|u| u.group.as_ref())
+            .map(|s| s.to_string());
+        match groups.iter_mut().find(|(g, _)| g == &group) {
+            Some(slot) => slot.1.push(field),
+            None => groups.push((group, vec![field])),
+        }
+    }
+    // Ungrouped fields lead; named groups follow in first-appearance order.
+    groups.sort_by_key(|(g, _)| g.is_some());
+    groups
 }
 
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
@@ -276,7 +307,6 @@ fn yaml_string(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::quill::QuillConfig;
 
     fn cfg(yaml: &str) -> QuillConfig {
@@ -431,7 +461,7 @@ card_types:
 "#)
         .blueprint();
         let after = &t[t.find("CARD: skills").unwrap()..];
-        assert!(!after.contains("<body>"));
+        assert!(!after.contains("<Markdown body>"));
     }
 
     #[test]
@@ -444,6 +474,29 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0\n"));
-        assert!(t.contains("<body>"));
+        assert!(t.contains("<Markdown body>"));
+    }
+
+    #[test]
+    fn ui_groups_emit_section_banners_in_first_appearance_order() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    memo_for: { type: array, required: true, ui: { group: Addressing } }
+    subject: { type: string, required: true, ui: { group: Addressing } }
+    letterhead_title: { type: string, default: HQ, ui: { group: Letterhead } }
+    notes: { type: string }
+"#)
+        .blueprint();
+        let after_quill = &t[t.find("QUILL:").unwrap()..];
+        let addressing = after_quill.find("# === Addressing ===").unwrap();
+        let letterhead = after_quill.find("# === Letterhead ===").unwrap();
+        let notes = after_quill.find("notes:").unwrap();
+        // Ungrouped (notes) leads; Addressing precedes Letterhead.
+        assert!(notes < addressing);
+        assert!(addressing < letterhead);
+        // No banner for the ungrouped section.
+        assert!(!after_quill[..notes].contains("# ==="));
     }
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -10,6 +10,8 @@
 //! `ui.group` produces `# === <Group> ===` banners and `ui.order` controls
 //! field ordering within a group.
 
+use std::collections::BTreeMap;
+
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
 
@@ -26,12 +28,16 @@ impl QuillConfig {
     ///   - `example:` is emitted only for optional fields with an example and
     ///     no enum (the example is illustrative, not prescriptive).
     /// - Inline `# <type>` annotation only for non-obvious types (number,
-    ///   integer, boolean, markdown, object, date, datetime). String and array
-    ///   are self-evident from the YAML value.
+    ///   integer, boolean, markdown, date, datetime). String and array are
+    ///   self-evident from the YAML value.
     /// - Placeholder value precedence:
     ///   - Required: example → default → type-based placeholder.
     ///   - Optional: default → type-based empty; example surfaces only as
     ///     `# example: …` above the field.
+    /// - Typed tables (arrays whose `items` is a typed object) render every
+    ///   item property with full annotations: an `example` or non-empty
+    ///   `default` is rendered as actual rows; otherwise one synthetic row is
+    ///   emitted to teach the shape.
     pub fn blueprint(&self) -> String {
         let mut out = String::new();
         let main_desc = self
@@ -121,7 +127,29 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     let pad = "  ".repeat(indent);
 
-    // Preceding comment block: description, required, enum, example.
+    // Typed table: array whose items are a typed object. Render with full
+    // per-property annotations; a synthetic row when no values are supplied.
+    if matches!(field.r#type, FieldType::Array) {
+        if let Some(items) = &field.items {
+            if matches!(items.r#type, FieldType::Object) {
+                if let Some(props) = &items.properties {
+                    write_typed_table_field(out, field, props, indent);
+                    return;
+                }
+            }
+        }
+    }
+
+    write_field_comments(out, field, &pad);
+    let comment = match type_annotation(&field.r#type) {
+        Some(hint) => format!("  # {}", hint),
+        None => String::new(),
+    };
+    let value = field_value(field);
+    write_value(out, &field.name, &value, &comment, &pad);
+}
+
+fn write_field_comments(out: &mut String, field: &FieldSchema, pad: &str) {
     if let Some(desc) = &field.description {
         let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
         out.push_str(&format!("{}# {}\n", pad, clean));
@@ -137,15 +165,75 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
             out.push_str(&format!("{}# example: {}\n", pad, eg));
         }
     }
+}
 
-    // Inline: type annotation only.
-    let comment = match type_annotation(&field.r#type) {
-        Some(hint) => format!("  # {}", hint),
-        None => String::new(),
-    };
+fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
+    let mut v: Vec<&FieldSchema> = props.values().map(|b| b.as_ref()).collect();
+    v.sort_by_key(|f| f.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX));
+    v
+}
 
-    let value = field_value(field);
-    write_value(out, &field.name, &value, &comment, &pad);
+/// Emit a typed-table field: description/required/enum comments, then the
+/// field key, then either example/default rows or one synthetic template row.
+fn write_typed_table_field(
+    out: &mut String,
+    field: &FieldSchema,
+    item_props: &BTreeMap<String, Box<FieldSchema>>,
+    indent: usize,
+) {
+    let pad = "  ".repeat(indent);
+    // Suppress `# example:` for typed tables — values or synthetic row carry it.
+    write_field_comments_no_example(out, field, &pad);
+
+    let rows = pick_table_rows(field);
+    out.push_str(&format!("{}{}:\n", pad, field.name));
+    match rows {
+        Some(items) => write_array_items(out, &items, &pad),
+        None => write_typed_table_row(out, item_props, indent),
+    }
+}
+
+fn write_field_comments_no_example(out: &mut String, field: &FieldSchema, pad: &str) {
+    if let Some(desc) = &field.description {
+        let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
+        out.push_str(&format!("{}# {}\n", pad, clean));
+    }
+    if field.required {
+        out.push_str(&format!("{}# required\n", pad));
+    }
+    if let Some(vals) = &field.enum_values {
+        out.push_str(&format!("{}# enum: {}\n", pad, vals.join(" | ")));
+    }
+}
+
+/// Pick concrete rows for a typed table: example (any required-ness) over
+/// non-empty default. None signals "use synthetic row."
+fn pick_table_rows(field: &FieldSchema) -> Option<Vec<serde_json::Value>> {
+    fn non_empty(v: &serde_json::Value) -> Option<Vec<serde_json::Value>> {
+        match v {
+            serde_json::Value::Array(items) if !items.is_empty() => Some(items.clone()),
+            _ => None,
+        }
+    }
+    field
+        .example
+        .as_ref()
+        .and_then(|e| non_empty(e.as_json()))
+        .or_else(|| field.default.as_ref().and_then(|d| non_empty(d.as_json())))
+}
+
+/// Emit one synthetic row of a typed-object array. The list marker `-` lives
+/// on its own line at `field_indent + 1`; item keys live at `field_indent + 2`.
+fn write_typed_table_row(
+    out: &mut String,
+    props: &BTreeMap<String, Box<FieldSchema>>,
+    field_indent: usize,
+) {
+    let dash_pad = "  ".repeat(field_indent + 1);
+    out.push_str(&format!("{}-\n", dash_pad));
+    for prop in sort_props(props) {
+        write_field(out, prop, field_indent + 2);
+    }
 }
 
 /// The value to render for a field in the template.
@@ -498,5 +586,88 @@ main:
         assert!(addressing < letterhead);
         // No banner for the ungrouped section.
         assert!(!after_quill[..notes].contains("# ==="));
+    }
+
+    #[test]
+    fn typed_table_emits_synthetic_row_when_no_example() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    references:
+      type: array
+      description: Cited works.
+      items:
+        type: object
+        properties:
+          org: { type: string, required: true, description: Citing organization. }
+          year: { type: integer, description: Publication year. }
+"#)
+        .blueprint();
+        assert!(t.contains("# Cited works.\nreferences:\n  -\n"));
+        assert!(t.contains("    # Citing organization.\n    # required\n    org: \"<org>\"\n"));
+        assert!(t.contains("    # Publication year.\n    year: 0  # integer\n"));
+    }
+
+    #[test]
+    fn typed_table_with_example_renders_example_rows() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      example:
+        - { org: ACME, year: 2020 }
+      items:
+        type: object
+        properties:
+          org: { type: string, required: true }
+          year: { type: integer }
+"#)
+        .blueprint();
+        // Example rows are rendered inline; no synthetic bare-dash row, and no
+        // `# example:` comment (which would be an unhelpful JSON blob).
+        assert!(t.contains("refs:\n  - org: ACME\n"));
+        assert!(!t.contains("refs:\n  -\n"));
+        assert!(!t.contains("# example:"));
+    }
+
+    #[test]
+    fn typed_table_with_default_renders_default_rows() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      default:
+        - { org: ACME }
+      items:
+        type: object
+        properties:
+          org: { type: string, required: true }
+"#)
+        .blueprint();
+        assert!(t.contains("refs:\n  - org: ACME\n"));
+        assert!(!t.contains("refs:\n  -\n"));
+    }
+
+    #[test]
+    fn typed_table_with_empty_default_falls_through_to_synthetic_row() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      default: []
+      items:
+        type: object
+        properties:
+          org: { type: string, required: true }
+"#)
+        .blueprint();
+        assert!(t.contains("refs:\n  -\n    # required\n    org: \"<org>\"\n"));
     }
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -1,15 +1,21 @@
-//! Auto-generated Markdown template for a Quill.
+//! Auto-generated Markdown blueprint for a Quill.
 //!
-//! Produces a fill-in-the-blank document that is dense enough to replace the
-//! schema for LLM consumers. Each field is annotated with preceding `# …`
-//! comment lines (description, `required`, `enum:`, `example:`) and a single
-//! inline type hint. No UI metadata is emitted.
+//! Produces an annotated reference document dense enough to replace the schema
+//! for LLM consumers. The blueprint shows the document's shape — fields,
+//! constraints, examples — so a consumer can write a fresh document from it.
+//! Each field is annotated with preceding `# …` comment lines (description,
+//! `required`, `enum:`, `example:`) and a single inline type hint. No UI
+//! metadata is emitted.
 
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
 
 impl QuillConfig {
-    /// Generate a fill-in-the-blank Markdown template for this quill.
+    /// Generate an annotated Markdown blueprint for this quill.
+    ///
+    /// The blueprint is a reference document — consumers (typically LLMs) read
+    /// it to understand the document's shape and write fresh content from
+    /// scratch, not to edit it in place.
     ///
     /// Annotation rules:
     /// - Preceding `# …` comment lines, in order: description, `required`,
@@ -23,7 +29,7 @@ impl QuillConfig {
     ///   - Required: example → default → type-based placeholder.
     ///   - Optional: default → type-based empty; example surfaces only as
     ///     `# example: …` above the field.
-    pub fn template(&self) -> String {
+    pub fn blueprint(&self) -> String {
         let mut out = String::new();
         let main_desc = self
             .main
@@ -285,7 +291,7 @@ main:
   fields:
     author: { type: string, required: true }
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# required\nauthor: \"<author>\"\n"));
     }
 
@@ -297,7 +303,7 @@ main:
   fields:
     status: { type: string, required: true, default: draft, example: final }
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# required\nstatus: final\n"));
     }
 
@@ -309,7 +315,7 @@ main:
   fields:
     classification: { type: string, default: "", example: CONFIDENTIAL }
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# example: CONFIDENTIAL\nclassification: \"\"\n"));
     }
 
@@ -324,7 +330,7 @@ main:
       example:
         - AFM 33-326, Communications
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# example: AFM 33-326, Communications\nrefs: []\n"));
     }
 
@@ -336,7 +342,7 @@ main:
   fields:
     format: { type: string, enum: [standard, informal], default: standard }
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# enum: standard | informal\nformat: standard\n"));
         assert!(!t.contains("example:"));
     }
@@ -354,7 +360,7 @@ main:
         - ORG/SYMBOL
         - City ST 12345
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# required\nmemo_from:\n  - ORG/SYMBOL\n  - City ST 12345\n"));
     }
 
@@ -369,7 +375,7 @@ main:
       required: true
       description: Be brief and clear.
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("# Be brief and clear.\n# required\nsubject: \"<subject>\"\n"));
     }
 
@@ -384,7 +390,7 @@ main:
     body: { type: markdown }
     issued: { type: date }
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains("size: 11  # number"));
         assert!(t.contains("flag: false  # boolean"));
         assert!(t.contains("body: \"\"  # markdown"));
@@ -404,7 +410,7 @@ card_types:
     fields:
       author: { type: string }
 "#)
-        .template();
+        .blueprint();
         assert!(t.contains(
             "# A short note appended to the document.\nCARD: note\n"
         ));
@@ -423,7 +429,7 @@ card_types:
     fields:
       items: { type: array, required: true }
 "#)
-        .template();
+        .blueprint();
         let after = &t[t.find("CARD: skills").unwrap()..];
         assert!(!after.contains("<body>"));
     }
@@ -436,7 +442,7 @@ main:
   fields:
     flavor: { type: string, default: taro }
 "#)
-        .template();
+        .blueprint();
         assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0\n"));
         assert!(t.contains("<body>"));
     }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -52,7 +52,6 @@ pub struct QuillConfig {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct CardSchemaDef {
-    pub title: Option<String>,
     pub description: Option<String>,
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub ui: Option<UiContainerSchema>,
@@ -777,13 +776,6 @@ impl QuillConfig {
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());
 
-        // Extract main.title (optional, authored under `main:` like any other card type).
-        let main_title = main_obj_opt
-            .and_then(|main_obj| main_obj.get("title"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| Some("main".to_string()));
-
         // Extract main.description (optional, authored under `main:` like any
         // other card type). This is independent of `quill.description`.
         let main_description = main_obj_opt
@@ -794,7 +786,6 @@ impl QuillConfig {
         // The main entry-point card.
         let main = CardSchema {
             name: "main".to_string(),
-            title: main_title,
             description: main_description,
             fields,
             ui: main_ui.or(ui_section),
@@ -840,7 +831,6 @@ impl QuillConfig {
 
                 let card_schema = CardSchema {
                     name: card_name.clone(),
-                    title: card_def.title,
                     description: card_def.description,
                     fields: card_fields,
                     ui: card_def.ui,

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -157,12 +157,10 @@ main:
 
 card_types:
   indorsement:
-    title: Indorsement
     fields:
       signature_block:
         type: string
   note:
-    title: Note
     fields:
       author:
         type: string

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -38,7 +38,6 @@ main:
       type: integer
 card_types:
   indorsement:
-    title: Indorsement
     fields:
       signature_block:
         type: string

--- a/crates/core/src/quill/template.rs
+++ b/crates/core/src/quill/template.rs
@@ -25,11 +25,17 @@ impl QuillConfig {
     ///   - Optional: default → type-based empty; example → `e.g.` comment only.
     pub fn template(&self) -> String {
         let mut out = String::new();
+        let main_desc = self
+            .main
+            .description
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .or_else(|| Some(self.description.as_str()).filter(|s| !s.is_empty()));
         write_card_frontmatter(
             &mut out,
             &self.main,
             &format!("QUILL: {}@{}", self.name, self.version),
-            None,
+            main_desc,
         );
         let hide_body = self
             .main
@@ -63,13 +69,13 @@ fn write_card_frontmatter(
     description: Option<&str>,
 ) {
     out.push_str("---\n");
-    out.push_str(sentinel_line);
-    out.push('\n');
     if let Some(desc) = description {
         for line in desc.lines() {
             out.push_str(&format!("# {}\n", line));
         }
     }
+    out.push_str(sentinel_line);
+    out.push('\n');
     let mut fields: Vec<&FieldSchema> = card.fields.values().collect();
     fields.sort_by_key(|f| f.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX));
     for field in fields {
@@ -412,7 +418,7 @@ card_types:
 "#)
         .template();
         assert!(t.contains(
-            "CARD: note  # Note\n# A short note appended to the document.\n"
+            "# A short note appended to the document.\nCARD: note  # Note\n"
         ));
     }
 
@@ -443,7 +449,7 @@ main:
     flavor: { type: string, default: taro }
 "#)
         .template();
-        assert!(t.starts_with("---\nQUILL: taro@0.1.0\n"));
+        assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0\n"));
         assert!(t.contains("<body>"));
     }
 }

--- a/crates/core/src/quill/template.rs
+++ b/crates/core/src/quill/template.rs
@@ -1,21 +1,35 @@
-//! Auto-generated Markdown template for a Quill, combining structure and format
-//! into a single fill-in-the-blank document for LLM consumers.
+//! Auto-generated Markdown template for a Quill.
+//!
+//! Produces a fill-in-the-blank document that is dense enough to replace the
+//! schema for LLM consumers. Each field is annotated with inline comments
+//! (type, required, enum constraints, e.g. hint) and a preceding description
+//! comment where the schema declares one. No UI metadata is emitted.
 
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
+use crate::value::QuillValue;
 
 impl QuillConfig {
     /// Generate a fill-in-the-blank Markdown template for this quill.
     ///
-    /// The template shows the correct document structure (YAML frontmatter +
-    /// body + cards) with placeholder values and inline comments for required
-    /// fields and enum constraints. Placeholder precedence: `example` →
-    /// `default` → type-based placeholder.
+    /// Annotation rules:
+    /// - Preceding `# <description>` comment for every field that declares one.
+    /// - Inline `# type | required | enum… | e.g. …` comment.
+    ///   - Type annotation only for non-obvious types (number, integer, boolean,
+    ///     markdown, object, date, datetime).
+    ///   - `required` marker when the field is required.
+    ///   - Enum values when declared.
+    ///   - `e.g. <value>` for optional fields that have an example but no enum
+    ///     (the example is illustrative, not prescriptive).
+    /// - Placeholder value precedence:
+    ///   - Required: example → default → type-based placeholder.
+    ///   - Optional: default → type-based empty; example → `e.g.` comment only.
     pub fn template(&self) -> String {
         let mut out = String::new();
         write_card_frontmatter(
             &mut out,
             &self.main,
             &format!("QUILL: {}@{}", self.name, self.version),
+            None,
         );
         let hide_body = self
             .main
@@ -27,14 +41,14 @@ impl QuillConfig {
             out.push_str("\n<body>\n");
         }
         for card in &self.card_types {
-            let card_label = match &card.title {
+            let sentinel = match &card.title {
                 Some(t) => format!("CARD: {}  # {} (optional, repeat as needed)", card.name, t),
                 None => format!("CARD: {}  # (optional, repeat as needed)", card.name),
             };
             out.push('\n');
-            write_card_frontmatter(&mut out, card, &card_label);
-            let card_hide_body = card.ui.as_ref().and_then(|u| u.hide_body).unwrap_or(false);
-            if !card_hide_body {
+            write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
+            let hide = card.ui.as_ref().and_then(|u| u.hide_body).unwrap_or(false);
+            if !hide {
                 out.push_str("\n<body>\n");
             }
         }
@@ -42,14 +56,22 @@ impl QuillConfig {
     }
 }
 
-fn write_card_frontmatter(out: &mut String, card: &CardSchema, first_line: &str) {
+fn write_card_frontmatter(
+    out: &mut String,
+    card: &CardSchema,
+    sentinel_line: &str,
+    description: Option<&str>,
+) {
     out.push_str("---\n");
-    out.push_str(first_line);
+    out.push_str(sentinel_line);
     out.push('\n');
-
+    if let Some(desc) = description {
+        for line in desc.lines() {
+            out.push_str(&format!("# {}\n", line));
+        }
+    }
     let mut fields: Vec<&FieldSchema> = card.fields.values().collect();
     fields.sort_by_key(|f| f.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX));
-
     for field in fields {
         write_field(out, field, 0);
     }
@@ -59,45 +81,119 @@ fn write_card_frontmatter(out: &mut String, card: &CardSchema, first_line: &str)
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     let pad = "  ".repeat(indent);
 
-    let mut comment_parts: Vec<&str> = Vec::new();
+    // Preceding description comment.
+    if let Some(desc) = &field.description {
+        let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
+        out.push_str(&format!("{}# {}\n", pad, clean));
+    }
+
+    // Build inline comment parts: type | required | enums | e.g.
+    let mut parts: Vec<String> = Vec::new();
+
+    if let Some(hint) = type_annotation(&field.r#type) {
+        parts.push(hint.to_string());
+    }
     if field.required {
-        comment_parts.push("required");
+        parts.push("required".to_string());
     }
-    let enum_str;
     if let Some(vals) = &field.enum_values {
-        enum_str = vals.join(" | ");
-        comment_parts.push(&enum_str);
+        parts.push(vals.join(" | "));
     }
-    let comment = if comment_parts.is_empty() {
+    // e.g. hint: only for optional fields with an example and no enum.
+    if !field.required && field.enum_values.is_none() {
+        if let Some(eg) = field.example.as_ref().map(|e| eg_hint(e)) {
+            parts.push(format!("e.g. {}", eg));
+        }
+    }
+
+    let comment = if parts.is_empty() {
         String::new()
     } else {
-        format!("  # {}", comment_parts.join(" | "))
+        format!("  # {}", parts.join(" | "))
     };
 
-    let source = field
-        .example
-        .as_ref()
-        .or(field.default.as_ref())
-        .map(|v| v.as_json());
+    let value = field_value(field);
+    write_value(out, &field.name, &value, &comment, &pad);
+}
 
-    match source {
-        Some(serde_json::Value::Array(items)) if !items.is_empty() => {
-            out.push_str(&format!("{}{}:{}\n", pad, field.name, comment));
-            write_array_items(out, items, indent + 1);
+/// The value to render for a field in the template.
+enum FieldValue {
+    Scalar(String),
+    Array(Vec<serde_json::Value>),
+    EmptyArray,
+    Empty, // renders as ""
+}
+
+fn field_value(field: &FieldSchema) -> FieldValue {
+    if field.required {
+        // Required: example > default > type-based placeholder.
+        if let Some(v) = field.example.as_ref().or(field.default.as_ref()) {
+            return json_to_value(v.as_json(), &field.r#type);
         }
-        Some(serde_json::Value::Array(_)) => {
-            out.push_str(&format!("{}{}: []{}\n", pad, field.name, comment));
+        required_placeholder(&field.r#type, field.title.as_deref().unwrap_or(&field.name))
+    } else {
+        // Optional: default only (example goes to e.g. comment).
+        if let Some(v) = field.default.as_ref() {
+            return json_to_value(v.as_json(), &field.r#type);
         }
-        Some(val) => {
-            let rendered = render_scalar(val);
-            out.push_str(&format!("{}{}: {}{}\n", pad, field.name, rendered, comment));
+        // Enum with no default: first enum value is the canonical placeholder.
+        if let Some(first) = field.enum_values.as_ref().and_then(|v| v.first()) {
+            return FieldValue::Scalar(first.clone());
         }
-        None => write_type_placeholder(out, field, &pad, &comment),
+        optional_placeholder(&field.r#type)
     }
 }
 
-fn write_array_items(out: &mut String, items: &[serde_json::Value], indent: usize) {
-    let pad = "  ".repeat(indent);
+fn required_placeholder(t: &FieldType, label: &str) -> FieldValue {
+    match t {
+        FieldType::Array => FieldValue::EmptyArray,
+        FieldType::Boolean => FieldValue::Scalar("false".to_string()),
+        FieldType::Number | FieldType::Integer => FieldValue::Scalar("0".to_string()),
+        // Date/datetime use empty string; type annotation carries the format hint.
+        FieldType::Date | FieldType::DateTime => FieldValue::Empty,
+        // String, markdown, object: angle-bracket placeholder signals "fill this in".
+        _ => FieldValue::Scalar(format!("\"<{}>\"", label)),
+    }
+}
+
+fn optional_placeholder(t: &FieldType) -> FieldValue {
+    match t {
+        FieldType::Array => FieldValue::EmptyArray,
+        FieldType::Boolean => FieldValue::Scalar("false".to_string()),
+        FieldType::Number | FieldType::Integer => FieldValue::Scalar("0".to_string()),
+        _ => FieldValue::Empty,
+    }
+}
+
+fn json_to_value(val: &serde_json::Value, _t: &FieldType) -> FieldValue {
+    match val {
+        serde_json::Value::Array(items) if items.is_empty() => FieldValue::EmptyArray,
+        serde_json::Value::Array(items) => FieldValue::Array(items.clone()),
+        serde_json::Value::String(s) if s.is_empty() => FieldValue::Empty,
+        other => FieldValue::Scalar(render_scalar(other)),
+    }
+}
+
+fn write_value(out: &mut String, key: &str, val: &FieldValue, comment: &str, pad: &str) {
+    match val {
+        FieldValue::Scalar(s) => {
+            out.push_str(&format!("{}{}: {}{}\n", pad, key, s, comment));
+        }
+        FieldValue::Empty => {
+            out.push_str(&format!("{}{}: \"\"{}\n", pad, key, comment));
+        }
+        FieldValue::EmptyArray => {
+            out.push_str(&format!("{}{}: []{}\n", pad, key, comment));
+        }
+        FieldValue::Array(items) => {
+            out.push_str(&format!("{}{}:{}\n", pad, key, comment));
+            write_array_items(out, items, pad);
+        }
+    }
+}
+
+fn write_array_items(out: &mut String, items: &[serde_json::Value], pad: &str) {
+    let item_pad = format!("{}  ", pad);
     for item in items {
         match item {
             serde_json::Value::Object(map) => {
@@ -105,86 +201,67 @@ fn write_array_items(out: &mut String, items: &[serde_json::Value], indent: usiz
                 if let Some((first_key, first_val)) = entries.next() {
                     out.push_str(&format!(
                         "{}- {}: {}\n",
-                        pad,
+                        item_pad,
                         first_key,
                         render_scalar(first_val)
                     ));
-                    let inner_pad = format!("{}  ", pad);
+                    let inner = format!("{}  ", item_pad);
                     for (k, v) in entries {
-                        out.push_str(&format!("{}{}: {}\n", inner_pad, k, render_scalar(v)));
+                        out.push_str(&format!("{}{}: {}\n", inner, k, render_scalar(v)));
                     }
                 }
             }
-            _ => out.push_str(&format!("{}- {}\n", pad, render_scalar(item))),
+            _ => out.push_str(&format!("{}- {}\n", item_pad, render_scalar(item))),
         }
     }
 }
 
-fn write_type_placeholder(out: &mut String, field: &FieldSchema, pad: &str, comment: &str) {
-    match field.r#type {
-        FieldType::Array => {
-            out.push_str(&format!("{}{}: []{}\n", pad, field.name, comment));
-        }
-        FieldType::Boolean => {
-            out.push_str(&format!("{}{}: false{}\n", pad, field.name, comment));
-        }
-        FieldType::Number | FieldType::Integer => {
-            out.push_str(&format!("{}{}: 0{}\n", pad, field.name, comment));
-        }
-        FieldType::Date => {
-            out.push_str(&format!(
-                "{}{}: \"\"  # YYYY-MM-DD{}\n",
-                pad,
-                field.name,
-                if comment.is_empty() {
-                    String::new()
-                } else {
-                    comment.trim_start_matches("  ").to_string()
-                }
-            ));
-        }
-        FieldType::DateTime => {
-            out.push_str(&format!(
-                "{}{}: \"\"  # ISO 8601{}\n",
-                pad,
-                field.name,
-                if comment.is_empty() {
-                    String::new()
-                } else {
-                    comment.trim_start_matches("  ").to_string()
-                }
-            ));
-        }
-        _ => {
-            let label = field.title.as_deref().unwrap_or(&field.name);
-            out.push_str(&format!(
-                "{}{}: \"<{}>\"{}\n",
-                pad, field.name, label, comment
-            ));
-        }
+/// Inline type annotation for non-obvious types. `string` and `array` are
+/// self-evident from the YAML value; no annotation needed.
+fn type_annotation(t: &FieldType) -> Option<&'static str> {
+    match t {
+        FieldType::Number => Some("number"),
+        FieldType::Integer => Some("integer"),
+        FieldType::Boolean => Some("boolean"),
+        FieldType::Markdown => Some("markdown"),
+        FieldType::Object => Some("object"),
+        FieldType::Date => Some("YYYY-MM-DD"),
+        FieldType::DateTime => Some("ISO 8601"),
+        FieldType::String | FieldType::Array => None,
     }
 }
 
-/// Render a JSON scalar (or array/object fallback) as a YAML-safe string.
+/// Format the first (or only) value of an example as a compact e.g. hint.
+fn eg_hint(example: &QuillValue) -> String {
+    match example.as_json() {
+        serde_json::Value::Array(items) => items
+            .first()
+            .map(|v| render_scalar(v))
+            .unwrap_or_default(),
+        val => render_scalar(val),
+    }
+}
+
 fn render_scalar(val: &serde_json::Value) -> String {
     match val {
         serde_json::Value::String(s) => yaml_string(s),
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::Bool(b) => b.to_string(),
         serde_json::Value::Null => "null".to_string(),
-        // Arrays/objects at scalar position: shouldn't appear but fall back gracefully
         other => yaml_string(&other.to_string()),
     }
 }
 
-/// Quote a string for YAML if it contains characters that would be misinterpreted.
+/// Quote a YAML string only when necessary.
 fn yaml_string(s: &str) -> String {
     let needs_quotes = s.is_empty()
-        || matches!(
-            s,
-            "true" | "false" | "null" | "yes" | "no" | "on" | "off"
-        )
-        || s.starts_with(|c: char| matches!(c, '{' | '[' | '&' | '*' | '!' | '|' | '>' | '\'' | '"' | '%' | '@' | '`'))
+        || matches!(s, "true" | "false" | "null" | "yes" | "no" | "on" | "off")
+        || s.starts_with(|c: char| {
+            matches!(
+                c,
+                '{' | '[' | '&' | '*' | '!' | '|' | '>' | '\'' | '"' | '%' | '@' | '`'
+            )
+        })
         || s.contains(": ")
         || s.contains(" #")
         || s.starts_with("- ")
@@ -206,77 +283,73 @@ mod tests {
     }
 
     #[test]
-    fn simple_quill_has_sentinel_and_body() {
-        let config = cfg(r#"
-quill:
-  name: taro
-  version: 0.1.0
-  backend: typst
-  description: test
+    fn required_string_without_example_uses_angle_bracket_placeholder() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    author:
-      type: string
-      title: Author
-      required: true
-    flavor:
-      type: string
-      default: taro
-"#);
-        let t = config.template();
-        assert!(t.contains("QUILL: taro@0.1.0"));
+    author: { type: string, title: Author, required: true }
+"#)
+        .template();
         assert!(t.contains("author: \"<Author>\"  # required"));
-        assert!(t.contains("flavor: taro"));
-        assert!(t.contains("<body>"));
     }
 
     #[test]
-    fn example_takes_precedence_over_default() {
-        let config = cfg(r#"
-quill:
-  name: x
-  version: 1.0.0
-  backend: typst
-  description: x
+    fn required_field_uses_example_over_default() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    status:
-      type: string
-      default: draft
-      example: final
-"#);
-        let t = config.template();
-        assert!(t.contains("status: final"));
-        assert!(!t.contains("draft"));
+    status: { type: string, required: true, default: draft, example: final }
+"#)
+        .template();
+        assert!(t.contains("status: final  # required"));
     }
 
     #[test]
-    fn enum_comment_appended() {
-        let config = cfg(r#"
-quill:
-  name: x
-  version: 1.0.0
-  backend: typst
-  description: x
+    fn optional_field_uses_default_example_becomes_eg() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    format:
-      type: string
-      enum: [standard, informal, separate_page]
-      default: standard
-"#);
-        let t = config.template();
-        assert!(t.contains("format: standard  # standard | informal | separate_page"));
+    classification: { type: string, default: "", example: CONFIDENTIAL }
+"#)
+        .template();
+        assert!(t.contains("classification: \"\"  # e.g. CONFIDENTIAL"));
     }
 
     #[test]
-    fn array_example_rendered_as_items() {
-        let config = cfg(r#"
-quill:
-  name: x
-  version: 1.0.0
-  backend: typst
-  description: x
+    fn optional_array_with_no_default_shows_empty_with_eg() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      example:
+        - AFM 33-326, Communications
+"#)
+        .template();
+        assert!(t.contains("refs: []  # e.g. AFM 33-326, Communications"));
+    }
+
+    #[test]
+    fn enum_field_shows_values_and_no_eg() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    format: { type: string, enum: [standard, informal], default: standard }
+"#)
+        .template();
+        assert!(t.contains("format: standard  # standard | informal"));
+        assert!(!t.contains("e.g."));
+    }
+
+    #[test]
+    fn required_array_uses_example_as_items() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     memo_from:
@@ -285,78 +358,92 @@ main:
       example:
         - ORG/SYMBOL
         - City ST 12345
-"#);
-        let t = config.template();
+"#)
+        .template();
         assert!(t.contains("memo_from:  # required\n  - ORG/SYMBOL\n  - City ST 12345\n"));
     }
 
     #[test]
-    fn card_has_sentinel_and_repeat_comment() {
-        let config = cfg(r#"
-quill:
-  name: x
-  version: 1.0.0
-  backend: typst
-  description: x
+    fn description_emitted_as_preceding_comment() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    title:
+    subject:
       type: string
+      required: true
+      description: Be brief and clear.
+"#)
+        .template();
+        assert!(t.contains("# Be brief and clear.\nsubject: \"<subject>\"  # required\n"));
+    }
+
+    #[test]
+    fn non_obvious_types_get_annotation() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    size: { type: number, default: 11 }
+    flag: { type: boolean, default: false }
+    body: { type: markdown }
+    issued: { type: date }
+"#)
+        .template();
+        assert!(t.contains("size: 11  # number"));
+        assert!(t.contains("flag: false  # boolean"));
+        assert!(t.contains("body: \"\"  # markdown"));
+        assert!(t.contains("issued: \"\"  # YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn card_description_emitted_after_sentinel() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
 card_types:
-  quote:
-    title: Inspirational Quote
+  note:
+    title: Note
+    description: A short note appended to the document.
     fields:
-      author:
-        type: string
-        required: true
-"#);
-        let t = config.template();
-        assert!(t.contains("CARD: quote  # Inspirational Quote (optional, repeat as needed)"));
-        assert!(t.contains("author: \"<author>\"  # required"));
+      author: { type: string }
+"#)
+        .template();
+        assert!(t.contains(
+            "CARD: note  # Note (optional, repeat as needed)\n# A short note appended to the document.\n"
+        ));
     }
 
     #[test]
     fn hide_body_card_omits_body_placeholder() {
-        let config = cfg(r#"
-quill:
-  name: x
-  version: 1.0.0
-  backend: typst
-  description: x
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    title:
-      type: string
+    title: { type: string }
 card_types:
   skills:
-    ui:
-      hide_body: true
+    ui: { hide_body: true }
     fields:
-      items:
-        type: array
-        required: true
-"#);
-        let t = config.template();
-        let skills_pos = t.find("CARD: skills").unwrap();
-        let after_skills = &t[skills_pos..];
-        // Should not have <body> after the skills card
-        assert!(!after_skills.contains("<body>"));
+      items: { type: array, required: true }
+"#)
+        .template();
+        let after = &t[t.find("CARD: skills").unwrap()..];
+        assert!(!after.contains("<body>"));
     }
 
     #[test]
-    fn date_type_gets_format_hint() {
-        let config = cfg(r#"
-quill:
-  name: x
-  version: 1.0.0
-  backend: typst
-  description: x
+    fn sentinel_and_body_present() {
+        let t = cfg(r#"
+quill: { name: taro, version: 0.1.0, backend: typst, description: x }
 main:
   fields:
-    issued:
-      type: date
-"#);
-        let t = config.template();
-        assert!(t.contains("issued: \"\"  # YYYY-MM-DD"));
+    flavor: { type: string, default: taro }
+"#)
+        .template();
+        assert!(t.starts_with("---\nQUILL: taro@0.1.0\n"));
+        assert!(t.contains("<body>"));
     }
 }

--- a/crates/core/src/quill/template.rs
+++ b/crates/core/src/quill/template.rs
@@ -42,8 +42,8 @@ impl QuillConfig {
         }
         for card in &self.card_types {
             let sentinel = match &card.title {
-                Some(t) => format!("CARD: {}  # {} (optional, repeat as needed)", card.name, t),
-                None => format!("CARD: {}  # (optional, repeat as needed)", card.name),
+                Some(t) => format!("CARD: {}  # {}", card.name, t),
+                None => format!("CARD: {}", card.name),
             };
             out.push('\n');
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
@@ -412,7 +412,7 @@ card_types:
 "#)
         .template();
         assert!(t.contains(
-            "CARD: note  # Note (optional, repeat as needed)\n# A short note appended to the document.\n"
+            "CARD: note  # Note\n# A short note appended to the document.\n"
         ));
     }
 

--- a/crates/core/src/quill/template.rs
+++ b/crates/core/src/quill/template.rs
@@ -47,10 +47,7 @@ impl QuillConfig {
             out.push_str("\n<body>\n");
         }
         for card in &self.card_types {
-            let sentinel = match &card.title {
-                Some(t) => format!("CARD: {}  # {}", card.name, t),
-                None => format!("CARD: {}", card.name),
-            };
+            let sentinel = format!("CARD: {}", card.name);
             out.push('\n');
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
             let hide = card.ui.as_ref().and_then(|u| u.hide_body).unwrap_or(false);
@@ -128,7 +125,7 @@ fn field_value(field: &FieldSchema) -> FieldValue {
         if let Some(v) = field.example.as_ref().or(field.default.as_ref()) {
             return json_to_value(v.as_json(), &field.r#type);
         }
-        required_placeholder(&field.r#type, field.title.as_deref().unwrap_or(&field.name))
+        required_placeholder(&field.r#type, &field.name)
     } else {
         // Optional: default only (example goes to e.g. comment).
         if let Some(v) = field.default.as_ref() {
@@ -286,10 +283,10 @@ mod tests {
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    author: { type: string, title: Author, required: true }
+    author: { type: string, required: true }
 "#)
         .template();
-        assert!(t.contains("# required\nauthor: \"<Author>\"\n"));
+        assert!(t.contains("# required\nauthor: \"<author>\"\n"));
     }
 
     #[test]
@@ -403,14 +400,13 @@ main:
     title: { type: string }
 card_types:
   note:
-    title: Note
     description: A short note appended to the document.
     fields:
       author: { type: string }
 "#)
         .template();
         assert!(t.contains(
-            "# A short note appended to the document.\nCARD: note  # Note\n"
+            "# A short note appended to the document.\nCARD: note\n"
         ));
     }
 

--- a/crates/core/src/quill/template.rs
+++ b/crates/core/src/quill/template.rs
@@ -1,0 +1,362 @@
+//! Auto-generated Markdown template for a Quill, combining structure and format
+//! into a single fill-in-the-blank document for LLM consumers.
+
+use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
+
+impl QuillConfig {
+    /// Generate a fill-in-the-blank Markdown template for this quill.
+    ///
+    /// The template shows the correct document structure (YAML frontmatter +
+    /// body + cards) with placeholder values and inline comments for required
+    /// fields and enum constraints. Placeholder precedence: `example` →
+    /// `default` → type-based placeholder.
+    pub fn template(&self) -> String {
+        let mut out = String::new();
+        write_card_frontmatter(
+            &mut out,
+            &self.main,
+            &format!("QUILL: {}@{}", self.name, self.version),
+        );
+        let hide_body = self
+            .main
+            .ui
+            .as_ref()
+            .and_then(|u| u.hide_body)
+            .unwrap_or(false);
+        if !hide_body {
+            out.push_str("\n<body>\n");
+        }
+        for card in &self.card_types {
+            let card_label = match &card.title {
+                Some(t) => format!("CARD: {}  # {} (optional, repeat as needed)", card.name, t),
+                None => format!("CARD: {}  # (optional, repeat as needed)", card.name),
+            };
+            out.push('\n');
+            write_card_frontmatter(&mut out, card, &card_label);
+            let card_hide_body = card.ui.as_ref().and_then(|u| u.hide_body).unwrap_or(false);
+            if !card_hide_body {
+                out.push_str("\n<body>\n");
+            }
+        }
+        out
+    }
+}
+
+fn write_card_frontmatter(out: &mut String, card: &CardSchema, first_line: &str) {
+    out.push_str("---\n");
+    out.push_str(first_line);
+    out.push('\n');
+
+    let mut fields: Vec<&FieldSchema> = card.fields.values().collect();
+    fields.sort_by_key(|f| f.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX));
+
+    for field in fields {
+        write_field(out, field, 0);
+    }
+    out.push_str("---\n");
+}
+
+fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
+    let pad = "  ".repeat(indent);
+
+    let mut comment_parts: Vec<&str> = Vec::new();
+    if field.required {
+        comment_parts.push("required");
+    }
+    let enum_str;
+    if let Some(vals) = &field.enum_values {
+        enum_str = vals.join(" | ");
+        comment_parts.push(&enum_str);
+    }
+    let comment = if comment_parts.is_empty() {
+        String::new()
+    } else {
+        format!("  # {}", comment_parts.join(" | "))
+    };
+
+    let source = field
+        .example
+        .as_ref()
+        .or(field.default.as_ref())
+        .map(|v| v.as_json());
+
+    match source {
+        Some(serde_json::Value::Array(items)) if !items.is_empty() => {
+            out.push_str(&format!("{}{}:{}\n", pad, field.name, comment));
+            write_array_items(out, items, indent + 1);
+        }
+        Some(serde_json::Value::Array(_)) => {
+            out.push_str(&format!("{}{}: []{}\n", pad, field.name, comment));
+        }
+        Some(val) => {
+            let rendered = render_scalar(val);
+            out.push_str(&format!("{}{}: {}{}\n", pad, field.name, rendered, comment));
+        }
+        None => write_type_placeholder(out, field, &pad, &comment),
+    }
+}
+
+fn write_array_items(out: &mut String, items: &[serde_json::Value], indent: usize) {
+    let pad = "  ".repeat(indent);
+    for item in items {
+        match item {
+            serde_json::Value::Object(map) => {
+                let mut entries = map.iter();
+                if let Some((first_key, first_val)) = entries.next() {
+                    out.push_str(&format!(
+                        "{}- {}: {}\n",
+                        pad,
+                        first_key,
+                        render_scalar(first_val)
+                    ));
+                    let inner_pad = format!("{}  ", pad);
+                    for (k, v) in entries {
+                        out.push_str(&format!("{}{}: {}\n", inner_pad, k, render_scalar(v)));
+                    }
+                }
+            }
+            _ => out.push_str(&format!("{}- {}\n", pad, render_scalar(item))),
+        }
+    }
+}
+
+fn write_type_placeholder(out: &mut String, field: &FieldSchema, pad: &str, comment: &str) {
+    match field.r#type {
+        FieldType::Array => {
+            out.push_str(&format!("{}{}: []{}\n", pad, field.name, comment));
+        }
+        FieldType::Boolean => {
+            out.push_str(&format!("{}{}: false{}\n", pad, field.name, comment));
+        }
+        FieldType::Number | FieldType::Integer => {
+            out.push_str(&format!("{}{}: 0{}\n", pad, field.name, comment));
+        }
+        FieldType::Date => {
+            out.push_str(&format!(
+                "{}{}: \"\"  # YYYY-MM-DD{}\n",
+                pad,
+                field.name,
+                if comment.is_empty() {
+                    String::new()
+                } else {
+                    comment.trim_start_matches("  ").to_string()
+                }
+            ));
+        }
+        FieldType::DateTime => {
+            out.push_str(&format!(
+                "{}{}: \"\"  # ISO 8601{}\n",
+                pad,
+                field.name,
+                if comment.is_empty() {
+                    String::new()
+                } else {
+                    comment.trim_start_matches("  ").to_string()
+                }
+            ));
+        }
+        _ => {
+            let label = field.title.as_deref().unwrap_or(&field.name);
+            out.push_str(&format!(
+                "{}{}: \"<{}>\"{}\n",
+                pad, field.name, label, comment
+            ));
+        }
+    }
+}
+
+/// Render a JSON scalar (or array/object fallback) as a YAML-safe string.
+fn render_scalar(val: &serde_json::Value) -> String {
+    match val {
+        serde_json::Value::String(s) => yaml_string(s),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        // Arrays/objects at scalar position: shouldn't appear but fall back gracefully
+        other => yaml_string(&other.to_string()),
+    }
+}
+
+/// Quote a string for YAML if it contains characters that would be misinterpreted.
+fn yaml_string(s: &str) -> String {
+    let needs_quotes = s.is_empty()
+        || matches!(
+            s,
+            "true" | "false" | "null" | "yes" | "no" | "on" | "off"
+        )
+        || s.starts_with(|c: char| matches!(c, '{' | '[' | '&' | '*' | '!' | '|' | '>' | '\'' | '"' | '%' | '@' | '`'))
+        || s.contains(": ")
+        || s.contains(" #")
+        || s.starts_with("- ")
+        || s.starts_with('#');
+    if needs_quotes {
+        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quill::QuillConfig;
+
+    fn cfg(yaml: &str) -> QuillConfig {
+        QuillConfig::from_yaml(yaml).expect("valid yaml")
+    }
+
+    #[test]
+    fn simple_quill_has_sentinel_and_body() {
+        let config = cfg(r#"
+quill:
+  name: taro
+  version: 0.1.0
+  backend: typst
+  description: test
+main:
+  fields:
+    author:
+      type: string
+      title: Author
+      required: true
+    flavor:
+      type: string
+      default: taro
+"#);
+        let t = config.template();
+        assert!(t.contains("QUILL: taro@0.1.0"));
+        assert!(t.contains("author: \"<Author>\"  # required"));
+        assert!(t.contains("flavor: taro"));
+        assert!(t.contains("<body>"));
+    }
+
+    #[test]
+    fn example_takes_precedence_over_default() {
+        let config = cfg(r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    status:
+      type: string
+      default: draft
+      example: final
+"#);
+        let t = config.template();
+        assert!(t.contains("status: final"));
+        assert!(!t.contains("draft"));
+    }
+
+    #[test]
+    fn enum_comment_appended() {
+        let config = cfg(r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    format:
+      type: string
+      enum: [standard, informal, separate_page]
+      default: standard
+"#);
+        let t = config.template();
+        assert!(t.contains("format: standard  # standard | informal | separate_page"));
+    }
+
+    #[test]
+    fn array_example_rendered_as_items() {
+        let config = cfg(r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    memo_from:
+      type: array
+      required: true
+      example:
+        - ORG/SYMBOL
+        - City ST 12345
+"#);
+        let t = config.template();
+        assert!(t.contains("memo_from:  # required\n  - ORG/SYMBOL\n  - City ST 12345\n"));
+    }
+
+    #[test]
+    fn card_has_sentinel_and_repeat_comment() {
+        let config = cfg(r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    title:
+      type: string
+card_types:
+  quote:
+    title: Inspirational Quote
+    fields:
+      author:
+        type: string
+        required: true
+"#);
+        let t = config.template();
+        assert!(t.contains("CARD: quote  # Inspirational Quote (optional, repeat as needed)"));
+        assert!(t.contains("author: \"<author>\"  # required"));
+    }
+
+    #[test]
+    fn hide_body_card_omits_body_placeholder() {
+        let config = cfg(r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    title:
+      type: string
+card_types:
+  skills:
+    ui:
+      hide_body: true
+    fields:
+      items:
+        type: array
+        required: true
+"#);
+        let t = config.template();
+        let skills_pos = t.find("CARD: skills").unwrap();
+        let after_skills = &t[skills_pos..];
+        // Should not have <body> after the skills card
+        assert!(!after_skills.contains("<body>"));
+    }
+
+    #[test]
+    fn date_type_gets_format_hint() {
+        let config = cfg(r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    issued:
+      type: date
+"#);
+        let t = config.template();
+        assert!(t.contains("issued: \"\"  # YYYY-MM-DD"));
+    }
+}

--- a/crates/core/src/quill/template.rs
+++ b/crates/core/src/quill/template.rs
@@ -1,9 +1,9 @@
 //! Auto-generated Markdown template for a Quill.
 //!
 //! Produces a fill-in-the-blank document that is dense enough to replace the
-//! schema for LLM consumers. Each field is annotated with inline comments
-//! (type, required, enum constraints, e.g. hint) and a preceding description
-//! comment where the schema declares one. No UI metadata is emitted.
+//! schema for LLM consumers. Each field is annotated with preceding `# …`
+//! comment lines (description, `required`, `enum:`, `example:`) and a single
+//! inline type hint. No UI metadata is emitted.
 
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
@@ -12,17 +12,17 @@ impl QuillConfig {
     /// Generate a fill-in-the-blank Markdown template for this quill.
     ///
     /// Annotation rules:
-    /// - Preceding `# <description>` comment for every field that declares one.
-    /// - Inline `# type | required | enum… | e.g. …` comment.
-    ///   - Type annotation only for non-obvious types (number, integer, boolean,
-    ///     markdown, object, date, datetime).
-    ///   - `required` marker when the field is required.
-    ///   - Enum values when declared.
-    ///   - `e.g. <value>` for optional fields that have an example but no enum
-    ///     (the example is illustrative, not prescriptive).
+    /// - Preceding `# …` comment lines, in order: description, `required`,
+    ///   `enum: a | b | c`, `example: <value>`.
+    ///   - `example:` is emitted only for optional fields with an example and
+    ///     no enum (the example is illustrative, not prescriptive).
+    /// - Inline `# <type>` annotation only for non-obvious types (number,
+    ///   integer, boolean, markdown, object, date, datetime). String and array
+    ///   are self-evident from the YAML value.
     /// - Placeholder value precedence:
     ///   - Required: example → default → type-based placeholder.
-    ///   - Optional: default → type-based empty; example → `e.g.` comment only.
+    ///   - Optional: default → type-based empty; example surfaces only as
+    ///     `# example: …` above the field.
     pub fn template(&self) -> String {
         let mut out = String::new();
         let main_desc = self
@@ -87,35 +87,27 @@ fn write_card_frontmatter(
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     let pad = "  ".repeat(indent);
 
-    // Preceding description comment.
+    // Preceding comment block: description, required, enum, example.
     if let Some(desc) = &field.description {
         let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
         out.push_str(&format!("{}# {}\n", pad, clean));
     }
-
-    // Build inline comment parts: type | required | enums | e.g.
-    let mut parts: Vec<String> = Vec::new();
-
-    if let Some(hint) = type_annotation(&field.r#type) {
-        parts.push(hint.to_string());
-    }
     if field.required {
-        parts.push("required".to_string());
+        out.push_str(&format!("{}# required\n", pad));
     }
     if let Some(vals) = &field.enum_values {
-        parts.push(vals.join(" | "));
+        out.push_str(&format!("{}# enum: {}\n", pad, vals.join(" | ")));
     }
-    // e.g. hint: only for optional fields with an example and no enum.
     if !field.required && field.enum_values.is_none() {
         if let Some(eg) = field.example.as_ref().map(|e| eg_hint(e)) {
-            parts.push(format!("e.g. {}", eg));
+            out.push_str(&format!("{}# example: {}\n", pad, eg));
         }
     }
 
-    let comment = if parts.is_empty() {
-        String::new()
-    } else {
-        format!("  # {}", parts.join(" | "))
+    // Inline: type annotation only.
+    let comment = match type_annotation(&field.r#type) {
+        Some(hint) => format!("  # {}", hint),
+        None => String::new(),
     };
 
     let value = field_value(field);
@@ -297,7 +289,7 @@ main:
     author: { type: string, title: Author, required: true }
 "#)
         .template();
-        assert!(t.contains("author: \"<Author>\"  # required"));
+        assert!(t.contains("# required\nauthor: \"<Author>\"\n"));
     }
 
     #[test]
@@ -309,7 +301,7 @@ main:
     status: { type: string, required: true, default: draft, example: final }
 "#)
         .template();
-        assert!(t.contains("status: final  # required"));
+        assert!(t.contains("# required\nstatus: final\n"));
     }
 
     #[test]
@@ -321,7 +313,7 @@ main:
     classification: { type: string, default: "", example: CONFIDENTIAL }
 "#)
         .template();
-        assert!(t.contains("classification: \"\"  # e.g. CONFIDENTIAL"));
+        assert!(t.contains("# example: CONFIDENTIAL\nclassification: \"\"\n"));
     }
 
     #[test]
@@ -336,7 +328,7 @@ main:
         - AFM 33-326, Communications
 "#)
         .template();
-        assert!(t.contains("refs: []  # e.g. AFM 33-326, Communications"));
+        assert!(t.contains("# example: AFM 33-326, Communications\nrefs: []\n"));
     }
 
     #[test]
@@ -348,8 +340,8 @@ main:
     format: { type: string, enum: [standard, informal], default: standard }
 "#)
         .template();
-        assert!(t.contains("format: standard  # standard | informal"));
-        assert!(!t.contains("e.g."));
+        assert!(t.contains("# enum: standard | informal\nformat: standard\n"));
+        assert!(!t.contains("example:"));
     }
 
     #[test]
@@ -366,7 +358,7 @@ main:
         - City ST 12345
 "#)
         .template();
-        assert!(t.contains("memo_from:  # required\n  - ORG/SYMBOL\n  - City ST 12345\n"));
+        assert!(t.contains("# required\nmemo_from:\n  - ORG/SYMBOL\n  - City ST 12345\n"));
     }
 
     #[test]
@@ -381,7 +373,7 @@ main:
       description: Be brief and clear.
 "#)
         .template();
-        assert!(t.contains("# Be brief and clear.\nsubject: \"<subject>\"  # required\n"));
+        assert!(t.contains("# Be brief and clear.\n# required\nsubject: \"<subject>\"\n"));
     }
 
     #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1334,10 +1334,8 @@ main:
     assert_eq!(ui.order, Some(0)); // First field should have order 0
 }
 #[test]
-fn test_field_schema_with_title_and_description() {
-    // Test parsing field with new schema format (title + description, no tooltip)
+fn test_field_schema_with_description() {
     let yaml = r#"
-title: "Field Title"
 description: "Detailed field description"
 type: "string"
 example: "Example value"
@@ -1347,7 +1345,6 @@ ui:
     let quill_value = QuillValue::from_yaml_str(yaml).unwrap();
     let schema = FieldSchema::from_quill_value("test_field".to_string(), &quill_value).unwrap();
 
-    assert_eq!(schema.title, Some("Field Title".to_string()));
     assert_eq!(
         schema.description,
         Some("Detailed field description".to_string())
@@ -1367,7 +1364,6 @@ fn test_parse_card_field_type() {
     // Test that FieldSchema no longer supports type = "card" (cards are in CardSchema now)
     let yaml = r#"
 type: "string"
-title: "Simple Field"
 description: "A simple string field"
 "#;
     let quill_value = QuillValue::from_yaml_str(yaml).unwrap();
@@ -1375,7 +1371,6 @@ description: "A simple string field"
 
     assert_eq!(schema.name, "simple_field");
     assert_eq!(schema.r#type, FieldType::String);
-    assert_eq!(schema.title, Some("Simple Field".to_string()));
     assert_eq!(
         schema.description,
         Some("A simple string field".to_string())
@@ -1394,17 +1389,14 @@ quill:
 
 card_types:
   endorsements:
-    title: Endorsements
     description: Chain of endorsements
     fields:
       name:
         type: string
-        title: Endorser Name
         description: Name of the endorsing official
         required: true
       org:
         type: string
-        title: Organization
         description: Endorser's organization
         default: Unknown
 "#;
@@ -1416,7 +1408,6 @@ card_types:
     let card = config.card_type("endorsements").unwrap();
 
     assert_eq!(card.name, "endorsements");
-    assert_eq!(card.title, Some("Endorsements".to_string()));
     assert_eq!(card.description, Some("Chain of endorsements".to_string()));
 
     // Verify card fields
@@ -1424,7 +1415,6 @@ card_types:
 
     let name_field = card.fields.get("name").unwrap();
     assert_eq!(name_field.r#type, FieldType::String);
-    assert_eq!(name_field.title, Some("Endorser Name".to_string()));
     assert!(name_field.required);
 
     let org_field = card.fields.get("org").unwrap();
@@ -1478,11 +1468,9 @@ main:
 
 card_types:
   indorsements:
-    title: Routing Indorsements
     description: Chain of endorsements
     fields:
       name:
-        title: Name
         type: string
         description: Name field
 "#;
@@ -1497,7 +1485,6 @@ card_types:
     // Check card-type is in config.card_types (not config.main.fields)
     assert!(config.card_type("indorsements").is_some());
     let card = config.card_type("indorsements").unwrap();
-    assert_eq!(card.title, Some("Routing Indorsements".to_string()));
     assert_eq!(card.description, Some("Chain of endorsements".to_string()));
     assert!(card.fields.contains_key("name"));
 }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -694,15 +694,14 @@ fn test_field_schema_struct() {
     );
     assert_eq!(schema1.description, Some("Test description".to_string()));
     assert_eq!(schema1.r#type, FieldType::String);
-    assert_eq!(schema1.examples, None);
+    assert_eq!(schema1.example, None);
     assert_eq!(schema1.default, None);
 
     // Test parsing FieldSchema from YAML with all fields
     let yaml_str = r#"
 description: "Full field schema"
 type: "string"
-examples:
-  - "Example value"
+example: "Example value"
 default: "Default value"
 "#;
     let quill_value = QuillValue::from_yaml_str(yaml_str).unwrap();
@@ -711,12 +710,7 @@ default: "Default value"
     assert_eq!(schema2.description, Some("Full field schema".to_string()));
     assert_eq!(schema2.r#type, FieldType::String);
     assert_eq!(
-        schema2
-            .examples
-            .as_ref()
-            .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(|v| v.as_str()),
+        schema2.example.as_ref().and_then(|v| v.as_str()),
         Some("Example value")
     );
     assert_eq!(
@@ -726,22 +720,17 @@ default: "Default value"
 }
 
 #[test]
-fn test_field_schema_scalar_examples_coerced_to_array() {
+fn test_field_schema_single_example() {
     let yaml_str = r#"
-description: "Field schema with scalar example"
+description: "Field schema with single example"
 type: "date"
-examples: "2024-01-15"
+example: "2024-01-15"
 "#;
     let quill_value = QuillValue::from_yaml_str(yaml_str).unwrap();
     let schema = FieldSchema::from_quill_value("effective_date".to_string(), &quill_value).unwrap();
 
     assert_eq!(
-        schema
-            .examples
-            .as_ref()
-            .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(|v| v.as_str()),
+        schema.example.as_ref().and_then(|v| v.as_str()),
         Some("2024-01-15")
     );
 }
@@ -1200,22 +1189,20 @@ main:
 }
 
 #[test]
-fn test_config_defaults_and_examples_methods() {
+fn test_config_defaults_method() {
     let yaml_content = r#"
 quill:
-  name: defaults_examples_test
+  name: defaults_test
   version: "1.0"
   backend: typst
-  description: Defaults and examples
+  description: Defaults test
 
 main:
   fields:
     author:
       type: string
       default: Anonymous
-      examples:
-        - Alice
-        - Bob
+      example: Alice
     status:
       type: string
       default: draft
@@ -1225,28 +1212,25 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let defaults = config.main.defaults();
-    let examples = config.main.examples();
 
     assert_eq!(defaults.len(), 2);
     assert_eq!(defaults.get("author").unwrap().as_str(), Some("Anonymous"));
     assert_eq!(defaults.get("status").unwrap().as_str(), Some("draft"));
     assert!(!defaults.contains_key("title"));
 
-    assert_eq!(examples.len(), 1);
-    let author_examples = examples.get("author").unwrap();
-    assert_eq!(author_examples.len(), 2);
-    assert_eq!(author_examples[0].as_str(), Some("Alice"));
-    assert_eq!(author_examples[1].as_str(), Some("Bob"));
+    // example takes precedence over default in template
+    let author_example = config.main.fields.get("author").unwrap().example.as_ref();
+    assert_eq!(author_example.and_then(|v| v.as_str()), Some("Alice"));
 }
 
 #[test]
-fn test_card_defaults_and_examples_methods() {
+fn test_card_defaults_method() {
     let yaml_content = r#"
 quill:
-  name: card_defaults_examples_test
+  name: card_defaults_test
   version: "1.0"
   backend: typst
-  description: Card defaults and examples
+  description: Card defaults test
 
 card_types:
   indorsement:
@@ -1254,8 +1238,7 @@ card_types:
       signature_block:
         type: string
         default: Commander
-        examples:
-          - Col Smith
+        example: Col Smith
       office:
         type: string
 "#;
@@ -1270,11 +1253,8 @@ card_types:
         Some("Commander")
     );
 
-    let card_examples = card.examples();
-    assert_eq!(card_examples.len(), 1);
-    let signature_examples = card_examples.get("signature_block").unwrap();
-    assert_eq!(signature_examples.len(), 1);
-    assert_eq!(signature_examples[0].as_str(), Some("Col Smith"));
+    let sig_example = card.fields.get("signature_block").unwrap().example.as_ref();
+    assert_eq!(sig_example.and_then(|v| v.as_str()), Some("Col Smith"));
 
     assert!(config.card_type("unknown").is_none());
 }
@@ -1360,8 +1340,7 @@ fn test_field_schema_with_title_and_description() {
 title: "Field Title"
 description: "Detailed field description"
 type: "string"
-examples:
-  - "Example value"
+example: "Example value"
 ui:
   group: "Test Group"
 "#;
@@ -1375,12 +1354,7 @@ ui:
     );
 
     assert_eq!(
-        schema
-            .examples
-            .as_ref()
-            .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(|v| v.as_str()),
+        schema.example.as_ref().and_then(|v| v.as_str()),
         Some("Example value")
     );
 

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -12,8 +12,6 @@ fn is_false(value: &bool) -> bool {
 /// Using constants provides IDE support (find references, autocomplete) and ensures
 /// consistency between parsing and output.
 pub mod field_key {
-    /// Short label for the field
-    pub const TITLE: &str = "title";
     /// Field type (string, number, boolean, array, etc.)
     pub const TYPE: &str = "type";
     /// Detailed field description
@@ -87,9 +85,6 @@ pub struct CardSchema {
     /// wire; skipped during serialization to avoid duplication.
     #[serde(skip_serializing, default)]
     pub name: String,
-    /// Short label for the card type
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
     /// Detailed description of this card type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -176,9 +171,6 @@ pub struct FieldSchema {
     /// serialization to avoid duplication.
     #[serde(skip_serializing, default)]
     pub name: String,
-    /// Short label for the field (used in JSON Schema title)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
     /// Field type (required)
     pub r#type: FieldType,
     /// Detailed description of the field (used in JSON Schema description)
@@ -210,7 +202,6 @@ pub struct FieldSchema {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct FieldSchemaDef {
-    pub title: Option<String>,
     pub r#type: FieldType,
     pub description: Option<String>,
     pub default: Option<QuillValue>,
@@ -230,7 +221,6 @@ impl FieldSchema {
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {
         Self {
             name,
-            title: None,
             r#type,
             description,
             default: None,
@@ -249,7 +239,6 @@ impl FieldSchema {
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
         Ok(Self {
             name: key,
-            title: def.title,
             r#type: def.r#type,
             description: def.description,
             default: def.default,

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -20,8 +20,8 @@ pub mod field_key {
     pub const DESCRIPTION: &str = "description";
     /// Default value for the field
     pub const DEFAULT: &str = "default";
-    /// Example values for the field
-    pub const EXAMPLES: &str = "examples";
+    /// Example value for the field (single, used as template placeholder)
+    pub const EXAMPLE: &str = "example";
     /// UI-specific metadata
     pub const UI: &str = "ui";
     /// Whether the field is required
@@ -110,22 +110,6 @@ impl CardSchema {
             .collect()
     }
 
-    /// Example values declared on this card's fields, keyed by field name.
-    /// Fields with no `examples` (or with an empty/non-array `examples`) are
-    /// omitted.
-    pub fn examples(&self) -> HashMap<String, Vec<QuillValue>> {
-        self.fields
-            .iter()
-            .filter_map(|(name, field)| {
-                let array = field.examples.as_ref()?.as_array()?;
-                let values: Vec<QuillValue> = array
-                    .iter()
-                    .map(|v| QuillValue::from_json(v.clone()))
-                    .collect();
-                (!values.is_empty()).then_some((name.clone(), values))
-            })
-            .collect()
-    }
 }
 
 /// Field type hint enum for type-safe field type definitions
@@ -203,9 +187,9 @@ pub struct FieldSchema {
     /// Default value for the field
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<QuillValue>,
-    /// Example values for the field
+    /// Example value for the field (single; used as template placeholder)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub examples: Option<QuillValue>,
+    pub example: Option<QuillValue>,
     /// UI layout hints
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiFieldSchema>,
@@ -230,7 +214,7 @@ struct FieldSchemaDef {
     pub r#type: FieldType,
     pub description: Option<String>,
     pub default: Option<QuillValue>,
-    pub examples: Option<QuillValue>,
+    pub example: Option<QuillValue>,
     pub ui: Option<UiFieldSchema>,
     #[serde(default)]
     pub required: bool,
@@ -250,7 +234,7 @@ impl FieldSchema {
             r#type,
             description,
             default: None,
-            examples: None,
+            example: None,
             ui: None,
             required: false,
             enum_values: None,
@@ -263,28 +247,13 @@ impl FieldSchema {
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
         let def: FieldSchemaDef = serde_json::from_value(value.clone().into_json())
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
-        let examples = match def.examples {
-            Some(examples) => {
-                if examples.is_null() {
-                    None
-                } else if examples.as_array().is_some() {
-                    Some(examples)
-                } else {
-                    Some(QuillValue::from_json(serde_json::Value::Array(vec![
-                        examples.into_json(),
-                    ])))
-                }
-            }
-            None => None,
-        };
-
         Ok(Self {
             name: key,
             title: def.title,
             r#type: def.r#type,
             description: def.description,
             default: def.default,
-            examples,
+            example: def.example,
             ui: def.ui,
             required: def.required,
             enum_values: def.enum_values,

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -12,8 +12,7 @@ main:
       title: Full Name
       type: string
       required: true
-      examples:
-        - John Doe
+      example: John Doe
       ui:
         group: Personal Info
 
@@ -21,10 +20,10 @@ main:
       title: Contact Information
       type: array
       required: true
-      examples:
-        - - john.doe@example.com
-          - 123-456-7890
-          - linkedin.com/in/johndoe
+      example:
+        - john.doe@example.com
+        - 123-456-7890
+        - linkedin.com/in/johndoe
       ui:
         group: Personal Info
       description: List of contact details (email, phone, links, etc.)
@@ -68,11 +67,11 @@ card_types:
         title: Skill Categories
         type: array
         required: true
-        examples:
-          - - category: Languages
-              skills: Python, Rust, C++
-            - category: DevOps
-              skills: Docker, Kubernetes
+        example:
+          - category: Languages
+            skills: Python, Rust, C++
+          - category: DevOps
+            skills: Docker, Kubernetes
         items:
           type: object
           properties:
@@ -117,7 +116,7 @@ card_types:
         title: Certification Names
         type: array
         required: true
-        examples:
-          - - AWS Certified Solutions Architect
-            - CKA
-            - OSCP
+        example:
+          - AWS Certified Solutions Architect
+          - CKA
+          - OSCP

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -9,7 +9,6 @@ quill:
 main:
   fields:
     name:
-      title: Full Name
       type: string
       required: true
       example: John Doe
@@ -17,7 +16,6 @@ main:
         group: Personal Info
 
     contacts:
-      title: Contact Information
       type: array
       required: true
       example:
@@ -30,41 +28,32 @@ main:
 
 card_types:
   experience_section:
-    title: Experience/Education Entry
     description: An entry with a heading, subheading, and bullet points.
     ui:
       default_title: "{headingLeft} — {subheadingLeft}"
     fields:
       title:
-        title: Section Title
         type: string
         default: Experience
       headingLeft:
-        title: Heading Left (e.g., Company/School)
         type: string
         required: true
       headingRight:
-        title: Heading Right (e.g., Location)
         type: string
       subheadingLeft:
-        title: Subheading Left (e.g., Title/Degree)
         type: string
       subheadingRight:
-        title: Subheading Right (e.g., Date)
         type: string
 
   skills_section:
-    title: Skills Grid
     description: A grid of skill categories with key-value pairs.
     ui:
       hide_body: true
     fields:
       title:
-        title: Section Title
         type: string
         default: Skills
       cells:
-        title: Skill Categories
         type: array
         required: true
         example:
@@ -77,43 +66,34 @@ card_types:
           properties:
             category:
               type: string
-              title: Category
               required: true
             skills:
               type: string
-              title: Skills
               required: true
 
   projects_section:
-    title: Project Entry
     description: A project entry with a name and optional URL.
     ui:
       default_title: "{name}"
     fields:
       title:
-        title: Section Title
         type: string
         default: Projects
       name:
-        title: Project Name
         type: string
         required: true
       url:
-        title: Project URL
         type: string
 
   certifications_section:
-    title: Certifications Grid
     description: A grid of certifications.
     ui:
       hide_body: true
     fields:
       title:
-        title: Section Title
         type: string
         default: Certifications
       cells:
-        title: Certification Names
         type: array
         required: true
         example:

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -11,10 +11,10 @@ main:
     recipient:
       title: Recipient's name and address
       type: array
-      examples:
-        - - Mr. John Doe
-          - 123 Main St
-          - Anytown, USA
+      example:
+        - Mr. John Doe
+        - 123 Main St
+        - Anytown, USA
       ui:
         group: Essentials
       description: The recipient's name and full mailing address.
@@ -22,9 +22,9 @@ main:
     signature_block:
       title: Signature block lines
       type: array
-      examples:
-        - - First M. Last
-          - Title
+      example:
+        - First M. Last
+        - Title
       ui:
         group: Essentials
       description: "The signer's information. Line 1: Name. Line 2: Title."
@@ -32,8 +32,7 @@ main:
     department:
       title: Name of the department or unit
       type: string
-      examples:
-        - Department of Electrical and Computer Engineering
+      example: Department of Electrical and Computer Engineering
       ui:
         group: Letterhead
       description: The department or organizational unit name for the letterhead.
@@ -41,9 +40,9 @@ main:
     address:
       title: Sender's address lines
       type: array
-      examples:
-        - - 5000 Forbes Avenue
-          - Pittsburgh, PA 15213-3890
+      example:
+        - 5000 Forbes Avenue
+        - Pittsburgh, PA 15213-3890
       ui:
         group: Letterhead
       description: The sender's institutional mailing address.
@@ -51,8 +50,7 @@ main:
     url:
       title: Department or university URL
       type: string
-      examples:
-        - www.ece.cmu.edu
+      example: www.ece.cmu.edu
       ui:
         group: Letterhead
       description: The department or university website URL.

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -9,7 +9,6 @@ quill:
 main:
   fields:
     recipient:
-      title: Recipient's name and address
       type: array
       example:
         - Mr. John Doe
@@ -20,7 +19,6 @@ main:
       description: The recipient's name and full mailing address.
 
     signature_block:
-      title: Signature block lines
       type: array
       example:
         - First M. Last
@@ -30,7 +28,6 @@ main:
       description: "The signer's information. Line 1: Name. Line 2: Title."
 
     department:
-      title: Name of the department or unit
       type: string
       example: Department of Electrical and Computer Engineering
       ui:
@@ -38,7 +35,6 @@ main:
       description: The department or organizational unit name for the letterhead.
 
     address:
-      title: Sender's address lines
       type: array
       example:
         - 5000 Forbes Avenue
@@ -48,7 +44,6 @@ main:
       description: The sender's institutional mailing address.
 
     url:
-      title: Department or university URL
       type: string
       example: www.ece.cmu.edu
       ui:
@@ -56,7 +51,6 @@ main:
       description: The department or university website URL.
 
     date:
-      title: Date of the letter
       type: date
       ui:
         group: Advanced

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -10,7 +10,6 @@ quill:
 main:
   fields:
     memo_for:
-      title: List of recipient organization(s)
       type: array
       required: true
       example:
@@ -21,7 +20,6 @@ main:
       description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
 
     memo_from:
-      title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
       type: array
       required: true
       example:
@@ -34,7 +32,6 @@ main:
       description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
 
     subject:
-      title: Subject of the memo
       type: string
       required: true
       example: Subject of the Memorandum
@@ -43,7 +40,6 @@ main:
       description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
 
     signature_block:
-      title: Signature block lines
       type: array
       required: true
       example:
@@ -54,7 +50,6 @@ main:
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
 
     letterhead_title:
-      title: Title in letterhead
       type: string
       default: DEPARTMENT OF THE AIR FORCE
       ui:
@@ -62,7 +57,6 @@ main:
       description: Standard title. Only change for Joint Commands or DoW Agencies.
 
     letterhead_caption:
-      title: Letterhead caption line(s)
       type: array
       default:
         - HEADQUARTERS [UNIT NAME]
@@ -71,7 +65,6 @@ main:
       description: The full organization name of your unit.
 
     tag_line:
-      title: Tag line at bottom of memo
       type: string
       default: ""
       ui:
@@ -79,7 +72,6 @@ main:
       description: Organizational motto at the bottom of the page.
 
     date:
-      title: Date of memo (YYYY-MM-DD); defaults to today
       type: string
       default: ""
       ui:
@@ -87,7 +79,6 @@ main:
       description: YYYY-MM-DD. Leave blank to use today's date.
 
     references:
-      title: References for the memo
       type: array
       default: []
       example:
@@ -97,7 +88,6 @@ main:
       description: "Cite by organization, type, date, and title."
 
     cc:
-      title: Carbon copy recipients
       type: array
       default: []
       example:
@@ -107,7 +97,6 @@ main:
       description: List office symbols of recipients to receive copies.
 
     distribution:
-      title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
       type: array
       default: []
       example:
@@ -118,7 +107,6 @@ main:
       description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
 
     attachments:
-      title: List of attachments
       type: array
       default: []
       example:
@@ -128,7 +116,6 @@ main:
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
     classification:
-      title: Classification level of the memo that displays in the banner
       type: string
       default: ""
       example: CONFIDENTIAL
@@ -137,7 +124,6 @@ main:
       description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
 
     font_size:
-      title: Font size for the memo text (int pt)
       type: number
       default: 11
       ui:
@@ -146,25 +132,21 @@ main:
 
 card_types:
   indorsement:
-    title: Routing indorsement
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     fields:
       from:
-        title: From office/symbol
         type: string
         default: ORG/SYMBOL
         ui:
           group: Addressing
         description: "Office symbol or Rank Name of the endorsing official (e.g., 'ORG/SYMBOL')."
       for:
-        title: To office/symbol
         type: string
         default: ORG/SYMBOL
         ui:
           group: Addressing
         description: Office symbol or organization receiving the endorsed memo.
       signature_block:
-        title: Signature block lines
         type: array
         example:
           - "FIRST M. LAST, Rank, USAF"
@@ -177,7 +159,6 @@ card_types:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title
       format:
-        title: Indorsement format
         type: string
         enum:
           - standard
@@ -188,19 +169,16 @@ card_types:
         description: "Format style: 'standard' (formal on same page), 'informal' (less formal routing), or 'separate_page' (starts on new page)."
         default: standard
       attachments:
-        title: Attachments for this endorsement
         type: array
         ui:
           group: Additional
         description: List of attachments specific to this endorsement.
       cc:
-        title: Carbon copy recipients
         type: array
         ui:
           group: Additional
         description: List of office symbols to receive copies of this endorsement.
       date:
-        title: Date of endorsement (YYYY-MM-DD)
         type: string
         ui:
           group: Additional

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -13,9 +13,9 @@ main:
       title: List of recipient organization(s)
       type: array
       required: true
-      examples:
-        - - ORG1/SYMBOL
-          - ORG2/SYMBOL
+      example:
+        - ORG1/SYMBOL
+        - ORG2/SYMBOL
       ui:
         group: Addressing
       description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
@@ -24,11 +24,11 @@ main:
       title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
       type: array
       required: true
-      examples:
-        - - ORG/SYMBOL
-          - Organization Name
-          - 123 Street Ave
-          - City ST 12345-6789
+      example:
+        - ORG/SYMBOL
+        - Organization Name
+        - 123 Street Ave
+        - City ST 12345-6789
       ui:
         group: Addressing
       description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
@@ -37,8 +37,7 @@ main:
       title: Subject of the memo
       type: string
       required: true
-      examples:
-        - Subject of the Memorandum
+      example: Subject of the Memorandum
       ui:
         group: Addressing
       description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
@@ -47,9 +46,9 @@ main:
       title: Signature block lines
       type: array
       required: true
-      examples:
-        - - "FIRST M. LAST, Rank, USSF"
-          - Duty Title
+      example:
+        - "FIRST M. LAST, Rank, USSF"
+        - Duty Title
       ui:
         group: Addressing
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
@@ -91,8 +90,8 @@ main:
       title: References for the memo
       type: array
       default: []
-      examples:
-        - - "AFM 33-326, 31 July 2019, Preparing Official Communications"
+      example:
+        - "AFM 33-326, 31 July 2019, Preparing Official Communications"
       ui:
         group: Additional
       description: "Cite by organization, type, date, and title."
@@ -101,8 +100,8 @@ main:
       title: Carbon copy recipients
       type: array
       default: []
-      examples:
-        - - Rank and Name, ORG/SYMBOL
+      example:
+        - Rank and Name, ORG/SYMBOL
       ui:
         group: Additional
       description: List office symbols of recipients to receive copies.
@@ -111,9 +110,9 @@ main:
       title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
       type: array
       default: []
-      examples:
-        - - ORG1/SYMBOL
-          - ORG2/SYMBOL
+      example:
+        - ORG1/SYMBOL
+        - ORG2/SYMBOL
       ui:
         group: Additional
       description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
@@ -122,8 +121,8 @@ main:
       title: List of attachments
       type: array
       default: []
-      examples:
-        - - Attachment description, YYYY MMM DD
+      example:
+        - Attachment description, YYYY MMM DD
       ui:
         group: Additional
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
@@ -132,8 +131,7 @@ main:
       title: Classification level of the memo that displays in the banner
       type: string
       default: ""
-      examples:
-        - CONFIDENTIAL
+      example: CONFIDENTIAL
       ui:
         group: Additional
       description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
@@ -142,8 +140,6 @@ main:
       title: Font size for the memo text (int pt)
       type: number
       default: 11
-      examples:
-        - 11
       ui:
         group: Additional
       description: Font size for the memo text (pt).
@@ -170,9 +166,9 @@ card_types:
       signature_block:
         title: Signature block lines
         type: array
-        examples:
-          - - "FIRST M. LAST, Rank, USAF"
-            - Duty Title
+        example:
+          - "FIRST M. LAST, Rank, USAF"
+          - Duty Title
         ui:
           group: Addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/form_schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/form_schema.yaml
@@ -1,5 +1,4 @@
 main:
-  title: main
   fields:
     QUILL:
       type: string
@@ -7,7 +6,6 @@ main:
       description: "Canonical quill reference. Must be exactly this value as the QUILL: sentinel in the document frontmatter."
       required: true
     attachments:
-      title: List of attachments
       type: array
       description: >-
         List attachments in the order they are mentioned in the memo. Briefly describe
@@ -19,7 +17,6 @@ main:
         group: Additional
         order: 11
     cc:
-      title: Carbon copy recipients
       type: array
       description: List office symbols of recipients to receive copies.
       default: []
@@ -29,7 +26,6 @@ main:
         group: Additional
         order: 9
     classification:
-      title: Classification level of the memo that displays in the banner
       type: string
       description: >-
         Follow AFI 31-401 and applicable DoD guidance for classification markings.
@@ -40,7 +36,6 @@ main:
         group: Additional
         order: 12
     date:
-      title: Date of memo (YYYY-MM-DD); defaults to today
       type: string
       description: YYYY-MM-DD. Leave blank to use today's date.
       default: ""
@@ -48,7 +43,6 @@ main:
         group: Additional
         order: 7
     distribution:
-      title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
       type: array
       description: >-
         Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For'
@@ -61,7 +55,6 @@ main:
         group: Additional
         order: 10
     font_size:
-      title: Font size for the memo text (int pt)
       type: number
       description: Font size for the memo text (pt).
       default: 11
@@ -69,7 +62,6 @@ main:
         group: Additional
         order: 13
     letterhead_caption:
-      title: Letterhead caption line(s)
       type: array
       description: The full organization name of your unit.
       default:
@@ -78,7 +70,6 @@ main:
         group: Letterhead
         order: 5
     letterhead_title:
-      title: Title in letterhead
       type: string
       description: Standard title. Only change for Joint Commands or DoW Agencies.
       default: DEPARTMENT OF THE AIR FORCE
@@ -86,7 +77,6 @@ main:
         group: Letterhead
         order: 4
     memo_for:
-      title: List of recipient organization(s)
       type: array
       description: >-
         Organization/office symbol in UPPERCASE. To address a specific person, add
@@ -100,7 +90,6 @@ main:
         order: 0
       required: true
     memo_from:
-      title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
       type: array
       description: >-
         If recipients are on the same installation, use only the office symbol. For
@@ -116,7 +105,6 @@ main:
         order: 1
       required: true
     references:
-      title: References for the memo
       type: array
       description: Cite by organization, type, date, and title.
       default: []
@@ -126,7 +114,6 @@ main:
         group: Additional
         order: 8
     signature_block:
-      title: Signature block lines
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
       example:
@@ -137,7 +124,6 @@ main:
         order: 3
       required: true
     subject:
-      title: Subject of the memo
       type: string
       description: >-
         Be brief and clear. Capitalize the first letter of each word except articles,
@@ -149,7 +135,6 @@ main:
         order: 2
       required: true
     tag_line:
-      title: Tag line at bottom of memo
       type: string
       description: Organizational motto at the bottom of the page.
       default: ""
@@ -158,7 +143,6 @@ main:
         order: 6
 card_types:
   indorsement:
-    title: Routing indorsement
     description: >-
       Chain of routing endorsements. Each endorsement block adds an official response
       or forwarding action to the original memo.
@@ -169,28 +153,24 @@ card_types:
         description: "Card type name. Must be exactly this value as the CARD: sentinel in the card frontmatter."
         required: true
       attachments:
-        title: Attachments for this endorsement
         type: array
         description: List of attachments specific to this endorsement.
         ui:
           group: Additional
           order: 4
       cc:
-        title: Carbon copy recipients
         type: array
         description: List of office symbols to receive copies of this endorsement.
         ui:
           group: Additional
           order: 5
       date:
-        title: Date of endorsement (YYYY-MM-DD)
         type: string
         description: Date of the endorsement. Leave blank to omit.
         ui:
           group: Additional
           order: 6
       for:
-        title: To office/symbol
         type: string
         description: Office symbol or organization receiving the endorsed memo.
         default: ORG/SYMBOL
@@ -198,7 +178,6 @@ card_types:
           group: Addressing
           order: 1
       format:
-        title: Indorsement format
         type: string
         description: "Format style: 'standard' (formal on same page), 'informal' (less formal routing), or 'separate_page' (starts on new page)."
         default: standard
@@ -210,7 +189,6 @@ card_types:
         - informal
         - separate_page
       from:
-        title: From office/symbol
         type: string
         description: Office symbol or Rank Name of the endorsing official (e.g., 'ORG/SYMBOL').
         default: ORG/SYMBOL
@@ -218,7 +196,6 @@ card_types:
           group: Addressing
           order: 0
       signature_block:
-        title: Signature block lines
         type: array
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
         default:

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/form_schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/form_schema.yaml
@@ -13,8 +13,8 @@ main:
         List attachments in the order they are mentioned in the memo. Briefly describe
         each; do not use 'as stated' or abbreviations.
       default: []
-      examples:
-      - - Attachment description, YYYY MMM DD
+      example:
+      - Attachment description, YYYY MMM DD
       ui:
         group: Additional
         order: 11
@@ -23,8 +23,8 @@ main:
       type: array
       description: List office symbols of recipients to receive copies.
       default: []
-      examples:
-      - - Rank and Name, ORG/SYMBOL
+      example:
+      - Rank and Name, ORG/SYMBOL
       ui:
         group: Additional
         order: 9
@@ -35,8 +35,7 @@ main:
         Follow AFI 31-401 and applicable DoD guidance for classification markings.
         Leave blank for unclassified.
       default: ""
-      examples:
-      - CONFIDENTIAL
+      example: CONFIDENTIAL
       ui:
         group: Additional
         order: 12
@@ -55,9 +54,9 @@ main:
         Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For'
         field.
       default: []
-      examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
+      example:
+      - ORG1/SYMBOL
+      - ORG2/SYMBOL
       ui:
         group: Additional
         order: 10
@@ -66,8 +65,6 @@ main:
       type: number
       description: Font size for the memo text (pt).
       default: 11
-      examples:
-      - 11
       ui:
         group: Additional
         order: 13
@@ -95,9 +92,9 @@ main:
         Organization/office symbol in UPPERCASE. To address a specific person, add
         their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For
         numerous recipients, use 'DISTRIBUTION'.
-      examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
+      example:
+      - ORG1/SYMBOL
+      - ORG2/SYMBOL
       ui:
         group: Addressing
         order: 0
@@ -109,11 +106,11 @@ main:
         If recipients are on the same installation, use only the office symbol. For
         recipients on other installations, include the full mailing address to enable return
         correspondence.
-      examples:
-      - - ORG/SYMBOL
-        - Organization Name
-        - 123 Street Ave
-        - City ST 12345-6789
+      example:
+      - ORG/SYMBOL
+      - Organization Name
+      - 123 Street Ave
+      - City ST 12345-6789
       ui:
         group: Addressing
         order: 1
@@ -123,8 +120,8 @@ main:
       type: array
       description: Cite by organization, type, date, and title.
       default: []
-      examples:
-      - - AFM 33-326, 31 July 2019, Preparing Official Communications
+      example:
+      - AFM 33-326, 31 July 2019, Preparing Official Communications
       ui:
         group: Additional
         order: 8
@@ -132,9 +129,9 @@ main:
       title: Signature block lines
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
-      examples:
-      - - FIRST M. LAST, Rank, USSF
-        - Duty Title
+      example:
+      - FIRST M. LAST, Rank, USSF
+      - Duty Title
       ui:
         group: Addressing
         order: 3
@@ -146,8 +143,7 @@ main:
         Be brief and clear. Capitalize the first letter of each word except articles,
         prepositions, and conjunctions. Include suspense dates in parentheses if
         applicable.
-      examples:
-      - Subject of the Memorandum
+      example: Subject of the Memorandum
       ui:
         group: Addressing
         order: 2
@@ -228,9 +224,9 @@ card_types:
         default:
         - FIRST M. LAST, Rank, USAF
         - Duty Title
-        examples:
-        - - FIRST M. LAST, Rank, USAF
-          - Duty Title
+        example:
+        - FIRST M. LAST, Rank, USAF
+        - Duty Title
         ui:
           group: Addressing
           order: 2

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -13,15 +13,15 @@ main:
         List attachments in the order they are mentioned in the memo. Briefly describe
         each; do not use 'as stated' or abbreviations.
       default: []
-      examples:
-      - - Attachment description, YYYY MMM DD
+      example:
+      - Attachment description, YYYY MMM DD
     cc:
       title: Carbon copy recipients
       type: array
       description: List office symbols of recipients to receive copies.
       default: []
-      examples:
-      - - Rank and Name, ORG/SYMBOL
+      example:
+      - Rank and Name, ORG/SYMBOL
     classification:
       title: Classification level of the memo that displays in the banner
       type: string
@@ -29,8 +29,7 @@ main:
         Follow AFI 31-401 and applicable DoD guidance for classification markings.
         Leave blank for unclassified.
       default: ""
-      examples:
-      - CONFIDENTIAL
+      example: CONFIDENTIAL
     date:
       title: Date of memo (YYYY-MM-DD); defaults to today
       type: string
@@ -43,16 +42,14 @@ main:
         Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For'
         field.
       default: []
-      examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
+      example:
+      - ORG1/SYMBOL
+      - ORG2/SYMBOL
     font_size:
       title: Font size for the memo text (int pt)
       type: number
       description: Font size for the memo text (pt).
       default: 11
-      examples:
-      - 11
     letterhead_caption:
       title: Letterhead caption line(s)
       type: array
@@ -71,9 +68,9 @@ main:
         Organization/office symbol in UPPERCASE. To address a specific person, add
         their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For
         numerous recipients, use 'DISTRIBUTION'.
-      examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
+      example:
+      - ORG1/SYMBOL
+      - ORG2/SYMBOL
       required: true
     memo_from:
       title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
@@ -82,26 +79,26 @@ main:
         If recipients are on the same installation, use only the office symbol. For
         recipients on other installations, include the full mailing address to enable return
         correspondence.
-      examples:
-      - - ORG/SYMBOL
-        - Organization Name
-        - 123 Street Ave
-        - City ST 12345-6789
+      example:
+      - ORG/SYMBOL
+      - Organization Name
+      - 123 Street Ave
+      - City ST 12345-6789
       required: true
     references:
       title: References for the memo
       type: array
       description: Cite by organization, type, date, and title.
       default: []
-      examples:
-      - - AFM 33-326, 31 July 2019, Preparing Official Communications
+      example:
+      - AFM 33-326, 31 July 2019, Preparing Official Communications
     signature_block:
       title: Signature block lines
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
-      examples:
-      - - FIRST M. LAST, Rank, USSF
-        - Duty Title
+      example:
+      - FIRST M. LAST, Rank, USSF
+      - Duty Title
       required: true
     subject:
       title: Subject of the memo
@@ -110,8 +107,7 @@ main:
         Be brief and clear. Capitalize the first letter of each word except articles,
         prepositions, and conjunctions. Include suspense dates in parentheses if
         applicable.
-      examples:
-      - Subject of the Memorandum
+      example: Subject of the Memorandum
       required: true
     tag_line:
       title: Tag line at bottom of memo
@@ -168,7 +164,7 @@ card_types:
         default:
         - FIRST M. LAST, Rank, USAF
         - Duty Title
-        examples:
-        - - FIRST M. LAST, Rank, USAF
-          - Duty Title
+        example:
+        - FIRST M. LAST, Rank, USAF
+        - Duty Title
         required: true

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -1,5 +1,4 @@
 main:
-  title: main
   fields:
     QUILL:
       type: string
@@ -7,7 +6,6 @@ main:
       description: "Canonical quill reference. Must be exactly this value as the QUILL: sentinel in the document frontmatter."
       required: true
     attachments:
-      title: List of attachments
       type: array
       description: >-
         List attachments in the order they are mentioned in the memo. Briefly describe
@@ -16,14 +14,12 @@ main:
       example:
       - Attachment description, YYYY MMM DD
     cc:
-      title: Carbon copy recipients
       type: array
       description: List office symbols of recipients to receive copies.
       default: []
       example:
       - Rank and Name, ORG/SYMBOL
     classification:
-      title: Classification level of the memo that displays in the banner
       type: string
       description: >-
         Follow AFI 31-401 and applicable DoD guidance for classification markings.
@@ -31,12 +27,10 @@ main:
       default: ""
       example: CONFIDENTIAL
     date:
-      title: Date of memo (YYYY-MM-DD); defaults to today
       type: string
       description: YYYY-MM-DD. Leave blank to use today's date.
       default: ""
     distribution:
-      title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
       type: array
       description: >-
         Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For'
@@ -46,23 +40,19 @@ main:
       - ORG1/SYMBOL
       - ORG2/SYMBOL
     font_size:
-      title: Font size for the memo text (int pt)
       type: number
       description: Font size for the memo text (pt).
       default: 11
     letterhead_caption:
-      title: Letterhead caption line(s)
       type: array
       description: The full organization name of your unit.
       default:
       - HEADQUARTERS [UNIT NAME]
     letterhead_title:
-      title: Title in letterhead
       type: string
       description: Standard title. Only change for Joint Commands or DoW Agencies.
       default: DEPARTMENT OF THE AIR FORCE
     memo_for:
-      title: List of recipient organization(s)
       type: array
       description: >-
         Organization/office symbol in UPPERCASE. To address a specific person, add
@@ -73,7 +63,6 @@ main:
       - ORG2/SYMBOL
       required: true
     memo_from:
-      title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
       type: array
       description: >-
         If recipients are on the same installation, use only the office symbol. For
@@ -86,14 +75,12 @@ main:
       - City ST 12345-6789
       required: true
     references:
-      title: References for the memo
       type: array
       description: Cite by organization, type, date, and title.
       default: []
       example:
       - AFM 33-326, 31 July 2019, Preparing Official Communications
     signature_block:
-      title: Signature block lines
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
       example:
@@ -101,7 +88,6 @@ main:
       - Duty Title
       required: true
     subject:
-      title: Subject of the memo
       type: string
       description: >-
         Be brief and clear. Capitalize the first letter of each word except articles,
@@ -110,13 +96,11 @@ main:
       example: Subject of the Memorandum
       required: true
     tag_line:
-      title: Tag line at bottom of memo
       type: string
       description: Organizational motto at the bottom of the page.
       default: ""
 card_types:
   indorsement:
-    title: Routing indorsement
     description: >-
       Chain of routing endorsements. Each endorsement block adds an official response
       or forwarding action to the original memo.
@@ -127,24 +111,19 @@ card_types:
         description: "Card type name. Must be exactly this value as the CARD: sentinel in the card frontmatter."
         required: true
       attachments:
-        title: Attachments for this endorsement
         type: array
         description: List of attachments specific to this endorsement.
       cc:
-        title: Carbon copy recipients
         type: array
         description: List of office symbols to receive copies of this endorsement.
       date:
-        title: Date of endorsement (YYYY-MM-DD)
         type: string
         description: Date of the endorsement. Leave blank to omit.
       for:
-        title: To office/symbol
         type: string
         description: Office symbol or organization receiving the endorsed memo.
         default: ORG/SYMBOL
       format:
-        title: Indorsement format
         type: string
         description: "Format style: 'standard' (formal on same page), 'informal' (less formal routing), or 'separate_page' (starts on new page)."
         default: standard
@@ -153,12 +132,10 @@ card_types:
         - informal
         - separate_page
       from:
-        title: From office/symbol
         type: string
         description: Office symbol or Rank Name of the endorsing official (e.g., 'ORG/SYMBOL').
         default: ORG/SYMBOL
       signature_block:
-        title: Signature block lines
         type: array
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
         default:

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -12,9 +12,9 @@ main:
       title: List of recipient organization(s)
       type: array
       required: true
-      examples:
-        - - ORG1/SYMBOL
-          - ORG2/SYMBOL
+      example:
+        - ORG1/SYMBOL
+        - ORG2/SYMBOL
       ui:
         group: Addressing
       description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
@@ -23,11 +23,11 @@ main:
       title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
       type: array
       required: true
-      examples:
-        - - ORG/SYMBOL
-          - Organization Name
-          - 123 Street Ave
-          - City ST 12345-6789
+      example:
+        - ORG/SYMBOL
+        - Organization Name
+        - 123 Street Ave
+        - City ST 12345-6789
       ui:
         group: Addressing
       description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
@@ -36,8 +36,7 @@ main:
       title: Subject of the memo
       type: string
       required: true
-      examples:
-        - Subject of the Memorandum
+      example: Subject of the Memorandum
       ui:
         group: Addressing
       description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
@@ -46,9 +45,9 @@ main:
       title: Signature block lines
       type: array
       required: true
-      examples:
-        - - "FIRST M. LAST, Rank, USSF"
-          - Duty Title
+      example:
+        - "FIRST M. LAST, Rank, USSF"
+        - Duty Title
       ui:
         group: Addressing
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
@@ -90,8 +89,8 @@ main:
       title: References for the memo
       type: array
       default: []
-      examples:
-        - - "AFM 33-326, 31 July 2019, Preparing Official Communications"
+      example:
+        - "AFM 33-326, 31 July 2019, Preparing Official Communications"
       ui:
         group: Additional
       description: "Cite by organization, type, date, and title."
@@ -100,8 +99,8 @@ main:
       title: Carbon copy recipients
       type: array
       default: []
-      examples:
-        - - Rank and Name, ORG/SYMBOL
+      example:
+        - Rank and Name, ORG/SYMBOL
       ui:
         group: Additional
       description: List office symbols of recipients to receive copies.
@@ -110,9 +109,9 @@ main:
       title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
       type: array
       default: []
-      examples:
-        - - ORG1/SYMBOL
-          - ORG2/SYMBOL
+      example:
+        - ORG1/SYMBOL
+        - ORG2/SYMBOL
       ui:
         group: Additional
       description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
@@ -121,8 +120,8 @@ main:
       title: List of attachments
       type: array
       default: []
-      examples:
-        - - Attachment description, YYYY MMM DD
+      example:
+        - Attachment description, YYYY MMM DD
       ui:
         group: Additional
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
@@ -131,8 +130,7 @@ main:
       title: Classification level of the memo that displays in the banner
       type: string
       default: ""
-      examples:
-        - CONFIDENTIAL
+      example: CONFIDENTIAL
       ui:
         group: Additional
       description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
@@ -141,8 +139,6 @@ main:
       title: Font size for the memo text (int pt)
       type: number
       default: 11
-      examples:
-        - 11
       ui:
         group: Additional
       description: Font size for the memo text (pt).
@@ -171,9 +167,9 @@ card_types:
       signature_block:
         title: Signature block lines
         type: array
-        examples:
-          - - "FIRST M. LAST, Rank, USAF"
-            - Duty Title
+        example:
+          - "FIRST M. LAST, Rank, USAF"
+          - Duty Title
         ui:
           group: Addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -9,7 +9,6 @@ quill:
 main:
   fields:
     memo_for:
-      title: List of recipient organization(s)
       type: array
       required: true
       example:
@@ -20,7 +19,6 @@ main:
       description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
 
     memo_from:
-      title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
       type: array
       required: true
       example:
@@ -33,7 +31,6 @@ main:
       description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
 
     subject:
-      title: Subject of the memo
       type: string
       required: true
       example: Subject of the Memorandum
@@ -42,7 +39,6 @@ main:
       description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
 
     signature_block:
-      title: Signature block lines
       type: array
       required: true
       example:
@@ -53,7 +49,6 @@ main:
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
 
     letterhead_title:
-      title: Title in letterhead
       type: string
       default: DEPARTMENT OF THE AIR FORCE
       ui:
@@ -61,7 +56,6 @@ main:
       description: Standard title. Only change for Joint Commands or DoW Agencies.
 
     letterhead_caption:
-      title: Letterhead caption line(s)
       type: array
       default:
         - HEADQUARTERS [UNIT NAME]
@@ -70,7 +64,6 @@ main:
       description: The full organization name of your unit.
 
     tag_line:
-      title: Tag line at bottom of memo
       type: string
       default: ""
       ui:
@@ -78,7 +71,6 @@ main:
       description: Organizational motto at the bottom of the page.
 
     date:
-      title: Date of memo (YYYY-MM-DD); defaults to today
       type: string
       default: ""
       ui:
@@ -86,7 +78,6 @@ main:
       description: YYYY-MM-DD. Leave blank to use today's date.
 
     references:
-      title: References for the memo
       type: array
       default: []
       example:
@@ -96,7 +87,6 @@ main:
       description: "Cite by organization, type, date, and title."
 
     cc:
-      title: Carbon copy recipients
       type: array
       default: []
       example:
@@ -106,7 +96,6 @@ main:
       description: List office symbols of recipients to receive copies.
 
     distribution:
-      title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
       type: array
       default: []
       example:
@@ -117,7 +106,6 @@ main:
       description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
 
     attachments:
-      title: List of attachments
       type: array
       default: []
       example:
@@ -127,7 +115,6 @@ main:
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
     classification:
-      title: Classification level of the memo that displays in the banner
       type: string
       default: ""
       example: CONFIDENTIAL
@@ -136,7 +123,6 @@ main:
       description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
 
     font_size:
-      title: Font size for the memo text (int pt)
       type: number
       default: 11
       ui:
@@ -145,27 +131,23 @@ main:
 
 card_types:
   indorsement:
-    title: Routing indorsement
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     ui:
       default_title: "{from} → {for}"
     fields:
       from:
-        title: From office/symbol
         type: string
         default: ORG/SYMBOL
         ui:
           group: Addressing
         description: "Office symbol or Rank Name of the endorsing official (e.g., 'ORG/SYMBOL')."
       for:
-        title: To office/symbol
         type: string
         default: ORG/SYMBOL
         ui:
           group: Addressing
         description: Office symbol or organization receiving the endorsed memo.
       signature_block:
-        title: Signature block lines
         type: array
         example:
           - "FIRST M. LAST, Rank, USAF"
@@ -178,7 +160,6 @@ card_types:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title
       format:
-        title: Indorsement format
         type: string
         enum:
           - standard
@@ -189,7 +170,6 @@ card_types:
         description: "Format style: 'standard' (formal on same page), 'informal' (less formal routing), or 'separate_page' (starts on new page)."
         default: standard
       action:
-        title: Action Decision
         type: string
         enum:
           - undecided
@@ -199,19 +179,16 @@ card_types:
           group: Addressing
         description: "Action taken by the endorser. Use 'undecided' to display the Approve/Disapprove line with neither option circled, 'approve' or 'disapprove' to circle the selected option."
       attachments:
-        title: Attachments for this endorsement
         type: array
         ui:
           group: Additional
         description: List of attachments specific to this endorsement.
       cc:
-        title: Carbon copy recipients
         type: array
         ui:
           group: Additional
         description: List of office symbols to receive copies of this endorsement.
       date:
-        title: Date of endorsement (YYYY-MM-DD)
         type: string
         ui:
           group: Additional

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -79,7 +79,7 @@ quillmark schema ./my-quill
 quillmark schema ./my-quill -o schema.yaml
 
 # Use with other tools
-quillmark schema ./my-quill | grep '^  title:'
+quillmark schema ./my-quill | grep '^  description:'
 ```
 
 ### validate

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -71,7 +71,7 @@ quill:
 
 ## `main` Section
 
-The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.title` and `main.description` describe the schema itself (independent of `quill.description`, which describes the quill package). Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
+The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.description` describes the schema itself (independent of `quill.description`, which describes the quill package). Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
 
 Field order under `main.fields` determines display order in UIs — the first field gets `order: 0`, the second gets `order: 1`, and so on.
 
@@ -81,7 +81,6 @@ Field keys must be `snake_case` (`^[a-z][a-z0-9_]*$`). Capitalized field keys ar
 main:
   fields:
     subject:          # Field name (used as the YAML frontmatter key)
-      title: Subject of the memo
       type: string
       required: true
       description: Be brief and clear.
@@ -92,7 +91,6 @@ main:
 | Property      | Type              | Required | Description |
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
-| `title`       | string            | no       | Short label shown in UIs |
 | `description` | string            | no       | Detailed help text |
 | `default`     | any               | no       | Default value when not provided |
 | `examples`    | array             | no       | Example values for documentation and LLMs |
@@ -257,14 +255,13 @@ main:
 
 ## `card_types` Section
 
-`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `title`, `description`, `ui`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
+`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
 
 Card-type names (the keys under `card_types`) must match `[a-z_][a-z0-9_]*` (leading underscore is allowed).
 
 ```yaml
 card_types:
   indorsement:                    # Card-type name
-    title: Routing indorsement    # Display label
     description: Chain of routing endorsements.
     fields:
       from:
@@ -287,7 +284,6 @@ Invalid card-type names include:
 
 | Property      | Type   | Required | Description |
 |---------------|--------|----------|-------------|
-| `title`       | string | no       | Display label for the card type |
 | `description` | string | no       | Help text describing the card's purpose |
 | `fields`      | object | no       | Field schemas (same structure as top-level fields) |
 | `ui`          | object | no       | Container-level UI hints |
@@ -304,7 +300,6 @@ Invalid card-type names include:
 ```yaml
 card_types:
   metadata_block:
-    title: Metadata
     ui:
       hide_body: true    # Card has fields only, no body/content editor
     fields:
@@ -319,16 +314,14 @@ A template string that UI consumers interpolate with field values to produce a h
 ```yaml
 card_types:
   entry:
-    title: Card Title
     ui:
       default_title: "{name}"
     fields:
       name:
         type: string
-        title: Name
 ```
 
-With the above, a UI rendering a list of `entry` cards can title each instance (e.g. `"Project Alpha"`) instead of falling back to a generic `"Card Title (2)"`.
+With the above, a UI rendering a list of `entry` cards can title each instance (e.g. `"Project Alpha"`) instead of falling back to a generic `"Card (2)"`.
 
 **Interpolation rules (for UI consumers):**
 - `{field_name}` is replaced with the current value of that field.
@@ -411,14 +404,12 @@ quill:
 main:
   fields:
     project_name:
-      title: Project name
       type: string
       required: true
       ui:
         group: Header
 
     status:
-      title: Overall status
       type: string
       required: true
       enum: [on_track, at_risk, blocked]
@@ -426,20 +417,17 @@ main:
         group: Header
 
     risk_description:
-      title: Risk description
       type: string
       ui:
         group: Header
       description: Describe the risk or blocker. Only needed when status is not on_track.
 
     date:
-      title: Report date
       type: date
       ui:
         group: Header
 
     team_members:
-      title: Team members
       type: array
       items:
         type: string
@@ -447,7 +435,6 @@ main:
         group: Team
 
     budget:
-      title: Budget amount
       type: number
       default: 0
       ui:
@@ -455,7 +442,6 @@ main:
 
 card_types:
   milestone:
-    title: Milestone
     description: A project milestone with target date and status.
     fields:
       name:

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -64,9 +64,9 @@ recursively stripping `ui` keys after serialisation.
 
 Top-level keys: `main`, optional `card_types` (map keyed by card name).
 `main` and each entry in `card_types` share the same `CardSchema` shape:
-`fields` (map keyed by field name), optional `title`, `description`, and —
+`fields` (map keyed by field name), optional `description`, and —
 in `form_schema()` only — `ui`. Each `FieldSchema` includes `type`,
-optional `title`/`description`/`default`/`examples`/`enum`/`properties`/
+optional `description`/`default`/`example`/`enum`/`properties`/
 `items`, optional `required` (omitted when false), and — in `form_schema()`
 only — optional `ui`.
 


### PR DESCRIPTION
- Rename FieldSchema.examples (array) → example (single Optional value),
  removing the array-wrapping normalization logic
- Remove CardSchema::examples() method
- Update all Quill.yaml fixtures to use example: with outer list unwrapped
- Remove quill.examples Python binding and examples_count CLI info line
- Update WASM TypeScript type hint examples? → example?
- Add QuillConfig::template() in new template.rs: generates a fill-in-the-
  blank Markdown document with placeholder values (example > default >
  type-based), inline # required / enum comments, and <body> placeholders
- Expose quill.template in Python and WASM bindings
- Regenerate golden schema snapshots for usaf_memo 0.1.0

https://claude.ai/code/session_018vHaPdob1Qio4VgTLb6BSw