### PR TITLE
Add proposal: move leaf kind discriminator into the info string

### DIFF
--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -314,6 +314,7 @@ pub(super) fn decompose_with_warnings(
         &frontmatter_block.pre_items,
         &frontmatter_block.pre_nested_comments,
         &frontmatter_block.yaml_value,
+        true,
     )?;
     // Surface pre-scan warnings (nested-comment drops, unsupported tags).
     let mut warnings = warnings;
@@ -347,6 +348,7 @@ pub(super) fn decompose_with_warnings(
             &block.pre_items,
             &block.pre_nested_comments,
             &block.yaml_value,
+            false,
         )
         .map_err(|e| match e {
             ParseError::InvalidStructure(msg) => ParseError::InvalidStructure(format!(
@@ -385,7 +387,7 @@ pub(super) fn decompose_with_warnings(
 }
 
 /// Build a [`Frontmatter`] from the pre-scan items and the parsed YAML
-/// mapping (with sentinel keys already stripped).
+/// mapping.
 ///
 /// The pre-scan defined source order for fields and comments; the parsed
 /// YAML defined the typed value for each key. We walk pre-scan order,
@@ -393,10 +395,16 @@ pub(super) fn decompose_with_warnings(
 /// didn't catch (e.g. it used a YAML key form the pre-scan doesn't
 /// recognise — exotic identifier, flow-mapping syntax, etc.) is appended at
 /// the end of the item list in parsed-map order so we never drop values.
+///
+/// `is_frontmatter` selects which sentinel key `extract_sentinels` stripped
+/// from `yaml_value`: `QUILL` for the document frontmatter, nothing for a
+/// leaf (its kind lives in the info string). The stripped key is skipped
+/// from the item list; in a leaf, `QUILL` is an ordinary field and is kept.
 fn build_frontmatter_from_pre_and_parsed(
     pre_items: &[PreItem],
     pre_nested_comments: &[NestedComment],
     yaml_value: &Option<serde_json::Value>,
+    is_frontmatter: bool,
 ) -> Result<Frontmatter, ParseError> {
     let mapping = match yaml_value {
         Some(serde_json::Value::Object(map)) => map.clone(),
@@ -429,10 +437,11 @@ fn build_frontmatter_from_pre_and_parsed(
                 });
             }
             PreItem::Field { key, fill } => {
-                // The `QUILL` sentinel key is stripped from the parsed map by
-                // `extract_sentinels`; skip it in the item list. (A leaf's
-                // kind lives in the info string, never the body.)
-                if key == "QUILL" {
+                // In frontmatter the `QUILL` sentinel key is stripped from the
+                // parsed map by `extract_sentinels`; skip it in the item list.
+                // In a leaf, `QUILL` is an ordinary field (the kind lives in
+                // the info string) and must be kept.
+                if is_frontmatter && key == "QUILL" {
                     after_stripped_sentinel = true;
                     continue;
                 }

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -13,7 +13,7 @@ use crate::Diagnostic;
 use super::fences::find_metadata_blocks;
 use super::frontmatter::{Frontmatter, FrontmatterItem};
 use super::prescan::{prescan_fence_content, NestedComment, PreItem};
-use super::sentinel::extract_sentinels;
+use super::sentinel::{extract_sentinels, is_valid_tag_name};
 use super::{Document, Leaf, Sentinel};
 
 /// Strip exactly one F2 structural separator from the tail of a body slice.
@@ -39,47 +39,49 @@ fn strip_f2_separator(body: &str) -> &str {
     }
 }
 
-/// Rewrite the first non-blank, non-comment line's `CARD:` prefix to `KIND:`.
+/// Parse a legacy `---/CARD: …/---` leaf body.
 ///
-/// Used by the Release-N legacy parser path (LEAF_REWORK.md §7) so that a
-/// document authored against the previous syntax (`---/CARD: foo/---`)
-/// produces the same `Leaf` as the canonical ` ```leaf / KIND: foo / ``` `
-/// form. The substitution is byte-for-byte length-preserving (both sentinels
-/// are four ASCII characters), so downstream offset bookkeeping is unaffected.
-/// Caller guarantees the first content key is `CARD:` before invoking.
-fn rewrite_first_card_to_kind(content: &str) -> String {
+/// Used by the Release-N legacy parser path (LEAF_REWORK.md §7). The previous
+/// leaf syntax carried the kind as a `CARD:` first body key; the canonical
+/// syntax carries it in the fence info string (`MARKDOWN.md §3.2`). To produce
+/// the same `Leaf` from a legacy block, the kind must be lifted *out* of the
+/// body — leaving `CARD:` (or `KIND:`) in place would now be a reserved-key
+/// hard error.
+///
+/// Returns `(kind, body_without_card_line)`: the trimmed value of the first
+/// `CARD:` line, and the body content with that line removed. Returns `None`
+/// if the first non-blank, non-comment line is not a `CARD:` key — the caller
+/// guarantees this never happens, but we stay defensive rather than corrupt
+/// the slice.
+fn extract_legacy_card_leaf(content: &str) -> Option<(String, String)> {
+    let mut kind: Option<String> = None;
     let mut out = String::with_capacity(content.len());
-    let mut rewrote = false;
     for line in content.split_inclusive('\n') {
-        if rewrote {
+        if kind.is_some() {
             out.push_str(line);
             continue;
         }
         let leading = line.len() - line.trim_start_matches([' ', '\t']).len();
-        let body = &line[leading..];
+        let body = line[leading..].trim_end_matches(['\n', '\r']);
         if body.trim().is_empty() || body.starts_with('#') {
             out.push_str(line);
             continue;
         }
-        if let Some(rest) = body.strip_prefix("CARD:") {
-            out.push_str(&line[..leading]);
-            out.push_str("KIND:");
-            out.push_str(rest);
-            rewrote = true;
-        } else {
-            // First non-blank, non-comment line is not `CARD:` — caller
-            // should never invoke us in this case, but stay verbatim
-            // rather than corrupt the slice.
-            out.push_str(line);
-            rewrote = true;
-        }
+        let rest = body.strip_prefix("CARD:")?;
+        // Drop a trailing inline `# …` comment, then trim surrounding space.
+        let value = match rest.find(" #") {
+            Some(idx) => &rest[..idx],
+            None => rest,
+        };
+        kind = Some(value.trim().to_string());
+        // The `CARD:` line itself is dropped — not pushed to `out`.
     }
-    out
+    kind.map(|k| (k, out))
 }
 
 /// Which sentinel a metadata block carries. `Main` is the top frontmatter's
 /// `QUILL:` reference (raw string, parsed to `QuillReference` later); `Leaf`
-/// is a leaf fence's `KIND:` tag.
+/// is a leaf fence's kind, from its `leaf <kind>` info string.
 #[derive(Debug)]
 pub(super) enum BlockSentinel {
     Main(String),
@@ -122,13 +124,17 @@ fn yaml_parse_options() -> serde_saphyr::Options {
 /// the opening fence line; `content_end` is the byte position at the start
 /// of the closing fence line. Returns errors per spec §9.
 ///
-/// When `legacy_card_to_kind` is true, the first occurrence of the literal
-/// sentinel key `CARD:` in the raw content is rewritten to `KIND:` before
-/// parsing. This is the Release-N round-trip migration path (LEAF_REWORK.md
-/// §7): legacy `---/CARD: …/---` blocks are recognised as leaves so the
-/// canonical emitter can rewrite them to ` ```leaf ` form on the next
-/// `to_markdown()`. Caller is responsible for verifying the first content
-/// key is actually `CARD:` and for emitting the deprecation warning.
+/// `leaf_kind` carries the kind for a canonical leaf fence — extracted from
+/// the `leaf <kind>` info string by `find_metadata_blocks` — and is `None`
+/// for the document frontmatter.
+///
+/// When `legacy_card` is true the block is a legacy `---/CARD: …/---` leaf
+/// (Release-N migration path, LEAF_REWORK.md §7): the kind is lifted out of
+/// the `CARD:` first body key, and that line is dropped before YAML parsing,
+/// so the resulting `Leaf` matches the canonical ` ```leaf <kind> ` form.
+/// Caller verifies the first content key is `CARD:` and emits the
+/// deprecation warning.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_block(
     markdown: &str,
     abs_pos: usize,
@@ -136,14 +142,29 @@ pub(super) fn build_block(
     content_end: usize,
     block_end: usize,
     block_index: usize,
-    legacy_card_to_kind: bool,
+    leaf_kind: Option<String>,
+    legacy_card: bool,
 ) -> Result<MetadataBlock, ParseError> {
-    let raw_content_owned: String;
-    let raw_content: &str = if legacy_card_to_kind {
-        raw_content_owned = rewrite_first_card_to_kind(&markdown[content_start..content_end]);
-        &raw_content_owned
+    let raw_slice = &markdown[content_start..content_end];
+    let legacy_owned: String;
+    let (raw_content, leaf_kind): (&str, Option<String>) = if legacy_card {
+        let line = markdown[..abs_pos].lines().count() + 1;
+        let (kind, stripped) = extract_legacy_card_leaf(raw_slice).ok_or_else(|| {
+            ParseError::InvalidStructure(format!(
+                "Legacy leaf at line {} is missing its `CARD:` first body key.",
+                line
+            ))
+        })?;
+        if !is_valid_tag_name(&kind) {
+            return Err(ParseError::InvalidStructure(format!(
+                "Legacy leaf at line {} has an invalid `CARD:` value `{}` — the kind must match pattern [a-z_][a-z0-9_]*.",
+                line, kind
+            )));
+        }
+        legacy_owned = stripped;
+        (legacy_owned.as_str(), Some(kind))
     } else {
-        &markdown[content_start..content_end]
+        (raw_slice, leaf_kind)
     };
 
     // Check YAML size limit (spec §8)
@@ -163,14 +184,15 @@ pub(super) fn build_block(
     }
 
     let content = pre.cleaned_yaml.trim().to_string();
-    let (tag, quill_ref, yaml_value) = if content.is_empty() {
-        (None, None, None)
+    let is_frontmatter = leaf_kind.is_none();
+    let (quill_ref, yaml_value) = if content.is_empty() {
+        (None, None)
     } else {
         match serde_saphyr::from_str_with_options::<serde_json::Value>(
             &content,
             yaml_parse_options(),
         ) {
-            Ok(parsed) => extract_sentinels(parsed)?,
+            Ok(parsed) => extract_sentinels(parsed, is_frontmatter)?,
             Err(e) => {
                 let line = markdown[..abs_pos].lines().count() + 1;
                 return Err(ParseError::YamlErrorWithLocation {
@@ -182,24 +204,22 @@ pub(super) fn build_block(
         }
     };
 
-    // The fence-detection pass (`find_metadata_blocks`) commits to a fence
-    // kind on the lexical cues alone — `---/---` with first key `QUILL:` for
-    // block 0, ` ```leaf ` with first key `KIND:` for the rest. So by the
-    // time we reach build_block, the expected sentinel is fully determined
-    // by `block_index` and `extract_sentinels` will have produced exactly
-    // the matching variant.
-    let sentinel = match (block_index, quill_ref, tag) {
-        (0, Some(r), _) => BlockSentinel::Main(r),
-        (_, _, Some(t)) => BlockSentinel::Leaf(t),
-        _ => unreachable!(
-            "find_metadata_blocks validates first-key sentinel before calling build_block"
+    // `find_metadata_blocks` classifies every block lexically before calling
+    // build_block — frontmatter carries `leaf_kind = None` and a `QUILL:`
+    // first key; a leaf carries `leaf_kind = Some(kind)` from its info string.
+    let sentinel = match (leaf_kind, quill_ref) {
+        (Some(k), _) => BlockSentinel::Leaf(k),
+        (None, Some(r)) => BlockSentinel::Main(r),
+        (None, None) => unreachable!(
+            "find_metadata_blocks classifies every block before calling build_block"
         ),
     };
 
-    // Per-fence field-count check (spec §8, §6.1 of GAP analysis). Add +1
-    // for the stripped sentinel so the cap matches what the user wrote.
+    // Per-fence field-count check (spec §8, §6.1 of GAP analysis). Frontmatter
+    // adds +1 for the stripped `QUILL` sentinel so the cap matches what the
+    // user wrote; a leaf's kind is not a body field, so it adds nothing.
     if let Some(serde_json::Value::Object(ref map)) = yaml_value {
-        let size = map.len() + 1;
+        let size = map.len() + usize::from(is_frontmatter);
         if size > crate::error::MAX_FIELD_COUNT {
             return Err(ParseError::InputTooLarge {
                 size,
@@ -390,7 +410,7 @@ fn build_frontmatter_from_pre_and_parsed(
 
     let mut items: Vec<FrontmatterItem> = Vec::new();
     let mut consumed: std::collections::HashSet<String> = std::collections::HashSet::new();
-    // When a QUILL/KIND sentinel field is skipped, its trailing inline comment
+    // When the QUILL sentinel field is skipped, its trailing inline comment
     // loses its host field. The emitter can only round-trip an inline comment
     // on the sentinel line when it sits at items[0] (sentinel-preview path).
     // If other items already precede it, it will never reach items[0] and will
@@ -409,9 +429,10 @@ fn build_frontmatter_from_pre_and_parsed(
                 });
             }
             PreItem::Field { key, fill } => {
-                // QUILL / KIND sentinel keys are stripped from the parsed
-                // map by `extract_sentinels`; skip them in the item list.
-                if key == "QUILL" || key == "KIND" {
+                // The `QUILL` sentinel key is stripped from the parsed map by
+                // `extract_sentinels`; skip it in the item list. (A leaf's
+                // kind lives in the info string, never the body.)
+                if key == "QUILL" {
                     after_stripped_sentinel = true;
                     continue;
                 }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -47,7 +47,7 @@ impl Document {
     /// - Line endings: `\n` only.  CRLF normalization happens on import.
     /// - Frontmatter: `---\n`, `QUILL: <ref>` first, remaining fields in
     ///   `IndexMap` insertion order, `---\n`, blank line.
-    /// - Leaves: one blank line before each, fence `` ```leaf\nKIND: <tag>\n<fields>\n```\n<body> ``.
+    /// - Leaves: one blank line before each, fence `` ```leaf <tag>\n<fields>\n```\n<body> ``.
     /// - Body: emitted verbatim after frontmatter (and leaves).
     /// - Mappings and sequences: **block style** at every nesting level.
     /// - Booleans: `true` / `false`.
@@ -73,11 +73,11 @@ impl Document {
     /// # What is preserved
     ///
     /// - **YAML comments**: own-line and inline trailing comments round-trip
-    ///   at their source position. Inline comments on sentinel lines
-    ///   (`QUILL: r # …` / `KIND: t # …`) round-trip too. Comments whose
-    ///   host disappears at emit time (empty-mapping omission, programmatic
-    ///   field removal) degrade to own-line comments at the same indent so
-    ///   the comment text is preserved even when its position shifts.
+    ///   at their source position. An inline comment on the frontmatter
+    ///   `QUILL: r # …` sentinel line round-trips too. Comments whose host
+    ///   disappears at emit time (empty-mapping omission, programmatic field
+    ///   removal) degrade to own-line comments at the same indent so the
+    ///   comment text is preserved even when its position shifts.
     /// - **`!fill` tags**: round-trip via the `fill` flag on `FrontmatterItem::Field`.
     ///
     /// # What is lost
@@ -110,15 +110,18 @@ impl Document {
 
 // ── Leaf emission ─────────────────────────────────────────────────────────────
 
-/// Emit a leaf's metadata fence (between `---\n` markers), including the
-/// sentinel line and every frontmatter item.
+/// Emit a leaf's metadata fence — frontmatter (`---\n` markers, `QUILL:`
+/// sentinel line) or a composable leaf (` ```leaf <kind> ` info string) —
+/// followed by every frontmatter item.
 ///
 /// ## Inline-comment handling
 ///
-/// - **Sentinel-inline preview.** If `items[0]` is a `Comment{inline:true}`,
-///   its text is appended to the sentinel line (`QUILL: r # text` /
-///   `KIND: tag # text`) and the item is skipped. This is the only way to
-///   round-trip a source-level inline comment on the sentinel line.
+/// - **Sentinel-inline preview (frontmatter only).** If `items[0]` is a
+///   `Comment{inline:true}`, its text is appended to the `QUILL: r # text`
+///   sentinel line and the item is skipped. This is the only way to
+///   round-trip a source-level inline comment on the sentinel line. A leaf's
+///   kind lives in the info string, which cannot host a YAML comment, so a
+///   leading inline comment on a leaf falls through to the orphan path.
 /// - **Field + trailing inline.** When iterating items, a `Field` peeks at
 ///   its successor: if the next item is `Comment{inline:true}`, the comment
 ///   text is passed to `emit_field` as a trailer and consumed here. The
@@ -129,34 +132,34 @@ impl Document {
 ///   degrade path for empty-object fields (whose key is omitted) — the
 ///   trailer becomes an own-line comment at the same indent.
 fn emit_leaf_fence(out: &mut String, leaf: &Leaf) {
-    let (open_fence, close_fence) = match leaf.sentinel() {
-        Sentinel::Main(_) => ("---\n", "---\n"),
-        Sentinel::Leaf(_) => ("```leaf\n", "```\n"),
-    };
-    out.push_str(open_fence);
-
-    // Sentinel line.
-    match leaf.sentinel() {
+    let close_fence = match leaf.sentinel() {
         Sentinel::Main(r) => {
+            out.push_str("---\n");
             out.push_str("QUILL: ");
             out.push_str(&r.to_string());
             out.push('\n');
+            "---\n"
         }
-        Sentinel::Leaf(tag) => {
-            out.push_str("KIND: ");
-            out.push_str(tag);
+        Sentinel::Leaf(kind) => {
+            // The kind is carried by the info string; the body has no
+            // sentinel line.
+            out.push_str("```leaf ");
+            out.push_str(kind);
             out.push('\n');
+            "```\n"
         }
-    }
+    };
 
     let nested = leaf.frontmatter().nested_comments();
     let items = leaf.frontmatter().items();
     let mut i = 0;
 
-    // Sentinel-inline preview.
-    if let Some(FrontmatterItem::Comment { text, inline: true }) = items.first() {
-        attach_inline_to_last_line(out, text);
-        i = 1;
+    // Sentinel-inline preview — frontmatter only (see doc comment).
+    if leaf.is_main() {
+        if let Some(FrontmatterItem::Comment { text, inline: true }) = items.first() {
+            attach_inline_to_last_line(out, text);
+            i = 1;
+        }
     }
 
     while i < items.len() {

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -1,14 +1,14 @@
 //! Line-oriented fence scanner for Quillmark Markdown.
 //!
 //! Detects the document's frontmatter (`---/---` at top, with `QUILL:` first
-//! key) and leaf fences (CommonMark fenced code blocks with the info string
-//! `leaf`, body starting with `KIND:`).
+//! key) and leaf fences (CommonMark fenced code blocks whose info string is
+//! `leaf <kind>`).
 
 use crate::error::ParseError;
 use crate::{Diagnostic, Severity};
 
 use super::assemble::{BlockSentinel, MetadataBlock};
-use super::sentinel::first_content_key;
+use super::sentinel::{first_content_key, is_valid_tag_name};
 
 /// Line-oriented view of the source.
 pub(super) struct Lines<'a> {
@@ -111,22 +111,54 @@ pub(super) fn code_fence_on_line(
     }
 }
 
-/// First whitespace-delimited token of a fence opener's info string, or
-/// `None` for non-opener lines and empty info strings.
-fn fence_info_first_token(line: &str) -> Option<&str> {
+/// Whitespace-delimited tokens of a fence opener's info string. Empty for
+/// non-opener lines and empty info strings.
+fn fence_info_tokens(line: &str) -> Vec<&str> {
     let line = line.strip_suffix('\r').unwrap_or(line);
     let indent = line.as_bytes().iter().take_while(|&&b| b == b' ').count();
     let trimmed = &line[indent..];
-    let &first = trimmed.as_bytes().first()?;
+    let Some(&first) = trimmed.as_bytes().first() else {
+        return Vec::new();
+    };
     if first != b'`' && first != b'~' {
-        return None;
+        return Vec::new();
     }
     let run_len = trimmed
         .as_bytes()
         .iter()
         .take_while(|&&b| b == first)
         .count();
-    trimmed[run_len..].split_whitespace().next()
+    trimmed[run_len..].split_whitespace().collect()
+}
+
+/// Validate a leaf fence's info string and extract its kind token.
+///
+/// The info string of a leaf fence is exactly `leaf <kind>` (`MARKDOWN.md
+/// §3.2`). The caller has already confirmed the first token is `leaf`;
+/// `tokens` is the full token list. Missing, malformed, or extra tokens are
+/// hard errors — the fence is committed to leaf-handling on the `leaf` token
+/// alone, so these are routing failures, not classification misses.
+fn leaf_kind_from_tokens(tokens: &[&str], opener_line: usize) -> Result<String, ParseError> {
+    match tokens {
+        [_, kind] => {
+            if is_valid_tag_name(kind) {
+                Ok((*kind).to_string())
+            } else {
+                Err(ParseError::InvalidStructure(format!(
+                    "Leaf fence at line {} has an invalid kind token `{}` — the kind must match pattern [a-z_][a-z0-9_]*.",
+                    opener_line, kind
+                )))
+            }
+        }
+        [_] => Err(ParseError::InvalidStructure(format!(
+            "Leaf fence at line {} is missing its kind token — the info string must be `leaf <kind>`.",
+            opener_line
+        ))),
+        _ => Err(ParseError::InvalidStructure(format!(
+            "Leaf fence at line {} has extra info-string tokens — the info string must be exactly `leaf <kind>`.",
+            opener_line
+        ))),
+    }
 }
 
 /// Outcome of the fence-detection pass: the recognised metadata blocks
@@ -184,6 +216,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                 content_end,
                 block_end,
                 0,
+                None,
                 false,
             )?;
             blocks.push(block);
@@ -219,12 +252,12 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
     // ── Step 2: leaves ───────────────────────────────────────────────────────
     // Two paths interleave by source order:
     //
-    // - **Canonical**: CommonMark fenced code block whose info-string first
-    //   token is `leaf`, body keyed by `KIND:`.
+    // - **Canonical**: CommonMark fenced code block whose info string is
+    //   `leaf <kind>`.
     // - **Legacy (Release N only, LEAF_REWORK.md §7)**: `---/---` block (F2)
     //   whose first body key is `CARD:`. Each occurrence emits a
     //   `parse::deprecated_leaf_syntax` warning; the canonical emitter
-    //   rewrites it to ` ```leaf ` on round-trip.
+    //   rewrites it to ` ```leaf <kind> ` on round-trip.
     let mut k = post_frontmatter_k;
     let mut open_code_fence: Option<(u8, usize, usize)> = None;
     while k < lines.len() {
@@ -256,6 +289,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                         content_end,
                         block_end,
                         blocks.len(),
+                        None,
                         true,
                     )?;
                     blocks.push(block);
@@ -265,7 +299,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                             format!(
                                 "Legacy `---/CARD: …/---` leaf at line {} is deprecated; \
                                  round-trip through `Document::to_markdown` to rewrite as \
-                                 the canonical ` ```leaf / KIND: … / ``` ` form. The legacy \
+                                 the canonical ` ```leaf <kind> ` form. The legacy \
                                  path will be removed in the next release.",
                                 k + 1
                             ),
@@ -279,8 +313,15 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
         }
 
         if let Some((ch, run_len, _)) = code_fence_on_line(text, None) {
-            if fence_info_first_token(text) == Some("leaf") {
+            let info_tokens = fence_info_tokens(text);
+            if info_tokens.first() == Some(&"leaf") {
                 let opener_k = k;
+
+                // Spec §3.2/§4.2: a `leaf`-prefixed fence commits to leaf
+                // parsing on that token alone. The kind lives in the info
+                // string; missing/invalid/extra tokens are hard errors.
+                let kind = leaf_kind_from_tokens(&info_tokens, opener_k + 1)?;
+
                 let Some(cj) = (k + 1..lines.len()).find(|&j| {
                     matches!(
                         code_fence_on_line(lines.line_text(j), Some((ch, run_len))),
@@ -298,27 +339,6 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                 let content_end = lines.line_start(cj);
                 let block_end = lines.line_end_inclusive(cj);
 
-                // Spec §3.2/§9, LEAF_REWORK.md §3.3: leaf-info-string fence
-                // commits to leaf parsing; missing or misplaced `KIND:` is a
-                // hard error, not a silent classification miss.
-                let content = &markdown[content_start..content_end];
-                match first_content_key(content) {
-                    Some("KIND") => {}
-                    Some(other) => {
-                        return Err(ParseError::InvalidStructure(format!(
-                            "Leaf fence at line {} must have `KIND:` as its first body key (found `{}:`).",
-                            opener_k + 1,
-                            other
-                        )));
-                    }
-                    None => {
-                        return Err(ParseError::InvalidStructure(format!(
-                            "Leaf fence at line {} is missing required `KIND:` first body key.",
-                            opener_k + 1
-                        )));
-                    }
-                }
-
                 let block = super::assemble::build_block(
                     markdown,
                     abs_pos,
@@ -326,6 +346,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                     content_end,
                     block_end,
                     blocks.len(),
+                    Some(kind),
                     false,
                 )?;
                 blocks.push(block);

--- a/crates/core/src/document/frontmatter.rs
+++ b/crates/core/src/document/frontmatter.rs
@@ -37,8 +37,8 @@ pub enum FrontmatterItem {
     /// inline comment attaches to the field that immediately precedes it
     /// in the items vector; if no such field exists at emit time (orphan)
     /// it degrades to an own-line comment. A `Comment { inline: true }` at
-    /// `items[0]` instead attaches to the sentinel line (`QUILL: …` /
-    /// `KIND: …`).
+    /// `items[0]` of frontmatter instead attaches to the `QUILL: …`
+    /// sentinel line.
     Comment {
         text: String,
         #[serde(default)]

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -12,7 +12,7 @@
 //! - [`Document`]: Typed in-memory Quillmark document — `main` leaf plus composable leaves.
 //! - [`Leaf`]: A single metadata fence block, main or composable, with a sentinel,
 //!   typed frontmatter, and a body.
-//! - [`Sentinel`]: Discriminates `QUILL:` main leaves from `KIND:` composable leaves.
+//! - [`Sentinel`]: Discriminates `QUILL:` main leaves from `` ```leaf <kind> `` composable leaves.
 //! - [`Frontmatter`]: Ordered list of items (fields + comments) parsed from a YAML fence.
 //!
 //! ## Examples
@@ -48,7 +48,7 @@
 //! ```
 //! use quillmark_core::Document;
 //!
-//! let markdown = "---\nQUILL: my_quill\ntitle: Catalog\n---\n\nIntro.\n\n```leaf\nKIND: product\nname: Widget\n```\n";
+//! let markdown = "---\nQUILL: my_quill\ntitle: Catalog\n---\n\nIntro.\n\n```leaf product\nname: Widget\n```\n";
 //! let doc = Document::from_markdown(markdown).unwrap();
 //! assert_eq!(doc.leaves().len(), 1);
 //! assert_eq!(doc.leaves()[0].tag(), "product");
@@ -75,7 +75,7 @@
 //! - Malformed YAML syntax
 //! - Unclosed frontmatter blocks
 //! - Multiple global frontmatter blocks
-//! - Both QUILL and KIND specified in the same block
+//! - A leaf fence with a missing, invalid, or extra info-string kind token
 //! - Reserved field name usage
 //! - Name collisions
 //!
@@ -117,14 +117,14 @@ pub struct ParseOutput {
 /// Discriminator for a [`Leaf`]'s metadata fence.
 ///
 /// The first fence in a Quillmark document carries `QUILL: <ref>` and is the
-/// document-level *main* leaf; every subsequent fence carries `KIND: <tag>`
-/// and is a composable leaf. `Sentinel` captures that distinction in the typed
-/// model so every fence is one uniform shape.
+/// document-level *main* leaf; every subsequent fence is a `` ```leaf <kind> ``
+/// code block and is a composable leaf. `Sentinel` captures that distinction
+/// in the typed model so every fence is one uniform shape.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Sentinel {
     /// `QUILL: <ref>` — the document entry leaf.
     Main(QuillReference),
-    /// `KIND: <tag>` — a composable leaf with the given tag.
+    /// `` ```leaf <tag> `` — a composable leaf with the given kind tag.
     Leaf(String),
 }
 
@@ -188,8 +188,8 @@ impl Leaf {
         &self.sentinel
     }
 
-    /// The leaf tag — the `KIND:` value for composable leaves, or the string
-    /// form of the quill reference for main leaves.
+    /// The leaf tag — the kind for composable leaves, or the string form of
+    /// the quill reference for main leaves.
     pub fn tag(&self) -> String {
         self.sentinel.as_str()
     }

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -285,7 +285,7 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
                 if let Some(err) = fill_target_err {
                     out.fill_target_errors.push(err);
                 }
-                if fill && (key == "QUILL" || key == "KIND") {
+                if fill && key == "QUILL" {
                     out.fill_target_errors.push(format!(
                         "`!fill` cannot be applied to the sentinel key `{}` — sentinels are routing keys, not data, and must resolve at parse time",
                         key

--- a/crates/core/src/document/sentinel.rs
+++ b/crates/core/src/document/sentinel.rs
@@ -1,4 +1,4 @@
-//! QUILL / KIND sentinel extraction and reserved-name validation.
+//! QUILL sentinel extraction and reserved-name validation.
 //!
 //! Implements the sentinel rules from MARKDOWN.md §4.2 and the reserved-name
 //! checks from spec §3.
@@ -68,69 +68,45 @@ fn strip_key(
     (!m.is_empty()).then(|| serde_json::Value::Object(m))
 }
 
-/// Extract `QUILL` / `KIND` sentinels and remaining fields from a parsed-YAML
-/// mapping. Returns `(tag, quill_ref, yaml_without_sentinel)`.
-#[allow(clippy::type_complexity)]
+/// Extract the `QUILL` sentinel (frontmatter only) and the remaining fields
+/// from a parsed-YAML mapping. Returns `(quill_ref, yaml_without_sentinel)`.
+///
+/// A leaf's kind is carried by the fence info string (`MARKDOWN.md §3.2`), so
+/// `KIND` no longer participates in sentinel extraction: it joins `BODY` and
+/// `LEAVES` as an output-only reserved key, and supplying it as an input body
+/// key is a hard parse error in both frontmatter and leaves.
 pub(super) fn extract_sentinels(
     parsed: serde_json::Value,
-) -> Result<(Option<String>, Option<String>, Option<serde_json::Value>), ParseError> {
+    is_frontmatter: bool,
+) -> Result<(Option<String>, Option<serde_json::Value>), ParseError> {
     let Some(mapping) = parsed.as_object() else {
         // Non-mapping (scalar/sequence); pass through — upstream will reject
         // if a frontmatter/leaf mapping was expected.
-        return Ok((None, None, Some(parsed)));
+        return Ok((None, Some(parsed)));
     };
 
-    let has_quill = mapping.contains_key("QUILL");
-    let has_leaf = mapping.contains_key("KIND");
-
-    if has_quill && has_leaf {
-        return Err(ParseError::InvalidStructure(
-            "Cannot specify both QUILL and KIND in the same block".to_string(),
-        ));
-    }
-
-    // Reserved keys (BODY, LEAVES) — spec §3.
-    for reserved in ["BODY", "LEAVES"] {
+    // Output-only reserved keys (spec §3): the parser populates these, so an
+    // author supplying any of them as an input field is a hard parse error.
+    for reserved in ["BODY", "LEAVES", "KIND"] {
         if mapping.contains_key(reserved) {
             return Err(ParseError::InvalidStructure(format!(
-                "Reserved field name '{}' cannot be used in YAML frontmatter",
+                "Reserved field name '{}' cannot be used as an input field",
                 reserved
             )));
         }
     }
 
-    if has_quill {
-        let quill_str = mapping
-            .get("QUILL")
-            .unwrap()
-            .as_str()
-            .ok_or("QUILL value must be a string")?;
-        quill_str.parse::<QuillReference>().map_err(|e| {
-            ParseError::InvalidStructure(format!("Invalid QUILL reference '{}': {}", quill_str, e))
-        })?;
-        Ok((
-            None,
-            Some(quill_str.to_string()),
-            strip_key(mapping, "QUILL"),
-        ))
-    } else if has_leaf {
-        let field_name = mapping
-            .get("KIND")
-            .unwrap()
-            .as_str()
-            .ok_or("KIND value must be a string")?;
-        if !is_valid_tag_name(field_name) {
-            return Err(ParseError::InvalidStructure(format!(
-                "Invalid leaf field name '{}': must match pattern [a-z_][a-z0-9_]*",
-                field_name
-            )));
+    if is_frontmatter {
+        if let Some(quill_val) = mapping.get("QUILL") {
+            let quill_str = quill_val.as_str().ok_or("QUILL value must be a string")?;
+            quill_str.parse::<QuillReference>().map_err(|e| {
+                ParseError::InvalidStructure(format!(
+                    "Invalid QUILL reference '{}': {}",
+                    quill_str, e
+                ))
+            })?;
+            return Ok((Some(quill_str.to_string()), strip_key(mapping, "QUILL")));
         }
-        Ok((
-            Some(field_name.to_string()),
-            None,
-            strip_key(mapping, "KIND"),
-        ))
-    } else {
-        Ok((None, None, Some(parsed)))
     }
+    Ok((None, Some(parsed)))
 }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -1660,6 +1660,25 @@ id: 2
 }
 
 #[test]
+fn test_leaf_may_carry_quill_field() {
+    // `QUILL` is not reserved inside a leaf (MARKDOWN.md §3.2) — the kind
+    // lives in the info string, so a body `QUILL:` is an ordinary field and
+    // is kept in source position.
+    let markdown = "---\nQUILL: q\n---\n\n```leaf item\nQUILL: not-a-ref\nname: x\n```\n";
+    let doc = decompose(markdown).unwrap();
+    let leaf = &doc.leaves()[0];
+    assert_eq!(leaf.tag(), "item");
+    assert_eq!(
+        leaf.frontmatter().get("QUILL").and_then(|v| v.as_str()),
+        Some("not-a-ref")
+    );
+    let emitted = doc.to_markdown();
+    let q = emitted.find("QUILL: \"not-a-ref\"").expect("QUILL field kept");
+    let n = emitted.find("name:").expect("name field kept");
+    assert!(q < n, "QUILL field must stay before name; got:\n{}", emitted);
+}
+
+#[test]
 fn test_leaf_with_body_containing_dashes() {
     let markdown = r#"---
 QUILL: test_quill

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -200,8 +200,7 @@ title: Main Document
 
 Main body content.
 
-```leaf
-KIND: items
+```leaf items
 name: Item 1
 ```
 
@@ -240,16 +239,14 @@ fn test_multiple_tagged_blocks() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 name: Item 1
 tags: [a, b]
 ```
 
 First item body.
 
-```leaf
-KIND: items
+```leaf items
 name: Item 2
 tags: [c, d]
 ```
@@ -284,15 +281,13 @@ author: John Doe
 
 Global body.
 
-```leaf
-KIND: sections
+```leaf sections
 title: Section 1
 ```
 
 Section 1 content.
 
-```leaf
-KIND: sections
+```leaf sections
 title: Section 2
 ```
 
@@ -320,8 +315,7 @@ fn test_empty_tagged_metadata() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 ```
 
 Body without metadata."#;
@@ -340,8 +334,7 @@ fn test_tagged_block_without_body() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 name: Item
 ```"#;
 
@@ -361,8 +354,7 @@ items: "global value"
 
 Body
 
-```leaf
-KIND: items
+```leaf items
 name: Item
 ```
 
@@ -384,8 +376,7 @@ items:
 
 Global body
 
-```leaf
-KIND: items
+```leaf items
 name: Scope Item 1
 ```
 
@@ -407,8 +398,7 @@ items: []
 
 Global body
 
-```leaf
-KIND: items
+```leaf items
 name: Item 1
 ```
 
@@ -428,8 +418,7 @@ fn test_reserved_field_body_rejected() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: section
+```leaf section
 BODY: Test
 ```"#;
 
@@ -491,8 +480,7 @@ title: Test
 Here is some code:
 
 ~~~yaml
-```leaf
-KIND: code_example
+```leaf code_example
 fake: frontmatter
 ```
 ~~~
@@ -514,8 +502,7 @@ title: Test
 Here is some code:
 
 ````yaml
-```leaf
-KIND: code_example
+```leaf code_example
 fake: frontmatter
 ```
 ````
@@ -534,8 +521,7 @@ fn test_invalid_tag_syntax() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: Invalid-Name
+```leaf Invalid-Name
 title: Test
 ```"#;
 
@@ -544,7 +530,7 @@ title: Test
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Invalid leaf field name"));
+        .contains("invalid kind token"));
 }
 
 #[test]
@@ -579,15 +565,13 @@ fn test_adjacent_blocks_different_tags() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 name: Item 1
 ```
 
 Item 1 body
 
-```leaf
-KIND: sections
+```leaf sections
 title: Section 1
 ```
 
@@ -617,22 +601,19 @@ fn test_order_preservation() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 id: 1
 ```
 
 First
 
-```leaf
-KIND: items
+```leaf items
 id: 2
 ```
 
 Second
 
-```leaf
-KIND: items
+```leaf items
 id: 3
 ```
 
@@ -659,8 +640,7 @@ date: 2024-01-01
 
 This is the main catalog description.
 
-```leaf
-KIND: products
+```leaf products
 name: Widget A
 price: 19.99
 sku: WID-001
@@ -668,8 +648,7 @@ sku: WID-001
 
 The **Widget A** is our most popular product.
 
-```leaf
-KIND: products
+```leaf products
 name: Gadget B
 price: 29.99
 sku: GAD-002
@@ -677,16 +656,14 @@ sku: GAD-002
 
 The **Gadget B** is perfect for professionals.
 
-```leaf
-KIND: reviews
+```leaf reviews
 product: Widget A
 rating: 5
 ```
 
 "Excellent product! Highly recommended."
 
-```leaf
-KIND: reviews
+```leaf reviews
 product: Gadget B
 rating: 4
 ```
@@ -822,8 +799,7 @@ title: Test Document
 
 Main body.
 
-```leaf
-KIND: sections
+```leaf sections
 name: Section 1
 ```
 
@@ -897,8 +873,7 @@ fn test_leaf_wrong_value_type() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: 123
+```leaf 123
 ```"#;
 
     let result = decompose(markdown);
@@ -906,11 +881,13 @@ KIND: 123
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("KIND value must be a string"));
+        .contains("invalid kind token"));
 }
 
 #[test]
-fn test_both_quill_and_kind_error() {
+fn test_kind_rejected_as_frontmatter_key() {
+    // `KIND` is an output-only reserved key — supplying it as an input body
+    // key is a hard parse error, in frontmatter and leaves alike.
     let markdown = r#"---
 QUILL: test
 KIND: items
@@ -921,7 +898,7 @@ KIND: items
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Cannot specify both QUILL and KIND"));
+        .contains("Reserved field name 'KIND'"));
 }
 
 #[test]
@@ -986,8 +963,7 @@ fn test_blank_lines_in_scope_blocks() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 name: Item 1
 
 price: 19.99
@@ -1292,8 +1268,7 @@ metadata:
 
 `<<inline code>>` and <<plain>>
 
-```leaf
-KIND: items
+```leaf items
 description: "<<leaf yaml>>"
 ```
 
@@ -1656,8 +1631,7 @@ fn test_leaf_with_empty_body() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 name: Item
 ```"#;
     let doc = decompose(markdown).unwrap();
@@ -1672,13 +1646,11 @@ fn test_leaf_consecutive_blocks() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: a
+```leaf a
 id: 1
 ```
 
-```leaf
-KIND: a
+```leaf a
 id: 2
 ```"#;
     let doc = decompose(markdown).unwrap();
@@ -1693,8 +1665,7 @@ fn test_leaf_with_body_containing_dashes() {
 QUILL: test_quill
 ---
 
-```leaf
-KIND: items
+```leaf items
 name: Item
 ```
 
@@ -1755,25 +1726,25 @@ Body content."#;
 
 #[test]
 fn test_invalid_scope_name_uppercase() {
-    let markdown = "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: ITEMS\n```\n\nBody.";
+    let markdown = "---\nQUILL: test_quill\n---\n\n```leaf ITEMS\n```\n\nBody.";
     let result = decompose(markdown);
     assert!(result.is_err());
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Invalid leaf field name"));
+        .contains("invalid kind token"));
 }
 
 #[test]
 fn test_invalid_scope_name_starts_with_number() {
-    let markdown = "```leaf\nKIND: 123items\n```\n\nBody.";
+    let markdown = "```leaf 123items\n```\n\nBody.";
     let result = decompose(markdown);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_invalid_scope_name_with_hyphen() {
-    let markdown = "```leaf\nKIND: my-items\n```\n\nBody.";
+    let markdown = "```leaf my-items\n```\n\nBody.";
     let result = decompose(markdown);
     assert!(result.is_err());
 }
@@ -1826,7 +1797,7 @@ fn test_f2_strip_global_body_followed_by_leaf_lf() {
     // Global body followed by a KIND fence: the source's tail `\n\n` is
     // (content line terminator) + (F2 blank line). Strip exactly the F2 `\n`,
     // leaving `\n` as the content terminator.
-    let markdown = "---\nQUILL: q\n---\n\nbody\n\n```leaf\nKIND: x\n```\n";
+    let markdown = "---\nQUILL: q\n---\n\nbody\n\n```leaf x\n```\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\nbody\n");
 }
@@ -1834,7 +1805,7 @@ fn test_f2_strip_global_body_followed_by_leaf_lf() {
 #[test]
 fn test_f2_strip_global_body_followed_by_leaf_crlf() {
     // CRLF line endings: strip exactly one `\r\n` as the F2 separator.
-    let markdown = "---\r\nQUILL: q\r\n---\r\n\r\nbody\r\n\r\n---\r\nKIND: x\r\n---\r\n";
+    let markdown = "---\r\nQUILL: q\r\n---\r\n\r\nbody\r\n\r\n```leaf x\r\n```\r\n";
     let doc = decompose(markdown).unwrap();
     assert!(
         doc.main().body().ends_with('\n') && !doc.main().body().ends_with("\n\n"),
@@ -1848,7 +1819,7 @@ fn test_f2_strip_leaf_body_followed_by_leaf() {
     // First leaf body is followed by another fence → F2 stripped.
     // Last leaf body is at EOF → preserved verbatim.
     let markdown =
-        "---\nQUILL: q\n---\n\n```leaf\nKIND: a\n```\nfirst\n\n```leaf\nKIND: b\n```\nsecond\n";
+        "---\nQUILL: q\n---\n\n```leaf a\n```\nfirst\n\n```leaf b\n```\nsecond\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.leaves()[0].body(), "first\n");
     assert_eq!(doc.leaves()[1].body(), "second\n");
@@ -1858,7 +1829,7 @@ fn test_f2_strip_leaf_body_followed_by_leaf() {
 fn test_f2_strip_preserves_author_blank_lines() {
     // Author wrote two blank lines after the body. Only the F2 blank (last
     // `\n`) is stripped; the author's blank line is preserved.
-    let markdown = "---\nQUILL: q\n---\n\nbody\n\n\n```leaf\nKIND: x\n```\n";
+    let markdown = "---\nQUILL: q\n---\n\nbody\n\n\n```leaf x\n```\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\nbody\n\n");
 }
@@ -1868,7 +1839,7 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
     // Content-fidelity: a body whose authored content ends with multiple
     // newlines (e.g. a code block with trailing blank lines) must survive
     // round-trip. The previous WASM-binding `trim_body` over-stripped this.
-    let markdown = "---\nQUILL: q\n---\n\n```\ncode\n```\n\n\n```leaf\nKIND: x\n```\n";
+    let markdown = "---\nQUILL: q\n---\n\n```\ncode\n```\n\n\n```leaf x\n```\n";
     let doc = decompose(markdown).unwrap();
     let emitted = doc.to_markdown();
     let reparsed = Document::from_markdown(&emitted).unwrap();
@@ -1968,8 +1939,7 @@ QUILL: test_quill
 my_leaf: "some global value"
 ---
 
-```leaf
-KIND: my_leaf
+```leaf my_leaf
 title: "My Leaf"
 ```
 Body
@@ -2041,14 +2011,12 @@ Main document body.
 
 More content after horizontal rule.
 
-```leaf
-KIND: section
+```leaf section
 heading: Introduction
 ```
 Introduction content.
 
-```leaf
-KIND: section
+```leaf section
 heading: Conclusion
 ```
 Conclusion content.
@@ -2134,8 +2102,7 @@ title: Test
 
 Global body.
 
-```leaf
-KIND: indorsement
+```leaf indorsement
 for: ORG
 ```
 
@@ -2261,8 +2228,8 @@ fn legacy_card_round_trip_emits_canonical_leaf_fence() {
     let canonical = doc.to_markdown();
 
     assert!(
-        canonical.contains("```leaf\nKIND: note"),
-        "emitted form must use canonical ```leaf / KIND: fence; got:\n{}",
+        canonical.contains("```leaf note\n"),
+        "emitted form must use canonical ```leaf <kind> fence; got:\n{}",
         canonical
     );
     assert!(
@@ -2291,7 +2258,7 @@ fn legacy_card_round_trip_emits_canonical_leaf_fence() {
 /// order; canonical re-emit normalises everything to ` ```leaf `.
 #[test]
 fn legacy_and_canonical_leaves_coexist_during_migration() {
-    let md = "---\nQUILL: q\n---\n\n---\nCARD: a\nx: 1\n---\n\nFirst body.\n\n```leaf\nKIND: b\ny: 2\n```\n\nSecond body.\n";
+    let md = "---\nQUILL: q\n---\n\n---\nCARD: a\nx: 1\n---\n\nFirst body.\n\n```leaf b\ny: 2\n```\n\nSecond body.\n";
     let doc = Document::from_markdown(md).unwrap();
 
     assert_eq!(doc.leaves().len(), 2);
@@ -2299,8 +2266,8 @@ fn legacy_and_canonical_leaves_coexist_during_migration() {
     assert_eq!(doc.leaves()[1].tag(), "b");
 
     let canonical = doc.to_markdown();
-    assert!(canonical.contains("```leaf\nKIND: a"));
-    assert!(canonical.contains("```leaf\nKIND: b"));
+    assert!(canonical.contains("```leaf a\n"));
+    assert!(canonical.contains("```leaf b\n"));
     assert!(!canonical.contains("CARD:"));
 }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -15,7 +15,7 @@ fn make_doc() -> Document {
 
 fn make_doc_with_leaves() -> Document {
     Document::from_markdown(
-        "---\nQUILL: test_quill\ntitle: Hello\n---\n\nBody.\n\n```leaf\nKIND: note\nfoo: bar\n```\n\nLeaf body.\n\n```leaf\nKIND: summary\n```\n",
+        "---\nQUILL: test_quill\ntitle: Hello\n---\n\nBody.\n\n```leaf note\nfoo: bar\n```\n\nLeaf body.\n\n```leaf summary\n```\n",
     )
     .unwrap()
 }

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -242,10 +242,9 @@ title: Test
 
 Body text.
 
----
-KIND: section
+```leaf section
 heading: Chapter 1
----
+```
 
 Leaf body here.
 ";
@@ -260,10 +259,9 @@ QUILL: q
 title: Test
 ---
 
----
-KIND: empty_body_leaf
+```leaf empty_body_leaf
 title: No body
----
+```
 ";
     assert_round_trip("leaf with empty body", src);
 }

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -1,8 +1,8 @@
 //! Round-trip tests for comments, `!fill`, and custom tags.
 //!
 //! Both own-line and trailing inline YAML comments round-trip at their
-//! source position. Inline comments on sentinel lines (`QUILL: r # …` /
-//! `KIND: t # …`) also round-trip. Comments whose host disappears at emit
+//! source position. An inline comment on the frontmatter `QUILL: r # …`
+//! sentinel line also round-trips. Comments whose host disappears at emit
 //! time (empty-mapping omission, programmatic field removal) degrade to
 //! own-line comments at the same indent so the comment text is preserved
 //! even when its position shifts. `!fill` on scalars and sequences round-
@@ -468,16 +468,17 @@ fn sentinel_inline_comment_round_trips() {
     assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
-/// Inline comment on a KIND sentinel line round-trips on that line.
+/// Inline comment on a leaf body field round-trips on that field's line.
+/// (A leaf's kind lives in the info string, which cannot carry a comment.)
 #[test]
-fn leaf_sentinel_inline_comment_round_trips() {
-    let src = "---\nQUILL: q\n---\n\n```leaf\nKIND: foo # the foo leaf\nx: 1\n```\n";
+fn leaf_field_inline_comment_round_trips() {
+    let src = "---\nQUILL: q\n---\n\n```leaf foo\nx: 1 # the x field\n```\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
     assert!(
-        emitted.contains("KIND: foo # the foo leaf\n"),
-        "inline comment on a KIND sentinel must round-trip on the sentinel line\nGot:\n{}",
+        emitted.contains("x: 1 # the x field\n"),
+        "inline comment on a leaf field must round-trip on that line\nGot:\n{}",
         emitted
     );
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -134,7 +134,7 @@ pub const MAX_NESTING_DEPTH: usize = 100;
 /// Re-exported from [`crate::document::limits::MAX_YAML_DEPTH`].
 pub use crate::document::limits::MAX_YAML_DEPTH;
 
-/// Maximum number of KIND blocks allowed per document
+/// Maximum number of leaf blocks allowed per document
 /// Prevents memory exhaustion from documents with excessive leaf blocks
 pub const MAX_LEAF_COUNT: usize = 1000;
 

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -804,7 +804,7 @@ mod tests {
     fn test_normalize_document_leaf_body_bidi_stripped() {
         use crate::document::Document;
 
-        let md = "---\nQUILL: test\n---\n\nbody\n\n```leaf\nKIND: note\n```\nleaf\u{202D}body\n";
+        let md = "---\nQUILL: test\n---\n\nbody\n\n```leaf note\n```\nleaf\u{202D}body\n";
         let doc = Document::from_markdown(md).unwrap();
         assert_eq!(doc.leaves().len(), 1, "expected 1 leaf");
         let normalized = super::normalize_document(doc).unwrap();
@@ -815,7 +815,7 @@ mod tests {
     fn test_normalize_document_leaf_field_bidi_preserved() {
         use crate::document::Document;
 
-        let md = "---\nQUILL: test\n---\n\nbody\n\n```leaf\nKIND: note\nname: Ali\u{202D}ce\n```\n";
+        let md = "---\nQUILL: test\n---\n\nbody\n\n```leaf note\nname: Ali\u{202D}ce\n```\n";
         let doc = Document::from_markdown(md).unwrap();
         assert_eq!(doc.leaves().len(), 1, "expected 1 leaf");
         let normalized = super::normalize_document(doc).unwrap();
@@ -835,7 +835,7 @@ mod tests {
         use crate::document::Document;
 
         let md =
-            "---\nQUILL: test\n---\n\n```leaf\nKIND: note\n```\n<!-- comment -->Trailing text\n";
+            "---\nQUILL: test\n---\n\n```leaf note\n```\n<!-- comment -->Trailing text\n";
         let doc = Document::from_markdown(md).unwrap();
         let normalized = super::normalize_document(doc).unwrap();
         assert_eq!(

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -43,10 +43,10 @@ impl QuillConfig {
         write_fence_block(
             &mut out,
             &self.main,
-            &format!(
+            Some(&format!(
                 "QUILL: {}@{}  # sentinel; required, verbatim",
                 self.name, self.version
-            ),
+            )),
             main_desc,
             "---\n",
             "---\n",
@@ -57,14 +57,13 @@ impl QuillConfig {
             out.push_str(&format!("\n{}\n", text));
         }
         for leaf in &self.leaf_kinds {
-            let sentinel = format!("KIND: {}  # sentinel; composable (0..N)", leaf.name);
             out.push('\n');
             write_fence_block(
                 &mut out,
                 leaf,
-                &sentinel,
+                None,
                 leaf.description.as_deref(),
-                "```leaf\n",
+                &format!("```leaf {}\n", leaf.name),
                 "```\n",
             );
             if leaf.body_enabled() {
@@ -81,7 +80,7 @@ impl QuillConfig {
 fn write_fence_block(
     out: &mut String,
     leaf: &LeafSchema,
-    sentinel_line: &str,
+    sentinel_line: Option<&str>,
     description: Option<&str>,
     open_fence: &str,
     close_fence: &str,
@@ -91,8 +90,10 @@ fn write_fence_block(
         let clean = desc.split_whitespace().collect::<Vec<_>>().join(" ");
         out.push_str(&format!("# {}\n", clean));
     }
-    out.push_str(sentinel_line);
-    out.push('\n');
+    if let Some(sentinel) = sentinel_line {
+        out.push_str(sentinel);
+        out.push('\n');
+    }
     for (_, fields) in group_fields(leaf.fields.values()) {
         for field in fields {
             write_field(out, field, 0);
@@ -654,7 +655,7 @@ main:
     }
 
     #[test]
-    fn leaf_sentinel_line_is_composable() {
+    fn leaf_kind_is_in_the_info_string() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -668,7 +669,7 @@ leaf_kinds:
 "#)
         .blueprint();
         assert!(t.contains(
-            "# A short note appended to the document.\nKIND: note  # sentinel; composable (0..N)\n"
+            "```leaf note\n# A short note appended to the document.\n"
         ));
     }
 
@@ -686,7 +687,7 @@ leaf_kinds:
       items: { type: array, required: true }
 "#)
         .blueprint();
-        let after = &t[t.find("KIND: skills").unwrap()..];
+        let after = &t[t.find("```leaf skills").unwrap()..];
         assert!(!after.contains("skills body"));
     }
 
@@ -705,7 +706,7 @@ leaf_kinds:
       author: { type: string }
 "#)
         .blueprint();
-        let after = &t[t.find("KIND: note").unwrap()..];
+        let after = &t[t.find("```leaf note").unwrap()..];
         assert!(after.contains("\nThis is an example note.\n"));
         assert!(!after.contains("Write note body here."));
     }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -106,7 +106,7 @@ impl QuillConfig {
                         &mut leaf_value,
                         "KIND",
                         &leaf.name,
-                        "Leaf kind name. Must be exactly this value as the KIND: sentinel in the leaf body.",
+                        "Leaf kind name. Must be exactly this value as the kind token in the leaf fence info string (```leaf <kind>).",
                     );
                     (leaf.name.clone(), leaf_value)
                 })

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -91,7 +91,7 @@ fn fence_marker_with_trailing_whitespace_is_accepted() {
 // §3 — `---` inside a fenced code block must be ignored.
 #[test]
 fn fences_inside_code_blocks_are_ignored() {
-    let md = "---\nQUILL: t\n---\n\n```\n```leaf\nKIND: x\n```\n```\n\nBody.";
+    let md = "---\nQUILL: t\n---\n\n```\n```leaf x\n```\n```\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert!(
         doc.leaves().is_empty(),
@@ -121,36 +121,49 @@ fn leaves_is_always_present_even_when_empty() {
     assert!(doc.leaves().is_empty());
 }
 
-// §3.2 / §9 — A leaf-info-string fence missing `KIND:` first-key is a hard
-// parse error, not a silent fallthrough to body content. This is the central
-// "no silent classification miss" promise of LEAF_REWORK.md §3.3.
+// §3.2 / §4.2 — a `leaf`-prefixed fence commits to leaf parsing on that token
+// alone; a missing, invalid, or extra info-string kind token is a hard parse
+// error, not a silent fallthrough to body content. This is the central "no
+// silent classification miss" promise of LEAF_REWORK.md §3.3.
 #[test]
-fn leaf_fence_without_kind_first_key_is_rejected() {
+fn leaf_fence_with_bad_kind_token_is_rejected() {
     let cases = [
-        // Missing KIND entirely.
+        // Missing kind token.
         "---\nQUILL: t\n---\n\n```leaf\nname: Widget\n```\n",
-        // Empty leaf body.
+        // Empty leaf body, still missing the kind token.
         "---\nQUILL: t\n---\n\n```leaf\n```\n",
-        // KIND present but not first.
-        "---\nQUILL: t\n---\n\n```leaf\nname: Widget\nKIND: product\n```\n",
-        // QUILL inside a leaf fence (sentinel-mismatch).
-        "---\nQUILL: t\n---\n\n```leaf\nQUILL: other@1\n```\n",
+        // Invalid kind token (must match [a-z_][a-z0-9_]*).
+        "---\nQUILL: t\n---\n\n```leaf Widget\nname: x\n```\n",
+        // Extra info-string tokens.
+        "---\nQUILL: t\n---\n\n```leaf a b\n```\n",
     ];
     for md in cases {
         let err = Document::from_markdown(md).unwrap_err().to_string();
         assert!(
-            err.contains("KIND") && err.contains("Leaf fence"),
-            "expected hard KIND error for {md:?}, got: {err}"
+            err.contains("Leaf fence at line"),
+            "expected hard leaf-fence kind-token error for {md:?}, got: {err}"
         );
     }
 }
 
-// §5 — KIND value pattern.
+// §3.2 — `KIND` is an output-only reserved key; supplying it as an input body
+// key is a hard parse error.
+#[test]
+fn kind_as_leaf_body_key_is_rejected() {
+    let md = "---\nQUILL: t\n---\n\n```leaf product\nKIND: product\n```\n";
+    let err = Document::from_markdown(md).unwrap_err().to_string();
+    assert!(
+        err.contains("Reserved field name") && err.contains("KIND"),
+        "got: {err}"
+    );
+}
+
+// §3.2 — leaf kind-token pattern.
 #[test]
 fn leaf_name_pattern_enforced() {
-    let md = "---\nQUILL: t\n---\n\nB.\n\n```leaf\nKIND: ITEMS\n```\n\nX.";
+    let md = "---\nQUILL: t\n---\n\nB.\n\n```leaf ITEMS\n```\n\nX.";
     let err = Document::from_markdown(md).unwrap_err().to_string();
-    assert!(err.contains("Invalid leaf field name"), "got: {}", err);
+    assert!(err.contains("invalid kind token"), "got: {}", err);
 }
 
 // §7 — Body bidi stripped during normalize_document.
@@ -182,7 +195,7 @@ fn normalize_yaml_scalar_keeps_bidi() {
 // §7 — Leaf body normalization reaches nested leaves.
 #[test]
 fn normalize_reaches_leaf_body() {
-    let md = "---\nQUILL: t\n---\n\n```leaf\nKIND: x\n```\n\n<!-- c -->trailing\u{202D}text";
+    let md = "---\nQUILL: t\n---\n\n```leaf x\n```\n\n<!-- c -->trailing\u{202D}text";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     let body = doc.leaves()[0].body();
@@ -247,7 +260,7 @@ fn body_crlf_line_endings_are_normalized() {
 // §7 — CRLF normalization reaches leaf bodies.
 #[test]
 fn leaf_body_crlf_line_endings_are_normalized() {
-    let md = "---\nQUILL: t\n---\n\n```leaf\nKIND: x\n```\n\nLeaf line one.\r\nLeaf line two.\r\n";
+    let md = "---\nQUILL: t\n---\n\n```leaf x\n```\n\nLeaf line one.\r\nLeaf line two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     let body = doc.leaves()[0].body();
@@ -305,7 +318,7 @@ fn first_fence_out_of_order_error_is_specific() {
 fn unclosed_code_block_emits_warning() {
     // 4-backtick opener with no matching 4+-backtick closer → unclosed.
     // The 3-backtick `leaf` fence inside is shielded (3 < 4 cannot close).
-    let md = "---\nQUILL: t\n---\n\n````\ncode line\n\n```leaf\nKIND: x\n```\n\ntrailing body";
+    let md = "---\nQUILL: t\n---\n\n````\ncode line\n\n```leaf x\n```\n\ntrailing body";
     let out = Document::from_markdown_with_warnings(md).unwrap();
     assert!(
         out.warnings
@@ -341,7 +354,7 @@ fn per_fence_field_count_cap() {
 fn leaf_count_cap_is_per_leaf() {
     let mut s = String::from("---\nQUILL: t\n---\n");
     for _ in 0..1001 {
-        s.push_str("\n```leaf\nKIND: x\n```\n\nB.\n");
+        s.push_str("\n```leaf x\n```\n\nB.\n");
     }
     let err = Document::from_markdown(&s).unwrap_err().to_string();
     assert!(err.contains("Input too large"), "got: {}", err);

--- a/crates/fixtures/resources/extended_metadata_demo.md
+++ b/crates/fixtures/resources/extended_metadata_demo.md
@@ -11,24 +11,21 @@ The extended standard allows you to define inline metadata records throughout yo
 
 ## Features Demonstrated
 
-```leaf
-KIND: features
+```leaf features
 name: Tag Directives
 status: implemented
 ```
 
-Use `` ```leaf `` fenced code blocks with `KIND: <name>` to create collections of related items. Each block creates an entry in an array keyed by `KIND`.
+Use `` ```leaf <name> `` fenced code blocks to create collections of related items. Each block creates an entry in an array keyed by its kind.
 
-```leaf
-KIND: features
+```leaf features
 name: Structured Content
 status: implemented
 ```
 
 Break your document into logical sections with their own metadata. Perfect for catalogs, lists, and structured documents.
 
-```leaf
-KIND: features
+```leaf features
 name: Backward Compatible
 status: stable
 ```
@@ -37,16 +34,14 @@ Documents without leaf blocks continue to work exactly as before.
 
 ## Use Cases
 
-```leaf
-KIND: use_cases
+```leaf use_cases
 category: Documentation
 example: Technical specifications with multiple sections
 ```
 
 Perfect for API documentation, user manuals, and technical guides where you need structured metadata for each section.
 
-```leaf
-KIND: use_cases
+```leaf use_cases
 category: Content Management
 example: Product catalogs, blog posts, portfolios
 ```

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/example.md
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/example.md
@@ -9,8 +9,7 @@ contacts:
   - Pittsburgh, PA
 ---
 
-```leaf
-KIND: certifications_section
+```leaf certifications_section
 title: Active Certifications
 cells:
   - Offensive Security Certified Professional (OSCP)
@@ -19,8 +18,7 @@ cells:
   - GIAC Machine Learning Engineer (GMLE)
 ```
 
-```leaf
-KIND: skills_section
+```leaf skills_section
 title: Skills
 cells:
   - category: Programming
@@ -33,8 +31,7 @@ cells:
     skills: AWS EC2/S3, Helm, Docker, Serverless
 ```
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 title: Work Experience
 headingLeft: Templar Archives Research Division
 headingRight: August 2024 – Present
@@ -45,8 +42,7 @@ subheadingRight: Aiur
 - Analyzed Khala disruption patterns following Amon's corruption, developing countermeasures to protect remaining neural link infrastructure.
 - Building automated threat detection pipelines using Khaydarin crystal arrays to monitor Void energy signatures across the sector.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: Terran Dominion Ghost Academy
 headingRight: May 2025 – July 2025
 subheadingLeft: Covert Ops Trainee
@@ -57,8 +53,7 @@ subheadingRight: Tarsonis (Remote)
 - Created automated target acquisition systems for nuclear launch protocols; involved cloaking field calibration and EMP targeting.
 - Discovered (and reported) a critical vulnerability in Adjutant defense networks exploitable by Zerg Infestors.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: Abathur's Evolution Pit
 headingRight: June 2023 – July 2023
 subheadingLeft: Biomass Research Intern
@@ -68,8 +63,7 @@ subheadingRight: Char
 - Developed tracking algorithms for Overlord surveillance networks; supported pattern-of-life analysis for Terran outpost elimination.
 - Prototyped a creep tumor optimization tool featuring swarm pathfinding, resource node mapping, and hatchery placement recommendations.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: Raynor's Raiders
 headingRight: January 2018 – June 2020
 subheadingLeft: Combat Engineer
@@ -81,8 +75,7 @@ subheadingRight: Mar Sara
 - Achieved Distinguished Graduate honors at the Mar Sara Militia Academy.
 - Awarded the Raynor's Star and Mar Sara Defense Medal for meritorious service against the Swarm.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 title: Education
 headingLeft: Carnegie Mellon University
 headingRight: December 2025
@@ -90,8 +83,7 @@ subheadingLeft: Master of Information Technology Strategy
 subheadingRight: Pittsburgh, PA
 ```
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: United States Air Force Academy
 headingRight: May 2024
 subheadingLeft: BS, Data Science
@@ -102,24 +94,21 @@ subheadingRight: Colorado Springs, CO
 - Delogrand deputy captain, cyber combat lead, and web exploit SME.
 - Professor Bradley A. Warner Data Science Catalyst and Top Cadet in Computer Networks.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: Western Governors University
 headingRight: April 2022
 subheadingLeft: BS, Cybersecurity and Information Assurance
 subheadingRight: Remote
 ```
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: Community College of the Air Force
 headingRight: February 2019
 subheadingLeft: AS, Information Systems Technology
 subheadingRight: Remote
 ```
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 title: Cyber Competition
 headingLeft: 1st in SANS Academy Cup 2024
 ```
@@ -127,38 +116,33 @@ headingLeft: 1st in SANS Academy Cup 2024
 - Competed as the Delogrand Web Exploit SME, solving SQLi, API, and HTTP packet crafting problems.
 - Also placed first in SANS Core Netwars competition.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: 1st in NCX 2023
 ```
 
 - Developed strategies, defensive scripts, and exploits for the Cyber Combat event.
 - Analyzed logs with Bash and Python for the Data Analysis event.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: 1st in SANS Academy Cup 2023
 ```
 
 - Competed as the Delogrand Web Exploit SME, solving XSS, XXE, SQLi, and HTTP crafting problems.
 - Took first place against rival Army, Navy, and Coast Guard service academy teams.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: 1st in RMCS 2023
 ```
 
 - Competed as the Delogrand Web Exploit SME, solving obfuscated JS, Wasm, XSS, and SQLi problems.
 
-```leaf
-KIND: experience_section
+```leaf experience_section
 headingLeft: 1st in NCX 2022
 ```
 
 - Trained and strategized teams for the Cyber Combat event.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 title: Projects
 name: TongueToQuill
 url: https://www.tonguetoquill.com
@@ -166,32 +150,28 @@ url: https://www.tonguetoquill.com
 
 - Rich markdown editor for perfectly formatted USAF and USSF documents with Claude MCP integration.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: Quillmark
 url: https://github.com/nibsbin/quillmark
 ```
 
 - Parameterization engine for generating arbitrarily typesetted documents from markdown content.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: RoboRA
 url: https://github.com/nibsbin/RoboRA
 ```
 
 - AI research automation framework for Dr. Nadiya Kostyuk's research on global cyber policy.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: Scraipe
 url: https://pypi.org/project/scraipe/
 ```
 
 - An asynchronous scraping and enrichment library to automate cybersecurity research.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: Quandry
 url: https://quandry.streamlit.app/
 ```
@@ -199,32 +179,28 @@ url: https://quandry.streamlit.app/
 - LLM Expectation Engine to automate security and behavior evaluation of LLM models.
 - Awarded 1st place out of 11 teams in CMU's Fall 2024 Information Security, Privacy, and Policy poster fair.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: Streamlit Scroll Navigation
 url: https://pypi.org/project/streamlit-scroll-navigation/
 ```
 
 - Published a Streamlit-featured PyPI package to help data scientists create fluid single-page applications.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: ADSBLookup
 url: <closed source>
 ```
 
 - Reversed the internal API of a popular ADSB web service to pull comprehensive live ADSB datasets; ported and exposed attributes in a user-friendly, Pandas-compatible Python library for data scientists.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: OSCP LaTeX Report Template
 url: https://github.com/SnpM/oscp-latex-report-template
 ```
 
 - Published a report template that features custom commands for streamlined penetration test documentation.
 
-```leaf
-KIND: projects_section
+```leaf projects_section
 name: Lockstep Framework
 url: https://github.com/SnpM/LockstepFramework
 ```

--- a/crates/fixtures/resources/quills/taro/0.1.0/example.md
+++ b/crates/fixtures/resources/quills/taro/0.1.0/example.md
@@ -8,20 +8,17 @@ title: "My Favorite Ice Cream Flavor"
 I love Taro ice cream for its subtly sweet, nutty flavor and creamy, earthy undertones that set it apart from more common flavors. Its unique purple hue and smooth texture make it both visually striking and deliciously comforting. Here are some quotes from satisfied customers:
 
 
-```leaf
-KIND: quotes
+```leaf quotes
 author: Albert Einstein
 ```
 Without taro ice cream, life would be a mistake.
 
-```leaf
-KIND: quotes
+```leaf quotes
 author: Friedrich Nietzsche
 ```
 He who has taro ice cream in his heart will never be alone.
 
-```leaf
-KIND: quotes
+```leaf quotes
 author: Mark Twain
 ```
 The secret of getting ahead is getting started... with taro ice cream.

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -150,7 +150,9 @@ leaf_kinds:
       KIND:
         type: string
         const: indorsement
-        description: "Leaf kind name. Must be exactly this value as the KIND: sentinel in the leaf body."
+        description: >-
+          Leaf kind name. Must be exactly this value as the kind token in the leaf fence
+          info string (```leaf <kind>).
         required: true
       attachments:
         type: array

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/example.md
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/example.md
@@ -42,8 +42,7 @@ The `usaf_memo` Quill package takes care of all 33-337 formatting details. Focus
 
 Do not include a complimentary close (e.g. "Respectfully,") in official memorandums.
 
-```leaf
-KIND: indorsement
+```leaf indorsement
 for: ORG/SYMBOL
 format: standard
 from: ORG/SYMBOL

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/examples/basic.md
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/examples/basic.md
@@ -42,8 +42,7 @@ The `usaf_memo` Quill package takes care of all 33-337 formatting details. Focus
 
 Do not include a complimentary close (e.g. "Respectfully,") in official memorandums.
 
-```leaf
-KIND: indorsement
+```leaf indorsement
 for: ORG/SYMBOL
 format: standard
 from: ORG/SYMBOL

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/example.md
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/example.md
@@ -42,8 +42,7 @@ The `usaf_memo` Quill package takes care of all 33-337 formatting details. Focus
 
 Do not include a complimentary close (e.g. "Respectfully,") in official memorandums.
 
-```leaf
-KIND: indorsement
+```leaf indorsement
 for: ORG/SYMBOL
 format: standard
 from: ORG/SYMBOL

--- a/crates/fuzz/src/emit_roundtrip_fuzz.rs
+++ b/crates/fuzz/src/emit_roundtrip_fuzz.rs
@@ -111,7 +111,7 @@ proptest! {
         leaf_value in "[a-zA-Z0-9 ]{0,50}"
     ) {
         let src = format!(
-            "---\nQUILL: {}\ntitle: \"test\"\n---\n\nBody here.\n\n```leaf\nKIND: {}\n{}: \"{}\"\n```\n\nLeaf body.\n",
+            "---\nQUILL: {}\ntitle: \"test\"\n---\n\nBody here.\n\n```leaf {}\n{}: \"{}\"\n```\n\nLeaf body.\n",
             quill, leaf_tag, leaf_key, leaf_value
         );
 

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -152,8 +152,8 @@ leaf_kinds:
     );
 
     let md = "---\nQUILL: unknown_leaf_test\ntitle: \"T\"\n---\n\n\
-              ```leaf\nKIND: known_leaf\nnote: \"A\"\n```\n\n\
-              ```leaf\nKIND: ghost_leaf\nnote: \"B\"\n```\n";
+              ```leaf known_leaf\nnote: \"A\"\n```\n\n\
+              ```leaf ghost_leaf\nnote: \"B\"\n```\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
@@ -206,7 +206,7 @@ leaf_kinds:
 
     // signature_block present, office absent (has default), extra absent (no default)
     let md = "---\nQUILL: leaf_fields_test\ntitle: \"T\"\n---\n\n\
-              ```leaf\nKIND: indorsement\nsignature_block: \"Col Smith\"\n```\n";
+              ```leaf indorsement\nsignature_block: \"Col Smith\"\n```\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);

--- a/crates/quillmark/tests/security_tests.rs
+++ b/crates/quillmark/tests/security_tests.rs
@@ -33,7 +33,7 @@ fn test_leaf_count_limit_attack() {
     // Generate more than MAX_LEAF_COUNT (1000) leaf blocks
     let mut markdown = String::from("---\nQUILL: test_quill\ntitle: Test\n---\n\nBody\n\n");
     for i in 0..1002 {
-        markdown.push_str(&format!("```leaf\nKIND: item{}\nvalue: {}\n```\n\n", i, i));
+        markdown.push_str(&format!("```leaf item{}\nvalue: {}\n```\n\n", i, i));
     }
     let result = Document::from_markdown(&markdown);
 
@@ -132,14 +132,14 @@ fn test_reserved_field_injection() {
     }
 }
 
-/// Test that KIND directive validation prevents invalid names
+/// Test that leaf kind-token validation prevents invalid names
 #[test]
 fn test_leaf_kind_name_validation() {
     let invalid_names = vec![
-        "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: Invalid-Name\n```\n\n",
-        "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: 123start\n```\n\n",
-        "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: UPPERCASE\n```\n\n",
-        "---\nQUILL: test_quill\n---\n\n```leaf\nKIND: spaces here\n```\n\n",
+        "---\nQUILL: test_quill\n---\n\n```leaf Invalid-Name\n```\n\n",
+        "---\nQUILL: test_quill\n---\n\n```leaf 123start\n```\n\n",
+        "---\nQUILL: test_quill\n---\n\n```leaf UPPERCASE\n```\n\n",
+        "---\nQUILL: test_quill\n---\n\n```leaf spaces here\n```\n\n",
     ];
 
     for markdown in invalid_names {
@@ -156,7 +156,7 @@ fn test_leaf_kind_name_validation() {
 #[test]
 fn test_yaml_error_location() {
     let markdown =
-        "---\nQUILL: test_quill\ntitle: Test\n---\n\nBody\n\n```leaf\nKIND: test\ninvalid yaml: {\n```\n\n";
+        "---\nQUILL: test_quill\ntitle: Test\n---\n\nBody\n\n```leaf test\ninvalid yaml: {\n```\n\n";
     let result = Document::from_markdown(markdown);
 
     assert!(result.is_err(), "Should reject invalid YAML");
@@ -168,17 +168,17 @@ fn test_yaml_error_location() {
     );
 }
 
-/// Test both QUILL and KIND in same block is rejected
+/// Test that `KIND` as an input body key is rejected as a reserved key
 #[test]
 fn test_quill_leaf_conflict() {
     let markdown = "---\nQUILL: template\nKIND: item\n---\n\n";
     let result = Document::from_markdown(markdown);
 
-    assert!(result.is_err(), "Should reject QUILL + KIND in same block");
+    assert!(result.is_err(), "Should reject KIND as an input body key");
     let err_msg = result.unwrap_err().to_string();
     assert!(
-        err_msg.contains("QUILL") && err_msg.contains("KIND"),
-        "Error should mention both keys: {}",
+        err_msg.contains("Reserved field name") && err_msg.contains("KIND"),
+        "Error should flag KIND as a reserved key: {}",
         err_msg
     );
 }
@@ -187,7 +187,7 @@ fn test_quill_leaf_conflict() {
 #[test]
 fn test_strict_fence_detection() {
     let markdown =
-        "---\nQUILL: test_quill\ntitle: Test\n---\n\n````\n```leaf\nKIND: test\nvalue: 1\n```\n````";
+        "---\nQUILL: test_quill\ntitle: Test\n---\n\n````\n```leaf test\nvalue: 1\n```\n````";
     let result = Document::from_markdown(markdown);
 
     assert!(result.is_ok(), "Should parse successfully");
@@ -203,7 +203,7 @@ fn test_strict_fence_detection() {
 #[test]
 fn test_tilde_fence_hides_metadata() {
     let markdown =
-        "---\nQUILL: test_quill\ntitle: Test\n---\n\n~~~\n```leaf\nKIND: test\nvalue: 1\n```\n~~~";
+        "---\nQUILL: test_quill\ntitle: Test\n---\n\n~~~\n```leaf test\nvalue: 1\n```\n~~~";
     let result = Document::from_markdown(markdown);
 
     assert!(result.is_ok(), "Should parse successfully");

--- a/docs/authoring/leaves.md
+++ b/docs/authoring/leaves.md
@@ -3,7 +3,7 @@
 Quillmark supports inline structured-data records — *leaves* — for repeated
 sections like product cards, indorsement chains, or experience entries. Each
 leaf is a [CommonMark fenced code block](https://spec.commonmark.org/0.31.2/#fenced-code-blocks)
-with the info string `leaf` and a YAML body whose first key is `KIND:`.
+whose info string is `leaf <kind>` and which carries a YAML body.
 
 ## Leaf syntax
 
@@ -17,16 +17,14 @@ title: Main Document
 
 Some content here.
 
-```leaf
-KIND: products
+```leaf products
 name: Widget
 price: 19.99
 ```
 
 Widget description goes here, as Markdown prose, up to the next leaf or EOF.
 
-```leaf
-KIND: products
+```leaf products
 name: Gadget
 price: 29.99
 ```
@@ -46,8 +44,7 @@ have at least as many backticks as the opener. To embed a fenced code block
 inside a leaf body, open the leaf with a longer fence:
 
 `````markdown
-````leaf
-KIND: example
+````leaf example
 caption: Hello world in Python
 ````
 
@@ -62,17 +59,18 @@ Indented fences (0–3 leading spaces) are permitted, matching CommonMark.
 
 ## Rules
 
-- `KIND:` must be the first key in the leaf body. Its value matches the
-  pattern `[a-z_][a-z0-9_]*`.
-- `BODY` is reserved inside a leaf — the parser populates it with the prose
-  attached to the leaf, and supplying it as an input key is a hard error.
+- The info string must be exactly `leaf <kind>`. The kind matches the
+  pattern `[a-z_][a-z0-9_]*`. A missing kind token, an invalid kind
+  token, or any extra info-string token is a hard parse error.
+- `BODY` and `KIND` are reserved inside a leaf — the parser populates them
+  (`BODY` with the attached prose, `KIND` from the info-string kind
+  token), and supplying either as an input body key is a hard error.
 - `QUILL` is *not* reserved inside leaves — it's only meaningful in
   frontmatter.
-- YAML tags such as `!fill` cannot decorate the sentinel keys (`QUILL`,
-  `KIND`).
+- YAML tags such as `!fill` cannot decorate the `QUILL` sentinel key.
 - Misspelt info strings (e.g. ` ```leef `) are just unknown-language code
-  blocks; the parser ignores them. Misspelt `KIND:` inside a `leaf` fence
-  is a schema-level error.
+  blocks; the parser ignores them. A `` ```leaf `` fence with a missing or
+  malformed kind token, however, is a hard parse error.
 
 ## Leaf body
 

--- a/docs/authoring/yaml-frontmatter.md
+++ b/docs/authoring/yaml-frontmatter.md
@@ -101,11 +101,13 @@ tags: !fill []
 
 ## Reserved Field Names
 
-`BODY` and `LEAVES` are reserved as **output-only** fields: the parser
-populates them, and supplying them as input keys is a hard parse error.
-`BODY` holds the document's Markdown body; `LEAVES` holds the ordered list
-of leaf records. `QUILL` is also reserved — it's the sentinel that names the
-quill format. YAML tags such as `!fill` cannot decorate `QUILL` or `KIND`.
+`BODY`, `LEAVES`, and `KIND` are reserved as **output-only** fields: the
+parser populates them, and supplying them as input keys is a hard parse
+error. `BODY` holds the document's Markdown body; `LEAVES` holds the
+ordered list of leaf records; `KIND` holds a leaf's kind (sourced from the
+`` ```leaf <kind> `` info string). `QUILL` is also reserved — it's the
+sentinel that names the quill format. YAML tags such as `!fill` cannot
+decorate `QUILL`.
 
 ## Rules Summary
 
@@ -118,9 +120,8 @@ quill format. YAML tags such as `!fill` cannot decorate `QUILL` or `KIND`.
 
 ## Leaves
 
-Inline structured records — *leaves* — use a `` ```leaf `` fenced code block
-with `KIND:` as the first body key. See [Leaves](leaves.md) for the full
-syntax.
+Inline structured records — *leaves* — use a `` ```leaf <kind> `` fenced
+code block. See [Leaves](leaves.md) for the full syntax.
 
 Frontmatter is coerced and validated against the schema declared in the
 Quill's `Quill.yaml` (`main.fields`). See the

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -384,8 +384,8 @@ leaf_kinds:
 
 ### Using Leaves in Markdown
 
-Leaves appear as fenced code blocks with the info string `leaf`, each
-declaring `KIND:` as the first body key:
+Leaves appear as fenced code blocks with the info string `leaf <kind>`,
+where the kind names the leaf schema:
 
 ````markdown
 ---
@@ -396,8 +396,7 @@ subject: Example
 
 Main memo body text here.
 
-```leaf
-KIND: indorsement
+```leaf indorsement
 from: ORG/SYMBOL
 for: RECIPIENT/SYMBOL
 signature_block:
@@ -407,8 +406,7 @@ signature_block:
 
 Body of the first endorsement.
 
-```leaf
-KIND: indorsement
+```leaf indorsement
 from: ANOTHER/ORG
 for: FINAL/RECIPIENT
 format: informal

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -26,9 +26,8 @@ field: value  # <type>; <role>
 
 Write main body here.
 
-```leaf
+```leaf <leaf_kind>
 # <leaf description>
-KIND: <leaf_kind>  # sentinel; composable (0..N)
 ...fields...
 ```
 
@@ -82,8 +81,9 @@ Form: **`# <type>[<format>]; <role>[, <extra>...]`**
   - `enum<a | b | c>`
   - omitted for `string`, `integer`, `number`, `boolean`, `object`,
     `markdown` (nothing meaningful to refine).
-- **Role slot** (mandatory, after `;`): `required`, `optional`, or
-  `composable (0..N)` (KIND-sentinel only).
+- **Role slot** (mandatory, after `;`): `required` or `optional`. (A
+  composable leaf is signalled by the `` ```leaf <kind> `` fence itself,
+  not by a role marker on a field line.)
 - **Extras** (optional, comma-separated, after the role): additional
   qualifiers. Currently used for `verbatim` on the QUILL sentinel,
   signaling that the rendered value is fixed and must not be modified.
@@ -102,7 +102,7 @@ Examples:
 | `published: ""  # datetime<ISO 8601>; required` | required datetime in ISO 8601 |
 | `level: low  # enum<low \| medium \| high>; optional` | optional enum, default is first value |
 | `QUILL: cmu_letter@0.1.0  # sentinel; required, verbatim` | quill binding, do not modify |
-| `KIND: skill  # sentinel; composable (0..N)` | repeat the entire ` ```leaf ... ``` ` block per instance |
+| ` ```leaf skill ` | composable leaf — repeat the entire ` ```leaf skill ... ``` ` block per instance |
 
 ## Placeholder value precedence
 

--- a/prose/designs/LEAVES.md
+++ b/prose/designs/LEAVES.md
@@ -6,10 +6,11 @@
 ## Overview
 
 Leaves are structured metadata records inline within document content,
-encoded as CommonMark fenced code blocks with the info string `leaf`. All
-leaves are stored in a single `LEAVES` array, discriminated by the `KIND`
-field. See [MARKDOWN.md](MARKDOWN.md) §3.2 for the syntax-level
-specification.
+encoded as CommonMark fenced code blocks whose info string is
+`leaf <kind>`. All leaves are stored in a single `LEAVES` array,
+discriminated by `KIND` — an output-only field the parser populates from
+the info-string kind token. See [MARKDOWN.md](MARKDOWN.md) §3.2 for the
+syntax-level specification.
 
 ## Data Model
 
@@ -91,15 +92,16 @@ leaf_kinds:
 `QuillConfig::schema()` emits the schema (with `ui` and `body` hints
 retained) and `schema_yaml()` is the YAML wrapper. The output keeps the
 same `leaf_kinds.<name>.fields` shape as `Quill.yaml` and injects a
-required `KIND` sentinel field whose `const` value is the leaf kind name.
+required `KIND` discriminator field whose `const` value is the leaf kind
+name (the kind token authors write in the `` ```leaf <kind> `` info
+string).
 The `leaf_kinds` key is omitted entirely when no named kinds are defined.
 See `SCHEMAS.md` for the full surface.
 
 ## Markdown Syntax
 
 ````markdown
-```leaf
-KIND: indorsement
+```leaf indorsement
 from: ORG1/SYMBOL
 for: ORG2/SYMBOL
 signature_block:

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -36,10 +36,9 @@ Document = Frontmatter? Body (LeafFence LeafBody)*
 - **Body** — markdown content between the frontmatter close and the first
   leaf fence (or EOF).
 - **Leaf fence + leaf body** — zero or more. Each leaf fence is a
-  CommonMark fenced code block with the info string `leaf`; its body
-  declares a typed structured record (first key `KIND:`). Markdown prose
-  attached to the leaf follows the closing fence, up to the next leaf
-  fence or EOF.
+  CommonMark fenced code block whose info string is `leaf <kind>`; its
+  body declares a typed structured record. Markdown prose attached to the
+  leaf follows the closing fence, up to the next leaf fence or EOF.
 
 The two structures use *different* delimiters by design — `---/---` for
 frontmatter (universal across the markdown ecosystem) and `` ```leaf `` for
@@ -56,10 +55,10 @@ whitespace, 0–3 leading spaces of indentation). The first body key must be
 
 - **Position.** Line 1 of the document, or preceded by a blank line.
 - **Line endings.** `\n` and `\r\n` are equally accepted.
-- **Reserved keys.** `BODY` and `LEAVES` are **output-only** — the parser
-  populates them on the parsed object and supplying them as input keys is
-  a hard parse error. `QUILL` is the sentinel and must be the first body
-  key. `KIND` is not reserved in frontmatter.
+- **Reserved keys.** `BODY`, `LEAVES`, and `KIND` are **output-only** —
+  the parser populates them on the parsed object and supplying them as
+  input keys is a hard parse error. `QUILL` is the sentinel and must be
+  the first body key.
 - **YAML comments.** Own-line comments (`# …`) between the fence
   delimiters round-trip as first-class ordered items. Inline comments on
   value lines (`key: value  # note`) round-trip on the same line.
@@ -75,12 +74,11 @@ whitespace, 0–3 leading spaces of indentation). The first body key must be
 ### 3.2 Leaves
 
 A leaf is a [CommonMark fenced code block](https://spec.commonmark.org/0.31.2/#fenced-code-blocks)
-whose info string's first whitespace-delimited token is `leaf`. The body
-of the fence is parsed as YAML; the first key must be `KIND:`.
+whose info string is exactly two whitespace-delimited tokens: `leaf`
+followed by the **kind**. The body of the fence is parsed as YAML.
 
 ````markdown
-```leaf
-KIND: product
+```leaf product
 name: Widget
 price: 19.99
 ```
@@ -93,12 +91,15 @@ Body prose for this leaf, up to the next leaf or EOF.
   embed a fenced code block inside a leaf body, open the leaf with a
   longer fence (e.g. four backticks).
 - **Indent.** 0–3 leading spaces are permitted, matching CommonMark.
-- **`KIND:` value.** Matches `[a-z_][a-z0-9_]*`.
-- **Reserved keys.** `BODY` is output-only inside a leaf — supplying it as
-  an input key is a hard parse error. `KIND` is the sentinel and must be
-  the first body key. `QUILL` is not reserved inside leaves.
-- **The `!fill` tag.** Same rules as frontmatter (§3.1), and **forbidden
-  on the sentinel key `KIND`**.
+- **Info string.** Exactly `leaf <kind>`. The kind matches
+  `[a-z_][a-z0-9_]*`. A missing kind token, an invalid kind token, or any
+  extra info-string token is a hard parse error (§4.2).
+- **Reserved keys.** `BODY` and `KIND` are output-only inside a leaf —
+  supplying either as an input body key is a hard parse error. `KIND` is
+  populated from the info-string kind token. `QUILL` is not reserved
+  inside leaves.
+- **The `!fill` tag.** Same rules as frontmatter (§3.1). The kind lives in
+  the info string, not the body, so `!fill` cannot reach it.
 
 ## 4. Fence Detection
 
@@ -124,13 +125,15 @@ Only **one** frontmatter block is recognised — the first matching
 ### 4.2 Leaf detection
 
 A fenced code block is a leaf iff its info string's first token is `leaf`.
-Detection is purely lexical: the parser commits to leaf-handling on the
-info string alone, before reading any body content.
+Detection is purely lexical: the parser commits to leaf-handling on that
+first token alone, before reading any body content.
 
-After fence detection commits, parsing the leaf body is *routing*: the
-first body key (`KIND:`) selects the schema, and any malformed leaf
-(missing `KIND:`, invalid kind name, reserved-key collision) is a hard
-parse error — not a fence-classification ambiguity.
+Once committed, the rest of the info string is *routing*: the second
+token is the kind and selects the schema. A leaf info string that is not
+exactly `leaf <kind>` — a missing kind token, an invalid kind token (one
+not matching `[a-z_][a-z0-9_]*`), or any extra token — is a hard parse
+error, not a fence-classification ambiguity. Likewise any malformed leaf
+body (reserved-key collision, invalid YAML) is a hard error.
 
 ### 4.3 Worked example
 
@@ -144,16 +147,14 @@ title: Spring Catalog
 
 Welcome to the spring catalog.
 
-```leaf
-KIND: product
+```leaf product
 name: Widget
 price: 19.99
 ```
 
 The Widget is our flagship product.
 
-```leaf
-KIND: product
+```leaf product
 name: Gadget
 price: 29.99
 ```
@@ -170,13 +171,14 @@ The Gadget complements the Widget.
 - **Unknown info string.** ` ```leef ` is just a code block with an
   unknown language — silently passed through. Misspelt info strings are
   not near-miss diagnostics.
-- **Missing `KIND:` in a leaf.** Hard parse error inside the leaf — the
-  fence has been classified, so the diagnostic is specific.
+- **Missing kind token in a leaf.** A `` ```leaf `` fence with no kind
+  token (or an invalid/extra token) is a hard parse error — the fence has
+  been classified on the `leaf` token, so the diagnostic is specific.
 - **Legacy `---/CARD: …/---` block.** Accepted in this release as a
-  Release-N migration path: parsed as a leaf, surfaces a
-  `parse::deprecated_leaf_syntax` warning, and rewritten to ` ```leaf `
-  on `to_markdown()` round-trip. The legacy form will be a hard parse
-  error in the next release.
+  Release-N migration path: parsed as a leaf (the `CARD:` value becomes
+  the kind), surfaces a `parse::deprecated_leaf_syntax` warning, and
+  rewritten to ` ```leaf <kind> ` on `to_markdown()` round-trip. The
+  legacy form will be a hard parse error in the next release.
 
 ## 5. Data Model
 
@@ -292,11 +294,12 @@ Parse errors include:
   `---` before EOF.
 - Frontmatter missing the `QUILL` key (no valid frontmatter found).
 - Leaf fence opened but never closed.
-- Leaf body missing the `KIND:` key, or `KIND:` not the first body key.
-- Leaf `KIND:` value failing the `/^[a-z_][a-z0-9_]*$/` pattern.
-- Use of an output-only reserved key (`BODY`, `LEAVES` in frontmatter;
-  `BODY` in leaves) as a user-defined input field.
-- `!fill` tag applied to a sentinel key (`QUILL` or `KIND`).
+- Leaf info string that is not exactly `leaf <kind>` — a missing kind
+  token, a kind token failing the `/^[a-z_][a-z0-9_]*$/` pattern, or any
+  extra info-string token.
+- Use of an output-only reserved key (`BODY`, `LEAVES`, `KIND`) as a
+  user-defined input field.
+- `!fill` tag applied to the sentinel key `QUILL`.
 - Invalid YAML inside any fence.
 - Any §8 limit exceeded.
 

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -54,7 +54,7 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - `ui` hints on fields and leaf kinds (`group`, `order`, `compact`, `multiline`, `title`)
 - `body` blocks on leaves (`enabled`, `description`)
 - A required `QUILL` sentinel prepended to `main.fields` (`const = "<name>@<version>"`)
-- A required `KIND` sentinel prepended to each `leaf_kinds.<name>.fields` (`const = "<name>"`)
+- A required `KIND` discriminator field prepended to each `leaf_kinds.<name>.fields` (`const = "<name>"`)
 
 `QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `LeafSchema`, `UiFieldSchema`, `UiLeafSchema`, and `BodyLeafSchema` — there is no parallel mirror struct.
 
@@ -75,7 +75,7 @@ Identity fields (`name`, `version`, `backend`, `author`, `description`) live on 
 
 ### `main.fields` and `leaf_kinds.<name>.fields` sentinels
 
-`schema()` prepends a synthetic field to each leaf's `fields` map so consumers know exactly which sentinel string to write:
+`schema()` prepends a synthetic field to each leaf's `fields` map so consumers know exactly which fixed value to write (`QUILL` as the frontmatter sentinel, `KIND` as the leaf fence's kind token):
 
 - `main.fields.QUILL` — `{ type: string, const: "<name>@<version>", required: true, description: ... }`
 - `leaf_kinds.<name>.fields.KIND` — `{ type: string, const: "<name>", required: true, description: ... }`

--- a/prose/proposals/LEAF_KIND_INFOSTRING.md
+++ b/prose/proposals/LEAF_KIND_INFOSTRING.md
@@ -1,6 +1,6 @@
 # Proposal — Move the Leaf Kind Discriminator into the Info String
 
-> **Status**: Proposed (for SWE planning & implementation)
+> **Status**: Implemented
 > **See also**: [MARKDOWN.md](../designs/MARKDOWN.md) (spec), [LEAF_REWORK.md](LEAF_REWORK.md) (current design), [LEAVES.md](../designs/LEAVES.md) (data model)
 > **Amends**: LEAF_REWORK.md §3.2, §5; MARKDOWN.md §2, §3.2, §4.2, §4.4
 
@@ -162,13 +162,18 @@ planning (§8).
   moves from sentinel to output-only, so it is still a reserved body key an
   author can collide with.
 
-## 8. Open questions for the planner
+## 8. Open questions for the planner — resolved
 
-1. **Extra-token policy.** `` ```leaf a b `` — hard error (strict; catches
-   typos) or ignore trailing tokens (CommonMark-ish)? Recommendation: **hard
-   error** — leaf info strings are structural, not free-form.
-2. **`---/CARD:---` legacy path.** Is it still present in `fences.rs`? If so,
-   confirm its emitter target retargets to `` ```leaf <kind> `` and that no
-   additional work is implied.
-3. **Error code naming.** New diagnostics ("missing kind token", "invalid
-   kind token") need codes consistent with the existing `parse::*` scheme.
+1. **Extra-token policy.** `` ```leaf a b `` — **hard error** (`fences.rs`
+   `leaf_kind_from_tokens`): a leaf info string must be exactly `leaf <kind>`.
+2. **`---/CARD:---` legacy path.** Still present and **reworked**. Because
+   `KIND:` as a body key is now a hard error, the legacy path can no longer
+   rewrite `CARD:`→`KIND:` in the body. `assemble.rs::extract_legacy_card_leaf`
+   instead lifts the kind out of the `CARD:` line and drops that line, so the
+   block parses as a canonical leaf; the emitter retargets to
+   `` ```leaf <kind> `` as before.
+3. **Error code naming.** Hard parse errors in this codebase all collapse to
+   the single code `parse::invalid_structure` (distinguished by message);
+   there is no granular `parse::*` code per error. The new "missing/invalid/
+   extra kind token" errors are `ParseError::InvalidStructure`, matching the
+   former "missing `KIND:`" error exactly.

--- a/prose/proposals/LEAF_REWORK.md
+++ b/prose/proposals/LEAF_REWORK.md
@@ -151,6 +151,12 @@ opener may sit anywhere in that range.
 
 ### 3.2 Why `KIND:` as a body key and not an info-string token
 
+> **Superseded** by [LEAF_KIND_INFOSTRING.md](LEAF_KIND_INFOSTRING.md): the
+> kind discriminator has since been moved into the info string
+> (` ```leaf <kind> `), for LLM-authoring robustness. The rationale below
+> records the original decision and is kept for history; the reserved-key
+> table in §5 reflects the current design.
+
 A natural alternative was ` ```leaf product ` — second-token in the info
 string carries the kind. Rejected because:
 
@@ -223,6 +229,10 @@ vocabulary would be a long-term translation tax.
 
 ## 5. Reserved keys
 
+> Updated per [LEAF_KIND_INFOSTRING.md](LEAF_KIND_INFOSTRING.md): `KIND`
+> is no longer a body sentinel — it is carried by the `` ```leaf <kind> ``
+> info string and joins the output-only set.
+
 Two categories, scoped to the fence they appear in:
 
 **Sentinels** — the user supplies these; the parser routes on them:
@@ -230,20 +240,21 @@ Two categories, scoped to the fence they appear in:
 | Position | Sentinel | Required position |
 |---|---|---|
 | Frontmatter body | `QUILL` | First body key |
-| Leaf body | `KIND` | First body key |
+
+The leaf kind is carried by the info string (`` ```leaf <kind> ``), not a
+body key.
 
 **Output-only** — the parser populates these on the output object (§6);
 supplying them as input keys is a hard parse error:
 
 | Position | Output-only keys |
 |---|---|
-| Frontmatter body | `BODY`, `LEAVES` |
-| Leaf body | `BODY` |
+| Frontmatter body | `BODY`, `LEAVES`, `KIND` |
+| Leaf body | `BODY`, `KIND` |
 
-`QUILL` is not reserved inside leaves; `KIND` is not reserved inside
-frontmatter. Sentinel keys (`QUILL`, `KIND`) may not carry YAML tags
-such as `!fill` — they are routing keys, not data, and must resolve
-at parse time.
+`QUILL` is not reserved inside leaves. The `QUILL` sentinel key may not
+carry YAML tags such as `!fill` — it is a routing key, not data, and must
+resolve at parse time.
 
 ## 6. Data model
 


### PR DESCRIPTION
Proposes switching leaf records from `KIND:`-first-body-key to a second
info-string token (```leaf <kind>), motivated by LLM-authoring
robustness. Design-level handover doc for SWE planning.

https://claude.ai/code/session_01W7noGZwHWuDPFny5RfcnP9