### PR TITLE
Add quillmark specs CLI command for Markdown blueprints

### DIFF
--- a/crates/bindings/cli/src/commands/mod.rs
+++ b/crates/bindings/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod info;
 pub mod render;
 pub mod schema;
+pub mod specs;
 pub mod validate;

--- a/crates/bindings/cli/src/commands/specs.rs
+++ b/crates/bindings/cli/src/commands/specs.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::PathBuf;
 
 #[derive(Parser)]
-pub struct SchemaArgs {
+pub struct SpecsArgs {
     /// Path to quill directory
     #[arg(value_name = "QUILL_PATH")]
     quill: PathBuf,
@@ -15,7 +15,7 @@ pub struct SchemaArgs {
     output: Option<PathBuf>,
 }
 
-pub fn execute(args: SchemaArgs) -> Result<()> {
+pub fn execute(args: SpecsArgs) -> Result<()> {
     // Validate quill path exists
     if !args.quill.exists() {
         return Err(CliError::InvalidArgument(format!(
@@ -28,16 +28,13 @@ pub fn execute(args: SchemaArgs) -> Result<()> {
     let engine = Quillmark::new();
     let quill = engine.quill_from_path(&args.quill)?;
 
-    let config = quill.source().config();
-    let schema_yaml = config
-        .schema_yaml()
-        .map_err(|e| CliError::InvalidArgument(format!("Failed to serialize schema: {}", e)))?;
+    let blueprint = quill.source().config().blueprint();
 
     // Output
     if let Some(output_path) = args.output {
-        fs::write(&output_path, schema_yaml).map_err(CliError::Io)?;
+        fs::write(&output_path, blueprint).map_err(CliError::Io)?;
     } else {
-        println!("{}", schema_yaml);
+        println!("{}", blueprint);
     }
 
     Ok(())

--- a/crates/bindings/cli/src/main.rs
+++ b/crates/bindings/cli/src/main.rs
@@ -22,6 +22,9 @@ enum Commands {
     /// Output the JSON schema for a quill
     Schema(commands::schema::SchemaArgs),
 
+    /// Output the annotated Markdown blueprint for a quill
+    Specs(commands::specs::SpecsArgs),
+
     /// Validate a quill's configuration (including defaults)
     Validate(commands::validate::ValidateArgs),
 
@@ -35,6 +38,7 @@ fn main() {
     let result = match cli.command {
         Commands::Render(args) => commands::render::execute(args),
         Commands::Schema(args) => commands::schema::execute(args),
+        Commands::Specs(args) => commands::specs::execute(args),
         Commands::Validate(args) => commands::validate::execute(args),
         Commands::Info(args) => commands::info::execute(args),
     };

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -82,6 +82,32 @@ quillmark schema ./my-quill -o schema.yaml
 quillmark schema ./my-quill | grep '^  description:'
 ```
 
+### specs
+
+Print a quill's Markdown blueprint — an annotated document showing the quill's fields, constraints, and examples. The blueprint is dense enough to replace the schema for LLM consumers and is itself a valid document an author can fill in.
+
+```bash
+quillmark specs [OPTIONS] <QUILL_PATH>
+```
+
+**Arguments:**
+
+- `<QUILL_PATH>`: Path to quill directory
+
+**Options:**
+
+- `-o <FILE>` / `--output <FILE>`: Output file (default: stdout)
+
+**Examples:**
+
+```bash
+# Print blueprint to stdout
+quillmark specs ./my-quill
+
+# Save blueprint to file
+quillmark specs ./my-quill -o blueprint.md
+```
+
 ### validate
 
 Validate quill configuration and structure.

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -292,7 +292,7 @@ Write main body here.
 | Rust | `QuillConfig::blueprint() -> String` |
 | Wasm | `Quill.blueprint` getter |
 | Python | `Quill.blueprint` property |
-| CLI | not yet exposed |
+| CLI | `quillmark specs <QUILL_PATH> [-o <FILE>]` |
 
 The Rust example `cargo run -p quillmark-core --example print_blueprint
 -- <quill_name> [<version>]` prints the blueprint for any bundled

--- a/prose/designs/CLI.md
+++ b/prose/designs/CLI.md
@@ -30,6 +30,14 @@ quillmark schema <QUILL_PATH> [-o <FILE>]
 
 Outputs the Quill's public schema contract as YAML to stdout or file.
 
+### `specs`
+
+```
+quillmark specs <QUILL_PATH> [-o <FILE>]
+```
+
+Outputs the Quill's annotated Markdown blueprint (see [BLUEPRINT.md](BLUEPRINT.md)) to stdout or file.
+
 ### `validate`
 
 ```
@@ -59,6 +67,7 @@ crates/bindings/cli/src/
 │   ├── info.rs
 │   ├── render.rs
 │   ├── schema.rs
+│   ├── specs.rs
 │   └── validate.rs
 ├── output.rs
 └── errors.rs


### PR DESCRIPTION
## Summary

- Add a `specs` CLI command — `quillmark specs <QUILL_PATH> [-o <FILE>]` — that prints a quill's annotated Markdown blueprint via `QuillConfig::blueprint()`, to stdout or a file. Mirrors the `schema` command's shape.
- Align the `schema` command's positional argument field name (`quill_path` → `quill`) with the `render` command's convention. The `QUILL_PATH` value name is unchanged, so the user-facing CLI is identical.
- Update CLI docs (`docs/cli/reference.md`) and design notes (`prose/designs/CLI.md`, `prose/designs/BLUEPRINT.md`) — the BLUEPRINT bindings table's CLI row changes from "not yet exposed" to the new command.

## Test plan

- [x] `cargo build -p quillmark-cli` compiles cleanly
- [x] `quillmark specs <quill>` prints the blueprint for bundled fixtures (taro, cmu_letter, usaf_memo)
- [x] `quillmark specs --help` shows the expected usage
- [x] `quillmark schema <quill>` still works after the argument rename

https://claude.ai/code/session_01GqE2otTdRJ7sUEH4FnVpV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqE2otTdRJ7sUEH4FnVpV3)_