### PR TITLE
Update CLI documentation terminology: "example content" → "blueprint"

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -21,7 +21,7 @@ quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
 **Arguments:**
 
 - `<QUILL_PATH>`: Path to quill directory
-- `[MARKDOWN_FILE]`: Path to markdown file with YAML frontmatter (optional — when omitted, the quill's example content is used)
+- `[MARKDOWN_FILE]`: Path to markdown file with YAML frontmatter (optional — when omitted, the quill's blueprint is rendered)
 
 `<QUILL_PATH>` selects the local quill bundle used for rendering. `MARKDOWN_FILE` frontmatter still requires top-level `QUILL` during parsing.
 
@@ -49,7 +49,7 @@ quillmark render ./my-quill input.md --output-data data.json
 # Output to stdout
 quillmark render ./my-quill input.md --stdout > output.pdf
 
-# Render the quill's built-in example
+# Render the quill's blueprint
 quillmark render ./my-quill
 ```
 


### PR DESCRIPTION
## Summary
Updated CLI reference documentation to use consistent terminology, replacing "example content" with "blueprint" when describing the default rendering behavior.

## Changes
- Updated the `[MARKDOWN_FILE]` argument description to clarify that when omitted, "the quill's blueprint is rendered" instead of "the quill's example content is used"
- Updated the example comment from "Render the quill's built-in example" to "Render the quill's blueprint"

## Details
This change improves documentation clarity by using the more precise term "blueprint" consistently throughout the CLI reference, making it clearer to users what content is rendered when no markdown file is provided to the `quillmark render` command.

https://claude.ai/code/session_01STwSTxkBpVnDkXoqYdL2y1