### PR TITLE
Simplify error handling in signature overlay injection

### DIFF
--- a/crates/backends/typst/src/sig_overlay/extract.rs
+++ b/crates/backends/typst/src/sig_overlay/extract.rs
@@ -61,7 +61,7 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<SigPlacement>, RenderEr
         let pos = intro.position(loc);
         placements.push(SigPlacement {
             name,
-            page: pos.page.get().saturating_sub(1),
+            page: pos.page.get() - 1,
             rect_typst_pt: [
                 pos.point.x.to_pt() as f32,
                 pos.point.y.to_pt() as f32,

--- a/crates/backends/typst/src/sig_overlay/inject.rs
+++ b/crates/backends/typst/src/sig_overlay/inject.rs
@@ -93,12 +93,12 @@ pub(crate) fn inject(
     }
 
     let chunk_bytes = chunk.as_bytes();
-    let offset_in_chunk = |id: i32| -> Result<usize, RenderError> {
+    let offset_in_chunk = |id: i32| -> usize {
         let marker = format!("{} 0 obj", id);
         chunk_bytes
             .windows(marker.len())
             .position(|w| w == marker.as_bytes())
-            .ok_or_else(|| err(CODE_PARSE, format!("emitted object {id} not located in chunk")))
+            .expect("pdf_writer emitted an indirect object but its header is missing from the chunk")
     };
 
     let (cs, ce) =
@@ -140,11 +140,11 @@ pub(crate) fn inject(
 
     let mut entries: Vec<(u32, usize)> = Vec::new();
     for wref in &widget_ids {
-        entries.push((wref.get() as u32, widget_chunk_off + offset_in_chunk(wref.get())?));
+        entries.push((wref.get() as u32, widget_chunk_off + offset_in_chunk(wref.get())));
     }
     entries.push((
         acroform_id.get() as u32,
-        widget_chunk_off + offset_in_chunk(acroform_id.get())?,
+        widget_chunk_off + offset_in_chunk(acroform_id.get()),
     ));
     let new_catalog_off = out.len();
     out.extend_from_slice(&updated_catalog);


### PR DESCRIPTION
This PR simplifies error handling in the signature overlay code by converting recoverable errors into panics where appropriate, reflecting the assumption that the PDF writer should always emit valid output.

## Summary
Refactored error handling in the signature overlay injection and extraction logic to use `expect()` and direct arithmetic operations instead of `Result` types and `saturating_sub()`, making the code more straightforward while maintaining safety guarantees.

## Key changes
- **inject.rs**: Changed `offset_in_chunk` closure from returning `Result<usize, RenderError>` to returning `usize`, replacing `ok_or_else()` with `expect()` to panic if the PDF object header is missing (which should never happen with valid pdf_writer output)
- **inject.rs**: Removed `?` operators from `offset_in_chunk()` call sites since the function no longer returns a Result
- **extract.rs**: Replaced `saturating_sub(1)` with direct subtraction (`- 1`) for page number calculation, as the page number is guaranteed to be at least 1 by the PDF specification

## Implementation details
These changes are based on the assumption that the pdf_writer library always emits valid PDF objects with proper headers, and that page numbers from the document are always valid (≥ 1). The use of `expect()` with descriptive messages provides clear panic information if these invariants are violated, which is preferable to silent error propagation in these internal utility functions.

https://claude.ai/code/session_01LhTbAWC16B3tANybBV9VqS