### PR TITLE
Replace body.description with body.example

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -31,8 +31,8 @@ export interface QuillCardUi {
 export interface QuillCardBody {
     /** When false, consumers must not accept or store body content for this card type. Defaults to true. */
     enabled?: boolean;
-    /** Description shown in the body editor placeholder area when the body is empty. */
-    description?: string;
+    /** Example body content embedded verbatim in the blueprint body region. Fallback is "Write <card> body here." */
+    example?: string;
 }
 
 /** Schema entry for a single field declared in a quill's `Quill.yaml`. */

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -12,9 +12,9 @@
 //!   ordinary fields, and `# sentinel` / `# sentinel, composable (0..N)` on
 //!   the `QUILL:` and `CARD:` lines respectively.
 //! - **Body regions** are signalled by `Write main body here.` after the main
-//!   fence and `Write <card name> body here.` after each card fence. When a
-//!   `body.description` is set, the marker expands to
-//!   `Write <tag> body here. <description>`. Absent when `body.enabled` is false.
+//!   fence and `Write <card name> body here.` after each card fence. When
+//!   `body.example` is set, the example text is embedded verbatim instead.
+//!   Absent when `body.enabled` is false.
 //!
 //! Most UI metadata is stripped, but two semantic-structure hints are honored:
 //! `ui.group` produces `# ==== SECTION ====` banners and `ui.order` controls
@@ -45,31 +45,22 @@ impl QuillConfig {
             main_desc,
         );
         if self.main.body_enabled() {
-            let desc = self
-                .main
-                .body
-                .as_ref()
-                .and_then(|b| b.description.as_deref());
-            out.push_str(&format!("\n{}\n", body_marker("main body", desc)));
+            let example = self.main.body.as_ref().and_then(|b| b.example.as_deref());
+            let text = example.unwrap_or("Write main body here.");
+            out.push_str(&format!("\n{}\n", text));
         }
         for card in &self.card_types {
             let sentinel = format!("CARD: {}  # sentinel, composable (0..N)", card.name);
             out.push('\n');
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
             if card.body_enabled() {
-                let label = format!("{} body", card.name);
-                let desc = card.body.as_ref().and_then(|b| b.description.as_deref());
-                out.push_str(&format!("\n{}\n", body_marker(&label, desc)));
+                let example = card.body.as_ref().and_then(|b| b.example.as_deref());
+                let fallback = format!("Write {} body here.", card.name);
+                let text = example.unwrap_or(fallback.as_str());
+                out.push_str(&format!("\n{}\n", text));
             }
         }
         out
-    }
-}
-
-fn body_marker(label: &str, description: Option<&str>) -> String {
-    match description {
-        Some(desc) => format!("Write {} here. {}", label, desc),
-        None => format!("Write {} here.", label),
     }
 }
 
@@ -562,7 +553,7 @@ card_types:
     }
 
     #[test]
-    fn body_description_appears_in_placeholder() {
+    fn body_example_appears_verbatim() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -571,29 +562,29 @@ main:
 card_types:
   note:
     body:
-      description: Write your note here
+      example: "This is an example note."
     fields:
       author: { type: string }
 "#)
         .blueprint();
         let after = &t[t.find("CARD: note").unwrap()..];
-        assert!(after.contains("\nWrite note body here. Write your note here\n"));
-        assert!(!after.contains("\nWrite note body here.\n"));
+        assert!(after.contains("\nThis is an example note.\n"));
+        assert!(!after.contains("Write note body here."));
     }
 
     #[test]
-    fn main_body_description_appears_in_placeholder() {
+    fn main_body_example_appears_verbatim() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   body:
-    description: Write the letter body here
+    example: "Dear Sir or Madam,\n\nI am writing to..."
   fields:
     to: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("\nWrite main body here. Write the letter body here\n"));
-        assert!(!t.contains("\nWrite main body here.\n"));
+        assert!(t.contains("\nDear Sir or Madam,\n\nI am writing to...\n"));
+        assert!(!t.contains("Write main body here."));
     }
 
     #[test]

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1098,6 +1098,42 @@ impl QuillConfig {
             }
         }
 
+        // Error when `body.example` contains a line that the document parser
+        // would interpret as a metadata fence (`---` with up to 3 leading
+        // spaces and optional trailing whitespace). Such a line would split the
+        // blueprint body region into a new fence, corrupting document structure.
+        let err_example_contains_fence = |label: &str,
+                                          body: &Option<BodyCardSchema>|
+         -> Option<Diagnostic> {
+            let example = body.as_ref()?.example.as_deref()?;
+            if example_contains_fence_line(example) {
+                Some(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "`{label}.body.example` contains a line that would be parsed as a metadata fence (`---`); this would corrupt the blueprint"
+                        ),
+                    )
+                    .with_code("quill::body_example_contains_fence".to_string())
+                    .with_hint(
+                        "Remove or reword any line that is exactly `---` (with up to 3 leading spaces and optional trailing whitespace).".to_string(),
+                    ),
+                )
+            } else {
+                None
+            }
+        };
+        if let Some(d) = err_example_contains_fence("main", &main.body) {
+            errors.push(d);
+        }
+        for card in &card_types {
+            if let Some(d) =
+                err_example_contains_fence(&format!("card_types.{}", card.name), &card.body)
+            {
+                errors.push(d);
+            }
+        }
+
         if !errors.is_empty() {
             return Err(errors);
         }
@@ -1119,4 +1155,21 @@ impl QuillConfig {
             warnings,
         ))
     }
+}
+
+/// Returns true if any line in `text` would be parsed as a metadata-fence
+/// marker by the document parser. Mirrors `document::fences::is_fence_marker_line`:
+/// up to 3 leading spaces (no leading tab), then `---`, then only whitespace.
+fn example_contains_fence_line(text: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        let indent = line.bytes().take_while(|&b| b == b' ').count();
+        if indent > 3 || line.as_bytes().first() == Some(&b'\t') {
+            return false;
+        }
+        matches!(
+            line[indent..].strip_prefix("---"),
+            Some(rest) if rest.chars().all(|c| c == ' ' || c == '\t')
+        )
+    })
 }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -965,9 +965,7 @@ impl QuillConfig {
                             format!("Invalid 'main.body' block: {}", e),
                         )
                         .with_code("quill::invalid_body".to_string())
-                        .with_hint(
-                            "Valid keys under 'body' are: enabled, example.".to_string(),
-                        ),
+                        .with_hint("Valid keys under 'body' are: enabled, example.".to_string()),
                     );
                     None
                 }
@@ -1095,9 +1093,7 @@ impl QuillConfig {
             warnings.push(d);
         }
         for card in &card_types {
-            if let Some(d) =
-                warn_example_unused(&format!("card_types.{}", card.name), &card.body)
-            {
+            if let Some(d) = warn_example_unused(&format!("card_types.{}", card.name), &card.body) {
                 warnings.push(d);
             }
         }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -966,7 +966,7 @@ impl QuillConfig {
                         )
                         .with_code("quill::invalid_body".to_string())
                         .with_hint(
-                            "Valid keys under 'body' are: enabled, description.".to_string(),
+                            "Valid keys under 'body' are: enabled, example.".to_string(),
                         ),
                     );
                     None
@@ -1067,23 +1067,23 @@ impl QuillConfig {
             }
         }
 
-        // Warn when `body.description` is set together with `body.enabled: false` —
-        // the description has no effect since the body editor is disabled.
-        let warn_description_unused = |label: &str,
-                                       body: &Option<BodyCardSchema>|
+        // Warn when `body.example` is set together with `body.enabled: false` —
+        // the example has no effect since the body editor is disabled.
+        let warn_example_unused = |label: &str,
+                                   body: &Option<BodyCardSchema>|
          -> Option<Diagnostic> {
             let body = body.as_ref()?;
-            if body.enabled == Some(false) && body.description.is_some() {
+            if body.enabled == Some(false) && body.example.is_some() {
                 Some(
                     Diagnostic::new(
                         Severity::Warning,
                         format!(
-                            "`{label}.body.description` is set but `{label}.body.enabled` is false; the description will have no effect"
+                            "`{label}.body.example` is set but `{label}.body.enabled` is false; the example will have no effect"
                         ),
                     )
-                    .with_code("quill::body_description_unused".to_string())
+                    .with_code("quill::body_example_unused".to_string())
                     .with_hint(
-                        "Set `body.enabled: true` to surface the description, or remove `body.description`."
+                        "Set `body.enabled: true` to surface the example, or remove `body.example`."
                             .to_string(),
                     ),
                 )
@@ -1091,12 +1091,12 @@ impl QuillConfig {
                 None
             }
         };
-        if let Some(d) = warn_description_unused("main", &main.body) {
+        if let Some(d) = warn_example_unused("main", &main.body) {
             warnings.push(d);
         }
         for card in &card_types {
             if let Some(d) =
-                warn_description_unused(&format!("card_types.{}", card.name), &card.body)
+                warn_example_unused(&format!("card_types.{}", card.name), &card.body)
             {
                 warnings.push(d);
             }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2529,7 +2529,10 @@ main:
     title: { type: string }
 "#;
     let result = QuillConfig::from_yaml_with_warnings(yaml);
-    assert!(result.is_ok(), "four-space indented --- should not trigger fence error");
+    assert!(
+        result.is_ok(),
+        "four-space indented --- should not trigger fence error"
+    );
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2453,7 +2453,7 @@ fn schema_snapshot_usaf_memo_0_1_0() {
 }
 
 #[test]
-fn body_description_with_body_disabled_emits_warning() {
+fn body_example_with_body_disabled_emits_warning() {
     let yaml = r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -2463,7 +2463,7 @@ card_types:
   skills:
     body:
       enabled: false
-      description: This description is unused
+      example: This example is unused
     fields:
       items: { type: array, required: true }
 "#;
@@ -2472,9 +2472,9 @@ card_types:
         warnings.iter().any(|d| d
             .code
             .as_deref()
-            .map(|c| c == "quill::body_description_unused")
+            .map(|c| c == "quill::body_example_unused")
             .unwrap_or(false)),
-        "expected body_description_unused warning, got: {:?}",
+        "expected body_example_unused warning, got: {:?}",
         warnings
     );
 }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2478,3 +2478,84 @@ card_types:
         warnings
     );
 }
+
+#[test]
+fn body_example_with_bare_fence_line_is_an_error() {
+    let yaml = r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  body:
+    example: "Opening paragraph.\n\n---\n\nClosing paragraph."
+  fields:
+    title: { type: string }
+"#;
+    let result = QuillConfig::from_yaml_with_warnings(yaml);
+    let errors = result.unwrap_err();
+    assert!(
+        errors.iter().any(|d| d
+            .code
+            .as_deref()
+            .map(|c| c == "quill::body_example_contains_fence")
+            .unwrap_or(false)),
+        "expected body_example_contains_fence error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn body_example_fence_line_with_leading_spaces_is_an_error() {
+    // Up to 3 leading spaces still counts as a fence marker.
+    let yaml = r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  body:
+    example: "text\n   ---\nmore text"
+  fields:
+    title: { type: string }
+"#;
+    let result = QuillConfig::from_yaml_with_warnings(yaml);
+    assert!(result.is_err());
+}
+
+#[test]
+fn body_example_four_leading_spaces_is_not_a_fence() {
+    // Four leading spaces = indented code block, not a fence marker.
+    let yaml = r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  body:
+    example: "text\n    ---\nmore text"
+  fields:
+    title: { type: string }
+"#;
+    let result = QuillConfig::from_yaml_with_warnings(yaml);
+    assert!(result.is_ok(), "four-space indented --- should not trigger fence error");
+}
+
+#[test]
+fn body_example_card_type_fence_line_is_an_error() {
+    // The fence check applies to card-type body examples too.
+    let yaml = r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+card_types:
+  note:
+    body:
+      example: "See below:\n---\nEnd."
+    fields:
+      author: { type: string }
+"#;
+    let result = QuillConfig::from_yaml_with_warnings(yaml);
+    let errors = result.unwrap_err();
+    assert!(
+        errors.iter().any(|d| d
+            .code
+            .as_deref()
+            .map(|c| c == "quill::body_example_contains_fence")
+            .unwrap_or(false)),
+        "expected body_example_contains_fence error for card type, got: {:?}",
+        errors
+    );
+}

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -77,7 +77,7 @@ pub struct BodyCardSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// Example body content embedded verbatim in the blueprint body region.
-    /// When absent, the blueprint falls back to "Write <card> body here.".
+    /// When absent, the blueprint falls back to `Write <card> body here.`.
     /// Has no effect when `enabled` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<String>,

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -76,10 +76,11 @@ pub struct BodyCardSchema {
     /// of this card type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    /// Description shown in the body editor placeholder area when the body is
-    /// empty. Has no effect when `enabled` is false.
+    /// Example body content embedded verbatim in the blueprint body region.
+    /// When absent, the blueprint falls back to "Write <card> body here.".
+    /// Has no effect when `enabled` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub example: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
body.description tried to serve as both a UI hint and an LLM instruction
embedded in blueprint text, producing awkward output like
"Write note body here. Write your note here". body.example instead embeds
the example text verbatim in the blueprint body region — concrete prose
that communicates format, tone, and length more reliably than instructions.

The fallback "Write <card> body here." is retained when no example is set.
The unused-when-disabled warning carries forward as quill::body_example_unused.

https://claude.ai/code/session_01A9Xqtwy1z3Ez38cXiQNjtF