### PR TITLE
Refactor quill loading and remove redundant QuillSource fields

### DIFF
--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -1,6 +1,6 @@
+use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
 use clap::Parser;
-use quillmark::Quillmark;
 use std::path::PathBuf;
 
 /// Standard metadata keys that are surfaced as top-level fields in the output.
@@ -19,17 +19,7 @@ pub struct InfoArgs {
 }
 
 pub fn execute(args: InfoArgs) -> Result<()> {
-    // Validate quill path exists
-    if !args.quill_path.exists() {
-        return Err(CliError::InvalidArgument(format!(
-            "Quill directory not found: {}",
-            args.quill_path.display()
-        )));
-    }
-
-    // Load Quill
-    let engine = Quillmark::new();
-    let quill = engine.quill_from_path(&args.quill_path)?;
+    let quill = load_quill(&args.quill_path)?;
 
     if args.json {
         print_json(&quill)?;

--- a/crates/bindings/cli/src/commands/mod.rs
+++ b/crates/bindings/cli/src/commands/mod.rs
@@ -3,3 +3,21 @@ pub mod render;
 pub mod schema;
 pub mod specs;
 pub mod validate;
+
+use crate::errors::{CliError, Result};
+use quillmark::{Quill, Quillmark};
+use std::path::Path;
+
+/// Load a quill from a directory path.
+///
+/// Upgrades the engine's missing-path error to a clearer message before
+/// delegating to `Quillmark::quill_from_path`.
+pub fn load_quill(path: &Path) -> Result<Quill> {
+    if !path.exists() {
+        return Err(CliError::InvalidArgument(format!(
+            "Quill directory not found: {}",
+            path.display()
+        )));
+    }
+    Ok(Quillmark::new().quill_from_path(path)?)
+}

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -1,7 +1,8 @@
+use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
 use crate::output::{derive_output_path, OutputWriter};
 use clap::Parser;
-use quillmark::{Document, Quillmark};
+use quillmark::Document;
 use quillmark_core::{OutputFormat, RenderOptions};
 use std::fs;
 use std::path::PathBuf;
@@ -42,21 +43,12 @@ pub struct RenderArgs {
 }
 
 pub fn execute(args: RenderArgs) -> Result<()> {
-    // Validate quill path exists
-    if !args.quill.exists() {
-        return Err(CliError::InvalidArgument(format!(
-            "Quill directory not found: {}",
-            args.quill.display()
-        )));
-    }
-
     if args.verbose {
         println!("Loading quill from: {}", args.quill.display());
     }
 
     // Load quill
-    let engine = Quillmark::new();
-    let quill = engine.quill_from_path(args.quill.clone())?;
+    let quill = load_quill(&args.quill)?;
 
     if args.verbose {
         println!("Quill loaded: {}", quill.source().name());

--- a/crates/bindings/cli/src/commands/schema.rs
+++ b/crates/bindings/cli/src/commands/schema.rs
@@ -1,6 +1,6 @@
+use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
 use clap::Parser;
-use quillmark::Quillmark;
 use std::fs;
 use std::path::PathBuf;
 
@@ -16,17 +16,7 @@ pub struct SchemaArgs {
 }
 
 pub fn execute(args: SchemaArgs) -> Result<()> {
-    // Validate quill path exists
-    if !args.quill.exists() {
-        return Err(CliError::InvalidArgument(format!(
-            "Quill directory not found: {}",
-            args.quill.display()
-        )));
-    }
-
-    // Load Quill
-    let engine = Quillmark::new();
-    let quill = engine.quill_from_path(&args.quill)?;
+    let quill = load_quill(&args.quill)?;
 
     let config = quill.source().config();
     let schema_yaml = config

--- a/crates/bindings/cli/src/commands/specs.rs
+++ b/crates/bindings/cli/src/commands/specs.rs
@@ -1,6 +1,6 @@
+use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
 use clap::Parser;
-use quillmark::Quillmark;
 use std::fs;
 use std::path::PathBuf;
 
@@ -16,17 +16,7 @@ pub struct SpecsArgs {
 }
 
 pub fn execute(args: SpecsArgs) -> Result<()> {
-    // Validate quill path exists
-    if !args.quill.exists() {
-        return Err(CliError::InvalidArgument(format!(
-            "Quill directory not found: {}",
-            args.quill.display()
-        )));
-    }
-
-    // Load Quill
-    let engine = Quillmark::new();
-    let quill = engine.quill_from_path(&args.quill)?;
+    let quill = load_quill(&args.quill)?;
 
     let blueprint = quill.source().config().blueprint();
 

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -33,8 +33,6 @@ use crate::value::QuillValue;
 #[derive(Clone)]
 pub struct QuillSource {
     pub(crate) metadata: HashMap<String, QuillValue>,
-    pub(crate) name: String,
-    pub(crate) backend_id: String,
     pub(crate) plate: Option<String>,
     pub(crate) config: QuillConfig,
     pub(crate) files: FileTreeNode,
@@ -43,12 +41,12 @@ pub struct QuillSource {
 impl QuillSource {
     /// The quill's declared name.
     pub fn name(&self) -> &str {
-        &self.name
+        &self.config.name
     }
 
     /// The backend identifier declared in Quill.yaml (e.g. `"typst"`).
     pub fn backend_id(&self) -> &str {
-        &self.backend_id
+        &self.config.backend
     }
 
     /// Quill-specific metadata parsed from Quill.yaml.
@@ -75,8 +73,8 @@ impl QuillSource {
 impl std::fmt::Debug for QuillSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QuillSource")
-            .field("name", &self.name)
-            .field("backend_id", &self.backend_id)
+            .field("name", &self.config.name)
+            .field("backend_id", &self.config.backend)
             .field(
                 "plate",
                 &self.plate.as_ref().map(|s| format!("<{} bytes>", s.len())),

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -99,8 +99,6 @@ impl QuillSource {
 
         let source = QuillSource {
             metadata,
-            name: config.name.clone(),
-            backend_id: config.backend.clone(),
             plate: plate_content,
             config,
             files: root,

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -247,7 +247,7 @@ quill:
     let quill = load_from_path(quill_dir).unwrap();
 
     // Test that name comes from YAML, not directory
-    assert_eq!(quill.name, "my_custom_quill");
+    assert_eq!(quill.name(), "my_custom_quill");
 
     // Test that backend is in metadata
     assert!(quill.metadata.contains_key("backend"));
@@ -308,7 +308,7 @@ fn test_from_tree() {
     let quill = QuillSource::from_tree(root).unwrap();
 
     // Validate the quill
-    assert_eq!(quill.name, "test_from_tree");
+    assert_eq!(quill.name(), "test_from_tree");
     assert_eq!(quill.plate.unwrap(), plate_content);
     assert!(quill.metadata.contains_key("backend"));
     assert!(quill.metadata.contains_key("description"));
@@ -353,7 +353,7 @@ fn test_from_tree_structure_direct() {
 
     let quill = QuillSource::from_tree(root).unwrap();
 
-    assert_eq!(quill.name, "direct_tree");
+    assert_eq!(quill.name(), "direct_tree");
     assert!(quill.file_exists("src/main.rs"));
     assert!(quill.file_exists("plate.typ"));
 }
@@ -626,7 +626,7 @@ fn test_quill_without_plate_file() {
 
     // Validate that plate is null (will use auto plate)
     assert!(quill.plate.clone().is_none());
-    assert_eq!(quill.name, "test_no_plate");
+    assert_eq!(quill.name(), "test_no_plate");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
This PR consolidates quill loading logic and eliminates redundant field duplication in `QuillSource` by sourcing `name` and `backend_id` directly from the config object.

## Key Changes

- **Extracted common quill loading logic**: Created a new `load_quill()` helper function in `crates/bindings/cli/src/commands/mod.rs` that centralizes path validation and quill loading, replacing duplicated code across multiple command modules
- **Removed redundant QuillSource fields**: Eliminated `name` and `backend_id` fields from `QuillSource` struct since they duplicate data already present in the `config` field
- **Updated accessors**: Modified `QuillSource::name()` and `QuillSource::backend_id()` methods to read directly from `self.config.name` and `self.config.backend` respectively
- **Updated all command modules**: Refactored `info.rs`, `render.rs`, `schema.rs`, and `specs.rs` to use the new `load_quill()` helper, removing ~10 lines of duplicated validation and initialization code from each
- **Updated tests**: Fixed test assertions to use the public `name()` method instead of accessing the private field directly

## Implementation Details

The `load_quill()` function provides a single point of validation that checks if the path exists before attempting to load, providing a clearer error message than the underlying engine would produce. This improves code maintainability and ensures consistent error handling across all CLI commands.

The removal of duplicate fields from `QuillSource` reduces memory overhead and eliminates the risk of data inconsistency between the cached fields and the config source of truth.

https://claude.ai/code/session_01JwR2bGZxoeUdSesyARgy7d