### PR TITLE
Close Python API gaps vs wasm binding

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -55,6 +55,25 @@ quill = engine.quill_from_path("path")
 result = quill.render(parsed, OutputFormat.PDF)
 session = quill.open(parsed)
 quill.dry_run(parsed)
+
+quill.backend            # "typst"
+quill.supports_canvas    # True when the backend supports canvas preview
+quill.schema             # structured dict of the quill's document schema
+quill.schema_yaml        # same schema rendered as a YAML string
+quill.blueprint          # auto-generated annotated Markdown blueprint
+```
+
+### `RenderSession`
+
+Created via `quill.open(doc)`; reuses the compiled snapshot across renders.
+
+```python
+session = quill.open(parsed)
+session.page_count
+session.backend_id            # backend that produced this session
+session.supports_canvas
+session.warnings              # session-level warnings (e.g. version shims)
+session.render(OutputFormat.SVG, [0])  # render a page subset
 ```
 
 ### `Document`
@@ -69,6 +88,20 @@ emitted = doc.to_markdown()          # canonical Quillmark Markdown
 stored = doc.to_json()               # JSON string carrying a schema version
 restored = Document.from_json(stored)
 assert restored.to_markdown() == doc.to_markdown()
+
+# Detect "is this content a stored DTO or raw Markdown?" without exceptions.
+doc = Document.try_from_json(blob) or Document.from_markdown(blob)
+
+# Schema-version probing for cross-version migrations.
+v = Document.schema_version_of(blob)          # raw tag, even for future versions
+current = Document.current_schema_version()   # version this build writes
+
+# Cheap structural equality and cloning.
+copy = doc.clone()                            # independent handle
+assert copy == doc                            # structural compare; warnings ignored
+
+# O(1) card count.
+doc.card_count
 ```
 
 `from_json` raises `ParseError` on malformed JSON or an unknown schema

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -13,6 +13,11 @@ use std::path::PathBuf;
 use crate::enums::{PyOutputFormat, PySeverity};
 use crate::errors::{convert_edit_error, convert_render_error};
 
+/// Backend identifier for the only canvas-capable backend today. Matches the
+/// wasm binding's `CANVAS_BACKEND_ID`; if a second canvas backend ever ships
+/// replace this with a richer check.
+const CANVAS_BACKEND_ID: &str = "typst";
+
 // Quillmark Engine wrapper
 #[pyclass(name = "Quillmark")]
 pub struct PyQuillmark {
@@ -69,6 +74,15 @@ impl PyQuill {
         self.inner.backend_id().to_string()
     }
 
+    /// Whether this quill's backend supports canvas preview.
+    ///
+    /// Mirrors the wasm binding's `Quill.supportsCanvas` — `True` iff the
+    /// resolved backend is the canvas-capable one (currently `"typst"`).
+    #[getter]
+    fn supports_canvas(&self) -> bool {
+        self.inner.backend_id() == CANVAS_BACKEND_ID
+    }
+
     #[getter]
     fn plate(&self) -> Option<String> {
         self.inner.source().plate().map(str::to_string)
@@ -94,16 +108,27 @@ impl PyQuill {
         Ok(dict)
     }
 
-    /// Document schema as YAML, including `ui` hints.
+    /// Document schema as a structured dict (matches the wasm `schema` shape).
+    ///
+    /// Includes optional `ui` keys. `main.fields.QUILL` and
+    /// `card_kinds[name].fields.CARD` are required reserved fields with
+    /// `const` values telling consumers what to write.
     #[getter]
     fn schema<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let yaml = self
-            .inner
+        let value = self.inner.source().config().schema();
+        json_to_py(py, &value)
+    }
+
+    /// Document schema as a YAML string. Equivalent to
+    /// `yaml.safe_dump(quill.schema)` but produced by the engine, which is
+    /// useful for rendering documentation or feeding into LLM prompts.
+    #[getter]
+    fn schema_yaml(&self) -> PyResult<String> {
+        self.inner
             .source()
             .config()
             .schema_yaml()
-            .map_err(|e| PyValueError::new_err(format!("schema: {}", e)))?;
-        Ok(yaml.into_pyobject(py)?.into_any())
+            .map_err(|e| PyValueError::new_err(format!("schema_yaml: {}", e)))
     }
 
     #[getter]
@@ -151,7 +176,10 @@ impl PyQuill {
 
     fn open(&self, doc: PyRef<'_, PyDocument>) -> PyResult<PyRenderSession> {
         let session = self.inner.open(&doc.inner).map_err(convert_render_error)?;
-        Ok(PyRenderSession { inner: session })
+        Ok(PyRenderSession {
+            inner: session,
+            backend_id: self.inner.backend_id().to_string(),
+        })
     }
 
     /// Perform a dry run validation without backend compilation.
@@ -307,6 +335,51 @@ impl PyDocument {
         })
     }
 
+    /// Reconstruct a `Document` from a storage DTO string, or `None`.
+    ///
+    /// Like [`from_json`](PyDocument::from_json), but returns `None` instead
+    /// of raising when `json` is not a valid storage DTO. Use this to detect
+    /// "is this content a stored DTO or raw Markdown?" without exception
+    /// control flow:
+    ///
+    /// ```python
+    /// doc = Document.try_from_json(content) or Document.from_markdown(content)
+    /// ```
+    ///
+    /// `None` only ever means "not a storage DTO" — `from_markdown` still
+    /// raises on genuinely malformed markdown.
+    #[staticmethod]
+    fn try_from_json(json: &str) -> Option<Self> {
+        let inner: Document = serde_json::from_str(json).ok()?;
+        Some(PyDocument {
+            inner,
+            parse_warnings: Vec::new(),
+        })
+    }
+
+    /// Read the schema version from a raw storage DTO string without a full
+    /// parse, or `None`.
+    ///
+    /// Returns the `schema` field as-is — including unknown future versions
+    /// that `from_json` would reject. Use this to distinguish "build too old
+    /// for the payload" from "payload is corrupt" when
+    /// [`from_json`](PyDocument::from_json) raises.
+    #[staticmethod]
+    fn schema_version_of(json: &str) -> Option<String> {
+        quillmark_core::document::peek_schema_version(json)
+    }
+
+    /// Schema version this build writes via [`to_json`](PyDocument::to_json).
+    ///
+    /// Compare a payload's [`schema_version_of`](PyDocument::schema_version_of)
+    /// against this to detect mismatches before calling
+    /// [`from_json`](PyDocument::from_json). The tag tracks the `Document`
+    /// model version, not the running crate version.
+    #[staticmethod]
+    fn current_schema_version() -> &'static str {
+        quillmark_core::document::SCHEMA_V0_81_0
+    }
+
     /// Emit canonical Quillmark Markdown.
     ///
     /// Returns the document serialised as a Quillmark Markdown string.
@@ -335,6 +408,60 @@ impl PyDocument {
     /// The QUILL reference string (e.g. `"usaf_memo@0.1"`).
     fn quill_ref(&self) -> String {
         self.inner.quill_reference().to_string()
+    }
+
+    /// Return a fresh `Document` handle with the same parsed state.
+    ///
+    /// Mutations on the returned handle do not affect the original and vice
+    /// versa. Parse-time warnings are snapshotted alongside the document —
+    /// they describe the original parse, not the edit history of either
+    /// handle.
+    fn clone(&self) -> Self {
+        PyDocument {
+            inner: self.inner.clone(),
+            parse_warnings: self.parse_warnings.clone(),
+        }
+    }
+
+    fn __copy__(&self) -> Self {
+        self.clone()
+    }
+
+    fn __deepcopy__(&self, _memo: Bound<'_, PyAny>) -> Self {
+        self.clone()
+    }
+
+    /// Structural equality against another `Document`.
+    ///
+    /// Compares `main` and `cards` by value (matching core's `PartialEq`).
+    /// Parse-time `warnings` are intentionally excluded — they describe the
+    /// source text, not the document's content. Identical to `__eq__`.
+    fn equals(&self, other: PyRef<'_, PyDocument>) -> bool {
+        self.inner == other.inner
+    }
+
+    fn __eq__(&self, other: Bound<'_, PyAny>) -> bool {
+        match other.extract::<PyRef<'_, PyDocument>>() {
+            Ok(other) => self.inner == other.inner,
+            Err(_) => false,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Document(quill_ref={:?}, cards={})",
+            self.inner.quill_reference().to_string(),
+            self.inner.cards().len()
+        )
+    }
+
+    /// Number of composable cards (excludes the main card).
+    ///
+    /// O(1). Use this to validate indices before calling card mutators
+    /// instead of materialising the full `cards` list.
+    #[getter]
+    fn card_count(&self) -> usize {
+        self.inner.cards().len()
     }
 
     /// Non-fatal parse-time warnings.
@@ -547,6 +674,29 @@ impl PyDocument {
         card.set_field(name, qv).map_err(convert_edit_error)
     }
 
+    /// Remove a payload field from the card at `index`, returning the value
+    /// or `None` if the field was absent.
+    ///
+    /// Raises `quillmark.EditError` if `index` is out of range, `name` is
+    /// reserved, or `name` does not match `[a-z_][a-z0-9_]*`.
+    ///
+    /// This method never modifies `warnings`.
+    fn remove_card_field<'py>(
+        &mut self,
+        py: Python<'py>,
+        index: usize,
+        name: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let len = self.inner.cards().len();
+        let card = self.inner.card_mut(index).ok_or_else(|| {
+            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
+        })?;
+        match card.remove_field(name).map_err(convert_edit_error)? {
+            Some(v) => quillvalue_to_py(py, &v),
+            None => py.None().into_bound_py_any(py),
+        }
+    }
+
     /// Replace the body of the card at `index`.
     ///
     /// Raises `quillmark.EditError` if `index` is out of range.
@@ -571,6 +721,7 @@ pub struct PyRenderResult {
 #[pyclass(name = "RenderSession")]
 pub struct PyRenderSession {
     pub(crate) inner: RenderSession,
+    pub(crate) backend_id: String,
 }
 
 #[pymethods]
@@ -578,6 +729,40 @@ impl PyRenderSession {
     #[getter]
     fn page_count(&self) -> usize {
         self.inner.page_count()
+    }
+
+    /// The backend that produced this session (e.g. `"typst"`).
+    ///
+    /// Equal to the `backend` of the [`Quill`] that opened this session
+    /// (sessions inherit their quill's backend).
+    #[getter]
+    fn backend_id(&self) -> &str {
+        &self.backend_id
+    }
+
+    /// Whether this session's backend supports canvas preview.
+    ///
+    /// Currently equal to `backend_id == "typst"`. Matches the wasm binding's
+    /// `RenderSession.supportsCanvas` shape.
+    #[getter]
+    fn supports_canvas(&self) -> bool {
+        self.backend_id == CANVAS_BACKEND_ID
+    }
+
+    /// Session-level warnings attached at `quill.open(...)` time.
+    ///
+    /// Snapshot of any non-fatal diagnostics emitted while opening the
+    /// session (e.g. version-compatibility shims). Stable across the
+    /// session's lifetime. These are also appended to
+    /// `RenderResult.warnings` on every `render()` call; this accessor
+    /// surfaces them for consumers that don't go through `render()`.
+    #[getter]
+    fn warnings(&self) -> Vec<PyDiagnostic> {
+        self.inner
+            .warnings()
+            .iter()
+            .map(|d| PyDiagnostic { inner: d.clone() })
+            .collect()
     }
 
     #[pyo3(signature = (format=None, pages=None))]

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -30,8 +30,13 @@ def test_quill_properties(taro_quill_dir):
     assert isinstance(metadata, dict)
 
     schema = quill.schema
-    assert isinstance(schema, str)
-    assert "fields:" in schema
+    assert isinstance(schema, dict)
+    assert "main" in schema
+    assert "fields" in schema["main"]
+
+    schema_yaml = quill.schema_yaml
+    assert isinstance(schema_yaml, str)
+    assert "fields:" in schema_yaml
 
     supported_formats = quill.supported_formats
     assert isinstance(supported_formats, list)

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -128,3 +128,172 @@ def test_json_dto_drops_parse_warnings():
 
     restored = Document.from_json(doc.to_json())
     assert restored.warnings == []
+
+
+def test_try_from_json_round_trip(taro_md):
+    """try_from_json returns a Document for valid DTOs."""
+    doc = Document.from_markdown(taro_md)
+    dto = doc.to_json()
+
+    restored = Document.try_from_json(dto)
+    assert restored is not None
+    assert restored.quill_ref() == doc.quill_ref()
+
+
+def test_try_from_json_returns_none_on_markdown(taro_md):
+    """try_from_json returns None for non-DTO content (e.g. raw markdown)."""
+    assert Document.try_from_json(taro_md) is None
+    assert Document.try_from_json("not json at all") is None
+    assert Document.try_from_json('{"schema":"quillmark/document@0.99.0"}') is None
+
+
+def test_schema_version_of_reads_dto(taro_md):
+    """schema_version_of returns the schema tag from a stored DTO."""
+    doc = Document.from_markdown(taro_md)
+    dto = doc.to_json()
+
+    assert Document.schema_version_of(dto) == "quillmark/document@0.81.0"
+
+
+def test_schema_version_of_returns_unknown_future_versions():
+    """schema_version_of returns the raw tag, even for unsupported versions."""
+    # Note: this would be rejected by from_json, but schema_version_of returns it
+    # so callers can distinguish "build too old" from "payload corrupt".
+    future = '{"schema":"quillmark/document@0.99.0"}'
+    assert Document.schema_version_of(future) == "quillmark/document@0.99.0"
+
+
+def test_schema_version_of_returns_none_for_non_dto():
+    """schema_version_of returns None when the input is not a schema-tagged object."""
+    assert Document.schema_version_of("not json") is None
+    assert Document.schema_version_of('{"foo":"bar"}') is None
+
+
+def test_current_schema_version_matches_emitted_tag(taro_md):
+    """current_schema_version equals the tag emitted by to_json."""
+    doc = Document.from_markdown(taro_md)
+    dto = doc.to_json()
+
+    current = Document.current_schema_version()
+    assert isinstance(current, str)
+    assert Document.schema_version_of(dto) == current
+
+
+def test_clone_preserves_state(taro_md):
+    """clone returns a fresh handle with the same parsed state."""
+    doc = Document.from_markdown(taro_md)
+    cloned = doc.clone()
+
+    assert cloned.quill_ref() == doc.quill_ref()
+    assert cloned == doc
+
+
+def test_clone_isolates_mutations(taro_md):
+    """Mutating a clone does not affect the original."""
+    doc = Document.from_markdown(taro_md)
+    cloned = doc.clone()
+
+    cloned.set_field("title", "Updated Title")
+    assert doc.payload["title"] != "Updated Title"
+    assert cloned.payload["title"] == "Updated Title"
+
+
+def test_copy_module_clones(taro_md):
+    """The standard library copy module works on Document."""
+    import copy
+
+    doc = Document.from_markdown(taro_md)
+
+    shallow = copy.copy(doc)
+    deep = copy.deepcopy(doc)
+
+    assert shallow == doc
+    assert deep == doc
+
+    shallow.set_field("title", "Shallow Edit")
+    assert doc.payload["title"] != "Shallow Edit"
+
+
+def test_equals_and_eq(taro_md):
+    """equals and == both compare structurally; warnings are ignored."""
+    doc1 = Document.from_markdown(taro_md)
+    doc2 = Document.from_markdown(taro_md)
+
+    assert doc1.equals(doc2)
+    assert doc1 == doc2
+
+
+def test_eq_after_mutation(taro_md):
+    """Mutation breaks equality."""
+    doc1 = Document.from_markdown(taro_md)
+    doc2 = Document.from_markdown(taro_md)
+
+    doc2.set_field("title", "Different")
+    assert doc1 != doc2
+
+
+def test_card_count_matches_cards_len():
+    """card_count is O(1) shortcut for len(cards)."""
+    md = (
+        "~~~card-yaml\n#@quill: q\n#@kind: main\ntitle: T\n~~~\n\nBody.\n\n"
+        "~~~card-yaml\n#@kind: note\n~~~\n\nFirst.\n\n"
+        "~~~card-yaml\n#@kind: summary\n~~~\n\nSecond.\n"
+    )
+    doc = Document.from_markdown(md)
+    assert doc.card_count == 2
+    assert doc.card_count == len(doc.cards)
+
+
+def test_repr_includes_quill_ref(taro_md):
+    """__repr__ surfaces the quill ref and card count."""
+    doc = Document.from_markdown(taro_md)
+    text = repr(doc)
+    assert "Document(" in text
+    assert "taro" in text
+
+
+def test_remove_card_field_returns_value():
+    """remove_card_field removes and returns the field's value."""
+    md = (
+        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nBody.\n\n"
+        "~~~card-yaml\n#@kind: note\nfoo: bar\nbaz: qux\n~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    removed = doc.remove_card_field(0, "foo")
+    assert removed == "bar"
+    assert "foo" not in doc.cards[0]["fields"]
+    assert doc.cards[0]["fields"]["baz"] == "qux"
+
+
+def test_remove_card_field_absent_returns_none():
+    """remove_card_field returns None when the field doesn't exist."""
+    md = (
+        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nBody.\n\n"
+        "~~~card-yaml\n#@kind: note\n~~~\n"
+    )
+    doc = Document.from_markdown(md)
+    assert doc.remove_card_field(0, "missing") is None
+
+
+def test_remove_card_field_out_of_range():
+    """remove_card_field raises EditError for an out-of-range card index."""
+    from quillmark import EditError
+
+    md = "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n"
+    doc = Document.from_markdown(md)
+    with pytest.raises(EditError, match="IndexOutOfRange"):
+        doc.remove_card_field(0, "foo")
+
+
+def test_remove_card_field_reserved_name():
+    """remove_card_field rejects reserved names."""
+    from quillmark import EditError
+
+    md = (
+        "~~~card-yaml\n#@quill: q\n#@kind: main\n~~~\n\nBody.\n\n"
+        "~~~card-yaml\n#@kind: note\n~~~\n"
+    )
+    doc = Document.from_markdown(md)
+    with pytest.raises(EditError, match="ReservedName"):
+        doc.remove_card_field(0, "BODY")

--- a/crates/bindings/python/tests/test_render.py
+++ b/crates/bindings/python/tests/test_render.py
@@ -80,6 +80,26 @@ def test_quill_open_session_page_selection(taro_quill_dir, taro_md):
     assert subset.output_format == OutputFormat.SVG
 
 
+def test_render_session_metadata(taro_quill_dir, taro_md):
+    """RenderSession exposes backend_id, supports_canvas, and warnings."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+    parsed = Document.from_markdown(taro_md)
+
+    session = quill.open(parsed)
+    assert session.backend_id == quill.backend
+    assert session.supports_canvas == quill.supports_canvas
+    assert isinstance(session.warnings, list)
+
+
+def test_quill_supports_canvas(taro_quill_dir):
+    """Quill.supports_canvas is True for the typst backend."""
+    engine = Quillmark()
+    quill = engine.quill_from_path(str(taro_quill_dir))
+    # The fixture quill uses the typst backend, which is canvas-capable.
+    assert quill.supports_canvas is True
+
+
 def test_quill_render_full_document(taro_quill_dir, taro_md):
     """quill.render(doc) renders successfully."""
     engine = Quillmark()


### PR DESCRIPTION
## Summary

A review of `crates/bindings/python` against the wasm binding surfaced several primitives that exist in wasm but not in Python — schema-version probing on the storage DTO, structural equality / clone, the `removeCardField` mutator, and the canvas-preview probes. The Python `schema` accessor also returned a YAML string instead of the structured dict the wasm `Quill.schema` exposes. This PR closes those gaps so callers picking either binding get the same primitives for the document / storage / edit / session paths.

Breaking changes are allowed per the task scope. The Python binding is still marked experimental (per `b6144a8`), so I changed `quill.schema` to return a structured dict and split YAML access out into `quill.schema_yaml`.

## Changes

**`Document`**
- New static methods: `try_from_json`, `schema_version_of`, `current_schema_version` — for "is this content a stored DTO or raw Markdown?" detection and cross-version migration.
- New instance methods: `clone()`, `__copy__`, `__deepcopy__` (the `copy` module Just Works), `equals(other)` / `__eq__`, `__repr__`, `card_count` getter (O(1)), and `remove_card_field(index, name)`.

**`Quill`**
- New `supports_canvas` getter.
- **Breaking:** `quill.schema` now returns a structured `dict` matching the wasm shape (`{"main": {...}, "card_kinds": {...}}`) instead of a YAML string. Use the new `quill.schema_yaml` getter when a YAML string is wanted.

**`RenderSession`**
- New `backend_id`, `supports_canvas`, and `warnings` getters. `warnings` surfaces session-level diagnostics emitted at `quill.open(...)` time.

Tests and the README are updated.

## Test plan
- [x] `cargo check -p quillmark-python` — clean
- [x] `cargo clippy -p quillmark-python --no-deps` — only a pre-existing warning in `errors.rs`, unrelated
- [x] `cargo fmt -p quillmark-python --check` — clean
- [x] `maturin develop` + `pytest` — 84/84 pass (17 new tests for the added surface)

https://claude.ai/code/session_01YaGCsyAztHkoLCcRqHTsh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaGCsyAztHkoLCcRqHTsh4)_