### PR TITLE
Quote ambiguous string scalars in blueprint emission

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -474,23 +474,25 @@ fn render_flow(val: &serde_json::Value) -> String {
 }
 
 /// Quote a YAML string only when necessary in block context.
+///
+/// The oracle is the parser itself: if `s` round-trips through
+/// `serde_saphyr` as a string equal to itself, it can be emitted unquoted —
+/// every consumer in the pipeline parses through the same library, so its
+/// answer is by construction the correct one. This avoids hand-maintaining
+/// YAML's plain-scalar resolution rules (numeric forms, YAML 1.1 boolean
+/// variants, null-aliases, anchor/alias indicators, comment triggers, …).
 fn yaml_string(s: &str) -> String {
-    let needs_quotes = s.is_empty()
-        || matches!(s, "true" | "false" | "null" | "yes" | "no" | "on" | "off")
-        || s.starts_with(|c: char| {
-            matches!(
-                c,
-                '{' | '[' | '&' | '*' | '!' | '|' | '>' | '\'' | '"' | '%' | '@' | '`'
-            )
-        })
-        || s.contains(": ")
-        || s.contains(" #")
-        || s.starts_with("- ")
-        || s.starts_with('#');
-    if needs_quotes {
-        quote(s)
-    } else {
+    if round_trips_as_string(s) {
         s.to_string()
+    } else {
+        quote(s)
+    }
+}
+
+fn round_trips_as_string(s: &str) -> bool {
+    match serde_saphyr::from_str::<serde_json::Value>(s) {
+        Ok(serde_json::Value::String(t)) => t == s,
+        _ => false,
     }
 }
 
@@ -991,6 +993,72 @@ card_kinds:
       label: { type: string, required: true }
       pages: { type: integer, default: 1 }
 "#;
+
+    #[test]
+    fn string_default_that_looks_numeric_is_quoted() {
+        // Regression: a string-typed field with a numeric-looking default
+        // (e.g. version "1.0") must emit quoted so that a model copying
+        // the line verbatim doesn't hand the renderer a float.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    version: { type: string, default: "1.0" }
+    build_number: { type: string, default: "42" }
+"#)
+        .blueprint();
+        assert!(t.contains("version: \"1.0\""), "got:\n{}", t);
+        assert!(t.contains("build_number: \"42\""), "got:\n{}", t);
+    }
+
+    #[test]
+    fn string_default_that_looks_boolean_or_null_is_quoted() {
+        // YAML 1.1 boolean variants and null aliases must also be quoted
+        // when they appear as string-typed defaults.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    truthy:  { type: string, default: "True" }
+    nully:   { type: string, default: "~" }
+    yessy:   { type: string, default: "Yes" }
+"#)
+        .blueprint();
+        assert!(t.contains("truthy: \"True\""), "got:\n{}", t);
+        assert!(t.contains("nully: \"~\""), "got:\n{}", t);
+        assert!(t.contains("yessy: \"Yes\""), "got:\n{}", t);
+    }
+
+    #[test]
+    fn ambiguous_string_defaults_round_trip_via_blueprint() {
+        // The blueprint's emitted YAML must reparse to the original string
+        // values — that is the whole guarantee this fix restores.
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    version:      { type: string, default: "1.0" }
+    build_number: { type: string, default: "42" }
+    truthy:       { type: string, default: "True" }
+    nully:        { type: string, default: "~" }
+"#)
+        .blueprint();
+        let doc = Document::from_markdown(&bp).expect("blueprint must parse");
+        let payload = doc.main().payload();
+        assert_eq!(
+            payload.get("version").and_then(|v| v.as_str()),
+            Some("1.0")
+        );
+        assert_eq!(
+            payload.get("build_number").and_then(|v| v.as_str()),
+            Some("42")
+        );
+        assert_eq!(
+            payload.get("truthy").and_then(|v| v.as_str()),
+            Some("True")
+        );
+        assert_eq!(payload.get("nully").and_then(|v| v.as_str()), Some("~"));
+    }
 
     #[test]
     fn blueprint_round_trips_idempotently() {


### PR DESCRIPTION
## Summary

A string-typed field whose default looked numeric, boolean, or null (e.g. `version: "1.0"`, `"True"`, `"~"`) was emitted **unquoted** by the blueprint serializer. YAML re-parses those tokens as a non-string, so a model copying the line verbatim handed the renderer a value of the wrong type — the dominant `render_failure` cause for `version` / `build_number` fields in production runs.

## Root cause

`yaml_string()` in `crates/core/src/quill/blueprint.rs` maintained a hand-written allow/deny list of "needs quoting" triggers. It covered `: `, ` #`, leading `-`/`#`, anchor/alias sigils, and the lowercase trio `true|false|null|yes|no|on|off` — but **not** numeric forms, YAML 1.1 boolean variants (`True`, `Yes`, `On`, `Y`, …), null aliases (`~`, `Null`, `NULL`), or numeric special forms (`.inf`, `0x1A`, scientific notation, …).

## Fix

Replace the hand-maintained predicate with a parser-driven oracle: emit unquoted iff the scalar round-trips through `serde_saphyr` as a string equal to itself.

```rust
fn round_trips_as_string(s: &str) -> bool {
    match serde_saphyr::from_str::<serde_json::Value>(s) {
        Ok(serde_json::Value::String(t)) => t == s,
        _ => false,
    }
}
```

Every consumer in the pipeline parses through the same library, so this answer is **correct by construction** — it covers numeric forms, YAML 1.1 boolean variants, null aliases, anchor/alias indicators, and comment triggers without us re-deriving the YAML plain-scalar resolution rules.

## Why not a full YAML emitter library?

Considered and rejected. The blueprint isn't plain YAML — it's YAML densely interleaved with structural inline comments (`key: value  # type; role`) that carry the schema contract for LLM consumers. Serde-based emitters serialize a value tree; they don't preserve or place comments. So we keep the hand-rolled layout/comment logic and outsource just the narrow quoting decision that was actually wrong.

## Test plan

- [x] All 26 pre-existing blueprint tests pass unchanged
- [x] New: `string_default_that_looks_numeric_is_quoted` — covers `"1.0"`, `"42"`
- [x] New: `string_default_that_looks_boolean_or_null_is_quoted` — covers `"True"`, `"~"`, `"Yes"`
- [x] New: `ambiguous_string_defaults_round_trip_via_blueprint` — end-to-end: blueprint → parse → confirm field values are still strings equal to the originals
- [x] Full workspace `cargo test` green


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4sGJmvzqC2f5Q461KKpdr)_