### PR TITLE
Remove `#` prefix from system metadata headers (@quill, @kind, @id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ let engine = Quillmark::new();
 let quill = engine.quill_from_path("path/to/quill")?;
 
 let markdown = r#"~~~card-yaml
-#@quill: my_quill
-#@kind: main
+@quill: my_quill
+@kind: main
 title: Example
 ~~~
 

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -19,8 +19,8 @@ engine = Quillmark()
 quill = engine.quill_from_path("path/to/quill")
 
 markdown = """~~~card-yaml
-#@quill: my_quill
-#@kind: main
+@quill: my_quill
+@kind: main
 title: Hello World
 ~~~
 

--- a/crates/bindings/python/examples/quill_demo.py
+++ b/crates/bindings/python/examples/quill_demo.py
@@ -28,8 +28,8 @@ def main():
     quill = engine.quill_from_path(str(taro_dir))
 
     markdown = """~~~card-yaml
-#@quill: taro
-#@kind: main
+@quill: taro
+@kind: main
 author: Alice
 ice_cream: Taro
 title: My Favorite Ice Cream

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -510,9 +510,9 @@ impl PyDocument {
             .map_err(convert_edit_error)
     }
 
-    /// Replace the `#@kind` of the composable card at `index`.
+    /// Replace the `@kind` of the composable card at `index`.
     ///
-    /// Mutates only the `#@kind` — the card's payload and body are
+    /// Mutates only the `@kind` — the card's payload and body are
     /// untouched. Schema-aware migration (clearing orphan fields, applying
     /// new defaults) is the caller's responsibility; `set_card_kind` is a
     /// structural primitive.

--- a/crates/bindings/python/tests/conftest.py
+++ b/crates/bindings/python/tests/conftest.py
@@ -43,8 +43,8 @@ def taro_quill_dir():
 
 
 TARO_MARKDOWN = '''~~~card-yaml
-#@quill: taro@0.1
-#@kind: main
+@quill: taro@0.1
+@kind: main
 author: Nibs
 ice_cream: Taro
 title: "My Favorite Ice Cream Flavor"
@@ -53,7 +53,7 @@ title: "My Favorite Ice Cream Flavor"
 I love Taro ice cream for its subtly sweet, nutty flavor and creamy, earthy undertones.
 
 ~~~card-yaml
-#@kind: quotes
+@kind: quotes
 author: Albert Einstein
 ~~~
 Without taro ice cream, life would be a mistake.

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -7,7 +7,7 @@ from conftest import QUILLS_PATH, _latest_version
 
 def test_parsed_document_quill_ref():
     """Test that Document exposes quill_ref method."""
-    markdown_with_quill = "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Test\n~~~\n\n# Content\n"
+    markdown_with_quill = "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Test\n~~~\n\n# Content\n"
     parsed = Document.from_markdown(markdown_with_quill)
     assert parsed.quill_ref() == "my_quill"
 
@@ -44,7 +44,7 @@ def test_full_workflow():
     taro_dir = QUILLS_PATH / "taro"
     quill = engine.quill_from_path(str(_latest_version(taro_dir)))
 
-    markdown = "~~~card-yaml\n#@quill: taro\n#@kind: main\nauthor: Test Author\nice_cream: Chocolate\ntitle: Test\n~~~\n\nContent.\n"
+    markdown = "~~~card-yaml\n@quill: taro\n@kind: main\nauthor: Test Author\nice_cream: Chocolate\ntitle: Test\n~~~\n\nContent.\n"
     parsed = Document.from_markdown(markdown)
     assert parsed.quill_ref() == "taro"
 
@@ -62,26 +62,26 @@ def test_full_workflow():
 # Phase 3 — editor surface tests
 # ---------------------------------------------------------------------------
 
-SIMPLE_MD = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hello\nauthor: Alice\n~~~\n\nBody text.\n"
+SIMPLE_MD = "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hello\nauthor: Alice\n~~~\n\nBody text.\n"
 
 MD_WITH_CARDS = """\
 ~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Hello
 ~~~
 
 Body.
 
 ~~~card-yaml
-#@kind: note
+@kind: note
 foo: bar
 ~~~
 
 Card one.
 
 ~~~card-yaml
-#@kind: summary
+@kind: summary
 ~~~
 
 Card two.

--- a/crates/bindings/python/tests/test_form.py
+++ b/crates/bindings/python/tests/test_form.py
@@ -49,8 +49,8 @@ card_kinds:
         type: string
 """
 
-MD_WITH_TITLE = "~~~card-yaml\n#@quill: py_form_smoke\n#@kind: main\ntitle: \"Hello\"\n~~~\n"
-MD_EMPTY = "~~~card-yaml\n#@quill: py_form_smoke\n#@kind: main\n~~~\n"
+MD_WITH_TITLE = "~~~card-yaml\n@quill: py_form_smoke\n@kind: main\ntitle: \"Hello\"\n~~~\n"
+MD_EMPTY = "~~~card-yaml\n@quill: py_form_smoke\n@kind: main\n~~~\n"
 
 
 def make_quill(tmp_path, yaml_content=QUILL_YAML_CONTENT):
@@ -141,8 +141,8 @@ def test_form_unknown_card_diagnostic(tmp_path):
     """Unknown card kinds produce a diagnostic and are excluded from cards."""
     quill = make_quill(tmp_path)
     md = (
-        "~~~card-yaml\n#@quill: py_form_smoke\n#@kind: main\ntitle: \"T\"\n~~~\n\n"
-        "~~~card-yaml\n#@kind: ghost_card\nnote: \"B\"\n~~~\n"
+        "~~~card-yaml\n@quill: py_form_smoke\n@kind: main\ntitle: \"T\"\n~~~\n\n"
+        "~~~card-yaml\n@kind: ghost_card\nnote: \"B\"\n~~~\n"
     )
     doc = Document.from_markdown(md)
 

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -22,8 +22,8 @@ def test_parse_invalid_yaml():
     """Test parsing invalid YAML payload."""
     invalid_md = (
         "~~~card-yaml\n"
-        "#@quill: test_quill\n"
-        "#@kind: main\n"
+        "@quill: test_quill\n"
+        "@kind: main\n"
         "title: [unclosed bracket\n"
         "~~~\n\nContent\n"
     )
@@ -52,7 +52,7 @@ def test_body_is_str(taro_md):
 
 def test_body_empty_when_absent():
     """Test that body is empty string when no body content."""
-    md = "~~~card-yaml\n#@quill: taro\n#@kind: main\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n~~~\n"
+    md = "~~~card-yaml\n@quill: taro\n@kind: main\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n~~~\n"
     doc = Document.from_markdown(md)
     assert doc.body == ""
 
@@ -60,8 +60,8 @@ def test_body_empty_when_absent():
 def test_cards_access():
     """Test accessing typed cards list."""
     md = (
-        "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Main\n~~~\n\nGlobal body.\n\n"
-        "~~~card-yaml\n#@kind: note\nfoo: bar\n~~~\n\nCard body.\n"
+        "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Main\n~~~\n\nGlobal body.\n\n"
+        "~~~card-yaml\n@kind: note\nfoo: bar\n~~~\n\nCard body.\n"
     )
     doc = Document.from_markdown(md)
     assert len(doc.cards) == 1
@@ -73,7 +73,7 @@ def test_cards_access():
 
 def test_cards_empty_when_none():
     """Test that cards is an empty list when no cards present."""
-    md = "~~~card-yaml\n#@quill: taro\n#@kind: main\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n~~~\n\nBody.\n"
+    md = "~~~card-yaml\n@quill: taro\n@kind: main\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n~~~\n\nBody.\n"
     doc = Document.from_markdown(md)
     assert doc.cards == []
 
@@ -122,7 +122,7 @@ def test_json_dto_rejects_invalid_input():
 def test_json_dto_drops_parse_warnings():
     """A DTO-reconstructed document carries no parse-time warnings."""
     # An unknown YAML tag triggers a `parse::unsupported_yaml_tag` warning.
-    warn_md = "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Hi\nweird: !custom value\n~~~\n\nBody\n"
+    warn_md = "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Hi\nweird: !custom value\n~~~\n\nBody\n"
     doc = Document.from_markdown(warn_md)
     assert len(doc.warnings) > 0, "source document should have a parse warning"
 

--- a/crates/bindings/python/tests/test_render.py
+++ b/crates/bindings/python/tests/test_render.py
@@ -52,8 +52,8 @@ def test_quill_render_ref_mismatch_warning(taro_quill_dir):
     # Build a document that names a different quill
     mismatch_md = (
         "~~~card-yaml\n"
-        "#@quill: completely_different_quill\n"
-        "#@kind: main\n"
+        "@quill: completely_different_quill\n"
+        "@kind: main\n"
         "author: Test Author\n"
         "ice_cream: Chocolate\n"
         "title: Mismatch Test\n"
@@ -100,8 +100,8 @@ def test_parse_error_carries_diagnostic_payload():
     when there is exactly one diagnostic.
     """
     invalid_md = """~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: [unclosed bracket
 ~~~
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -35,8 +35,8 @@ const engine = new Quillmark();
 const quill = engine.quill(tree);
 
 const markdown = `~~~card-yaml
-#@quill: my_quill
-#@kind: main
+@quill: my_quill
+@kind: main
 title: My Document
 ~~~
 
@@ -57,7 +57,7 @@ Build + validate + attach backend. Returns a render-ready `Quill`.
 ### `Document.fromMarkdown(markdown)`
 Parse markdown to a parsed document. Throws a JS `Error` (with `.diagnostics`
 attached, see [Errors](#errors)) on any parse failure, including a missing
-root `#@quill` metadata line, malformed YAML, and inputs over the 10 MB
+root `@quill` metadata line, malformed YAML, and inputs over the 10 MB
 `parse::input_too_large` limit.
 
 ### `doc.toMarkdown()`
@@ -260,7 +260,7 @@ backend compilation errors. `message` is derived from `diagnostics`
 Read `err.diagnostics[0]` for the primary diagnostic; iterate the array for
 compilation failures. The same shape applies to every throw site:
 
-- `Document.fromMarkdown` — parse errors (missing root `#@quill` metadata, YAML
+- `Document.fromMarkdown` — parse errors (missing root `@quill` metadata, YAML
   errors, `parse::input_too_large` for inputs > 10 MB).
 - `Document` mutators (`setField`, `updateCardField`, etc.) — `EditError`
   variants (`ReservedName`, `InvalidFieldName`, `InvalidKindName`,
@@ -299,7 +299,7 @@ try {
 ## Notes
 
 - Parsed markdown requires a root `~~~card-yaml` block with a
-  `#@quill` system-metadata line. Empty input surfaces a dedicated
+  `@quill` system-metadata line. Empty input surfaces a dedicated
   "Empty markdown input cannot be parsed" message.
 - QUILL mismatch during `quill.render(parsed)` is a warning (`quill::ref_mismatch`), not an error.
 - Output schema APIs are no longer engine-level in WASM.

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -12,8 +12,8 @@ import { Quillmark, Document } from '@quillmark-wasm'
 import { makeQuill } from './test-helpers.js'
 
 const TEST_MARKDOWN = `~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test Document
 author: Test Author
 ~~~
@@ -68,14 +68,14 @@ describe('Document.fromMarkdown', () => {
 
   it('should expose card fields and body', () => {
     const md = `~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 Global body.
 
 ~~~card-yaml
-#@kind: note
+@kind: note
 foo: bar
 ~~~
 
@@ -97,8 +97,8 @@ Card body.
 
   it('should throw on invalid YAML payload', () => {
     const badMarkdown = `~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 this is not valid yaml
 ~~~
@@ -118,7 +118,7 @@ author: Test Author
 
 # Hello Default
 
-This document has no #@quill metadata.`
+This document has no @quill metadata.`
 
     expect(() => {
       Document.fromMarkdown(markdownWithoutQuill)
@@ -249,7 +249,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
   it('drops parse-time warnings on reconstruction', () => {
     // An unknown YAML tag triggers a `parse::unsupported_yaml_tag` warning.
     const warnMd =
-      '~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hi\nweird: !custom value\n~~~\n\nBody\n'
+      '~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hi\nweird: !custom value\n~~~\n\nBody\n'
     const doc = Document.fromMarkdown(warnMd)
     expect(doc.warnings.length).toBeGreaterThan(0)
 
@@ -408,8 +408,8 @@ describe('Quillmark.quill', () => {
 
     // Document declares a different quill name
     const otherMarkdown = `~~~card-yaml
-#@quill: other_quill
-#@kind: main
+@quill: other_quill
+@kind: main
 title: Mismatch Test
 ~~~
 
@@ -516,21 +516,21 @@ describe('Document editor surface — setQuillRef / replaceBody', () => {
 
 describe('Document editor surface — card mutations', () => {
   const MD_WITH_CARDS = `~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 Body.
 
 ~~~card-yaml
-#@kind: note
+@kind: note
 foo: bar
 ~~~
 
 Card one.
 
 ~~~card-yaml
-#@kind: summary
+@kind: summary
 ~~~
 
 Card two.
@@ -669,14 +669,14 @@ describe('Document.equals', () => {
 
 describe('Document editor surface — updateCardField / updateCardBody', () => {
   const MD_WITH_CARD = `~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 Body.
 
 ~~~card-yaml
-#@kind: note
+@kind: note
 foo: bar
 ~~~
 
@@ -931,8 +931,8 @@ card_kinds:
 `
 
   const MD_WITH_TITLE = `~~~card-yaml
-#@quill: form_smoke_test
-#@kind: main
+@quill: form_smoke_test
+@kind: main
 title: "Hello"
 ~~~
 `

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -75,8 +75,8 @@ const { Quillmark, Document } = await import('@quillmark-wasm')
 const { makeQuill } = await import('./test-helpers.js')
 
 const TEST_MARKDOWN = `~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Canvas Test
 ~~~
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -860,9 +860,9 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Replace the `#@kind` of the composable card at `index`.
+    /// Replace the `@kind` of the composable card at `index`.
     ///
-    /// Mutates only the `#@kind` — the card's payload and body are
+    /// Mutates only the `@kind` — the card's payload and body are
     /// untouched. Schema-aware migration (clearing orphan fields, applying
     /// new defaults) is the caller's responsibility; `setCardKind` is a
     /// structural primitive.

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -183,7 +183,7 @@ pub enum PayloadItem {
         /// `true` when the comment was a trailing inline comment in source
         /// (`field: value # text`). Inline comments attach to the previous
         /// field on emit; `Comment{inline:true}` at index 0 attaches to the
-        /// `#@` metadata header. Inline comments without a host degrade to
+        /// `@` metadata header. Inline comments without a host degrade to
         /// own-line on emit.
         #[serde(default)]
         inline: bool,
@@ -193,7 +193,7 @@ pub enum PayloadItem {
 /// A single card block parsed from a Quillmark Markdown document.
 ///
 /// Exposed as a plain JS object via `Document.main`, `Document.cards`, etc.
-/// Carries a `kind` string (the block's `#@kind`, empty when the block
+/// Carries a `kind` string (the block's `@kind`, empty when the block
 /// declares none), typed payload (map view under `payload`, ordered item
 /// list under `payloadItems`), and the body. Whether a card is the document
 /// entry (main) card or a composable card is positional — it is whichever
@@ -202,10 +202,10 @@ pub enum PayloadItem {
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct Card {
-    /// The block's `#@kind` value (e.g. `"endorsement"`); empty string when
-    /// the block declares no `#@kind`.
+    /// The block's `@kind` value (e.g. `"endorsement"`); empty string when
+    /// the block declares no `@kind`.
     pub kind: String,
-    /// Map-keyed view of payload values (no `#@` metadata, comments invisible).
+    /// Map-keyed view of payload values (no `@` metadata, comments invisible).
     #[tsify(type = "Record<string, unknown>")]
     pub payload: serde_json::Value,
     /// Ordered payload item list — fields and comments, in source order.
@@ -362,11 +362,11 @@ mod tests {
         use quillmark_core::Document;
 
         let md =
-            "~~~card-yaml\n#@quill: q\n#@kind: main\ntitle: Hi # inline note\nauthor: Alice\n~~~\n";
+            "~~~card-yaml\n@quill: q\n@kind: main\ntitle: Hi # inline note\nauthor: Alice\n~~~\n";
         let doc = Document::from_markdown(md).unwrap();
         let card = Card::from(doc.main());
 
-        // Map view: title and author present, #@quill absent.
+        // Map view: title and author present, @quill absent.
         assert_eq!(card.payload["title"], "Hi");
         assert_eq!(card.payload["author"], "Alice");
         assert!(card.payload.get("quill").is_none());

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -17,7 +17,7 @@ fn small_quill_tree() -> wasm_bindgen::JsValue {
 }
 
 const SIMPLE_MARKDOWN: &str =
-    "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hello\n~~~\n\n# Hello\n";
+    "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hello\n~~~\n\n# Hello\n";
 
 #[wasm_bindgen_test]
 fn test_parse_markdown_static() {
@@ -43,7 +43,7 @@ fn test_quill_from_tree() {
     let _ = quill;
 }
 
-/// Rendering with a `#@quill` ref that differs from the quill name must yield
+/// Rendering with a `@quill` ref that differs from the quill name must yield
 /// exactly one warning with code `quill::ref_mismatch` and still produce an artifact.
 #[wasm_bindgen_test]
 fn test_render_ref_mismatch_warning() {
@@ -51,7 +51,7 @@ fn test_render_ref_mismatch_warning() {
     let quill = engine.quill(small_quill_tree()).expect("quill failed");
 
     let mismatch_md =
-        "~~~card-yaml\n#@quill: other_quill\n#@kind: main\ntitle: Mismatch\n~~~\n\n# Content\n";
+        "~~~card-yaml\n@quill: other_quill\n@kind: main\ntitle: Mismatch\n~~~\n\n# Content\n";
     let doc = Document::from_markdown(mismatch_md).expect("fromMarkdown failed");
     let result = quill
         .render(&doc, Some(RenderOptions::default()))
@@ -165,7 +165,7 @@ fn test_to_markdown_round_trip() {
 /// round-trips it back to an equal `Document`.
 #[wasm_bindgen_test]
 fn test_json_dto_round_trip() {
-    let md = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hello\nsubject: !fill A Subject\n~~~\n\n# Hello\n\n~~~card-yaml\n#@kind: note\nfor: someone\n~~~\n\nNote body.\n";
+    let md = "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hello\nsubject: !fill A Subject\n~~~\n\n# Hello\n\n~~~card-yaml\n@kind: note\nfor: someone\n~~~\n\nNote body.\n";
     let doc = Document::from_markdown(md).expect("fromMarkdown failed");
 
     // toJson yields a string carrying the schema version.
@@ -190,7 +190,7 @@ fn test_json_dto_round_trip() {
 fn test_json_dto_drops_parse_warnings() {
     // An unknown YAML tag triggers a `parse::unsupported_yaml_tag` warning.
     let warn_md =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hi\nweird: !custom value\n~~~\n\nBody\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hi\nweird: !custom value\n~~~\n\nBody\n";
     let doc = Document::from_markdown(warn_md).expect("fromMarkdown failed");
     assert!(
         js_sys::Array::from(&doc.warnings()).length() > 0,

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -1,7 +1,7 @@
 //! Assembly of card-yaml blocks into a [`Document`].
 //!
 //! This module contains the top-level parsing glue: it calls the fence
-//! scanner, parses each block's `#@` system-metadata header, and assembles a
+//! scanner, parses each block's `@` system-metadata header, and assembles a
 //! typed [`Document`] from the pieces.
 
 use crate::error::ParseError;
@@ -37,7 +37,7 @@ pub(super) struct MetadataBlock {
     pub(super) start: usize, // Position of the opening `~~~card-yaml`
     pub(super) end: usize,   // Position after the closing `~~~`
     pub(super) yaml_value: Option<serde_json::Value>, // Parsed YAML payload as JSON
-    pub(super) meta: CardMetadata, // The block's typed `#@` system metadata
+    pub(super) meta: CardMetadata, // The block's typed `@` system metadata
     /// Pre-scan items (comments + fill-tagged field keys) in source order.
     pub(super) pre_items: Vec<PreItem>,
     /// Pre-scan nested comments (with structural paths).
@@ -46,12 +46,12 @@ pub(super) struct MetadataBlock {
     pub(super) pre_warnings: Vec<Diagnostic>,
 }
 
-/// Split a block's raw content into its `#@` system-metadata header and the
+/// Split a block's raw content into its `@` system-metadata header and the
 /// YAML payload that follows it.
 ///
-/// The metadata header is the run of `#@`-prefixed lines at the top of the
+/// The metadata header is the run of `@`-prefixed lines at the top of the
 /// block (blank lines interspersed are skipped). The payload is everything
-/// after the last header line. A block with no `#@` line yields an empty
+/// after the last header line. A block with no `@` line yields an empty
 /// header.
 fn split_meta_header(content: &str) -> (Vec<&str>, &str) {
     let mut header: Vec<&str> = Vec::new();
@@ -63,7 +63,7 @@ fn split_meta_header(content: &str) -> (Vec<&str>, &str) {
             payload_start += line.len();
             continue;
         }
-        if trimmed.starts_with("#@") {
+        if trimmed.starts_with("@") {
             header.push(line_text);
             payload_start += line.len();
             continue;
@@ -97,7 +97,7 @@ pub(super) fn build_block(
         });
     }
 
-    // Separate the `#@` system-metadata header from the YAML payload.
+    // Separate the `@` system-metadata header from the YAML payload.
     let (header, yaml_payload) = split_meta_header(raw_content);
     let meta = parse_meta_header(&header)?;
 
@@ -167,7 +167,7 @@ pub(super) fn decompose_with_warnings(
     if markdown.trim().is_empty() {
         return Err(crate::error::ParseError::EmptyInput(
             "Empty markdown input cannot be parsed as a Quillmark Document. \
-             Provide at least a root card-yaml block declaring `#@quill: <name>`."
+             Provide at least a root card-yaml block declaring `@quill: <name>`."
                 .to_string(),
         ));
     }
@@ -187,36 +187,36 @@ pub(super) fn decompose_with_warnings(
     if blocks.is_empty() {
         return Err(crate::error::ParseError::MissingQuill(
             "Missing required root card-yaml block. The document must open with a \
-             `~~~card-yaml` block declaring `#@quill: <name>`."
+             `~~~card-yaml` block declaring `@quill: <name>`."
                 .to_string(),
         ));
     }
 
-    // The root block must declare a `#@quill` reference. (Its value is
-    // validated into a typed `QuillReference` during `#@` header parsing.)
+    // The root block must declare a `@quill` reference. (Its value is
+    // validated into a typed `QuillReference` during `@` header parsing.)
     let root_block = &blocks[0];
     if root_block.meta.quill.is_none() {
         return Err(ParseError::MissingQuill(
-            "The document's root card-yaml block must declare `#@quill: <name>`.".to_string(),
+            "The document's root card-yaml block must declare `@quill: <name>`.".to_string(),
         ));
     }
 
     // `main` is the reserved kind for the document root. The root block
-    // must declare `#@kind: main`; no other value is permitted there, and a
-    // composable card may not declare `#@kind: main` (checked below).
+    // must declare `@kind: main`; no other value is permitted there, and a
+    // composable card may not declare `@kind: main` (checked below).
     match root_block.meta.kind.as_deref() {
         Some("main") => {}
         Some(other) => {
             return Err(ParseError::InvalidStructure(format!(
-                "The document's root card-yaml block must declare `#@kind: main`, \
-                 not `#@kind: {}` — `main` is reserved for the document root.",
+                "The document's root card-yaml block must declare `@kind: main`, \
+                 not `@kind: {}` — `main` is reserved for the document root.",
                 other
             )));
         }
         None => {
             return Err(ParseError::InvalidStructure(
-                "The document's root card-yaml block must declare `#@kind: main` \
-                 alongside `#@quill:`."
+                "The document's root card-yaml block must declare `@kind: main` \
+                 alongside `@quill:`."
                     .to_string(),
             ));
         }
@@ -258,12 +258,12 @@ pub(super) fn decompose_with_warnings(
         let block = &blocks[idx];
 
         // Only the root block binds the document to a quill. A composable
-        // card declaring `#@quill` is a structural error — `#@quill` is
+        // card declaring `@quill` is a structural error — `@quill` is
         // captured by the per-block header parser, but rejected here, where
         // root-vs-composable position is known.
         if block.meta.quill.is_some() {
             return Err(ParseError::InvalidStructure(
-                "A composable card-yaml block must not declare `#@quill` — only \
+                "A composable card-yaml block must not declare `@quill` — only \
                  the document's root block binds the document to a quill."
                     .to_string(),
             ));
@@ -272,7 +272,7 @@ pub(super) fn decompose_with_warnings(
         // `main` is reserved for the document root.
         if block.meta.kind.as_deref() == Some("main") {
             return Err(ParseError::InvalidStructure(
-                "A composable card-yaml block must not declare `#@kind: main` — \
+                "A composable card-yaml block must not declare `@kind: main` — \
                  `main` is reserved for the document root."
                     .to_string(),
             ));

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -26,7 +26,7 @@
 //! The V0_81_0 wire format uses the names current at the time it was frozen
 //! (`sentinel`, `frontmatter`, `tag`). The in-memory model has since renamed
 //! these to `meta`, `payload`, and `kind` respectively; the conversion code
-//! below maps between the two. The `#@id` system-metadata field, added after
+//! below maps between the two. The `@id` system-metadata field, added after
 //! V0_81_0 was frozen, is carried as an optional, soft-additive field on
 //! the wire-format sentinel variants — documents without an `id` serialize
 //! to byte-identical output, preserving the V0_81_0 byte-stability contract
@@ -107,27 +107,27 @@ pub struct CardV0_81_0 {
 ///
 /// Maps the V0_81_0 wire enum (`Main { quill }` vs `Card { tag }`) onto the
 /// model's unified [`CardMetadata`]. The `id` field is a soft-additive
-/// extension: absent on documents written before `#@id` existed, optional
+/// extension: absent on documents written before `@id` existed, optional
 /// on documents written after.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum SentinelV0_81_0 {
     /// Document entry card. `quill` is the rendered quill reference string
     /// (e.g. `usaf_memo@0.1`), parsed back via [`QuillReference::from_str`].
-    /// The root's `#@kind` is always `"main"` per the spec (§3.3); the wire
+    /// The root's `@kind` is always `"main"` per the spec (§3.3); the wire
     /// format omits it because the variant discriminator already implies it.
     Main {
         /// Quill reference string.
         quill: String,
-        /// `#@id` opaque identifier, if any.
+        /// `@id` opaque identifier, if any.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
     /// Composable card with a kind tag.
     Card {
-        /// Card kind tag (matches the model's `#@kind`).
+        /// Card kind tag (matches the model's `@kind`).
         tag: String,
-        /// `#@id` opaque identifier, if any.
+        /// `@id` opaque identifier, if any.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
@@ -455,9 +455,9 @@ impl TryFrom<SentinelV0_81_0> for CardMetadata {
                         reason,
                     }
                 })?;
-                // The `Main` variant implies `#@kind: main` (spec §3.3); the
+                // The `Main` variant implies `@kind: main` (spec §3.3); the
                 // reconstructed model carries the canonical kind so the
-                // markdown emit emits `#@kind: main` and the round-trip is
+                // markdown emit emits `@kind: main` and the round-trip is
                 // symmetric with the parser, which requires it.
                 Ok(CardMetadata {
                     quill: Some(reference),
@@ -538,8 +538,8 @@ mod tests {
         Document::from_markdown(
             "\
 ~~~card-yaml
-#@quill: usaf_memo@0.1
-#@kind: main
+@quill: usaf_memo@0.1
+@kind: main
 # a top-level comment
 memo_for:
   - ORG/SYMBOL # inline comment inside a sequence
@@ -550,7 +550,7 @@ subject: !fill Subject of the Memorandum
 The body of the memorandum.
 
 ~~~card-yaml
-#@kind: indorsement
+@kind: indorsement
 for: ORG/SYMBOL
 from: ORG/SYMBOL
 ~~~
@@ -576,7 +576,7 @@ This body and the metadata above are an indorsement card.
     #[test]
     fn root_kind_is_main_through_round_trip() {
         let doc = Document::from_markdown(
-            "~~~card-yaml\n#@quill: usaf_memo@0.1\n#@kind: main\ntitle: \"Hi\"\n~~~\n",
+            "~~~card-yaml\n@quill: usaf_memo@0.1\n@kind: main\ntitle: \"Hi\"\n~~~\n",
         )
         .unwrap();
         assert_eq!(doc.main().meta().kind.as_deref(), Some("main"));

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -6,7 +6,7 @@
 //!
 //! Every successful mutator call leaves the document in a state that:
 //! - Contains no reserved key in any card's payload (`BODY`, `CARDS`, `QUILL`, `CARD`).
-//! - Has every composable card's `#@kind` passing `meta::is_valid_kind_name`.
+//! - Has every composable card's `@kind` passing `meta::is_valid_kind_name`.
 //! - Can be safely serialized via [`Document::to_plate_json`].
 //!
 //! **Mutators never modify `warnings`.**  Warnings are parse-time observations
@@ -87,7 +87,7 @@ pub enum EditError {
     InvalidKindName(String),
 
     /// The supplied card kind is `"main"`, which is reserved for the
-    /// document root. Composable cards may not declare `#@kind: main`.
+    /// document root. Composable cards may not declare `@kind: main`.
     #[error("card kind 'main' is reserved for the document root")]
     ReservedKind,
 
@@ -99,7 +99,7 @@ pub enum EditError {
 // ── impl Document ────────────────────────────────────────────────────────────
 
 impl Document {
-    /// Replace the root block's `#@quill` system-metadata entry.
+    /// Replace the root block's `@quill` system-metadata entry.
     ///
     /// # Invariants enforced
     ///
@@ -165,9 +165,9 @@ impl Document {
         Some(self.cards_vec_mut().remove(index))
     }
 
-    /// Replace the `#@kind` of the composable card at `index`.
+    /// Replace the `@kind` of the composable card at `index`.
     ///
-    /// **Field-bag semantics.** This mutates only the `#@kind` metadata; the
+    /// **Field-bag semantics.** This mutates only the `@kind` metadata; the
     /// card's payload and body are untouched. After the call:
     ///
     /// - Fields valid under both old and new schemas round-trip unchanged.
@@ -254,7 +254,7 @@ impl Card {
     /// - `kind` must not be `"main"` — that kind is reserved for the
     ///   document root. Returns [`EditError::ReservedKind`].
     ///
-    /// The new card declares `#@kind: <kind>`, has no fields, and an empty body.
+    /// The new card declares `@kind: <kind>`, has no fields, and an empty body.
     pub fn new(kind: impl Into<String>) -> Result<Self, EditError> {
         let kind = kind.into();
         if !is_valid_kind_name(&kind) {

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -46,8 +46,8 @@ impl Document {
     ///
     /// - Line endings: `\n` only.  CRLF normalization happens on import.
     /// - Every block is emitted as a `~~~card-yaml` fence: a `~~~card-yaml`
-    ///   opener, the `#@` system-metadata header (`#@quill: <ref>` for the
-    ///   root block, `#@kind: <kind>` for composable cards), the block's YAML
+    ///   opener, the `@` system-metadata header (`@quill: <ref>` for the
+    ///   root block, `@kind: <kind>` for composable cards), the block's YAML
     ///   payload, then a closing `~~~`.
     /// - Cards: one blank line before each, then the block, then the card body.
     /// - Body: emitted verbatim after the root block (and after each card).
@@ -112,11 +112,11 @@ impl Document {
 
 // ── Block emission ────────────────────────────────────────────────────────────
 
-/// Emit a card-yaml block: `~~~card-yaml`, the `#@` system-metadata header,
+/// Emit a card-yaml block: `~~~card-yaml`, the `@` system-metadata header,
 /// the YAML payload, then a closing `~~~`.
 ///
-/// The `#@` header is emitted in the canonical key order `quill`, `kind`,
-/// `id` — only keys the block declares appear. There is no `#@` line for an
+/// The `@` header is emitted in the canonical key order `quill`, `kind`,
+/// `id` — only keys the block declares appear. There is no `@` line for an
 /// inline comment to attach to, so an inline comment carried over at
 /// `items[0]` degrades to an own-line comment as the first payload line,
 /// preserving its text.
@@ -126,7 +126,7 @@ impl Document {
 /// `-`, strings are double-quoted, comments start with `#`), so the fence can
 /// never be closed early.
 fn emit_meta_line(out: &mut String, key: &str, value: &str) {
-    out.push_str("#@");
+    out.push_str("@");
     out.push_str(key);
     out.push_str(": ");
     out.push_str(value);

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -1,13 +1,13 @@
-//! Card-yaml block metadata: the `#@`-prefixed system-metadata header.
+//! Card-yaml block metadata: the `@`-prefixed system-metadata header.
 //!
-//! Every `~~~card-yaml` block may carry a leading run of `#@key: value` lines.
+//! Every `~~~card-yaml` block may carry a leading run of `@key: value` lines.
 //! These are **system metadata** drawn from a closed set of three reserved
-//! keys — `#@quill`, `#@kind`, `#@id`. Any other `#@key` is a parse error.
-//! The `#@` prefix keeps them invisible to a plain YAML parser (a `#` line is
-//! a comment).
+//! keys — `@quill`, `@kind`, `@id`. Any other `@key` is a parse error.
+//! The `@` prefix segregates them from the YAML payload: header lines are
+//! extracted before the payload is handed to the YAML parser.
 //!
-//! `#@quill` on the root block binds the document to a quill; `#@kind` is
-//! name-validated against `[a-z_][a-z0-9_]*` at parse time. `#@id` is opaque
+//! `@quill` on the root block binds the document to a quill; `@kind` is
+//! name-validated against `[a-z_][a-z0-9_]*` at parse time. `@id` is opaque
 //! metadata, carried through round-trip unchanged.
 
 use std::str::FromStr;
@@ -15,36 +15,36 @@ use std::str::FromStr;
 use crate::error::ParseError;
 use crate::version::QuillReference;
 
-/// Typed `#@`-metadata of a single card-yaml block.
+/// Typed `@`-metadata of a single card-yaml block.
 ///
-/// The `#@` header is a **closed set** of three optional keys; an unknown
-/// `#@key` is rejected at parse time. `#@quill` is parsed into a typed
+/// The `@` header is a **closed set** of three optional keys; an unknown
+/// `@key` is rejected at parse time. `@quill` is parsed into a typed
 /// [`QuillReference`] as the block is read.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CardMetadata {
-    /// The `#@quill` reference. Required on the document's root block and
+    /// The `@quill` reference. Required on the document's root block and
     /// rejected on composable cards (see `assemble`); `None` on every card
     /// in a successfully parsed [`crate::Document`].
     pub quill: Option<QuillReference>,
-    /// The `#@kind` card kind, if the block declares one. Validated against
+    /// The `@kind` card kind, if the block declares one. Validated against
     /// `[a-z_][a-z0-9_]*` at parse time.
     pub kind: Option<String>,
-    /// The `#@id` opaque identifier, if the block declares one.
+    /// The `@id` opaque identifier, if the block declares one.
     pub id: Option<String>,
 }
 
-/// Parse a block's `#@` header lines into a typed [`CardMetadata`].
+/// Parse a block's `@` header lines into a typed [`CardMetadata`].
 ///
 /// Header lines may appear in any order. The accepted keys are the closed set
-/// `{quill, kind, id}`. A malformed `#@` line, an unknown `#@key`, a duplicate
-/// key, an invalid `#@quill` reference, or a `#@kind` that does not match
+/// `{quill, kind, id}`. A malformed `@` line, an unknown `@key`, a duplicate
+/// key, an invalid `@quill` reference, or a `@kind` that does not match
 /// `[a-z_][a-z0-9_]*` is a parse error.
 pub(super) fn parse_meta_header(header: &[&str]) -> Result<CardMetadata, ParseError> {
     let mut meta = CardMetadata::default();
     for line in header {
         let (key, value) = parse_meta_line(line).ok_or_else(|| {
             ParseError::InvalidStructure(format!(
-                "Malformed `#@` metadata line `{}` — expected `#@<key>: <value>`",
+                "Malformed `@` metadata line `{}` — expected `@<key>: <value>`",
                 line.trim()
             ))
         })?;
@@ -55,7 +55,7 @@ pub(super) fn parse_meta_header(header: &[&str]) -> Result<CardMetadata, ParseEr
                 }
                 let reference = QuillReference::from_str(&value).map_err(|e| {
                     ParseError::InvalidStructure(format!(
-                        "Invalid #@quill reference '{}': {}",
+                        "Invalid @quill reference '{}': {}",
                         value, e
                     ))
                 })?;
@@ -67,7 +67,7 @@ pub(super) fn parse_meta_header(header: &[&str]) -> Result<CardMetadata, ParseEr
                 }
                 if !is_valid_kind_name(&value) {
                     return Err(ParseError::InvalidStructure(format!(
-                        "Invalid `#@kind` value '{}' — a card kind must match \
+                        "Invalid `@kind` value '{}' — a card kind must match \
                          `[a-z_][a-z0-9_]*`",
                         value
                     )));
@@ -82,8 +82,8 @@ pub(super) fn parse_meta_header(header: &[&str]) -> Result<CardMetadata, ParseEr
             }
             other => {
                 return Err(ParseError::InvalidStructure(format!(
-                    "Unknown `#@{}` system-metadata key — the card-yaml header \
-                     accepts only `#@quill`, `#@kind`, and `#@id`",
+                    "Unknown `@{}` system-metadata key — the card-yaml header \
+                     accepts only `@quill`, `@kind`, and `@id`",
                     other
                 )));
             }
@@ -94,29 +94,29 @@ pub(super) fn parse_meta_header(header: &[&str]) -> Result<CardMetadata, ParseEr
 
 fn duplicate_meta_error(key: &str) -> ParseError {
     ParseError::InvalidStructure(format!(
-        "Duplicate `#@{}` system-metadata entry in one card-yaml block",
+        "Duplicate `@{}` system-metadata entry in one card-yaml block",
         key
     ))
 }
 
-/// Parse a `#@`-prefixed metadata line into its `(key, value)` pair.
+/// Parse a `@`-prefixed metadata line into its `(key, value)` pair.
 ///
-/// `#@quill: example@0.1.0` parses to `("quill", "example@0.1.0")`. A trailing
+/// `@quill: example@0.1.0` parses to `("quill", "example@0.1.0")`. A trailing
 /// inline comment (` # …` to end of line) is dropped from the value, matching
 /// YAML's own comment rule:
 ///
 /// ```text
-/// #@quill: example@0.1.0  # bound at build time
+/// @quill: example@0.1.0  # bound at build time
 /// →                ↳ key="quill", value="example@0.1.0"
 /// ```
 ///
 /// A `#` is only treated as a comment marker when preceded by whitespace
-/// (or at the start of the value), so `#@id: abc#def` keeps `abc#def` intact.
+/// (or at the start of the value), so `@id: abc#def` keeps `abc#def` intact.
 ///
-/// Returns `None` when `line` is not a `#@` metadata line (no `#@` prefix,
+/// Returns `None` when `line` is not a `@` metadata line (no `@` prefix,
 /// or no `:` separator).
 fn parse_meta_line(line: &str) -> Option<(String, String)> {
-    let rest = line.trim_start().strip_prefix("#@")?;
+    let rest = line.trim_start().strip_prefix("@")?;
     let colon = rest.find(':')?;
     let key = rest[..colon].trim().to_string();
     let value_raw = &rest[colon + 1..];
@@ -124,7 +124,7 @@ fn parse_meta_line(line: &str) -> Option<(String, String)> {
     Some((key, value))
 }
 
-/// Strip a YAML-style trailing comment from a `#@` value.
+/// Strip a YAML-style trailing comment from a `@` value.
 ///
 /// A `#` starts a comment when it is the first non-whitespace character of
 /// the value or is preceded by whitespace. Other `#`s are kept verbatim.
@@ -189,14 +189,14 @@ mod tests {
 
     #[test]
     fn trailing_comment_stripped_from_quill_value() {
-        let (k, v) = parse_meta_line("#@quill: foo@0.1  # bound at build").unwrap();
+        let (k, v) = parse_meta_line("@quill: foo@0.1  # bound at build").unwrap();
         assert_eq!(k, "quill");
         assert_eq!(v, "foo@0.1");
     }
 
     #[test]
     fn trailing_comment_stripped_from_kind_value() {
-        let (k, v) = parse_meta_line("#@kind: main # the root").unwrap();
+        let (k, v) = parse_meta_line("@kind: main # the root").unwrap();
         assert_eq!(k, "kind");
         assert_eq!(v, "main");
     }
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn hash_inside_value_is_kept_when_not_preceded_by_whitespace() {
         // `abc#def` is a single token — `#` has no whitespace before it.
-        let (_, v) = parse_meta_line("#@id: abc#def").unwrap();
+        let (_, v) = parse_meta_line("@id: abc#def").unwrap();
         assert_eq!(v, "abc#def");
     }
 
@@ -212,14 +212,14 @@ mod tests {
     fn hash_at_start_of_value_is_a_comment() {
         // After the colon-space, `#` is the first non-whitespace character —
         // matches YAML's rule for "comment starts at column 0 of value".
-        let (k, v) = parse_meta_line("#@id: # gone").unwrap();
+        let (k, v) = parse_meta_line("@id: # gone").unwrap();
         assert_eq!(k, "id");
         assert_eq!(v, "");
     }
 
     #[test]
     fn no_trailing_comment_leaves_value_unchanged() {
-        let (_, v) = parse_meta_line("#@quill: foo@0.1").unwrap();
+        let (_, v) = parse_meta_line("@quill: foo@0.1").unwrap();
         assert_eq!(v, "foo@0.1");
     }
 }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -10,9 +10,9 @@
 //! ## Key Types
 //!
 //! - [`Document`]: Typed in-memory Quillmark document — `main` card plus composable cards.
-//! - [`Card`]: A single card block, root or composable, with a `#@` metadata
+//! - [`Card`]: A single card block, root or composable, with a `@` metadata
 //!   header, a typed payload, and a body.
-//! - [`CardMetadata`]: A block's typed `#@` system metadata (`#@quill`, `#@kind`, `#@id`).
+//! - [`CardMetadata`]: A block's typed `@` system metadata (`@quill`, `@kind`, `@id`).
 //! - [`Payload`]: Ordered list of items (fields + comments) parsed from a
 //!   block's YAML payload.
 //!
@@ -24,8 +24,8 @@
 //! use quillmark_core::Document;
 //!
 //! let markdown = r#"~~~card-yaml
-//! #@quill: my_quill
-//! #@kind: main
+//! @quill: my_quill
+//! @kind: main
 //! title: My Document
 //! author: John Doe
 //! ~~~
@@ -51,7 +51,7 @@
 //! use quillmark_core::Document;
 //!
 //! let doc = Document::from_markdown(
-//!     "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Hi\n~~~\n\nBody here.\n"
+//!     "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Hi\n~~~\n\nBody here.\n"
 //! ).unwrap();
 //! let json = doc.to_plate_json();
 //! assert_eq!(json["QUILL"], "my_quill");
@@ -65,8 +65,8 @@
 //! [`Document::from_markdown`] returns errors for:
 //! - Malformed YAML syntax
 //! - Unclosed `~~~card-yaml` blocks
-//! - A root block missing its required `#@quill` system metadata
-//! - A malformed or duplicated `#@` metadata line
+//! - A root block missing its required `@quill` system metadata
+//! - A malformed or duplicated `@` metadata line
 //! - Reserved field name usage
 //!
 //! See [MARKDOWN.md](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/MARKDOWN.md)
@@ -115,7 +115,7 @@ pub struct ParseOutput {
 /// recording which collection it belongs to.
 ///
 /// Every card has:
-/// - `meta` — the block's typed `#@` system metadata (`#@quill`, `#@kind`, `#@id`).
+/// - `meta` — the block's typed `@` system metadata (`@quill`, `@kind`, `@id`).
 /// - `payload` — ordered items parsed from the block's YAML payload.
 /// - `body` — the Markdown text that follows the closing `~~~` fence, up to
 ///   the next block (or EOF).
@@ -146,7 +146,7 @@ impl Card {
         }
     }
 
-    /// The block's typed `#@` system metadata.
+    /// The block's typed `@` system metadata.
     pub fn meta(&self) -> &CardMetadata {
         &self.meta
     }
@@ -156,12 +156,12 @@ impl Card {
         &mut self.meta
     }
 
-    /// The `#@kind` card kind, if the block declares one.
+    /// The `@kind` card kind, if the block declares one.
     pub fn kind(&self) -> Option<&str> {
         self.meta.kind.as_deref()
     }
 
-    /// The `#@id` opaque identifier, if the block declares one.
+    /// The `@id` opaque identifier, if the block declares one.
     pub fn id(&self) -> Option<&str> {
         self.meta.id.as_deref()
     }
@@ -235,13 +235,13 @@ impl PartialEq for Document {
 impl Document {
     /// Create a `Document` from a pre-built main `Card` and composable cards.
     ///
-    /// The caller must guarantee that `main`'s `#@quill` metadata is present
-    /// and valid, and that composable cards do not carry `#@quill`.
+    /// The caller must guarantee that `main`'s `@quill` metadata is present
+    /// and valid, and that composable cards do not carry `@quill`.
     pub fn from_main_and_cards(main: Card, cards: Vec<Card>, warnings: Vec<Diagnostic>) -> Self {
-        debug_assert!(main.meta.quill.is_some(), "main card must carry `#@quill`");
+        debug_assert!(main.meta.quill.is_some(), "main card must carry `@quill`");
         debug_assert!(
             cards.iter().all(|c| c.meta.quill.is_none()),
-            "composable cards must not carry `#@quill`"
+            "composable cards must not carry `@quill`"
         );
         Self {
             main,
@@ -274,16 +274,16 @@ impl Document {
     }
 
     /// The quill reference (`name@version-selector`) the document binds to,
-    /// parsed from the root block's `#@quill` system metadata.
+    /// parsed from the root block's `@quill` system metadata.
     ///
-    /// The root `#@quill` is validated when the document is parsed, so this
+    /// The root `@quill` is validated when the document is parsed, so this
     /// never fails for a `Document` produced by [`Document::from_markdown`].
     pub fn quill_reference(&self) -> QuillReference {
         self.main
             .meta
             .quill
             .clone()
-            .expect("root block's #@quill is validated at parse time")
+            .expect("root block's @quill is validated at parse time")
     }
 
     /// Ordered list of composable card blocks.

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -1,7 +1,7 @@
 //! Ordered payload representation.
 //!
 //! A [`Payload`] is the typed representation of a card-yaml block's YAML
-//! payload (the `#@` metadata header already separated off). Unlike a plain
+//! payload (the `@` metadata header already separated off). Unlike a plain
 //! `IndexMap`, it preserves YAML comments as first-class ordered items and
 //! carries a `fill: bool` marker on each field (for `!fill` tags).
 //!
@@ -36,7 +36,7 @@ pub enum PayloadItem {
     /// itself) from trailing inline comments (`field: value # text`). An
     /// inline comment attaches to the field that immediately precedes it
     /// in the items vector; if no such field exists at emit time (orphan)
-    /// it degrades to an own-line comment. The `#@` metadata header of
+    /// it degrades to an own-line comment. The `@` metadata header of
     /// a card-yaml block has no inline-comment slot, so a `Comment { inline:
     /// true }` at `items[0]` degrades to an own-line comment.
     Comment {

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -107,7 +107,7 @@ enum FrameKind {
 
 /// Scan the YAML payload of a card-yaml block.
 ///
-/// `content` is the block's YAML payload — the text below the `#@`
+/// `content` is the block's YAML payload — the text below the `@`
 /// metadata header — with leading/trailing whitespace preserved.
 pub fn prescan_fence_content(content: &str) -> PreScan {
     let mut out = PreScan::default();

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -64,8 +64,8 @@ fn test_missing_quill_diagnostic_code() {
 #[test]
 fn test_with_payload() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test Document
 author: Test Author
 ~~~
@@ -98,8 +98,8 @@ This is the body.";
 #[test]
 fn test_complex_yaml_payload() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Complex Document
 tags:
   - test
@@ -136,8 +136,8 @@ Content here.";
 fn test_invalid_yaml() {
     // Root card-yaml block with invalid YAML payload.
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: [invalid yaml
 author: missing close bracket
 ~~~
@@ -154,8 +154,8 @@ Content here.";
 fn test_unclosed_payload() {
     // Root card-yaml block without a closing `~~~` fence.
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 author: Test Author
 
@@ -174,15 +174,15 @@ Content without closing fence";
 #[test]
 fn test_basic_card_block() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Main Document
 ~~~
 
 Main body content.
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item 1
 ~~~
 
@@ -212,12 +212,12 @@ Body of item 1.";
 #[test]
 fn test_multiple_card_blocks() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item 1
 tags: [a, b]
 ~~~
@@ -225,7 +225,7 @@ tags: [a, b]
 First item body.
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item 2
 tags: [c, d]
 ~~~
@@ -253,8 +253,8 @@ Second item body.";
 #[test]
 fn test_mixed_global_and_cards() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Global
 author: John Doe
 ~~~
@@ -262,14 +262,14 @@ author: John Doe
 Global body.
 
 ~~~card-yaml
-#@kind: sections
+@kind: sections
 title: Section 1
 ~~~
 
 Section 1 content.
 
 ~~~card-yaml
-#@kind: sections
+@kind: sections
 title: Section 2
 ~~~
 
@@ -289,12 +289,12 @@ Section 2 content.";
 #[test]
 fn test_empty_card_metadata() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 ~~~
 
 Body without metadata.";
@@ -310,12 +310,12 @@ Body without metadata.";
 #[test]
 fn test_card_block_without_body() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item
 ~~~";
 
@@ -329,15 +329,15 @@ name: Item
 #[test]
 fn test_name_collision_global_and_card() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 items: \"global value\"
 ~~~
 
 Body
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item
 ~~~
 
@@ -351,8 +351,8 @@ Item body";
 fn test_card_name_collision_with_array_field() {
     // Card kind names CAN now conflict with payload field names.
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 items:
   - name: Global Item 1
     value: 100
@@ -361,7 +361,7 @@ items:
 Global body
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Scope Item 1
 ~~~
 
@@ -377,15 +377,15 @@ Scope item 1 body";
 #[test]
 fn test_empty_global_array_with_card() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 items: []
 ~~~
 
 Global body
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item 1
 ~~~
 
@@ -402,12 +402,12 @@ Item 1 body";
 fn test_reserved_field_body_rejected() {
     // BODY reserved inside a card block.
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: section
+@kind: section
 BODY: Test
 ~~~";
 
@@ -423,8 +423,8 @@ BODY: Test
 fn test_reserved_field_cards_rejected() {
     // CARDS reserved inside the root payload.
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 CARDS: []
 ~~~";
@@ -440,8 +440,8 @@ CARDS: []
 #[test]
 fn test_delimiter_inside_fenced_code_block_backticks() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 ~~~
 
@@ -449,7 +449,7 @@ Here is some code:
 
 ```yaml
 ~~~card-yaml
-#@kind: code_example
+@kind: code_example
 fake: payload
 ~~~
 ```
@@ -467,8 +467,8 @@ More content.
 #[test]
 fn test_four_backticks_are_fences() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 ~~~
 
@@ -476,7 +476,7 @@ Here is some code:
 
 ````yaml
 ~~~card-yaml
-#@kind: code_example
+@kind: code_example
 fake: payload
 ~~~
 ````
@@ -493,19 +493,19 @@ More content.
 #[test]
 fn test_adjacent_blocks_different_kinds() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item 1
 ~~~
 
 Item 1 body
 
 ~~~card-yaml
-#@kind: sections
+@kind: sections
 title: Section 1
 ~~~
 
@@ -532,26 +532,26 @@ Section 1 body";
 #[test]
 fn test_order_preservation() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 id: 1
 ~~~
 
 First
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 id: 2
 ~~~
 
 Second
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 id: 3
 ~~~
 
@@ -570,8 +570,8 @@ Third";
 #[test]
 fn test_product_catalog_integration() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Product Catalog
 author: John Doe
 date: 2024-01-01
@@ -580,7 +580,7 @@ date: 2024-01-01
 This is the main catalog description.
 
 ~~~card-yaml
-#@kind: products
+@kind: products
 name: Widget A
 price: 19.99
 sku: WID-001
@@ -589,7 +589,7 @@ sku: WID-001
 The **Widget A** is our most popular product.
 
 ~~~card-yaml
-#@kind: products
+@kind: products
 name: Gadget B
 price: 29.99
 sku: GAD-002
@@ -598,7 +598,7 @@ sku: GAD-002
 The **Gadget B** is perfect for professionals.
 
 ~~~card-yaml
-#@kind: reviews
+@kind: reviews
 product: Widget A
 rating: 5
 ~~~
@@ -606,7 +606,7 @@ rating: 5
 \"Excellent product! Highly recommended.\"
 
 ~~~card-yaml
-#@kind: reviews
+@kind: reviews
 product: Gadget B
 rating: 4
 ~~~
@@ -700,8 +700,8 @@ rating: 4
 #[test]
 fn taro_quill_directive() {
     let markdown = "~~~card-yaml
-#@quill: usaf_memo
-#@kind: main
+@quill: usaf_memo
+@kind: main
 memo_for: [ORG/SYMBOL]
 memo_from: [ORG/SYMBOL]
 ~~~
@@ -727,15 +727,15 @@ This is the memo body.";
 #[test]
 fn test_quill_with_card_blocks() {
     let markdown = "~~~card-yaml
-#@quill: document
-#@kind: main
+@quill: document
+@kind: main
 title: Test Document
 ~~~
 
 Main body.
 
 ~~~card-yaml
-#@kind: sections
+@kind: sections
 name: Section 1
 ~~~
 
@@ -755,26 +755,26 @@ Section 1 body.";
 #[test]
 fn test_non_root_block_declaring_quill_is_error() {
     // Only the root block binds the document to a quill. A composable card
-    // declaring `#@quill` is a structural parse error.
+    // declaring `@quill` is a structural parse error.
     let markdown = "~~~card-yaml
-#@quill: first
-#@kind: main
+@quill: first
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@quill: second
-#@kind: note
+@quill: second
+@kind: note
 ~~~";
 
     let err = decompose(markdown).unwrap_err().to_string();
-    assert!(err.contains("must not declare `#@quill`"), "got: {err}");
+    assert!(err.contains("must not declare `@quill`"), "got: {err}");
 }
 
 #[test]
 fn test_invalid_quill_ref() {
     let markdown = "~~~card-yaml
-#@quill: Invalid-Name
-#@kind: main
+@quill: Invalid-Name
+@kind: main
 ~~~";
 
     let result = decompose(markdown);
@@ -782,13 +782,13 @@ fn test_invalid_quill_ref() {
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Invalid #@quill reference"));
+        .contains("Invalid @quill reference"));
 }
 
 #[test]
 fn test_quill_empty_value() {
     let markdown = "~~~card-yaml
-#@quill:
+@quill:
 ~~~";
 
     let result = decompose(markdown);
@@ -796,26 +796,26 @@ fn test_quill_empty_value() {
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("Invalid #@quill reference"));
+        .contains("Invalid @quill reference"));
 }
 
 #[test]
 fn test_card_with_unknown_meta_key_is_error() {
-    // The `#@` header is a closed set `{quill, kind, id}`. Any other `#@key`
+    // The `@` header is a closed set `{quill, kind, id}`. Any other `@key`
     // is a parse error.
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@foo: bar
-#@kind: note
+@foo: bar
+@kind: note
 ~~~";
 
     let err = decompose(markdown).unwrap_err().to_string();
     assert!(
-        err.contains("Unknown `#@foo`"),
+        err.contains("Unknown `@foo`"),
         "expected unknown-key parse error, got: {err}"
     );
 }
@@ -823,8 +823,8 @@ fn test_card_with_unknown_meta_key_is_error() {
 #[test]
 fn test_blank_lines_in_payload() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test Document
 author: Test Author
 
@@ -875,12 +875,12 @@ This is the body.";
 #[test]
 fn test_blank_lines_in_scope_blocks() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item 1
 
 price: 19.99
@@ -911,8 +911,8 @@ Body of item 1.";
 #[test]
 fn test_triple_dash_between_paragraphs_is_delegated() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 ~~~
 
@@ -932,8 +932,8 @@ Second paragraph.";
 #[test]
 fn test_lone_triple_dash_in_body_is_delegated() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 ~~~
 
@@ -952,8 +952,8 @@ Second paragraph.";
 #[test]
 fn test_multiple_blank_lines_in_yaml() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test
 
 
@@ -1065,7 +1065,7 @@ fn test_input_size_limit() {
 
 #[test]
 fn test_yaml_size_limit() {
-    let mut markdown = String::from("~~~card-yaml\n#@quill: test_quill\n#@kind: main\n");
+    let mut markdown = String::from("~~~card-yaml\n@quill: test_quill\n@kind: main\n");
     let size = crate::error::MAX_YAML_SIZE + 1;
     markdown.push_str("data: \"");
     markdown.push_str(&"x".repeat(size));
@@ -1080,7 +1080,7 @@ fn test_yaml_size_limit() {
 fn test_input_within_size_limit() {
     let size = 1000;
     let markdown = format!(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\n{}",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\n{}",
         "a".repeat(size)
     );
 
@@ -1091,7 +1091,7 @@ fn test_input_within_size_limit() {
 #[test]
 fn test_yaml_within_size_limit() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\nauthor: John Doe\n~~~\n\nBody content";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\nauthor: John Doe\n~~~\n\nBody content";
     let result = decompose(markdown);
     assert!(result.is_ok());
 }
@@ -1105,7 +1105,7 @@ fn test_yaml_depth_limit() {
     }
 
     let markdown = format!(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n{}~~~\n\nBody",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\n{}~~~\n\nBody",
         yaml_content
     );
     let result = decompose(&markdown);
@@ -1124,8 +1124,8 @@ fn test_yaml_depth_limit() {
 #[test]
 fn test_yaml_depth_within_limit() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 level1:
   level2:
     level3:
@@ -1148,8 +1148,8 @@ Body content";
 #[test]
 fn test_chevrons_preserved_in_all_contexts() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Test <<with chevrons>>
 items:
   - \"<<first>>\"
@@ -1167,7 +1167,7 @@ metadata:
 `<<inline code>>` and <<plain>>
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 description: \"<<card yaml>>\"
 ~~~
 
@@ -1220,8 +1220,8 @@ Use <<card body>> here.";
 #[test]
 fn test_yaml_numbers_not_affected() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 count: 42
 ~~~
 
@@ -1236,8 +1236,8 @@ Body.";
 #[test]
 fn test_yaml_booleans_not_affected() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 active: true
 ~~~
 
@@ -1254,7 +1254,7 @@ Body.";
 
 #[test]
 fn test_multiline_chevrons_preserved() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n<<text\nacross lines>>";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n<<text\nacross lines>>";
     let doc = decompose(markdown).unwrap();
     let body = doc.main().body();
     assert!(body.contains("<<text"));
@@ -1263,7 +1263,7 @@ fn test_multiline_chevrons_preserved() {
 
 #[test]
 fn test_unmatched_chevrons_preserved() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n<<unmatched";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n<<unmatched";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\n<<unmatched");
 }
@@ -1287,7 +1287,7 @@ fn test_missing_quill() {
 #[test]
 fn test_dashes_in_middle_of_line() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\nsome text --- more text";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\nsome text --- more text";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\nsome text --- more text");
 }
@@ -1296,8 +1296,8 @@ fn test_dashes_in_middle_of_line() {
 #[test]
 fn test_line_ending_normalization() {
     for markdown in [
-        "~~~card-yaml\r\n#@quill: test_quill\r\n#@kind: main\r\ntitle: Test\r\n~~~\r\n\r\nBody content.",
-        "~~~card-yaml\n#@quill: test_quill\r\n#@kind: main\r\ntitle: Test\r\n~~~\n\nBody.",
+        "~~~card-yaml\r\n@quill: test_quill\r\n@kind: main\r\ntitle: Test\r\n~~~\r\n\r\nBody content.",
+        "~~~card-yaml\n@quill: test_quill\r\n@kind: main\r\ntitle: Test\r\n~~~\n\nBody.",
     ] {
         let doc = decompose(markdown).unwrap();
         assert_eq!(
@@ -1309,7 +1309,7 @@ fn test_line_ending_normalization() {
 
 #[test]
 fn test_payload_at_eof_no_trailing_newline() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
@@ -1323,7 +1323,7 @@ fn test_payload_at_eof_no_trailing_newline() {
 #[test]
 fn test_unicode_in_yaml_keys() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitre: Bonjour\nタイトル: こんにちは\n~~~\n\nBody.";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitre: Bonjour\nタイトル: こんにちは\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
         doc.main().payload().get("titre").unwrap().as_str().unwrap(),
@@ -1343,7 +1343,7 @@ fn test_unicode_in_yaml_keys() {
 #[test]
 fn test_unicode_in_yaml_values() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: 你好世界 🎉\n~~~\n\nBody.";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: 你好世界 🎉\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
@@ -1354,7 +1354,7 @@ fn test_unicode_in_yaml_values() {
 #[test]
 fn test_unicode_in_body() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\n日本語テキスト with emoji 🚀";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\n日本語テキスト with emoji 🚀";
     let doc = decompose(markdown).unwrap();
     assert!(doc.main().body().contains("日本語テキスト"));
     assert!(doc.main().body().contains("🚀"));
@@ -1365,8 +1365,8 @@ fn test_unicode_in_body() {
 #[test]
 fn test_yaml_multiline_string() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 description: |
   This is a
   multiline string
@@ -1389,8 +1389,8 @@ Body.";
 #[test]
 fn test_yaml_folded_string() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 description: >
   This is a folded
   string that becomes
@@ -1411,14 +1411,14 @@ Body.";
 
 #[test]
 fn test_yaml_null_value() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\noptional: null\n~~~\n\nBody.";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\noptional: null\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert!(doc.main().payload().get("optional").unwrap().is_null());
 }
 
 #[test]
 fn test_yaml_empty_string_value() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nempty: \"\"\n~~~\n\nBody.";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\nempty: \"\"\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
         doc.main().payload().get("empty").unwrap().as_str().unwrap(),
@@ -1429,7 +1429,7 @@ fn test_yaml_empty_string_value() {
 #[test]
 fn test_yaml_special_characters_in_string() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nspecial: \"colon: here, and [brackets]\"\n~~~\n\nBody.";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\nspecial: \"colon: here, and [brackets]\"\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
         doc.main()
@@ -1445,8 +1445,8 @@ fn test_yaml_special_characters_in_string() {
 #[test]
 fn test_yaml_nested_objects() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 config:
   database:
     host: localhost
@@ -1474,12 +1474,12 @@ Body.";
 #[test]
 fn test_card_with_empty_body() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item
 ~~~";
     let doc = decompose(markdown).unwrap();
@@ -1491,17 +1491,17 @@ name: Item
 #[test]
 fn test_card_consecutive_blocks() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: a
+@kind: a
 id: 1
 ~~~
 
 ~~~card-yaml
-#@kind: a
+@kind: a
 id: 2
 ~~~";
     let doc = decompose(markdown).unwrap();
@@ -1513,12 +1513,12 @@ id: 2
 #[test]
 fn test_card_with_body_containing_dashes() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 ~~~
 
 ~~~card-yaml
-#@kind: items
+@kind: items
 name: Item
 ~~~
 
@@ -1532,14 +1532,14 @@ Some text with --- dashes in it.";
 
 #[test]
 fn test_quill_with_underscore_prefix() {
-    let markdown = "~~~card-yaml\n#@quill: _internal\n#@kind: main\n~~~\n\nBody.";
+    let markdown = "~~~card-yaml\n@quill: _internal\n@kind: main\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "_internal");
 }
 
 #[test]
 fn test_quill_with_numbers() {
-    let markdown = "~~~card-yaml\n#@quill: form_8_v2\n#@kind: main\n~~~\n\nBody.";
+    let markdown = "~~~card-yaml\n@quill: form_8_v2\n@kind: main\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.quill_reference().name, "form_8_v2");
 }
@@ -1547,8 +1547,8 @@ fn test_quill_with_numbers() {
 #[test]
 fn test_quill_with_additional_fields() {
     let markdown = "~~~card-yaml
-#@quill: my_quill
-#@kind: main
+@quill: my_quill
+@kind: main
 title: Document Title
 author: John Doe
 ~~~
@@ -1575,14 +1575,14 @@ Body content.";
 
 #[test]
 fn test_invalid_card_kind_names_are_rejected() {
-    // `#@kind` is name-validated at parse time against `[a-z_][a-z0-9_]*`.
+    // `@kind` is name-validated at parse time against `[a-z_][a-z0-9_]*`.
     for kind in ["ITEMS", "123items", "my-items", "Invalid-Name", ""] {
         let markdown = format!(
-            "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: {kind}\n~~~\n\nBody."
+            "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: {kind}\n~~~\n\nBody."
         );
         let err = decompose(&markdown).unwrap_err().to_string();
         assert!(
-            err.contains("Invalid `#@kind`"),
+            err.contains("Invalid `@kind`"),
             "kind {kind:?} should be rejected; got: {err}"
         );
     }
@@ -1590,14 +1590,14 @@ fn test_invalid_card_kind_names_are_rejected() {
 
 #[test]
 fn test_invalid_quill_ref_uppercase() {
-    let markdown = "~~~card-yaml\n#@quill: MyQuill\n#@kind: main\n~~~\n\nBody.";
+    let markdown = "~~~card-yaml\n@quill: MyQuill\n@kind: main\n~~~\n\nBody.";
     let result = decompose(markdown);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_yaml_syntax_error_missing_colon() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle Test\n~~~\n\nBody.";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle Test\n~~~\n\nBody.";
     let result = decompose(markdown);
     assert!(result.is_err());
 }
@@ -1605,7 +1605,7 @@ fn test_yaml_syntax_error_missing_colon() {
 #[test]
 fn test_yaml_syntax_error_bad_indentation() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nitems:\n- one\n - two\n~~~\n\nBody.";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\nitems:\n- one\n - two\n~~~\n\nBody.";
     let result = decompose(markdown);
     // Bad indentation may or may not be an error depending on YAML parser
     let _ = result;
@@ -1616,7 +1616,7 @@ fn test_yaml_syntax_error_bad_indentation() {
 #[test]
 fn test_body_with_leading_newlines() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\n\n\nBody with leading newlines.";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\n\n\nBody with leading newlines.";
     let doc = decompose(markdown).unwrap();
     assert!(doc.main().body().starts_with('\n'));
 }
@@ -1626,7 +1626,7 @@ fn test_body_with_trailing_newlines() {
     // Body at EOF: no blank-line separator to strip, source's trailing
     // newlines are preserved verbatim as authored content.
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\nBody.\n\n\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\nBody.\n\n\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\nBody.\n\n\n");
 }
@@ -1640,7 +1640,7 @@ fn test_blank_separator_strip_global_body_followed_by_card_lf() {
     // (content line terminator) + (blank-line separator). Strip exactly the
     // separator `\n`, leaving `\n` as the content terminator.
     let markdown =
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nbody\n\n~~~card-yaml\n#@kind: x\n~~~\n";
+        "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\nbody\n\n~~~card-yaml\n@kind: x\n~~~\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\nbody\n");
 }
@@ -1649,7 +1649,7 @@ fn test_blank_separator_strip_global_body_followed_by_card_lf() {
 fn test_blank_separator_strip_global_body_followed_by_card_crlf() {
     // CRLF line endings: strip exactly one `\r\n` as the blank-line separator.
     let markdown =
-        "~~~card-yaml\r\n#@quill: q\r\n#@kind: main\r\n~~~\r\n\r\nbody\r\n\r\n~~~card-yaml\r\n#@kind: x\r\n~~~\r\n";
+        "~~~card-yaml\r\n@quill: q\r\n@kind: main\r\n~~~\r\n\r\nbody\r\n\r\n~~~card-yaml\r\n@kind: x\r\n~~~\r\n";
     let doc = decompose(markdown).unwrap();
     assert!(
         doc.main().body().ends_with('\n') && !doc.main().body().ends_with("\n\n"),
@@ -1662,7 +1662,7 @@ fn test_blank_separator_strip_global_body_followed_by_card_crlf() {
 fn test_blank_separator_strip_card_body_followed_by_card() {
     // First card body is followed by another fence → separator stripped.
     // Last card body is at EOF → preserved verbatim.
-    let markdown = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: a\n~~~\n\nfirst\n\n~~~card-yaml\n#@kind: b\n~~~\n\nsecond\n";
+    let markdown = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: a\n~~~\n\nfirst\n\n~~~card-yaml\n@kind: b\n~~~\n\nsecond\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.cards()[0].body(), "\nfirst\n");
     assert_eq!(doc.cards()[1].body(), "\nsecond\n");
@@ -1673,7 +1673,7 @@ fn test_blank_separator_strip_preserves_author_blank_lines() {
     // Author wrote two blank lines after the body. Only the blank-line
     // separator (last `\n`) is stripped; the author's blank line is preserved.
     let markdown =
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nbody\n\n\n~~~card-yaml\n#@kind: x\n~~~\n";
+        "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\nbody\n\n\n~~~card-yaml\n@kind: x\n~~~\n";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "\nbody\n\n");
 }
@@ -1684,7 +1684,7 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
     // newlines (e.g. a code block with trailing blank lines) must survive
     // round-trip.
     let markdown =
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n```\ncode\n```\n\n\n~~~card-yaml\n#@kind: x\n~~~\n";
+        "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n```\ncode\n```\n\n\n~~~card-yaml\n@kind: x\n~~~\n";
     let doc = decompose(markdown).unwrap();
     let emitted = doc.to_markdown();
     let reparsed = Document::from_markdown(&emitted).unwrap();
@@ -1699,7 +1699,7 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
 
 #[test]
 fn test_no_body_after_payload() {
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.main().body(), "");
 }
@@ -1723,8 +1723,8 @@ fn test_kind_name_validator() {
 #[test]
 fn test_guillemet_in_yaml_preserves_non_strings() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 count: 42
 price: 19.99
 active: true
@@ -1756,7 +1756,7 @@ Body.";
 #[test]
 fn test_guillemet_double_conversion_prevention() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Already «converted»\n~~~\n\nBody.";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Already «converted»\n~~~\n\nBody.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
@@ -1767,13 +1767,13 @@ fn test_guillemet_double_conversion_prevention() {
 #[test]
 fn test_allowed_card_field_collision() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 my_card: \"some global value\"
 ~~~
 
 ~~~card-yaml
-#@kind: my_card
+@kind: my_card
 title: \"My Card\"
 ~~~
 
@@ -1805,8 +1805,8 @@ Body
 #[test]
 fn test_yaml_custom_tags_in_payload() {
     let markdown = "~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 memo_from: !fill 2d lt example
 regular_field: normal value
 ~~~
@@ -1838,8 +1838,8 @@ Body content.";
 #[test]
 fn test_spec_example() {
     let markdown = "~~~card-yaml
-#@quill: blog_post
-#@kind: main
+@quill: blog_post
+@kind: main
 title: My Document
 ~~~
 
@@ -1850,14 +1850,14 @@ Main document body.
 More content after horizontal rule.
 
 ~~~card-yaml
-#@kind: section
+@kind: section
 heading: Introduction
 ~~~
 
 Introduction content.
 
 ~~~card-yaml
-#@kind: section
+@kind: section
 heading: Conclusion
 ~~~
 
@@ -1919,7 +1919,7 @@ fn test_missing_quill_errors() {
 #[test]
 fn test_to_plate_json_simple() {
     let doc = Document::from_markdown(
-        "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Hello\n~~~\n\nBody text.\n",
+        "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Hello\n~~~\n\nBody text.\n",
     )
     .unwrap();
     let json = doc.to_plate_json();
@@ -1935,15 +1935,15 @@ fn test_to_plate_json_simple() {
 #[test]
 fn test_to_plate_json_with_cards() {
     let markdown = "~~~card-yaml
-#@quill: usaf_memo
-#@kind: main
+@quill: usaf_memo
+@kind: main
 title: Test
 ~~~
 
 Global body.
 
 ~~~card-yaml
-#@kind: indorsement
+@kind: indorsement
 for: ORG
 ~~~
 
@@ -1969,7 +1969,7 @@ Card body here.
 #[test]
 fn test_to_plate_json_quill_first() {
     let doc = Document::from_markdown(
-        "~~~card-yaml\n#@quill: my_quill\n#@kind: main\nfoo: bar\nbaz: qux\n~~~\n",
+        "~~~card-yaml\n@quill: my_quill\n@kind: main\nfoo: bar\nbaz: qux\n~~~\n",
     )
     .unwrap();
     let json = doc.to_plate_json();
@@ -1982,8 +1982,8 @@ fn test_to_plate_json_quill_first() {
 #[test]
 fn test_to_plate_json_fixture_snapshot() {
     let markdown = "~~~card-yaml
-#@quill: usaf_memo@0.1
-#@kind: main
+@quill: usaf_memo@0.1
+@kind: main
 memo_for:
   - ORG/SYMBOL
 date: 2504-10-05
@@ -1993,7 +1993,7 @@ subject: Subject of the Memorandum
 The body of the memorandum.
 
 ~~~card-yaml
-#@kind: indorsement
+@kind: indorsement
 for: ORG/SYMBOL
 from: ORG/SYMBOL
 ~~~
@@ -2027,7 +2027,7 @@ This body and the metadata above are an indorsement card.
 /// preserved.
 #[test]
 fn payload_field_order_preserved_after_quill_removal() {
-    let md = "~~~card-yaml\n#@quill: q\n#@kind: main\nsender: Alice\nrecipient: Bob\ndate: March 15\nsubject: hi\n~~~\n";
+    let md = "~~~card-yaml\n@quill: q\n@kind: main\nsender: Alice\nrecipient: Bob\ndate: March 15\nsubject: hi\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
     let keys: Vec<&str> = doc.main().payload().keys().map(|s| s.as_str()).collect();
     // Fields must appear in YAML document order, not alphabetical or swap-order.

--- a/crates/core/src/document/tests/card_fence_tests.rs
+++ b/crates/core/src/document/tests/card_fence_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the `~~~card-yaml` composable-card syntax.
 //!
 //! Coverage:
-//! - Composable cards declared with `#@kind:` parse to `Card`s; `#@kind` is optional.
+//! - Composable cards declared with `@kind:` parse to `Card`s; `@kind` is optional.
 //! - Every card round-trips to the canonical `~~~card-yaml` form.
 //! - Ordinary fenced code blocks and the blank-line rule for `~~~card-yaml` openers.
 //!
@@ -13,7 +13,7 @@ use crate::document::Document;
 
 #[test]
 fn card_fence_parses_kind_fields_and_body() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: product\nname: Widget\nprice: 19\n~~~\n\nWidget description.\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: product\nname: Widget\nprice: 19\n~~~\n\nWidget description.\n";
     let doc = Document::from_markdown(src).unwrap();
 
     assert_eq!(doc.cards().len(), 1);
@@ -25,7 +25,7 @@ fn card_fence_parses_kind_fields_and_body() {
 
 #[test]
 fn card_fence_empty_body_has_no_fields() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: marker\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: marker\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 1);
     assert!(doc.cards()[0].payload().is_empty());
@@ -34,7 +34,7 @@ fn card_fence_empty_body_has_no_fields() {
 
 #[test]
 fn card_fence_multiple_cards() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: product\nname: A\n~~~\n\n~~~card-yaml\n#@kind: product\nname: B\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: product\nname: A\n~~~\n\n~~~card-yaml\n@kind: product\nname: B\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 2);
     assert_eq!(
@@ -51,18 +51,18 @@ fn card_fence_multiple_cards() {
 
 #[test]
 fn emit_uses_canonical_card_fence() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: product\nname: Widget\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: product\nname: Widget\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
     assert_eq!(
         emitted,
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: product\nname: \"Widget\"\n~~~\n"
+        "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: product\nname: \"Widget\"\n~~~\n"
     );
 }
 
 #[test]
 fn emit_is_idempotent_for_card_fences() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: product\nname: Widget\n~~~\n\nTrailing body.\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: product\nname: Widget\n~~~\n\nTrailing body.\n";
     let doc = Document::from_markdown(src).unwrap();
     let once = doc.to_markdown();
     let twice = Document::from_markdown(&once).unwrap().to_markdown();
@@ -71,7 +71,7 @@ fn emit_is_idempotent_for_card_fences() {
 
 #[test]
 fn card_fence_body_round_trips() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nMain body.\n\n~~~card-yaml\n#@kind: product\nname: Widget\n~~~\n\nCard body.\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\nMain body.\n\n~~~card-yaml\n@kind: product\nname: Widget\n~~~\n\nCard body.\n";
     let a = Document::from_markdown(src).unwrap();
     let b = Document::from_markdown(&a.to_markdown()).unwrap();
     assert_eq!(a, b);
@@ -81,11 +81,11 @@ fn card_fence_body_round_trips() {
 
 #[test]
 fn card_fence_preserves_yaml_comments() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: product\n# a banner\nname: Widget\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: product\n# a banner\nname: Widget\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
     assert!(
-        emitted.contains("~~~card-yaml\n#@kind: product\n# a banner\nname: \"Widget\"\n~~~\n"),
+        emitted.contains("~~~card-yaml\n@kind: product\n# a banner\nname: \"Widget\"\n~~~\n"),
         "emit:\n{emitted}"
     );
     let reparsed = Document::from_markdown(&emitted).unwrap();
@@ -96,8 +96,8 @@ fn card_fence_preserves_yaml_comments() {
 
 #[test]
 fn card_fence_without_kind_is_allowed() {
-    // A composable block with no `#@kind` — `#@kind` is optional metadata.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\nname: Widget\n~~~\n";
+    // A composable block with no `@kind` — `@kind` is optional metadata.
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\nname: Widget\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].kind(), None);
@@ -107,7 +107,7 @@ fn card_fence_without_kind_is_allowed() {
 
 #[test]
 fn ordinary_code_fence_is_not_a_card() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n```rust\nlet x = 1;\n```\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n```rust\nlet x = 1;\n```\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
     assert!(doc.main().body().contains("```rust"));
@@ -116,7 +116,7 @@ fn ordinary_code_fence_is_not_a_card() {
 #[test]
 fn card_yaml_info_inside_outer_code_fence_is_not_a_card() {
     // A `~~~card-yaml` line shielded by an outer code fence is plain text.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n````text\n~~~card-yaml\n#@kind: product\nname: Widget\n~~~\n````\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n````text\n~~~card-yaml\n@kind: product\nname: Widget\n~~~\n````\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
 }
@@ -125,7 +125,7 @@ fn card_yaml_info_inside_outer_code_fence_is_not_a_card() {
 fn card_fence_without_blank_line_above_is_not_a_card() {
     // The blank-line rule fails — the `~~~card-yaml` fence is delegated to
     // CommonMark as a code block, with a non-fatal lint warning.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nSome prose.\n~~~card-yaml\n#@kind: product\nname: Widget\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\nSome prose.\n~~~card-yaml\n@kind: product\nname: Widget\n~~~\n";
     let out = Document::from_markdown_with_warnings(src).unwrap();
     assert_eq!(out.document.cards().len(), 0);
     assert!(out

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -11,14 +11,14 @@ use std::str::FromStr;
 
 fn make_doc() -> Document {
     Document::from_markdown(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hello\n~~~\n\nBody text.\n",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hello\n~~~\n\nBody text.\n",
     )
     .unwrap()
 }
 
 fn make_doc_with_cards() -> Document {
     Document::from_markdown(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Hello\n~~~\n\nBody.\n\n~~~card-yaml\n#@kind: note\nfoo: bar\n~~~\n\nCard body.\n\n~~~card-yaml\n#@kind: summary\n~~~\n",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Hello\n~~~\n\nBody.\n\n~~~card-yaml\n@kind: note\nfoo: bar\n~~~\n\nCard body.\n\n~~~card-yaml\n@kind: summary\n~~~\n",
     )
     .unwrap()
 }
@@ -371,7 +371,7 @@ fn test_move_card_to_out_of_range() {
 fn test_set_card_kind_renames_in_place() {
     let mut doc = make_doc_with_cards(); // note(0) with field foo=bar, summary(1)
     doc.set_card_kind(0, "annotation").unwrap();
-    // `#@kind` changed.
+    // `@kind` changed.
     assert_eq!(doc.cards()[0].kind(), Some("annotation"));
     // Payload and body untouched.
     assert_eq!(

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -130,8 +130,8 @@ fn fixture_corpus_round_trip() {
 fn emit_twice_is_byte_equal() {
     let src = "\
 ~~~card-yaml
-#@quill: test@1.0.0
-#@kind: main
+@quill: test@1.0.0
+@kind: main
 title: Stability Test
 flags:
   - on
@@ -157,44 +157,44 @@ Body content here.
 
 #[test]
 fn round_trip_booleans() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nflag_true: true\nflag_false: false\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nflag_true: true\nflag_false: false\n~~~\n";
     assert_round_trip("booleans", src);
 }
 
 #[test]
 fn round_trip_null() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nnull_field: null\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nnull_field: null\n~~~\n";
     assert_round_trip("null", src);
 }
 
 #[test]
 fn round_trip_numbers() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\ncount: 42\nfloat: 3.14\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\ncount: 42\nfloat: 3.14\n~~~\n";
     assert_round_trip("numbers", src);
 }
 
 #[test]
 fn round_trip_string_ambiguous() {
     // These are the strings most likely to be mis-parsed as booleans/numbers.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nfield_on: \"on\"\nfield_yes: \"yes\"\nfield_01234: \"01234\"\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nfield_on: \"on\"\nfield_yes: \"yes\"\nfield_01234: \"01234\"\n~~~\n";
     assert_round_trip("ambiguous strings", src);
 }
 
 #[test]
 fn round_trip_nested_map() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nsender:\n  name: Alice\n  city: Springfield\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nsender:\n  name: Alice\n  city: Springfield\n~~~\n";
     assert_round_trip("nested map", src);
 }
 
 #[test]
 fn round_trip_sequence() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\ntags:\n  - demo\n  - test\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\ntags:\n  - demo\n  - test\n~~~\n";
     assert_round_trip("sequence", src);
 }
 
 #[test]
 fn round_trip_empty_sequence() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nempty: []\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nempty: []\n~~~\n";
     assert_round_trip("empty sequence", src);
 }
 
@@ -202,15 +202,15 @@ fn round_trip_empty_sequence() {
 fn round_trip_cards() {
     let src = "\
 ~~~card-yaml
-#@quill: q
-#@kind: main
+@quill: q
+@kind: main
 title: Test
 ~~~
 
 Body text.
 
 ~~~card-yaml
-#@kind: section
+@kind: section
 heading: Chapter 1
 ~~~
 
@@ -223,13 +223,13 @@ Card body here.
 fn round_trip_card_empty_body() {
     let src = "\
 ~~~card-yaml
-#@quill: q
-#@kind: main
+@quill: q
+@kind: main
 title: Test
 ~~~
 
 ~~~card-yaml
-#@kind: empty_body_card
+@kind: empty_body_card
 title: No body
 ~~~
 ";
@@ -239,14 +239,14 @@ title: No body
 #[test]
 fn round_trip_string_with_escapes() {
     // String containing backslash and quotes — must survive as a string.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\npath: \"C:\\\\Users\\\\test\"\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\npath: \"C:\\\\Users\\\\test\"\n~~~\n";
     assert_round_trip("string with backslash", src);
 }
 
 #[test]
 fn round_trip_multiline_string() {
     // A string containing a literal newline.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nbio: \"Line one\\nLine two\"\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nbio: \"Line one\\nLine two\"\n~~~\n";
     assert_round_trip("multiline string", src);
 }
 
@@ -254,7 +254,7 @@ fn round_trip_multiline_string() {
 fn round_trip_quill_version_selectors() {
     for qref in &["q", "q@1", "q@1.2", "q@1.2.3", "q@latest"] {
         let src = format!(
-            "~~~card-yaml\n#@quill: {}\n#@kind: main\ntitle: t\n~~~\n",
+            "~~~card-yaml\n@quill: {}\n@kind: main\ntitle: t\n~~~\n",
             qref
         );
         assert_round_trip(&format!("quill ref {}", qref), &src);

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Both own-line and trailing inline YAML comments round-trip at their
 //! source position. Own-line comments in a block's payload (below the
-//! `#@quill` / `#@kind` metadata header) also round-trip. Comments whose
+//! `@quill` / `@kind` metadata header) also round-trip. Comments whose
 //! host disappears at emit
 //! time (empty-mapping omission, programmatic field removal) degrade to
 //! own-line comments at the same indent so the comment text is preserved
@@ -18,7 +18,7 @@ use crate::document::Document;
 #[test]
 fn top_level_comments_round_trip() {
     let src =
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n~~~\n\nBody.\n";
+        "~~~card-yaml\n@quill: q\n@kind: main\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n~~~\n\nBody.\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -47,7 +47,7 @@ fn top_level_comments_round_trip() {
 /// Trailing inline comments on top-level fields round-trip inline.
 #[test]
 fn top_level_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\ntitle: My Document # this is a comment\n~~~\n\nBody.\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\ntitle: My Document # this is a comment\n~~~\n\nBody.\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -82,7 +82,7 @@ fn top_level_inline_comments_round_trip() {
 #[test]
 fn custom_tags_lose_tag_but_keep_value() {
     // `!fill` case: round-trip with fill preserved.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nmemo_from: !fill 2d lt example\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nmemo_from: !fill 2d lt example\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
 
     let fm = doc.main().payload();
@@ -107,7 +107,7 @@ fn custom_tags_lose_tag_but_keep_value() {
     );
 
     // Non-`!fill` tag case: warning + dropped tag.
-    let src2 = "~~~card-yaml\n#@quill: q\n#@kind: main\nmemo_from: !include value.txt\n~~~\n";
+    let src2 = "~~~card-yaml\n@quill: q\n@kind: main\nmemo_from: !include value.txt\n~~~\n";
     let out = Document::from_markdown_with_warnings(src2).unwrap();
     assert!(
         out.warnings
@@ -127,7 +127,7 @@ fn custom_tags_lose_tag_but_keep_value() {
 /// `!fill` on a bare key (no value) emits `key: !fill` and preserves null.
 #[test]
 fn fill_tag_bare_null_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nrecipient: !fill\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nrecipient: !fill\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let fm = doc.main().payload();
@@ -147,7 +147,7 @@ fn fill_tag_bare_null_round_trip() {
 /// the fill marker.
 #[test]
 fn fill_tag_block_sequence_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nrecipient: !fill\n  - Dr. Who\n  - 1 TARDIS Lane\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nrecipient: !fill\n  - Dr. Who\n  - 1 TARDIS Lane\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let fm = doc.main().payload();
@@ -173,7 +173,7 @@ fn fill_tag_block_sequence_round_trip() {
 /// `!fill` on a flow sequence round-trips (normalised to block form).
 #[test]
 fn fill_tag_flow_sequence_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\ntags: !fill [a, b, c]\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\ntags: !fill [a, b, c]\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     let fm = doc.main().payload();
     assert!(fm.is_fill("tags"));
@@ -191,7 +191,7 @@ fn fill_tag_flow_sequence_round_trip() {
 /// `!fill` on an empty sequence round-trips as `key: !fill []`.
 #[test]
 fn fill_tag_empty_sequence_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nitems: !fill []\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nitems: !fill []\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     let fm = doc.main().payload();
     assert!(fm.is_fill("items"));
@@ -214,7 +214,7 @@ fn fill_tag_empty_sequence_round_trip() {
 /// `!fill` on a top-level mapping is rejected at parse.
 #[test]
 fn fill_tag_mapping_rejected() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nx: !fill {a: 1}\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nx: !fill {a: 1}\n~~~\n";
     let err = Document::from_markdown(src).unwrap_err();
     assert!(
         err.to_string().contains("!fill") && err.to_string().contains("mapping"),
@@ -227,7 +227,7 @@ fn fill_tag_mapping_rejected() {
 #[test]
 fn fill_tag_all_scalar_types_round_trip() {
     let src = concat!(
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n",
+        "~~~card-yaml\n@quill: q\n@kind: main\n",
         "s: !fill hello\n",
         "i: !fill 42\n",
         "f: !fill 3.14\n",
@@ -273,7 +273,7 @@ fn fill_tag_all_scalar_types_round_trip() {
 #[test]
 fn original_quoting_style_is_not_preserved() {
     // Mix of single-quoted, unquoted, and double-quoted strings.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nsingle_q: 'hello'\nunquoted: world\ndouble_q: \"already\"\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nsingle_q: 'hello'\nunquoted: world\ndouble_q: \"already\"\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -335,7 +335,7 @@ fn original_quoting_style_is_not_preserved() {
 #[test]
 fn nested_sequence_comments_round_trip() {
     let src =
-        "~~~card-yaml\n#@quill: q\n#@kind: main\nitems:\n  # before-first\n  - a\n  # between\n  - b\n  # after-last\n~~~\n";
+        "~~~card-yaml\n@quill: q\n@kind: main\nitems:\n  # before-first\n  - a\n  # between\n  - b\n  # after-last\n~~~\n";
 
     let out = Document::from_markdown_with_warnings(src).unwrap();
     assert!(
@@ -371,7 +371,7 @@ fn nested_sequence_comments_round_trip() {
 /// Comments inside nested mappings round-trip at the matching position.
 #[test]
 fn nested_mapping_comments_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nouter:\n  # leading\n  inner: 1\n  # trailing\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nouter:\n  # leading\n  inner: 1\n  # trailing\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -395,7 +395,7 @@ fn nested_mapping_comments_round_trip() {
 /// Trailing inline comments on nested sequence items round-trip inline.
 #[test]
 fn nested_sequence_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nitems:\n  - a # inline\n  - b\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nitems:\n  - a # inline\n  - b\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -414,7 +414,7 @@ fn nested_sequence_inline_comments_round_trip() {
 /// Trailing inline comments on nested mapping fields round-trip inline.
 #[test]
 fn nested_mapping_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nouter:\n  inner: 1 # tail\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nouter:\n  inner: 1 # tail\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -433,7 +433,7 @@ fn nested_mapping_inline_comments_round_trip() {
 /// line, before the indented children.
 #[test]
 fn inline_on_container_key_round_trips() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nouter: # describes outer\n  inner: 1\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nouter: # describes outer\n  inner: 1\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -448,17 +448,17 @@ fn inline_on_container_key_round_trips() {
     assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
-/// An own-line comment in the root payload — directly below the `#@quill`
+/// An own-line comment in the root payload — directly below the `@quill`
 /// metadata header — round-trips at its source position.
 #[test]
 fn root_payload_comment_round_trips() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n# main entry\ntitle: Hi\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n# main entry\ntitle: Hi\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
     assert!(
-        emitted.starts_with("~~~card-yaml\n#@quill: q\n#@kind: main\n# main entry\n"),
-        "own-line comment below the `#@quill` header must round-trip\nGot:\n{}",
+        emitted.starts_with("~~~card-yaml\n@quill: q\n@kind: main\n# main entry\n"),
+        "own-line comment below the `@quill` header must round-trip\nGot:\n{}",
         emitted
     );
 
@@ -467,18 +467,18 @@ fn root_payload_comment_round_trips() {
     assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
-/// An own-line comment in a card payload — directly below the `#@kind`
+/// An own-line comment in a card payload — directly below the `@kind`
 /// metadata header — round-trips at its source position.
 #[test]
 fn card_payload_comment_round_trips() {
     let src =
-        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: foo\n# the foo card\nx: 1\n~~~\n";
+        "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: foo\n# the foo card\nx: 1\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
     assert!(
-        emitted.contains("~~~card-yaml\n#@kind: foo\n# the foo card\n"),
-        "own-line comment below the `#@kind` header must round-trip\nGot:\n{}",
+        emitted.contains("~~~card-yaml\n@kind: foo\n# the foo card\n"),
+        "own-line comment below the `@kind` header must round-trip\nGot:\n{}",
         emitted
     );
 
@@ -490,7 +490,7 @@ fn card_payload_comment_round_trips() {
 /// Inline comment with `!fill` round-trips with the tag intact.
 #[test]
 fn fill_with_inline_comment_round_trips() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\ndept: !fill Sales # placeholder\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\ndept: !fill Sales # placeholder\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     assert!(
@@ -514,7 +514,7 @@ fn fill_with_inline_comment_round_trips() {
 /// item — all preserved in one document.
 #[test]
 fn mixed_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\ntitle: Hello # greeting\nitems:\n  - a # first\n  - b\nouter:\n  inner: 1 # nested tail\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\ntitle: Hello # greeting\nitems:\n  - a # first\n  - b\nouter:\n  inner: 1 # nested tail\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();
@@ -532,7 +532,7 @@ fn mixed_inline_comments_round_trip() {
 /// degrades to an own-line comment instead of being silently dropped.
 #[test]
 fn orphan_inline_after_remove_degrades_to_own_line() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nfield: value # tail\nother: 2\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nfield: value # tail\nother: 2\n~~~\n";
 
     let mut doc = Document::from_markdown(src).unwrap();
     // Remove the host field. The inline comment is now orphaned in items.
@@ -569,7 +569,7 @@ fn inline_on_empty_mapping_degrades_to_own_line() {
     use crate::QuillValue;
 
     // Construct programmatically since `key: {}` doesn't appear in source.
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n~~~\n";
     let mut doc = Document::from_markdown(src).unwrap();
     doc.main_mut()
         .payload_mut()
@@ -600,7 +600,7 @@ fn inline_on_empty_mapping_degrades_to_own_line() {
 /// Mixed: own-line and inline comments referencing the same field.
 #[test]
 fn own_line_then_inline_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\n# header\ntitle: Hi # tail\n# footer\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\n# header\ntitle: Hi # tail\n# footer\n~~~\n";
 
     let doc = Document::from_markdown(src).unwrap();
     let emitted = doc.to_markdown();

--- a/crates/core/src/document/tests/number_edge_tests.rs
+++ b/crates/core/src/document/tests/number_edge_tests.rs
@@ -26,7 +26,7 @@ fn assert_round_trip(label: &str, src: &str) {
 /// After round-trip the number value must be preserved.
 #[test]
 fn number_scientific_notation_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nbig: 1e10\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nbig: 1e10\n~~~\n";
     assert_round_trip("1e10", src);
 
     // The parsed value must be a number (not a string).
@@ -42,7 +42,7 @@ fn number_scientific_notation_round_trip() {
 /// `"1e10"` as a quoted string must round-trip as a string, not a float.
 #[test]
 fn string_that_looks_like_scientific_notation_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nbig: \"1e10\"\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nbig: \"1e10\"\n~~~\n";
     assert_round_trip("\"1e10\" string", src);
 
     let doc = Document::from_markdown(src).unwrap();
@@ -61,7 +61,7 @@ fn string_that_looks_like_scientific_notation_round_trip() {
 /// string.  Confirm it round-trips as a string.
 #[test]
 fn string_hex_like_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nhex: \"0x1F\"\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nhex: \"0x1F\"\n~~~\n";
     assert_round_trip("0x1F string", src);
 
     let doc = Document::from_markdown(src).unwrap();
@@ -79,7 +79,7 @@ fn string_hex_like_round_trip() {
 /// An integer beyond `i32::MAX` but within `i64::MAX` must round-trip correctly.
 #[test]
 fn large_integer_round_trip() {
-    let src = "~~~card-yaml\n#@quill: q\n#@kind: main\nbig_int: 9999999999999\n~~~\n";
+    let src = "~~~card-yaml\n@quill: q\n@kind: main\nbig_int: 9999999999999\n~~~\n";
     assert_round_trip("large integer", src);
 
     let doc = Document::from_markdown(src).unwrap();
@@ -128,7 +128,7 @@ fn emitted_number_representation_matches_parse() {
 
     for case in &cases {
         let src = format!(
-            "~~~card-yaml\n#@quill: q\n#@kind: main\n{}: {}\n~~~\n",
+            "~~~card-yaml\n@quill: q\n@kind: main\n{}: {}\n~~~\n",
             case.key, case.src_value
         );
         let doc = Document::from_markdown(&src).unwrap();

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -326,7 +326,7 @@ pub enum ParseError {
     EmptyInput(String),
 
     /// The document is missing its root `~~~card-yaml` block, or that block
-    /// does not declare the required `#@quill` system metadata.
+    /// does not declare the required `@quill` system metadata.
     ///
     /// Emitted as code `parse::missing_quill` so consumers can
     /// pattern-match without inspecting the message text.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,7 +18,7 @@
 //! use quillmark_core::Document;
 //!
 //! // Parse markdown with a card-yaml metadata block
-//! let markdown = "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Example\n~~~\n\n# Content";
+//! let markdown = "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Example\n~~~\n\n# Content";
 //! let doc = Document::from_markdown(markdown).unwrap();
 //! let title = doc.main()
 //!     .payload()

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -390,7 +390,7 @@ pub fn normalize_field_name(name: &str) -> String {
 /// ```no_run
 /// use quillmark_core::{Document, normalize::normalize_document};
 ///
-/// let markdown = "~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Example\n~~~\n\nBody with <<placeholder>>";
+/// let markdown = "~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Example\n~~~\n\nBody with <<placeholder>>";
 /// let doc = Document::from_markdown(markdown).unwrap();
 /// let normalized = normalize_document(doc).unwrap();
 /// ```
@@ -400,7 +400,7 @@ pub fn normalize_document(
     use crate::document::Document;
 
     // NFC-normalize main-card field names; values pass through verbatim.
-    // The `#@` system metadata passes through unchanged.
+    // The `@` system metadata passes through unchanged.
     let normalized_main_fm_map = normalize_fields(doc.main().payload().to_index_map());
     let normalized_main_body = normalize_markdown(doc.main().body());
     let main = Card::from_parts(
@@ -727,7 +727,7 @@ mod tests {
         use crate::document::Document;
 
         let doc = Document::from_markdown(
-            "~~~card-yaml\n#@quill: test\n#@kind: main\ntitle: <<placeholder>>\n~~~\n\n<<content>> \u{202D}**bold**",
+            "~~~card-yaml\n@quill: test\n@kind: main\ntitle: <<placeholder>>\n~~~\n\n<<content>> \u{202D}**bold**",
         )
         .unwrap();
         let normalized = super::normalize_document(doc).unwrap();
@@ -753,7 +753,7 @@ mod tests {
         use crate::document::Document;
 
         let doc =
-            Document::from_markdown("~~~card-yaml\n#@quill: custom_quill\n#@kind: main\n~~~\n")
+            Document::from_markdown("~~~card-yaml\n@quill: custom_quill\n@kind: main\n~~~\n")
                 .unwrap();
         let normalized = super::normalize_document(doc).unwrap();
 
@@ -765,7 +765,7 @@ mod tests {
         use crate::document::Document;
 
         let doc = Document::from_markdown(
-            "~~~card-yaml\n#@quill: test\n#@kind: main\n~~~\n\n<<content>>",
+            "~~~card-yaml\n@quill: test\n@kind: main\n~~~\n\n<<content>>",
         )
         .unwrap();
         let normalized_once = super::normalize_document(doc).unwrap();
@@ -782,7 +782,7 @@ mod tests {
         use crate::document::Document;
 
         let doc = Document::from_markdown(
-            "~~~card-yaml\n#@quill: test\n#@kind: main\n~~~\n\nhello\u{202D}world",
+            "~~~card-yaml\n@quill: test\n@kind: main\n~~~\n\nhello\u{202D}world",
         )
         .unwrap();
         let normalized = super::normalize_document(doc).unwrap();
@@ -794,7 +794,7 @@ mod tests {
         use crate::document::Document;
 
         let doc = Document::from_markdown(
-            "~~~card-yaml\n#@quill: test\n#@kind: main\ntitle: a\u{202D}b\n~~~\n",
+            "~~~card-yaml\n@quill: test\n@kind: main\ntitle: a\u{202D}b\n~~~\n",
         )
         .unwrap();
         let normalized = super::normalize_document(doc).unwrap();
@@ -815,7 +815,7 @@ mod tests {
     fn test_normalize_document_card_body_bidi_stripped() {
         use crate::document::Document;
 
-        let md = "~~~card-yaml\n#@quill: test\n#@kind: main\n~~~\n\nbody\n\n~~~card-yaml\n#@kind: note\n~~~\ncard\u{202D}body\n";
+        let md = "~~~card-yaml\n@quill: test\n@kind: main\n~~~\n\nbody\n\n~~~card-yaml\n@kind: note\n~~~\ncard\u{202D}body\n";
         let doc = Document::from_markdown(md).unwrap();
         assert_eq!(doc.cards().len(), 1, "expected 1 card");
         let normalized = super::normalize_document(doc).unwrap();
@@ -826,7 +826,7 @@ mod tests {
     fn test_normalize_document_card_field_bidi_preserved() {
         use crate::document::Document;
 
-        let md = "~~~card-yaml\n#@quill: test\n#@kind: main\n~~~\n\nbody\n\n~~~card-yaml\n#@kind: note\nname: Ali\u{202D}ce\n~~~\n";
+        let md = "~~~card-yaml\n@quill: test\n@kind: main\n~~~\n\nbody\n\n~~~card-yaml\n@kind: note\nname: Ali\u{202D}ce\n~~~\n";
         let doc = Document::from_markdown(md).unwrap();
         assert_eq!(doc.cards().len(), 1, "expected 1 card");
         let normalized = super::normalize_document(doc).unwrap();
@@ -845,7 +845,7 @@ mod tests {
     fn test_normalize_document_card_body_html_comment_repair() {
         use crate::document::Document;
 
-        let md = "~~~card-yaml\n#@quill: test\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: note\n~~~\n<!-- comment -->Trailing text\n";
+        let md = "~~~card-yaml\n@quill: test\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: note\n~~~\n<!-- comment -->Trailing text\n";
         let doc = Document::from_markdown(md).unwrap();
         let normalized = super::normalize_document(doc).unwrap();
         assert_eq!(
@@ -858,7 +858,7 @@ mod tests {
     fn test_normalize_document_toplevel_body_html_comment_repair() {
         use crate::document::Document;
 
-        let md = "~~~card-yaml\n#@quill: test\n#@kind: main\n~~~\n\n<!-- note -->Content here";
+        let md = "~~~card-yaml\n@quill: test\n@kind: main\n~~~\n\n<!-- note -->Content here";
         let doc = Document::from_markdown(md).unwrap();
         let normalized = super::normalize_document(doc).unwrap();
         assert_eq!(normalized.main().body(), "\n<!-- note -->\nContent here");

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -5,8 +5,8 @@
 //! constraints, examples — so a consumer can write a fresh document from it.
 //!
 //! Every block is a `~~~card-yaml` fence: the root block declares
-//! `#@quill: <name>@<version>` and each composable card declares
-//! `#@kind: <kind>` (see `MARKDOWN.md`).
+//! `@quill: <name>@<version>` and each composable card declares
+//! `@kind: <kind>` (see `MARKDOWN.md`).
 //!
 //! Annotation grammar:
 //! - **Leading `# …` lines** carry prose: `# <description>` (single line,
@@ -17,11 +17,11 @@
 //!   field. Format slot uses angle brackets (`array<string>`,
 //!   `date<YYYY-MM-DD>`, `enum<a | b | c>`). Role is `required` or
 //!   `optional`.
-//! - **Metadata annotation.** The `#@quill` / `#@kind` system-metadata lines
+//! - **Metadata annotation.** The `@quill` / `@kind` system-metadata lines
 //!   have no inline-annotation slot, so their role annotation
 //!   (`system metadata; required, verbatim` for the root block,
 //!   `composable (0..N)` for cards) is emitted as an own-line `# …` comment
-//!   directly under the `#@` line.
+//!   directly under the `@` line.
 //! - **Body regions** are signalled by `Write main body here.` after the main
 //!   fence and `Write <card kind> body here.` after each card fence. When
 //!   `body.example` is set, the example text is embedded verbatim instead.
@@ -88,9 +88,9 @@ fn write_comment(out: &mut String, text: &str) {
 }
 
 /// Emit the root block:
-/// `~~~card-yaml\n#@quill: …\n#@kind: main\n# system metadata; …\n[# desc\n]<fields>~~~\n`.
+/// `~~~card-yaml\n@quill: …\n@kind: main\n# system metadata; …\n[# desc\n]<fields>~~~\n`.
 ///
-/// The `#@quill` system-metadata line leads the block; the role annotation
+/// The `@quill` system-metadata line leads the block; the role annotation
 /// and the optional description follow as own-line comments.
 fn write_main_fence(
     out: &mut String,
@@ -99,10 +99,10 @@ fn write_main_fence(
     description: Option<&str>,
 ) {
     out.push_str("~~~card-yaml\n");
-    out.push_str("#@quill: ");
+    out.push_str("@quill: ");
     out.push_str(quill_ref);
     out.push('\n');
-    out.push_str("#@kind: main\n");
+    out.push_str("@kind: main\n");
     write_comment(out, "system metadata; required, verbatim");
     if let Some(desc) = description {
         write_comment(out, desc);
@@ -111,12 +111,12 @@ fn write_main_fence(
     out.push_str("~~~\n");
 }
 
-/// Emit a composable card as a `~~~card-yaml` block declaring `#@kind: <kind>`.
+/// Emit a composable card as a `~~~card-yaml` block declaring `@kind: <kind>`.
 /// The `composable (0..N)` role annotation and the optional description are
-/// emitted as own-line comments directly under the `#@kind` header.
+/// emitted as own-line comments directly under the `@kind` header.
 fn write_card_fence(out: &mut String, card: &CardSchema) {
     out.push_str("~~~card-yaml\n");
-    out.push_str("#@kind: ");
+    out.push_str("@kind: ");
     out.push_str(&card.name);
     out.push('\n');
     out.push_str("# composable (0..N)\n");
@@ -683,7 +683,7 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with(
-            "~~~card-yaml\n#@quill: taro@0.1.0\n#@kind: main\n# system metadata; required, verbatim\n# x\n"
+            "~~~card-yaml\n@quill: taro@0.1.0\n@kind: main\n# system metadata; required, verbatim\n# x\n"
         ));
         assert!(t.contains("\nWrite main body here.\n"));
     }
@@ -703,7 +703,7 @@ card_kinds:
 "#)
         .blueprint();
         assert!(t.contains(
-            "~~~card-yaml\n#@kind: note\n# composable (0..N)\n# A short note appended to the document.\n"
+            "~~~card-yaml\n@kind: note\n# composable (0..N)\n# A short note appended to the document.\n"
         ));
     }
 
@@ -721,7 +721,7 @@ card_kinds:
       items: { type: array, required: true }
 "#)
         .blueprint();
-        let after = &t[t.find("#@kind: skills").unwrap()..];
+        let after = &t[t.find("@kind: skills").unwrap()..];
         assert!(!after.contains("skills body"));
     }
 
@@ -740,7 +740,7 @@ card_kinds:
       author: { type: string }
 "#)
         .blueprint();
-        let after = &t[t.find("#@kind: note").unwrap()..];
+        let after = &t[t.find("@kind: note").unwrap()..];
         assert!(after.contains("\nThis is an example note.\n"));
         assert!(!after.contains("Write note body here."));
     }
@@ -788,7 +788,7 @@ main:
     notes: { type: string }
 "#)
         .blueprint();
-        let after_quill = &t[t.find("#@quill:").unwrap()..];
+        let after_quill = &t[t.find("@quill:").unwrap()..];
         // No banners emitted at all.
         assert!(!after_quill.contains("===="));
         // Order: ungrouped first, then groups in first-appearance order.

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -87,7 +87,7 @@ impl QuillConfig {
             &mut main_value,
             "QUILL",
             &canonical_ref,
-            "Canonical quill reference. Must be exactly this value as the #@quill system metadata in the root card-yaml block.",
+            "Canonical quill reference. Must be exactly this value as the @quill system metadata in the root card-yaml block.",
         );
         obj.insert("main".to_string(), main_value);
 
@@ -102,7 +102,7 @@ impl QuillConfig {
                         &mut card_value,
                         "CARD",
                         &card.name,
-                        "Card kind name. Must match the card kind in the card block's #@kind system metadata.",
+                        "Card kind name. Must match the card kind in the card block's @kind system metadata.",
                     );
                     (card.name.clone(), card_value)
                 })

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2283,7 +2283,7 @@ fn body_example_with_card_yaml_fence_line_is_an_error() {
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   body:
-    example: "Opening paragraph.\n\n~~~card-yaml\n#@kind: note\n~~~\n\nClosing paragraph."
+    example: "Opening paragraph.\n\n~~~card-yaml\n@kind: note\n~~~\n\nClosing paragraph."
   fields:
     title: { type: string }
 "#;
@@ -2362,7 +2362,7 @@ main:
 card_kinds:
   note:
     body:
-      example: "See below:\n~~~card-yaml\n#@kind: other\n~~~\nEnd."
+      example: "See below:\n~~~card-yaml\n@kind: other\n~~~\nEnd."
     fields:
       author: { type: string }
 "#;

--- a/crates/core/tests/markdown_field_test.rs
+++ b/crates/core/tests/markdown_field_test.rs
@@ -35,7 +35,7 @@ main:
 #[test]
 fn test_markdown_field_normalization() {
     // Create a document via from_markdown
-    let md = "~~~card-yaml\n#@quill: test\n#@kind: main\nmarkdown_field: This has <<guillemets>>\nstring_field: This has <<stripped>>\n~~~\n";
+    let md = "~~~card-yaml\n@quill: test\n@kind: main\nmarkdown_field: This has <<guillemets>>\nstring_field: This has <<stripped>>\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     // Normalize
@@ -56,7 +56,7 @@ fn test_markdown_field_normalization() {
 #[test]
 fn test_normalize_document_body_is_str_not_option() {
     // body() now returns &str (not Option<&str>)
-    let doc = Document::from_markdown("~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nHello body.")
+    let doc = Document::from_markdown("~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nHello body.")
         .unwrap();
     let normalized = normalize_document(doc).unwrap();
     assert!(normalized.main().body().contains("Hello body."));

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -10,7 +10,7 @@ use quillmark_core::Document;
 // A bare `---` thematic break inside body prose is not a metadata block.
 #[test]
 fn thematic_break_in_body_is_not_a_block() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nParagraph text.\n\n---\n\nAfter.";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nParagraph text.\n\n---\n\nAfter.";
     let doc = Document::from_markdown(md).unwrap();
     let body = doc.main().body();
     assert!(
@@ -21,18 +21,18 @@ fn thematic_break_in_body_is_not_a_block() {
     assert!(doc.cards().is_empty(), "no cards expected");
 }
 
-// The document's root card-yaml block must declare `#@quill:`.
+// The document's root card-yaml block must declare `@quill:`.
 #[test]
 fn first_block_without_quill_is_rejected() {
     let md = "~~~card-yaml\ntitle: X\n~~~\n\nBody.";
     let err = Document::from_markdown(md).unwrap_err().to_string();
-    assert!(err.contains("must declare `#@quill"), "got: {}", err);
+    assert!(err.contains("must declare `@quill"), "got: {}", err);
 }
 
 // YAML `#` comment lines inside a block are accepted as ordinary YAML.
 #[test]
 fn yaml_comment_banners_inside_block_are_accepted() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n# Essential\ntitle: T\n~~~\n\nBody.";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n# Essential\ntitle: T\n~~~\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
@@ -40,20 +40,20 @@ fn yaml_comment_banners_inside_block_are_accepted() {
     );
 }
 
-// A composable card-yaml block declares `#@kind:`.
+// A composable card-yaml block declares `@kind:`.
 #[test]
 fn composable_card_block_registers_a_card() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nB.\n\n~~~card-yaml\n#@kind: endorsement\nname: X\n~~~\n\nTrailing.";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nB.\n\n~~~card-yaml\n@kind: endorsement\nname: X\n~~~\n\nTrailing.";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].kind(), Some("endorsement"));
 }
 
-// A non-root block missing `#@kind:` is allowed — `#@kind` is optional
+// A non-root block missing `@kind:` is allowed — `@kind` is optional
 // metadata.
 #[test]
 fn non_root_block_without_kind_is_allowed() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nB.\n\n~~~card-yaml\nname: X\n~~~\n";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nB.\n\n~~~card-yaml\nname: X\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].kind(), None);
@@ -62,7 +62,7 @@ fn non_root_block_without_kind_is_allowed() {
 // `~~~card-yaml` inside an ordinary fenced code block must be ignored.
 #[test]
 fn fences_inside_code_blocks_are_ignored() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\n```\n~~~card-yaml\n#@kind: x\n~~~\n```\n\nBody.";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\n```\n~~~card-yaml\n@kind: x\n~~~\n```\n\nBody.";
     let doc = Document::from_markdown(md).unwrap();
     assert!(
         doc.cards().is_empty(),
@@ -75,7 +75,7 @@ fn fences_inside_code_blocks_are_ignored() {
 fn reserved_keys_in_payload_are_rejected() {
     for reserved in ["BODY", "CARDS"] {
         let md = format!(
-            "~~~card-yaml\n#@quill: t\n#@kind: main\n{}: nope\n~~~\n\nBody.",
+            "~~~card-yaml\n@quill: t\n@kind: main\n{}: nope\n~~~\n\nBody.",
             reserved
         );
         let err = Document::from_markdown(&md).unwrap_err().to_string();
@@ -92,17 +92,17 @@ fn reserved_keys_in_payload_are_rejected() {
 #[test]
 fn cards_is_always_present_even_when_empty() {
     let doc =
-        Document::from_markdown("~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nBody.").unwrap();
+        Document::from_markdown("~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nBody.").unwrap();
     assert!(doc.cards().is_empty());
 }
 
-// `#@kind:` is name-validated at parse time against `[a-z_][a-z0-9_]*`.
+// `@kind:` is name-validated at parse time against `[a-z_][a-z0-9_]*`.
 #[test]
 fn card_kind_is_name_validated() {
-    let bad = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nB.\n\n~~~card-yaml\n#@kind: ITEMS\n~~~\n\nX.";
+    let bad = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nB.\n\n~~~card-yaml\n@kind: ITEMS\n~~~\n\nX.";
     assert!(Document::from_markdown(bad).is_err());
 
-    let ok = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nB.\n\n~~~card-yaml\n#@kind: items\n~~~\n\nX.";
+    let ok = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nB.\n\n~~~card-yaml\n@kind: items\n~~~\n\nX.";
     let doc = Document::from_markdown(ok).unwrap();
     assert_eq!(doc.cards()[0].kind(), Some("items"));
 }
@@ -110,7 +110,7 @@ fn card_kind_is_name_validated() {
 // Body bidi stripped during normalize_document.
 #[test]
 fn normalize_body_strips_bidi() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nhi\u{202D}there";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nhi\u{202D}there";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     assert_eq!(doc.main().body(), "\nhithere");
@@ -119,7 +119,7 @@ fn normalize_body_strips_bidi() {
 // YAML scalar bidi NOT stripped.
 #[test]
 fn normalize_yaml_scalar_keeps_bidi() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\ntitle: hi\u{202D}there\n~~~\n";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\ntitle: hi\u{202D}there\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     assert_eq!(
@@ -131,7 +131,7 @@ fn normalize_yaml_scalar_keeps_bidi() {
 // Card body normalization reaches nested cards.
 #[test]
 fn normalize_reaches_card_body() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: x\n~~~\n\n<!-- c -->trailing\u{202D}text";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: x\n~~~\n\n<!-- c -->trailing\u{202D}text";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     let body = doc.cards()[0].body();
@@ -145,7 +145,7 @@ fn normalize_reaches_card_body() {
 // CRLF line endings in the body are canonicalized to LF.
 #[test]
 fn body_crlf_line_endings_are_normalized() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\nLine one.\r\nLine two.\r\n";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\nLine one.\r\nLine two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     let body = doc.main().body();
@@ -160,7 +160,7 @@ fn body_crlf_line_endings_are_normalized() {
 // CRLF normalization reaches card bodies.
 #[test]
 fn card_body_crlf_line_endings_are_normalized() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\n~~~card-yaml\n#@kind: x\n~~~\n\nCard line one.\r\nCard line two.\r\n";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\n~~~card-yaml\n@kind: x\n~~~\n\nCard line one.\r\nCard line two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
     let body = doc.cards()[0].body();
@@ -194,7 +194,7 @@ fn missing_root_block_is_rejected() {
 // A card-yaml block opened but never closed is a fatal error.
 #[test]
 fn unclosed_card_yaml_block_is_rejected() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\ntitle: T\n";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\ntitle: T\n";
     let err = Document::from_markdown(md).unwrap_err().to_string();
     assert!(err.contains("never closed with `~~~`"), "got: {}", err);
 }
@@ -204,7 +204,7 @@ fn unclosed_card_yaml_block_is_rejected() {
 #[test]
 fn card_fence_missing_blank_emits_warning() {
     let md =
-        "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\nBody line.\n~~~card-yaml\n#@kind: x\n~~~\n";
+        "~~~card-yaml\n@quill: t\n@kind: main\n~~~\nBody line.\n~~~card-yaml\n@kind: x\n~~~\n";
     let out = Document::from_markdown_with_warnings(md).unwrap();
     assert!(
         out.warnings
@@ -223,7 +223,7 @@ fn card_fence_missing_blank_emits_warning() {
 // Unclosed fenced code block at end-of-document emits a warning.
 #[test]
 fn unclosed_code_block_emits_warning() {
-    let md = "~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n\n```\ncode line\n\n~~~card-yaml\n#@kind: x\n~~~\n\ntrailing body";
+    let md = "~~~card-yaml\n@quill: t\n@kind: main\n~~~\n\n```\ncode line\n\n~~~card-yaml\n@kind: x\n~~~\n\ntrailing body";
     let out = Document::from_markdown_with_warnings(md).unwrap();
     assert!(
         out.warnings
@@ -245,7 +245,7 @@ fn unclosed_code_block_emits_warning() {
 // Per-block field-count cap.
 #[test]
 fn per_block_field_count_cap() {
-    let mut s = String::from("~~~card-yaml\n#@quill: t\n#@kind: main\n");
+    let mut s = String::from("~~~card-yaml\n@quill: t\n@kind: main\n");
     for i in 0..1001 {
         s.push_str(&format!("f{}: v\n", i));
     }
@@ -257,9 +257,9 @@ fn per_block_field_count_cap() {
 // Card count cap counts cards only.
 #[test]
 fn card_count_cap_is_per_card() {
-    let mut s = String::from("~~~card-yaml\n#@quill: t\n#@kind: main\n~~~\n");
+    let mut s = String::from("~~~card-yaml\n@quill: t\n@kind: main\n~~~\n");
     for _ in 0..1001 {
-        s.push_str("\n~~~card-yaml\n#@kind: x\n~~~\n\nB.\n");
+        s.push_str("\n~~~card-yaml\n@kind: x\n~~~\n\nB.\n");
     }
     let err = Document::from_markdown(&s).unwrap_err().to_string();
     assert!(err.contains("Input too large"), "got: {}", err);

--- a/crates/fixtures/resources/ambiguous_strings.md
+++ b/crates/fixtures/resources/ambiguous_strings.md
@@ -1,6 +1,6 @@
 ~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 on_word: "on"
 off_word: "off"
 yes_word: "yes"

--- a/crates/fixtures/resources/card_yaml_demo.md
+++ b/crates/fixtures/resources/card_yaml_demo.md
@@ -1,6 +1,6 @@
 ~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Quillmark Card-YAML Demo
 author: Quillmark Team
 date: 2024-01-01
@@ -28,7 +28,7 @@ Quillmark parses a **`~~~card-yaml` block** at the beginning of the document. Th
 - **YAML Parsing**: Supports standard YAML syntax in the payload
 - **Field Extraction**: All payload fields are available as dictionary entries
 - **Body Separation**: Only the markdown body (not the payload) gets converted
-- **System Metadata**: `#@quill` and `#@kind` are `#@`-prefixed metadata lines
+- **System Metadata**: `@quill` and `@kind` are `@`-prefixed metadata lines
 
 ## Example Usage
 

--- a/crates/fixtures/resources/extended_metadata_demo.md
+++ b/crates/fixtures/resources/extended_metadata_demo.md
@@ -1,6 +1,6 @@
 ~~~card-yaml
-#@quill: test_quill
-#@kind: main
+@quill: test_quill
+@kind: main
 title: Extended Metadata Demo
 author: Quillmark Team
 version: 1.0
@@ -13,15 +13,15 @@ The format isolates structured metadata from markdown prose using `~~~card-yaml`
 ## Features Demonstrated
 
 ~~~card-yaml
-#@kind: features
+@kind: features
 name: Tag Directives
 status: implemented
 ~~~
 
-Use the `~~~card-yaml` block syntax with a `#@kind:` metadata key to create collections of related items. Each card block creates an entry in an array.
+Use the `~~~card-yaml` block syntax with a `@kind:` metadata key to create collections of related items. Each card block creates an entry in an array.
 
 ~~~card-yaml
-#@kind: features
+@kind: features
 name: Structured Content
 status: implemented
 ~~~
@@ -29,7 +29,7 @@ status: implemented
 Break your document into logical sections with their own metadata. Perfect for catalogs, lists, and structured documents.
 
 ~~~card-yaml
-#@kind: features
+@kind: features
 name: Stable Generation
 status: stable
 ~~~
@@ -39,7 +39,7 @@ Isolating structured metadata from prose keeps LLM generation stable and prevent
 ## Use Cases
 
 ~~~card-yaml
-#@kind: use_cases
+@kind: use_cases
 category: Documentation
 example: Technical specifications with multiple sections
 ~~~
@@ -47,7 +47,7 @@ example: Technical specifications with multiple sections
 Perfect for API documentation, user manuals, and technical guides where you need structured metadata for each section.
 
 ~~~card-yaml
-#@kind: use_cases
+@kind: use_cases
 category: Content Management
 example: Product catalogs, blog posts, portfolios
 ~~~
@@ -58,6 +58,6 @@ Ideal for content-heavy sites where each item needs its own metadata (price, cat
 
 - **Card kind pattern**: `[a-z_][a-z0-9_]*`
 - **Blank lines**: Allowed within card-yaml blocks
-- **Card syntax**: a `~~~card-yaml` block declaring `#@kind: <kind>`, preceded by a blank line
+- **Card syntax**: a `~~~card-yaml` block declaring `@kind: <kind>`, preceded by a blank line
 - **Reserved names**: Cannot use `QUILL`, `CARD`, `BODY`, or `CARDS` as field names
 - **Collections**: The same card kind creates an array of objects

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -3,7 +3,9 @@ main:
     QUILL:
       type: string
       const: usaf_memo@0.1.0
-      description: "Canonical quill reference. Must be exactly this value as the #@quill system metadata in the root card-yaml block."
+      description: >-
+        Canonical quill reference. Must be exactly this value as the @quill system
+        metadata in the root card-yaml block.
       required: true
     attachments:
       type: array
@@ -150,7 +152,9 @@ card_kinds:
       CARD:
         type: string
         const: indorsement
-        description: "Card kind name. Must match the card kind in the card block's #@kind system metadata."
+        description: >-
+          Card kind name. Must match the card kind in the card block's @kind system
+          metadata.
         required: true
       attachments:
         type: array

--- a/crates/fixtures/resources/versioned_letter_latest.md
+++ b/crates/fixtures/resources/versioned_letter_latest.md
@@ -1,6 +1,6 @@
 ~~~card-yaml
-#@quill: business_letter@latest
-#@kind: main
+@quill: business_letter@latest
+@kind: main
 sender:
   name: Alice Johnson
   title: Engineering Manager

--- a/crates/fixtures/resources/versioned_resume_exact.md
+++ b/crates/fixtures/resources/versioned_resume_exact.md
@@ -1,6 +1,6 @@
 ~~~card-yaml
-#@quill: classic_resume@2.1
-#@kind: main
+@quill: classic_resume@2.1
+@kind: main
 name: Jane Doe
 email: jane.doe@example.com
 phone: (555) 123-4567

--- a/crates/fixtures/resources/versioned_resume_major.md
+++ b/crates/fixtures/resources/versioned_resume_major.md
@@ -1,6 +1,6 @@
 ~~~card-yaml
-#@quill: classic_resume@2
-#@kind: main
+@quill: classic_resume@2
+@kind: main
 name: John Smith
 email: john.smith@example.com
 phone: (555) 987-6543

--- a/crates/fuzz/src/emit_roundtrip_fuzz.rs
+++ b/crates/fuzz/src/emit_roundtrip_fuzz.rs
@@ -62,7 +62,7 @@ proptest! {
         );
     }
 
-    /// Inputs that look like a valid card-yaml block with a `#@quill:` metadata key.
+    /// Inputs that look like a valid card-yaml block with a `@quill:` metadata key.
     #[test]
     fn fuzz_emit_roundtrip_payload_shaped(
         quill in "[a-z][a-z0-9_]{0,20}",
@@ -70,7 +70,7 @@ proptest! {
         value in "\\PC{0,100}"
     ) {
         // Build a minimal Quillmark document.
-        let src = format!("~~~card-yaml\n#@quill: {}\n#@kind: main\n{}: \"{}\"\n~~~\n\nBody.\n",
+        let src = format!("~~~card-yaml\n@quill: {}\n@kind: main\n{}: \"{}\"\n~~~\n\nBody.\n",
             quill, key, value.replace('\\', "\\\\").replace('"', "\\\""));
 
         let doc_a = match Document::from_markdown(&src) {
@@ -111,7 +111,7 @@ proptest! {
         card_value in "[a-zA-Z0-9 ]{0,50}"
     ) {
         let src = format!(
-            "~~~card-yaml\n#@quill: {}\n#@kind: main\ntitle: \"test\"\n~~~\n\nBody here.\n\n~~~card-yaml\n#@kind: {}\n{}: \"{}\"\n~~~\n\nCard body.\n",
+            "~~~card-yaml\n@quill: {}\n@kind: main\ntitle: \"test\"\n~~~\n\nBody here.\n\n~~~card-yaml\n@kind: {}\n{}: \"{}\"\n~~~\n\nCard body.\n",
             quill, card_kind, card_key, card_value
         );
 

--- a/crates/fuzz/src/parse_fuzz.rs
+++ b/crates/fuzz/src/parse_fuzz.rs
@@ -35,7 +35,7 @@ proptest! {
     ) {
         // Test with a well-formed root card-yaml block
         let markdown = format!(
-            "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: {}\nauthor: {}\n~~~\n\n{}",
+            "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: {}\nauthor: {}\n~~~\n\n{}",
             title, author, content
         );
 
@@ -46,10 +46,10 @@ proptest! {
 
     #[test]
     fn fuzz_decompose_card_kinds(kind_name in "[a-z][a-z0-9_]{0,19}") {
-        // Test composable card parsing with a `#@kind` discriminator
+        // Test composable card parsing with a `@kind` discriminator
         let markdown = format!(
-            "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n\
-             ~~~card-yaml\n#@kind: {}\nfield: data\n~~~\n\nContent",
+            "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n\
+             ~~~card-yaml\n@kind: {}\nfield: data\n~~~\n\nContent",
             kind_name
         );
 
@@ -64,7 +64,7 @@ proptest! {
     #[test]
     fn fuzz_decompose_malformed_yaml(s in "[^a-zA-Z0-9\\s]{1,50}") {
         // Test with potentially malformed YAML in the payload
-        let markdown = format!("~~~card-yaml\n#@quill: test_quill\n#@kind: main\n{}\n~~~\n\nContent", s);
+        let markdown = format!("~~~card-yaml\n@quill: test_quill\n@kind: main\n{}\n~~~\n\nContent", s);
         let _ = Document::from_markdown(&markdown);
         // Should handle errors gracefully
     }
@@ -77,7 +77,7 @@ proptest! {
             .collect();
         let payload = fields.join("\n");
         let markdown =
-            format!("~~~card-yaml\n#@quill: test_quill\n#@kind: main\n{}\n~~~\n\nContent", payload);
+            format!("~~~card-yaml\n@quill: test_quill\n@kind: main\n{}\n~~~\n\nContent", payload);
 
         let result = Document::from_markdown(&markdown);
         if let Ok(doc) = result {
@@ -97,7 +97,7 @@ proptest! {
         yaml.push_str(&format!("{}value: data", "  ".repeat(depth + 1)));
 
         let markdown =
-            format!("~~~card-yaml\n#@quill: test_quill\n#@kind: main\n{}\n~~~\n\nContent", yaml);
+            format!("~~~card-yaml\n@quill: test_quill\n@kind: main\n{}\n~~~\n\nContent", yaml);
         let _ = Document::from_markdown(&markdown);
     }
 }
@@ -109,7 +109,7 @@ proptest! {
     fn fuzz_decompose_special_characters(s in "[\\\\\"'`$#*_\\[\\]<>@\\n\\r\\t]{0,100}") {
         // Test with special characters in body content
         let markdown =
-            format!("~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\n{}", s);
+            format!("~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\n{}", s);
         let result = Document::from_markdown(&markdown);
 
         if let Ok(doc) = result {
@@ -123,7 +123,7 @@ proptest! {
     fn fuzz_decompose_unicode(s in "\\PC{0,100}") {
         // Test with Unicode body content
         let markdown =
-            format!("~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\n{}", s);
+            format!("~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\n{}", s);
         let result = Document::from_markdown(&markdown);
 
         if let Ok(doc) = result {
@@ -134,11 +134,11 @@ proptest! {
     #[test]
     fn fuzz_decompose_multiple_cards(count in 1usize..10) {
         // Test with multiple composable card blocks
-        let mut markdown = String::from("~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n");
+        let mut markdown = String::from("~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n");
 
         for i in 0..count {
             markdown.push_str(&format!(
-                "~~~card-yaml\n#@kind: section{}\ndata: value{}\n~~~\n\nContent {}\n\n",
+                "~~~card-yaml\n@kind: section{}\ndata: value{}\n~~~\n\nContent {}\n\n",
                 i, i, i
             ));
         }

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -44,7 +44,7 @@ main:
 "#,
     );
 
-    let md = "~~~card-yaml\n#@quill: form_test\n#@kind: main\ntitle: \"My Title\"\nstatus: \"final\"\n~~~\n";
+    let md = "~~~card-yaml\n@quill: form_test\n@kind: main\ntitle: \"My Title\"\nstatus: \"final\"\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
@@ -99,7 +99,7 @@ main:
     // `title` is required — that produces a validation diagnostic.
     // `status` is absent but has a default.
     // `notes` is absent and has no default.
-    let md = "~~~card-yaml\n#@quill: form_defaults_test\n#@kind: main\n~~~\n";
+    let md = "~~~card-yaml\n@quill: form_defaults_test\n@kind: main\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
@@ -151,9 +151,9 @@ card_kinds:
 "#,
     );
 
-    let md = "~~~card-yaml\n#@quill: unknown_card_test\n#@kind: main\ntitle: \"T\"\n~~~\n\n\
-              ~~~card-yaml\n#@kind: known_card\nnote: \"A\"\n~~~\n\n\
-              ~~~card-yaml\n#@kind: ghost_card\nnote: \"B\"\n~~~\n";
+    let md = "~~~card-yaml\n@quill: unknown_card_test\n@kind: main\ntitle: \"T\"\n~~~\n\n\
+              ~~~card-yaml\n@kind: known_card\nnote: \"A\"\n~~~\n\n\
+              ~~~card-yaml\n@kind: ghost_card\nnote: \"B\"\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
@@ -205,8 +205,8 @@ card_kinds:
     );
 
     // signature_block present, office absent (has default), extra absent (no default)
-    let md = "~~~card-yaml\n#@quill: card_fields_test\n#@kind: main\ntitle: \"T\"\n~~~\n\n\
-              ~~~card-yaml\n#@kind: indorsement\nsignature_block: \"Col Smith\"\n~~~\n";
+    let md = "~~~card-yaml\n@quill: card_fields_test\n@kind: main\ntitle: \"T\"\n~~~\n\n\
+              ~~~card-yaml\n@kind: indorsement\nsignature_block: \"Col Smith\"\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
@@ -251,7 +251,7 @@ main:
 
     // `count` is a string, not an integer → TypeMismatch validation error
     let md =
-        "~~~card-yaml\n#@quill: validation_diag_test\n#@kind: main\ncount: \"not-a-number\"\n~~~\n";
+        "~~~card-yaml\n@quill: validation_diag_test\n@kind: main\ncount: \"not-a-number\"\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
@@ -289,7 +289,7 @@ main:
 "#,
     );
 
-    let md = "~~~card-yaml\n#@quill: serial_test\n#@kind: main\ntitle: \"Hello\"\n~~~\n";
+    let md = "~~~card-yaml\n@quill: serial_test\n@kind: main\ntitle: \"Hello\"\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
     let form = quill.form(&doc);
 

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -11,7 +11,7 @@
 //! let engine = Quillmark::new();
 //! let quill = engine.quill_from_path("path/to/quill").unwrap();
 //!
-//! let parsed = Document::from_markdown("~~~card-yaml\n#@quill: my_quill\n#@kind: main\ntitle: Hello\n~~~\n\n# Hello World").unwrap();
+//! let parsed = Document::from_markdown("~~~card-yaml\n@quill: my_quill\n@kind: main\ntitle: Hello\n~~~\n\n# Hello World").unwrap();
 //! let result = quill.render(&parsed, &RenderOptions {
 //!     output_format: Some(OutputFormat::Pdf),
 //!     ..Default::default()

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -106,7 +106,7 @@ fn test_render_with_custom_backend() {
     assert!(quill.supported_formats().contains(&OutputFormat::Txt));
 
     let markdown =
-        "~~~card-yaml\n#@quill: custom_backend_quill\n#@kind: main\ntitle: Hello Custom Backend\n~~~\n\n# Test\n";
+        "~~~card-yaml\n@quill: custom_backend_quill\n@kind: main\ntitle: Hello Custom Backend\n~~~\n\n# Test\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
     let result = quill
         .render(

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -47,7 +47,7 @@ main:
         .expect("quill_from_path failed");
 
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: My Document\n~~~\n\n# Content\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: My Document\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);
@@ -85,7 +85,7 @@ main:
         .expect("quill_from_path failed");
 
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: My Document\nstatus: published\n~~~\n\n# Content\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: My Document\nstatus: published\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);
@@ -123,7 +123,7 @@ main:
         .quill_from_path(&quill_path)
         .expect("quill_from_path failed");
 
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n# Content";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n# Content";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let dry_run_result = quill.dry_run(&parsed);
@@ -162,7 +162,7 @@ main:
         .expect("quill_from_path failed");
 
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nstatus: published\n~~~\n\n# Content\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\nstatus: published\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -36,7 +36,7 @@ fn test_dry_run_success() {
         .expect("quill_from_path failed");
 
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: My Document\nauthor: Test\n~~~\n\n# Content\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: My Document\nauthor: Test\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);
@@ -54,7 +54,7 @@ fn test_dry_run_missing_required_field() {
         .expect("quill_from_path failed");
 
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nauthor: Test\n~~~\n\n# Content\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\nauthor: Test\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);
@@ -82,7 +82,7 @@ fn test_dry_run_no_schema() {
         .quill_from_path(&quill_path)
         .expect("quill_from_path failed");
 
-    let markdown = "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nrandom_field: anything\n~~~\n\n# Content\n";
+    let markdown = "~~~card-yaml\n@quill: test_quill\n@kind: main\nrandom_field: anything\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -82,7 +82,7 @@ fn test_quill_engine_end_to_end() {
         .expect("quill_from_path failed");
 
     let markdown =
-        "~~~card-yaml\n#@quill: my_test_quill\n#@kind: main\ntitle: Test Document\n~~~\n\n# Introduction\n";
+        "~~~card-yaml\n@quill: my_test_quill\n@kind: main\ntitle: Test Document\n~~~\n\n# Introduction\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
     let result = quill.dry_run(&parsed);
@@ -99,7 +99,7 @@ fn test_quill_render_succeeds_with_engine_loaded_quill() {
     let quill = engine
         .quill_from_path(quill_path)
         .expect("quill_from_path failed");
-    let parsed = Document::from_markdown("~~~card-yaml\n#@quill: my_quill\n#@kind: main\n~~~\n")
+    let parsed = Document::from_markdown("~~~card-yaml\n@quill: my_quill\n@kind: main\n~~~\n")
         .expect("parse failed");
     let result = quill.render(
         &parsed,

--- a/crates/quillmark/tests/security_tests.rs
+++ b/crates/quillmark/tests/security_tests.rs
@@ -15,7 +15,7 @@ fn test_yaml_depth_limit_attack() {
         deep_yaml.push_str("a:\n");
     }
     let markdown = format!(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n{}~~~\n\nBody",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\n{}~~~\n\nBody",
         deep_yaml
     );
     let result = Document::from_markdown(&markdown);
@@ -35,11 +35,11 @@ fn test_yaml_depth_limit_attack() {
 fn test_card_count_limit_attack() {
     // Generate more than MAX_CARD_COUNT (1000) card blocks
     let mut markdown = String::from(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\nBody\n\n",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\nBody\n\n",
     );
     for i in 0..1002 {
         markdown.push_str(&format!(
-            "~~~card-yaml\n#@kind: item{}\nvalue: {}\n~~~\n\n",
+            "~~~card-yaml\n@kind: item{}\nvalue: {}\n~~~\n\n",
             i, i
         ));
     }
@@ -68,7 +68,7 @@ fn test_typst_injection_via_special_chars() {
 
     for input in malicious_inputs {
         let markdown = format!(
-            "~~~card-yaml\n#@quill: test_quill\n#@kind: main\n~~~\n\n{}",
+            "~~~card-yaml\n@quill: test_quill\n@kind: main\n~~~\n\n{}",
             input
         );
         let result = Document::from_markdown(&markdown);
@@ -86,7 +86,7 @@ fn test_typst_injection_via_special_chars() {
 fn test_input_size_limit() {
     let large_content = "a".repeat(11 * 1024 * 1024); // 11 MB
     let markdown = format!(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Large\n~~~\n\n{}",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Large\n~~~\n\n{}",
         large_content
     );
     let result = Document::from_markdown(&markdown);
@@ -105,7 +105,7 @@ fn test_input_size_limit() {
 fn test_yaml_size_limit() {
     let large_value = "x".repeat(1024 * 1024 + 100);
     let markdown = format!(
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ndata: {}\n~~~\n\nBody",
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ndata: {}\n~~~\n\nBody",
         large_value
     );
     let result = Document::from_markdown(&markdown);
@@ -124,11 +124,11 @@ fn test_yaml_size_limit() {
 fn test_reserved_field_injection() {
     let reserved_tests = vec![
         (
-            "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nBODY: injected\n~~~\n\nBody",
+            "~~~card-yaml\n@quill: test_quill\n@kind: main\nBODY: injected\n~~~\n\nBody",
             "BODY",
         ),
         (
-            "~~~card-yaml\n#@quill: test_quill\n#@kind: main\nCARDS: []\n~~~\n\nBody",
+            "~~~card-yaml\n@quill: test_quill\n@kind: main\nCARDS: []\n~~~\n\nBody",
             "CARDS",
         ),
     ];
@@ -151,7 +151,7 @@ fn test_reserved_field_injection() {
 
 /// Test that card kind validation prevents invalid names via the edit API.
 ///
-/// `#@kind` is now opaque system metadata at parse time, so `from_markdown`
+/// `@kind` is now opaque system metadata at parse time, so `from_markdown`
 /// no longer validates kind names. The `[a-z_][a-z0-9_]*` rule is still
 /// enforced by the structural edit API (`Card::new`), which is what this
 /// test now exercises.
@@ -173,7 +173,7 @@ fn test_card_name_validation() {
 #[test]
 fn test_yaml_error_location() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\nBody\n\n~~~card-yaml\n#@kind: test\ninvalid yaml: {\n~~~\n\n";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\nBody\n\n~~~card-yaml\n@kind: test\ninvalid yaml: {\n~~~\n\n";
     let result = Document::from_markdown(markdown);
 
     assert!(result.is_err(), "Should reject invalid YAML");
@@ -189,7 +189,7 @@ fn test_yaml_error_location() {
 #[test]
 fn test_strict_fence_detection() {
     let markdown =
-        "~~~card-yaml\n#@quill: test_quill\n#@kind: main\ntitle: Test\n~~~\n\n````\n~~~card-yaml\n#@kind: test\nvalue: 1\n~~~\n````";
+        "~~~card-yaml\n@quill: test_quill\n@kind: main\ntitle: Test\n~~~\n\n````\n~~~card-yaml\n@kind: test\nvalue: 1\n~~~\n````";
     let result = Document::from_markdown(markdown);
 
     assert!(result.is_ok(), "Should parse successfully: {:?}", result);

--- a/docs/authoring/card-yaml.md
+++ b/docs/authoring/card-yaml.md
@@ -7,8 +7,8 @@ to render the document; later blocks are composable [cards](cards.md).
 
 ```
 ~~~card-yaml
-#@quill: my_format
-#@kind: main
+@quill: my_format
+@kind: main
 title: My Document
 author: Jane Doe
 date: 2025-01-15
@@ -25,11 +25,11 @@ A card-yaml block has four parts, in order:
 1. **Opening fence** — exactly `~~~card-yaml` (three tildes plus the info
    string). No leading indentation. The info string alone identifies a
    metadata block.
-2. **System metadata header** — an optional leading run of `#@key: value`
-   lines inside the block. The root block must declare `#@quill`; all other
-   `#@` entries are optional.
+2. **System metadata header** — an optional leading run of `@key: value`
+   lines inside the block. The root block must declare `@quill`; all other
+   `@` entries are optional.
 3. **Data payload** — standard YAML key/value pairs directly below the
-   `#@` header.
+   `@` header.
 4. **Closing fence** — exactly `~~~`.
 
 The unstructured Markdown body begins immediately after the closing `~~~`
@@ -40,34 +40,34 @@ A blank line is required immediately above every `~~~card-yaml` opener,
 `~~~card-yaml` line without a blank line above it is **not** an opener — it is
 treated as an ordinary code block.
 
-## System Metadata (`#@`)
+## System Metadata (`@`)
 
 A block may begin with a **system metadata header** — an optional leading run
-of `#@key: value` lines. These lines carry no parser semantics; they are kept
+of `@key: value` lines. These lines carry no parser semantics; they are kept
 out of the YAML payload's user field set.
 
-- **`#@quill: <name>@<version>`** names the format used to render the
+- **`@quill: <name>@<version>`** names the format used to render the
   document. The root block (the first block, identified by position) **must
-  declare `#@quill`** — it is the only required `#@` entry. If the root block
-  is missing `#@quill`, parsing fails.
-- **`#@kind: <kind>`** is optional metadata identifying a card's kind. There
+  declare `@quill`** — it is the only required `@` entry. If the root block
+  is missing `@quill`, parsing fails.
+- **`@kind: <kind>`** is optional metadata identifying a card's kind. There
   is no reserved kind, but `<kind>` must match `[a-z_][a-z0-9_]*` — an invalid
   kind is a parse error.
-- **`#@id: <value>`** is an opaque, optional identifier — plain metadata with
+- **`@id: <value>`** is an opaque, optional identifier — plain metadata with
   no validation or uniqueness requirement, carried through the round-trip.
 
-`#@` header lines may appear in any order; the emitter preserves their source
-order. A duplicate `#@key` within a single block, or a malformed `#@` line, is
+`@` header lines may appear in any order; the emitter preserves their source
+order. A duplicate `@key` within a single block, or a malformed `@` line, is
 a parse error.
 
 ### Version Selectors
 
-Pin a specific version with `@version` syntax on the `#@quill` line:
+Pin a specific version with `@version` syntax on the `@quill` line:
 
 ```
 ~~~card-yaml
-#@quill: my_format@2.1
-#@kind: main
+@quill: my_format@2.1
+@kind: main
 title: Document Title
 ~~~
 ```
@@ -85,7 +85,7 @@ underscores; must start with a lowercase letter).
 
 ## Payload Data Types
 
-The data payload below the `#@` metadata header is standard YAML.
+The data payload below the `@` metadata header is standard YAML.
 
 **Strings:**
 ```yaml
@@ -140,7 +140,7 @@ YAML comments are supported in the payload and round-trip through
 title: My Document  # an inline comment
 ```
 
-Comments are **not** supported on a `#@` header line itself.
+Comments are **not** supported on a `@` header line itself.
 
 ## Placeholder Fields (`!fill`)
 
@@ -163,17 +163,17 @@ dropped with a warning.
 `QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and cannot be used as field
 names — the parser rejects documents that include them. `BODY` holds the
 block's Markdown body; `CARDS` holds the array of card blocks; `QUILL` and
-`CARD` hold the values declared by the `#@quill` and `#@kind` metadata.
+`CARD` hold the values declared by the `@quill` and `@kind` metadata.
 
 ## Card Blocks
 
 Every card-yaml block after the root block is a **card**. It may carry a
-`#@kind: <kind>` metadata line, where `<kind>` matches `[a-z_][a-z0-9_]*`. All
+`@kind: <kind>` metadata line, where `<kind>` matches `[a-z_][a-z0-9_]*`. All
 card blocks are collected into the `CARDS` array available to templates.
 
 ```
 ~~~card-yaml
-#@kind: endorsement
+@kind: endorsement
 from: ORG/SYMBOL
 for: ORG2/SYMBOL
 ~~~
@@ -186,8 +186,8 @@ See [Cards](cards.md) for details on card syntax and usage.
 ## Emission
 
 `toMarkdown` always emits the canonical block form — a `~~~card-yaml` opener,
-the `#@` metadata lines in source order, the YAML payload, and a `~~~` closer.
-The root block's header includes `#@quill`; other blocks emit whatever `#@`
+the `@` metadata lines in source order, the YAML payload, and a `~~~` closer.
+The root block's header includes `@quill`; other blocks emit whatever `@`
 entries they declared, or none. Fence markers, key ordering, and YAML quoting
 are normalised; `!fill` tags and payload comments survive the round-trip.
 

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -6,14 +6,14 @@ with the Markdown prose that follows it.
 
 ## Card Block Syntax
 
-A card is a `~~~card-yaml` block, optionally led by a `#@kind: <kind>`
-metadata line. The block's YAML payload sits below the `#@` header; the
+A card is a `~~~card-yaml` block, optionally led by a `@kind: <kind>`
+metadata line. The block's YAML payload sits below the `@` header; the
 Markdown after the closing `~~~` fence is the card's body.
 
 ```
 ~~~card-yaml
-#@quill: my_quill@1.0
-#@kind: main
+@quill: my_quill@1.0
+@kind: main
 title: Main Document
 ~~~
 
@@ -22,7 +22,7 @@ title: Main Document
 Some content here.
 
 ~~~card-yaml
-#@kind: products
+@kind: products
 name: Widget
 price: 19.99
 ~~~
@@ -30,7 +30,7 @@ price: 19.99
 Widget description.
 
 ~~~card-yaml
-#@kind: products
+@kind: products
 name: Gadget
 price: 29.99
 ~~~
@@ -44,20 +44,20 @@ All card blocks are collected into the `CARDS` array.
 
 - A card block opens with exactly `~~~card-yaml` and closes with exactly `~~~`
   (three tildes).
-- A card block may begin with a `#@kind: <kind>` metadata line naming the card
+- A card block may begin with a `@kind: <kind>` metadata line naming the card
   kind.
-- The card kind (`#@kind` value) must match `[a-z_][a-z0-9_]*`. Invalid
+- The card kind (`@kind` value) must match `[a-z_][a-z0-9_]*`. Invalid
   examples: `BadCard`, `my-card`, `2nd_card`.
 - `QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and cannot be used as field
   names inside a card.
 - A blank line is required immediately above every `~~~card-yaml` opener
   (unless the block is the very first line of the document). A `~~~card-yaml`
   line without a blank line above it is treated as an ordinary code block.
-- Comments are **not** supported on a `#@` header line itself. YAML
+- Comments are **not** supported on a `@` header line itself. YAML
   comments are supported in the payload below it.
 
 The document is positional: the **first** `~~~card-yaml` block is the root
-block, and it must declare a `#@quill: <name>@<version>` metadata line. Every
+block, and it must declare a `@quill: <name>@<version>` metadata line. Every
 subsequent block is a card.
 
 ## Card Body Content
@@ -68,6 +68,6 @@ closing `~~~` fence and the next block's opening fence (or document end).
 ## Emission
 
 Round-tripping a document through `toMarkdown` always emits the canonical
-`~~~card-yaml` / `#@` metadata header / payload / `~~~` form. Fence markers,
+`~~~card-yaml` / `@` metadata header / payload / `~~~` form. Fence markers,
 key ordering, and YAML quoting are normalised. `!fill` tags and payload
 comments survive the round-trip.

--- a/docs/authoring/markdown-syntax.md
+++ b/docs/authoring/markdown-syntax.md
@@ -62,7 +62,7 @@ Some constructs (like link titles) are accepted by the parser but may be dropped
 
 Quillmark carries structured metadata in [card-yaml blocks](card-yaml.md) —
 blocks delimited by `~~~card-yaml` / `~~~` fences, optionally led by a run of
-`#@`-prefixed system metadata lines. Each block is followed by its Markdown
+`@`-prefixed system metadata lines. Each block is followed by its Markdown
 prose body. The document's first block (the root block) names the rendering
 format; later blocks are composable [cards](cards.md).
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -23,7 +23,7 @@ quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
 - `<QUILL_PATH>`: Path to quill directory
 - `[MARKDOWN_FILE]`: Path to markdown file with a root card-yaml block (optional — when omitted, the quill's blueprint is rendered)
 
-`<QUILL_PATH>` selects the local quill bundle used for rendering. `MARKDOWN_FILE` still requires a root `~~~card-yaml` block with a `#@quill` system metadata line during parsing.
+`<QUILL_PATH>` selects the local quill bundle used for rendering. `MARKDOWN_FILE` still requires a root `~~~card-yaml` block with a `@quill` system metadata line during parsing.
 
 **Options:**
 

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -65,8 +65,8 @@ Create a `document.md` that matches the fields you defined:
 
 ```markdown
 ~~~card-yaml
-#@quill: my_quill
-#@kind: main
+@quill: my_quill
+@kind: main
 sender: Jane Doe
 recipient: John Smith
 date: 2026-01-15

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -381,12 +381,12 @@ card_kinds:
 
 ### Using Cards in Markdown
 
-Cards appear as `~~~card-yaml` blocks with a `#@kind: <kind>` metadata line in the document body:
+Cards appear as `~~~card-yaml` blocks with a `@kind: <kind>` metadata line in the document body:
 
 ```markdown
 ~~~card-yaml
-#@quill: usaf_memo
-#@kind: main
+@quill: usaf_memo
+@kind: main
 subject: Example
 # ... other fields ...
 ~~~
@@ -394,7 +394,7 @@ subject: Example
 Main memo body text here.
 
 ~~~card-yaml
-#@kind: indorsement
+@kind: indorsement
 from: ORG/SYMBOL
 for: RECIPIENT/SYMBOL
 signature_block:
@@ -405,7 +405,7 @@ signature_block:
 Body of the first endorsement.
 
 ~~~card-yaml
-#@kind: indorsement
+@kind: indorsement
 from: ANOTHER/ORG
 for: FINAL/RECIPIENT
 format: informal

--- a/docs/format-designer/versioning.md
+++ b/docs/format-designer/versioning.md
@@ -24,12 +24,12 @@ Use semantic versioning (`MAJOR.MINOR.PATCH`) to communicate compatibility:
 
 ## How Authors Select Versions
 
-Authors can target versions through the root block's `#@quill` system metadata:
+Authors can target versions through the root block's `@quill` system metadata:
 
 ```markdown
 ~~~card-yaml
-#@quill: my_quill@1.2
-#@kind: main
+@quill: my_quill@1.2
+@kind: main
 title: Quarterly Report
 ~~~
 ```

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -24,12 +24,12 @@ A **Quill** is a format bundle that defines how Markdown content should be rende
 
 Quillmark documents use **card-yaml blocks** to provide structured metadata. A
 card-yaml block is delimited by `~~~card-yaml` / `~~~` fences and may begin
-with a run of `#@`-prefixed system metadata lines followed by a YAML payload:
+with a run of `@`-prefixed system metadata lines followed by a YAML payload:
 
 ```markdown
 ~~~card-yaml
-#@quill: my_format
-#@kind: main
+@quill: my_format
+@kind: main
 title: My Document
 author: John Doe
 date: 2025-01-15
@@ -44,21 +44,21 @@ This metadata is accessible in formats and is validated against native schema ru
 
 A backend compiles the plate plus injected JSON data into the final artifact. The Typst backend is currently the only one — it produces PDF, SVG, and PNG, and converts fields declared `type: markdown` to Typst markup during compilation.
 
-### Required `#@quill` Metadata
+### Required `@quill` Metadata
 
-Each document must declare its target format in the root block's `#@quill`
+Each document must declare its target format in the root block's `@quill`
 system metadata line.
 
 ```markdown
 ~~~card-yaml
-#@quill: my_custom_format
-#@kind: main
+@quill: my_custom_format
+@kind: main
 title: My First Document
 author: Jane Doe
 ~~~
 ```
 
-If the root block's `#@quill` line is missing, parsing fails. Quill names must be `snake_case` (`[a-z][a-z0-9_]*`); hyphens are not allowed.
+If the root block's `@quill` line is missing, parsing fails. Quill names must be `snake_case` (`[a-z][a-z0-9_]*`); hyphens are not allowed.
 
 ## The Rendering Pipeline
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,8 +19,8 @@ Get started with Quillmark in Python or JavaScript.
     quill = engine.quill_from_path("path/to/quill")
 
     markdown = """~~~card-yaml
-    #@quill: my_quill
-    #@kind: main
+    @quill: my_quill
+    @kind: main
     title: Example Document
     ~~~
 
@@ -56,8 +56,8 @@ Get started with Quillmark in Python or JavaScript.
     ]));
 
     const markdown = `~~~card-yaml
-    #@quill: my_quill
-    #@kind: main
+    @quill: my_quill
+    @kind: main
     title: Example Document
     ~~~
 

--- a/docs/migrations/0.80-to-0.81.md
+++ b/docs/migrations/0.80-to-0.81.md
@@ -13,8 +13,8 @@ unchanged.
 ## TL;DR
 
 Every metadata block is now a `~~~card-yaml` fence. A block may begin with an
-optional **system-metadata header** of `#@key: value` lines; the root block
-must declare `#@quill`:
+optional **system-metadata header** of `@key: value` lines; the root block
+must declare `@quill`:
 
 ```diff
 - ---
@@ -22,7 +22,7 @@ must declare `#@quill`:
 - title: Main Document
 - ---
 + ~~~card-yaml
-+ #@quill: my_quill
++ @quill: my_quill
 + title: Main Document
 + ~~~
 
@@ -33,7 +33,7 @@ must declare `#@quill`:
 - price: 19.99
 - ```
 + ~~~card-yaml
-+ #@kind: products
++ @kind: products
 + name: Widget
 + price: 19.99
 + ~~~
@@ -52,9 +52,9 @@ A card-yaml block has four parts, in order:
 
 1. **Opening fence** — exactly `~~~card-yaml` (three tildes, at column zero).
    The info string alone identifies a metadata block.
-2. **System-metadata header** — an optional leading run of `#@key: value`
+2. **System-metadata header** — an optional leading run of `@key: value`
    lines inside the block.
-3. **Data payload** — standard YAML key/value pairs below the `#@` header.
+3. **Data payload** — standard YAML key/value pairs below the `@` header.
 4. **Closing fence** — exactly `~~~`.
 
 The prose body begins immediately after the closing `~~~` and runs to the next
@@ -64,30 +64,30 @@ block or end of document.
 
 The document is **positional**: the **first** `~~~card-yaml` block is the
 document root, and every later block is a composable **card**. The root is
-identified both positionally (first block) and by its mandatory `#@kind: main`
+identified both positionally (first block) and by its mandatory `@kind: main`
 declaration. The kind `main` is **reserved for the document root**.
 
-### System metadata (`#@`)
+### System metadata (`@`)
 
-A block may begin with a run of `#@key: value` lines. The `#@` prefix keeps
+A block may begin with a run of `@key: value` lines. The `@` prefix keeps
 these lines out of the YAML payload's user field set (a bare `#` line is an
 ordinary YAML comment).
 
-- **`#@quill: <name>@<version>`** — binds the document to a quill (replacing
-  the old `QUILL:` frontmatter key). The **root block must declare `#@quill`**;
+- **`@quill: <name>@<version>`** — binds the document to a quill (replacing
+  the old `QUILL:` frontmatter key). The **root block must declare `@quill`**;
   composable cards must not.
-- **`#@kind: <kind>`** — identifies a card's kind. This replaces the
+- **`@kind: <kind>`** — identifies a card's kind. This replaces the
   ` ```card <kind> ` info string and the legacy `CARD:` key. The root block
-  **must** declare `#@kind: main`; composable cards must declare some other
+  **must** declare `@kind: main`; composable cards must declare some other
   kind matching `[a-z_][a-z0-9_]*`.
-- **`#@id: <value>`** — an opaque, optional identifier. Plain metadata: no
+- **`@id: <value>`** — an opaque, optional identifier. Plain metadata: no
   validation, no uniqueness; carried through the round-trip unchanged.
-- **Trailing inline comments** are supported on `#@` header lines:
-  `#@quill: foo  # bound at build time` is accepted; the comment is dropped
+- **Trailing inline comments** are supported on `@` header lines:
+  `@quill: foo  # bound at build time` is accepted; the comment is dropped
   from the typed value and not preserved through emit.
 
-`#@` header lines may appear in **any order**, and the emitter preserves their
-source order. A duplicate `#@key` within a block, or a malformed `#@` line, is
+`@` header lines may appear in **any order**, and the emitter preserves their
+source order. A duplicate `@key` within a block, or a malformed `@` line, is
 a parse error.
 
 ### Blank-line rule
@@ -103,14 +103,14 @@ emitted).
 For each document:
 
 1. Replace the opening `---` of the frontmatter with `~~~card-yaml`, rename
-   the `QUILL:` line to `#@quill:`, and add a `#@kind: main` line below it.
+   the `QUILL:` line to `@quill:`, and add a `@kind: main` line below it.
    Replace the closing `---` with `~~~`.
 2. For each card written as ` ```card <kind> `, replace the opener with
-   `~~~card-yaml` followed by a `#@kind: <kind>` line, and replace the closing
+   `~~~card-yaml` followed by a `@kind: <kind>` line, and replace the closing
    ` ``` ` with `~~~`. The kind must not be `main` — that's reserved for the
    document root.
 3. For each legacy card written as a `---` block with a `CARD:` key, replace
-   the fences with `~~~card-yaml` / `~~~` and rename `CARD:` to `#@kind:`.
+   the fences with `~~~card-yaml` / `~~~` and rename `CARD:` to `@kind:`.
 4. Ensure every `~~~card-yaml` opener has a blank line above it.
 
 A bare `---` in body prose was already an ordinary CommonMark thematic break;
@@ -152,12 +152,12 @@ Parse errors are reworded for the new syntax. Match on `ParseError` variants
 
 | Situation | Variant |
 |---|---|
-| No `~~~card-yaml` block, or the root block has no `#@quill` | `MissingQuill` |
+| No `~~~card-yaml` block, or the root block has no `@quill` | `MissingQuill` |
 | `~~~card-yaml` opener with no `~~~` closer | `InvalidStructure` |
-| Malformed `#@` header line, or a duplicate `#@key` within a block | `InvalidStructure` |
-| Invalid `#@kind` value | `InvalidStructure` |
-| Root block missing `#@kind: main`, or declaring a non-`main` `#@kind` | `InvalidStructure` |
-| Composable card declaring `#@kind: main` | `InvalidStructure` |
+| Malformed `@` header line, or a duplicate `@key` within a block | `InvalidStructure` |
+| Invalid `@kind` value | `InvalidStructure` |
+| Root block missing `@kind: main`, or declaring a non-`main` `@kind` | `InvalidStructure` |
+| Composable card declaring `@kind: main` | `InvalidStructure` |
 | Reserved name used as a field | `InvalidStructure` |
 | Invalid YAML payload | `YamlErrorWithLocation` |
 
@@ -165,7 +165,7 @@ Parse errors are reworded for the new syntax. Match on `ParseError` variants
 
 ### 6.1 `Frontmatter` → `Payload` rename
 
-The card-yaml format calls the structured YAML data below a block's `#@`
+The card-yaml format calls the structured YAML data below a block's `@`
 metadata header its **payload**. The in-memory type that held it —
 historically named `Frontmatter` — is renamed to match. This is a pure rename:
 the type's shape, methods, and behavior are unchanged.
@@ -199,19 +199,19 @@ the type's shape, methods, and behavior are unchanged.
 
 ### 6.2 System metadata: `Sentinel` removed, `CardMetadata` added
 
-A block's leading `#@key: value` lines are now **system metadata** drawn from
-a closed set of three keys — `#@quill`, `#@kind`, `#@id`. Any other `#@key`
+A block's leading `@key: value` lines are now **system metadata** drawn from
+a closed set of three keys — `@quill`, `@kind`, `@id`. Any other `@key`
 is a parse error. The API reflects this:
 
 - The `Sentinel` enum is **removed**.
 - A new type **`CardMetadata`** is exported — a typed struct with three
   optional public fields: `quill: Option<QuillReference>`, `kind:
-  Option<String>`, `id: Option<String>`. `#@quill` is parsed into a typed
+  Option<String>`, `id: Option<String>`. `@quill` is parsed into a typed
   `QuillReference` at parse time.
 - `Card::sentinel()` is replaced by:
   - `Card::meta()` — the block's `CardMetadata` struct.
-  - `Card::kind()` — the `#@kind` value, if present.
-  - `Card::id()` — the `#@id` value, if present.
+  - `Card::kind()` — the `@kind` value, if present.
+  - `Card::id()` — the `@id` value, if present.
 - `Card::is_main()` is **removed**, along with the `is_main` argument to
   `Card::from_parts`. Root vs. composable is positional: the root `Card` lives
   in `Document::main`, composable cards in `Document::cards`.
@@ -245,8 +245,8 @@ core and the bindings:
 ## Checklist
 
 - [ ] Migrate stored Markdown from `---` frontmatter / `card` fences to
-      `~~~card-yaml` blocks with an optional `#@` system-metadata header.
-- [ ] Ensure the root (first) block declares `#@quill`.
+      `~~~card-yaml` blocks with an optional `@` system-metadata header.
+- [ ] Ensure the root (first) block declares `@quill`.
 - [ ] Ensure every `~~~card-yaml` opener has a blank line above it.
 - [ ] Move any inline comment that sat on a `QUILL:` / `CARD:` line into an
       own-line payload comment.

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -10,15 +10,15 @@ constraint hints. It is the **authoring surface** for LLM and MCP
 consumers; [SCHEMAS.md](SCHEMAS.md) covers the validation/form surface.
 
 A blueprint is the document, not a description of the document. Fill in
-the placeholders; the structure, `#@` metadata, and body markers come for
+the placeholders; the structure, `@` metadata, and body markers come for
 free.
 
 ## Output shape
 
 ````
 ~~~card-yaml
-#@quill: <name>@<version>
-#@kind: main
+@quill: <name>@<version>
+@kind: main
 # <description>
 
 # <field description>
@@ -29,7 +29,7 @@ field: value  # <type>; <role>
 Write main body here.
 
 ~~~card-yaml
-#@kind: <card_kind>
+@kind: <card_kind>
 # composable (0..N)
 # <card description>
 ...fields...
@@ -39,8 +39,8 @@ Write <card_kind> body here.
 ````
 
 Every block is a `~~~card-yaml` block (see [MARKDOWN.md](MARKDOWN.md) §3):
-the root block carries the `#@quill` system-metadata line; each composable
-card carries a `#@kind: <card_kind>` metadata line.
+the root block carries the `@quill` system-metadata line; each composable
+card carries a `@kind: <card_kind>` metadata line.
 
 When `body.example` is set, its text replaces the body marker entirely.
 When `body.enabled` is false the marker is omitted entirely.
@@ -93,14 +93,14 @@ Form: **`# <type>[<format>]; <role>[, <extra>...]`**
 - **Extras** (optional, comma-separated, after the role): additional
   qualifiers.
 
-The `#@` system-metadata lines (`#@quill`, `#@kind`, …) have no
+The `@` system-metadata lines (`@quill`, `@kind`, …) have no
 inline-annotation slot — they are not YAML fields. (Parsers accept a
-trailing ` # comment` on a `#@` line, but the blueprint emitter does not
+trailing ` # comment` on a `@` line, but the blueprint emitter does not
 attach one — the canonical form drops it.) The root block's
-`#@quill` line is emitted verbatim; its value is fixed and must not be
-modified. A composable card's kind is carried in its `#@kind: <card_kind>`
+`@quill` line is emitted verbatim; its value is fixed and must not be
+modified. A composable card's kind is carried in its `@kind: <card_kind>`
 metadata line. Its `composable (0..N)` role is emitted as an own-line
-`# composable (0..N)` comment directly under the `#@` header, ahead of the
+`# composable (0..N)` comment directly under the `@` header, ahead of the
 card description.
 
 Examples:
@@ -116,8 +116,8 @@ Examples:
 | `date: ""  # date<YYYY-MM-DD>; required` | required date in `YYYY-MM-DD` format |
 | `published: ""  # datetime<ISO 8601>; required` | required datetime in ISO 8601 |
 | `level: low  # enum<low \| medium \| high>; optional` | optional enum, default is first value |
-| `#@quill: cmu_letter@0.1.0` | quill binding metadata, emitted verbatim, do not modify |
-| `#@kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~card-yaml` … `~~~` block per instance |
+| `@quill: cmu_letter@0.1.0` | quill binding metadata, emitted verbatim, do not modify |
+| `@kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~card-yaml` … `~~~` block per instance |
 
 ## Placeholder value precedence
 
@@ -279,8 +279,8 @@ blueprint's document structure.
 
 ```
 ~~~card-yaml
-#@quill: cmu_letter@0.1.0
-#@kind: main
+@quill: cmu_letter@0.1.0
+@kind: main
 # Typeset letters that comply with Carnegie Mellon University letterhead standards.
 
 # The recipient's name and full mailing address.

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -77,13 +77,13 @@ card_kinds:
 ## Markdown Syntax
 
 A composable card is a `~~~card-yaml` block, optionally led by a
-`#@kind: <kind>` system-metadata line. The kind is the on-the-wire `CARD`
+`@kind: <kind>` system-metadata line. The kind is the on-the-wire `CARD`
 discriminator; the block's payload is the card's YAML data, and the markdown
 after the closing `~~~` fence is the card's body.
 
 ````markdown
 ~~~card-yaml
-#@kind: indorsement
+@kind: indorsement
 from: ORG1/SYMBOL
 for: ORG2/SYMBOL
 signature_block:

--- a/prose/canon/CLI.md
+++ b/prose/canon/CLI.md
@@ -11,7 +11,7 @@
 quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
 ```
 
-`QUILL_PATH` provides the local quill bundle used for rendering. `MARKDOWN_FILE` still requires a root `~~~card-yaml` block with a `#@quill` system-metadata line because parsing enforces it.
+`QUILL_PATH` provides the local quill bundle used for rendering. `MARKDOWN_FILE` still requires a root `~~~card-yaml` block with a `@quill` system-metadata line because parsing enforces it.
 
 Options:
 - `-o, --output <FILE>` — output file path (default: derived from input filename)

--- a/prose/canon/MARKDOWN.md
+++ b/prose/canon/MARKDOWN.md
@@ -37,7 +37,7 @@ followed by its prose body:
 Document = (CardYamlBlock ProseBody)+
 ```
 
-- **Root block** — the first block, identified purely by position. Its `#@`
+- **Root block** — the first block, identified purely by position. Its `@`
   header declares the quill that renders the document.
 - **Subsequent blocks** — zero or more *cards*. Each declares a composable
   structured record.
@@ -48,8 +48,8 @@ Document = (CardYamlBlock ProseBody)+
 
 ```
 ~~~card-yaml
-#@quill: example@0.1.0
-#@kind: main
+@quill: example@0.1.0
+@kind: main
 from: "bob"
 to: "alice"
 ~~~
@@ -57,8 +57,8 @@ to: "alice"
 This is the primary document container body text.
 
 ~~~card-yaml
-#@kind: endorsement
-#@id: rev-1
+@kind: endorsement
+@id: rev-1
 from: "charlie"
 role: "reviewer"
 clearance: "alpha"
@@ -67,9 +67,9 @@ clearance: "alpha"
 I have reviewed the contents and officially endorse this flight plan.
 ```
 
-The first block is the root block (by position); its `#@quill` header binds
+The first block is the root block (by position); its `@quill` header binds
 the document to the `example` quill at version `0.1.0`. The second block is a
-card whose `#@kind` is `endorsement`. The text after each closing `~~~` fence
+card whose `@kind` is `endorsement`. The text after each closing `~~~` fence
 is that block's prose body.
 
 ## 3. card-yaml Blocks
@@ -80,10 +80,10 @@ A card-yaml block has four parts, in order:
 
 1. **Opening fence** — exactly `~~~card-yaml` (see §3.2). The info string
    alone identifies the block; no further declaration is needed.
-2. **System metadata header** — an optional leading run of `#@key: value`
-   lines inside the block (see §3.3). The root block must declare `#@quill`;
-   all other `#@` entries are optional.
-3. **Data payload** — standard YAML key/value pairs below the `#@` header
+2. **System metadata header** — an optional leading run of `@key: value`
+   lines inside the block (see §3.3). The root block must declare `@quill`;
+   all other `@` entries are optional.
+3. **Data payload** — standard YAML key/value pairs below the `@` header
    (see §3.4).
 4. **Closing fence** — exactly `~~~` (see §3.2).
 
@@ -107,12 +107,12 @@ the next opening fence or EOF.
   block. Requiring the blank line keeps prose-body round-tripping stable and
   prevents a card-yaml block from being absorbed into a preceding paragraph.
 
-### 3.3 System Metadata (`#@`)
+### 3.3 System Metadata (`@`)
 
 A block may begin with a **system metadata header** — an optional leading run
-of `#@key: value` lines. The header is a **closed set** of three keys —
-`#@quill`, `#@kind`, `#@id`; any other `#@key` is a parse error. These lines
-are kept out of the YAML payload's user field set (§3.4); the `#@` header is
+of `@key: value` lines. The header is a **closed set** of three keys —
+`@quill`, `@kind`, `@id`; any other `@key` is a parse error. These lines
+are kept out of the YAML payload's user field set (§3.4); the `@` header is
 not part of the data model's field map.
 
 In the typed model, the header parses to a `CardMetadata` struct with three
@@ -121,37 +121,37 @@ the root block always carries `quill = Some(_)` and `kind = Some("main")`;
 composable cards always carry `quill = None` and `kind = Some(_)` (any
 value other than `"main"`).
 
-- **`#@quill: <name>@<version>`** — binds the document to a quill (see §3.5
+- **`@quill: <name>@<version>`** — binds the document to a quill (see §3.5
   for the version-selector forms). The root block (the first block) must
   declare it; no other block may. It is parsed into a typed quill reference
   as the block is read.
-- **`#@kind: <value>`** — identifies a card's kind. The value is
+- **`@kind: <value>`** — identifies a card's kind. The value is
   name-validated at parse time and must match `[a-z_][a-z0-9_]*`. The kind
   `main` is **reserved for the document root**: the root block must declare
-  `#@kind: main`, and no composable card may declare `#@kind: main`.
-- **`#@id: <value>`** — an opaque, optional identifier. Plain metadata: no
+  `@kind: main`, and no composable card may declare `@kind: main`.
+- **`@id: <value>`** — an opaque, optional identifier. Plain metadata: no
   validation, no uniqueness requirement; carried through round-trip
   unchanged.
 
 Rules:
 
-- The root block must declare both `#@quill: <ref>` and `#@kind: main`. A
-  composable (non-root) block must declare `#@kind: <kind>` for some
-  `<kind>` other than `main`, and must not declare `#@quill`.
-- `#@` header lines may appear in any order. The emitter emits them in the
+- The root block must declare both `@quill: <ref>` and `@kind: main`. A
+  composable (non-root) block must declare `@kind: <kind>` for some
+  `<kind>` other than `main`, and must not declare `@quill`.
+- `@` header lines may appear in any order. The emitter emits them in the
   canonical key order `quill`, `kind`, `id` (see §9).
-- A duplicate `#@key` within a single block is a parse error.
-- A malformed `#@` line (not of the form `#@key: value`) is a parse error.
-- An unknown `#@key` (anything outside `{quill, kind, id}`) is a parse error.
-- An invalid `#@quill` reference is a parse error.
-- **Trailing inline comments are supported on `#@` header lines.** A `#@`
-  line of the form `#@key: value  # note` is accepted: the trailing
+- A duplicate `@key` within a single block is a parse error.
+- A malformed `@` line (not of the form `@key: value`) is a parse error.
+- An unknown `@key` (anything outside `{quill, kind, id}`) is a parse error.
+- An invalid `@quill` reference is a parse error.
+- **Trailing inline comments are supported on `@` header lines.** A `@`
+  line of the form `@key: value  # note` is accepted: the trailing
   ` # …` is treated as a comment and dropped from the typed value. The
   comment is not preserved through emit — the canonical form (§9) omits it.
 
 ### 3.4 Data Payload
 
-Standard YAML key/value pairs sit directly below the `#@` metadata header.
+Standard YAML key/value pairs sit directly below the `@` metadata header.
 
 - **Field names.** Every field name matches `/^[a-z_][a-z0-9_]*$/`.
 - **Reserved names.** `QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and
@@ -160,7 +160,7 @@ Standard YAML key/value pairs sit directly below the `#@` metadata header.
   yields an empty field set.
 - **YAML comments.** Both own-line comments (`# …` on their own line) and
   inline comments (`field: value  # note`) are supported in the payload and
-  round-trip through `toMarkdown`. (A `#@` header line is the one
+  round-trip through `toMarkdown`. (A `@` header line is the one
   exception — see §3.3.) Comments inside nested YAML values (arrays, maps)
   are also preserved: the pre-scan captures each nested comment with a
   structural path and the emitter re-injects it at the matching position.
@@ -174,7 +174,7 @@ Standard YAML key/value pairs sit directly below the `#@` metadata header.
 
 ### 3.5 Version Selectors
 
-The `#@quill` value is `<name>@<version>`, where `<version>` is one
+The `@quill` value is `<name>@<version>`, where `<version>` is one
 of:
 
 | Form | Meaning |
@@ -210,8 +210,8 @@ before EOF is a hard parse error (§9).
 
 ```
 ~~~card-yaml
-#@quill: resume@1.0.0
-#@kind: main
+@quill: resume@1.0.0
+@kind: main
 title: CV
 ~~~
 
@@ -222,7 +222,7 @@ Main body text.
 A thematic break in prose stays a thematic break.
 
 ~~~card-yaml
-#@kind: profile
+@kind: profile
 name: "Alice"
 ~~~
 
@@ -240,7 +240,7 @@ Parsing yields:
 
 ```typescript
 interface Document {
-  QUILL: string;          // quill name@version, from the root block #@quill
+  QUILL: string;          // quill name@version, from the root block @quill
   BODY: string;           // prose body of the root block
   CARDS: Card[];          // zero or more cards, in document order
   [field: string]: any;   // other root-block payload fields
@@ -346,18 +346,18 @@ error when any is exceeded:
 
 ```
 ~~~card-yaml
-<#@ header lines, in canonical order>
+<@ header lines, in canonical order>
 <payload>
 ~~~
 ```
 
-That is: a `~~~card-yaml` opener, the `#@` system-metadata lines (in the
+That is: a `~~~card-yaml` opener, the `@` system-metadata lines (in the
 canonical key order `quill`, `kind`, `id`), the YAML payload, and a `~~~`
-closer. The root block emits both `#@quill` and `#@kind: main`; composable
-cards emit `#@kind: <kind>` plus any other `#@` entries they declared. A
+closer. The root block emits both `@quill` and `@kind: main`; composable
+cards emit `@kind: <kind>` plus any other `@` entries they declared. A
 document round-trips to this canonical shape — fence markers, key ordering,
 and YAML quoting are normalised. `!fill` tags and payload comments (own-line
-and inline) survive the round-trip; `#@`-header trailing comments do not —
+and inline) survive the round-trip; `@`-header trailing comments do not —
 the canonical form drops them.
 
 ### 9.1 Canonical Idempotence
@@ -381,7 +381,7 @@ A document in canonical form round-trips byte-equal under both
 Arbitrary (non-canonical) input parses successfully when it satisfies §1–8
 and converges to the canonical form on the first emit. Type fidelity (a
 quoted `"42"` survives as a string, an unquoted `42` survives as an
-integer) is preserved; fence-marker length, quoting style, and `#@` key
+integer) is preserved; fence-marker length, quoting style, and `@` key
 ordering are not. The canonical form is what consumers should content-hash,
 content-address, or compare for equality.
 
@@ -390,15 +390,15 @@ content-address, or compare for equality.
 Parse errors include:
 
 - A `~~~card-yaml` opener with no matching `~~~` closer before EOF.
-- The root block missing its `#@quill` entry.
-- The root block missing its `#@kind: main` entry, or declaring a
-  non-`main` `#@kind`.
-- A composable (non-root) block declaring `#@quill`, or declaring
-  `#@kind: main` (which is reserved for the document root).
-- A malformed `#@` header line (not of the form `#@key: value`).
-- A duplicate `#@key` within a single block.
-- An unknown `#@key` outside the closed set `{quill, kind, id}`.
-- An invalid `#@quill` reference.
+- The root block missing its `@quill` entry.
+- The root block missing its `@kind: main` entry, or declaring a
+  non-`main` `@kind`.
+- A composable (non-root) block declaring `@quill`, or declaring
+  `@kind: main` (which is reserved for the document root).
+- A malformed `@` header line (not of the form `@key: value`).
+- A duplicate `@key` within a single block.
+- An unknown `@key` outside the closed set `{quill, kind, id}`.
+- An invalid `@quill` reference.
 - A field name failing `/^[a-z_][a-z0-9_]*$/`.
 - Use of a reserved name (`QUILL`, `CARD`, `BODY`, `CARDS`) as a field name.
 - Invalid YAML inside any block payload.

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -77,7 +77,7 @@ Identity fields (`name`, `version`, `backend`, `author`, `description`) live on 
 
 ### `main.fields` and `card_kinds.<name>.fields` discriminators
 
-`schema()` prepends a synthetic discriminator field to each card's `fields` map so consumers know exactly which discriminator value to use — the `QUILL` reference for the main card, and the card kind (the `#@kind: <kind>` metadata value) for each card kind:
+`schema()` prepends a synthetic discriminator field to each card's `fields` map so consumers know exactly which discriminator value to use — the `QUILL` reference for the main card, and the card kind (the `@kind: <kind>` metadata value) for each card kind:
 
 - `main.fields.QUILL` — `{ type: string, const: "<name>@<version>", required: true, description: ... }`
 - `card_kinds.<name>.fields.CARD` — `{ type: string, const: "<name>", required: true, description: ... }`

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -14,15 +14,15 @@ Semantic versioning: `MAJOR.MINOR.PATCH` (two-segment `MAJOR.MINOR` also accepte
 
 ## Document Syntax
 
-The version selector is carried on the root block's `#@quill` system-metadata
+The version selector is carried on the root block's `@quill` system-metadata
 line (see [MARKDOWN.md](MARKDOWN.md) §3.3):
 
 ```
-#@quill: my_format@2.1.0    # exact version
-#@quill: my_format@2.1      # latest 2.1.x
-#@quill: my_format@2        # latest 2.x.x
-#@quill: my_format@latest   # latest overall (explicit)
-#@quill: my_format          # latest overall (default)
+@quill: my_format@2.1.0    # exact version
+@quill: my_format@2.1      # latest 2.1.x
+@quill: my_format@2        # latest 2.x.x
+@quill: my_format@latest   # latest overall (explicit)
+@quill: my_format          # latest overall (default)
 ```
 
 ## Resolution


### PR DESCRIPTION
This change simplifies the Quillmark syntax by removing the `#` prefix from system metadata headers in card-yaml blocks. The metadata keys are now written as `@quill`, `@kind`, and `@id` instead of `#@quill`, `#@kind`, and `#@id`.

## Summary

The `#` character was originally used to make metadata lines appear as YAML comments (since `#` starts a comment in YAML). However, the metadata header is now extracted before YAML parsing, so the `#` prefix is no longer necessary. This change makes the syntax cleaner and more intuitive.

## Key Changes

- **Syntax update**: All metadata headers changed from `#@key: value` to `@key: value`
  - `#@quill:` → `@quill:`
  - `#@kind:` → `@kind:`
  - `#@id:` → `@id:`

- **Documentation updates**: Updated all references in:
  - Markdown specification documents (MARKDOWN.md, BLUEPRINT.md, CARDS.md, VERSIONING.md, CLI.md, SCHEMAS.md)
  - User guides (card-yaml.md, cards.md, concepts.md, quickstart.md, markdown-syntax.md, creating-quills.md)
  - Migration guide (0.80-to-0.81.md)

- **Code updates**: Updated all test fixtures, examples, and comments throughout:
  - Test files (assemble_tests.rs, lossiness_tests.rs, emit_tests.rs, card_fence_tests.rs, etc.)
  - Example markdown files in fixtures
  - Python and JavaScript/WASM binding tests and examples
  - Source code comments and docstrings

- **Implementation details**: Updated comments in core modules to reflect that the `@` prefix now segregates metadata from the YAML payload through extraction, rather than relying on YAML comment syntax.

## Backward Compatibility

This is a breaking change to the document syntax. Documents using the old `#@` prefix will need to be migrated to the new `@` prefix.

https://claude.ai/code/session_01H9H9G8odnaJqpCVj1BDHEe