### PR TITLE
Document byte-stability guarantees and schema versioning

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -563,6 +563,12 @@ impl Document {
     /// Compare a payload's [`schemaVersionOf`](Document::schema_version_of)
     /// against this to detect mismatches before calling
     /// [`fromJson`](Document::from_json).
+    ///
+    /// The tag tracks the **`Document` model version** — the crate version
+    /// at which the wire format was last changed — not the running crate
+    /// version. Every patch and minor release within the same model
+    /// generation returns the same string; the tag advances only when a
+    /// new schema variant ships.
     #[wasm_bindgen(js_name = currentSchemaVersion)]
     pub fn current_schema_version() -> String {
         quillmark_core::document::SCHEMA_V0_81_0.to_string()
@@ -594,6 +600,22 @@ impl Document {
     /// The result is standard JSON text, so callers that want to inspect it
     /// may `JSON.parse` it — but treating it as an opaque blob is the
     /// intended use.
+    ///
+    /// ## Byte-stability
+    ///
+    /// The output is a **byte-deterministic** function of the document's
+    /// value within a given `schema` version: two documents that compare
+    /// equal under [`equals`](Document::equals) serialize to byte-equal
+    /// strings, and the same document re-serialized in a later patch or
+    /// minor release of this crate (same `schema`) produces the same bytes.
+    /// Content-hash use cases (template-divergence detection, cache keys)
+    /// can rely on this without re-canonicalizing.
+    ///
+    /// Specifics: object fields are emitted in struct-declaration order;
+    /// frontmatter field values preserve their YAML insertion order (no
+    /// key sorting); whitespace is `serde_json`'s compact form (no spaces
+    /// between tokens, no trailing newline); strings use `serde_json`'s
+    /// standard escape set. A schema-version bump may change any of these.
     #[wasm_bindgen(js_name = toJson)]
     pub fn to_json(&self) -> Result<String, JsValue> {
         serde_json::to_string(&self.inner).map_err(|e| {

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -522,6 +522,28 @@ This body and the metadata above are an indorsement card.
     }
 
     #[test]
+    fn serialization_is_byte_deterministic() {
+        // The wasm `toJson` docstring promises byte-equal output for
+        // equal documents within a schema version; consumers content-hash
+        // the result for divergence detection. Re-serializing the same
+        // document, and round-tripping through deserialization, must both
+        // produce the same bytes.
+        let doc = sample();
+        let first = serde_json::to_string(&doc).unwrap();
+        let second = serde_json::to_string(&doc).unwrap();
+        assert_eq!(
+            first, second,
+            "to_string must be deterministic (byte-equal on repeated calls)"
+        );
+        let restored: Document = serde_json::from_str(&first).unwrap();
+        let third = serde_json::to_string(&restored).unwrap();
+        assert_eq!(
+            first, third,
+            "byte-equality must survive a round-trip through fromJson/toJson"
+        );
+    }
+
+    #[test]
     fn serialized_form_carries_schema_version() {
         let doc = sample();
         let value: serde_json::Value = serde_json::to_value(&doc).unwrap();

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -61,6 +61,23 @@ let restored: Document = serde_json::from_str(&json)?;  // load
 assert_eq!(doc, restored);
 ```
 
+## Byte-stability
+
+Serialization is **byte-deterministic** within a given schema version:
+equal `Document`s (by `PartialEq`) produce byte-equal JSON, and the same
+document re-serialized in any later patch or minor release tagged with
+the same `schema` produces the same bytes. This is load-bearing for
+consumers that content-hash stored documents (template-divergence
+detection, cache keys).
+
+The guarantee follows from: struct field order is fixed in the frozen
+DTO tree; `Vec` fields preserve order by definition; `serde_json::Value`
+inside frontmatter field values keeps YAML insertion order via the
+workspace's `serde_json/preserve_order` feature. No key sorting or
+whitespace normalization is applied — the output is `serde_json`'s
+compact form. Bumping the `schema` version is the only event that may
+change the byte layout.
+
 ## Schema Versioning
 
 The schema version is tied to the **crate version at which the `Document`


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation about the byte-deterministic nature of document serialization and clarifies the relationship between schema versions and crate releases. It includes a new test to verify serialization stability across round-trips.

## Key Changes

- **Enhanced `currentSchemaVersion()` documentation**: Clarified that the schema version tag tracks the Document model version (when wire format last changed), not the running crate version. Patch and minor releases within the same model generation return the same schema string.

- **Added byte-stability guarantees to `toJson()` documentation**: Documented that serialization is byte-deterministic within a schema version—equal documents produce byte-equal JSON, and re-serialization in later patch/minor releases produces identical bytes. This is critical for content-hashing use cases (cache keys, divergence detection).

- **Detailed serialization specifics**: Documented the exact serialization behavior: object fields in struct-declaration order, frontmatter field values preserve YAML insertion order, compact JSON whitespace, and standard escape sequences. Noted that schema-version bumps may change these details.

- **New test `serialization_is_byte_deterministic()`**: Added test in `crates/core/src/document/dto.rs` that verifies:
  - Repeated serialization of the same document produces identical bytes
  - Round-tripping through deserialization preserves byte-equality

- **Updated DOCUMENT_STORAGE.md**: Added "Byte-stability" section explaining the guarantee, its implementation basis (fixed field order, preserved insertion order via `serde_json/preserve_order`), and that only schema version bumps can change byte layout.

## Implementation Details

The changes are purely documentation and testing—no functional changes to serialization logic. The byte-stability guarantee is already provided by the existing implementation (fixed struct field order, `serde_json` determinism, and the `preserve_order` feature for frontmatter values). This PR makes that guarantee explicit and testable.

https://claude.ai/code/session_013HJZ9YuCjkwWkASJEp3sg1