### PR TITLE
Add Document.tryFromJson() and document storage compatibility

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -65,7 +65,7 @@ emitted = doc.to_markdown()          # canonical Quillmark Markdown
 # Versioned storage DTO — use this to persist a document across a
 # process restart or crate upgrade. The wire format is frozen per
 # schema version, whereas Markdown syntax evolves.
-stored = doc.to_json()               # JSON string carrying a schema tag
+stored = doc.to_json()               # JSON string carrying a schema version
 restored = Document.from_json(stored)
 assert restored.to_markdown() == doc.to_markdown()
 ```

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -69,7 +69,7 @@ semantic equality.
 
 ### `doc.toJson()`
 Serialize the document to a versioned storage DTO — a JSON **string**
-carrying a `schema` version tag. Use this (not `toMarkdown`) to persist a
+carrying a `schema` version. Use this (not `toMarkdown`) to persist a
 document across a process restart or crate upgrade: the wire format is
 frozen per `schema` version, whereas Markdown syntax evolves. Parse-time
 `warnings` are not part of the DTO.
@@ -81,7 +81,7 @@ persist and hand back.
 
 `toJson()` is **deterministic**: a `Document` that is `equals` to another
 serializes to a byte-identical string — across repeated calls, and across
-any crate upgrade that keeps the same `schema` tag (every release does until
+any crate upgrade that keeps the same `schema` version (every release does until
 the `Document` model changes; see [Storage compatibility](#storage-compatibility-across-versions)).
 Field order is fixed and object key order is preserved, so content hashes
 and string-equality dirty-checks over the output are stable.
@@ -96,7 +96,7 @@ const restored = Document.fromJson(stored);
 restored.equals(doc);               // true
 ```
 
-Throws a JS `Error` on malformed JSON, an unknown `schema` tag, or a
+Throws a JS `Error` on malformed JSON, an unknown `schema` version, or a
 malformed payload. The restored document has no parse-time `warnings`.
 
 ### `Document.tryFromJson(json)`
@@ -114,10 +114,10 @@ genuinely malformed Markdown.
 
 ### Storage compatibility across versions
 
-The `schema` tag (`quillmark/document@0.81.0`) is the **model version**, not
-the running crate version. It is a hand-set constant, bumped only when the
-`Document` model itself changes — so every `0.81.x` patch release reads and
-writes that same tag.
+The `schema` value (`quillmark/document@0.81.0`) is the **model version**,
+not the running crate version. It is a hand-set constant, bumped only when
+the `Document` model itself changes — so every `0.81.x` patch release reads
+and writes that same value.
 
 - **Upgrading is safe.** A newer build always reads documents written by an
   older one. Each schema version's wire format is frozen and never changes;
@@ -126,8 +126,22 @@ writes that same tag.
   on-disk format keeps loading across crate upgrades — there is no need to
   pin old wasm to read old data.
 - **Downgrading is not.** `fromJson` rejects an *unknown* (i.e. newer)
-  `schema` tag rather than guessing at a format it predates. Don't feed
+  `schema` version rather than guessing at a format it predates. Don't feed
   documents written by a newer build back into an older one.
+
+To detect a version mismatch before parsing, use the static accessors:
+
+```ts
+const v = Document.schemaVersionOf(blob); // undefined | string
+if (v && v !== Document.currentSchemaVersion()) {
+  // payload is from a build with a different model version
+}
+```
+
+`schemaVersionOf` does not validate the payload — it only reads the
+`schema` field, returning `undefined` for non-JSON, non-objects, or
+payloads that don't carry one. Use it to distinguish "wrong version" from
+"corrupt" when `fromJson` throws.
 
 In short: persist the `toJson` string, upgrade freely, never downgrade. The
 full design — including how migrations are added — is in

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -112,13 +112,6 @@ const doc = Document.tryFromJson(content) ?? Document.fromMarkdown(content);
 `undefined` means only "not a storage DTO"; `fromMarkdown` still throws on
 genuinely malformed Markdown.
 
-### `Document.markdownToJson(markdown)` / `Document.jsonToMarkdown(json)`
-Pure `string → string` conversions for storage layers that don't need a
-`Document` handle. `markdownToJson` is `fromMarkdown(md).toJson()` and
-`jsonToMarkdown` is `fromJson(json).toMarkdown()`, with no intermediate
-handle to track or `free()`. Each throws on the same inputs as the
-underlying parse method.
-
 ### Storage compatibility across versions
 
 The `schema` tag (`quillmark/document@0.81.0`) is the **model version**, not

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -99,6 +99,26 @@ restored.equals(doc);               // true
 Throws a JS `Error` on malformed JSON, an unknown `schema` tag, or a
 malformed payload. The restored document has no parse-time `warnings`.
 
+### `Document.tryFromJson(json)`
+Like `fromJson`, but returns `undefined` instead of throwing when `json` is
+not a valid storage DTO. Use it to branch on format without a heuristic or
+`try`/`catch` as control flow:
+
+```ts
+// "JSON canonical, Markdown fallback" — no exceptions, no string sniffing
+const doc = Document.tryFromJson(content) ?? Document.fromMarkdown(content);
+```
+
+`undefined` means only "not a storage DTO"; `fromMarkdown` still throws on
+genuinely malformed Markdown.
+
+### `Document.markdownToJson(markdown)` / `Document.jsonToMarkdown(json)`
+Pure `string → string` conversions for storage layers that don't need a
+`Document` handle. `markdownToJson` is `fromMarkdown(md).toJson()` and
+`jsonToMarkdown` is `fromJson(json).toMarkdown()`, with no intermediate
+handle to track or `free()`. Each throws on the same inputs as the
+underlying parse method.
+
 ### Storage compatibility across versions
 
 The `schema` tag (`quillmark/document@0.81.0`) is the **model version**, not

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -79,6 +79,13 @@ global is not involved. It is standard JSON text, so callers may
 `JSON.parse` it to inspect it — but it is intended as an opaque blob you
 persist and hand back.
 
+`toJson()` is **deterministic**: a `Document` that is `equals` to another
+serializes to a byte-identical string — across repeated calls, and across
+any crate upgrade that keeps the same `schema` tag (every release does until
+the `Document` model changes; see [Storage compatibility](#storage-compatibility-across-versions)).
+Field order is fixed and object key order is preserved, so content hashes
+and string-equality dirty-checks over the output are stable.
+
 ### `Document.fromJson(json)`
 Reconstruct a `Document` from a storage DTO string produced by `toJson`.
 Round-trips losslessly:
@@ -91,6 +98,27 @@ restored.equals(doc);               // true
 
 Throws a JS `Error` on malformed JSON, an unknown `schema` tag, or a
 malformed payload. The restored document has no parse-time `warnings`.
+
+### Storage compatibility across versions
+
+The `schema` tag (`quillmark/document@0.81.0`) is the **model version**, not
+the running crate version. It is a hand-set constant, bumped only when the
+`Document` model itself changes — so every `0.81.x` patch release reads and
+writes that same tag.
+
+- **Upgrading is safe.** A newer build always reads documents written by an
+  older one. Each schema version's wire format is frozen and never changes;
+  when the model does change, the new build ships a migration that converts
+  old payloads on `fromJson`. A document you commit as your canonical
+  on-disk format keeps loading across crate upgrades — there is no need to
+  pin old wasm to read old data.
+- **Downgrading is not.** `fromJson` rejects an *unknown* (i.e. newer)
+  `schema` tag rather than guessing at a format it predates. Don't feed
+  documents written by a newer build back into an older one.
+
+In short: persist the `toJson` string, upgrade freely, never downgrade. The
+full design — including how migrations are added — is in
+`prose/canon/DOCUMENT_STORAGE.md`.
 
 ### `doc.equals(other)`
 Structural equality between two `Document` handles. Compares `main` and

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -266,8 +266,11 @@ compilation failures. The same shape applies to every throw site:
 The wasm bindings are built with `--weak-refs`, so dropped `Document`,
 `Quill`, and `RenderSession` handles are reclaimed by `FinalizationRegistry`
 without manual `.free()` discipline. `.free()` is still emitted as an eager
-teardown hook for callers that want deterministic release. Requires
-Node 14.6+ / current evergreen browsers (all supported targets).
+teardown hook for callers that want deterministic release.
+
+The package requires Node 24+ (`engines: { node: ">=24" }`) and current
+evergreen browsers; `--weak-refs` itself only needs Node 14.6+, but the
+published package floor is 24.
 
 For environments where `using` (the [explicit resource management][erm]
 proposal) hasn't landed, use an explicit `try` / `finally`:

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -288,19 +288,6 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     ).toBeUndefined()
     expect(Document.tryFromJson(TEST_MARKDOWN)).toBeUndefined()
   })
-
-  it('markdownToJson / jsonToMarkdown convert without a handle', () => {
-    const json = Document.markdownToJson(TEST_MARKDOWN)
-    expect(json).toBe(Document.fromMarkdown(TEST_MARKDOWN).toJson())
-
-    const markdown = Document.jsonToMarkdown(json)
-    expect(markdown).toBe(Document.fromJson(json).toMarkdown())
-  })
-
-  it('markdownToJson / jsonToMarkdown throw on bad input', () => {
-    expect(() => Document.markdownToJson('no quill frontmatter')).toThrow()
-    expect(() => Document.jsonToMarkdown('not a dto')).toThrow()
-  })
 })
 
 describe('Quillmark.quill', () => {

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -208,7 +208,7 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
 // ---------------------------------------------------------------------------
 
 describe('Document JSON DTO — toJson / fromJson', () => {
-  it('toJson emits a string carrying the versioned schema tag', () => {
+  it('toJson emits a string carrying the schema version', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const dto = doc.toJson()
     expect(typeof dto).toBe('string')
@@ -252,7 +252,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     expect(restored.warnings.length).toBe(0)
   })
 
-  it('fromJson rejects an unknown schema tag', () => {
+  it('fromJson rejects an unknown schema version', () => {
     expect(() =>
       Document.fromJson('{"schema":"quillmark/document@0.99.0","main":{}}'),
     ).toThrow()
@@ -287,6 +287,29 @@ describe('Document JSON DTO — toJson / fromJson', () => {
       Document.tryFromJson('{"schema":"quillmark/document@0.99.0","main":{}}'),
     ).toBeUndefined()
     expect(Document.tryFromJson(TEST_MARKDOWN)).toBeUndefined()
+  })
+
+  it('currentSchemaVersion matches what toJson writes', () => {
+    const dto = JSON.parse(Document.fromMarkdown(TEST_MARKDOWN).toJson())
+    expect(dto.schema).toBe(Document.currentSchemaVersion())
+  })
+
+  it('schemaVersionOf reads the schema field from any object payload', () => {
+    const current = Document.fromMarkdown(TEST_MARKDOWN).toJson()
+    expect(Document.schemaVersionOf(current)).toBe(
+      Document.currentSchemaVersion(),
+    )
+
+    // Future versions are returned as-is, even though fromJson would reject.
+    expect(
+      Document.schemaVersionOf(
+        '{"schema":"quillmark/document@0.99.0","main":{}}',
+      ),
+    ).toBe('quillmark/document@0.99.0')
+
+    expect(Document.schemaVersionOf('not json')).toBeUndefined()
+    expect(Document.schemaVersionOf('{"foo":"bar"}')).toBeUndefined()
+    expect(Document.schemaVersionOf(TEST_MARKDOWN)).toBeUndefined()
   })
 })
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -261,6 +261,46 @@ describe('Document JSON DTO — toJson / fromJson', () => {
   it('fromJson rejects malformed JSON', () => {
     expect(() => Document.fromJson('not json at all')).toThrow()
   })
+
+  it('toJson is deterministic across repeated calls', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(doc.toJson()).toBe(doc.toJson())
+  })
+
+  it('toJson is byte-identical for equal documents', () => {
+    const a = Document.fromMarkdown(TEST_MARKDOWN)
+    const b = Document.fromJson(a.toJson())
+    expect(b.equals(a)).toBe(true)
+    expect(b.toJson()).toBe(a.toJson())
+  })
+
+  it('tryFromJson returns a Document for a valid DTO', () => {
+    const dto = Document.fromMarkdown(TEST_MARKDOWN).toJson()
+    const restored = Document.tryFromJson(dto)
+    expect(restored).toBeDefined()
+    expect(restored.equals(Document.fromMarkdown(TEST_MARKDOWN))).toBe(true)
+  })
+
+  it('tryFromJson returns undefined for non-DTO input instead of throwing', () => {
+    expect(Document.tryFromJson('not json at all')).toBeUndefined()
+    expect(
+      Document.tryFromJson('{"schema":"quillmark/document@0.99.0","main":{}}'),
+    ).toBeUndefined()
+    expect(Document.tryFromJson(TEST_MARKDOWN)).toBeUndefined()
+  })
+
+  it('markdownToJson / jsonToMarkdown convert without a handle', () => {
+    const json = Document.markdownToJson(TEST_MARKDOWN)
+    expect(json).toBe(Document.fromMarkdown(TEST_MARKDOWN).toJson())
+
+    const markdown = Document.jsonToMarkdown(json)
+    expect(markdown).toBe(Document.fromJson(json).toMarkdown())
+  })
+
+  it('markdownToJson / jsonToMarkdown throw on bad input', () => {
+    expect(() => Document.markdownToJson('no quill frontmatter')).toThrow()
+    expect(() => Document.jsonToMarkdown('not a dto')).toThrow()
+  })
 })
 
 describe('Quillmark.quill', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -520,6 +520,12 @@ impl Document {
     ///
     /// `undefined` only ever means "not a storage DTO" — `fromMarkdown`
     /// still throws on genuinely malformed markdown.
+    //
+    // No `tryFromMarkdown` counterpart: a malformed-markdown failure is a
+    // real input error the caller wants to see, not a format-discriminator
+    // signal. The asymmetry is intentional — the only motivating use case
+    // is "is this content a storage DTO, or markdown?", and JSON is the
+    // discriminating side of that test.
     #[wasm_bindgen(js_name = tryFromJson)]
     pub fn try_from_json(json: &str) -> Option<Document> {
         let inner: quillmark_core::Document = serde_json::from_str(json).ok()?;
@@ -560,28 +566,6 @@ impl Document {
         serde_json::to_string(&self.inner).map_err(|e| {
             WasmError::from(format!("toJson: serialization failed: {e}")).to_js_value()
         })
-    }
-
-    /// Convert Quillmark Markdown directly to a storage DTO string.
-    ///
-    /// Equivalent to `fromMarkdown(markdown).toJson()` without exposing an
-    /// intermediate `Document` handle — a pure `string -> string` function
-    /// for storage layers that only need the conversion. Throws on the same
-    /// inputs as [`fromMarkdown`](Document::from_markdown).
-    #[wasm_bindgen(js_name = markdownToJson)]
-    pub fn markdown_to_json(markdown: &str) -> Result<String, JsValue> {
-        Document::from_markdown(markdown)?.to_json()
-    }
-
-    /// Convert a storage DTO string directly to Quillmark Markdown.
-    ///
-    /// Equivalent to `fromJson(json).toMarkdown()` without exposing an
-    /// intermediate `Document` handle — a pure `string -> string` function
-    /// for storage layers that only need the conversion. Throws on the same
-    /// inputs as [`fromJson`](Document::from_json).
-    #[wasm_bindgen(js_name = jsonToMarkdown)]
-    pub fn json_to_markdown(json: &str) -> Result<String, JsValue> {
-        Ok(Document::from_json(json)?.to_markdown())
     }
 
     /// Return a fresh `Document` handle with the same parse state.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -535,6 +535,39 @@ impl Document {
         })
     }
 
+    /// Read the schema version from a raw storage DTO string without
+    /// performing a full parse, or `undefined`.
+    ///
+    /// Returns the `schema` field as-is — including unknown future versions
+    /// that `fromJson` would reject. Use this to distinguish "this build is
+    /// too old for the payload" from "the payload is corrupt" when
+    /// [`fromJson`](Document::from_json) throws:
+    ///
+    /// ```js
+    /// const v = Document.schemaVersionOf(blob);
+    /// if (v === undefined) {
+    ///   // not a stored DTO at all — try fromMarkdown
+    /// } else if (v !== Document.currentSchemaVersion()) {
+    ///   // newer (or older unmigrated) schema — prompt the user to upgrade
+    /// } else {
+    ///   doc = Document.fromJson(blob);
+    /// }
+    /// ```
+    #[wasm_bindgen(js_name = schemaVersionOf)]
+    pub fn schema_version_of(json: &str) -> Option<String> {
+        quillmark_core::document::peek_schema_version(json)
+    }
+
+    /// Schema version this build writes via [`toJson`](Document::to_json).
+    ///
+    /// Compare a payload's [`schemaVersionOf`](Document::schema_version_of)
+    /// against this to detect mismatches before calling
+    /// [`fromJson`](Document::from_json).
+    #[wasm_bindgen(js_name = currentSchemaVersion)]
+    pub fn current_schema_version() -> String {
+        quillmark_core::document::SCHEMA_V0_81_0.to_string()
+    }
+
     /// Emit canonical Quillmark Markdown.
     ///
     /// Returns the document serialised as a Quillmark Markdown string.
@@ -548,7 +581,7 @@ impl Document {
     /// Serialize this document to a versioned storage DTO string.
     ///
     /// Returns the document as a JSON string carrying a `schema` version
-    /// tag. The string is produced inside the module via `serde_json` and
+    /// field. The string is produced inside the module via `serde_json` and
     /// round-trips losslessly back to an equal `Document` via
     /// [`fromJson`](Document::from_json) — the JS `JSON` global is not
     /// involved in either direction.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -508,6 +508,27 @@ impl Document {
         })
     }
 
+    /// Reconstruct a `Document` from a storage DTO string, or `undefined`.
+    ///
+    /// Like [`fromJson`](Document::from_json), but returns `undefined`
+    /// instead of throwing when `json` is not a valid storage DTO. Use this
+    /// to detect format and fall back without exceptions as control flow:
+    ///
+    /// ```js
+    /// const doc = Document.tryFromJson(content) ?? Document.fromMarkdown(content);
+    /// ```
+    ///
+    /// `undefined` only ever means "not a storage DTO" — `fromMarkdown`
+    /// still throws on genuinely malformed markdown.
+    #[wasm_bindgen(js_name = tryFromJson)]
+    pub fn try_from_json(json: &str) -> Option<Document> {
+        let inner: quillmark_core::Document = serde_json::from_str(json).ok()?;
+        Some(Document {
+            inner,
+            parse_warnings: Vec::new(),
+        })
+    }
+
     /// Emit canonical Quillmark Markdown.
     ///
     /// Returns the document serialised as a Quillmark Markdown string.
@@ -539,6 +560,28 @@ impl Document {
         serde_json::to_string(&self.inner).map_err(|e| {
             WasmError::from(format!("toJson: serialization failed: {e}")).to_js_value()
         })
+    }
+
+    /// Convert Quillmark Markdown directly to a storage DTO string.
+    ///
+    /// Equivalent to `fromMarkdown(markdown).toJson()` without exposing an
+    /// intermediate `Document` handle — a pure `string -> string` function
+    /// for storage layers that only need the conversion. Throws on the same
+    /// inputs as [`fromMarkdown`](Document::from_markdown).
+    #[wasm_bindgen(js_name = markdownToJson)]
+    pub fn markdown_to_json(markdown: &str) -> Result<String, JsValue> {
+        Document::from_markdown(markdown)?.to_json()
+    }
+
+    /// Convert a storage DTO string directly to Quillmark Markdown.
+    ///
+    /// Equivalent to `fromJson(json).toMarkdown()` without exposing an
+    /// intermediate `Document` handle — a pure `string -> string` function
+    /// for storage layers that only need the conversion. Throws on the same
+    /// inputs as [`fromJson`](Document::from_json).
+    #[wasm_bindgen(js_name = jsonToMarkdown)]
+    pub fn json_to_markdown(json: &str) -> Result<String, JsValue> {
+        Ok(Document::from_json(json)?.to_markdown())
     }
 
     /// Return a fresh `Document` handle with the same parse state.

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -166,11 +166,11 @@ fn test_json_dto_round_trip() {
     let md = "---\nQUILL: test_quill\ntitle: Hello\nsubject: !fill A Subject\n---\n\n# Hello\n\n```card note\nfor: someone\n```\n\nNote body.\n";
     let doc = Document::from_markdown(md).expect("fromMarkdown failed");
 
-    // toJson yields a string carrying the versioned schema tag.
+    // toJson yields a string carrying the schema version.
     let dto = doc.to_json().expect("toJson failed");
     assert!(
         dto.contains("\"quillmark/document@0.81.0\""),
-        "DTO string must carry the versioned schema tag, got: {dto}"
+        "DTO string must carry the schema version, got: {dto}"
     );
 
     // fromJson reconstructs an equal document.
@@ -210,7 +210,7 @@ fn test_json_dto_rejects_invalid_input() {
     let unknown_schema = r#"{"schema":"quillmark/document@0.99.0","main":{}}"#;
     assert!(
         Document::from_json(unknown_schema).is_err(),
-        "fromJson must reject an unknown schema tag"
+        "fromJson must reject an unknown schema version"
     );
 
     assert!(

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -26,8 +26,8 @@
 //!
 //! ## Schema versioning
 //!
-//! The schema tag tracks the crate version at which the `Document` model was
-//! last changed — currently `0.81.0` (see [`SCHEMA_V0_81_0`]). A model change
+//! The schema version tracks the crate version at which the `Document` model
+//! was last changed — currently `0.81.0` (see [`SCHEMA_V0_81_0`]). A model change
 //! adds a new [`StoredDocument`] variant with its own frozen type tree and a
 //! migration; older variants stay frozen so previously stored rows keep
 //! deserializing.
@@ -49,9 +49,25 @@ use super::{Card, Document, Sentinel};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
-/// Schema tag for the Document model as established in crate version
+/// Schema version for the Document model as established in crate version
 /// `0.81.0`. Bumped only when the model itself changes.
 pub const SCHEMA_V0_81_0: &str = "quillmark/document@0.81.0";
+
+/// Read the `schema` field from a raw storage DTO payload without performing
+/// full deserialization.
+///
+/// Returns `None` if `json` is not valid JSON, is not an object, or has no
+/// `schema` field. The returned string is **not** validated against the set
+/// of supported schema versions — callers use this to distinguish "unknown
+/// future version" from "corrupt payload" when [`Document`] deserialization
+/// fails.
+pub fn peek_schema_version(json: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct Peek {
+        schema: Option<String>,
+    }
+    serde_json::from_str::<Peek>(json).ok()?.schema
+}
 
 /// Versioned envelope for a persisted [`Document`].
 ///
@@ -506,7 +522,7 @@ This body and the metadata above are an indorsement card.
     }
 
     #[test]
-    fn serialized_form_carries_versioned_schema_tag() {
+    fn serialized_form_carries_schema_version() {
         let doc = sample();
         let value: serde_json::Value = serde_json::to_value(&doc).unwrap();
         assert_eq!(value["schema"], SCHEMA_V0_81_0);
@@ -516,6 +532,27 @@ This body and the metadata above are an indorsement card.
     fn rejects_unknown_schema_version() {
         let json = r#"{"schema":"quillmark/document@0.99.0","main":{}}"#;
         assert!(serde_json::from_str::<Document>(json).is_err());
+    }
+
+    #[test]
+    fn peek_schema_version_reads_field_without_full_parse() {
+        let doc = sample();
+        let json = serde_json::to_string(&doc).unwrap();
+        assert_eq!(peek_schema_version(&json).as_deref(), Some(SCHEMA_V0_81_0));
+
+        // Unknown future version: peek still succeeds, even though full
+        // deserialization would reject it.
+        let future = r#"{"schema":"quillmark/document@0.99.0","main":{}}"#;
+        assert_eq!(
+            peek_schema_version(future).as_deref(),
+            Some("quillmark/document@0.99.0")
+        );
+
+        // Not JSON, no schema field, wrong type — all None.
+        assert_eq!(peek_schema_version("not json"), None);
+        assert_eq!(peek_schema_version(r#"{"foo":"bar"}"#), None);
+        assert_eq!(peek_schema_version(r#"{"schema":42}"#), None);
+        assert_eq!(peek_schema_version("[1,2,3]"), None);
     }
 
     #[test]

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -87,7 +87,7 @@ pub mod limits;
 pub mod prescan;
 pub mod sentinel;
 
-pub use dto::{StorageError, StoredDocument};
+pub use dto::{peek_schema_version, StorageError, StoredDocument, SCHEMA_V0_81_0};
 pub use edit::EditError;
 pub use frontmatter::{Frontmatter, FrontmatterItem};
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -15,11 +15,14 @@ syntax also evolves), `Document` serializes to a **versioned JSON envelope**,
 | Form | Round-trips? | Stable for storage? |
 |---|---|---|
 | Markdown (`Document::to_markdown`) | Yes | No — syntax evolves |
-| Plate JSON (`Document::to_plate_json`) | No — lossy, one-way export to backends | — |
 | `StoredDocument` JSON | Yes — lossless | Yes — frozen per schema version |
 
 Use `StoredDocument` JSON whenever a `Document` must survive a process
 restart or a crate upgrade: database rows, caches, message payloads.
+
+`Document::to_plate_json` also exists as a lossy, one-way export to
+Plate-shaped backends; it is core-only (not exposed by the WASM or Python
+bindings) and never a storage option.
 
 ## Design Principles
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -63,10 +63,11 @@ assert_eq!(doc, restored);
 
 ## Schema Versioning
 
-The schema tag is tied to the **crate version at which the `Document` model
-was last changed** — not the running crate version. The current model was
-fixed in `0.81.0`, so the tag is `quillmark/document@0.81.0`; every `0.81.x`
-patch release writes that same tag, because patches do not change the model.
+The schema version is tied to the **crate version at which the `Document`
+model was last changed** — not the running crate version. The current model
+was fixed in `0.81.0`, so the version is `quillmark/document@0.81.0`; every
+`0.81.x` patch release writes that same value, because patches do not
+change the model.
 
 `0.81.0` is the **baseline** schema: it has no predecessor and requires no
 migration. The first migration work occurs at the next model change.
@@ -104,9 +105,9 @@ any past version always loads.
 
 ## Gotchas
 
-- The schema tag is a hand-set constant (`SCHEMA_V0_81_0`), **not**
+- The schema version is a hand-set constant (`SCHEMA_V0_81_0`), **not**
   `CARGO_PKG_VERSION` — bumping it is a deliberate act tied to a model change.
-- Unknown schema tags are rejected on read, never silently ignored.
+- Unknown schema versions are rejected on read, never silently ignored.
 - DTO type names carry version suffixes with underscores
   (`DocumentV0_81_0`); `non_camel_case_types` is allowed module-wide for this.
 


### PR DESCRIPTION
## Summary
This PR adds a non-throwing variant of `Document.fromJson()` and expands documentation around storage compatibility and determinism guarantees for the WASM bindings.

## Key Changes

**New API:**
- Added `Document.tryFromJson(json)` method that returns `undefined` instead of throwing when the input is not a valid storage DTO. This enables format detection without exceptions as control flow (e.g., "JSON canonical, Markdown fallback").

**Documentation:**
- Documented that `toJson()` is deterministic: equal documents serialize to byte-identical strings across repeated calls and crate upgrades (when schema tag remains the same)
- Added comprehensive "Storage compatibility across versions" section explaining:
  - The `schema` tag represents the model version, not the running crate version
  - Upgrading is safe; newer builds always read documents from older ones via migrations
  - Downgrading is not safe; unknown schema tags are rejected
  - Guidance to persist `toJson` strings, upgrade freely, never downgrade
- Clarified Node.js version requirement (24+) for the published package
- Reorganized table in `DOCUMENT_STORAGE.md` to clarify that `to_plate_json` is core-only and not a storage option

**Tests:**
- Added test verifying `toJson()` is deterministic across repeated calls
- Added test verifying equal documents produce byte-identical JSON
- Added tests for `tryFromJson()` with valid DTOs and various invalid inputs (malformed JSON, unknown schema, Markdown)

## Implementation Details
- `tryFromJson` uses `serde_json::from_str().ok()?` to silently handle deserialization failures and return `None` for invalid storage DTOs
- Intentionally asymmetric with no `tryFromMarkdown` counterpart, as malformed Markdown is a real input error, not a format-discriminator signal

https://claude.ai/code/session_01EtUvZgXWv8DAJ49d5rgjHE