### PR TITLE
blueprint: comment out optional fields that have no default or enum

### DIFF
--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -320,6 +320,7 @@ fn push_trailer(out: &mut String, trailer: Option<&str>) {
 ///   scalars, `key: !fill\n  - …` for non-empty sequences,
 ///   `key: !fill []` for empty sequences, and `key: !fill` for null.
 ///   Mappings are rejected at parse and never reach this path.
+#[allow(clippy::too_many_arguments)]
 fn emit_field(
     out: &mut String,
     key: &str,

--- a/crates/core/src/document/frontmatter.rs
+++ b/crates/core/src/document/frontmatter.rs
@@ -279,7 +279,7 @@ impl<'a> IntoIterator for &'a Frontmatter {
     >;
 
     fn into_iter(self) -> Self::IntoIter {
-        fn filter<'a>(item: &'a FrontmatterItem) -> Option<(&'a String, &'a QuillValue)> {
+        fn filter(item: &FrontmatterItem) -> Option<(&String, &QuillValue)> {
             match item {
                 FrontmatterItem::Field { key, value, .. } => Some((key, value)),
                 FrontmatterItem::Comment { .. } => None,

--- a/crates/core/src/document/sentinel.rs
+++ b/crates/core/src/document/sentinel.rs
@@ -55,6 +55,7 @@ pub(super) fn first_content_key(content: &str) -> Option<&str> {
 
 /// Extract `QUILL` / `CARD` sentinels and remaining fields from a parsed-YAML
 /// mapping. Returns `(tag, quill_ref, yaml_without_sentinel)`.
+#[allow(clippy::type_complexity)]
 pub(super) fn extract_sentinels(
     parsed: serde_json::Value,
     _markdown: &str,

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -209,9 +209,10 @@ pub fn fix_html_comment_fences(s: &str) -> String {
             let after_content = &s[after_fence..];
 
             // Determine if we need to insert a newline
-            let needs_newline = if after_content.is_empty() {
-                false
-            } else if after_content.starts_with('\n') || after_content.starts_with("\r\n") {
+            let needs_newline = if after_content.is_empty()
+                || after_content.starts_with('\n')
+                || after_content.starts_with("\r\n")
+            {
                 false
             } else {
                 // Check if there's only whitespace until end of line

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -146,7 +146,10 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
         None => String::new(),
     };
     let value = field_value(field);
-    write_value(out, &field.name, &value, &comment, &pad);
+    // Optional fields with no default and no enum have nothing concrete to
+    // offer; comment them out so the author can uncomment what they need.
+    let commented = !field.required && field.default.is_none() && field.enum_values.is_none();
+    write_value(out, &field.name, &value, &comment, &pad, commented);
 }
 
 /// Description / `# required` / `# enum:` lines. Always safe to emit; carries
@@ -274,9 +277,15 @@ fn json_to_value(val: &serde_json::Value) -> FieldValue {
     }
 }
 
-fn write_value(out: &mut String, key: &str, val: &FieldValue, comment: &str, pad: &str) {
+fn write_value(out: &mut String, key: &str, val: &FieldValue, comment: &str, pad: &str, commented: bool) {
     match val {
-        FieldValue::Inline(s) => out.push_str(&format!("{}{}: {}{}\n", pad, key, s, comment)),
+        FieldValue::Inline(s) => {
+            if commented {
+                out.push_str(&format!("{}# {}: {}{}\n", pad, key, s, comment));
+            } else {
+                out.push_str(&format!("{}{}: {}{}\n", pad, key, s, comment));
+            }
+        }
         FieldValue::Block(items) => {
             out.push_str(&format!("{}{}:{}\n", pad, key, comment));
             write_array_items(out, items, pad);
@@ -457,7 +466,7 @@ main:
 "#)
         .blueprint();
         assert!(
-            t.contains("# example: [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\nrecipient: []\n")
+            t.contains("# example: [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\n# recipient: []\n")
         );
     }
 
@@ -520,8 +529,8 @@ main:
         .blueprint();
         assert!(t.contains("size: 11  # number"));
         assert!(t.contains("flag: false  # boolean"));
-        assert!(t.contains("body: \"\"  # markdown"));
-        assert!(t.contains("issued: \"\"  # YYYY-MM-DD"));
+        assert!(t.contains("# body: \"\"  # markdown"));
+        assert!(t.contains("# issued: \"\"  # YYYY-MM-DD"));
     }
 
     #[test]
@@ -666,7 +675,7 @@ main:
         .blueprint();
         assert!(t.contains("# Cited works.\nreferences:\n  -\n"));
         assert!(t.contains("    # Citing organization.\n    # required\n    org: \"<org>\"\n"));
-        assert!(t.contains("    # Publication year.\n    year: 0  # integer\n"));
+        assert!(t.contains("    # Publication year.\n    # year: 0  # integer\n"));
     }
 
     #[test]
@@ -759,6 +768,48 @@ card_types:
       label: { type: string, required: true }
       pages: { type: integer, default: 1 }
 "#;
+
+    #[test]
+    fn optional_no_default_field_is_commented_out() {
+        // No default, no enum → value line gets a leading `# `.
+        // Description and `# example:` comments are still emitted above it.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    note:
+      type: string
+      description: An optional note.
+      example: See attached.
+    count: { type: integer }
+    flag: { type: boolean }
+    issued: { type: date }
+    tags: { type: array }
+"#)
+        .blueprint();
+        assert!(t.contains("# An optional note.\n# example: See attached.\n# note: \"\"\n"));
+        assert!(t.contains("# count: 0  # integer\n"));
+        assert!(t.contains("# flag: false  # boolean\n"));
+        assert!(t.contains("# issued: \"\"  # YYYY-MM-DD\n"));
+        assert!(t.contains("# tags: []\n"));
+    }
+
+    #[test]
+    fn optional_with_default_stays_active() {
+        // A default value is meaningful; the field line must not be commented out.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    priority: { type: string, default: normal }
+    count: { type: integer, default: 0 }
+"#)
+        .blueprint();
+        assert!(t.contains("priority: normal\n"));
+        assert!(t.contains("count: 0  # integer\n"));
+        assert!(!t.contains("# priority:"));
+        assert!(!t.contains("# count:"));
+    }
 
     #[test]
     fn blueprint_round_trips_idempotently() {

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -277,7 +277,14 @@ fn json_to_value(val: &serde_json::Value) -> FieldValue {
     }
 }
 
-fn write_value(out: &mut String, key: &str, val: &FieldValue, comment: &str, pad: &str, commented: bool) {
+fn write_value(
+    out: &mut String,
+    key: &str,
+    val: &FieldValue,
+    comment: &str,
+    pad: &str,
+    commented: bool,
+) {
     match val {
         FieldValue::Inline(s) => {
             if commented {
@@ -465,9 +472,9 @@ main:
         - "Anytown, USA"
 "#)
         .blueprint();
-        assert!(
-            t.contains("# example: [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\n# recipient: []\n")
-        );
+        assert!(t.contains(
+            "# example: [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\n# recipient: []\n"
+        ));
     }
 
     #[test]

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -155,6 +155,7 @@ pub enum FieldType {
 
 impl FieldType {
     /// Parse a FieldType from a string
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "string" => Some(FieldType::String),

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -144,7 +144,7 @@ pub(crate) fn validate_field(
                 true
             } else {
                 match value.as_str() {
-                    Some(text) if text.is_empty() => true,
+                    Some("") => true,
                     Some(text) => {
                         if is_valid_date(text) {
                             true
@@ -165,7 +165,7 @@ pub(crate) fn validate_field(
                 true
             } else {
                 match value.as_str() {
-                    Some(text) if text.is_empty() => true,
+                    Some("") => true,
                     Some(text) => {
                         if is_valid_datetime(text) {
                             true

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -39,5 +39,3 @@ pub struct RenderOptions {
     /// a `FormatNotSupported` error when this is `Some`.
     pub pages: Option<Vec<usize>>,
 }
-
-

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -23,7 +23,7 @@ pub struct Artifact {
 }
 
 /// Internal rendering options.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RenderOptions {
     /// Optional output format specification
     pub output_format: Option<OutputFormat>,
@@ -40,12 +40,4 @@ pub struct RenderOptions {
     pub pages: Option<Vec<usize>>,
 }
 
-impl Default for RenderOptions {
-    fn default() -> Self {
-        Self {
-            output_format: None,
-            ppi: None,
-            pages: None,
-        }
-    }
-}
+

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -85,10 +85,24 @@ canonical placeholder.
 | Required, neither | type-based placeholder (`"<name>"`, `0`, `false`, `[]`, `""`) |
 | Optional, has `default` | default |
 | Optional, has `enum` only | first enum value |
-| Optional, neither | type-based empty (`""`, `0`, `false`, `[]`) |
+| Optional, neither | **commented-out** type-based empty (`# field: ""`, `# field: 0`, …) |
 
 Optional fields' examples surface in the `# example:` comment, never as
 the value.
+
+### Commented-out optional fields
+
+An optional field with no `default` and no `enum` has nothing concrete to
+offer. Its value line is prefixed with `# ` so the author can uncomment what
+they need and ignore the rest:
+
+```
+# field_name: ""
+```
+
+The leading description and `# example:` comments are still emitted unchanged
+above it. Fields with a `default` or `enum` stay active — they carry a
+meaningful value the author should be aware of.
 
 ### Multi-element example arrays
 


### PR DESCRIPTION
An optional field with no default and no enum has no concrete value to
show; rendering it as an active YAML line with an empty placeholder
(e.g. `field: ""`) implies the field is present, which is misleading.

The value line is now prefixed with `# ` so authors can uncomment only
the fields they want and ignore the rest. Fields with a `default` or
`enum` remain active since they carry a meaningful starting value.
Description and `# example:` comments are still emitted above the
commented-out line. Typed-table fields (array of objects) are exempt
because their multi-line block structure is inherently instructional;
optional properties *within* a synthetic row are commented out normally.

https://claude.ai/code/session_01H5NdAzyetpyL642Z4SSWnm