### PR TITLE
Make Quill.yaml parsing strict: collect all errors, never silently drop fields

### DIFF
--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -112,16 +112,25 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
     // Step 1: Parse the YAML config first (before full Quill load)
     let yaml_content = fs::read_to_string(&quill_yaml_path).map_err(CliError::Io)?;
 
-    let config = match QuillConfig::from_yaml(&yaml_content) {
-        Ok(c) => c,
-        Err(e) => {
-            result.add_error(format!("Failed to parse Quill.yaml: {}", e));
-            print_validation_result(&result, args.verbose);
+    let (config, config_warnings) = match QuillConfig::from_yaml_with_warnings(&yaml_content) {
+        Ok(pair) => pair,
+        Err(diags) => {
+            for diag in &diags {
+                eprintln!("{}", diag.fmt_pretty());
+            }
+            eprintln!(
+                "\nValidation failed: {} error(s) in Quill.yaml",
+                diags.len()
+            );
             return Err(CliError::InvalidArgument(
                 "Quill configuration is invalid".to_string(),
             ));
         }
     };
+
+    for diag in &config_warnings {
+        result.add_warning(diag.message.clone());
+    }
 
     if args.verbose {
         println!("  Quill name: {}", config.name);

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -51,14 +51,29 @@ pub fn convert_render_error(err: RenderError) -> PyErr {
             }
             py_err
         }
+        RenderError::QuillConfig { diags } => {
+            let msg = if diags.len() == 1 {
+                diags[0].message.clone()
+            } else {
+                format!("Quill configuration has {} error(s)", diags.len())
+            };
+            let py_err = QuillmarkError::new_err(msg);
+            if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
+                let py_diags: Vec<crate::types::PyDiagnostic> = diags
+                    .into_iter()
+                    .map(|d| crate::types::PyDiagnostic { inner: d.into() })
+                    .collect();
+                let _ = exc.setattr("diagnostics", py_diags);
+            }
+            py_err
+        }
         RenderError::InvalidFrontmatter { diag } => {
             with_diag_attached(py, ParseError::new_err(diag.message.clone()), *diag)
         }
         RenderError::EngineCreation { diag }
         | RenderError::FormatNotSupported { diag }
         | RenderError::UnsupportedBackend { diag }
-        | RenderError::ValidationFailed { diag }
-        | RenderError::QuillConfig { diag } => {
+        | RenderError::ValidationFailed { diag } => {
             with_diag_attached(py, QuillmarkError::new_err(diag.message.clone()), *diag)
         }
     })

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -382,11 +382,12 @@ pub enum RenderError {
         diag: Box<Diagnostic>,
     },
 
-    /// Quill configuration error
-    #[error("{diag}")]
+    /// Quill configuration error — may carry multiple diagnostics when several
+    /// problems are detected during parsing (e.g. several unknown keys at once).
+    #[error("Quill configuration failed with {} error(s)", diags.len())]
     QuillConfig {
-        /// Diagnostic information
-        diag: Box<Diagnostic>,
+        /// All configuration diagnostics. Always non-empty.
+        diags: Vec<Diagnostic>,
     },
 }
 
@@ -394,13 +395,14 @@ impl RenderError {
     /// Extract all diagnostics from this error
     pub fn diagnostics(&self) -> Vec<&Diagnostic> {
         match self {
-            RenderError::CompilationFailed { diags } => diags.iter().collect(),
+            RenderError::CompilationFailed { diags } | RenderError::QuillConfig { diags } => {
+                diags.iter().collect()
+            }
             RenderError::EngineCreation { diag }
             | RenderError::InvalidFrontmatter { diag }
             | RenderError::FormatNotSupported { diag }
             | RenderError::UnsupportedBackend { diag }
-            | RenderError::ValidationFailed { diag }
-            | RenderError::QuillConfig { diag } => vec![diag.as_ref()],
+            | RenderError::ValidationFailed { diag } => vec![diag.as_ref()],
         }
     }
 }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -40,9 +40,6 @@ pub struct QuillConfig {
     pub example_markdown: Option<String>,
     /// Plate file (template)
     pub plate_file: Option<String>,
-    /// Additional unstructured metadata
-    #[serde(flatten)]
-    pub metadata: HashMap<String, QuillValue>,
     /// Backend-specific configuration parsed from the top-level YAML section
     /// whose key matches `backend` (e.g. `[typst]`, `[html]`).
     #[serde(default)]
@@ -501,7 +498,6 @@ impl QuillConfig {
         fields_map: &serde_json::Map<String, serde_json::Value>,
         key_order: &[String],
         context: &str,
-        _warnings: &mut Vec<Diagnostic>,
         errors: &mut Vec<Diagnostic>,
     ) -> BTreeMap<String, FieldSchema> {
         let mut fields = BTreeMap::new();
@@ -913,44 +909,45 @@ impl QuillConfig {
         }
 
         // Reject unknown top-level sections. Known sections are: quill, main, card_types,
-        // and the backend name (e.g. typst). Everything else is a mistake.
+        // and the backend name (e.g. typst). Everything else is a mistake. `fields` gets
+        // a targeted hint since it's the most common shape mistake.
         if let Some(top_obj) = quill_yaml_val.as_object() {
             for key in top_obj.keys() {
                 let is_known = key == "quill"
                     || key == "main"
                     || key == "card_types"
                     || (!backend.is_empty() && key == &backend);
-                if !is_known {
-                    errors.push(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!("Unknown top-level section '{}'", key),
-                        )
-                        .with_code("quill::unknown_section".to_string())
-                        .with_hint(format!(
-                            "Valid top-level sections are: quill, main, card_types{}",
-                            if backend.is_empty() {
-                                String::new()
-                            } else {
-                                format!(", {}", backend)
-                            }
-                        )),
-                    );
+                if is_known {
+                    continue;
                 }
+
+                let mut diag = Diagnostic::new(
+                    Severity::Error,
+                    format!("Unknown top-level section '{}'", key),
+                )
+                .with_code("quill::unknown_section".to_string());
+
+                diag = if key == "fields" {
+                    diag.with_hint(
+                        "Root-level `fields` is not supported; use `main.fields` instead."
+                            .to_string(),
+                    )
+                } else {
+                    diag.with_hint(format!(
+                        "Valid top-level sections are: quill, main, card_types{}",
+                        if backend.is_empty() {
+                            String::new()
+                        } else {
+                            format!(", {}", backend)
+                        }
+                    ))
+                };
+
+                errors.push(diag);
             }
         }
 
         let main_obj_opt = quill_yaml_val.get("main").and_then(|v| v.as_object());
-
-        if quill_yaml_val.get("fields").is_some() {
-            errors.push(
-                Diagnostic::new(
-                    Severity::Error,
-                    "Root-level `fields` is not supported; use `main.fields` instead.".to_string(),
-                )
-                .with_code("quill::root_fields_not_supported".to_string()),
-            );
-        }
 
         // Extract main.fields (optional)
         let fields = if let Some(main_obj) = main_obj_opt {
@@ -962,7 +959,6 @@ impl QuillConfig {
                         fields_map,
                         &field_order,
                         "field schema",
-                        &mut warnings,
                         &mut errors,
                     )
                 } else {
@@ -1072,7 +1068,6 @@ impl QuillConfig {
                                 card_fields_table,
                                 &card_field_order,
                                 &format!("card_type '{}' field", card_name),
-                                &mut warnings,
                                 &mut errors,
                             )
                         } else {
@@ -1106,7 +1101,6 @@ impl QuillConfig {
                 example_file,
                 example_markdown: None,
                 plate_file,
-                metadata: HashMap::new(),
                 backend_config,
             },
             warnings,

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -501,18 +501,27 @@ impl QuillConfig {
         fields_map: &serde_json::Map<String, serde_json::Value>,
         key_order: &[String],
         context: &str,
-        warnings: &mut Vec<Diagnostic>,
-    ) -> Result<BTreeMap<String, FieldSchema>, Box<dyn StdError + Send + Sync>> {
+        _warnings: &mut Vec<Diagnostic>,
+        errors: &mut Vec<Diagnostic>,
+    ) -> BTreeMap<String, FieldSchema> {
         let mut fields = BTreeMap::new();
         let mut fallback_counter = 0;
 
         for (field_name, field_value) in fields_map {
             if !Self::is_snake_case_identifier(field_name) {
-                return Err(format!(
-                    "Invalid {} '{}': field keys must be snake_case (lowercase letters, digits, and underscores only), and capitalized field keys are reserved.",
-                    context, field_name
-                )
-                .into());
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "Invalid {} '{}': field keys must be snake_case \
+                             (lowercase letters, digits, and underscores only), \
+                             and capitalized field keys are reserved.",
+                            context, field_name
+                        ),
+                    )
+                    .with_code("quill::invalid_field_name".to_string()),
+                );
+                continue;
             }
 
             // Determine order from key_order, or use fallback counter
@@ -529,12 +538,13 @@ impl QuillConfig {
                 Ok(mut schema) => {
                     // Reject standalone object/dict fields — object is only valid inside array items.
                     if schema.r#type == FieldType::Object {
-                        warnings.push(
+                        errors.push(
                             Diagnostic::new(
-                                Severity::Warning,
+                                Severity::Error,
                                 format!(
                                     "Field '{}' uses standalone type: object, which is not supported. \
-                                    Use separate fields with ui.group instead, or use type: array with items: {{type: object, properties: {{...}}}}.",
+                                    Use separate fields with ui.group instead, or use \
+                                    type: array with items: {{type: object, properties: {{...}}}}.",
                                     field_name
                                 ),
                             )
@@ -544,9 +554,9 @@ impl QuillConfig {
                     }
 
                     if Self::has_disallowed_nested_object(&schema, false) {
-                        warnings.push(
+                        errors.push(
                             Diagnostic::new(
-                                Severity::Warning,
+                                Severity::Error,
                                 format!(
                                     "Field '{}' uses nested type: object, which is not supported. \
                                     Only object schemas nested under array.items are supported.",
@@ -567,7 +577,6 @@ impl QuillConfig {
                             multiline: None,
                         });
                     } else if let Some(ui) = &mut schema.ui {
-                        // Only set if not already set
                         if ui.order.is_none() {
                             ui.order = Some(order);
                         }
@@ -576,18 +585,18 @@ impl QuillConfig {
                     fields.insert(field_name.clone(), schema);
                 }
                 Err(e) => {
-                    warnings.push(
+                    errors.push(
                         Diagnostic::new(
-                            Severity::Warning,
+                            Severity::Error,
                             format!("Failed to parse {} '{}': {}", context, field_name, e),
                         )
-                        .with_code("quill::field_parse_warning".to_string()),
+                        .with_code("quill::field_parse_error".to_string()),
                     );
                 }
             }
         }
 
-        Ok(fields)
+        fields
     }
 
     fn is_snake_case_identifier(name: &str) -> bool {
@@ -616,80 +625,218 @@ impl QuillConfig {
 
     /// Parse QuillConfig from YAML content
     pub fn from_yaml(yaml_content: &str) -> Result<Self, Box<dyn StdError + Send + Sync>> {
-        let (config, _warnings) = Self::from_yaml_with_warnings(yaml_content)?;
-        Ok(config)
+        match Self::from_yaml_with_warnings(yaml_content) {
+            Ok((config, _warnings)) => Ok(config),
+            Err(diags) => {
+                let msg = diags
+                    .iter()
+                    .map(|d| d.fmt_pretty())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Err(msg.into())
+            }
+        }
     }
 
     /// Parse QuillConfig from YAML content while collecting non-fatal warnings.
+    ///
+    /// Returns `Ok((config, warnings))` on success, or `Err(errors)` containing all
+    /// parse/validation errors when the config is invalid. Errors are always collected
+    /// exhaustively — callers see every problem, not just the first.
     pub fn from_yaml_with_warnings(
         yaml_content: &str,
-    ) -> Result<(Self, Vec<Diagnostic>), Box<dyn StdError + Send + Sync>> {
-        let mut warnings = Vec::new();
+    ) -> Result<(Self, Vec<Diagnostic>), Vec<Diagnostic>> {
+        let mut warnings: Vec<Diagnostic> = Vec::new();
+        let mut errors: Vec<Diagnostic> = Vec::new();
 
         // Parse YAML into serde_json::Value via serde_saphyr
         // Note: serde_json with "preserve_order" feature is required for this to work as expected
-        let quill_yaml_val: serde_json::Value = serde_saphyr::from_str(yaml_content)
-            .map_err(|e| format!("Failed to parse Quill.yaml: {}", e))?;
-
-        // Extract [quill] section (required)
-        let quill_section = quill_yaml_val
-            .get("quill")
-            .ok_or("Missing required 'quill' section in Quill.yaml")?;
-
-        // Extract required fields
-        let name = quill_section
-            .get("name")
-            .and_then(|v| v.as_str())
-            .ok_or("Missing required 'name' field in 'quill' section")?
-            .to_string();
-        if !Self::is_valid_quill_name(&name) {
-            return Err(format!(
-                "Invalid Quill name '{}': quill.name must be snake_case (lowercase letters, digits, and underscores only).",
-                name
-            )
-            .into());
-        }
-
-        let backend = quill_section
-            .get("backend")
-            .and_then(|v| v.as_str())
-            .ok_or("Missing required 'backend' field in 'quill' section")?
-            .to_string();
-
-        let description = quill_section
-            .get("description")
-            .and_then(|v| v.as_str())
-            .ok_or("Missing required 'description' field in 'quill' section")?;
-
-        if description.trim().is_empty() {
-            return Err("'description' field in 'quill' section cannot be empty".into());
-        }
-        let description = description.to_string();
-
-        // Extract optional fields (now version is required)
-        let version_val = quill_section
-            .get("version")
-            .ok_or("Missing required 'version' field in 'quill' section")?;
-
-        // Handle version as string or number (YAML might parse 1.0 as number)
-        let version = if let Some(s) = version_val.as_str() {
-            s.to_string()
-        } else if let Some(n) = version_val.as_f64() {
-            n.to_string()
-        } else {
-            return Err("Invalid 'version' field format".into());
+        let quill_yaml_val: serde_json::Value = match serde_saphyr::from_str(yaml_content) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(vec![Diagnostic::new(
+                    Severity::Error,
+                    format!("Failed to parse Quill.yaml: {}", e),
+                )
+                .with_code("quill::yaml_parse_error".to_string())]);
+            }
         };
 
-        // Validate version format (semver: MAJOR.MINOR.PATCH or MAJOR.MINOR)
-        use std::str::FromStr;
-        crate::version::Version::from_str(&version)
-            .map_err(|e| format!("Invalid version '{}': {}", version, e))?;
+        // Extract [quill] section (required) — fail immediately if absent since all
+        // subsequent validation depends on it.
+        let quill_section = match quill_yaml_val.get("quill") {
+            Some(v) => v,
+            None => {
+                return Err(vec![Diagnostic::new(
+                    Severity::Error,
+                    "Missing required 'quill' section in Quill.yaml".to_string(),
+                )
+                .with_code("quill::missing_section".to_string())
+                .with_hint(
+                    "Add a 'quill:' section with name, backend, version, and description."
+                        .to_string(),
+                )]);
+            }
+        };
+
+        // Validate that no unknown keys appear in the [quill] section.
+        const KNOWN_QUILL_KEYS: &[&str] = &[
+            "name",
+            "backend",
+            "description",
+            "version",
+            "author",
+            "example",
+            "example_file",
+            "plate_file",
+            "ui",
+        ];
+        if let Some(quill_obj) = quill_section.as_object() {
+            for key in quill_obj.keys() {
+                if !KNOWN_QUILL_KEYS.contains(&key.as_str()) {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!("Unknown key '{}' in 'quill:' section", key),
+                        )
+                        .with_code("quill::unknown_key".to_string())
+                        .with_hint(format!(
+                            "Valid keys are: {}",
+                            KNOWN_QUILL_KEYS.join(", ")
+                        )),
+                    );
+                }
+            }
+        }
+
+        // Extract required fields — collect all missing-field errors before returning.
+        let name = match quill_section.get("name").and_then(|v| v.as_str()) {
+            Some(n) => {
+                if !Self::is_valid_quill_name(n) {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "Invalid Quill name '{}': quill.name must be snake_case \
+                                 (lowercase letters, digits, and underscores only).",
+                                n
+                            ),
+                        )
+                        .with_code("quill::invalid_name".to_string())
+                        .with_hint(format!(
+                            "Rename '{}' to '{}'",
+                            n,
+                            n.to_lowercase().replace('-', "_")
+                        )),
+                    );
+                }
+                n.to_string()
+            }
+            None => {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        "Missing required 'name' field in 'quill' section".to_string(),
+                    )
+                    .with_code("quill::missing_name".to_string())
+                    .with_hint("Add 'name: your_quill_name' under the 'quill:' section.".to_string()),
+                );
+                String::new()
+            }
+        };
+
+        let backend = match quill_section.get("backend").and_then(|v| v.as_str()) {
+            Some(b) => b.to_string(),
+            None => {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        "Missing required 'backend' field in 'quill' section".to_string(),
+                    )
+                    .with_code("quill::missing_backend".to_string())
+                    .with_hint("Add 'backend: typst' (or another supported backend).".to_string()),
+                );
+                String::new()
+            }
+        };
+
+        let description = match quill_section.get("description").and_then(|v| v.as_str()) {
+            Some(d) if !d.trim().is_empty() => d.to_string(),
+            Some(_) => {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        "'description' field in 'quill' section cannot be empty".to_string(),
+                    )
+                    .with_code("quill::empty_description".to_string()),
+                );
+                String::new()
+            }
+            None => {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        "Missing required 'description' field in 'quill' section".to_string(),
+                    )
+                    .with_code("quill::missing_description".to_string())
+                    .with_hint("Add a brief 'description:' of what this quill is for.".to_string()),
+                );
+                String::new()
+            }
+        };
+
+        // Extract optional fields (now version is required)
+        let version = match quill_section.get("version") {
+            Some(version_val) => {
+                // Handle version as string or number (YAML might parse 1.0 as number)
+                let raw = if let Some(s) = version_val.as_str() {
+                    s.to_string()
+                } else if let Some(n) = version_val.as_f64() {
+                    n.to_string()
+                } else {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            "Invalid 'version' field format".to_string(),
+                        )
+                        .with_code("quill::invalid_version".to_string())
+                        .with_hint("Use semver format: '1.0' or '1.0.0'.".to_string()),
+                    );
+                    String::new()
+                };
+                if !raw.is_empty() {
+                    use std::str::FromStr;
+                    if let Err(e) = crate::version::Version::from_str(&raw) {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!("Invalid version '{}': {}", raw, e),
+                            )
+                            .with_code("quill::invalid_version".to_string())
+                            .with_hint("Use semver format: '1.0' or '1.0.0'.".to_string()),
+                        );
+                    }
+                }
+                raw
+            }
+            None => {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        "Missing required 'version' field in 'quill' section".to_string(),
+                    )
+                    .with_code("quill::missing_version".to_string())
+                    .with_hint("Add 'version: 1.0' under the 'quill:' section.".to_string()),
+                );
+                String::new()
+            }
+        };
 
         let author = quill_section
             .get("author")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
-            .unwrap_or_else(|| "Unknown".to_string()); // Default author
+            .unwrap_or_else(|| "Unknown".to_string());
 
         let example_file = quill_section
             .get("example")
@@ -712,32 +859,42 @@ impl QuillConfig {
             .cloned()
             .and_then(|v| serde_json::from_value(v).ok());
 
-        // Extract additional metadata from [quill] section (excluding standard fields)
-        let mut metadata = HashMap::new();
-        if let Some(table) = quill_section.as_object() {
-            for (key, value) in table {
-                // Skip standard fields that are stored in dedicated struct fields
-                if key != "name"
-                    && key != "backend"
-                    && key != "description"
-                    && key != "version"
-                    && key != "author"
-                    && key != "example"
-                    && key != "example_file"
-                    && key != "plate_file"
-                    && key != "ui"
-                {
-                    metadata.insert(key.clone(), QuillValue::from_json(value.clone()));
+        // Extract optional backend-specific section (keyed by `quill.backend`).
+        let mut backend_config = HashMap::new();
+        if !backend.is_empty() {
+            if let Some(section_val) = quill_yaml_val.get(&backend) {
+                if let Some(table) = section_val.as_object() {
+                    for (key, value) in table {
+                        backend_config.insert(key.clone(), QuillValue::from_json(value.clone()));
+                    }
                 }
             }
         }
 
-        // Extract optional backend-specific section (keyed by `quill.backend`).
-        let mut backend_config = HashMap::new();
-        if let Some(section_val) = quill_yaml_val.get(&backend) {
-            if let Some(table) = section_val.as_object() {
-                for (key, value) in table {
-                    backend_config.insert(key.clone(), QuillValue::from_json(value.clone()));
+        // Reject unknown top-level sections. Known sections are: quill, main, card_types,
+        // and the backend name (e.g. typst). Everything else is a mistake.
+        if let Some(top_obj) = quill_yaml_val.as_object() {
+            for key in top_obj.keys() {
+                let is_known = key == "quill"
+                    || key == "main"
+                    || key == "card_types"
+                    || (!backend.is_empty() && key == &backend);
+                if !is_known {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!("Unknown top-level section '{}'", key),
+                        )
+                        .with_code("quill::unknown_section".to_string())
+                        .with_hint(format!(
+                            "Valid top-level sections are: quill, main, card_types{}",
+                            if backend.is_empty() {
+                                String::new()
+                            } else {
+                                format!(", {}", backend)
+                            }
+                        )),
+                    );
                 }
             }
         }
@@ -745,7 +902,13 @@ impl QuillConfig {
         let main_obj_opt = quill_yaml_val.get("main").and_then(|v| v.as_object());
 
         if quill_yaml_val.get("fields").is_some() {
-            return Err("Root-level `fields` is not supported; use `main.fields` instead.".into());
+            errors.push(
+                Diagnostic::new(
+                    Severity::Error,
+                    "Root-level `fields` is not supported; use `main.fields` instead.".to_string(),
+                )
+                .with_code("quill::root_fields_not_supported".to_string()),
+            );
         }
 
         // Extract main.fields (optional)
@@ -759,7 +922,8 @@ impl QuillConfig {
                         &field_order,
                         "field schema",
                         &mut warnings,
-                    )?
+                        &mut errors,
+                    )
                 } else {
                     BTreeMap::new()
                 }
@@ -794,50 +958,82 @@ impl QuillConfig {
         // Extract [card_types] section (optional)
         let mut card_types: Vec<CardSchema> = Vec::new();
         if let Some(card_types_val) = quill_yaml_val.get("card_types") {
-            let card_types_table = card_types_val
-                .as_object()
-                .ok_or("'card_types' section must be an object")?;
-
-            for (card_name, card_value) in card_types_table {
-                if !Self::is_valid_card_identifier(card_name) {
-                    return Err(format!(
-                        "Invalid card-type name '{}': names must match [a-z_][a-z0-9_]* (lowercase letters, digits, and underscores only).",
-                        card_name
-                    )
-                    .into());
+            match card_types_val.as_object() {
+                None => {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            "'card_types' section must be an object (mapping of type names to schemas)".to_string(),
+                        )
+                        .with_code("quill::invalid_card_types".to_string()),
+                    );
                 }
+                Some(card_types_table) => {
+                    for (card_name, card_value) in card_types_table {
+                        if !Self::is_valid_card_identifier(card_name) {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Invalid card-type name '{}': names must match \
+                                         [a-z_][a-z0-9_]* (lowercase letters, digits, and underscores only).",
+                                        card_name
+                                    ),
+                                )
+                                .with_code("quill::invalid_card_name".to_string()),
+                            );
+                            continue;
+                        }
 
-                // Parse card basic info using serde
-                let card_def: CardSchemaDef = serde_json::from_value(card_value.clone())
-                    .map_err(|e| format!("Failed to parse card_type '{}': {}", card_name, e))?;
+                        // Parse card basic info using serde
+                        let card_def: CardSchemaDef =
+                            match serde_json::from_value(card_value.clone()) {
+                                Ok(d) => d,
+                                Err(e) => {
+                                    errors.push(
+                                        Diagnostic::new(
+                                            Severity::Error,
+                                            format!(
+                                                "Failed to parse card_type '{}': {}",
+                                                card_name, e
+                                            ),
+                                        )
+                                        .with_code("quill::invalid_card_schema".to_string()),
+                                    );
+                                    continue;
+                                }
+                            };
 
-                // Parse card fields
-                let card_fields = if let Some(card_fields_table) =
-                    card_value.get("fields").and_then(|v| v.as_object())
-                {
-                    let card_field_order: Vec<String> = card_fields_table.keys().cloned().collect();
+                        // Parse card fields
+                        let card_fields = if let Some(card_fields_table) =
+                            card_value.get("fields").and_then(|v| v.as_object())
+                        {
+                            let card_field_order: Vec<String> =
+                                card_fields_table.keys().cloned().collect();
+                            Self::parse_fields_with_order(
+                                card_fields_table,
+                                &card_field_order,
+                                &format!("card_type '{}' field", card_name),
+                                &mut warnings,
+                                &mut errors,
+                            )
+                        } else {
+                            BTreeMap::new()
+                        };
 
-                    Self::parse_fields_with_order(
-                        card_fields_table,
-                        &card_field_order,
-                        &format!("card_type '{}' field", card_name),
-                        &mut warnings,
-                    )?
-                } else if let Some(_toml_fields) = &card_def.fields {
-                    BTreeMap::new()
-                } else {
-                    BTreeMap::new()
-                };
-
-                let card_schema = CardSchema {
-                    name: card_name.clone(),
-                    description: card_def.description,
-                    fields: card_fields,
-                    ui: card_def.ui,
-                };
-
-                card_types.push(card_schema);
+                        card_types.push(CardSchema {
+                            name: card_name.clone(),
+                            description: card_def.description,
+                            fields: card_fields,
+                            ui: card_def.ui,
+                        });
+                    }
+                }
             }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
         }
 
         Ok((
@@ -852,7 +1048,7 @@ impl QuillConfig {
                 example_file,
                 example_markdown: None,
                 plate_file,
-                metadata,
+                metadata: HashMap::new(),
                 backend_config,
             },
             warnings,

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -585,18 +585,44 @@ impl QuillConfig {
                     fields.insert(field_name.clone(), schema);
                 }
                 Err(e) => {
-                    errors.push(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!("Failed to parse {} '{}': {}", context, field_name, e),
-                        )
-                        .with_code("quill::field_parse_error".to_string()),
-                    );
+                    let hint = Self::field_parse_hint(field_value);
+                    let mut diag = Diagnostic::new(
+                        Severity::Error,
+                        format!("Failed to parse {} '{}': {}", context, field_name, e),
+                    )
+                    .with_code("quill::field_parse_error".to_string());
+                    if let Some(h) = hint {
+                        diag = diag.with_hint(h);
+                    }
+                    errors.push(diag);
                 }
             }
         }
 
         fields
+    }
+
+    /// Produce an actionable hint for common field schema mistakes based on the raw value.
+    fn field_parse_hint(field_value: &serde_json::Value) -> Option<String> {
+        if let Some(obj) = field_value.as_object() {
+            if obj.contains_key("title") {
+                return Some(
+                    "'title' is not a valid field key; use 'description' instead.".to_string(),
+                );
+            }
+            if let Some(ui_val) = obj.get("ui") {
+                if let Some(ui_obj) = ui_val.as_object() {
+                    if ui_obj.contains_key("title") {
+                        return Some(
+                            "'ui.title' is only valid on card type schemas (under card_types:), \
+                             not on individual fields."
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+        None
     }
 
     fn is_snake_case_identifier(name: &str) -> bool {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -880,10 +880,25 @@ impl QuillConfig {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let ui_section: Option<UiCardSchema> = quill_section
-            .get("ui")
-            .cloned()
-            .and_then(|v| serde_json::from_value(v).ok());
+        let ui_section: Option<UiCardSchema> = match quill_section.get("ui").cloned() {
+            None => None,
+            Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
+                Ok(parsed) => Some(parsed),
+                Err(e) => {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!("Invalid 'quill.ui' block: {}", e),
+                        )
+                        .with_code("quill::invalid_ui".to_string())
+                        .with_hint(
+                            "Valid keys under 'ui' are: title, hide_body.".to_string(),
+                        ),
+                    );
+                    None
+                }
+            },
+        };
 
         // Extract optional backend-specific section (keyed by `quill.backend`).
         let mut backend_config = HashMap::new();
@@ -960,11 +975,28 @@ impl QuillConfig {
             BTreeMap::new()
         };
 
-        // Extract main.ui (optional)
-        let main_ui: Option<UiCardSchema> = main_obj_opt
-            .and_then(|main_obj| main_obj.get("ui"))
-            .cloned()
-            .and_then(|v| serde_json::from_value(v).ok());
+        // Extract main.ui (optional). Fail loudly on malformed UI metadata rather
+        // than silently dropping it — see `quill.ui` handling above.
+        let main_ui: Option<UiCardSchema> =
+            match main_obj_opt.and_then(|main_obj| main_obj.get("ui")).cloned() {
+                None => None,
+                Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
+                    Ok(parsed) => Some(parsed),
+                    Err(e) => {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!("Invalid 'main.ui' block: {}", e),
+                            )
+                            .with_code("quill::invalid_ui".to_string())
+                            .with_hint(
+                                "Valid keys under 'ui' are: title, hide_body.".to_string(),
+                            ),
+                        );
+                        None
+                    }
+                },
+            };
 
         // Extract main.description (optional, authored under `main:` like any
         // other card type). This is independent of `quill.description`.

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -50,6 +50,9 @@ pub struct QuillConfig {
 #[serde(deny_unknown_fields)]
 struct CardSchemaDef {
     pub description: Option<String>,
+    // Declared so `deny_unknown_fields` accepts a `fields:` block on a card.
+    // Fields are re-parsed via `parse_fields_with_order` for ordering.
+    #[allow(dead_code)]
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub ui: Option<UiCardSchema>,
 }
@@ -668,7 +671,7 @@ impl QuillConfig {
     pub fn from_yaml_with_warnings(
         yaml_content: &str,
     ) -> Result<(Self, Vec<Diagnostic>), Vec<Diagnostic>> {
-        let mut warnings: Vec<Diagnostic> = Vec::new();
+        let warnings: Vec<Diagnostic> = Vec::new();
         let mut errors: Vec<Diagnostic> = Vec::new();
 
         // Parse YAML into serde_json::Value via serde_saphyr
@@ -722,10 +725,7 @@ impl QuillConfig {
                             format!("Unknown key '{}' in 'quill:' section", key),
                         )
                         .with_code("quill::unknown_key".to_string())
-                        .with_hint(format!(
-                            "Valid keys are: {}",
-                            KNOWN_QUILL_KEYS.join(", ")
-                        )),
+                        .with_hint(format!("Valid keys are: {}", KNOWN_QUILL_KEYS.join(", "))),
                     );
                 }
             }
@@ -761,7 +761,9 @@ impl QuillConfig {
                         "Missing required 'name' field in 'quill' section".to_string(),
                     )
                     .with_code("quill::missing_name".to_string())
-                    .with_hint("Add 'name: your_quill_name' under the 'quill:' section.".to_string()),
+                    .with_hint(
+                        "Add 'name: your_quill_name' under the 'quill:' section.".to_string(),
+                    ),
                 );
                 String::new()
             }
@@ -887,9 +889,7 @@ impl QuillConfig {
                             format!("Invalid 'quill.ui' block: {}", e),
                         )
                         .with_code("quill::invalid_ui".to_string())
-                        .with_hint(
-                            "Valid keys under 'ui' are: title, hide_body.".to_string(),
-                        ),
+                        .with_hint("Valid keys under 'ui' are: title, hide_body.".to_string()),
                     );
                     None
                 }
@@ -973,26 +973,23 @@ impl QuillConfig {
 
         // Extract main.ui (optional). Fail loudly on malformed UI metadata rather
         // than silently dropping it — see `quill.ui` handling above.
-        let main_ui: Option<UiCardSchema> =
-            match main_obj_opt.and_then(|main_obj| main_obj.get("ui")).cloned() {
-                None => None,
-                Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
-                    Ok(parsed) => Some(parsed),
-                    Err(e) => {
-                        errors.push(
-                            Diagnostic::new(
-                                Severity::Error,
-                                format!("Invalid 'main.ui' block: {}", e),
-                            )
+        let main_ui: Option<UiCardSchema> = match main_obj_opt
+            .and_then(|main_obj| main_obj.get("ui"))
+            .cloned()
+        {
+            None => None,
+            Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
+                Ok(parsed) => Some(parsed),
+                Err(e) => {
+                    errors.push(
+                        Diagnostic::new(Severity::Error, format!("Invalid 'main.ui' block: {}", e))
                             .with_code("quill::invalid_ui".to_string())
-                            .with_hint(
-                                "Valid keys under 'ui' are: title, hide_body.".to_string(),
-                            ),
-                        );
-                        None
-                    }
-                },
-            };
+                            .with_hint("Valid keys under 'ui' are: title, hide_body.".to_string()),
+                    );
+                    None
+                }
+            },
+        };
 
         // Extract main.description (optional, authored under `main:` like any
         // other card type). This is independent of `quill.description`.

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -51,8 +51,8 @@ impl QuillSource {
         mut config: QuillConfig,
         root: FileTreeNode,
     ) -> Result<Self, Vec<Diagnostic>> {
-        // Build metadata from config
-        let mut metadata = config.metadata.clone();
+        let mut metadata: std::collections::HashMap<String, QuillValue> =
+            std::collections::HashMap::new();
 
         metadata.insert(
             "backend".to_string(),

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -1,10 +1,14 @@
 //! QuillSource loading and construction routines.
-use std::error::Error as StdError;
 use std::path::{Component, Path};
 
+use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::{FileTreeNode, QuillConfig, QuillSource};
+
+fn diag(message: impl Into<String>, code: &str) -> Diagnostic {
+    Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string())
+}
 
 impl QuillSource {
     /// Create a QuillSource from a tree structure.
@@ -19,24 +23,26 @@ impl QuillSource {
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - Quill.yaml is not found in the file tree
-    /// - Quill.yaml is not valid UTF-8 or YAML
-    /// - The plate file specified in Quill.yaml is not found or not valid UTF-8
-    /// - Validation fails
-    pub fn from_tree(root: FileTreeNode) -> Result<Self, Box<dyn StdError + Send + Sync>> {
-        // Read Quill.yaml
+    /// Returns a non-empty `Vec<Diagnostic>` describing every problem found.
+    /// When `Quill.yaml` itself contains multiple errors they are all
+    /// reported together; subsequent failures (missing plate, malformed
+    /// example) surface as single-element vectors.
+    pub fn from_tree(root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
         let quill_yaml_bytes = root
             .get_file("Quill.yaml")
-            .ok_or("Quill.yaml not found in file tree")?;
+            .ok_or_else(|| vec![diag("Quill.yaml not found in file tree", "quill::missing_file")])?;
 
-        let quill_yaml_content = String::from_utf8(quill_yaml_bytes.to_vec())
-            .map_err(|e| format!("Quill.yaml is not valid UTF-8: {}", e))?;
+        let quill_yaml_content = String::from_utf8(quill_yaml_bytes.to_vec()).map_err(|e| {
+            vec![diag(
+                format!("Quill.yaml is not valid UTF-8: {}", e),
+                "quill::invalid_utf8",
+            )]
+        })?;
 
-        // Parse YAML into QuillConfig
-        let config = QuillConfig::from_yaml(&quill_yaml_content)?;
+        // Parse YAML into QuillConfig — propagate the full diagnostic vector
+        // so every Quill.yaml error reaches the caller.
+        let (config, _warnings) = QuillConfig::from_yaml_with_warnings(&quill_yaml_content)?;
 
-        // Construct QuillSource from QuillConfig
         Self::from_config(config, root)
     }
 
@@ -44,11 +50,10 @@ impl QuillSource {
     fn from_config(
         mut config: QuillConfig,
         root: FileTreeNode,
-    ) -> Result<Self, Box<dyn StdError + Send + Sync>> {
+    ) -> Result<Self, Vec<Diagnostic>> {
         // Build metadata from config
         let mut metadata = config.metadata.clone();
 
-        // Add backend to metadata
         metadata.insert(
             "backend".to_string(),
             QuillValue::from_json(serde_json::Value::String(config.backend.clone())),
@@ -59,13 +64,11 @@ impl QuillSource {
             QuillValue::from_json(serde_json::Value::String(config.description.clone())),
         );
 
-        // Add author
         metadata.insert(
             "author".to_string(),
             QuillValue::from_json(serde_json::Value::String(config.author.clone())),
         );
 
-        // Add version
         metadata.insert(
             "version".to_string(),
             QuillValue::from_json(serde_json::Value::String(config.version.clone())),
@@ -79,15 +82,20 @@ impl QuillSource {
         // Read the plate content from plate file (if specified)
         let plate_content: Option<String> = if let Some(ref plate_file_name) = config.plate_file {
             let plate_bytes = root.get_file(plate_file_name).ok_or_else(|| {
-                format!("Plate file '{}' not found in file tree", plate_file_name)
+                vec![diag(
+                    format!("Plate file '{}' not found in file tree", plate_file_name),
+                    "quill::plate_missing",
+                )]
             })?;
 
             let content = String::from_utf8(plate_bytes.to_vec()).map_err(|e| {
-                format!("Plate file '{}' is not valid UTF-8: {}", plate_file_name, e)
+                vec![diag(
+                    format!("Plate file '{}' is not valid UTF-8: {}", plate_file_name, e),
+                    "quill::invalid_utf8",
+                )]
             })?;
             Some(content)
         } else {
-            // No plate file specified
             None
         };
 
@@ -99,35 +107,42 @@ impl QuillSource {
                     .components()
                     .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
             {
-                return Err(format!(
-                    "Example file '{}' is outside the quill directory",
-                    example_file_name
-                )
-                .into());
+                return Err(vec![diag(
+                    format!(
+                        "Example file '{}' is outside the quill directory",
+                        example_file_name
+                    ),
+                    "quill::example_path_traversal",
+                )]);
             }
 
             let bytes = root.get_file(example_file_name).ok_or_else(|| {
-                format!(
-                    "Example file '{}' referenced in Quill.yaml not found",
-                    example_file_name
-                )
+                vec![diag(
+                    format!(
+                        "Example file '{}' referenced in Quill.yaml not found",
+                        example_file_name
+                    ),
+                    "quill::example_missing",
+                )]
             })?;
             Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
-                format!(
-                    "Example file '{}' is not valid UTF-8: {}",
-                    example_file_name, e
-                )
+                vec![diag(
+                    format!(
+                        "Example file '{}' is not valid UTF-8: {}",
+                        example_file_name, e
+                    ),
+                    "quill::invalid_utf8",
+                )]
             })?)
         } else if root.file_exists("example.md") {
-            // Smart default: use example.md if it exists
             let bytes = root
                 .get_file("example.md")
                 .expect("invariant violation: file_exists(example.md) but get_file returned None");
             Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
-                format!(
-                    "Default example file 'example.md' is not valid UTF-8: {}",
-                    e
-                )
+                vec![diag(
+                    format!("Default example file 'example.md' is not valid UTF-8: {}", e),
+                    "quill::invalid_utf8",
+                )]
             })?)
         } else {
             None

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -28,9 +28,12 @@ impl QuillSource {
     /// reported together; subsequent failures (missing plate, malformed
     /// example) surface as single-element vectors.
     pub fn from_tree(root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
-        let quill_yaml_bytes = root
-            .get_file("Quill.yaml")
-            .ok_or_else(|| vec![diag("Quill.yaml not found in file tree", "quill::missing_file")])?;
+        let quill_yaml_bytes = root.get_file("Quill.yaml").ok_or_else(|| {
+            vec![diag(
+                "Quill.yaml not found in file tree",
+                "quill::missing_file",
+            )]
+        })?;
 
         let quill_yaml_content = String::from_utf8(quill_yaml_bytes.to_vec()).map_err(|e| {
             vec![diag(
@@ -47,10 +50,7 @@ impl QuillSource {
     }
 
     /// Create a QuillSource from a QuillConfig and file tree.
-    fn from_config(
-        mut config: QuillConfig,
-        root: FileTreeNode,
-    ) -> Result<Self, Vec<Diagnostic>> {
+    fn from_config(mut config: QuillConfig, root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
         let mut metadata: std::collections::HashMap<String, QuillValue> =
             std::collections::HashMap::new();
 
@@ -140,7 +140,10 @@ impl QuillSource {
                 .expect("invariant violation: file_exists(example.md) but get_file returned None");
             Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
                 vec![diag(
-                    format!("Default example file 'example.md' is not valid UTF-8: {}", e),
+                    format!(
+                        "Default example file 'example.md' is not valid UTF-8: {}",
+                        e
+                    ),
                     "quill::invalid_utf8",
                 )]
             })?)

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for quill types and loading.
 
 use super::*;
-use crate::Severity;
+use crate::{Diagnostic, Severity};
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fs;
@@ -1675,7 +1675,7 @@ main:
 }
 
 #[test]
-fn test_standalone_object_field_rejected_with_warning() {
+fn test_standalone_object_field_rejected_with_error() {
     let yaml_content = r#"
 quill:
   name: obj_test
@@ -1708,7 +1708,7 @@ main:
 }
 
 #[test]
-fn test_nested_object_in_typed_table_rejected_with_warning() {
+fn test_nested_object_in_typed_table_rejected_with_error() {
     let yaml_content = r#"
 quill:
   name: nested_obj_test
@@ -2208,6 +2208,161 @@ main:
     assert_eq!(err[0].severity, Severity::Error);
     assert_eq!(err[0].code.as_deref(), Some("quill::field_parse_error"));
     assert!(err[0].message.contains("broken_field"));
+}
+
+#[test]
+fn test_unknown_key_in_quill_section_errors() {
+    // Typos like 'platefile' should fail loudly, not silently land in metadata.
+    let yaml_content = r#"
+quill:
+  name: unk_key
+  version: "1.0"
+  backend: typst
+  description: Unknown key test
+  platefile: foo.typ
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    assert_eq!(err.len(), 1);
+    assert_eq!(err[0].code.as_deref(), Some("quill::unknown_key"));
+    assert!(err[0].message.contains("platefile"));
+    assert!(err[0]
+        .hint
+        .as_deref()
+        .unwrap_or("")
+        .contains("plate_file"));
+}
+
+#[test]
+fn test_unknown_top_level_section_errors() {
+    // 'card_type' is a common typo for 'card_types'. Must not be silently ignored.
+    let yaml_content = r#"
+quill:
+  name: unk_section
+  version: "1.0"
+  backend: typst
+  description: Unknown section test
+
+card_type:
+  foo:
+    description: Should not silently disappear
+    fields:
+      bar:
+        type: string
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    assert!(err.iter().any(|d| {
+        d.code.as_deref() == Some("quill::unknown_section") && d.message.contains("card_type")
+    }));
+}
+
+#[test]
+fn test_root_level_fields_gets_targeted_hint() {
+    // Root-level `fields:` (instead of `main.fields:`) should produce a single
+    // unknown_section error with a targeted hint, not a duplicate error.
+    let yaml_content = r#"
+quill:
+  name: root_fields
+  version: "1.0"
+  backend: typst
+  description: Root fields test
+
+fields:
+  author:
+    type: string
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    let fields_errors: Vec<&Diagnostic> = err
+        .iter()
+        .filter(|d| d.message.contains("fields"))
+        .collect();
+    assert_eq!(
+        fields_errors.len(),
+        1,
+        "expected exactly one error for root-level `fields`, got {} ({:?})",
+        fields_errors.len(),
+        fields_errors
+    );
+    assert_eq!(
+        fields_errors[0].code.as_deref(),
+        Some("quill::unknown_section")
+    );
+    assert!(fields_errors[0]
+        .hint
+        .as_deref()
+        .unwrap_or("")
+        .contains("main.fields"));
+}
+
+#[test]
+fn test_multiple_errors_collected_in_one_pass() {
+    // The headline DX behavior: an author with several mistakes should see
+    // them all in one shot, not fix-rerun-fix-rerun.
+    let yaml_content = r#"
+quill:
+  name: BadName
+  version: "1.0"
+  backend: typst
+  description: Multi-error test
+  platefile: foo.typ
+
+main:
+  fields:
+    BadFieldName:
+      type: string
+    legit:
+      title: Bad legacy key
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    // We expect at least: invalid_name + unknown_key + invalid_field_name + field_parse_error
+    assert!(
+        err.len() >= 4,
+        "expected >=4 errors collected at once, got {}: {:?}",
+        err.len(),
+        err.iter().map(|d| d.code.as_deref()).collect::<Vec<_>>()
+    );
+    let codes: Vec<&str> = err.iter().filter_map(|d| d.code.as_deref()).collect();
+    assert!(codes.contains(&"quill::invalid_name"), "missing invalid_name: {:?}", codes);
+    assert!(codes.contains(&"quill::unknown_key"), "missing unknown_key: {:?}", codes);
+    assert!(
+        codes.contains(&"quill::invalid_field_name"),
+        "missing invalid_field_name: {:?}",
+        codes
+    );
+    assert!(
+        codes.contains(&"quill::field_parse_error"),
+        "missing field_parse_error: {:?}",
+        codes
+    );
+}
+
+#[test]
+fn test_main_ui_malformed_errors_with_hint() {
+    // main.ui should fail loudly when malformed, not be silently dropped.
+    let yaml_content = r#"
+quill:
+  name: bad_ui
+  version: "1.0"
+  backend: typst
+  description: Bad UI test
+
+main:
+  ui:
+    bogus_key: nope
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::invalid_ui")));
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2203,6 +2203,63 @@ main:
     assert!(err[0].message.contains("broken_field"));
 }
 
+#[test]
+fn test_field_with_title_key_errors_with_hint() {
+    // 'title' is a common mistake — authors expect it to work like 'description'.
+    // We must fail loudly with an actionable hint rather than silently dropping the field.
+    let yaml_content = r#"
+quill:
+  name: hint_test
+  version: "1.0"
+  backend: typst
+  description: Hint test
+
+main:
+  fields:
+    author:
+      type: string
+      title: The document author
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    assert_eq!(err.len(), 1);
+    assert_eq!(err[0].code.as_deref(), Some("quill::field_parse_error"));
+    assert_eq!(
+        err[0].hint.as_deref(),
+        Some("'title' is not a valid field key; use 'description' instead.")
+    );
+}
+
+#[test]
+fn test_field_with_ui_title_errors_with_hint() {
+    // 'ui.title' is valid on card_types but not on individual fields.
+    let yaml_content = r#"
+quill:
+  name: ui_title_test
+  version: "1.0"
+  backend: typst
+  description: ui.title hint test
+
+main:
+  fields:
+    status:
+      type: string
+      ui:
+        title: Status Label
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+
+    assert_eq!(err.len(), 1);
+    assert_eq!(err[0].code.as_deref(), Some("quill::field_parse_error"));
+    assert!(err[0]
+        .hint
+        .as_deref()
+        .unwrap_or("")
+        .contains("only valid on card type schemas"));
+}
+
 fn check_schema_snapshot(
     yaml_of: impl Fn(&QuillConfig) -> String,
     json_of: impl Fn(&QuillConfig) -> serde_json::Value,

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -67,7 +67,14 @@ fn load_dir(
 /// Test helper: filesystem equivalent of the old `Quill::from_path`.
 fn load_from_path<P: AsRef<Path>>(path: P) -> Result<QuillSource, Box<dyn StdError + Send + Sync>> {
     let tree = load_tree(path.as_ref())?;
-    QuillSource::from_tree(tree)
+    QuillSource::from_tree(tree).map_err(|diags| {
+        diags
+            .iter()
+            .map(|d| d.fmt_pretty())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .into()
+    })
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2227,11 +2227,7 @@ quill:
     assert_eq!(err.len(), 1);
     assert_eq!(err[0].code.as_deref(), Some("quill::unknown_key"));
     assert!(err[0].message.contains("platefile"));
-    assert!(err[0]
-        .hint
-        .as_deref()
-        .unwrap_or("")
-        .contains("plate_file"));
+    assert!(err[0].hint.as_deref().unwrap_or("").contains("plate_file"));
 }
 
 #[test]
@@ -2329,8 +2325,16 @@ main:
         err.iter().map(|d| d.code.as_deref()).collect::<Vec<_>>()
     );
     let codes: Vec<&str> = err.iter().filter_map(|d| d.code.as_deref()).collect();
-    assert!(codes.contains(&"quill::invalid_name"), "missing invalid_name: {:?}", codes);
-    assert!(codes.contains(&"quill::unknown_key"), "missing unknown_key: {:?}", codes);
+    assert!(
+        codes.contains(&"quill::invalid_name"),
+        "missing invalid_name: {:?}",
+        codes
+    );
+    assert!(
+        codes.contains(&"quill::unknown_key"),
+        "missing unknown_key: {:?}",
+        codes
+    );
     assert!(
         codes.contains(&"quill::invalid_field_name"),
         "missing invalid_field_name: {:?}",

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1103,10 +1103,9 @@ quill:
   backend: typst
   description: Test metadata flow
   author: Test Author
-  custom_field: custom_value
 
 typst:
-  packages: 
+  packages:
     - "@preview/bubble:0.2.2"
 "#;
     root_files.insert(
@@ -1124,13 +1123,6 @@ typst:
     assert!(quill.metadata.contains_key("description"));
     assert!(quill.metadata.contains_key("author"));
 
-    // Verify custom field is in metadata
-    assert!(quill.metadata.contains_key("custom_field"));
-    assert_eq!(
-        quill.metadata.get("custom_field").unwrap().as_str(),
-        Some("custom_value")
-    );
-
     // Verify typst config with typst_ prefix
     assert!(quill.metadata.contains_key("typst_packages"));
 }
@@ -1147,10 +1139,9 @@ quill:
   backend: typst
   description: Test metadata flow
   author: Test Author
-  custom_field: custom_value
 
 typst:
-  packages: 
+  packages:
     - "@preview/bubble:0.2.2"
 
 main:
@@ -1698,20 +1689,15 @@ main:
           type: string
 "#;
 
-    let (config, warnings) = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap();
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
 
-    // Standalone object field should be skipped
-    assert!(config.main.fields.contains_key("valid_field"));
-    assert!(!config.main.fields.contains_key("address"));
-
-    // A warning should be emitted
-    assert_eq!(warnings.len(), 1);
-    assert_eq!(warnings[0].severity, Severity::Warning);
+    assert_eq!(err.len(), 1);
+    assert_eq!(err[0].severity, Severity::Error);
     assert_eq!(
-        warnings[0].code.as_deref(),
+        err[0].code.as_deref(),
         Some("quill::standalone_object_not_supported")
     );
-    assert!(warnings[0].message.contains("address"));
+    assert!(err[0].message.contains("address"));
 }
 
 #[test]
@@ -1739,16 +1725,15 @@ main:
                 type: string
 "#;
 
-    let (config, warnings) = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap();
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
 
-    assert!(!config.main.fields.contains_key("rows"));
-    assert_eq!(warnings.len(), 1);
-    assert_eq!(warnings[0].severity, Severity::Warning);
+    assert_eq!(err.len(), 1);
+    assert_eq!(err[0].severity, Severity::Error);
     assert_eq!(
-        warnings[0].code.as_deref(),
+        err[0].code.as_deref(),
         Some("quill::nested_object_not_supported")
     );
-    assert!(warnings[0].message.contains("rows"));
+    assert!(err[0].message.contains("rows"));
 }
 
 #[test]
@@ -2193,13 +2178,13 @@ main:
 }
 
 #[test]
-fn test_quill_config_from_yaml_collects_non_fatal_field_warnings() {
+fn test_quill_config_from_yaml_errors_on_invalid_field() {
     let yaml_content = r#"
 quill:
-  name: warning_config
+  name: error_config
   version: "1.0"
   backend: typst
-  description: Warning collection test
+  description: Error on invalid field test
 
 main:
   fields:
@@ -2210,19 +2195,12 @@ main:
       description: Missing required type
 "#;
 
-    let (config, warnings) = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap();
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
 
-    assert!(config.main.fields.contains_key("valid_field"));
-    assert!(!config.main.fields.contains_key("broken_field"));
-    assert_eq!(warnings.len(), 1);
-    assert_eq!(warnings[0].severity, Severity::Warning);
-    assert_eq!(
-        warnings[0].code.as_deref(),
-        Some("quill::field_parse_warning")
-    );
-    assert!(warnings[0]
-        .message
-        .contains("Failed to parse field schema 'broken_field'"));
+    assert_eq!(err.len(), 1);
+    assert_eq!(err[0].severity, Severity::Error);
+    assert_eq!(err[0].code.as_deref(), Some("quill::field_parse_error"));
+    assert!(err[0].message.contains("broken_field"));
 }
 
 fn check_schema_snapshot(

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -36,8 +36,8 @@ impl Quillmark {
 
     /// Build and return a render-ready quill from an in-memory file tree.
     pub fn quill(&self, tree: FileTreeNode) -> Result<Quill, RenderError> {
-        let source = QuillSource::from_tree(tree)
-            .map_err(|diags| RenderError::QuillConfig { diags })?;
+        let source =
+            QuillSource::from_tree(tree).map_err(|diags| RenderError::QuillConfig { diags })?;
         self.assemble(source)
     }
 

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -36,25 +36,18 @@ impl Quillmark {
 
     /// Build and return a render-ready quill from an in-memory file tree.
     pub fn quill(&self, tree: FileTreeNode) -> Result<Quill, RenderError> {
-        let source = QuillSource::from_tree(tree).map_err(|e| RenderError::QuillConfig {
-            diag: Box::new(
-                Diagnostic::new(
-                    Severity::Error,
-                    format!("Failed to load quill from tree: {}", e),
-                )
-                .with_code("quill::load_failed".to_string()),
-            ),
-        })?;
+        let source = QuillSource::from_tree(tree)
+            .map_err(|diags| RenderError::QuillConfig { diags })?;
         self.assemble(source)
     }
 
     /// Load a quill from a filesystem path and attach the appropriate backend.
     pub fn quill_from_path<P: AsRef<Path>>(&self, path: P) -> Result<Quill, RenderError> {
         let tree = load_tree_from_path(path.as_ref()).map_err(|e| RenderError::QuillConfig {
-            diag: Box::new(
+            diags: vec![
                 Diagnostic::new(Severity::Error, format!("Failed to load quill: {}", e))
                     .with_code("quill::load_failed".to_string()),
-            ),
+            ],
         })?;
         self.quill(tree)
     }

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -22,7 +22,9 @@ typst:        # Optional — backend-specific configuration
   ...
 ```
 
-Root-level `fields:` is not supported; define the main document’s field schemas under `main.fields`.
+Root-level `fields:` is not supported; define the main document's field schemas under `main.fields`.
+
+`Quill.yaml` is parsed strictly. Unknown keys in the `quill:` section, unknown top-level sections, malformed `ui:` blocks, and field schemas that can't be parsed all produce errors — they are never silently dropped. Every error is collected in a single pass, so authors see all problems at once. Run `quillmark validate <quill_dir>` to surface them.
 
 ---
 

--- a/prose/designs/ERROR.md
+++ b/prose/designs/ERROR.md
@@ -19,7 +19,7 @@
 - `FormatNotSupported` — requested output format not supported
 - `UnsupportedBackend` — backend not registered
 - `ValidationFailed` — field coercion/schema validation failure
-- `QuillConfig` — quill configuration error
+- `QuillConfig` — Quill.yaml configuration error; carries `Vec<Diagnostic>` so every parse problem reaches the caller in one pass
 
 **`RenderResult`**: successful result carrying artifacts, output format, and non-fatal `Vec<Diagnostic>` warnings
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -100,8 +100,20 @@ Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`
 
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card type.
-- `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, any extra `Quill.*` keys, and `typst_*` keys from the `[typst]` section
+- `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, and `typst_*` keys from the `[typst]` section. The `quill:` section accepts only the documented keys; unknown keys produce a `quill::unknown_key` error rather than landing in `metadata`.
 - `example_file` also accepts the alias `example` in YAML
+
+## Strict Parsing
+
+`Quill.yaml` is parsed strictly: every problem the parser can detect is collected and reported in one pass as a `Vec<Diagnostic>`, rather than failing on the first error or silently dropping unsupported shapes. Specifically:
+
+- Unknown keys in the `quill:` section error with `quill::unknown_key` (typos like `platefile` are not silently captured).
+- Unknown top-level sections error with `quill::unknown_section` (typos like `card_type:` are not silently ignored). Root-level `fields:` gets a targeted hint pointing to `main.fields:`.
+- Field schemas that fail to parse (e.g. legacy `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
+- Standalone `object` fields and disallowed nested-object shapes error with `quill::standalone_object_not_supported` / `quill::nested_object_not_supported`.
+- Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
+
+Errors flow through `RenderError::QuillConfig { diags: Vec<Diagnostic> }` and surface to bindings as a structured array (`err.diagnostics` in WASM, `.diagnostics` attribute in Python).
 
 ## File Ignore Rules
 


### PR DESCRIPTION
- from_yaml_with_warnings now returns Result<_, Vec<Diagnostic>> so callers
  see every problem at once instead of just the first
- Unknown keys in the quill: section are now hard errors (previously silently
  collected into metadata, masking typos like platefile vs plate_file)
- Unknown top-level sections are now hard errors (previously ignored, so
  card_type: instead of card_types: would silently succeed)
- Failed field schema parses are now errors not warnings — a field that cannot
  be parsed is no longer silently dropped from the schema (addresses consumer
  feedback: never silently drop schema fields)
- Standalone object fields and disallowed nested objects are now errors not
  warnings (same principle: drop == silent failure for the author)
- validate.rs uses from_yaml_with_warnings directly so each error is emitted
  as a separate [ERROR] line rather than one joined string
- All error diagnostics include stable codes and actionable hints

https://claude.ai/code/session_01UViGYf1rsuoksrmiymvmK1