### PR TITLE
Remove unused parameters from extract_sentinels function

### DIFF
--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -23,7 +23,7 @@ use super::{Card, Document, Sentinel};
 /// slice ends with that blank line's terminator — exactly one `\n` or
 /// `\r\n`. This helper strips that single line ending so stored bodies
 /// contain only authored content. The emitter re-adds the separator on
-/// output via `ensure_blank_line_before_fence`.
+/// output via `ensure_f2_before_fence`.
 ///
 /// Stripping more than one line ending (as the WASM binding's former
 /// `trim_body` did) would silently drop content-meaningful trailing
@@ -136,7 +136,7 @@ pub(super) fn build_block(
                 (Some(kind.to_string()), None, yaml)
             }
             // Legacy `---` fence: extract the QUILL / CARD sentinel.
-            None => extract_sentinels(parsed, markdown, block_start, block_index)?,
+            None => extract_sentinels(parsed)?,
         }
     };
 
@@ -262,7 +262,7 @@ pub(super) fn decompose_with_warnings(
     // When a fence follows, the body slice ends with the F2 blank-line
     // terminator — strip it so stored bodies contain only authored content.
     // The emitter re-derives the separator on output (see `emit.rs`'s
-    // `ensure_blank_line_before_fence`).
+    // `ensure_f2_before_fence`).
     let body_start = blocks[0].end;
     let first_card_block = blocks.iter().skip(1).find(|b| b.tag.is_some());
     let (body_end, body_is_followed_by_fence) = match first_card_block {

--- a/crates/core/src/document/sentinel.rs
+++ b/crates/core/src/document/sentinel.rs
@@ -80,13 +80,10 @@ pub(super) fn validate_card_fence_yaml(
 #[allow(clippy::type_complexity)]
 pub(super) fn extract_sentinels(
     parsed: serde_json::Value,
-    _markdown: &str,
-    _abs_pos: usize,
-    _block_index: usize,
 ) -> Result<(Option<String>, Option<String>, Option<serde_json::Value>), ParseError> {
     let Some(mapping) = parsed.as_object() else {
         // Non-mapping (scalar/sequence); keep as-is — upstream will reject if
-        // it's a frontmatter/card mapping was expected.
+        // a frontmatter/card mapping was expected.
         return Ok((None, None, Some(parsed)));
     };
 
@@ -103,7 +100,7 @@ pub(super) fn extract_sentinels(
     for reserved in ["BODY", "CARDS"] {
         if mapping.contains_key(reserved) {
             return Err(ParseError::InvalidStructure(format!(
-                "Reserved field name '{}' cannot be used in YAML frontmatter",
+                "Reserved field name '{}' cannot be used as an input field",
                 reserved
             )));
         }


### PR DESCRIPTION
## Summary
This PR removes unused parameters from the `extract_sentinels` function and updates related documentation and error messages for clarity.

## Key Changes
- **Removed unused parameters** from `extract_sentinels()`: `_markdown`, `_abs_pos`, and `_block_index` were not being used in the function body
- **Updated function call** in `build_block()` to match the new signature, removing the three unused arguments
- **Improved error message** for reserved field validation: changed from "cannot be used in YAML frontmatter" to "cannot be used as an input field" for better accuracy
- **Fixed documentation comments**: corrected typos and updated references from `ensure_blank_line_before_fence` to `ensure_f2_before_fence` in comments

## Implementation Details
The changes are straightforward cleanup:
- The function signature in `sentinel.rs` is simplified by removing parameters that were prefixed with `_` (indicating they were intentionally unused)
- The corresponding call site in `assemble.rs` is updated to pass only the required `parsed` parameter
- Documentation improvements clarify the actual behavior and naming conventions used in the codebase

https://claude.ai/code/session_01V1c3vMGrrPgzF9jLHyXPQU