### PR TITLE
Unify RenderError variants on a single Vec<Diagnostic> payload

### DIFF
--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -53,14 +53,12 @@ pub fn compile_to_document(
 ) -> Result<PagedDocument, RenderError> {
     let world = QuillWorld::new_with_data(source, plated_content, json_data).map_err(|e| {
         RenderError::EngineCreation {
-            diag: Box::new(
-                Diagnostic::new(
-                    Severity::Error,
-                    format!("Failed to create Typst compilation environment: {}", e),
-                )
-                .with_code("typst::world_creation".to_string())
-                .with_source(e.as_ref()),
-            ),
+            diags: vec![Diagnostic::new(
+                Severity::Error,
+                format!("Failed to create Typst compilation environment: {}", e),
+            )
+            .with_code("typst::world_creation".to_string())
+            .with_source(e.as_ref())],
         }
     })?;
 
@@ -167,13 +165,11 @@ pub(crate) fn render_document_pages(
     // PDF does not support selective page rendering
     if format == OutputFormat::Pdf && pages.is_some() {
         return Err(RenderError::FormatNotSupported {
-            diag: Box::new(
-                Diagnostic::new(
-                    Severity::Error,
-                    "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG".to_string(),
-                )
-                .with_code("typst::pdf_page_selection_not_supported".to_string()),
-            ),
+            diags: vec![Diagnostic::new(
+                Severity::Error,
+                "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG".to_string(),
+            )
+            .with_code("typst::pdf_page_selection_not_supported".to_string())],
         });
     }
 
@@ -251,13 +247,11 @@ pub(crate) fn render_document_pages(
             ))
         }
         OutputFormat::Txt => Err(RenderError::FormatNotSupported {
-            diag: Box::new(
-                Diagnostic::new(
-                    Severity::Error,
-                    "TXT output is not supported for Typst".into(),
-                )
-                .with_code("typst::format_not_supported".to_string()),
-            ),
+            diags: vec![Diagnostic::new(
+                Severity::Error,
+                "TXT output is not supported for Typst".into(),
+            )
+            .with_code("typst::format_not_supported".to_string())],
         }),
     }
 }

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -112,14 +112,12 @@ impl SessionHandle for TypstSession {
 
         if !SUPPORTED_FORMATS.contains(&format) {
             return Err(RenderError::FormatNotSupported {
-                diag: Box::new(
-                    Diagnostic::new(
-                        Severity::Error,
-                        format!("{:?} not supported by typst backend", format),
-                    )
-                    .with_code("backend::format_not_supported".to_string())
-                    .with_hint(format!("Supported formats: {:?}", SUPPORTED_FORMATS)),
-                ),
+                diags: vec![Diagnostic::new(
+                    Severity::Error,
+                    format!("{:?} not supported by typst backend", format),
+                )
+                .with_code("backend::format_not_supported".to_string())
+                .with_hint(format!("Supported formats: {:?}", SUPPORTED_FORMATS))],
             });
         }
 

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -27,80 +27,69 @@ pub fn convert_edit_error(err: EditError) -> PyErr {
     PyEditError::new_err(format!("[EditError::{}] {}", variant, err))
 }
 
-fn with_diag_attached(py: Python, py_err: PyErr, diag: Diagnostic) -> PyErr {
-    if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
-        let py_diag = crate::types::PyDiagnostic { inner: diag.into() };
-        let _ = exc.setattr("diagnostic", py_diag);
-    }
-    py_err
-}
-
 pub fn convert_render_error(err: RenderError) -> PyErr {
-    Python::attach(|py| match err {
-        RenderError::CompilationFailed { diags } => {
-            let py_err = CompilationError::new_err(format!(
+    Python::attach(|py| {
+        let diags = err.diagnostics();
+        debug_assert!(
+            !diags.is_empty(),
+            "RenderError always carries at least one diagnostic"
+        );
+
+        // The variant kind selects the Python exception type and the summary
+        // message; the diagnostic payload is uniform across every variant.
+        let py_err = match &err {
+            RenderError::CompilationFailed { diags } => CompilationError::new_err(format!(
                 "Compilation failed with {} error(s)",
                 diags.len()
-            ));
-            if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
-                let py_diags: Vec<crate::types::PyDiagnostic> = diags
-                    .into_iter()
-                    .map(|d| crate::types::PyDiagnostic { inner: d.into() })
-                    .collect();
-                let _ = exc.setattr("diagnostics", py_diags);
+            )),
+            RenderError::InvalidFrontmatter { diags } => {
+                ParseError::new_err(primary_message(diags))
             }
-            py_err
-        }
-        RenderError::QuillConfig { diags } => {
-            let msg = if diags.len() == 1 {
-                diags[0].message.clone()
-            } else {
-                format!("Quill configuration has {} error(s)", diags.len())
-            };
-            let py_err = QuillmarkError::new_err(msg);
-            if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
-                let py_diags: Vec<crate::types::PyDiagnostic> = diags
-                    .into_iter()
-                    .map(|d| crate::types::PyDiagnostic { inner: d.into() })
-                    .collect();
-                let _ = exc.setattr("diagnostics", py_diags);
+            RenderError::QuillConfig { diags } => {
+                QuillmarkError::new_err(summary_message("Quill configuration has", diags))
             }
-            py_err
-        }
-        RenderError::ValidationFailed { diags } => {
-            // Multi-diagnostic: each entry sets `path` to anchor the error
-            // in the document model. Consumers should iterate `.diagnostics`.
-            //
-            // Pre-PR-#566 versions of this binding attached a single
-            // `.diagnostic` for `ValidationFailed`. To soften that
-            // breaking change for the common single-error case, we also
-            // attach `.diagnostic = diagnostics[0]` when there is exactly
-            // one diagnostic. New code should prefer `.diagnostics`.
-            let msg = if diags.len() == 1 {
-                diags[0].message.clone()
-            } else {
-                format!("Validation failed with {} error(s)", diags.len())
-            };
-            let py_err = QuillmarkError::new_err(msg);
-            if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
-                let py_diags: Vec<crate::types::PyDiagnostic> = diags
-                    .into_iter()
-                    .map(|d| crate::types::PyDiagnostic { inner: d.into() })
-                    .collect();
-                if py_diags.len() == 1 {
-                    let _ = exc.setattr("diagnostic", py_diags[0].clone());
-                }
-                let _ = exc.setattr("diagnostics", py_diags);
+            RenderError::ValidationFailed { diags } => {
+                QuillmarkError::new_err(summary_message("Validation failed with", diags))
             }
-            py_err
+            RenderError::EngineCreation { diags }
+            | RenderError::FormatNotSupported { diags }
+            | RenderError::UnsupportedBackend { diags } => {
+                QuillmarkError::new_err(primary_message(diags))
+            }
+        };
+
+        // Every exception carries the full `.diagnostics` list; the
+        // convenience `.diagnostic` singular is attached when there is
+        // exactly one diagnostic. Each diagnostic's `path` anchors the
+        // error in the document model for UI navigation.
+        let py_diags: Vec<crate::types::PyDiagnostic> = err
+            .into_diagnostics()
+            .into_iter()
+            .map(|d| crate::types::PyDiagnostic { inner: d.into() })
+            .collect();
+        if let Ok(exc) = py_err.value(py).downcast::<pyo3::types::PyAny>() {
+            if let [only] = py_diags.as_slice() {
+                let _ = exc.setattr("diagnostic", only.clone());
+            }
+            let _ = exc.setattr("diagnostics", py_diags);
         }
-        RenderError::InvalidFrontmatter { diag } => {
-            with_diag_attached(py, ParseError::new_err(diag.message.clone()), *diag)
-        }
-        RenderError::EngineCreation { diag }
-        | RenderError::FormatNotSupported { diag }
-        | RenderError::UnsupportedBackend { diag } => {
-            with_diag_attached(py, QuillmarkError::new_err(diag.message.clone()), *diag)
-        }
+        py_err
     })
+}
+
+/// Message for single-diagnostic error kinds: the primary diagnostic's text.
+fn primary_message(diags: &[Diagnostic]) -> String {
+    diags
+        .first()
+        .map(|d| d.message.clone())
+        .unwrap_or_else(|| "render error".to_string())
+}
+
+/// Message for multi-diagnostic error kinds: the lone diagnostic's text when
+/// there is exactly one, otherwise an aggregate `"<prefix> N error(s)"`.
+fn summary_message(prefix: &str, diags: &[Diagnostic]) -> String {
+    match diags {
+        [only] => only.message.clone(),
+        _ => format!("{} {} error(s)", prefix, diags.len()),
+    }
 }

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -62,23 +62,12 @@ impl From<ParseError> for WasmError {
 
 impl From<RenderError> for WasmError {
     fn from(error: RenderError) -> Self {
-        match error {
-            // Multi-diagnostic variants forward every diagnostic so JS
-            // consumers can iterate `err.diagnostics` and read each entry's
-            // `path` for document-model navigation.
-            RenderError::CompilationFailed { diags }
-            | RenderError::QuillConfig { diags }
-            | RenderError::ValidationFailed { diags } => WasmError { diagnostics: diags },
-            _ => {
-                let diagnostic = error
-                    .diagnostics()
-                    .first()
-                    .map(|d| (*d).clone())
-                    .unwrap_or_else(|| Diagnostic::new(Severity::Error, error.to_string()));
-                WasmError {
-                    diagnostics: vec![diagnostic],
-                }
-            }
+        // Every `RenderError` variant carries a non-empty diagnostic vector,
+        // so the conversion is uniform: forward every diagnostic so JS
+        // consumers can iterate `err.diagnostics` and read each entry's
+        // `path` for document-model navigation.
+        WasmError {
+            diagnostics: error.into_diagnostics(),
         }
     }
 }
@@ -135,9 +124,7 @@ mod tests {
 
     #[test]
     fn test_validation_failed_carries_all_diagnostics() {
-        // Regression: prior to the PR-#566 fix, the `From<RenderError>`
-        // fallback called `.diagnostics().first()` and dropped every
-        // diagnostic after the first for non-CompilationFailed variants.
+        // Every multi-diagnostic variant forwards its full diagnostic vector.
         let diag1 = Diagnostic::new(Severity::Error, "missing title".to_string())
             .with_path("title".to_string());
         let diag2 = Diagnostic::new(Severity::Error, "missing author".to_string())
@@ -154,7 +141,6 @@ mod tests {
 
     #[test]
     fn test_quill_config_carries_all_diagnostics() {
-        // Same regression as above, for `QuillConfig`.
         let diag1 = Diagnostic::new(Severity::Error, "config error 1".to_string());
         let diag2 = Diagnostic::new(Severity::Error, "config error 2".to_string());
         let render_err = RenderError::QuillConfig {

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -538,9 +538,7 @@ mod tests {
             })
             .with_hint("This is a hint".to_string());
 
-        let render_err = quillmark_core::RenderError::InvalidFrontmatter {
-            diag: Box::new(diag),
-        };
+        let render_err = quillmark_core::RenderError::InvalidFrontmatter { diags: vec![diag] };
         let wasm_err: WasmError = render_err.into();
 
         assert_eq!(wasm_err.message(), "Test error message");

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -399,48 +399,50 @@ impl From<&str> for ParseError {
 }
 
 /// Main error type for rendering operations.
-#[derive(thiserror::Error, Debug)]
+///
+/// Every variant carries a non-empty `diags: Vec<Diagnostic>`. Variants whose
+/// failure is inherently a single diagnostic still carry a one-element vector
+/// — the uniform shape lets every consumer, and every language binding,
+/// handle all rendering errors through a single code path. See
+/// [`RenderError::diagnostics`] and [`RenderError::into_diagnostics`]. The
+/// variant itself records the *kind* of failure (which bindings map to typed
+/// exceptions); the payload is always just the diagnostics.
+#[derive(Debug)]
 pub enum RenderError {
-    /// Failed to create rendering engine
-    #[error("{diag}")]
+    /// Failed to create rendering engine.
     EngineCreation {
-        /// Diagnostic information
-        diag: Box<Diagnostic>,
-    },
-
-    /// Invalid YAML frontmatter in markdown document
-    #[error("{diag}")]
-    InvalidFrontmatter {
-        /// Diagnostic information
-        diag: Box<Diagnostic>,
-    },
-
-    /// Backend compilation failed with one or more errors
-    #[error("Backend compilation failed with {} error(s)", diags.len())]
-    CompilationFailed {
-        /// List of diagnostics
+        /// Diagnostics describing the failure. Always non-empty.
         diags: Vec<Diagnostic>,
     },
 
-    /// Requested output format not supported by backend
-    #[error("{diag}")]
-    FormatNotSupported {
-        /// Diagnostic information
-        diag: Box<Diagnostic>,
+    /// Invalid YAML frontmatter in markdown document.
+    InvalidFrontmatter {
+        /// Diagnostics describing the failure. Always non-empty.
+        diags: Vec<Diagnostic>,
     },
 
-    /// Backend not registered with engine
-    #[error("{diag}")]
+    /// Backend compilation failed with one or more errors.
+    CompilationFailed {
+        /// All compilation diagnostics. Always non-empty.
+        diags: Vec<Diagnostic>,
+    },
+
+    /// Requested output format not supported by backend.
+    FormatNotSupported {
+        /// Diagnostics describing the failure. Always non-empty.
+        diags: Vec<Diagnostic>,
+    },
+
+    /// Backend not registered with engine.
     UnsupportedBackend {
-        /// Diagnostic information
-        diag: Box<Diagnostic>,
+        /// Diagnostics describing the failure. Always non-empty.
+        diags: Vec<Diagnostic>,
     },
 
     /// Validation failed for parsed document — may carry multiple diagnostics
     /// when several problems are detected during a single validation pass
     /// (e.g. multiple missing required fields). Each diagnostic should set
     /// `path` to anchor the error at a specific location in the document model.
-    #[error("Validation failed with {} error(s)", diags.len())]
     ValidationFailed {
         /// All validation diagnostics. Always non-empty.
         diags: Vec<Diagnostic>,
@@ -448,7 +450,6 @@ pub enum RenderError {
 
     /// Quill configuration error — may carry multiple diagnostics when several
     /// problems are detected during parsing (e.g. several unknown keys at once).
-    #[error("Quill configuration failed with {} error(s)", diags.len())]
     QuillConfig {
         /// All configuration diagnostics. Always non-empty.
         diags: Vec<Diagnostic>,
@@ -456,28 +457,65 @@ pub enum RenderError {
 }
 
 impl RenderError {
-    /// Extract all diagnostics from this error
-    pub fn diagnostics(&self) -> Vec<&Diagnostic> {
+    /// All diagnostics carried by this error, in order. Always non-empty.
+    pub fn diagnostics(&self) -> &[Diagnostic] {
         match self {
-            RenderError::CompilationFailed { diags }
-            | RenderError::QuillConfig { diags }
-            | RenderError::ValidationFailed { diags } => diags.iter().collect(),
-            RenderError::EngineCreation { diag }
-            | RenderError::InvalidFrontmatter { diag }
-            | RenderError::FormatNotSupported { diag }
-            | RenderError::UnsupportedBackend { diag } => vec![diag.as_ref()],
+            RenderError::EngineCreation { diags }
+            | RenderError::InvalidFrontmatter { diags }
+            | RenderError::CompilationFailed { diags }
+            | RenderError::FormatNotSupported { diags }
+            | RenderError::UnsupportedBackend { diags }
+            | RenderError::ValidationFailed { diags }
+            | RenderError::QuillConfig { diags } => diags,
+        }
+    }
+
+    /// Consume the error and return its diagnostics. Always non-empty.
+    pub fn into_diagnostics(self) -> Vec<Diagnostic> {
+        match self {
+            RenderError::EngineCreation { diags }
+            | RenderError::InvalidFrontmatter { diags }
+            | RenderError::CompilationFailed { diags }
+            | RenderError::FormatNotSupported { diags }
+            | RenderError::UnsupportedBackend { diags }
+            | RenderError::ValidationFailed { diags }
+            | RenderError::QuillConfig { diags } => diags,
         }
     }
 }
+
+impl std::fmt::Display for RenderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RenderError::CompilationFailed { diags } => {
+                write!(f, "Backend compilation failed with {} error(s)", diags.len())
+            }
+            RenderError::ValidationFailed { diags } => {
+                write!(f, "Validation failed with {} error(s)", diags.len())
+            }
+            RenderError::QuillConfig { diags } => {
+                write!(f, "Quill configuration failed with {} error(s)", diags.len())
+            }
+            // Single-diagnostic kinds display their primary diagnostic message.
+            RenderError::EngineCreation { .. }
+            | RenderError::InvalidFrontmatter { .. }
+            | RenderError::FormatNotSupported { .. }
+            | RenderError::UnsupportedBackend { .. } => match self.diagnostics().first() {
+                Some(d) => write!(f, "{}", d.message),
+                None => write!(f, "render error"),
+            },
+        }
+    }
+}
+
+impl std::error::Error for RenderError {}
 
 /// Convert ParseError to RenderError
 impl From<ParseError> for RenderError {
     fn from(err: ParseError) -> Self {
         RenderError::InvalidFrontmatter {
-            diag: Box::new(
-                Diagnostic::new(Severity::Error, err.to_string())
-                    .with_code("parse::error".to_string()),
-            ),
+            diags: vec![Diagnostic::new(Severity::Error, err.to_string())
+                .with_code("parse::error".to_string())],
         }
     }
 }
@@ -559,6 +597,32 @@ mod tests {
 
         let diags = err.diagnostics();
         assert_eq!(diags.len(), 2);
+    }
+
+    #[test]
+    fn test_render_error_uniform_single_diagnostic_shape() {
+        // Single-diagnostic kinds carry a one-element vector and expose it
+        // through the same accessors as the multi-diagnostic kinds.
+        let err = RenderError::UnsupportedBackend {
+            diags: vec![Diagnostic::new(Severity::Error, "no such backend".to_string())],
+        };
+        assert_eq!(err.diagnostics().len(), 1);
+        assert_eq!(err.to_string(), "no such backend");
+
+        let owned = err.into_diagnostics();
+        assert_eq!(owned.len(), 1);
+        assert_eq!(owned[0].message, "no such backend");
+    }
+
+    #[test]
+    fn test_render_error_display_aggregates_multi_diagnostic() {
+        let err = RenderError::ValidationFailed {
+            diags: vec![
+                Diagnostic::new(Severity::Error, "a".to_string()),
+                Diagnostic::new(Severity::Error, "b".to_string()),
+            ],
+        };
+        assert_eq!(err.to_string(), "Validation failed with 2 error(s)");
     }
 
     #[test]

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -58,17 +58,15 @@ impl Quillmark {
             self.backends
                 .get(backend_id)
                 .ok_or_else(|| RenderError::UnsupportedBackend {
-                    diag: Box::new(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!("Backend '{}' not registered or not enabled", backend_id),
-                        )
-                        .with_code("engine::backend_not_found".to_string())
-                        .with_hint(format!(
-                            "Available backends: {}",
-                            self.backends.keys().cloned().collect::<Vec<_>>().join(", ")
-                        )),
-                    ),
+                    diags: vec![Diagnostic::new(
+                        Severity::Error,
+                        format!("Backend '{}' not registered or not enabled", backend_id),
+                    )
+                    .with_code("engine::backend_not_found".to_string())
+                    .with_hint(format!(
+                        "Available backends: {}",
+                        self.backends.keys().cloned().collect::<Vec<_>>().join(", ")
+                    ))],
                 })?;
         Ok(Quill::new(Arc::new(source), Arc::clone(backend)))
     }

--- a/crates/quillmark/tests/blueprint_render_test.rs
+++ b/crates/quillmark/tests/blueprint_render_test.rs
@@ -33,8 +33,8 @@ fn assert_blueprint_renders(quill_dir: &str) {
 
     // Font-less CI environments cannot exercise the renderer; skip rather
     // than fail, matching the convention in quill_engine_test.rs.
-    if let Err(RenderError::EngineCreation { diag }) = &result {
-        if diag.message.contains("No fonts found") {
+    if let Err(RenderError::EngineCreation { diags }) = &result {
+        if diags[0].message.contains("No fonts found") {
             eprintln!("{quill_dir}: skipping — no fonts available");
             return;
         }

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -107,8 +107,8 @@ fn test_quill_render_succeeds_with_engine_loaded_quill() {
         },
     );
 
-    if let Err(quillmark::RenderError::EngineCreation { diag }) = &result {
-        if diag.message.contains("No fonts found") {
+    if let Err(quillmark::RenderError::EngineCreation { diags }) = &result {
+        if diags[0].message.contains("No fonts found") {
             return;
         }
     }

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -12,14 +12,23 @@
 
 **`ParseError`**: parsing-stage error enum — input too large, YAML errors (with and without location), invalid structure; converts to `Diagnostic` via `to_diagnostic()`
 
-**`RenderError`**: main rendering error enum with variants:
+**`RenderError`**: main rendering error enum. Every variant carries the same
+payload — a non-empty `diags: Vec<Diagnostic>` — so all consumers (and all
+language bindings) handle errors through one code path. The variant records
+only the *kind* of failure; `diagnostics()` borrows the vector and
+`into_diagnostics()` consumes the error into it. Variants:
 - `EngineCreation` — failed to create engine
 - `InvalidFrontmatter` — malformed YAML frontmatter (also wraps `ParseError`)
-- `CompilationFailed` — backend compilation failed; carries `Vec<Diagnostic>`
+- `CompilationFailed` — backend compilation failed
 - `FormatNotSupported` — requested output format not supported
 - `UnsupportedBackend` — backend not registered
 - `ValidationFailed` — field coercion/schema validation failure
-- `QuillConfig` — Quill.yaml configuration error; carries `Vec<Diagnostic>` so every parse problem reaches the caller in one pass
+- `QuillConfig` — Quill.yaml configuration error
+
+`ValidationFailed`, `QuillConfig`, and `CompilationFailed` routinely carry
+several diagnostics so every problem reaches the caller in one pass; the
+remaining kinds are inherently single-diagnostic and carry a one-element
+vector.
 
 **`RenderResult`**: successful result carrying artifacts, output format, and non-fatal `Vec<Diagnostic>` warnings
 
@@ -27,7 +36,7 @@
 
 Python and WASM bindings delegate to core types:
 
-- **Python**: `PyDiagnostic` wraps `Diagnostic`. `RenderError` is mapped to typed Python exceptions: `CompilationError` (carries a `diagnostics` list), `ParseError` (frontmatter errors), and `QuillmarkError` (all other variants) — each with an attached `diagnostic` attribute. Base hierarchy: `QuillmarkError → PyException`.
+- **Python**: `PyDiagnostic` wraps `Diagnostic`. `RenderError` is mapped to typed Python exceptions: `CompilationError` (compilation failures), `ParseError` (frontmatter errors), and `QuillmarkError` (all other variants). Every exception carries a `diagnostics` list; the convenience singular `diagnostic` attribute is attached when there is exactly one diagnostic. Base hierarchy: `QuillmarkError → PyException`.
 - **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics`: `diagnostics[0].message` for single-diagnostic errors, an aggregate `"<N> error(s): <first.message>"` summary for backend compilation failures. Same shape regardless of underlying variant; consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for compilation errors. Parse failures (`Document.fromMarkdown`) carry the same shape — including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MB) and the various `EditError::*` variants for post-parse mutators.
 
 ## Backend Error Mapping


### PR DESCRIPTION
Every RenderError variant now carries the same payload — a non-empty
`diags: Vec<Diagnostic>`. Previously four variants boxed a single
`Box<Diagnostic>` while three carried `Vec<Diagnostic>`, forcing every
consumer and every language binding to branch on the single-vs-multi
shape. That split is what produced the WASM regression fixed in PR #566
(the fallback arm silently dropped all diagnostics after the first) and
the Python back-compat shim for `.diagnostic` vs `.diagnostics`.

With a uniform shape:
- `RenderError::diagnostics()` returns `&[Diagnostic]` instead of
  reassembling a `Vec<&Diagnostic>`; `into_diagnostics()` is added for
  zero-clone consumption.
- The WASM `From<RenderError>` collapses from a multi-arm match to one
  line: `error.into_diagnostics()`.
- The Python converter no longer special-cases diagnostic attachment per
  variant — every exception uniformly carries `.diagnostics`, plus the
  singular `.diagnostic` when there is exactly one.

The variant kind still records the failure category (bindings map it to
typed exceptions); only the payload is unified. Display is implemented
directly rather than via thiserror so single-diagnostic kinds keep
showing their primary message.

https://claude.ai/code/session_01KpicYUTHVaR3xf9FfidM9v