### PR TITLE
Improve body marker clarity with action-oriented labels

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -67,14 +67,9 @@ impl QuillConfig {
 }
 
 fn body_marker(label: &str, description: Option<&str>) -> String {
-    let mut chars = label.chars();
-    let capitalized = match chars.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
-    };
     match description {
-        Some(desc) => format!("{} here. {}", capitalized, desc),
-        None => format!("{} here.", capitalized),
+        Some(desc) => format!("Write {} here. {}", label, desc),
+        None => format!("Write {} here.", label),
     }
 }
 
@@ -582,8 +577,8 @@ card_types:
 "#)
         .blueprint();
         let after = &t[t.find("CARD: note").unwrap()..];
-        assert!(after.contains("\nNote body here. Write your note here\n"));
-        assert!(!after.contains("\nNote body here.\n"));
+        assert!(after.contains("\nWrite note body here. Write your note here\n"));
+        assert!(!after.contains("\nWrite note body here.\n"));
     }
 
     #[test]
@@ -597,8 +592,8 @@ main:
     to: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nMain body here. Write the letter body here\n"));
-        assert!(!t.contains("\nMain body here.\n"));
+        assert!(t.contains("\nWrite main body here. Write the letter body here\n"));
+        assert!(!t.contains("\nWrite main body here.\n"));
     }
 
     #[test]
@@ -611,7 +606,7 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel\n"));
-        assert!(t.contains("\nMain body here.\n"));
+        assert!(t.contains("\nWrite main body here.\n"));
     }
 
     #[test]
@@ -627,7 +622,7 @@ card_types:
       from: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nIndorsement body here.\n"));
+        assert!(t.contains("\nWrite indorsement body here.\n"));
     }
 
     #[test]

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -11,10 +11,10 @@
 //!   non-obvious type hints (`# integer`, `# YYYY-MM-DD`, `# markdown`) on
 //!   ordinary fields, and `# sentinel` / `# sentinel, composable (0..N)` on
 //!   the `QUILL:` and `CARD:` lines respectively.
-//! - **Body regions** are signalled by `main body` after the main fence and
-//!   `<card name> body` after each card fence. When a `body.description` is
-//!   set, the marker expands to `<tag> body — <description>` using an em dash
-//!   separator. Absent when `body.enabled` is false.
+//! - **Body regions** are signalled by `Write main body here.` after the main
+//!   fence and `Write <card name> body here.` after each card fence. When a
+//!   `body.description` is set, the marker expands to
+//!   `Write <tag> body here. <description>`. Absent when `body.enabled` is false.
 //!
 //! Most UI metadata is stripped, but two semantic-structure hints are honored:
 //! `ui.group` produces `# ==== SECTION ====` banners and `ui.order` controls

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -67,9 +67,14 @@ impl QuillConfig {
 }
 
 fn body_marker(label: &str, description: Option<&str>) -> String {
+    let mut chars = label.chars();
+    let capitalized = match chars.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+    };
     match description {
-        Some(desc) => format!("{} \u{2014} {}", label, desc),
-        None => label.to_string(),
+        Some(desc) => format!("{} here. {}", capitalized, desc),
+        None => format!("{} here.", capitalized),
     }
 }
 
@@ -577,8 +582,8 @@ card_types:
 "#)
         .blueprint();
         let after = &t[t.find("CARD: note").unwrap()..];
-        assert!(after.contains("\nnote body \u{2014} Write your note here\n"));
-        assert!(!after.contains("\nnote body\n"));
+        assert!(after.contains("\nNote body here. Write your note here\n"));
+        assert!(!after.contains("\nNote body here.\n"));
     }
 
     #[test]
@@ -592,8 +597,8 @@ main:
     to: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nmain body \u{2014} Write the letter body here\n"));
-        assert!(!t.contains("\nmain body\n"));
+        assert!(t.contains("\nMain body here. Write the letter body here\n"));
+        assert!(!t.contains("\nMain body here.\n"));
     }
 
     #[test]
@@ -606,7 +611,7 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel\n"));
-        assert!(t.contains("\nmain body\n"));
+        assert!(t.contains("\nMain body here.\n"));
     }
 
     #[test]
@@ -622,7 +627,7 @@ card_types:
       from: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nindorsement body\n"));
+        assert!(t.contains("\nIndorsement body here.\n"));
     }
 
     #[test]

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -25,7 +25,7 @@ field: value
 
 ---
 
-main body
+Main body here.
 
 ---
 # <card description>
@@ -33,7 +33,7 @@ CARD: <card_name>  # sentinel, composable (0..N)
 ...fields...
 ---
 
-<card_name> body
+<Card_name> body here.
 ```
 
 When a `body.description` is set, the body marker line expands to
@@ -128,15 +128,11 @@ Most `ui:` keys are stripped, but two structural hints survive:
 
 ## Body markers
 
-- `main body` after the main fence
-- `<card_name> body` after each card fence
+- `Main body here.` after the main fence
+- `<Card_name> body here.` after each card fence
 - When `body.description` is set, the marker becomes
-  `<tag> body — <description>` (em dash separator). The structural
-  `<tag> body` label is preserved so the consumer always sees what kind
-  of body region they're filling in.
-
-The named region echoes the sentinel above it. There is no markup
-conflict with HTML (avoiding the `<u>` deviation).
+  `<Tag> body here. <description>` (space-separated). The label names
+  the region; the description tells the author what to write.
 
 `body.enabled: false` suppresses the marker entirely for body-less cards
 (e.g., a `skills` card whose data is purely structured).

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -25,7 +25,7 @@ field: value
 
 ---
 
-Main body here.
+Write main body here.
 
 ---
 # <card description>
@@ -33,7 +33,7 @@ CARD: <card_name>  # sentinel, composable (0..N)
 ...fields...
 ---
 
-<Card_name> body here.
+Write <card_name> body here.
 ```
 
 When a `body.description` is set, the body marker line expands to
@@ -128,11 +128,11 @@ Most `ui:` keys are stripped, but two structural hints survive:
 
 ## Body markers
 
-- `Main body here.` after the main fence
-- `<Card_name> body here.` after each card fence
+- `Write main body here.` after the main fence
+- `Write <card_name> body here.` after each card fence
 - When `body.description` is set, the marker becomes
-  `<Tag> body here. <description>` (space-separated). The label names
-  the region; the description tells the author what to write.
+  `Write <tag> body here. <description>`. The label names the region;
+  the description tells the author what to write.
 
 `body.enabled: false` suppresses the marker entirely for body-less cards
 (e.g., a `skills` card whose data is purely structured).


### PR DESCRIPTION
## Summary
Updated body marker formatting in Quill blueprints to use more descriptive, action-oriented labels that guide users on what to do, rather than just naming the region.

## Changes
- **Body marker format**: Changed from `<label> — <description>` (or just `<label>`) to `Write <label> here.` (or `Write <label> here. <description>` when a description is provided)
  - Main body: `main body` → `Write main body here.`
  - Card bodies: `<card_name> body` → `Write <card_name> body here.`
  - With descriptions: `note body — Write your note here` → `Write note body here. Write your note here`

- **Implementation**: Modified `body_marker()` function in `crates/core/src/quill/blueprint.rs` to generate the new format

- **Documentation**: Updated `prose/designs/BLUEPRINT.md` to reflect the new marker format and clarify that the label names the region while the description guides the author

## Rationale
The new format is more user-friendly by providing clear instructions ("Write X here") rather than just structural labels. When a description is present, it complements the instruction rather than being separated by an em dash, creating a more natural reading experience for blueprint consumers.

https://claude.ai/code/session_014LQNrofxnnSDMeFC21Un5S