### PR TITLE
docs(blueprint): fix three inaccuracies in BLUEPRINT.md

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -117,15 +117,11 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     let pad = "  ".repeat(indent);
 
-    // Typed table: array whose items are a typed object.
+    // Typed table: array with a properties map directly on the field.
     if matches!(field.r#type, FieldType::Array) {
-        if let Some(items) = &field.items {
-            if matches!(items.r#type, FieldType::Object) {
-                if let Some(props) = &items.properties {
-                    write_typed_table_field(out, field, props, indent);
-                    return;
-                }
-            }
+        if let Some(props) = &field.properties {
+            write_typed_table_field(out, field, props, indent);
+            return;
         }
     }
 
@@ -778,11 +774,9 @@ main:
     references:
       type: array
       description: Cited works.
-      items:
-        type: object
-        properties:
-          org: { type: string, required: true, description: Citing organization. }
-          year: { type: integer, description: Publication year. }
+      properties:
+        org: { type: string, required: true, description: Citing organization. }
+        year: { type: integer, description: Publication year. }
 "#)
         .blueprint();
         assert!(t.contains("# Cited works.\nreferences:  # array<object>; optional\n  -\n"));
@@ -800,11 +794,9 @@ main:
       type: array
       example:
         - { org: ACME, year: 2020 }
-      items:
-        type: object
-        properties:
-          org: { type: string, required: true }
-          year: { type: integer }
+      properties:
+        org: { type: string, required: true }
+        year: { type: integer }
 "#)
         .blueprint();
         assert!(t.contains("refs:  # array<object>; optional\n  - org: ACME\n"));
@@ -822,10 +814,8 @@ main:
       type: array
       default:
         - { org: ACME }
-      items:
-        type: object
-        properties:
-          org: { type: string, required: true }
+      properties:
+        org: { type: string, required: true }
 "#)
         .blueprint();
         assert!(t.contains("refs:  # array<object>; optional\n  - org: ACME\n"));
@@ -841,10 +831,8 @@ main:
     refs:
       type: array
       default: []
-      items:
-        type: object
-        properties:
-          org: { type: string, required: true }
+      properties:
+        org: { type: string, required: true }
 "#)
         .blueprint();
         assert!(t.contains("refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"));

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -286,8 +286,8 @@ fn write_typed_object_field(
 }
 
 /// Build the inline annotation body (without the leading `# `).
-/// `force_array_object` is `true` for typed-table outer fields, so the format
-/// slot is always `<object>` regardless of `field.items`.
+/// `force_array_object` is `true` for typed-table outer fields, which always
+/// renders as `array<object>`; plain arrays render as `array<string>`.
 fn inline_annotation(field: &FieldSchema, force_array_object: bool) -> String {
     let role = if field.required { "required" } else { "optional" };
     let type_expr = type_expression(field, force_array_object);
@@ -308,29 +308,9 @@ fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
         FieldType::Date => "date<YYYY-MM-DD>".into(),
         FieldType::DateTime => "datetime<ISO 8601>".into(),
         FieldType::Array => {
-            let item = if force_array_object {
-                "object"
-            } else {
-                array_item_label(field)
-            };
+            let item = if force_array_object { "object" } else { "string" };
             format!("array<{}>", item)
         }
-    }
-}
-
-fn array_item_label(field: &FieldSchema) -> &'static str {
-    match field.items.as_deref().map(|i| &i.r#type) {
-        Some(FieldType::String) => "string",
-        Some(FieldType::Number) => "number",
-        Some(FieldType::Integer) => "integer",
-        Some(FieldType::Boolean) => "boolean",
-        Some(FieldType::Object) => "object",
-        Some(FieldType::Markdown) => "markdown",
-        Some(FieldType::Date) => "date",
-        Some(FieldType::DateTime) => "datetime",
-        // Nested arrays and missing items default to string — the most
-        // common case in existing fixtures and the safest fallback.
-        Some(FieldType::Array) | None => "string",
     }
 }
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -129,6 +129,14 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
         }
     }
 
+    // Typed dictionary: standalone object with defined properties.
+    if matches!(field.r#type, FieldType::Object) {
+        if let Some(props) = &field.properties {
+            write_typed_object_field(out, field, props, indent);
+            return;
+        }
+    }
+
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
@@ -231,6 +239,51 @@ fn write_typed_table_field(
             out.push_str(&format!("{}-\n", dash_pad));
             for prop in sort_props(item_props) {
                 write_field(out, prop, indent + 2);
+            }
+        }
+    }
+}
+
+/// Emit a typed-dictionary field: description + optional `# e.g.` line, then the
+/// field key with its `object; <role>` inline annotation, then either a concrete
+/// mapping from example/default or per-property annotations. When concrete values
+/// are rendered, the `# e.g.` comment is suppressed (the mapping itself carries
+/// the example shape).
+fn write_typed_object_field(
+    out: &mut String,
+    field: &FieldSchema,
+    props: &BTreeMap<String, Box<FieldSchema>>,
+    indent: usize,
+) {
+    let pad = "  ".repeat(indent);
+
+    let concrete = field
+        .example
+        .as_ref()
+        .or(field.default.as_ref())
+        .and_then(|v| match v.as_json() {
+            serde_json::Value::Object(map) if !map.is_empty() => Some(map.clone()),
+            _ => None,
+        });
+
+    write_description(out, field, &pad);
+    if concrete.is_none() {
+        write_eg_comment(out, field, &pad);
+    }
+
+    let inline = inline_annotation(field, false);
+    out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+
+    match concrete {
+        Some(map) => {
+            let inner_pad = format!("{}  ", pad);
+            for (k, v) in &map {
+                out.push_str(&format!("{}{}: {}\n", inner_pad, k, render_scalar(v)));
+            }
+        }
+        None => {
+            for prop in sort_props(props) {
+                write_field(out, prop, indent + 1);
             }
         }
     }
@@ -795,6 +848,84 @@ main:
 "#)
         .blueprint();
         assert!(t.contains("refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"));
+    }
+
+    #[test]
+    fn typed_dict_emits_per_property_annotations() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      description: Mailing address.
+      properties:
+        street: { type: string, required: true, description: Street line. }
+        city:   { type: string, required: true }
+        zip:    { type: string }
+"#)
+        .blueprint();
+        assert!(t.contains("# Mailing address.\naddress:  # object; optional\n"));
+        assert!(t.contains("  # Street line.\n  street: \"\"  # string; required\n"));
+        assert!(t.contains("  city: \"\"  # string; required\n"));
+        assert!(t.contains("  zip: \"\"  # string; optional\n"));
+    }
+
+    #[test]
+    fn typed_dict_required_carries_role() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      required: true
+      properties:
+        street: { type: string, required: true }
+"#)
+        .blueprint();
+        assert!(t.contains("address:  # object; required\n"));
+    }
+
+    #[test]
+    fn typed_dict_with_default_renders_block_mapping_no_annotations() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      default: { street: "5000 Forbes Ave", city: Pittsburgh }
+      properties:
+        street: { type: string, required: true }
+        city:   { type: string, required: true }
+"#)
+        .blueprint();
+        assert!(t.contains("address:  # object; optional\n"));
+        assert!(t.contains("  street: 5000 Forbes Ave\n") || t.contains("  street: \"5000 Forbes Ave\"\n"));
+        assert!(t.contains("  city: Pittsburgh\n"));
+        // No per-property annotations when concrete values are present.
+        assert!(!t.contains("# string; required"));
+    }
+
+    #[test]
+    fn typed_dict_with_example_suppresses_eg_line() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      example: { street: "1 Infinite Loop", city: Cupertino }
+      properties:
+        street: { type: string, required: true }
+        city:   { type: string }
+"#)
+        .blueprint();
+        assert!(t.contains("address:  # object; optional\n"));
+        // eg comment suppressed when concrete values are rendered.
+        assert!(!t.contains("# e.g."));
+        assert!(t.contains("  city: Cupertino\n"));
     }
 
     const LETTER_QUILL: &str = r#"

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -289,7 +289,11 @@ fn write_typed_object_field(
 /// `force_array_object` is `true` for typed-table outer fields, which always
 /// renders as `array<object>`; plain arrays render as `array<string>`.
 fn inline_annotation(field: &FieldSchema, force_array_object: bool) -> String {
-    let role = if field.required { "required" } else { "optional" };
+    let role = if field.required {
+        "required"
+    } else {
+        "optional"
+    };
     let type_expr = type_expression(field, force_array_object);
     format!("{}; {}", type_expr, role)
 }
@@ -308,7 +312,11 @@ fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
         FieldType::Date => "date<YYYY-MM-DD>".into(),
         FieldType::DateTime => "datetime<ISO 8601>".into(),
         FieldType::Array => {
-            let item = if force_array_object { "object" } else { "string" };
+            let item = if force_array_object {
+                "object"
+            } else {
+                "string"
+            };
             format!("array<{}>", item)
         }
     }
@@ -815,7 +823,9 @@ main:
         org: { type: string, required: true }
 "#)
         .blueprint();
-        assert!(t.contains("refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"));
+        assert!(t.contains(
+            "refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"
+        ));
     }
 
     #[test]
@@ -870,7 +880,10 @@ main:
 "#)
         .blueprint();
         assert!(t.contains("address:  # object; optional\n"));
-        assert!(t.contains("  street: 5000 Forbes Ave\n") || t.contains("  street: \"5000 Forbes Ave\"\n"));
+        assert!(
+            t.contains("  street: 5000 Forbes Ave\n")
+                || t.contains("  street: \"5000 Forbes Ave\"\n")
+        );
         assert!(t.contains("  city: Pittsburgh\n"));
         // No per-property annotations when concrete values are present.
         assert!(!t.contains("# string; required"));

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -210,7 +210,34 @@ impl QuillConfig {
                     vec![json_value.clone()]
                 };
 
-                if let Some(items_schema) = &field_schema.items {
+                if let Some(props) = &field_schema.properties {
+                    let mut out = Vec::with_capacity(arr.len());
+                    for (idx, elem) in arr.iter().enumerate() {
+                        if let Some(obj) = elem.as_object() {
+                            let mut coerced_obj = serde_json::Map::new();
+                            for (k, v) in obj {
+                                if let Some(prop_schema) = props.get(k) {
+                                    let child_path = format!("{path}[{idx}].{k}");
+                                    coerced_obj.insert(
+                                        k.clone(),
+                                        Self::coerce_value_strict(
+                                            &QuillValue::from_json(v.clone()),
+                                            prop_schema,
+                                            &child_path,
+                                        )?
+                                        .into_json(),
+                                    );
+                                } else {
+                                    coerced_obj.insert(k.clone(), v.clone());
+                                }
+                            }
+                            out.push(serde_json::Value::Object(coerced_obj));
+                        } else {
+                            out.push(elem.clone());
+                        }
+                    }
+                    Ok(QuillValue::from_json(serde_json::Value::Array(out)))
+                } else if let Some(items_schema) = &field_schema.items {
                     let mut out = Vec::with_capacity(arr.len());
                     for (idx, elem) in arr.iter().enumerate() {
                         let item_path = format!("{path}[{idx}]");
@@ -452,6 +479,13 @@ impl QuillConfig {
             if let Some(items_schema) = &schema.items {
                 return Self::has_disallowed_nested_object(items_schema, true);
             }
+            if let Some(props) = &schema.properties {
+                for prop_schema in props.values() {
+                    if Self::has_disallowed_nested_object(prop_schema, false) {
+                        return true;
+                    }
+                }
+            }
         }
 
         false
@@ -585,7 +619,7 @@ impl QuillConfig {
                                     format!(
                                         "Field '{}' has type: object but no properties defined. \
                                         Declare a properties map, or use type: array with \
-                                        items: {{type: object, properties: {{...}}}} for a list of objects.",
+                                        a properties map for a list of objects.",
                                         field_name
                                     ),
                                 )

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -237,18 +237,6 @@ impl QuillConfig {
                         }
                     }
                     Ok(QuillValue::from_json(serde_json::Value::Array(out)))
-                } else if let Some(items_schema) = &field_schema.items {
-                    let mut out = Vec::with_capacity(arr.len());
-                    for (idx, elem) in arr.iter().enumerate() {
-                        let item_path = format!("{path}[{idx}]");
-                        let coerced = Self::coerce_value_strict(
-                            &QuillValue::from_json(elem.clone()),
-                            items_schema,
-                            &item_path,
-                        )?;
-                        out.push(coerced.into_json());
-                    }
-                    Ok(QuillValue::from_json(serde_json::Value::Array(out)))
                 } else {
                     Ok(QuillValue::from_json(serde_json::Value::Array(arr)))
                 }
@@ -476,9 +464,6 @@ impl QuillConfig {
         }
 
         if schema.r#type == FieldType::Array {
-            if let Some(items_schema) = &schema.items {
-                return Self::has_disallowed_nested_object(items_schema, true);
-            }
             if let Some(props) = &schema.properties {
                 for prop_schema in props.values() {
                     if Self::has_disallowed_nested_object(prop_schema, false) {
@@ -540,8 +525,8 @@ impl QuillConfig {
         }
     }
 
-    /// Recursively validate field-level blueprint constraints across the field,
-    /// its array items, and any nested object properties.
+    /// Recursively validate field-level blueprint constraints across the field
+    /// and any nested object properties.
     fn validate_field_blueprint_constraints(
         schema: &FieldSchema,
         owner_label: &str,
@@ -549,10 +534,6 @@ impl QuillConfig {
     ) {
         Self::validate_description_singleline(schema.description.as_deref(), owner_label, errors);
         Self::validate_enum_literals(schema, owner_label, errors);
-        if let Some(items) = &schema.items {
-            let nested = format!("{} (items)", owner_label);
-            Self::validate_field_blueprint_constraints(items, &nested, errors);
-        }
         if let Some(props) = &schema.properties {
             for (name, prop) in props {
                 let nested = format!("{}.{}", owner_label, name);
@@ -650,7 +631,7 @@ impl QuillConfig {
                                 Severity::Error,
                                 format!(
                                     "Field '{}' uses nested type: object, which is not supported. \
-                                    Only object schemas nested under array.items are supported.",
+                                    Use type: array with a properties map for a list of objects.",
                                     field_name
                                 ),
                             )

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -504,7 +504,11 @@ impl QuillConfig {
     /// Reject `>`, `;`, `|` in enum literals. These characters are reserved by
     /// the blueprint inline annotation grammar (`<format>` close, role
     /// separator, enum value separator) and have no escape syntax.
-    fn validate_enum_literals(field: &FieldSchema, owner_label: &str, errors: &mut Vec<Diagnostic>) {
+    fn validate_enum_literals(
+        field: &FieldSchema,
+        owner_label: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) {
         if let Some(values) = &field.enum_values {
             for v in values {
                 if v.contains('>') || v.contains(';') || v.contains('|') {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -574,24 +574,43 @@ impl QuillConfig {
             let quill_value = QuillValue::from_json(field_value.clone());
             match FieldSchema::from_quill_value(field_name.clone(), &quill_value) {
                 Ok(mut schema) => {
-                    // Reject standalone object/dict fields — object is only valid inside array items.
+                    // Typed dictionaries (type: object with properties) are supported.
+                    // Freeform objects (no properties) and objects nested inside
+                    // typed-dictionary properties are not.
                     if schema.r#type == FieldType::Object {
-                        errors.push(
-                            Diagnostic::new(
-                                Severity::Error,
-                                format!(
-                                    "Field '{}' uses standalone type: object, which is not supported. \
-                                    Use separate fields with ui.group instead, or use \
-                                    type: array with items: {{type: object, properties: {{...}}}}.",
-                                    field_name
-                                ),
-                            )
-                            .with_code("quill::standalone_object_not_supported".to_string()),
-                        );
-                        continue;
-                    }
-
-                    if Self::has_disallowed_nested_object(&schema, false) {
+                        if schema.properties.is_none() {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Field '{}' has type: object but no properties defined. \
+                                        Declare a properties map, or use type: array with \
+                                        items: {{type: object, properties: {{...}}}} for a list of objects.",
+                                        field_name
+                                    ),
+                                )
+                                .with_code("quill::object_missing_properties".to_string()),
+                            );
+                            continue;
+                        }
+                        // Properties of a typed dictionary may not themselves be objects.
+                        if Self::has_disallowed_nested_object(&schema, true) {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Field '{}' contains a nested type: object property, \
+                                        which is not supported. Properties of a typed dictionary \
+                                        may not themselves be objects.",
+                                        field_name
+                                    ),
+                                )
+                                .with_code("quill::nested_object_not_supported".to_string()),
+                            );
+                            continue;
+                        }
+                        // Typed dictionary — fall through to normal processing.
+                    } else if Self::has_disallowed_nested_object(&schema, false) {
                         errors.push(
                             Diagnostic::new(
                                 Severity::Error,

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -56,7 +56,19 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                     "type".to_string(),
                     serde_json::Value::String("array".to_string()),
                 );
-                if let Some(items) = &field.items {
+                if let Some(props) = &field.properties {
+                    let mut prop_schemas = serde_json::Map::new();
+                    for (name, prop) in props {
+                        prop_schemas.insert(name.clone(), field_to_schema(prop));
+                    }
+                    schema.insert(
+                        "items".to_string(),
+                        serde_json::json!({
+                            "type": "object",
+                            "properties": prop_schemas
+                        }),
+                    );
+                } else if let Some(items) = &field.items {
                     schema.insert("items".to_string(), field_to_schema(items));
                 }
             }
@@ -139,6 +151,55 @@ mod tests {
     fn build_from_yaml(yaml: &str) -> QuillValue {
         let config = QuillConfig::from_yaml(yaml).expect("yaml parses");
         build_transform_schema(&config)
+    }
+
+    #[test]
+    fn typed_table_emits_items_with_object_and_properties() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    refs:
+      type: array
+      properties:
+        org: { type: string, required: true }
+        year: { type: integer }
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let refs = &json["properties"]["refs"];
+        assert_eq!(refs["type"], "array");
+        assert_eq!(refs["items"]["type"], "object");
+        assert_eq!(refs["items"]["properties"]["org"]["type"], "string");
+        assert_eq!(refs["items"]["properties"]["year"]["type"], "integer");
+    }
+
+    #[test]
+    fn typed_dict_emits_object_with_properties() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street: { type: string, required: true }
+        city: { type: string }
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let address = &json["properties"]["address"];
+        assert_eq!(address["type"], "object");
+        assert_eq!(address["properties"]["street"]["type"], "string");
+        assert_eq!(address["properties"]["city"]["type"], "string");
     }
 
     #[test]

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -68,8 +68,6 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                             "properties": prop_schemas
                         }),
                     );
-                } else if let Some(items) = &field.items {
-                    schema.insert("items".to_string(), field_to_schema(items));
                 }
             }
             FieldType::Object => {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1645,29 +1645,22 @@ main:
     my_list:
       type: array
       description: List of objects
-      items:
-        type: object
-        properties:
-          sub_a:
-            type: string
-            description: Subfield A
-          sub_b:
-            type: number
-            description: Subfield B
+      properties:
+        sub_a:
+          type: string
+          description: Subfield A
+        sub_b:
+          type: number
+          description: Subfield B
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    // Check array with items
     let list_field = config.main.fields.get("my_list").unwrap();
     assert_eq!(list_field.r#type, FieldType::Array);
-    assert!(list_field.items.is_some());
+    assert!(list_field.properties.is_some());
 
-    let items_schema = list_field.items.as_ref().unwrap();
-    assert_eq!(items_schema.r#type, FieldType::Object);
-    assert!(items_schema.properties.is_some());
-
-    let props = items_schema.properties.as_ref().unwrap();
+    let props = list_field.properties.as_ref().unwrap();
     assert!(props.contains_key("sub_a"));
     assert!(props.contains_key("sub_b"));
     assert_eq!(props["sub_a"].r#type, FieldType::String);
@@ -1746,16 +1739,14 @@ main:
   fields:
     rows:
       type: array
-      items:
-        type: object
-        properties:
-          score:
-            type: number
-          nested:
-            type: object
-            properties:
-              inner:
-                type: string
+      properties:
+        score:
+          type: number
+        nested:
+          type: object
+          properties:
+            inner:
+              type: string
 "#;
 
     let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
@@ -1782,15 +1773,13 @@ main:
   fields:
     scores:
       type: array
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-          value:
-            type: number
-          active:
-            type: boolean
+      properties:
+        name:
+          type: string
+        value:
+          type: number
+        active:
+          type: boolean
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
@@ -1940,13 +1929,11 @@ main:
   fields:
     items:
       type: array
-      items:
-        type: object
-        properties:
-          score:
-            type: number
-          active:
-            type: boolean
+      properties:
+        score:
+          type: number
+        active:
+          type: boolean
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1675,13 +1675,13 @@ main:
 }
 
 #[test]
-fn test_standalone_object_field_rejected_with_error() {
+fn test_typed_object_field_accepted() {
     let yaml_content = r#"
 quill:
   name: obj_test
   version: "1.0"
   backend: typst
-  description: Test standalone object rejection
+  description: Test typed dictionary acceptance
 
 main:
   fields:
@@ -1690,10 +1690,36 @@ main:
       description: A normal field
     address:
       type: object
-      description: Standalone object — should be rejected
+      description: Typed dictionary with properties
       properties:
         street:
           type: string
+          required: true
+        city:
+          type: string
+          required: true
+"#;
+
+    let (config, warnings) = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap();
+    assert!(warnings.is_empty());
+    let field = &config.main.fields["address"];
+    assert_eq!(field.r#type, FieldType::Object);
+    assert!(field.properties.as_ref().unwrap().contains_key("street"));
+}
+
+#[test]
+fn test_untyped_object_field_rejected() {
+    let yaml_content = r#"
+quill:
+  name: obj_test
+  version: "1.0"
+  backend: typst
+  description: Test freeform object rejection
+
+main:
+  fields:
+    metadata:
+      type: object
 "#;
 
     let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
@@ -1702,9 +1728,9 @@ main:
     assert_eq!(err[0].severity, Severity::Error);
     assert_eq!(
         err[0].code.as_deref(),
-        Some("quill::standalone_object_not_supported")
+        Some("quill::object_missing_properties")
     );
-    assert!(err[0].message.contains("address"));
+    assert!(err[0].message.contains("metadata"));
 }
 
 #[test]

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -218,9 +218,6 @@ pub struct FieldSchema {
     /// Properties for dict/object types (nested field schemas)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, Box<FieldSchema>>>,
-    /// Item schema for array types
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Box<FieldSchema>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -237,7 +234,6 @@ struct FieldSchemaDef {
     pub enum_values: Option<Vec<String>>,
     // Nested schema support
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
-    pub items: Option<serde_json::Value>,
 }
 
 impl FieldSchema {
@@ -253,7 +249,6 @@ impl FieldSchema {
             required: false,
             enum_values: None,
             properties: None,
-            items: None,
         }
     }
 
@@ -282,14 +277,6 @@ impl FieldSchema {
                     );
                 }
                 Some(p)
-            } else {
-                None
-            },
-            items: if let Some(item_def) = def.items {
-                Some(Box::new(FieldSchema::from_quill_value(
-                    "items".to_string(),
-                    &QuillValue::from_json(item_def),
-                )?))
             } else {
                 None
             },

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -203,14 +203,6 @@ pub(crate) fn validate_field(
                             }
                         }
                     }
-                } else if let Some(item_schema) = &field.items {
-                    for (idx, item) in items.iter().enumerate() {
-                        errors.extend(validate_field(
-                            item_schema,
-                            &QuillValue::from_json(item.clone()),
-                            &index_path(path, idx),
-                        ));
-                    }
                 }
                 true
             }
@@ -511,30 +503,6 @@ main:
         let config = config_with("    body:\n      type: markdown", "");
         let doc = doc_from_fm(&[("body", json!("# Heading\n\nBody text"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
-    }
-
-    #[test]
-    fn validates_array_of_strings() {
-        let config = config_with(
-            "    tags:\n      type: array\n      items:\n        type: string",
-            "",
-        );
-        let doc = doc_from_fm(&[("tags", json!(["a", "b"]))]);
-        assert!(validate_typed_document(&config, &doc).is_ok());
-    }
-
-    #[test]
-    fn rejects_invalid_array_element_type() {
-        let config = config_with(
-            "    tags:\n      type: array\n      items:\n        type: string",
-            "",
-        );
-        let doc = doc_from_fm(&[("tags", json!(["a", 2]))]);
-        let errors = validate_typed_document(&config, &doc).unwrap_err();
-        assert!(has_error(&errors, |e| matches!(
-            e,
-            ValidationError::TypeMismatch { path, .. } if path == "tags[1]"
-        )));
     }
 
     #[test]

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -303,10 +303,6 @@ fn child_path(parent: &str, child: &str) -> String {
     }
 }
 
-fn index_path(parent: &str, index: usize) -> String {
-    format!("{parent}[{index}]")
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -183,7 +183,27 @@ pub(crate) fn validate_field(
         }
         FieldType::Array => match value.as_array() {
             Some(items) => {
-                if let Some(item_schema) = &field.items {
+                if let Some(properties) = &field.properties {
+                    for (idx, item) in items.iter().enumerate() {
+                        let obj = item.as_object();
+                        for (prop_name, prop_schema) in properties {
+                            let prop_path = format!("{}[{}].{}", path, idx, prop_name);
+                            match obj.and_then(|o| o.get(prop_name)) {
+                                Some(v) => errors.extend(validate_field(
+                                    prop_schema,
+                                    &QuillValue::from_json(v.clone()),
+                                    &prop_path,
+                                )),
+                                None if prop_schema.required => {
+                                    errors.push(ValidationError::MissingRequired {
+                                        path: prop_path,
+                                    })
+                                }
+                                None => {}
+                            }
+                        }
+                    }
+                } else if let Some(item_schema) = &field.items {
                     for (idx, item) in items.iter().enumerate() {
                         errors.extend(validate_field(
                             item_schema,
@@ -520,7 +540,7 @@ main:
     #[test]
     fn validates_array_of_objects() {
         let config = config_with(
-            "    recipients:\n      type: array\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n            required: true\n          org:\n            type: string",
+            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n          required: true\n        org:\n          type: string",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "name": "Sam", "org": "HQ" }]))]);
@@ -530,7 +550,7 @@ main:
     #[test]
     fn reports_missing_required_field_in_array_object() {
         let config = config_with(
-            "    recipients:\n      type: array\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n            required: true\n          org:\n            type: string",
+            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n          required: true\n        org:\n          type: string",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -540,11 +540,10 @@ main:
         }));
     }
 
-    // NOTE: top-level `type: object` fields are explicitly unsupported by
-    // the config parser (see `config::parse_fields_with_order`). Object
-    // schemas only appear inside `array.items`; coverage for that shape lives
-    // in `validates_array_of_objects` and
-    // `reports_missing_required_field_in_array_object`.
+    // NOTE: top-level typed-dictionary fields (`type: object` with `properties`)
+    // are supported. Coverage lives in `validates_array_of_objects` (typed
+    // tables) and the blueprint tests. Freeform objects without properties are
+    // rejected at config parse time.
 
     #[test]
     fn accumulates_multiple_missing_required_errors() {

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -194,11 +194,8 @@ pub(crate) fn validate_field(
                                     &QuillValue::from_json(v.clone()),
                                     &prop_path,
                                 )),
-                                None if prop_schema.required => {
-                                    errors.push(ValidationError::MissingRequired {
-                                        path: prop_path,
-                                    })
-                                }
+                                None if prop_schema.required => errors
+                                    .push(ValidationError::MissingRequired { path: prop_path }),
                                 None => {}
                             }
                         }

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -61,15 +61,13 @@ card_types:
             skills: Python, Rust, C++
           - category: DevOps
             skills: Docker, Kubernetes
-        items:
-          type: object
-          properties:
-            category:
-              type: string
-              required: true
-            skills:
-              type: string
-              required: true
+        properties:
+          category:
+            type: string
+            required: true
+          skills:
+            type: string
+            required: true
 
   projects_section:
     description: A project entry with a name and optional URL.

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -98,13 +98,13 @@ main:
 | `number`   | Numeric scalar (integers and decimals) |
 | `integer`  | Integer-only numeric scalar |
 | `boolean`  | `true` or `false` |
-| `array`    | Use `items` for element schema |
+| `array`    | Ordered list; add `properties:` for typed rows |
 | `date`     | YYYY-MM-DD |
 | `datetime`  | ISO 8601 |
 | `markdown` | Rich text; backends convert to target format |
-| `object`   | Structured map; valid only inside `array.items` (not as a standalone field) |
+| `object`   | Structured map; requires a `properties:` map |
 
-Use `type: array` with `items: { type: object, properties: {...} }` when you need a **list** of structured rows. Quill does not yet provide a general-purpose deep-nesting field type, so `type: object` is currently scoped to `array.items` rather than standalone top-level fields.
+Use `type: array` with `properties:` when you need a **list** of structured rows. Use `type: object` with `properties:` for a single structured mapping. Nesting beyond one level is not supported.
 
 ### Enum Constraints
 
@@ -123,37 +123,36 @@ main:
       description: "Format style for the endorsement."
 ```
 
-### Typed Arrays
+### Typed Arrays and Typed Dictionaries
 
-Define array element schemas with `items`:
-
-```yaml
-main:
-  fields:
-    recipients:
-      type: array
-      items:
-        type: string
-      example:
-        - ORG1/SYMBOL
-        - ORG2/SYMBOL
-```
-
-Use `type: object` inside `items` to define structured rows. Coercion recurses into each element and converts property values to their declared types:
+Add `properties:` to a `type: array` field to define a typed table — each element is a structured object. Coercion recurses into each element and converts property values to their declared types:
 
 ```yaml
 main:
   fields:
     cells:
       type: array
-      items:
-        type: object
-        properties:
-          category:
-            type: string
-            required: true
-          score:
-            type: number
+      properties:
+        category:
+          type: string
+          required: true
+        score:
+          type: number
+```
+
+Use `type: object` with `properties:` for a single structured mapping:
+
+```yaml
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street:
+          type: string
+          required: true
+        city:
+          type: string
 ```
 
 ---

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -88,7 +88,7 @@ main:
 | `required`    | boolean           | no       | Whether the field must be present (default: `false`) |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
-| `items`       | object            | no       | Item schema (for `array` type; use `type: object` with `properties` for structured rows) |
+| `properties`  | object            | no       | Nested field schemas (for `array` typed-table rows or `object` typed dictionaries) |
 
 ### Field Types
 
@@ -481,8 +481,6 @@ main:
 
     team_members:
       type: array
-      items:
-        type: string
       ui:
         group: Team
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -68,11 +68,12 @@ That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 Form: **`# <type>[<format>]; <role>[, <extra>...]`**
 
 - **Type slot** (mandatory, first): one of
-  `string`, `integer`, `number`, `boolean`, `array`,
+  `string`, `integer`, `number`, `boolean`, `array`, `object`,
   `markdown`, `date`, `datetime`, `enum`, `sentinel`.
   Every field is labeled — there is no "self-evident" exemption.
-  (`object` appears only in the format slot of typed-table fields as
-  `array<object>`; standalone `object` fields are not supported.)
+  (`object` requires a `properties` map; freeform untyped objects are not
+  supported. `object` also appears in the format slot of typed-table fields
+  as `array<object>`.)
 - **Format slot** (optional, in `<…>` angle brackets): refines the type
   when the refinement carries information beyond the type name itself.
   - `date<YYYY-MM-DD>`
@@ -186,6 +187,44 @@ A field of `type: array` whose `items` is a typed object (`type: object`
   its own description, inline type/format, and role.
 
 The outer field's inline annotation is `# array<object>; <role>`.
+
+## Typed dictionaries
+
+A field of `type: object` with a `properties` map renders as an indented
+block mapping with per-property annotations — no outer value on the key
+line:
+
+- An `example:` or non-empty `default:` renders as a concrete block
+  mapping (property values only, no annotations).
+- Otherwise each property is emitted with its own description, inline
+  type/format, and role — the same annotation rules as any other field.
+
+The outer field's inline annotation is `# object; <role>`.
+
+```
+# The sender's mailing address.
+address:  # object; optional
+  # Street address line.
+  street: ""  # string; required
+  # City name.
+  city: ""  # string; required
+  # ZIP or postal code.
+  zip: ""  # string; optional
+```
+
+With a default:
+
+```
+address:  # object; optional
+  street: 5000 Forbes Avenue
+  city: Pittsburgh
+  zip: "15213"
+```
+
+Properties of a typed dictionary may not themselves be objects (nesting
+beyond one level is not supported). Freeform `type: object` fields without
+a `properties` map are rejected at `Quill.yaml` parse time
+(`quill::object_missing_properties`).
 
 ## UI metadata honored
 

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -68,9 +68,11 @@ That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 Form: **`# <type>[<format>]; <role>[, <extra>...]`**
 
 - **Type slot** (mandatory, first): one of
-  `string`, `integer`, `number`, `boolean`, `array`, `object`,
+  `string`, `integer`, `number`, `boolean`, `array`,
   `markdown`, `date`, `datetime`, `enum`, `sentinel`.
   Every field is labeled — there is no "self-evident" exemption.
+  (`object` appears only in the format slot of typed-table fields as
+  `array<object>`; standalone `object` fields are not supported.)
 - **Format slot** (optional, in `<…>` angle brackets): refines the type
   when the refinement carries information beyond the type name itself.
   - `date<YYYY-MM-DD>`
@@ -110,7 +112,7 @@ Role drives "must fill"; the value rendering follows a single cascade:
 |---|---|
 | Has `default` | default |
 | Has `enum` only | first enum value |
-| Otherwise | type-empty (`""`, `0`, `false`, `[]`, `{}`, or block scalar for markdown — see below) |
+| Otherwise | type-empty (`""`, `0`, `false`, `[]`, or block scalar for markdown — see below) |
 
 Examples never become the rendered value, regardless of role. Examples
 are inherently illustrative and unsafe to ship; they always surface in
@@ -230,7 +232,7 @@ address: []  # array<string>; optional
 # e.g. www.ece.cmu.edu
 url: ""  # string; optional
 # The date to appear on the letter.
-date: ""  # date<YYYY-MM-DD>; required
+date: ""  # date<YYYY-MM-DD>; optional
 ---
 
 Write main body here.

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -179,8 +179,8 @@ fallback; authors needing these characters must reshape their values.
 
 ## Typed tables
 
-A field of `type: array` whose `items` is a typed object (`type: object`
-+ `properties`) renders with full per-property annotations:
+A field of `type: array` with a `properties` map renders with full
+per-property annotations:
 
 - An `example:` or non-empty `default:` renders as actual rows.
 - Otherwise one synthetic row is emitted, with each property carrying
@@ -222,9 +222,9 @@ address:  # object; optional
 ```
 
 Properties of a typed dictionary may not themselves be objects (nesting
-beyond one level is not supported). Freeform `type: object` fields without
-a `properties` map are rejected at `Quill.yaml` parse time
-(`quill::object_missing_properties`).
+beyond one level is not supported). The same rule applies to typed table
+properties. Freeform `type: object` fields without a `properties` map are
+rejected at `Quill.yaml` parse time (`quill::object_missing_properties`).
 
 ## UI metadata honored
 

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -99,7 +99,7 @@ typst:
     - "@preview/some-package:1.0.0"
 ```
 
-Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`) are reserved by the engine. Standalone `object` fields are not supported; use `array` with `items: {type: object, properties: {...}}` instead.
+Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`) are reserved by the engine. Standalone `object` fields require a `properties` map; use `type: array` with `properties:` for a list of objects.
 
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card type.

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -20,8 +20,8 @@ Supported field types:
 | `number` | Numeric value (integers and decimals) |
 | `integer` | Integer-only numeric value |
 | `boolean` | `true` / `false` |
-| `array` | Ordered list; use `items:` |
-| `object` | Structured map; use `properties:` (only valid inside `array.items`) |
+| `array` | Ordered list; add `properties:` for typed rows |
+| `object` | Structured map; requires `properties:` |
 | `date` | `YYYY-MM-DD` |
 | `datetime` | ISO 8601 |
 | `markdown` | Rich text; backends handle conversion |
@@ -60,7 +60,7 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_types` (map keyed by card name). `main` and each entry in `card_types` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`items`/`ui`, and optional `required` (omitted when false).
+Top-level schema keys: `main`, optional `card_types` (map keyed by card name). `main` and each entry in `card_types` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`, and optional `required` (omitted when false).
 
 Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters). The bundled example markdown is exposed separately (Wasm: `Quill.example`; Python: `Quill.example`) so consumers choose whether to include it in a prompt.
 


### PR DESCRIPTION
- Worked example: `date` field in cmu_letter has no `required: true` in
  Quill.yaml, so the blueprint emits `optional` not `required`. The
  example was wrong.

- Type-empty table: `{}` listed as type-empty for `object`, but
  standalone `type: object` fields are rejected at parse time
  (`quill::standalone_object_not_supported`). Remove the unreachable
  entry.

- Type slot list: `object` listed as a valid standalone type token in
  the inline annotation, but it can only appear in the format slot of
  typed-table fields (`array<object>`). Add a clarifying note and
  remove it from the type slot enumeration.

https://claude.ai/code/session_01K9JKQVVa8yjScE1QLsSmdt