### PR TITLE
Rename "Formats" to "Quills" for consistency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ A format-first Markdown rendering system that converts Markdown with YAML frontm
 - **Writing documents?** You author Markdown content using existing formats.  
   → [Markdown Syntax](authoring/markdown-syntax.md)
 
-- **Building formats?** You create Quill formats that control rendering.  
+- **Building quills?** You create Quill formats that control rendering.  
   → [Creating Quills](format-designer/creating-quills.md)
 
 - **Integrating into an app?** You use Quillmark via Python or JavaScript.  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
       - Markdown Syntax: authoring/markdown-syntax.md
       - YAML Frontmatter: authoring/yaml-frontmatter.md
       - Cards: authoring/cards.md
-  - Formats:
+  - Quills:
       - Creating Quills: format-designer/creating-quills.md
       - Quill.yaml Reference: format-designer/quill-yaml-reference.md
       - Typst Backend: format-designer/typst-backend.md


### PR DESCRIPTION
## Summary
Updated documentation to use "Quills" terminology consistently throughout the project, replacing references to "Formats" where appropriate.

## Key Changes
- Updated the main documentation index to refer to "Building quills?" instead of "Building formats?"
- Renamed the navigation section in mkdocs.yml from "Formats" to "Quills" to align with the project's terminology

## Details
This change improves terminology consistency across the documentation. The project uses "Quill" as the primary term for format definitions, and this update ensures the documentation navigation and introductory content reflect that naming convention consistently.

https://claude.ai/code/session_015aWJV63h8VBj6ipwLEPQ47