### PR TITLE
prose: sync designs with leaf rework implementation

### DIFF
--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -16,12 +16,12 @@ render on validity have to call `form` for its side effects. Expose a
 
 ## 2. Stringly-typed field types in the schema payload
 
-`crates/core/src/quill/types.rs:152` — `FieldType` serializes to bare strings
-(`"string"`, `"integer"`, `"array"`, `"dict"`, `"markdown"`). The wasm
+`crates/core/src/quill/types.rs:136` — `FieldType` serializes to bare strings
+(`"string"`, `"integer"`, `"array"`, `"object"`, `"markdown"`). The wasm
 `.d.ts` advertises return types via wasm-bindgen `unchecked_return_type =
-"Leaf"` (`crates/bindings/wasm/src/engine.rs:347`) but the named type isn't
-defined anywhere in the emitted declarations, so it collapses to `any` for
-TS consumers. Either ship a real discriminated-union type alongside the
+"Leaf"` (`crates/bindings/wasm/src/engine.rs:530,538`) but the named type
+isn't defined anywhere in the emitted declarations, so it collapses to `any`
+for TS consumers. Either ship a real discriminated-union type alongside the
 schema payload, or document that consumers must hand-write the TS interface.
 
 ## 3. `setField` / `setFill` are schema-blind

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -13,7 +13,7 @@ free.
 
 ## Output shape
 
-```
+````
 ---
 # <description>
 QUILL: <name>@<version>  # sentinel; required, verbatim
@@ -26,14 +26,14 @@ field: value  # <type>; <role>
 
 Write main body here.
 
----
+```leaf
 # <leaf description>
 KIND: <leaf_kind>  # sentinel; composable (0..N)
 ...fields...
----
+```
 
 Write <leaf_kind> body here.
-```
+````
 
 When `body.example` is set, its text replaces the body marker entirely.
 When `body.enabled` is false the marker is omitted entirely.
@@ -102,7 +102,7 @@ Examples:
 | `published: ""  # datetime<ISO 8601>; required` | required datetime in ISO 8601 |
 | `level: low  # enum<low \| medium \| high>; optional` | optional enum, default is first value |
 | `QUILL: cmu_letter@0.1.0  # sentinel; required, verbatim` | quill binding, do not modify |
-| `KIND: skill  # sentinel; composable (0..N)` | repeat the entire `--- KIND ... ---` block per instance |
+| `KIND: skill  # sentinel; composable (0..N)` | repeat the entire ` ```leaf ... ``` ` block per instance |
 
 ## Placeholder value precedence
 

--- a/prose/designs/CI_CD.md
+++ b/prose/designs/CI_CD.md
@@ -15,10 +15,9 @@ Not published: `quillmark-fixtures`, `quillmark-fuzz`, `bindings/quillmark-pytho
 
 | Job | What it does |
 |-----|-------------|
-| `lint` | `cargo fmt --all -- --check` (Clippy commented out, not yet enforced) |
-| `test` | `cargo test --locked` in a matrix: default features and `--all-features` |
-| `docs` | `cargo doc --no-deps --locked` with `-Dwarnings` |
-| `wasm` | `cargo check --package quillmark-wasm --target wasm32-unknown-unknown --locked` |
+| `lint` | `cargo doc --no-deps --locked` with `-Dwarnings` (Clippy commented out, not yet enforced) |
+| `test` | `cargo test --workspace --all-features --locked` |
+| `wasm` | builds WASM via `scripts/build-wasm.sh --ci`, then runs the WASM test suite via `npx vitest run` |
 
 Excluded: multi-OS matrix, MSRV, security scanners, coverage, benchmarks.
 

--- a/prose/designs/LEAF_REWORK.md
+++ b/prose/designs/LEAF_REWORK.md
@@ -1,7 +1,7 @@
 # LEAF Rework — Quillmark Markdown Inline Records
 
-> **Status**: Draft proposal
-> **Targets**: future revision of [MARKDOWN.md](MARKDOWN.md), [CARDS.md](CARDS.md)
+> **Status**: Implemented
+> **See also**: [MARKDOWN.md](MARKDOWN.md) (spec), [LEAVES.md](LEAVES.md) (data model)
 > **Supersedes**: ad-hoc design-vector discussion
 
 ## 1. Core insight
@@ -406,8 +406,8 @@ proposition depends on at least the VSCode extension being real.
 
 ## 12. References
 
-- [MARKDOWN.md](MARKDOWN.md) — current specification (to be revised)
-- [CARDS.md](CARDS.md) — current data model (to be revised)
+- [MARKDOWN.md](MARKDOWN.md) — specification
+- [LEAVES.md](LEAVES.md) — data model
 - [SCHEMAS.md](SCHEMAS.md) — schema model, affected by §4 rename
 - [CommonMark 0.31.2 §4.5](https://spec.commonmark.org/0.31.2/#fenced-code-blocks)
   — fenced code block rules this design relies on

--- a/prose/designs/LEAVES.md
+++ b/prose/designs/LEAVES.md
@@ -30,8 +30,8 @@ see `body.enabled` and `body.description` below.
 
 `QuillConfig` exposes the entry-point document schema as `main: LeafSchema`
 and the additional named leaf kinds as `leaf_kinds: Vec<LeafSchema>`. Look
-up a named kind by name via `leaf_kind(name)` or get a name-keyed map via
-`leaf_kinds_map()`.
+up a named kind by name via `leaf_kind(name)`, or iterate `leaf_kinds`
+directly for the full list.
 
 ## Quill.yaml Configuration
 


### PR DESCRIPTION
LEAF_REWORK.md still carried "Draft proposal" status and two references
to the deleted CARDS.md. Update status to Implemented, point the See-also
and §12 references at the live LEAVES.md doc.

BLUEPRINT.md's Output-shape section still showed the old `---/---` fence
for leaf blocks. Switch to the ` ```leaf … ``` ` form that blueprint.rs
now emits (verified in crates/core/src/quill/blueprint.rs:67). Also
update the annotation table row that described the sentinel as
"--- KIND ... ---".