### PR TITLE
docs: retitle card-yaml migration as 0.81 → 0.82

### DIFF
--- a/docs/migrations/0.81-to-0.82.md
+++ b/docs/migrations/0.81-to-0.82.md
@@ -1,7 +1,7 @@
-# 0.80.0 → 0.81.0 — card-yaml syntax
+# 0.81.0 → 0.82.0 — card-yaml syntax
 
-`0.81.0` replaces Quillmark's Markdown metadata syntax with the **card-yaml**
-format. This is a **hard cutover**: the `0.80.0` `---`/`QUILL:` frontmatter and
+`0.82.0` replaces Quillmark's Markdown metadata syntax with the **card-yaml**
+format. This is a **hard cutover**: the `0.81.0` `---`/`QUILL:` frontmatter and
 the ` ```card <kind> ` fenced cards (and the legacy `---`/`CARD:` fence) are
 removed and no longer parse. Stored documents must be migrated.
 
@@ -183,23 +183,24 @@ This is a pure rename: the type's shape, methods, and behavior are unchanged.
 
 **WASM** (`@quillmark/wasm`):
 
-| Old | New (0.81) | Superseded in 0.82 |
-|---|---|---|
-| `card.frontmatter` | `card.payload` | **Removed** — derive from `card.payloadItems` |
-| `card.frontmatterItems` | `card.payloadItems` | unchanged |
-| `FrontmatterItem` (TS type) | `PayloadItem` | unchanged |
+| Old | New |
+|---|---|
+| `card.frontmatter` (map view) | **Removed** — derive from `card.payloadItems` |
+| `card.frontmatterItems` | `card.payloadItems` |
+| `FrontmatterItem` (TS type) | `PayloadItem` |
 
 **Python** (`quillmark`):
 
-| Old | New (0.81) | Superseded in 0.82 |
-|---|---|---|
-| `doc.frontmatter` | `doc.payload` | **Removed** — derive from `doc.main["payload_items"]` |
-| `card["frontmatter"]` | `card["payload"]` | **Removed** — use `card["payload_items"]` |
-| `card["frontmatter_items"]` | `card["payload_items"]` | unchanged |
+| Old | New |
+|---|---|
+| `doc.frontmatter` (map view) | **Removed** — derive from `doc.main["payload_items"]` |
+| `card["frontmatter"]` (map view) | **Removed** — use `card["payload_items"]` |
+| `card["frontmatter_items"]` | `card["payload_items"]` |
 
-> **0.82 note**: the `payload` map view (`card.payload` / `doc.payload`)
-> was removed because it duplicated `payloadItems`. Read fields by
-> filtering: `card.payloadItems.find(i => i.type === 'field' && i.key === 'x')?.value`
+> The map view (`card.frontmatter` / `doc.frontmatter`) is not replaced by a
+> `payload` map: it duplicated the items list and was dropped during the
+> rename. Read fields by filtering:
+> `card.payloadItems.find(i => i.type === 'field' && i.key === 'x')?.value`
 > in JS, or the equivalent comprehension in Python.
 
 ### 6.2 System metadata: `Sentinel` removed, `CardMetadata` added


### PR DESCRIPTION
The card-yaml syntax change (#598) shipped with v0.82.0, not v0.81.0 —
v0.81.0 released first without the change. Rename the migration doc
file/title accordingly, update the prose to reference 0.81 as the prior
state and 0.82 as the cutover, and collapse the WASM/Python tables since
the brief `payload` map-view stage never shipped.