### PR TITLE
test(python): repair binding tests for current card-model API

### DIFF
--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -36,7 +36,7 @@ def test_quill_properties(taro_quill_dir):
     example = quill.example
     assert example is not None
 
-    supported_formats = quill.supported_formats()
+    supported_formats = quill.supported_formats
     assert isinstance(supported_formats, list)
     assert OutputFormat.PDF in supported_formats
 
@@ -53,7 +53,7 @@ def test_full_workflow():
 
     assert "taro" in quill.quill_ref
     assert quill.backend == "typst"
-    assert OutputFormat.PDF in quill.supported_formats()
+    assert OutputFormat.PDF in quill.supported_formats
 
     result = quill.render(parsed, OutputFormat.PDF)
     assert len(result.artifacts) > 0
@@ -139,10 +139,11 @@ def test_remove_field_absent():
     assert doc.remove_field("nonexistent") is None
 
 
-def test_remove_field_reserved_returns_none():
-    """remove_field returns None for reserved names (they can't be in frontmatter)."""
+def test_remove_field_reserved_raises():
+    """remove_field raises EditError for reserved names."""
     doc = Document.from_markdown(SIMPLE_MD)
-    assert doc.remove_field("BODY") is None
+    with pytest.raises(EditError, match="ReservedName"):
+        doc.remove_field("BODY")
 
 
 def test_set_quill_ref():
@@ -328,7 +329,7 @@ def test_to_markdown_general_round_trip():
     # Re-parse and assert structure survives
     doc2 = Document.from_markdown(emitted)
     assert doc2.frontmatter["title"] == "New Title"
-    assert doc2.body == "Updated body"
+    assert doc2.body.rstrip("\n") == "Updated body"
     assert len(doc2.cards) == original_card_count + 1
     assert doc2.cards[0]["tag"] == "note"
     assert doc2.cards[0]["fields"]["author"] == "Alice"

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -78,9 +78,9 @@ def test_cards_empty_when_none():
 
 
 def test_quill_ref(taro_md):
-    """Test that quill_ref returns the QUILL field value."""
+    """Test that quill_ref returns the QUILL reference, including version."""
     doc = Document.from_markdown(taro_md)
-    assert doc.quill_ref() == "taro"
+    assert doc.quill_ref() == "taro@0.1"
 
 
 def test_warnings_empty_on_clean_doc(taro_md):
@@ -89,8 +89,9 @@ def test_warnings_empty_on_clean_doc(taro_md):
     assert doc.warnings == []
 
 
-def test_to_markdown_is_stub(taro_md):
-    """Test that to_markdown raises NotImplementedError (phase 4 stub)."""
+def test_to_markdown_emits_string(taro_md):
+    """Test that to_markdown emits a non-empty markdown string."""
     doc = Document.from_markdown(taro_md)
-    with pytest.raises(NotImplementedError):
-        doc.to_markdown()
+    emitted = doc.to_markdown()
+    assert isinstance(emitted, str)
+    assert emitted.strip() != ""


### PR DESCRIPTION
## Summary

Six Python binding tests had drifted behind the current card-model API (after the composable cards rework in #581/#579). The tests were stale, not the bindings. All 60 tests now pass.

- `test_quill_properties` / `test_full_workflow`: `supported_formats` is a `#[getter]` property, not a method
- `test_remove_field_reserved_returns_none` → `test_remove_field_reserved_raises`: reserved names raise `EditError(ReservedName)` per the documented contract
- `test_to_markdown_general_round_trip`: a card following the body leaves a separating newline on re-parse, so compare with `body.rstrip("\n")`
- `test_quill_ref`: `quill_ref()` returns the full reference; the taro fixture is `QUILL: taro@0.1`
- `test_to_markdown_is_stub` → `test_to_markdown_emits_string`: `to_markdown` is now implemented rather than a stub

## Test plan

- [x] `maturin develop` builds the extension
- [x] `pytest` — 60 passed

https://claude.ai/code/session_01WW7bauRvFut9H26Km9V2Vw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW7bauRvFut9H26Km9V2Vw)_