### PR TITLE
Add Release-N legacy `---/CARD:---` parser for round-trip migration

### DIFF
--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -39,6 +39,44 @@ fn strip_f2_separator(body: &str) -> &str {
     }
 }
 
+/// Rewrite the first non-blank, non-comment line's `CARD:` prefix to `KIND:`.
+///
+/// Used by the Release-N legacy parser path (LEAF_REWORK.md §7) so that a
+/// document authored against the previous syntax (`---/CARD: foo/---`)
+/// produces the same `Leaf` as the canonical ` ```leaf / KIND: foo / ``` `
+/// form. The substitution is byte-for-byte length-preserving (both sentinels
+/// are four ASCII characters), so downstream offset bookkeeping is unaffected.
+/// Caller guarantees the first content key is `CARD:` before invoking.
+fn rewrite_first_card_to_kind(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut rewrote = false;
+    for line in content.split_inclusive('\n') {
+        if rewrote {
+            out.push_str(line);
+            continue;
+        }
+        let leading = line.len() - line.trim_start_matches([' ', '\t']).len();
+        let body = &line[leading..];
+        if body.trim().is_empty() || body.starts_with('#') {
+            out.push_str(line);
+            continue;
+        }
+        if let Some(rest) = body.strip_prefix("CARD:") {
+            out.push_str(&line[..leading]);
+            out.push_str("KIND:");
+            out.push_str(rest);
+            rewrote = true;
+        } else {
+            // First non-blank, non-comment line is not `CARD:` — caller
+            // should never invoke us in this case, but stay verbatim
+            // rather than corrupt the slice.
+            out.push_str(line);
+            rewrote = true;
+        }
+    }
+    out
+}
+
 /// Which sentinel a metadata block carries. `Main` is the top frontmatter's
 /// `QUILL:` reference (raw string, parsed to `QuillReference` later); `Leaf`
 /// is a leaf fence's `KIND:` tag.
@@ -83,6 +121,14 @@ fn yaml_parse_options() -> serde_saphyr::Options {
 /// `MetadataBlock`. `content_start` is the byte position immediately after
 /// the opening fence line; `content_end` is the byte position at the start
 /// of the closing fence line. Returns errors per spec §9.
+///
+/// When `legacy_card_to_kind` is true, the first occurrence of the literal
+/// sentinel key `CARD:` in the raw content is rewritten to `KIND:` before
+/// parsing. This is the Release-N round-trip migration path (LEAF_REWORK.md
+/// §7): legacy `---/CARD: …/---` blocks are recognised as leaves so the
+/// canonical emitter can rewrite them to ` ```leaf ` form on the next
+/// `to_markdown()`. Caller is responsible for verifying the first content
+/// key is actually `CARD:` and for emitting the deprecation warning.
 pub(super) fn build_block(
     markdown: &str,
     abs_pos: usize,
@@ -90,8 +136,15 @@ pub(super) fn build_block(
     content_end: usize,
     block_end: usize,
     block_index: usize,
+    legacy_card_to_kind: bool,
 ) -> Result<MetadataBlock, ParseError> {
-    let raw_content = &markdown[content_start..content_end];
+    let raw_content_owned: String;
+    let raw_content: &str = if legacy_card_to_kind {
+        raw_content_owned = rewrite_first_card_to_kind(&markdown[content_start..content_end]);
+        &raw_content_owned
+    } else {
+        &markdown[content_start..content_end]
+    };
 
     // Check YAML size limit (spec §8)
     if raw_content.len() > crate::error::MAX_YAML_SIZE {

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -185,6 +185,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                 content_end,
                 block_end,
                 0,
+                false,
             )?;
             blocks.push(block);
             post_frontmatter_k = cj + 1;
@@ -216,7 +217,15 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
         }
     }
 
-    // ── Step 2: leaf code fences ─────────────────────────────────────────────
+    // ── Step 2: leaves ───────────────────────────────────────────────────────
+    // Two paths interleave by source order:
+    //
+    // - **Canonical**: CommonMark fenced code block whose info-string first
+    //   token is `leaf`, body keyed by `KIND:`.
+    // - **Legacy (Release N only, LEAF_REWORK.md §7)**: `---/---` block (F2)
+    //   whose first body key is `CARD:`. Each occurrence emits a
+    //   `parse::deprecated_leaf_syntax` warning; the canonical emitter
+    //   rewrites it to ` ```leaf ` on round-trip.
     let mut k = post_frontmatter_k;
     let mut open_code_fence: Option<(u8, usize, usize)> = None;
     while k < lines.len() {
@@ -228,6 +237,46 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
             }
             k += 1;
             continue;
+        }
+
+        // Legacy `---/CARD: …/---` leaf — Release-N migration path.
+        if is_fence_marker_line(text) && (k == 0 || lines.is_blank(k - 1)) {
+            if let Some(cj) =
+                (k + 1..lines.len()).find(|&j| is_fence_marker_line(lines.line_text(j)))
+            {
+                let content_start = lines.line_end_inclusive(k);
+                let content_end = lines.line_start(cj);
+                let content = &markdown[content_start..content_end];
+                if first_content_key(content) == Some("CARD") {
+                    let abs_pos = lines.line_start(k);
+                    let block_end = lines.line_end_inclusive(cj);
+                    let block = super::assemble::build_block(
+                        markdown,
+                        abs_pos,
+                        content_start,
+                        content_end,
+                        block_end,
+                        blocks.len(),
+                        true,
+                    )?;
+                    blocks.push(block);
+                    warnings.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            format!(
+                                "Legacy `---/CARD: …/---` leaf at line {} is deprecated; \
+                                 round-trip through `Document::to_markdown` to rewrite as \
+                                 the canonical ` ```leaf / KIND: … / ``` ` form. The legacy \
+                                 path will be removed in the next release.",
+                                k + 1
+                            ),
+                        )
+                        .with_code("parse::deprecated_leaf_syntax".to_string()),
+                    );
+                    k = cj + 1;
+                    continue;
+                }
+            }
         }
 
         if let Some((ch, run_len, _)) = code_fence_on_line(text, None) {
@@ -278,6 +327,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                     content_end,
                     block_end,
                     blocks.len(),
+                    false,
                 )?;
                 blocks.push(block);
                 k = cj + 1;

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -2209,3 +2209,101 @@ fn frontmatter_field_order_preserved_after_quill_removal() {
         "Frontmatter fields must preserve insertion order after QUILL removal"
     );
 }
+
+// ── Legacy `---/CARD:/---` migration path (LEAF_REWORK.md §7) ──────────────
+
+/// A legacy `---/CARD:/---` block parses as a leaf and surfaces a
+/// `parse::deprecated_leaf_syntax` warning.
+#[test]
+fn legacy_card_block_parses_as_leaf_with_deprecation_warning() {
+    let md = "---\nQUILL: q\n---\n\n---\nCARD: note\nauthor: Alice\n---\n\nLeaf body.\n";
+    let doc = Document::from_markdown(md).unwrap();
+
+    assert_eq!(doc.leaves().len(), 1, "legacy CARD block must parse as leaf");
+    let leaf = &doc.leaves()[0];
+    assert_eq!(leaf.tag(), "note");
+    assert_eq!(
+        leaf.frontmatter()
+            .get("author")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        Some("Alice".to_string()),
+    );
+    assert!(leaf.body().contains("Leaf body."));
+
+    let warning_codes: Vec<_> = doc
+        .warnings()
+        .iter()
+        .filter_map(|w| w.code.as_deref())
+        .collect();
+    assert!(
+        warning_codes.contains(&"parse::deprecated_leaf_syntax"),
+        "expected parse::deprecated_leaf_syntax warning, got: {:?}",
+        warning_codes
+    );
+}
+
+/// `parse → to_markdown` rewrites legacy CARD blocks to canonical ` ```leaf `
+/// form. This is the consumer's one-step migration tool.
+#[test]
+fn legacy_card_round_trip_emits_canonical_leaf_fence() {
+    let legacy = "---\nQUILL: q\n---\n\n---\nCARD: note\nauthor: Alice\n---\n\nLeaf body.\n";
+    let doc = Document::from_markdown(legacy).unwrap();
+    let canonical = doc.to_markdown();
+
+    assert!(
+        canonical.contains("```leaf\nKIND: note"),
+        "emitted form must use canonical ```leaf / KIND: fence; got:\n{}",
+        canonical
+    );
+    assert!(
+        !canonical.contains("CARD:"),
+        "emitted form must not retain legacy CARD: sentinel; got:\n{}",
+        canonical
+    );
+
+    // Reparsing the canonical form yields the same leaf, with no
+    // deprecation warning this time.
+    let doc2 = Document::from_markdown(&canonical).unwrap();
+    assert_eq!(doc2.leaves().len(), 1);
+    assert_eq!(doc2.leaves()[0].tag(), "note");
+    let canonical_codes: Vec<_> = doc2
+        .warnings()
+        .iter()
+        .filter_map(|w| w.code.as_deref())
+        .collect();
+    assert!(
+        !canonical_codes.contains(&"parse::deprecated_leaf_syntax"),
+        "canonical re-emit must not re-trigger deprecation warning"
+    );
+}
+
+/// Mixed legacy and canonical leaves in the same document parse in source
+/// order; canonical re-emit normalises everything to ` ```leaf `.
+#[test]
+fn legacy_and_canonical_leaves_coexist_during_migration() {
+    let md = "---\nQUILL: q\n---\n\n---\nCARD: a\nx: 1\n---\n\nFirst body.\n\n```leaf\nKIND: b\ny: 2\n```\n\nSecond body.\n";
+    let doc = Document::from_markdown(md).unwrap();
+
+    assert_eq!(doc.leaves().len(), 2);
+    assert_eq!(doc.leaves()[0].tag(), "a");
+    assert_eq!(doc.leaves()[1].tag(), "b");
+
+    let canonical = doc.to_markdown();
+    assert!(canonical.contains("```leaf\nKIND: a"));
+    assert!(canonical.contains("```leaf\nKIND: b"));
+    assert!(!canonical.contains("CARD:"));
+}
+
+/// Legacy CARD blocks without F2 (no blank line above) are NOT leaves —
+/// they fall through to CommonMark thematic-break handling, same as today.
+#[test]
+fn legacy_card_without_f2_is_not_a_leaf() {
+    let md = "---\nQUILL: q\n---\n\nBody text directly above.\n---\nCARD: note\nauthor: Alice\n---\n";
+    let doc = Document::from_markdown(md).unwrap();
+    assert_eq!(
+        doc.leaves().len(),
+        0,
+        "F2 violation must prevent legacy-CARD recognition"
+    );
+}

--- a/prose/designs/LEAF_REWORK.md
+++ b/prose/designs/LEAF_REWORK.md
@@ -211,14 +211,15 @@ with the syntax:
 - Templates: `cards.X[i].field` → `leaves.X[i].field`.
 - Output data: `data.CARDS` → `data.LEAVES`.
 
-Vocabulary and syntax flip together in a single release (§7). There
-is no dual-parser deprecation window: legacy `---/CARD:---` is a hard
-parse error from day one, and the codebase carries no legacy code
-path. Document migration is the consumer's responsibility (§7).
-Bindings are pre-1.0 and acceptable to break; a syntax-only rename
-that preserved `CARDS`/`card_types` internally was considered and
-rejected — permanent author-vs-internal dual vocabulary would be a
-long-term translation tax.
+Vocabulary and syntax flip together in a single release (§7). Release
+N keeps a legacy parser path for `---/CARD:---` that exists solely
+for round-trip migration — parsing it surfaces a
+`parse::deprecated_leaf_syntax` warning, and the canonical emitter
+re-writes the document into ` ```leaf ` form. Release N+1 deletes the
+legacy parser path. Bindings are pre-1.0 and acceptable to break; a
+syntax-only rename that preserved `CARDS`/`card_types` internally was
+considered and rejected — permanent author-vs-internal dual
+vocabulary would be a long-term translation tax.
 
 ## 5. Reserved keys
 
@@ -267,21 +268,25 @@ the parser preserves document order within each kind, mirroring today's
 
 ## 7. Migration
 
-The entire migration ships in **one release**. The codebase carries
-no dual-parser path: legacy `---/CARD:---` is a hard parse error
-from the first commit of the new release, with a diagnostic naming
-the canonical syntax.
+Quillmark has a single primary consumer (the project's own
+application), so the migration policy is round-trip-driven, not
+calendar-driven.
 
-Quillmark ships only the canonical emitter; consumers handle their
-own legacy-document conversion. The emitter's existing round-trip
-guarantees (comments, ordering, `!fill` tags) carry forward
-unchanged, so a consumer that wants a one-shot converter can build
-one against a pinned snapshot of the previous-release parser plus
-the new emitter. In-repo fixtures and sample quills are converted by
-Quillmark contributors as part of the release PR, using whatever
-ad-hoc script they prefer — not a shipped tool.
+**Release N** ships ` ```leaf ` / `KIND:` as the canonical inline form
+and keeps a legacy parser path for `---/CARD: foo/---`. The legacy
+parser exists exclusively for round-trip migration: the consumer reads
+each existing `.md` document, parses it, and emits the new form.
+Comments, ordering, and `!fill` tags round-trip losslessly per today's
+emitter guarantee (carried forward unchanged). Every legacy block
+parsed surfaces a `parse::deprecated_leaf_syntax` warning naming the
+canonical ` ```leaf ` form, so consumers cannot fall through a
+migration without notice.
 
-All other surfaces flip in the same release, no dual support:
+**Release N+1** removes the legacy parser path entirely. Encountering
+`---/CARD: foo/---` becomes a hard parse error with a pointer to the
+migration tool.
+
+The non-syntax surfaces flip atomically in Release N, no dual support:
 
 | Surface | Change |
 |---|---|
@@ -311,16 +316,18 @@ diagnostic + reserved-key disambiguation.
 After this change:
 
 - **Frontmatter detection** keeps F2 (top-of-file or preceded by blank)
-  and F3 (zero-to-three space indent). When a top `---/---` block is
-  present, the F1 sentinel check simplifies to "first body key is
-  `QUILL:` — fail with a specific error if not." There is no
-  `CARD`-vs-`QUILL` branching because `---/---` only ever means
-  frontmatter now. Documents with no top `---/---` block at all parse
-  as quill-less (today's behaviour, unchanged).
-- **Leaf detection** delegates to CommonMark's existing fenced-code-block
-  rules (including the 0–3 space indent allowance and run-length
-  closure semantics). Quillmark only inspects fenced code blocks whose
-  info string's first token is `leaf`.
+  and F3 (zero-to-three space indent). The first F2-valid `---/---`
+  block whose first body key is `QUILL:` is the frontmatter; any prior
+  `---/---` pair is a thematic break (with a near-miss warning if the
+  first key looks like a typo for `QUILL`).
+- **Leaf detection** is two paths in Release N. The canonical path
+  delegates to CommonMark's fenced-code-block rules and routes blocks
+  whose info-string first token is `leaf` to leaf parsing. The legacy
+  path scans for `---/---` pairs after the frontmatter whose first
+  body key is `CARD:`; each one is parsed as a leaf and emits a
+  `parse::deprecated_leaf_syntax` warning. Round-trip through the
+  canonical emitter rewrites the document into ` ```leaf ` form.
+  Release N+1 deletes the legacy path.
 - **Near-miss-sentinel diagnostic** for inline records is gone. The
   closest analogue inside a `leaf` fence is "missing `KIND:` first key,"
   which is a hard error rather than a silent classification miss.
@@ -347,12 +354,16 @@ In the spirit of honest accounting:
   apply for leaf detection. Net rule count shifts from one custom system
   to (smaller custom system + already-implemented CommonMark rules) —
   net engineering win, but not a clean collapse.
-- **Migration burden lands on consumers.** The single-release plan
-  (§7) keeps Quillmark's codebase free of dual-support code, but
-  pushes legacy-document conversion entirely onto consumers in one
-  cliff. "Mechanical sweep" covers the renames inside Quillmark; the
-  binding-API breakage, backend contract updates, and downstream
-  template breakage land on consumers simultaneously.
+- **Migration burden is round-trip-shaped, not eliminated.** The
+  Release-N legacy parser converts documents on `parse → to_markdown`,
+  but the binding-API breakage (`Card*` → `Leaf*`, `data.CARDS` →
+  `data.LEAVES`), backend contract updates, and Quill.yaml /
+  template renames still land on consumers in one release. Only the
+  inline-syntax migration is automated.
+- **The legacy parser path is dead code in Release N+1.** Carrying it
+  for one release costs ~50 lines in `fences.rs`; the cost lands on
+  Quillmark, not the design's stated minimalism. Deleting it in N+1
+  is the back-half of the bargain.
 
 ## 10. What survives the design
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -172,6 +172,11 @@ The Gadget complements the Widget.
   not near-miss diagnostics.
 - **Missing `KIND:` in a leaf.** Hard parse error inside the leaf — the
   fence has been classified, so the diagnostic is specific.
+- **Legacy `---/CARD: …/---` block.** Accepted in this release as a
+  Release-N migration path: parsed as a leaf, surfaces a
+  `parse::deprecated_leaf_syntax` warning, and rewritten to ` ```leaf `
+  on `to_markdown()` round-trip. The legacy form will be a hard parse
+  error in the next release.
 
 ## 5. Data Model
 


### PR DESCRIPTION
## Summary

Implements the Release-N migration path for the leaf syntax rework (LEAF_REWORK.md §7). Legacy `---/CARD: …/---` blocks are now parsed as leaves with a deprecation warning, enabling one-step round-trip migration to the canonical ` ```leaf / KIND: … / ``` ` form.

## Key Changes

- **Legacy parser path in `fences.rs`**: Added detection for `---/CARD: …/---` blocks (F2-valid, first key is `CARD:`) that interleaves with canonical ` ```leaf ` fences by source order. Each legacy block emits a `parse::deprecated_leaf_syntax` warning.

- **Sentinel rewriting in `assemble.rs`**: Introduced `rewrite_first_card_to_kind()` to transparently convert the first `CARD:` sentinel to `KIND:` before YAML parsing. This ensures legacy blocks produce identical `Leaf` objects as canonical syntax, enabling lossless round-trip through the existing emitter.

- **`build_block()` signature**: Added `legacy_card_to_kind: bool` parameter to control whether sentinel rewriting is applied. Frontmatter blocks pass `false`; legacy leaf blocks pass `true`.

- **Comprehensive test coverage**: Four new tests validate:
  - Legacy blocks parse as leaves with deprecation warning
  - Round-trip `parse → to_markdown` rewrites to canonical form
  - Mixed legacy and canonical leaves coexist and normalize on emit
  - F2 violation (no blank line above) correctly prevents legacy recognition

- **Design documentation**: Updated LEAF_REWORK.md §7 to clarify the two-release migration strategy: Release N keeps the legacy parser for round-trip conversion; Release N+1 removes it entirely. Non-syntax surfaces (API, templates, data keys) flip atomically in Release N.

## Implementation Details

- The legacy path scans for `---/---` pairs after frontmatter whose first non-blank, non-comment line starts with `CARD:`, respecting the F2 (blank-line-preceded) requirement.
- Sentinel rewriting is byte-for-byte length-preserving (`CARD:` and `KIND:` are both 5 characters), so downstream offset bookkeeping is unaffected.
- The deprecation warning names the canonical form and notes that round-trip through `to_markdown()` performs the migration automatically.
- Legacy and canonical leaves parse in source order; the canonical emitter normalizes all leaves to ` ```leaf ` form on output.

https://claude.ai/code/session_01DnDvgUab2zvwv8JXSi63Tc