### PR TITLE
Consolidate schema emission and remove form_schema API

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -99,7 +99,7 @@ impl PyQuill {
         Ok(dict)
     }
 
-    /// Document schema (no ui hints) as YAML.
+    /// Document schema as YAML, including `ui` hints.
     #[getter]
     fn schema<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let yaml = self

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -57,8 +57,7 @@ export interface QuillCardSchema {
 }
 
 /**
- * Document schema. Returned by both `Quill.schema` (no ui hints) and
- * `Quill.formSchema` (with ui hints) — same shape, optional `ui` keys.
+ * Document schema returned by `Quill.schema`. Includes optional `ui` keys.
  *
  * `main.fields.QUILL` and `card_types[name].fields.CARD` are required
  * sentinels with `const` values telling consumers what to write.
@@ -71,8 +70,8 @@ export interface QuillSchema {
 
 /**
  * Identity snapshot mirroring the `quill:` section of `Quill.yaml`.
- * Schemas live on `Quill.schema` / `Quill.formSchema`; the example on
- * `Quill.example`. Extra `quill:` keys appear as `unknown`.
+ * The schema lives on `Quill.schema`; the example on `Quill.example`.
+ * Extra `quill:` keys appear as `unknown`.
  */
 export interface QuillMetadata {
     name: string;

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -193,8 +193,7 @@ fn test_quill_from_object_tree() {
     assert_eq!(r_map.artifacts.len(), r_obj.artifacts.len());
 }
 
-/// `metadata` is identity only; `schema` strips ui and injects QUILL/CARD
-/// sentinels; `formSchema` keeps ui hints.
+/// `metadata` is identity only; `schema` keeps ui hints and injects QUILL/CARD sentinels.
 #[wasm_bindgen_test]
 fn test_quill_metadata_and_schemas() {
     use js_sys::Reflect;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -17,7 +17,7 @@ pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;
 pub use types::{
-    body_key, field_key, ui_key, BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema,
+    field_key, ui_key, BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema,
     UiFieldSchema,
 };
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -45,7 +45,11 @@ impl QuillConfig {
             main_desc,
         );
         if self.main.body_enabled() {
-            let desc = self.main.body.as_ref().and_then(|b| b.description.as_deref());
+            let desc = self
+                .main
+                .body
+                .as_ref()
+                .and_then(|b| b.description.as_deref());
             out.push_str(&format!("\n{}\n", body_marker("main body", desc)));
         }
         for card in &self.card_types {

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -45,14 +45,6 @@ pub mod ui_key {
     pub const MULTILINE: &str = "multiline";
 }
 
-/// Semantic constants for body namespace keys
-pub mod body_key {
-    /// Whether the body editor is enabled for this card (default: true)
-    pub const ENABLED: &str = "enabled";
-    /// Optional description shown in the body editor placeholder area
-    pub const DESCRIPTION: &str = "description";
-}
-
 /// UI-specific metadata for field rendering
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -134,14 +126,6 @@ impl CardSchema {
     /// Defaults to true when no `body` namespace is declared.
     pub fn body_enabled(&self) -> bool {
         self.body.as_ref().and_then(|b| b.enabled).unwrap_or(true)
-    }
-
-    /// Returns the body description text, falling back to `default` when none is set.
-    pub fn body_description<'a>(&'a self, default: &'a str) -> &'a str {
-        self.body
-            .as_ref()
-            .and_then(|b| b.description.as_deref())
-            .unwrap_or(default)
     }
 }
 

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -10,10 +10,11 @@ A `Quill.yaml` has these top-level sections:
 quill:        # Required — format metadata
   ...
 
-main:         # Optional — main entry-point card: field schemas and optional ui
+main:         # Optional — main entry-point card: field schemas and optional ui/body
   fields:
     ...
-  ui:         # optional container hints (e.g. hide_body)
+  ui:         # optional UI hints (e.g. title)
+  body:       # optional body-region config (e.g. enabled, description)
 
 card_types:   # Optional — additional composable card types
   ...
@@ -263,7 +264,7 @@ main:
 
 ## `card_types` Section
 
-`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
+`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`, `body`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
 
 Card-type names (the keys under `card_types`) must match `[a-z_][a-z0-9_]*` (leading underscore is allowed).
 
@@ -294,7 +295,8 @@ Invalid card-type names include:
 |---------------|--------|----------|-------------|
 | `description` | string | no       | Help text describing the card's purpose |
 | `fields`      | object | no       | Field schemas (same structure as top-level fields) |
-| `ui`          | object | no       | Container-level UI hints |
+| `ui`          | object | no       | Container-level UI hints (see [Card-level `ui`](#card-level-ui)) |
+| `body`        | object | no       | Body-region config (see [Card-level `body`](#card-level-body)) |
 
 ### Card-level `ui`
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -25,7 +25,7 @@ field: value
 
 ---
 
-main body...
+main body
 
 ---
 # <card description>
@@ -33,8 +33,12 @@ CARD: <card_name>  # sentinel, composable (0..N)
 ...fields...
 ---
 
-<card_name> body...
+<card_name> body
 ```
+
+When a `body.description` is set, the body marker line expands to
+`<tag> body — <description>` (em dash separator). When `body.enabled` is
+false the marker is omitted entirely.
 
 ## Annotation grammar
 
@@ -124,16 +128,18 @@ Most `ui:` keys are stripped, but two structural hints survive:
 
 ## Body markers
 
-- `main body...` after the main fence (or `<guide>...` when `body.description` is set)
-- `<card_name> body...` after each card fence (or `<guide>...` when `body.description` is set)
+- `main body` after the main fence
+- `<card_name> body` after each card fence
+- When `body.description` is set, the marker becomes
+  `<tag> body — <description>` (em dash separator). The structural
+  `<tag> body` label is preserved so the consumer always sees what kind
+  of body region they're filling in.
 
-Trailing ellipsis reads as "prose continues here." No markup conflict
-with HTML (avoiding the `<u>` deviation), and the named region echoes
-the sentinel above it.
+The named region echoes the sentinel above it. There is no markup
+conflict with HTML (avoiding the `<u>` deviation).
 
 `body.enabled: false` suppresses the marker entirely for body-less cards
-(e.g., a `skills` card whose data is purely structured). `body.description` replaces
-the default placeholder text with a custom hint for consumers.
+(e.g., a `skills` card whose data is purely structured).
 
 ## Bindings surface
 

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -58,6 +58,8 @@ card_types:
 card_types:
   indorsement:
     description: Chain of routing endorsements for multi-level correspondence.
+    ui:
+      title: Routing Endorsement
     fields:
       from:
         type: string
@@ -66,9 +68,11 @@ card_types:
       signature_block:
         type: array
         required: true
+        ui:
+          group: Addressing
 ```
 
-The schema is emitted by `QuillConfig::schema()` (clean, no `ui` hints) and `QuillConfig::form_schema()` (with `ui` hints, for form builders), with YAML wrappers `schema_yaml()` and `form_schema_yaml()`. Both keep the same `card_types.<name>.fields` shape as `Quill.yaml` and inject a required `CARD` sentinel field whose `const` value is the card name. The `card_types` key is omitted entirely when no named card-types are defined. See `SCHEMAS.md` for the full surface.
+`QuillConfig::schema()` emits the schema (with `ui` and `body` hints retained) and `schema_yaml()` is the YAML wrapper. The output keeps the same `card_types.<name>.fields` shape as `Quill.yaml` and injects a required `CARD` sentinel field whose `const` value is the card name. The `card_types` key is omitted entirely when no named card-types are defined. See `SCHEMAS.md` for the full surface.
 
 ## Markdown Syntax
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -84,8 +84,11 @@ main:
 
 card_types:
   quote:
-    title: Quote block
     description: A single pull quote
+    ui:
+      title: Quote block      # optional UI display label
+    body:
+      description: The quote text  # optional editor placeholder
     fields:
       author:
         type: string
@@ -112,6 +115,8 @@ Metadata resolution:
 - Field schemas that fail to parse (e.g. legacy `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
 - Standalone `object` fields and disallowed nested-object shapes error with `quill::standalone_object_not_supported` / `quill::nested_object_not_supported`.
 - Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
+- Malformed `main.body` / `card_types.<name>.body` blocks error with `quill::invalid_body`.
+- A `body.description` set together with `body.enabled: false` warns with `quill::body_description_unused` (the description has no effect).
 
 Errors flow through `RenderError::QuillConfig { diags: Vec<Diagnostic> }` and surface to bindings as a structured array (`err.diagnostics` in WASM, `.diagnostics` attribute in Python).
 

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -2,15 +2,15 @@
 
 ## TL;DR
 
-`QuillConfig` is the only schema model in quillmark. Validation, coercion, defaults/examples extraction, and public schema emission all read directly from it.
+`QuillConfig` is the only schema model in quillmark. Validation, coercion, defaults extraction, and public schema emission all read directly from it.
 
 ## Quill.yaml DSL
 
 Schema authoring lives in `Quill.yaml` under:
 
 - `main.fields`
-- `cards.<card_name>.fields`
-- optional `ui` hints on fields/cards/main
+- `card_types.<card_name>.fields`
+- optional `ui` and `body` blocks on `main` and each card type
 
 Supported field types:
 
@@ -21,17 +21,17 @@ Supported field types:
 | `integer` | Integer-only numeric value |
 | `boolean` | `true` / `false` |
 | `array` | Ordered list; use `items:` |
-| `object` | Structured map; use `properties:` |
+| `object` | Structured map; use `properties:` (only valid inside `array.items`) |
 | `date` | `YYYY-MM-DD` |
 | `datetime` | ISO 8601 |
 | `markdown` | Rich text; backends handle conversion |
 
 ## Type coercion
 
-`QuillConfig::coerce(&HashMap<String, QuillValue>)` runs before validation.
+`QuillConfig::coerce_frontmatter` and `coerce_card` run before validation.
 
-- Returns `Result<HashMap<String, QuillValue>, CoercionError>`
-- Coerces top-level fields and card fields in `CARDS` to their declared types
+- Returns `Result<IndexMap<String, QuillValue>, CoercionError>`
+- Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
 - Coercion rules per type: array wrapping, boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
 
@@ -39,63 +39,45 @@ Supported field types:
 
 Validation is implemented by a native walker over `QuillConfig` in `quill/validation.rs`.
 
-- Entry point: `QuillConfig::validate(&HashMap<String, QuillValue>)` (dispatches to `validate_document`)
+- Entry point: `QuillConfig::validate_document(&Document)` (dispatches to `validate_typed_document`)
 - Returns `Result<(), Vec<ValidationError>>`
 - Collects all errors (does not short-circuit)
 - Emits path-aware errors for top-level fields and card fields
-- Validates `CARDS` array: each element must have a `CARD` discriminator matching a known card type
+- Validates each card has a `CARD` discriminator matching a known card type
+- Enforces `body.enabled: false` on the main card and on each card type — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
 
 ## Schema emission
 
-Two projections of the same `QuillConfig` source are exposed:
+`QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:
 
-- `QuillConfig::schema()` — **structural schema**. Types, constraints,
-  `QUILL`/`CARD` sentinels with `const` values. No `ui` keys. The surface
-  for validators, machine consumers, and CLI inspection.
-- `QuillConfig::form_schema()` — same shape **plus** field-level (`group`,
-  `order`, `compact`, `multiline`) and card-level (`title`, `hide_body`)
-  `ui` hints. The surface for form builders.
+- Field types, constraints, and `enum`/`default`/`example` annotations
+- `ui` hints on fields and card types (`group`, `order`, `compact`, `multiline`, `title`)
+- `body` blocks on cards (`enabled`, `description`)
+- A required `QUILL` sentinel prepended to `main.fields` (`const = "<name>@<version>"`)
+- A required `CARD` sentinel prepended to each `card_types.<name>.fields` (`const = "<name>"`)
 
-For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()`
-emits a document-shaped, pre-filled Markdown reference that's denser
-than schema for prompt-time use.
+`QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `CardSchema`, `UiFieldSchema`, `UiCardSchema`, and `BodyCardSchema` — there is no parallel mirror struct.
 
-YAML wrappers `QuillConfig::schema_yaml()` and `QuillConfig::form_schema_yaml()`
-encode the same values. Both projections are pinned by serde attributes on
-`FieldSchema`, `CardSchema`, `UiFieldSchema`, and `UiCardSchema` —
-there is no parallel mirror struct. The clean variant is produced by
-recursively stripping `ui` keys after serialisation.
+For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level keys: `main`, optional `card_types` (map keyed by card name).
-`main` and each entry in `card_types` share the same `CardSchema` shape:
-`fields` (map keyed by field name), optional `description`, and —
-in `form_schema()` only — `ui`. Each `FieldSchema` includes `type`,
-optional `description`/`default`/`example`/`enum`/`properties`/
-`items`, optional `required` (omitted when false), and — in `form_schema()`
-only — optional `ui`.
+Top-level schema keys: `main`, optional `card_types` (map keyed by card name). `main` and each entry in `card_types` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`items`/`ui`, and optional `required` (omitted when false).
 
-Identity fields (`name`, `version`, `backend`, `author`, `description`)
-live on the parent metadata object (Wasm: `Quill.metadata`; Python:
-`Quill.metadata` plus dedicated getters). The bundled example markdown is
-exposed separately (Wasm: `Quill.example`; Python: `Quill.example`) so
-consumers choose whether to include it in a prompt.
+Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters). The bundled example markdown is exposed separately (Wasm: `Quill.example`; Python: `Quill.example`) so consumers choose whether to include it in a prompt.
 
 ### Bindings surface
 
-| Binding | Clean schema | Form schema |
-|---|---|---|
-| Rust | `QuillConfig::schema()` / `schema_yaml()` | `QuillConfig::form_schema()` / `form_schema_yaml()` |
-| Wasm | `Quill.schema` getter | `Quill.formSchema` getter |
-| Python | `Quill.schema` getter (YAML) | `Quill.form_schema` getter (YAML) |
-| CLI | `quillmark schema <path>` | `quillmark schema <path> --with-ui` |
+| Binding | Schema accessor |
+|---|---|
+| Rust | `QuillConfig::schema()` (JSON) / `schema_yaml()` (YAML) |
+| Wasm | `Quill.schema` getter (JSON) |
+| Python | `Quill.schema` getter (YAML) |
+| CLI | `quillmark schema <path>` |
 
 ### `main.fields` and `card_types.<name>.fields` sentinels
 
-Both `schema()` and `form_schema()` prepend a synthetic field to each card's
-`fields` map so consumers know exactly which sentinel string to write:
+`schema()` prepends a synthetic field to each card's `fields` map so consumers know exactly which sentinel string to write:
 
 - `main.fields.QUILL` — `{ type: string, const: "<name>@<version>", required: true, description: ... }`
 - `card_types.<name>.fields.CARD` — `{ type: string, const: "<name>", required: true, description: ... }`
 
-These appear ahead of the author's declared fields. They are not present in
-`Quill.yaml`; the projection injects them.
+These appear ahead of the author's declared fields. They are not present in `Quill.yaml`; the projection injects them.


### PR DESCRIPTION
This PR unifies the schema emission API by removing the separate `form_schema()` and `form_schema_yaml()` methods. The structural schema now includes `ui` and `body` hints by default, eliminating the need for two parallel projections.

## Key Changes

- **Removed dual schema API**: Deleted `QuillConfig::form_schema()` and `form_schema_yaml()` methods. The single `schema()` method now returns the complete schema with `ui` and `body` blocks included.

- **Updated documentation**: Revised `SCHEMAS.md` to reflect the unified schema approach:
  - Removed references to "clean schema" vs "form schema" distinction
  - Updated bindings surface table to show single schema accessor per binding
  - Clarified that `ui` and `body` hints are now part of the standard schema output

- **Simplified bindings**:
  - Wasm: Removed `formSchema` getter, kept `schema` getter
  - Python: Removed `form_schema` getter, kept `schema` getter
  - CLI: Removed `--with-ui` flag from `quillmark schema` command
  - Rust: Kept `schema()` and `schema_yaml()` as the primary API

- **Removed unused code**: Deleted `body_key` module constants that were no longer needed after API consolidation.

- **Updated type exports**: Removed `body_key` from public re-exports in `quill.rs`.

- **Refined documentation examples**: Updated `QUILL.md` and `CARDS.md` to show `ui` and `body` blocks in their proper locations within card type definitions.

- **Clarified blueprint behavior**: Updated `BLUEPRINT.md` to document how `body.description` affects marker output and how `body.enabled: false` suppresses markers entirely.

## Implementation Details

The schema structure remains unchanged—it still includes `fields`, optional `description`, optional `ui`, and optional `body` at both the `main` and `card_types.<name>` levels. The change is purely API-level: consumers now get a single, complete schema projection instead of choosing between two variants. This simplifies the API surface while maintaining all the information needed for both structural validation and UI rendering.

https://claude.ai/code/session_016YbNidn2oFqSCjQJ48VozS