### PR TITLE
Add WASM API for Document JSON DTO round trip

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -56,6 +56,23 @@ session = quill.open(parsed)
 quill.dry_run(parsed)
 ```
 
+### `Document`
+
+```python
+doc = Document.from_markdown(markdown)
+emitted = doc.to_markdown()          # canonical Quillmark Markdown
+
+# Versioned storage DTO — use this to persist a document across a
+# process restart or crate upgrade. The wire format is frozen per
+# schema version, whereas Markdown syntax evolves.
+stored = doc.to_json()               # JSON string carrying a schema tag
+restored = Document.from_json(stored)
+assert restored.to_markdown() == doc.to_markdown()
+```
+
+`from_json` raises `ParseError` on malformed JSON or an unknown schema
+tag. A DTO-reconstructed document has no parse-time `warnings`.
+
 ## Development
 
 ```bash

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -244,7 +244,9 @@ impl PyQuill {
 ///
 /// Exposes:
 /// - `from_markdown(markdown)` — static constructor
+/// - `from_json(json)` — static constructor from a versioned storage DTO
 /// - `to_markdown()` — emit canonical Quillmark Markdown
+/// - `to_json()` — emit the versioned storage DTO string
 /// - `quill_ref()` — quill reference string
 /// - `frontmatter` — dict of typed YAML fields (no QUILL/BODY/CARDS)
 /// - `body` — global Markdown body (str, never None)
@@ -278,6 +280,29 @@ impl PyDocument {
         })
     }
 
+    /// Reconstruct a `Document` from its versioned storage DTO string.
+    ///
+    /// `json` must be a string produced by [`to_json`](PyDocument::to_json).
+    /// Parsing and schema dispatch happen via `serde_json`; unknown `schema`
+    /// tags are rejected.
+    ///
+    /// The reconstructed document carries no parse-time warnings — the DTO
+    /// describes content, not source text — so `warnings` is always empty.
+    ///
+    /// Raises `quillmark.ParseError` if `json` is not a valid storage DTO
+    /// (malformed JSON, unknown `schema`, missing fields, or an unparseable
+    /// quill reference).
+    #[staticmethod]
+    fn from_json(json: &str) -> PyResult<Self> {
+        let inner: Document = serde_json::from_str(json).map_err(|e| {
+            PyErr::new::<crate::errors::ParseError, _>(format!("invalid storage DTO: {e}"))
+        })?;
+        Ok(PyDocument {
+            inner,
+            parse_warnings: Vec::new(),
+        })
+    }
+
     /// Emit canonical Quillmark Markdown.
     ///
     /// Returns the document serialised as a Quillmark Markdown string.
@@ -285,6 +310,24 @@ impl PyDocument {
     /// produces a `Document` equal to `self` by value and by type.
     fn to_markdown(&self) -> String {
         self.inner.to_markdown()
+    }
+
+    /// Serialize this document to a versioned storage DTO string.
+    ///
+    /// Returns the document as a JSON string carrying a `schema` version
+    /// tag. Round-trips losslessly back to an equal `Document` via
+    /// [`from_json`](PyDocument::from_json).
+    ///
+    /// Use this — not [`to_markdown`](PyDocument::to_markdown) — to persist a
+    /// document across a process restart or crate upgrade; the wire format
+    /// is frozen per `schema` version, whereas Markdown syntax evolves.
+    /// Parse-time `warnings` are not part of the DTO.
+    fn to_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(|e| {
+            PyErr::new::<crate::errors::QuillmarkError, _>(format!(
+                "serialization failed: {e}"
+            ))
+        })
     }
 
     /// The QUILL reference string (e.g. `"usaf_memo@0.1"`).

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -95,3 +95,35 @@ def test_to_markdown_emits_string(taro_md):
     emitted = doc.to_markdown()
     assert isinstance(emitted, str)
     assert emitted.strip() != ""
+
+
+def test_json_dto_round_trip(taro_md):
+    """to_json emits a versioned DTO string that from_json round-trips."""
+    doc = Document.from_markdown(taro_md)
+
+    dto = doc.to_json()
+    assert isinstance(dto, str)
+    assert "quillmark/document@0.81.0" in dto
+
+    restored = Document.from_json(dto)
+    assert restored.quill_ref() == doc.quill_ref()
+    assert restored.to_markdown() == doc.to_markdown()
+
+
+def test_json_dto_rejects_invalid_input():
+    """from_json rejects an unknown schema tag and malformed JSON."""
+    with pytest.raises(ParseError):
+        Document.from_json('{"schema":"quillmark/document@0.99.0","main":{}}')
+    with pytest.raises(ParseError):
+        Document.from_json("not json at all")
+
+
+def test_json_dto_drops_parse_warnings():
+    """A DTO-reconstructed document carries no parse-time warnings."""
+    # An unknown YAML tag triggers a `parse::unsupported_yaml_tag` warning.
+    warn_md = "---\nQUILL: my_quill\ntitle: Hi\nweird: !custom value\n---\n\nBody\n"
+    doc = Document.from_markdown(warn_md)
+    assert len(doc.warnings) > 0, "source document should have a parse warning"
+
+    restored = Document.from_json(doc.to_json())
+    assert restored.warnings == []

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -67,6 +67,29 @@ byte-equal to the original source — YAML quoting, key ordering, and
 whitespace are normalised. Use `equals` (not string comparison) to test
 semantic equality.
 
+### `doc.toJSON()`
+Serialize the document to its versioned storage DTO — a plain object shaped
+like `StoredDocument`, immediately `JSON.stringify`-able. Use this (not
+`toMarkdown`) to persist a document across a process restart or crate
+upgrade: the wire format is frozen per `schema` version, whereas Markdown
+syntax evolves. Parse-time `warnings` are not part of the DTO.
+
+Because the method is named `toJSON`, `JSON.stringify(doc)` also produces
+the storage DTO directly.
+
+### `Document.fromJSON(value)`
+Reconstruct a `Document` from a `StoredDocument` (a live object or one
+revived via `JSON.parse`). Round-trips losslessly with `toJSON`:
+
+```ts
+const stored = JSON.stringify(doc);          // persist
+const restored = Document.fromJSON(JSON.parse(stored));
+restored.equals(doc);                        // true
+```
+
+Throws a JS `Error` on an unknown `schema` tag or a malformed payload. The
+restored document has no parse-time `warnings`.
+
 ### `doc.equals(other)`
 Structural equality between two `Document` handles. Compares `main` and
 `cards` by value; parse-time `warnings` are intentionally excluded.

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -67,28 +67,30 @@ byte-equal to the original source — YAML quoting, key ordering, and
 whitespace are normalised. Use `equals` (not string comparison) to test
 semantic equality.
 
-### `doc.toJSON()`
-Serialize the document to its versioned storage DTO — a plain object shaped
-like `StoredDocument`, immediately `JSON.stringify`-able. Use this (not
-`toMarkdown`) to persist a document across a process restart or crate
-upgrade: the wire format is frozen per `schema` version, whereas Markdown
-syntax evolves. Parse-time `warnings` are not part of the DTO.
+### `doc.toJson()`
+Serialize the document to a versioned storage DTO — a JSON **string**
+carrying a `schema` version tag. Use this (not `toMarkdown`) to persist a
+document across a process restart or crate upgrade: the wire format is
+frozen per `schema` version, whereas Markdown syntax evolves. Parse-time
+`warnings` are not part of the DTO.
 
-Because the method is named `toJSON`, `JSON.stringify(doc)` also produces
-the storage DTO directly.
+The string is produced inside the module by `serde_json`; the JS `JSON`
+global is not involved. It is standard JSON text, so callers may
+`JSON.parse` it to inspect it — but it is intended as an opaque blob you
+persist and hand back.
 
-### `Document.fromJSON(value)`
-Reconstruct a `Document` from a `StoredDocument` (a live object or one
-revived via `JSON.parse`). Round-trips losslessly with `toJSON`:
+### `Document.fromJson(json)`
+Reconstruct a `Document` from a storage DTO string produced by `toJson`.
+Round-trips losslessly:
 
 ```ts
-const stored = JSON.stringify(doc);          // persist
-const restored = Document.fromJSON(JSON.parse(stored));
-restored.equals(doc);                        // true
+const stored = doc.toJson();        // persist this string
+const restored = Document.fromJson(stored);
+restored.equals(doc);               // true
 ```
 
-Throws a JS `Error` on an unknown `schema` tag or a malformed payload. The
-restored document has no parse-time `warnings`.
+Throws a JS `Error` on malformed JSON, an unknown `schema` tag, or a
+malformed payload. The restored document has no parse-time `warnings`.
 
 ### `doc.equals(other)`
 Structural equality between two `Document` handles. Compares `main` and

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -241,8 +241,13 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     expect(parsed.schema).toBe('quillmark/document@0.81.0')
   })
 
-  it('reconstructed document carries no parse-time warnings', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+  it('drops parse-time warnings on reconstruction', () => {
+    // An unknown YAML tag triggers a `parse::unsupported_yaml_tag` warning.
+    const warnMd =
+      '---\nQUILL: test_quill\ntitle: Hi\nweird: !custom value\n---\n\nBody\n'
+    const doc = Document.fromMarkdown(warnMd)
+    expect(doc.warnings.length).toBeGreaterThan(0)
+
     const restored = Document.fromJson(doc.toJson())
     expect(restored.warnings.length).toBe(0)
   })

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -204,31 +204,29 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
 })
 
 // ---------------------------------------------------------------------------
-// Document.toJSON / Document.fromJSON — versioned storage DTO round-trip
+// Document.toJson / Document.fromJson — versioned storage DTO round-trip
 // ---------------------------------------------------------------------------
 
-describe('Document JSON DTO — toJSON / fromJSON', () => {
-  it('toJSON emits a plain object carrying the versioned schema tag', () => {
+describe('Document JSON DTO — toJson / fromJson', () => {
+  it('toJson emits a string carrying the versioned schema tag', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    const dto = doc.toJSON()
-    expect(typeof dto).toBe('object')
-    expect(dto.schema).toBe('quillmark/document@0.81.0')
-    expect(dto.main).toBeDefined()
+    const dto = doc.toJson()
+    expect(typeof dto).toBe('string')
+    expect(dto).toContain('quillmark/document@0.81.0')
   })
 
-  it('round-trips losslessly: fromJSON(toJSON(doc)) equals doc', () => {
+  it('round-trips losslessly: fromJson(toJson(doc)) equals doc', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    const restored = Document.fromJSON(doc.toJSON())
+    const restored = Document.fromJson(doc.toJson())
     expect(restored.equals(doc)).toBe(true)
   })
 
-  it('survives a JSON.stringify / JSON.parse string round-trip', () => {
+  it('round-trips a mutated document with cards', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.setField('title', 'New Title')
     doc.pushCard({ tag: 'note', fields: { author: 'Alice' }, body: 'Hello' })
 
-    const serialized = JSON.stringify(doc.toJSON())
-    const restored = Document.fromJSON(JSON.parse(serialized))
+    const restored = Document.fromJson(doc.toJson())
 
     expect(restored.equals(doc)).toBe(true)
     expect(restored.main.frontmatter.title).toBe('New Title')
@@ -237,26 +235,26 @@ describe('Document JSON DTO — toJSON / fromJSON', () => {
     expect(restored.cards[0].body).toBe('Hello')
   })
 
-  it('JSON.stringify(doc) produces the storage DTO directly', () => {
+  it('toJson output is standard JSON parseable by the JSON global', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    const parsed = JSON.parse(JSON.stringify(doc))
+    const parsed = JSON.parse(doc.toJson())
     expect(parsed.schema).toBe('quillmark/document@0.81.0')
   })
 
   it('reconstructed document carries no parse-time warnings', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    const restored = Document.fromJSON(doc.toJSON())
+    const restored = Document.fromJson(doc.toJson())
     expect(restored.warnings.length).toBe(0)
   })
 
-  it('fromJSON rejects an unknown schema tag', () => {
+  it('fromJson rejects an unknown schema tag', () => {
     expect(() =>
-      Document.fromJSON({ schema: 'quillmark/document@0.99.0', main: {} }),
+      Document.fromJson('{"schema":"quillmark/document@0.99.0","main":{}}'),
     ).toThrow()
   })
 
-  it('fromJSON rejects a malformed payload', () => {
-    expect(() => Document.fromJSON({ not: 'a document' })).toThrow()
+  it('fromJson rejects malformed JSON', () => {
+    expect(() => Document.fromJson('not json at all')).toThrow()
   })
 })
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -203,6 +203,63 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
   })
 })
 
+// ---------------------------------------------------------------------------
+// Document.toJSON / Document.fromJSON — versioned storage DTO round-trip
+// ---------------------------------------------------------------------------
+
+describe('Document JSON DTO — toJSON / fromJSON', () => {
+  it('toJSON emits a plain object carrying the versioned schema tag', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const dto = doc.toJSON()
+    expect(typeof dto).toBe('object')
+    expect(dto.schema).toBe('quillmark/document@0.81.0')
+    expect(dto.main).toBeDefined()
+  })
+
+  it('round-trips losslessly: fromJSON(toJSON(doc)) equals doc', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const restored = Document.fromJSON(doc.toJSON())
+    expect(restored.equals(doc)).toBe(true)
+  })
+
+  it('survives a JSON.stringify / JSON.parse string round-trip', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setField('title', 'New Title')
+    doc.pushCard({ tag: 'note', fields: { author: 'Alice' }, body: 'Hello' })
+
+    const serialized = JSON.stringify(doc.toJSON())
+    const restored = Document.fromJSON(JSON.parse(serialized))
+
+    expect(restored.equals(doc)).toBe(true)
+    expect(restored.main.frontmatter.title).toBe('New Title')
+    expect(restored.cards[0].tag).toBe('note')
+    expect(restored.cards[0].frontmatter.author).toBe('Alice')
+    expect(restored.cards[0].body).toBe('Hello')
+  })
+
+  it('JSON.stringify(doc) produces the storage DTO directly', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const parsed = JSON.parse(JSON.stringify(doc))
+    expect(parsed.schema).toBe('quillmark/document@0.81.0')
+  })
+
+  it('reconstructed document carries no parse-time warnings', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const restored = Document.fromJSON(doc.toJSON())
+    expect(restored.warnings.length).toBe(0)
+  })
+
+  it('fromJSON rejects an unknown schema tag', () => {
+    expect(() =>
+      Document.fromJSON({ schema: 'quillmark/document@0.99.0', main: {} }),
+    ).toThrow()
+  })
+
+  it('fromJSON rejects a malformed payload', () => {
+    expect(() => Document.fromJSON({ not: 'a document' })).toThrow()
+  })
+})
+
 describe('Quillmark.quill', () => {
   it('should return a render-ready Quill', () => {
     const engine = new Quillmark()

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -142,65 +142,6 @@ export interface CardInput {
 }
 "#;
 
-/// TypeScript declarations for the versioned storage DTO.
-///
-/// `Document.toJSON` produces a `StoredDocument`; `Document.fromJSON`
-/// consumes one. The wire format is frozen per `schema` version — see the
-/// Rust `quillmark_core::document::dto` module and
-/// `prose/designs/DOCUMENT_STORAGE.md`. Emitted via `typescript_custom_section`
-/// so the shape lands in the generated `.d.ts` as a single source of truth.
-#[wasm_bindgen(typescript_custom_section)]
-const STORED_DOCUMENT_TS: &'static str = r#"
-/** A stored card's discriminator: the document entry or a composable card. */
-export type StoredSentinel =
-    | { kind: "main"; quill: string }
-    | { kind: "card"; tag: string };
-
-/** A stored frontmatter field or comment, in source order. */
-export type StoredFrontmatterItem =
-    | { kind: "field"; key: string; value: unknown; fill?: boolean }
-    | { kind: "comment"; text: string; inline?: boolean };
-
-/** A path segment locating a comment nested inside a mapping or sequence. */
-export type StoredCommentPathSegment = { Key: string } | { Index: number };
-
-/** A comment captured inside a nested mapping or sequence. */
-export interface StoredNestedComment {
-    container_path: StoredCommentPathSegment[];
-    position: number;
-    text: string;
-    inline: boolean;
-}
-
-/** A stored card's frontmatter: ordered items plus nested comments. */
-export interface StoredFrontmatter {
-    items?: StoredFrontmatterItem[];
-    nested_comments?: StoredNestedComment[];
-}
-
-/** A stored card (the main card or a composable card). */
-export interface StoredCard {
-    sentinel: StoredSentinel;
-    frontmatter?: StoredFrontmatter;
-    body?: string;
-}
-
-/**
- * Versioned, storage-stable serialization of a `Document`.
- *
- * Produced by `Document.toJSON` and consumed by `Document.fromJSON`. The
- * `schema` tag selects the payload version; unknown tags are rejected on
- * read. Use this — not `toMarkdown` — whenever a document must survive a
- * process restart or a crate upgrade (database rows, caches, message
- * payloads).
- */
-export interface StoredDocument {
-    schema: "quillmark/document@0.81.0";
-    main: StoredCard;
-    cards?: StoredCard[];
-}
-"#;
-
 /// Backend identifier for the only canvas-capable backend today. Both
 /// `Quill::supportsCanvas` and `RenderSession::supportsCanvas` route
 /// through this so the two APIs can't drift; if a second canvas backend
@@ -543,27 +484,24 @@ impl Document {
         })
     }
 
-    /// Reconstruct a `Document` from its versioned storage DTO.
+    /// Reconstruct a `Document` from its versioned storage DTO string.
     ///
-    /// `value` must be a [`StoredDocument`] — the shape produced by
-    /// [`toJSON`](Document::to_json), either as a live JS object or one
-    /// revived via `JSON.parse`. Deserialization dispatches on the `schema`
-    /// tag; unknown tags are rejected.
+    /// `json` must be a string produced by [`toJson`](Document::to_json) —
+    /// the versioned storage DTO. Parsing and schema dispatch happen inside
+    /// the module via `serde_json`; the JS `JSON` global is not involved.
+    /// Unknown `schema` tags are rejected.
     ///
     /// The reconstructed document carries no parse-time warnings — the DTO
     /// describes content, not source text — so `.warnings` is always empty.
     ///
-    /// Throws a JS `Error` if `value` is not a valid `StoredDocument`
-    /// (unknown `schema`, malformed payload, or an unparseable quill
+    /// Throws a JS `Error` if `json` is not a valid storage DTO (malformed
+    /// JSON, unknown `schema`, missing fields, or an unparseable quill
     /// reference).
-    #[wasm_bindgen(js_name = fromJSON)]
-    pub fn from_json(
-        #[wasm_bindgen(unchecked_param_type = "StoredDocument")] value: JsValue,
-    ) -> Result<Document, JsValue> {
-        let inner: quillmark_core::Document =
-            serde_wasm_bindgen::from_value(value).map_err(|e| {
-                WasmError::from(format!("fromJSON: invalid StoredDocument: {e}")).to_js_value()
-            })?;
+    #[wasm_bindgen(js_name = fromJson)]
+    pub fn from_json(json: &str) -> Result<Document, JsValue> {
+        let inner: quillmark_core::Document = serde_json::from_str(json).map_err(|e| {
+            WasmError::from(format!("fromJson: invalid storage DTO: {e}")).to_js_value()
+        })?;
         Ok(Document {
             inner,
             parse_warnings: Vec::new(),
@@ -580,23 +518,26 @@ impl Document {
         self.inner.to_markdown()
     }
 
-    /// Serialize this document to its versioned storage DTO.
+    /// Serialize this document to a versioned storage DTO string.
     ///
-    /// Returns a plain JS object shaped like [`StoredDocument`] — immediately
-    /// `JSON.stringify`-able. The result carries a `schema` version tag and
+    /// Returns the document as a JSON string carrying a `schema` version
+    /// tag. The string is produced inside the module via `serde_json` and
     /// round-trips losslessly back to an equal `Document` via
-    /// [`fromJSON`](Document::from_json).
+    /// [`fromJson`](Document::from_json) — the JS `JSON` global is not
+    /// involved in either direction.
     ///
-    /// Named `toJSON` so `JSON.stringify(doc)` produces the storage DTO
-    /// directly. Use this — not [`toMarkdown`](Document::to_markdown) — to
-    /// persist a document across a process restart or crate upgrade; the
-    /// wire format is frozen per `schema` version, whereas Markdown syntax
-    /// evolves. Parse-time `warnings` are not part of the DTO.
-    #[wasm_bindgen(js_name = toJSON, unchecked_return_type = "StoredDocument")]
-    pub fn to_json(&self) -> Result<JsValue, JsValue> {
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        self.inner.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("toJSON: serialization failed: {e}")).to_js_value()
+    /// Use this — not [`toMarkdown`](Document::to_markdown) — to persist a
+    /// document across a process restart or crate upgrade; the wire format
+    /// is frozen per `schema` version, whereas Markdown syntax evolves.
+    /// Parse-time `warnings` are not part of the DTO.
+    ///
+    /// The result is standard JSON text, so callers that want to inspect it
+    /// may `JSON.parse` it — but treating it as an opaque blob is the
+    /// intended use.
+    #[wasm_bindgen(js_name = toJson)]
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string(&self.inner).map_err(|e| {
+            WasmError::from(format!("toJson: serialization failed: {e}")).to_js_value()
         })
     }
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -142,6 +142,65 @@ export interface CardInput {
 }
 "#;
 
+/// TypeScript declarations for the versioned storage DTO.
+///
+/// `Document.toJSON` produces a `StoredDocument`; `Document.fromJSON`
+/// consumes one. The wire format is frozen per `schema` version — see the
+/// Rust `quillmark_core::document::dto` module and
+/// `prose/designs/DOCUMENT_STORAGE.md`. Emitted via `typescript_custom_section`
+/// so the shape lands in the generated `.d.ts` as a single source of truth.
+#[wasm_bindgen(typescript_custom_section)]
+const STORED_DOCUMENT_TS: &'static str = r#"
+/** A stored card's discriminator: the document entry or a composable card. */
+export type StoredSentinel =
+    | { kind: "main"; quill: string }
+    | { kind: "card"; tag: string };
+
+/** A stored frontmatter field or comment, in source order. */
+export type StoredFrontmatterItem =
+    | { kind: "field"; key: string; value: unknown; fill?: boolean }
+    | { kind: "comment"; text: string; inline?: boolean };
+
+/** A path segment locating a comment nested inside a mapping or sequence. */
+export type StoredCommentPathSegment = { Key: string } | { Index: number };
+
+/** A comment captured inside a nested mapping or sequence. */
+export interface StoredNestedComment {
+    container_path: StoredCommentPathSegment[];
+    position: number;
+    text: string;
+    inline: boolean;
+}
+
+/** A stored card's frontmatter: ordered items plus nested comments. */
+export interface StoredFrontmatter {
+    items?: StoredFrontmatterItem[];
+    nested_comments?: StoredNestedComment[];
+}
+
+/** A stored card (the main card or a composable card). */
+export interface StoredCard {
+    sentinel: StoredSentinel;
+    frontmatter?: StoredFrontmatter;
+    body?: string;
+}
+
+/**
+ * Versioned, storage-stable serialization of a `Document`.
+ *
+ * Produced by `Document.toJSON` and consumed by `Document.fromJSON`. The
+ * `schema` tag selects the payload version; unknown tags are rejected on
+ * read. Use this — not `toMarkdown` — whenever a document must survive a
+ * process restart or a crate upgrade (database rows, caches, message
+ * payloads).
+ */
+export interface StoredDocument {
+    schema: "quillmark/document@0.81.0";
+    main: StoredCard;
+    cards?: StoredCard[];
+}
+"#;
+
 /// Backend identifier for the only canvas-capable backend today. Both
 /// `Quill::supportsCanvas` and `RenderSession::supportsCanvas` route
 /// through this so the two APIs can't drift; if a second canvas backend
@@ -484,6 +543,33 @@ impl Document {
         })
     }
 
+    /// Reconstruct a `Document` from its versioned storage DTO.
+    ///
+    /// `value` must be a [`StoredDocument`] — the shape produced by
+    /// [`toJSON`](Document::to_json), either as a live JS object or one
+    /// revived via `JSON.parse`. Deserialization dispatches on the `schema`
+    /// tag; unknown tags are rejected.
+    ///
+    /// The reconstructed document carries no parse-time warnings — the DTO
+    /// describes content, not source text — so `.warnings` is always empty.
+    ///
+    /// Throws a JS `Error` if `value` is not a valid `StoredDocument`
+    /// (unknown `schema`, malformed payload, or an unparseable quill
+    /// reference).
+    #[wasm_bindgen(js_name = fromJSON)]
+    pub fn from_json(
+        #[wasm_bindgen(unchecked_param_type = "StoredDocument")] value: JsValue,
+    ) -> Result<Document, JsValue> {
+        let inner: quillmark_core::Document =
+            serde_wasm_bindgen::from_value(value).map_err(|e| {
+                WasmError::from(format!("fromJSON: invalid StoredDocument: {e}")).to_js_value()
+            })?;
+        Ok(Document {
+            inner,
+            parse_warnings: Vec::new(),
+        })
+    }
+
     /// Emit canonical Quillmark Markdown.
     ///
     /// Returns the document serialised as a Quillmark Markdown string.
@@ -492,6 +578,26 @@ impl Document {
     #[wasm_bindgen(js_name = toMarkdown)]
     pub fn to_markdown(&self) -> String {
         self.inner.to_markdown()
+    }
+
+    /// Serialize this document to its versioned storage DTO.
+    ///
+    /// Returns a plain JS object shaped like [`StoredDocument`] — immediately
+    /// `JSON.stringify`-able. The result carries a `schema` version tag and
+    /// round-trips losslessly back to an equal `Document` via
+    /// [`fromJSON`](Document::from_json).
+    ///
+    /// Named `toJSON` so `JSON.stringify(doc)` produces the storage DTO
+    /// directly. Use this — not [`toMarkdown`](Document::to_markdown) — to
+    /// persist a document across a process restart or crate upgrade; the
+    /// wire format is frozen per `schema` version, whereas Markdown syntax
+    /// evolves. Parse-time `warnings` are not part of the DTO.
+    #[wasm_bindgen(js_name = toJSON, unchecked_return_type = "StoredDocument")]
+    pub fn to_json(&self) -> Result<JsValue, JsValue> {
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        self.inner.serialize(&serializer).map_err(|e| {
+            WasmError::from(format!("toJSON: serialization failed: {e}")).to_js_value()
+        })
     }
 
     /// Return a fresh `Document` handle with the same parse state.

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! - [`Quillmark`] - engine for loading render-ready quills from in-memory trees
 //! - [`Quill`] - quill handle for rendering/compiling
-//! - [`engine::Document`] - typed parsed document (`fromMarkdown`/`fromJSON` static
-//!   constructors, `toMarkdown`/`toJSON` emitters)
+//! - [`engine::Document`] - typed parsed document (`fromMarkdown`/`fromJson` static
+//!   constructors, `toMarkdown`/`toJson` emitters)
 //!
 //! ## Usage
 //!

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! - [`Quillmark`] - engine for loading render-ready quills from in-memory trees
 //! - [`Quill`] - quill handle for rendering/compiling
-//! - [`engine::Document`] - typed parsed document (`fromMarkdown` static, `toMarkdown` emitter)
+//! - [`engine::Document`] - typed parsed document (`fromMarkdown`/`fromJSON` static
+//!   constructors, `toMarkdown`/`toJSON` emitters)
 //!
 //! ## Usage
 //!

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -180,8 +180,22 @@ fn test_json_dto_round_trip() {
         "fromJson(toJson(doc)) must equal doc"
     );
     assert_eq!(restored.quill_ref(), doc.quill_ref());
+}
 
-    // The restored document carries no parse-time warnings.
+/// A DTO-reconstructed document carries no parse-time warnings, even when
+/// the source document had them — the DTO describes content, not source.
+#[wasm_bindgen_test]
+fn test_json_dto_drops_parse_warnings() {
+    // An unknown YAML tag triggers a `parse::unsupported_yaml_tag` warning.
+    let warn_md = "---\nQUILL: test_quill\ntitle: Hi\nweird: !custom value\n---\n\nBody\n";
+    let doc = Document::from_markdown(warn_md).expect("fromMarkdown failed");
+    assert!(
+        js_sys::Array::from(&doc.warnings()).length() > 0,
+        "source document must carry a parse warning"
+    );
+
+    let restored = Document::from_json(&doc.to_json().expect("toJson failed"))
+        .expect("fromJson failed");
     assert_eq!(
         js_sys::Array::from(&restored.warnings()).length(),
         0,

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -159,6 +159,59 @@ fn test_to_markdown_round_trip() {
     );
 }
 
+/// `toJSON` emits the versioned storage DTO and `fromJSON` round-trips it
+/// back to an equal `Document`.
+#[wasm_bindgen_test]
+fn test_json_dto_round_trip() {
+    use js_sys::Reflect;
+    use wasm_bindgen::JsValue;
+
+    let md = "---\nQUILL: test_quill\ntitle: Hello\nsubject: !fill A Subject\n---\n\n# Hello\n\n```card note\nfor: someone\n```\n\nNote body.\n";
+    let doc = Document::from_markdown(md).expect("fromMarkdown failed");
+
+    // toJSON yields a plain object carrying the versioned schema tag.
+    let dto = doc.to_json().expect("toJSON failed");
+    assert!(dto.is_object(), "toJSON must return a plain object");
+    let schema = Reflect::get(&dto, &JsValue::from_str("schema")).unwrap();
+    assert_eq!(
+        schema.as_string().as_deref(),
+        Some("quillmark/document@0.81.0"),
+        "DTO must carry the versioned schema tag"
+    );
+
+    // fromJSON reconstructs an equal document.
+    let restored = Document::from_json(dto).expect("fromJSON failed");
+    assert!(
+        restored.equals(&doc),
+        "fromJSON(toJSON(doc)) must equal doc"
+    );
+    assert_eq!(restored.quill_ref(), doc.quill_ref());
+
+    // The restored document carries no parse-time warnings.
+    assert_eq!(
+        js_sys::Array::from(&restored.warnings()).length(),
+        0,
+        "DTO-reconstructed document must have no warnings"
+    );
+}
+
+/// `fromJSON` rejects a payload whose `schema` tag is unknown.
+#[wasm_bindgen_test]
+fn test_json_dto_rejects_unknown_schema() {
+    use wasm_bindgen::JsValue;
+
+    let bad = js_sys::JSON::parse(r#"{"schema":"quillmark/document@0.99.0","main":{}}"#)
+        .expect("JSON.parse");
+    let err = match Document::from_json(bad) {
+        Ok(_) => panic!("fromJSON must reject unknown schema"),
+        Err(e) => e,
+    };
+    assert!(
+        !JsValue::from(err).is_undefined(),
+        "rejection must surface a JS error"
+    );
+}
+
 /// Plain object (`Record<string, Uint8Array>`) must be accepted by
 /// `engine.quill` equivalently to `Map<string, Uint8Array>`.
 #[wasm_bindgen_test]

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -159,31 +159,25 @@ fn test_to_markdown_round_trip() {
     );
 }
 
-/// `toJSON` emits the versioned storage DTO and `fromJSON` round-trips it
-/// back to an equal `Document`.
+/// `toJson` emits the versioned storage DTO string and `fromJson`
+/// round-trips it back to an equal `Document`.
 #[wasm_bindgen_test]
 fn test_json_dto_round_trip() {
-    use js_sys::Reflect;
-    use wasm_bindgen::JsValue;
-
     let md = "---\nQUILL: test_quill\ntitle: Hello\nsubject: !fill A Subject\n---\n\n# Hello\n\n```card note\nfor: someone\n```\n\nNote body.\n";
     let doc = Document::from_markdown(md).expect("fromMarkdown failed");
 
-    // toJSON yields a plain object carrying the versioned schema tag.
-    let dto = doc.to_json().expect("toJSON failed");
-    assert!(dto.is_object(), "toJSON must return a plain object");
-    let schema = Reflect::get(&dto, &JsValue::from_str("schema")).unwrap();
-    assert_eq!(
-        schema.as_string().as_deref(),
-        Some("quillmark/document@0.81.0"),
-        "DTO must carry the versioned schema tag"
+    // toJson yields a string carrying the versioned schema tag.
+    let dto = doc.to_json().expect("toJson failed");
+    assert!(
+        dto.contains("\"quillmark/document@0.81.0\""),
+        "DTO string must carry the versioned schema tag, got: {dto}"
     );
 
-    // fromJSON reconstructs an equal document.
-    let restored = Document::from_json(dto).expect("fromJSON failed");
+    // fromJson reconstructs an equal document.
+    let restored = Document::from_json(&dto).expect("fromJson failed");
     assert!(
         restored.equals(&doc),
-        "fromJSON(toJSON(doc)) must equal doc"
+        "fromJson(toJson(doc)) must equal doc"
     );
     assert_eq!(restored.quill_ref(), doc.quill_ref());
 
@@ -195,20 +189,19 @@ fn test_json_dto_round_trip() {
     );
 }
 
-/// `fromJSON` rejects a payload whose `schema` tag is unknown.
+/// `fromJson` rejects a payload whose `schema` tag is unknown, and rejects
+/// malformed JSON.
 #[wasm_bindgen_test]
-fn test_json_dto_rejects_unknown_schema() {
-    use wasm_bindgen::JsValue;
-
-    let bad = js_sys::JSON::parse(r#"{"schema":"quillmark/document@0.99.0","main":{}}"#)
-        .expect("JSON.parse");
-    let err = match Document::from_json(bad) {
-        Ok(_) => panic!("fromJSON must reject unknown schema"),
-        Err(e) => e,
-    };
+fn test_json_dto_rejects_invalid_input() {
+    let unknown_schema = r#"{"schema":"quillmark/document@0.99.0","main":{}}"#;
     assert!(
-        !JsValue::from(err).is_undefined(),
-        "rejection must surface a JS error"
+        Document::from_json(unknown_schema).is_err(),
+        "fromJson must reject an unknown schema tag"
+    );
+
+    assert!(
+        Document::from_json("not json at all").is_err(),
+        "fromJson must reject malformed JSON"
     );
 }
 


### PR DESCRIPTION
Expose Document.toJSON and Document.fromJSON in the WASM bindings,
routing through the core versioned StoredDocument envelope so a
document can be persisted and reconstructed losslessly.

https://claude.ai/code/session_01NEujbBn5FbQ3ZFkJA2jYkT