### PR TITLE
Retire legacy uppercase reserved keys; use $-prefixed metadata in plate JSON

### DIFF
--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn test_generate_lib_typ_basic() {
-        let json = r#"{"title":"Test","BODY":"Hello","date":"2025-01-15","__meta__":{"content_fields":["BODY"],"card_content_fields":{},"date_fields":["date"],"card_date_fields":{}}}"#;
+        let json = r#"{"title":"Test","$body":"Hello","date":"2025-01-15","__meta__":{"content_fields":["$body"],"card_content_fields":{},"date_fields":["date"],"card_date_fields":{}}}"#;
         let lib = generate_lib_typ(json);
 
         assert!(lib.contains("Version: 0.1.0"));

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -237,7 +237,7 @@ fn is_date_field(field_schema: &serde_json::Value) -> bool {
 ///
 /// Identifies fields with `contentMediaType = "text/markdown"` and converts
 /// their content using `mark_to_typst()`. This includes recursive handling
-/// of CARDS arrays.
+/// of the `$cards` array.
 ///
 /// Also injects a `__meta__` key into the result containing the names of
 /// converted fields, which the quillmark-helper package uses to auto-evaluate
@@ -279,12 +279,12 @@ fn transform_markdown_fields(
         .map(|(name, _)| name.as_str())
         .collect();
 
-    // Handle CARDS array recursively
-    if let Some(cards_value) = result.get("CARDS") {
+    // Handle `$cards` array recursively
+    if let Some(cards_value) = result.get("$cards") {
         if let Some(cards_array) = cards_value.as_array() {
             let transformed_cards = transform_cards_array(schema, cards_array);
             result.insert(
-                "CARDS".to_string(),
+                "$cards".to_string(),
                 QuillValue::from_json(serde_json::Value::Array(transformed_cards)),
             );
         }
@@ -359,7 +359,7 @@ fn transform_markdown_fields(
     result
 }
 
-/// Transform markdown fields in CARDS array items.
+/// Transform markdown fields in `$cards` array items.
 fn transform_cards_array(
     document_schema: &QuillValue,
     cards_array: &[serde_json::Value],
@@ -374,7 +374,7 @@ fn transform_cards_array(
 
     for card in cards_array {
         if let Some(card_obj) = card.as_object() {
-            if let Some(card_kind) = card_obj.get("CARD").and_then(|v| v.as_str()) {
+            if let Some(card_kind) = card_obj.get("$kind").and_then(|v| v.as_str()) {
                 // Construct the definition name: {kind}_card
                 let def_name = format!("{}_card", card_kind);
 
@@ -404,7 +404,7 @@ fn transform_cards_array(
             }
         }
 
-        // If not an object, no CARD kind, or no matching schema, keep as-is
+        // If not an object, no `$kind`, or no matching schema, keep as-is
         transformed_cards.push(card.clone());
     }
 
@@ -471,7 +471,7 @@ mod tests {
             "type": "object",
             "properties": {
                 "title": { "type": "string" },
-                "BODY": { "type": "string", "contentMediaType": "text/markdown" }
+                "$body": { "type": "string", "contentMediaType": "text/markdown" }
             }
         }));
 
@@ -481,7 +481,7 @@ mod tests {
             QuillValue::from_json(json!("My Title")),
         );
         fields.insert(
-            "BODY".to_string(),
+            "$body".to_string(),
             QuillValue::from_json(json!("This is **bold** text.")),
         );
 
@@ -490,8 +490,8 @@ mod tests {
         // title should be unchanged
         assert_eq!(result.get("title").unwrap().as_str(), Some("My Title"));
 
-        // BODY should be converted to Typst markup
-        let body = result.get("BODY").unwrap().as_str().unwrap();
+        // `$body` should be converted to Typst markup
+        let body = result.get("$body").unwrap().as_str().unwrap();
         assert!(body.contains("#strong[bold]"));
     }
 
@@ -524,19 +524,19 @@ mod tests {
         let schema = QuillValue::from_json(json!({
             "type": "object",
             "properties": {
-                "BODY": { "type": "string", "contentMediaType": "text/markdown" }
+                "$body": { "type": "string", "contentMediaType": "text/markdown" }
             }
         }));
 
         let mut fields = HashMap::new();
         fields.insert(
-            "BODY".to_string(),
+            "$body".to_string(),
             QuillValue::from_json(json!("_italic_ text")),
         );
 
         let result = transform_markdown_fields(&fields, &schema);
 
-        let body = result.get("BODY").unwrap().as_str().unwrap();
+        let body = result.get("$body").unwrap().as_str().unwrap();
         assert!(body.contains("#emph[italic]"));
     }
 
@@ -574,7 +574,7 @@ mod tests {
                     "properties": {
                         "date": { "type": "string", "format": "date" },
                         "created_at": { "type": "string", "format": "date-time" },
-                        "BODY": { "type": "string", "contentMediaType": "text/markdown" }
+                        "$body": { "type": "string", "contentMediaType": "text/markdown" }
                     }
                 }
             }

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -82,11 +82,11 @@
     }
   }
 
-  // Auto-eval content fields within each CARD
-  if "CARDS" in d {
+  // Auto-eval content fields within each card under `$cards`
+  if "$cards" in d {
     let cards = ()
-    for card in d.at("CARDS") {
-      let card-type = card.at("CARD", default: none)
+    for card in d.at("$cards") {
+      let card-type = card.at("$kind", default: none)
       let fields = meta.card_content_fields.at(card-type, default: ())
       for key in fields {
         if key in card {
@@ -110,7 +110,7 @@
 
       cards.push(card)
     }
-    d.insert("CARDS", cards)
+    d.insert("$cards", cards)
   }
 
   d

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -19,7 +19,6 @@ create_exception!(_quillmark, PyEditError, QuillmarkError);
 /// Convert an [`EditError`] to a `PyErr` (raises `quillmark.EditError`).
 pub fn convert_edit_error(err: EditError) -> PyErr {
     let variant = match &err {
-        EditError::ReservedName(_) => "ReservedName",
         EditError::InvalidFieldName(_) => "InvalidFieldName",
         EditError::InvalidKindName(_) => "InvalidKindName",
         EditError::ReservedKind => "ReservedKind",

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -104,8 +104,9 @@ impl PyQuill {
     }
 
     /// Document schema as a structured dict (matches the wasm `schema` shape).
-    /// Includes optional `ui` keys. `main.fields.QUILL` and `card_kinds[name].fields.CARD`
-    /// are reserved fields with `const` values telling consumers what to write.
+    /// Includes optional `ui` keys. Describes only the user-fillable fields;
+    /// the quill reference and card-kind discriminators live on the quill's
+    /// metadata, not the schema.
     #[getter]
     fn schema<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let value = self.inner.source().config().schema();
@@ -403,7 +404,7 @@ impl PyDocument {
     }
 
     /// Set a payload field on the main card. Clears any `!fill` marker.
-    /// Raises `quillmark.EditError` if `name` is reserved or does not match `[a-z_][a-z0-9_]*`.
+    /// Raises `quillmark.EditError` if `name` does not match `[a-z_][a-z0-9_]*`.
     fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         self.inner
@@ -422,7 +423,7 @@ impl PyDocument {
     }
 
     /// Remove a payload field from the main card, returning the value or `None` if absent.
-    /// Raises `quillmark.EditError` if `name` is reserved or invalid.
+    /// Raises `quillmark.EditError` if `name` is invalid.
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match self
             .inner
@@ -435,7 +436,7 @@ impl PyDocument {
         }
     }
 
-    /// Replace the QUILL reference string. Raises `ValueError` if `ref_str` is not a valid `QuillReference`.
+    /// Replace the quill reference string. Raises `ValueError` if `ref_str` is not a valid `QuillReference`.
     fn set_quill_ref(&mut self, ref_str: &str) -> PyResult<()> {
         let qr: quillmark_core::QuillReference = ref_str.parse().map_err(|e| {
             PyValueError::new_err(format!("invalid QuillReference '{}': {}", ref_str, e))
@@ -493,7 +494,7 @@ impl PyDocument {
     }
 
     /// Update a field on the card at `index`. Raises `quillmark.EditError` if `index` is out of range
-    /// or `name` is reserved or invalid.
+    /// or `name` is invalid.
     fn update_card_field(
         &mut self,
         index: usize,
@@ -509,7 +510,7 @@ impl PyDocument {
     }
 
     /// Remove a field from the card at `index`, returning the value or `None` if absent.
-    /// Raises `quillmark.EditError` if `index` is out of range or `name` is reserved or invalid.
+    /// Raises `quillmark.EditError` if `index` is out of range or `name` is invalid.
     fn remove_card_field<'py>(
         &mut self,
         py: Python<'py>,

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -1,5 +1,7 @@
 """Tests for the API requirements."""
 
+import re
+
 import pytest
 from quillmark import Quillmark, Document, OutputFormat, ParseError, EditError
 from conftest import QUILLS_PATH, _latest_version
@@ -127,20 +129,28 @@ def test_set_field_updates():
     assert field(doc.main, "title") == "New Title"
 
 
-def test_set_field_reserved_name_matrix():
-    """set_field raises EditError for all four reserved names."""
+def test_set_field_legacy_uppercase_rejected_matrix():
+    """set_field raises InvalidFieldName for the legacy uppercase sentinels."""
     for name in ("BODY", "CARDS", "QUILL", "CARD"):
         doc = Document.from_markdown(SIMPLE_MD)
-        with pytest.raises(EditError, match="ReservedName"):
+        with pytest.raises(EditError, match="InvalidFieldName"):
             doc.set_field(name, "value")
 
 
-def test_card_set_field_reserved_name_matrix():
-    """Card set_field raises EditError for all four reserved names."""
+def test_card_set_field_legacy_uppercase_rejected_matrix():
+    """Card update_card_field raises InvalidFieldName for legacy uppercase names."""
     for name in ("BODY", "CARDS", "QUILL", "CARD"):
         doc = Document.from_markdown(MD_WITH_CARDS)
-        with pytest.raises(EditError, match="ReservedName"):
+        with pytest.raises(EditError, match="InvalidFieldName"):
             doc.update_card_field(0, name, "value")
+
+
+def test_set_field_dollar_prefix_rejected_matrix():
+    """set_field raises InvalidFieldName for `$`-prefixed names."""
+    for name in ("$body", "$cards", "$quill", "$kind"):
+        doc = Document.from_markdown(SIMPLE_MD)
+        with pytest.raises(EditError, match="InvalidFieldName"):
+            doc.set_field(name, "value")
 
 
 def test_set_field_invalid_field_name():
@@ -164,15 +174,15 @@ def test_remove_field_absent():
     assert doc.remove_field("nonexistent") is None
 
 
-def test_remove_field_reserved_raises():
-    """remove_field raises EditError for reserved names."""
+def test_remove_field_legacy_uppercase_rejected():
+    """remove_field raises InvalidFieldName for legacy uppercase names."""
     doc = Document.from_markdown(SIMPLE_MD)
-    with pytest.raises(EditError, match="ReservedName"):
+    with pytest.raises(EditError, match="InvalidFieldName"):
         doc.remove_field("BODY")
 
 
 def test_set_quill_ref():
-    """set_quill_ref changes the QUILL reference."""
+    """set_quill_ref changes the quill reference."""
     doc = Document.from_markdown(SIMPLE_MD)
     doc.set_quill_ref("new_quill")
     assert doc.quill_ref() == "new_quill"
@@ -263,10 +273,10 @@ def test_update_card_field():
     assert field(doc.cards[0], "content") == "hello"
 
 
-def test_update_card_field_reserved_name():
-    """update_card_field raises EditError for reserved names."""
+def test_update_card_field_legacy_uppercase_rejected():
+    """update_card_field raises InvalidFieldName for legacy uppercase names."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    with pytest.raises(EditError, match="ReservedName"):
+    with pytest.raises(EditError, match="InvalidFieldName"):
         doc.update_card_field(0, "BODY", "value")
 
 
@@ -317,10 +327,10 @@ def test_invariants_after_mutation_sequence():
     doc.set_field("extra_author", "Bob")
     doc.remove_field("extra_author")
 
-    # Assertions: no reserved key in payload
-    RESERVED = {"BODY", "CARDS", "QUILL", "CARD"}
+    # Assertions: every payload key passes the user-field regex.
+    field_name_re = re.compile(r"^[a-z_][a-z0-9_]*$")
     for key in field_keys(doc.main):
-        assert key not in RESERVED, f"reserved key '{key}' found in payload"
+        assert field_name_re.match(key), f"invalid key '{key}' found in payload"
 
     # Every card kind is lowercase-valid (just check non-empty and lowercase)
     for card in doc.cards:

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -47,13 +47,13 @@ def test_parse_invalid_yaml():
 
 
 def test_payload_access(taro_md):
-    """Test accessing typed payload_items (no BODY/CARDS/QUILL)."""
+    """Test accessing typed payload_items (no $-prefixed metadata as fields)."""
     doc = Document.from_markdown(taro_md)
     assert "Ice Cream" in (field(doc.main, "title") or "")
-    # BODY, CARDS, QUILL must NOT appear as field entries
-    assert not has_field(doc.main, "BODY")
-    assert not has_field(doc.main, "CARDS")
-    assert not has_field(doc.main, "QUILL")
+    # `$`-prefixed metadata is not exposed as payload fields
+    assert not has_field(doc.main, "$body")
+    assert not has_field(doc.main, "$cards")
+    assert not has_field(doc.main, "$quill")
 
 
 def test_body_is_str(taro_md):
@@ -299,8 +299,8 @@ def test_remove_card_field_out_of_range():
         doc.remove_card_field(0, "foo")
 
 
-def test_remove_card_field_reserved_name():
-    """remove_card_field rejects reserved names."""
+def test_remove_card_field_legacy_uppercase_rejected():
+    """remove_card_field rejects legacy uppercase names as InvalidFieldName."""
     from quillmark import EditError
 
     md = (
@@ -308,5 +308,5 @@ def test_remove_card_field_reserved_name():
         "~~~card-yaml\n#@kind: note\n~~~\n"
     )
     doc = Document.from_markdown(md)
-    with pytest.raises(EditError, match="ReservedName"):
+    with pytest.raises(EditError, match="InvalidFieldName"):
         doc.remove_card_field(0, "BODY")

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -263,7 +263,7 @@ compilation failures. The same shape applies to every throw site:
 - `Document.fromMarkdown` — parse errors (missing root `$quill` metadata, YAML
   errors, `parse::input_too_large` for inputs > 10 MB).
 - `Document` mutators (`setField`, `updateCardField`, etc.) — `EditError`
-  variants (`ReservedName`, `InvalidFieldName`, `InvalidKindName`,
+  variants (`InvalidFieldName`, `InvalidKindName`, `ReservedKind`,
   `IndexOutOfRange`) appear in `diagnostics[0].message` with the
   `[EditError::<Variant>]` prefix.
 - `quill.render` / `session.render` — backend compilation failures and

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -32,7 +32,7 @@ This is a test document.`
 
 const TEST_PLATE = `#import "@local/quillmark-helper:0.1.0": data
 #let title = data.title
-#let body = data.BODY
+#let body = data.at("$body")
 
 = #title
 
@@ -46,16 +46,16 @@ describe('Document.fromMarkdown', () => {
     expect(doc.quillRef).toBe('test_quill')
   })
 
-  it('should expose typed payload (no QUILL/BODY/CARDS)', () => {
+  it('should expose typed payload (no $quill / $body / $cards as fields)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
 
     expect(field(doc.main, 'title')).toBe('Test Document')
     expect(field(doc.main, 'author')).toBe('Test Author')
-    // $quill/$kind and reserved names must NOT appear in payloadItems
+    // $-prefixed system metadata must NOT appear as payload fields
     expect(hasField(doc.main, 'quill')).toBe(false)
-    expect(hasField(doc.main, 'QUILL')).toBe(false)
-    expect(hasField(doc.main, 'BODY')).toBe(false)
-    expect(hasField(doc.main, 'CARDS')).toBe(false)
+    expect(hasField(doc.main, '$quill')).toBe(false)
+    expect(hasField(doc.main, '$body')).toBe(false)
+    expect(hasField(doc.main, '$cards')).toBe(false)
   })
 
   it('should expose body as a string', () => {
@@ -116,7 +116,7 @@ this is not valid yaml
     }).toThrow()
   })
 
-  it('should throw when QUILL field is absent', () => {
+  it('should throw when $quill metadata is absent', () => {
     const markdownWithoutQuill = `~~~card-yaml
 title: Default Test
 author: Test Author
@@ -408,7 +408,7 @@ describe('Quillmark.quill', () => {
     expect(svg.artifacts[0].mimeType).toBe('image/svg+xml')
   })
 
-  it('should emit a quill::ref_mismatch warning when Document QUILL differs from quill name', () => {
+  it('should emit a quill::ref_mismatch warning when the document quill ref differs from the quill name', () => {
     const engine = new Quillmark()
     const quill = engine.quill(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
 
@@ -446,24 +446,18 @@ describe('Document editor surface — setField / removeField', () => {
     expect(field(doc.main, 'title')).toBe('Updated')
   })
 
-  it('setField throws EditError::ReservedName for BODY', () => {
+  it('setField throws EditError::InvalidFieldName for legacy uppercase names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setField('BODY', 'x')).toThrow(/ReservedName/)
+    for (const name of ['BODY', 'CARDS', 'QUILL', 'CARD']) {
+      expect(() => doc.setField(name, 'x')).toThrow(/InvalidFieldName/)
+    }
   })
 
-  it('setField throws EditError::ReservedName for CARDS', () => {
+  it('setField throws EditError::InvalidFieldName for `$`-prefixed names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setField('CARDS', [])).toThrow(/ReservedName/)
-  })
-
-  it('setField throws EditError::ReservedName for QUILL', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setField('QUILL', 'x')).toThrow(/ReservedName/)
-  })
-
-  it('setField throws EditError::ReservedName for CARD', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setField('CARD', 'x')).toThrow(/ReservedName/)
+    for (const name of ['$body', '$cards', '$quill', '$kind']) {
+      expect(() => doc.setField(name, 'x')).toThrow(/InvalidFieldName/)
+    }
   })
 
   it('setField throws EditError::InvalidFieldName for uppercase name', () => {
@@ -483,15 +477,17 @@ describe('Document editor surface — setField / removeField', () => {
     expect(doc.removeField('nonexistent')).toBeUndefined()
   })
 
-  it('removeField throws EditError::ReservedName for QUILL', () => {
+  it('removeField throws EditError::InvalidFieldName for legacy uppercase names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.removeField('QUILL')).toThrow(/ReservedName/)
+    for (const name of ['BODY', 'CARDS', 'QUILL', 'CARD']) {
+      expect(() => doc.removeField(name)).toThrow(/InvalidFieldName/)
+    }
   })
 
-  it('removeField throws EditError::ReservedName for BODY/CARDS/CARD', () => {
+  it('removeField throws EditError::InvalidFieldName for `$`-prefixed names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    for (const reserved of ['BODY', 'CARDS', 'CARD']) {
-      expect(() => doc.removeField(reserved)).toThrow(/ReservedName/)
+    for (const name of ['$body', '$cards', '$quill', '$kind']) {
+      expect(() => doc.removeField(name)).toThrow(/InvalidFieldName/)
     }
   })
 
@@ -695,9 +691,9 @@ Card body.
     expect(field(doc.cards[0], 'content')).toBe('hello')
   })
 
-  it('updateCardField throws EditError::ReservedName for BODY', () => {
+  it('updateCardField throws EditError::InvalidFieldName for uppercase names', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    expect(() => doc.updateCardField(0, 'BODY', 'x')).toThrow(/ReservedName/)
+    expect(() => doc.updateCardField(0, 'BODY', 'x')).toThrow(/InvalidFieldName/)
   })
 
   it('updateCardField throws IndexOutOfRange when card absent', () => {
@@ -852,14 +848,14 @@ card_kinds:
     expect(meta.supportedFormats.length).toBeGreaterThan(0)
     expect(meta.schema).toBeUndefined()
 
-    // schema: structure + ui hints. QUILL/CARD reserved fields with const values.
+    // schema: user-fillable fields + ui hints. No QUILL/CARD sentinels.
     const schema = quill.schema
     expect(schema.main.description).toBe('The main card schema')
     expect(schema.main.fields.title).toBeDefined()
-    expect(schema.main.fields.QUILL.const).toBe('meta_test_quill@0.2.1')
+    expect(schema.main.fields.QUILL).toBeUndefined()
     expect(schema.card_kinds.main).toBeUndefined()
     expect(schema.card_kinds.indorsement.fields.signature_block).toBeDefined()
-    expect(schema.card_kinds.indorsement.fields.CARD.const).toBe('indorsement')
+    expect(schema.card_kinds.indorsement.fields.CARD).toBeUndefined()
   })
 
   it('metadata and schema are JSON.stringify-able (plain objects)', () => {
@@ -870,7 +866,8 @@ card_kinds:
     const meta = JSON.parse(JSON.stringify(quill.metadata))
     expect(meta.name).toBe('meta_test_quill')
     const schema = JSON.parse(JSON.stringify(quill.schema))
-    expect(schema.main.fields.QUILL.const).toBe('meta_test_quill@0.2.1')
+    expect(schema.main.fields.title).toBeDefined()
+    expect(schema.main.fields.QUILL).toBeUndefined()
   })
 })
 

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -86,7 +86,7 @@ title: Canvas Test
 const TEST_PLATE = `#import "@local/quillmark-helper:0.1.0": data
 = #data.title
 
-#data.BODY`
+#data.at("$body")`
 
 function openQuill() {
   const engine = new Quillmark()

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -56,8 +56,9 @@ export interface QuillCardSchema {
 /**
  * Document schema returned by `Quill.schema`. Includes optional `ui` keys.
  *
- * `main.fields.QUILL` and `card_kinds[name].fields.CARD` are required
- * reserved fields with `const` values telling consumers what to write.
+ * Describes only the user-fillable fields. The quill reference
+ * (constructed as `${metadata.name}@${metadata.version}`) and card-kind
+ * discriminators are document-level metadata, not schema fields.
  */
 export interface QuillSchema {
     main: QuillCardSchema;
@@ -550,8 +551,7 @@ impl Document {
 
     /// Update a payload field on the main card. Clears any existing `!fill` marker.
     ///
-    /// Throws if `name` is reserved (`BODY`, `CARDS`, `QUILL`, `CARD`) or does
-    /// not match `[a-z_][a-z0-9_]*`.
+    /// Throws if `name` does not match `[a-z_][a-z0-9_]*`.
     #[wasm_bindgen(js_name = setField)]
     pub fn set_field(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
@@ -578,8 +578,7 @@ impl Document {
     }
 
     /// Remove a payload field on the main card, returning the removed value or
-    /// `undefined`. Throws if `name` is reserved or does not match
-    /// `[a-z_][a-z0-9_]*`.
+    /// `undefined`. Throws if `name` does not match `[a-z_][a-z0-9_]*`.
     #[wasm_bindgen(js_name = removeField)]
     pub fn remove_field(&mut self, name: &str) -> Result<JsValue, JsValue> {
         let removed = self
@@ -732,7 +731,6 @@ impl Document {
 /// Maps `EditError` to a JS `Error` with the variant name and details in the message.
 fn edit_error_to_js(err: &quillmark_core::EditError) -> JsValue {
     let variant = match err {
-        quillmark_core::EditError::ReservedName(_) => "ReservedName",
         quillmark_core::EditError::InvalidFieldName(_) => "InvalidFieldName",
         quillmark_core::EditError::InvalidKindName(_) => "InvalidKindName",
         quillmark_core::EditError::ReservedKind => "ReservedKind",

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -287,19 +287,13 @@ fn test_quill_metadata_and_schemas() {
     assert!(js_sys::Array::from(&get(&meta, "supportedFormats")).length() > 0);
     assert!(get(&meta, "schema").is_undefined());
 
-    // schema: QUILL/CARD reserved fields with const values, ui hints included.
+    // schema: user-fillable fields with ui hints. No QUILL/CARD sentinels.
     let schema = quill.schema();
     let main_fields = get(&get(&schema, "main"), "fields");
     assert!(get(&get(&main_fields, "title"), "ui").is_object());
-    assert_eq!(
-        get_str(&get(&main_fields, "QUILL"), "const").as_deref(),
-        Some("meta_quill@0.2.1")
-    );
+    assert!(get(&main_fields, "QUILL").is_undefined());
     let card_fields = get(&get(&get(&schema, "card_kinds"), "indorsement"), "fields");
-    assert_eq!(
-        get_str(&get(&card_fields, "CARD"), "const").as_deref(),
-        Some("indorsement")
-    );
+    assert!(get(&card_fields, "CARD").is_undefined());
 }
 
 /// `doc.clone()` returns an independent handle: mutations on the clone

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -26,7 +26,7 @@ use crate::value::QuillValue;
 use crate::Diagnostic;
 
 use super::fences::find_metadata_blocks;
-use super::meta::{extract_meta_items, meta_key, validate_payload_yaml};
+use super::meta::{extract_meta_items, meta_key};
 use super::payload::{Payload, PayloadItem};
 use super::prescan::{prescan_fence_content, NestedComment, PreItem};
 use super::{Card, Document};
@@ -127,7 +127,7 @@ pub(super) fn build_block(
             }
         };
         let meta = extract_meta_items(&mut parsed)?;
-        (meta, Some(validate_payload_yaml(parsed)?))
+        (meta, Some(parsed))
     };
 
     // Per-block field-count check (spec §8) — applied after `$`-key

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -87,10 +87,9 @@ pub enum StoredDocument {
 /// The taxonomy is intentionally minimal: only [`Self::InvalidQuillReference`]
 /// is typed, because that is the one error a non-malicious caller hits at
 /// the document/quill boundary. Every other defect — wrong-role card,
-/// invalid kind, reserved field name, duplicate key, too many fields —
-/// can only arise from a hand-crafted storage DTO (the markdown parser
-/// already rejects them) and is reported through [`Self::Malformed`] with
-/// a descriptive message.
+/// invalid kind, duplicate key, too many fields — can only arise from a
+/// hand-crafted storage DTO (the markdown parser already rejects them)
+/// and is reported through [`Self::Malformed`] with a descriptive message.
 #[derive(Debug, Clone, PartialEq)]
 pub enum StorageError {
     /// A stored quill reference string could not be parsed.
@@ -413,9 +412,8 @@ impl From<CommentPathSegmentV0_82_0> for CommentPathSegment {
 }
 
 /// Reject a payload no markdown-parsed `Document` could produce: too many
-/// fields, a reserved sentinel key, or a duplicate user-field key. The
-/// markdown parser already rejects all three; this only guards hand-crafted
-/// storage DTOs.
+/// fields or a duplicate user-field key. The markdown parser already
+/// rejects both; this only guards hand-crafted storage DTOs.
 fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
     if payload.len() > crate::error::MAX_FIELD_COUNT {
         return Err(StorageError::Malformed(format!(
@@ -426,11 +424,6 @@ fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
     }
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for key in payload.keys() {
-        if super::edit::is_reserved_name(key) {
-            return Err(StorageError::Malformed(format!(
-                "reserved name {key:?} cannot be used as a field name"
-            )));
-        }
         if !seen.insert(key.as_str()) {
             return Err(StorageError::Malformed(format!(
                 "duplicate user-field key {key:?}"
@@ -813,21 +806,4 @@ title: Hi
         assert!(err.to_string().contains("invalid quill reference"));
     }
 
-    #[test]
-    fn rejects_reserved_field_name() {
-        let json = r#"{
-            "schema": "quillmark/document@0.82.0",
-            "main": {
-                "payload": {"items": [
-                    {"type": "quill", "value": "q@1.0"},
-                    {"type": "kind", "value": "main"},
-                    {"type": "field", "key": "BODY", "value": "x"}
-                ]},
-                "body": ""
-            },
-            "cards": []
-        }"#;
-        let err = serde_json::from_str::<Document>(json).unwrap_err();
-        assert!(err.to_string().contains("reserved name"));
-    }
 }

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -1,9 +1,10 @@
 //! Typed mutators for [`Document`] and [`Card`] with invariant enforcement.
 //!
-//! Every successful mutator leaves the document free of reserved keys in any
-//! payload, with every composable `$kind` passing `meta::is_valid_kind_name`,
-//! and safely serializable via [`Document::to_plate_json`]. Mutators never
-//! modify `warnings` — those are immutable parse-time observations.
+//! Every successful mutator leaves the document with every user field name
+//! matching `[a-z_][a-z0-9_]*` and every composable `$kind` passing
+//! `meta::is_valid_kind_name`, so the result is safely serializable via
+//! [`Document::to_plate_json`]. Mutators never modify `warnings` — those
+//! are immutable parse-time observations.
 //!
 //! Payload/body mutators live on [`Card`] (`set_field`, `set_fill`,
 //! `remove_field`, `replace_body`); [`Document`] keeps document-level ops
@@ -15,15 +16,6 @@ use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::document::{Card, Document, Payload};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
-
-/// Reserved field names (`BODY`, `CARDS`, `QUILL`, `CARD`). Their presence in
-/// user fields would corrupt the plate wire format or structural invariants.
-pub const RESERVED_NAMES: &[&str] = &["BODY", "CARDS", "QUILL", "CARD"];
-
-#[inline]
-pub fn is_reserved_name(name: &str) -> bool {
-    RESERVED_NAMES.contains(&name)
-}
 
 /// `true` if `name` matches `[a-z_][a-z0-9_]*` after NFC normalisation.
 pub fn is_valid_field_name(name: &str) -> bool {
@@ -47,9 +39,6 @@ pub fn is_valid_field_name(name: &str) -> bool {
 /// Errors returned by document and card mutators.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum EditError {
-    #[error("reserved name '{0}' cannot be used as a field name")]
-    ReservedName(String),
-
     #[error("invalid field name '{0}': must match [a-z_][a-z0-9_]*")]
     InvalidFieldName(String),
 
@@ -154,11 +143,9 @@ impl Card {
 
     /// Set a payload field, clearing any `!fill` marker on that key.
     ///
-    /// Returns [`EditError::ReservedName`] or [`EditError::InvalidFieldName`].
+    /// Returns [`EditError::InvalidFieldName`] when `name` does not match
+    /// `[a-z_][a-z0-9_]*`.
     pub fn set_field(&mut self, name: &str, value: QuillValue) -> Result<(), EditError> {
-        if is_reserved_name(name) {
-            return Err(EditError::ReservedName(name.to_string()));
-        }
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
@@ -170,9 +157,6 @@ impl Card {
     /// `Null` emits as `key: !fill`; scalars/sequences as `key: !fill <value>`.
     /// Same validation as [`Card::set_field`].
     pub fn set_fill(&mut self, name: &str, value: QuillValue) -> Result<(), EditError> {
-        if is_reserved_name(name) {
-            return Err(EditError::ReservedName(name.to_string()));
-        }
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
@@ -183,9 +167,6 @@ impl Card {
     /// Remove a payload field; returns `Ok(None)` if the name is absent.
     /// Same validation as [`Card::set_field`].
     pub fn remove_field(&mut self, name: &str) -> Result<Option<QuillValue>, EditError> {
-        if is_reserved_name(name) {
-            return Err(EditError::ReservedName(name.to_string()));
-        }
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -144,25 +144,6 @@ fn yaml_type_name(value: &JsonValue) -> &'static str {
     }
 }
 
-/// Reject the reserved wire-format keys (`QUILL`, `CARD`, `BODY`, `CARDS`)
-/// appearing as user-defined fields — they would collide with
-/// [`crate::Document::to_plate_json`]'s output.
-pub(super) fn validate_payload_yaml(
-    parsed: serde_json::Value,
-) -> Result<serde_json::Value, ParseError> {
-    if let Some(mapping) = parsed.as_object() {
-        for reserved in ["QUILL", "CARD", "BODY", "CARDS"] {
-            if mapping.contains_key(reserved) {
-                return Err(ParseError::InvalidStructure(format!(
-                    "Reserved field name '{}' cannot be used in a card-yaml block",
-                    reserved
-                )));
-            }
-        }
-    }
-    Ok(parsed)
-}
-
 /// `true` when `name` matches `[a-z_][a-z0-9_]*`.
 pub fn is_valid_kind_name(name: &str) -> bool {
     if name.is_empty() {

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -11,7 +11,7 @@
 //! ## Errors
 //!
 //! [`Document::from_markdown`] returns errors for malformed YAML, unclosed
-//! fences, a missing root `$quill`, unknown `$` keys, or reserved field names.
+//! fences, a missing root `$quill`, or unknown `$`-prefixed system keys.
 //!
 //! See [MARKDOWN.md](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/MARKDOWN.md)
 //! for the card-yaml format specification.
@@ -172,25 +172,27 @@ impl Document {
     ///
     /// ```json
     /// {
-    ///   "QUILL": "<ref>", "<field>": <value>, ...,
-    ///   "BODY": "<global-body>",
-    ///   "CARDS": [{ "CARD": "<tag>", "<field>": <value>, ..., "BODY": "<card-body>" }]
+    ///   "$quill": "<ref>",
+    ///   "$body": "<global-body>",
+    ///   "$cards": [{ "$kind": "<tag>", "$body": "<card-body>", "<field>": <value>, ... }],
+    ///   "<field>": <value>, ...
     /// }
     /// ```
+    ///
+    /// `$`-prefixed keys carry document-level metadata (quill ref, body
+    /// text, card list, card kind). User payload fields stay flat at the
+    /// root — they cannot collide with `$` keys because field names must
+    /// match `[a-z_][a-z0-9_]*`.
     pub fn to_plate_json(&self) -> serde_json::Value {
         let mut map = serde_json::Map::new();
 
         map.insert(
-            "QUILL".to_string(),
+            "$quill".to_string(),
             serde_json::Value::String(self.quill_reference().to_string()),
         );
 
-        for (key, value) in self.main.payload.iter() {
-            map.insert(key.clone(), value.as_json().clone());
-        }
-
         map.insert(
-            "BODY".to_string(),
+            "$body".to_string(),
             serde_json::Value::String(self.main.body.clone()),
         );
 
@@ -200,21 +202,25 @@ impl Document {
             .map(|card| {
                 let mut card_map = serde_json::Map::new();
                 card_map.insert(
-                    "CARD".to_string(),
+                    "$kind".to_string(),
                     serde_json::Value::String(card.kind().unwrap_or("").to_string()),
+                );
+                card_map.insert(
+                    "$body".to_string(),
+                    serde_json::Value::String(card.body.clone()),
                 );
                 for (key, value) in card.payload.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());
                 }
-                card_map.insert(
-                    "BODY".to_string(),
-                    serde_json::Value::String(card.body.clone()),
-                );
                 serde_json::Value::Object(card_map)
             })
             .collect();
 
-        map.insert("CARDS".to_string(), serde_json::Value::Array(cards_array));
+        map.insert("$cards".to_string(), serde_json::Value::Array(cards_array));
+
+        for (key, value) in self.main.payload.iter() {
+            map.insert(key.clone(), value.as_json().clone());
+        }
 
         serde_json::Value::Object(map)
     }

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -163,8 +163,8 @@ impl Payload {
 
     /// Mutable access to the raw item list. Callers must preserve the
     /// invariants (at most one `Quill`/`Kind`/`Id`, no duplicate field
-    /// keys, no reserved field names) — use the typed mutators when in
-    /// doubt.
+    /// keys, every field name matches `[a-z_][a-z0-9_]*`) — use the
+    /// typed mutators when in doubt.
     pub fn items_mut(&mut self) -> &mut [PayloadItem] {
         &mut self.items
     }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -399,8 +399,12 @@ Item 1 body";
 }
 
 #[test]
-fn test_reserved_field_body_rejected() {
-    // BODY reserved inside a card block.
+fn test_uppercase_payload_keys_pass_parser() {
+    // Uppercase YAML keys (e.g. legacy `BODY`/`CARDS`) used to be rejected
+    // because they collided with the flat plate-JSON wire format. The wire
+    // format now namespaces metadata under `$`-prefixed keys, so user
+    // payload keys can be arbitrary — they're filtered downstream by the
+    // editor surface's `[a-z_][a-z0-9_]*` rule, not the parser.
     let markdown = "~~~card-yaml
 $quill: test_quill
 $kind: main
@@ -412,29 +416,7 @@ BODY: Test
 ~~~";
 
     let result = decompose(markdown);
-    assert!(result.is_err(), "BODY is a reserved field name");
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Reserved field name"));
-}
-
-#[test]
-fn test_reserved_field_cards_rejected() {
-    // CARDS reserved inside the root payload.
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-title: Test
-CARDS: []
-~~~";
-
-    let result = decompose(markdown);
-    assert!(result.is_err(), "CARDS is a reserved field name");
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Reserved field name"));
+    assert!(result.is_ok(), "uppercase payload keys parse fine");
 }
 
 #[test]
@@ -1577,7 +1559,7 @@ Some text with --- dashes in it.";
     assert!(doc.cards()[0].body().contains("--- dashes"));
 }
 
-// QUILL directive edge cases
+// `$quill` reference edge cases
 
 #[test]
 fn test_quill_with_underscore_prefix() {
@@ -1972,14 +1954,15 @@ fn test_to_plate_json_simple() {
     .unwrap();
     let json = doc.to_plate_json();
 
-    assert_eq!(json["QUILL"], "my_quill");
+    assert_eq!(json["$quill"], "my_quill");
     assert_eq!(json["title"], "Hello");
-    assert_eq!(json["BODY"], "\nBody text.\n");
-    assert!(json["CARDS"].is_array());
-    assert_eq!(json["CARDS"].as_array().unwrap().len(), 0);
+    assert_eq!(json["$body"], "\nBody text.\n");
+    assert!(json["$cards"].is_array());
+    assert_eq!(json["$cards"].as_array().unwrap().len(), 0);
 }
 
-/// to_plate_json with cards produces CARDS array with CARD, fields, BODY.
+/// to_plate_json with cards produces a `$cards` array containing `$kind`,
+/// fields, and `$body`.
 #[test]
 fn test_to_plate_json_with_cards() {
     let markdown = "~~~card-yaml
@@ -2000,20 +1983,20 @@ Card body here.
     let doc = Document::from_markdown(markdown).unwrap();
     let json = doc.to_plate_json();
 
-    assert_eq!(json["QUILL"], "usaf_memo");
+    assert_eq!(json["$quill"], "usaf_memo");
     assert_eq!(json["title"], "Test");
-    // Blank-line separator stripped on parse; plate `BODY` reflects the same
+    // Blank-line separator stripped on parse; plate `$body` reflects the same
     // content-only string as `Document::body()`.
-    assert_eq!(json["BODY"], "\nGlobal body.\n");
+    assert_eq!(json["$body"], "\nGlobal body.\n");
 
-    let cards = json["CARDS"].as_array().unwrap();
+    let cards = json["$cards"].as_array().unwrap();
     assert_eq!(cards.len(), 1);
-    assert_eq!(cards[0]["CARD"], "indorsement");
+    assert_eq!(cards[0]["$kind"], "indorsement");
     assert_eq!(cards[0]["for"], "ORG");
-    assert_eq!(cards[0]["BODY"], "\nCard body here.\n");
+    assert_eq!(cards[0]["$body"], "\nCard body here.\n");
 }
 
-/// to_plate_json parity: the QUILL key appears first.
+/// to_plate_json parity: the `$quill` key appears first.
 #[test]
 fn test_to_plate_json_quill_first() {
     let doc = Document::from_markdown(
@@ -2023,7 +2006,7 @@ fn test_to_plate_json_quill_first() {
     let json = doc.to_plate_json();
     let obj = json.as_object().unwrap();
     let keys: Vec<&String> = obj.keys().collect();
-    assert_eq!(keys[0], "QUILL");
+    assert_eq!(keys[0], "$quill");
 }
 
 /// Snapshot test over a representative usaf_memo-shaped document.
@@ -2051,20 +2034,20 @@ This body and the metadata above are an indorsement card.
     let doc = Document::from_markdown(markdown).unwrap();
     let json = doc.to_plate_json();
 
-    // QUILL key is present
-    assert_eq!(json["QUILL"], "usaf_memo@0.1");
+    // `$quill` is present
+    assert_eq!(json["$quill"], "usaf_memo@0.1");
     // payload fields are present at top level
     assert!(json.get("memo_for").is_some());
     assert!(json.get("date").is_some());
-    // BODY and CARDS present
-    assert!(json.get("BODY").is_some());
-    assert!(json["CARDS"].is_array());
+    // `$body` and `$cards` are present
+    assert!(json.get("$body").is_some());
+    assert!(json["$cards"].is_array());
     // One indorsement card
-    let cards = json["CARDS"].as_array().unwrap();
+    let cards = json["$cards"].as_array().unwrap();
     assert_eq!(cards.len(), 1);
-    assert_eq!(cards[0]["CARD"], "indorsement");
-    // Card has BODY
-    assert!(cards[0].get("BODY").is_some());
+    assert_eq!(cards[0]["$kind"], "indorsement");
+    // Card has `$body`
+    assert!(cards[0].get("$body").is_some());
 }
 
 /// Regression test for the `serde_json::Map::remove` / `shift_remove` bug.

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the document editor surface.
 
-use crate::document::edit::{is_reserved_name, is_valid_field_name, EditError, RESERVED_NAMES};
+use crate::document::edit::{is_valid_field_name, EditError};
 use crate::document::meta::is_valid_kind_name;
 use crate::document::{Card, Document};
 use crate::value::QuillValue;
@@ -51,31 +51,12 @@ fn test_invalid_field_names() {
     assert!(!is_valid_field_name("123abc")); // starts with digit
     assert!(!is_valid_field_name("my-field")); // hyphen not allowed
     assert!(!is_valid_field_name("my field")); // space not allowed
-    assert!(!is_valid_field_name("BODY")); // uppercase (reserved)
-    assert!(!is_valid_field_name("CARDS")); // uppercase (reserved)
-}
-
-// ── is_reserved_name ────────────────────────────────────────────────────────
-
-#[test]
-fn test_is_reserved_name() {
-    assert!(is_reserved_name("BODY"));
-    assert!(is_reserved_name("CARDS"));
-    assert!(is_reserved_name("QUILL"));
-    assert!(is_reserved_name("CARD"));
-    assert!(!is_reserved_name("body")); // case-sensitive
-    assert!(!is_reserved_name("title"));
-    assert!(!is_reserved_name(""));
+    assert!(!is_valid_field_name("BODY")); // uppercase
+    assert!(!is_valid_field_name("CARDS")); // uppercase
+    assert!(!is_valid_field_name("$body")); // $-prefix reserved for metadata
 }
 
 // ── EditError variants ───────────────────────────────────────────────────────
-
-#[test]
-fn test_edit_error_reserved_name() {
-    let mut doc = make_doc();
-    let result = doc.main_mut().set_field("BODY", qv("value"));
-    assert_eq!(result, Err(EditError::ReservedName("BODY".to_string())));
-}
 
 #[test]
 fn test_edit_error_invalid_field_name() {
@@ -84,6 +65,16 @@ fn test_edit_error_invalid_field_name() {
     assert_eq!(
         result,
         Err(EditError::InvalidFieldName("My-Field".to_string()))
+    );
+}
+
+#[test]
+fn test_edit_error_uppercase_rejected() {
+    let mut doc = make_doc();
+    let result = doc.main_mut().set_field("BODY", qv("value"));
+    assert_eq!(
+        result,
+        Err(EditError::InvalidFieldName("BODY".to_string()))
     );
 }
 
@@ -108,9 +99,6 @@ fn test_edit_error_index_out_of_range() {
 
 #[test]
 fn test_edit_error_display() {
-    assert!(EditError::ReservedName("BODY".to_string())
-        .to_string()
-        .contains("BODY"));
     assert!(EditError::InvalidFieldName("Bad-Name".to_string())
         .to_string()
         .contains("Bad-Name"));
@@ -122,17 +110,19 @@ fn test_edit_error_display() {
         .contains("3"));
 }
 
-// ── Reserved-name matrix: Document::set_field ────────────────────────────────
+// ── Uppercase/`$`-prefixed names: Document::set_field ────────────────────────
 
 #[test]
-fn test_document_set_field_rejects_all_reserved_names() {
-    for &name in RESERVED_NAMES {
+fn test_document_set_field_rejects_legacy_uppercase_names() {
+    // Names that used to be reserved sentinels — now rejected by the
+    // field-name regex like any other uppercase or `$`-prefixed input.
+    for name in ["BODY", "CARDS", "QUILL", "CARD", "$body", "$cards"] {
         let mut doc = make_doc();
         let result = doc.main_mut().set_field(name, qv("value"));
         assert_eq!(
             result,
-            Err(EditError::ReservedName(name.to_string())),
-            "expected ReservedName for '{}'",
+            Err(EditError::InvalidFieldName(name.to_string())),
+            "expected InvalidFieldName for '{}'",
             name
         );
     }
@@ -178,14 +168,14 @@ fn test_document_remove_field_absent() {
 }
 
 #[test]
-fn test_document_remove_field_reserved_throws() {
-    // Symmetric with set_field: reserved names are programmer errors and
-    // throw, rather than silently returning None.
+fn test_document_remove_field_legacy_uppercase_rejected() {
+    // Symmetric with set_field: the legacy uppercase sentinels are now
+    // rejected like any other invalid field name.
     let mut doc = make_doc();
-    for reserved in ["BODY", "CARDS", "QUILL", "CARD"] {
-        match doc.main_mut().remove_field(reserved) {
-            Err(EditError::ReservedName(name)) => assert_eq!(name, reserved),
-            other => panic!("expected ReservedName for {reserved}, got {other:?}"),
+    for name in ["BODY", "CARDS", "QUILL", "CARD"] {
+        match doc.main_mut().remove_field(name) {
+            Err(EditError::InvalidFieldName(got)) => assert_eq!(got, name),
+            other => panic!("expected InvalidFieldName for {name}, got {other:?}"),
         }
     }
 }
@@ -449,12 +439,12 @@ fn test_card_remove_field_absent() {
 }
 
 #[test]
-fn test_card_remove_field_reserved_throws() {
+fn test_card_remove_field_legacy_uppercase_rejected() {
     let mut card = Card::new("note").unwrap();
-    for reserved in ["BODY", "CARDS", "QUILL", "CARD"] {
-        match card.remove_field(reserved) {
-            Err(EditError::ReservedName(name)) => assert_eq!(name, reserved),
-            other => panic!("expected ReservedName for {reserved}, got {other:?}"),
+    for name in ["BODY", "CARDS", "QUILL", "CARD"] {
+        match card.remove_field(name) {
+            Err(EditError::InvalidFieldName(got)) => assert_eq!(got, name),
+            other => panic!("expected InvalidFieldName for {name}, got {other:?}"),
         }
     }
 }
@@ -480,7 +470,7 @@ fn test_card_set_body() {
 // ── Invariant check: sequence of mutations ───────────────────────────────────
 
 /// After a deterministic sequence of mutations, the document must satisfy:
-/// - No reserved key in payload
+/// - Every payload key passes is_valid_field_name
 /// - Every card kind passes is_valid_kind_name
 /// - The plate JSON can be produced without panicking
 #[test]
@@ -519,11 +509,11 @@ fn test_invariants_after_mutation_sequence() {
 
     // --- Assertions ---
 
-    // No reserved key in payload
+    // Every payload key is valid
     for key in doc.main().payload().keys() {
         assert!(
-            !is_reserved_name(key),
-            "reserved key '{}' found in payload",
+            is_valid_field_name(key),
+            "invalid key '{}' found in payload",
             key
         );
     }
@@ -538,9 +528,9 @@ fn test_invariants_after_mutation_sequence() {
     // Can produce plate JSON without panicking
     let json = doc.to_plate_json();
     assert!(json.is_object());
-    assert_eq!(json["QUILL"].as_str(), Some("test_quill"));
-    assert!(json["CARDS"].is_array());
-    assert_eq!(json["BODY"].as_str(), Some("Updated body."));
+    assert_eq!(json["$quill"].as_str(), Some("test_quill"));
+    assert!(json["$cards"].is_array());
+    assert_eq!(json["$body"].as_str(), Some("Updated body."));
 
     // Payload still has expected keys
     assert_eq!(

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -73,22 +73,14 @@ impl QuillConfig {
 
     /// Full schema including `ui` hints.
     ///
-    /// `main.fields` is prefixed with a required `QUILL` entry (`const = name@version`);
-    /// each `card_kinds[<name>].fields` is prefixed with a required `CARD` entry
-    /// (`const = <name>`). Identity (`name`, `version`, etc.) lives elsewhere
-    /// on the host's metadata surface.
+    /// Describes the user-fillable fields of the main card and each named
+    /// card kind. The quill reference (constructed as `name@version` from
+    /// quill metadata) and card-kind discriminators are document-level
+    /// metadata, not fields, so they do not appear here.
     pub fn schema(&self) -> serde_json::Value {
-        let canonical_ref = format!("{}@{}", self.name, self.version);
-
         let mut obj = serde_json::Map::new();
 
-        let mut main_value = serde_json::to_value(&self.main).unwrap_or(serde_json::Value::Null);
-        Self::prepend_reserved_field(
-            &mut main_value,
-            "QUILL",
-            &canonical_ref,
-            "Canonical quill reference. Must be exactly this value as the $quill system metadata in the root card-yaml block.",
-        );
+        let main_value = serde_json::to_value(&self.main).unwrap_or(serde_json::Value::Null);
         obj.insert("main".to_string(), main_value);
 
         if !self.card_kinds.is_empty() {
@@ -96,14 +88,7 @@ impl QuillConfig {
                 .card_kinds
                 .iter()
                 .map(|card| {
-                    let mut card_value =
-                        serde_json::to_value(card).unwrap_or(serde_json::Value::Null);
-                    Self::prepend_reserved_field(
-                        &mut card_value,
-                        "CARD",
-                        &card.name,
-                        "Card kind name. Must match the card kind in the card block's $kind system metadata.",
-                    );
+                    let card_value = serde_json::to_value(card).unwrap_or(serde_json::Value::Null);
                     (card.name.clone(), card_value)
                 })
                 .collect();
@@ -116,27 +101,7 @@ impl QuillConfig {
         serde_json::Value::Object(obj)
     }
 
-    /// Insert a `QUILL`/`CARD` reserved field as the first entry of a card's `fields`.
-    fn prepend_reserved_field(
-        card_value: &mut serde_json::Value,
-        key: &str,
-        const_value: &str,
-        description: &str,
-    ) {
-        let reserved = serde_json::json!({
-            "type": "string",
-            "const": const_value,
-            "description": description,
-            "required": true
-        });
-        if let Some(serde_json::Value::Object(fields)) = card_value.get_mut("fields") {
-            let existing = std::mem::take(fields);
-            fields.insert(key.to_string(), reserved);
-            fields.extend(existing);
-        }
-    }
-
-    /// Coerce typed payload fields (IndexMap, no CARDS/BODY keys).
+    /// Coerce typed payload fields (IndexMap of user fields only).
     pub fn coerce_payload(
         &self,
         payload: &IndexMap<String, QuillValue>,
@@ -156,7 +121,7 @@ impl QuillConfig {
         Ok(coerced)
     }
 
-    /// Coerce typed fields for a single card (IndexMap, no CARD/BODY keys).
+    /// Coerce typed fields for a single card (IndexMap of user fields only).
     ///
     /// Returns the input unchanged when the card kind is unknown.
     pub fn coerce_card(

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -112,7 +112,7 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
         properties.insert(name.clone(), field_to_schema(field));
     }
     properties.insert(
-        "BODY".to_string(),
+        "$body".to_string(),
         serde_json::json!({ "type": "string", "contentMediaType": "text/markdown" }),
     );
 
@@ -123,7 +123,7 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             card_properties.insert(name.clone(), field_to_schema(field));
         }
         card_properties.insert(
-            "BODY".to_string(),
+            "$body".to_string(),
             serde_json::json!({ "type": "string", "contentMediaType": "text/markdown" }),
         );
         defs.insert(
@@ -228,19 +228,19 @@ card_kinds:
         let schema = build_from_yaml(yaml);
         let json = schema.as_json();
 
-        let main_body = &json["properties"]["BODY"];
+        let main_body = &json["properties"]["$body"];
         assert_eq!(main_body["type"], "string");
         assert_eq!(main_body["contentMediaType"], "text/markdown");
 
         for def_name in ["indorsement_card", "note_card"] {
-            let card_body = &json["$defs"][def_name]["properties"]["BODY"];
+            let card_body = &json["$defs"][def_name]["properties"]["$body"];
             assert_eq!(
                 card_body["type"], "string",
-                "{def_name} BODY type should be string"
+                "{def_name} $body type should be string"
             );
             assert_eq!(
                 card_body["contentMediaType"], "text/markdown",
-                "{def_name} BODY should be markdown"
+                "{def_name} $body should be markdown"
             );
         }
     }

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -70,19 +70,21 @@ fn fences_inside_code_blocks_are_ignored() {
     );
 }
 
-// Reserved keys BODY/CARDS cannot be user-defined.
+// `$`-prefixed payload keys other than `$quill`/`$kind`/`$id` are
+// rejected, so user content can't shadow the plate wire format's `$body`
+// or `$cards` metadata.
 #[test]
-fn reserved_keys_in_payload_are_rejected() {
-    for reserved in ["BODY", "CARDS"] {
+fn unknown_dollar_keys_in_payload_are_rejected() {
+    for key in ["$body", "$cards", "$arbitrary"] {
         let md = format!(
             "~~~card-yaml\n$quill: t\n$kind: main\n{}: nope\n~~~\n\nBody.",
-            reserved
+            key
         );
         let err = Document::from_markdown(&md).unwrap_err().to_string();
         assert!(
-            err.contains(&format!("Reserved field name '{}'", reserved)),
-            "reserved key {} must error, got: {}",
-            reserved,
+            err.contains("system-metadata") || err.contains(key),
+            "unknown $-key {} must error, got: {}",
+            key,
             err
         );
     }

--- a/crates/fixtures/resources/extended_metadata_demo.md
+++ b/crates/fixtures/resources/extended_metadata_demo.md
@@ -59,5 +59,5 @@ Ideal for content-heavy sites where each item needs its own metadata (price, cat
 - **Card kind pattern**: `[a-z_][a-z0-9_]*`
 - **Blank lines**: Allowed within card-yaml blocks
 - **Card syntax**: a `~~~card-yaml` block declaring `$kind: <kind>`, preceded by a blank line
-- **Reserved names**: Cannot use `QUILL`, `CARD`, `BODY`, or `CARDS` as field names
+- **Field names**: must match `[a-z_][a-z0-9_]*` — uppercase and `$`-prefixed keys are rejected so user payload can never shadow the `$`-prefixed plate-JSON metadata (`$quill`, `$body`, `$cards`, `$kind`)
 - **Collections**: The same card kind creates an array of objects

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/plate.typ
@@ -8,20 +8,21 @@
   contacts: data.contacts,
 )
 
-#for card in data.CARDS {
+#for card in data.at("$cards") {
   if "title" in card and card.title != "" {
     section-header(card.title)
   }
 
-  if card.CARD == "experience_section" {
+  let kind = card.at("$kind")
+  if kind == "experience_section" {
     timeline-entry(
       heading-left: card.at("heading_left", default: ""),
       heading-right: card.at("heading_right", default: ""),
       subheading-left: card.at("subheading_left", default: none),
       subheading-right: card.at("subheading_right", default: none),
-      body: card.at("BODY", default: ""),
+      body: card.at("$body", default: ""),
     )
-  } else if card.CARD == "skills_section" {
+  } else if kind == "skills_section" {
     table(
       columns: 2,
       items: card.cells.map(item => (
@@ -29,13 +30,13 @@
         text: item.skills,
       ))
     )
-  } else if card.CARD == "projects_section" {
+  } else if kind == "projects_section" {
     project-entry(
       name: card.name,
       url: card.at("url", default: none),
-      body: card.at("BODY", default: ""),
+      body: card.at("$body", default: ""),
     )
-  } else if card.CARD == "certifications_section" {
+  } else if kind == "certifications_section" {
     table(
       columns: 2,
       items: card.cells

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/plate.typ
@@ -12,7 +12,7 @@
 
 #show: mainmatter
 
-#data.BODY
+#data.at("$body")
 
 #backmatter(
   signature_block: data.signature_block,

--- a/crates/fixtures/resources/quills/taro/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/taro/0.1.0/plate.typ
@@ -15,12 +15,12 @@
 *Favorite Ice Cream: #data.ice_cream*__
 
 
-#data.BODY
+#data.at("$body")
 
 // Present each sub-document programatically
-#for card in data.CARDS {
-  if card.CARD == "quotes" [
-    *#card.author*: _#card.BODY _
+#for card in data.at("$cards") {
+  if card.at("$kind") == "quotes" [
+    *#card.author*: _#card.at("$body") _
   ]
 }
 

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -1,12 +1,5 @@
 main:
   fields:
-    QUILL:
-      type: string
-      const: usaf_memo@0.1.0
-      description: >-
-        Canonical quill reference. Must be exactly this value as the $quill system
-        metadata in the root card-yaml block.
-      required: true
     attachments:
       type: array
       description: >-
@@ -149,13 +142,6 @@ card_kinds:
       Chain of routing endorsements. Each endorsement block adds an official response
       or forwarding action to the original memo.
     fields:
-      CARD:
-        type: string
-        const: indorsement
-        description: >-
-          Card kind name. Must match the card kind in the card block's $kind system
-          metadata.
-        required: true
       attachments:
         type: array
         description: List of attachments specific to this endorsement.

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/plate.typ
@@ -38,7 +38,7 @@
 
 // Mainmatter configuration
 #mainmatter[
-  #data.BODY
+  #data.at("$body")
 ]
 
 // Backmatter
@@ -56,9 +56,9 @@
   ..if "attachments" in data { (attachments: data.attachments) },
 )
 
-// Indorsements - iterate through CARDS array and filter by CARD type
-#for card in data.CARDS {
-  if card.CARD == "indorsement" {
+// Indorsements - iterate through `$cards` and filter by `$kind`
+#for card in data.at("$cards") {
+  if card.at("$kind") == "indorsement" {
     indorsement(
       from: card.at("from", default: ""),
       to: card.at("for", default: ""),
@@ -68,7 +68,7 @@
       format: card.at("format", default: "standard"),
       ..if "date" in card { (date: card.date) },
     )[
-      #card.BODY
+      #card.at("$body")
     ]
   }
 }

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
@@ -38,7 +38,7 @@
 
 // Mainmatter configuration
 #mainmatter[
-  #data.BODY
+  #data.at("$body")
 ]
 
 // Backmatter
@@ -56,9 +56,9 @@
   ..if "attachments" in data { (attachments: data.attachments) },
 )
 
-// Indorsements - iterate through CARDS array and filter by CARD type
-#for card in data.CARDS {
-  if card.CARD == "indorsement" {
+// Indorsements - iterate through `$cards` and filter by `$kind`
+#for card in data.at("$cards") {
+  if card.at("$kind") == "indorsement" {
     indorsement(
       from: card.at("from", default: ""),
       to: card.at("for", default: ""),
@@ -69,7 +69,7 @@
       ..if "date" in card { (date: card.date) },
       ..if "action" in card { (action: card.action) },
     )[
-      #card.BODY
+      #card.at("$body")
     ]
   }
 }

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -153,14 +153,14 @@ impl Quill {
                 Diagnostic::new(
                     Severity::Warning,
                     format!(
-                        "document declares QUILL '{}' but was rendered with '{}'",
+                        "document declares $quill '{}' but was rendered with '{}'",
                         doc_ref,
                         self.source.name()
                     ),
                 )
                 .with_code("quill::ref_mismatch".to_string())
                 .with_hint(
-                    "the QUILL field is informational; ensure you are rendering with the intended quill"
+                    "the $quill reference is informational; ensure you are rendering with the intended quill"
                         .to_string(),
                 ),
             )

--- a/crates/quillmark/tests/security_tests.rs
+++ b/crates/quillmark/tests/security_tests.rs
@@ -118,31 +118,27 @@ fn test_yaml_size_limit() {
     );
 }
 
-/// Test reserved field names are rejected
+/// `$`-prefixed payload keys other than the documented system metadata
+/// (`$quill`, `$kind`, `$id`) are rejected — including any key that could
+/// collide with the plate wire format's `$body` / `$cards` keys.
 #[test]
-fn test_reserved_field_injection() {
-    let reserved_tests = vec![
-        (
-            "~~~card-yaml\n$quill: test_quill\n$kind: main\nBODY: injected\n~~~\n\nBody",
-            "BODY",
-        ),
-        (
-            "~~~card-yaml\n$quill: test_quill\n$kind: main\nCARDS: []\n~~~\n\nBody",
-            "CARDS",
-        ),
-    ];
+fn test_unknown_dollar_metadata_rejected() {
+    let injections = ["$body", "$cards", "$arbitrary"];
 
-    for (markdown, reserved) in reserved_tests {
-        let result = Document::from_markdown(markdown);
+    for key in injections {
+        let markdown = format!(
+            "~~~card-yaml\n$quill: test_quill\n$kind: main\n{key}: injected\n~~~\n\nBody",
+        );
+        let result = Document::from_markdown(&markdown);
         assert!(
             result.is_err(),
-            "Should reject reserved field '{}' in YAML",
-            reserved
+            "Should reject unknown `$`-prefixed key '{}' in YAML",
+            key
         );
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("Reserved") || err_msg.contains(reserved),
-            "Error should mention reserved field: {}",
+            err_msg.contains("system-metadata") || err_msg.contains(key),
+            "Error should mention the rejected `$` key: {}",
             err_msg
         );
     }

--- a/docs/authoring/card-yaml.md
+++ b/docs/authoring/card-yaml.md
@@ -159,19 +159,20 @@ tags: !fill []
 rejected on mappings. Other custom YAML tags (`!include`, `!env`, …) are
 dropped with a warning.
 
-## Reserved Field Names
+## Field-name Rules
 
-`QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and cannot be used as field
-names — the parser rejects documents that include them. `BODY` holds the
-block's Markdown body; `CARDS` holds the array of card blocks; `QUILL` and
-`CARD` hold the values declared by the `$quill` and `$kind` metadata.
+User field names match `[a-z_][a-z0-9_]*`. Uppercase, hyphens, and the
+`$` sigil are not allowed — the `$` prefix is reserved for system
+metadata that the engine projects onto the plate JSON (`$quill`,
+`$kind`, `$id`, `$body`, `$cards`). Keeping user fields lowercase
+guarantees they can never shadow that metadata.
 
 ## Card Blocks
 
 Every card-yaml block after the root block is a **card**. It must declare a
 `$kind: <kind>` entry, where `<kind>` matches `[a-z_][a-z0-9_]*` and is not
-`main`. All card blocks are collected into the `CARDS` array available to
-templates.
+`main`. All card blocks are collected into the `$cards` array on the
+plate JSON available to templates.
 
 ```
 ~~~card-yaml

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -38,7 +38,7 @@ price: 29.99
 Gadget description.
 ```
 
-All card blocks are collected into the `CARDS` array.
+All card blocks are collected into the plate JSON's `$cards` array.
 
 ## Structural Rules
 
@@ -48,8 +48,8 @@ All card blocks are collected into the `CARDS` array.
   card kind. The kind must match `[a-z_][a-z0-9_]*` and must not be `main`
   (reserved for the document root). Invalid examples: `BadCard`, `my-card`,
   `2nd_card`, `main`.
-- `QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and cannot be used as field
-  names inside a card.
+- Field names must match `[a-z_][a-z0-9_]*`. Uppercase and `$`-prefixed
+  keys are reserved for system metadata and cannot be used as user fields.
 - A blank line is required immediately above every `~~~card-yaml` opener
   (unless the block is the very first line of the document). A `~~~card-yaml`
   line without a blank line above it is treated as an ordinary code block.
@@ -63,8 +63,9 @@ subsequent block is a card.
 
 ## Card Body Content
 
-Each card includes a `BODY` field containing the Markdown between that card's
-closing `~~~` fence and the next block's opening fence (or document end).
+Each card carries a `$body` value on the plate JSON containing the
+Markdown between that card's closing `~~~` fence and the next block's
+opening fence (or document end).
 
 ## Emission
 

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -50,14 +50,14 @@ Your first plate template:
 
 Dear #data.recipient,
 
-#data.at("BODY", default: "")
+#data.at("$body", default: "")
 
 Sincerely,
 
 #data.sender
 ```
 
-For data access patterns, helper package details, optional fields, and CARDS iteration, see the [Typst Backend](typst-backend.md) guide.
+For data access patterns, helper package details, optional fields, and `$cards` iteration, see the [Typst Backend](typst-backend.md) guide.
 
 ## 4. Write a document
 
@@ -88,7 +88,7 @@ For command options and output controls, see the [CLI Reference](../cli/referenc
 ## 6. Next steps
 
 - [Quill.yaml Reference](quill-yaml-reference.md) — full field types, UI hints, `card_kinds`, `typst` section
-- [Typst Backend](typst-backend.md) — data access patterns, CARDS iteration, helper package
+- [Typst Backend](typst-backend.md) — data access patterns, `$cards` iteration, helper package
 - [Quill Versioning](versioning.md)
 
 **Tip:** To exclude files (fonts, build artifacts) from the bundle when loading from disk, add a `.quillignore` file at the bundle root using gitignore syntax.

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -311,7 +311,7 @@ Invalid card-kind names include:
 
 A human-readable display label for the card kind. UI consumers should prefer it over the snake_case map key when rendering section headers, chips, picker entries, or per-instance titles in a list.
 
-The label is decoupled from the map key (e.g. `indorsement`), which is the on-the-wire `CARD` discriminator. Authors can rename the label freely without invalidating stored documents.
+The label is decoupled from the map key (e.g. `indorsement`), which is the on-the-wire `$kind` discriminator. Authors can rename the label freely without invalidating stored documents.
 
 **Two flavors:**
 

--- a/docs/format-designer/typst-backend.md
+++ b/docs/format-designer/typst-backend.md
@@ -54,16 +54,16 @@ Use Typst's `in` operator to check for optional fields:
 
 ### Body, arrays, and cards
 
-The document body is at `data.BODY`. Arrays come through as Typst arrays. Cards live under `data.CARDS`, each carrying its own `CARD` discriminator, fields, and `BODY`:
+The document body is at `data.$body` (accessed via `data.at("$body")` because Typst identifiers exclude `$`). Arrays come through as Typst arrays. Cards live under `data.$cards`, each carrying its own `$kind` discriminator, fields, and `$body`:
 
 ```typst
-#data.at("BODY", default: "")
+#data.at("$body", default: "")
 
 #for author in data.authors [- #author]
 
-#for card in data.at("CARDS", default: ()) {
-  if card.CARD == "product" {
-    [Product: #card.name — #card.BODY]
+#for card in data.at("$cards", default: ()) {
+  if card.at("$kind") == "product" {
+    [Product: #card.name — #card.at("$body")]
   }
 }
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -52,7 +52,7 @@ Get started with Quillmark in Python or JavaScript.
 
     const quill = engine.quill(new Map([
       ["Quill.yaml", enc.encode("quill:\n  name: my_quill\n  backend: typst\n  version: \"1.0.0\"\n  description: Demo\n  plate_file: plate.typ\n")],
-      ["plate.typ", enc.encode("#import \"@local/quillmark-helper:0.1.0\": data\n#data.BODY\n")],
+      ["plate.typ", enc.encode("#import \"@local/quillmark-helper:0.1.0\": data\n#data.at(\"$body\")\n")],
     ]));
 
     const markdown = `~~~card-yaml

--- a/docs/migrations/0.82-to-0.83.md
+++ b/docs/migrations/0.82-to-0.83.md
@@ -1,0 +1,105 @@
+# 0.82.0 → 0.83.0 — `$`-prefixed plate JSON wire format
+
+`0.83.0` retires the legacy uppercase reserved keys from the plate JSON
+that backends and Typst plates consume. The same conceptual data is now
+exposed under `$`-prefixed metadata keys, alongside flat user payload
+fields. This is a **hard cutover**: there is no compatibility shim — plates
+that read the old keys (`QUILL`, `BODY`, `CARDS`, `CARD`) will fail to
+compile.
+
+## Wire-format change
+
+| Key (0.82)            | Key (0.83)              | Access in Typst plates                |
+|-----------------------|-------------------------|---------------------------------------|
+| `data.QUILL`          | `data.$quill`           | `data.at("$quill")`                   |
+| `data.BODY`           | `data.$body`            | `data.at("$body")`                    |
+| `data.CARDS`          | `data.$cards`           | `data.at("$cards")`                   |
+| `card.CARD`           | `card.$kind`            | `card.at("$kind")`                    |
+| `card.BODY`           | `card.$body`            | `card.at("$body")`                    |
+
+User payload fields stay flat at the root of the plate JSON, alongside
+the `$` metadata. They cannot collide with the `$` keys because field
+names match `[a-z_][a-z0-9_]*` — the `$` sigil is excluded from valid
+identifiers.
+
+```diff
+- #mainmatter[
+-   #data.BODY
+- ]
++ #mainmatter[
++   #data.at("$body")
++ ]
+
+- #for card in data.CARDS {
+-   if card.CARD == "indorsement" [
+-     #card.BODY
+-   ]
+- }
++ #for card in data.at("$cards") {
++   if card.at("$kind") == "indorsement" [
++     #card.at("$body")
++   ]
++ }
+```
+
+> **Why `.at("$...")`?** Typst identifiers do not allow the `$` character,
+> so `data.$body` is a parse error. Dictionary access via `.at("$body")`
+> is the supported form. Lowercase user fields (e.g. `data.title`,
+> `card.from`) keep their familiar `.field` access.
+
+## Removed APIs and validation
+
+- `quillmark_core::document::edit::RESERVED_NAMES`, `is_reserved_name`,
+  and `EditError::ReservedName` are removed. The editor surface
+  (`Card::set_field`, `remove_field`, `set_fill`) now returns
+  `EditError::InvalidFieldName` for any name that does not match
+  `[a-z_][a-z0-9_]*` — including the legacy uppercase sentinels and any
+  `$`-prefixed name. WASM and Python bindings track the variant change
+  in `edit_error_to_js` and `convert_edit_error`.
+- The markdown parser no longer rejects uppercase YAML keys like
+  `BODY:`. They are simply parsed as user payload fields with invalid
+  names; the editor surface refuses to mutate them, but `from_markdown`
+  no longer errors on parse. The new wire format makes this safe — the
+  user field cannot shadow `$body` regardless.
+- `QuillConfig::schema()` no longer prepends synthetic `QUILL` / `CARD`
+  discriminator fields to `main.fields` / `card_kinds.<name>.fields`. The
+  schema describes only the user-fillable fields. To construct a
+  document:
+  - The root `$quill` is `${meta.name}@${meta.version}` (read from
+    `quill.metadata`).
+  - Each card's `$kind` is the key under which it is declared in
+    `card_kinds`.
+- The `quillmark::compile_data` JSON output uses the new shape end-to-
+  end. Any host code that inspected `data["QUILL"]`, `data["BODY"]`,
+  `data["CARDS"]`, or a card's `CARD`/`BODY` keys must switch to the
+  `$`-prefixed equivalents.
+
+## Updating a quill bundle
+
+1. Edit every `plate.typ` (or other backend template) in the bundle.
+   Replace `data.BODY` → `data.at("$body")`, `data.CARDS` →
+   `data.at("$cards")`, `card.CARD` → `card.at("$kind")`, and
+   `card.BODY` → `card.at("$body")`.
+2. Regenerate any stored `schema.yaml` golden files — the discriminator
+   entries (`QUILL`, `CARD`) no longer appear.
+3. If host code reads the plate JSON directly (form builders, custom
+   exporters), switch every reserved-name lookup to the `$`-prefixed
+   equivalent.
+
+## Editor-surface migration
+
+Code that catches `EditError::ReservedName` should fold that branch
+into `EditError::InvalidFieldName`:
+
+```diff
+  match doc.set_field(name, value) {
+-     Err(EditError::ReservedName(n)) => handle_invalid(n),
+      Err(EditError::InvalidFieldName(n)) => handle_invalid(n),
+      ...
+  }
+```
+
+In WASM / Python bindings the thrown / raised error string changes from
+`[EditError::ReservedName] ...` to `[EditError::InvalidFieldName] ...`
+for the legacy uppercase names. Any tests that asserted on the
+`ReservedName` substring need updating.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - CLI:
       - Reference: cli/reference.md
   - Migration:
+      - 0.82 → 0.83 ($-prefixed plate JSON): migrations/0.82-to-0.83.md
       - 0.81 → 0.82 (card-yaml): migrations/0.81-to-0.82.md
       - WASM 0.77 → 0.80: migrations/wasm-0.77-to-0.80.md
 

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Cards are structured metadata blocks inline within document content. All cards are stored in a single `CARDS` array, discriminated by the `CARD` field.
+Cards are structured metadata blocks inline within document content. All cards are stored in a single `$cards` array on the plate JSON, discriminated by each card's `$kind` value.
 
 ## Data Model
 
@@ -50,7 +50,7 @@ card_kinds:
         description: Name, grade, and duty title.
 ```
 
-`ui.title` is the display label for UI consumers (section headers, chips, picker entries, per-instance list titles). It may be a literal string or a template containing `{field_name}` tokens that consumers interpolate with live field values (e.g. `"{from} → {for}"`). It's decoupled from the snake_case map key (`indorsement`), which is the on-the-wire `CARD` discriminator — so authors can rename the label without breaking stored documents.
+`ui.title` is the display label for UI consumers (section headers, chips, picker entries, per-instance list titles). It may be a literal string or a template containing `{field_name}` tokens that consumers interpolate with live field values (e.g. `"{from} → {for}"`). It's decoupled from the snake_case map key (`indorsement`), which is the on-the-wire `$kind` discriminator — so authors can rename the label without breaking stored documents.
 
 ## Public Schema YAML Output
 
@@ -72,14 +72,15 @@ card_kinds:
           group: Addressing
 ```
 
-`QuillConfig::schema()` emits the schema (with `ui` and `body` hints retained) and `schema_yaml()` is the YAML wrapper. The output keeps the same `card_kinds.<name>.fields` shape as `Quill.yaml` and injects a required `CARD` discriminator field whose `const` value is the card name. The `card_kinds` key is omitted entirely when no named card-kinds are defined. See `SCHEMAS.md` for the full surface.
+`QuillConfig::schema()` emits the schema (with `ui` and `body` hints retained) and `schema_yaml()` is the YAML wrapper. The output keeps the same `card_kinds.<name>.fields` shape as `Quill.yaml` — only the user-fillable fields, no sentinel discriminator. The `card_kinds` map key (e.g. `indorsement`) is itself the `$kind` discriminator value. The `card_kinds` key is omitted entirely when no named card-kinds are defined. See `SCHEMAS.md` for the full surface.
 
 ## Markdown Syntax
 
 A composable card is a `~~~card-yaml` block, optionally led by a
-`$kind: <kind>` system-metadata line. The kind is the on-the-wire `CARD`
-discriminator; the block's payload is the card's YAML data, and the markdown
-after the closing `~~~` fence is the card's body.
+`$kind: <kind>` system-metadata line. The kind surfaces on the plate
+JSON as the card's `$kind` discriminator; the block's payload is the
+card's YAML data, and the markdown after the closing `~~~` fence is the
+card's body.
 
 ````markdown
 ~~~card-yaml
@@ -98,5 +99,5 @@ See [`MARKDOWN.md`](./MARKDOWN.md) §3 for the full syntax specification.
 
 ## Backend Consumption
 
-- **All backends**: cards are delivered as `data.CARDS`, an array of objects each containing a `CARD` discriminator field, the card's metadata fields, and a `BODY` field with the card's body Markdown.
-- **`Quill::compile_data()`** returns the fully coerced and validated JSON, including `CARDS`.
+- **All backends**: cards are delivered as `data.$cards`, an array of objects each containing a `$kind` discriminator, the card's metadata fields, and a `$body` key with the card's body Markdown.
+- **`Quill::compile_data()`** returns the fully coerced and validated JSON, including `$cards`.

--- a/prose/canon/GLUE_METADATA.md
+++ b/prose/canon/GLUE_METADATA.md
@@ -12,7 +12,9 @@ Quillmark does not use a template engine for plates. Data flows in two stages:
 
 ### Data Shape
 
-- Keys mirror normalized root-block fields (including `BODY` and `CARDS`)
+- Document-level metadata uses `$`-prefixed keys: `$quill` (quill ref string), `$body` (root prose body), `$cards` (array of card objects)
+- Each card object carries `$kind` (discriminator), `$body` (card prose body), and the card's user fields flat
+- User payload fields sit flat at the root next to the `$` keys; field names match `[a-z_][a-z0-9_]*` and therefore never collide with `$` metadata
 - Defaults from the Quill schema are applied before serialization in stage 1
 - Markdown-to-Typst conversion and date parsing happen in stage 2, inside the backend
 
@@ -23,10 +25,18 @@ The Typst backend injects a virtual package `@local/quillmark-helper:<version>` 
 ```typst
 #import "@local/quillmark-helper:0.1.0": data
 
-#data.title          // plain field access
-#data.BODY           // BODY is automatically converted to content
-#data.date           // date fields are auto-converted to datetime
+#data.title                  // plain field access
+#data.at("$body")            // $body is automatically converted to content
+#data.date                   // date fields are auto-converted to datetime
+#for card in data.at("$cards") {
+  if card.at("$kind") == "indorsement" {
+    // ... per-kind handling using card.<field> and card.at("$body")
+  }
+}
 ```
+
+The `$`-prefixed keys must be accessed via `.at("$...")` because Typst
+identifiers do not include the `$` character.
 
 Helper contents (generated in `backends/typst/helper.rs` from `lib.typ.template`):
 - `data`: parsed JSON dictionary of all fields; a `__meta__` key injected by the backend carries the list of markdown and date fields to process, then is consumed by the helper before `data` is exposed to plates — plates never see `__meta__`

--- a/prose/canon/INDEX.md
+++ b/prose/canon/INDEX.md
@@ -14,7 +14,7 @@
 - **[VERSIONING.md](VERSIONING.md)** - Quill version resolution
 - **[SCHEMAS.md](SCHEMAS.md)** - `QuillConfig` schema model, native validation, and emission overview
 - **[BLUEPRINT.md](BLUEPRINT.md)** - Annotated Markdown blueprint for LLM/MCP authoring
-- **[CARDS.md](CARDS.md)** - Composable cards with unified CARDS array
+- **[CARDS.md](CARDS.md)** - Composable cards delivered on the `$cards` plate-JSON array
 - **[GLUE_METADATA.md](GLUE_METADATA.md)** - Plate data injection
 
 ## Backends

--- a/prose/canon/MARKDOWN.md
+++ b/prose/canon/MARKDOWN.md
@@ -163,10 +163,9 @@ User-defined fields sit in the same YAML payload as the `$` metadata keys
 data payload.
 
 - **Field names.** Every field name matches `/^[a-z_][a-z0-9_]*$/`. The
-  pattern excludes `$`, so a data field name can never collide with the
-  metadata sigil.
-- **Reserved names.** `QUILL`, `CARD`, `BODY`, and `CARDS` are reserved and
-  may not be used as field names.
+  pattern excludes `$` and uppercase, so a data field name can never collide
+  with the metadata sigil (`$quill`, `$kind`, `$id`, `$body`, `$cards`) and
+  is consistently lowercase across the wire format.
 - **Whitespace-only payload.** A block whose payload (after metadata
   extraction) is only whitespace yields an empty field set.
 - **YAML comments.** Both own-line comments (`# …` on their own line) and
@@ -249,24 +248,28 @@ syntax.
 
 ## 5. Data Model
 
-Parsing yields:
+Parsing yields the `Document` model, which serialises via
+`to_plate_json` into the following wire shape for backend templates.
+All system-metadata keys are `$`-prefixed; user payload fields live flat
+at the root and cannot collide with metadata because field names exclude
+the `$` sigil.
 
 ```typescript
-interface Document {
-  QUILL: string;          // quill name@version, from the root block $quill
-  BODY: string;           // prose body of the root block
-  CARDS: Card[];          // zero or more cards, in document order
-  [field: string]: any;   // other root-block payload fields
+interface PlateJson {
+  $quill: string;         // quill name@version, from the root block $quill
+  $body: string;          // prose body of the root block
+  $cards: Card[];         // zero or more cards, in document order
+  [field: string]: any;   // root-block payload fields, flat
 }
 
 interface Card {
-  CARD: string;           // card kind, matches /^[a-z_][a-z0-9_]*$/
-  BODY: string;           // card prose body
-  [field: string]: any;   // other card payload fields
+  $kind: string;          // card kind, matches /^[a-z_][a-z0-9_]*$/
+  $body: string;          // card prose body
+  [field: string]: any;   // card payload fields, flat
 }
 ```
 
-- `CARDS` is always present, possibly empty.
+- `$cards` is always present, possibly empty.
 - Root-block fields and card-field names may collide freely; each card is its
   own scope.
 - Body text is preserved verbatim — whitespace, line endings, and inline
@@ -418,7 +421,6 @@ Parse errors include:
 - An invalid `$quill` reference.
 - A `$` metadata key whose value type is incompatible with the key.
 - A data-field name failing `/^[a-z_][a-z0-9_]*$/`.
-- Use of a reserved name (`QUILL`, `CARD`, `BODY`, `CARDS`) as a field name.
 - Invalid YAML inside any block payload.
 - Any §8 limit exceeded.
 

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -97,7 +97,7 @@ typst:
     - "@preview/some-package:1.0.0"
 ```
 
-Field names must be `snake_case`. Capitalized keys (e.g. `BODY`, `CARDS`, `CARD`) are reserved by the engine. Standalone `object` fields require a `properties` map; use `type: array` with `properties:` for a list of objects.
+Field names must be `snake_case` (match `[a-z_][a-z0-9_]*`). Capitalized or `$`-prefixed keys are rejected by the editor surface — document-level metadata sits on dedicated `$`-prefixed keys in the plate JSON (`$quill`, `$body`, `$cards`, `$kind`), and user fields stay lowercase so they cannot shadow it. Standalone `object` fields require a `properties` map; use `type: array` with `properties:` for a list of objects.
 
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card kind.

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -45,7 +45,7 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Returns `Result<(), Vec<ValidationError>>`
 - Collects all errors (does not short-circuit)
 - Emits path-aware errors for top-level fields and card fields
-- Validates each card has a `CARD` discriminator matching a known card kind
+- Validates each card's `$kind` matches a known card kind
 - Enforces `body.enabled: false` on the main card and on each card kind — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
 
 ## Schema emission
@@ -55,8 +55,11 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Field types, constraints, and `enum`/`default`/`example` annotations
 - `ui` hints on fields and card kinds (`group`, `order`, `compact`, `multiline`, `title`)
 - `body` blocks on cards (`enabled`, `description`)
-- A required `QUILL` discriminator field prepended to `main.fields` (`const = "<name>@<version>"`)
-- A required `CARD` discriminator field prepended to each `card_kinds.<name>.fields` (`const = "<name>"`)
+
+The schema describes only the user-fillable fields. The quill reference
+(`name@version`, available from quill metadata) and card-kind
+discriminators (the `card_kinds` map keys themselves) are document-level
+metadata, not schema fields, and do not appear in `fields`.
 
 `QuillConfig::schema_yaml()` is a YAML wrapper over the same value. The schema is pinned by serde attributes on `FieldSchema`, `CardSchema`, `UiFieldSchema`, `UiCardSchema`, and `BodyCardSchema` — there is no parallel mirror struct.
 
@@ -75,11 +78,13 @@ Identity fields (`name`, `version`, `backend`, `author`, `description`) live on 
 | Python | `Quill.schema` getter (YAML) |
 | CLI | `quillmark schema <path>` |
 
-### `main.fields` and `card_kinds.<name>.fields` discriminators
+### Where the discriminators come from
 
-`schema()` prepends a synthetic discriminator field to each card's `fields` map so consumers know exactly which discriminator value to use — the `QUILL` reference for the main card, and the card kind (the `$kind: <kind>` metadata value) for each card kind:
+The schema response omits discriminator fields. Consumers that need to
+construct a document derive the discriminators from elsewhere:
 
-- `main.fields.QUILL` — `{ type: string, const: "<name>@<version>", required: true, description: ... }`
-- `card_kinds.<name>.fields.CARD` — `{ type: string, const: "<name>", required: true, description: ... }`
-
-These appear ahead of the author's declared fields. They are not present in `Quill.yaml`; the projection injects them.
+- The root block's `$quill` value is `<name>@<version>`, built from
+  `quill.metadata.name` and `quill.metadata.version`.
+- Each composable card's `$kind` is the key under which it is declared
+  in `card_kinds` (e.g. a card listed under `card_kinds.indorsement` is
+  written as `$kind: indorsement`).


### PR DESCRIPTION
## Summary

This is a hard cutover that retires the legacy uppercase reserved keys (`QUILL`, `BODY`, `CARDS`, `CARD`) from the plate JSON wire format. System metadata is now exposed under `$`-prefixed keys (`$quill`, `$body`, `$cards`, `$kind`), while user payload fields remain flat at the root and cannot collide with metadata because field names are restricted to `[a-z_][a-z0-9_]*`.

## Key Changes

**Wire Format Migration:**
- `data.QUILL` → `data.$quill` (accessed via `data.at("$quill")` in Typst)
- `data.BODY` → `data.$body`
- `data.CARDS` → `data.$cards`
- `card.CARD` → `card.$kind`
- `card.BODY` → `card.$body`

**API Removals:**
- Removed `RESERVED_NAMES` constant, `is_reserved_name()`, and `EditError::ReservedName` variant
- Field-name validation now uses a single regex rule: `[a-z_][a-z0-9_]*` (rejects uppercase, hyphens, and `$` prefix)
- Uppercase names like `BODY` are now rejected as `InvalidFieldName` rather than `ReservedName`

**Parser Changes:**
- Markdown parser no longer rejects uppercase YAML keys; they parse as user fields with invalid names
- The editor surface (via `Card::set_field`, `remove_field`, `set_fill`) enforces the field-name regex and rejects them
- Removed `validate_payload_yaml()` function that checked for reserved names

**Schema Generation:**
- `QuillConfig::schema()` no longer prepends synthetic `QUILL`/`CARD` discriminator fields
- Schema describes only user-fillable fields; quill reference and card-kind discriminators are document-level metadata

**Document Serialization:**
- `Document::to_plate_json()` uses the new shape end-to-end with `$`-prefixed keys
- `$quill` appears first in the JSON object for parity

**Binding Updates:**
- WASM: Updated `edit_error_to_js` to reflect `InvalidFieldName` for legacy uppercase names
- Python: Updated `convert_edit_error` similarly
- Test assertions updated to expect `InvalidFieldName` instead of `ReservedName`

**Template Updates:**
- All fixture quill plates (usaf_memo, taro, classic_resume, cmu_letter) updated to use `data.at("$body")`, `data.at("$cards")`, `card.at("$kind")`, `card.at("$body")`
- Typst backend helper template updated to reference `$cards` and `$kind`

**Documentation:**
- Added migration guide (0.82-to-0.83.md) with wire-format table and update instructions
- Updated MARKDOWN.md, CARDS.md, GLUE_METADATA.md, and other canon docs
- Updated authoring guides to reflect new field-name rules and `$`-prefixed metadata

## Implementation Details

The field-name validation now uses a single, consistent rule across all surfaces: `[a-z_][a-z0-9_]*` after NFC normalization. This excludes uppercase letters and the `$` sigil, making it impossible for user fields to shadow system metadata. The parser is permissive (accepts any YAML key), but the editor surface enforces the rule, so hand-crafted storage DTOs with invalid names are caught at mutation time rather than parse time.

The `$quill` key is constructed as `${meta.name}@${meta.version}` from quill metadata, and each card's `$kind` is the key under which it is declared in `card_kinds`. These are no longer part of the schema but are injected by the engine during serialization.

https://claude.ai/code/session_013KFVkcMBhBfWiooJTii1Vf