### PR TITLE
docs: repair mkdocs nav for renamed 0.81→0.82 migration and correct API description

### DIFF
--- a/docs/migrations/0.81-to-0.82.md
+++ b/docs/migrations/0.81-to-0.82.md
@@ -203,21 +203,18 @@ This is a pure rename: the type's shape, methods, and behavior are unchanged.
 > `card.payloadItems.find(i => i.type === 'field' && i.key === 'x')?.value`
 > in JS, or the equivalent comprehension in Python.
 
-### 6.2 System metadata: `Sentinel` removed, `CardMetadata` added
+### 6.2 System metadata: `Sentinel` removed, typed accessors added
 
 A block's `$`-prefixed reserved keys are now **system metadata** drawn from
 a closed set of three keys — `$quill`, `$kind`, `$id`. Any other `$key`
 is a parse error. The API reflects this:
 
 - The `Sentinel` enum is **removed**.
-- A new type **`CardMetadata`** is exported — a typed struct with three
-  optional public fields: `quill: Option<QuillReference>`, `kind:
-  Option<String>`, `id: Option<String>`. `$quill` is parsed into a typed
-  `QuillReference` at parse time.
-- `Card::sentinel()` is replaced by:
-  - `Card::meta()` — the block's `CardMetadata` struct.
-  - `Card::kind()` — the `$kind` value, if present.
-  - `Card::id()` — the `$id` value, if present.
+- `$quill` is parsed into a typed `QuillReference` at parse time.
+- `Card::sentinel()` is replaced by three typed accessors on `Card`:
+  - `Card::quill()` — `Option<&QuillReference>` for the block's `$quill`.
+  - `Card::kind()` — `Option<&str>` for the block's `$kind`.
+  - `Card::id()` — `Option<&str>` for the block's `$id`.
 - `Card::is_main()` is **removed**, along with the `is_main` argument to
   `Card::from_parts`. Root vs. composable is positional: the root `Card` lives
   in `Document::main`, composable cards in `Document::cards`.
@@ -226,7 +223,7 @@ is a parse error. The API reflects this:
   raise it.
 
 Code that matched on `Sentinel` variants or called `Card::sentinel()` must be
-updated to read `meta()` / `kind()` / `id()`.
+updated to read `Card::quill()` / `kind()` / `id()`.
 
 **Bindings.** The card object's discriminator key is renamed `tag` → `kind`
 to match core vocabulary:
@@ -258,8 +255,8 @@ core and the bindings:
       survive on data-field lines but not on `$` metadata lines.
 - [ ] Rename `Frontmatter` / `.frontmatter` API usages to `Payload` /
       `.payload` (see §6.1).
-- [ ] Replace `Card::sentinel()` / `Sentinel` usage with `Card::meta()` /
-      `kind()` / `id()` and the `CardMetadata` type (see §6.2).
+- [ ] Replace `Card::sentinel()` / `Sentinel` usage with the `Card::quill()` /
+      `kind()` / `id()` accessors (see §6.2).
 - [ ] In WASM/Python binding callers, rename the card `tag` key to `kind`
       (card objects and `CardInput`) — see §6.2.
 - [ ] Rename `set_card_tag` / `setCardTag` to `set_card_kind` / `setCardKind`,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,7 @@ nav:
   - CLI:
       - Reference: cli/reference.md
   - Migration:
-      - 0.80 → 0.81 (card-yaml): migrations/0.80-to-0.81.md
+      - 0.81 → 0.82 (card-yaml): migrations/0.81-to-0.82.md
       - WASM 0.77 → 0.80: migrations/wasm-0.77-to-0.80.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary

- Fix the mkdocs `Migration` nav entry that broke when #626 renamed `docs/migrations/0.80-to-0.81.md` → `0.81-to-0.82.md` — `mkdocs.yml` still referenced the old filename, so the link 404'd. Updated the path and the label ("0.80 → 0.81" → "0.81 → 0.82").
- Sanity-checked the migration page itself. §6.2 described a `CardMetadata` struct and `Card::meta()` accessor that never shipped — the released v0.82.0 API exposes typed metadata via direct `Card::quill()` / `Card::kind()` / `Card::id()` accessors. Rewrote that section (and the matching checklist entry) to describe the API actually in the codebase. Verified the rest of the page (Payload rename, removed map views, `tag` → `kind` binding rename, `set_card_kind`, `EditError::InvalidKindName`, `form::unknown_card_kind`) matches the source.

## Test plan

- [x] `mkdocs build --strict` passes (no broken nav references)
- [x] Cross-checked §6.2 against `crates/core/src/document/mod.rs` (`Card::quill/kind/id`, no `CardMetadata` exported)
- [x] Cross-checked the WASM and Python bindings against the binding sections of §6.1/§6.2

https://claude.ai/code/session_016siMFhHUaW99k6LM5DSsy8

---
_Generated by [Claude Code](https://claude.ai/code/session_016siMFhHUaW99k6LM5DSsy8)_