### PR TITLE
Remove rustfmt from CI workflow and disable format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,10 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-
-      - name: Format check
-        run: cargo fmt --all -- --check
 
       # TODO: formalize Clippy later
       # - name: Clippy check


### PR DESCRIPTION
## Summary
This PR removes the rustfmt component from the Rust toolchain setup and disables the format check step in the CI workflow.

## Changes
- Removed `rustfmt` from the installed toolchain components (keeping only `clippy`)
- Removed the "Format check" CI job that ran `cargo fmt --all -- --check`

## Rationale
This change simplifies the CI pipeline by removing automated code formatting validation. The format check step is no longer part of the continuous integration process.

https://claude.ai/code/session_01UPL9hw255FjJKhvsWYA6ib