### PR TITLE
Add LEAF rework design proposal

### DIFF
--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -284,7 +284,7 @@ fn transform_markdown_fields(
     // Handle LEAVES array recursively
     if let Some(leaves_value) = result.get("LEAVES") {
         if let Some(leaves_array) = leaves_value.as_array() {
-            let transformed_leaves = transform_cards_array(schema, leaves_array);
+            let transformed_leaves = transform_leaves_array(schema, leaves_array);
             result.insert(
                 "LEAVES".to_string(),
                 QuillValue::from_json(serde_json::Value::Array(transformed_leaves)),
@@ -362,7 +362,7 @@ fn transform_markdown_fields(
 }
 
 /// Transform markdown fields in LEAVES array items.
-fn transform_cards_array(
+fn transform_leaves_array(
     document_schema: &QuillValue,
     leaves_array: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
@@ -389,18 +389,18 @@ fn transform_cards_array(
                     }
 
                     // Recursively transform this leaf's fields
-                    let transformed_card_fields = transform_markdown_fields(
+                    let transformed_leaf_fields = transform_markdown_fields(
                         &leaf_fields,
                         &QuillValue::from_json(leaf_schema_json.clone()),
                     );
 
                     // Convert back to JSON Value
-                    let mut transformed_card_obj = serde_json::Map::new();
-                    for (k, v) in transformed_card_fields {
-                        transformed_card_obj.insert(k, v.into_json());
+                    let mut transformed_leaf_obj = serde_json::Map::new();
+                    for (k, v) in transformed_leaf_fields {
+                        transformed_leaf_obj.insert(k, v.into_json());
                     }
 
-                    transformed_leaves.push(serde_json::Value::Object(transformed_card_obj));
+                    transformed_leaves.push(serde_json::Value::Object(transformed_leaf_obj));
                     continue;
                 }
             }
@@ -566,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transform_markdown_fields_collects_card_date_metadata() {
+    fn test_transform_markdown_fields_collects_leaf_date_metadata() {
         let schema = QuillValue::from_json(json!({
             "type": "object",
             "properties": {},

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -147,7 +147,7 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
 
     // Step 4: Validate leaf-type schemas
     for leaf_schema in &config.leaf_kinds {
-        validate_card_schema(&leaf_schema.name, leaf_schema, &mut result);
+        validate_leaf_schema(&leaf_schema.name, leaf_schema, &mut result);
     }
 
     // Step 5: Try to load the full Quill (this validates schema generation)
@@ -268,7 +268,7 @@ fn validate_field_schemas(
     }
 }
 
-fn validate_card_schema(leaf_name: &str, leaf_schema: &LeafSchema, result: &mut ValidationResult) {
+fn validate_leaf_schema(leaf_name: &str, leaf_schema: &LeafSchema, result: &mut ValidationResult) {
     // Warn about missing description
     if leaf_schema
         .description

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -183,7 +183,7 @@ impl PyQuill {
     /// to the document to obtain an updated view.
     ///
     /// Leaves with unknown tags are excluded from `leaves`; each produces a
-    /// diagnostic with code `"form::unknown_card_tag"`.
+    /// diagnostic with code `"form::unknown_leaf_kind"`.
     fn form<'py>(
         &self,
         py: Python<'py>,
@@ -474,16 +474,16 @@ impl PyDocument {
     ///
     /// Mutates only the sentinel — the leaf's frontmatter and body are
     /// untouched. Schema-aware migration (clearing orphan fields, applying
-    /// new defaults) is the caller's responsibility; `set_card_tag` is a
+    /// new defaults) is the caller's responsibility; `set_leaf_tag` is a
     /// structural primitive.
     ///
     /// Raises `quillmark.EditError` if `index` is out of range or `new_tag`
     /// does not match `[a-z_][a-z0-9_]*`.
     ///
     /// This method never modifies `warnings`.
-    fn set_card_tag(&mut self, index: usize, new_tag: &str) -> PyResult<()> {
+    fn set_leaf_tag(&mut self, index: usize, new_tag: &str) -> PyResult<()> {
         self.inner
-            .set_card_tag(index, new_tag)
+            .set_leaf_tag(index, new_tag)
             .map_err(convert_edit_error)
     }
 
@@ -493,7 +493,7 @@ impl PyDocument {
     /// reserved or invalid, or `value` cannot be converted.
     ///
     /// This method never modifies `warnings`.
-    fn update_card_field(
+    fn update_leaf_field(
         &mut self,
         index: usize,
         name: &str,
@@ -512,7 +512,7 @@ impl PyDocument {
     /// Raises `quillmark.EditError` if `index` is out of range.
     ///
     /// This method never modifies `warnings`.
-    fn update_card_body(&mut self, index: usize, body: &str) -> PyResult<()> {
+    fn update_leaf_body(&mut self, index: usize, body: &str) -> PyResult<()> {
         let len = self.inner.leaves().len();
         let leaf = self.inner.leaf_mut(index).ok_or_else(|| {
             convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -112,12 +112,12 @@ def test_set_field_reserved_name_matrix():
             doc.set_field(name, "value")
 
 
-def test_card_set_field_reserved_name_matrix():
+def test_leaf_set_field_reserved_name_matrix():
     """Leaf set_field raises EditError for all four reserved names."""
     for name in ("BODY", "LEAVES", "QUILL", "KIND"):
         doc = Document.from_markdown(MD_WITH_LEAVES)
         with pytest.raises(EditError, match="ReservedName"):
-            doc.update_card_field(0, name, "value")
+            doc.update_leaf_field(0, name, "value")
 
 
 def test_set_field_invalid_field_name():
@@ -170,14 +170,14 @@ def test_push_leaf():
     assert doc.leaves[0]["body"] == "Leaf body."
 
 
-def test_push_card_invalid_tag():
+def test_push_leaf_invalid_tag():
     """push_leaf raises EditError for an invalid tag."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(EditError, match="InvalidTagName"):
         doc.push_leaf({"tag": "BadTag"})
 
 
-def test_insert_card_at_front():
+def test_insert_leaf_at_front():
     """insert_leaf at index 0 prepends the leaf."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
     doc.insert_leaf(0, {"tag": "intro"})
@@ -185,7 +185,7 @@ def test_insert_card_at_front():
     assert doc.leaves[1]["tag"] == "note"
 
 
-def test_insert_card_out_of_range():
+def test_insert_leaf_out_of_range():
     """insert_leaf raises EditError when index > len."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 leaves
     with pytest.raises(EditError, match="IndexOutOfRange"):
@@ -202,13 +202,13 @@ def test_remove_leaf():
     assert doc.leaves[0]["tag"] == "summary"
 
 
-def test_remove_card_out_of_range():
+def test_remove_leaf_out_of_range():
     """remove_leaf returns None for an out-of-range index."""
     doc = Document.from_markdown(SIMPLE_MD)
     assert doc.remove_leaf(0) is None
 
 
-def test_move_card_no_op():
+def test_move_leaf_no_op():
     """move_leaf(0, 0) is a no-op."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
     doc.move_leaf(0, 0)
@@ -216,7 +216,7 @@ def test_move_card_no_op():
     assert doc.leaves[1]["tag"] == "summary"
 
 
-def test_move_card_last_to_first():
+def test_move_leaf_last_to_first():
     """move_leaf rotates the last leaf to the front."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
     last = len(doc.leaves) - 1
@@ -225,46 +225,46 @@ def test_move_card_last_to_first():
     assert doc.leaves[1]["tag"] == "note"
 
 
-def test_move_card_out_of_range():
+def test_move_leaf_out_of_range():
     """move_leaf raises EditError for an out-of-range index."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
     with pytest.raises(EditError, match="IndexOutOfRange"):
         doc.move_leaf(10, 0)
 
 
-def test_update_card_field():
-    """update_card_field sets a field on a specific leaf."""
+def test_update_leaf_field():
+    """update_leaf_field sets a field on a specific leaf."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
-    doc.update_card_field(0, "content", "hello")
+    doc.update_leaf_field(0, "content", "hello")
     assert doc.leaves[0]["fields"]["content"] == "hello"
 
 
-def test_update_card_field_reserved_name():
-    """update_card_field raises EditError for reserved names."""
+def test_update_leaf_field_reserved_name():
+    """update_leaf_field raises EditError for reserved names."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
     with pytest.raises(EditError, match="ReservedName"):
-        doc.update_card_field(0, "BODY", "value")
+        doc.update_leaf_field(0, "BODY", "value")
 
 
-def test_update_card_field_out_of_range():
-    """update_card_field raises EditError when leaf index is out of range."""
+def test_update_leaf_field_out_of_range():
+    """update_leaf_field raises EditError when leaf index is out of range."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 leaves
     with pytest.raises(EditError, match="IndexOutOfRange"):
-        doc.update_card_field(0, "title", "x")
+        doc.update_leaf_field(0, "title", "x")
 
 
-def test_update_card_body():
-    """update_card_body replaces the leaf body."""
+def test_update_leaf_body():
+    """update_leaf_body replaces the leaf body."""
     doc = Document.from_markdown(MD_WITH_LEAVES)
-    doc.update_card_body(0, "New leaf body.")
+    doc.update_leaf_body(0, "New leaf body.")
     assert doc.leaves[0]["body"] == "New leaf body."
 
 
-def test_update_card_body_out_of_range():
-    """update_card_body raises EditError when leaf index is out of range."""
+def test_update_leaf_body_out_of_range():
+    """update_leaf_body raises EditError when leaf index is out of range."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 leaves
     with pytest.raises(EditError, match="IndexOutOfRange"):
-        doc.update_card_body(0, "x")
+        doc.update_leaf_body(0, "x")
 
 
 def test_mutators_do_not_touch_warnings():
@@ -315,7 +315,7 @@ def test_invariants_after_mutation_sequence():
 def test_to_markdown_general_round_trip():
     """Mutated document survives emit → re-parse with structure intact."""
     doc = Document.from_markdown(SIMPLE_MD)
-    original_card_count = len(doc.leaves)  # 0 for SIMPLE_MD
+    original_leaf_count = len(doc.leaves)  # 0 for SIMPLE_MD
 
     # Mutate
     doc.set_field("title", "New Title")
@@ -331,7 +331,7 @@ def test_to_markdown_general_round_trip():
     doc2 = Document.from_markdown(emitted)
     assert doc2.frontmatter["title"] == "New Title"
     assert doc2.body == "Updated body"
-    assert len(doc2.leaves) == original_card_count + 1
+    assert len(doc2.leaves) == original_leaf_count + 1
     assert doc2.leaves[0]["tag"] == "note"
     assert doc2.leaves[0]["fields"]["author"] == "Alice"
     assert doc2.leaves[0]["body"] == "Hello"

--- a/crates/bindings/python/tests/test_form.py
+++ b/crates/bindings/python/tests/test_form.py
@@ -137,7 +137,7 @@ def test_form_json_serializable(tmp_path):
     assert parsed["main"]["values"]["title"]["source"] == "document"
 
 
-def test_form_unknown_card_diagnostic(tmp_path):
+def test_form_unknown_leaf_kind_diagnostic(tmp_path):
     """Unknown leaf tags produce a diagnostic and are excluded from leaves."""
     quill = make_quill(tmp_path)
     md = (
@@ -150,8 +150,8 @@ def test_form_unknown_card_diagnostic(tmp_path):
 
     assert form["leaves"] == [], "unknown-tag leaf must be excluded"
     diag_codes = [d.get("code") for d in form["diagnostics"]]
-    assert "form::unknown_card_tag" in diag_codes, (
-        f"expected form::unknown_card_tag diagnostic; got: {diag_codes}"
+    assert "form::unknown_leaf_kind" in diag_codes, (
+        f"expected form::unknown_leaf_kind diagnostic; got: {diag_codes}"
     )
 
 
@@ -159,7 +159,7 @@ def test_form_unknown_card_diagnostic(tmp_path):
 # Tests: blank_main / blank_leaf
 # ---------------------------------------------------------------------------
 
-def test_blank_main_returns_card_with_no_document_values(tmp_path):
+def test_blank_main_returns_leaf_with_no_document_values(tmp_path):
     """blank_main returns a leaf with every value at default or missing."""
     quill = make_quill(tmp_path)
 
@@ -177,7 +177,7 @@ def test_blank_main_returns_card_with_no_document_values(tmp_path):
     assert values["count"]["default"] is None
 
 
-def test_blank_card_known_type(tmp_path):
+def test_blank_leaf_known_kind(tmp_path):
     """blank_leaf returns a dict for a known leaf type."""
     quill = make_quill(tmp_path)
 
@@ -190,7 +190,7 @@ def test_blank_card_known_type(tmp_path):
     assert values["tag"]["source"] == "missing"
 
 
-def test_blank_card_unknown_type(tmp_path):
+def test_blank_leaf_unknown_kind(tmp_path):
     """blank_leaf returns None for an unknown leaf type."""
     quill = make_quill(tmp_path)
 

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -56,11 +56,11 @@ def test_body_empty_when_absent():
     assert doc.body == ""
 
 
-def test_cards_access():
+def test_leaves_access():
     """Test accessing typed leaves list."""
     md = (
         "---\nQUILL: my_quill\ntitle: Main\n---\n\nGlobal body.\n\n"
-        "```leaf\nKIND: note\nfoo: bar\n```\n\nCard body.\n"
+        "```leaf\nKIND: note\nfoo: bar\n```\n\nLeaf body.\n"
     )
     doc = Document.from_markdown(md)
     assert len(doc.leaves) == 1
@@ -70,7 +70,7 @@ def test_cards_access():
     assert "Leaf body." in leaf["body"]
 
 
-def test_cards_empty_when_none():
+def test_leaves_empty_when_none():
     """Test that leaves is an empty list when no leaves present."""
     md = "---\nQUILL: taro\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n---\n\nBody.\n"
     doc = Document.from_markdown(md)

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -748,9 +748,9 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = setLeafKind)]
-    pub fn set_card_tag(&mut self, index: usize, new_tag: &str) -> Result<(), JsValue> {
+    pub fn set_leaf_tag(&mut self, index: usize, new_tag: &str) -> Result<(), JsValue> {
         self.inner
-            .set_card_tag(index, new_tag)
+            .set_leaf_tag(index, new_tag)
             .map_err(|e| edit_error_to_js(&e))
     }
 
@@ -763,7 +763,7 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = updateLeafField)]
-    pub fn update_card_field(
+    pub fn update_leaf_field(
         &mut self,
         index: usize,
         name: &str,
@@ -788,7 +788,7 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = removeLeafField)]
-    pub fn remove_card_field(&mut self, index: usize, name: &str) -> Result<JsValue, JsValue> {
+    pub fn remove_leaf_field(&mut self, index: usize, name: &str) -> Result<JsValue, JsValue> {
         let len = self.inner.leaves().len();
         let leaf = self.inner.leaf_mut(index).ok_or_else(|| {
             edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
@@ -812,7 +812,7 @@ impl Document {
     ///
     /// Mutators never modify `warnings`.
     #[wasm_bindgen(js_name = updateLeafBody)]
-    pub fn update_card_body(&mut self, index: usize, body: &str) -> Result<(), JsValue> {
+    pub fn update_leaf_body(&mut self, index: usize, body: &str) -> Result<(), JsValue> {
         let len = self.inner.leaves().len();
         let leaf = self.inner.leaf_mut(index).ok_or_else(|| {
             edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -206,7 +206,7 @@ fn test_quill_metadata_and_schemas() {
         .quill(common::tree(&[
             (
                 "Quill.yaml",
-                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\nmain:\n  fields:\n    title:\n      type: string\n      ui:\n        group: Header\ncard_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n",
+                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\nmain:\n  fields:\n    title:\n      type: string\n      ui:\n        group: Header\nleaf_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n",
             ),
             ("plate.typ", b"= Title"),
         ]))

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -39,14 +39,23 @@ fn strip_f2_separator(body: &str) -> &str {
     }
 }
 
-/// An intermediate representation of one `---…---` metadata block.
+/// Which sentinel a metadata block carries. `Main` is the top frontmatter's
+/// `QUILL:` reference (raw string, parsed to `QuillReference` later); `Leaf`
+/// is a leaf fence's `KIND:` tag.
+#[derive(Debug)]
+pub(super) enum BlockSentinel {
+    Main(String),
+    Leaf(String),
+}
+
+/// An intermediate representation of one parsed metadata fence (frontmatter
+/// or leaf).
 #[derive(Debug)]
 pub(super) struct MetadataBlock {
-    pub(super) start: usize,                          // Position of opening "---"
-    pub(super) end: usize,                            // Position after closing "---\n"
-    pub(super) yaml_value: Option<serde_json::Value>, // Parsed YAML as JSON (None if empty or parse failed)
-    pub(super) tag: Option<String>,                   // Field name from KIND key
-    pub(super) quill_ref: Option<String>,             // Quill reference from QUILL key
+    pub(super) start: usize,                          // Position of opening fence
+    pub(super) end: usize,                            // Position after closing fence
+    pub(super) yaml_value: Option<serde_json::Value>, // Parsed YAML (None when fence body is empty)
+    pub(super) sentinel: BlockSentinel,
     /// Pre-scan items (comments + fill-tagged field keys) in source order.
     pub(super) pre_items: Vec<PreItem>,
     /// Pre-scan nested comments (with structural paths).
@@ -108,7 +117,7 @@ pub(super) fn build_block(
             &content,
             yaml_parse_options(),
         ) {
-            Ok(parsed) => extract_sentinels(parsed, markdown, abs_pos, block_index)?,
+            Ok(parsed) => extract_sentinels(parsed)?,
             Err(e) => {
                 let line = markdown[..abs_pos].lines().count() + 1;
                 return Err(ParseError::YamlErrorWithLocation {
@@ -120,18 +129,27 @@ pub(super) fn build_block(
         }
     };
 
-    // Per-fence field-count check (spec §8, §6.1 of GAP analysis)
+    // The fence-detection pass (`find_metadata_blocks`) commits to a fence
+    // kind on the lexical cues alone — `---/---` with first key `QUILL:` for
+    // block 0, ` ```leaf ` with first key `KIND:` for the rest. So by the
+    // time we reach build_block, the expected sentinel is fully determined
+    // by `block_index` and `extract_sentinels` will have produced exactly
+    // the matching variant.
+    let sentinel = match (block_index, quill_ref, tag) {
+        (0, Some(r), _) => BlockSentinel::Main(r),
+        (_, _, Some(t)) => BlockSentinel::Leaf(t),
+        _ => unreachable!(
+            "find_metadata_blocks validates first-key sentinel before calling build_block"
+        ),
+    };
+
+    // Per-fence field-count check (spec §8, §6.1 of GAP analysis). Add +1
+    // for the stripped sentinel so the cap matches what the user wrote.
     if let Some(serde_json::Value::Object(ref map)) = yaml_value {
-        // Add +1 for QUILL (stripped) or KIND (stripped) so the cap matches
-        // what the user wrote, not what's left after sentinel extraction.
-        let sentinel_extra = if quill_ref.is_some() || tag.is_some() {
-            1
-        } else {
-            0
-        };
-        if map.len() + sentinel_extra > crate::error::MAX_FIELD_COUNT {
+        let size = map.len() + 1;
+        if size > crate::error::MAX_FIELD_COUNT {
             return Err(ParseError::InputTooLarge {
-                size: map.len() + sentinel_extra,
+                size,
                 max: crate::error::MAX_FIELD_COUNT,
             });
         }
@@ -141,8 +159,7 @@ pub(super) fn build_block(
         start: abs_pos,
         end: block_end,
         yaml_value,
-        tag,
-        quill_ref,
+        sentinel,
         pre_items: pre.items,
         pre_nested_comments: pre.nested_comments,
         pre_warnings: pre.warnings,
@@ -201,29 +218,25 @@ pub(super) fn decompose_with_warnings(
         });
     }
 
-    // Find all metadata blocks. F1/F2 already guarantee that block 0 carries
-    // QUILL and that every subsequent block carries KIND.
+    // Find all metadata blocks. `find_metadata_blocks` guarantees that
+    // block 0 (if present) carries `BlockSentinel::Main` and every block
+    // after it carries `BlockSentinel::Leaf`.
     let (blocks, warnings, first_fence_issue) = find_metadata_blocks(markdown)?;
 
-    if blocks.is_empty() {
-        return Err(crate::error::ParseError::MissingQuillField(
-            missing_quill_message(first_fence_issue),
-        ));
-    }
+    let frontmatter_block = match blocks.first() {
+        Some(b) if matches!(b.sentinel, BlockSentinel::Main(_)) => b,
+        _ => {
+            return Err(crate::error::ParseError::MissingQuillField(
+                missing_quill_message(first_fence_issue),
+            ))
+        }
+    };
+    let BlockSentinel::Main(ref quill_tag) = frontmatter_block.sentinel else {
+        unreachable!("matched above")
+    };
 
-    // Block 0 is always the QUILL frontmatter (F1 guarantee).
-    let frontmatter_block = &blocks[0];
-    let quill_tag = frontmatter_block.quill_ref.clone().ok_or_else(|| {
-        ParseError::MissingQuillField(
-            "Missing required QUILL field. Add `QUILL: <name>` to the frontmatter.".to_string(),
-        )
-    })?;
-
-    // Build frontmatter item list (YAML content with QUILL stripped).
-    //
-    // The pre-scan captured top-level comments and `!fill` markers in source
-    // order; serde_saphyr produced the parsed values. We iterate the pre-scan
-    // order and pull each field's value from the parsed map.
+    // Build frontmatter item list (YAML content with QUILL stripped). The
+    // pre-scan defined source order; serde_saphyr produced typed values.
     let frontmatter = build_frontmatter_from_pre_and_parsed(
         &frontmatter_block.pre_items,
         &frontmatter_block.pre_nested_comments,
@@ -236,15 +249,11 @@ pub(super) fn decompose_with_warnings(
     }
 
     // Global body: between end of frontmatter (block 0) and start of the
-    // first KIND block (or EOF).
-    //
-    // When a fence follows, the body slice ends with the F2 blank-line
-    // terminator — strip it so stored bodies contain only authored content.
-    // The emitter re-derives the separator on output (see `emit.rs`'s
-    // `ensure_blank_line_before_fence`).
-    let body_start = blocks[0].end;
-    let first_leaf_block = blocks.iter().skip(1).find(|b| b.tag.is_some());
-    let (body_end, body_is_followed_by_fence) = match first_leaf_block {
+    // first leaf (or EOF). When a fence follows, the raw slice ends with
+    // the F2 blank-line terminator — strip it so stored bodies hold only
+    // authored content. The emitter re-derives the separator on output.
+    let body_start = frontmatter_block.end;
+    let (body_end, body_is_followed_by_fence) = match blocks.get(1) {
         Some(b) => (b.start, true),
         None => (markdown.len(), false),
     };
@@ -255,51 +264,44 @@ pub(super) fn decompose_with_warnings(
         global_body_raw.to_string()
     };
 
-    // Parse tagged blocks (KIND blocks) into typed Leaves.
+    // Parse leaf blocks into typed Leaves.
     let mut leaves: Vec<Leaf> = Vec::new();
-    for (idx, block) in blocks.iter().enumerate() {
-        if let Some(ref tag_name) = block.tag {
-            // Build the leaf's typed frontmatter from pre-scan + parsed YAML.
-            let leaf_frontmatter = build_frontmatter_from_pre_and_parsed(
-                &block.pre_items,
-                &block.pre_nested_comments,
-                &block.yaml_value,
-            )
-            .map_err(|e| match e {
-                ParseError::InvalidStructure(msg) => ParseError::InvalidStructure(format!(
-                    "Invalid YAML in leaf block '{}': {}",
-                    tag_name, msg
-                )),
-                other => other,
-            })?;
-            for w in &block.pre_warnings {
-                warnings.push(w.clone());
-            }
-
-            // Leaf body: between this block's end and the next block's start (or EOF).
-            let leaf_body_start = block.end;
-            let has_next_block = idx + 1 < blocks.len();
-            let leaf_body_end = if has_next_block {
-                blocks[idx + 1].start
-            } else {
-                markdown.len()
-            };
-            let leaf_body_raw = &markdown[leaf_body_start..leaf_body_end];
-            let leaf_body = if has_next_block {
-                strip_f2_separator(leaf_body_raw).to_string()
-            } else {
-                leaf_body_raw.to_string()
-            };
-
-            leaves.push(Leaf::new_with_sentinel(
-                Sentinel::Leaf(tag_name.clone()),
-                leaf_frontmatter,
-                leaf_body,
-            ));
+    for (idx, block) in blocks.iter().enumerate().skip(1) {
+        let BlockSentinel::Leaf(ref tag_name) = block.sentinel else {
+            unreachable!("blocks[1..] are leaves by construction")
+        };
+        let leaf_frontmatter = build_frontmatter_from_pre_and_parsed(
+            &block.pre_items,
+            &block.pre_nested_comments,
+            &block.yaml_value,
+        )
+        .map_err(|e| match e {
+            ParseError::InvalidStructure(msg) => ParseError::InvalidStructure(format!(
+                "Invalid YAML in leaf block '{}': {}",
+                tag_name, msg
+            )),
+            other => other,
+        })?;
+        for w in &block.pre_warnings {
+            warnings.push(w.clone());
         }
+
+        // Leaf body: from this block's end to the next block's start (or EOF).
+        // If another fence follows, the body slice ends with the F2 blank-line
+        // terminator — strip it so stored bodies hold only authored content.
+        let leaf_body = match blocks.get(idx + 1) {
+            Some(next) => strip_f2_separator(&markdown[block.end..next.start]).to_string(),
+            None => markdown[block.end..].to_string(),
+        };
+
+        leaves.push(Leaf::new_with_sentinel(
+            Sentinel::Leaf(tag_name.clone()),
+            leaf_frontmatter,
+            leaf_body,
+        ));
     }
 
-    let quill_ref = QuillReference::from_str(&quill_tag).map_err(|e| {
+    let quill_ref = QuillReference::from_str(quill_tag).map_err(|e| {
         ParseError::InvalidStructure(format!("Invalid QUILL tag '{}': {}", quill_tag, e))
     })?;
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -243,8 +243,8 @@ pub(super) fn decompose_with_warnings(
     // The emitter re-derives the separator on output (see `emit.rs`'s
     // `ensure_blank_line_before_fence`).
     let body_start = blocks[0].end;
-    let first_card_block = blocks.iter().skip(1).find(|b| b.tag.is_some());
-    let (body_end, body_is_followed_by_fence) = match first_card_block {
+    let first_leaf_block = blocks.iter().skip(1).find(|b| b.tag.is_some());
+    let (body_end, body_is_followed_by_fence) = match first_leaf_block {
         Some(b) => (b.start, true),
         None => (markdown.len(), false),
     };

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -187,7 +187,7 @@ impl Document {
     ///   `validate_document`.
     ///
     /// Schema-aware migration (clearing orphans, applying defaults, etc.) is
-    /// the caller's responsibility — `set_card_tag` is a structural primitive.
+    /// the caller's responsibility — `set_leaf_tag` is a structural primitive.
     ///
     /// # Invariants enforced
     ///
@@ -199,7 +199,7 @@ impl Document {
     /// # Warnings
     ///
     /// This method never modifies `warnings`.
-    pub fn set_card_tag(
+    pub fn set_leaf_tag(
         &mut self,
         index: usize,
         new_tag: impl Into<String>,

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -7,7 +7,7 @@
 use crate::error::ParseError;
 use crate::{Diagnostic, Severity};
 
-use super::assemble::MetadataBlock;
+use super::assemble::{BlockSentinel, MetadataBlock};
 use super::sentinel::first_content_key;
 
 /// Line-oriented view of the source.
@@ -111,34 +111,22 @@ pub(super) fn code_fence_on_line(
     }
 }
 
-/// Extract the info string from a fence-opener line (everything after the
-/// fence-char run, with surrounding whitespace trimmed).
-fn code_fence_info_string(line: &str) -> &str {
+/// First whitespace-delimited token of a fence opener's info string, or
+/// `None` for non-opener lines and empty info strings.
+fn fence_info_first_token(line: &str) -> Option<&str> {
     let line = line.strip_suffix('\r').unwrap_or(line);
     let indent = line.as_bytes().iter().take_while(|&&b| b == b' ').count();
     let trimmed = &line[indent..];
-    let Some(&first) = trimmed.as_bytes().first() else {
-        return "";
-    };
+    let &first = trimmed.as_bytes().first()?;
     if first != b'`' && first != b'~' {
-        return "";
+        return None;
     }
     let run_len = trimmed
         .as_bytes()
         .iter()
         .take_while(|&&b| b == first)
         .count();
-    trimmed[run_len..].trim()
-}
-
-/// First whitespace-delimited token of an info string.
-fn first_info_token(info: &str) -> Option<&str> {
-    let trimmed = info.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.split_whitespace().next().unwrap())
-    }
+    trimmed[run_len..].split_whitespace().next()
 }
 
 /// Outcome of the fence-detection pass: the recognised metadata blocks
@@ -172,15 +160,8 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
             k += 1;
             continue;
         }
-        let mut closer_k: Option<usize> = None;
-        let mut j = k + 1;
-        while j < lines.len() {
-            if is_fence_marker_line(lines.line_text(j)) {
-                closer_k = Some(j);
-                break;
-            }
-            j += 1;
-        }
+        let closer_k =
+            (k + 1..lines.len()).find(|&j| is_fence_marker_line(lines.line_text(j)));
 
         let content_start = lines.line_end_inclusive(k);
         let content_end = closer_k
@@ -250,21 +231,14 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
         }
 
         if let Some((ch, run_len, _)) = code_fence_on_line(text, None) {
-            let info = code_fence_info_string(text);
-            if first_info_token(info) == Some("leaf") {
+            if fence_info_first_token(text) == Some("leaf") {
                 let opener_k = k;
-                let mut closer_k: Option<usize> = None;
-                let mut j = k + 1;
-                while j < lines.len() {
-                    if let Some((_, _, true)) =
-                        code_fence_on_line(lines.line_text(j), Some((ch, run_len)))
-                    {
-                        closer_k = Some(j);
-                        break;
-                    }
-                    j += 1;
-                }
-                let Some(cj) = closer_k else {
+                let Some(cj) = (k + 1..lines.len()).find(|&j| {
+                    matches!(
+                        code_fence_on_line(lines.line_text(j), Some((ch, run_len))),
+                        Some((_, _, true))
+                    )
+                }) else {
                     return Err(ParseError::InvalidStructure(format!(
                         "Leaf fence opened at line {} but never closed",
                         opener_k + 1
@@ -318,7 +292,10 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
         k += 1;
     }
 
-    let leaf_count = blocks.iter().filter(|b| b.tag.is_some()).count();
+    let leaf_count = blocks
+        .iter()
+        .filter(|b| matches!(b.sentinel, BlockSentinel::Leaf(_)))
+        .count();
     if leaf_count > crate::error::MAX_LEAF_COUNT {
         return Err(ParseError::InputTooLarge {
             size: leaf_count,

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -276,6 +276,27 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                 let content_end = lines.line_start(cj);
                 let block_end = lines.line_end_inclusive(cj);
 
+                // Spec §3.2/§9, LEAF_REWORK.md §3.3: leaf-info-string fence
+                // commits to leaf parsing; missing or misplaced `KIND:` is a
+                // hard error, not a silent classification miss.
+                let content = &markdown[content_start..content_end];
+                match first_content_key(content) {
+                    Some("KIND") => {}
+                    Some(other) => {
+                        return Err(ParseError::InvalidStructure(format!(
+                            "Leaf fence at line {} must have `KIND:` as its first body key (found `{}:`).",
+                            opener_k + 1,
+                            other
+                        )));
+                    }
+                    None => {
+                        return Err(ParseError::InvalidStructure(format!(
+                            "Leaf fence at line {} is missing required `KIND:` first body key.",
+                            opener_k + 1
+                        )));
+                    }
+                }
+
                 let block = super::assemble::build_block(
                     markdown,
                     abs_pos,

--- a/crates/core/src/document/sentinel.rs
+++ b/crates/core/src/document/sentinel.rs
@@ -7,7 +7,7 @@ use crate::error::ParseError;
 use crate::version::QuillReference;
 
 /// Validate tag name follows pattern [a-z_][a-z0-9_]*
-pub(super) fn is_valid_tag_name(name: &str) -> bool {
+pub(crate) fn is_valid_tag_name(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
@@ -53,18 +53,30 @@ pub(super) fn first_content_key(content: &str) -> Option<&str> {
     }
 }
 
+/// Clone `mapping`, strip `key`, return the remainder (or `None` if empty).
+///
+/// `serde_json::Map` with the `preserve_order` feature (enabled in this
+/// workspace) is backed by `indexmap::IndexMap`; its default `remove` is
+/// `swap_remove` (O(1) but order-disrupting). We use `shift_remove` so that
+/// the surviving keys keep their source order.
+fn strip_key(
+    mapping: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<serde_json::Value> {
+    let mut m = mapping.clone();
+    m.shift_remove(key);
+    (!m.is_empty()).then(|| serde_json::Value::Object(m))
+}
+
 /// Extract `QUILL` / `KIND` sentinels and remaining fields from a parsed-YAML
 /// mapping. Returns `(tag, quill_ref, yaml_without_sentinel)`.
 #[allow(clippy::type_complexity)]
 pub(super) fn extract_sentinels(
     parsed: serde_json::Value,
-    _markdown: &str,
-    _abs_pos: usize,
-    _block_index: usize,
 ) -> Result<(Option<String>, Option<String>, Option<serde_json::Value>), ParseError> {
     let Some(mapping) = parsed.as_object() else {
-        // Non-mapping (scalar/sequence); keep as-is — upstream will reject if
-        // it's a frontmatter/leaf mapping was expected.
+        // Non-mapping (scalar/sequence); pass through — upstream will reject
+        // if a frontmatter/leaf mapping was expected.
         return Ok((None, None, Some(parsed)));
     };
 
@@ -77,7 +89,7 @@ pub(super) fn extract_sentinels(
         ));
     }
 
-    // Reserved keys (BODY, LEAVES) — spec §3
+    // Reserved keys (BODY, LEAVES) — spec §3.
     for reserved in ["BODY", "LEAVES"] {
         if mapping.contains_key(reserved) {
             return Err(ParseError::InvalidStructure(format!(
@@ -96,19 +108,7 @@ pub(super) fn extract_sentinels(
         quill_str.parse::<QuillReference>().map_err(|e| {
             ParseError::InvalidStructure(format!("Invalid QUILL reference '{}': {}", quill_str, e))
         })?;
-        let mut new_map = mapping.clone();
-        // Use `shift_remove` (order-preserving, O(n)) rather than the
-        // default `remove` which is `swap_remove` (O(1), disrupts order).
-        // serde_json::Map with `preserve_order` uses indexmap internally;
-        // its `.remove()` calls `swap_remove`, not `shift_remove`, so we
-        // call `shift_remove` explicitly to maintain insertion order.
-        new_map.shift_remove("QUILL");
-        let new_val = if new_map.is_empty() {
-            None
-        } else {
-            Some(serde_json::Value::Object(new_map))
-        };
-        Ok((None, Some(quill_str.to_string()), new_val))
+        Ok((None, Some(quill_str.to_string()), strip_key(mapping, "QUILL")))
     } else if has_leaf {
         let field_name = mapping
             .get("KIND")
@@ -121,14 +121,11 @@ pub(super) fn extract_sentinels(
                 field_name
             )));
         }
-        let mut new_map = mapping.clone();
-        new_map.shift_remove("KIND");
-        let new_val = if new_map.is_empty() {
-            None
-        } else {
-            Some(serde_json::Value::Object(new_map))
-        };
-        Ok((Some(field_name.to_string()), None, new_val))
+        Ok((
+            Some(field_name.to_string()),
+            None,
+            strip_key(mapping, "KIND"),
+        ))
     } else {
         Ok((None, None, Some(parsed)))
     }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -259,17 +259,17 @@ Second item body."#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.leaves().len(), 2);
 
-    let card1 = &doc.leaves()[0];
-    assert_eq!(card1.tag(), "items");
+    let leaf1 = &doc.leaves()[0];
+    assert_eq!(leaf1.tag(), "items");
     assert_eq!(
-        card1.frontmatter().get("name").unwrap().as_str().unwrap(),
+        leaf1.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
 
-    let card2 = &doc.leaves()[1];
-    assert_eq!(card2.tag(), "items");
+    let leaf2 = &doc.leaves()[1];
+    assert_eq!(leaf2.tag(), "items");
     assert_eq!(
-        card2.frontmatter().get("name").unwrap().as_str().unwrap(),
+        leaf2.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 2"
     );
 }
@@ -373,7 +373,7 @@ Item body"#;
 }
 
 #[test]
-fn test_card_name_collision_with_array_field() {
+fn test_leaf_kind_name_collision_with_array_field() {
     // KIND type names CAN now conflict with frontmatter field names
     let markdown = r#"---
 QUILL: test_quill
@@ -442,7 +442,7 @@ BODY: Test
 }
 
 #[test]
-fn test_reserved_field_cards_rejected() {
+fn test_reserved_field_leaves_rejected() {
     // LEAVES reserved inside the QUILL frontmatter.
     let markdown = r#"---
 QUILL: test_quill
@@ -596,17 +596,17 @@ Section 1 body"#;
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.leaves().len(), 2);
 
-    let card0 = &doc.leaves()[0];
-    assert_eq!(card0.tag(), "items");
+    let leaf0 = &doc.leaves()[0];
+    assert_eq!(leaf0.tag(), "items");
     assert_eq!(
-        card0.frontmatter().get("name").unwrap().as_str().unwrap(),
+        leaf0.frontmatter().get("name").unwrap().as_str().unwrap(),
         "Item 1"
     );
 
-    let card1 = &doc.leaves()[1];
-    assert_eq!(card1.tag(), "sections");
+    let leaf1 = &doc.leaves()[1];
+    assert_eq!(leaf1.tag(), "sections");
     assert_eq!(
-        card1.frontmatter().get("title").unwrap().as_str().unwrap(),
+        leaf1.frontmatter().get("title").unwrap().as_str().unwrap(),
         "Section 1"
     );
 }
@@ -814,7 +814,7 @@ This is the memo body."#;
 }
 
 #[test]
-fn test_quill_with_card_blocks() {
+fn test_quill_with_leaf_blocks() {
     let markdown = r#"---
 QUILL: document
 title: Test Document
@@ -892,7 +892,7 @@ QUILL: 123
 }
 
 #[test]
-fn test_card_wrong_value_type() {
+fn test_leaf_wrong_value_type() {
     let markdown = r#"---
 QUILL: test_quill
 ---
@@ -910,7 +910,7 @@ KIND: 123
 }
 
 #[test]
-fn test_both_quill_and_card_error() {
+fn test_both_quill_and_kind_error() {
     let markdown = r#"---
 QUILL: test
 KIND: items
@@ -1647,7 +1647,7 @@ Body."#;
 // KIND block edge cases
 
 #[test]
-fn test_card_with_empty_body() {
+fn test_leaf_with_empty_body() {
     let markdown = r#"---
 QUILL: test_quill
 ---
@@ -1663,7 +1663,7 @@ name: Item
 }
 
 #[test]
-fn test_card_consecutive_blocks() {
+fn test_leaf_consecutive_blocks() {
     let markdown = r#"---
 QUILL: test_quill
 ---
@@ -1684,7 +1684,7 @@ id: 2
 }
 
 #[test]
-fn test_card_with_body_containing_dashes() {
+fn test_leaf_with_body_containing_dashes() {
     let markdown = r#"---
 QUILL: test_quill
 ---
@@ -1818,7 +1818,7 @@ fn test_body_with_trailing_newlines() {
 // See `assemble.rs::strip_f2_separator` and `MARKDOWN.md §3 F2`.
 
 #[test]
-fn test_f2_strip_global_body_followed_by_card_lf() {
+fn test_f2_strip_global_body_followed_by_leaf_lf() {
     // Global body followed by a KIND fence: the source's tail `\n\n` is
     // (content line terminator) + (F2 blank line). Strip exactly the F2 `\n`,
     // leaving `\n` as the content terminator.
@@ -1828,7 +1828,7 @@ fn test_f2_strip_global_body_followed_by_card_lf() {
 }
 
 #[test]
-fn test_f2_strip_global_body_followed_by_card_crlf() {
+fn test_f2_strip_global_body_followed_by_leaf_crlf() {
     // CRLF line endings: strip exactly one `\r\n` as the F2 separator.
     let markdown = "---\r\nQUILL: q\r\n---\r\n\r\nbody\r\n\r\n---\r\nKIND: x\r\n---\r\n";
     let doc = decompose(markdown).unwrap();
@@ -1840,7 +1840,7 @@ fn test_f2_strip_global_body_followed_by_card_crlf() {
 }
 
 #[test]
-fn test_f2_strip_card_body_followed_by_leaf() {
+fn test_f2_strip_leaf_body_followed_by_leaf() {
     // First leaf body is followed by another fence → F2 stripped.
     // Last leaf body is at EOF → preserved verbatim.
     let markdown = "---\nQUILL: q\n---\n\n```leaf\nKIND: a\n```\nfirst\n\n```leaf\nKIND: b\n```\nsecond\n";
@@ -1957,7 +1957,7 @@ fn test_guillemet_double_conversion_prevention() {
 }
 
 #[test]
-fn test_allowed_card_field_collision() {
+fn test_allowed_leaf_field_collision() {
     let markdown = r#"---
 QUILL: test_quill
 my_leaf: "some global value"

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -15,7 +15,7 @@ fn make_doc() -> Document {
 
 fn make_doc_with_leaves() -> Document {
     Document::from_markdown(
-        "---\nQUILL: test_quill\ntitle: Hello\n---\n\nBody.\n\n```leaf\nKIND: note\nfoo: bar\n```\n\nCard body.\n\n```leaf\nKIND: summary\n```\n",
+        "---\nQUILL: test_quill\ntitle: Hello\n---\n\nBody.\n\n```leaf\nKIND: note\nfoo: bar\n```\n\nLeaf body.\n\n```leaf\nKIND: summary\n```\n",
     )
     .unwrap()
 }
@@ -148,7 +148,7 @@ fn test_document_set_field_rejects_all_reserved_names() {
 // ── Reserved-name matrix: Leaf::set_field ────────────────────────────────────
 
 #[test]
-fn test_card_set_field_rejects_all_reserved_names() {
+fn test_leaf_set_field_rejects_all_reserved_names() {
     for &name in RESERVED_NAMES {
         let mut leaf = Leaf::new("note").unwrap();
         let result = leaf.set_field(name, qv("value"));
@@ -255,7 +255,7 @@ fn test_document_push_leaf() {
 // ── Document::insert_leaf ────────────────────────────────────────────────────
 
 #[test]
-fn test_document_insert_card_at_zero() {
+fn test_document_insert_leaf_at_zero() {
     let mut doc = make_doc_with_leaves(); // 2 leaves: note, summary
     let leaf = Leaf::new("intro").unwrap();
     doc.insert_leaf(0, leaf).unwrap();
@@ -265,7 +265,7 @@ fn test_document_insert_card_at_zero() {
 }
 
 #[test]
-fn test_document_insert_card_at_end() {
+fn test_document_insert_leaf_at_end() {
     let mut doc = make_doc_with_leaves(); // 2 leaves
     let len = doc.leaves().len();
     let leaf = Leaf::new("footer").unwrap();
@@ -274,7 +274,7 @@ fn test_document_insert_card_at_end() {
 }
 
 #[test]
-fn test_document_insert_card_out_of_range() {
+fn test_document_insert_leaf_out_of_range() {
     let mut doc = make_doc(); // 0 leaves
     let leaf = Leaf::new("note").unwrap();
     let result = doc.insert_leaf(1, leaf);
@@ -294,7 +294,7 @@ fn test_document_remove_leaf() {
 }
 
 #[test]
-fn test_document_remove_card_out_of_range() {
+fn test_document_remove_leaf_out_of_range() {
     let mut doc = make_doc();
     let removed = doc.remove_leaf(0);
     assert!(removed.is_none());
@@ -303,7 +303,7 @@ fn test_document_remove_card_out_of_range() {
 // ── Document::leaf_mut ───────────────────────────────────────────────────────
 
 #[test]
-fn test_document_card_mut() {
+fn test_document_leaf_mut() {
     let mut doc = make_doc_with_leaves();
     {
         let leaf = doc.leaf_mut(0).unwrap();
@@ -313,7 +313,7 @@ fn test_document_card_mut() {
 }
 
 #[test]
-fn test_document_card_mut_out_of_range() {
+fn test_document_leaf_mut_out_of_range() {
     let mut doc = make_doc();
     assert!(doc.leaf_mut(0).is_none());
 }
@@ -321,7 +321,7 @@ fn test_document_card_mut_out_of_range() {
 // ── Document::move_leaf ──────────────────────────────────────────────────────
 
 #[test]
-fn test_move_card_no_op_same_index() {
+fn test_move_leaf_no_op_same_index() {
     let mut doc = make_doc_with_leaves(); // note(0), summary(1)
     let result = doc.move_leaf(0, 0);
     assert_eq!(result, Ok(()));
@@ -330,7 +330,7 @@ fn test_move_card_no_op_same_index() {
 }
 
 #[test]
-fn test_move_card_last_to_first() {
+fn test_move_leaf_last_to_first() {
     let mut doc = make_doc_with_leaves(); // note(0), summary(1)
     doc.move_leaf(1, 0).unwrap();
     assert_eq!(doc.leaves()[0].tag(), "summary");
@@ -338,7 +338,7 @@ fn test_move_card_last_to_first() {
 }
 
 #[test]
-fn test_move_card_first_to_last() {
+fn test_move_leaf_first_to_last() {
     let mut doc = make_doc_with_leaves(); // note(0), summary(1)
     let last = doc.leaves().len() - 1;
     doc.move_leaf(0, last).unwrap();
@@ -347,7 +347,7 @@ fn test_move_card_first_to_last() {
 }
 
 #[test]
-fn test_move_card_from_out_of_range() {
+fn test_move_leaf_from_out_of_range() {
     let mut doc = make_doc_with_leaves(); // 2 leaves
     let len = doc.leaves().len();
     let result = doc.move_leaf(len, 0);
@@ -355,19 +355,19 @@ fn test_move_card_from_out_of_range() {
 }
 
 #[test]
-fn test_move_card_to_out_of_range() {
+fn test_move_leaf_to_out_of_range() {
     let mut doc = make_doc_with_leaves(); // 2 leaves
     let len = doc.leaves().len();
     let result = doc.move_leaf(0, len);
     assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
 }
 
-// ── Document::set_card_tag ───────────────────────────────────────────────────
+// ── Document::set_leaf_tag ───────────────────────────────────────────────────
 
 #[test]
-fn test_set_card_tag_renames_in_place() {
+fn test_set_leaf_tag_renames_in_place() {
     let mut doc = make_doc_with_leaves(); // note(0) with field foo=bar, summary(1)
-    doc.set_card_tag(0, "annotation").unwrap();
+    doc.set_leaf_tag(0, "annotation").unwrap();
     // Sentinel changed.
     assert_eq!(doc.leaves()[0].tag(), "annotation");
     // Frontmatter and body untouched.
@@ -380,10 +380,10 @@ fn test_set_card_tag_renames_in_place() {
 }
 
 #[test]
-fn test_set_card_tag_rejects_invalid_tag() {
+fn test_set_leaf_tag_rejects_invalid_tag() {
     let mut doc = make_doc_with_leaves();
     for bad in ["", "Bad", "with-dash", "1leading_digit"] {
-        match doc.set_card_tag(0, bad) {
+        match doc.set_leaf_tag(0, bad) {
             Err(EditError::InvalidTagName(t)) => assert_eq!(t, bad),
             other => panic!("expected InvalidTagName for {bad:?}, got {other:?}"),
         }
@@ -393,19 +393,19 @@ fn test_set_card_tag_rejects_invalid_tag() {
 }
 
 #[test]
-fn test_set_card_tag_index_out_of_range() {
+fn test_set_leaf_tag_index_out_of_range() {
     let mut doc = make_doc_with_leaves();
     let len = doc.leaves().len();
-    let result = doc.set_card_tag(len, "annotation");
+    let result = doc.set_leaf_tag(len, "annotation");
     assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
 }
 
 #[test]
-fn test_set_card_tag_round_trips_via_markdown() {
+fn test_set_leaf_tag_round_trips_via_markdown() {
     // Verify that renaming a leaf and re-emitting markdown produces a doc
     // that re-parses with the new tag.
     let mut doc = make_doc_with_leaves();
-    doc.set_card_tag(0, "annotation").unwrap();
+    doc.set_leaf_tag(0, "annotation").unwrap();
     let md = doc.to_markdown();
     let reparsed = crate::Document::from_markdown(&md).unwrap();
     assert_eq!(reparsed.leaves()[0].tag(), "annotation");
@@ -414,7 +414,7 @@ fn test_set_card_tag_round_trips_via_markdown() {
 // ── Leaf::new ────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_card_new_valid() {
+fn test_leaf_new_valid() {
     let leaf = Leaf::new("note").unwrap();
     assert_eq!(leaf.tag(), "note");
     assert!(leaf.frontmatter().is_empty());
@@ -422,7 +422,7 @@ fn test_card_new_valid() {
 }
 
 #[test]
-fn test_card_new_invalid_tag_rejected() {
+fn test_leaf_new_invalid_tag_rejected() {
     for tag in ["Note", "", "my-leaf"] {
         assert_eq!(
             Leaf::new(tag),
@@ -434,7 +434,7 @@ fn test_card_new_invalid_tag_rejected() {
 // ── Leaf::set_field ──────────────────────────────────────────────────────────
 
 #[test]
-fn test_card_set_field_valid() {
+fn test_leaf_set_field_valid() {
     let mut leaf = Leaf::new("note").unwrap();
     leaf.set_field("content", qv("Some text")).unwrap();
     assert_eq!(
@@ -444,7 +444,7 @@ fn test_card_set_field_valid() {
 }
 
 #[test]
-fn test_card_set_field_invalid_name() {
+fn test_leaf_set_field_invalid_name() {
     let mut leaf = Leaf::new("note").unwrap();
     let result = leaf.set_field("Content", qv("text"));
     assert_eq!(
@@ -456,7 +456,7 @@ fn test_card_set_field_invalid_name() {
 // ── Leaf::remove_field ───────────────────────────────────────────────────────
 
 #[test]
-fn test_card_remove_field_existing() {
+fn test_leaf_remove_field_existing() {
     let mut doc = make_doc_with_leaves();
     // doc.leaves()[0] is "note" with field "foo" = "bar"
     let leaf = doc.leaf_mut(0).unwrap();
@@ -466,13 +466,13 @@ fn test_card_remove_field_existing() {
 }
 
 #[test]
-fn test_card_remove_field_absent() {
+fn test_leaf_remove_field_absent() {
     let mut leaf = Leaf::new("note").unwrap();
     assert!(leaf.remove_field("nonexistent").unwrap().is_none());
 }
 
 #[test]
-fn test_card_remove_field_reserved_throws() {
+fn test_leaf_remove_field_reserved_throws() {
     let mut leaf = Leaf::new("note").unwrap();
     for reserved in ["BODY", "LEAVES", "QUILL", "KIND"] {
         match leaf.remove_field(reserved) {
@@ -483,7 +483,7 @@ fn test_card_remove_field_reserved_throws() {
 }
 
 #[test]
-fn test_card_remove_field_invalid_name_throws() {
+fn test_leaf_remove_field_invalid_name_throws() {
     let mut leaf = Leaf::new("note").unwrap();
     match leaf.remove_field("Bad-Name") {
         Err(EditError::InvalidFieldName(name)) => assert_eq!(name, "Bad-Name"),
@@ -494,7 +494,7 @@ fn test_card_remove_field_invalid_name_throws() {
 // ── Leaf::set_body ───────────────────────────────────────────────────────────
 
 #[test]
-fn test_card_set_body() {
+fn test_leaf_set_body() {
     let mut leaf = Leaf::new("note").unwrap();
     leaf.replace_body("Leaf body text.");
     assert_eq!(leaf.body(), "Leaf body text.");

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -253,7 +253,7 @@ Leaf body here.
 }
 
 #[test]
-fn round_trip_card_empty_body() {
+fn round_trip_leaf_empty_body() {
     let src = "\
 ---
 QUILL: q

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -415,16 +415,16 @@ pub fn normalize_document(
         .leaves()
         .iter()
         .map(|leaf| {
-            let normalized_card_fields: IndexMap<String, QuillValue> = leaf
+            let normalized_leaf_fields: IndexMap<String, QuillValue> = leaf
                 .frontmatter()
                 .iter()
                 .map(|(k, v)| (normalize_field_name(k), v.clone()))
                 .collect();
-            let normalized_card_body = normalize_markdown(leaf.body());
+            let normalized_leaf_body = normalize_markdown(leaf.body());
             Leaf::new_with_sentinel(
                 Sentinel::Leaf(leaf.tag()),
-                crate::document::Frontmatter::from_index_map(normalized_card_fields),
-                normalized_card_body,
+                crate::document::Frontmatter::from_index_map(normalized_leaf_fields),
+                normalized_leaf_body,
             )
         })
         .collect();
@@ -801,7 +801,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_document_card_body_bidi_stripped() {
+    fn test_normalize_document_leaf_body_bidi_stripped() {
         use crate::document::Document;
 
         let md = "---\nQUILL: test\n---\n\nbody\n\n```leaf\nKIND: note\n```\nleaf\u{202D}body\n";
@@ -812,7 +812,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_document_card_field_bidi_preserved() {
+    fn test_normalize_document_leaf_field_bidi_preserved() {
         use crate::document::Document;
 
         let md = "---\nQUILL: test\n---\n\nbody\n\n```leaf\nKIND: note\nname: Ali\u{202D}ce\n```\n";
@@ -831,7 +831,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_document_card_body_html_comment_repair() {
+    fn test_normalize_document_leaf_body_html_comment_repair() {
         use crate::document::Document;
 
         let md = "---\nQUILL: test\n---\n\n```leaf\nKIND: note\n```\n<!-- comment -->Trailing text\n";

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -17,8 +17,8 @@ pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;
 pub use types::{
-    field_key, ui_key, BodyCardSchema, LeafSchema, FieldSchema, FieldType, UiCardSchema,
-    UiFieldSchema,
+    field_key, ui_key, BodyLeafSchema, FieldSchema, FieldType, LeafSchema, UiFieldSchema,
+    UiLeafSchema,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -12,7 +12,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::formats::DATE_FORMAT;
-use super::{BodyCardSchema, LeafSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
+use super::{BodyLeafSchema, LeafSchema, FieldSchema, FieldType, UiLeafSchema, UiFieldSchema};
 
 /// Top-level configuration for a Quillmark project
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -54,8 +54,8 @@ struct LeafSchemaDef {
     // Fields are re-parsed via `parse_fields_with_order` for ordering.
     #[allow(dead_code)]
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
-    pub ui: Option<UiCardSchema>,
-    pub body: Option<BodyCardSchema>,
+    pub ui: Option<UiLeafSchema>,
+    pub body: Option<BodyLeafSchema>,
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -939,9 +939,9 @@ impl QuillConfig {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let ui_section: Option<UiCardSchema> = match quill_section.get("ui").cloned() {
+        let ui_section: Option<UiLeafSchema> = match quill_section.get("ui").cloned() {
             None => None,
-            Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
+            Some(v) => match serde_json::from_value::<UiLeafSchema>(v) {
                 Ok(parsed) => Some(parsed),
                 Err(e) => {
                     errors.push(
@@ -1034,12 +1034,12 @@ impl QuillConfig {
 
         // Extract main.ui (optional). Fail loudly on malformed UI metadata rather
         // than silently dropping it — see `quill.ui` handling above.
-        let main_ui: Option<UiCardSchema> = match main_obj_opt
+        let main_ui: Option<UiLeafSchema> = match main_obj_opt
             .and_then(|main_obj| main_obj.get("ui"))
             .cloned()
         {
             None => None,
-            Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
+            Some(v) => match serde_json::from_value::<UiLeafSchema>(v) {
                 Ok(parsed) => Some(parsed),
                 Err(e) => {
                     errors.push(
@@ -1053,12 +1053,12 @@ impl QuillConfig {
         };
 
         // Extract main.body (optional). Fail loudly on malformed body metadata.
-        let main_body: Option<BodyCardSchema> = match main_obj_opt
+        let main_body: Option<BodyLeafSchema> = match main_obj_opt
             .and_then(|main_obj| main_obj.get("body"))
             .cloned()
         {
             None => None,
-            Some(v) => match serde_json::from_value::<BodyCardSchema>(v) {
+            Some(v) => match serde_json::from_value::<BodyLeafSchema>(v) {
                 Ok(parsed) => Some(parsed),
                 Err(e) => {
                     errors.push(
@@ -1101,7 +1101,7 @@ impl QuillConfig {
                             Severity::Error,
                             "'leaf_kinds' section must be an object (mapping of type names to schemas)".to_string(),
                         )
-                        .with_code("quill::invalid_card_types".to_string()),
+                        .with_code("quill::invalid_leaf_kinds".to_string()),
                     );
                 }
                 Some(leaf_kinds_table) => {
@@ -1116,7 +1116,7 @@ impl QuillConfig {
                                         leaf_name
                                     ),
                                 )
-                                .with_code("quill::invalid_card_name".to_string()),
+                                .with_code("quill::invalid_leaf_kind_name".to_string()),
                             );
                             continue;
                         }
@@ -1134,7 +1134,7 @@ impl QuillConfig {
                                                 leaf_name, e
                                             ),
                                         )
-                                        .with_code("quill::invalid_card_schema".to_string()),
+                                        .with_code("quill::invalid_leaf_kind_schema".to_string()),
                                     );
                                     continue;
                                 }
@@ -1176,7 +1176,7 @@ impl QuillConfig {
         // Warn when `body.example` is set together with `body.enabled: false` —
         // the example has no effect since the body editor is disabled.
         let warn_example_unused = |label: &str,
-                                   body: &Option<BodyCardSchema>|
+                                   body: &Option<BodyLeafSchema>|
          -> Option<Diagnostic> {
             let body = body.as_ref()?;
             if body.enabled == Some(false) && body.example.is_some() {
@@ -1211,7 +1211,7 @@ impl QuillConfig {
         // spaces and optional trailing whitespace). Such a line would split the
         // blueprint body region into a new fence, corrupting document structure.
         let err_example_contains_fence = |label: &str,
-                                          body: &Option<BodyCardSchema>|
+                                          body: &Option<BodyLeafSchema>|
          -> Option<Diagnostic> {
             let example = body.as_ref()?.example.as_deref()?;
             if example_contains_fence_line(example) {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -702,16 +702,6 @@ impl QuillConfig {
         chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
     }
 
-    fn is_valid_card_identifier(name: &str) -> bool {
-        let mut chars = name.chars();
-        match chars.next() {
-            Some(c) if c.is_ascii_lowercase() || c == '_' => {}
-            _ => return false,
-        }
-
-        chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
-    }
-
     fn is_valid_quill_name(name: &str) -> bool {
         name == "__default__" || Self::is_snake_case_identifier(name)
     }
@@ -1116,7 +1106,7 @@ impl QuillConfig {
                 }
                 Some(leaf_kinds_table) => {
                     for (leaf_name, leaf_value) in leaf_kinds_table {
-                        if !Self::is_valid_card_identifier(leaf_name) {
+                        if !crate::document::sentinel::is_valid_tag_name(leaf_name) {
                             errors.push(
                                 Diagnostic::new(
                                     Severity::Error,

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -201,7 +201,7 @@ main:
     }
 
     #[test]
-    fn injects_body_as_markdown_for_main_and_each_card_type() {
+    fn injects_body_as_markdown_for_main_and_each_leaf_kind() {
         let yaml = r#"
 quill:
   name: example

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -48,7 +48,7 @@ leaf_kinds:
     }
 
     #[test]
-    fn omits_card_types_when_absent() {
+    fn omits_leaf_kinds_when_absent() {
         let yaml = cfg(r#"
 quill: { name: solo, version: "1.0", backend: typst, description: x }
 main:

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1011,7 +1011,7 @@ quill:
 }
 
 #[test]
-fn test_quill_config_rejects_non_snake_case_card_name() {
+fn test_quill_config_rejects_non_snake_case_leaf_kind_name() {
     let yaml = r#"
 quill:
   name: good_quill
@@ -1034,7 +1034,7 @@ leaf_kinds:
 }
 
 #[test]
-fn test_quill_config_accepts_leading_underscore_card_name() {
+fn test_quill_config_accepts_leading_underscore_leaf_kind_name() {
     let yaml = r#"
 quill:
   name: good_quill
@@ -1076,10 +1076,10 @@ main:
 }
 
 #[test]
-fn test_quill_config_rejects_non_snake_case_card_field_keys() {
+fn test_quill_config_rejects_non_snake_case_leaf_field_keys() {
     let yaml = r#"
 quill:
-  name: bad_card_field_key
+  name: bad_leaf_field_key
   version: "1.0"
   backend: typst
   description: Bad leaf field key
@@ -1222,7 +1222,7 @@ main:
 }
 
 #[test]
-fn test_card_defaults_method() {
+fn test_leaf_defaults_method() {
     let yaml_content = r#"
 quill:
   name: leaf_defaults_test
@@ -1358,7 +1358,7 @@ ui:
 }
 
 #[test]
-fn test_parse_card_field_type() {
+fn test_parse_leaf_field_type() {
     // Test that FieldSchema no longer supports type = "leaf" (leaves are in LeafSchema now)
     let yaml = r#"
 type: "string"
@@ -1376,7 +1376,7 @@ description: "A simple string field"
 }
 
 #[test]
-fn test_parse_card_with_fields_in_yaml() {
+fn test_parse_leaf_with_fields_in_yaml() {
     // Test parsing [leaves] section with [leaves.X.fields.Y] syntax
     let yaml_content = r#"
 quill:
@@ -1450,7 +1450,7 @@ invalid_key:
 }
 
 #[test]
-fn test_quill_config_with_cards_section() {
+fn test_quill_config_with_leaf_kinds_section() {
     let yaml_content = r#"
 quill:
   name: leaves_test
@@ -1488,7 +1488,7 @@ leaf_kinds:
 }
 
 #[test]
-fn test_quill_config_cards_empty_fields() {
+fn test_quill_config_leaf_kinds_empty_fields() {
     // Test that leaves with no fields section are valid
     let yaml_content = r#"
 quill:
@@ -1510,7 +1510,7 @@ leaf_kinds:
 }
 
 #[test]
-fn test_quill_config_allows_card_collision() {
+fn test_quill_config_allows_leaf_kind_collision() {
     // Test that scope name colliding with field name is ALLOWED
     let yaml_content = r#"
 quill:
@@ -1589,11 +1589,11 @@ leaf_kinds:
 
     // Leaf fields should also have ordering
     let leaf_field = second.fields.get("leaf_field").unwrap();
-    let ord_card_field = leaf_field.ui.as_ref().unwrap().order.unwrap();
-    assert_eq!(ord_card_field, 0); // First (and only) field in this leaf
+    let ord_leaf_field = leaf_field.ui.as_ref().unwrap().order.unwrap();
+    assert_eq!(ord_leaf_field, 0); // First (and only) field in this leaf
 }
 #[test]
-fn test_card_field_order_preservation() {
+fn test_leaf_field_order_preservation() {
     // Test that leaf fields preserve definition order (not alphabetical)
     // defined: z_first, then a_second
     // alphabetical: a_second, then z_first
@@ -1957,10 +1957,10 @@ main:
 }
 
 #[test]
-fn test_config_coerce_cards_item_wise() {
+fn test_config_coerce_leaves_item_wise() {
     let yaml_content = r#"
 quill:
-  name: coerce_cards_items_test
+  name: coerce_leaves_items_test
   version: "1.0"
   backend: typst
   description: Coerce leaves
@@ -2115,7 +2115,7 @@ main:
 }
 
 #[test]
-fn test_card_ui_title_parses_literal_and_template_forms() {
+fn test_leaf_ui_title_parses_literal_and_template_forms() {
     let yaml_content = r#"
 quill:
   name: leaf_title_test
@@ -2164,7 +2164,7 @@ leaf_kinds:
 }
 
 #[test]
-fn test_card_ui_title_omitted_when_absent() {
+fn test_leaf_ui_title_omitted_when_absent() {
     let yaml_content = r#"
 quill:
   name: no_title_test
@@ -2549,7 +2549,7 @@ main:
 }
 
 #[test]
-fn body_example_card_type_fence_line_is_an_error() {
+fn body_example_leaf_kind_fence_line_is_an_error() {
     // The fence check applies to leaf-type body examples too.
     let yaml = r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -70,7 +70,7 @@ pub struct UiFieldSchema {
 /// Body namespace configuration for a leaf type
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct BodyCardSchema {
+pub struct BodyLeafSchema {
     /// Whether the body editor is enabled for this leaf (default: true).
     /// When false, consumers must not accept or store body content for instances
     /// of this leaf type.
@@ -85,7 +85,7 @@ pub struct BodyCardSchema {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct UiCardSchema {
+pub struct UiLeafSchema {
     /// Display label for the leaf type — literal string or `{field_name}`
     /// template. See `docs/format-designer/quill-yaml-reference.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -106,11 +106,11 @@ pub struct LeafSchema {
     pub fields: BTreeMap<String, FieldSchema>,
     /// UI layout hints
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ui: Option<UiCardSchema>,
+    pub ui: Option<UiLeafSchema>,
     /// Body namespace: controls whether a body editor is shown and provides
     /// optional guide text.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<BodyCardSchema>,
+    pub body: Option<BodyLeafSchema>,
 }
 
 impl LeafSchema {

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -656,7 +656,7 @@ main:
     }
 
     #[test]
-    fn validates_multiple_card_types_mixed() {
+    fn validates_multiple_leaf_kinds_mixed() {
         let config = config_with(
             "    title:\n      type: string",
             "leaf_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true\n  routing:\n    fields:\n      office:\n        type: string\n        required: true",

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -247,7 +247,7 @@ fn body_crlf_line_endings_are_normalized() {
 // §7 — CRLF normalization reaches leaf bodies.
 #[test]
 fn leaf_body_crlf_line_endings_are_normalized() {
-    let md = "---\nQUILL: t\n---\n\n```leaf\nKIND: x\n```\n\nCard line one.\r\nCard line two.\r\n";
+    let md = "---\nQUILL: t\n---\n\n```leaf\nKIND: x\n```\n\nLeaf line one.\r\nLeaf line two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     let body = doc.leaves()[0].body();

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -121,6 +121,30 @@ fn leaves_is_always_present_even_when_empty() {
     assert!(doc.leaves().is_empty());
 }
 
+// §3.2 / §9 — A leaf-info-string fence missing `KIND:` first-key is a hard
+// parse error, not a silent fallthrough to body content. This is the central
+// "no silent classification miss" promise of LEAF_REWORK.md §3.3.
+#[test]
+fn leaf_fence_without_kind_first_key_is_rejected() {
+    let cases = [
+        // Missing KIND entirely.
+        "---\nQUILL: t\n---\n\n```leaf\nname: Widget\n```\n",
+        // Empty leaf body.
+        "---\nQUILL: t\n---\n\n```leaf\n```\n",
+        // KIND present but not first.
+        "---\nQUILL: t\n---\n\n```leaf\nname: Widget\nKIND: product\n```\n",
+        // QUILL inside a leaf fence (sentinel-mismatch).
+        "---\nQUILL: t\n---\n\n```leaf\nQUILL: other@1\n```\n",
+    ];
+    for md in cases {
+        let err = Document::from_markdown(md).unwrap_err().to_string();
+        assert!(
+            err.contains("KIND") && err.contains("Leaf fence"),
+            "expected hard KIND error for {md:?}, got: {err}"
+        );
+    }
+}
+
 // §5 — KIND value pattern.
 #[test]
 fn leaf_name_pattern_enforced() {
@@ -157,7 +181,7 @@ fn normalize_yaml_scalar_keeps_bidi() {
 
 // §7 — Leaf body normalization reaches nested leaves.
 #[test]
-fn normalize_reaches_card_body() {
+fn normalize_reaches_leaf_body() {
     let md = "---\nQUILL: t\n---\n\n```leaf\nKIND: x\n```\n\n<!-- c -->trailing\u{202D}text";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();

--- a/crates/fuzz/src/emit_roundtrip_fuzz.rs
+++ b/crates/fuzz/src/emit_roundtrip_fuzz.rs
@@ -111,7 +111,7 @@ proptest! {
         leaf_value in "[a-zA-Z0-9 ]{0,50}"
     ) {
         let src = format!(
-            "---\nQUILL: {}\ntitle: \"test\"\n---\n\nBody here.\n\n```leaf\nKIND: {}\n{}: \"{}\"\n```\n\nCard body.\n",
+            "---\nQUILL: {}\ntitle: \"test\"\n---\n\nBody here.\n\n```leaf\nKIND: {}\n{}: \"{}\"\n```\n\nLeaf body.\n",
             quill, leaf_tag, leaf_key, leaf_value
         );
 

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -41,7 +41,7 @@
 //!
 //! Leaves whose tag is not declared in the schema are dropped from
 //! [`Form::leaves`]. Each such leaf produces one [`Diagnostic`] in
-//! [`Form::diagnostics`] with code `"form::unknown_card_tag"`.
+//! [`Form::diagnostics`] with code `"form::unknown_leaf_kind"`.
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -108,7 +108,7 @@ impl FormLeaf {
 /// # Unknown leaves
 ///
 /// Document leaves whose tag is not declared in the schema are dropped and
-/// each produces a [`Diagnostic`] with code `"form::unknown_card_tag"` in
+/// each produces a [`Diagnostic`] with code `"form::unknown_leaf_kind"` in
 /// [`Form::diagnostics`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Form {
@@ -124,7 +124,7 @@ pub struct Form {
 
 // ── Internal projection ─────────────────────────────────────────────────────
 //
-// `project_leaf`, `build_form`, and `blank_card_for_tag` are the internal
+// `project_leaf`, `build_form`, and `blank_leaf_for_kind` are the internal
 // machinery used by `Quill::form`, `Quill::blank_main`, and
 // `Quill::blank_leaf`. They are **deliberately not public**: consumers
 // reach the form module through methods on `Quill`, never by holding a
@@ -164,7 +164,7 @@ pub(crate) fn build_form(quill: &Quill, doc: &Document) -> Form {
                              excluded from the form view"
                         ),
                     )
-                    .with_code("form::unknown_card_tag".to_string()),
+                    .with_code("form::unknown_leaf_kind".to_string()),
                 );
             }
         }
@@ -188,7 +188,7 @@ pub(crate) fn build_form(quill: &Quill, doc: &Document) -> Form {
 
 /// Build a blank [`FormLeaf`] for a leaf type by tag, or `None` if the tag
 /// isn't declared in the quill's schema.
-pub(crate) fn blank_card_for_tag(quill: &Quill, leaf_kind: &str) -> Option<FormLeaf> {
+pub(crate) fn blank_leaf_for_kind(quill: &Quill, leaf_kind: &str) -> Option<FormLeaf> {
     quill
         .source()
         .config()

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -129,14 +129,14 @@ main:
 }
 
 #[test]
-fn form_unknown_card_tag_drops_card_and_emits_diagnostic() {
+fn form_unknown_leaf_kind_drops_leaf_and_emits_diagnostic() {
     let quill = quill_from_yaml(
         r#"
 quill:
-  name: unknown_card_test
+  name: unknown_leaf_test
   version: "1.0"
   backend: typst
-  description: Unknown leaf tag test
+  description: Unknown leaf kind test
 
 main:
   fields:
@@ -151,7 +151,7 @@ leaf_kinds:
 "#,
     );
 
-    let md = "---\nQUILL: unknown_card_test\ntitle: \"T\"\n---\n\n\
+    let md = "---\nQUILL: unknown_leaf_test\ntitle: \"T\"\n---\n\n\
               ```leaf\nKIND: known_leaf\nnote: \"A\"\n```\n\n\
               ```leaf\nKIND: ghost_leaf\nnote: \"B\"\n```\n";
     let doc = Document::from_markdown(md).unwrap();
@@ -166,8 +166,8 @@ leaf_kinds:
     let unknown_diag = form
         .diagnostics
         .iter()
-        .find(|d| d.code.as_deref() == Some("form::unknown_card_tag"))
-        .expect("expected unknown_card_tag diagnostic");
+        .find(|d| d.code.as_deref() == Some("form::unknown_leaf_kind"))
+        .expect("expected unknown_leaf_kind diagnostic");
     assert!(
         unknown_diag.message.contains("ghost_leaf"),
         "diagnostic should name the tag: {:?}",
@@ -176,7 +176,7 @@ leaf_kinds:
 }
 
 #[test]
-fn form_card_field_sources() {
+fn form_leaf_field_sources() {
     let quill = quill_from_yaml(
         r#"
 quill:
@@ -413,11 +413,11 @@ main:
 }
 
 #[test]
-fn blank_card_returns_form_card_for_known_type() {
+fn blank_leaf_returns_form_leaf_for_known_kind() {
     let quill = quill_from_yaml(
         r#"
 quill:
-  name: blank_card_test
+  name: blank_leaf_test
   version: "1.0"
   backend: typst
   description: Blank leaf test
@@ -456,7 +456,7 @@ leaf_kinds:
 }
 
 #[test]
-fn blank_card_returns_none_for_unknown_type() {
+fn blank_leaf_returns_none_for_unknown_kind() {
     let quill = quill_from_yaml(
         r#"
 quill:

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -208,7 +208,7 @@ impl Quill {
     /// after editing `doc`.
     ///
     /// **Unknown leaf tags** are dropped from [`Form::leaves`] and surface as
-    /// `form::unknown_card_tag` diagnostics. Validation errors are appended
+    /// `form::unknown_leaf_kind` diagnostics. Validation errors are appended
     /// as `form::validation_error` diagnostics; the view itself is never
     /// altered or filtered by validation failures.
     pub fn form(&self, doc: &Document) -> Form {
@@ -232,7 +232,7 @@ impl Quill {
     /// This is the "user is about to add a new leaf" view: the UI can render
     /// the form before the leaf is committed to the document.
     pub fn blank_leaf(&self, leaf_kind: &str) -> Option<FormLeaf> {
-        form::blank_card_for_tag(self, leaf_kind)
+        form::blank_leaf_for_kind(self, leaf_kind)
     }
 
     fn validate_document(&self, doc: &Document) -> Result<(), RenderError> {

--- a/crates/quillmark/tests/security_tests.rs
+++ b/crates/quillmark/tests/security_tests.rs
@@ -29,7 +29,7 @@ fn test_yaml_depth_limit_attack() {
 
 /// Test leaf count limit prevents DoS
 #[test]
-fn test_card_count_limit_attack() {
+fn test_leaf_count_limit_attack() {
     // Generate more than MAX_LEAF_COUNT (1000) leaf blocks
     let mut markdown = String::from("---\nQUILL: test_quill\ntitle: Test\n---\n\nBody\n\n");
     for i in 0..1002 {
@@ -134,7 +134,7 @@ fn test_reserved_field_injection() {
 
 /// Test that KIND directive validation prevents invalid names
 #[test]
-fn test_card_name_validation() {
+fn test_leaf_kind_name_validation() {
     let invalid_names = vec![
         "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: Invalid-Name\n```\n\n",
         "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: 123start\n```\n\n",
@@ -170,7 +170,7 @@ fn test_yaml_error_location() {
 
 /// Test both QUILL and KIND in same block is rejected
 #[test]
-fn test_quill_card_conflict() {
+fn test_quill_leaf_conflict() {
     let markdown = "---\nQUILL: template\nKIND: item\n---\n\n";
     let result = Document::from_markdown(markdown);
 

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -37,7 +37,7 @@ boundary.
 ## 4. Diagnostic codes are unstable, undocumented strings
 
 `crates/quillmark/src/form.rs:167,178` use bare literals
-(`"form::unknown_card_tag"`, `"form::validation_error"`); edit errors
+(`"form::unknown_leaf_kind"`, `"form::validation_error"`); edit errors
 surface Rust variant names like `"ReservedName"`
 (`crates/bindings/wasm/src/engine.rs:571-577`). No exported enum, no
 constants, no stability guarantee. Consumers that key behavior off

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -56,7 +56,7 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - A required `QUILL` sentinel prepended to `main.fields` (`const = "<name>@<version>"`)
 - A required `KIND` sentinel prepended to each `leaf_kinds.<name>.fields` (`const = "<name>"`)
 
-`QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `LeafSchema`, `UiFieldSchema`, `UiCardSchema`, and `BodyCardSchema` — there is no parallel mirror struct.
+`QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `LeafSchema`, `UiFieldSchema`, `UiLeafSchema`, and `BodyLeafSchema` — there is no parallel mirror struct.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 


### PR DESCRIPTION
Proposes splitting Quillmark Markdown's overloaded `---/---` fence into
two distinct shapes: frontmatter retains `---/QUILL:/---` at top-of-file,
while inline records move to a CommonMark fenced code block (` ```leaf `)
with `KIND:` as the body-key discriminator. Documents the rationale for
choosing `leaf` over `yaml` as the info string, why `KIND:` lives as a
body key rather than an info-string token, and the migration scope
including binding API breakage and the `card` -> `leaf` vocabulary
rename. Includes honest accounting of tradeoffs (worse GitHub preview
legibility for leaves, IDE plugin required to close tooling gap,
partial F1/F2/F3 rule-count reduction) and open questions on rename
scope and deprecation window length.

https://claude.ai/code/session_01AmH4w5ikAhaGJ81Dzn5QtM