### PR TITLE
Rename card_types to card_kinds throughout codebase

### DIFF
--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -377,7 +377,7 @@ fn transform_cards_array(
     for card in cards_array {
         if let Some(card_obj) = card.as_object() {
             if let Some(card_kind) = card_obj.get("CARD").and_then(|v| v.as_str()) {
-                // Construct the definition name: {type}_card
+                // Construct the definition name: {kind}_card
                 let def_name = format!("{}_card", card_kind);
 
                 // Look up the schema for this card kind

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -292,12 +292,12 @@ fn transform_markdown_fields(
         }
     }
 
-    // Collect per-card-type content field names from schema $defs
+    // Collect per-card-kind content field names from schema $defs
     let mut card_content_fields = serde_json::Map::new();
     let mut card_date_fields = serde_json::Map::new();
     if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
         for (def_name, def_schema) in defs {
-            if let Some(card_type) = def_name.strip_suffix("_card") {
+            if let Some(card_kind) = def_name.strip_suffix("_card") {
                 let card_fields: Vec<&str> = def_schema
                     .get("properties")
                     .and_then(|v| v.as_object())
@@ -311,7 +311,7 @@ fn transform_markdown_fields(
                     .unwrap_or_default();
                 if !card_fields.is_empty() {
                     card_content_fields.insert(
-                        card_type.to_string(),
+                        card_kind.to_string(),
                         serde_json::Value::Array(
                             card_fields
                                 .into_iter()
@@ -334,7 +334,7 @@ fn transform_markdown_fields(
                     .unwrap_or_default();
                 if !date_fields.is_empty() {
                     card_date_fields.insert(
-                        card_type.to_string(),
+                        card_kind.to_string(),
                         serde_json::Value::Array(
                             date_fields
                                 .into_iter()
@@ -376,11 +376,11 @@ fn transform_cards_array(
 
     for card in cards_array {
         if let Some(card_obj) = card.as_object() {
-            if let Some(card_type) = card_obj.get("CARD").and_then(|v| v.as_str()) {
+            if let Some(card_kind) = card_obj.get("CARD").and_then(|v| v.as_str()) {
                 // Construct the definition name: {type}_card
-                let def_name = format!("{}_card", card_type);
+                let def_name = format!("{}_card", card_kind);
 
-                // Look up the schema for this card type
+                // Look up the schema for this card kind
                 if let Some(card_schema_json) = defs.and_then(|d| d.get(&def_name)) {
                     // Convert the card object to HashMap<String, QuillValue>
                     let mut card_fields: HashMap<String, QuillValue> = HashMap::new();
@@ -406,7 +406,7 @@ fn transform_cards_array(
             }
         }
 
-        // If not an object, no CARD type, or no matching schema, keep as-is
+        // If not an object, no CARD kind, or no matching schema, keep as-is
         transformed_cards.push(card.clone());
     }
 

--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -60,7 +60,7 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
         "field_count".to_string(),
         serde_json::Value::Number(source.config().main.fields.len().into()),
     );
-    let card_count = source.config().card_types.len();
+    let card_count = source.config().card_kinds.len();
     if card_count > 0 {
         info.insert(
             "card_count".to_string(),
@@ -126,7 +126,7 @@ fn print_human_readable(quill: &quillmark::Quill) {
     println!("  Fields:      {}", field_count);
 
     // Card count from schema $defs
-    let card_count = config.card_types.len();
+    let card_count = config.card_kinds.len();
     if card_count > 0 {
         println!("  Cards:       {}", card_count);
     }

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -136,7 +136,7 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
         println!("  Quill name: {}", config.name);
         println!("  Backend: {}", config.backend);
         println!("  Fields: {}", config.main.fields.len());
-        println!("  Cards: {}", config.card_types.len());
+        println!("  Cards: {}", config.card_kinds.len());
     }
 
     // Step 2: Validate file references
@@ -145,8 +145,8 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
     // Step 3: Validate field schemas including defaults
     validate_field_schemas(&config.main.fields, &mut result, "field");
 
-    // Step 4: Validate card-type schemas
-    for card_schema in &config.card_types {
+    // Step 4: Validate card-kind schemas
+    for card_schema in &config.card_kinds {
         validate_card_schema(&card_schema.name, card_schema, &mut result);
     }
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -219,14 +219,14 @@ impl PyQuill {
 
     /// A blank form for a card of the given type — no document values supplied.
     ///
-    /// Returns `None` if `card_type` is not declared in this quill's schema.
+    /// Returns `None` if `card_kind` is not declared in this quill's schema.
     /// Otherwise returns a dict shaped like a single entry in `form()['cards']`.
     fn blank_card<'py>(
         &self,
         py: Python<'py>,
-        card_type: &str,
+        card_kind: &str,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
-        let Some(card) = self.inner.blank_card(card_type) else {
+        let Some(card) = self.inner.blank_card(card_kind) else {
             return Ok(None);
         };
         let json_value = serde_json::to_value(&card).map_err(|e| {

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -217,7 +217,7 @@ impl PyQuill {
         Ok(dict.clone())
     }
 
-    /// A blank form for a card of the given type — no document values supplied.
+    /// A blank form for a card of the given kind — no document values supplied.
     ///
     /// Returns `None` if `card_kind` is not declared in this quill's schema.
     /// Otherwise returns a dict shaped like a single entry in `form()['cards']`.

--- a/crates/bindings/python/tests/test_form.py
+++ b/crates/bindings/python/tests/test_form.py
@@ -39,7 +39,7 @@ main:
     count:
       type: integer
 
-card_types:
+card_kinds:
   note:
     fields:
       body:
@@ -178,7 +178,7 @@ def test_blank_main_returns_card_with_no_document_values(tmp_path):
 
 
 def test_blank_card_known_type(tmp_path):
-    """blank_card returns a dict for a known card type."""
+    """blank_card returns a dict for a known card kind."""
     quill = make_quill(tmp_path)
 
     blank = quill.blank_card("note")
@@ -191,7 +191,7 @@ def test_blank_card_known_type(tmp_path):
 
 
 def test_blank_card_unknown_type(tmp_path):
-    """blank_card returns None for an unknown card type."""
+    """blank_card returns None for an unknown card kind."""
     quill = make_quill(tmp_path)
 
     assert quill.blank_card("does_not_exist") is None

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -699,7 +699,7 @@ main:
       type: string
       description: The title
 
-card_types:
+card_kinds:
   indorsement:
     description: Indorsement
     fields:
@@ -730,9 +730,9 @@ card_types:
     expect(schema.main.description).toBe('The main card schema')
     expect(schema.main.fields.title).toBeDefined()
     expect(schema.main.fields.QUILL.const).toBe('meta_test_quill@0.2.1')
-    expect(schema.card_types.main).toBeUndefined()
-    expect(schema.card_types.indorsement.fields.signature_block).toBeDefined()
-    expect(schema.card_types.indorsement.fields.CARD.const).toBe('indorsement')
+    expect(schema.card_kinds.main).toBeUndefined()
+    expect(schema.card_kinds.indorsement.fields.signature_block).toBeDefined()
+    expect(schema.card_kinds.indorsement.fields.CARD.const).toBe('indorsement')
   })
 
   it('metadata and schema are JSON.stringify-able (plain objects)', () => {
@@ -799,7 +799,7 @@ main:
     count:
       type: integer
 
-card_types:
+card_kinds:
   note:
     fields:
       body:

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -443,7 +443,7 @@ impl Quill {
         })
     }
 
-    /// A blank form for a card of the given type — no document values supplied.
+    /// A blank form for a card of the given kind — no document values supplied.
     ///
     /// Returns `null` if `cardKind` is not declared in this quill's schema.
     /// Otherwise returns a plain JS object shaped like a single entry in

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -22,14 +22,14 @@ export interface QuillFieldUi {
     multiline?: boolean;
 }
 
-/** UI layout hints for a card (main or named card type). */
+/** UI layout hints for a card (main or named card kind). */
 export interface QuillCardUi {
     title?: string;
 }
 
-/** Body namespace for a card (main or named card type). */
+/** Body namespace for a card (main or named card kind). */
 export interface QuillCardBody {
-    /** When false, consumers must not accept or store body content for this card type. Defaults to true. */
+    /** When false, consumers must not accept or store body content for this card kind. Defaults to true. */
     enabled?: boolean;
     /** Example body content embedded verbatim in the blueprint body region. Fallback is "Write <card> body here." */
     example?: string;
@@ -48,7 +48,7 @@ export interface QuillFieldSchema {
     items?: QuillFieldSchema;
 }
 
-/** Schema entry for the main card or a named card type. */
+/** Schema entry for the main card or a named card kind. */
 export interface QuillCardSchema {
     description?: string;
     fields: Record<string, QuillFieldSchema>;
@@ -59,13 +59,13 @@ export interface QuillCardSchema {
 /**
  * Document schema returned by `Quill.schema`. Includes optional `ui` keys.
  *
- * `main.fields.QUILL` and `card_types[name].fields.CARD` are required
+ * `main.fields.QUILL` and `card_kinds[name].fields.CARD` are required
  * sentinels with `const` values telling consumers what to write.
  */
 export interface QuillSchema {
     main: QuillCardSchema;
-    /** Present only when the quill declares at least one named card type. */
-    card_types?: Record<string, QuillCardSchema>;
+    /** Present only when the quill declares at least one named card kind. */
+    card_kinds?: Record<string, QuillCardSchema>;
 }
 
 /**
@@ -445,14 +445,14 @@ impl Quill {
 
     /// A blank form for a card of the given type — no document values supplied.
     ///
-    /// Returns `null` if `cardType` is not declared in this quill's schema.
+    /// Returns `null` if `cardKind` is not declared in this quill's schema.
     /// Otherwise returns a plain JS object shaped like a single entry in
     /// [`Form::cards`].
     ///
     /// [`Form::cards`]: quillmark::form::Form::cards
     #[wasm_bindgen(js_name = blankCard, unchecked_return_type = "FormCard | null")]
-    pub fn blank_card(&self, card_type: &str) -> Result<JsValue, JsValue> {
-        match self.inner.blank_card(card_type) {
+    pub fn blank_card(&self, card_kind: &str) -> Result<JsValue, JsValue> {
+        match self.inner.blank_card(card_kind) {
             Some(card) => {
                 let serializer = serde_wasm_bindgen::Serializer::new()
                     .serialize_maps_as_objects(true)

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -206,7 +206,7 @@ fn test_quill_metadata_and_schemas() {
         .quill(common::tree(&[
             (
                 "Quill.yaml",
-                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\nmain:\n  fields:\n    title:\n      type: string\n      ui:\n        group: Header\ncard_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n",
+                b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\nmain:\n  fields:\n    title:\n      type: string\n      ui:\n        group: Header\ncard_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n",
             ),
             ("plate.typ", b"= Title"),
         ]))
@@ -233,7 +233,7 @@ fn test_quill_metadata_and_schemas() {
         get_str(&get(&main_fields, "QUILL"), "const").as_deref(),
         Some("meta_quill@0.2.1")
     );
-    let card_fields = get(&get(&get(&schema, "card_types"), "indorsement"), "fields");
+    let card_fields = get(&get(&get(&schema, "card_kinds"), "indorsement"), "fields");
     assert_eq!(
         get_str(&get(&card_fields, "CARD"), "const").as_deref(),
         Some("indorsement")

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -374,7 +374,7 @@ Item body"#;
 
 #[test]
 fn test_card_name_collision_with_array_field() {
-    // CARD type names CAN now conflict with frontmatter field names
+    // CARD kind names CAN now conflict with frontmatter field names
     let markdown = r#"---
 QUILL: test_quill
 items:

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -61,7 +61,7 @@ impl QuillConfig {
             let text = example.unwrap_or("Write main body here.");
             out.push_str(&format!("\n{}\n", text));
         }
-        for card in &self.card_types {
+        for card in &self.card_kinds {
             out.push('\n');
             write_card_fence(&mut out, card);
             if card.body_enabled() {
@@ -686,7 +686,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
-card_types:
+card_kinds:
   note:
     description: A short note appended to the document.
     fields:
@@ -705,7 +705,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
-card_types:
+card_kinds:
   skills:
     body: { enabled: false }
     fields:
@@ -723,7 +723,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
-card_types:
+card_kinds:
   note:
     body:
       example: "This is an example note."
@@ -758,7 +758,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
-card_types:
+card_kinds:
   indorsement:
     fields:
       from: { type: string }
@@ -967,7 +967,7 @@ main:
       type: array
       example:
         - report.pdf
-card_types:
+card_kinds:
   enclosure:
     description: An enclosure attached to the letter.
     fields:

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -22,7 +22,7 @@
 //!   kind is in the info string), so its `composable (0..N)` role is emitted
 //!   as an own-line `# composable (0..N)` comment directly under the opener.
 //! - **Body regions** are signalled by `Write main body here.` after the main
-//!   fence and `Write <card name> body here.` after each card fence. When
+//!   fence and `Write <card kind> body here.` after each card fence. When
 //!   `body.example` is set, the example text is embedded verbatim instead.
 //!   Absent when `body.enabled` is false.
 //!

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -25,9 +25,9 @@ pub struct QuillConfig {
     pub description: String,
     /// The entry-point card schema (parsed from the Quill.yaml `main:` section).
     pub main: CardSchema,
-    /// Named, composable card-type schemas (parsed from the Quill.yaml
-    /// `card_types:` section). Does not include `main`.
-    pub card_types: Vec<CardSchema>,
+    /// Named, composable card-kind schemas (parsed from the Quill.yaml
+    /// `card_kinds:` section). Does not include `main`.
+    pub card_kinds: Vec<CardSchema>,
     /// Backend to use for rendering (e.g., "typst", "html")
     pub backend: String,
     /// Version of the Quillmark spec
@@ -66,15 +66,15 @@ pub enum CoercionError {
 }
 
 impl QuillConfig {
-    /// Returns a named card-type schema by name.
-    pub fn card_type(&self, name: &str) -> Option<&CardSchema> {
-        self.card_types.iter().find(|card| card.name == name)
+    /// Returns a named card-kind schema by name.
+    pub fn card_kind(&self, name: &str) -> Option<&CardSchema> {
+        self.card_kinds.iter().find(|card| card.name == name)
     }
 
     /// Full schema including `ui` hints.
     ///
     /// `main.fields` is prefixed with a required `QUILL` entry (`const = name@version`);
-    /// each `card_types[<name>].fields` is prefixed with a required `CARD` entry
+    /// each `card_kinds[<name>].fields` is prefixed with a required `CARD` entry
     /// (`const = <name>`). Identity (`name`, `version`, etc.) lives elsewhere
     /// on the host's metadata surface.
     pub fn schema(&self) -> serde_json::Value {
@@ -91,9 +91,9 @@ impl QuillConfig {
         );
         obj.insert("main".to_string(), main_value);
 
-        if !self.card_types.is_empty() {
-            let card_types: BTreeMap<String, serde_json::Value> = self
-                .card_types
+        if !self.card_kinds.is_empty() {
+            let card_kinds: BTreeMap<String, serde_json::Value> = self
+                .card_kinds
                 .iter()
                 .map(|card| {
                     let mut card_value =
@@ -102,14 +102,14 @@ impl QuillConfig {
                         &mut card_value,
                         "CARD",
                         &card.name,
-                        "Card type name. Must match the card kind in the card block's ```card <kind>``` info string.",
+                        "Card kind name. Must match the card kind in the card block's ```card <kind>``` info string.",
                     );
                     (card.name.clone(), card_value)
                 })
                 .collect();
             obj.insert(
-                "card_types".to_string(),
-                serde_json::to_value(&card_types).unwrap_or(serde_json::Value::Null),
+                "card_kinds".to_string(),
+                serde_json::to_value(&card_kinds).unwrap_or(serde_json::Value::Null),
             );
         }
 
@@ -164,13 +164,13 @@ impl QuillConfig {
         card_tag: &str,
         fields: &IndexMap<String, QuillValue>,
     ) -> Result<IndexMap<String, QuillValue>, CoercionError> {
-        let Some(card_schema) = self.card_type(card_tag) else {
+        let Some(card_schema) = self.card_kind(card_tag) else {
             return Ok(fields.clone());
         };
         let mut coerced: IndexMap<String, QuillValue> = IndexMap::new();
         for (field_name, field_value) in fields {
             if let Some(field_schema) = card_schema.fields.get(field_name) {
-                let path = format!("card_types.{card_tag}.{field_name}");
+                let path = format!("card_kinds.{card_tag}.{field_name}");
                 coerced.insert(
                     field_name.clone(),
                     Self::coerce_value_strict(field_value, field_schema, &path)?,
@@ -962,14 +962,14 @@ impl QuillConfig {
             }
         }
 
-        // Reject unknown top-level sections. Known sections are: quill, main, card_types,
+        // Reject unknown top-level sections. Known sections are: quill, main, card_kinds,
         // and the backend name (e.g. typst). Everything else is a mistake. `fields` gets
         // a targeted hint since it's the most common shape mistake.
         if let Some(top_obj) = quill_yaml_val.as_object() {
             for key in top_obj.keys() {
                 let is_known = key == "quill"
                     || key == "main"
-                    || key == "card_types"
+                    || key == "card_kinds"
                     || (!backend.is_empty() && key == &backend);
                 if is_known {
                     continue;
@@ -988,7 +988,7 @@ impl QuillConfig {
                     )
                 } else {
                     diag.with_hint(format!(
-                        "Valid top-level sections are: quill, main, card_types{}",
+                        "Valid top-level sections are: quill, main, card_kinds{}",
                         if backend.is_empty() {
                             String::new()
                         } else {
@@ -1068,7 +1068,7 @@ impl QuillConfig {
         };
 
         // Extract main.description (optional, authored under `main:` like any
-        // other card type). This is independent of `quill.description`.
+        // other card kind). This is independent of `quill.description`.
         let main_description = main_obj_opt
             .and_then(|main_obj| main_obj.get("description"))
             .and_then(|v| v.as_str())
@@ -1084,27 +1084,27 @@ impl QuillConfig {
             body: main_body,
         };
 
-        // Extract [card_types] section (optional)
-        let mut card_types: Vec<CardSchema> = Vec::new();
-        if let Some(card_types_val) = quill_yaml_val.get("card_types") {
-            match card_types_val.as_object() {
+        // Extract [card_kinds] section (optional)
+        let mut card_kinds: Vec<CardSchema> = Vec::new();
+        if let Some(card_kinds_val) = quill_yaml_val.get("card_kinds") {
+            match card_kinds_val.as_object() {
                 None => {
                     errors.push(
                         Diagnostic::new(
                             Severity::Error,
-                            "'card_types' section must be an object (mapping of type names to schemas)".to_string(),
+                            "'card_kinds' section must be an object (mapping of type names to schemas)".to_string(),
                         )
-                        .with_code("quill::invalid_card_types".to_string()),
+                        .with_code("quill::invalid_card_kinds".to_string()),
                     );
                 }
-                Some(card_types_table) => {
-                    for (card_name, card_value) in card_types_table {
+                Some(card_kinds_table) => {
+                    for (card_name, card_value) in card_kinds_table {
                         if !Self::is_valid_card_identifier(card_name) {
                             errors.push(
                                 Diagnostic::new(
                                     Severity::Error,
                                     format!(
-                                        "Invalid card-type name '{}': names must match \
+                                        "Invalid card-kind name '{}': names must match \
                                          [a-z_][a-z0-9_]* (lowercase letters, digits, and underscores only).",
                                         card_name
                                     ),
@@ -1123,7 +1123,7 @@ impl QuillConfig {
                                         Diagnostic::new(
                                             Severity::Error,
                                             format!(
-                                                "Failed to parse card_type '{}': {}",
+                                                "Failed to parse card_kind '{}': {}",
                                                 card_name, e
                                             ),
                                         )
@@ -1142,7 +1142,7 @@ impl QuillConfig {
                             Self::parse_fields_with_order(
                                 card_fields_table,
                                 &card_field_order,
-                                &format!("card_type '{}' field", card_name),
+                                &format!("card_kind '{}' field", card_name),
                                 &mut errors,
                             )
                         } else {
@@ -1151,10 +1151,10 @@ impl QuillConfig {
 
                         Self::validate_description_singleline(
                             card_def.description.as_deref(),
-                            &format!("card_type '{}'", card_name),
+                            &format!("card_kind '{}'", card_name),
                             &mut errors,
                         );
-                        card_types.push(CardSchema {
+                        card_kinds.push(CardSchema {
                             name: card_name.clone(),
                             description: card_def.description,
                             fields: card_fields,
@@ -1193,8 +1193,8 @@ impl QuillConfig {
         if let Some(d) = warn_example_unused("main", &main.body) {
             warnings.push(d);
         }
-        for card in &card_types {
-            if let Some(d) = warn_example_unused(&format!("card_types.{}", card.name), &card.body) {
+        for card in &card_kinds {
+            if let Some(d) = warn_example_unused(&format!("card_kinds.{}", card.name), &card.body) {
                 warnings.push(d);
             }
         }
@@ -1227,9 +1227,9 @@ impl QuillConfig {
         if let Some(d) = err_example_contains_fence("main", &main.body) {
             errors.push(d);
         }
-        for card in &card_types {
+        for card in &card_kinds {
             if let Some(d) =
-                err_example_contains_fence(&format!("card_types.{}", card.name), &card.body)
+                err_example_contains_fence(&format!("card_kinds.{}", card.name), &card.body)
             {
                 errors.push(d);
             }
@@ -1244,7 +1244,7 @@ impl QuillConfig {
                 name,
                 description,
                 main,
-                card_types,
+                card_kinds,
                 backend,
                 version,
                 author,

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1092,7 +1092,7 @@ impl QuillConfig {
                     errors.push(
                         Diagnostic::new(
                             Severity::Error,
-                            "'card_kinds' section must be an object (mapping of type names to schemas)".to_string(),
+                            "'card_kinds' section must be an object (mapping of kind names to schemas)".to_string(),
                         )
                         .with_code("quill::invalid_card_kinds".to_string()),
                     );

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -117,7 +117,7 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     );
 
     let mut defs = serde_json::Map::new();
-    for card in &config.card_types {
+    for card in &config.card_kinds {
         let mut card_properties = serde_json::Map::new();
         for (name, field) in &card.fields {
             card_properties.insert(name.clone(), field_to_schema(field));
@@ -201,7 +201,7 @@ main:
     }
 
     #[test]
-    fn injects_body_as_markdown_for_main_and_each_card_type() {
+    fn injects_body_as_markdown_for_main_and_each_card_kind() {
         let yaml = r#"
 quill:
   name: example
@@ -214,7 +214,7 @@ main:
     title:
       type: string
 
-card_types:
+card_kinds:
   indorsement:
     fields:
       signature_block:

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -31,7 +31,7 @@ main:
         group: Meta
     page_count:
       type: integer
-card_types:
+card_kinds:
   indorsement:
     fields:
       signature_block:
@@ -43,12 +43,12 @@ card_types:
         let config = cfg(FULL);
         let yaml = config.schema_yaml().unwrap();
         assert!(yaml.contains("enum:") && yaml.contains("type: integer"));
-        assert!(yaml.contains("card_types:") && yaml.contains("indorsement:"));
+        assert!(yaml.contains("card_kinds:") && yaml.contains("indorsement:"));
         assert!(yaml.contains("ui:") && yaml.contains("group: Meta"));
     }
 
     #[test]
-    fn omits_card_types_when_absent() {
+    fn omits_card_kinds_when_absent() {
         let yaml = cfg(r#"
 quill: { name: solo, version: "1.0", backend: typst, description: x }
 main:
@@ -57,7 +57,7 @@ main:
 "#)
         .schema_yaml()
         .unwrap();
-        assert!(yaml.contains("main:") && !yaml.contains("card_types:"));
+        assert!(yaml.contains("main:") && !yaml.contains("card_kinds:"));
     }
 
     #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -803,7 +803,7 @@ quill:
   backend: typst
   description: Bad card name
 
-card_types:
+card_kinds:
   BadCard:
     fields:
       title:
@@ -826,7 +826,7 @@ quill:
   backend: typst
   description: Leading underscore card name
 
-card_types:
+card_kinds:
   _private_card:
     fields:
       title:
@@ -868,7 +868,7 @@ quill:
   backend: typst
   description: Bad card field key
 
-card_types:
+card_kinds:
   profile:
     fields:
       DisplayName:
@@ -1014,7 +1014,7 @@ quill:
   backend: typst
   description: Card defaults test
 
-card_types:
+card_kinds:
   indorsement:
     fields:
       signature_block:
@@ -1027,7 +1027,7 @@ card_types:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    let card = config.card_type("indorsement").unwrap();
+    let card = config.card_kind("indorsement").unwrap();
     let card_defaults = card.defaults();
     assert_eq!(card_defaults.len(), 1);
     assert_eq!(
@@ -1038,7 +1038,7 @@ card_types:
     let sig_example = card.fields.get("signature_block").unwrap().example.as_ref();
     assert_eq!(sig_example.and_then(|v| v.as_str()), Some("Col Smith"));
 
-    assert!(config.card_type("unknown").is_none());
+    assert!(config.card_kind("unknown").is_none());
 }
 
 #[test]
@@ -1169,7 +1169,7 @@ quill:
   backend: typst
   description: Test [cards.X.fields.Y] syntax
 
-card_types:
+card_kinds:
   endorsements:
     description: Chain of endorsements
     fields:
@@ -1185,9 +1185,9 @@ card_types:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    // Verify the card-type was parsed into config.card_types
-    assert!(config.card_type("endorsements").is_some());
-    let card = config.card_type("endorsements").unwrap();
+    // Verify the card-kind was parsed into config.card_kinds
+    assert!(config.card_kind("endorsements").is_some());
+    let card = config.card_kind("endorsements").unwrap();
 
     assert_eq!(card.name, "endorsements");
     assert_eq!(card.description, Some("Chain of endorsements".to_string()));
@@ -1248,7 +1248,7 @@ main:
       description: Regular field
       type: string
 
-card_types:
+card_kinds:
   indorsements:
     description: Chain of endorsements
     fields:
@@ -1264,9 +1264,9 @@ card_types:
     let regular = config.main.fields.get("regular").unwrap();
     assert_eq!(regular.r#type, FieldType::String);
 
-    // Check card-type is in config.card_types (not config.main.fields)
-    assert!(config.card_type("indorsements").is_some());
-    let card = config.card_type("indorsements").unwrap();
+    // Check card-kind is in config.card_kinds (not config.main.fields)
+    assert!(config.card_kind("indorsements").is_some());
+    let card = config.card_kind("indorsements").unwrap();
     assert_eq!(card.description, Some("Chain of endorsements".to_string()));
     assert!(card.fields.contains_key("name"));
 }
@@ -1281,13 +1281,13 @@ quill:
   backend: typst
   description: Test cards without fields
 
-card_types:
+card_kinds:
   myscope:
     description: My scope
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let card = config.card_type("myscope").unwrap();
+    let card = config.card_kind("myscope").unwrap();
     assert_eq!(card.name, "myscope");
     assert_eq!(card.description, Some("My scope".to_string()));
     assert!(card.fields.is_empty());
@@ -1309,7 +1309,7 @@ main:
       description: Field
       type: string
 
-card_types:
+card_kinds:
   conflict:
     description: Card
 "#;
@@ -1325,7 +1325,7 @@ card_types:
 
     let config = result.unwrap();
     assert!(config.main.fields.contains_key("conflict"));
-    assert!(config.card_type("conflict").is_some());
+    assert!(config.card_kind("conflict").is_some());
 }
 
 #[test]
@@ -1347,7 +1347,7 @@ main:
       type: string
       description: Zero
 
-card_types:
+card_kinds:
   second:
     description: Second
     fields:
@@ -1360,7 +1360,7 @@ card_types:
 
     let first = config.main.fields.get("first").unwrap();
     let zero = config.main.fields.get("zero").unwrap();
-    let second = config.card_type("second").unwrap();
+    let second = config.card_kind("second").unwrap();
 
     // Check field ordering
     let ord_first = first.ui.as_ref().unwrap().order.unwrap();
@@ -1388,7 +1388,7 @@ quill:
   backend: typst
   description: Test card field order
 
-card_types:
+card_kinds:
   mycard:
     description: Test card
     fields:
@@ -1401,7 +1401,7 @@ card_types:
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
-    let card = config.card_type("mycard").unwrap();
+    let card = config.card_kind("mycard").unwrap();
 
     let z_first = card.fields.get("z_first").unwrap();
     let a_second = card.fields.get("a_second").unwrap();
@@ -1749,7 +1749,7 @@ quill:
   backend: typst
   description: Coerce cards
 
-card_types:
+card_kinds:
   indorsement:
     fields:
       score:
@@ -1914,7 +1914,7 @@ main:
     subject:
       type: string
 
-card_types:
+card_kinds:
   indorsement:
     ui:
       title: "{from} → {for}"
@@ -1932,7 +1932,7 @@ card_types:
         Some("Memorandum"),
         "literal main.ui.title"
     );
-    let indorsement = config.card_type("indorsement").unwrap();
+    let indorsement = config.card_kind("indorsement").unwrap();
     assert_eq!(
         indorsement.ui.as_ref().unwrap().title.as_deref(),
         Some("{from} → {for}"),
@@ -1942,7 +1942,7 @@ card_types:
     let schema = config.schema();
     assert_eq!(schema["main"]["ui"]["title"].as_str(), Some("Memorandum"));
     assert_eq!(
-        schema["card_types"]["indorsement"]["ui"]["title"].as_str(),
+        schema["card_kinds"]["indorsement"]["ui"]["title"].as_str(),
         Some("{from} → {for}")
     );
 }
@@ -2018,7 +2018,7 @@ quill:
 
 #[test]
 fn test_unknown_top_level_section_errors() {
-    // 'card_type' is a common typo for 'card_types'. Must not be silently ignored.
+    // 'card_kind' is a common typo for 'card_kinds'. Must not be silently ignored.
     let yaml_content = r#"
 quill:
   name: unk_section
@@ -2026,7 +2026,7 @@ quill:
   backend: typst
   description: Unknown section test
 
-card_type:
+card_kind:
   foo:
     description: Should not silently disappear
     fields:
@@ -2037,7 +2037,7 @@ card_type:
     let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
 
     assert!(err.iter().any(|d| {
-        d.code.as_deref() == Some("quill::unknown_section") && d.message.contains("card_type")
+        d.code.as_deref() == Some("quill::unknown_section") && d.message.contains("card_kind")
     }));
 }
 
@@ -2239,7 +2239,7 @@ fn check_schema_snapshot(
     let parsed: serde_json::Value = serde_saphyr::from_str(&yaml).expect("parse yaml");
     assert_eq!(json_of(&quill.config), parsed, "{golden} json/yaml parity");
     assert!(parsed.get("main").and_then(|v| v.get("fields")).is_some());
-    assert!(parsed.get("card_types").is_some());
+    assert!(parsed.get("card_kinds").is_some());
     assert!(parsed.get("ref").is_none() && parsed.get("example").is_none());
     assert!(yaml.contains("ui:"), "{golden} must include ui hints");
 }
@@ -2256,7 +2256,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
-card_types:
+card_kinds:
   skills:
     body:
       enabled: false
@@ -2357,14 +2357,14 @@ main:
 }
 
 #[test]
-fn body_example_card_type_fence_line_is_an_error() {
-    // The fence check applies to card-type body examples too.
+fn body_example_card_kind_fence_line_is_an_error() {
+    // The fence check applies to card-kind body examples too.
     let yaml = r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
-card_types:
+card_kinds:
   note:
     body:
       example: "See below:\n---\nEnd."
@@ -2379,7 +2379,7 @@ card_types:
             .as_deref()
             .map(|c| c == "quill::body_example_contains_fence")
             .unwrap_or(false)),
-        "expected body_example_contains_fence error for card type, got: {:?}",
+        "expected body_example_contains_fence error for card kind, got: {:?}",
         errors
     );
 }

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -36,7 +36,7 @@ pub mod ui_key {
     pub const GROUP: &str = "group";
     /// Display order within the UI
     pub const ORDER: &str = "order";
-    /// Display label for a card type. May be a literal string or a template
+    /// Display label for a card kind. May be a literal string or a template
     /// containing `{field_name}` tokens interpolated per-instance by UI consumers.
     pub const TITLE: &str = "title";
     /// Compact rendering hint for UI consumers
@@ -67,13 +67,13 @@ pub struct UiFieldSchema {
     pub multiline: Option<bool>,
 }
 
-/// Body namespace configuration for a card type
+/// Body namespace configuration for a card kind
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BodyCardSchema {
     /// Whether the body editor is enabled for this card (default: true).
     /// When false, consumers must not accept or store body content for instances
-    /// of this card type.
+    /// of this card kind.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// Example body content embedded verbatim in the blueprint body region.
@@ -86,20 +86,20 @@ pub struct BodyCardSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UiCardSchema {
-    /// Display label for the card type — literal string or `{field_name}`
+    /// Display label for the card kind — literal string or `{field_name}`
     /// template. See `docs/format-designer/quill-yaml-reference.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 }
 
-/// Schema definition for a card type (composable content blocks)
+/// Schema definition for a card kind (composable content blocks)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CardSchema {
-    /// Card type name (e.g., "indorsements"). The map key carries this on the
+    /// Card kind name (e.g., "indorsements"). The map key carries this on the
     /// wire; skipped during serialization to avoid duplication.
     #[serde(skip_serializing, default)]
     pub name: String,
-    /// Detailed description of this card type
+    /// Detailed description of this card kind
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// List of fields in the card

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -31,14 +31,14 @@ pub enum ValidationError {
     #[error("field `{path}` does not match expected format `{format}`")]
     FormatViolation { path: String, format: String },
 
-    #[error("unknown card type `{card}` at `{path}`")]
+    #[error("unknown card kind `{card}` at `{path}`")]
     UnknownCard { path: String, card: String },
 
     #[error("card at `{path}` missing `CARD` discriminator")]
     MissingCardDiscriminator { path: String },
 
     #[error(
-        "card `{card}` at `{path}` has body content but the card type declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card type"
+        "card `{card}` at `{path}` has body content but the card kind declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card kind"
     )]
     BodyDisabled { path: String, card: String },
 }
@@ -130,11 +130,11 @@ pub fn validate_typed_document(
         let card_name = card.tag();
         let item_path = format!("cards[{index}]");
         // NOTE: `cards[N]` is the document-instance-side path (the cards
-        // array on a Document). Card-type definitions live under
-        // `card_types:` in Quill.yaml, but instances on a document are
+        // array on a Document). Card-kind definitions live under
+        // `card_kinds:` in Quill.yaml, but instances on a document are
         // still a `cards` list.
 
-        let Some(card_schema) = config.card_type(card_name.as_str()) else {
+        let Some(card_schema) = config.card_kind(card_name.as_str()) else {
             errors.push(ValidationError::UnknownCard {
                 path: item_path,
                 card: card_name,
@@ -614,7 +614,7 @@ main:
     fn validates_card_with_valid_discriminator() {
         let config = config_with(
             "    title:\n      type: string",
-            "card_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -630,7 +630,7 @@ main:
     fn rejects_unknown_card_discriminator() {
         let config = config_with(
             "    title:\n      type: string",
-            "card_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(&[], vec![typed_card("unknown", &[])]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
@@ -643,7 +643,7 @@ main:
     fn validates_multiple_card_instances_same_type() {
         let config = config_with(
             "    title:\n      type: string",
-            "card_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -656,10 +656,10 @@ main:
     }
 
     #[test]
-    fn validates_multiple_card_types_mixed() {
+    fn validates_multiple_card_kinds_mixed() {
         let config = config_with(
             "    title:\n      type: string",
-            "card_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true\n  routing:\n    fields:\n      office:\n        type: string\n        required: true",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true\n  routing:\n    fields:\n      office:\n        type: string\n        required: true",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -675,7 +675,7 @@ main:
     fn reports_card_field_paths_with_card_name_and_index() {
         let config = config_with(
             "    title:\n      type: string",
-            "card_types:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
         );
         let doc = doc_with_typed_cards(&[], vec![typed_card("indorsement", &[])]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
@@ -688,7 +688,7 @@ main:
     fn body_disabled_card_enforces_trim_boundary() {
         let config = config_with(
             "    title:\n      type: string",
-            "card_types:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        required: true",
+            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        required: true",
         );
         // Prose triggers the error; whitespace-only does not.
         let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -25,7 +25,7 @@ main:
         group: Personal Info
       description: List of contact details (email, phone, links, etc.)
 
-card_types:
+card_kinds:
   experience_section:
     description: An entry with a heading, subheading, and bullet points.
     ui:

--- a/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
@@ -18,7 +18,7 @@ main:
       description: title of document
       type: string
 
-card_types:
+card_kinds:
   quotes:
     description: A collection of quotes about taro ice cream
     ui:

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -128,7 +128,7 @@ main:
         group: Additional
       description: Font size for the memo text (pt).
 
-card_types:
+card_kinds:
   indorsement:
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     fields:

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -141,7 +141,7 @@ main:
       ui:
         group: Letterhead
         order: 6
-card_types:
+card_kinds:
   indorsement:
     description: >-
       Chain of routing endorsements. Each endorsement block adds an official response
@@ -151,7 +151,7 @@ card_types:
         type: string
         const: indorsement
         description: >-
-          Card type name. Must match the card kind in the card block's ```card <kind>```
+          Card kind name. Must match the card kind in the card block's ```card <kind>```
           info string.
         required: true
       attachments:

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -128,7 +128,7 @@ main:
         group: Additional
       description: Font size for the memo text (pt).
 
-card_types:
+card_kinds:
   indorsement:
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     ui:

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -125,7 +125,7 @@ fn config_with_one_field(schema: FieldSchema) -> QuillConfig {
         name: "test".to_string(),
         description: String::new(),
         main,
-        card_types: Vec::new(),
+        card_kinds: Vec::new(),
         backend: "typst".to_string(),
         version: "1.0".to_string(),
         author: String::new(),

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -132,7 +132,7 @@ pub struct Form {
 
 /// Build the [`Form`] for a document. Composes:
 /// - `QuillConfig::main` — the main card schema.
-/// - `QuillConfig::card_type` — to look up card schemas by tag.
+/// - `QuillConfig::card_kind` — to look up card schemas by tag.
 /// - `QuillConfig::validate_document` — to gather validation diagnostics.
 ///
 /// Coercion (`coerce_frontmatter` / `coerce_card`) is **not** applied here:
@@ -149,7 +149,7 @@ pub(crate) fn build_form(quill: &Quill, doc: &Document) -> Form {
     let mut cards: Vec<FormCard> = Vec::new();
     for (index, card) in doc.cards().iter().enumerate() {
         let tag = card.tag();
-        match quill.source().config().card_type(&tag) {
+        match quill.source().config().card_kind(&tag) {
             Some(card_schema) => {
                 let card_fields = card.frontmatter().to_index_map();
                 cards.push(project_card(card_schema, &card_fields));
@@ -186,13 +186,13 @@ pub(crate) fn build_form(quill: &Quill, doc: &Document) -> Form {
     }
 }
 
-/// Build a blank [`FormCard`] for a card type by tag, or `None` if the tag
+/// Build a blank [`FormCard`] for a card kind by tag, or `None` if the tag
 /// isn't declared in the quill's schema.
-pub(crate) fn blank_card_for_tag(quill: &Quill, card_type: &str) -> Option<FormCard> {
+pub(crate) fn blank_card_for_tag(quill: &Quill, card_kind: &str) -> Option<FormCard> {
     quill
         .source()
         .config()
-        .card_type(card_type)
+        .card_kind(card_kind)
         .map(FormCard::blank)
 }
 

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -143,7 +143,7 @@ main:
     title:
       type: string
 
-card_types:
+card_kinds:
   known_card:
     fields:
       note:
@@ -190,7 +190,7 @@ main:
     title:
       type: string
 
-card_types:
+card_kinds:
   indorsement:
     fields:
       signature_block:
@@ -422,7 +422,7 @@ main:
     title:
       type: string
 
-card_types:
+card_kinds:
   indorsement:
     fields:
       office:
@@ -435,7 +435,7 @@ card_types:
 
     let blank = quill
         .blank_card("indorsement")
-        .expect("known card type should yield a FormCard");
+        .expect("known card kind should yield a FormCard");
 
     assert_eq!(blank.schema.name, "indorsement");
 
@@ -465,7 +465,7 @@ main:
     title:
       type: string
 
-card_types:
+card_kinds:
   known:
     fields:
       x:

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -108,7 +108,7 @@ impl Quill {
                 let defaults = self
                     .source
                     .config()
-                    .card_type(&card.tag())
+                    .card_kind(&card.tag())
                     .map(|c| c.defaults())
                     .unwrap_or_default();
                 let fields = apply_defaults(&card.frontmatter().to_index_map(), defaults);
@@ -227,13 +227,13 @@ impl Quill {
     }
 
     /// A blank form for a card of the given type — no document values
-    /// supplied. Returns `None` if `card_type` is not declared in the
+    /// supplied. Returns `None` if `card_kind` is not declared in the
     /// quill's schema.
     ///
     /// This is the "user is about to add a new card" view: the UI can render
     /// the form before the card is committed to the document.
-    pub fn blank_card(&self, card_type: &str) -> Option<FormCard> {
-        form::blank_card_for_tag(self, card_type)
+    pub fn blank_card(&self, card_kind: &str) -> Option<FormCard> {
+        form::blank_card_for_tag(self, card_kind)
     }
 
     fn validate_document(&self, doc: &Document) -> Result<(), RenderError> {

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -226,7 +226,7 @@ impl Quill {
         FormCard::blank(&self.source.config().main)
     }
 
-    /// A blank form for a card of the given type — no document values
+    /// A blank form for a card of the given kind — no document values
     /// supplied. Returns `None` if `card_kind` is not declared in the
     /// quill's schema.
     ///

--- a/docs/authoring/yaml-frontmatter.md
+++ b/docs/authoring/yaml-frontmatter.md
@@ -112,7 +112,7 @@ tags: !fill []
 
 ## Card Blocks
 
-Fenced code blocks with the info string `card <type>` embedded in the document body are **card blocks**, where `<type>` matches `[a-z_][a-z0-9_]*`. All card blocks are collected into the `CARDS` array available to templates.
+Fenced code blocks with the info string `card <kind>` embedded in the document body are **card blocks**, where `<kind>` matches `[a-z_][a-z0-9_]*`. All card blocks are collected into the `CARDS` array available to templates.
 
 ````markdown
 ```card indorsement
@@ -123,7 +123,7 @@ for: ORG2/SYMBOL
 Indorsement body text here.
 ````
 
-The legacy `---`-delimited form with a `CARD: <type>` key is still accepted on input.
+The legacy `---`-delimited form with a `CARD: <kind>` key is still accepted on input.
 
 See [Cards](cards.md) for details on card syntax and usage.
 

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -86,7 +86,7 @@ For command options and output controls, see the [CLI Reference](../cli/referenc
 
 ## 6. Next steps
 
-- [Quill.yaml Reference](quill-yaml-reference.md) — full field types, UI hints, `card_types`, `typst` section
+- [Quill.yaml Reference](quill-yaml-reference.md) — full field types, UI hints, `card_kinds`, `typst` section
 - [Typst Backend](typst-backend.md) — data access patterns, CARDS iteration, helper package
 - [Quill Versioning](versioning.md)
 

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -16,7 +16,7 @@ main:         # Optional — main entry-point card: field schemas and optional u
   ui:         # optional UI hints (e.g. title)
   body:       # optional body-region config (e.g. enabled, description)
 
-card_types:   # Optional — additional composable card types
+card_kinds:   # Optional — additional composable card kinds
   ...
 
 typst:        # Optional — backend-specific configuration
@@ -258,15 +258,15 @@ main:
 
 ---
 
-## `card_types` Section
+## `card_kinds` Section
 
-`card_types` define composable, repeatable content blocks (the *types* — a document can then carry zero or more *instances* of each type, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`, `body`); think of `main:` as the single mandatory card-type for the document body, and `card_types:` as the library of additional types that may attach to it.
+`card_kinds` define composable, repeatable content blocks (the *kinds* — a document can then carry zero or more *instances* of each kind, interleaved with body content). Each entry is shaped exactly like `main:` (`fields`, optional `description`, `ui`, `body`); think of `main:` as the single mandatory card-kind for the document body, and `card_kinds:` as the library of additional kinds that may attach to it.
 
-Card-type names (the keys under `card_types`) must match `[a-z_][a-z0-9_]*` (leading underscore is allowed).
+Card-kind names (the keys under `card_kinds`) must match `[a-z_][a-z0-9_]*` (leading underscore is allowed).
 
 ```yaml
-card_types:
-  indorsement:                    # Card-type name
+card_kinds:
+  indorsement:                    # Card-kind name
     description: Chain of routing endorsements.
     fields:
       from:
@@ -279,7 +279,7 @@ card_types:
         default: standard
 ```
 
-Invalid card-type names include:
+Invalid card-kind names include:
 
 - `BadCard` (uppercase letters)
 - `my-card` (hyphen)
@@ -298,18 +298,18 @@ Invalid card-type names include:
 
 | Property | Type   | Description |
 |----------|--------|-------------|
-| `title`  | string | Display label for the card type. Literal string or `{field}` template |
+| `title`  | string | Display label for the card kind. Literal string or `{field}` template |
 
 ### Card-level `body`
 
 | Property  | Type   | Description |
 |-----------|--------|-------------|
-| `enabled`     | bool   | Whether the body editor is enabled (default: true). When false, consumers must not accept or store body content for this card type. |
+| `enabled`     | bool   | Whether the body editor is enabled (default: true). When false, consumers must not accept or store body content for this card kind. |
 | `description` | string | Description shown in the body editor placeholder when the body is empty. |
 
 #### `title`
 
-A human-readable display label for the card type. UI consumers should prefer it over the snake_case map key when rendering section headers, chips, picker entries, or per-instance titles in a list.
+A human-readable display label for the card kind. UI consumers should prefer it over the snake_case map key when rendering section headers, chips, picker entries, or per-instance titles in a list.
 
 The label is decoupled from the map key (e.g. `indorsement`), which is the on-the-wire `CARD` discriminator. Authors can rename the label freely without invalidating stored documents.
 
@@ -318,7 +318,7 @@ The label is decoupled from the map key (e.g. `indorsement`), which is the on-th
 A literal string serves as a static type label:
 
 ```yaml
-card_types:
+card_kinds:
   indorsement:
     ui:
       title: Routing Endorsement
@@ -330,7 +330,7 @@ card_types:
 A template containing `{field_name}` tokens lets UI consumers produce a per-instance title by interpolating live field values:
 
 ```yaml
-card_types:
+card_kinds:
   endorsement:
     ui:
       title: "{from} → {for}"
@@ -353,10 +353,10 @@ With the template form, a UI rendering a list of cards can title each instance (
 
 #### `body.enabled`
 
-When `false`, the card type has no body/content area. Consumers must not accept or store body content for instances of this card type. The validator enforces this: a document instance that provides body content for a `body.enabled: false` card type is rejected with a `BodyDisabled` error.
+When `false`, the card kind has no body/content area. Consumers must not accept or store body content for instances of this card kind. The validator enforces this: a document instance that provides body content for a `body.enabled: false` card kind is rejected with a `BodyDisabled` error.
 
 ```yaml
-card_types:
+card_kinds:
   metadata_block:
     body:
       enabled: false    # Card has fields only, no body/content area
@@ -370,7 +370,7 @@ card_types:
 Optional description displayed in the body editor placeholder area when the body is empty. Has no effect when `body.enabled` is false.
 
 ```yaml
-card_types:
+card_kinds:
   experience:
     body:
       description: Describe your role, responsibilities, and key achievements.
@@ -491,7 +491,7 @@ main:
       ui:
         group: Financials
 
-card_types:
+card_kinds:
   milestone:
     description: A project milestone with target date and status.
     fields:

--- a/docs/migrations/wasm-0.77-to-0.80.md
+++ b/docs/migrations/wasm-0.77-to-0.80.md
@@ -23,15 +23,17 @@ Migration notes for `@quillmark/wasm` consumers upgrading across the
 
 ## TL;DR
 
-The `Quillmark`, `Quill`, `Document`, and `RenderSession` class APIs are
-**unchanged**. Three things move:
+The `Quillmark`, `Document`, and `RenderSession` class APIs are **unchanged**.
+Four things change:
 
 1. The canonical Markdown **card syntax** is a fenced code block
    (`` ```card <kind> ``). The legacy `---`/`CARD:` fence still parses, but
    `doc.toMarkdown()` now emits the fenced form.
-2. The quill schema returned by `Quill.schema` names its composable-card
+2. The `Quill.example` getter is **removed** — the bundled example-document
+   concept no longer exists.
+3. The quill schema returned by `Quill.schema` names its composable-card
    section `card_kinds` (a map keyed by **card kind** name).
-3. `Diagnostic` objects gain an optional `path` field, and validation /
+4. `Diagnostic` objects gain an optional `path` field, and validation /
    quill-config render errors now surface **every** diagnostic instead of
    just the first.
 
@@ -39,6 +41,8 @@ The `Quillmark`, `Quill`, `Document`, and `RenderSession` class APIs are
    const doc = Document.fromMarkdown(markdown);   // still accepts legacy CARD: fences
 - // doc.toMarkdown() emitted `---`/`CARD:` card fences
 + // doc.toMarkdown() now emits ```card <kind> fenced blocks
+
+- const sample = quill.example;                   // removed — no bundled example
 
 - const kinds = quill.schema.card_types;          // experimental 0.79.0 spelling
 + const kinds = quill.schema.card_kinds;          // stable 0.80.0 spelling
@@ -110,7 +114,24 @@ This is the one behavior change most likely to affect you:
 The `Document` card mutators (`pushCard`, `insertCard`, `updateCardField`,
 etc.) and the `CardInput` shape (`{ tag, fields?, body? }`) are unchanged.
 
-## 2. Quill schema uses `card_kinds`
+## 2. `Quill.example` getter removed
+
+`0.77.0` bundled an optional example document inside a quill, exposed as the
+`Quill.example` getter (`string | undefined`). The bundled-document concept
+has been removed entirely — there is no `Quill.example` getter in `0.80.0`.
+
+```diff
+- const sample = quill.example;        // string | undefined in 0.77.0
+- if (sample) showPreview(sample);
+```
+
+If you relied on a quill shipping a ready-made sample document, generate a
+starter document from the quill's **blueprint** instead — an annotated
+Markdown skeleton derived from the schema. Per-field `example` values in the
+schema are a separate, unaffected concept and are still available via
+`Quill.schema`.
+
+## 3. Quill schema uses `card_kinds`
 
 The schema returned by `Quill.schema` describes the main card and any number
 of named **card kinds**. The card-kinds section is keyed `card_kinds`:
@@ -135,7 +156,7 @@ Quills themselves declare composable cards under a `card_kinds:` section in
 `Quill.yaml`. The experimental `card_types:` spelling from `0.79.0` is no
 longer accepted — any bundled quill must use `card_kinds:`.
 
-## 3. `Diagnostic` gains a `path` field
+## 4. `Diagnostic` gains a `path` field
 
 `Diagnostic` objects — returned in `err.diagnostics`, `quill.form().diagnostics`,
 and `session.warnings` — now carry an optional `path` string:
@@ -157,7 +178,7 @@ diagnostics; it is `undefined` otherwise. This is purely additive — no code
 change is required, but you can now point a user at the offending field
 without parsing the message string.
 
-## 4. Validation errors carry all diagnostics
+## 5. Validation errors carry all diagnostics
 
 Before `0.80.0`, only the `CompilationFailed` render error forwarded its full
 diagnostic list to JS. The `QuillConfig` and `ValidationFailed` variants fell
@@ -192,6 +213,7 @@ diagnostics.
       experimental `0.78.0` and `0.79.0`).
 - [ ] Regenerate any snapshot/golden fixtures that compare `toMarkdown()` output.
 - [ ] Replace string comparisons of `toMarkdown()` output with `doc.equals`.
+- [ ] Remove any use of the `Quill.example` getter — it no longer exists.
 - [ ] Rename any `quill.schema.card_types` access to `quill.schema.card_kinds`.
 - [ ] Ensure bundled quills declare composable cards under `card_kinds:` (not
       the deprecated `card_types:`).

--- a/docs/migrations/wasm-0.77-to-0.80.md
+++ b/docs/migrations/wasm-0.77-to-0.80.md
@@ -1,23 +1,37 @@
-# `@quillmark/wasm` 0.77.0 → 0.79.0
+# `@quillmark/wasm` 0.77.0 → 0.80.0
 
 Migration notes for `@quillmark/wasm` consumers upgrading across the
 **card-syntax** release.
 
-!!! warning "Skip 0.78.0"
-    `@quillmark/wasm@0.78.0` was never published for general use and is being
-    yanked. Upgrade straight from `0.77.0` to `0.79.0`; the intermediate
-    "leaf" terminology from `0.78.0` never reached a stable release and does
-    not appear in `0.79.0`.
+!!! warning "Skip 0.78.0 and 0.79.0"
+    `@quillmark/wasm@0.78.0` and `@quillmark/wasm@0.79.0` were experimental
+    pre-releases and are being yanked. Upgrade straight from `0.77.0` to
+    `0.80.0`.
+
+    The card model evolved through two experimental iterations before
+    stabilizing:
+
+    - **`0.78.0`** introduced "leaf" terminology. It was never published for
+      general use and the leaf concept does not survive into `0.80.0`.
+    - **`0.79.0`** introduced the "card" model but spelled the schema's
+      composable-card section `card_types`. That spelling is **officially
+      deprecated**.
+
+    `0.80.0` is the first stable release of the card model. Its composable
+    cards are described by **card kinds**, and the schema section is named
+    `card_kinds`. Treat both `0.78.0` and `0.79.0` as skip-this versions.
 
 ## TL;DR
 
 The `Quillmark`, `Quill`, `Document`, and `RenderSession` class APIs are
-**unchanged**. Two things move:
+**unchanged**. Three things move:
 
-1. The canonical Markdown **card syntax** is now a fenced code block
+1. The canonical Markdown **card syntax** is a fenced code block
    (`` ```card <kind> ``). The legacy `---`/`CARD:` fence still parses, but
    `doc.toMarkdown()` now emits the fenced form.
-2. `Diagnostic` objects gain an optional `path` field, and validation /
+2. The quill schema returned by `Quill.schema` names its composable-card
+   section `card_kinds` (a map keyed by **card kind** name).
+3. `Diagnostic` objects gain an optional `path` field, and validation /
    quill-config render errors now surface **every** diagnostic instead of
    just the first.
 
@@ -25,6 +39,9 @@ The `Quillmark`, `Quill`, `Document`, and `RenderSession` class APIs are
    const doc = Document.fromMarkdown(markdown);   // still accepts legacy CARD: fences
 - // doc.toMarkdown() emitted `---`/`CARD:` card fences
 + // doc.toMarkdown() now emits ```card <kind> fenced blocks
+
+- const kinds = quill.schema.card_types;          // experimental 0.79.0 spelling
++ const kinds = quill.schema.card_kinds;          // stable 0.80.0 spelling
 
   try {
     quill.render(doc, { format: "pdf" });
@@ -39,9 +56,10 @@ The `Quillmark`, `Quill`, `Document`, and `RenderSession` class APIs are
 
 ## 1. Card Markdown syntax
 
-In `0.79.0` the canonical card block is a fenced code block whose info string
+In `0.80.0` the canonical card block is a fenced code block whose info string
 is `card <kind>`. The block content is the card's YAML; the Markdown after the
-closing fence is the card body.
+closing fence is the card body. `<kind>` is the **card kind** — the on-the-wire
+`CARD` discriminator.
 
 ```diff
   ---
@@ -92,7 +110,32 @@ This is the one behavior change most likely to affect you:
 The `Document` card mutators (`pushCard`, `insertCard`, `updateCardField`,
 etc.) and the `CardInput` shape (`{ tag, fields?, body? }`) are unchanged.
 
-## 2. `Diagnostic` gains a `path` field
+## 2. Quill schema uses `card_kinds`
+
+The schema returned by `Quill.schema` describes the main card and any number
+of named **card kinds**. The card-kinds section is keyed `card_kinds`:
+
+```ts
+interface QuillSchema {
+  main: QuillCardSchema;
+  /** Present only when the quill declares at least one named card kind. */
+  card_kinds?: Record<string, QuillCardSchema>;
+}
+```
+
+If you read this section under the experimental `0.79.0` name `card_types`,
+rename the access:
+
+```diff
+- const kinds = quill.schema.card_types;
++ const kinds = quill.schema.card_kinds;
+```
+
+Quills themselves declare composable cards under a `card_kinds:` section in
+`Quill.yaml`. The experimental `card_types:` spelling from `0.79.0` is no
+longer accepted — any bundled quill must use `card_kinds:`.
+
+## 3. `Diagnostic` gains a `path` field
 
 `Diagnostic` objects — returned in `err.diagnostics`, `quill.form().diagnostics`,
 and `session.warnings` — now carry an optional `path` string:
@@ -101,7 +144,7 @@ and `session.warnings` — now carry an optional `path` string:
 interface Diagnostic {
   severity: "error" | "warning" | "note";
   message: string;
-  path?: string;        // new in 0.79.0
+  path?: string;        // new in 0.80.0
   location?: Location;
   hint?: string;
   // ...
@@ -114,14 +157,14 @@ diagnostics; it is `undefined` otherwise. This is purely additive — no code
 change is required, but you can now point a user at the offending field
 without parsing the message string.
 
-## 3. Validation errors carry all diagnostics
+## 4. Validation errors carry all diagnostics
 
-Before `0.79.0`, only the `CompilationFailed` render error forwarded its full
+Before `0.80.0`, only the `CompilationFailed` render error forwarded its full
 diagnostic list to JS. The `QuillConfig` and `ValidationFailed` variants fell
 through a path that kept just the first diagnostic, so `err.diagnostics` had
 length 1 even when several fields failed validation.
 
-In `0.79.0` all three variants forward every diagnostic. If your error
+In `0.80.0` all three variants forward every diagnostic. If your error
 handling assumed `err.diagnostics.length === 1` for validation or
 quill-config failures, that assumption is no longer correct — iterate the
 array instead:
@@ -145,9 +188,13 @@ diagnostics.
 
 ## Checklist
 
-- [ ] Bump `@quillmark/wasm` from `0.77.0` directly to `0.79.0` (skip `0.78.0`).
+- [ ] Bump `@quillmark/wasm` from `0.77.0` directly to `0.80.0` (skip the
+      experimental `0.78.0` and `0.79.0`).
 - [ ] Regenerate any snapshot/golden fixtures that compare `toMarkdown()` output.
 - [ ] Replace string comparisons of `toMarkdown()` output with `doc.equals`.
+- [ ] Rename any `quill.schema.card_types` access to `quill.schema.card_kinds`.
+- [ ] Ensure bundled quills declare composable cards under `card_kinds:` (not
+      the deprecated `card_types:`).
 - [ ] Update error handling to iterate `err.diagnostics` rather than reading
       only `err.diagnostics[0]`.
 - [ ] Optionally surface `diagnostic.path` in validation UIs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,7 @@ nav:
   - CLI:
       - Reference: cli/reference.md
   - Migration:
-      - WASM 0.77 → 0.79: migrations/wasm-0.77-to-0.79.md
+      - WASM 0.77 → 0.80: migrations/wasm-0.77-to-0.80.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/prose/designs/BLUEPRINT.md
+++ b/prose/designs/BLUEPRINT.md
@@ -245,7 +245,7 @@ within the same `ui.group` still cluster together via `ui.order`.
 ## Body markers
 
 - `Write main body here.` after the main fence
-- `Write <card_name> body here.` after each card fence
+- `Write <card_kind> body here.` after each card fence
 - When `body.example` is set, its text replaces the marker verbatim.
 
 `body.enabled: false` suppresses the marker entirely for body-less cards

--- a/prose/designs/CARDS.md
+++ b/prose/designs/CARDS.md
@@ -19,9 +19,9 @@ pub struct CardSchema {
 }
 ```
 
-The static display label for a card type lives on `UiCardSchema::title`, not on `CardSchema` directly — see `ui.title` below. Body behavior (whether body content is permitted and optional guide text) lives under `body` — see `body.enabled` and `body.description` below.
+The static display label for a card kind lives on `UiCardSchema::title`, not on `CardSchema` directly — see `ui.title` below. Body behavior (whether body content is permitted and optional guide text) lives under `body` — see `body.enabled` and `body.description` below.
 
-`QuillConfig` exposes the entry-point card as `main: CardSchema` and the additional named card-types as `card_types: Vec<CardSchema>`. Look up a named card-type by name via `card_type(name)` or get a name-keyed map via `card_types_map()`.
+`QuillConfig` exposes the entry-point card as `main: CardSchema` and the additional named card-kinds as `card_kinds: Vec<CardSchema>`. Look up a named card-kind by name via `card_kind(name)` or get a name-keyed map via `card_kinds_map()`.
 
 ## Quill.yaml Configuration
 
@@ -30,7 +30,7 @@ main:
   fields:
     # ... main-card fields ...
 
-card_types:
+card_kinds:
   indorsement:
     description: Chain of routing endorsements for multi-level correspondence.
     ui:
@@ -55,7 +55,7 @@ card_types:
 ## Public Schema YAML Output
 
 ```yaml
-card_types:
+card_kinds:
   indorsement:
     description: Chain of routing endorsements for multi-level correspondence.
     ui:
@@ -72,7 +72,7 @@ card_types:
           group: Addressing
 ```
 
-`QuillConfig::schema()` emits the schema (with `ui` and `body` hints retained) and `schema_yaml()` is the YAML wrapper. The output keeps the same `card_types.<name>.fields` shape as `Quill.yaml` and injects a required `CARD` sentinel field whose `const` value is the card name. The `card_types` key is omitted entirely when no named card-types are defined. See `SCHEMAS.md` for the full surface.
+`QuillConfig::schema()` emits the schema (with `ui` and `body` hints retained) and `schema_yaml()` is the YAML wrapper. The output keeps the same `card_kinds.<name>.fields` shape as `Quill.yaml` and injects a required `CARD` sentinel field whose `const` value is the card name. The `card_kinds` key is omitted entirely when no named card-kinds are defined. See `SCHEMAS.md` for the full surface.
 
 ## Markdown Syntax
 

--- a/prose/designs/MARKDOWN.md
+++ b/prose/designs/MARKDOWN.md
@@ -271,7 +271,7 @@ interface Document {
 }
 
 interface Card {
-  CARD: string;           // card type, matches /^[a-z_][a-z0-9_]*$/
+  CARD: string;           // card kind, matches /^[a-z_][a-z0-9_]*$/
   BODY: string;           // card body prose
   [field: string]: any;   // other card fields
 }

--- a/prose/designs/QUILL.md
+++ b/prose/designs/QUILL.md
@@ -60,7 +60,7 @@ Validation rules:
 
 ## `Quill.yaml` Structure
 
-Required top-level sections: `Quill` (bundle metadata). Optional: `main` (document fields), `card_types` (card type definitions), `typst` (backend config).
+Required top-level sections: `Quill` (bundle metadata). Optional: `main` (document fields), `card_kinds` (card kind definitions), `typst` (backend config).
 
 ```yaml
 quill:
@@ -80,7 +80,7 @@ main:
       type: integer
       description: Whole-number count
 
-card_types:
+card_kinds:
   quote:
     description: A single pull quote
     ui:
@@ -100,7 +100,7 @@ typst:
 Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`) are reserved by the engine. Standalone `object` fields require a `properties` map; use `type: array` with `properties:` for a list of objects.
 
 Metadata resolution:
-- `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card type.
+- `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card kind.
 - `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, and `typst_*` keys from the `[typst]` section. The `quill:` section accepts only the documented keys; unknown keys produce a `quill::unknown_key` error rather than landing in `metadata`.
 
 ## Strict Parsing
@@ -108,11 +108,11 @@ Metadata resolution:
 `Quill.yaml` is parsed strictly: every problem the parser can detect is collected and reported in one pass as a `Vec<Diagnostic>`, rather than failing on the first error or silently dropping unsupported shapes. Specifically:
 
 - Unknown keys in the `quill:` section error with `quill::unknown_key` (typos like `platefile` are not silently captured).
-- Unknown top-level sections error with `quill::unknown_section` (typos like `card_type:` are not silently ignored). Root-level `fields:` gets a targeted hint pointing to `main.fields:`.
+- Unknown top-level sections error with `quill::unknown_section` (typos like `card_kind:` are not silently ignored). Root-level `fields:` gets a targeted hint pointing to `main.fields:`.
 - Field schemas that fail to parse (e.g. legacy `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
 - Standalone `object` fields and disallowed nested-object shapes error with `quill::standalone_object_not_supported` / `quill::nested_object_not_supported`.
 - Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
-- Malformed `main.body` / `card_types.<name>.body` blocks error with `quill::invalid_body`.
+- Malformed `main.body` / `card_kinds.<name>.body` blocks error with `quill::invalid_body`.
 - A `body.description` set together with `body.enabled: false` warns with `quill::body_description_unused` (the description has no effect).
 
 Errors flow through `RenderError::QuillConfig { diags: Vec<Diagnostic> }` and surface to bindings as a structured array (`err.diagnostics` in WASM, `.diagnostics` attribute in Python).

--- a/prose/designs/SCHEMAS.md
+++ b/prose/designs/SCHEMAS.md
@@ -9,8 +9,8 @@
 Schema authoring lives in `Quill.yaml` under:
 
 - `main.fields`
-- `card_types.<card_name>.fields`
-- optional `ui` and `body` blocks on `main` and each card type
+- `card_kinds.<card_name>.fields`
+- optional `ui` and `body` blocks on `main` and each card kind
 
 Supported field types:
 
@@ -43,24 +43,24 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Returns `Result<(), Vec<ValidationError>>`
 - Collects all errors (does not short-circuit)
 - Emits path-aware errors for top-level fields and card fields
-- Validates each card has a `CARD` discriminator matching a known card type
-- Enforces `body.enabled: false` on the main card and on each card type — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
+- Validates each card has a `CARD` discriminator matching a known card kind
+- Enforces `body.enabled: false` on the main card and on each card kind — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
 
 ## Schema emission
 
 `QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:
 
 - Field types, constraints, and `enum`/`default`/`example` annotations
-- `ui` hints on fields and card types (`group`, `order`, `compact`, `multiline`, `title`)
+- `ui` hints on fields and card kinds (`group`, `order`, `compact`, `multiline`, `title`)
 - `body` blocks on cards (`enabled`, `description`)
 - A required `QUILL` sentinel prepended to `main.fields` (`const = "<name>@<version>"`)
-- A required `CARD` sentinel prepended to each `card_types.<name>.fields` (`const = "<name>"`)
+- A required `CARD` sentinel prepended to each `card_kinds.<name>.fields` (`const = "<name>"`)
 
 `QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `CardSchema`, `UiFieldSchema`, `UiCardSchema`, and `BodyCardSchema` — there is no parallel mirror struct.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_types` (map keyed by card name). `main` and each entry in `card_types` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`, and optional `required` (omitted when false).
+Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`, and optional `required` (omitted when false).
 
 Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters).
 
@@ -73,11 +73,11 @@ Identity fields (`name`, `version`, `backend`, `author`, `description`) live on 
 | Python | `Quill.schema` getter (YAML) |
 | CLI | `quillmark schema <path>` |
 
-### `main.fields` and `card_types.<name>.fields` sentinels
+### `main.fields` and `card_kinds.<name>.fields` sentinels
 
-`schema()` prepends a synthetic discriminator field to each card's `fields` map so consumers know exactly which discriminator value to use — the `QUILL` reference for the main card, and the card kind (the ```` ```card <kind> ```` info-string token) for each card type:
+`schema()` prepends a synthetic discriminator field to each card's `fields` map so consumers know exactly which discriminator value to use — the `QUILL` reference for the main card, and the card kind (the ```` ```card <kind> ```` info-string token) for each card kind:
 
 - `main.fields.QUILL` — `{ type: string, const: "<name>@<version>", required: true, description: ... }`
-- `card_types.<name>.fields.CARD` — `{ type: string, const: "<name>", required: true, description: ... }`
+- `card_kinds.<name>.fields.CARD` — `{ type: string, const: "<name>", required: true, description: ... }`
 
 These appear ahead of the author's declared fields. They are not present in `Quill.yaml`; the projection injects them.


### PR DESCRIPTION
## Summary

This PR standardizes the terminology for composable card definitions across the entire codebase, renaming `card_types` to `card_kinds`. This change reflects the stabilization of the card model in `@quillmark/wasm` 0.80.0 and clarifies that these are distinct "kinds" of cards rather than "types."

## Key Changes

- **Core API**: Renamed `QuillConfig::card_types` field to `card_kinds` and the lookup method from `card_type()` to `card_kind()`
- **Schema naming**: Updated the Quill.yaml schema section from `card_types:` to `card_kinds:` throughout all quill definitions and documentation
- **JSON schema output**: Changed the schema JSON key from `card_types` to `card_kinds` in the `QuillConfig::schema()` output
- **Error messages and diagnostics**: Updated all error codes, messages, and validation paths to reference `card_kinds` instead of `card_types`
- **Documentation**: Updated migration guide (0.77→0.80), API reference, and all design documents to use the new terminology
- **Tests**: Updated all test fixtures, YAML configurations, and test assertions to use `card_kinds`
- **Bindings**: Updated TypeScript, Python, and CLI bindings to reflect the new API names

## Implementation Details

- The change is purely a rename with no functional behavior modifications
- All references to the experimental `0.79.0` spelling `card_types` are now marked as deprecated
- The migration guide clarifies that both `0.78.0` and `0.79.0` should be skipped when upgrading from `0.77.0` to `0.80.0`
- Validation error messages now correctly reference "card kind" terminology
- Schema generation includes updated field descriptions and comments reflecting the new naming

https://claude.ai/code/session_018apcxG2pHNHBZwgXU8EZ3H