### PR TITLE
Remove example/example_file bundled-document concept

### DIFF
--- a/crates/bindings/cli/README.md
+++ b/crates/bindings/cli/README.md
@@ -64,9 +64,9 @@ quillmark render ./quills/usaf_memo memo.md -o output/final.pdf
 quillmark render ./quills/usaf_memo memo.md --format svg
 ```
 
-### Using quill example content
+### Rendering the generated blueprint
 
-If you omit `MARKDOWN_FILE`, the quill's bundled example content is rendered:
+If you omit `MARKDOWN_FILE`, the quill's generated blueprint is rendered:
 
 ```bash
 quillmark render ./quills/usaf_memo
@@ -98,7 +98,7 @@ quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
 
 **Arguments:**
 - `<QUILL_PATH>` - Path to quill directory
-- `[MARKDOWN_FILE]` - Path to markdown file with YAML frontmatter (optional; when omitted, quill example content is used)
+- `[MARKDOWN_FILE]` - Path to markdown file with YAML frontmatter (optional; when omitted, the quill's generated blueprint is used)
 
 **Options:**
 - `-o, --output <FILE>` - Output file path (default: derived from input filename)

--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -81,10 +81,6 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
         "has_plate".to_string(),
         serde_json::Value::Bool(source.plate().is_some()),
     );
-    info.insert(
-        "has_example".to_string(),
-        serde_json::Value::Bool(source.example().is_some()),
-    );
 
     // Add any additional metadata (excluding the standard fields already included)
     let mut extra_metadata = serde_json::Map::new();
@@ -145,24 +141,16 @@ fn print_human_readable(quill: &quillmark::Quill) {
         println!("  Cards:       {}", card_count);
     }
 
-    // Defaults and examples
+    // Defaults
     let defaults_count = config.main.defaults().len();
     if defaults_count > 0 {
         println!("  Defaults:    {}", defaults_count);
     }
 
-    // Plate and example
+    // Plate
     println!(
         "  Has plate:   {}",
         if source.plate().is_some() {
-            "yes"
-        } else {
-            "no"
-        }
-    );
-    println!(
-        "  Has example: {}",
-        if source.example().is_some() {
             "yes"
         } else {
             "no"

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -62,7 +62,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         println!("Quill loaded: {}", quill.source().name());
     }
 
-    // Determine if we have a markdown file or need to use example content
+    // Determine if we have a markdown file or need to use the generated blueprint
     let (parse_output, markdown_path_for_output) =
         if let Some(ref markdown_path) = args.markdown_file {
             // Validate markdown file exists
@@ -88,27 +88,18 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
             (output, Some(markdown_path.clone()))
         } else {
-            // Get example content
-            let markdown = quill
-                .source()
-                .example()
-                .map(|s| s.to_string())
-                .ok_or_else(|| {
-                    CliError::InvalidArgument(format!(
-                        "Quill '{}' does not have example content",
-                        quill.source().name()
-                    ))
-                })?;
+            // Fall back to the quill's generated blueprint.
+            let markdown = quill.source().config().blueprint();
 
             if args.verbose {
-                println!("Using example content from quill");
+                println!("Using generated blueprint from quill");
             }
 
             // Parse markdown
             let output = Document::from_markdown_with_warnings(&markdown)?;
 
             if args.verbose {
-                println!("Example markdown parsed successfully");
+                println!("Blueprint parsed successfully");
             }
 
             (output, None)
@@ -194,7 +185,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             if let Some(ref path) = markdown_path_for_output {
                 derive_output_path(path, &args.format)
             } else {
-                PathBuf::from(format!("example.{}", args.format))
+                PathBuf::from(format!("blueprint.{}", args.format))
             }
         }))
     };

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -198,17 +198,6 @@ fn validate_file_references(
             ));
         }
     }
-
-    // Check example_file reference
-    if let Some(ref example_file) = config.example_file {
-        let example_path = quill_path.join(example_file);
-        if !example_path.exists() {
-            result.add_warning(format!(
-                "Referenced example_file '{}' does not exist",
-                example_file
-            ));
-        }
-    }
 }
 
 fn validate_field_schemas(

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -75,11 +75,6 @@ impl PyQuill {
     }
 
     #[getter]
-    fn example(&self) -> Option<String> {
-        self.inner.source().example().map(str::to_string)
-    }
-
-    #[getter]
     fn quill_ref(&self) -> String {
         let source = self.inner.source();
         let version = source

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -33,9 +33,6 @@ def test_quill_properties(taro_quill_dir):
     assert isinstance(schema, str)
     assert "fields:" in schema
 
-    example = quill.example
-    assert example is not None
-
     supported_formats = quill.supported_formats()
     assert isinstance(supported_formats, list)
     assert OutputFormat.PDF in supported_formats

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -70,7 +70,7 @@ export interface QuillSchema {
 
 /**
  * Identity snapshot mirroring the `quill:` section of `Quill.yaml`.
- * The schema lives on `Quill.schema`; the example on `Quill.example`.
+ * The schema lives on `Quill.schema`.
  * Extra `quill:` keys appear as `unknown`.
  */
 export interface QuillMetadata {
@@ -313,12 +313,6 @@ impl Quill {
     #[wasm_bindgen(getter, js_name = supportsCanvas)]
     pub fn supports_canvas(&self) -> bool {
         self.inner.backend_id() == CANVAS_BACKEND_ID
-    }
-
-    /// Bundled example document, or `undefined` if none was declared.
-    #[wasm_bindgen(getter, js_name = example)]
-    pub fn example(&self) -> Option<String> {
-        self.inner.source().config().example_markdown.clone()
     }
 
     /// Auto-generated annotated Markdown blueprint for LLM consumers.

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -36,7 +36,6 @@ pub struct QuillSource {
     pub(crate) name: String,
     pub(crate) backend_id: String,
     pub(crate) plate: Option<String>,
-    pub(crate) example: Option<String>,
     pub(crate) config: QuillConfig,
     pub(crate) files: FileTreeNode,
 }
@@ -62,11 +61,6 @@ impl QuillSource {
         self.plate.as_deref()
     }
 
-    /// The example Markdown content, if the quill ships one.
-    pub fn example(&self) -> Option<&str> {
-        self.example.as_deref()
-    }
-
     /// The parsed schema configuration.
     pub fn config(&self) -> &QuillConfig {
         &self.config
@@ -87,7 +81,6 @@ impl std::fmt::Debug for QuillSource {
                 "plate",
                 &self.plate.as_ref().map(|s| format!("<{} bytes>", s.len())),
             )
-            .field("example", &self.example.is_some())
             .field("files", &"<FileTreeNode>")
             .finish()
     }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -34,10 +34,6 @@ pub struct QuillConfig {
     pub version: String,
     /// Author of the project
     pub author: String,
-    /// Example data file for preview
-    pub example_file: Option<String>,
-    /// Loaded markdown example content from `Quill.example`/`Quill.example_file`
-    pub example_markdown: Option<String>,
     /// Plate file (template)
     pub plate_file: Option<String>,
     /// Backend-specific configuration parsed from the top-level YAML section
@@ -79,8 +75,8 @@ impl QuillConfig {
     ///
     /// `main.fields` is prefixed with a required `QUILL` entry (`const = name@version`);
     /// each `card_types[<name>].fields` is prefixed with a required `CARD` entry
-    /// (`const = <name>`). Identity (`name`, `version`, etc.) and the bundled
-    /// example live elsewhere on the host's metadata surface.
+    /// (`const = <name>`). Identity (`name`, `version`, etc.) lives elsewhere
+    /// on the host's metadata surface.
     pub fn schema(&self) -> serde_json::Value {
         let canonical_ref = format!("{}@{}", self.name, self.version);
 
@@ -779,8 +775,6 @@ impl QuillConfig {
             "description",
             "version",
             "author",
-            "example",
-            "example_file",
             "plate_file",
             "ui",
         ];
@@ -932,17 +926,6 @@ impl QuillConfig {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .unwrap_or_else(|| "Unknown".to_string());
-
-        let example_file = quill_section
-            .get("example")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| {
-                quill_section
-                    .get("example_file")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-            });
 
         let plate_file = quill_section
             .get("plate_file")
@@ -1265,8 +1248,6 @@ impl QuillConfig {
                 backend,
                 version,
                 author,
-                example_file,
-                example_markdown: None,
                 plate_file,
                 backend_config,
             },

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -1,6 +1,4 @@
 //! QuillSource loading and construction routines.
-use std::path::{Component, Path};
-
 use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
@@ -25,8 +23,8 @@ impl QuillSource {
     ///
     /// Returns a non-empty `Vec<Diagnostic>` describing every problem found.
     /// When `Quill.yaml` itself contains multiple errors they are all
-    /// reported together; subsequent failures (missing plate, malformed
-    /// example) surface as single-element vectors.
+    /// reported together; subsequent failures (missing plate) surface as
+    /// single-element vectors.
     pub fn from_tree(root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
         let quill_yaml_bytes = root.get_file("Quill.yaml").ok_or_else(|| {
             vec![diag(
@@ -50,7 +48,7 @@ impl QuillSource {
     }
 
     /// Create a QuillSource from a QuillConfig and file tree.
-    fn from_config(mut config: QuillConfig, root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
+    fn from_config(config: QuillConfig, root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
         let mut metadata: std::collections::HashMap<String, QuillValue> =
             std::collections::HashMap::new();
 
@@ -99,66 +97,11 @@ impl QuillSource {
             None
         };
 
-        // Read the markdown example content if specified, or check for default "example.md"
-        let example_content = if let Some(ref example_file_name) = config.example_file {
-            let example_path = Path::new(example_file_name);
-            if example_path.is_absolute()
-                || example_path
-                    .components()
-                    .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
-            {
-                return Err(vec![diag(
-                    format!(
-                        "Example file '{}' is outside the quill directory",
-                        example_file_name
-                    ),
-                    "quill::example_path_traversal",
-                )]);
-            }
-
-            let bytes = root.get_file(example_file_name).ok_or_else(|| {
-                vec![diag(
-                    format!(
-                        "Example file '{}' referenced in Quill.yaml not found",
-                        example_file_name
-                    ),
-                    "quill::example_missing",
-                )]
-            })?;
-            Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
-                vec![diag(
-                    format!(
-                        "Example file '{}' is not valid UTF-8: {}",
-                        example_file_name, e
-                    ),
-                    "quill::invalid_utf8",
-                )]
-            })?)
-        } else if root.file_exists("example.md") {
-            let bytes = root
-                .get_file("example.md")
-                .expect("invariant violation: file_exists(example.md) but get_file returned None");
-            Some(String::from_utf8(bytes.to_vec()).map_err(|e| {
-                vec![diag(
-                    format!(
-                        "Default example file 'example.md' is not valid UTF-8: {}",
-                        e
-                    ),
-                    "quill::invalid_utf8",
-                )]
-            })?)
-        } else {
-            None
-        };
-
-        config.example_markdown = example_content.clone();
-
         let source = QuillSource {
             metadata,
             name: config.name.clone(),
             backend_id: config.backend.clone(),
             plate: plate_content,
-            example: example_content,
             config,
             files: root,
         };

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -61,11 +61,8 @@ main:
     }
 
     #[test]
-    fn omits_example_and_ref() {
-        let mut config = cfg(FULL);
-        config.example_markdown = Some("# x".to_string());
-        let yaml = config.schema_yaml().unwrap();
-        assert!(!yaml.contains("example:"));
+    fn omits_ref() {
+        let yaml = cfg(FULL).schema_yaml().unwrap();
         assert!(!yaml.contains("ref:"));
     }
 

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -274,104 +274,6 @@ quill:
 }
 
 #[test]
-fn test_template_loading() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_dir = temp_dir.path();
-
-    // Create test files with example specified
-    let yaml_content = r#"quill:
-  name: "test_with_template"
-  version: "1.0"
-  backend: "typst"
-  plate_file: "plate.typ"
-  example_file: "example.md"
-  description: "Test quill with template"
-"#;
-    fs::write(quill_dir.join("Quill.yaml"), yaml_content).unwrap();
-    fs::write(quill_dir.join("plate.typ"), "plate content").unwrap();
-    fs::write(
-        quill_dir.join("example.md"),
-        "---\ntitle: Test\n---\n\nThis is a test template.",
-    )
-    .unwrap();
-
-    // Load quill
-    let quill = load_from_path(quill_dir).unwrap();
-
-    // Test that example content is loaded and includes some the text
-    assert!(quill.example.is_some());
-    let example = quill.example.unwrap();
-    assert!(example.contains("title: Test"));
-    assert!(example.contains("This is a test template"));
-    assert!(quill
-        .config
-        .example_markdown
-        .as_ref()
-        .is_some_and(|value| value.contains("title: Test")));
-
-    // Test that plate template is still loaded
-    assert_eq!(quill.plate.unwrap(), "plate content");
-}
-
-#[test]
-fn test_template_smart_default() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_dir = temp_dir.path();
-
-    // Create test files without example specified
-    let yaml_content = r#"quill:
-  name: "test_smart_default"
-  version: "1.0"
-  backend: "typst"
-  plate_file: "plate.typ"
-  description: "Test quill with smart default"
-"#;
-    fs::write(quill_dir.join("Quill.yaml"), yaml_content).unwrap();
-    fs::write(quill_dir.join("plate.typ"), "plate content").unwrap();
-    // Create example.md which should be picked up automatically
-    fs::write(
-        quill_dir.join("example.md"),
-        "---\ntitle: Smart Default\n---\n\nPicked up automatically.",
-    )
-    .unwrap();
-
-    // Load quill
-    let quill = load_from_path(quill_dir).unwrap();
-
-    // Test that example content is loaded
-    assert!(quill.example.is_some());
-    let example = quill.example.unwrap();
-    assert!(example.contains("title: Smart Default"));
-    assert!(example.contains("Picked up automatically"));
-}
-
-#[test]
-fn test_template_optional() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_dir = temp_dir.path();
-
-    // Create test files without example specified
-    let yaml_content = r#"quill:
-  name: "test_without_template"
-  version: "1.0"
-  backend: "typst"
-  plate_file: "plate.typ"
-  description: "Test quill without template"
-"#;
-    fs::write(quill_dir.join("Quill.yaml"), yaml_content).unwrap();
-    fs::write(quill_dir.join("plate.typ"), "plate content").unwrap();
-
-    // Load quill
-    let quill = load_from_path(quill_dir).unwrap();
-
-    // Test that example fields are None
-    assert_eq!(quill.example, None);
-
-    // Test that plate template is still loaded
-    assert_eq!(quill.plate.unwrap(), "plate content");
-}
-
-#[test]
 fn test_from_tree() {
     // Create a simple in-memory file tree
     let mut root_files = HashMap::new();
@@ -410,54 +312,6 @@ fn test_from_tree() {
     assert_eq!(quill.plate.unwrap(), plate_content);
     assert!(quill.metadata.contains_key("backend"));
     assert!(quill.metadata.contains_key("description"));
-}
-
-#[test]
-fn test_from_tree_with_template() {
-    let mut root_files = HashMap::new();
-
-    // Add Quill.yaml with example specified
-    // Add Quill.yaml with example specified
-    let quill_yaml = r#"
-quill:
-  name: test_tree_template
-  version: "1.0"
-  backend: typst
-  plate_file: plate.typ
-  example_file: template.md
-  description: Test tree with template
-"#;
-    root_files.insert(
-        "Quill.yaml".to_string(),
-        FileTreeNode::File {
-            contents: quill_yaml.as_bytes().to_vec(),
-        },
-    );
-
-    // Add plate file
-    root_files.insert(
-        "plate.typ".to_string(),
-        FileTreeNode::File {
-            contents: b"plate content".to_vec(),
-        },
-    );
-
-    // Add template file
-    let template_content = "# {{ title }}\n\n{{ body }}";
-    root_files.insert(
-        "template.md".to_string(),
-        FileTreeNode::File {
-            contents: template_content.as_bytes().to_vec(),
-        },
-    );
-
-    let root = FileTreeNode::Directory { files: root_files };
-
-    // Create Quill from tree
-    let quill = QuillSource::from_tree(root).unwrap();
-
-    // Validate template is loaded
-    assert_eq!(quill.example, Some(template_content.to_string()));
 }
 
 #[test]
@@ -619,7 +473,6 @@ fn test_field_schemas_parsing() {
   version: "1.0"
   backend: "typst"
   plate_file: "plate.typ"
-  example_file: "taro.md"
   description: "Test template for field schemas"
 
 main:
@@ -647,14 +500,6 @@ main:
         "plate.typ".to_string(),
         FileTreeNode::File {
             contents: plate_content.as_bytes().to_vec(),
-        },
-    );
-
-    // Add template file
-    root_files.insert(
-        "taro.md".to_string(),
-        FileTreeNode::File {
-            contents: b"# Template".to_vec(),
         },
     );
 
@@ -795,7 +640,6 @@ quill:
   description: Test configuration parsing
   author: Test Author
   plate_file: plate.typ
-  example_file: example.md
 
 typst:
   packages: 
@@ -826,7 +670,6 @@ main:
     assert_eq!(config.version, "1.0");
     assert_eq!(config.author, "Test Author");
     assert_eq!(config.plate_file, Some("plate.typ".to_string()));
-    assert_eq!(config.example_file, Some("example.md".to_string()));
 
     // Verify backend-specific config (parsed from the [typst] section).
     assert!(config.backend_config.contains_key("packages"));
@@ -839,65 +682,6 @@ main:
     let title_field = &config.main.fields["title"];
     assert_eq!(title_field.description, Some("Document title".to_string()));
     assert_eq!(title_field.r#type, FieldType::String);
-}
-
-#[test]
-fn test_quill_config_parses_example_alias() {
-    let yaml_content = r#"
-quill:
-  name: test_example_alias
-  version: "1.0"
-  backend: typst
-  description: Test example alias parsing
-  example: examples/basic.md
-"#;
-
-    let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    assert_eq!(config.example_file, Some("examples/basic.md".to_string()));
-}
-
-#[test]
-fn test_quill_from_path_rejects_example_traversal() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_dir = temp_dir.path();
-
-    let yaml_content = r#"quill:
-  name: traversal_test
-  version: "1.0"
-  backend: typst
-  description: Traversal test
-  example: ../outside.md
-"#;
-    fs::write(quill_dir.join("Quill.yaml"), yaml_content).unwrap();
-
-    let result = load_from_path(quill_dir);
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("outside the quill directory"));
-}
-
-#[test]
-fn test_quill_from_path_errors_when_explicit_example_missing() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_dir = temp_dir.path();
-
-    let yaml_content = r#"quill:
-  name: missing_example_test
-  version: "1.0"
-  backend: typst
-  description: Missing explicit example test
-  example: examples/missing.md
-"#;
-    fs::write(quill_dir.join("Quill.yaml"), yaml_content).unwrap();
-
-    let result = load_from_path(quill_dir);
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("referenced in Quill.yaml not found"));
 }
 
 #[test]

--- a/crates/fixtures/resources/appreciated_letter/Quill.yaml
+++ b/crates/fixtures/resources/appreciated_letter/Quill.yaml
@@ -3,7 +3,6 @@ quill:
   version: "0.1"
   backend: typst
   plate_file: plate.typ
-  example_file: appreciated_letter.md
   description: Professional letter template with appreciation styling
 
 typst:

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -3,7 +3,6 @@ quill:
   version: 0.1.0
   backend: typst
   plate_file: plate.typ
-  example_file: example.md
   description: A clean and modern classic resume template.
 
 main:

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -3,7 +3,6 @@ quill:
   version: 0.1.0
   backend: typst
   plate_file: plate.typ
-  example_file: example.md
   description: Typeset letters that comply with Carnegie Mellon University letterhead standards.
 
 main:

--- a/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
@@ -3,7 +3,6 @@ quill:
   version: 0.1.0
   backend: typst
   plate_file: plate.typ
-  example_file: example.md
   description: A simple document template for testing
 
 main:

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -3,8 +3,6 @@ quill:
   version: 0.1.0
   backend: typst
   plate_file: plate.typ
-  example: examples/basic.md
-  example_file: example.md
   description: Typesetted USAF Official Memorandum
 
 main:

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -3,7 +3,6 @@ quill:
   version: 0.2.0
   backend: typst
   plate_file: plate.typ
-  example_file: example.md
   description: Typesetted USAF Official Memorandum
 
 main:

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -129,8 +129,6 @@ fn config_with_one_field(schema: FieldSchema) -> QuillConfig {
         backend: "typst".to_string(),
         version: "1.0".to_string(),
         author: String::new(),
-        example_file: None,
-        example_markdown: None,
         plate_file: None,
         backend_config: HashMap::new(),
     }

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -313,21 +313,16 @@ main:
 
 #[test]
 fn form_over_usaf_memo_fixture() {
-    // Integration test: load the usaf_memo fixture quill and view the
-    // bundled example.  Checks that every required field gets a deterministic
-    // FormFieldSource and no projection panics.
+    // Integration test: load the usaf_memo fixture quill and view its
+    // generated blueprint.  Checks that every required field gets a
+    // deterministic FormFieldSource and no projection panics.
     let quill_path = quillmark_fixtures::resource_path("quills/usaf_memo/0.1.0");
     let quill = Quillmark::new()
         .quill_from_path(quill_path)
         .expect("failed to load usaf_memo fixture");
 
-    let example_md = quill.source().example().unwrap_or("");
-    // If the example can't parse, skip gracefully (it uses YAML comments that
-    // are valid but the field values may not match the schema exactly).
-    let doc = match Document::from_markdown(example_md) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
+    let blueprint = quill.source().config().blueprint();
+    let doc = Document::from_markdown(&blueprint).expect("blueprint must parse");
 
     let form = quill.form(&doc);
 

--- a/crates/quillmark/tests/common.rs
+++ b/crates/quillmark/tests/common.rs
@@ -5,22 +5,22 @@
 //! ## Purpose
 //!
 //! This module provides common functionality used across multiple test files:
-//! - **`demo()` function** - Centralized example plumbing for rendering demos
+//! - **`demo()` function** - Centralized plumbing for rendering demos
 //!
 //! ## Usage
 //!
 //! The `demo()` helper simplifies the common pattern of:
 //! 1. Loading a quill from a path
-//! 2. Using the quill's example markdown
+//! 2. Using the quill's generated blueprint
 //! 3. Rendering to final output
-//! 4. Writing outputs to example directory
+//! 4. Writing outputs to the demo output directory
 
 use quillmark_fixtures::{example_output_dir, quills_path, write_example_output};
 use std::error::Error;
 
-/// Demo helper that centralizes example plumbing.
+/// Demo helper that centralizes rendering plumbing.
 ///
-/// It loads the quill and uses its markdown template, then renders it.
+/// It loads the quill and renders its generated blueprint.
 pub fn demo(
     quill_dir: &str,
     render_output: &str,
@@ -38,12 +38,8 @@ pub fn demo(
         .quill_from_path(quill_path.clone())
         .expect("Failed to load quill");
 
-    // Load the markdown template from the quill
-    let markdown = quill
-        .source()
-        .example()
-        .ok_or("Quill does not have a markdown template")?
-        .to_string();
+    // Render the quill's generated blueprint.
+    let markdown = quill.source().config().blueprint();
 
     // Parse the markdown once
     let parsed = quillmark::Document::from_markdown(&markdown)?;

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -24,7 +24,6 @@ quill:
   version: "1.0.0"
   description: A simple letter format
   plate_file: plate.typ
-  example_file: example.md
 
 main:
   fields:

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -43,8 +43,6 @@ Every Quill.yaml must have a `quill` section with format metadata.
 | `version`        | string | yes      | Semantic version (`MAJOR.MINOR` or `MAJOR.MINOR.PATCH`) |
 | `author`         | string | no       | Creator of the Quill (defaults to `"Unknown"`) |
 | `plate_file`     | string | no       | Path to the plate file |
-| `example`        | string | no       | Path to an example Markdown document |
-| `example_file`   | string | no       | Alias for `example` |
 | `ui`             | object | no       | Document-level UI metadata |
 
 ```yaml
@@ -55,7 +53,6 @@ quill:
   description: Typesetted USAF Official Memorandum
   author: TongueToQuill
   plate_file: plate.typ
-  example: example.md
 ```
 
 ---

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -28,7 +28,6 @@ pub struct QuillSource {
     pub name: String,
     pub backend_id: String,
     pub plate: Option<String>,
-    pub example: Option<String>,
     pub config: QuillConfig,
     pub files: FileTreeNode,
 }
@@ -71,7 +70,6 @@ quill:
   description: A beautiful format  # required; non-empty
   author: Jane Doe        # optional; defaults to "Unknown"
   plate_file: plate.typ   # optional; path to Typst template
-  example_file: example.md  # optional; example document for preview
 
 main:
   fields:
@@ -104,7 +102,6 @@ Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card type.
 - `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, and `typst_*` keys from the `[typst]` section. The `quill:` section accepts only the documented keys; unknown keys produce a `quill::unknown_key` error rather than landing in `metadata`.
-- `example_file` also accepts the alias `example` in YAML
 
 ## Strict Parsing
 

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -62,7 +62,7 @@ For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits 
 
 Top-level schema keys: `main`, optional `card_types` (map keyed by card name). `main` and each entry in `card_types` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`, and optional `required` (omitted when false).
 
-Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters). The bundled example markdown is exposed separately (Wasm: `Quill.example`; Python: `Quill.example`) so consumers choose whether to include it in a prompt.
+Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters).
 
 ### Bindings surface
 


### PR DESCRIPTION
## Summary

Removes the `example` / `example_file` bundled-document concept from Quillmark entirely. Per-field `example:` values are a separate concept and were left untouched.

- **Core**: dropped `QuillSource.example` (field + getter + Debug entry), `QuillConfig.example_file` / `example_markdown`, the `example`/`example_file` Quill.yaml keys, and the example-file loading / path-traversal / default `example.md` auto-pickup logic.
- **Bindings**: removed the WASM and Python `Quill.example` getters. The CLI no longer reports `has_example` (`info`) or validates `example_file` references (`validate`); `render` with no markdown file now falls back to the generated blueprint (output named `blueprint.<ext>`).
- **Fixtures / tests / docs**: removed the keys from 6 `Quill.yaml` fixtures, removed/trimmed the example-only tests, repointed the `demo()` helper and `form_over_usaf_memo_fixture` to the blueprint, and updated the affected docs. Standalone `.md` files are kept — they're still exercised directly by other tests and round-trip fixtures.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` (no failures)
- [ ] Python binding tests (`pytest`) — Rust side compiles; pytest not run in this environment

https://claude.ai/code/session_01HfyuN56S2g5n1k7wXnBZ8b

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfyuN56S2g5n1k7wXnBZ8b)_