### PR TITLE
Restructure Quill schema: move titles to UI config

### DIFF
--- a/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
@@ -9,22 +9,22 @@ quill:
 main:
   fields:
     author:
-      title: Author of document
+      description: Author of document
       type: string
     ice_cream:
-      title: favorite ice cream flavor
+      description: favorite ice cream flavor
       type: string
       default: taro
     title:
-      title: title of document
+      description: title of document
       type: string
 
 leaf_kinds:
   quotes:
-    title: Inspirational Quotes
     description: A collection of quotes about taro ice cream
+    ui:
+      title: Inspirational Quotes
     fields:
       author:
-        title: Quote author
-        type: string
         description: The person who said this quote
+        type: string


### PR DESCRIPTION
## Summary
Refactored the Quill schema structure to better separate content metadata from UI presentation concerns by moving `title` fields to a dedicated `ui` configuration section.

## Key Changes
- **Field-level changes**: Renamed `title` to `description` for all field definitions (`author`, `ice_cream`, `title`) in the main section to clarify their semantic purpose
- **Leaf kind restructuring**: Moved the `title: Inspirational Quotes` from the root level of `quotes` leaf kind into a new `ui.title` nested structure
- **Quote author field**: Reorganized the `author` field within quotes to use `description` instead of `title`, and reordered properties for consistency (description before type)

## Implementation Details
This change establishes a clearer separation of concerns where:
- `description` fields contain semantic metadata about the field's purpose
- `ui.title` contains presentation-layer information for UI rendering
- Property ordering is normalized across field definitions for consistency

This structure makes the schema more maintainable and allows UI configuration to be managed independently from core field definitions.

https://claude.ai/code/session_01AA13EhnuCP6o5fttMUiD5s