### PR TITLE
Add `$ext` system metadata for out-of-band extension data

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -386,13 +386,14 @@ impl PyDocument {
         self.inner.main().body()
     }
 
-    /// Main (entry) card as a dict with `kind`, `payload_items`, and `body`.
+    /// Main (entry) card as a dict with `kind`, `payload_items`, `ext`, and `body`.
     #[getter]
     fn main<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         card_to_pydict(py, self.inner.main())
     }
 
-    /// Ordered list of composable card blocks, each a dict with `kind`, `payload_items`, and `body`.
+    /// Ordered list of composable card blocks, each a dict with `kind`,
+    /// `payload_items`, `ext`, and `body`.
     #[getter]
     fn cards<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
         let mut result = Vec::new();
@@ -768,11 +769,24 @@ fn card_to_pydict<'py>(
             }
             quillmark_core::PayloadItem::Quill { .. }
             | quillmark_core::PayloadItem::Kind { .. }
-            | quillmark_core::PayloadItem::Id { .. } => continue,
+            | quillmark_core::PayloadItem::Id { .. }
+            | quillmark_core::PayloadItem::Ext { .. } => continue,
         }
         items.append(entry)?;
     }
     d.set_item("payload_items", items)?;
+
+    // `$ext` map for out-of-band extension data (UI editor state, agent
+    // annotations, …). `None` when no `$ext` was declared on the block;
+    // stripped from `payload_items` so binding consumers do not see it
+    // twice. Quillmark never emits `$ext` into the plate JSON.
+    match card.ext() {
+        Some(ext_map) => {
+            let ext_value = serde_json::Value::Object(ext_map.clone());
+            d.set_item("ext", json_to_py(py, &ext_value)?)?;
+        }
+        None => d.set_item("ext", py.None())?,
+    }
 
     d.set_item("body", card.body())?;
     Ok(d)

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -194,10 +194,11 @@ pub enum PayloadItem {
 /// Exposed as a plain JS object via `Document.main`, `Document.cards`, etc.
 /// Carries a `kind` string (the block's `$kind`, empty when the block
 /// declares none), an ordered `payloadItems` list (fields + comments in
-/// source order), and the body. To read a specific field by name, filter
-/// `payloadItems` for `{type: "field", key: "..."}`. Whether a card is the
-/// document entry (main) card or a composable card is positional — it is
-/// whichever `Document` accessor it came from (`main` vs `cards`).
+/// source order), an optional opaque `$ext` map, and the body. To read a
+/// specific field by name, filter `payloadItems` for
+/// `{type: "field", key: "..."}`. Whether a card is the document entry
+/// (main) card or a composable card is positional — it is whichever
+/// `Document` accessor it came from (`main` vs `cards`).
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -206,10 +207,19 @@ pub struct Card {
     /// the block declares no `$kind`.
     pub kind: String,
     /// Ordered payload item list — fields and comments, in source order.
-    /// Typed `$` entries (`$quill`, `$kind`, `$id`) are exposed via the
-    /// typed accessors (`card.kind` etc.) and are absent from this list.
+    /// Typed `$` entries (`$quill`, `$kind`, `$id`, `$ext`) are exposed
+    /// via the typed accessors (`card.kind`, `card.ext`, etc.) and are
+    /// absent from this list.
     #[tsify(type = "PayloadItem[]")]
     pub payload_items: Vec<PayloadItem>,
+    /// The block's `$ext` map, if declared. Opaque storage for out-of-band
+    /// extension data (UI editor state, agent annotations, …) that
+    /// Quillmark carries through Markdown and storage DTO round-trips but
+    /// never feeds into the plate JSON consumed by backends.
+    /// `null`/`undefined` when no `$ext` was declared.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[tsify(type = "Record<string, unknown> | undefined")]
+    pub ext: Option<serde_json::Map<String, serde_json::Value>>,
     /// Markdown body after the card's closing `~~~`. Empty string when absent.
     pub body: String,
 }
@@ -236,13 +246,15 @@ impl From<&quillmark_core::Card> for Card {
                 }
                 quillmark_core::PayloadItem::Quill { .. }
                 | quillmark_core::PayloadItem::Kind { .. }
-                | quillmark_core::PayloadItem::Id { .. } => None,
+                | quillmark_core::PayloadItem::Id { .. }
+                | quillmark_core::PayloadItem::Ext { .. } => None,
             })
             .collect();
 
         Card {
             kind: card.kind().unwrap_or("").to_string(),
             payload_items,
+            ext: card.ext().cloned(),
             body: card.body().to_string(),
         }
     }
@@ -392,6 +404,49 @@ mod tests {
         assert!(
             inline_comment.is_some(),
             "inline comment must appear in payload_items"
+        );
+    }
+
+    #[test]
+    fn card_from_core_carries_ext_and_strips_it_from_payload_items() {
+        use quillmark_core::Document;
+
+        let md = "~~~card-yaml\n$quill: q\n$kind: main\n$ext:\n  presentation:\n    title: \"Greeting\"\ntitle: Hi\n~~~\n";
+        let doc = Document::from_markdown(md).unwrap();
+        let card = Card::from(doc.main());
+
+        // `$ext` is surfaced through the typed accessor.
+        let ext = card.ext.as_ref().expect("ext should be present");
+        assert_eq!(
+            ext.get("presentation")
+                .and_then(|v| v.get("title"))
+                .and_then(|v| v.as_str()),
+            Some("Greeting"),
+        );
+
+        // …and is absent from `payloadItems`, like the other `$` entries.
+        let has_ext_field = card.payload_items.iter().any(|it| match it {
+            PayloadItem::Field { key, .. } => key == "$ext",
+            _ => false,
+        });
+        assert!(!has_ext_field, "$ext must not leak into payload_items");
+    }
+
+    #[test]
+    fn card_from_core_omits_ext_when_absent() {
+        use quillmark_core::Document;
+
+        let md = "~~~card-yaml\n$quill: q\n$kind: main\ntitle: Hi\n~~~\n";
+        let doc = Document::from_markdown(md).unwrap();
+        let card = Card::from(doc.main());
+        assert!(card.ext.is_none());
+
+        // `skip_serializing_if = "Option::is_none"` keeps the field out of
+        // the JS-facing object entirely when not declared.
+        let json = serde_json::to_string(&card).unwrap();
+        assert!(
+            !json.contains("\"ext\""),
+            "ext should be omitted when None, got: {json}",
         );
     }
 

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -159,6 +159,12 @@ pub enum PayloadItemV0_82_0 {
     Kind { value: String },
     /// `$id` system metadata.
     Id { value: String },
+    /// `$ext` system metadata — an opaque mapping carrying out-of-band
+    /// extension data (UI editor state, agent annotations, …). Never
+    /// emitted into the plate JSON; round-trips through the DTO unchanged.
+    Ext {
+        value: serde_json::Map<String, serde_json::Value>,
+    },
     /// A user-defined field.
     Field {
         key: String,
@@ -243,6 +249,9 @@ impl From<&PayloadItem> for PayloadItemV0_82_0 {
                 value: value.clone(),
             },
             PayloadItem::Id { value } => PayloadItemV0_82_0::Id {
+                value: value.clone(),
+            },
+            PayloadItem::Ext { value } => PayloadItemV0_82_0::Ext {
                 value: value.clone(),
             },
             PayloadItem::Field { key, value, fill } => PayloadItemV0_82_0::Field {
@@ -378,6 +387,7 @@ impl TryFrom<PayloadItemV0_82_0> for PayloadItem {
             }
             PayloadItemV0_82_0::Kind { value } => PayloadItem::Kind { value },
             PayloadItemV0_82_0::Id { value } => PayloadItem::Id { value },
+            PayloadItemV0_82_0::Ext { value } => PayloadItem::Ext { value },
             PayloadItemV0_82_0::Field { key, value, fill } => PayloadItem::Field {
                 key,
                 value: QuillValue::from_json(value),

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -128,6 +128,30 @@ fn emit_meta_line(out: &mut String, key: &str, value: &str, trailer: Option<&str
     out.push('\n');
 }
 
+/// Emit the `$ext: …` block. An empty map emits inline as `$ext: {}` so the
+/// declaration survives the round-trip; a non-empty map emits as a `$ext:`
+/// header followed by indented block-style children. Nested comments
+/// captured under the `$ext` key are re-injected by the child mapping
+/// walker.
+fn emit_ext_block(
+    out: &mut String,
+    value: &serde_json::Map<String, JsonValue>,
+    trailer: Option<&str>,
+    nested: &[NestedComment],
+) {
+    if value.is_empty() {
+        out.push_str("$ext: {}");
+        push_trailer(out, trailer);
+        out.push('\n');
+        return;
+    }
+    out.push_str("$ext:");
+    push_trailer(out, trailer);
+    out.push('\n');
+    let path = vec![CommentPathSegment::Key("$ext".to_string())];
+    emit_mapping_children(out, value, 2, &path, nested);
+}
+
 fn emit_block(out: &mut String, card: &Card) {
     out.push_str("~~~card-yaml\n");
     emit_payload_items(
@@ -159,6 +183,9 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem], nested: &[NestedC
             }
             PayloadItem::Id { value } => {
                 emit_meta_line(out, "id", value, trailer);
+            }
+            PayloadItem::Ext { value } => {
+                emit_ext_block(out, value, trailer, nested);
             }
             PayloadItem::Field { key, value, fill } => {
                 let path = vec![CommentPathSegment::Key(key.clone())];

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -1,9 +1,9 @@
 //! Validation helpers for card-yaml `$`-prefixed system metadata.
 //!
-//! The closed set of `$` keys (`$quill`, `$kind`, `$id`) and their typed
-//! values are stored as variants of [`super::PayloadItem`] inside a card's
-//! unified [`super::Payload`] item list — they sit alongside user fields
-//! and comments in source order, which is what makes inline-comment
+//! The closed set of `$` keys (`$quill`, `$kind`, `$id`, `$ext`) and their
+//! typed values are stored as variants of [`super::PayloadItem`] inside a
+//! card's unified [`super::Payload`] item list — they sit alongside user
+//! fields and comments in source order, which is what makes inline-comment
 //! preservation symmetric across the `$`/non-`$` boundary.
 //!
 //! This module retains only the validation primitives shared between the
@@ -31,22 +31,24 @@ pub(super) fn meta_key(item: &PayloadItem) -> Option<&'static str> {
         PayloadItem::Quill { .. } => Some("$quill"),
         PayloadItem::Kind { .. } => Some("$kind"),
         PayloadItem::Id { .. } => Some("$id"),
+        PayloadItem::Ext { .. } => Some("$ext"),
         PayloadItem::Field { .. } | PayloadItem::Comment { .. } => None,
     }
 }
 
 /// Walk the parsed YAML payload, extracting `$`-prefixed reserved keys into
-/// typed system-metadata [`PayloadItem`]s (`Quill` / `Kind` / `Id`) in
-/// source order. The keys are removed from `payload` so the caller can
+/// typed system-metadata [`PayloadItem`]s (`Quill` / `Kind` / `Id` / `Ext`)
+/// in source order. The keys are removed from `payload` so the caller can
 /// build the user-field portion from what remains.
 ///
-/// The accepted keys are the closed set `{$quill, $kind, $id}`. Any other
-/// `$`-prefixed key is a parse error. Duplicate keys cannot arise here —
-/// the YAML parser rejects them as duplicate mapping keys before this
-/// function runs.
+/// The accepted keys are the closed set `{$quill, $kind, $id, $ext}`. Any
+/// other `$`-prefixed key is a parse error. Duplicate keys cannot arise
+/// here — the YAML parser rejects them as duplicate mapping keys before
+/// this function runs.
 ///
 /// `$quill` and `$kind` require string scalars (non-string YAML types are
-/// rejected). `$id` accepts any scalar and stringifies it.
+/// rejected). `$id` accepts any scalar and stringifies it. `$ext` requires
+/// a YAML mapping (object) — its contents are carried opaquely.
 pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadItem>, ParseError> {
     let map = match payload {
         JsonValue::Object(m) => m,
@@ -91,10 +93,19 @@ pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadI
             "$id" => PayloadItem::Id {
                 value: scalar_to_string(&key, value)?,
             },
+            "$ext" => match value {
+                JsonValue::Object(map) => PayloadItem::Ext { value: map },
+                other => {
+                    return Err(ParseError::InvalidStructure(format!(
+                        "Invalid `$ext` value — expected a mapping, got {}",
+                        yaml_type_name(&other)
+                    )));
+                }
+            },
             other => {
                 return Err(ParseError::InvalidStructure(format!(
                     "Unknown `{}` system-metadata key — the card-yaml block \
-                     accepts only `$quill`, `$kind`, and `$id`",
+                     accepts only `$quill`, `$kind`, `$id`, and `$ext`",
                     other
                 )));
             }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -74,6 +74,14 @@ impl Card {
         self.payload.id()
     }
 
+    /// Opaque `$ext` map for out-of-band extension data (UI editor state,
+    /// agent annotations, …). Carried through Markdown and storage DTO
+    /// round-trips; never emitted into the plate JSON consumed by
+    /// backends.
+    pub fn ext(&self) -> Option<&serde_json::Map<String, serde_json::Value>> {
+        self.payload.ext()
+    }
+
     pub fn payload(&self) -> &Payload {
         &self.payload
     }

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -21,13 +21,15 @@
 //! map-keyed access (`get`, `iter`, `insert`, `remove`). The map-style
 //! accessors filter to [`PayloadItem::Field`] only — they intentionally
 //! don't expose `$` entries because typed `$` access has dedicated methods
-//! (`quill`, `kind`, `id`, `set_quill`, `set_kind`, `set_id`).
+//! (`quill`, `kind`, `id`, `ext`, `set_quill`, `set_kind`, `set_id`,
+//! `set_ext`).
 //!
 //! This preserves the historical "payload as a key/value map of user data"
 //! API while letting comment preservation and `$` access ride on the same
 //! underlying storage.
 
 use indexmap::IndexMap;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use super::prescan::NestedComment;
 use crate::value::QuillValue;
@@ -47,6 +49,11 @@ pub enum PayloadItem {
     Kind { value: String },
     /// `$id` system metadata — opaque identifier.
     Id { value: String },
+    /// `$ext` system metadata — an opaque mapping reserved for out-of-band
+    /// extension data (UI editor state, agent annotations, …). Never
+    /// emitted into the plate JSON, always round-trips through Markdown
+    /// and the storage DTO.
+    Ext { value: JsonMap<String, JsonValue> },
     /// A user-defined YAML field, optionally tagged `!fill`.
     Field {
         key: String,
@@ -90,13 +97,14 @@ impl PayloadItem {
     }
 
     /// Canonical sort rank for typed `$` entries: `$quill` < `$kind` <
-    /// `$id`. Returns `None` for user fields and comments, which are
-    /// positioned by source order and never reshuffled.
+    /// `$id` < `$ext`. Returns `None` for user fields and comments, which
+    /// are positioned by source order and never reshuffled.
     fn meta_rank(&self) -> Option<u8> {
         match self {
             PayloadItem::Quill { .. } => Some(0),
             PayloadItem::Kind { .. } => Some(1),
             PayloadItem::Id { .. } => Some(2),
+            PayloadItem::Ext { .. } => Some(3),
             _ => None,
         }
     }
@@ -202,8 +210,18 @@ impl Payload {
         })
     }
 
+    /// The `$ext` map, if declared. The map is opaque — Quillmark does not
+    /// interpret its contents and never emits them into the plate JSON.
+    pub fn ext(&self) -> Option<&JsonMap<String, JsonValue>> {
+        self.items.iter().find_map(|i| match i {
+            PayloadItem::Ext { value } => Some(value),
+            _ => None,
+        })
+    }
+
     /// Set or replace the `$quill` entry. Inserts at canonical position
-    /// (before any `$kind` / `$id`) when adding. Comments are untouched.
+    /// (before any `$kind` / `$id` / `$ext`) when adding. Comments are
+    /// untouched.
     pub fn set_quill(&mut self, reference: QuillReference) {
         self.upsert_meta(PayloadItem::Quill { reference });
     }
@@ -220,6 +238,13 @@ impl Payload {
         self.upsert_meta(PayloadItem::Id { value: id.into() });
     }
 
+    /// Set or replace the `$ext` entry. Same insertion rules as
+    /// [`set_quill`](Self::set_quill); the canonical position is after
+    /// `$quill` / `$kind` / `$id` and before any user field.
+    pub fn set_ext(&mut self, value: JsonMap<String, JsonValue>) {
+        self.upsert_meta(PayloadItem::Ext { value });
+    }
+
     /// Remove the `$quill` entry, returning the previous value if any.
     pub fn take_quill(&mut self) -> Option<QuillReference> {
         let pos = self
@@ -228,6 +253,18 @@ impl Payload {
             .position(|i| matches!(i, PayloadItem::Quill { .. }))?;
         match self.items.remove(pos) {
             PayloadItem::Quill { reference } => Some(reference),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Remove the `$ext` entry, returning the previous map if any.
+    pub fn take_ext(&mut self) -> Option<JsonMap<String, JsonValue>> {
+        let pos = self
+            .items
+            .iter()
+            .position(|i| matches!(i, PayloadItem::Ext { .. }))?;
+        match self.items.remove(pos) {
+            PayloadItem::Ext { value } => Some(value),
             _ => unreachable!(),
         }
     }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -801,8 +801,8 @@ $quill:
 
 #[test]
 fn test_card_with_unknown_meta_key_is_error() {
-    // `$`-prefixed metadata keys are a closed set `{quill, kind, id}`. Any other `$key`
-    // is a parse error.
+    // `$`-prefixed metadata keys are a closed set `{quill, kind, id, ext}`. Any
+    // other `$key` is a parse error.
     let markdown = "~~~card-yaml
 $quill: test_quill
 $kind: main

--- a/crates/core/src/document/tests/ext_tests.rs
+++ b/crates/core/src/document/tests/ext_tests.rs
@@ -1,0 +1,328 @@
+//! End-to-end tests for the `$ext` system-metadata key.
+//!
+//! `$ext` is the opaque-mapping extension hook: parsers accept it, the
+//! emitter preserves it, the storage DTO round-trips it, and the plate
+//! JSON consumed by backends strips it.
+
+use serde_json::json;
+
+use crate::document::{Document, PayloadItem};
+
+fn parse(src: &str) -> Document {
+    Document::from_markdown(src).expect("source should parse")
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn ext_with_mapping_value_is_accepted() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  presentation:
+    title: \"My Display Name\"
+  collapsed: false
+title: Hi
+~~~
+",
+    );
+    let ext = doc.main().ext().expect("$ext present");
+    assert_eq!(
+        ext.get("presentation")
+            .and_then(|v| v.get("title"))
+            .and_then(|v| v.as_str()),
+        Some("My Display Name"),
+    );
+    assert_eq!(ext.get("collapsed").and_then(|v| v.as_bool()), Some(false),);
+}
+
+#[test]
+fn ext_with_empty_mapping_is_preserved() {
+    // `$ext: {}` survives the round-trip as an explicit empty map — it is
+    // distinct from "no `$ext` declared at all".
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext: {}
+~~~
+",
+    );
+    let ext = doc.main().ext().expect("$ext present");
+    assert!(ext.is_empty());
+}
+
+#[test]
+fn ext_with_scalar_value_is_rejected() {
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext: just-a-string
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("Invalid `$ext`") && err.contains("mapping"),
+        "expected $ext-must-be-mapping rejection, got: {err}",
+    );
+}
+
+#[test]
+fn ext_with_sequence_value_is_rejected() {
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  - foo
+  - bar
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("Invalid `$ext`") && err.contains("mapping"),
+        "expected $ext-must-be-mapping rejection, got: {err}",
+    );
+}
+
+#[test]
+fn fill_on_ext_is_rejected() {
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext: !fill
+  foo: 1
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("`!fill`") && err.contains("$ext"),
+        "expected !fill-on-$ext rejection, got: {err}",
+    );
+}
+
+#[test]
+fn ext_on_composable_card_is_accepted() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+~~~
+
+~~~card-yaml
+$kind: indorsement
+$ext:
+  rename: \"Cmdr's response\"
+from: ORG1/SYMBOL
+~~~
+",
+    );
+    assert_eq!(doc.cards().len(), 1);
+    let card = &doc.cards()[0];
+    assert_eq!(card.kind(), Some("indorsement"));
+    let ext = card.ext().expect("composable card $ext present");
+    assert_eq!(
+        ext.get("rename").and_then(|v| v.as_str()),
+        Some("Cmdr's response"),
+    );
+}
+
+// ── Emit / round-trip ──────────────────────────────────────────────────────
+
+#[test]
+fn ext_round_trips_through_markdown() {
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  presentation:
+    title: A
+  flag: true
+title: Body
+~~~
+
+Body content.
+";
+    let doc = parse(src);
+    let emitted = doc.to_markdown();
+    let reparsed = parse(&emitted);
+    assert_eq!(doc, reparsed);
+    // The emitted form is canonical, so the inner $ext map shows up as
+    // indented block-style entries under `$ext:`.
+    assert!(
+        emitted.contains("$ext:\n  presentation:\n    title: A\n  flag: true\n"),
+        "unexpected emit:\n{emitted}",
+    );
+}
+
+#[test]
+fn empty_ext_emits_as_inline_braces() {
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext: {}
+~~~
+";
+    let doc = parse(src);
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$ext: {}\n"),
+        "expected `$ext: {{}}` literal in emit, got:\n{emitted}",
+    );
+    // Survives a second round-trip too.
+    let reparsed = parse(&emitted);
+    assert_eq!(doc, reparsed);
+}
+
+#[test]
+fn ext_emit_is_idempotent() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  a: 1
+~~~
+",
+    );
+    let once = doc.to_markdown();
+    let twice = parse(&once).to_markdown();
+    assert_eq!(once, twice);
+}
+
+// ── Programmatic construction ──────────────────────────────────────────────
+
+#[test]
+fn set_ext_inserts_after_id_and_before_user_fields() {
+    let mut doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$id: rev-1
+title: Hi
+~~~
+",
+    );
+    let mut ext = serde_json::Map::new();
+    ext.insert("rename".into(), json!("Greeting"));
+    doc.main_mut().payload_mut().set_ext(ext);
+
+    let items = doc.main().payload().items();
+    // Canonical order: $quill, $kind, $id, $ext, then user fields in
+    // source order.
+    assert!(matches!(items[0], PayloadItem::Quill { .. }));
+    assert!(matches!(items[1], PayloadItem::Kind { .. }));
+    assert!(matches!(items[2], PayloadItem::Id { .. }));
+    assert!(matches!(items[3], PayloadItem::Ext { .. }));
+    assert!(matches!(items[4], PayloadItem::Field { .. }));
+}
+
+#[test]
+fn take_ext_removes_the_entry() {
+    let mut doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  a: 1
+~~~
+",
+    );
+    let taken = doc.main_mut().payload_mut().take_ext().unwrap();
+    assert_eq!(taken.get("a").and_then(|v| v.as_i64()), Some(1));
+    assert!(doc.main().ext().is_none());
+}
+
+// ── Plate JSON ─────────────────────────────────────────────────────────────
+
+#[test]
+fn ext_is_stripped_from_plate_json() {
+    // Backends must never see `$ext` — it carries out-of-band UI / agent
+    // state, not template data.
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  presentation:
+    title: \"Should not reach the backend\"
+title: Hi
+~~~
+",
+    );
+    let plate = doc.to_plate_json();
+    let obj = plate.as_object().expect("plate is an object");
+    assert!(
+        !obj.contains_key("$ext"),
+        "plate must not contain `$ext`: {plate}",
+    );
+    assert!(
+        !obj.contains_key("ext"),
+        "plate must not contain `ext`: {plate}",
+    );
+    // Plate still carries user fields and the canonical QUILL/BODY/CARDS keys.
+    assert_eq!(obj.get("title").and_then(|v| v.as_str()), Some("Hi"));
+    assert!(obj.contains_key("QUILL"));
+    assert!(obj.contains_key("BODY"));
+    assert!(obj.contains_key("CARDS"));
+}
+
+// ── Storage DTO ────────────────────────────────────────────────────────────
+
+#[test]
+fn ext_round_trips_through_serde_json() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  presentation:
+    title: \"Greeting Card\"
+  collapsed: false
+title: Hi
+~~~
+
+Body.
+
+~~~card-yaml
+$kind: indorsement
+$ext:
+  rename: \"Cmdr's response\"
+from: X
+~~~
+",
+    );
+    let json = serde_json::to_string(&doc).unwrap();
+    let restored: Document = serde_json::from_str(&json).unwrap();
+    assert_eq!(doc, restored);
+    assert_eq!(doc.to_markdown(), restored.to_markdown());
+
+    // The new DTO variant carries `"type": "ext"` with the map inline.
+    assert!(
+        json.contains("\"type\":\"ext\""),
+        "expected ext variant in DTO, got: {json}",
+    );
+}

--- a/crates/core/src/document/tests/mod.rs
+++ b/crates/core/src/document/tests/mod.rs
@@ -5,5 +5,6 @@ mod edit_tests;
 mod emit_idempotence_tests;
 mod emit_stability_tests;
 mod emit_tests;
+mod ext_tests;
 mod lossiness_tests;
 mod number_edge_tests;

--- a/docs/migrations/0.81-to-0.82.md
+++ b/docs/migrations/0.81-to-0.82.md
@@ -68,7 +68,7 @@ declaration. The kind `main` is **reserved for the document root**.
 
 ### System metadata (`$`)
 
-The block's YAML payload may carry up to three reserved `$`-prefixed keys.
+The block's YAML payload may carry up to four reserved `$`-prefixed keys.
 Parsing extracts them from the user field set into a typed `CardMetadata`;
 any other `$`-prefixed key is a parse error (the set is closed).
 
@@ -81,6 +81,11 @@ any other `$`-prefixed key is a parse error (the set is closed).
   kind matching `[a-z_][a-z0-9_]*`.
 - **`$id: <value>`** — an opaque, optional identifier. Plain metadata: no
   validation, no uniqueness; carried through the round-trip unchanged.
+- **`$ext: <mapping>`** — an opaque, optional mapping reserved for
+  out-of-band extension data (UI editor state, agent annotations, …).
+  Required to be a YAML mapping; carried through round-trips and **never**
+  emitted into the plate JSON. See §7 "Legacy `PRESENTATION_METADATA`" for
+  the pre-0.82 convention this replaces.
 
 `$` metadata entries are read as ordinary YAML keys, so they may appear at
 any position within the block's payload. Canonical emission preserves
@@ -324,6 +329,47 @@ core and the bindings:
 | `EditError::InvalidTagName` | `EditError::InvalidKindName` |
 | `form::unknown_card_tag` diagnostic code | `form::unknown_card_kind` |
 
+## 7. Legacy `PRESENTATION_METADATA`
+
+Some pre-0.82 UI consumers stashed editor-only state (per-card display
+renames, collapse flags, …) under an all-uppercase frontmatter key —
+typically `PRESENTATION_METADATA`. The convention worked because pre-0.82
+field names were also expected to be lowercase, so an uppercase key did
+not collide with user data and renderers ignored it.
+
+Under card-yaml, uppercase keys other than the reserved
+`{QUILL, CARD, BODY, CARDS}` are no longer special: they pass through as
+ordinary payload fields and reach the plate JSON that backends consume.
+Continuing to use `PRESENTATION_METADATA` leaks editor state into renders
+and risks template surprises.
+
+Move that state into **`$ext`** (§1):
+
+```diff
+- ~~~card-yaml
+- $kind: indorsement
+- PRESENTATION_METADATA:
+-   title: "Cmdr's response"
+- from: ORG/SYMBOL
+- ~~~
++ ~~~card-yaml
++ $kind: indorsement
++ $ext:
++   presentation:
++     title: "Cmdr's response"
++ from: ORG/SYMBOL
++ ~~~
+```
+
+`$ext` is the typed system-metadata key for opaque, out-of-band data. It
+must be a YAML mapping; consumers namespace inside it
+(`$ext.presentation`, `$ext.agent`, …) to avoid collisions when more than
+one consumer carries state on the same card. The map is stripped from
+`Document::to_plate_json()` before backends see it and round-trips through
+both Markdown and the storage DTO. Read it via `Card::ext()` in Rust,
+`card.ext` in WASM, or `card["ext"]` in Python (`None`/`undefined` when
+the block declared none).
+
 ## Checklist
 
 - [ ] Migrate stored Markdown from `---` frontmatter / `card` fences to
@@ -340,6 +386,9 @@ core and the bindings:
       `.payload` (see §6.1).
 - [ ] Replace `Card::sentinel()` / `Sentinel` usage with the `Card::quill()` /
       `kind()` / `id()` accessors (see §6.2).
+- [ ] If you used a legacy uppercase metadata key (e.g.
+      `PRESENTATION_METADATA`) for editor-only state, lift it into `$ext`
+      under a consumer-namespaced sub-key (see §7).
 - [ ] In WASM/Python binding callers, rename the card `tag` key to `kind`
       (card objects and `CardInput`) — see §6.2.
 - [ ] Rename `set_card_tag` / `setCardTag` to `set_card_kind` / `setCardKind`,

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -100,3 +100,15 @@ See [`MARKDOWN.md`](./MARKDOWN.md) §3 for the full syntax specification.
 
 - **All backends**: cards are delivered as `data.CARDS`, an array of objects each containing a `CARD` discriminator field, the card's metadata fields, and a `BODY` field with the card's body Markdown.
 - **`Quill::compile_data()`** returns the fully coerced and validated JSON, including `CARDS`.
+
+## Out-of-band Metadata (`$ext`)
+
+Per-card editor state — display renames, collapse flags, agent
+annotations, anything bespoke to a UI consumer — belongs in the card's
+`$ext` system-metadata key, **not** in user fields. `$ext` is an opaque
+mapping that round-trips through Markdown and the storage DTO but is
+stripped from `Document::to_plate_json()` before backends see it, so
+template renders are not affected by editor state. Consumers
+namespace inside the map (`$ext.presentation`, `$ext.agent`, …) to avoid
+collisions when more than one tool carries state on the same card. See
+[MARKDOWN.md §3.3](./MARKDOWN.md) for the full specification.

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -52,6 +52,7 @@ the `$`/non-`$` boundary.
       "items": [
         { "type": "quill", "value": "usaf_memo@0.1" },
         { "type": "kind",  "value": "main" },
+        { "type": "ext",   "value": { "presentation": { "title": "Greeting Card" } } },
         { "type": "field", "key": "title", "value": "Hi" }
       ]
     },
@@ -65,9 +66,12 @@ the `$`/non-`$` boundary.
 each variant carries a frozen DTO tree. Quill references are stored as
 strings (parsed back via `QuillReference::from_str`). The discriminator on
 payload items is `type` (not `kind`) to keep it unambiguous next to the
-`$kind` metadata semantic. Parse-time warnings are not part of `Document`
-— they are returned separately by `Document::from_markdown_with_warnings`
-— so they never reach this format.
+`$kind` metadata semantic. The full variant set is `quill | kind | id |
+ext | field | comment`; the `ext` variant carries the opaque `$ext` map
+verbatim and is stripped from `to_plate_json()` before backends see it.
+Parse-time warnings are not part of `Document` — they are returned
+separately by `Document::from_markdown_with_warnings` — so they never
+reach this format.
 
 ### Legacy schema (V0_81_0)
 

--- a/prose/canon/MARKDOWN.md
+++ b/prose/canon/MARKDOWN.md
@@ -108,21 +108,21 @@ the next opening fence or EOF.
 ### 3.3 System Metadata (`$`)
 
 A block's YAML payload may contain **`$`-prefixed reserved keys** that carry
-system metadata. The set is **closed**: only `$quill`, `$kind`, and `$id`
-are accepted. Any other `$`-prefixed key is a parse error. These keys are
-ordinary YAML — they are read by the same YAML parser that handles the rest
-of the payload — but they are **extracted** from the user field set after
-parsing; they are not part of the data model's field map (§3.4).
+system metadata. The set is **closed**: only `$quill`, `$kind`, `$id`, and
+`$ext` are accepted. Any other `$`-prefixed key is a parse error. These
+keys are ordinary YAML — they are read by the same YAML parser that handles
+the rest of the payload — but they are **extracted** from the user field
+set after parsing; they are not part of the data model's field map (§3.4).
 
 In the typed model, the `$` entries live as typed variants of the
 unified payload-item list (`PayloadItem::Quill`, `PayloadItem::Kind`,
-`PayloadItem::Id`), interleaved in source order with user fields and
-YAML comments. They are surfaced through typed accessors —
-`card.quill()`, `card.kind()`, `card.id()` — which return `Option<…>`.
-On a successfully parsed document the root card always returns
-`Some(_)` for both `quill()` and `kind()` (with `kind() == "main"`);
-composable cards return `None` for `quill()` and `Some(_)` for `kind()`
-(any value other than `"main"`).
+`PayloadItem::Id`, `PayloadItem::Ext`), interleaved in source order with
+user fields and YAML comments. They are surfaced through typed
+accessors — `card.quill()`, `card.kind()`, `card.id()`, `card.ext()` —
+which return `Option<…>`. On a successfully parsed document the root
+card always returns `Some(_)` for both `quill()` and `kind()` (with
+`kind() == "main"`); composable cards return `None` for `quill()` and
+`Some(_)` for `kind()` (any value other than `"main"`).
 
 - **`$quill: <name>@<version>`** — binds the document to a quill (see §3.5
   for the version-selector forms). The root block (the first block) must
@@ -135,6 +135,14 @@ composable cards return `None` for `quill()` and `Some(_)` for `kind()`
 - **`$id: <value>`** — an opaque, optional identifier. Plain metadata: no
   validation, no uniqueness requirement; carried through round-trip
   unchanged.
+- **`$ext: <mapping>`** — an opaque, optional **mapping** reserved for
+  out-of-band extension data (UI editor state, agent annotations, …).
+  Required to be a YAML mapping (object); scalars and sequences are
+  rejected. Contents are carried verbatim through Markdown and storage
+  DTO round-trips, and **never** appear in the plate JSON consumed by
+  backends (§5). Bespoke consumers namespace their state inside the
+  map — e.g. `$ext.presentation.title` for an editor-side card rename.
+  An empty `$ext: {}` is preserved as a distinct, explicit declaration.
 
 Rules:
 
@@ -144,13 +152,14 @@ Rules:
 - `$` metadata entries may appear at any position within the payload, and
   may be interleaved with data fields. The emitter preserves source order
   (see §9); newly constructed metadata that does not have a source-order
-  is emitted in the canonical key order `$quill`, `$kind`, `$id`.
+  is emitted in the canonical key order `$quill`, `$kind`, `$id`, `$ext`.
 - A duplicate `$key` within a single block is a parse error (a YAML mapping
   cannot carry two entries under the same key).
-- An unknown `$key` (anything outside `{quill, kind, id}`) is a parse error.
+- An unknown `$key` (anything outside `{quill, kind, id, ext}`) is a parse
+  error.
 - An invalid `$quill` reference is a parse error.
 - A `$`-prefixed key whose value type is wrong for the key (e.g. a sequence
-  under `$quill`) is a parse error.
+  under `$quill`, a scalar under `$ext`) is a parse error.
 - **YAML comments on `$` lines.** Inline trailing comments (`$quill: foo  #
   bound at build`) and adjacent own-line comments round-trip through the
   unified payload-item list — the same mechanism that preserves comments


### PR DESCRIPTION
## Summary

Introduces `$ext` as a fourth system-metadata key in the closed set alongside `$quill`, `$kind`, and `$id`. The `$ext` key holds an opaque YAML mapping reserved for out-of-band extension data such as UI editor state, agent annotations, or consumer-specific metadata. The map round-trips through Markdown and the storage DTO but is stripped from `Document::to_plate_json()` so backends never see it.

## Key Changes

- **Core data model**: Added `PayloadItem::Ext` variant to the unified payload-item list, with canonical sort rank 3 (after `$id`)
- **Parser**: Extended `extract_meta_items()` to accept and validate `$ext` as a YAML mapping; rejects scalars, sequences, and `!fill` tags
- **Emitter**: Implemented `emit_ext_block()` to emit empty maps as `$ext: {}` (inline) and non-empty maps as block-style children; preserves nested comments
- **API surface**:
  - Rust: `Card::ext()` getter and `Payload::set_ext()` / `take_ext()` mutators
  - WASM: `Card.ext` field (typed as `Record<string, unknown> | undefined`), stripped from `payloadItems` list
  - Python: `card["ext"]` dict or `None`, stripped from `payload_items` list
- **Storage DTO**: Added `PayloadItemV0_82_0::Ext` variant with inline `value` field; additive change to wire format (documents without `$ext` remain byte-identical to 0.82.0)
- **Plate JSON**: `$ext` is filtered out before serialization so backends never receive it
- **Documentation**: Updated MARKDOWN.md §3.3, CARDS.md, and DOCUMENT_STORAGE.md with specification and migration guidance for legacy `PRESENTATION_METADATA`-style state

## Implementation Details

- The `$ext` map is opaque — Quillmark does not validate or interpret its contents; consumers namespace inside it (`$ext.presentation`, `$ext.agent`, …) to avoid collisions
- An explicit `$ext: {}` is preserved as distinct from "no `$ext` declared" and survives round-trips
- Canonical field order is maintained: `$quill` → `$kind` → `$id` → `$ext` → user fields
- Comprehensive end-to-end test suite (`ext_tests.rs`) covers parsing, round-tripping, programmatic construction, and plate JSON stripping

https://claude.ai/code/session_01Gk3s4pTz5zYJMSZYt6DsN4