### PR TITLE
Add release candidate versioning support to release workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -11,6 +11,11 @@ on:
           - patch
           - minor
           - major
+          - patch-rc
+          - minor-rc
+          - major-rc
+          - rc
+          - promote-rc
 
 jobs:
   prepare:
@@ -46,12 +51,35 @@ jobs:
         run: |
           CURRENT=$(cargo metadata --format-version=1 --no-deps \
             | jq -r '.packages[] | select(.name == "quillmark") | .version')
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          # Strip any pre-release suffix before splitting on '.' so that
+          # PATCH isn't "0-rc.1" when the current version is e.g. 0.81.0-rc.1.
+          BASE_VERSION="${CURRENT%%-*}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
 
           case "${{ inputs.bump }}" in
-            major) NEXT="$((MAJOR + 1)).0.0" ;;
-            minor) NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
-            patch) NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            major)      NEXT="$((MAJOR + 1)).0.0" ;;
+            minor)      NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch)      NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            major-rc)   NEXT="$((MAJOR + 1)).0.0-rc.1" ;;
+            minor-rc)   NEXT="${MAJOR}.$((MINOR + 1)).0-rc.1" ;;
+            patch-rc)   NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))-rc.1" ;;
+            rc)
+              if [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+                NEXT="${BASH_REMATCH[1]}-rc.$((BASH_REMATCH[2] + 1))"
+              else
+                echo "Error: current version '$CURRENT' is not an RC version; cannot bump RC." >&2
+                exit 1
+              fi
+              ;;
+            promote-rc)
+              if [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.[0-9]+$ ]]; then
+                NEXT="${BASH_REMATCH[1]}"
+              else
+                echo "Error: current version '$CURRENT' is not an RC version; cannot promote." >&2
+                exit 1
+              fi
+              ;;
           esac
 
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Extended the release preparation workflow to support release candidate (RC) versions, enabling a more flexible release process with pre-release versions.

## Key Changes
- Added five new bump options to the workflow input:
  - `patch-rc`, `minor-rc`, `major-rc`: Create RC versions for each semver bump type
  - `rc`: Increment an existing RC version (e.g., rc.1 → rc.2)
  - `promote-rc`: Promote an RC version to a stable release (e.g., 1.0.0-rc.1 → 1.0.0)

- Fixed version parsing to correctly handle pre-release suffixes by stripping them before splitting on dots, preventing issues like treating "0-rc.1" as the patch version

- Implemented validation logic for `rc` and `promote-rc` operations to ensure they only work with appropriate current versions, with clear error messages for invalid states

## Implementation Details
- The version bump logic now uses regex matching to validate and extract version components from RC versions
- Pre-release suffix stripping uses bash parameter expansion (`${CURRENT%%-*}`) to isolate the base semantic version
- All new RC bump types follow the standard format `X.Y.Z-rc.N` for consistency

https://claude.ai/code/session_01JYr71xy3Ewteu11LsDfhQ5