### PR TITLE
ci: add fast wasm-ci profile to speed up PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            target/wasm32-unknown-unknown/wasm-release
+            target/wasm32-unknown-unknown/wasm-ci
             pkg
-          key: wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
+          # Namespaced cache key: never share artifacts with the release
+          # workflow, which builds with the size-optimized wasm-release
+          # profile and publishes pkg/ to npm.
+          key: wasm-ci-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
 
       - name: Install wasm-bindgen-cli
         if: steps.wasm-cache.outputs.cache-hit != 'true'
@@ -96,7 +99,7 @@ jobs:
 
       - name: Build WASM
         if: steps.wasm-cache.outputs.cache-hit != 'true'
-        run: ./scripts/build-wasm.sh
+        run: ./scripts/build-wasm.sh --ci
 
       - name: Install npm dependencies
         working-directory: crates/bindings/wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,9 +131,12 @@ jobs:
           path: |
             target/wasm32-unknown-unknown/wasm-release
             pkg
-          key: wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
+          # Namespaced under wasm-release- so a CI cache (wasm-ci-...) can
+          # never satisfy this restore — that would publish an unoptimized
+          # bundle to npm.
+          key: wasm-release-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
           restore-keys: |
-            wasm-${{ runner.os }}-
+            wasm-release-${{ runner.os }}-
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,15 @@ panic = "abort"      # Smaller binary
 strip = true         # Remove debug symbols
 [profile.wasm-release.package."*"]
 opt-level = "z" # Optimize all dependencies for size
+
+# Fast-compiling WASM profile for CI / local iteration. Produces a larger,
+# unoptimized binary — only correctness matters here, not size.
+[profile.wasm-ci]
+inherits = "dev"
+opt-level = 0
+lto = false
+codegen-units = 16
+panic = "abort"      # Required: wasm32 has no unwinding
+debug = false        # Smaller artifacts, faster link
+strip = "debuginfo"
+incremental = false  # Matches CARGO_INCREMENTAL=0 in CI

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
 set -e
 
-echo "Building WASM module for @quillmark/wasm..."
+# Profile selection. Default is the size-optimized release build used for
+# npm publish. `--ci` switches to a fast-compiling profile for PR validation
+# where only correctness matters. Keep these two paths in sync with the
+# cache namespacing in .github/workflows/{ci,release}.yml.
+PROFILE="wasm-release"
+MODE_LABEL="release (size-optimized)"
+for arg in "$@"; do
+    case "$arg" in
+        --ci)
+            PROFILE="wasm-ci"
+            MODE_LABEL="ci (fast compile, unoptimized)"
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [--ci]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+echo "Building WASM module for @quillmark/wasm... [profile: $MODE_LABEL]"
 
 cd "$(dirname "$0")/.."
 
@@ -13,13 +33,13 @@ if ! command -v wasm-bindgen &> /dev/null; then
 fi
 
 echo ""
-echo "Building for target: bundler (optimized for size)"
+echo "Building for target: bundler"
 
 # Step 1: Build WASM binary with cargo
 echo "Building WASM binary..."
 cargo build \
     --target wasm32-unknown-unknown \
-    --profile wasm-release \
+    --profile "$PROFILE" \
     --manifest-path crates/bindings/wasm/Cargo.toml
 
 # Step 2: Generate JS bindings with wasm-bindgen
@@ -32,7 +52,7 @@ cargo build \
 echo "Generating JS bindings for bundler..."
 mkdir -p pkg/bundler
 wasm-bindgen \
-    target/wasm32-unknown-unknown/wasm-release/quillmark_wasm.wasm \
+    "target/wasm32-unknown-unknown/$PROFILE/quillmark_wasm.wasm" \
     --out-dir pkg/bundler \
     --out-name wasm \
     --target bundler \


### PR DESCRIPTION
The wasm-release profile (fat LTO, codegen-units=1, opt-level=z) is great
for npm-published artifacts but punishingly slow on every PR cache miss —
and CI cache misses are common since the key includes crates/**/*.rs.

Add a wasm-ci profile (no LTO, codegen-units=16, opt-level=0) and a --ci
flag on build-wasm.sh that selects it. CI uses --ci with a separate
wasm-ci- cache namespace; release.yml is renamed to wasm-release- so the
two caches can never cross-pollinate and ship an unoptimized bundle to
npm.

Default behavior of build-wasm.sh is unchanged (release profile), so
local devs and the release workflow keep producing the size-optimized
binary.