### PR TITLE
Add "required" marker to Quill sentinel comment

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -41,7 +41,7 @@ impl QuillConfig {
         write_card_frontmatter(
             &mut out,
             &self.main,
-            &format!("QUILL: {}@{}  # sentinel", self.name, self.version),
+            &format!("QUILL: {}@{}  # sentinel; required", self.name, self.version),
             main_desc,
         );
         if self.main.body_enabled() {
@@ -612,7 +612,7 @@ main:
     flavor: { type: string, default: taro }
 "#)
         .blueprint();
-        assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel\n"));
+        assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel; required\n"));
         assert!(t.contains("\nWrite main body here.\n"));
     }
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -41,7 +41,10 @@ impl QuillConfig {
         write_card_frontmatter(
             &mut out,
             &self.main,
-            &format!("QUILL: {}@{}  # sentinel; required", self.name, self.version),
+            &format!(
+                "QUILL: {}@{}  # sentinel; required",
+                self.name, self.version
+            ),
             main_desc,
         );
         if self.main.body_enabled() {


### PR DESCRIPTION
## Summary
Updated the Quill blueprint sentinel comment to include a "required" marker, clarifying that this field is mandatory in the configuration.

## Changes
- Modified the sentinel comment format from `# sentinel` to `# sentinel; required` in the blueprint generation
- Updated the corresponding test assertion to match the new sentinel format

## Details
The sentinel comment is used to mark the main Quill configuration field in generated card frontmatter. Adding the "required" marker makes it explicit that this field must be present in valid configurations, improving clarity for users reading the generated blueprints.

https://claude.ai/code/session_016xwhfAhuCJ9pZj8vaUJ9qc