### PR TITLE
Redesign blueprint annotation grammar for clarity and consistency

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -5,20 +5,22 @@
 //! constraints, examples — so a consumer can write a fresh document from it.
 //!
 //! Annotation grammar:
-//! - **Leading `# …` comment lines** carry human prose: description,
-//!   `required`, `enum: a | b | c`, `example: <value>`.
-//! - **Inline `# …` annotations** carry structural type/constraint info:
-//!   non-obvious type hints (`# integer`, `# YYYY-MM-DD`, `# markdown`) on
-//!   ordinary fields, and `# sentinel` / `# sentinel, composable (0..N)` on
-//!   the `QUILL:` and `CARD:` lines respectively.
+//! - **Leading `# …` lines** carry prose: `# <description>` (single line,
+//!   whitespace-collapsed) and `# e.g. <value>` (whenever an `example:` is
+//!   configured, regardless of role or type).
+//! - **Inline `# …` annotation** on the value line is structural:
+//!   `# <type>[<format>]; <role>[, <extras>...]`. Type is mandatory on every
+//!   field. Format slot uses angle brackets (`array<string>`,
+//!   `date<YYYY-MM-DD>`, `enum<a | b | c>`). Role is `required`, `optional`,
+//!   or `composable (0..N)` for cards. The QUILL sentinel adds a `verbatim`
+//!   extra signaling that the value must not be modified.
 //! - **Body regions** are signalled by `Write main body here.` after the main
 //!   fence and `Write <card name> body here.` after each card fence. When
 //!   `body.example` is set, the example text is embedded verbatim instead.
 //!   Absent when `body.enabled` is false.
 //!
-//! Most UI metadata is stripped, but two semantic-structure hints are honored:
-//! `ui.group` produces `# ==== SECTION ====` banners and `ui.order` controls
-//! field ordering within a group.
+//! `ui.order` controls field ordering. `ui.group` clusters fields together
+//! within the document but emits no banner.
 
 use std::collections::BTreeMap;
 
@@ -42,7 +44,7 @@ impl QuillConfig {
             &mut out,
             &self.main,
             &format!(
-                "QUILL: {}@{}  # sentinel; required",
+                "QUILL: {}@{}  # sentinel; required, verbatim",
                 self.name, self.version
             ),
             main_desc,
@@ -53,7 +55,7 @@ impl QuillConfig {
             out.push_str(&format!("\n{}\n", text));
         }
         for card in &self.card_types {
-            let sentinel = format!("CARD: {}  # sentinel, composable (0..N)", card.name);
+            let sentinel = format!("CARD: {}  # sentinel; composable (0..N)", card.name);
             out.push('\n');
             write_card_frontmatter(&mut out, card, &sentinel, card.description.as_deref());
             if card.body_enabled() {
@@ -75,16 +77,12 @@ fn write_card_frontmatter(
 ) {
     out.push_str("---\n");
     if let Some(desc) = description {
-        for line in desc.lines() {
-            out.push_str(&format!("# {}\n", line));
-        }
+        let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
+        out.push_str(&format!("# {}\n", clean));
     }
     out.push_str(sentinel_line);
     out.push('\n');
-    for (group, fields) in group_fields(card.fields.values()) {
-        if let Some(name) = group {
-            out.push_str(&format!("# ==== {} ====\n", name.to_uppercase()));
-        }
+    for (_, fields) in group_fields(card.fields.values()) {
         for field in fields {
             write_field(out, field, 0);
         }
@@ -92,9 +90,9 @@ fn write_card_frontmatter(
     out.push_str("---\n");
 }
 
-/// Partition fields by `ui.group`, preserving first-appearance order of groups
-/// and sorting fields within each group by `ui.order`. Ungrouped fields form
-/// the leading section (no banner).
+/// Cluster fields by `ui.group` (preserving first-appearance order; ungrouped
+/// fields lead) and sort within each group by `ui.order`. The grouping is
+/// purely positional now — no banner is emitted.
 fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
     fields: I,
 ) -> Vec<(Option<String>, Vec<&'a FieldSchema>)> {
@@ -112,7 +110,6 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
             None => groups.push((group, vec![field])),
         }
     }
-    // Ungrouped fields lead; named groups follow in first-appearance order.
     groups.sort_by_key(|(g, _)| g.is_some());
     groups
 }
@@ -120,8 +117,7 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     let pad = "  ".repeat(indent);
 
-    // Typed table: array whose items are a typed object. Render with full
-    // per-property annotations; a synthetic row when no values are supplied.
+    // Typed table: array whose items are a typed object.
     if matches!(field.r#type, FieldType::Array) {
         if let Some(items) = &field.items {
             if matches!(items.r#type, FieldType::Object) {
@@ -133,41 +129,57 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
         }
     }
 
-    write_field_comments(out, field, &pad);
-    write_example_comment(out, field, &pad);
-    let comment = match type_annotation(&field.r#type) {
-        Some(hint) => format!("  # {}", hint),
-        None => String::new(),
-    };
+    write_description(out, field, &pad);
+    write_eg_comment(out, field, &pad);
+
+    // Markdown fields render as a YAML block scalar so multi-line content has
+    // a consistent shape regardless of whether a default is configured.
+    if matches!(field.r#type, FieldType::Markdown) {
+        let inline = inline_annotation(field, false);
+        write_markdown_block(out, field, &pad, &inline);
+        return;
+    }
+
+    let inline = format!("  # {}", inline_annotation(field, false));
     let value = field_value(field);
-    // Optional fields with no default and no enum have nothing concrete to
-    // offer; comment them out so the author can uncomment what they need.
-    let commented = !field.required && field.default.is_none() && field.enum_values.is_none();
-    write_value(out, &field.name, &value, &comment, &pad, commented);
+    write_value(out, &field.name, &value, &inline, &pad);
 }
 
-/// Description / `# required` / `# enum:` lines. Always safe to emit; carries
-/// the structural prose every field needs.
-fn write_field_comments(out: &mut String, field: &FieldSchema, pad: &str) {
+fn write_description(out: &mut String, field: &FieldSchema, pad: &str) {
     if let Some(desc) = &field.description {
         let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
-        out.push_str(&format!("{}# {}\n", pad, clean));
-    }
-    if field.required {
-        out.push_str(&format!("{}# required\n", pad));
-    }
-    if let Some(vals) = &field.enum_values {
-        out.push_str(&format!("{}# enum: {}\n", pad, vals.join(" | ")));
+        if !clean.is_empty() {
+            out.push_str(&format!("{}# {}\n", pad, clean));
+        }
     }
 }
 
-/// `# example: …` line — emitted only for optional, non-enum fields. Required
-/// fields use the example as the value; enum fields use the first enum value;
-/// typed tables surface examples as actual rows.
-fn write_example_comment(out: &mut String, field: &FieldSchema, pad: &str) {
-    if !field.required && field.enum_values.is_none() {
-        if let Some(eg) = field.example.as_ref().map(eg_hint) {
-            out.push_str(&format!("{}# example: {}\n", pad, eg));
+/// `# e.g. <value>` — emitted whenever `example:` is configured on the field.
+/// Independent of role, type, or enum-ness; examples never become rendered
+/// values.
+fn write_eg_comment(out: &mut String, field: &FieldSchema, pad: &str) {
+    if let Some(eg) = field.example.as_ref().map(eg_hint) {
+        out.push_str(&format!("{}# e.g. {}\n", pad, eg));
+    }
+}
+
+fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline: &str) {
+    out.push_str(&format!("{}{}: |-  # {}\n", pad, field.name, inline));
+    let body_pad = format!("{}  ", pad);
+    // Render default content if present; otherwise leave one indented blank
+    // line so the block scalar has a body for the author to fill in.
+    let content = field.default.as_ref().and_then(|v| match v.as_json() {
+        serde_json::Value::String(s) => Some(s),
+        _ => None,
+    });
+    match content {
+        Some(text) if !text.is_empty() => {
+            for line in text.lines() {
+                out.push_str(&format!("{}{}\n", body_pad, line));
+            }
+        }
+        _ => {
+            out.push_str(&format!("{}\n", body_pad));
         }
     }
 }
@@ -182,9 +194,11 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
     v
 }
 
-/// Emit a typed-table field: description/required/enum comments, then the
-/// field key, then either example/default rows or one synthetic template row.
-/// `# example:` is intentionally suppressed — the rows below carry the example.
+/// Emit a typed-table field: description + optional `# e.g.` line, then the
+/// field key with its `array<object>; <role>` inline annotation, then either
+/// example/default rows or a synthetic template row. When concrete rows are
+/// rendered, the `# e.g.` comment is suppressed (the rows themselves carry
+/// the example shape).
 fn write_typed_table_field(
     out: &mut String,
     field: &FieldSchema,
@@ -192,8 +206,6 @@ fn write_typed_table_field(
     indent: usize,
 ) {
     let pad = "  ".repeat(indent);
-    write_field_comments(out, field, &pad);
-    out.push_str(&format!("{}{}:\n", pad, field.name));
 
     let concrete_rows = field
         .example
@@ -203,6 +215,14 @@ fn write_typed_table_field(
             serde_json::Value::Array(items) if !items.is_empty() => Some(items.clone()),
             _ => None,
         });
+
+    write_description(out, field, &pad);
+    if concrete_rows.is_none() {
+        write_eg_comment(out, field, &pad);
+    }
+
+    let inline = inline_annotation(field, true);
+    out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete_rows {
         Some(items) => write_array_items(out, &items, &pad),
@@ -216,49 +236,81 @@ fn write_typed_table_field(
     }
 }
 
-/// The value to render for a field in the template.
-enum FieldValue {
-    Inline(String),                // goes on the same line as the key
-    Block(Vec<serde_json::Value>), // rendered as indented items below the key
+/// Build the inline annotation body (without the leading `# `).
+/// `force_array_object` is `true` for typed-table outer fields, so the format
+/// slot is always `<object>` regardless of `field.items`.
+fn inline_annotation(field: &FieldSchema, force_array_object: bool) -> String {
+    let role = if field.required { "required" } else { "optional" };
+    let type_expr = type_expression(field, force_array_object);
+    format!("{}; {}", type_expr, role)
 }
 
-fn field_value(field: &FieldSchema) -> FieldValue {
-    if field.required {
-        // Required: example > default > type-based placeholder.
-        if let Some(v) = field.example.as_ref().or(field.default.as_ref()) {
-            return json_to_value(v.as_json());
+fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
+    if let Some(values) = &field.enum_values {
+        return format!("enum<{}>", values.join(" | "));
+    }
+    match field.r#type {
+        FieldType::String => "string".into(),
+        FieldType::Number => "number".into(),
+        FieldType::Integer => "integer".into(),
+        FieldType::Boolean => "boolean".into(),
+        FieldType::Object => "object".into(),
+        FieldType::Markdown => "markdown".into(),
+        FieldType::Date => "date<YYYY-MM-DD>".into(),
+        FieldType::DateTime => "datetime<ISO 8601>".into(),
+        FieldType::Array => {
+            let item = if force_array_object {
+                "object"
+            } else {
+                array_item_label(field)
+            };
+            format!("array<{}>", item)
         }
-        placeholder(&field.r#type, Some(&field.name))
-    } else {
-        // Optional: default only (example goes to the `# example:` comment).
-        if let Some(v) = field.default.as_ref() {
-            return json_to_value(v.as_json());
-        }
-        // Enum with no default: first enum value is the canonical placeholder.
-        if let Some(first) = field.enum_values.as_ref().and_then(|v| v.first()) {
-            return FieldValue::Inline(first.clone());
-        }
-        placeholder(&field.r#type, None)
     }
 }
 
-/// Type-based placeholder for a field that has no usable example/default.
-/// `label` is `Some(field_name)` when the field is required (string/markdown/
-/// object then render as `"<field_name>"`); `None` for optional fields, which
-/// fall through to an empty value.
-fn placeholder(t: &FieldType, label: Option<&str>) -> FieldValue {
+fn array_item_label(field: &FieldSchema) -> &'static str {
+    match field.items.as_deref().map(|i| &i.r#type) {
+        Some(FieldType::String) => "string",
+        Some(FieldType::Number) => "number",
+        Some(FieldType::Integer) => "integer",
+        Some(FieldType::Boolean) => "boolean",
+        Some(FieldType::Object) => "object",
+        Some(FieldType::Markdown) => "markdown",
+        Some(FieldType::Date) => "date",
+        Some(FieldType::DateTime) => "datetime",
+        // Nested arrays and missing items default to string — the most
+        // common case in existing fixtures and the safest fallback.
+        Some(FieldType::Array) | None => "string",
+    }
+}
+
+/// The value to render for a field. Single cascade independent of role:
+/// default → first enum value → type-empty.
+enum FieldValue {
+    Inline(String),
+    Block(Vec<serde_json::Value>),
+}
+
+fn field_value(field: &FieldSchema) -> FieldValue {
+    if let Some(v) = field.default.as_ref() {
+        return json_to_value(v.as_json());
+    }
+    if let Some(first) = field.enum_values.as_ref().and_then(|v| v.first()) {
+        return FieldValue::Inline(first.clone());
+    }
+    type_empty(&field.r#type)
+}
+
+fn type_empty(t: &FieldType) -> FieldValue {
     match t {
         FieldType::Array => FieldValue::Inline("[]".into()),
         FieldType::Boolean => FieldValue::Inline("false".into()),
         FieldType::Number | FieldType::Integer => FieldValue::Inline("0".into()),
-        // Date/datetime use empty string; type annotation carries the format hint.
         FieldType::Date | FieldType::DateTime => FieldValue::Inline("\"\"".into()),
-        // String, markdown, object: angle-bracket placeholder when required;
-        // empty when optional.
-        _ => FieldValue::Inline(match label {
-            Some(name) => format!("\"<{}>\"", name),
-            None => "\"\"".into(),
-        }),
+        // String, markdown, object: empty string. Markdown is special-cased
+        // earlier in `write_field` and never reaches this code path.
+        _ => FieldValue::Inline("\"\"".into()),
     }
 }
 
@@ -271,21 +323,10 @@ fn json_to_value(val: &serde_json::Value) -> FieldValue {
     }
 }
 
-fn write_value(
-    out: &mut String,
-    key: &str,
-    val: &FieldValue,
-    comment: &str,
-    pad: &str,
-    commented: bool,
-) {
+fn write_value(out: &mut String, key: &str, val: &FieldValue, comment: &str, pad: &str) {
     match val {
         FieldValue::Inline(s) => {
-            if commented {
-                out.push_str(&format!("{}# {}: {}{}\n", pad, key, s, comment));
-            } else {
-                out.push_str(&format!("{}{}: {}{}\n", pad, key, s, comment));
-            }
+            out.push_str(&format!("{}{}: {}{}\n", pad, key, s, comment));
         }
         FieldValue::Block(items) => {
             out.push_str(&format!("{}{}:{}\n", pad, key, comment));
@@ -315,21 +356,6 @@ fn write_array_items(out: &mut String, items: &[serde_json::Value], pad: &str) {
             }
             _ => out.push_str(&format!("{}- {}\n", item_pad, render_scalar(item))),
         }
-    }
-}
-
-/// Inline type annotation for non-obvious types. `string` and `array` are
-/// self-evident from the YAML value; no annotation needed.
-fn type_annotation(t: &FieldType) -> Option<&'static str> {
-    match t {
-        FieldType::Number => Some("number"),
-        FieldType::Integer => Some("integer"),
-        FieldType::Boolean => Some("boolean"),
-        FieldType::Markdown => Some("markdown"),
-        FieldType::Object => Some("object"),
-        FieldType::Date => Some("YYYY-MM-DD"),
-        FieldType::DateTime => Some("ISO 8601"),
-        FieldType::String | FieldType::Array => None,
     }
 }
 
@@ -414,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    fn required_string_without_example_uses_angle_bracket_placeholder() {
+    fn required_string_renders_empty_with_required_role() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -422,11 +448,12 @@ main:
     author: { type: string, required: true }
 "#)
         .blueprint();
-        assert!(t.contains("# required\nauthor: \"<author>\"\n"));
+        assert!(t.contains("author: \"\"  # string; required\n"));
     }
 
     #[test]
-    fn required_field_uses_example_over_default() {
+    fn required_field_with_example_does_not_use_example_as_value() {
+        // Examples never render as values — they always surface in `# e.g.`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -434,11 +461,11 @@ main:
     status: { type: string, required: true, default: draft, example: final }
 "#)
         .blueprint();
-        assert!(t.contains("# required\nstatus: final\n"));
+        assert!(t.contains("# e.g. final\nstatus: draft  # string; required\n"));
     }
 
     #[test]
-    fn optional_field_uses_default_example_becomes_eg() {
+    fn optional_field_default_renders_as_value_with_eg_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -446,14 +473,11 @@ main:
     classification: { type: string, default: "", example: CONFIDENTIAL }
 "#)
         .blueprint();
-        assert!(t.contains("# example: CONFIDENTIAL\nclassification: \"\"\n"));
+        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; optional\n"));
     }
 
     #[test]
     fn optional_array_example_renders_as_flow_sequence_with_context_quoting() {
-        // Multi-element array examples render as YAML flow sequences so the
-        // full shape survives. Items containing flow indicators (`,`, `[`, `]`,
-        // `{`, `}`) get quoted; bare items don't.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -467,12 +491,12 @@ main:
 "#)
         .blueprint();
         assert!(t.contains(
-            "# example: [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\n# recipient: []\n"
+            "# e.g. [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\nrecipient: []  # array<string>; optional\n"
         ));
     }
 
     #[test]
-    fn enum_field_shows_values_and_no_eg() {
+    fn enum_field_uses_enum_format_slot_and_no_eg() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -480,12 +504,14 @@ main:
     format: { type: string, enum: [standard, informal], default: standard }
 "#)
         .blueprint();
-        assert!(t.contains("# enum: standard | informal\nformat: standard\n"));
-        assert!(!t.contains("example:"));
+        assert!(t.contains("format: standard  # enum<standard | informal>; optional\n"));
+        assert!(!t.contains("e.g."));
     }
 
     #[test]
-    fn required_array_uses_example_as_items() {
+    fn required_array_with_example_renders_eg_only_not_value() {
+        // Plain (non-typed-table) required arrays render type-empty; the
+        // example surfaces in the leading `# e.g.` line.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -498,11 +524,13 @@ main:
         - City ST 12345
 "#)
         .blueprint();
-        assert!(t.contains("# required\nmemo_from:\n  - ORG/SYMBOL\n  - City ST 12345\n"));
+        assert!(t.contains(
+            "# e.g. [ORG/SYMBOL, City ST 12345]\nmemo_from: []  # array<string>; required\n"
+        ));
     }
 
     #[test]
-    fn description_emitted_as_preceding_comment() {
+    fn description_emitted_as_single_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -513,29 +541,72 @@ main:
       description: Be brief and clear.
 "#)
         .blueprint();
-        assert!(t.contains("# Be brief and clear.\n# required\nsubject: \"<subject>\"\n"));
+        assert!(t.contains("# Be brief and clear.\nsubject: \"\"  # string; required\n"));
     }
 
     #[test]
-    fn non_obvious_types_get_annotation() {
+    fn every_field_carries_inline_type_and_role() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
+    title: { type: string }
     size: { type: number, default: 11 }
     flag: { type: boolean, default: false }
-    body: { type: markdown }
     issued: { type: date }
+    published: { type: datetime }
+    refs: { type: array }
 "#)
         .blueprint();
-        assert!(t.contains("size: 11  # number"));
-        assert!(t.contains("flag: false  # boolean"));
-        assert!(t.contains("# body: \"\"  # markdown"));
-        assert!(t.contains("# issued: \"\"  # YYYY-MM-DD"));
+        assert!(t.contains("title: \"\"  # string; optional\n"));
+        assert!(t.contains("size: 11  # number; optional\n"));
+        assert!(t.contains("flag: false  # boolean; optional\n"));
+        assert!(t.contains("issued: \"\"  # date<YYYY-MM-DD>; optional\n"));
+        assert!(t.contains("published: \"\"  # datetime<ISO 8601>; optional\n"));
+        assert!(t.contains("refs: []  # array<string>; optional\n"));
     }
 
     #[test]
-    fn card_description_emitted_after_sentinel() {
+    fn markdown_field_renders_as_block_scalar() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown }
+"#)
+        .blueprint();
+        assert!(t.contains("bio: |-  # markdown; optional\n  \n"));
+    }
+
+    #[test]
+    fn markdown_field_with_default_fills_block() {
+        let t = cfg(r###"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio:
+      type: markdown
+      default: "## About me\n\nHello."
+"###)
+        .blueprint();
+        assert!(t.contains("bio: |-  # markdown; optional\n  ## About me\n  \n  Hello.\n"));
+    }
+
+    #[test]
+    fn quill_sentinel_line_is_required_verbatim() {
+        let t = cfg(r#"
+quill: { name: taro, version: 0.1.0, backend: typst, description: x }
+main:
+  fields:
+    flavor: { type: string, default: taro }
+"#)
+        .blueprint();
+        assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel; required, verbatim\n"));
+        assert!(t.contains("\nWrite main body here.\n"));
+    }
+
+    #[test]
+    fn card_sentinel_line_is_composable() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -549,7 +620,7 @@ card_types:
 "#)
         .blueprint();
         assert!(t.contains(
-            "# A short note appended to the document.\nCARD: note  # sentinel, composable (0..N)\n"
+            "# A short note appended to the document.\nCARD: note  # sentinel; composable (0..N)\n"
         ));
     }
 
@@ -607,19 +678,6 @@ main:
     }
 
     #[test]
-    fn sentinel_and_body_present() {
-        let t = cfg(r#"
-quill: { name: taro, version: 0.1.0, backend: typst, description: x }
-main:
-  fields:
-    flavor: { type: string, default: taro }
-"#)
-        .blueprint();
-        assert!(t.starts_with("---\n# x\nQUILL: taro@0.1.0  # sentinel; required\n"));
-        assert!(t.contains("\nWrite main body here.\n"));
-    }
-
-    #[test]
     fn card_body_placeholder_uses_card_name() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -636,7 +694,7 @@ card_types:
     }
 
     #[test]
-    fn ui_groups_emit_section_banners_in_first_appearance_order() {
+    fn ui_groups_cluster_fields_without_emitting_banner() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -648,14 +706,14 @@ main:
 "#)
         .blueprint();
         let after_quill = &t[t.find("QUILL:").unwrap()..];
-        let addressing = after_quill.find("# ==== ADDRESSING ====").unwrap();
-        let letterhead = after_quill.find("# ==== LETTERHEAD ====").unwrap();
+        // No banners emitted at all.
+        assert!(!after_quill.contains("===="));
+        // Order: ungrouped first, then groups in first-appearance order.
         let notes = after_quill.find("notes:").unwrap();
-        // Ungrouped (notes) leads; Addressing precedes Letterhead.
-        assert!(notes < addressing);
-        assert!(addressing < letterhead);
-        // No banner for the ungrouped section.
-        assert!(!after_quill[..notes].contains("# ===="));
+        let memo_for = after_quill.find("memo_for:").unwrap();
+        let letterhead = after_quill.find("letterhead_title:").unwrap();
+        assert!(notes < memo_for);
+        assert!(memo_for < letterhead);
     }
 
     #[test]
@@ -674,13 +732,13 @@ main:
           year: { type: integer, description: Publication year. }
 "#)
         .blueprint();
-        assert!(t.contains("# Cited works.\nreferences:\n  -\n"));
-        assert!(t.contains("    # Citing organization.\n    # required\n    org: \"<org>\"\n"));
-        assert!(t.contains("    # Publication year.\n    # year: 0  # integer\n"));
+        assert!(t.contains("# Cited works.\nreferences:  # array<object>; optional\n  -\n"));
+        assert!(t.contains("    # Citing organization.\n    org: \"\"  # string; required\n"));
+        assert!(t.contains("    # Publication year.\n    year: 0  # integer; optional\n"));
     }
 
     #[test]
-    fn typed_table_with_example_renders_example_rows() {
+    fn typed_table_with_example_renders_example_rows_no_eg_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -696,11 +754,9 @@ main:
           year: { type: integer }
 "#)
         .blueprint();
-        // Example rows are rendered inline; no synthetic bare-dash row, and no
-        // `# example:` comment (which would be an unhelpful JSON blob).
-        assert!(t.contains("refs:\n  - org: ACME\n"));
-        assert!(!t.contains("refs:\n  -\n"));
-        assert!(!t.contains("# example:"));
+        assert!(t.contains("refs:  # array<object>; optional\n  - org: ACME\n"));
+        assert!(!t.contains("refs:  # array<object>; optional\n  -\n"));
+        assert!(!t.contains("# e.g."));
     }
 
     #[test]
@@ -719,8 +775,8 @@ main:
           org: { type: string, required: true }
 "#)
         .blueprint();
-        assert!(t.contains("refs:\n  - org: ACME\n"));
-        assert!(!t.contains("refs:\n  -\n"));
+        assert!(t.contains("refs:  # array<object>; optional\n  - org: ACME\n"));
+        assert!(!t.contains("refs:  # array<object>; optional\n  -\n"));
     }
 
     #[test]
@@ -738,7 +794,7 @@ main:
           org: { type: string, required: true }
 "#)
         .blueprint();
-        assert!(t.contains("refs:\n  -\n    # required\n    org: \"<org>\"\n"));
+        assert!(t.contains("refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"));
     }
 
     const LETTER_QUILL: &str = r#"
@@ -769,48 +825,6 @@ card_types:
       label: { type: string, required: true }
       pages: { type: integer, default: 1 }
 "#;
-
-    #[test]
-    fn optional_no_default_field_is_commented_out() {
-        // No default, no enum → value line gets a leading `# `.
-        // Description and `# example:` comments are still emitted above it.
-        let t = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    note:
-      type: string
-      description: An optional note.
-      example: See attached.
-    count: { type: integer }
-    flag: { type: boolean }
-    issued: { type: date }
-    tags: { type: array }
-"#)
-        .blueprint();
-        assert!(t.contains("# An optional note.\n# example: See attached.\n# note: \"\"\n"));
-        assert!(t.contains("# count: 0  # integer\n"));
-        assert!(t.contains("# flag: false  # boolean\n"));
-        assert!(t.contains("# issued: \"\"  # YYYY-MM-DD\n"));
-        assert!(t.contains("# tags: []\n"));
-    }
-
-    #[test]
-    fn optional_with_default_stays_active() {
-        // A default value is meaningful; the field line must not be commented out.
-        let t = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    priority: { type: string, default: normal }
-    count: { type: integer, default: 0 }
-"#)
-        .blueprint();
-        assert!(t.contains("priority: normal\n"));
-        assert!(t.contains("count: 0  # integer\n"));
-        assert!(!t.contains("# priority:"));
-        assert!(!t.contains("# count:"));
-    }
 
     #[test]
     fn blueprint_round_trips_idempotently() {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -457,6 +457,76 @@ impl QuillConfig {
         false
     }
 
+    /// Reject multi-line descriptions. Single-line is required so the leading
+    /// `# <description>` blueprint slot stays one line and the field-comment
+    /// stack remains parseable for LLM consumers.
+    fn validate_description_singleline(
+        desc: Option<&str>,
+        owner_label: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) {
+        if let Some(d) = desc {
+            if d.contains('\n') {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "{} description must be a single line; multi-line \
+                             descriptions are not allowed.",
+                            owner_label
+                        ),
+                    )
+                    .with_code("quill::description_multiline".to_string()),
+                );
+            }
+        }
+    }
+
+    /// Reject `>`, `;`, `|` in enum literals. These characters are reserved by
+    /// the blueprint inline annotation grammar (`<format>` close, role
+    /// separator, enum value separator) and have no escape syntax.
+    fn validate_enum_literals(field: &FieldSchema, owner_label: &str, errors: &mut Vec<Diagnostic>) {
+        if let Some(values) = &field.enum_values {
+            for v in values {
+                if v.contains('>') || v.contains(';') || v.contains('|') {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "{} enum value '{}' contains a reserved character \
+                                 ('>', ';', or '|') that conflicts with the \
+                                 blueprint inline annotation grammar.",
+                                owner_label, v
+                            ),
+                        )
+                        .with_code("quill::format_literal_reserved_char".to_string()),
+                    );
+                }
+            }
+        }
+    }
+
+    /// Recursively validate field-level blueprint constraints across the field,
+    /// its array items, and any nested object properties.
+    fn validate_field_blueprint_constraints(
+        schema: &FieldSchema,
+        owner_label: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) {
+        Self::validate_description_singleline(schema.description.as_deref(), owner_label, errors);
+        Self::validate_enum_literals(schema, owner_label, errors);
+        if let Some(items) = &schema.items {
+            let nested = format!("{} (items)", owner_label);
+            Self::validate_field_blueprint_constraints(items, &nested, errors);
+        }
+        if let Some(props) = &schema.properties {
+            for (name, prop) in props {
+                let nested = format!("{}.{}", owner_label, name);
+                Self::validate_field_blueprint_constraints(prop, &nested, errors);
+            }
+        }
+    }
+
     /// Parse fields from a JSON Value map, assigning ui.order based on key_order.
     ///
     /// This helper ensures consistent field ordering logic for both top-level
@@ -550,6 +620,9 @@ impl QuillConfig {
                             ui.order = Some(order);
                         }
                     }
+
+                    let owner = format!("{} '{}'", context, field_name);
+                    Self::validate_field_blueprint_constraints(&schema, &owner, errors);
 
                     fields.insert(field_name.clone(), schema);
                 }
@@ -744,7 +817,10 @@ impl QuillConfig {
         };
 
         let description = match quill_section.get("description").and_then(|v| v.as_str()) {
-            Some(d) if !d.trim().is_empty() => d.to_string(),
+            Some(d) if !d.trim().is_empty() => {
+                Self::validate_description_singleline(Some(d), "quill", &mut errors);
+                d.to_string()
+            }
             Some(_) => {
                 errors.push(
                     Diagnostic::new(
@@ -978,6 +1054,7 @@ impl QuillConfig {
             .and_then(|main_obj| main_obj.get("description"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        Self::validate_description_singleline(main_description.as_deref(), "main", &mut errors);
 
         // The main entry-point card.
         let main = CardSchema {
@@ -1053,6 +1130,11 @@ impl QuillConfig {
                             BTreeMap::new()
                         };
 
+                        Self::validate_description_singleline(
+                            card_def.description.as_deref(),
+                            &format!("card_type '{}'", card_name),
+                            &mut errors,
+                        );
                         card_types.push(CardSchema {
                             name: card_name.clone(),
                             description: card_def.description,

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -8,20 +8,19 @@ constraint hints. It is the **authoring surface** for LLM and MCP
 consumers; [SCHEMAS.md](SCHEMAS.md) covers the validation/form surface.
 
 A blueprint is the document, not a description of the document. Fill in
-the placeholders; the structure, sentinels, group banners, and body
-markers come for free.
+the placeholders; the structure, sentinels, and body markers come for
+free.
 
 ## Output shape
 
 ```
 ---
 # <description>
-QUILL: <name>@<version>  # sentinel; required
+QUILL: <name>@<version>  # sentinel; required, verbatim
 
-# ==== <GROUP> ====
 # <field description>
-# required
-field: value
+# e.g. <example value>
+field: value  # <type>; <role>
 
 ---
 
@@ -29,7 +28,7 @@ Write main body here.
 
 ---
 # <card description>
-CARD: <card_name>  # sentinel, composable (0..N)
+CARD: <card_name>  # sentinel; composable (0..N)
 ...fields...
 ---
 
@@ -41,76 +40,139 @@ When `body.enabled` is false the marker is omitted entirely.
 
 ## Annotation grammar
 
-| Slot | Carries |
-|---|---|
-| **Leading `# …` lines** above a field | Human prose: description, `required`, `enum: a \| b \| c`, `example: <value>` |
-| **Inline `# …`** at end of a value line | Structural type/constraint info: `# integer`, `# YYYY-MM-DD`, `# markdown`, `# sentinel`, `# sentinel, composable (0..N)` |
+| Slot | Form | Carries |
+|---|---|---|
+| **Leading `# …` lines** above a field | `# <prose>` or `# e.g. <value>` | description (single-line prose) and an illustrative example |
+| **Inline `# …`** at end of the value line | `# <type>[<format>]; <role>[, <extra>...]` | structural metadata: type, optional format refinement, role, optional extras |
 
-### Leading comments — order
+The two slots have disjoint purposes: leading is prose, inline is
+structural. No colon-separated `key: value` annotation syntax appears in
+either slot, so neither pattern collides with YAML key/value parsing.
+
+### Leading lines — order
 
 Per field, in order:
 
-1. `# <description>` — `description:` from `Quill.yaml`, whitespace-collapsed
-2. `# required` — only when `required: true`
-3. `# enum: a | b | c` — when `enum:` is present
-4. `# example: <value>` — only for optional, non-enum fields with an example
+1. `# <description>` — `description:` from `Quill.yaml`,
+   whitespace-collapsed. **Single line only**; multi-line descriptions are
+   rejected at `Quill.yaml` parse time.
+2. `# e.g. <value>` — emitted whenever `example:` is configured on a
+   field. Independent of role and type. The example never becomes the
+   rendered value (see precedence below).
 
-Required fields skip the `# example:` line because the example is rendered
-*as the value*. Enum fields skip it because the first enum value is the
-canonical placeholder.
+That's it. There is no leading `# required`, `# enum:`, `# default:`, or
+`# type:` — those collapse into the inline.
 
-### Inline annotations
+### Inline annotation
 
-- `# number`, `# integer`, `# boolean`, `# markdown`, `# object`,
-  `# YYYY-MM-DD`, `# ISO 8601` — emitted only for non-obvious types.
-  `string` and `array` are self-evident from the YAML value.
-- `# sentinel` on the `QUILL:` line — copy verbatim; the value binds the
-  document to a specific quill@version.
-- `# sentinel, composable (0..N)` on each `CARD:` line — copy the sentinel
-  value verbatim; repeat the entire `--- … --- card body...` block per
-  instance.
+Form: **`# <type>[<format>]; <role>[, <extra>...]`**
+
+- **Type slot** (mandatory, first): one of
+  `string`, `integer`, `number`, `boolean`, `array`, `object`,
+  `markdown`, `date`, `datetime`, `enum`, `sentinel`.
+  Every field is labeled — there is no "self-evident" exemption.
+- **Format slot** (optional, in `<…>` angle brackets): refines the type
+  when the refinement carries information beyond the type name itself.
+  - `date<YYYY-MM-DD>`
+  - `datetime<ISO 8601>`
+  - `array<string>`, `array<integer>`, `array<object>`, …
+  - `enum<a | b | c>`
+  - omitted for `string`, `integer`, `number`, `boolean`, `object`,
+    `markdown` (nothing meaningful to refine).
+- **Role slot** (mandatory, after `;`): `required`, `optional`, or
+  `composable (0..N)` (CARD-sentinel only).
+- **Extras** (optional, comma-separated, after the role): additional
+  qualifiers. Currently used for `verbatim` on the QUILL sentinel,
+  signaling that the rendered value is fixed and must not be modified.
+
+Examples:
+
+| Line | Reading |
+|---|---|
+| `name: ""  # string; required` | required string field, no format refinement |
+| `count: 0  # integer; required` | required integer field |
+| `active: false  # boolean; optional` | optional boolean field |
+| `bio: |-` followed by indented block, then `# markdown; optional` | optional markdown field — see "Markdown fields render as block scalars" |
+| `recipient: []  # array<string>; optional` | optional array of strings |
+| `entries: [...]  # array<object>; required` | required array of objects (typed table follows) |
+| `date: ""  # date<YYYY-MM-DD>; required` | required date in `YYYY-MM-DD` format |
+| `published: ""  # datetime<ISO 8601>; required` | required datetime in ISO 8601 |
+| `level: low  # enum<low \| medium \| high>; optional` | optional enum, default is first value |
+| `QUILL: cmu_letter@0.1.0  # sentinel; required, verbatim` | quill binding, do not modify |
+| `CARD: skill  # sentinel; composable (0..N)` | repeat the entire `--- CARD ... ---` block per instance |
 
 ## Placeholder value precedence
 
+The rendered value is independent of the role (required vs. optional).
+Role drives "must fill"; the value rendering follows a single cascade:
+
 | Field state | Value rendered |
 |---|---|
-| Required, has `example` | example |
-| Required, has `default` only | default |
-| Required, neither | type-based placeholder (`"<name>"`, `0`, `false`, `[]`, `""`) |
-| Optional, has `default` | default |
-| Optional, has `enum` only | first enum value |
-| Optional, neither | **commented-out** type-based empty (`# field: ""`, `# field: 0`, …) |
+| Has `default` | default |
+| Has `enum` only | first enum value |
+| Otherwise | type-empty (`""`, `0`, `false`, `[]`, `{}`, or block scalar for markdown — see below) |
 
-Optional fields' examples surface in the `# example:` comment, never as
-the value.
+Examples never become the rendered value, regardless of role. Examples
+are inherently illustrative and unsafe to ship; they always surface in
+the `# e.g.` leading line while the value follows the cascade above.
 
-`date` and `datetime` required fields with no example or default always
-render `""` (not `"<name>"`); the inline type annotation (`# YYYY-MM-DD` or
-`# ISO 8601`) carries the format hint.
+All fields render as **live YAML** — no commented-out fields. The role
+tag (`; required` / `; optional`) is the sole "must fill" signal. The
+rendered value is the effective default: what the field will be if the
+author leaves it untouched.
 
-### Commented-out optional fields
+`date` and `datetime` fields render `""` when no example or default is
+configured; the inline format slot (`<YYYY-MM-DD>` or `<ISO 8601>`)
+carries the shape hint.
 
-An optional field with no `default` and no `enum` is commented out so the
-author can uncomment what they need:
+There is no string `"<name>"` placeholder — required strings render as
+`""` like every other type.
+
+### Markdown fields render as block scalars
+
+A `markdown` field renders as a YAML literal block scalar (`|-`), even
+when the type-empty case applies:
 
 ```
-# field_name: ""
+bio: |-
+  
 ```
 
-The leading description and `# example:` comments are still emitted above it.
+When a `default:` is configured, its content fills the block:
+
+```
+bio: |-
+  ## About me
+  
+  <body>
+```
+
+The block-scalar shape is type-driven — it's the only YAML form that
+cleanly accommodates multi-line markdown content. By rendering it from
+the start, the LLM consumer writes into the indented block without
+needing to switch shapes mid-fill.
 
 ### Multi-element example arrays
 
-Examples on optional array fields render as a YAML flow sequence so
+Examples on array fields render as a YAML flow sequence so
 multi-element shape information is preserved:
 
 ```
-# example: [Mr. John Doe, 123 Main St, "Anytown, USA"]
-recipient: []
+# e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
+recipient: []  # array<string>; optional
 ```
 
 Items containing flow indicators (`,`, `[`, `]`, `{`, `}`) get quoted so
 the flow form round-trips.
+
+### Reserved characters in format and enum literals
+
+To keep the inline grammar unambiguous, format slot contents — including
+enum values — may not contain `>`, `;`, or `|`. These are the closing
+delimiter, the role separator, and the enum-value separator respectively.
+`Quill.yaml` parsing rejects offending values with
+`quill::format_literal_reserved_char`. There is no escape or quoting
+fallback; authors needing these characters must reshape their values.
 
 ## Typed tables
 
@@ -118,19 +180,19 @@ A field of `type: array` whose `items` is a typed object (`type: object`
 + `properties`) renders with full per-property annotations:
 
 - An `example:` or non-empty `default:` renders as actual rows.
-- Otherwise one synthetic row is emitted, with each property carrying its
-  own description / `# required` / `# enum:` / type annotation.
+- Otherwise one synthetic row is emitted, with each property carrying
+  its own description, inline type/format, and role.
+
+The outer field's inline annotation is `# array<object>; <role>`.
 
 ## UI metadata honored
 
-Most `ui:` keys are stripped, but two structural hints survive:
-
-- `ui.group` — produces `# ==== GROUPNAME ====` banners between sections.
-  Group names are uppercased. Ungrouped fields lead (no banner); named
-  groups follow in first-appearance order.
-- `ui.order` — controls field ordering within a group.
-
-`ui.compact`, `ui.multiline`, `ui.title` are presentation-only and dropped.
+`ui.order` controls field ordering within the document. Most other `ui:`
+keys (`ui.group`, `ui.compact`, `ui.multiline`, `ui.title`) are
+presentation-only and do not affect blueprint output. In particular,
+`ui.group` no longer emits `# ==== GROUPNAME ====` banner lines — the
+banners were visually confusable with field-description comments. Fields
+within the same `ui.group` still cluster together via `ui.order`.
 
 ## Body markers
 
@@ -141,10 +203,38 @@ Most `ui:` keys are stripped, but two structural hints survive:
 `body.enabled: false` suppresses the marker entirely for body-less cards
 (e.g., a `skills` card whose data is purely structured).
 
-A `body.example` whose text contains a line that would parse as a metadata
-fence (`---`, with up to three leading spaces) is rejected at `Quill.yaml`
-parse time (`quill::body_example_contains_fence`) to prevent corrupting
-the blueprint's document structure.
+A `body.example` whose text contains a line that would parse as a
+metadata fence (`---`, with up to three leading spaces) is rejected at
+`Quill.yaml` parse time (`quill::body_example_contains_fence`) to
+prevent corrupting the blueprint's document structure.
+
+## Worked example
+
+```
+---
+# Typeset letters that comply with Carnegie Mellon University letterhead standards.
+QUILL: cmu_letter@0.1.0  # sentinel; required, verbatim
+# The recipient's name and full mailing address.
+# e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
+recipient: []  # array<string>; optional
+# The signer's information. Line 1: Name. Line 2: Title.
+# e.g. [First M. Last, Title]
+signature_block: []  # array<string>; optional
+# The department or organizational unit name for the letterhead.
+# e.g. Department of Electrical and Computer Engineering
+department: ""  # string; optional
+# The sender's institutional mailing address.
+# e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
+address: []  # array<string>; optional
+# The department or university website URL.
+# e.g. www.ece.cmu.edu
+url: ""  # string; optional
+# The date to appear on the letter.
+date: ""  # date<YYYY-MM-DD>; required
+---
+
+Write main body here.
+```
 
 ## Bindings surface
 


### PR DESCRIPTION
## Summary

This PR redesigns the blueprint annotation grammar to be more consistent, explicit, and easier for LLM consumers to parse. The changes unify how type information, roles, and constraints are expressed, moving from scattered comment patterns to a single structured inline annotation format.

## Key Changes

**Annotation Grammar Overhaul**
- Replaced multi-line leading comment patterns (`# required`, `# enum: a | b | c`, `# example: ...`) with a unified inline annotation: `# <type>[<format>]; <role>[, <extras>...]`
- Every field now carries an explicit type annotation (no "self-evident" exemptions for `string` or `array`)
- Format refinements use angle brackets: `date<YYYY-MM-DD>`, `enum<a | b | c>`, `array<string>`, etc.
- Role slot is mandatory after semicolon: `required`, `optional`, or `composable (0..N)` for cards
- Added `verbatim` extra to QUILL sentinel to signal immutability

**Leading Comment Simplification**
- Reduced leading comments to two slots: `# <description>` (single line, whitespace-collapsed) and `# e.g. <value>` (whenever an example is configured)
- Removed separate `# required`, `# enum:`, and `# example:` lines
- Examples now always surface in `# e.g.` comments, never as rendered values (independent of role)

**Value Rendering Simplification**
- Unified value precedence: `default` → first enum value → type-empty
- Removed commented-out optional fields; all fields render as live YAML
- Required strings now render as `""` instead of `"<name>"` placeholder
- Markdown fields render as YAML block scalars (`|-`) consistently

**UI Metadata Changes**
- Removed `ui.group` banner emission (`# ==== GROUPNAME ====`)
- Fields still cluster by group via `ui.order`, but without visual banners
- Reduces visual confusion between field descriptions and section markers

**Validation Enhancements**
- Added `validate_description_singleline()` to reject multi-line descriptions (required for single-line blueprint slot)
- Added `validate_enum_literals()` to reject reserved characters (`>`, `;`, `|`) in enum values
- Added `validate_field_blueprint_constraints()` for recursive validation across nested fields and properties

**Typed Table Updates**
- Outer field annotation is now `# array<object>; <role>`
- Suppresses `# e.g.` comment when concrete example rows are rendered
- Each property in the table carries full inline annotation

## Notable Implementation Details

- The `inline_annotation()` function now generates the complete `<type>[<format>]; <role>` string
- New `type_expression()` and `array_item_label()` functions centralize type formatting logic
- Markdown fields are special-cased in `write_field()` to render as block scalars before other field types
- The `field_value()` function now uses a single cascade independent of role
- Removed the `type_annotation()` function (replaced by comprehensive `type_expression()`)
- Updated all tests to reflect new annotation patterns and removed tests for commented-out fields

## Documentation

Updated `BLUEPRINT.md` with:
- New annotation grammar table with form and meaning
- Worked example showing the new output format
- Clarified placeholder value precedence
- Documented reserved characters in format/enum literals
- Explained markdown block scalar rendering

https://claude.ai/code/session_01LYVGQK3A73oXZAZ3FWcvWe