### PR TITLE
docs: document storage DTO migration in 0.81→0.82 guide

### DIFF
--- a/docs/migrations/0.81-to-0.82.md
+++ b/docs/migrations/0.81-to-0.82.md
@@ -119,6 +119,85 @@ it is unaffected and needs no change.
 Python) emits the **canonical card-yaml form**, so re-serializing a parsed
 document produces compliant output automatically.
 
+### Storage DTO (JSON) — `quillmark/document@0.81.0` → `@0.82.0`
+
+The versioned JSON envelope (`Document::toJson` / `fromJson` in WASM,
+`serde_json` on `Document` in Rust) also bumped its `schema` tag from
+`quillmark/document@0.81.0` to `quillmark/document@0.82.0`. Two paths apply,
+depending on how you consume the DTO.
+
+**You use `Document.fromJson` (recommended).** Nothing to do. `fromJson`
+accepts both schema tags: V0_81_0 payloads are migrated forward in-process
+on read, and the next `toJson` re-emits them under the V0_82_0 tag. The
+migration is structural (the V0_81_0 `sentinel` becomes typed `$` items at
+the head of `payload.items`), so a round-trip through the new build
+produces a `Document` equal to one re-parsed from the same Markdown.
+Migration is forward-only: a V0_82_0 blob cannot be read by a 0.81.x
+build.
+
+**You read the DTO JSON directly.** The wire shape changed. The separate
+`sentinel` and `frontmatter` collapse into a single ordered
+`payload.items` list, and the per-item discriminator is renamed `kind` →
+`type` (the field name `kind` is reused as a payload-item *variant* for
+`$kind`, so the discriminator had to move):
+
+```diff
+  {
+-   "schema": "quillmark/document@0.81.0",
++   "schema": "quillmark/document@0.82.0",
+    "main": {
+-     "sentinel":    { "kind": "main", "quill": "usaf_memo@0.1" },
+-     "frontmatter": { "items": [ { "kind": "field", "key": "title", "value": "Hi" } ] },
++     "payload": {
++       "items": [
++         { "type": "quill", "value": "usaf_memo@0.1" },
++         { "type": "kind",  "value": "main" },
++         { "type": "field", "key": "title", "value": "Hi" }
++       ]
++     },
+      "body": "..."
+    },
+    "cards": [
+      {
+-       "sentinel":    { "kind": "card", "tag": "indorsement" },
+-       "frontmatter": { "items": [ { "kind": "field", "key": "for", "value": "X" } ] },
++       "payload": {
++         "items": [
++           { "type": "kind",  "value": "indorsement" },
++           { "type": "field", "key": "for", "value": "X" }
++         ]
++       },
+        "body": "..."
+      }
+    ]
+  }
+```
+
+Concrete deltas:
+
+- `card.sentinel` is gone. The main card emits `$quill` then `$kind: main`
+  as the first two `payload.items` entries; a composable card emits a
+  single `$kind` entry. The old `{"kind":"card","tag":"X"}` becomes
+  `{"type":"kind","value":"X"}`.
+- `card.frontmatter` → `card.payload`. `frontmatter.nested_comments` →
+  `payload.nested_comments` (same shape).
+- Payload-item discriminator: `"kind"` → `"type"`. New variants:
+  `quill`, `kind`, `id` alongside the existing `field` and `comment`.
+- The user-facing `fill` flag on `field` items and the `inline` flag on
+  `comment` items are unchanged.
+
+Detection helpers on the WASM `Document` class:
+
+```ts
+Document.currentSchemaVersion()   // "quillmark/document@0.82.0"
+Document.schemaVersionOf(blob)    // reads the schema tag without a full parse
+Document.tryFromJson(blob)        // returns undefined instead of throwing
+```
+
+`schemaVersionOf` does not validate the payload — use it to distinguish
+"wrong schema version" from "corrupt" when `fromJson` throws. The full
+design lives in `prose/canon/DOCUMENT_STORAGE.md`.
+
 ## 3. What is unchanged
 
 - **Field names** still match `[a-z_][a-z0-9_]*`; **card kinds** still match
@@ -249,6 +328,10 @@ core and the bindings:
 
 - [ ] Migrate stored Markdown from `---` frontmatter / `card` fences to
       `~~~card-yaml` blocks carrying `$`-prefixed reserved metadata keys.
+- [ ] Stored JSON DTOs (`schema: quillmark/document@0.81.0`) load
+      transparently via `Document.fromJson`; only consumers that read the
+      DTO JSON **directly** need to update for the `sentinel` +
+      `frontmatter` → unified `payload.items` shape (see §2 "Storage DTO").
 - [ ] Ensure the root (first) block declares `$quill`.
 - [ ] Ensure every `~~~card-yaml` opener has a blank line above it.
 - [ ] Drop any inline comment that sat on a `QUILL:` / `CARD:` line — they


### PR DESCRIPTION
Note that `Document.fromJson` reads `quillmark/document@0.81.0` payloads
transparently via the V0_81_0 → V0_82_0 structural migration, and show
the wire-shape delta (`sentinel` + `frontmatter` → unified
`payload.items`, `kind` → `type` discriminator) for consumers that read
the DTO JSON directly.

https://claude.ai/code/session_01EcS44dSpqYcuTVTR2HpUum