### PR TITLE
Preserve inline YAML comments through round-trip

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -749,9 +749,10 @@ fn card_to_pydict<'py>(
                 entry.set_item("value", quillvalue_to_py(py, value)?)?;
                 entry.set_item("fill", *fill)?;
             }
-            quillmark_core::FrontmatterItem::Comment { text } => {
+            quillmark_core::FrontmatterItem::Comment { text, inline } => {
                 entry.set_item("kind", "comment")?;
                 entry.set_item("text", text)?;
+                entry.set_item("inline", *inline)?;
             }
         }
         items.append(entry)?;

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -155,7 +155,7 @@ pub struct RenderResult {
     pub render_time_ms: f64,
 }
 
-/// A single frontmatter item — either a field or an own-line comment.
+/// A single frontmatter item — either a field or a comment line.
 ///
 /// Exposed via `Card.frontmatterItems`.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -173,6 +173,13 @@ pub enum FrontmatterItem {
     },
     Comment {
         text: String,
+        /// `true` when the comment was a trailing inline comment in source
+        /// (`field: value # text`). Inline comments attach to the previous
+        /// field on emit; `Comment{inline:true}` at index 0 attaches to the
+        /// sentinel line. Inline comments without a host degrade to
+        /// own-line on emit.
+        #[serde(default)]
+        inline: bool,
     },
 }
 
@@ -221,8 +228,11 @@ impl From<&quillmark_core::Card> for Card {
                         fill: *fill,
                     }
                 }
-                quillmark_core::FrontmatterItem::Comment { text } => {
-                    FrontmatterItem::Comment { text: text.clone() }
+                quillmark_core::FrontmatterItem::Comment { text, inline } => {
+                    FrontmatterItem::Comment {
+                        text: text.clone(),
+                        inline: *inline,
+                    }
                 }
             })
             .collect();

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -336,7 +336,10 @@ fn build_frontmatter_from_pre_and_parsed(
 
     for pre in pre_items {
         match pre {
-            PreItem::Comment(text) => items.push(FrontmatterItem::comment(text.clone())),
+            PreItem::Comment { text, inline } => items.push(FrontmatterItem::Comment {
+                text: text.clone(),
+                inline: *inline,
+            }),
             PreItem::Field { key, fill } => {
                 // QUILL / CARD sentinel keys are stripped from the parsed
                 // map by `extract_sentinels`; skip them in the item list.

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -70,11 +70,20 @@ impl Document {
     ///   - Empty object (`{}`) → the key is **omitted** from emit entirely.
     ///   - Empty array (`[]`) → emitted as `key: []\n`.
     ///
+    /// # What is preserved
+    ///
+    /// - **YAML comments**: own-line and inline trailing comments round-trip
+    ///   at their source position. Inline comments on sentinel lines
+    ///   (`QUILL: r # …` / `CARD: t # …`) round-trip too. Comments whose
+    ///   host disappears at emit time (empty-mapping omission, programmatic
+    ///   field removal) degrade to own-line comments at the same indent so
+    ///   the comment text is preserved even when its position shifts.
+    /// - **`!fill` tags**: round-trip via the `fill` flag on `FrontmatterItem::Field`.
+    ///
     /// # What is lost
     ///
-    /// - **YAML comments**: stripped during parsing; not stored in `Document`.
-    /// - **Custom tags** (`!fill`): the tag is dropped; the scalar value is
-    ///   preserved.  On re-emit the tag does not appear.
+    /// - **Other custom tags** (`!include`, `!env`, …): the tag is dropped;
+    ///   the scalar value is preserved.
     /// - **Original quoting style**: all strings are re-emitted double-quoted
     ///   regardless of how they were written in the source.
     pub fn to_markdown(&self) -> String {
@@ -103,6 +112,22 @@ impl Document {
 
 /// Emit a card's metadata fence (between `---\n` markers), including the
 /// sentinel line and every frontmatter item.
+///
+/// ## Inline-comment handling
+///
+/// - **Sentinel-inline preview.** If `items[0]` is a `Comment{inline:true}`,
+///   its text is appended to the sentinel line (`QUILL: r # text` /
+///   `CARD: tag # text`) and the item is skipped. This is the only way to
+///   round-trip a source-level inline comment on the sentinel line.
+/// - **Field + trailing inline.** When iterating items, a `Field` peeks at
+///   its successor: if the next item is `Comment{inline:true}`, the comment
+///   text is passed to `emit_field` as a trailer and consumed here. The
+///   trailer lands on the field's key/value line.
+/// - **Orphan inline.** A `Comment{inline:true}` that is *not* consumed by
+///   either the sentinel preview or a field's lookahead has no host. It is
+///   emitted as an own-line `# text` comment instead. This is also the
+///   degrade path for empty-object fields (whose key is omitted) — the
+///   trailer becomes an own-line comment at the same indent.
 fn emit_card_fence(out: &mut String, card: &Card) {
     out.push_str("---\n");
 
@@ -120,18 +145,42 @@ fn emit_card_fence(out: &mut String, card: &Card) {
         }
     }
 
-    // Frontmatter items in order.
     let nested = card.frontmatter().nested_comments();
-    for item in card.frontmatter().items() {
-        match item {
+    let items = card.frontmatter().items();
+    let mut i = 0;
+
+    // Sentinel-inline preview.
+    if let Some(FrontmatterItem::Comment {
+        text,
+        inline: true,
+    }) = items.first()
+    {
+        attach_inline_to_last_line(out, text);
+        i = 1;
+    }
+
+    while i < items.len() {
+        match &items[i] {
             FrontmatterItem::Field { key, value, fill } => {
+                let trailer = items.get(i + 1).and_then(|next| match next {
+                    FrontmatterItem::Comment {
+                        text,
+                        inline: true,
+                    } => Some(text.as_str()),
+                    _ => None,
+                });
                 let path = vec![CommentPathSegment::Key(key.clone())];
-                emit_field(out, key, value.as_json(), 0, *fill, &path, nested);
+                emit_field(out, key, value.as_json(), 0, *fill, &path, nested, trailer);
+                i += if trailer.is_some() { 2 } else { 1 };
             }
-            FrontmatterItem::Comment { text } => {
+            FrontmatterItem::Comment { text, .. } => {
+                // Either own-line, or an inline orphan (lookahead would have
+                // consumed any inline whose predecessor was a Field). Both
+                // render as own-line.
                 out.push_str("# ");
                 out.push_str(text);
                 out.push('\n');
+                i += 1;
             }
         }
     }
@@ -163,9 +212,29 @@ fn ensure_f2_before_fence(out: &mut String) {
 
 // ── YAML value emission ───────────────────────────────────────────────────────
 
-/// Emit comments captured at `path` whose `position` matches `position`,
-/// each as a `# text` line indented by `indent` spaces.
-fn emit_pending_comments(
+/// Strip the trailing `\n` from `out`, append ` # text`, and restore `\n`.
+///
+/// The caller is responsible for ensuring the previous line is a valid host
+/// for an inline comment (a field/sequence-item line, not a fence or another
+/// comment line).
+fn attach_inline_to_last_line(out: &mut String, text: &str) {
+    if !out.ends_with('\n') {
+        // Defensive: shouldn't happen given how this is called.
+        out.push_str(" # ");
+        out.push_str(text);
+        out.push('\n');
+        return;
+    }
+    out.pop();
+    out.push_str(" # ");
+    out.push_str(text);
+    out.push('\n');
+}
+
+/// Emit own-line nested comments at `position` in `path` as `# text` lines
+/// indented by `indent` spaces. Inline comments are skipped here — they are
+/// consumed by `find_inline_trailer` at the host's emission site.
+fn emit_own_line_pending(
     out: &mut String,
     path: &[CommentPathSegment],
     position: usize,
@@ -173,12 +242,68 @@ fn emit_pending_comments(
     nested: &[NestedComment],
 ) {
     for c in nested {
-        if c.position == position && c.container_path.as_slice() == path {
+        if c.position == position && !c.inline && c.container_path.as_slice() == path {
             push_indent(out, indent);
             out.push_str("# ");
             out.push_str(&c.text);
             out.push('\n');
         }
+    }
+}
+
+/// Look up the inline trailer for the child at `position` in `path`. If
+/// multiple inline comments share this slot (programmatic edge case), the
+/// first one is returned and the rest are emitted as own-line comments at
+/// `indent` to preserve their text.
+fn find_inline_trailer<'a>(
+    out: &mut String,
+    path: &[CommentPathSegment],
+    position: usize,
+    indent: usize,
+    nested: &'a [NestedComment],
+) -> Option<&'a str> {
+    let mut chosen: Option<&str> = None;
+    for c in nested {
+        if c.position == position && c.inline && c.container_path.as_slice() == path {
+            if chosen.is_none() {
+                chosen = Some(c.text.as_str());
+            } else {
+                push_indent(out, indent);
+                out.push_str("# ");
+                out.push_str(&c.text);
+                out.push('\n');
+            }
+        }
+    }
+    chosen
+}
+
+/// Emit any orphan inline comments (`inline=true` with `position >=
+/// container_len`) as own-line comments at the trailing slot. These are
+/// programmatic edge cases — well-formed prescan output never produces them.
+fn emit_orphan_inlines(
+    out: &mut String,
+    path: &[CommentPathSegment],
+    container_len: usize,
+    indent: usize,
+    nested: &[NestedComment],
+) {
+    for c in nested {
+        if c.inline && c.position >= container_len && c.container_path.as_slice() == path {
+            push_indent(out, indent);
+            out.push_str("# ");
+            out.push_str(&c.text);
+            out.push('\n');
+        }
+    }
+}
+
+/// Append ` # trailer` to `out` if `trailer` is `Some`. Caller writes the
+/// terminating `\n` afterwards.
+fn push_trailer(out: &mut String, trailer: Option<&str>) {
+    if let Some(t) = trailer {
+        out.push_str(" # ");
+        out.push_str(t);
     }
 }
 
@@ -188,7 +313,14 @@ fn emit_pending_comments(
 /// the *container* path when recursing into the value: nested comments
 /// captured at this path are interleaved between the value's children.
 ///
-/// - Empty objects are **omitted** (caller skips them).
+/// `inline_trailer`, when `Some`, is rendered as ` # text` on the field's
+/// key/value line. For scalars this trails the value; for containers it
+/// trails the `key:` line (before the indented children).
+///
+/// - Empty objects are **omitted** (caller skips them). An empty-object
+///   field with an inline trailer degrades the trailer to an own-line
+///   comment at `indent`, so the comment text is preserved even though its
+///   host disappears.
 /// - Empty arrays emit `key: []\n`.
 /// - All other values follow the block-style rules.
 /// - When `fill` is `true`, the emitted form is `key: !fill <value>` for
@@ -203,28 +335,39 @@ fn emit_field(
     fill: bool,
     path: &[CommentPathSegment],
     nested: &[NestedComment],
+    inline_trailer: Option<&str>,
 ) {
     if fill {
         push_indent(out, indent);
         out.push_str(key);
         match value {
-            JsonValue::Null => out.push_str(": !fill\n"),
+            JsonValue::Null => {
+                out.push_str(": !fill");
+                push_trailer(out, inline_trailer);
+                out.push('\n');
+            }
             JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
                 out.push_str(": !fill ");
                 emit_scalar(out, value);
+                push_trailer(out, inline_trailer);
                 out.push('\n');
             }
             JsonValue::Array(items) if items.is_empty() => {
-                out.push_str(": !fill []\n");
+                out.push_str(": !fill []");
+                push_trailer(out, inline_trailer);
+                out.push('\n');
             }
             JsonValue::Array(items) => {
-                out.push_str(": !fill\n");
+                out.push_str(": !fill");
+                push_trailer(out, inline_trailer);
+                out.push('\n');
                 emit_sequence_children(out, items, indent + 2, path, nested);
             }
             JsonValue::Object(_) => {
                 // Parser rejects !fill on mappings; recovery path only.
                 out.push_str(": ");
                 emit_scalar(out, value);
+                push_trailer(out, inline_trailer);
                 out.push('\n');
             }
         }
@@ -232,24 +375,37 @@ fn emit_field(
     }
     match value {
         JsonValue::Object(map) if map.is_empty() => {
-            // Empty object → omit the key entirely.
-            return;
+            // Empty object → omit the key entirely. If there's an inline
+            // trailer, degrade it to an own-line comment so its text isn't
+            // lost.
+            if let Some(t) = inline_trailer {
+                push_indent(out, indent);
+                out.push_str("# ");
+                out.push_str(t);
+                out.push('\n');
+            }
         }
         JsonValue::Object(map) => {
             push_indent(out, indent);
             out.push_str(key);
-            out.push_str(":\n");
+            out.push(':');
+            push_trailer(out, inline_trailer);
+            out.push('\n');
             emit_mapping_children(out, map, indent + 2, path, nested);
         }
         JsonValue::Array(items) if items.is_empty() => {
             push_indent(out, indent);
             out.push_str(key);
-            out.push_str(": []\n");
+            out.push_str(": []");
+            push_trailer(out, inline_trailer);
+            out.push('\n');
         }
         JsonValue::Array(items) => {
             push_indent(out, indent);
             out.push_str(key);
-            out.push_str(":\n");
+            out.push(':');
+            push_trailer(out, inline_trailer);
+            out.push('\n');
             emit_sequence_children(out, items, indent + 2, path, nested);
         }
         _ => {
@@ -257,6 +413,7 @@ fn emit_field(
             out.push_str(key);
             out.push_str(": ");
             emit_scalar(out, value);
+            push_trailer(out, inline_trailer);
             out.push('\n');
         }
     }
@@ -275,12 +432,14 @@ fn emit_mapping_children(
     nested: &[NestedComment],
 ) {
     for (i, (k, v)) in map.iter().enumerate() {
-        emit_pending_comments(out, path, i, child_indent, nested);
+        emit_own_line_pending(out, path, i, child_indent, nested);
+        let trailer = find_inline_trailer(out, path, i, child_indent, nested);
         let mut child_path = path.to_vec();
         child_path.push(CommentPathSegment::Key(k.clone()));
-        emit_field(out, k, v, child_indent, false, &child_path, nested);
+        emit_field(out, k, v, child_indent, false, &child_path, nested, trailer);
     }
-    emit_pending_comments(out, path, map.len(), child_indent, nested);
+    emit_own_line_pending(out, path, map.len(), child_indent, nested);
+    emit_orphan_inlines(out, path, map.len(), child_indent, nested);
 }
 
 /// Emit the children of a sequence value with comment interleaving.
@@ -295,70 +454,114 @@ fn emit_sequence_children(
     nested: &[NestedComment],
 ) {
     for (i, item) in items.iter().enumerate() {
-        emit_pending_comments(out, path, i, base_indent, nested);
+        emit_own_line_pending(out, path, i, base_indent, nested);
+        let trailer = find_inline_trailer(out, path, i, base_indent, nested);
         let mut child_path = path.to_vec();
         child_path.push(CommentPathSegment::Index(i));
-        emit_sequence_item(out, item, base_indent, &child_path, nested);
+        emit_sequence_item(out, item, base_indent, &child_path, nested, trailer);
     }
-    emit_pending_comments(out, path, items.len(), base_indent, nested);
+    emit_own_line_pending(out, path, items.len(), base_indent, nested);
+    emit_orphan_inlines(out, path, items.len(), base_indent, nested);
 }
 
 /// Emit a single `- <value>\n` sequence item at `base_indent` spaces.
 ///
 /// `path` is the path to *this* item (parent path + item index).
+///
+/// `inline_trailer`, when `Some`, is rendered as ` # text` on the `-` line.
+/// For mapping items the trailer co-exists with any inline trailer at index
+/// 0 of the inner mapping (the latter would be on the same physical line);
+/// in well-formed input only one of them is present, but if both appear
+/// the inner one degrades to an own-line comment beneath the `- ` line.
 fn emit_sequence_item(
     out: &mut String,
     value: &JsonValue,
     base_indent: usize,
     path: &[CommentPathSegment],
     nested: &[NestedComment],
+    inline_trailer: Option<&str>,
 ) {
     match value {
         JsonValue::Object(map) if map.is_empty() => {
             // Empty nested object in a sequence: emit as `- {}`
             push_indent(out, base_indent);
-            out.push_str("- {}\n");
+            out.push_str("- {}");
+            push_trailer(out, inline_trailer);
+            out.push('\n');
         }
         JsonValue::Object(map) => {
-            // Block mapping inside a sequence.
-            // First key on same line as `- `, subsequent keys indented by 2.
-            // Comments inside this mapping use this item's path as the
-            // container. There is no slot to emit a "before-first-key"
-            // comment naturally, so we emit them as a leading line above
-            // the `- ` prefix at the same indent.
-            emit_pending_comments(out, path, 0, base_indent, nested);
+            // Block mapping inside a sequence. First key on the same line
+            // as `- `; subsequent keys indented by 2. Comments inside this
+            // mapping use this item's path as the container.
+            emit_own_line_pending(out, path, 0, base_indent, nested);
+
             let mut first = true;
             for (i, (k, v)) in map.iter().enumerate() {
                 if !first {
-                    emit_pending_comments(out, path, i, base_indent + 2, nested);
+                    emit_own_line_pending(out, path, i, base_indent + 2, nested);
                 }
+                let inner_trailer =
+                    find_inline_trailer(out, path, i, base_indent + 2, nested);
                 let mut child_path = path.to_vec();
                 child_path.push(CommentPathSegment::Key(k.clone()));
                 if first {
+                    // The seq-item's trailer and the first key's trailer
+                    // both target the `- key: ...` line. Prefer the
+                    // seq-item's; degrade the loser to own-line.
+                    let line_trailer = inline_trailer.or(inner_trailer);
                     push_indent(out, base_indent);
                     out.push_str("- ");
-                    emit_field_inline(out, k, v, base_indent + 2, &child_path, nested);
+                    emit_field_inline(
+                        out,
+                        k,
+                        v,
+                        base_indent + 2,
+                        &child_path,
+                        nested,
+                        line_trailer,
+                    );
+                    if let (Some(_), Some(loser)) = (inline_trailer, inner_trailer) {
+                        push_indent(out, base_indent + 2);
+                        out.push_str("# ");
+                        out.push_str(loser);
+                        out.push('\n');
+                    }
                     first = false;
                 } else {
-                    emit_field(out, k, v, base_indent + 2, false, &child_path, nested);
+                    emit_field(
+                        out,
+                        k,
+                        v,
+                        base_indent + 2,
+                        false,
+                        &child_path,
+                        nested,
+                        inner_trailer,
+                    );
                 }
             }
-            emit_pending_comments(out, path, map.len(), base_indent + 2, nested);
+            emit_own_line_pending(out, path, map.len(), base_indent + 2, nested);
+            emit_orphan_inlines(out, path, map.len(), base_indent + 2, nested);
         }
         JsonValue::Array(inner) if inner.is_empty() => {
             push_indent(out, base_indent);
-            out.push_str("- []\n");
+            out.push_str("- []");
+            push_trailer(out, inline_trailer);
+            out.push('\n');
         }
         JsonValue::Array(inner) => {
-            // Nested sequence: emit `- ` for first item, then recurse.
+            // Nested sequence: `-` line then recurse.
             push_indent(out, base_indent);
-            out.push_str("-\n");
+            out.push('-');
+            push_trailer(out, inline_trailer);
+            out.push('\n');
             emit_sequence_children(out, inner, base_indent + 2, path, nested);
         }
         _ => {
             push_indent(out, base_indent);
             out.push_str("- ");
             emit_scalar(out, value);
+            push_trailer(out, inline_trailer);
             out.push('\n');
         }
     }
@@ -373,31 +576,40 @@ fn emit_field_inline(
     child_indent: usize,
     path: &[CommentPathSegment],
     nested: &[NestedComment],
+    inline_trailer: Option<&str>,
 ) {
     match value {
         JsonValue::Object(map) if map.is_empty() => {
-            // key: {}
             out.push_str(key);
-            out.push_str(": {}\n");
+            out.push_str(": {}");
+            push_trailer(out, inline_trailer);
+            out.push('\n');
         }
         JsonValue::Object(map) => {
             out.push_str(key);
-            out.push_str(":\n");
+            out.push(':');
+            push_trailer(out, inline_trailer);
+            out.push('\n');
             emit_mapping_children(out, map, child_indent, path, nested);
         }
         JsonValue::Array(items) if items.is_empty() => {
             out.push_str(key);
-            out.push_str(": []\n");
+            out.push_str(": []");
+            push_trailer(out, inline_trailer);
+            out.push('\n');
         }
         JsonValue::Array(items) => {
             out.push_str(key);
-            out.push_str(":\n");
+            out.push(':');
+            push_trailer(out, inline_trailer);
+            out.push('\n');
             emit_sequence_children(out, items, child_indent + 2, path, nested);
         }
         _ => {
             out.push_str(key);
             out.push_str(": ");
             emit_scalar(out, value);
+            push_trailer(out, inline_trailer);
             out.push('\n');
         }
     }
@@ -519,8 +731,27 @@ mod tests {
             false,
             &p("empty_map"),
             &[],
+            None,
         );
         assert_eq!(out, ""); // omitted
+    }
+
+    #[test]
+    fn empty_object_with_inline_trailer_degrades() {
+        let value = QuillValue::from_json(serde_json::json!({}));
+        let mut out = String::new();
+        emit_field(
+            &mut out,
+            "empty_map",
+            value.as_json(),
+            0,
+            false,
+            &p("empty_map"),
+            &[],
+            Some("orphan"),
+        );
+        // Host omitted; trailer survives as own-line at the same indent.
+        assert_eq!(out, "# orphan\n");
     }
 
     #[test]
@@ -535,8 +766,44 @@ mod tests {
             false,
             &p("empty_seq"),
             &[],
+            None,
         );
         assert_eq!(out, "empty_seq: []\n");
+    }
+
+    #[test]
+    fn scalar_field_with_inline_trailer() {
+        let value = QuillValue::from_json(serde_json::json!("Hello"));
+        let mut out = String::new();
+        emit_field(
+            &mut out,
+            "title",
+            value.as_json(),
+            0,
+            false,
+            &p("title"),
+            &[],
+            Some("greeting"),
+        );
+        assert_eq!(out, "title: \"Hello\" # greeting\n");
+    }
+
+    #[test]
+    fn container_field_with_inline_trailer_lands_on_key_line() {
+        let value = QuillValue::from_json(serde_json::json!({"inner": 1}));
+        let mut out = String::new();
+        emit_field(
+            &mut out,
+            "outer",
+            value.as_json(),
+            0,
+            false,
+            &p("outer"),
+            &[],
+            Some("note"),
+        );
+        // Trailer lands on the key line, not after the children.
+        assert_eq!(out, "outer: # note\n  inner: 1\n");
     }
 
     #[test]
@@ -551,6 +818,7 @@ mod tests {
             true,
             &p("recipient"),
             &[],
+            None,
         );
         assert_eq!(out, "recipient: !fill\n");
     }
@@ -559,8 +827,34 @@ mod tests {
     fn fill_string_emits_tag_with_value() {
         let value = QuillValue::from_json(serde_json::json!("placeholder"));
         let mut out = String::new();
-        emit_field(&mut out, "dept", value.as_json(), 0, true, &p("dept"), &[]);
+        emit_field(
+            &mut out,
+            "dept",
+            value.as_json(),
+            0,
+            true,
+            &p("dept"),
+            &[],
+            None,
+        );
         assert_eq!(out, "dept: !fill \"placeholder\"\n");
+    }
+
+    #[test]
+    fn fill_with_inline_trailer() {
+        let value = QuillValue::from_json(serde_json::json!("placeholder"));
+        let mut out = String::new();
+        emit_field(
+            &mut out,
+            "dept",
+            value.as_json(),
+            0,
+            true,
+            &p("dept"),
+            &[],
+            Some("note"),
+        );
+        assert_eq!(out, "dept: !fill \"placeholder\" # note\n");
     }
 
     #[test]
@@ -575,6 +869,7 @@ mod tests {
             true,
             &p("count"),
             &[],
+            None,
         );
         assert_eq!(out, "count: !fill 42\n");
     }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -150,11 +150,7 @@ fn emit_card_fence(out: &mut String, card: &Card) {
     let mut i = 0;
 
     // Sentinel-inline preview.
-    if let Some(FrontmatterItem::Comment {
-        text,
-        inline: true,
-    }) = items.first()
-    {
+    if let Some(FrontmatterItem::Comment { text, inline: true }) = items.first() {
         attach_inline_to_last_line(out, text);
         i = 1;
     }
@@ -163,10 +159,7 @@ fn emit_card_fence(out: &mut String, card: &Card) {
         match &items[i] {
             FrontmatterItem::Field { key, value, fill } => {
                 let trailer = items.get(i + 1).and_then(|next| match next {
-                    FrontmatterItem::Comment {
-                        text,
-                        inline: true,
-                    } => Some(text.as_str()),
+                    FrontmatterItem::Comment { text, inline: true } => Some(text.as_str()),
                     _ => None,
                 });
                 let path = vec![CommentPathSegment::Key(key.clone())];
@@ -500,8 +493,7 @@ fn emit_sequence_item(
                 if !first {
                     emit_own_line_pending(out, path, i, base_indent + 2, nested);
                 }
-                let inner_trailer =
-                    find_inline_trailer(out, path, i, base_indent + 2, nested);
+                let inner_trailer = find_inline_trailer(out, path, i, base_indent + 2, nested);
                 let mut child_path = path.to_vec();
                 child_path.push(CommentPathSegment::Key(k.clone()));
                 if first {

--- a/crates/core/src/document/frontmatter.rs
+++ b/crates/core/src/document/frontmatter.rs
@@ -30,9 +30,20 @@ pub enum FrontmatterItem {
         #[serde(default)]
         fill: bool,
     },
-    /// An own-line YAML comment. Text excludes the leading `#` and one
-    /// optional space.
-    Comment { text: String },
+    /// A YAML comment. Text excludes the leading `#` and one optional space.
+    ///
+    /// `inline` distinguishes own-line comments (`# text` on a line by
+    /// itself) from trailing inline comments (`field: value # text`). An
+    /// inline comment attaches to the field that immediately precedes it
+    /// in the items vector; if no such field exists at emit time (orphan)
+    /// it degrades to an own-line comment. A `Comment { inline: true }` at
+    /// `items[0]` instead attaches to the sentinel line (`QUILL: …` /
+    /// `CARD: …`).
+    Comment {
+        text: String,
+        #[serde(default)]
+        inline: bool,
+    },
 }
 
 impl FrontmatterItem {
@@ -45,9 +56,21 @@ impl FrontmatterItem {
         }
     }
 
-    /// Build a comment item.
+    /// Build an own-line comment item.
     pub fn comment(text: impl Into<String>) -> Self {
-        FrontmatterItem::Comment { text: text.into() }
+        FrontmatterItem::Comment {
+            text: text.into(),
+            inline: false,
+        }
+    }
+
+    /// Build an inline (trailing) comment item. Attaches to the previous
+    /// field on emit; degrades to own-line if none exists.
+    pub fn comment_inline(text: impl Into<String>) -> Self {
+        FrontmatterItem::Comment {
+            text: text.into(),
+            inline: true,
+        }
     }
 }
 
@@ -328,7 +351,7 @@ mod tests {
             .items()
             .iter()
             .filter_map(|item| match item {
-                FrontmatterItem::Comment { text } => Some(text.as_str()),
+                FrontmatterItem::Comment { text, .. } => Some(text.as_str()),
                 FrontmatterItem::Field { .. } => None,
             })
             .collect();

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -29,10 +29,15 @@ use crate::Severity;
 /// `Comment` stands alone; `Field` captures only the `fill` flag because the
 /// value is produced by serde_saphyr parsing the cleaned text. The matching
 /// YAML key is the lookup key into the parsed map.
+///
+/// `Comment.inline` distinguishes own-line comments (`# text` on a line by
+/// itself) from inline trailing comments (`field: value # text`). Inline
+/// top-level comments always immediately follow their host `Field` in the
+/// item stream; the emitter peeks ahead by one slot to attach them.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PreItem {
     Field { key: String, fill: bool },
-    Comment(String),
+    Comment { text: String, inline: bool },
 }
 
 /// One segment of a path into the parsed YAML structure.
@@ -44,15 +49,23 @@ pub enum CommentPathSegment {
 
 /// A comment that appears inside a nested mapping or sequence.
 ///
-/// `container_path` locates the immediate parent container; `position` is
-/// the ordinal within that container's child list before which the comment
-/// sits. A position equal to the container's length means "after all
-/// children".
+/// `container_path` locates the immediate parent container.
+///
+/// Position semantics depend on `inline`:
+/// - **Own-line (`inline = false`)**: `position` is the slot ordinal within
+///   the container's child list, ranging `0..=child_count`. The comment is
+///   rendered before the child at this position. `position == child_count`
+///   means "after all children".
+/// - **Inline (`inline = true`)**: `position` is the host child's index,
+///   ranging `0..child_count`. The comment is attached to that child's
+///   trailing line. An inline comment whose host is missing at emit time
+///   (orphan) degrades to an own-line comment at the same indent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NestedComment {
     pub container_path: Vec<CommentPathSegment>,
     pub position: usize,
     pub text: String,
+    pub inline: bool,
 }
 
 /// Output of [`prescan_fence_content`].
@@ -150,12 +163,16 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
 
             if frame.path.is_empty() {
                 // Top-level comment — preserve via PreItem::Comment.
-                out.items.push(PreItem::Comment(text.to_string()));
+                out.items.push(PreItem::Comment {
+                    text: text.to_string(),
+                    inline: false,
+                });
             } else {
                 out.nested_comments.push(NestedComment {
                     container_path: frame.path.clone(),
                     position: frame.child_count,
                     text: text.to_string(),
+                    inline: false,
                 });
             }
             // Don't emit the line into the cleaned YAML — serde_saphyr
@@ -222,14 +239,15 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
             // Otherwise: inline scalar value, no further nesting.
 
             // Rebuild the line with the trailing comment stripped, and
-            // capture it as a NestedComment that lands after this item.
+            // capture it as an inline NestedComment attached to this item.
             if let Some(c) = trailing_comment {
                 let stripped = c.trim_start_matches('#');
                 let text = stripped.strip_prefix(' ').unwrap_or(stripped);
                 out.nested_comments.push(NestedComment {
                     container_path: parent_path,
-                    position: item_index + 1,
+                    position: item_index,
                     text: text.to_string(),
+                    inline: true,
                 });
                 let head = format!("{:width$}", "", width = indent);
                 let body = if after_dash.trim_end().is_empty() {
@@ -309,7 +327,10 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
                 if let Some(c) = trailing_comment {
                     let stripped = c.trim_start_matches('#');
                     let text = stripped.strip_prefix(' ').unwrap_or(stripped);
-                    out.items.push(PreItem::Comment(text.to_string()));
+                    out.items.push(PreItem::Comment {
+                        text: text.to_string(),
+                        inline: true,
+                    });
                 }
 
                 continue;
@@ -338,15 +359,16 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
 
             // Detach a possible trailing comment on the line. We keep the
             // value (sans comment) in the cleaned YAML and capture the
-            // comment as a NestedComment that lands after this entry.
+            // comment as an inline NestedComment attached to this key.
             let (value_part, trailing_comment) = split_trailing_comment(&after_colon);
             if let Some(c) = trailing_comment {
                 let stripped = c.trim_start_matches('#');
                 let text = stripped.strip_prefix(' ').unwrap_or(stripped);
                 out.nested_comments.push(NestedComment {
                     container_path: parent_path,
-                    position: key_index + 1,
+                    position: key_index,
                     text: text.to_string(),
+                    inline: true,
                 });
                 let head = format!("{:width$}", "", width = indent);
                 cleaned_lines.push(format!("{}{}:{}", head, key, value_part));
@@ -580,12 +602,18 @@ mod tests {
         assert_eq!(
             out.items,
             vec![
-                PreItem::Comment("top".to_string()),
+                PreItem::Comment {
+                    text: "top".to_string(),
+                    inline: false,
+                },
                 PreItem::Field {
                     key: "title".to_string(),
                     fill: false,
                 },
-                PreItem::Comment("mid".to_string()),
+                PreItem::Comment {
+                    text: "mid".to_string(),
+                    inline: false,
+                },
                 PreItem::Field {
                     key: "author".to_string(),
                     fill: false,
@@ -606,7 +634,10 @@ mod tests {
                     key: "title".to_string(),
                     fill: false,
                 },
-                PreItem::Comment("inline".to_string()),
+                PreItem::Comment {
+                    text: "inline".to_string(),
+                    inline: true,
+                },
             ]
         );
         assert!(out.cleaned_yaml.contains("title: foo"));
@@ -665,16 +696,19 @@ mod tests {
                     container_path: vec![CommentPathSegment::Key("arr".to_string())],
                     position: 0,
                     text: "before-first".to_string(),
+                    inline: false,
                 },
                 NestedComment {
                     container_path: vec![CommentPathSegment::Key("arr".to_string())],
                     position: 1,
                     text: "between".to_string(),
+                    inline: false,
                 },
                 NestedComment {
                     container_path: vec![CommentPathSegment::Key("arr".to_string())],
                     position: 2,
                     text: "after-last".to_string(),
+                    inline: false,
                 },
             ]
         );
@@ -696,6 +730,7 @@ mod tests {
                 container_path: vec![CommentPathSegment::Key("outer".to_string())],
                 position: 0,
                 text: "comment".to_string(),
+                inline: false,
             }]
         );
     }
@@ -713,6 +748,7 @@ mod tests {
                 ],
                 position: 0,
                 text: "deep".to_string(),
+                inline: false,
             }]
         );
     }
@@ -732,6 +768,42 @@ mod tests {
                 ],
                 position: 1,
                 text: "inside-first".to_string(),
+                inline: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn nested_inline_on_sequence_item() {
+        // `- a # tail` attaches an inline comment to item 0 (host index, not
+        // the slot after).
+        let input = "arr:\n  - a # tail\n  - b\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.nested_comments,
+            vec![NestedComment {
+                container_path: vec![CommentPathSegment::Key("arr".to_string())],
+                position: 0,
+                text: "tail".to_string(),
+                inline: true,
+            }]
+        );
+        assert!(out.cleaned_yaml.contains("- a\n"));
+        assert!(!out.cleaned_yaml.contains("tail"));
+    }
+
+    #[test]
+    fn nested_inline_on_mapping_field() {
+        // `inner: 1 # tail` inside `outer:` attaches inline at host index 0.
+        let input = "outer:\n  inner: 1 # tail\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.nested_comments,
+            vec![NestedComment {
+                container_path: vec![CommentPathSegment::Key("outer".to_string())],
+                position: 0,
+                text: "tail".to_string(),
+                inline: true,
             }]
         );
     }

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -554,7 +554,10 @@ fn orphan_inline_after_remove_degrades_to_own_line() {
     // Re-parsing the emitted form yields a stable round-trip.
     let doc2 = Document::from_markdown(&emitted).unwrap();
     let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "post-orphan round-trip must be idempotent");
+    assert_eq!(
+        emitted, emitted2,
+        "post-orphan round-trip must be idempotent"
+    );
 }
 
 /// Inline comment on an empty-mapping field — the field is omitted on emit

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -1,8 +1,13 @@
 //! Round-trip tests for comments, `!fill`, and custom tags.
 //!
-//! Top-level YAML comments round-trip as own-line comments, `!fill` on
-//! scalars and sequences round-trips, and string quoting is normalised to
-//! double-quoted (the type-fidelity guarantee).
+//! Both own-line and trailing inline YAML comments round-trip at their
+//! source position. Inline comments on sentinel lines (`QUILL: r # …` /
+//! `CARD: t # …`) also round-trip. Comments whose host disappears at emit
+//! time (empty-mapping omission, programmatic field removal) degrade to
+//! own-line comments at the same indent so the comment text is preserved
+//! even when its position shifts. `!fill` on scalars and sequences round-
+//! trips, and string quoting is normalised to double-quoted (the type-
+//! fidelity guarantee).
 
 use crate::document::Document;
 
@@ -38,27 +43,26 @@ fn top_level_comments_round_trip() {
     assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
-/// Trailing comments on value lines normalise to own-line comments on the
-/// next line (canonical form).
+/// Trailing inline comments on top-level fields round-trip inline.
 #[test]
-fn trailing_comments_become_own_line_on_round_trip() {
+fn top_level_inline_comments_round_trip() {
     let src = "---\nQUILL: q\ntitle: My Document # this is a comment\n---\n\nBody.\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
 
     assert!(
-        emitted.contains("# this is a comment"),
-        "trailing comment text must survive\nGot:\n{}",
+        emitted.contains("title: \"My Document\" # this is a comment"),
+        "trailing inline comment must round-trip on the same line\nGot:\n{}",
         emitted
     );
     assert!(
-        emitted.contains("title: \"My Document\"\n# this is a comment"),
-        "trailing comment must normalise to own-line on the next line\nGot:\n{}",
+        !emitted.contains("\"My Document\"\n# this is a comment"),
+        "trailing inline comment must NOT degrade to own-line\nGot:\n{}",
         emitted
     );
 
-    // And the value is still intact.
+    // Value still intact.
     let doc2 = Document::from_markdown(&emitted).unwrap();
     assert_eq!(
         doc2.main()
@@ -67,6 +71,10 @@ fn trailing_comments_become_own_line_on_round_trip() {
             .and_then(|v| v.as_str()),
         Some("My Document"),
     );
+
+    // Idempotent across repeated round-trips.
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
 // ── Category: Custom tags ─────────────────────────────────────────────────────
@@ -386,24 +394,218 @@ fn nested_mapping_comments_round_trip() {
     assert_eq!(emitted, emitted2);
 }
 
-/// Trailing comments on nested sequence items become own-line comments at
-/// the next position on round-trip (canonical form, mirroring the
-/// top-level rule).
+/// Trailing inline comments on nested sequence items round-trip inline.
 #[test]
-fn trailing_nested_comments_become_own_line() {
+fn nested_sequence_inline_comments_round_trip() {
     let src = "---\nQUILL: q\nitems:\n  - a # inline\n  - b\n---\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
     assert!(
-        emitted.contains("# inline"),
-        "trailing nested comment must survive\nGot:\n{}",
+        emitted.contains("- \"a\" # inline"),
+        "trailing inline comment on a sequence item must round-trip on the same line\nGot:\n{}",
         emitted
     );
-    // It must land on its own line, not on the item line.
+
+    // Idempotent across repeated round-trips.
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Trailing inline comments on nested mapping fields round-trip inline.
+#[test]
+fn nested_mapping_inline_comments_round_trip() {
+    let src = "---\nQUILL: q\nouter:\n  inner: 1 # tail\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
     assert!(
-        !emitted.contains("\"a\" # inline"),
-        "trailing nested comment must normalise to own-line\nGot:\n{}",
+        emitted.contains("inner: 1 # tail"),
+        "trailing inline comment on a nested mapping field must round-trip\nGot:\n{}",
         emitted
     );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Inline comment on a container key (`outer: # tail`) lands on the key
+/// line, before the indented children.
+#[test]
+fn inline_on_container_key_round_trips() {
+    let src = "---\nQUILL: q\nouter: # describes outer\n  inner: 1\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("outer: # describes outer\n  inner: 1"),
+        "inline comment on a container key must land on the key line\nGot:\n{}",
+        emitted
+    );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Inline comment on the QUILL sentinel line round-trips on that line.
+#[test]
+fn sentinel_inline_comment_round_trips() {
+    let src = "---\nQUILL: q # main entry\ntitle: Hi\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.starts_with("---\nQUILL: q # main entry\n"),
+        "inline comment on the QUILL sentinel must round-trip on the sentinel line\nGot:\n{}",
+        emitted
+    );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Inline comment on a CARD sentinel line round-trips on that line.
+#[test]
+fn card_sentinel_inline_comment_round_trips() {
+    let src = "---\nQUILL: q\n---\n\n---\nCARD: foo # the foo card\nx: 1\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("CARD: foo # the foo card\n"),
+        "inline comment on a CARD sentinel must round-trip on the sentinel line\nGot:\n{}",
+        emitted
+    );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Inline comment with `!fill` round-trips with the tag intact.
+#[test]
+fn fill_with_inline_comment_round_trips() {
+    let src = "---\nQUILL: q\ndept: !fill Sales # placeholder\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    assert!(
+        doc.main().frontmatter().is_fill("dept"),
+        "fill marker must be set"
+    );
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("dept: !fill \"Sales\" # placeholder"),
+        "`!fill` and inline comment must round-trip together\nGot:\n{}",
+        emitted
+    );
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Multiple inline comments — top-level scalar, nested scalar, sequence
+/// item — all preserved in one document.
+#[test]
+fn mixed_inline_comments_round_trip() {
+    let src = "---\nQUILL: q\ntitle: Hello # greeting\nitems:\n  - a # first\n  - b\nouter:\n  inner: 1 # nested tail\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
+
+    assert!(emitted.contains("title: \"Hello\" # greeting"));
+    assert!(emitted.contains("- \"a\" # first"));
+    assert!(emitted.contains("inner: 1 # nested tail"));
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+}
+
+/// Orphan inline comment whose host is removed via `Frontmatter::remove`
+/// degrades to an own-line comment instead of being silently dropped.
+#[test]
+fn orphan_inline_after_remove_degrades_to_own_line() {
+    let src = "---\nQUILL: q\nfield: value # tail\nother: 2\n---\n";
+
+    let mut doc = Document::from_markdown(src).unwrap();
+    // Remove the host field. The inline comment is now orphaned in items.
+    doc.main_mut().frontmatter_mut().remove("field");
+
+    let emitted = doc.to_markdown();
+    // Comment text preserved as own-line.
+    assert!(
+        emitted.contains("# tail"),
+        "orphan comment text must be preserved\nGot:\n{}",
+        emitted
+    );
+    // It must NOT have ended up inline on any value line.
+    assert!(
+        !emitted.contains("\" # tail"),
+        "orphan comment must not appear inline on another line\nGot:\n{}",
+        emitted
+    );
+
+    // Re-parsing the emitted form yields a stable round-trip.
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "post-orphan round-trip must be idempotent");
+}
+
+/// Inline comment on an empty-mapping field — the field is omitted on emit
+/// per the canonical-emission rule, but the inline trailer survives as an
+/// own-line comment at the same indent so its text is not lost.
+#[test]
+fn inline_on_empty_mapping_degrades_to_own_line() {
+    use crate::QuillValue;
+
+    // Construct programmatically since `key: {}` doesn't appear in source.
+    let src = "---\nQUILL: q\n---\n";
+    let mut doc = Document::from_markdown(src).unwrap();
+    doc.main_mut()
+        .frontmatter_mut()
+        .insert("empty", QuillValue::from_json(serde_json::json!({})));
+    // Append an inline comment item right after the empty-mapping field.
+    {
+        let fm = doc.main_mut().frontmatter_mut();
+        let items = fm.items().to_vec();
+        let mut new_items = items;
+        new_items.push(crate::FrontmatterItem::comment_inline("notes about empty"));
+        *fm = crate::document::Frontmatter::from_items(new_items);
+    }
+
+    let emitted = doc.to_markdown();
+    // Empty-mapping host is omitted. Trailer surfaces as own-line.
+    assert!(
+        !emitted.contains("empty:"),
+        "empty mapping must be omitted\nGot:\n{}",
+        emitted
+    );
+    assert!(
+        emitted.contains("# notes about empty"),
+        "inline trailer for an omitted host must degrade to own-line\nGot:\n{}",
+        emitted
+    );
+}
+
+/// Mixed: own-line and inline comments referencing the same field.
+#[test]
+fn own_line_then_inline_round_trip() {
+    let src = "---\nQUILL: q\n# header\ntitle: Hi # tail\n# footer\n---\n";
+
+    let doc = Document::from_markdown(src).unwrap();
+    let emitted = doc.to_markdown();
+
+    assert!(emitted.contains("# header\n"));
+    assert!(emitted.contains("title: \"Hi\" # tail\n"));
+    assert!(emitted.contains("# footer\n"));
+
+    let doc2 = Document::from_markdown(&emitted).unwrap();
+    let emitted2 = doc2.to_markdown();
+    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }


### PR DESCRIPTION
Inline trailing comments (`field: value # text`) now round-trip on the
same line they appear in source, instead of being normalised to own-line
comments. The change is positional: `Comment { inline: bool }` flags
which side of the previous sibling's `\n` the emitter should place the
text. Source patterns covered:

- Top-level scalar fields: `title: Hi # tail`
- Top-level container keys: `outer: # tail` (lands on the key line)
- Nested mapping fields and nested sequence items
- Sentinel lines: `QUILL: q # …` and `CARD: t # …` via items[0] preview
- `!fill` fields: `dept: !fill Sales # placeholder`

Orphan handling: an inline comment whose host disappears at emit time
(empty-object omission, programmatic `Frontmatter::remove`) degrades to
an own-line comment at the same indent so the text is preserved. All
emit paths are idempotent: round-tripping a document is a fixed point.

`NestedComment` gains an `inline` field; for inline comments `position`
is the host child's index (rather than the slot after it), matching the
"attach to predecessor" semantic. Prescan unit tests updated; eight new
round-trip / idempotency / orphan tests added in lossiness_tests.rs.
The WASM `FrontmatterItem` and Python frontmatter-item dict now expose
the `inline` flag.

https://claude.ai/code/session_01U5dRjG7Ygxce7xoL7bsTY3