### PR TITLE
Fix panic in strong tag detection with multi-byte UTF-8 characters

### DIFF
--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -283,8 +283,11 @@ where
                     Tag::Strong => {
                         // <u>…</u> is synthesized as Tag::Strong by MarkdownFixer; detect it
                         // by peeking at the source. Both ** and __ render as #strong[…].
-                        let kind = if range.start + 2 <= source.len()
-                            && source[range.start..range.start + 2].eq_ignore_ascii_case("<u")
+                        // `get` (not direct indexing) keeps this panic-free when
+                        // `range.start + 2` lands inside a multi-byte UTF-8 character.
+                        let kind = if source
+                            .get(range.start..range.start + 2)
+                            .is_some_and(|s| s.eq_ignore_ascii_case("<u"))
                         {
                             StrongKind::Underline
                         } else {
@@ -1908,6 +1911,23 @@ mod robustness_tests {
     fn test_emoji() {
         let result = mark_to_typst("Hello 🎉 World 🚀").unwrap();
         assert_eq!(result, "Hello 🎉 World 🚀\n\n");
+    }
+
+    #[test]
+    fn test_strong_detection_with_multibyte_does_not_panic() {
+        // The Tag::Strong handler peeks two bytes of source to tell `<u>`
+        // apart from `**`/`__`. A multi-byte character adjacent to the strong
+        // span must not cause a byte-index slice panic.
+        for input in [
+            "–**bold**",
+            "**bold**–",
+            "你好**世界**",
+            "<u>你好</u>",
+            "–<u>x</u>",
+            "“**quoted**”",
+        ] {
+            let _ = mark_to_typst(input).unwrap();
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixed a potential panic in the Typst backend's strong tag detection when multi-byte UTF-8 characters appear adjacent to strong spans (e.g., `**bold**` or `<u>text</u>`).

## Key Changes
- **Replaced unsafe byte indexing with safe slice access**: Changed from direct indexing (`source[range.start..range.start + 2]`) to using `get()` method, which returns `None` instead of panicking when indices are out of bounds or land inside multi-byte UTF-8 characters
- **Simplified condition logic**: Used `is_some_and()` to combine the bounds check and string comparison into a single, more idiomatic expression
- **Added comprehensive test coverage**: Added `test_strong_detection_with_multibyte_does_not_panic()` that verifies the fix handles various edge cases including:
  - Multi-byte dashes (en-dash `–`) before and after bold text
  - CJK characters (Chinese `你好`) adjacent to strong spans
  - HTML underline tags with multi-byte characters
  - Curly quotes with bold text

## Implementation Details
The strong tag handler needs to peek at the source to distinguish between `<u>` tags (synthesized by MarkdownFixer) and `**`/`__` markdown syntax. The original code used direct byte indexing which could panic if `range.start + 2` fell inside a multi-byte UTF-8 character boundary. The fix uses the safe `get()` method which gracefully handles this case by returning `None`, allowing the code to fall through to the default strong kind.

https://claude.ai/code/session_011tLvU3Whkom1zeUn9RWkVw