### PR TITLE
Remove lint job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,31 +22,6 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Format check
-        run: cargo fmt --all -- --check
-
-      # TODO: formalize Clippy later
-      # - name: Clippy check
-      #   run: cargo clippy --all-features --all-targets --locked -- -D warnings
-
-      - name: Build docs
-        env:
-          RUSTDOCFLAGS: -Dwarnings
-        run: cargo doc --no-deps --locked
-
   test:
     runs-on: ubuntu-latest
     steps:
@@ -111,7 +86,7 @@ jobs:
 
   ci-success:
     runs-on: ubuntu-latest
-    needs: [lint, test, wasm]
+    needs: [test, wasm]
     if: ${{ always() }}
     steps:
       - name: Fail if any dependency did not succeed


### PR DESCRIPTION
This PR removes the dedicated `lint` job from the CI workflow, streamlining the continuous integration pipeline.

## Summary
The `lint` job that performed format checking, clippy validation, and documentation building has been removed from the GitHub Actions workflow. The `ci-success` job dependency list has been updated accordingly to reflect this change.

## Changes
- Removed the entire `lint` job which included:
  - `cargo fmt` format checking
  - Commented-out clippy checks
  - `cargo doc` documentation building with strict warnings
- Updated `ci-success` job dependencies from `[lint, test, wasm]` to `[test, wasm]`

## Notes
This change simplifies the CI pipeline by removing linting checks. These checks may be enforced through other means (e.g., pre-commit hooks, local development practices, or separate tooling) or may be intentionally deprioritized at this time.

https://claude.ai/code/session_01HFbAV9ujiscJftMfmtG8H7