### PR TITLE
Add ui.title for cards and rename UiContainerSchema to UiCardSchema

### DIFF
--- a/crates/bindings/cli/src/commands/schema.rs
+++ b/crates/bindings/cli/src/commands/schema.rs
@@ -15,7 +15,7 @@ pub struct SchemaArgs {
     output: Option<PathBuf>,
 
     /// Include form-builder ui hints (group, order, compact, multiline,
-    /// hide_body, default_title). Default emits the structural schema only.
+    /// title, hide_body, default_title). Default emits the structural schema only.
     #[arg(long)]
     with_ui: bool,
 }

--- a/crates/bindings/cli/src/commands/schema.rs
+++ b/crates/bindings/cli/src/commands/schema.rs
@@ -15,7 +15,7 @@ pub struct SchemaArgs {
     output: Option<PathBuf>,
 
     /// Include form-builder ui hints (group, order, compact, multiline,
-    /// title, hide_body, default_title). Default emits the structural schema only.
+    /// title, hide_body). Default emits the structural schema only.
     #[arg(long)]
     with_ui: bool,
 }

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -24,6 +24,7 @@ export interface QuillFieldUi {
 
 /** UI layout hints for a card (main or named card type). */
 export interface QuillCardUi {
+    title?: string;
     hide_body?: boolean;
     default_title?: string;
 }

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -26,7 +26,6 @@ export interface QuillFieldUi {
 export interface QuillCardUi {
     title?: string;
     hide_body?: boolean;
-    default_title?: string;
 }
 
 /** Schema entry for a single field declared in a quill's `Quill.yaml`. */

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -17,7 +17,7 @@ pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;
 pub use types::{
-    field_key, ui_key, CardSchema, FieldSchema, FieldType, UiContainerSchema, UiFieldSchema,
+    field_key, ui_key, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -12,7 +12,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::formats::DATE_FORMAT;
-use super::{CardSchema, FieldSchema, FieldType, UiContainerSchema, UiFieldSchema};
+use super::{CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
 
 /// Top-level configuration for a Quillmark project
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -54,7 +54,7 @@ pub struct QuillConfig {
 struct CardSchemaDef {
     pub description: Option<String>,
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
-    pub ui: Option<UiContainerSchema>,
+    pub ui: Option<UiCardSchema>,
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -707,7 +707,7 @@ impl QuillConfig {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let ui_section: Option<UiContainerSchema> = quill_section
+        let ui_section: Option<UiCardSchema> = quill_section
             .get("ui")
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());
@@ -771,7 +771,7 @@ impl QuillConfig {
         };
 
         // Extract main.ui (optional)
-        let main_ui: Option<UiContainerSchema> = main_obj_opt
+        let main_ui: Option<UiCardSchema> = main_obj_opt
             .and_then(|main_obj| main_obj.get("ui"))
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2111,10 +2111,6 @@ main:
 
 #[test]
 fn test_card_ui_title_parses_literal_and_template_forms() {
-    // `ui.title` accepts a literal label (no tokens) for the type-level
-    // display name, and a `{field}` template for per-instance titles.
-    // Both forms use the same field — the body is just a string carried
-    // verbatim through the schema.
     let yaml_content = r#"
 quill:
   name: card_title_test

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2110,6 +2110,90 @@ main:
 }
 
 #[test]
+fn test_card_ui_title_parses_and_emits_in_form_schema_only() {
+    let yaml_content = r#"
+quill:
+  name: card_title_test
+  version: "1.0"
+  backend: typst
+  description: Test ui.title on cards
+
+main:
+  ui:
+    title: Memorandum
+  fields:
+    subject:
+      type: string
+
+card_types:
+  indorsement:
+    ui:
+      title: Routing Endorsement
+    fields:
+      from:
+        type: string
+"#;
+
+    let config = QuillConfig::from_yaml(yaml_content).unwrap();
+
+    assert_eq!(
+        config.main.ui.as_ref().unwrap().title.as_deref(),
+        Some("Memorandum")
+    );
+    let indorsement = config.card_type("indorsement").unwrap();
+    assert_eq!(
+        indorsement.ui.as_ref().unwrap().title.as_deref(),
+        Some("Routing Endorsement")
+    );
+
+    // form_schema includes ui.title; structural schema strips it.
+    let form = config.form_schema();
+    assert_eq!(
+        form["main"]["ui"]["title"].as_str(),
+        Some("Memorandum"),
+        "main.ui.title missing from form_schema"
+    );
+    assert_eq!(
+        form["card_types"]["indorsement"]["ui"]["title"].as_str(),
+        Some("Routing Endorsement"),
+        "card_types.indorsement.ui.title missing from form_schema"
+    );
+
+    let clean = config.schema();
+    assert!(
+        clean["main"].get("ui").is_none(),
+        "main.ui must be stripped from structural schema"
+    );
+    assert!(
+        clean["card_types"]["indorsement"].get("ui").is_none(),
+        "card_types.indorsement.ui must be stripped from structural schema"
+    );
+}
+
+#[test]
+fn test_card_ui_title_omitted_when_absent() {
+    let yaml_content = r#"
+quill:
+  name: no_title_test
+  version: "1.0"
+  backend: typst
+  description: ui.title omitted when not declared
+
+main:
+  fields:
+    subject:
+      type: string
+"#;
+
+    let config = QuillConfig::from_yaml(yaml_content).unwrap();
+    assert!(config
+        .main
+        .ui
+        .as_ref()
+        .map_or(true, |ui| ui.title.is_none()));
+}
+
+#[test]
 fn test_quill_config_from_yaml_collects_non_fatal_field_warnings() {
     let yaml_content = r#"
 quill:

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2110,7 +2110,11 @@ main:
 }
 
 #[test]
-fn test_card_ui_title_parses_and_emits_in_form_schema_only() {
+fn test_card_ui_title_parses_literal_and_template_forms() {
+    // `ui.title` accepts a literal label (no tokens) for the type-level
+    // display name, and a `{field}` template for per-instance titles.
+    // Both forms use the same field — the body is just a string carried
+    // verbatim through the schema.
     let yaml_content = r#"
 quill:
   name: card_title_test
@@ -2128,9 +2132,11 @@ main:
 card_types:
   indorsement:
     ui:
-      title: Routing Endorsement
+      title: "{from} → {for}"
     fields:
       from:
+        type: string
+      for:
         type: string
 "#;
 
@@ -2138,25 +2144,22 @@ card_types:
 
     assert_eq!(
         config.main.ui.as_ref().unwrap().title.as_deref(),
-        Some("Memorandum")
+        Some("Memorandum"),
+        "literal main.ui.title"
     );
     let indorsement = config.card_type("indorsement").unwrap();
     assert_eq!(
         indorsement.ui.as_ref().unwrap().title.as_deref(),
-        Some("Routing Endorsement")
+        Some("{from} → {for}"),
+        "template card ui.title carried verbatim"
     );
 
     // form_schema includes ui.title; structural schema strips it.
     let form = config.form_schema();
-    assert_eq!(
-        form["main"]["ui"]["title"].as_str(),
-        Some("Memorandum"),
-        "main.ui.title missing from form_schema"
-    );
+    assert_eq!(form["main"]["ui"]["title"].as_str(), Some("Memorandum"));
     assert_eq!(
         form["card_types"]["indorsement"]["ui"]["title"].as_str(),
-        Some("Routing Endorsement"),
-        "card_types.indorsement.ui.title missing from form_schema"
+        Some("{from} → {for}")
     );
 
     let clean = config.schema();

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -36,6 +36,8 @@ pub mod ui_key {
     pub const GROUP: &str = "group";
     /// Display order within the UI
     pub const ORDER: &str = "order";
+    /// Static human-readable display label for a card type
+    pub const TITLE: &str = "title";
     /// Whether the field or specific component is hide-body (no body editor)
     pub const HIDE_BODY: &str = "hide_body";
     /// Default title template for card instances
@@ -67,7 +69,13 @@ pub struct UiFieldSchema {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct UiContainerSchema {
+pub struct UiCardSchema {
+    /// Static human-readable display label for the card type. UI consumers
+    /// should prefer this over the snake_case map key when rendering section
+    /// headers, chips, or buttons. Decoupled from the key so authors can
+    /// rename the label without changing the on-the-wire `CARD` discriminator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Whether to hide the body editor for this element (metadata only)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_body: Option<bool>,
@@ -92,7 +100,7 @@ pub struct CardSchema {
     pub fields: BTreeMap<String, FieldSchema>,
     /// UI layout hints
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ui: Option<UiContainerSchema>,
+    pub ui: Option<UiCardSchema>,
 }
 
 impl CardSchema {

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -69,12 +69,8 @@ pub struct UiFieldSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UiCardSchema {
-    /// Display label for the card type. May be a literal string (e.g.
-    /// `"Routing Endorsement"`) or a template containing `{field_name}`
-    /// tokens that UI consumers interpolate with live field values
-    /// (e.g. `"{from} → {for}"`). Decoupled from the snake_case map key,
-    /// which is the on-the-wire `CARD` discriminator — authors can rename
-    /// the label without invalidating stored documents.
+    /// Display label for the card type — literal string or `{field_name}`
+    /// template. See `docs/format-designer/quill-yaml-reference.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// Whether to hide the body editor for this element (metadata only)

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -36,12 +36,11 @@ pub mod ui_key {
     pub const GROUP: &str = "group";
     /// Display order within the UI
     pub const ORDER: &str = "order";
-    /// Static human-readable display label for a card type
+    /// Display label for a card type. May be a literal string or a template
+    /// containing `{field_name}` tokens interpolated per-instance by UI consumers.
     pub const TITLE: &str = "title";
     /// Whether the field or specific component is hide-body (no body editor)
     pub const HIDE_BODY: &str = "hide_body";
-    /// Default title template for card instances
-    pub const DEFAULT_TITLE: &str = "default_title";
     /// Compact rendering hint for UI consumers
     pub const COMPACT: &str = "compact";
     /// Multi-line text box hint for string and markdown fields
@@ -70,20 +69,17 @@ pub struct UiFieldSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UiCardSchema {
-    /// Static human-readable display label for the card type. UI consumers
-    /// should prefer this over the snake_case map key when rendering section
-    /// headers, chips, or buttons. Decoupled from the key so authors can
-    /// rename the label without changing the on-the-wire `CARD` discriminator.
+    /// Display label for the card type. May be a literal string (e.g.
+    /// `"Routing Endorsement"`) or a template containing `{field_name}`
+    /// tokens that UI consumers interpolate with live field values
+    /// (e.g. `"{from} → {for}"`). Decoupled from the snake_case map key,
+    /// which is the on-the-wire `CARD` discriminator — authors can rename
+    /// the label without invalidating stored documents.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// Whether to hide the body editor for this element (metadata only)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_body: Option<bool>,
-    /// Template for generating a default per-instance title in UI consumers.
-    /// Uses `{field_name}` tokens interpolated with live field values.
-    /// Example: `"{name}"`
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_title: Option<String>,
 }
 
 /// Schema definition for a card type (composable content blocks)

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -30,7 +30,7 @@ card_types:
   experience_section:
     description: An entry with a heading, subheading, and bullet points.
     ui:
-      default_title: "{headingLeft} — {subheadingLeft}"
+      title: "{headingLeft} — {subheadingLeft}"
     fields:
       title:
         type: string
@@ -74,7 +74,7 @@ card_types:
   projects_section:
     description: A project entry with a name and optional URL.
     ui:
-      default_title: "{name}"
+      title: "{name}"
     fields:
       title:
         type: string

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -133,7 +133,7 @@ card_types:
   indorsement:
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     ui:
-      default_title: "{from} → {for}"
+      title: "{from} → {for}"
     fields:
       from:
         type: string

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -291,15 +291,20 @@ Invalid card-type names include:
 
 ### Card-level `ui`
 
-| Property        | Type   | Description |
-|-----------------|--------|-------------|
-| `title`         | string | Static human-readable label for the card type (UI display) |
-| `hide_body`     | bool   | Suppress the body/content editor for this card type |
-| `default_title` | string | Template for per-instance titles in UI consumers |
+| Property    | Type   | Description |
+|-------------|--------|-------------|
+| `title`     | string | Display label for the card type. Literal string or `{field}` template |
+| `hide_body` | bool   | Suppress the body/content editor for this card type |
 
 #### `title`
 
-A static, human-readable display label for the card type. UI consumers should prefer it over the snake_case map key when rendering section headers, chips, or card-picker entries.
+A human-readable display label for the card type. UI consumers should prefer it over the snake_case map key when rendering section headers, chips, picker entries, or per-instance titles in a list.
+
+The label is decoupled from the map key (e.g. `indorsement`), which is the on-the-wire `CARD` discriminator. Authors can rename the label freely without invalidating stored documents.
+
+**Two flavors:**
+
+A literal string serves as a static type label:
 
 ```yaml
 card_types:
@@ -311,7 +316,27 @@ card_types:
         type: string
 ```
 
-The label is decoupled from the map key (`indorsement`), which is the on-the-wire `CARD` discriminator. Authors can rename the label freely without invalidating stored documents.
+A template containing `{field_name}` tokens lets UI consumers produce a per-instance title by interpolating live field values:
+
+```yaml
+card_types:
+  endorsement:
+    ui:
+      title: "{from} → {for}"
+    fields:
+      from:
+        type: string
+      for:
+        type: string
+```
+
+With the template form, a UI rendering a list of cards can title each instance (e.g. `"ORG1/SYM → ORG2/SYM"`) instead of falling back to a generic `"Card (2)"`.
+
+**Interpolation rules (for UI consumers):**
+- `{field_name}` is replaced with the current value of that field.
+- A title with no `{}` tokens is rendered verbatim — it's just a literal label.
+- If a referenced field is absent or empty, the token resolves to an empty string.
+- UI consumers are responsible for trimming degenerate separators (e.g. `" — "` with one empty side).
 
 `title` is a UI hint only — it has no effect on validation or rendering. When omitted, UI consumers fall back to the prettified map key.
 
@@ -326,29 +351,6 @@ card_types:
       category:
         type: string
 ```
-
-#### `default_title`
-
-A template string that UI consumers interpolate with field values to produce a human-readable title for each card instance. Uses `{field_name}` tokens referencing fields in the same card.
-
-```yaml
-card_types:
-  entry:
-    ui:
-      default_title: "{name}"
-    fields:
-      name:
-        type: string
-```
-
-With the above, a UI rendering a list of `entry` cards can title each instance (e.g. `"Project Alpha"`) instead of falling back to a generic `"Card (2)"`.
-
-**Interpolation rules (for UI consumers):**
-- `{field_name}` is replaced with the current value of that field.
-- If a field is absent or empty, the token resolves to an empty string.
-- UI consumers are responsible for trimming degenerate separators (e.g. `" — "` with one empty side).
-
-`default_title` is a UI hint only — it has no effect on validation or rendering.
 
 ### Using Cards in Markdown
 

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -291,10 +291,29 @@ Invalid card-type names include:
 
 ### Card-level `ui`
 
-| Property       | Type   | Description |
-|----------------|--------|-------------|
-| `hide_body`    | bool   | Suppress the body/content editor for this card type |
+| Property        | Type   | Description |
+|-----------------|--------|-------------|
+| `title`         | string | Static human-readable label for the card type (UI display) |
+| `hide_body`     | bool   | Suppress the body/content editor for this card type |
 | `default_title` | string | Template for per-instance titles in UI consumers |
+
+#### `title`
+
+A static, human-readable display label for the card type. UI consumers should prefer it over the snake_case map key when rendering section headers, chips, or card-picker entries.
+
+```yaml
+card_types:
+  indorsement:
+    ui:
+      title: Routing Endorsement
+    fields:
+      from:
+        type: string
+```
+
+The label is decoupled from the map key (`indorsement`), which is the on-the-wire `CARD` discriminator. Authors can rename the label freely without invalidating stored documents.
+
+`title` is a UI hint only — it has no effect on validation or rendering. When omitted, UI consumers fall back to the prettified map key.
 
 #### `hide_body`
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -122,8 +122,7 @@ Most `ui:` keys are stripped, but two structural hints survive:
 - `ui.hide_body` (on `main` or a card) — suppresses the
   `<region> body...` marker for cards that hold no prose.
 
-`ui.compact`, `ui.multiline`, `ui.title`, `ui.default_title` are
-presentation-only and dropped.
+`ui.compact`, `ui.multiline`, `ui.title` are presentation-only and dropped.
 
 ## Body markers
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -122,8 +122,8 @@ Most `ui:` keys are stripped, but two structural hints survive:
 - `ui.hide_body` (on `main` or a card) — suppresses the
   `<region> body...` marker for cards that hold no prose.
 
-`ui.compact`, `ui.multiline`, `ui.default_title` are presentation-only
-and dropped.
+`ui.compact`, `ui.multiline`, `ui.title`, `ui.default_title` are
+presentation-only and dropped.
 
 ## Body markers
 

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -12,12 +12,13 @@ Cards are structured metadata blocks inline within document content. All cards a
 ```rust
 pub struct CardSchema {
     pub name: String,
-    pub title: Option<String>,
     pub description: Option<String>,
     pub fields: HashMap<String, FieldSchema>,
-    pub ui: Option<UiContainerSchema>,
+    pub ui: Option<UiCardSchema>,
 }
 ```
+
+The static display label for a card type lives on `UiCardSchema::title`, not on `CardSchema` directly — see `ui.title` below.
 
 `QuillConfig` exposes the entry-point card as `main: CardSchema` and the additional named card-types as `card_types: Vec<CardSchema>`. Look up a named card-type by name via `card_type(name)` or get a name-keyed map via `card_types_map()`.
 
@@ -30,19 +31,17 @@ main:
 
 card_types:
   indorsement:
-    title: Routing Indorsement
     description: Chain of routing endorsements for multi-level correspondence.
+    ui:
+      title: Routing Endorsement
     fields:
       from:
-        title: From office/symbol
         type: string
         description: Office symbol of the endorsing official.
       for:
-        title: To office/symbol
         type: string
         description: Office symbol receiving the endorsed memo.
       signature_block:
-        title: Signature block lines
         type: array
         required: true
         ui:
@@ -50,12 +49,13 @@ card_types:
         description: Name, grade, and duty title.
 ```
 
+`ui.title` is a static display label for UI consumers (section headers, chips, picker entries). It's decoupled from the snake_case map key (`indorsement`), which is the on-the-wire `CARD` discriminator — so authors can rename the label without breaking stored documents.
+
 ## Public Schema YAML Output
 
 ```yaml
 card_types:
   indorsement:
-    title: Routing Indorsement
     description: Chain of routing endorsements for multi-level correspondence.
     fields:
       from:

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -49,7 +49,7 @@ card_types:
         description: Name, grade, and duty title.
 ```
 
-`ui.title` is a static display label for UI consumers (section headers, chips, picker entries). It's decoupled from the snake_case map key (`indorsement`), which is the on-the-wire `CARD` discriminator — so authors can rename the label without breaking stored documents.
+`ui.title` is the display label for UI consumers (section headers, chips, picker entries, per-instance list titles). It may be a literal string or a template containing `{field_name}` tokens that consumers interpolate with live field values (e.g. `"{from} → {for}"`). It's decoupled from the snake_case map key (`indorsement`), which is the on-the-wire `CARD` discriminator — so authors can rename the label without breaking stored documents.
 
 ## Public Schema YAML Output
 

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -53,8 +53,8 @@ Two projections of the same `QuillConfig` source are exposed:
   `QUILL`/`CARD` sentinels with `const` values. No `ui` keys. The surface
   for validators, machine consumers, and CLI inspection.
 - `QuillConfig::form_schema()` — same shape **plus** field-level (`group`,
-  `order`, `compact`, `multiline`) and card-level (`title`, `hide_body`,
-  `default_title`) `ui` hints. The surface for form builders.
+  `order`, `compact`, `multiline`) and card-level (`title`, `hide_body`)
+  `ui` hints. The surface for form builders.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()`
 emits a document-shaped, pre-filled Markdown reference that's denser

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -53,7 +53,7 @@ Two projections of the same `QuillConfig` source are exposed:
   `QUILL`/`CARD` sentinels with `const` values. No `ui` keys. The surface
   for validators, machine consumers, and CLI inspection.
 - `QuillConfig::form_schema()` — same shape **plus** field-level (`group`,
-  `order`, `compact`, `multiline`) and card-level (`hide_body`,
+  `order`, `compact`, `multiline`) and card-level (`title`, `hide_body`,
   `default_title`) `ui` hints. The surface for form builders.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()`
@@ -62,7 +62,7 @@ than schema for prompt-time use.
 
 YAML wrappers `QuillConfig::schema_yaml()` and `QuillConfig::form_schema_yaml()`
 encode the same values. Both projections are pinned by serde attributes on
-`FieldSchema`, `CardSchema`, `UiFieldSchema`, and `UiContainerSchema` —
+`FieldSchema`, `CardSchema`, `UiFieldSchema`, and `UiCardSchema` —
 there is no parallel mirror struct. The clean variant is produced by
 recursively stripping `ui` keys after serialisation.
 


### PR DESCRIPTION
Adds an optional static display label `ui.title` on `main` and named
card types so UI consumers can render section headers, chips, and
picker entries decoupled from the snake_case map key (which is the
on-the-wire `CARD` discriminator). Authors can now rename the
displayed label without invalidating stored documents.

Renames `UiContainerSchema` to `UiCardSchema` for naming consistency
with `CardSchema`.