### PR TITLE
docs: fix soft link in WASM migration guide

### DIFF
--- a/docs/migrations/wasm-0.77-to-0.79.md
+++ b/docs/migrations/wasm-0.77-to-0.79.md
@@ -87,8 +87,7 @@ This is the one behavior change most likely to affect you:
   on-disk bytes change.
 - **Diffing the original source against `toMarkdown()`** to detect edits will
   report a spurious diff for documents that contained legacy card fences. Use
-  [`doc.equals`](https://github.com/quillmark-org/quillmark) for semantic
-  comparison instead of string comparison.
+  `doc.equals(other)` for semantic comparison instead of string comparison.
 
 The `Document` card mutators (`pushCard`, `insertCard`, `updateCardField`,
 etc.) and the `CardInput` shape (`{ tag, fields?, body? }`) are unchanged.


### PR DESCRIPTION
The `doc.equals` reference in `docs/migrations/wasm-0.77-to-0.79.md` linked to the bare repo root (`https://github.com/quillmark-org/quillmark`) — a soft link with no real target. Replaced with an inline-code `doc.equals(other)` call.

Cosmetic doc-only fix surfaced during the post-merge sanity check of the migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)