### PR TITLE
Add document-model path anchors to validation diagnostics

### DIFF
--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -184,16 +184,14 @@ pub(crate) fn render_document_pages(
                 slice.iter().copied().filter(|&i| i >= page_count).collect();
             if !out_of_bounds.is_empty() {
                 return Err(RenderError::ValidationFailed {
-                    diag: Box::new(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!(
-                                "Page index out of bounds (page_count={}); offending indices: {:?}. Check `RenderSession.pageCount` before requesting pages.",
-                                page_count, out_of_bounds
-                            ),
-                        )
-                        .with_code("typst::page_index_out_of_bounds".to_string()),
-                    ),
+                    diags: vec![Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "Page index out of bounds (page_count={}); offending indices: {:?}. Check `RenderSession.pageCount` before requesting pages.",
+                            page_count, out_of_bounds
+                        ),
+                    )
+                    .with_code("typst::page_index_out_of_bounds".to_string())],
                 });
             }
             slice.to_vec()

--- a/crates/backends/typst/src/error_mapping.rs
+++ b/crates/backends/typst/src/error_mapping.rs
@@ -37,6 +37,7 @@ fn map_single_diagnostic(error: &SourceDiagnostic, world: &QuillWorld) -> Diagno
         code,
         message: error.message.to_string(),
         location,
+        path: None,
         hint,
         source_chain: Vec::new(),
     }

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -70,6 +70,12 @@ pub fn convert_render_error(err: RenderError) -> PyErr {
         RenderError::ValidationFailed { diags } => {
             // Multi-diagnostic: each entry sets `path` to anchor the error
             // in the document model. Consumers should iterate `.diagnostics`.
+            //
+            // Pre-PR-#566 versions of this binding attached a single
+            // `.diagnostic` for `ValidationFailed`. To soften that
+            // breaking change for the common single-error case, we also
+            // attach `.diagnostic = diagnostics[0]` when there is exactly
+            // one diagnostic. New code should prefer `.diagnostics`.
             let msg = if diags.len() == 1 {
                 diags[0].message.clone()
             } else {
@@ -81,6 +87,9 @@ pub fn convert_render_error(err: RenderError) -> PyErr {
                     .into_iter()
                     .map(|d| crate::types::PyDiagnostic { inner: d.into() })
                     .collect();
+                if py_diags.len() == 1 {
+                    let _ = exc.setattr("diagnostic", py_diags[0].clone());
+                }
                 let _ = exc.setattr("diagnostics", py_diags);
             }
             py_err

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -67,13 +67,30 @@ pub fn convert_render_error(err: RenderError) -> PyErr {
             }
             py_err
         }
+        RenderError::ValidationFailed { diags } => {
+            // Multi-diagnostic: each entry sets `path` to anchor the error
+            // in the document model. Consumers should iterate `.diagnostics`.
+            let msg = if diags.len() == 1 {
+                diags[0].message.clone()
+            } else {
+                format!("Validation failed with {} error(s)", diags.len())
+            };
+            let py_err = QuillmarkError::new_err(msg);
+            if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
+                let py_diags: Vec<crate::types::PyDiagnostic> = diags
+                    .into_iter()
+                    .map(|d| crate::types::PyDiagnostic { inner: d.into() })
+                    .collect();
+                let _ = exc.setattr("diagnostics", py_diags);
+            }
+            py_err
+        }
         RenderError::InvalidFrontmatter { diag } => {
             with_diag_attached(py, ParseError::new_err(diag.message.clone()), *diag)
         }
         RenderError::EngineCreation { diag }
         | RenderError::FormatNotSupported { diag }
-        | RenderError::UnsupportedBackend { diag }
-        | RenderError::ValidationFailed { diag } => {
+        | RenderError::UnsupportedBackend { diag } => {
             with_diag_attached(py, QuillmarkError::new_err(diag.message.clone()), *diag)
         }
     })

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -662,6 +662,15 @@ impl PyDiagnostic {
         self.inner.hint.as_deref()
     }
 
+    /// Document-model path anchor (e.g. `"cards.indorsement[0].signature_block"`).
+    ///
+    /// Set on schema validation diagnostics; `None` otherwise. See the Rust
+    /// `quillmark_core::error` module docs for the path grammar.
+    #[getter]
+    fn path(&self) -> Option<&str> {
+        self.inner.path.as_deref()
+    }
+
     #[getter]
     fn source_chain(&self) -> Vec<String> {
         self.inner.source_chain.clone()

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -134,6 +134,40 @@ mod tests {
     }
 
     #[test]
+    fn test_validation_failed_carries_all_diagnostics() {
+        // Regression: prior to the PR-#566 fix, the `From<RenderError>`
+        // fallback called `.diagnostics().first()` and dropped every
+        // diagnostic after the first for non-CompilationFailed variants.
+        let diag1 = Diagnostic::new(Severity::Error, "missing title".to_string())
+            .with_path("title".to_string());
+        let diag2 = Diagnostic::new(Severity::Error, "missing author".to_string())
+            .with_path("author".to_string());
+        let render_err = RenderError::ValidationFailed {
+            diags: vec![diag1, diag2],
+        };
+        let wasm_err: WasmError = render_err.into();
+
+        assert_eq!(wasm_err.diagnostics.len(), 2);
+        assert_eq!(wasm_err.diagnostics[0].path.as_deref(), Some("title"));
+        assert_eq!(wasm_err.diagnostics[1].path.as_deref(), Some("author"));
+    }
+
+    #[test]
+    fn test_quill_config_carries_all_diagnostics() {
+        // Same regression as above, for `QuillConfig`.
+        let diag1 = Diagnostic::new(Severity::Error, "config error 1".to_string());
+        let diag2 = Diagnostic::new(Severity::Error, "config error 2".to_string());
+        let render_err = RenderError::QuillConfig {
+            diags: vec![diag1, diag2],
+        };
+        let wasm_err: WasmError = render_err.into();
+
+        assert_eq!(wasm_err.diagnostics.len(), 2);
+        assert_eq!(wasm_err.diagnostics[0].message, "config error 1");
+        assert_eq!(wasm_err.diagnostics[1].message, "config error 2");
+    }
+
+    #[test]
     fn test_string_conversion_yields_single_diagnostic() {
         let wasm_err: WasmError = "Simple error".into();
         assert_eq!(wasm_err.message(), "Simple error");

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -63,7 +63,12 @@ impl From<ParseError> for WasmError {
 impl From<RenderError> for WasmError {
     fn from(error: RenderError) -> Self {
         match error {
-            RenderError::CompilationFailed { diags } => WasmError { diagnostics: diags },
+            // Multi-diagnostic variants forward every diagnostic so JS
+            // consumers can iterate `err.diagnostics` and read each entry's
+            // `path` for document-model navigation.
+            RenderError::CompilationFailed { diags }
+            | RenderError::QuillConfig { diags }
+            | RenderError::ValidationFailed { diags } => WasmError { diagnostics: diags },
             _ => {
                 let diagnostic = error
                     .diagnostics()

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -88,6 +88,12 @@ pub struct Diagnostic {
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
+    /// Document-model path anchor (e.g. `"cards.indorsement[0].signature_block"`).
+    ///
+    /// Set on schema validation diagnostics; `undefined` otherwise. See the
+    /// Rust `quillmark_core::error` module docs for the path grammar.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -101,6 +107,7 @@ impl From<quillmark_core::Diagnostic> for Diagnostic {
             code: diag.code,
             message: diag.message,
             location: diag.location.map(Into::into),
+            path: diag.path,
             hint: diag.hint,
             source_chain: diag.source_chain,
         }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -16,6 +16,44 @@
 //! - [`Severity`]: Error severity levels (Error, Warning, Note)
 //! - [`RenderResult`]: Result type with artifacts and warnings
 //!
+//! ## Document Anchors
+//!
+//! A [`Diagnostic`] can carry two independent "where" anchors, both optional:
+//!
+//! - [`Diagnostic::location`] — a source-text anchor (`file:line:column`).
+//!   Produced by parsers and backend compilers that operate on raw text.
+//! - [`Diagnostic::path`] — a document-model anchor pointing into the typed
+//!   [`crate::document::Document`]. Produced by schema validation and
+//!   coercion, which run on the typed model after line spans are gone.
+//!
+//! ### Path grammar
+//!
+//! ```text
+//! path        := segment ( "." field_name | "[" index "]" )*
+//! field_name  := [a-z_][a-z0-9_]*       // same charset enforced for fields/tags
+//! index       := [0-9]+
+//! ```
+//!
+//! Because field and card tag names are validated to that charset (no `.`,
+//! `[`, `]`, or whitespace can appear in any segment), the dotted form
+//! round-trips unambiguously.
+//!
+//! ### Path conventions
+//!
+//! | Anchor                        | Path                                          |
+//! |-------------------------------|-----------------------------------------------|
+//! | Main frontmatter field        | `title`                                       |
+//! | Nested in array of objects    | `recipients[0].name`                          |
+//! | Main card body                | `main.body`                                   |
+//! | Typed card (whole)            | `cards.indorsement[0]`                        |
+//! | Field on typed card           | `cards.indorsement[0].signature_block`        |
+//! | Body on typed card            | `cards.indorsement[0].body`                   |
+//! | Card with unknown tag         | `cards[0]`                                    |
+//!
+//! The `cards.<tag>[<index>]` form fuses the card tag and the document
+//! array index into one segment so consumers receive both pieces of
+//! information without a second lookup.
+//!
 //! ## Error Hierarchy
 //!
 //! ### RenderError Variants
@@ -144,9 +182,19 @@ pub struct Diagnostic {
     pub code: Option<String>,
     /// Human-readable error message
     pub message: String,
-    /// Primary source location
+    /// Primary source location (text anchor: file/line/column).
+    ///
+    /// Set by parsers and backend compilers. May co-exist with [`Self::path`]
+    /// — the two anchors are independent.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub location: Option<Location>,
+    /// Document-model anchor — a dotted/bracketed path into the typed
+    /// [`crate::document::Document`].
+    ///
+    /// Set by schema validation and coercion. See the module-level docs for
+    /// the path grammar and conventions. May co-exist with [`Self::location`].
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub path: Option<String>,
     /// Optional hint for fixing the error
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
@@ -163,6 +211,7 @@ impl Diagnostic {
             code: None,
             message,
             location: None,
+            path: None,
             hint: None,
             source_chain: Vec::new(),
         }
@@ -177,6 +226,14 @@ impl Diagnostic {
     /// Set the primary location
     pub fn with_location(mut self, location: Location) -> Self {
         self.location = Some(location);
+        self
+    }
+
+    /// Set the document-model path anchor.
+    ///
+    /// See the module-level docs for the path grammar and conventions.
+    pub fn with_path(mut self, path: String) -> Self {
+        self.path = Some(path);
         self
     }
 
@@ -214,6 +271,10 @@ impl Diagnostic {
 
         if let Some(ref loc) = self.location {
             result.push_str(&format!("\n  --> {}:{}:{}", loc.file, loc.line, loc.column));
+        }
+
+        if let Some(ref path) = self.path {
+            result.push_str(&format!("\n  at {}", path));
         }
 
         if let Some(ref hint) = self.hint {
@@ -375,11 +436,14 @@ pub enum RenderError {
         diag: Box<Diagnostic>,
     },
 
-    /// Validation failed for parsed document
-    #[error("{diag}")]
+    /// Validation failed for parsed document — may carry multiple diagnostics
+    /// when several problems are detected during a single validation pass
+    /// (e.g. multiple missing required fields). Each diagnostic should set
+    /// `path` to anchor the error at a specific location in the document model.
+    #[error("Validation failed with {} error(s)", diags.len())]
     ValidationFailed {
-        /// Diagnostic information
-        diag: Box<Diagnostic>,
+        /// All validation diagnostics. Always non-empty.
+        diags: Vec<Diagnostic>,
     },
 
     /// Quill configuration error — may carry multiple diagnostics when several
@@ -395,14 +459,13 @@ impl RenderError {
     /// Extract all diagnostics from this error
     pub fn diagnostics(&self) -> Vec<&Diagnostic> {
         match self {
-            RenderError::CompilationFailed { diags } | RenderError::QuillConfig { diags } => {
-                diags.iter().collect()
-            }
+            RenderError::CompilationFailed { diags }
+            | RenderError::QuillConfig { diags }
+            | RenderError::ValidationFailed { diags } => diags.iter().collect(),
             RenderError::EngineCreation { diag }
             | RenderError::InvalidFrontmatter { diag }
             | RenderError::FormatNotSupported { diag }
-            | RenderError::UnsupportedBackend { diag }
-            | RenderError::ValidationFailed { diag } => vec![diag.as_ref()],
+            | RenderError::UnsupportedBackend { diag } => vec![diag.as_ref()],
         }
     }
 }
@@ -515,6 +578,31 @@ mod tests {
         assert!(output.contains("W001"));
         assert!(output.contains("input.md:5:10"));
         assert!(output.contains("hint:"));
+    }
+
+    #[test]
+    fn test_diagnostic_with_path() {
+        let diag = Diagnostic::new(Severity::Error, "Missing field".to_string())
+            .with_code("validation::missing_required".to_string())
+            .with_path("cards.indorsement[0].signature_block".to_string());
+
+        assert_eq!(
+            diag.path.as_deref(),
+            Some("cards.indorsement[0].signature_block")
+        );
+
+        let json = serde_json::to_string(&diag).unwrap();
+        assert!(json.contains("\"path\":\"cards.indorsement[0].signature_block\""));
+
+        let pretty = diag.fmt_pretty();
+        assert!(pretty.contains("at cards.indorsement[0].signature_block"));
+    }
+
+    #[test]
+    fn test_diagnostic_path_omitted_when_none() {
+        let diag = Diagnostic::new(Severity::Error, "No path".to_string());
+        let json = serde_json::to_string(&diag).unwrap();
+        assert!(!json.contains("\"path\""));
     }
 
     #[test]

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -3,6 +3,7 @@ use time::format_description::well_known::Rfc3339;
 use time::{Date, OffsetDateTime};
 
 use crate::document::Document;
+use crate::error::{Diagnostic, Severity};
 use crate::quill::formats::DATE_FORMAT;
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
@@ -42,6 +43,70 @@ pub enum ValidationError {
     BodyDisabled { path: String, card: String },
 }
 
+impl ValidationError {
+    /// Document-model path anchor for this error.
+    ///
+    /// See [`crate::error`] module docs for the path grammar and conventions.
+    pub fn path(&self) -> &str {
+        match self {
+            ValidationError::MissingRequired { path }
+            | ValidationError::TypeMismatch { path, .. }
+            | ValidationError::EnumViolation { path, .. }
+            | ValidationError::FormatViolation { path, .. }
+            | ValidationError::UnknownCard { path, .. }
+            | ValidationError::MissingCardDiscriminator { path }
+            | ValidationError::BodyDisabled { path, .. } => path,
+        }
+    }
+
+    /// Stable diagnostic code for this error variant. Pattern-match on this
+    /// instead of the message text.
+    pub fn code(&self) -> &'static str {
+        match self {
+            ValidationError::MissingRequired { .. } => "validation::missing_required",
+            ValidationError::TypeMismatch { .. } => "validation::type_mismatch",
+            ValidationError::EnumViolation { .. } => "validation::enum_violation",
+            ValidationError::FormatViolation { .. } => "validation::format_violation",
+            ValidationError::UnknownCard { .. } => "validation::unknown_card",
+            ValidationError::MissingCardDiscriminator { .. } => {
+                "validation::missing_card_discriminator"
+            }
+            ValidationError::BodyDisabled { .. } => "validation::body_disabled",
+        }
+    }
+
+    /// Convert this error into a structured [`Diagnostic`] carrying the
+    /// stable code, the document-model `path`, and an optional hint.
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        let mut diag = Diagnostic::new(Severity::Error, self.to_string())
+            .with_code(self.code().to_string())
+            .with_path(self.path().to_string());
+
+        if let Some(hint) = self.hint() {
+            diag = diag.with_hint(hint);
+        }
+        diag
+    }
+
+    fn hint(&self) -> Option<String> {
+        match self {
+            ValidationError::MissingRequired { .. } => {
+                Some("Add this field to the document.".to_string())
+            }
+            ValidationError::TypeMismatch { expected, .. } => {
+                Some(format!("Provide a value of type `{}`.", expected))
+            }
+            ValidationError::EnumViolation { allowed, .. } => {
+                Some(format!("Use one of: {}.", allowed.join(", ")))
+            }
+            ValidationError::FormatViolation { format, .. } => {
+                Some(format!("Use the `{}` format.", format))
+            }
+            _ => None,
+        }
+    }
+}
+
 /// Validate a typed [`Document`] (with `IndexMap` frontmatter + typed `Card` list).
 ///
 /// This is the typed entry point used by `QuillConfig::validate_document`.
@@ -56,7 +121,7 @@ pub fn validate_typed_document(
     // treated as empty — only meaningful prose triggers the diagnostic.
     if !config.main.body_enabled() && !doc.main().body().trim().is_empty() {
         errors.push(ValidationError::BodyDisabled {
-            path: "main".to_string(),
+            path: "main.body".to_string(),
             card: "main".to_string(),
         });
     }
@@ -87,7 +152,7 @@ pub fn validate_typed_document(
 
         if !card_schema.body_enabled() && !card.body().trim().is_empty() {
             errors.push(ValidationError::BodyDisabled {
-                path: card_path,
+                path: format!("{card_path}.body"),
                 card: card_name,
             });
         }
@@ -632,13 +697,28 @@ main:
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
-            ValidationError::BodyDisabled { card, .. } if card == "skills"
+            ValidationError::BodyDisabled { path, card }
+            if card == "skills" && path == "cards.skills[0].body"
         )));
 
         let mut ws_card = typed_card("skills", &[("items", json!(["Rust"]))]);
         ws_card.replace_body("\n   \n");
         let ok_doc = doc_with_typed_cards(&[], vec![ws_card]);
         assert!(validate_typed_document(&config, &ok_doc).is_ok());
+    }
+
+    #[test]
+    fn to_diagnostic_carries_path_and_code() {
+        let err = ValidationError::MissingRequired {
+            path: "cards.indorsement[0].signature_block".to_string(),
+        };
+        let diag = err.to_diagnostic();
+        assert_eq!(diag.code.as_deref(), Some("validation::missing_required"));
+        assert_eq!(
+            diag.path.as_deref(),
+            Some("cards.indorsement[0].signature_block")
+        );
+        assert_eq!(diag.severity, Severity::Error);
     }
 
     #[test]
@@ -669,7 +749,8 @@ main:
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
-            ValidationError::BodyDisabled { card, .. } if card == "main"
+            ValidationError::BodyDisabled { path, card }
+            if card == "main" && path == "main.body"
         )));
     }
 }

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -243,7 +243,14 @@ impl Quill {
                 // `path` anchor for UI navigation. Consumers should iterate
                 // `RenderError::diagnostics()` rather than reading a single
                 // flattened message.
-                let diags = errors.iter().map(|e| e.to_diagnostic()).collect();
+                //
+                // `validate_document` only returns `Err` with a non-empty
+                // error list, but the `ValidationFailed` variant documents
+                // the same invariant — assert it here so any future
+                // refactor of the underlying validator can't quietly
+                // produce an empty-diags error.
+                debug_assert!(!errors.is_empty(), "ValidationFailed must carry at least one diagnostic");
+                let diags: Vec<Diagnostic> = errors.iter().map(|e| e.to_diagnostic()).collect();
                 Err(RenderError::ValidationFailed { diags })
             }
         }

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -239,21 +239,12 @@ impl Quill {
         match self.source.config().validate_document(doc) {
             Ok(_) => Ok(()),
             Err(errors) => {
-                let error_message = errors
-                    .into_iter()
-                    .map(|e| format!("- {}", e))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                Err(RenderError::ValidationFailed {
-                    diag: Box::new(
-                        Diagnostic::new(Severity::Error, error_message)
-                            .with_code("validation::document_invalid".to_string())
-                            .with_hint(
-                                "Ensure all required fields are present and have correct types"
-                                    .to_string(),
-                            ),
-                    ),
-                })
+                // One diagnostic per ValidationError so each carries its own
+                // `path` anchor for UI navigation. Consumers should iterate
+                // `RenderError::diagnostics()` rather than reading a single
+                // flattened message.
+                let diags = errors.iter().map(|e| e.to_diagnostic()).collect();
+                Err(RenderError::ValidationFailed { diags })
             }
         }
     }
@@ -261,15 +252,14 @@ impl Quill {
 
 /// Wrap a coercion error from `QuillConfig::coerce_frontmatter` /
 /// `coerce_card` into a `RenderError::ValidationFailed` with a uniform hint.
+///
+/// Coercion happens before validation walks the typed document, so we don't
+/// have a structured `path` here — `Diagnostic::path` is left unset.
 fn coercion_error(e: impl std::fmt::Display) -> RenderError {
     RenderError::ValidationFailed {
-        diag: Box::new(
-            Diagnostic::new(Severity::Error, e.to_string())
-                .with_code("validation::coercion_failed".to_string())
-                .with_hint(
-                    "Ensure all fields can be coerced to their declared types".to_string(),
-                ),
-        ),
+        diags: vec![Diagnostic::new(Severity::Error, e.to_string())
+            .with_code("validation::coercion_failed".to_string())
+            .with_hint("Ensure all fields can be coerced to their declared types".to_string())],
     }
 }
 

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -170,9 +170,14 @@ main:
     );
 
     let err = result.unwrap_err();
+    let mentions_title = err
+        .diagnostics()
+        .iter()
+        .any(|d| d.message.contains("title") || d.path.as_deref() == Some("title"));
     assert!(
-        err.to_string().contains("title"),
-        "Error should mention missing 'title' field"
+        mentions_title,
+        "Validation diagnostics should mention missing 'title' field; got {:?}",
+        err.diagnostics()
     );
 }
 


### PR DESCRIPTION
## Summary

This PR introduces document-model path anchors to validation diagnostics, enabling UI consumers to pinpoint errors at specific locations within the typed document structure (e.g., `cards.indorsement[0].signature_block`). Previously, validation errors only carried source-text locations; now they can also carry structured paths into the document model.

## Key Changes

- **Core error types** (`crate::error`):
  - Added `Diagnostic::path: Option<String>` field to carry document-model anchors
  - Added `with_path()` builder method and updated `fmt_pretty()` to render paths
  - Changed `RenderError::ValidationFailed` from single `diag` to `diags: Vec<Diagnostic>` to support multiple validation errors with independent path anchors
  - Updated `diagnostics()` method to handle the new multi-diagnostic variant

- **Validation layer** (`crate::quill::validation`):
  - Added `ValidationError::path()` method to extract the document-model path from each error variant
  - Added `ValidationError::code()` method to provide stable diagnostic codes (e.g., `validation::missing_required`)
  - Added `ValidationError::to_diagnostic()` to convert validation errors into structured `Diagnostic` objects with code, path, and contextual hints
  - Updated path values in `BodyDisabled` errors to include `.body` suffix (e.g., `main.body` instead of `main`)

- **Orchestration** (`quillmark`):
  - Updated validation error handling to collect all `ValidationError`s and convert each to a `Diagnostic` with its own path anchor
  - Updated coercion error handling to use the new `diags` vector format

- **Language bindings**:
  - **Python**: Updated error conversion to attach multiple diagnostics to `ValidationFailed` exceptions
  - **WebAssembly**: Updated error conversion to forward all diagnostics from multi-diagnostic variants
  - **TypeScript types**: Added `path` field to `Diagnostic` struct

- **Documentation**:
  - Added comprehensive module-level documentation in `crate::error` covering path grammar, conventions, and examples
  - Updated field documentation to clarify that `location` and `path` are independent anchors

## Implementation Details

The path grammar follows a simple dotted/bracketed notation:
- Field access: `title`, `recipients[0].name`
- Card navigation: `cards.indorsement[0].signature_block`
- Main card body: `main.body`

Field and tag names are validated to exclude special characters (`.`, `[`, `]`, whitespace), ensuring unambiguous round-tripping. The `cards.<tag>[<index>]` form fuses the card tag and document array index so consumers receive both pieces of information without a second lookup.

Validation errors now carry stable diagnostic codes (e.g., `validation::missing_required`, `validation::type_mismatch`) and contextual hints, making it easier for consumers to programmatically handle and display validation failures.

https://claude.ai/code/session_015MaianNmqTcU3keVMVikvo