### PR TITLE
Preserve comments in card-yaml metadata blocks

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -951,7 +951,10 @@ fn card_to_pydict<'py>(
     d.set_item("payload", fm.clone())?;
     d.set_item("fields", fm)?;
 
-    // Ordered item list with comments and fill flags.
+    // Ordered item list with comments and fill flags. Typed `$` entries
+    // are exposed via the typed accessors (e.g. `card["kind"]`); for full
+    // round-trip fidelity through the binding, callers use the versioned
+    // storage DTO via `Document.to_json()`.
     let items = pyo3::types::PyList::empty(py);
     for item in card.payload().items() {
         let entry = PyDict::new(py);
@@ -967,6 +970,9 @@ fn card_to_pydict<'py>(
                 entry.set_item("text", text)?;
                 entry.set_item("inline", *inline)?;
             }
+            quillmark_core::PayloadItem::Quill { .. }
+            | quillmark_core::PayloadItem::Kind { .. }
+            | quillmark_core::PayloadItem::Id { .. } => continue,
         }
         items.append(entry)?;
     }

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -229,14 +229,14 @@ describe('Document JSON DTO — toJson / fromJson', () => {
   it('round-trips a mutated document with cards', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.setField('title', 'New Title')
-    doc.pushCard({ tag: 'note', fields: { author: 'Alice' }, body: 'Hello' })
+    doc.pushCard({ kind: 'note', fields: { author: 'Alice' }, body: 'Hello' })
 
     const restored = Document.fromJson(doc.toJson())
 
     expect(restored.equals(doc)).toBe(true)
-    expect(restored.main.frontmatter.title).toBe('New Title')
-    expect(restored.cards[0].tag).toBe('note')
-    expect(restored.cards[0].frontmatter.author).toBe('Alice')
+    expect(restored.main.payload.title).toBe('New Title')
+    expect(restored.cards[0].kind).toBe('note')
+    expect(restored.cards[0].payload.author).toBe('Alice')
     expect(restored.cards[0].body).toBe('Hello')
   })
 

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -221,20 +221,31 @@ impl From<&quillmark_core::Card> for Card {
             fields_map.insert(k.clone(), v.as_json().clone());
         }
 
+        // `payloadItems` exposes user fields + comments. Typed `$` entries
+        // are visible through the typed accessors (`card.kind` etc.); for
+        // full round-trip fidelity through the binding, callers use the
+        // versioned storage DTO via `Document.toJson()`.
         let items: Vec<PayloadItem> = card
             .payload()
             .items()
             .iter()
-            .map(|item| match item {
-                quillmark_core::PayloadItem::Field { key, value, fill } => PayloadItem::Field {
-                    key: key.clone(),
-                    value: value.as_json().clone(),
-                    fill: *fill,
-                },
-                quillmark_core::PayloadItem::Comment { text, inline } => PayloadItem::Comment {
+            .filter_map(|item| match item {
+                quillmark_core::PayloadItem::Field { key, value, fill } => {
+                    Some(PayloadItem::Field {
+                        key: key.clone(),
+                        value: value.as_json().clone(),
+                        fill: *fill,
+                    })
+                }
+                quillmark_core::PayloadItem::Comment { text, inline } => Some(PayloadItem::Comment {
                     text: text.clone(),
                     inline: *inline,
-                },
+                }),
+                // `$` entries are typed system metadata; expose them via
+                // `card.kind` and friends rather than as opaque items.
+                quillmark_core::PayloadItem::Quill { .. }
+                | quillmark_core::PayloadItem::Kind { .. }
+                | quillmark_core::PayloadItem::Id { .. } => None,
             })
             .collect();
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -1,8 +1,23 @@
 //! Assembly of card-yaml blocks into a [`Document`].
 //!
-//! This module contains the top-level parsing glue: it calls the fence
-//! scanner, parses each block's YAML payload, extracts the `$`-prefixed
-//! system metadata, and assembles a typed [`Document`] from the pieces.
+//! This module is the top-level parsing glue: it calls the fence scanner,
+//! parses each block's YAML payload, extracts the `$`-prefixed system
+//! metadata into typed values, and assembles a typed [`Document`] from the
+//! pieces.
+//!
+//! ## Unified payload items
+//!
+//! Both `$`-prefixed system metadata and user fields end up as variants of
+//! [`PayloadItem`] in the card's [`Payload`] item list, in source order.
+//! There is no separate "metadata region" or "metadata vs payload" routing
+//! — a comment is a comment, attached to whichever item precedes it. This
+//! is what keeps inline-comment preservation symmetric across the
+//! `$`/non-`$` boundary.
+//!
+//! `extract_meta_from_payload` returns typed [`MetaValue`]s in source order;
+//! `build_payload` then walks the prescan items, replacing `$` field
+//! markers with the corresponding typed `Quill`/`Kind`/`Id` payload item
+//! and preserving every comment as-authored.
 
 use std::collections::HashMap;
 
@@ -11,7 +26,7 @@ use crate::value::QuillValue;
 use crate::Diagnostic;
 
 use super::fences::find_metadata_blocks;
-use super::meta::{extract_meta_from_payload, validate_payload_yaml, CardMetadata, MetaItem};
+use super::meta::{extract_meta_from_payload, validate_payload_yaml, MetaValue};
 use super::payload::{Payload, PayloadItem};
 use super::prescan::{prescan_fence_content, NestedComment, PreItem};
 use super::{Card, Document};
@@ -39,10 +54,8 @@ pub(super) struct MetadataBlock {
     pub(super) start: usize, // Position of the opening `~~~card-yaml`
     pub(super) end: usize,   // Position after the closing `~~~`
     pub(super) yaml_value: Option<serde_json::Value>, // Parsed YAML payload as JSON
-    /// Typed `$` system-metadata entries, in source order. Comments are not
-    /// here — they live in `pre_items` and get interleaved by the assembler
-    /// (`build_meta_and_payload`).
-    pub(super) meta_typed: Vec<MetaItem>,
+    /// Typed `$` system metadata values in source order.
+    pub(super) meta_values: Vec<MetaValue>,
     /// Pre-scan items (comments + fill-tagged field keys) in source order.
     pub(super) pre_items: Vec<PreItem>,
     /// Pre-scan nested comments (with structural paths).
@@ -75,10 +88,6 @@ pub(super) fn build_block(
         });
     }
 
-    // Run the pre-scan over the full block contents to extract top-level
-    // comments, `!fill` markers, and warn on unsupported tags / nested
-    // comments. `$`-prefixed reserved keys are ordinary YAML fields at this
-    // stage; they get extracted into typed metadata after parsing below.
     let pre = prescan_fence_content(raw_content);
 
     if let Some(err) = pre.fill_target_errors.first() {
@@ -86,7 +95,7 @@ pub(super) fn build_block(
     }
 
     // `!fill` is not permitted on `$` metadata keys — those are extracted into
-    // a typed [`CardMetadata`] and have no placeholder semantics.
+    // typed values and have no placeholder semantics.
     for item in &pre.items {
         if let PreItem::Field { key, fill: true } = item {
             if key.starts_with('$') {
@@ -100,7 +109,7 @@ pub(super) fn build_block(
     }
 
     let content = pre.cleaned_yaml.trim().to_string();
-    let (meta_typed, yaml_value) = if content.is_empty() {
+    let (meta_values, yaml_value) = if content.is_empty() {
         (Vec::new(), None)
     } else {
         let mut parsed = match serde_saphyr::from_str_with_options::<serde_json::Value>(
@@ -117,8 +126,8 @@ pub(super) fn build_block(
                 });
             }
         };
-        let meta_typed = extract_meta_from_payload(&mut parsed)?;
-        (meta_typed, Some(validate_payload_yaml(parsed)?))
+        let meta = extract_meta_from_payload(&mut parsed)?;
+        (meta, Some(validate_payload_yaml(parsed)?))
     };
 
     // Per-block field-count check (spec §8) — applied after `$`-key
@@ -136,7 +145,7 @@ pub(super) fn build_block(
         start: block_start,
         end: block_end,
         yaml_value,
-        meta_typed,
+        meta_values,
         pre_items: pre.items,
         pre_nested_comments: pre.nested_comments,
         pre_warnings: pre.warnings,
@@ -184,27 +193,21 @@ pub(super) fn decompose_with_warnings(
         ));
     }
 
-    // The root block must declare a `$quill` reference. (Its value is
-    // validated into a typed `QuillReference` during `$` metadata extraction.)
+    // The root block must declare a `$quill` reference.
     let root_block = &blocks[0];
-    let root_quill = root_block
-        .meta_typed
+    let has_root_quill = root_block
+        .meta_values
         .iter()
-        .find_map(|i| match i {
-            MetaItem::Quill(_) => Some(()),
-            _ => None,
-        });
-    if root_quill.is_none() {
+        .any(|m| matches!(m, MetaValue::Quill(_)));
+    if !has_root_quill {
         return Err(ParseError::MissingQuill(
             "The document's root card-yaml block must declare `$quill: <name>`.".to_string(),
         ));
     }
 
-    // `main` is the reserved kind for the document root. The root block
-    // must declare `$kind: main`; no other value is permitted there, and a
-    // composable card may not declare `$kind: main` (checked below).
-    let root_kind = root_block.meta_typed.iter().find_map(|i| match i {
-        MetaItem::Kind(k) => Some(k.as_str()),
+    // The root block must declare `$kind: main`.
+    let root_kind = root_block.meta_values.iter().find_map(|m| match m {
+        MetaValue::Kind(k) => Some(k.as_str()),
         _ => None,
     });
     match root_kind {
@@ -225,23 +228,21 @@ pub(super) fn decompose_with_warnings(
         }
     }
 
-    // Build the root block's metadata and payload item lists.
-    let (main_meta, main_payload) = build_meta_and_payload(
-        &root_block.meta_typed,
+    // Build the root block's payload.
+    let main_payload = build_payload(
+        &root_block.meta_values,
         &root_block.pre_items,
         &root_block.pre_nested_comments,
         &root_block.yaml_value,
     )?;
-    // Surface pre-scan warnings (nested-comment drops, unsupported tags).
     let mut warnings = warnings;
     for w in &root_block.pre_warnings {
         warnings.push(w.clone());
     }
 
     // Global body: between the end of the root block and the start of the
-    // first composable card block (or EOF). When a block follows, the slice
-    // ends with the blank-line separator — strip it so stored bodies contain
-    // only authored content.
+    // first composable card block (or EOF). Strip the structural blank-line
+    // separator when a block follows.
     let body_start = blocks[0].end;
     let (body_end, body_is_followed_by_fence) = match blocks.get(1) {
         Some(b) => (b.start, true),
@@ -254,22 +255,19 @@ pub(super) fn decompose_with_warnings(
         global_body_raw.to_string()
     };
 
-    let main = Card::from_parts(main_meta, main_payload, global_body);
+    let main = Card::from_parts(main_payload, global_body);
 
     // Parse composable card blocks (every block after the root) into Cards.
     let mut cards: Vec<Card> = Vec::new();
     for idx in 1..blocks.len() {
         let block = &blocks[idx];
 
-        // Only the root block binds the document to a quill. A composable
-        // card declaring `$quill` is a structural error — `$quill` is
-        // captured by the per-block header parser, but rejected here, where
-        // root-vs-composable position is known.
-        let has_quill = block
-            .meta_typed
+        // Only the root block binds the document to a quill.
+        if block
+            .meta_values
             .iter()
-            .any(|i| matches!(i, MetaItem::Quill(_)));
-        if has_quill {
+            .any(|m| matches!(m, MetaValue::Quill(_)))
+        {
             return Err(ParseError::InvalidStructure(
                 "A composable card-yaml block must not declare `$quill` — only \
                  the document's root block binds the document to a quill."
@@ -278,8 +276,8 @@ pub(super) fn decompose_with_warnings(
         }
 
         // `main` is reserved for the document root.
-        let kind_is_main = block.meta_typed.iter().any(|i| match i {
-            MetaItem::Kind(k) => k == "main",
+        let kind_is_main = block.meta_values.iter().any(|m| match m {
+            MetaValue::Kind(k) => k == "main",
             _ => false,
         });
         if kind_is_main {
@@ -290,8 +288,8 @@ pub(super) fn decompose_with_warnings(
             ));
         }
 
-        let (card_meta, card_payload) = build_meta_and_payload(
-            &block.meta_typed,
+        let card_payload = build_payload(
+            &block.meta_values,
             &block.pre_items,
             &block.pre_nested_comments,
             &block.yaml_value,
@@ -321,7 +319,7 @@ pub(super) fn decompose_with_warnings(
             card_body_raw.to_string()
         };
 
-        cards.push(Card::from_parts(card_meta, card_payload, card_body));
+        cards.push(Card::from_parts(card_payload, card_body));
     }
 
     let doc = Document::from_main_and_cards(main, cards, warnings.clone());
@@ -329,40 +327,20 @@ pub(super) fn decompose_with_warnings(
     Ok((doc, warnings))
 }
 
-/// Build a [`CardMetadata`] and [`Payload`] in lockstep from the pre-scan
-/// items and the parsed YAML mapping.
+/// Build a unified [`Payload`] from the pre-scan items, the typed `$`
+/// metadata values, and the parsed YAML mapping.
 ///
-/// `meta_typed` carries the typed `$` entries extracted from `yaml_value`,
-/// in source order. They have no comments attached — those live in
-/// `pre_items` and are interleaved here.
-///
-/// **Comment routing.** Comments are partitioned by region:
-///
-/// - Comments inline-trailing a `$` field, or own-line comments appearing
-///   **before** the first non-`$` field, go into the metadata items list.
-///   They round-trip on the metadata side of the block.
-/// - All other comments (after the first non-`$` field, or trailing a
-///   non-`$` field inline) go into the payload items list.
-///
-/// This mirrors how [`Payload`] preserves comments adjacent to fields:
-/// inline comments attach to the preceding field, own-line comments hold
-/// their source position. The metadata/payload split is purely about *where*
-/// the round-trip stores them; emit re-renders both regions in the same
-/// `~~~card-yaml` block.
-///
-/// `$`-prefixed entries themselves come from `meta_typed`. The pre-scan
-/// also carries their `Field` markers; those drive the position of each
-/// typed entry within the metadata items list but the typed value comes
-/// from `meta_typed`.
-///
+/// Walks `pre_items` in source order. Each non-`$` field pulls its typed
+/// value from `yaml_value`; each `$` field is replaced with the matching
+/// typed [`MetaValue`] from `meta_values`; comments pass through verbatim.
 /// Any parsed-map keys the pre-scan didn't capture are appended at the end
-/// of the payload in parsed-map order so we never drop values.
-fn build_meta_and_payload(
-    meta_typed: &[MetaItem],
+/// so we never silently drop values.
+fn build_payload(
+    meta_values: &[MetaValue],
     pre_items: &[PreItem],
     pre_nested_comments: &[NestedComment],
     yaml_value: &Option<serde_json::Value>,
-) -> Result<(CardMetadata, Payload), ParseError> {
+) -> Result<Payload, ParseError> {
     let mapping = match yaml_value {
         Some(serde_json::Value::Object(map)) => map.clone(),
         Some(serde_json::Value::Null) | None => serde_json::Map::new(),
@@ -373,111 +351,83 @@ fn build_meta_and_payload(
         }
     };
 
-    // Build a lookup from `$key` → typed MetaItem so we can attach values in
-    // source order as the pre-scan walks fields.
-    let mut typed_by_key: HashMap<String, MetaItem> = HashMap::with_capacity(meta_typed.len());
-    for item in meta_typed {
-        let key = match item {
-            MetaItem::Quill(_) => "$quill",
-            MetaItem::Kind(_) => "$kind",
-            MetaItem::Id(_) => "$id",
-            MetaItem::Comment { .. } => continue,
-        };
-        typed_by_key.insert(key.to_string(), item.clone());
+    // Look up typed `$` values by `$key`. Each entry is consumed at most
+    // once; anything left over at the end is appended in source order.
+    let mut typed_by_key: HashMap<&'static str, MetaValue> = HashMap::with_capacity(meta_values.len());
+    for m in meta_values {
+        typed_by_key.insert(m.key(), m.clone());
     }
 
-    let mut meta_items: Vec<MetaItem> = Vec::new();
-    let mut payload_items: Vec<PayloadItem> = Vec::new();
-    let mut consumed: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut in_meta_region = true;
+    let mut items: Vec<PayloadItem> = Vec::new();
+    let mut consumed_user_keys: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
 
-    let mut idx = 0;
-    while idx < pre_items.len() {
-        match &pre_items[idx] {
+    for item in pre_items {
+        match item {
             PreItem::Comment { text, inline } => {
-                let bucket_into_meta = in_meta_region
-                    || (*inline
-                        && idx > 0
-                        && matches!(
-                            pre_items.get(idx - 1),
-                            Some(PreItem::Field { key, .. }) if key.starts_with('$')
-                        ));
-                if bucket_into_meta {
-                    meta_items.push(MetaItem::Comment {
-                        text: text.clone(),
-                        inline: *inline,
-                    });
-                } else {
-                    payload_items.push(PayloadItem::Comment {
-                        text: text.clone(),
-                        inline: *inline,
-                    });
-                }
-                idx += 1;
+                items.push(PayloadItem::Comment {
+                    text: text.clone(),
+                    inline: *inline,
+                });
             }
             PreItem::Field { key, fill } => {
                 if key.starts_with('$') {
-                    if let Some(item) = typed_by_key.remove(key) {
-                        meta_items.push(item);
+                    if let Some(meta) = typed_by_key.remove(key.as_str()) {
+                        items.push(meta_to_payload_item(meta));
                     }
-                    // (No-op when `$key` was present in the prescan but the
-                    // typed-extraction map didn't contain it — that means the
-                    // YAML parser produced a payload that doesn't include the
-                    // key, which should never happen for a $-prefixed field.
-                    // The fallthrough silently drops the prescan marker.)
-                    idx += 1;
                     continue;
                 }
-                in_meta_region = false;
                 if let Some(value) = mapping.get(key).cloned() {
-                    // `!fill` applies to scalars and sequences. Mappings are
-                    // rejected because top-level `type: object` is unsupported.
                     if *fill && value.is_object() {
                         return Err(ParseError::InvalidStructure(format!(
                             "`!fill` on key `{}` targets a mapping; `!fill` is supported on scalars and sequences only",
                             key
                         )));
                     }
-                    payload_items.push(PayloadItem::Field {
+                    items.push(PayloadItem::Field {
                         key: key.clone(),
                         value: QuillValue::from_json(value),
                         fill: *fill,
                     });
-                    consumed.insert(key.clone());
+                    consumed_user_keys.insert(key.clone());
                 }
-                idx += 1;
             }
         }
     }
 
-    // Drain any typed `$` entries the prescan didn't reach (shouldn't happen
-    // in well-formed input but keeps the conversion total).
-    for item in meta_typed {
-        let key = match item {
-            MetaItem::Quill(_) => "$quill",
-            MetaItem::Kind(_) => "$kind",
-            MetaItem::Id(_) => "$id",
-            MetaItem::Comment { .. } => continue,
-        };
-        if typed_by_key.contains_key(key) {
-            meta_items.push(item.clone());
+    // Drain any typed `$` entries the prescan didn't reach (shouldn't
+    // happen in well-formed input but keeps the conversion total). Walk
+    // `meta_values` in source order so the relative `$` ordering is
+    // preserved.
+    for meta in meta_values {
+        if typed_by_key.contains_key(meta.key()) {
+            items.push(meta_to_payload_item(meta.clone()));
+            typed_by_key.remove(meta.key());
         }
     }
 
     // Append any parsed-map keys that the pre-scan didn't capture.
     for (key, value) in &mapping {
-        if consumed.contains(key) {
+        if consumed_user_keys.contains(key) {
             continue;
         }
-        payload_items.push(PayloadItem::Field {
+        items.push(PayloadItem::Field {
             key: key.clone(),
             value: QuillValue::from_json(value.clone()),
             fill: false,
         });
     }
 
-    Ok((
-        CardMetadata::from_items(meta_items),
-        Payload::from_items_with_nested(payload_items, pre_nested_comments.to_vec()),
+    Ok(Payload::from_items_with_nested(
+        items,
+        pre_nested_comments.to_vec(),
     ))
+}
+
+fn meta_to_payload_item(meta: MetaValue) -> PayloadItem {
+    match meta {
+        MetaValue::Quill(reference) => PayloadItem::Quill { reference },
+        MetaValue::Kind(value) => PayloadItem::Kind { value },
+        MetaValue::Id(value) => PayloadItem::Id { value },
+    }
 }

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -4,12 +4,14 @@
 //! scanner, parses each block's YAML payload, extracts the `$`-prefixed
 //! system metadata, and assembles a typed [`Document`] from the pieces.
 
+use std::collections::HashMap;
+
 use crate::error::ParseError;
 use crate::value::QuillValue;
 use crate::Diagnostic;
 
 use super::fences::find_metadata_blocks;
-use super::meta::{extract_meta_from_payload, validate_payload_yaml, CardMetadata};
+use super::meta::{extract_meta_from_payload, validate_payload_yaml, CardMetadata, MetaItem};
 use super::payload::{Payload, PayloadItem};
 use super::prescan::{prescan_fence_content, NestedComment, PreItem};
 use super::{Card, Document};
@@ -37,7 +39,10 @@ pub(super) struct MetadataBlock {
     pub(super) start: usize, // Position of the opening `~~~card-yaml`
     pub(super) end: usize,   // Position after the closing `~~~`
     pub(super) yaml_value: Option<serde_json::Value>, // Parsed YAML payload as JSON
-    pub(super) meta: CardMetadata, // The block's typed `$` system metadata
+    /// Typed `$` system-metadata entries, in source order. Comments are not
+    /// here — they live in `pre_items` and get interleaved by the assembler
+    /// (`build_meta_and_payload`).
+    pub(super) meta_typed: Vec<MetaItem>,
     /// Pre-scan items (comments + fill-tagged field keys) in source order.
     pub(super) pre_items: Vec<PreItem>,
     /// Pre-scan nested comments (with structural paths).
@@ -95,8 +100,8 @@ pub(super) fn build_block(
     }
 
     let content = pre.cleaned_yaml.trim().to_string();
-    let (meta, yaml_value) = if content.is_empty() {
-        (CardMetadata::default(), None)
+    let (meta_typed, yaml_value) = if content.is_empty() {
+        (Vec::new(), None)
     } else {
         let mut parsed = match serde_saphyr::from_str_with_options::<serde_json::Value>(
             &content,
@@ -112,8 +117,8 @@ pub(super) fn build_block(
                 });
             }
         };
-        let meta = extract_meta_from_payload(&mut parsed)?;
-        (meta, Some(validate_payload_yaml(parsed)?))
+        let meta_typed = extract_meta_from_payload(&mut parsed)?;
+        (meta_typed, Some(validate_payload_yaml(parsed)?))
     };
 
     // Per-block field-count check (spec §8) — applied after `$`-key
@@ -131,7 +136,7 @@ pub(super) fn build_block(
         start: block_start,
         end: block_end,
         yaml_value,
-        meta,
+        meta_typed,
         pre_items: pre.items,
         pre_nested_comments: pre.nested_comments,
         pre_warnings: pre.warnings,
@@ -182,7 +187,14 @@ pub(super) fn decompose_with_warnings(
     // The root block must declare a `$quill` reference. (Its value is
     // validated into a typed `QuillReference` during `$` metadata extraction.)
     let root_block = &blocks[0];
-    if root_block.meta.quill.is_none() {
+    let root_quill = root_block
+        .meta_typed
+        .iter()
+        .find_map(|i| match i {
+            MetaItem::Quill(_) => Some(()),
+            _ => None,
+        });
+    if root_quill.is_none() {
         return Err(ParseError::MissingQuill(
             "The document's root card-yaml block must declare `$quill: <name>`.".to_string(),
         ));
@@ -191,7 +203,11 @@ pub(super) fn decompose_with_warnings(
     // `main` is the reserved kind for the document root. The root block
     // must declare `$kind: main`; no other value is permitted there, and a
     // composable card may not declare `$kind: main` (checked below).
-    match root_block.meta.kind.as_deref() {
+    let root_kind = root_block.meta_typed.iter().find_map(|i| match i {
+        MetaItem::Kind(k) => Some(k.as_str()),
+        _ => None,
+    });
+    match root_kind {
         Some("main") => {}
         Some(other) => {
             return Err(ParseError::InvalidStructure(format!(
@@ -209,8 +225,9 @@ pub(super) fn decompose_with_warnings(
         }
     }
 
-    // Build the root block's payload item list.
-    let main_payload = build_payload_from_pre_and_parsed(
+    // Build the root block's metadata and payload item lists.
+    let (main_meta, main_payload) = build_meta_and_payload(
+        &root_block.meta_typed,
         &root_block.pre_items,
         &root_block.pre_nested_comments,
         &root_block.yaml_value,
@@ -237,7 +254,7 @@ pub(super) fn decompose_with_warnings(
         global_body_raw.to_string()
     };
 
-    let main = Card::from_parts(blocks[0].meta.clone(), main_payload, global_body);
+    let main = Card::from_parts(main_meta, main_payload, global_body);
 
     // Parse composable card blocks (every block after the root) into Cards.
     let mut cards: Vec<Card> = Vec::new();
@@ -248,7 +265,11 @@ pub(super) fn decompose_with_warnings(
         // card declaring `$quill` is a structural error — `$quill` is
         // captured by the per-block header parser, but rejected here, where
         // root-vs-composable position is known.
-        if block.meta.quill.is_some() {
+        let has_quill = block
+            .meta_typed
+            .iter()
+            .any(|i| matches!(i, MetaItem::Quill(_)));
+        if has_quill {
             return Err(ParseError::InvalidStructure(
                 "A composable card-yaml block must not declare `$quill` — only \
                  the document's root block binds the document to a quill."
@@ -257,7 +278,11 @@ pub(super) fn decompose_with_warnings(
         }
 
         // `main` is reserved for the document root.
-        if block.meta.kind.as_deref() == Some("main") {
+        let kind_is_main = block.meta_typed.iter().any(|i| match i {
+            MetaItem::Kind(k) => k == "main",
+            _ => false,
+        });
+        if kind_is_main {
             return Err(ParseError::InvalidStructure(
                 "A composable card-yaml block must not declare `$kind: main` — \
                  `main` is reserved for the document root."
@@ -265,7 +290,8 @@ pub(super) fn decompose_with_warnings(
             ));
         }
 
-        let card_payload = build_payload_from_pre_and_parsed(
+        let (card_meta, card_payload) = build_meta_and_payload(
+            &block.meta_typed,
             &block.pre_items,
             &block.pre_nested_comments,
             &block.yaml_value,
@@ -295,11 +321,7 @@ pub(super) fn decompose_with_warnings(
             card_body_raw.to_string()
         };
 
-        cards.push(Card::from_parts(
-            block.meta.clone(),
-            card_payload,
-            card_body,
-        ));
+        cards.push(Card::from_parts(card_meta, card_payload, card_body));
     }
 
     let doc = Document::from_main_and_cards(main, cards, warnings.clone());
@@ -307,24 +329,40 @@ pub(super) fn decompose_with_warnings(
     Ok((doc, warnings))
 }
 
-/// Build a [`Payload`] from the pre-scan items and the parsed YAML mapping.
+/// Build a [`CardMetadata`] and [`Payload`] in lockstep from the pre-scan
+/// items and the parsed YAML mapping.
 ///
-/// The pre-scan defined source order for fields and comments; the parsed
-/// YAML defined the typed value for each key. We walk pre-scan order, pulling
-/// each field's value from `parsed`. Any field the pre-scan didn't catch is
-/// appended at the end in parsed-map order so we never drop values.
+/// `meta_typed` carries the typed `$` entries extracted from `yaml_value`,
+/// in source order. They have no comments attached — those live in
+/// `pre_items` and are interleaved here.
 ///
-/// `$`-prefixed reserved keys have already been extracted into the block's
-/// [`CardMetadata`] by [`extract_meta_from_payload`] and removed from
-/// `yaml_value`. The pre-scan still carries their `Field` entries (and any
-/// inline comments that trailed them); we drop both here so they do not
-/// appear in the user-visible payload. Own-line comments adjacent to a `$`
-/// line remain in place — they round-trip as ordinary payload comments.
-fn build_payload_from_pre_and_parsed(
+/// **Comment routing.** Comments are partitioned by region:
+///
+/// - Comments inline-trailing a `$` field, or own-line comments appearing
+///   **before** the first non-`$` field, go into the metadata items list.
+///   They round-trip on the metadata side of the block.
+/// - All other comments (after the first non-`$` field, or trailing a
+///   non-`$` field inline) go into the payload items list.
+///
+/// This mirrors how [`Payload`] preserves comments adjacent to fields:
+/// inline comments attach to the preceding field, own-line comments hold
+/// their source position. The metadata/payload split is purely about *where*
+/// the round-trip stores them; emit re-renders both regions in the same
+/// `~~~card-yaml` block.
+///
+/// `$`-prefixed entries themselves come from `meta_typed`. The pre-scan
+/// also carries their `Field` markers; those drive the position of each
+/// typed entry within the metadata items list but the typed value comes
+/// from `meta_typed`.
+///
+/// Any parsed-map keys the pre-scan didn't capture are appended at the end
+/// of the payload in parsed-map order so we never drop values.
+fn build_meta_and_payload(
+    meta_typed: &[MetaItem],
     pre_items: &[PreItem],
     pre_nested_comments: &[NestedComment],
     yaml_value: &Option<serde_json::Value>,
-) -> Result<Payload, ParseError> {
+) -> Result<(CardMetadata, Payload), ParseError> {
     let mapping = match yaml_value {
         Some(serde_json::Value::Object(map)) => map.clone(),
         Some(serde_json::Value::Null) | None => serde_json::Map::new(),
@@ -335,31 +373,62 @@ fn build_payload_from_pre_and_parsed(
         }
     };
 
-    let mut items: Vec<PayloadItem> = Vec::new();
+    // Build a lookup from `$key` → typed MetaItem so we can attach values in
+    // source order as the pre-scan walks fields.
+    let mut typed_by_key: HashMap<String, MetaItem> = HashMap::with_capacity(meta_typed.len());
+    for item in meta_typed {
+        let key = match item {
+            MetaItem::Quill(_) => "$quill",
+            MetaItem::Kind(_) => "$kind",
+            MetaItem::Id(_) => "$id",
+            MetaItem::Comment { .. } => continue,
+        };
+        typed_by_key.insert(key.to_string(), item.clone());
+    }
+
+    let mut meta_items: Vec<MetaItem> = Vec::new();
+    let mut payload_items: Vec<PayloadItem> = Vec::new();
     let mut consumed: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut in_meta_region = true;
 
     let mut idx = 0;
     while idx < pre_items.len() {
         match &pre_items[idx] {
             PreItem::Comment { text, inline } => {
-                items.push(PayloadItem::Comment {
-                    text: text.clone(),
-                    inline: *inline,
-                });
+                let bucket_into_meta = in_meta_region
+                    || (*inline
+                        && idx > 0
+                        && matches!(
+                            pre_items.get(idx - 1),
+                            Some(PreItem::Field { key, .. }) if key.starts_with('$')
+                        ));
+                if bucket_into_meta {
+                    meta_items.push(MetaItem::Comment {
+                        text: text.clone(),
+                        inline: *inline,
+                    });
+                } else {
+                    payload_items.push(PayloadItem::Comment {
+                        text: text.clone(),
+                        inline: *inline,
+                    });
+                }
                 idx += 1;
             }
             PreItem::Field { key, fill } => {
                 if key.starts_with('$') {
-                    // `$`-key Field is system metadata, already extracted.
-                    // Drop the Field itself, and drop any inline comment that
-                    // immediately follows it (it targeted the metadata line).
-                    let drop_trailing_inline = matches!(
-                        pre_items.get(idx + 1),
-                        Some(PreItem::Comment { inline: true, .. })
-                    );
-                    idx += if drop_trailing_inline { 2 } else { 1 };
+                    if let Some(item) = typed_by_key.remove(key) {
+                        meta_items.push(item);
+                    }
+                    // (No-op when `$key` was present in the prescan but the
+                    // typed-extraction map didn't contain it — that means the
+                    // YAML parser produced a payload that doesn't include the
+                    // key, which should never happen for a $-prefixed field.
+                    // The fallthrough silently drops the prescan marker.)
+                    idx += 1;
                     continue;
                 }
+                in_meta_region = false;
                 if let Some(value) = mapping.get(key).cloned() {
                     // `!fill` applies to scalars and sequences. Mappings are
                     // rejected because top-level `type: object` is unsupported.
@@ -369,7 +438,7 @@ fn build_payload_from_pre_and_parsed(
                             key
                         )));
                     }
-                    items.push(PayloadItem::Field {
+                    payload_items.push(PayloadItem::Field {
                         key: key.clone(),
                         value: QuillValue::from_json(value),
                         fill: *fill,
@@ -381,20 +450,34 @@ fn build_payload_from_pre_and_parsed(
         }
     }
 
+    // Drain any typed `$` entries the prescan didn't reach (shouldn't happen
+    // in well-formed input but keeps the conversion total).
+    for item in meta_typed {
+        let key = match item {
+            MetaItem::Quill(_) => "$quill",
+            MetaItem::Kind(_) => "$kind",
+            MetaItem::Id(_) => "$id",
+            MetaItem::Comment { .. } => continue,
+        };
+        if typed_by_key.contains_key(key) {
+            meta_items.push(item.clone());
+        }
+    }
+
     // Append any parsed-map keys that the pre-scan didn't capture.
     for (key, value) in &mapping {
         if consumed.contains(key) {
             continue;
         }
-        items.push(PayloadItem::Field {
+        payload_items.push(PayloadItem::Field {
             key: key.clone(),
             value: QuillValue::from_json(value.clone()),
             fill: false,
         });
     }
 
-    Ok(Payload::from_items_with_nested(
-        items,
-        pre_nested_comments.to_vec(),
+    Ok((
+        CardMetadata::from_items(meta_items),
+        Payload::from_items_with_nested(payload_items, pre_nested_comments.to_vec()),
     ))
 }

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1,64 +1,62 @@
 //! Versioned, storage-stable serialization for [`Document`].
 //!
-//! [`Document`] and its component types (`Card`, `CardMetadata`, `Payload`,
-//! …) track the evolving Quillmark model; their in-memory layout is an
-//! internal detail and is deliberately *not* serialized directly. To persist
-//! a document — e.g. in a database — it is converted to a [`StoredDocument`]:
-//! a versioned envelope whose wire format is frozen per schema version.
+//! [`Document`] and its component types (`Card`, `Payload`, …) track the
+//! evolving Quillmark model; their in-memory layout is an internal detail
+//! and is deliberately *not* serialized directly. To persist a document —
+//! e.g. in a database — it is converted to a [`StoredDocument`]: a versioned
+//! envelope whose wire format is frozen per schema version.
 //!
 //! `Document` itself serializes through this envelope via
 //! `#[serde(into / try_from)]`, so the ordinary serde entry points produce
 //! and consume the versioned form transparently.
 //!
-//! ## Schema versioning
+//! ## Schema versions
 //!
-//! The schema version tracks the crate version at which the `Document` wire
-//! format was last changed — currently `0.81.0` (see [`SCHEMA_V0_81_0`]). A
-//! wire-format change adds a new [`StoredDocument`] variant with its own
-//! frozen type tree and a migration; older variants stay frozen so previously
-//! stored rows keep deserializing.
+//! - **`quillmark/document@0.82.0`** — current. Encodes the unified
+//!   [`Payload`] item list (typed `$` entries, user fields, and comments
+//!   interleaved in source order). This is the format newly serialized
+//!   documents use.
+//! - **`quillmark/document@0.81.0`** — legacy. Encodes the pre-unification
+//!   shape with a separate `sentinel` (the typed `$quill` / `$kind`) and a
+//!   `frontmatter` item list (user fields + comments only). Kept read-only
+//!   so documents written by `0.81.x` consumers still load; on
+//!   reconstruction it is migrated to the V0_82_0 in-memory shape.
 //!
-//! The canonical design — including the step-by-step procedure for adding a
-//! schema version — is `prose/canon/DOCUMENT_STORAGE.md`.
-//!
-//! ## Wire-format naming
-//!
-//! The V0_81_0 wire format uses the names current at the time it was frozen
-//! (`sentinel`, `frontmatter`, `tag`). The in-memory model has since renamed
-//! these to `meta`, `payload`, and `kind` respectively; the conversion code
-//! below maps between the two. The `$id` system-metadata field, added after
-//! V0_81_0 was frozen, is carried as an optional, soft-additive field on
-//! the wire-format sentinel variants — documents without an `id` serialize
-//! to byte-identical output, preserving the V0_81_0 byte-stability contract
-//! for the original field set.
+//! The canonical design — including the step-by-step procedure for adding
+//! a schema version — is `prose/canon/DOCUMENT_STORAGE.md`.
 
-// Storage DTO types are deliberately named after the crate version that
-// fixed their shape (e.g. `DocumentV0_81_0`); the underscores are intentional.
+// Storage DTO types are named after the crate version that fixed their shape
+// (e.g. `DocumentV0_81_0`); the underscores are intentional.
 #![allow(non_camel_case_types)]
 
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use super::meta::CardMetadata;
+use super::meta::validate_composable_kind;
 use super::payload::{Payload, PayloadItem};
 use super::prescan::{CommentPathSegment, NestedComment};
 use super::{Card, Document};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
-/// Schema version for the Document model as established in crate version
-/// `0.81.0`. Bumped only when the wire format itself changes.
+/// Schema version for the V0_81_0 wire format. Documents written by
+/// `quillmark-core` `0.81.x` carry this tag and are migrated forward on
+/// read.
 pub const SCHEMA_V0_81_0: &str = "quillmark/document@0.81.0";
 
-/// Read the `schema` field from a raw storage DTO payload without performing
-/// full deserialization.
+/// Schema version for the V0_82_0 wire format. Newly serialized documents
+/// carry this tag.
+pub const SCHEMA_V0_82_0: &str = "quillmark/document@0.82.0";
+
+/// Read the `schema` field from a raw storage DTO payload without
+/// performing full deserialization.
 ///
 /// Returns `None` if `json` is not valid JSON, is not an object, or has no
-/// `schema` field. The returned string is **not** validated against the set
-/// of supported schema versions — callers use this to distinguish "unknown
-/// future version" from "corrupt payload" when [`Document`] deserialization
-/// fails.
+/// `schema` field. The returned string is **not** validated against the
+/// set of supported schema versions — callers use this to distinguish
+/// "unknown future version" from "corrupt payload" when [`Document`]
+/// deserialization fails.
 pub fn peek_schema_version(json: &str) -> Option<String> {
     #[derive(Deserialize)]
     struct Peek {
@@ -75,122 +73,24 @@ pub fn peek_schema_version(json: &str) -> Option<String> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "schema")]
 pub enum StoredDocument {
-    /// Document model as of crate version `0.81.0`.
+    /// Current (V0_82_0) document model — unified payload items.
+    #[serde(rename = "quillmark/document@0.82.0")]
+    V0_82_0(DocumentV0_82_0),
+    /// Legacy (V0_81_0) document model — separate sentinel + frontmatter.
+    /// Read-only; migrated on reconstruction.
     #[serde(rename = "quillmark/document@0.81.0")]
     V0_81_0(DocumentV0_81_0),
 }
 
-/// Frozen `0.81.0` representation of a [`Document`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct DocumentV0_81_0 {
-    /// The document entry card.
-    pub main: CardV0_81_0,
-    /// Composable cards, in order.
-    #[serde(default)]
-    pub cards: Vec<CardV0_81_0>,
-}
-
-/// Frozen `0.81.0` representation of a [`Card`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CardV0_81_0 {
-    /// Card discriminator.
-    pub sentinel: SentinelV0_81_0,
-    /// Ordered frontmatter.
-    #[serde(default)]
-    pub frontmatter: FrontmatterV0_81_0,
-    /// Markdown body following the card fence.
-    #[serde(default)]
-    pub body: String,
-}
-
-/// Frozen `0.81.0` representation of a card discriminator.
-///
-/// Maps the V0_81_0 wire enum (`Main { quill }` vs `Card { tag }`) onto the
-/// model's unified [`CardMetadata`]. The `id` field is a soft-additive
-/// extension: absent on documents written before `$id` existed, optional
-/// on documents written after.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
-pub enum SentinelV0_81_0 {
-    /// Document entry card. `quill` is the rendered quill reference string
-    /// (e.g. `usaf_memo@0.1`), parsed back via [`QuillReference::from_str`].
-    /// The root's `$kind` is always `"main"` per the spec (§3.3); the wire
-    /// format omits it because the variant discriminator already implies it.
-    Main {
-        /// Quill reference string.
-        quill: String,
-        /// `$id` opaque identifier, if any.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        id: Option<String>,
-    },
-    /// Composable card with a kind tag.
-    Card {
-        /// Card kind tag (matches the model's `$kind`).
-        tag: String,
-        /// `$id` opaque identifier, if any.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        id: Option<String>,
-    },
-}
-
-/// Frozen `0.81.0` representation of a card payload.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct FrontmatterV0_81_0 {
-    /// Ordered fields and top-level comments.
-    #[serde(default)]
-    pub items: Vec<FrontmatterItemV0_81_0>,
-    /// Comments captured inside nested mappings/sequences.
-    #[serde(default)]
-    pub nested_comments: Vec<NestedCommentV0_81_0>,
-}
-
-/// Frozen `0.81.0` representation of a payload item.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
-pub enum FrontmatterItemV0_81_0 {
-    /// A YAML field.
-    Field {
-        /// Field key.
-        key: String,
-        /// Field value as raw JSON.
-        value: serde_json::Value,
-        /// `true` when tagged `!fill` in source.
-        #[serde(default)]
-        fill: bool,
-    },
-    /// A YAML comment.
-    Comment {
-        /// Comment text (no leading `#`).
-        text: String,
-        /// `true` for trailing inline comments.
-        #[serde(default)]
-        inline: bool,
-    },
-}
-
-/// Frozen `0.81.0` representation of a [`NestedComment`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct NestedCommentV0_81_0 {
-    /// Path to the immediate parent container.
-    pub container_path: Vec<CommentPathSegmentV0_81_0>,
-    /// Slot or host index (see [`NestedComment`]).
-    pub position: usize,
-    /// Comment text.
-    pub text: String,
-    /// `true` for trailing inline comments.
-    pub inline: bool,
-}
-
-/// Frozen `0.81.0` representation of a [`CommentPathSegment`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum CommentPathSegmentV0_81_0 {
-    /// Mapping key.
-    Key(String),
-    /// Sequence index.
-    Index(usize),
-}
-
 /// Failure while reconstructing a [`Document`] from a [`StoredDocument`].
+///
+/// The taxonomy is intentionally minimal: only [`Self::InvalidQuillReference`]
+/// is typed, because that is the one error a non-malicious caller hits at
+/// the document/quill boundary. Every other defect — wrong-role card,
+/// invalid kind, reserved field name, duplicate key, too many fields —
+/// can only arise from a hand-crafted storage DTO (the markdown parser
+/// already rejects them) and is reported through [`Self::Malformed`] with
+/// a descriptive message.
 #[derive(Debug, Clone, PartialEq)]
 pub enum StorageError {
     /// A stored quill reference string could not be parsed.
@@ -200,34 +100,9 @@ pub enum StorageError {
         /// Parser explanation.
         reason: String,
     },
-    /// The document's `main` card carried a non-`Main` sentinel. The entry
-    /// card must carry a `QUILL` reference.
-    MainCardNotMain,
-    /// A composable card carried a `Main` sentinel; only `main` may.
-    ComposableCardIsMain,
-    /// A composable card's tag was not a valid `[a-z_][a-z0-9_]*` identifier,
-    /// or it was `"main"` — the reserved root kind.
-    InvalidCardTag {
-        /// The offending tag.
-        tag: String,
-    },
-    /// A card carried more payload fields than
-    /// [`MAX_FIELD_COUNT`](crate::error::MAX_FIELD_COUNT).
-    TooManyFields {
-        /// The field count found.
-        count: usize,
-    },
-    /// A payload field used a reserved sentinel key
-    /// (`BODY`, `CARDS`, `QUILL`, `CARD`).
-    ReservedFieldName {
-        /// The offending key.
-        key: String,
-    },
-    /// Two payload fields in the same card shared a key.
-    DuplicateFieldKey {
-        /// The duplicated key.
-        key: String,
-    },
+    /// The stored document is structurally malformed in a way the markdown
+    /// parser would reject. The message describes the specific defect.
+    Malformed(String),
 }
 
 impl std::fmt::Display for StorageError {
@@ -236,143 +111,146 @@ impl std::fmt::Display for StorageError {
             StorageError::InvalidQuillReference { value, reason } => {
                 write!(f, "invalid quill reference {value:?}: {reason}")
             }
-            StorageError::MainCardNotMain => {
-                write!(f, "main card must carry a QUILL sentinel, not a card tag")
-            }
-            StorageError::ComposableCardIsMain => write!(
-                f,
-                "composable cards must carry a card tag, not a QUILL sentinel"
-            ),
-            StorageError::InvalidCardTag { tag } => {
-                if tag == "main" {
-                    write!(
-                        f,
-                        "card tag {tag:?} is reserved for the document root \
-                         and may not appear on a composable card"
-                    )
-                } else {
-                    write!(f, "invalid card tag {tag:?}: must match [a-z_][a-z0-9_]*")
-                }
-            }
-            StorageError::TooManyFields { count } => write!(
-                f,
-                "card has {count} payload fields, exceeding the maximum of {}",
-                crate::error::MAX_FIELD_COUNT
-            ),
-            StorageError::ReservedFieldName { key } => {
-                write!(f, "reserved name {key:?} cannot be used as a field name")
-            }
-            StorageError::DuplicateFieldKey { key } => {
-                write!(f, "duplicate payload field key {key:?}")
-            }
+            StorageError::Malformed(msg) => f.write_str(msg),
         }
     }
 }
 
 impl std::error::Error for StorageError {}
 
-/// Reject a payload no markdown-parsed `Document` could produce: too many
-/// fields, a reserved sentinel key, or a duplicate key. The markdown parser
-/// already rejects all three, so this only guards hand-crafted storage DTOs.
-fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
-    if payload.len() > crate::error::MAX_FIELD_COUNT {
-        return Err(StorageError::TooManyFields {
-            count: payload.len(),
-        });
-    }
-    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    for key in payload.keys() {
-        if super::edit::is_reserved_name(key) {
-            return Err(StorageError::ReservedFieldName { key: key.clone() });
-        }
-        if !seen.insert(key.as_str()) {
-            return Err(StorageError::DuplicateFieldKey { key: key.clone() });
-        }
-    }
-    Ok(())
+// ─── V0_82_0 wire format (current) ────────────────────────────────────────────
+
+/// Frozen `0.82.0` representation of a [`Document`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentV0_82_0 {
+    pub main: CardV0_82_0,
+    #[serde(default)]
+    pub cards: Vec<CardV0_82_0>,
 }
 
-// ── Document → StoredDocument (infallible) ────────────────────────────────────
+/// Frozen `0.82.0` representation of a [`Card`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardV0_82_0 {
+    pub payload: PayloadV0_82_0,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// Frozen `0.82.0` representation of a [`Payload`].
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PayloadV0_82_0 {
+    #[serde(default)]
+    pub items: Vec<PayloadItemV0_82_0>,
+    #[serde(default)]
+    pub nested_comments: Vec<NestedCommentV0_82_0>,
+}
+
+/// Frozen `0.82.0` representation of a unified payload item.
+///
+/// Discriminator field is `type` to keep it unambiguous next to the `$kind`
+/// metadata semantic (a `kind` discriminator would yield `{"kind":"kind"}`
+/// for `$kind` entries).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum PayloadItemV0_82_0 {
+    /// `$quill` system metadata — the quill reference string.
+    Quill { value: String },
+    /// `$kind` system metadata.
+    Kind { value: String },
+    /// `$id` system metadata.
+    Id { value: String },
+    /// A user-defined field.
+    Field {
+        key: String,
+        value: serde_json::Value,
+        #[serde(default)]
+        fill: bool,
+    },
+    /// A YAML comment.
+    Comment {
+        text: String,
+        #[serde(default)]
+        inline: bool,
+    },
+}
+
+/// Frozen `0.82.0` representation of a [`NestedComment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NestedCommentV0_82_0 {
+    pub container_path: Vec<CommentPathSegmentV0_82_0>,
+    pub position: usize,
+    pub text: String,
+    pub inline: bool,
+}
+
+/// Frozen `0.82.0` representation of a [`CommentPathSegment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommentPathSegmentV0_82_0 {
+    Key(String),
+    Index(usize),
+}
+
+// ─── Document ↔ V0_82_0 (live conversion) ─────────────────────────────────────
 
 impl From<Document> for StoredDocument {
     fn from(doc: Document) -> Self {
-        StoredDocument::V0_81_0(DocumentV0_81_0::from(&doc))
+        StoredDocument::V0_82_0(DocumentV0_82_0::from(&doc))
     }
 }
 
-impl From<&Document> for DocumentV0_81_0 {
+impl From<&Document> for DocumentV0_82_0 {
     fn from(doc: &Document) -> Self {
-        DocumentV0_81_0 {
-            main: CardV0_81_0::from(doc.main()),
-            cards: doc.cards().iter().map(CardV0_81_0::from).collect(),
+        DocumentV0_82_0 {
+            main: CardV0_82_0::from(doc.main()),
+            cards: doc.cards().iter().map(CardV0_82_0::from).collect(),
         }
     }
 }
 
-impl From<&Card> for CardV0_81_0 {
+impl From<&Card> for CardV0_82_0 {
     fn from(card: &Card) -> Self {
-        CardV0_81_0 {
-            sentinel: SentinelV0_81_0::from(card.meta()),
-            frontmatter: FrontmatterV0_81_0::from(card.payload()),
+        CardV0_82_0 {
+            payload: PayloadV0_82_0::from(card.payload()),
             body: card.body().to_string(),
         }
     }
 }
 
-impl From<&CardMetadata> for SentinelV0_81_0 {
-    fn from(meta: &CardMetadata) -> Self {
-        // A valid Card has either `quill` set (the main/entry card) or `kind`
-        // set (a composable card); the model invariant rules out both being
-        // `None` on a card produced by parsing or by the `Card::new` editor.
-        // If both happen to be set (only constructable via low-level
-        // `Card::from_parts`), preferring `quill` keeps the entry-card shape
-        // intact on the wire — the root's `kind` is always `"main"` per the
-        // spec and is implied by the `Main` variant itself.
-        //
-        // V0_81_0 predates comment-preserving metadata: any comments on
-        // `$` lines are dropped here. Storage paths that need comment
-        // fidelity should use a newer schema version.
-        if let Some(reference) = meta.quill() {
-            SentinelV0_81_0::Main {
-                quill: reference.to_string(),
-                id: meta.id().map(|s| s.to_string()),
-            }
-        } else {
-            let tag = meta.kind().unwrap_or_default().to_string();
-            SentinelV0_81_0::Card {
-                tag,
-                id: meta.id().map(|s| s.to_string()),
-            }
-        }
-    }
-}
-
-impl From<&Payload> for FrontmatterV0_81_0 {
+impl From<&Payload> for PayloadV0_82_0 {
     fn from(payload: &Payload) -> Self {
-        FrontmatterV0_81_0 {
+        PayloadV0_82_0 {
             items: payload
                 .items()
                 .iter()
-                .map(FrontmatterItemV0_81_0::from)
+                .map(PayloadItemV0_82_0::from)
                 .collect(),
             nested_comments: payload
                 .nested_comments()
                 .iter()
-                .map(NestedCommentV0_81_0::from)
+                .map(NestedCommentV0_82_0::from)
                 .collect(),
         }
     }
 }
 
-impl From<&PayloadItem> for FrontmatterItemV0_81_0 {
+impl From<&PayloadItem> for PayloadItemV0_82_0 {
     fn from(item: &PayloadItem) -> Self {
         match item {
-            PayloadItem::Field { key, value, fill } => FrontmatterItemV0_81_0::Field {
+            PayloadItem::Quill { reference } => PayloadItemV0_82_0::Quill {
+                value: reference.to_string(),
+            },
+            PayloadItem::Kind { value } => PayloadItemV0_82_0::Kind {
+                value: value.clone(),
+            },
+            PayloadItem::Id { value } => PayloadItemV0_82_0::Id {
+                value: value.clone(),
+            },
+            PayloadItem::Field { key, value, fill } => PayloadItemV0_82_0::Field {
                 key: key.clone(),
                 value: value.as_json().clone(),
                 fill: *fill,
             },
-            PayloadItem::Comment { text, inline } => FrontmatterItemV0_81_0::Comment {
+            PayloadItem::Comment { text, inline } => PayloadItemV0_82_0::Comment {
                 text: text.clone(),
                 inline: *inline,
             },
@@ -380,13 +258,13 @@ impl From<&PayloadItem> for FrontmatterItemV0_81_0 {
     }
 }
 
-impl From<&NestedComment> for NestedCommentV0_81_0 {
+impl From<&NestedComment> for NestedCommentV0_82_0 {
     fn from(nc: &NestedComment) -> Self {
-        NestedCommentV0_81_0 {
+        NestedCommentV0_82_0 {
             container_path: nc
                 .container_path
                 .iter()
-                .map(CommentPathSegmentV0_81_0::from)
+                .map(CommentPathSegmentV0_82_0::from)
                 .collect(),
             position: nc.position,
             text: nc.text.clone(),
@@ -395,126 +273,115 @@ impl From<&NestedComment> for NestedCommentV0_81_0 {
     }
 }
 
-impl From<&CommentPathSegment> for CommentPathSegmentV0_81_0 {
+impl From<&CommentPathSegment> for CommentPathSegmentV0_82_0 {
     fn from(seg: &CommentPathSegment) -> Self {
         match seg {
-            CommentPathSegment::Key(k) => CommentPathSegmentV0_81_0::Key(k.clone()),
-            CommentPathSegment::Index(i) => CommentPathSegmentV0_81_0::Index(*i),
+            CommentPathSegment::Key(k) => CommentPathSegmentV0_82_0::Key(k.clone()),
+            CommentPathSegment::Index(i) => CommentPathSegmentV0_82_0::Index(*i),
         }
     }
 }
-
-// ── StoredDocument → Document (fallible) ──────────────────────────────────────
 
 impl TryFrom<StoredDocument> for Document {
     type Error = StorageError;
 
     fn try_from(stored: StoredDocument) -> Result<Self, Self::Error> {
         match stored {
-            StoredDocument::V0_81_0(payload) => Document::try_from(payload),
+            StoredDocument::V0_82_0(payload) => Document::try_from(payload),
+            StoredDocument::V0_81_0(payload) => Document::try_from(DocumentV0_82_0::from(payload)),
         }
     }
 }
 
-impl TryFrom<DocumentV0_81_0> for Document {
+impl TryFrom<DocumentV0_82_0> for Document {
     type Error = StorageError;
 
-    fn try_from(payload: DocumentV0_81_0) -> Result<Self, Self::Error> {
+    fn try_from(payload: DocumentV0_82_0) -> Result<Self, Self::Error> {
         let main = Card::try_from(payload.main)?;
-        if main.meta().quill().is_none() {
-            return Err(StorageError::MainCardNotMain);
+        if main.quill().is_none() {
+            return Err(StorageError::Malformed(
+                "main card must carry a $quill entry".into(),
+            ));
         }
         let cards = payload
             .cards
             .into_iter()
             .map(Card::try_from)
             .collect::<Result<Vec<_>, _>>()?;
-        if cards.iter().any(|c| c.meta().quill().is_some()) {
-            return Err(StorageError::ComposableCardIsMain);
+        for card in &cards {
+            if card.quill().is_some() {
+                return Err(StorageError::Malformed(
+                    "composable cards must not carry a $quill entry".into(),
+                ));
+            }
+            if let Some(kind) = card.kind() {
+                if let Err(_) = validate_composable_kind(kind) {
+                    return Err(StorageError::Malformed(format!(
+                        "invalid composable card kind {kind:?}: must match \
+                         [a-z_][a-z0-9_]* and not be \"main\""
+                    )));
+                }
+            }
         }
         Ok(Document::from_main_and_cards(main, cards, Vec::new()))
     }
 }
 
-impl TryFrom<CardV0_81_0> for Card {
+impl TryFrom<CardV0_82_0> for Card {
     type Error = StorageError;
 
-    fn try_from(card: CardV0_81_0) -> Result<Self, Self::Error> {
-        let meta = CardMetadata::try_from(card.sentinel)?;
-        let payload = Payload::from(card.frontmatter);
+    fn try_from(card: CardV0_82_0) -> Result<Self, Self::Error> {
+        let payload = Payload::try_from(card.payload)?;
         validate_dto_payload(&payload)?;
-        Ok(Card::from_parts(meta, payload, card.body))
+        Ok(Card::from_parts(payload, card.body))
     }
 }
 
-impl TryFrom<SentinelV0_81_0> for CardMetadata {
+impl TryFrom<PayloadV0_82_0> for Payload {
     type Error = StorageError;
 
-    fn try_from(sentinel: SentinelV0_81_0) -> Result<Self, Self::Error> {
-        match sentinel {
-            SentinelV0_81_0::Main { quill, id } => {
-                let reference = QuillReference::from_str(&quill).map_err(|reason| {
-                    StorageError::InvalidQuillReference {
-                        value: quill.clone(),
-                        reason,
-                    }
-                })?;
-                // The `Main` variant implies `$kind: main` (spec §3.3); the
-                // reconstructed model carries the canonical kind so the
-                // markdown emit emits `$kind: main` and the round-trip is
-                // symmetric with the parser, which requires it.
-                let mut meta = CardMetadata::new();
-                meta.set_quill(reference);
-                meta.set_kind("main");
-                if let Some(id) = id {
-                    meta.set_id(id);
-                }
-                Ok(meta)
-            }
-            SentinelV0_81_0::Card { tag, id } => {
-                if let Err(_) = super::meta::validate_composable_kind(&tag) {
-                    return Err(StorageError::InvalidCardTag { tag });
-                }
-                let mut meta = CardMetadata::new();
-                meta.set_kind(tag);
-                if let Some(id) = id {
-                    meta.set_id(id);
-                }
-                Ok(meta)
-            }
+    fn try_from(p: PayloadV0_82_0) -> Result<Self, Self::Error> {
+        let mut items = Vec::with_capacity(p.items.len());
+        for item in p.items {
+            items.push(PayloadItem::try_from(item)?);
         }
-    }
-}
-
-impl From<FrontmatterV0_81_0> for Payload {
-    fn from(fm: FrontmatterV0_81_0) -> Self {
-        let items = fm.items.into_iter().map(PayloadItem::from).collect();
-        let nested = fm
+        let nested = p
             .nested_comments
             .into_iter()
             .map(NestedComment::from)
             .collect();
-        Payload::from_items_with_nested(items, nested)
+        Ok(Payload::from_items_with_nested(items, nested))
     }
 }
 
-impl From<FrontmatterItemV0_81_0> for PayloadItem {
-    fn from(item: FrontmatterItemV0_81_0) -> Self {
-        match item {
-            FrontmatterItemV0_81_0::Field { key, value, fill } => PayloadItem::Field {
+impl TryFrom<PayloadItemV0_82_0> for PayloadItem {
+    type Error = StorageError;
+
+    fn try_from(item: PayloadItemV0_82_0) -> Result<Self, Self::Error> {
+        Ok(match item {
+            PayloadItemV0_82_0::Quill { value } => {
+                let reference = QuillReference::from_str(&value).map_err(|reason| {
+                    StorageError::InvalidQuillReference {
+                        value: value.clone(),
+                        reason,
+                    }
+                })?;
+                PayloadItem::Quill { reference }
+            }
+            PayloadItemV0_82_0::Kind { value } => PayloadItem::Kind { value },
+            PayloadItemV0_82_0::Id { value } => PayloadItem::Id { value },
+            PayloadItemV0_82_0::Field { key, value, fill } => PayloadItem::Field {
                 key,
                 value: QuillValue::from_json(value),
                 fill,
             },
-            FrontmatterItemV0_81_0::Comment { text, inline } => {
-                PayloadItem::Comment { text, inline }
-            }
-        }
+            PayloadItemV0_82_0::Comment { text, inline } => PayloadItem::Comment { text, inline },
+        })
     }
 }
 
-impl From<NestedCommentV0_81_0> for NestedComment {
-    fn from(nc: NestedCommentV0_81_0) -> Self {
+impl From<NestedCommentV0_82_0> for NestedComment {
+    fn from(nc: NestedCommentV0_82_0) -> Self {
         NestedComment {
             container_path: nc
                 .container_path
@@ -528,11 +395,214 @@ impl From<NestedCommentV0_81_0> for NestedComment {
     }
 }
 
-impl From<CommentPathSegmentV0_81_0> for CommentPathSegment {
+impl From<CommentPathSegmentV0_82_0> for CommentPathSegment {
+    fn from(seg: CommentPathSegmentV0_82_0) -> Self {
+        match seg {
+            CommentPathSegmentV0_82_0::Key(k) => CommentPathSegment::Key(k),
+            CommentPathSegmentV0_82_0::Index(i) => CommentPathSegment::Index(i),
+        }
+    }
+}
+
+/// Reject a payload no markdown-parsed `Document` could produce: too many
+/// fields, a reserved sentinel key, or a duplicate user-field key. The
+/// markdown parser already rejects all three; this only guards hand-crafted
+/// storage DTOs.
+fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
+    if payload.len() > crate::error::MAX_FIELD_COUNT {
+        return Err(StorageError::Malformed(format!(
+            "card has {} user fields, exceeding the maximum of {}",
+            payload.len(),
+            crate::error::MAX_FIELD_COUNT
+        )));
+    }
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for key in payload.keys() {
+        if super::edit::is_reserved_name(key) {
+            return Err(StorageError::Malformed(format!(
+                "reserved name {key:?} cannot be used as a field name"
+            )));
+        }
+        if !seen.insert(key.as_str()) {
+            return Err(StorageError::Malformed(format!(
+                "duplicate user-field key {key:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+// ─── V0_81_0 wire format (legacy, read-only) ──────────────────────────────────
+
+/// Frozen `0.81.0` representation of a [`Document`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentV0_81_0 {
+    pub main: CardV0_81_0,
+    #[serde(default)]
+    pub cards: Vec<CardV0_81_0>,
+}
+
+/// Frozen `0.81.0` representation of a [`Card`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardV0_81_0 {
+    pub sentinel: SentinelV0_81_0,
+    #[serde(default)]
+    pub frontmatter: FrontmatterV0_81_0,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// Frozen `0.81.0` representation of a card discriminator (sentinel).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum SentinelV0_81_0 {
+    Main {
+        quill: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    Card {
+        tag: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+}
+
+/// Frozen `0.81.0` representation of a card payload (user fields only).
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct FrontmatterV0_81_0 {
+    #[serde(default)]
+    pub items: Vec<FrontmatterItemV0_81_0>,
+    #[serde(default)]
+    pub nested_comments: Vec<NestedCommentV0_81_0>,
+}
+
+/// Frozen `0.81.0` representation of a payload item (no `$` entries).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum FrontmatterItemV0_81_0 {
+    Field {
+        key: String,
+        value: serde_json::Value,
+        #[serde(default)]
+        fill: bool,
+    },
+    Comment {
+        text: String,
+        #[serde(default)]
+        inline: bool,
+    },
+}
+
+/// Frozen `0.81.0` representation of a [`NestedComment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NestedCommentV0_81_0 {
+    pub container_path: Vec<CommentPathSegmentV0_81_0>,
+    pub position: usize,
+    pub text: String,
+    pub inline: bool,
+}
+
+/// Frozen `0.81.0` representation of a [`CommentPathSegment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommentPathSegmentV0_81_0 {
+    Key(String),
+    Index(usize),
+}
+
+// ─── V0_81_0 → V0_82_0 migration ──────────────────────────────────────────────
+//
+// The migration is purely structural — it converts the old separate
+// `sentinel + frontmatter` shape into a unified items list, then defers to
+// the V0_82_0 → Document path for typed validation. Quill-reference
+// validity is checked once, on the V0_82_0 side.
+
+impl From<DocumentV0_81_0> for DocumentV0_82_0 {
+    fn from(d: DocumentV0_81_0) -> Self {
+        DocumentV0_82_0 {
+            main: CardV0_82_0::from(d.main),
+            cards: d.cards.into_iter().map(CardV0_82_0::from).collect(),
+        }
+    }
+}
+
+impl From<CardV0_81_0> for CardV0_82_0 {
+    fn from(c: CardV0_81_0) -> Self {
+        let mut items: Vec<PayloadItemV0_82_0> = Vec::new();
+
+        // The sentinel migrates to a prelude of typed `$` entries. The
+        // `Main` variant implies `$kind: main` (spec §3.3); the
+        // reconstructed model carries the canonical kind so the markdown
+        // emit produces a parseable document.
+        match c.sentinel {
+            SentinelV0_81_0::Main { quill, id } => {
+                items.push(PayloadItemV0_82_0::Quill { value: quill });
+                items.push(PayloadItemV0_82_0::Kind {
+                    value: "main".into(),
+                });
+                if let Some(id) = id {
+                    items.push(PayloadItemV0_82_0::Id { value: id });
+                }
+            }
+            SentinelV0_81_0::Card { tag, id } => {
+                items.push(PayloadItemV0_82_0::Kind { value: tag });
+                if let Some(id) = id {
+                    items.push(PayloadItemV0_82_0::Id { value: id });
+                }
+            }
+        }
+
+        // Append user fields and comments in their original order. V0_81_0
+        // didn't track `$`-line comments separately, so the comment
+        // positions migrate as-is (after the `$` prelude).
+        for item in c.frontmatter.items {
+            items.push(match item {
+                FrontmatterItemV0_81_0::Field { key, value, fill } => {
+                    PayloadItemV0_82_0::Field { key, value, fill }
+                }
+                FrontmatterItemV0_81_0::Comment { text, inline } => {
+                    PayloadItemV0_82_0::Comment { text, inline }
+                }
+            });
+        }
+
+        let nested_comments = c
+            .frontmatter
+            .nested_comments
+            .into_iter()
+            .map(NestedCommentV0_82_0::from)
+            .collect();
+
+        CardV0_82_0 {
+            payload: PayloadV0_82_0 {
+                items,
+                nested_comments,
+            },
+            body: c.body,
+        }
+    }
+}
+
+impl From<NestedCommentV0_81_0> for NestedCommentV0_82_0 {
+    fn from(nc: NestedCommentV0_81_0) -> Self {
+        NestedCommentV0_82_0 {
+            container_path: nc
+                .container_path
+                .into_iter()
+                .map(CommentPathSegmentV0_82_0::from)
+                .collect(),
+            position: nc.position,
+            text: nc.text,
+            inline: nc.inline,
+        }
+    }
+}
+
+impl From<CommentPathSegmentV0_81_0> for CommentPathSegmentV0_82_0 {
     fn from(seg: CommentPathSegmentV0_81_0) -> Self {
         match seg {
-            CommentPathSegmentV0_81_0::Key(k) => CommentPathSegment::Key(k),
-            CommentPathSegmentV0_81_0::Index(i) => CommentPathSegment::Index(i),
+            CommentPathSegmentV0_81_0::Key(k) => CommentPathSegmentV0_82_0::Key(k),
+            CommentPathSegmentV0_81_0::Index(i) => CommentPathSegmentV0_82_0::Index(i),
         }
     }
 }
@@ -577,75 +647,38 @@ This body and the metadata above are an indorsement card.
         assert_eq!(doc.to_markdown(), restored.to_markdown());
     }
 
-    /// Every parsed root carries `meta.kind == Some("main")` per the spec,
-    /// and the DTO round-trip preserves that — the wire `Main` variant
-    /// implies it, so the restored model populates it unconditionally.
+    #[test]
+    fn serialization_uses_v0_82_0_schema() {
+        let doc = sample();
+        let value: serde_json::Value = serde_json::to_value(&doc).unwrap();
+        assert_eq!(value["schema"], SCHEMA_V0_82_0);
+    }
+
     #[test]
     fn root_kind_is_main_through_round_trip() {
         let doc = Document::from_markdown(
             "~~~card-yaml\n$quill: usaf_memo@0.1\n$kind: main\ntitle: \"Hi\"\n~~~\n",
         )
         .unwrap();
-        assert_eq!(doc.main().meta().kind(), Some("main"));
+        assert_eq!(doc.main().kind(), Some("main"));
         let restored: Document =
             serde_json::from_str(&serde_json::to_string(&doc).unwrap()).unwrap();
         assert_eq!(doc, restored);
-        assert_eq!(restored.main().meta().kind(), Some("main"));
-    }
-
-    /// A composable card tagged `"main"` on the wire must be rejected on
-    /// reconstruction — `main` is reserved for the document root.
-    #[test]
-    fn rejects_composable_card_tagged_main() {
-        let json = r#"{"schema":"quillmark/document@0.81.0",
-            "main":{"sentinel":{"kind":"main","quill":"usaf_memo@0.1"},
-                    "frontmatter":{},"body":""},
-            "cards":[{"sentinel":{"kind":"card","tag":"main"},
-                      "frontmatter":{},"body":""}]}"#;
-        let err = serde_json::from_str::<Document>(json).unwrap_err();
-        assert!(err.to_string().contains("reserved for the document root"));
+        assert_eq!(restored.main().kind(), Some("main"));
     }
 
     #[test]
     fn serialization_is_byte_deterministic() {
-        // The wasm `toJson` docstring promises byte-equal output for
-        // equal documents within a schema version; consumers content-hash
-        // the result for divergence detection. Three guarantees are
-        // checked: re-serialization stability, round-trip stability, and
-        // path-independence — a parsed document and a DTO-restored copy of
-        // it serialize to the same bytes.
+        // Re-serialization stability, round-trip stability, and
+        // path-independence — checked together because consumers
+        // content-hash the result.
         let doc = sample();
         let first = serde_json::to_string(&doc).unwrap();
         let second = serde_json::to_string(&doc).unwrap();
-        assert_eq!(
-            first, second,
-            "to_string must be deterministic (byte-equal on repeated calls)"
-        );
+        assert_eq!(first, second, "to_string must be deterministic");
         let restored: Document = serde_json::from_str(&first).unwrap();
         let third = serde_json::to_string(&restored).unwrap();
-        assert_eq!(
-            first, third,
-            "byte-equality must survive a round-trip through fromJson/toJson"
-        );
-
-        // Path independence: documents arrived at by different routes but
-        // value-equal must serialize identically.
-        let from_markdown = sample();
-        let from_dto: Document =
-            serde_json::from_str(&serde_json::to_string(&from_markdown).unwrap()).unwrap();
-        assert_eq!(from_markdown, from_dto);
-        assert_eq!(
-            serde_json::to_string(&from_markdown).unwrap(),
-            serde_json::to_string(&from_dto).unwrap(),
-            "value-equal documents must serialize to byte-equal strings regardless of construction path"
-        );
-    }
-
-    #[test]
-    fn serialized_form_carries_schema_version() {
-        let doc = sample();
-        let value: serde_json::Value = serde_json::to_value(&doc).unwrap();
-        assert_eq!(value["schema"], SCHEMA_V0_81_0);
+        assert_eq!(first, third, "byte-equality must survive a round-trip");
     }
 
     #[test]
@@ -658,173 +691,149 @@ This body and the metadata above are an indorsement card.
     fn peek_schema_version_reads_field_without_full_parse() {
         let doc = sample();
         let json = serde_json::to_string(&doc).unwrap();
-        assert_eq!(peek_schema_version(&json).as_deref(), Some(SCHEMA_V0_81_0));
+        assert_eq!(peek_schema_version(&json).as_deref(), Some(SCHEMA_V0_82_0));
 
-        // Unknown future version: peek still succeeds, even though full
-        // deserialization would reject it.
+        // Unknown future version: peek still succeeds.
         let future = r#"{"schema":"quillmark/document@0.99.0","main":{}}"#;
         assert_eq!(
             peek_schema_version(future).as_deref(),
             Some("quillmark/document@0.99.0")
         );
-
-        // Not JSON, no schema field, wrong type — all None.
         assert_eq!(peek_schema_version("not json"), None);
         assert_eq!(peek_schema_version(r#"{"foo":"bar"}"#), None);
-        assert_eq!(peek_schema_version(r#"{"schema":42}"#), None);
-        assert_eq!(peek_schema_version("[1,2,3]"), None);
+    }
+
+    #[test]
+    fn comment_on_dollar_line_round_trips() {
+        // The headline case the unification enables: a `$kind` line with an
+        // inline trailing comment survives a JSON round-trip.
+        let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main # required for root
+title: Hi
+~~~
+";
+        let doc = Document::from_markdown(src).unwrap();
+        let json = serde_json::to_string(&doc).unwrap();
+        let restored: Document = serde_json::from_str(&json).unwrap();
+        assert_eq!(doc, restored);
+        // And the emitted markdown carries the comment back on the `$kind` line.
+        assert!(restored
+            .to_markdown()
+            .contains("$kind: main # required for root"));
+    }
+
+    #[test]
+    fn v0_81_0_payload_loads_via_migration() {
+        let json = r#"{
+            "schema": "quillmark/document@0.81.0",
+            "main": {
+                "sentinel": {"kind": "main", "quill": "usaf_memo@0.1"},
+                "frontmatter": {
+                    "items": [{"kind": "field", "key": "title", "value": "Hello"}]
+                },
+                "body": "Body."
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.main().kind(), Some("main"));
+        assert_eq!(doc.quill_reference().to_string(), "usaf_memo@0.1");
+        assert_eq!(
+            doc.main().payload().get("title").unwrap().as_str(),
+            Some("Hello")
+        );
+    }
+
+    #[test]
+    fn v0_81_0_with_composable_card_migrates() {
+        let json = r#"{
+            "schema": "quillmark/document@0.81.0",
+            "main": {
+                "sentinel": {"kind": "main", "quill": "q@1.0"},
+                "frontmatter": {"items": []},
+                "body": ""
+            },
+            "cards": [
+                {
+                    "sentinel": {"kind": "card", "tag": "indorsement"},
+                    "frontmatter": {"items": [{"kind": "field", "key": "for", "value": "X"}]},
+                    "body": "C body"
+                }
+            ]
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.cards().len(), 1);
+        assert_eq!(doc.cards()[0].kind(), Some("indorsement"));
+        assert_eq!(
+            doc.cards()[0].payload().get("for").unwrap().as_str(),
+            Some("X")
+        );
+    }
+
+    #[test]
+    fn rejects_main_card_without_quill() {
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {"payload": {"items": [{"type": "kind", "value": "main"}]}, "body": ""},
+            "cards": []
+        }"#;
+        let err = serde_json::from_str::<Document>(json).unwrap_err();
+        assert!(err.to_string().contains("$quill"));
+    }
+
+    #[test]
+    fn rejects_composable_card_tagged_main() {
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"}
+                ]},
+                "body": ""
+            },
+            "cards": [
+                {"payload": {"items": [{"type": "kind", "value": "main"}]}, "body": ""}
+            ]
+        }"#;
+        let err = serde_json::from_str::<Document>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid composable card kind"));
     }
 
     #[test]
     fn rejects_invalid_quill_reference() {
-        let stored = StoredDocument::V0_81_0(DocumentV0_81_0 {
-            main: CardV0_81_0 {
-                sentinel: SentinelV0_81_0::Main {
-                    quill: "not a valid ref!!".to_string(),
-                    id: None,
-                },
-                frontmatter: FrontmatterV0_81_0::default(),
-                body: String::new(),
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "not a valid ref!!"},
+                    {"type": "kind", "value": "main"}
+                ]},
+                "body": ""
             },
-            cards: Vec::new(),
-        });
-        let err = Document::try_from(stored).unwrap_err();
-        assert!(matches!(err, StorageError::InvalidQuillReference { .. }));
-    }
-
-    #[test]
-    fn rejects_main_card_with_card_sentinel() {
-        // A crafted DTO whose `main` carries a card tag instead of a QUILL
-        // reference must be rejected — not built into a Document that later
-        // panics in `to_markdown()` / the render path.
-        let json = r#"{"schema":"quillmark/document@0.81.0",
-            "main":{"sentinel":{"kind":"card","tag":"x"},"frontmatter":{},"body":""}}"#;
+            "cards": []
+        }"#;
         let err = serde_json::from_str::<Document>(json).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("main card must carry a QUILL sentinel"));
-    }
-
-    #[test]
-    fn rejects_composable_card_with_main_sentinel() {
-        let stored = StoredDocument::V0_81_0(DocumentV0_81_0 {
-            main: CardV0_81_0 {
-                sentinel: SentinelV0_81_0::Main {
-                    quill: "usaf_memo@0.1".to_string(),
-                    id: None,
-                },
-                frontmatter: FrontmatterV0_81_0::default(),
-                body: String::new(),
-            },
-            cards: vec![CardV0_81_0 {
-                sentinel: SentinelV0_81_0::Main {
-                    quill: "usaf_memo@0.1".to_string(),
-                    id: None,
-                },
-                frontmatter: FrontmatterV0_81_0::default(),
-                body: String::new(),
-            }],
-        });
-        let err = Document::try_from(stored).unwrap_err();
-        assert_eq!(err, StorageError::ComposableCardIsMain);
-    }
-
-    /// A minimal valid main card wrapping `fm`, with no composable cards.
-    fn doc_with_main_frontmatter(fm: FrontmatterV0_81_0) -> StoredDocument {
-        StoredDocument::V0_81_0(DocumentV0_81_0 {
-            main: CardV0_81_0 {
-                sentinel: SentinelV0_81_0::Main {
-                    quill: "usaf_memo@0.1".to_string(),
-                    id: None,
-                },
-                frontmatter: fm,
-                body: String::new(),
-            },
-            cards: Vec::new(),
-        })
-    }
-
-    fn dto_field(key: &str) -> FrontmatterItemV0_81_0 {
-        FrontmatterItemV0_81_0::Field {
-            key: key.to_string(),
-            value: serde_json::json!("x"),
-            fill: false,
-        }
-    }
-
-    #[test]
-    fn rejects_invalid_card_tag() {
-        let stored = StoredDocument::V0_81_0(DocumentV0_81_0 {
-            main: CardV0_81_0 {
-                sentinel: SentinelV0_81_0::Main {
-                    quill: "usaf_memo@0.1".to_string(),
-                    id: None,
-                },
-                frontmatter: FrontmatterV0_81_0::default(),
-                body: String::new(),
-            },
-            cards: vec![CardV0_81_0 {
-                sentinel: SentinelV0_81_0::Card {
-                    tag: "Bad Tag".to_string(),
-                    id: None,
-                },
-                frontmatter: FrontmatterV0_81_0::default(),
-                body: String::new(),
-            }],
-        });
-        let err = Document::try_from(stored).unwrap_err();
-        assert!(matches!(err, StorageError::InvalidCardTag { .. }));
+        assert!(err.to_string().contains("invalid quill reference"));
     }
 
     #[test]
     fn rejects_reserved_field_name() {
-        let fm = FrontmatterV0_81_0 {
-            items: vec![dto_field("BODY")],
-            nested_comments: Vec::new(),
-        };
-        let err = Document::try_from(doc_with_main_frontmatter(fm)).unwrap_err();
-        assert!(matches!(err, StorageError::ReservedFieldName { .. }));
-    }
-
-    #[test]
-    fn rejects_duplicate_field_key() {
-        let fm = FrontmatterV0_81_0 {
-            items: vec![dto_field("a"), dto_field("a")],
-            nested_comments: Vec::new(),
-        };
-        let err = Document::try_from(doc_with_main_frontmatter(fm)).unwrap_err();
-        assert!(matches!(err, StorageError::DuplicateFieldKey { .. }));
-    }
-
-    #[test]
-    fn rejects_too_many_fields() {
-        let items = (0..=crate::error::MAX_FIELD_COUNT)
-            .map(|i| dto_field(&format!("f{i}")))
-            .collect();
-        let fm = FrontmatterV0_81_0 {
-            items,
-            nested_comments: Vec::new(),
-        };
-        let err = Document::try_from(doc_with_main_frontmatter(fm)).unwrap_err();
-        assert!(matches!(err, StorageError::TooManyFields { .. }));
-    }
-
-    #[test]
-    fn accepts_non_identifier_field_keys() {
-        // The markdown parser produces keys like `memo-for`; the DTO must
-        // round-trip them rather than reject them on charset grounds.
-        let fm = FrontmatterV0_81_0 {
-            items: vec![dto_field("memo-for")],
-            nested_comments: Vec::new(),
-        };
-        assert!(Document::try_from(doc_with_main_frontmatter(fm)).is_ok());
-    }
-
-    #[test]
-    fn explicit_dto_conversion_round_trips() {
-        let doc = sample();
-        let dto = DocumentV0_81_0::from(&doc);
-        let restored = Document::try_from(dto).unwrap();
-        assert_eq!(doc, restored);
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "field", "key": "BODY", "value": "x"}
+                ]},
+                "body": ""
+            },
+            "cards": []
+        }"#;
+        let err = serde_json::from_str::<Document>(json).unwrap_err();
+        assert!(err.to_string().contains("reserved name"));
     }
 }

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -40,7 +40,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use super::meta::{is_valid_kind_name, CardMetadata};
+use super::meta::CardMetadata;
 use super::payload::{Payload, PayloadItem};
 use super::prescan::{CommentPathSegment, NestedComment};
 use super::{Card, Document};
@@ -328,16 +328,20 @@ impl From<&CardMetadata> for SentinelV0_81_0 {
         // `Card::from_parts`), preferring `quill` keeps the entry-card shape
         // intact on the wire — the root's `kind` is always `"main"` per the
         // spec and is implied by the `Main` variant itself.
-        if let Some(reference) = &meta.quill {
+        //
+        // V0_81_0 predates comment-preserving metadata: any comments on
+        // `$` lines are dropped here. Storage paths that need comment
+        // fidelity should use a newer schema version.
+        if let Some(reference) = meta.quill() {
             SentinelV0_81_0::Main {
                 quill: reference.to_string(),
-                id: meta.id.clone(),
+                id: meta.id().map(|s| s.to_string()),
             }
         } else {
-            let tag = meta.kind.clone().unwrap_or_default();
+            let tag = meta.kind().unwrap_or_default().to_string();
             SentinelV0_81_0::Card {
                 tag,
-                id: meta.id.clone(),
+                id: meta.id().map(|s| s.to_string()),
             }
         }
     }
@@ -417,7 +421,7 @@ impl TryFrom<DocumentV0_81_0> for Document {
 
     fn try_from(payload: DocumentV0_81_0) -> Result<Self, Self::Error> {
         let main = Card::try_from(payload.main)?;
-        if main.meta().quill.is_none() {
+        if main.meta().quill().is_none() {
             return Err(StorageError::MainCardNotMain);
         }
         let cards = payload
@@ -425,7 +429,7 @@ impl TryFrom<DocumentV0_81_0> for Document {
             .into_iter()
             .map(Card::try_from)
             .collect::<Result<Vec<_>, _>>()?;
-        if cards.iter().any(|c| c.meta().quill.is_some()) {
+        if cards.iter().any(|c| c.meta().quill().is_some()) {
             return Err(StorageError::ComposableCardIsMain);
         }
         Ok(Document::from_main_and_cards(main, cards, Vec::new()))
@@ -459,21 +463,24 @@ impl TryFrom<SentinelV0_81_0> for CardMetadata {
                 // reconstructed model carries the canonical kind so the
                 // markdown emit emits `$kind: main` and the round-trip is
                 // symmetric with the parser, which requires it.
-                Ok(CardMetadata {
-                    quill: Some(reference),
-                    kind: Some("main".to_string()),
-                    id,
-                })
+                let mut meta = CardMetadata::new();
+                meta.set_quill(reference);
+                meta.set_kind("main");
+                if let Some(id) = id {
+                    meta.set_id(id);
+                }
+                Ok(meta)
             }
             SentinelV0_81_0::Card { tag, id } => {
-                if !is_valid_kind_name(&tag) || tag == "main" {
+                if let Err(_) = super::meta::validate_composable_kind(&tag) {
                     return Err(StorageError::InvalidCardTag { tag });
                 }
-                Ok(CardMetadata {
-                    quill: None,
-                    kind: Some(tag),
-                    id,
-                })
+                let mut meta = CardMetadata::new();
+                meta.set_kind(tag);
+                if let Some(id) = id {
+                    meta.set_id(id);
+                }
+                Ok(meta)
             }
         }
     }
@@ -579,11 +586,11 @@ This body and the metadata above are an indorsement card.
             "~~~card-yaml\n$quill: usaf_memo@0.1\n$kind: main\ntitle: \"Hi\"\n~~~\n",
         )
         .unwrap();
-        assert_eq!(doc.main().meta().kind.as_deref(), Some("main"));
+        assert_eq!(doc.main().meta().kind(), Some("main"));
         let restored: Document =
             serde_json::from_str(&serde_json::to_string(&doc).unwrap()).unwrap();
         assert_eq!(doc, restored);
-        assert_eq!(restored.main().meta().kind.as_deref(), Some("main"));
+        assert_eq!(restored.main().meta().kind(), Some("main"));
     }
 
     /// A composable card tagged `"main"` on the wire must be rejected on

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -21,7 +21,7 @@
 
 use unicode_normalization::UnicodeNormalization;
 
-use crate::document::meta::is_valid_kind_name;
+use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::document::{Card, CardMetadata, Document, Payload};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
@@ -110,7 +110,7 @@ impl Document {
     ///
     /// This method never modifies `warnings`.
     pub fn set_quill_ref(&mut self, reference: QuillReference) {
-        self.main_mut().meta_mut().quill = Some(reference);
+        self.main_mut().meta_mut().set_quill(reference);
     }
 
     // ── Card mutators ────────────────────────────────────────────────────────
@@ -199,17 +199,15 @@ impl Document {
         new_kind: impl Into<String>,
     ) -> Result<(), EditError> {
         let new_kind = new_kind.into();
-        if !is_valid_kind_name(&new_kind) {
-            return Err(EditError::InvalidKindName(new_kind));
-        }
-        if new_kind == "main" {
-            return Err(EditError::ReservedKind);
-        }
+        validate_composable_kind(&new_kind).map_err(|e| match e {
+            CardKindError::InvalidName => EditError::InvalidKindName(new_kind.clone()),
+            CardKindError::Reserved => EditError::ReservedKind,
+        })?;
         let len = self.cards().len();
         let card = self
             .card_mut(index)
             .ok_or(EditError::IndexOutOfRange { index, len })?;
-        card.meta_mut().kind = Some(new_kind);
+        card.meta_mut().set_kind(new_kind);
         Ok(())
     }
 
@@ -257,16 +255,12 @@ impl Card {
     /// The new card declares `$kind: <kind>`, has no fields, and an empty body.
     pub fn new(kind: impl Into<String>) -> Result<Self, EditError> {
         let kind = kind.into();
-        if !is_valid_kind_name(&kind) {
-            return Err(EditError::InvalidKindName(kind));
-        }
-        if kind == "main" {
-            return Err(EditError::ReservedKind);
-        }
-        let meta = CardMetadata {
-            kind: Some(kind),
-            ..CardMetadata::default()
-        };
+        validate_composable_kind(&kind).map_err(|e| match e {
+            CardKindError::InvalidName => EditError::InvalidKindName(kind.clone()),
+            CardKindError::Reserved => EditError::ReservedKind,
+        })?;
+        let mut meta = CardMetadata::new();
+        meta.set_kind(kind);
         Ok(Card::from_parts(meta, Payload::new(), String::new()))
     }
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -22,7 +22,7 @@
 use unicode_normalization::UnicodeNormalization;
 
 use crate::document::meta::{validate_composable_kind, CardKindError};
-use crate::document::{Card, CardMetadata, Document, Payload};
+use crate::document::{Card, Document, Payload};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
@@ -110,7 +110,7 @@ impl Document {
     ///
     /// This method never modifies `warnings`.
     pub fn set_quill_ref(&mut self, reference: QuillReference) {
-        self.main_mut().meta_mut().set_quill(reference);
+        self.main_mut().payload_mut().set_quill(reference);
     }
 
     // ── Card mutators ────────────────────────────────────────────────────────
@@ -207,7 +207,7 @@ impl Document {
         let card = self
             .card_mut(index)
             .ok_or(EditError::IndexOutOfRange { index, len })?;
-        card.meta_mut().set_kind(new_kind);
+        card.payload_mut().set_kind(new_kind);
         Ok(())
     }
 
@@ -259,9 +259,9 @@ impl Card {
             CardKindError::InvalidName => EditError::InvalidKindName(kind.clone()),
             CardKindError::Reserved => EditError::ReservedKind,
         })?;
-        let mut meta = CardMetadata::new();
-        meta.set_kind(kind);
-        Ok(Card::from_parts(meta, Payload::new(), String::new()))
+        let mut payload = Payload::new();
+        payload.set_kind(kind);
+        Ok(Card::from_parts(payload, String::new()))
     }
 
     /// Set a payload field by name. Always clears the `!fill` marker for

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -24,6 +24,7 @@
 use serde_json::Value as JsonValue;
 use serde_saphyr::{FlowMap, FlowSeq, SerializerOptions};
 
+use super::meta::MetaItem;
 use super::payload::PayloadItem;
 use super::prescan::{CommentPathSegment, NestedComment};
 use super::{Card, Document};
@@ -119,38 +120,56 @@ impl Document {
 
 // ── Block emission ────────────────────────────────────────────────────────────
 
-/// Emit a card-yaml block: `~~~card-yaml`, the `$`-prefixed system-metadata
-/// lines, the YAML data payload, then a closing `~~~`.
+/// Emit a `$key: value` system-metadata line with optional inline trailer.
 ///
-/// The `$` lines are emitted in the canonical key order `$quill`, `$kind`,
-/// `$id` — only keys the block declares appear. They lead the YAML payload
-/// as ordinary mapping entries; the parser extracts them back into typed
-/// metadata via [`super::meta::extract_meta_from_payload`].
-///
-/// Three tildes are always a safe fence length: canonically emitted payload
-/// lines never begin with `~` (keys are identifiers, sequence items start with
-/// `-`, saphyr quotes any string that would, comments start with `#`), so the
-/// fence can never be closed early.
-fn emit_meta_line(out: &mut String, key: &str, value: &str) {
+/// Three tildes around the block are always a safe fence length: canonically
+/// emitted payload lines never begin with `~` (keys are identifiers, sequence
+/// items start with `-`, saphyr quotes any string that would, comments start
+/// with `#`), so the fence can never be closed early.
+fn emit_meta_line(out: &mut String, key: &str, value: &str, trailer: Option<&str>) {
     out.push('$');
     out.push_str(key);
     out.push_str(": ");
     out.push_str(&saphyr_emit_scalar(&JsonValue::String(value.to_string())));
+    push_trailer(out, trailer);
     out.push('\n');
 }
 
+/// Emit a card-yaml block: `~~~card-yaml`, the `$`-prefixed system-metadata
+/// section, the YAML data payload, then a closing `~~~`.
+///
+/// The metadata section walks [`super::CardMetadata::items`] in source order
+/// (or canonical order for programmatically constructed metadata): each
+/// `$` entry emits its line, with any following `Comment { inline: true }`
+/// consumed as a trailer on the same line. Own-line comments inside the
+/// metadata region render as `# text` lines. The parser extracts `$` keys
+/// back into typed metadata via [`super::meta::extract_meta_from_payload`].
 fn emit_block(out: &mut String, card: &Card) {
     out.push_str("~~~card-yaml\n");
 
-    let meta = card.meta();
-    if let Some(quill) = &meta.quill {
-        emit_meta_line(out, "quill", &quill.to_string());
-    }
-    if let Some(kind) = &meta.kind {
-        emit_meta_line(out, "kind", kind);
-    }
-    if let Some(id) = &meta.id {
-        emit_meta_line(out, "id", id);
+    let meta_items = card.meta().items();
+    let mut i = 0;
+    while i < meta_items.len() {
+        let trailer = meta_items.get(i + 1).and_then(|next| match next {
+            MetaItem::Comment { text, inline: true } => Some(text.as_str()),
+            _ => None,
+        });
+        let consumed_trailer = trailer.is_some();
+        match &meta_items[i] {
+            MetaItem::Quill(q) => emit_meta_line(out, "quill", &q.to_string(), trailer),
+            MetaItem::Kind(k) => emit_meta_line(out, "kind", k, trailer),
+            MetaItem::Id(id) => emit_meta_line(out, "id", id, trailer),
+            MetaItem::Comment { text, .. } => {
+                out.push_str("# ");
+                out.push_str(text);
+                out.push('\n');
+            }
+        }
+        i += if consumed_trailer && !matches!(meta_items[i], MetaItem::Comment { .. }) {
+            2
+        } else {
+            1
+        };
     }
 
     emit_fence_items(

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -24,7 +24,6 @@
 use serde_json::Value as JsonValue;
 use serde_saphyr::{FlowMap, FlowSeq, SerializerOptions};
 
-use super::meta::MetaItem;
 use super::payload::PayloadItem;
 use super::prescan::{CommentPathSegment, NestedComment};
 use super::{Card, Document};
@@ -135,83 +134,53 @@ fn emit_meta_line(out: &mut String, key: &str, value: &str, trailer: Option<&str
     out.push('\n');
 }
 
-/// Emit a card-yaml block: `~~~card-yaml`, the `$`-prefixed system-metadata
-/// section, the YAML data payload, then a closing `~~~`.
-///
-/// The metadata section walks [`super::CardMetadata::items`] in source order
-/// (or canonical order for programmatically constructed metadata): each
-/// `$` entry emits its line, with any following `Comment { inline: true }`
-/// consumed as a trailer on the same line. Own-line comments inside the
-/// metadata region render as `# text` lines. The parser extracts `$` keys
-/// back into typed metadata via [`super::meta::extract_meta_from_payload`].
 fn emit_block(out: &mut String, card: &Card) {
     out.push_str("~~~card-yaml\n");
-
-    let meta_items = card.meta().items();
-    let mut i = 0;
-    while i < meta_items.len() {
-        let trailer = meta_items.get(i + 1).and_then(|next| match next {
-            MetaItem::Comment { text, inline: true } => Some(text.as_str()),
-            _ => None,
-        });
-        let consumed_trailer = trailer.is_some();
-        match &meta_items[i] {
-            MetaItem::Quill(q) => emit_meta_line(out, "quill", &q.to_string(), trailer),
-            MetaItem::Kind(k) => emit_meta_line(out, "kind", k, trailer),
-            MetaItem::Id(id) => emit_meta_line(out, "id", id, trailer),
-            MetaItem::Comment { text, .. } => {
-                out.push_str("# ");
-                out.push_str(text);
-                out.push('\n');
-            }
-        }
-        i += if consumed_trailer && !matches!(meta_items[i], MetaItem::Comment { .. }) {
-            2
-        } else {
-            1
-        };
-    }
-
-    emit_fence_items(
-        out,
-        card.payload().items(),
-        card.payload().nested_comments(),
-    );
-
+    emit_payload_items(out, card.payload().items(), card.payload().nested_comments());
     out.push_str("~~~\n");
 }
 
-/// Emit the ordered YAML items (fields and comments) of a fence body.
+/// Emit the ordered payload items of a card-yaml block.
 ///
-/// ## Inline-comment handling
-///
-/// - **Field + trailing inline.** A `Field` peeks at its successor: if the
-///   next item is `Comment{inline:true}`, the comment text is passed to
-///   [`emit_field`] as a trailer and consumed here. The trailer lands on the
-///   field's key/value line.
-/// - **Own-line / orphan.** A `Comment` that is not consumed by a field's
-///   lookahead — own-line, or an inline orphan — renders as an own-line
-///   `# text` comment.
-fn emit_fence_items(out: &mut String, items: &[PayloadItem], nested: &[NestedComment]) {
+/// Walks the unified item list — typed `$` entries, user fields, and
+/// comments interleaved in source order. A `Comment { inline: true }` that
+/// immediately follows any non-comment item is consumed as a trailer on
+/// that item's line; otherwise comments render own-line.
+fn emit_payload_items(out: &mut String, items: &[PayloadItem], nested: &[NestedComment]) {
     let mut i = 0;
     while i < items.len() {
+        // Peek for a trailing inline comment to use as the line trailer.
+        let trailer = items.get(i + 1).and_then(|next| match next {
+            PayloadItem::Comment { text, inline: true } => Some(text.as_str()),
+            _ => None,
+        });
+        let mut consumed_trailer = trailer.is_some();
+
         match &items[i] {
+            PayloadItem::Quill { reference } => {
+                emit_meta_line(out, "quill", &reference.to_string(), trailer);
+            }
+            PayloadItem::Kind { value } => {
+                emit_meta_line(out, "kind", value, trailer);
+            }
+            PayloadItem::Id { value } => {
+                emit_meta_line(out, "id", value, trailer);
+            }
             PayloadItem::Field { key, value, fill } => {
-                let trailer = items.get(i + 1).and_then(|next| match next {
-                    PayloadItem::Comment { text, inline: true } => Some(text.as_str()),
-                    _ => None,
-                });
                 let path = vec![CommentPathSegment::Key(key.clone())];
                 emit_field(out, key, value.as_json(), 0, *fill, &path, nested, trailer);
-                i += if trailer.is_some() { 2 } else { 1 };
             }
             PayloadItem::Comment { text, .. } => {
+                // Standalone comment line. A trailer would attach to
+                // *another* comment, which doesn't make sense; render it
+                // own-line on the next iteration instead.
                 out.push_str("# ");
                 out.push_str(text);
                 out.push('\n');
-                i += 1;
+                consumed_trailer = false;
             }
         }
+        i += if consumed_trailer { 2 } else { 1 };
     }
 }
 

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -2,15 +2,20 @@
 //!
 //! Every `~~~card-yaml` block's YAML payload may carry up to three reserved
 //! keys — `$quill`, `$kind`, `$id`. These are **system metadata** drawn from
-//! a closed set; any other `$`-prefixed key is a parse error. The keys are
-//! ordinary YAML and are read by the same parser that handles the rest of
-//! the payload; this module then **extracts** them from the user field set
-//! into a typed [`CardMetadata`].
+//! a closed set; any other `$`-prefixed key is a parse error.
 //!
-//! `$quill` on the root block binds the document to a quill; `$kind` is
-//! name-validated against `[a-z_][a-z0-9_]*` at parse time. `$id` is opaque
-//! metadata: any scalar is accepted and stringified on extraction, then
-//! carried through round-trip unchanged.
+//! ## Data shape
+//!
+//! [`CardMetadata`] is an ordered list of [`MetaItem`]s — the typed `$`
+//! entries interleaved with any YAML comments that sit on or among them.
+//! This mirrors how [`super::Payload`] preserves comments inside the user
+//! payload: the round-trip is symmetric on both sides of the `$`/non-`$`
+//! boundary.
+//!
+//! Typed accessors ([`CardMetadata::quill`] etc.) return the value of each
+//! entry; mutators ([`CardMetadata::set_quill`] etc.) replace it in place
+//! when present, or insert it at canonical position (`$quill` → `$kind` →
+//! `$id`) when absent. Comments are untouched by typed mutators.
 
 use std::str::FromStr;
 
@@ -19,44 +24,174 @@ use serde_json::Value as JsonValue;
 use crate::error::ParseError;
 use crate::version::QuillReference;
 
-/// Typed `$`-metadata of a single card-yaml block.
+/// One entry in a [`CardMetadata`] block — a typed `$` system-metadata
+/// field or a YAML comment.
 ///
-/// The reserved keys are a **closed set** of three optional entries; an
-/// unknown `$key` is rejected at parse time. `$quill` is parsed into a typed
-/// [`QuillReference`] as the block is read.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CardMetadata {
-    /// The `$quill` reference. Required on the document's root block and
-    /// rejected on composable cards (see `assemble`); `None` on every card
-    /// in a successfully parsed [`crate::Document`].
-    pub quill: Option<QuillReference>,
-    /// The `$kind` card kind, if the block declares one. Validated against
-    /// `[a-z_][a-z0-9_]*` at parse time.
-    pub kind: Option<String>,
-    /// The `$id` opaque identifier, if the block declares one.
-    pub id: Option<String>,
+/// `Comment.inline` distinguishes own-line comments (`# text` on a line by
+/// itself) from inline trailing comments (`$kind: value # note`). Inline
+/// comments attach to the `$` entry that immediately precedes them in the
+/// items vector; if no such entry exists at emit time they degrade to
+/// own-line comments. This mirrors [`super::payload::PayloadItem`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetaItem {
+    /// The `$quill` reference. Required on the document root; rejected on
+    /// composable cards.
+    Quill(QuillReference),
+    /// The `$kind` card kind. `$kind: main` is reserved for the root.
+    Kind(String),
+    /// The `$id` opaque identifier.
+    Id(String),
+    /// A YAML comment line sitting on or among the `$` entries.
+    Comment {
+        text: String,
+        inline: bool,
+    },
 }
 
-/// Walk the parsed YAML payload, extracting `$`-prefixed reserved keys into
-/// a typed [`CardMetadata`] and removing them from the user field set.
+impl MetaItem {
+    /// Canonical sort key for `$` entries. Returns `None` for comments,
+    /// which are positioned by source order and never reshuffled by typed
+    /// mutators.
+    fn canonical_rank(&self) -> Option<u8> {
+        match self {
+            MetaItem::Quill(_) => Some(0),
+            MetaItem::Kind(_) => Some(1),
+            MetaItem::Id(_) => Some(2),
+            MetaItem::Comment { .. } => None,
+        }
+    }
+}
+
+/// Ordered system-metadata of a single card-yaml block.
+///
+/// Holds the block's `$`-prefixed entries (closed set: `$quill`, `$kind`,
+/// `$id`) plus any YAML comments interleaved among them, in source order.
+/// Typed accessors look up entries by kind; the [`items`](Self::items)
+/// iterator walks the full ordered list (used by emit and the storage DTO).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CardMetadata {
+    items: Vec<MetaItem>,
+}
+
+impl CardMetadata {
+    /// Empty metadata — no `$` entries, no comments.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build from a pre-computed item list (parser and DTO entry point).
+    ///
+    /// The caller is responsible for ordering and validity: at most one
+    /// `Quill`, `Kind`, or `Id` entry; kind values matching
+    /// `[a-z_][a-z0-9_]*`; etc. Use [`set_quill`](Self::set_quill) and
+    /// friends for safe interactive construction.
+    pub fn from_items(items: Vec<MetaItem>) -> Self {
+        Self { items }
+    }
+
+    /// Ordered iterator over the underlying item list.
+    pub fn items(&self) -> &[MetaItem] {
+        &self.items
+    }
+
+    /// The `$quill` reference, if declared.
+    pub fn quill(&self) -> Option<&QuillReference> {
+        self.items.iter().find_map(|i| match i {
+            MetaItem::Quill(q) => Some(q),
+            _ => None,
+        })
+    }
+
+    /// The `$kind` value, if declared.
+    pub fn kind(&self) -> Option<&str> {
+        self.items.iter().find_map(|i| match i {
+            MetaItem::Kind(k) => Some(k.as_str()),
+            _ => None,
+        })
+    }
+
+    /// The `$id` value, if declared.
+    pub fn id(&self) -> Option<&str> {
+        self.items.iter().find_map(|i| match i {
+            MetaItem::Id(id) => Some(id.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Set the `$quill` reference. Replaces the existing entry in place if
+    /// present, or inserts at canonical position (before any `$kind` /
+    /// `$id`) otherwise. Comments are not moved.
+    pub fn set_quill(&mut self, reference: QuillReference) {
+        self.upsert_canonical(MetaItem::Quill(reference));
+    }
+
+    /// Set the `$kind` value. Same insertion rules as
+    /// [`set_quill`](Self::set_quill).
+    pub fn set_kind(&mut self, kind: impl Into<String>) {
+        self.upsert_canonical(MetaItem::Kind(kind.into()));
+    }
+
+    /// Set the `$id` value. Same insertion rules as
+    /// [`set_quill`](Self::set_quill).
+    pub fn set_id(&mut self, id: impl Into<String>) {
+        self.upsert_canonical(MetaItem::Id(id.into()));
+    }
+
+    /// Remove the `$quill` entry, returning the previous value if any.
+    pub fn take_quill(&mut self) -> Option<QuillReference> {
+        let pos = self
+            .items
+            .iter()
+            .position(|i| matches!(i, MetaItem::Quill(_)))?;
+        match self.items.remove(pos) {
+            MetaItem::Quill(q) => Some(q),
+            _ => unreachable!(),
+        }
+    }
+
+    fn upsert_canonical(&mut self, new: MetaItem) {
+        let new_rank = new
+            .canonical_rank()
+            .expect("upsert_canonical only accepts typed $ entries");
+        for slot in self.items.iter_mut() {
+            if slot.canonical_rank() == Some(new_rank) {
+                *slot = new;
+                return;
+            }
+        }
+        let insert_at = self
+            .items
+            .iter()
+            .position(|i| matches!(i.canonical_rank(), Some(r) if r > new_rank))
+            .unwrap_or(self.items.len());
+        self.items.insert(insert_at, new);
+    }
+}
+
+/// Walk the parsed YAML payload, extracting `$`-prefixed reserved keys
+/// from the user field set and validating each into a typed
+/// [`MetaItem`]. Returns the items in source order (saphyr preserves
+/// mapping insertion order via the workspace's `serde_json/preserve_order`
+/// feature).
+///
+/// Comments are not handled here — the caller interleaves them with these
+/// typed items using the prescan's source-order [`super::prescan::PreItem`]
+/// list. See `assemble::build_meta_and_payload`.
 ///
 /// The accepted keys are the closed set `{$quill, $kind, $id}`. Any other
-/// `$`-prefixed key is a parse error. Duplicate keys cannot arise here —
-/// the YAML parser rejects them as duplicate mapping keys before this
-/// function runs. A `$quill` value that fails to parse as a
-/// [`QuillReference`], or a `$kind` value that fails [`is_valid_kind_name`],
-/// is also a parse error.
+/// `$`-prefixed key is a parse error. Duplicate keys cannot arise — the
+/// YAML parser rejects them as duplicate mapping keys before this function
+/// runs. A `$quill` value that fails to parse as a [`QuillReference`], or a
+/// `$kind` value that fails [`is_valid_kind_name`], is also a parse error.
 ///
 /// `$quill` and `$kind` require string scalars (non-string YAML types are
-/// rejected). `$id` accepts any scalar and stringifies it, matching the
-/// "opaque identifier" semantics of the spec (§3.3).
+/// rejected). `$id` accepts any scalar and stringifies it.
 pub(super) fn extract_meta_from_payload(
     payload: &mut JsonValue,
-) -> Result<CardMetadata, ParseError> {
-    let mut meta = CardMetadata::default();
+) -> Result<Vec<MetaItem>, ParseError> {
     let map = match payload {
         JsonValue::Object(m) => m,
-        _ => return Ok(meta),
+        _ => return Ok(Vec::new()),
     };
 
     let dollar_keys: Vec<String> = map
@@ -65,11 +200,12 @@ pub(super) fn extract_meta_from_payload(
         .cloned()
         .collect();
 
+    let mut items = Vec::with_capacity(dollar_keys.len());
     for key in dollar_keys {
         let value = map
             .shift_remove(&key)
             .expect("key was just enumerated from the same map");
-        match key.as_str() {
+        let item = match key.as_str() {
             "$quill" => {
                 let s = require_string("$quill reference", value)?;
                 let reference = QuillReference::from_str(&s).map_err(|e| {
@@ -78,7 +214,7 @@ pub(super) fn extract_meta_from_payload(
                         s, e
                     ))
                 })?;
-                meta.quill = Some(reference);
+                MetaItem::Quill(reference)
             }
             "$kind" => {
                 let s = match value {
@@ -98,11 +234,9 @@ pub(super) fn extract_meta_from_payload(
                         s
                     )));
                 }
-                meta.kind = Some(s);
+                MetaItem::Kind(s)
             }
-            "$id" => {
-                meta.id = Some(scalar_to_string(&key, value)?);
-            }
+            "$id" => MetaItem::Id(scalar_to_string(&key, value)?),
             other => {
                 return Err(ParseError::InvalidStructure(format!(
                     "Unknown `{}` system-metadata key — the card-yaml block \
@@ -110,10 +244,11 @@ pub(super) fn extract_meta_from_payload(
                     other
                 )));
             }
-        }
+        };
+        items.push(item);
     }
 
-    Ok(meta)
+    Ok(items)
 }
 
 /// Require a YAML string scalar. The `label` is interpolated into the error
@@ -182,7 +317,7 @@ pub(super) fn validate_payload_yaml(
 }
 
 /// Validate a card kind name follows the pattern `[a-z_][a-z0-9_]*`.
-pub(super) fn is_valid_kind_name(name: &str) -> bool {
+pub fn is_valid_kind_name(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
@@ -203,10 +338,39 @@ pub(super) fn is_valid_kind_name(name: &str) -> bool {
     true
 }
 
+/// Validate a composable card kind: must match `[a-z_][a-z0-9_]*` and must
+/// not be the reserved root kind `"main"`.
+///
+/// Single source of truth for the composable-kind rule. Used by
+/// [`crate::Card::new`], [`crate::Document::set_card_kind`], and the storage
+/// DTO conversion so the rule cannot drift between editor and reader paths.
+pub fn validate_composable_kind(kind: &str) -> Result<(), CardKindError> {
+    if !is_valid_kind_name(kind) {
+        return Err(CardKindError::InvalidName);
+    }
+    if kind == "main" {
+        return Err(CardKindError::Reserved);
+    }
+    Ok(())
+}
+
+/// Reason [`validate_composable_kind`] rejected a kind string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardKindError {
+    /// Kind did not match `[a-z_][a-z0-9_]*`.
+    InvalidName,
+    /// Kind was `"main"`, reserved for the document root.
+    Reserved,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn extract(payload: &mut JsonValue) -> CardMetadata {
+        CardMetadata::from_items(extract_meta_from_payload(payload).unwrap())
+    }
 
     #[test]
     fn extracts_quill_kind_and_leaves_data_intact() {
@@ -215,31 +379,31 @@ mod tests {
             "$kind": "main",
             "title": "Doc",
         });
-        let meta = extract_meta_from_payload(&mut payload).unwrap();
-        assert_eq!(meta.quill.unwrap().to_string(), "foo@0.1");
-        assert_eq!(meta.kind.as_deref(), Some("main"));
+        let meta = extract(&mut payload);
+        assert_eq!(meta.quill().unwrap().to_string(), "foo@0.1");
+        assert_eq!(meta.kind(), Some("main"));
         assert_eq!(payload, json!({"title": "Doc"}));
     }
 
     #[test]
     fn extracts_id_from_string() {
         let mut payload = json!({"$id": "rev-1"});
-        let meta = extract_meta_from_payload(&mut payload).unwrap();
-        assert_eq!(meta.id.as_deref(), Some("rev-1"));
+        let meta = extract(&mut payload);
+        assert_eq!(meta.id(), Some("rev-1"));
     }
 
     #[test]
     fn extracts_id_from_number() {
         let mut payload = json!({"$id": 42});
-        let meta = extract_meta_from_payload(&mut payload).unwrap();
-        assert_eq!(meta.id.as_deref(), Some("42"));
+        let meta = extract(&mut payload);
+        assert_eq!(meta.id(), Some("42"));
     }
 
     #[test]
     fn extracts_id_from_bool() {
         let mut payload = json!({"$id": true});
-        let meta = extract_meta_from_payload(&mut payload).unwrap();
-        assert_eq!(meta.id.as_deref(), Some("true"));
+        let meta = extract(&mut payload);
+        assert_eq!(meta.id(), Some("true"));
     }
 
     #[test]
@@ -302,7 +466,64 @@ mod tests {
     #[test]
     fn non_object_payload_returns_empty_meta() {
         let mut payload = JsonValue::Null;
-        let meta = extract_meta_from_payload(&mut payload).unwrap();
-        assert_eq!(meta, CardMetadata::default());
+        let items = extract_meta_from_payload(&mut payload).unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn set_quill_inserts_at_position_zero() {
+        let mut meta = CardMetadata::new();
+        meta.set_kind("main");
+        meta.set_quill("foo@0.1".parse().unwrap());
+        assert!(matches!(meta.items()[0], MetaItem::Quill(_)));
+        assert!(matches!(meta.items()[1], MetaItem::Kind(_)));
+    }
+
+    #[test]
+    fn set_id_inserts_after_quill_and_kind() {
+        let mut meta = CardMetadata::new();
+        meta.set_quill("foo@0.1".parse().unwrap());
+        meta.set_kind("main");
+        meta.set_id("rev-1");
+        assert_eq!(meta.items().len(), 3);
+        assert!(matches!(meta.items()[2], MetaItem::Id(_)));
+    }
+
+    #[test]
+    fn set_replaces_in_place_preserving_position() {
+        let mut meta = CardMetadata::from_items(vec![
+            MetaItem::Quill("foo@0.1".parse().unwrap()),
+            MetaItem::Comment {
+                text: "trailing".into(),
+                inline: true,
+            },
+            MetaItem::Kind("main".into()),
+        ]);
+        meta.set_quill("bar@0.2".parse().unwrap());
+        assert_eq!(meta.quill().unwrap().to_string(), "bar@0.2");
+        // Item count unchanged, comment still between quill and kind.
+        assert_eq!(meta.items().len(), 3);
+        assert!(matches!(meta.items()[1], MetaItem::Comment { .. }));
+    }
+
+    #[test]
+    fn validate_composable_kind_rejects_main() {
+        assert_eq!(
+            validate_composable_kind("main"),
+            Err(CardKindError::Reserved)
+        );
+    }
+
+    #[test]
+    fn validate_composable_kind_rejects_bad_name() {
+        assert_eq!(
+            validate_composable_kind("Bad-Name"),
+            Err(CardKindError::InvalidName)
+        );
+    }
+
+    #[test]
+    fn validate_composable_kind_accepts_valid() {
+        assert!(validate_composable_kind("indorsement").is_ok());
     }
 }

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -1,21 +1,18 @@
-//! Card-yaml block metadata: the `$`-prefixed reserved keys.
+//! Validation helpers for card-yaml `$`-prefixed system metadata.
 //!
-//! Every `~~~card-yaml` block's YAML payload may carry up to three reserved
-//! keys — `$quill`, `$kind`, `$id`. These are **system metadata** drawn from
-//! a closed set; any other `$`-prefixed key is a parse error.
+//! The closed set of `$` keys (`$quill`, `$kind`, `$id`) and their typed
+//! values are now stored as variants of [`super::PayloadItem`] inside a
+//! card's unified [`super::Payload`] item list — they sit alongside user
+//! fields and comments in source order, which is what makes inline-comment
+//! preservation symmetric across the `$`/non-`$` boundary.
 //!
-//! ## Data shape
+//! This module retains only the validation primitives shared between the
+//! parser, the editor surface, and the storage DTO:
 //!
-//! [`CardMetadata`] is an ordered list of [`MetaItem`]s — the typed `$`
-//! entries interleaved with any YAML comments that sit on or among them.
-//! This mirrors how [`super::Payload`] preserves comments inside the user
-//! payload: the round-trip is symmetric on both sides of the `$`/non-`$`
-//! boundary.
-//!
-//! Typed accessors ([`CardMetadata::quill`] etc.) return the value of each
-//! entry; mutators ([`CardMetadata::set_quill`] etc.) replace it in place
-//! when present, or insert it at canonical position (`$quill` → `$kind` →
-//! `$id`) when absent. Comments are untouched by typed mutators.
+//! - [`extract_meta_from_payload`] — strip `$` keys from a parsed YAML
+//!   mapping and validate each into a typed [`MetaValue`].
+//! - [`is_valid_kind_name`] / [`validate_composable_kind`] — name checks
+//!   for `$kind`.
 
 use std::str::FromStr;
 
@@ -24,171 +21,44 @@ use serde_json::Value as JsonValue;
 use crate::error::ParseError;
 use crate::version::QuillReference;
 
-/// One entry in a [`CardMetadata`] block — a typed `$` system-metadata
-/// field or a YAML comment.
+/// A typed `$`-prefixed metadata value, decoupled from its position in the
+/// containing card's item list.
 ///
-/// `Comment.inline` distinguishes own-line comments (`# text` on a line by
-/// itself) from inline trailing comments (`$kind: value # note`). Inline
-/// comments attach to the `$` entry that immediately precedes them in the
-/// items vector; if no such entry exists at emit time they degrade to
-/// own-line comments. This mirrors [`super::payload::PayloadItem`].
+/// `extract_meta_from_payload` returns these in source order; the assembler
+/// then interleaves them with comments and user fields when building the
+/// final [`super::Payload`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MetaItem {
-    /// The `$quill` reference. Required on the document root; rejected on
-    /// composable cards.
+pub(super) enum MetaValue {
     Quill(QuillReference),
-    /// The `$kind` card kind. `$kind: main` is reserved for the root.
     Kind(String),
-    /// The `$id` opaque identifier.
     Id(String),
-    /// A YAML comment line sitting on or among the `$` entries.
-    Comment {
-        text: String,
-        inline: bool,
-    },
 }
 
-impl MetaItem {
-    /// Canonical sort key for `$` entries. Returns `None` for comments,
-    /// which are positioned by source order and never reshuffled by typed
-    /// mutators.
-    fn canonical_rank(&self) -> Option<u8> {
+impl MetaValue {
+    /// The `$key` string this value corresponds to.
+    pub(super) fn key(&self) -> &'static str {
         match self {
-            MetaItem::Quill(_) => Some(0),
-            MetaItem::Kind(_) => Some(1),
-            MetaItem::Id(_) => Some(2),
-            MetaItem::Comment { .. } => None,
+            MetaValue::Quill(_) => "$quill",
+            MetaValue::Kind(_) => "$kind",
+            MetaValue::Id(_) => "$id",
         }
     }
 }
 
-/// Ordered system-metadata of a single card-yaml block.
-///
-/// Holds the block's `$`-prefixed entries (closed set: `$quill`, `$kind`,
-/// `$id`) plus any YAML comments interleaved among them, in source order.
-/// Typed accessors look up entries by kind; the [`items`](Self::items)
-/// iterator walks the full ordered list (used by emit and the storage DTO).
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CardMetadata {
-    items: Vec<MetaItem>,
-}
-
-impl CardMetadata {
-    /// Empty metadata — no `$` entries, no comments.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Build from a pre-computed item list (parser and DTO entry point).
-    ///
-    /// The caller is responsible for ordering and validity: at most one
-    /// `Quill`, `Kind`, or `Id` entry; kind values matching
-    /// `[a-z_][a-z0-9_]*`; etc. Use [`set_quill`](Self::set_quill) and
-    /// friends for safe interactive construction.
-    pub fn from_items(items: Vec<MetaItem>) -> Self {
-        Self { items }
-    }
-
-    /// Ordered iterator over the underlying item list.
-    pub fn items(&self) -> &[MetaItem] {
-        &self.items
-    }
-
-    /// The `$quill` reference, if declared.
-    pub fn quill(&self) -> Option<&QuillReference> {
-        self.items.iter().find_map(|i| match i {
-            MetaItem::Quill(q) => Some(q),
-            _ => None,
-        })
-    }
-
-    /// The `$kind` value, if declared.
-    pub fn kind(&self) -> Option<&str> {
-        self.items.iter().find_map(|i| match i {
-            MetaItem::Kind(k) => Some(k.as_str()),
-            _ => None,
-        })
-    }
-
-    /// The `$id` value, if declared.
-    pub fn id(&self) -> Option<&str> {
-        self.items.iter().find_map(|i| match i {
-            MetaItem::Id(id) => Some(id.as_str()),
-            _ => None,
-        })
-    }
-
-    /// Set the `$quill` reference. Replaces the existing entry in place if
-    /// present, or inserts at canonical position (before any `$kind` /
-    /// `$id`) otherwise. Comments are not moved.
-    pub fn set_quill(&mut self, reference: QuillReference) {
-        self.upsert_canonical(MetaItem::Quill(reference));
-    }
-
-    /// Set the `$kind` value. Same insertion rules as
-    /// [`set_quill`](Self::set_quill).
-    pub fn set_kind(&mut self, kind: impl Into<String>) {
-        self.upsert_canonical(MetaItem::Kind(kind.into()));
-    }
-
-    /// Set the `$id` value. Same insertion rules as
-    /// [`set_quill`](Self::set_quill).
-    pub fn set_id(&mut self, id: impl Into<String>) {
-        self.upsert_canonical(MetaItem::Id(id.into()));
-    }
-
-    /// Remove the `$quill` entry, returning the previous value if any.
-    pub fn take_quill(&mut self) -> Option<QuillReference> {
-        let pos = self
-            .items
-            .iter()
-            .position(|i| matches!(i, MetaItem::Quill(_)))?;
-        match self.items.remove(pos) {
-            MetaItem::Quill(q) => Some(q),
-            _ => unreachable!(),
-        }
-    }
-
-    fn upsert_canonical(&mut self, new: MetaItem) {
-        let new_rank = new
-            .canonical_rank()
-            .expect("upsert_canonical only accepts typed $ entries");
-        for slot in self.items.iter_mut() {
-            if slot.canonical_rank() == Some(new_rank) {
-                *slot = new;
-                return;
-            }
-        }
-        let insert_at = self
-            .items
-            .iter()
-            .position(|i| matches!(i.canonical_rank(), Some(r) if r > new_rank))
-            .unwrap_or(self.items.len());
-        self.items.insert(insert_at, new);
-    }
-}
-
-/// Walk the parsed YAML payload, extracting `$`-prefixed reserved keys
-/// from the user field set and validating each into a typed
-/// [`MetaItem`]. Returns the items in source order (saphyr preserves
-/// mapping insertion order via the workspace's `serde_json/preserve_order`
-/// feature).
-///
-/// Comments are not handled here — the caller interleaves them with these
-/// typed items using the prescan's source-order [`super::prescan::PreItem`]
-/// list. See `assemble::build_meta_and_payload`.
+/// Walk the parsed YAML payload, extracting `$`-prefixed reserved keys into
+/// typed [`MetaValue`]s in source order. The keys are removed from `payload`
+/// so the caller can build the user-field portion from what remains.
 ///
 /// The accepted keys are the closed set `{$quill, $kind, $id}`. Any other
-/// `$`-prefixed key is a parse error. Duplicate keys cannot arise — the
-/// YAML parser rejects them as duplicate mapping keys before this function
-/// runs. A `$quill` value that fails to parse as a [`QuillReference`], or a
-/// `$kind` value that fails [`is_valid_kind_name`], is also a parse error.
+/// `$`-prefixed key is a parse error. Duplicate keys cannot arise here —
+/// the YAML parser rejects them as duplicate mapping keys before this
+/// function runs.
 ///
 /// `$quill` and `$kind` require string scalars (non-string YAML types are
 /// rejected). `$id` accepts any scalar and stringifies it.
 pub(super) fn extract_meta_from_payload(
     payload: &mut JsonValue,
-) -> Result<Vec<MetaItem>, ParseError> {
+) -> Result<Vec<MetaValue>, ParseError> {
     let map = match payload {
         JsonValue::Object(m) => m,
         _ => return Ok(Vec::new()),
@@ -200,12 +70,12 @@ pub(super) fn extract_meta_from_payload(
         .cloned()
         .collect();
 
-    let mut items = Vec::with_capacity(dollar_keys.len());
+    let mut out = Vec::with_capacity(dollar_keys.len());
     for key in dollar_keys {
         let value = map
             .shift_remove(&key)
             .expect("key was just enumerated from the same map");
-        let item = match key.as_str() {
+        let meta = match key.as_str() {
             "$quill" => {
                 let s = require_string("$quill reference", value)?;
                 let reference = QuillReference::from_str(&s).map_err(|e| {
@@ -214,7 +84,7 @@ pub(super) fn extract_meta_from_payload(
                         s, e
                     ))
                 })?;
-                MetaItem::Quill(reference)
+                MetaValue::Quill(reference)
             }
             "$kind" => {
                 let s = match value {
@@ -234,9 +104,9 @@ pub(super) fn extract_meta_from_payload(
                         s
                     )));
                 }
-                MetaItem::Kind(s)
+                MetaValue::Kind(s)
             }
-            "$id" => MetaItem::Id(scalar_to_string(&key, value)?),
+            "$id" => MetaValue::Id(scalar_to_string(&key, value)?),
             other => {
                 return Err(ParseError::InvalidStructure(format!(
                     "Unknown `{}` system-metadata key — the card-yaml block \
@@ -245,14 +115,12 @@ pub(super) fn extract_meta_from_payload(
                 )));
             }
         };
-        items.push(item);
+        out.push(meta);
     }
 
-    Ok(items)
+    Ok(out)
 }
 
-/// Require a YAML string scalar. The `label` is interpolated into the error
-/// message — pass `"$quill reference"` to get `"Invalid $quill reference …"`.
 fn require_string(label: &str, value: JsonValue) -> Result<String, ParseError> {
     match value {
         JsonValue::String(s) => Ok(s),
@@ -264,8 +132,6 @@ fn require_string(label: &str, value: JsonValue) -> Result<String, ParseError> {
     }
 }
 
-/// Coerce any YAML scalar to its string form (for `$id`, the opaque
-/// identifier). Mappings, sequences, and explicit null are rejected.
 fn scalar_to_string(key: &str, value: JsonValue) -> Result<String, ParseError> {
     match value {
         JsonValue::String(s) => Ok(s),
@@ -294,12 +160,9 @@ fn yaml_type_name(value: &JsonValue) -> &'static str {
     }
 }
 
-/// Validate a card-yaml block's YAML payload (after `$` metadata extraction).
-///
-/// Rejects the reserved wire-format keys (`QUILL`, `CARD`, `BODY`, `CARDS`)
+/// Reject the reserved wire-format keys (`QUILL`, `CARD`, `BODY`, `CARDS`)
 /// appearing as user-defined fields — they would collide with
-/// [`crate::Document::to_plate_json`]'s output. The parsed value is returned
-/// unchanged.
+/// [`crate::Document::to_plate_json`]'s output.
 pub(super) fn validate_payload_yaml(
     parsed: serde_json::Value,
 ) -> Result<serde_json::Value, ParseError> {
@@ -316,32 +179,28 @@ pub(super) fn validate_payload_yaml(
     Ok(parsed)
 }
 
-/// Validate a card kind name follows the pattern `[a-z_][a-z0-9_]*`.
+/// `true` when `name` matches `[a-z_][a-z0-9_]*`.
 pub fn is_valid_kind_name(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
-
     let mut chars = name.chars();
     let first = chars.next().unwrap();
-
     if !first.is_ascii_lowercase() && first != '_' {
         return false;
     }
-
     for ch in chars {
         if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '_' {
             return false;
         }
     }
-
     true
 }
 
 /// Validate a composable card kind: must match `[a-z_][a-z0-9_]*` and must
 /// not be the reserved root kind `"main"`.
 ///
-/// Single source of truth for the composable-kind rule. Used by
+/// Single source of truth for the composable-kind rule, used by
 /// [`crate::Card::new`], [`crate::Document::set_card_kind`], and the storage
 /// DTO conversion so the rule cannot drift between editor and reader paths.
 pub fn validate_composable_kind(kind: &str) -> Result<(), CardKindError> {
@@ -368,10 +227,6 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn extract(payload: &mut JsonValue) -> CardMetadata {
-        CardMetadata::from_items(extract_meta_from_payload(payload).unwrap())
-    }
-
     #[test]
     fn extracts_quill_kind_and_leaves_data_intact() {
         let mut payload = json!({
@@ -379,131 +234,39 @@ mod tests {
             "$kind": "main",
             "title": "Doc",
         });
-        let meta = extract(&mut payload);
-        assert_eq!(meta.quill().unwrap().to_string(), "foo@0.1");
-        assert_eq!(meta.kind(), Some("main"));
+        let meta = extract_meta_from_payload(&mut payload).unwrap();
+        assert_eq!(meta.len(), 2);
+        assert!(matches!(meta[0], MetaValue::Quill(_)));
+        assert!(matches!(meta[1], MetaValue::Kind(_)));
         assert_eq!(payload, json!({"title": "Doc"}));
-    }
-
-    #[test]
-    fn extracts_id_from_string() {
-        let mut payload = json!({"$id": "rev-1"});
-        let meta = extract(&mut payload);
-        assert_eq!(meta.id(), Some("rev-1"));
     }
 
     #[test]
     fn extracts_id_from_number() {
         let mut payload = json!({"$id": 42});
-        let meta = extract(&mut payload);
-        assert_eq!(meta.id(), Some("42"));
-    }
-
-    #[test]
-    fn extracts_id_from_bool() {
-        let mut payload = json!({"$id": true});
-        let meta = extract(&mut payload);
-        assert_eq!(meta.id(), Some("true"));
+        let meta = extract_meta_from_payload(&mut payload).unwrap();
+        assert!(matches!(meta[0], MetaValue::Id(ref s) if s == "42"));
     }
 
     #[test]
     fn rejects_unknown_dollar_key() {
         let mut payload = json!({"$unknown": "x"});
         let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Unknown `$unknown`"), "got: {msg}");
+        assert!(err.to_string().contains("Unknown `$unknown`"));
     }
 
     #[test]
     fn rejects_non_string_quill() {
         let mut payload = json!({"$quill": 42});
         let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("$quill reference"), "got: {msg}");
-    }
-
-    #[test]
-    fn rejects_non_string_kind() {
-        let mut payload = json!({"$kind": ["main"]});
-        let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Invalid `$kind`"), "got: {msg}");
-    }
-
-    #[test]
-    fn null_kind_reports_invalid_kind() {
-        let mut payload = json!({"$kind": JsonValue::Null});
-        let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Invalid `$kind`"), "got: {msg}");
-    }
-
-    #[test]
-    fn null_quill_reports_invalid_quill_reference() {
-        let mut payload = json!({"$quill": JsonValue::Null});
-        let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Invalid $quill reference"), "got: {msg}");
+        assert!(err.to_string().contains("$quill reference"));
     }
 
     #[test]
     fn rejects_invalid_kind_pattern() {
         let mut payload = json!({"$kind": "Bad-Kind"});
         let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Invalid `$kind`"), "got: {msg}");
-    }
-
-    #[test]
-    fn rejects_id_mapping() {
-        let mut payload = json!({"$id": {"nested": "yes"}});
-        let err = extract_meta_from_payload(&mut payload).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("`$id`"), "got: {msg}");
-        assert!(msg.contains("scalar"), "got: {msg}");
-    }
-
-    #[test]
-    fn non_object_payload_returns_empty_meta() {
-        let mut payload = JsonValue::Null;
-        let items = extract_meta_from_payload(&mut payload).unwrap();
-        assert!(items.is_empty());
-    }
-
-    #[test]
-    fn set_quill_inserts_at_position_zero() {
-        let mut meta = CardMetadata::new();
-        meta.set_kind("main");
-        meta.set_quill("foo@0.1".parse().unwrap());
-        assert!(matches!(meta.items()[0], MetaItem::Quill(_)));
-        assert!(matches!(meta.items()[1], MetaItem::Kind(_)));
-    }
-
-    #[test]
-    fn set_id_inserts_after_quill_and_kind() {
-        let mut meta = CardMetadata::new();
-        meta.set_quill("foo@0.1".parse().unwrap());
-        meta.set_kind("main");
-        meta.set_id("rev-1");
-        assert_eq!(meta.items().len(), 3);
-        assert!(matches!(meta.items()[2], MetaItem::Id(_)));
-    }
-
-    #[test]
-    fn set_replaces_in_place_preserving_position() {
-        let mut meta = CardMetadata::from_items(vec![
-            MetaItem::Quill("foo@0.1".parse().unwrap()),
-            MetaItem::Comment {
-                text: "trailing".into(),
-                inline: true,
-            },
-            MetaItem::Kind("main".into()),
-        ]);
-        meta.set_quill("bar@0.2".parse().unwrap());
-        assert_eq!(meta.quill().unwrap().to_string(), "bar@0.2");
-        // Item count unchanged, comment still between quill and kind.
-        assert_eq!(meta.items().len(), 3);
-        assert!(matches!(meta.items()[1], MetaItem::Comment { .. }));
+        assert!(err.to_string().contains("Invalid `$kind`"));
     }
 
     #[test]

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -91,7 +91,7 @@ pub mod prescan;
 
 pub use dto::{peek_schema_version, StorageError, StoredDocument, SCHEMA_V0_81_0};
 pub use edit::EditError;
-pub use meta::CardMetadata;
+pub use meta::{CardKindError, CardMetadata, MetaItem};
 pub use payload::{Payload, PayloadItem};
 
 #[cfg(test)]
@@ -159,12 +159,12 @@ impl Card {
 
     /// The `$kind` card kind, if the block declares one.
     pub fn kind(&self) -> Option<&str> {
-        self.meta.kind.as_deref()
+        self.meta.kind()
     }
 
     /// The `$id` opaque identifier, if the block declares one.
     pub fn id(&self) -> Option<&str> {
-        self.meta.id.as_deref()
+        self.meta.id()
     }
 
     /// Typed payload (map-keyed view and ordered item list).
@@ -239,9 +239,9 @@ impl Document {
     /// The caller must guarantee that `main`'s `$quill` metadata is present
     /// and valid, and that composable cards do not carry `$quill`.
     pub fn from_main_and_cards(main: Card, cards: Vec<Card>, warnings: Vec<Diagnostic>) -> Self {
-        debug_assert!(main.meta.quill.is_some(), "main card must carry `$quill`");
+        debug_assert!(main.meta.quill().is_some(), "main card must carry `$quill`");
         debug_assert!(
-            cards.iter().all(|c| c.meta.quill.is_none()),
+            cards.iter().all(|c| c.meta.quill().is_none()),
             "composable cards must not carry `$quill`"
         );
         Self {
@@ -282,8 +282,8 @@ impl Document {
     pub fn quill_reference(&self) -> QuillReference {
         self.main
             .meta
-            .quill
-            .clone()
+            .quill()
+            .cloned()
             .expect("root block's $quill is validated at parse time")
     }
 
@@ -362,7 +362,7 @@ impl Document {
                 let mut card_map = serde_json::Map::new();
                 card_map.insert(
                     "CARD".to_string(),
-                    serde_json::Value::String(card.meta.kind.as_deref().unwrap_or("").to_string()),
+                    serde_json::Value::String(card.meta.kind().unwrap_or("").to_string()),
                 );
                 for (key, value) in card.payload.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -91,7 +91,7 @@ pub mod prescan;
 
 pub use dto::{peek_schema_version, StorageError, StoredDocument, SCHEMA_V0_81_0};
 pub use edit::EditError;
-pub use meta::{CardKindError, CardMetadata, MetaItem};
+pub use meta::{CardKindError, is_valid_kind_name, validate_composable_kind};
 pub use payload::{Payload, PayloadItem};
 
 #[cfg(test)]
@@ -116,8 +116,9 @@ pub struct ParseOutput {
 /// recording which collection it belongs to.
 ///
 /// Every card has:
-/// - `meta` — the block's typed `$` system metadata (`$quill`, `$kind`, `$id`).
-/// - `payload` — ordered items parsed from the block's YAML payload.
+/// - `payload` — ordered items parsed from the block's YAML payload,
+///   carrying typed `$` system metadata, user fields, and comments
+///   interleaved in source order.
 /// - `body` — the Markdown text that follows the closing `~~~` fence, up to
 ///   the next block (or EOF).
 ///
@@ -129,7 +130,6 @@ pub struct ParseOutput {
 /// should check `card.body().is_empty()`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Card {
-    meta: CardMetadata,
     payload: Payload,
     body: String,
 }
@@ -139,35 +139,27 @@ impl Card {
     /// field names — callers are responsible for providing already-valid
     /// data. For user-facing construction of composable cards use
     /// [`Card::new`] (defined in `edit.rs`).
-    pub fn from_parts(meta: CardMetadata, payload: Payload, body: String) -> Self {
-        Self {
-            meta,
-            payload,
-            body,
-        }
+    pub fn from_parts(payload: Payload, body: String) -> Self {
+        Self { payload, body }
     }
 
-    /// The block's typed `$` system metadata.
-    pub fn meta(&self) -> &CardMetadata {
-        &self.meta
-    }
-
-    /// Mutable access to the system metadata.
-    pub fn meta_mut(&mut self) -> &mut CardMetadata {
-        &mut self.meta
+    /// The `$quill` reference, if the block declares one.
+    pub fn quill(&self) -> Option<&QuillReference> {
+        self.payload.quill()
     }
 
     /// The `$kind` card kind, if the block declares one.
     pub fn kind(&self) -> Option<&str> {
-        self.meta.kind()
+        self.payload.kind()
     }
 
     /// The `$id` opaque identifier, if the block declares one.
     pub fn id(&self) -> Option<&str> {
-        self.meta.id()
+        self.payload.id()
     }
 
-    /// Typed payload (map-keyed view and ordered item list).
+    /// Typed payload (map-keyed view and ordered item list, including `$`
+    /// entries).
     pub fn payload(&self) -> &Payload {
         &self.payload
     }
@@ -239,9 +231,9 @@ impl Document {
     /// The caller must guarantee that `main`'s `$quill` metadata is present
     /// and valid, and that composable cards do not carry `$quill`.
     pub fn from_main_and_cards(main: Card, cards: Vec<Card>, warnings: Vec<Diagnostic>) -> Self {
-        debug_assert!(main.meta.quill().is_some(), "main card must carry `$quill`");
+        debug_assert!(main.quill().is_some(), "main card must carry `$quill`");
         debug_assert!(
-            cards.iter().all(|c| c.meta.quill().is_none()),
+            cards.iter().all(|c| c.quill().is_none()),
             "composable cards must not carry `$quill`"
         );
         Self {
@@ -281,7 +273,6 @@ impl Document {
     /// never fails for a `Document` produced by [`Document::from_markdown`].
     pub fn quill_reference(&self) -> QuillReference {
         self.main
-            .meta
             .quill()
             .cloned()
             .expect("root block's $quill is validated at parse time")
@@ -362,7 +353,7 @@ impl Document {
                 let mut card_map = serde_json::Map::new();
                 card_map.insert(
                     "CARD".to_string(),
-                    serde_json::Value::String(card.meta.kind().unwrap_or("").to_string()),
+                    serde_json::Value::String(card.kind().unwrap_or("").to_string()),
                 );
                 for (key, value) in card.payload.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -1,48 +1,68 @@
-//! Ordered payload representation.
+//! Unified payload representation.
 //!
-//! A [`Payload`] is the typed representation of a card-yaml block's YAML
-//! payload after `$`-prefixed reserved keys have been extracted into a
-//! typed [`super::meta::CardMetadata`]. Unlike a plain `IndexMap`, it
-//! preserves YAML comments as first-class ordered items and carries a
-//! `fill: bool` marker on each field (for `!fill` tags).
+//! A [`Payload`] is the typed representation of a card-yaml block's full
+//! YAML content. It carries — in source order, as variants of a single
+//! [`PayloadItem`] enum:
 //!
-//! It provides both ordered iteration (over [`PayloadItem`]s) and
-//! map-keyed access (`get`, `contains_key`, `insert`, `remove`) so existing
-//! callers that treat the payload as a map keep working. The map-keyed
-//! accessors walk the item vec; field count is small enough that a linear
-//! scan is fine.
+//! - **System metadata** — typed `$quill` / `$kind` / `$id` entries.
+//! - **User fields** — `key: value` pairs with an optional `!fill` flag.
+//! - **Comments** — own-line or trailing inline, attached to whichever
+//!   item they immediately follow at emit time.
+//!
+//! The unified item list is the canonical storage of the block; treating
+//! `$` entries as just another variant means a comment adjacent to a `$`
+//! line round-trips through the same mechanism as a comment adjacent to a
+//! user field. No "metadata region" vs "payload region" routing decision is
+//! ever made — there is only the source-ordered list.
+//!
+//! ## Two faces
+//!
+//! [`Payload`] exposes both ordered iteration (over the raw items vec) and
+//! map-keyed access (`get`, `iter`, `insert`, `remove`). The map-style
+//! accessors filter to [`PayloadItem::Field`] only — they intentionally
+//! don't expose `$` entries because typed `$` access has dedicated methods
+//! (`quill`, `kind`, `id`, `set_quill`, `set_kind`, `set_id`).
+//!
+//! This preserves the historical "payload as a key/value map of user data"
+//! API while letting comment preservation and `$` access ride on the same
+//! underlying storage.
 
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
 
 use super::prescan::NestedComment;
 use crate::value::QuillValue;
+use crate::version::QuillReference;
 
-/// One entry in a [`Payload`]: a field or a comment line.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
+/// One entry in a [`Payload`]: a typed `$` system metadata entry, a user
+/// field, or a comment line.
+///
+/// `PayloadItem` is the live in-memory model; it is intentionally **not**
+/// `Serialize`/`Deserialize`. Storage uses the versioned DTOs in
+/// `document::dto`, and bindings translate to their own wire types.
+#[derive(Debug, Clone, PartialEq)]
 pub enum PayloadItem {
-    /// A YAML field (key-value pair), optionally tagged `!fill`.
+    /// `$quill` system metadata, holding the parsed quill reference.
+    Quill { reference: QuillReference },
+    /// `$kind` system metadata — the card's kind name.
+    Kind { value: String },
+    /// `$id` system metadata — opaque identifier.
+    Id { value: String },
+    /// A user-defined YAML field, optionally tagged `!fill`.
     Field {
         key: String,
         value: QuillValue,
         /// `true` when the field was written as `key: !fill <value>` or
         /// `key: !fill` in source.
-        #[serde(default)]
         fill: bool,
     },
     /// A YAML comment. Text excludes the leading `#` and one optional space.
     ///
     /// `inline` distinguishes own-line comments (`# text` on a line by
     /// itself) from trailing inline comments (`field: value # text`). An
-    /// inline comment attaches to the field that immediately precedes it
-    /// in the items vector; if no such field exists at emit time (orphan)
+    /// inline comment attaches to the item that immediately precedes it
+    /// in the items vector; if no such item exists at emit time (orphan)
     /// it degrades to an own-line comment.
-    Comment {
-        text: String,
-        #[serde(default)]
-        inline: bool,
-    },
+    Comment { text: String, inline: bool },
 }
 
 impl PayloadItem {
@@ -63,22 +83,31 @@ impl PayloadItem {
         }
     }
 
-    /// Build an inline (trailing) comment item. Attaches to the previous
-    /// field on emit; degrades to own-line if none exists.
+    /// Build an inline (trailing) comment item.
     pub fn comment_inline(text: impl Into<String>) -> Self {
         PayloadItem::Comment {
             text: text.into(),
             inline: true,
         }
     }
+
+    /// Canonical sort rank for typed `$` entries: `$quill` < `$kind` <
+    /// `$id`. Returns `None` for user fields and comments, which are
+    /// positioned by source order and never reshuffled.
+    fn meta_rank(&self) -> Option<u8> {
+        match self {
+            PayloadItem::Quill { .. } => Some(0),
+            PayloadItem::Kind { .. } => Some(1),
+            PayloadItem::Id { .. } => Some(2),
+            _ => None,
+        }
+    }
 }
 
-/// Ordered list of payload items with map-keyed convenience accessors.
+/// Ordered, comment-preserving payload of a card-yaml block.
 ///
-/// Top-level YAML comments live in `items` as [`PayloadItem::Comment`].
-/// Comments inside nested mappings/sequences live in `nested_comments`,
-/// keyed by structural path; the emitter re-injects them at the matching
-/// position when serialising the value tree.
+/// Contains the block's `$` entries, user fields, and comments interleaved
+/// in source order. See the module docs for the full design.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Payload {
     items: Vec<PayloadItem>,
@@ -88,13 +117,11 @@ pub struct Payload {
 impl Payload {
     /// Create an empty `Payload`.
     pub fn new() -> Self {
-        Self {
-            items: Vec::new(),
-            nested_comments: Vec::new(),
-        }
+        Self::default()
     }
 
-    /// Build from an `IndexMap` of fields (no comments, no fill markers).
+    /// Build from an `IndexMap` of user fields. No `$` entries, no
+    /// comments, no fill markers.
     pub fn from_index_map(map: IndexMap<String, QuillValue>) -> Self {
         let items = map
             .into_iter()
@@ -110,7 +137,7 @@ impl Payload {
         }
     }
 
-    /// Build from a pre-computed item list.
+    /// Build from a pre-computed item list (parser and DTO entry point).
     pub fn from_items(items: Vec<PayloadItem>) -> Self {
         Self {
             items,
@@ -118,7 +145,7 @@ impl Payload {
         }
     }
 
-    /// Build from a pre-computed item list and a set of nested comments.
+    /// Build from a pre-computed item list and nested comments.
     pub fn from_items_with_nested(
         items: Vec<PayloadItem>,
         nested_comments: Vec<NestedComment>,
@@ -129,6 +156,21 @@ impl Payload {
         }
     }
 
+    // ── Item-level access ───────────────────────────────────────────────────
+
+    /// Ordered iterator over raw items (`$` entries, fields, comments).
+    pub fn items(&self) -> &[PayloadItem] {
+        &self.items
+    }
+
+    /// Mutable access to the raw item list. Callers must preserve the
+    /// invariants (at most one `Quill`/`Kind`/`Id`, no duplicate field
+    /// keys, no reserved field names) — use the typed mutators when in
+    /// doubt.
+    pub fn items_mut(&mut self) -> &mut [PayloadItem] {
+        &mut self.items
+    }
+
     /// Comments captured inside nested mappings/sequences. The emitter
     /// re-injects these at the matching position when serialising the
     /// value tree.
@@ -136,28 +178,112 @@ impl Payload {
         &self.nested_comments
     }
 
-    /// Ordered iterator over raw items (including comments).
-    pub fn items(&self) -> &[PayloadItem] {
-        &self.items
+    // ── Typed `$` access ────────────────────────────────────────────────────
+
+    /// The `$quill` reference, if declared.
+    pub fn quill(&self) -> Option<&QuillReference> {
+        self.items.iter().find_map(|i| match i {
+            PayloadItem::Quill { reference } => Some(reference),
+            _ => None,
+        })
     }
 
-    /// Iterator over `(key, value)` pairs, skipping comments. Preserves order.
+    /// The `$kind` value, if declared.
+    pub fn kind(&self) -> Option<&str> {
+        self.items.iter().find_map(|i| match i {
+            PayloadItem::Kind { value } => Some(value.as_str()),
+            _ => None,
+        })
+    }
+
+    /// The `$id` value, if declared.
+    pub fn id(&self) -> Option<&str> {
+        self.items.iter().find_map(|i| match i {
+            PayloadItem::Id { value } => Some(value.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Set or replace the `$quill` entry. Inserts at canonical position
+    /// (before any `$kind` / `$id`) when adding. Comments are untouched.
+    pub fn set_quill(&mut self, reference: QuillReference) {
+        self.upsert_meta(PayloadItem::Quill { reference });
+    }
+
+    /// Set or replace the `$kind` entry. Same insertion rules as
+    /// [`set_quill`](Self::set_quill).
+    pub fn set_kind(&mut self, kind: impl Into<String>) {
+        self.upsert_meta(PayloadItem::Kind {
+            value: kind.into(),
+        });
+    }
+
+    /// Set or replace the `$id` entry. Same insertion rules as
+    /// [`set_quill`](Self::set_quill).
+    pub fn set_id(&mut self, id: impl Into<String>) {
+        self.upsert_meta(PayloadItem::Id { value: id.into() });
+    }
+
+    /// Remove the `$quill` entry, returning the previous value if any.
+    pub fn take_quill(&mut self) -> Option<QuillReference> {
+        let pos = self
+            .items
+            .iter()
+            .position(|i| matches!(i, PayloadItem::Quill { .. }))?;
+        match self.items.remove(pos) {
+            PayloadItem::Quill { reference } => Some(reference),
+            _ => unreachable!(),
+        }
+    }
+
+    fn upsert_meta(&mut self, new: PayloadItem) {
+        let new_rank = new
+            .meta_rank()
+            .expect("upsert_meta only accepts $-typed items");
+        for slot in self.items.iter_mut() {
+            if slot.meta_rank() == Some(new_rank) {
+                *slot = new;
+                return;
+            }
+        }
+        let insert_at = self
+            .items
+            .iter()
+            .position(|i| matches!(i.meta_rank(), Some(r) if r > new_rank))
+            .unwrap_or_else(|| {
+                // No higher-ranked `$` item; insert after the last lower
+                // (or equal-rank-impossible) `$` item, before any non-`$`
+                // entry. This keeps the `$quill < $kind < $id` ordering
+                // while not displacing user fields.
+                self.items
+                    .iter()
+                    .rposition(|i| matches!(i.meta_rank(), Some(r) if r < new_rank))
+                    .map(|p| p + 1)
+                    .unwrap_or(0)
+            });
+        self.items.insert(insert_at, new);
+    }
+
+    // ── User-field access (map-style, `$` entries filtered out) ─────────────
+
+    /// Iterator over user `(key, &value)` pairs. Excludes `$` entries and
+    /// comments; preserves source order.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &QuillValue)> + '_ {
         self.items.iter().filter_map(|item| match item {
             PayloadItem::Field { key, value, .. } => Some((key, value)),
-            PayloadItem::Comment { .. } => None,
+            _ => None,
         })
     }
 
-    /// Iterator over field keys, skipping comments. Preserves order.
+    /// Iterator over user field keys.
     pub fn keys(&self) -> impl Iterator<Item = &String> + '_ {
         self.items.iter().filter_map(|item| match item {
             PayloadItem::Field { key, .. } => Some(key),
-            PayloadItem::Comment { .. } => None,
+            _ => None,
         })
     }
 
-    /// Number of *field* items (comments excluded).
+    /// Number of *user-field* items (`$` entries and comments excluded).
     pub fn len(&self) -> usize {
         self.items
             .iter()
@@ -165,12 +291,14 @@ impl Payload {
             .count()
     }
 
-    /// Returns `true` if there are no field items (comments are ignored).
+    /// `true` when there are no user-field items.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Look up a field value by key.
+    /// Look up a user-field value by key. `$` entries are not visible via
+    /// this accessor — use [`quill`](Self::quill) / [`kind`](Self::kind) /
+    /// [`id`](Self::id).
     pub fn get(&self, key: &str) -> Option<&QuillValue> {
         self.items.iter().find_map(|item| match item {
             PayloadItem::Field { key: k, value, .. } if k == key => Some(value),
@@ -178,14 +306,23 @@ impl Payload {
         })
     }
 
-    /// Returns `true` if a field with this key is present.
+    /// `true` if a user field with this key is present.
     pub fn contains_key(&self, key: &str) -> bool {
         self.get(key).is_some()
     }
 
-    /// Insert or update a field. Always clears the `fill` marker (field is no
-    /// longer a placeholder). Preserves position for existing keys; appends
-    /// new keys at the end. Adjacent comments are untouched.
+    /// `true` if a user field with this key is marked `!fill`.
+    pub fn is_fill(&self, key: &str) -> bool {
+        self.items.iter().any(|item| match item {
+            PayloadItem::Field { key: k, fill, .. } => k == key && *fill,
+            _ => false,
+        })
+    }
+
+    /// Insert or update a user field. Always clears the `fill` marker
+    /// (field is no longer a placeholder). Preserves position for existing
+    /// keys; appends new keys at the end. `$` entries and comments are
+    /// untouched.
     pub fn insert(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
@@ -210,8 +347,8 @@ impl Payload {
         None
     }
 
-    /// Insert or update a field and mark it as a `!fill` placeholder. Preserves
-    /// position for existing keys; appends new keys at the end.
+    /// Insert or update a user field and mark it as a `!fill` placeholder.
+    /// Preserves position for existing keys; appends new keys at the end.
     pub fn insert_fill(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
@@ -236,8 +373,8 @@ impl Payload {
         None
     }
 
-    /// Remove a field by key and return its value. Adjacent comments stay
-    /// where they are.
+    /// Remove a user field by key, returning its value. Comments and `$`
+    /// entries are untouched.
     pub fn remove(&mut self, key: &str) -> Option<QuillValue> {
         let pos = self
             .items
@@ -245,20 +382,12 @@ impl Payload {
             .position(|item| matches!(item, PayloadItem::Field { key: k, .. } if k == key))?;
         match self.items.remove(pos) {
             PayloadItem::Field { value, .. } => Some(value),
-            PayloadItem::Comment { .. } => unreachable!(),
+            _ => unreachable!(),
         }
     }
 
-    /// Returns `true` if a field with this key is marked `!fill`.
-    pub fn is_fill(&self, key: &str) -> bool {
-        self.items.iter().any(|item| match item {
-            PayloadItem::Field { key: k, fill, .. } => k == key && *fill,
-            _ => false,
-        })
-    }
-
-    /// Project the field portion into an `IndexMap<String, QuillValue>`.
-    /// Comments are dropped; fill markers are lost. Preserves order.
+    /// Project the user-field portion into an `IndexMap<String, QuillValue>`.
+    /// Comments, fill markers, and `$` entries are dropped. Preserves order.
     pub fn to_index_map(&self) -> IndexMap<String, QuillValue> {
         let mut map = IndexMap::new();
         for item in &self.items {
@@ -281,7 +410,7 @@ impl<'a> IntoIterator for &'a Payload {
         fn filter(item: &PayloadItem) -> Option<(&String, &QuillValue)> {
             match item {
                 PayloadItem::Field { key, value, .. } => Some((key, value)),
-                PayloadItem::Comment { .. } => None,
+                _ => None,
             }
         }
         self.items.iter().filter_map(filter)
@@ -297,13 +426,13 @@ mod tests {
     }
 
     #[test]
-    fn insert_new_appends() {
+    fn insert_new_appends_after_meta() {
         let mut fm = Payload::new();
+        fm.set_quill("foo@0.1".parse().unwrap());
+        fm.set_kind("main");
         fm.insert("title", qv("Hello"));
-        fm.insert("author", qv("Alice"));
-        assert_eq!(fm.len(), 2);
-        let keys: Vec<&String> = fm.keys().collect();
-        assert_eq!(keys, vec!["title", "author"]);
+        let last = fm.items().last().unwrap();
+        assert!(matches!(last, PayloadItem::Field { key, .. } if key == "title"));
     }
 
     #[test]
@@ -327,54 +456,87 @@ mod tests {
     }
 
     #[test]
-    fn insert_fill_preserves_position_and_sets_flag() {
+    fn map_style_iter_skips_meta_and_comments() {
         let mut fm = Payload::new();
-        fm.insert("k", qv("v"));
-        fm.insert_fill("k", qv("placeholder"));
-        assert!(fm.is_fill("k"));
-        assert_eq!(fm.get("k").unwrap().as_str(), Some("placeholder"));
+        fm.set_quill("foo@0.1".parse().unwrap());
+        fm.set_kind("main");
+        fm.insert("title", qv("Hello"));
+        let items = std::mem::take(&mut fm).items().to_vec();
+        // Reconstruct with an interleaved comment.
+        let mut items_with_comment = items;
+        items_with_comment.insert(2, PayloadItem::comment("c"));
+        let fm = Payload::from_items(items_with_comment);
+        let pairs: Vec<(String, String)> = fm
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string()))
+            .collect();
+        assert_eq!(pairs, vec![("title".to_string(), "Hello".to_string())]);
+        // But the typed access still works:
+        assert_eq!(fm.kind(), Some("main"));
     }
 
     #[test]
-    fn remove_leaves_comments_alone() {
-        let items = vec![
+    fn set_quill_inserts_at_position_zero() {
+        let mut fm = Payload::new();
+        fm.set_kind("main");
+        fm.set_quill("foo@0.1".parse().unwrap());
+        assert!(matches!(fm.items()[0], PayloadItem::Quill { .. }));
+        assert!(matches!(fm.items()[1], PayloadItem::Kind { .. }));
+    }
+
+    #[test]
+    fn set_id_inserts_after_quill_and_kind() {
+        let mut fm = Payload::new();
+        fm.set_quill("foo@0.1".parse().unwrap());
+        fm.set_kind("main");
+        fm.set_id("rev-1");
+        assert_eq!(fm.items().len(), 3);
+        assert!(matches!(fm.items()[2], PayloadItem::Id { .. }));
+    }
+
+    #[test]
+    fn set_replaces_in_place_preserving_comments() {
+        let mut fm = Payload::from_items(vec![
+            PayloadItem::Quill {
+                reference: "foo@0.1".parse().unwrap(),
+            },
+            PayloadItem::comment_inline("trailing"),
+            PayloadItem::Kind {
+                value: "main".into(),
+            },
+        ]);
+        fm.set_quill("bar@0.2".parse().unwrap());
+        assert_eq!(fm.quill().unwrap().to_string(), "bar@0.2");
+        assert_eq!(fm.items().len(), 3);
+        assert!(matches!(fm.items()[1], PayloadItem::Comment { .. }));
+    }
+
+    #[test]
+    fn remove_leaves_comments_and_meta_alone() {
+        let mut fm = Payload::from_items(vec![
+            PayloadItem::Quill {
+                reference: "q".parse().unwrap(),
+            },
+            PayloadItem::Kind {
+                value: "main".into(),
+            },
             PayloadItem::comment("header"),
             PayloadItem::field("a", qv("1")),
             PayloadItem::comment("mid"),
             PayloadItem::field("b", qv("2")),
-        ];
-        let mut fm = Payload::from_items(items);
+        ]);
         let removed = fm.remove("a").unwrap();
         assert_eq!(removed.as_str(), Some("1"));
+        assert!(matches!(fm.items()[0], PayloadItem::Quill { .. }));
+        assert!(matches!(fm.items()[1], PayloadItem::Kind { .. }));
         let comments: Vec<&str> = fm
             .items()
             .iter()
             .filter_map(|item| match item {
                 PayloadItem::Comment { text, .. } => Some(text.as_str()),
-                PayloadItem::Field { .. } => None,
+                _ => None,
             })
             .collect();
         assert_eq!(comments, vec!["header", "mid"]);
-    }
-
-    #[test]
-    fn map_style_iter_skips_comments() {
-        let items = vec![
-            PayloadItem::comment("c"),
-            PayloadItem::field("a", qv("1")),
-            PayloadItem::field("b", qv("2")),
-        ];
-        let fm = Payload::from_items(items);
-        let pairs: Vec<(String, String)> = fm
-            .iter()
-            .map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string()))
-            .collect();
-        assert_eq!(
-            pairs,
-            vec![
-                ("a".to_string(), "1".to_string()),
-                ("b".to_string(), "2".to_string())
-            ]
-        );
     }
 }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -823,7 +823,8 @@ $kind: note
 #[test]
 fn dollar_keys_at_any_position_in_payload_work() {
     // `$`-prefixed reserved keys are ordinary YAML; they may appear at any
-    // position in the block's mapping. Canonical emit places them first.
+    // position in the block's mapping. Emit preserves source order so that
+    // any comments adjacent to a `$` line round-trip in place.
     let markdown = "~~~card-yaml
 title: First
 $quill: test_quill
@@ -835,10 +836,10 @@ Body.";
 
     let doc = decompose(markdown).expect("payload with $-keys mid-mapping should parse");
     assert_eq!(
-        doc.main().meta().quill().unwrap().to_string(),
+        doc.main().quill().unwrap().to_string(),
         "test_quill"
     );
-    assert_eq!(doc.main().meta().kind(), Some("main"));
+    assert_eq!(doc.main().kind(), Some("main"));
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str(),
         Some("First")
@@ -847,16 +848,14 @@ Body.";
         doc.main().payload().get("author").unwrap().as_str(),
         Some("Bob")
     );
-    // `$` keys do not appear in the user payload.
+    // `$` keys do not appear in the user-field accessors.
     assert!(doc.main().payload().get("$quill").is_none());
     assert!(doc.main().payload().get("$kind").is_none());
 
-    // Round-trip places `$` keys first in canonical order.
+    // Round-trip stability: emit then re-parse produces an equal Document.
     let emitted = doc.to_markdown();
-    assert!(
-        emitted.starts_with("~~~card-yaml\n$quill: test_quill\n$kind: main\n"),
-        "canonical emit must lead with $-keys; got:\n{emitted}"
-    );
+    let reparsed = decompose(&emitted).expect("round-trip should re-parse");
+    assert_eq!(doc, reparsed);
 }
 
 #[test]

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -835,10 +835,10 @@ Body.";
 
     let doc = decompose(markdown).expect("payload with $-keys mid-mapping should parse");
     assert_eq!(
-        doc.main().meta().quill.as_ref().unwrap().to_string(),
+        doc.main().meta().quill().unwrap().to_string(),
         "test_quill"
     );
-    assert_eq!(doc.main().meta().kind.as_deref(), Some("main"));
+    assert_eq!(doc.main().meta().kind(), Some("main"));
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str(),
         Some("First")

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -279,10 +279,8 @@ fn empty_map_omitted_from_emit() {
     );
 
     use crate::document::{Card, CardMetadata, Payload};
-    let meta = CardMetadata {
-        quill: Some("test".parse().unwrap()),
-        ..CardMetadata::default()
-    };
+    let mut meta = CardMetadata::new();
+    meta.set_quill("test".parse().unwrap());
     let main = Card::from_parts(meta, Payload::from_index_map(payload), String::new());
     let doc = crate::document::Document::from_main_and_cards(main, vec![], vec![]);
 

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -278,10 +278,11 @@ fn empty_map_omitted_from_emit() {
         QuillValue::from_json(serde_json::json!("hello")),
     );
 
-    use crate::document::{Card, CardMetadata, Payload};
-    let mut meta = CardMetadata::new();
-    meta.set_quill("test".parse().unwrap());
-    let main = Card::from_parts(meta, Payload::from_index_map(payload), String::new());
+    use crate::document::{Card, Payload};
+    let mut p = Payload::from_index_map(payload);
+    p.set_quill("test".parse().unwrap());
+    p.set_kind("main");
+    let main = Card::from_parts(p, String::new());
     let doc = crate::document::Document::from_main_and_cards(main, vec![], vec![]);
 
     let md = doc.to_markdown();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,7 +44,7 @@
 //! - [Examples](https://github.com/quillmark-org/quillmark/tree/main/crates/core/examples) - Working examples
 
 pub mod document;
-pub use document::{Card, CardMetadata, Document, EditError, ParseOutput, Payload, PayloadItem};
+pub use document::{Card, Document, EditError, ParseOutput, Payload, PayloadItem};
 
 pub mod backend;
 pub use backend::Backend;

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -399,41 +399,34 @@ pub fn normalize_document(
 ) -> Result<crate::document::Document, crate::error::ParseError> {
     use crate::document::Document;
 
-    // NFC-normalize main-card field names; values pass through verbatim.
-    // The `$` system metadata passes through unchanged.
-    let normalized_main_fm_map = normalize_fields(doc.main().payload().to_index_map());
-    let normalized_main_body = normalize_markdown(doc.main().body());
-    let main = Card::from_parts(
-        doc.main().meta().clone(),
-        crate::document::Payload::from_index_map(normalized_main_fm_map),
-        normalized_main_body,
-    );
-
-    // Normalize each composable card's body; NFC-normalize its field names;
-    // values pass through verbatim.
-    let normalized_cards: Vec<Card> = doc
-        .cards()
-        .iter()
-        .map(|card| {
-            let normalized_card_fields: IndexMap<String, QuillValue> = card
-                .payload()
-                .iter()
-                .map(|(k, v)| (normalize_field_name(k), v.clone()))
-                .collect();
-            let normalized_card_body = normalize_markdown(card.body());
-            Card::from_parts(
-                card.meta().clone(),
-                crate::document::Payload::from_index_map(normalized_card_fields),
-                normalized_card_body,
-            )
-        })
-        .collect();
+    let main = normalize_card(doc.main());
+    let normalized_cards: Vec<Card> = doc.cards().iter().map(normalize_card).collect();
 
     Ok(Document::from_main_and_cards(
         main,
         normalized_cards,
         doc.warnings().to_vec(),
     ))
+}
+
+/// Build a new `Card` with NFC-normalized field names and a normalized body.
+///
+/// The card's payload is cloned and walked: each user-field `key` is
+/// rewritten to NFC, and the body has Unicode normalization plus HTML
+/// comment fence repair applied. `$` system metadata, fill markers, and
+/// comments pass through verbatim.
+fn normalize_card(card: &Card) -> Card {
+    use crate::document::PayloadItem;
+    let mut payload = card.payload().clone();
+    for item in payload.items_mut() {
+        if let PayloadItem::Field { key, .. } = item {
+            let normalized = normalize_field_name(key);
+            if normalized != *key {
+                *key = normalized;
+            }
+        }
+    }
+    Card::from_parts(payload, normalize_markdown(card.body()))
 }
 
 #[cfg(test)]

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -404,10 +404,8 @@ main:
         for (k, v) in fm {
             payload.insert(k.to_string(), QuillValue::from_json(v.clone()));
         }
-        let meta = CardMetadata {
-            quill: Some("test_quill".parse().unwrap()),
-            ..CardMetadata::default()
-        };
+        let mut meta = CardMetadata::new();
+        meta.set_quill("test_quill".parse().unwrap());
         let main = Card::from_parts(meta, Payload::from_index_map(payload), String::new());
         Document::from_main_and_cards(main, cards, vec![])
     }
@@ -737,10 +735,8 @@ main:
         )
         .unwrap();
         use crate::document::{CardMetadata, Payload};
-        let meta = CardMetadata {
-            quill: Some("test_quill".parse().unwrap()),
-            ..CardMetadata::default()
-        };
+        let mut meta = CardMetadata::new();
+        meta.set_quill("test_quill".parse().unwrap());
         let main = Card::from_parts(
             meta,
             Payload::from_index_map(IndexMap::new()),

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -399,14 +399,15 @@ main:
     }
 
     fn doc_with_typed_cards(fm: &[(&str, serde_json::Value)], cards: Vec<Card>) -> Document {
-        use crate::document::{CardMetadata, Payload};
+        use crate::document::Payload;
         let mut payload = IndexMap::new();
         for (k, v) in fm {
             payload.insert(k.to_string(), QuillValue::from_json(v.clone()));
         }
-        let mut meta = CardMetadata::new();
-        meta.set_quill("test_quill".parse().unwrap());
-        let main = Card::from_parts(meta, Payload::from_index_map(payload), String::new());
+        let mut p = Payload::from_index_map(payload);
+        p.set_quill("test_quill".parse().unwrap());
+        p.set_kind("main");
+        let main = Card::from_parts(p, String::new());
         Document::from_main_and_cards(main, cards, vec![])
     }
 
@@ -734,14 +735,11 @@ main:
 "#,
         )
         .unwrap();
-        use crate::document::{CardMetadata, Payload};
-        let mut meta = CardMetadata::new();
-        meta.set_quill("test_quill".parse().unwrap());
-        let main = Card::from_parts(
-            meta,
-            Payload::from_index_map(IndexMap::new()),
-            "Body content that should not be here.".to_string(),
-        );
+        use crate::document::Payload;
+        let mut p = Payload::from_index_map(IndexMap::new());
+        p.set_quill("test_quill".parse().unwrap());
+        p.set_kind("main");
+        let main = Card::from_parts(p, "Body content that should not be here.".to_string());
         let doc = Document::from_main_and_cards(main, vec![], vec![]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -112,16 +112,14 @@ impl Quill {
                     .unwrap_or_default();
                 let fields = apply_defaults(&card.payload().to_index_map(), defaults);
                 Card::from_parts(
-                    card.meta().clone(),
-                    Payload::from_index_map(fields),
+                    rebuild_payload_with_meta(card, fields),
                     card.body().to_string(),
                 )
             })
             .collect();
 
         let final_main = Card::from_parts(
-            normalized.main().meta().clone(),
-            Payload::from_index_map(main_with_defaults),
+            rebuild_payload_with_meta(normalized.main(), main_with_defaults),
             normalized.main().body().to_string(),
         );
         let final_doc = Document::from_main_and_cards(final_main, cards_with_defaults, Vec::new());
@@ -151,15 +149,13 @@ impl Quill {
                 .coerce_card(card.kind().unwrap_or(""), &card.payload().to_index_map())
                 .map_err(coercion_error)?;
             coerced_cards.push(Card::from_parts(
-                card.meta().clone(),
-                Payload::from_index_map(coerced_fields),
+                rebuild_payload_with_meta(card, coerced_fields),
                 card.body().to_string(),
             ));
         }
 
         let coerced_main = Card::from_parts(
-            doc.main().meta().clone(),
-            Payload::from_index_map(coerced_payload),
+            rebuild_payload_with_meta(doc.main(), coerced_payload),
             doc.main().body().to_string(),
         );
         let coerced_doc = Document::from_main_and_cards(coerced_main, coerced_cards, Vec::new());
@@ -281,6 +277,29 @@ fn apply_defaults(
         result.entry(k).or_insert(v);
     }
     result
+}
+
+/// Build a fresh [`Payload`] from a coerced/defaulted user-field map,
+/// carrying the source card's `$` system-metadata entries forward.
+///
+/// Used by the orchestration coercion path: the coerced field map is the
+/// product of schema-aware coercion, so it doesn't carry `$` entries or
+/// comments. We rebuild from the map and re-attach `$quill` / `$kind` /
+/// `$id` from `source` so the resulting payload still identifies its
+/// quill and kind. Comments are intentionally dropped — the coerced
+/// payload feeds backend rendering, not round-trip storage.
+fn rebuild_payload_with_meta(source: &Card, fields: IndexMap<String, QuillValue>) -> Payload {
+    let mut payload = Payload::from_index_map(fields);
+    if let Some(q) = source.quill() {
+        payload.set_quill(q.clone());
+    }
+    if let Some(k) = source.kind() {
+        payload.set_kind(k.to_string());
+    }
+    if let Some(id) = source.id() {
+        payload.set_id(id.to_string());
+    }
+    payload
 }
 
 impl std::fmt::Debug for Quill {

--- a/docs/migrations/0.80-to-0.81.md
+++ b/docs/migrations/0.80-to-0.81.md
@@ -83,11 +83,11 @@ any other `$`-prefixed key is a parse error (the set is closed).
   validation, no uniqueness; carried through the round-trip unchanged.
 
 `$` metadata entries are read as ordinary YAML keys, so they may appear at
-any position within the block's payload. The canonical emission places them
-first, in the order `$quill`, `$kind`, `$id`. A duplicate `$key` within a
-block is rejected by the YAML parser as a duplicate mapping key. Comments
-on `$` lines (inline or own-line) are accepted on parse but dropped from
-the canonical form.
+any position within the block's payload. Canonical emission preserves
+source order — including any YAML comments adjacent to `$` lines.
+Programmatically constructed metadata (no source order) emits in the
+canonical key order `$quill`, `$kind`, `$id`. A duplicate `$key` within a
+block is rejected by the YAML parser as a duplicate mapping key.
 
 ### Blank-line rule
 

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -1,0 +1,43 @@
+# Bookmarks
+
+Known gaps surfaced from code review. Each item is captured for later
+attention — no commitment to a schedule. When an item turns into work, give
+it a proposal in `prose/proposals/` and remove it from here.
+
+## 1. No constructor for root cards
+
+`crates/core/src/document/edit.rs:258` — `Card::new(kind)` constructs a
+composable card. There is no equivalent for the document root; callers must
+hand-build a `CardMetadata` and pass it to `Card::from_parts`, then assemble
+via `Document::from_main_and_cards` which `debug_assert!`s the result.
+
+No use case for programmatic root construction has surfaced yet (every
+production path goes through `Document::from_markdown` or `from_json`), so
+the asymmetry is a latent gap, not an active problem. Add a
+`Card::new_root(quill: QuillReference)` plus a `Document::new(main, cards)`
+the first time a caller actually needs to build a document from scratch.
+
+## 2. `Document` clones on serialize
+
+`crates/core/src/document/mod.rs:218` — `#[serde(into = "StoredDocument")]`
+forces a by-value `From<Document>` conversion, which `.clone()`s every
+field of every card. For "store this in a database" the per-write copy of
+the whole document is wasted work.
+
+`From<&Document> for DocumentV0_82_0` already exists; the path forward is
+a manual `Serialize` impl on `Document` that converts by reference. The
+deserialization side is unaffected (`try_from = "StoredDocument"` already
+fits the `TryFrom<StoredDocument> for Document` shape).
+
+## 3. `from_main_and_cards` overloads two intents
+
+`crates/core/src/document/mod.rs:241` — `Document::from_main_and_cards`
+accepts `warnings: Vec<Diagnostic>`, but every callsite that isn't the
+parser passes `Vec::new()`. Storage-DTO reconstruction, programmatic
+construction, and the parser all funnel through one constructor whose
+warnings argument is meaningful in exactly one of those cases.
+
+Split into `Document::from_parts(main, cards)` for the empty-warnings path
+and `Document::from_parsed(main, cards, warnings)` (or keep the existing
+name) for the parser. Makes the intent of each callsite obvious and stops
+the DTO conversion from having to know it should pass empty warnings.

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -72,7 +72,7 @@ detection, cache keys).
 
 The guarantee follows from: struct field order is fixed in the frozen
 DTO tree; `Vec` fields preserve order by definition; `serde_json::Value`
-inside frontmatter field values keeps YAML insertion order via the
+inside payload field values keeps YAML insertion order via the
 workspace's `serde_json/preserve_order` feature. No key sorting or
 whitespace normalization is applied — the output is `serde_json`'s
 compact form. Bumping the `schema` version is the only event that may
@@ -133,4 +133,4 @@ any past version always loads.
 - [ARCHITECTURE.md](ARCHITECTURE.md) — `Document` in the core type overview
 - [MARKDOWN.md](MARKDOWN.md) — Markdown syntax and the in-memory data model
 - [VERSIONING.md](VERSIONING.md) — quill version resolution (a separate concern)
-- [QUILL_VALUE.md](QUILL_VALUE.md) — value type stored inside frontmatter fields
+- [QUILL_VALUE.md](QUILL_VALUE.md) — value type stored inside payload fields

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -38,19 +38,43 @@ bindings) and never a storage option.
 
 ## The Format
 
+The current schema (`quillmark/document@0.82.0`) carries each card's full
+ordered payload — typed `$` system metadata, user fields, and YAML
+comments interleaved in source order — as a single discriminated-union
+item list. This is what makes inline-comment preservation symmetric across
+the `$`/non-`$` boundary.
+
 ```json
 {
-  "schema": "quillmark/document@0.81.0",
-  "main":  { "sentinel": { ... }, "frontmatter": { ... }, "body": "..." },
+  "schema": "quillmark/document@0.82.0",
+  "main": {
+    "payload": {
+      "items": [
+        { "type": "quill", "value": "usaf_memo@0.1" },
+        { "type": "kind",  "value": "main" },
+        { "type": "field", "key": "title", "value": "Hi" }
+      ]
+    },
+    "body": "..."
+  },
   "cards": [ ... ]
 }
 ```
 
 `StoredDocument` is an internally-tagged enum (`#[serde(tag = "schema")]`);
 each variant carries a frozen DTO tree. Quill references are stored as
-strings (parsed back via `QuillReference::from_str`). Parse-time warnings are
-not part of `Document` — they are returned separately by
-`Document::from_markdown_with_warnings` — so they never reach this format.
+strings (parsed back via `QuillReference::from_str`). The discriminator on
+payload items is `type` (not `kind`) to keep it unambiguous next to the
+`$kind` metadata semantic. Parse-time warnings are not part of `Document`
+— they are returned separately by `Document::from_markdown_with_warnings`
+— so they never reach this format.
+
+### Legacy schema (V0_81_0)
+
+Documents written by `quillmark-core` `0.81.x` carry
+`"schema": "quillmark/document@0.81.0"` and a separate `sentinel` + `frontmatter`
+shape. Readers accept them and migrate forward on load; writers no longer
+produce this shape.
 
 ```rust
 use quillmark_core::Document;
@@ -81,44 +105,52 @@ change the byte layout.
 ## Schema Versioning
 
 The schema version is tied to the **crate version at which the `Document`
-model was last changed** — not the running crate version. The current model
-was fixed in `0.81.0`, so the version is `quillmark/document@0.81.0`; every
-`0.81.x` patch release writes that same value, because patches do not
-change the model.
+wire format was last changed** — not the running crate version. The
+current format was fixed in `0.82.0`, so the version tag is
+`quillmark/document@0.82.0`; every `0.82.x` patch release writes that same
+value, because patches do not change the format.
 
-`0.81.0` is the **baseline** schema: it has no predecessor and requires no
-migration. The first migration work occurs at the next model change.
+The first schema version was `0.81.0`. `0.82.0` migrated `Document` to a
+unified payload-item list (typed `$` entries living alongside user fields
+and comments in a single `Vec<PayloadItem>` instead of a separate
+`sentinel + frontmatter` pair). The migration is structural: the V0_81_0
+sentinel becomes a prelude of typed `$` items, then user fields and
+comments append in their original order.
 
 ## Adding a Schema Version
 
-When the `Document` model changes (planned for `0.82.0`):
+When the `Document` wire format changes again:
 
-1. **Freeze** the `DocumentV0_81_0` type tree — leave its struct/enum
-   definitions and serde derives untouched so existing rows still parse.
+1. **Freeze** the current `DocumentV0_82_0` type tree — leave its struct
+   /enum definitions and serde derives untouched so existing rows still parse.
 2. **Remove** the conversions binding the old DTO to the *live* `Document`
    (`From<&Document>` and `TryFrom<… for Document>`); they no longer compile
    and are superseded below.
-3. **Add** a new frozen tree `DocumentV0_82_0` reflecting the new model, plus
-   its `From<&Document>` and `TryFrom<… for Document>` conversions.
-4. **Add** the `StoredDocument::V0_82_0` variant, tagged
-   `#[serde(rename = "quillmark/document@0.82.0")]`.
-5. **Write the migration** — `From<DocumentV0_81_0> for DocumentV0_82_0`.
+3. **Add** a new frozen tree `DocumentV0_NN_0` reflecting the new model,
+   plus its `From<&Document>` and `TryFrom<… for Document>` conversions.
+4. **Add** the `StoredDocument::V0_NN_0` variant, tagged
+   `#[serde(rename = "quillmark/document@0.NN.0")]`.
+5. **Write the migration** — `From<DocumentV0_82_0> for DocumentV0_NN_0`.
    This is the only real labor: it encodes how old fields map to the new
    model (renames, restructures, defaults for new fields).
 6. **Extend** the reader:
    ```rust
    match stored {
-       StoredDocument::V0_82_0(p) => Document::try_from(p),
-       StoredDocument::V0_81_0(p) => Document::try_from(DocumentV0_82_0::from(p)),
+       StoredDocument::V0_NN_0(p) => Document::try_from(p),
+       StoredDocument::V0_82_0(p) => Document::try_from(DocumentV0_NN_0::from(p)),
+       StoredDocument::V0_81_0(p) => {
+           let v82 = DocumentV0_82_0::from(p);
+           Document::try_from(DocumentV0_NN_0::from(v82))
+       }
    }
    ```
 
 Old and new DTOs **coexist permanently** in `dto.rs`. Migrations chain
-(`V0_81_0 → V0_82_0 → …`); only the newest DTO converts to the live
-`Document`, so each migration step stays small as versions accumulate. The
-cost of this design is one frozen type tree per schema version plus one
-migration function per version bump; the benefit is that a row written by
-any past version always loads.
+(`V0_81_0 → V0_82_0 → V0_NN_0 → …`); only the newest DTO converts to the
+live `Document`, so each migration step stays small as versions accumulate.
+The cost of this design is one frozen type tree per schema version plus
+one migration function per version bump; the benefit is that a row written
+by any past version always loads.
 
 ## Gotchas
 

--- a/prose/canon/MARKDOWN.md
+++ b/prose/canon/MARKDOWN.md
@@ -114,11 +114,15 @@ ordinary YAML — they are read by the same YAML parser that handles the rest
 of the payload — but they are **extracted** from the user field set after
 parsing; they are not part of the data model's field map (§3.4).
 
-In the typed model, the extracted metadata is exposed as a `CardMetadata`
-struct with three optional fields — `quill`, `kind`, `id`. On a successfully
-parsed document the root block always carries `quill = Some(_)` and
-`kind = Some("main")`; composable cards always carry `quill = None` and
-`kind = Some(_)` (any value other than `"main"`).
+In the typed model, the `$` entries live as typed variants of the
+unified payload-item list (`PayloadItem::Quill`, `PayloadItem::Kind`,
+`PayloadItem::Id`), interleaved in source order with user fields and
+YAML comments. They are surfaced through typed accessors —
+`card.quill()`, `card.kind()`, `card.id()` — which return `Option<…>`.
+On a successfully parsed document the root card always returns
+`Some(_)` for both `quill()` and `kind()` (with `kind() == "main"`);
+composable cards return `None` for `quill()` and `Some(_)` for `kind()`
+(any value other than `"main"`).
 
 - **`$quill: <name>@<version>`** — binds the document to a quill (see §3.5
   for the version-selector forms). The root block (the first block) must
@@ -138,8 +142,9 @@ Rules:
   composable (non-root) block must declare `$kind: <kind>` for some
   `<kind>` other than `main`, and must not declare `$quill`.
 - `$` metadata entries may appear at any position within the payload, and
-  may be interleaved with data fields. The emitter places them first, in
-  the canonical key order `$quill`, `$kind`, `$id` (see §9).
+  may be interleaved with data fields. The emitter preserves source order
+  (see §9); newly constructed metadata that does not have a source-order
+  is emitted in the canonical key order `$quill`, `$kind`, `$id`.
 - A duplicate `$key` within a single block is a parse error (a YAML mapping
   cannot carry two entries under the same key).
 - An unknown `$key` (anything outside `{quill, kind, id}`) is a parse error.
@@ -147,10 +152,9 @@ Rules:
 - A `$`-prefixed key whose value type is wrong for the key (e.g. a sequence
   under `$quill`) is a parse error.
 - **YAML comments on `$` lines.** Inline trailing comments (`$quill: foo  #
-  bound at build`) and adjacent own-line comments are accepted by the
-  YAML parser, but they are **not preserved** through emit — the canonical
-  form (§9) drops every comment that targets a `$` metadata key. Comments
-  on data fields round-trip normally (§3.4).
+  bound at build`) and adjacent own-line comments round-trip through the
+  unified payload-item list — the same mechanism that preserves comments
+  on data fields (§3.4). Both flavors survive parse → emit → parse.
 
 ### 3.4 Data Payload
 
@@ -356,20 +360,21 @@ error when any is exceeded:
 
 ```
 ~~~card-yaml
-<$ metadata lines, in canonical order>
-<data fields>
+<payload items in source order>
 ~~~
 ```
 
-That is: a `~~~card-yaml` opener, the `$` system-metadata lines (in the
-canonical key order `$quill`, `$kind`, `$id`) leading the YAML payload, the
-remaining data fields, and a `~~~` closer. The root block emits both
-`$quill` and `$kind: main`; composable cards emit `$kind: <kind>` plus any
-other `$` entries they declared. A document round-trips to this canonical
-shape — fence markers, key ordering, and YAML quoting are normalised.
-`!fill` tags and data-field comments (own-line and inline) survive the
-round-trip; comments targeting `$` metadata keys do not — the canonical
-form drops them.
+That is: a `~~~card-yaml` opener, the YAML payload (typed `$` system
+metadata, user data fields, and YAML comments interleaved in source
+order), and a `~~~` closer. The root block must declare `$quill` and
+`$kind: main`; composable cards must declare `$kind: <kind>`. A document
+round-trips to this canonical shape — fence markers and YAML quoting are
+normalised. `!fill` tags and YAML comments (own-line and inline, including
+those adjacent to `$` lines) survive the round-trip.
+
+Programmatically constructed metadata that does not have a source-order
+emits in the canonical key order `$quill`, `$kind`, `$id` — the typed
+mutators (`set_quill` / `set_kind` / `set_id`) insert at these positions.
 
 ### 9.1 Canonical Idempotence
 
@@ -392,9 +397,10 @@ A document in canonical form round-trips byte-equal under both
 Arbitrary (non-canonical) input parses successfully when it satisfies §1–8
 and converges to the canonical form on the first emit. Type fidelity (a
 quoted `"42"` survives as a string, an unquoted `42` survives as an
-integer) is preserved; fence-marker length, quoting style, and the source
-position of `$` metadata keys are not. The canonical form is what consumers
-should content-hash, content-address, or compare for equality.
+integer) is preserved, along with the source positions of `$` metadata
+keys and YAML comments; fence-marker length and quoting style are not.
+The canonical form is what consumers should content-hash, content-address,
+or compare for equality.
 
 ## 10. Errors
 


### PR DESCRIPTION
## Summary

Refactor card-yaml system metadata (`$quill`, `$kind`, `$id`) handling to preserve YAML comments that appear on or among these entries, enabling symmetric round-trip fidelity on both sides of the `$`/non-`$` boundary.

## Key Changes

- **New `MetaItem` enum** (`meta.rs`): Replaces flat `CardMetadata` struct fields with an ordered list of typed entries (`Quill`, `Kind`, `Id`) and `Comment` items. Comments distinguish inline trailing comments from own-line comments, mirroring the `PayloadItem` design.

- **`CardMetadata` refactored to ordered container** (`meta.rs`): Now wraps `Vec<MetaItem>` instead of three `Option<T>` fields. Provides typed accessors (`quill()`, `kind()`, `id()`) that search the items list, and mutators (`set_quill()`, `set_kind()`, `set_id()`) that replace entries in place or insert at canonical position (`$quill` → `$kind` → `$id`). Comments are never reshuffled by typed mutators.

- **Comment routing in assembly** (`assemble.rs`): `build_meta_and_payload()` (renamed from `build_payload_from_pre_and_parsed()`) now partitions comments by region:
  - Comments inline-trailing a `$` field, or own-line comments appearing before the first non-`$` field, go into metadata items
  - All other comments go into payload items
  - This preserves the structural relationship between comments and their associated entries across the metadata/payload split

- **Metadata extraction returns `Vec<MetaItem>`** (`meta.rs`): `extract_meta_from_payload()` now returns typed items in source order rather than a pre-constructed `CardMetadata`. The assembler interleaves these with comments from the prescan.

- **Emit walks metadata items in order** (`emit.rs`): Renders each `$` entry with any immediately following inline comment as a trailer on the same line. Own-line comments render as `# text` lines. Preserves source order and comment positioning.

- **New validation helper** (`meta.rs`): `validate_composable_kind()` centralizes the rule that composable card kinds must match `[a-z_][a-z0-9_]*` and cannot be `"main"`. Returns `CardKindError` enum for structured error handling.

- **DTO compatibility** (`dto.rs`): V0_81_0 serialization drops comments (predates comment preservation); newer schema versions will preserve them. Deserialization reconstructs metadata via the new `set_*` mutators.

- **Test updates**: All test sites updated to use `CardMetadata::new()` and `set_*()` mutators instead of struct literal construction.

## Notable Implementation Details

- **Canonical ordering**: Typed mutators maintain the order `$quill` (rank 0) → `$kind` (rank 1) → `$id` (rank 2) when inserting absent entries, but preserve position when replacing existing entries.

- **Comment attachment semantics**: Inline comments attach to the preceding `$` entry; if no such entry exists at emit time, they degrade to own-line comments. This mirrors `PayloadItem` behavior.

- **Prescan integration**: The prescan's `PreItem` list (which preserves source order and comment positions) drives the interleaving; typed values come from the extracted `MetaItem` list.

- **Symmetric round-trip**: Comments on metadata lines now survive parse → emit → parse cycles, just as payload comments do. The split between metadata and payload is purely about storage location; both regions render in the same `~~~card-yaml` block.

https://claude.ai/code/session_01Y4UoQMgfKCdjxv9L675Cdv