### PR TITLE
Feat/body schema

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -99,7 +99,7 @@ impl PyQuill {
         Ok(dict)
     }
 
-    /// Document schema (no ui hints) as YAML.
+    /// Document schema as YAML, including `ui` hints.
     #[getter]
     fn schema<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let yaml = self

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -57,8 +57,7 @@ export interface QuillCardSchema {
 }
 
 /**
- * Document schema. Returned by both `Quill.schema` (no ui hints) and
- * `Quill.formSchema` (with ui hints) — same shape, optional `ui` keys.
+ * Document schema returned by `Quill.schema`. Includes optional `ui` keys.
  *
  * `main.fields.QUILL` and `card_types[name].fields.CARD` are required
  * sentinels with `const` values telling consumers what to write.
@@ -71,8 +70,8 @@ export interface QuillSchema {
 
 /**
  * Identity snapshot mirroring the `quill:` section of `Quill.yaml`.
- * Schemas live on `Quill.schema` / `Quill.formSchema`; the example on
- * `Quill.example`. Extra `quill:` keys appear as `unknown`.
+ * The schema lives on `Quill.schema`; the example on `Quill.example`.
+ * Extra `quill:` keys appear as `unknown`.
  */
 export interface QuillMetadata {
     name: string;

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -25,7 +25,14 @@ export interface QuillFieldUi {
 /** UI layout hints for a card (main or named card type). */
 export interface QuillCardUi {
     title?: string;
-    hide_body?: boolean;
+}
+
+/** Body namespace for a card (main or named card type). */
+export interface QuillCardBody {
+    /** When false, consumers must not accept or store body content for this card type. Defaults to true. */
+    enabled?: boolean;
+    /** Description shown in the body editor placeholder area when the body is empty. */
+    description?: string;
 }
 
 /** Schema entry for a single field declared in a quill's `Quill.yaml`. */
@@ -46,6 +53,7 @@ export interface QuillCardSchema {
     description?: string;
     fields: Record<string, QuillFieldSchema>;
     ui?: QuillCardUi;
+    body?: QuillCardBody;
 }
 
 /**

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -193,8 +193,7 @@ fn test_quill_from_object_tree() {
     assert_eq!(r_map.artifacts.len(), r_obj.artifacts.len());
 }
 
-/// `metadata` is identity only; `schema` strips ui and injects QUILL/CARD
-/// sentinels; `formSchema` keeps ui hints.
+/// `metadata` is identity only; `schema` keeps ui hints and injects QUILL/CARD sentinels.
 #[wasm_bindgen_test]
 fn test_quill_metadata_and_schemas() {
     use js_sys::Reflect;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -17,7 +17,7 @@ pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;
 pub use types::{
-    body_key, field_key, ui_key, BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema,
+    field_key, ui_key, BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema,
     UiFieldSchema,
 };
 

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -17,7 +17,8 @@ pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;
 pub use types::{
-    field_key, ui_key, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema,
+    body_key, field_key, ui_key, BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema,
+    UiFieldSchema,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -45,7 +45,11 @@ impl QuillConfig {
             main_desc,
         );
         if self.main.body_enabled() {
-            let desc = self.main.body.as_ref().and_then(|b| b.description.as_deref());
+            let desc = self
+                .main
+                .body
+                .as_ref()
+                .and_then(|b| b.description.as_deref());
             out.push_str(&format!("\n{}\n", body_marker("main body", desc)));
         }
         for card in &self.card_types {

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -11,10 +11,10 @@
 //!   non-obvious type hints (`# integer`, `# YYYY-MM-DD`, `# markdown`) on
 //!   ordinary fields, and `# sentinel` / `# sentinel, composable (0..N)` on
 //!   the `QUILL:` and `CARD:` lines respectively.
-//! - **Body regions** are signalled by `main body...` after the main fence
-//!   and `<card name> body...` after each card fence. The trailing ellipsis
-//!   reads as "prose continues here"; no markup conflict with HTML or
-//!   Markdown.
+//! - **Body regions** are signalled by `main body` after the main fence and
+//!   `<card name> body` after each card fence. When a `body.description` is
+//!   set, the marker expands to `<tag> body — <description>` using an em dash
+//!   separator. Absent when `body.enabled` is false.
 //!
 //! Most UI metadata is stripped, but two semantic-structure hints are honored:
 //! `ui.group` produces `# === <Group> ===` banners and `ui.order` controls
@@ -45,21 +45,27 @@ impl QuillConfig {
             main_desc,
         );
         if self.main.body_enabled() {
-            out.push_str(&format!(
-                "\n{}...\n",
-                self.main.body_description("main body")
-            ));
+            let desc = self.main.body.as_ref().and_then(|b| b.description.as_deref());
+            out.push_str(&format!("\n{}\n", body_marker("main body", desc)));
         }
         for card in &self.card_types {
             let sentinel = format!("CARD: {}  # sentinel, composable (0..N)", card.name);
             out.push('\n');
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
             if card.body_enabled() {
-                let default = format!("{} body", card.name);
-                out.push_str(&format!("\n{}...\n", card.body_description(&default)));
+                let label = format!("{} body", card.name);
+                let desc = card.body.as_ref().and_then(|b| b.description.as_deref());
+                out.push_str(&format!("\n{}\n", body_marker(&label, desc)));
             }
         }
         out
+    }
+}
+
+fn body_marker(label: &str, description: Option<&str>) -> String {
+    match description {
+        Some(desc) => format!("{} \u{2014} {}", label, desc),
+        None => label.to_string(),
     }
 }
 
@@ -548,7 +554,7 @@ card_types:
 "#)
         .blueprint();
         let after = &t[t.find("CARD: skills").unwrap()..];
-        assert!(!after.contains("body..."));
+        assert!(!after.contains("skills body"));
     }
 
     #[test]
@@ -567,8 +573,8 @@ card_types:
 "#)
         .blueprint();
         let after = &t[t.find("CARD: note").unwrap()..];
-        assert!(after.contains("\nWrite your note here...\n"));
-        assert!(!after.contains("\nnote body...\n"));
+        assert!(after.contains("\nnote body \u{2014} Write your note here\n"));
+        assert!(!after.contains("\nnote body\n"));
     }
 
     #[test]
@@ -582,8 +588,8 @@ main:
     to: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nWrite the letter body here...\n"));
-        assert!(!t.contains("\nmain body...\n"));
+        assert!(t.contains("\nmain body \u{2014} Write the letter body here\n"));
+        assert!(!t.contains("\nmain body\n"));
     }
 
     #[test]
@@ -596,7 +602,7 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel\n"));
-        assert!(t.contains("\nmain body...\n"));
+        assert!(t.contains("\nmain body\n"));
     }
 
     #[test]
@@ -612,7 +618,7 @@ card_types:
       from: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nindorsement body...\n"));
+        assert!(t.contains("\nindorsement body\n"));
     }
 
     #[test]

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -44,22 +44,19 @@ impl QuillConfig {
             &format!("QUILL: {}@{}  # sentinel", self.name, self.version),
             main_desc,
         );
-        let hide_body = self
-            .main
-            .ui
-            .as_ref()
-            .and_then(|u| u.hide_body)
-            .unwrap_or(false);
-        if !hide_body {
-            out.push_str("\nmain body...\n");
+        if self.main.body_enabled() {
+            out.push_str(&format!(
+                "\n{}...\n",
+                self.main.body_description("main body")
+            ));
         }
         for card in &self.card_types {
             let sentinel = format!("CARD: {}  # sentinel, composable (0..N)", card.name);
             out.push('\n');
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
-            let hide = card.ui.as_ref().and_then(|u| u.hide_body).unwrap_or(false);
-            if !hide {
-                out.push_str(&format!("\n{} body...\n", card.name));
+            if card.body_enabled() {
+                let default = format!("{} body", card.name);
+                out.push_str(&format!("\n{}...\n", card.body_description(&default)));
             }
         }
         out
@@ -537,7 +534,7 @@ card_types:
     }
 
     #[test]
-    fn hide_body_card_omits_body_placeholder() {
+    fn body_disabled_card_omits_body_placeholder() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -545,13 +542,48 @@ main:
     title: { type: string }
 card_types:
   skills:
-    ui: { hide_body: true }
+    body: { enabled: false }
     fields:
       items: { type: array, required: true }
 "#)
         .blueprint();
         let after = &t[t.find("CARD: skills").unwrap()..];
         assert!(!after.contains("body..."));
+    }
+
+    #[test]
+    fn body_description_appears_in_placeholder() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+card_types:
+  note:
+    body:
+      description: Write your note here
+    fields:
+      author: { type: string }
+"#)
+        .blueprint();
+        let after = &t[t.find("CARD: note").unwrap()..];
+        assert!(after.contains("\nWrite your note here...\n"));
+        assert!(!after.contains("\nnote body...\n"));
+    }
+
+    #[test]
+    fn main_body_description_appears_in_placeholder() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  body:
+    description: Write the letter body here
+  fields:
+    to: { type: string }
+"#)
+        .blueprint();
+        assert!(t.contains("\nWrite the letter body here...\n"));
+        assert!(!t.contains("\nmain body...\n"));
     }
 
     #[test]

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -12,7 +12,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::formats::DATE_FORMAT;
-use super::{CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
+use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
 
 /// Top-level configuration for a Quillmark project
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -55,6 +55,7 @@ struct CardSchemaDef {
     #[allow(dead_code)]
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub ui: Option<UiCardSchema>,
+    pub body: Option<BodyCardSchema>,
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -629,7 +630,7 @@ impl QuillConfig {
     pub fn from_yaml_with_warnings(
         yaml_content: &str,
     ) -> Result<(Self, Vec<Diagnostic>), Vec<Diagnostic>> {
-        let warnings: Vec<Diagnostic> = Vec::new();
+        let mut warnings: Vec<Diagnostic> = Vec::new();
         let mut errors: Vec<Diagnostic> = Vec::new();
 
         // Parse YAML into serde_json::Value via serde_saphyr
@@ -847,7 +848,7 @@ impl QuillConfig {
                             format!("Invalid 'quill.ui' block: {}", e),
                         )
                         .with_code("quill::invalid_ui".to_string())
-                        .with_hint("Valid keys under 'ui' are: title, hide_body.".to_string()),
+                        .with_hint("Valid key under 'ui' is: title.".to_string()),
                     );
                     None
                 }
@@ -942,7 +943,31 @@ impl QuillConfig {
                     errors.push(
                         Diagnostic::new(Severity::Error, format!("Invalid 'main.ui' block: {}", e))
                             .with_code("quill::invalid_ui".to_string())
-                            .with_hint("Valid keys under 'ui' are: title, hide_body.".to_string()),
+                            .with_hint("Valid key under 'ui' is: title.".to_string()),
+                    );
+                    None
+                }
+            },
+        };
+
+        // Extract main.body (optional). Fail loudly on malformed body metadata.
+        let main_body: Option<BodyCardSchema> = match main_obj_opt
+            .and_then(|main_obj| main_obj.get("body"))
+            .cloned()
+        {
+            None => None,
+            Some(v) => match serde_json::from_value::<BodyCardSchema>(v) {
+                Ok(parsed) => Some(parsed),
+                Err(e) => {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!("Invalid 'main.body' block: {}", e),
+                        )
+                        .with_code("quill::invalid_body".to_string())
+                        .with_hint(
+                            "Valid keys under 'body' are: enabled, description.".to_string(),
+                        ),
                     );
                     None
                 }
@@ -962,6 +987,7 @@ impl QuillConfig {
             description: main_description,
             fields,
             ui: main_ui.or(ui_section),
+            body: main_body,
         };
 
         // Extract [card_types] section (optional)
@@ -1034,9 +1060,45 @@ impl QuillConfig {
                             description: card_def.description,
                             fields: card_fields,
                             ui: card_def.ui,
+                            body: card_def.body,
                         });
                     }
                 }
+            }
+        }
+
+        // Warn when `body.description` is set together with `body.enabled: false` —
+        // the description has no effect since the body editor is disabled.
+        let warn_description_unused = |label: &str,
+                                       body: &Option<BodyCardSchema>|
+         -> Option<Diagnostic> {
+            let body = body.as_ref()?;
+            if body.enabled == Some(false) && body.description.is_some() {
+                Some(
+                    Diagnostic::new(
+                        Severity::Warning,
+                        format!(
+                            "`{label}.body.description` is set but `{label}.body.enabled` is false; the description will have no effect"
+                        ),
+                    )
+                    .with_code("quill::body_description_unused".to_string())
+                    .with_hint(
+                        "Set `body.enabled: true` to surface the description, or remove `body.description`."
+                            .to_string(),
+                    ),
+                )
+            } else {
+                None
+            }
+        };
+        if let Some(d) = warn_description_unused("main", &main.body) {
+            warnings.push(d);
+        }
+        for card in &card_types {
+            if let Some(d) =
+                warn_description_unused(&format!("card_types.{}", card.name), &card.body)
+            {
+                warnings.push(d);
             }
         }
 

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2451,3 +2451,30 @@ fn check_schema_snapshot(
 fn schema_snapshot_usaf_memo_0_1_0() {
     check_schema_snapshot(|c| c.schema_yaml().unwrap(), |c| c.schema(), "schema.yaml");
 }
+
+#[test]
+fn body_description_with_body_disabled_emits_warning() {
+    let yaml = r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+card_types:
+  skills:
+    body:
+      enabled: false
+      description: This description is unused
+    fields:
+      items: { type: array, required: true }
+"#;
+    let (_config, warnings) = QuillConfig::from_yaml_with_warnings(yaml).unwrap();
+    assert!(
+        warnings.iter().any(|d| d
+            .code
+            .as_deref()
+            .map(|c| c == "quill::body_description_unused")
+            .unwrap_or(false)),
+        "expected body_description_unused warning, got: {:?}",
+        warnings
+    );
+}

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -45,14 +45,6 @@ pub mod ui_key {
     pub const MULTILINE: &str = "multiline";
 }
 
-/// Semantic constants for body namespace keys
-pub mod body_key {
-    /// Whether the body editor is enabled for this card (default: true)
-    pub const ENABLED: &str = "enabled";
-    /// Optional description shown in the body editor placeholder area
-    pub const DESCRIPTION: &str = "description";
-}
-
 /// UI-specific metadata for field rendering
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -134,14 +126,6 @@ impl CardSchema {
     /// Defaults to true when no `body` namespace is declared.
     pub fn body_enabled(&self) -> bool {
         self.body.as_ref().and_then(|b| b.enabled).unwrap_or(true)
-    }
-
-    /// Returns the body description text, falling back to `default` when none is set.
-    pub fn body_description<'a>(&'a self, default: &'a str) -> &'a str {
-        self.body
-            .as_ref()
-            .and_then(|b| b.description.as_deref())
-            .unwrap_or(default)
     }
 }
 

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -39,12 +39,18 @@ pub mod ui_key {
     /// Display label for a card type. May be a literal string or a template
     /// containing `{field_name}` tokens interpolated per-instance by UI consumers.
     pub const TITLE: &str = "title";
-    /// Whether the field or specific component is hide-body (no body editor)
-    pub const HIDE_BODY: &str = "hide_body";
     /// Compact rendering hint for UI consumers
     pub const COMPACT: &str = "compact";
     /// Multi-line text box hint for string and markdown fields
     pub const MULTILINE: &str = "multiline";
+}
+
+/// Semantic constants for body namespace keys
+pub mod body_key {
+    /// Whether the body editor is enabled for this card (default: true)
+    pub const ENABLED: &str = "enabled";
+    /// Optional description shown in the body editor placeholder area
+    pub const DESCRIPTION: &str = "description";
 }
 
 /// UI-specific metadata for field rendering
@@ -69,6 +75,21 @@ pub struct UiFieldSchema {
     pub multiline: Option<bool>,
 }
 
+/// Body namespace configuration for a card type
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BodyCardSchema {
+    /// Whether the body editor is enabled for this card (default: true).
+    /// When false, consumers must not accept or store body content for instances
+    /// of this card type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Description shown in the body editor placeholder area when the body is
+    /// empty. Has no effect when `enabled` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UiCardSchema {
@@ -76,9 +97,6 @@ pub struct UiCardSchema {
     /// template. See `docs/format-designer/quill-yaml-reference.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    /// Whether to hide the body editor for this element (metadata only)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hide_body: Option<bool>,
 }
 
 /// Schema definition for a card type (composable content blocks)
@@ -96,6 +114,10 @@ pub struct CardSchema {
     /// UI layout hints
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiCardSchema>,
+    /// Body namespace: controls whether a body editor is shown and provides
+    /// optional guide text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<BodyCardSchema>,
 }
 
 impl CardSchema {
@@ -106,6 +128,20 @@ impl CardSchema {
             .iter()
             .filter_map(|(name, field)| field.default.as_ref().map(|v| (name.clone(), v.clone())))
             .collect()
+    }
+
+    /// Returns true if body content is permitted for instances of this card.
+    /// Defaults to true when no `body` namespace is declared.
+    pub fn body_enabled(&self) -> bool {
+        self.body.as_ref().and_then(|b| b.enabled).unwrap_or(true)
+    }
+
+    /// Returns the body description text, falling back to `default` when none is set.
+    pub fn body_description<'a>(&'a self, default: &'a str) -> &'a str {
+        self.body
+            .as_ref()
+            .and_then(|b| b.description.as_deref())
+            .unwrap_or(default)
     }
 }
 

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -35,6 +35,11 @@ pub enum ValidationError {
 
     #[error("card at `{path}` missing `CARD` discriminator")]
     MissingCardDiscriminator { path: String },
+
+    #[error(
+        "card `{card}` at `{path}` has body content but the card type declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card type"
+    )]
+    BodyDisabled { path: String, card: String },
 }
 
 /// Validate a typed [`Document`] (with `IndexMap` frontmatter + typed `Card` list).
@@ -46,6 +51,15 @@ pub fn validate_typed_document(
 ) -> Result<(), Vec<ValidationError>> {
     let main_fields = doc.main().frontmatter().to_index_map();
     let mut errors = validate_fields_for_card_indexmap(&config.main, &main_fields, "");
+
+    // Enforce body.enabled on the main card. Whitespace-only bodies are
+    // treated as empty — only meaningful prose triggers the diagnostic.
+    if !config.main.body_enabled() && !doc.main().body().trim().is_empty() {
+        errors.push(ValidationError::BodyDisabled {
+            path: "main".to_string(),
+            card: "main".to_string(),
+        });
+    }
 
     for (index, card) in doc.cards().iter().enumerate() {
         let card_name = card.tag();
@@ -70,6 +84,13 @@ pub fn validate_typed_document(
             &card_fields,
             &card_path,
         ));
+
+        if !card_schema.body_enabled() && !card.body().trim().is_empty() {
+            errors.push(ValidationError::BodyDisabled {
+                path: card_path,
+                card: card_name,
+            });
+        }
     }
 
     if errors.is_empty() {
@@ -616,5 +637,59 @@ main:
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::MissingRequired { path } if path == "cards.indorsement[0].signature_block")
         }));
+    }
+
+    #[test]
+    fn body_disabled_card_enforces_trim_boundary() {
+        let config = config_with(
+            "    title:\n      type: string",
+            "card_types:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        required: true",
+        );
+        // Prose triggers the error; whitespace-only does not.
+        let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);
+        prose_card.replace_body("Should not be here.");
+        let doc = doc_with_typed_cards(&[], vec![prose_card]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| matches!(
+            e,
+            ValidationError::BodyDisabled { card, .. } if card == "skills"
+        )));
+
+        let mut ws_card = typed_card("skills", &[("items", json!(["Rust"]))]);
+        ws_card.replace_body("\n   \n");
+        let ok_doc = doc_with_typed_cards(&[], vec![ws_card]);
+        assert!(validate_typed_document(&config, &ok_doc).is_ok());
+    }
+
+    #[test]
+    fn main_body_disabled_with_body_content_is_an_error() {
+        let config = QuillConfig::from_yaml(
+            r#"
+quill:
+  name: native_validation
+  backend: typst
+  description: Native validator tests
+  version: 1.0.0
+main:
+  body:
+    enabled: false
+  fields:
+    title:
+      type: string
+"#,
+        )
+        .unwrap();
+        use crate::document::{Frontmatter, Sentinel};
+        let main = Card::new_with_sentinel(
+            Sentinel::Main(crate::version::QuillReference::from_str("test_quill").unwrap()),
+            Frontmatter::from_index_map(IndexMap::new()),
+            "Body content that should not be here.".to_string(),
+        );
+        let doc = Document::from_main_and_cards(main, vec![], vec![]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| matches!(
+            e,
+            ValidationError::BodyDisabled { card, .. } if card == "main"
+        )));
     }
 }

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -47,8 +47,8 @@ card_types:
 
   skills_section:
     description: A grid of skill categories with key-value pairs.
-    ui:
-      hide_body: true
+    body:
+      enabled: false
     fields:
       title:
         type: string
@@ -87,8 +87,8 @@ card_types:
 
   certifications_section:
     description: A grid of certifications.
-    ui:
-      hide_body: true
+    body:
+      enabled: false
     fields:
       title:
         type: string

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -10,10 +10,11 @@ A `Quill.yaml` has these top-level sections:
 quill:        # Required — format metadata
   ...
 
-main:         # Optional — main entry-point card: field schemas and optional ui
+main:         # Optional — main entry-point card: field schemas and optional ui/body
   fields:
     ...
-  ui:         # optional container hints (e.g. hide_body)
+  ui:         # optional UI hints (e.g. title)
+  body:       # optional body-region config (e.g. enabled, description)
 
 card_types:   # Optional — additional composable card types
   ...
@@ -263,7 +264,7 @@ main:
 
 ## `card_types` Section
 
-`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
+`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`, `body`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
 
 Card-type names (the keys under `card_types`) must match `[a-z_][a-z0-9_]*` (leading underscore is allowed).
 
@@ -294,7 +295,8 @@ Invalid card-type names include:
 |---------------|--------|----------|-------------|
 | `description` | string | no       | Help text describing the card's purpose |
 | `fields`      | object | no       | Field schemas (same structure as top-level fields) |
-| `ui`          | object | no       | Container-level UI hints |
+| `ui`          | object | no       | Container-level UI hints (see [Card-level `ui`](#card-level-ui)) |
+| `body`        | object | no       | Body-region config (see [Card-level `body`](#card-level-body)) |
 
 ### Card-level `ui`
 

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -57,23 +57,11 @@ quill:
   example: example.md
 ```
 
-### Document-level `ui`
-
-Controls UI behavior for the document root:
-
-```yaml
-quill:
-  name: metadata-only-doc
-  # ...
-  ui:
-    hide_body: true    # Suppress the body/content editor in form UIs
-```
-
 ---
 
 ## `main` Section
 
-The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.description` describes the schema itself (independent of `quill.description`, which describes the quill package). Optional `main.ui` sets container-level UI for that card (for example `hide_body`). `quill.ui` is merged with `main.ui` when building the main card.
+The main document card holds **frontmatter field schemas** under `main.fields`. Optional `main.description` describes the schema itself (independent of `quill.description`, which describes the quill package). Optional `main.ui` sets container-level UI for that card. `quill.ui` is merged with `main.ui` when building the main card.
 
 Field order under `main.fields` determines display order in UIs — the first field gets `order: 0`, the second gets `order: 1`, and so on.
 
@@ -310,10 +298,16 @@ Invalid card-type names include:
 
 ### Card-level `ui`
 
-| Property    | Type   | Description |
-|-------------|--------|-------------|
-| `title`     | string | Display label for the card type. Literal string or `{field}` template |
-| `hide_body` | bool   | Suppress the body/content editor for this card type |
+| Property | Type   | Description |
+|----------|--------|-------------|
+| `title`  | string | Display label for the card type. Literal string or `{field}` template |
+
+### Card-level `body`
+
+| Property  | Type   | Description |
+|-----------|--------|-------------|
+| `enabled`     | bool   | Whether the body editor is enabled (default: true). When false, consumers must not accept or store body content for this card type. |
+| `description` | string | Description shown in the body editor placeholder when the body is empty. |
 
 #### `title`
 
@@ -359,15 +353,31 @@ With the template form, a UI rendering a list of cards can title each instance (
 
 `title` is a UI hint only — it has no effect on validation or rendering. When omitted, UI consumers fall back to the prettified map key.
 
-#### `hide_body`
+#### `body.enabled`
+
+When `false`, the card type has no body/content area. Consumers must not accept or store body content for instances of this card type. The validator enforces this: a document instance that provides body content for a `body.enabled: false` card type is rejected with a `BodyDisabled` error.
 
 ```yaml
 card_types:
   metadata_block:
-    ui:
-      hide_body: true    # Card has fields only, no body/content editor
+    body:
+      enabled: false    # Card has fields only, no body/content area
     fields:
       category:
+        type: string
+```
+
+#### `body.description`
+
+Optional description displayed in the body editor placeholder area when the body is empty. Has no effect when `body.enabled` is false.
+
+```yaml
+card_types:
+  experience:
+    body:
+      description: Describe your role, responsibilities, and key achievements.
+    fields:
+      company:
         type: string
 ```
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -119,22 +119,21 @@ Most `ui:` keys are stripped, but two structural hints survive:
   Ungrouped fields lead (no banner); named groups follow in
   first-appearance order.
 - `ui.order` — controls field ordering within a group.
-- `ui.hide_body` (on `main` or a card) — suppresses the
-  `<region> body...` marker for cards that hold no prose.
 
 `ui.compact`, `ui.multiline`, `ui.title` are presentation-only and dropped.
 
 ## Body markers
 
-- `main body...` after the main fence
-- `<card_name> body...` after each card fence
+- `main body...` after the main fence (or `<guide>...` when `body.description` is set)
+- `<card_name> body...` after each card fence (or `<guide>...` when `body.description` is set)
 
 Trailing ellipsis reads as "prose continues here." No markup conflict
 with HTML (avoiding the `<u>` deviation), and the named region echoes
 the sentinel above it.
 
-`ui.hide_body: true` suppresses the marker entirely for body-less cards
-(e.g., a `skills` card whose data is purely structured).
+`body.enabled: false` suppresses the marker entirely for body-less cards
+(e.g., a `skills` card whose data is purely structured). `body.description` replaces
+the default placeholder text with a custom hint for consumers.
 
 ## Bindings surface
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -25,7 +25,7 @@ field: value
 
 ---
 
-main body...
+main body
 
 ---
 # <card description>
@@ -33,8 +33,12 @@ CARD: <card_name>  # sentinel, composable (0..N)
 ...fields...
 ---
 
-<card_name> body...
+<card_name> body
 ```
+
+When a `body.description` is set, the body marker line expands to
+`<tag> body — <description>` (em dash separator). When `body.enabled` is
+false the marker is omitted entirely.
 
 ## Annotation grammar
 
@@ -124,16 +128,18 @@ Most `ui:` keys are stripped, but two structural hints survive:
 
 ## Body markers
 
-- `main body...` after the main fence (or `<guide>...` when `body.description` is set)
-- `<card_name> body...` after each card fence (or `<guide>...` when `body.description` is set)
+- `main body` after the main fence
+- `<card_name> body` after each card fence
+- When `body.description` is set, the marker becomes
+  `<tag> body — <description>` (em dash separator). The structural
+  `<tag> body` label is preserved so the consumer always sees what kind
+  of body region they're filling in.
 
-Trailing ellipsis reads as "prose continues here." No markup conflict
-with HTML (avoiding the `<u>` deviation), and the named region echoes
-the sentinel above it.
+The named region echoes the sentinel above it. There is no markup
+conflict with HTML (avoiding the `<u>` deviation).
 
 `body.enabled: false` suppresses the marker entirely for body-less cards
-(e.g., a `skills` card whose data is purely structured). `body.description` replaces
-the default placeholder text with a custom hint for consumers.
+(e.g., a `skills` card whose data is purely structured).
 
 ## Bindings surface
 

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -58,6 +58,8 @@ card_types:
 card_types:
   indorsement:
     description: Chain of routing endorsements for multi-level correspondence.
+    ui:
+      title: Routing Endorsement
     fields:
       from:
         type: string
@@ -66,9 +68,11 @@ card_types:
       signature_block:
         type: array
         required: true
+        ui:
+          group: Addressing
 ```
 
-The schema is emitted by `QuillConfig::schema()` (clean, no `ui` hints) and `QuillConfig::form_schema()` (with `ui` hints, for form builders), with YAML wrappers `schema_yaml()` and `form_schema_yaml()`. Both keep the same `card_types.<name>.fields` shape as `Quill.yaml` and inject a required `CARD` sentinel field whose `const` value is the card name. The `card_types` key is omitted entirely when no named card-types are defined. See `SCHEMAS.md` for the full surface.
+`QuillConfig::schema()` emits the schema (with `ui` and `body` hints retained) and `schema_yaml()` is the YAML wrapper. The output keeps the same `card_types.<name>.fields` shape as `Quill.yaml` and injects a required `CARD` sentinel field whose `const` value is the card name. The `card_types` key is omitted entirely when no named card-types are defined. See `SCHEMAS.md` for the full surface.
 
 ## Markdown Syntax
 

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -15,10 +15,11 @@ pub struct CardSchema {
     pub description: Option<String>,
     pub fields: HashMap<String, FieldSchema>,
     pub ui: Option<UiCardSchema>,
+    pub body: Option<BodyCardSchema>,
 }
 ```
 
-The static display label for a card type lives on `UiCardSchema::title`, not on `CardSchema` directly — see `ui.title` below.
+The static display label for a card type lives on `UiCardSchema::title`, not on `CardSchema` directly — see `ui.title` below. Body behavior (whether body content is permitted and optional guide text) lives under `body` — see `body.enabled` and `body.description` below.
 
 `QuillConfig` exposes the entry-point card as `main: CardSchema` and the additional named card-types as `card_types: Vec<CardSchema>`. Look up a named card-type by name via `card_type(name)` or get a name-keyed map via `card_types_map()`.
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -84,8 +84,11 @@ main:
 
 card_types:
   quote:
-    title: Quote block
     description: A single pull quote
+    ui:
+      title: Quote block      # optional UI display label
+    body:
+      description: The quote text  # optional editor placeholder
     fields:
       author:
         type: string
@@ -112,6 +115,8 @@ Metadata resolution:
 - Field schemas that fail to parse (e.g. legacy `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
 - Standalone `object` fields and disallowed nested-object shapes error with `quill::standalone_object_not_supported` / `quill::nested_object_not_supported`.
 - Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
+- Malformed `main.body` / `card_types.<name>.body` blocks error with `quill::invalid_body`.
+- A `body.description` set together with `body.enabled: false` warns with `quill::body_description_unused` (the description has no effect).
 
 Errors flow through `RenderError::QuillConfig { diags: Vec<Diagnostic> }` and surface to bindings as a structured array (`err.diagnostics` in WASM, `.diagnostics` attribute in Python).
 

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -2,15 +2,15 @@
 
 ## TL;DR
 
-`QuillConfig` is the only schema model in quillmark. Validation, coercion, defaults/examples extraction, and public schema emission all read directly from it.
+`QuillConfig` is the only schema model in quillmark. Validation, coercion, defaults extraction, and public schema emission all read directly from it.
 
 ## Quill.yaml DSL
 
 Schema authoring lives in `Quill.yaml` under:
 
 - `main.fields`
-- `cards.<card_name>.fields`
-- optional `ui` hints on fields/cards/main
+- `card_types.<card_name>.fields`
+- optional `ui` and `body` blocks on `main` and each card type
 
 Supported field types:
 
@@ -21,17 +21,17 @@ Supported field types:
 | `integer` | Integer-only numeric value |
 | `boolean` | `true` / `false` |
 | `array` | Ordered list; use `items:` |
-| `object` | Structured map; use `properties:` |
+| `object` | Structured map; use `properties:` (only valid inside `array.items`) |
 | `date` | `YYYY-MM-DD` |
 | `datetime` | ISO 8601 |
 | `markdown` | Rich text; backends handle conversion |
 
 ## Type coercion
 
-`QuillConfig::coerce(&HashMap<String, QuillValue>)` runs before validation.
+`QuillConfig::coerce_frontmatter` and `coerce_card` run before validation.
 
-- Returns `Result<HashMap<String, QuillValue>, CoercionError>`
-- Coerces top-level fields and card fields in `CARDS` to their declared types
+- Returns `Result<IndexMap<String, QuillValue>, CoercionError>`
+- Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
 - Coercion rules per type: array wrapping, boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
 
@@ -39,63 +39,45 @@ Supported field types:
 
 Validation is implemented by a native walker over `QuillConfig` in `quill/validation.rs`.
 
-- Entry point: `QuillConfig::validate(&HashMap<String, QuillValue>)` (dispatches to `validate_document`)
+- Entry point: `QuillConfig::validate_document(&Document)` (dispatches to `validate_typed_document`)
 - Returns `Result<(), Vec<ValidationError>>`
 - Collects all errors (does not short-circuit)
 - Emits path-aware errors for top-level fields and card fields
-- Validates `CARDS` array: each element must have a `CARD` discriminator matching a known card type
+- Validates each card has a `CARD` discriminator matching a known card type
+- Enforces `body.enabled: false` on the main card and on each card type — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
 
 ## Schema emission
 
-Two projections of the same `QuillConfig` source are exposed:
+`QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:
 
-- `QuillConfig::schema()` — **structural schema**. Types, constraints,
-  `QUILL`/`CARD` sentinels with `const` values. No `ui` keys. The surface
-  for validators, machine consumers, and CLI inspection.
-- `QuillConfig::form_schema()` — same shape **plus** field-level (`group`,
-  `order`, `compact`, `multiline`) and card-level (`title`, `hide_body`)
-  `ui` hints. The surface for form builders.
+- Field types, constraints, and `enum`/`default`/`example` annotations
+- `ui` hints on fields and card types (`group`, `order`, `compact`, `multiline`, `title`)
+- `body` blocks on cards (`enabled`, `description`)
+- A required `QUILL` sentinel prepended to `main.fields` (`const = "<name>@<version>"`)
+- A required `CARD` sentinel prepended to each `card_types.<name>.fields` (`const = "<name>"`)
 
-For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()`
-emits a document-shaped, pre-filled Markdown reference that's denser
-than schema for prompt-time use.
+`QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `CardSchema`, `UiFieldSchema`, `UiCardSchema`, and `BodyCardSchema` — there is no parallel mirror struct.
 
-YAML wrappers `QuillConfig::schema_yaml()` and `QuillConfig::form_schema_yaml()`
-encode the same values. Both projections are pinned by serde attributes on
-`FieldSchema`, `CardSchema`, `UiFieldSchema`, and `UiCardSchema` —
-there is no parallel mirror struct. The clean variant is produced by
-recursively stripping `ui` keys after serialisation.
+For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level keys: `main`, optional `card_types` (map keyed by card name).
-`main` and each entry in `card_types` share the same `CardSchema` shape:
-`fields` (map keyed by field name), optional `description`, and —
-in `form_schema()` only — `ui`. Each `FieldSchema` includes `type`,
-optional `description`/`default`/`example`/`enum`/`properties`/
-`items`, optional `required` (omitted when false), and — in `form_schema()`
-only — optional `ui`.
+Top-level schema keys: `main`, optional `card_types` (map keyed by card name). `main` and each entry in `card_types` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`items`/`ui`, and optional `required` (omitted when false).
 
-Identity fields (`name`, `version`, `backend`, `author`, `description`)
-live on the parent metadata object (Wasm: `Quill.metadata`; Python:
-`Quill.metadata` plus dedicated getters). The bundled example markdown is
-exposed separately (Wasm: `Quill.example`; Python: `Quill.example`) so
-consumers choose whether to include it in a prompt.
+Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters). The bundled example markdown is exposed separately (Wasm: `Quill.example`; Python: `Quill.example`) so consumers choose whether to include it in a prompt.
 
 ### Bindings surface
 
-| Binding | Clean schema | Form schema |
-|---|---|---|
-| Rust | `QuillConfig::schema()` / `schema_yaml()` | `QuillConfig::form_schema()` / `form_schema_yaml()` |
-| Wasm | `Quill.schema` getter | `Quill.formSchema` getter |
-| Python | `Quill.schema` getter (YAML) | `Quill.form_schema` getter (YAML) |
-| CLI | `quillmark schema <path>` | `quillmark schema <path> --with-ui` |
+| Binding | Schema accessor |
+|---|---|
+| Rust | `QuillConfig::schema()` (JSON) / `schema_yaml()` (YAML) |
+| Wasm | `Quill.schema` getter (JSON) |
+| Python | `Quill.schema` getter (YAML) |
+| CLI | `quillmark schema <path>` |
 
 ### `main.fields` and `card_types.<name>.fields` sentinels
 
-Both `schema()` and `form_schema()` prepend a synthetic field to each card's
-`fields` map so consumers know exactly which sentinel string to write:
+`schema()` prepends a synthetic field to each card's `fields` map so consumers know exactly which sentinel string to write:
 
 - `main.fields.QUILL` — `{ type: string, const: "<name>@<version>", required: true, description: ... }`
 - `card_types.<name>.fields.CARD` — `{ type: string, const: "<name>", required: true, description: ... }`
 
-These appear ahead of the author's declared fields. They are not present in
-`Quill.yaml`; the projection injects them.
+These appear ahead of the author's declared fields. They are not present in `Quill.yaml`; the projection injects them.


### PR DESCRIPTION
This pull request introduces a new, more flexible way to control the presence and appearance of body regions in Quill schemas. It replaces the old `ui.hide_body` boolean with a dedicated `body` namespace, allowing schema authors to enable/disable body editors and provide custom placeholder descriptions. The implementation includes updates to schema parsing, validation, and blueprint generation, as well as new warnings for misconfigurations.

**Body region configuration overhaul:**

- Introduced a new `body` namespace (`BodyCardSchema`) for both main and card types, supporting `enabled` (to toggle the body editor) and `description` (to show placeholder text in the editor). The old `ui.hide_body` is removed. [[1]](diffhunk://#diff-c0492d05ead88fe69915f00b0baf8c6d85c9b55308f85d783953c6b1c5d436fcR70-L81) [[2]](diffhunk://#diff-c0492d05ead88fe69915f00b0baf8c6d85c9b55308f85d783953c6b1c5d436fcR109-R112) [[3]](diffhunk://#diff-c0492d05ead88fe69915f00b0baf8c6d85c9b55308f85d783953c6b1c5d436fcR124-R129) [[4]](diffhunk://#diff-4873d8e4d62e3a8ce154dc62ef4a1fa316d42be7d6d12264687e7bbd435cefb5L28-R35) [[5]](diffhunk://#diff-0b20f8715b7c13198eaebc3220a4912779159c571ea2ab6456c41f1c697be186L20-R21) [[6]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeL15-R15) [[7]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeR58)
- Updated all schema parsing, serialization, and documentation to use the new `body` namespace, including error handling for malformed `body` blocks and warnings if a description is set but the body is disabled. [[1]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeL945-R970) [[2]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeR990) [[3]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeR1063-R1104) [[4]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeL632-R633) [[5]](diffhunk://#diff-908a19a15d0d06b2d4a02998d7ce6f17938885839581a2a7630b70d893de53aeL850-R851) [[6]](diffhunk://#diff-820296c73996481fea1f554cc838e395807c74b943b9c111fe3fa79ff2c4f21cR2454-R2480)

**Blueprint and UI marker improvements:**

- Blueprint generation now uses the new `body` configuration: the body region marker is only present if enabled, and includes the description if provided (using an em dash separator). Tests are added to verify correct marker formatting and omission. [[1]](diffhunk://#diff-c6b2ff2ac6922fc64820db0058cc4601e21cfda7d22e28649ce0419b0e3143efL14-R17) [[2]](diffhunk://#diff-c6b2ff2ac6922fc64820db0058cc4601e21cfda7d22e28649ce0419b0e3143efL47-R75) [[3]](diffhunk://#diff-c6b2ff2ac6922fc64820db0058cc4601e21cfda7d22e28649ce0419b0e3143efL540-R596) [[4]](diffhunk://#diff-c6b2ff2ac6922fc64820db0058cc4601e21cfda7d22e28649ce0419b0e3143efL567-R609) [[5]](diffhunk://#diff-c6b2ff2ac6922fc64820db0058cc4601e21cfda7d22e28649ce0419b0e3143efL583-R625)

**Validation enhancements:**

- Added a validation error if a card instance contains body content but the schema disables the body editor for that type. [[1]](diffhunk://#diff-d94292fd37ee0e3641eacf4e9afe8195749111136a750fccd680d3818b1ff2c2R38-R42) [[2]](diffhunk://#diff-d94292fd37ee0e3641eacf4e9afe8195749111136a750fccd680d3818b1ff2c2R55-R63)

**WASM and Python bindings:**

- Updated WASM bindings and TypeScript definitions to expose the new `body` namespace, and clarified documentation/comments to match the new behavior. The Python binding's schema getter now includes UI hints. [[1]](diffhunk://#diff-4873d8e4d62e3a8ce154dc62ef4a1fa316d42be7d6d12264687e7bbd435cefb5R56-R60) [[2]](diffhunk://#diff-4873d8e4d62e3a8ce154dc62ef4a1fa316d42be7d6d12264687e7bbd435cefb5L66-R74) [[3]](diffhunk://#diff-b9f4e3f1f623630b3c447bf0dfc7c081ea5e9e6be0753e7f2b5733a125a45b96L102-R102) [[4]](diffhunk://#diff-a3be5c3911f8a6a0b7b33c78638195ad75e38278792b102abca8bd0b53159193L196-R196)

**Cleanup and deprecation:**

- Removed the deprecated `ui.hide_body` field and related code. [[1]](diffhunk://#diff-c0492d05ead88fe69915f00b0baf8c6d85c9b55308f85d783953c6b1c5d436fcL42-L43) [[2]](diffhunk://#diff-c0492d05ead88fe69915f00b0baf8c6d85c9b55308f85d783953c6b1c5d436fcR70-L81)

These changes make Quill's body region handling more explicit, customizable, and robust, while improving schema clarity and error reporting.