### PR TITLE
Store nested YAML comments per-item instead of payload-level

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -757,7 +757,9 @@ fn card_to_pydict<'py>(
     for item in card.payload().items() {
         let entry = PyDict::new(py);
         match item {
-            quillmark_core::PayloadItem::Field { key, value, fill } => {
+            quillmark_core::PayloadItem::Field {
+                key, value, fill, ..
+            } => {
                 entry.set_item("type", "field")?;
                 entry.set_item("key", key)?;
                 entry.set_item("value", quillvalue_to_py(py, value)?)?;

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -231,13 +231,13 @@ impl From<&quillmark_core::Card> for Card {
             .items()
             .iter()
             .filter_map(|item| match item {
-                quillmark_core::PayloadItem::Field { key, value, fill } => {
-                    Some(PayloadItem::Field {
-                        key: key.clone(),
-                        value: value.as_json().clone(),
-                        fill: *fill,
-                    })
-                }
+                quillmark_core::PayloadItem::Field {
+                    key, value, fill, ..
+                } => Some(PayloadItem::Field {
+                    key: key.clone(),
+                    value: value.as_json().clone(),
+                    fill: *fill,
+                }),
                 quillmark_core::PayloadItem::Comment { text, inline } => {
                     Some(PayloadItem::Comment {
                         text: text.clone(),

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -353,15 +353,15 @@ fn build_payload(
 
     // Look up typed `$` items by `$key`. Each entry is consumed at most
     // once; anything left over at the end is appended in source order.
-    // `extract_meta_items` only ever returns the three system variants;
-    // assert that contract here so a regression upstream is loud, not a
-    // silent drop of user fields/comments.
+    // `extract_meta_items` only ever returns the closed-set system
+    // variants; assert that contract here so a regression upstream is
+    // loud, not a silent drop of user fields/comments.
     let mut typed_by_key: HashMap<&'static str, PayloadItem> =
         HashMap::with_capacity(meta_items.len());
     for m in meta_items {
         let k = meta_key(m).expect(
             "build_payload: meta_items must contain only system variants \
-             ($quill/$kind/$id); got a Field or Comment",
+             ($quill/$kind/$id/$ext); got a Field or Comment",
         );
         typed_by_key.insert(k, m.clone());
     }
@@ -396,6 +396,7 @@ fn build_payload(
                         key: key.clone(),
                         value: QuillValue::from_json(value),
                         fill: *fill,
+                        nested_comments: Vec::new(),
                     });
                     consumed_user_keys.insert(key.clone());
                 }
@@ -423,10 +424,13 @@ fn build_payload(
             key: key.clone(),
             value: QuillValue::from_json(value.clone()),
             fill: false,
+            nested_comments: Vec::new(),
         });
     }
 
-    Ok(Payload::from_items_with_nested(
+    // Partition the prescan's flat `nested_comments` onto the matching
+    // Field / Ext items (paths become relative to the owning value).
+    Ok(Payload::from_items_with_flat_nested(
         items,
         pre_nested_comments.to_vec(),
     ))

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -223,17 +223,21 @@ impl From<&Card> for CardV0_82_0 {
 
 impl From<&Payload> for PayloadV0_82_0 {
     fn from(payload: &Payload) -> Self {
+        // The wire format keeps `nested_comments` as a flat sidecar at
+        // the payload level. The in-memory model carries them per-item
+        // with relative paths, so we re-prefix and flatten here.
+        let nested_comments = payload
+            .flat_nested_comments()
+            .iter()
+            .map(NestedCommentV0_82_0::from)
+            .collect();
         PayloadV0_82_0 {
             items: payload
                 .items()
                 .iter()
                 .map(PayloadItemV0_82_0::from)
                 .collect(),
-            nested_comments: payload
-                .nested_comments()
-                .iter()
-                .map(NestedCommentV0_82_0::from)
-                .collect(),
+            nested_comments,
         }
     }
 }
@@ -250,10 +254,18 @@ impl From<&PayloadItem> for PayloadItemV0_82_0 {
             PayloadItem::Id { value } => PayloadItemV0_82_0::Id {
                 value: value.clone(),
             },
-            PayloadItem::Ext { value } => PayloadItemV0_82_0::Ext {
+            // The wire `Ext` variant has no `nested_comments` field —
+            // its comments live in the payload-level sidecar after
+            // `flat_nested_comments` re-prefixes them with `$ext`.
+            PayloadItem::Ext { value, .. } => PayloadItemV0_82_0::Ext {
                 value: value.clone(),
             },
-            PayloadItem::Field { key, value, fill } => PayloadItemV0_82_0::Field {
+            // Same story for `Field` — the per-item `nested_comments`
+            // are flattened onto the payload-level sidecar with the
+            // field's key as the leading path segment.
+            PayloadItem::Field {
+                key, value, fill, ..
+            } => PayloadItemV0_82_0::Field {
                 key: key.clone(),
                 value: value.as_json().clone(),
                 fill: *fill,
@@ -366,7 +378,9 @@ impl TryFrom<PayloadV0_82_0> for Payload {
             .into_iter()
             .map(NestedComment::from)
             .collect();
-        Ok(Payload::from_items_with_nested(items, nested))
+        // Partition the flat wire-format sidecar onto the matching
+        // Field / Ext items (paths become relative to the owning value).
+        Ok(Payload::from_items_with_flat_nested(items, nested))
     }
 }
 
@@ -386,11 +400,15 @@ impl TryFrom<PayloadItemV0_82_0> for PayloadItem {
             }
             PayloadItemV0_82_0::Kind { value } => PayloadItem::Kind { value },
             PayloadItemV0_82_0::Id { value } => PayloadItem::Id { value },
-            PayloadItemV0_82_0::Ext { value } => PayloadItem::Ext { value },
+            PayloadItemV0_82_0::Ext { value } => PayloadItem::Ext {
+                value,
+                nested_comments: Vec::new(),
+            },
             PayloadItemV0_82_0::Field { key, value, fill } => PayloadItem::Field {
                 key,
                 value: QuillValue::from_json(value),
                 fill,
+                nested_comments: Vec::new(),
             },
             PayloadItemV0_82_0::Comment { text, inline } => PayloadItem::Comment { text, inline },
         })

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -130,9 +130,10 @@ fn emit_meta_line(out: &mut String, key: &str, value: &str, trailer: Option<&str
 
 /// Emit the `$ext: …` block. An empty map emits inline as `$ext: {}` so the
 /// declaration survives the round-trip; a non-empty map emits as a `$ext:`
-/// header followed by indented block-style children. Nested comments
-/// captured under the `$ext` key are re-injected by the child mapping
-/// walker.
+/// header followed by indented block-style children. `nested` carries
+/// comments with paths relative to the `$ext` value tree (the `$ext` key
+/// itself is not in the path) — the child mapping walker re-injects them
+/// at the matching positions.
 fn emit_ext_block(
     out: &mut String,
     value: &serde_json::Map<String, JsonValue>,
@@ -148,23 +149,23 @@ fn emit_ext_block(
     out.push_str("$ext:");
     push_trailer(out, trailer);
     out.push('\n');
-    let path = vec![CommentPathSegment::Key("$ext".to_string())];
+    let path: Vec<CommentPathSegment> = Vec::new();
     emit_mapping_children(out, value, 2, &path, nested);
 }
 
 fn emit_block(out: &mut String, card: &Card) {
     out.push_str("~~~card-yaml\n");
-    emit_payload_items(
-        out,
-        card.payload().items(),
-        card.payload().nested_comments(),
-    );
+    emit_payload_items(out, card.payload().items());
     out.push_str("~~~\n");
 }
 
 /// Walk the unified item list and emit each entry. An `inline: true` comment
 /// immediately following a non-comment item is consumed as that item's trailer.
-fn emit_payload_items(out: &mut String, items: &[PayloadItem], nested: &[NestedComment]) {
+///
+/// Each `Field` / `Ext` item carries its own `nested_comments` slice with
+/// paths relative to the field's value tree, so emission of nested
+/// structures starts with an empty container path.
+fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
     let mut i = 0;
     while i < items.len() {
         // Peek for a trailing inline comment to use as the line trailer.
@@ -184,12 +185,31 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem], nested: &[NestedC
             PayloadItem::Id { value } => {
                 emit_meta_line(out, "id", value, trailer);
             }
-            PayloadItem::Ext { value } => {
-                emit_ext_block(out, value, trailer, nested);
+            PayloadItem::Ext {
+                value,
+                nested_comments,
+            } => {
+                emit_ext_block(out, value, trailer, nested_comments);
             }
-            PayloadItem::Field { key, value, fill } => {
-                let path = vec![CommentPathSegment::Key(key.clone())];
-                emit_field(out, key, value.as_json(), 0, *fill, &path, nested, trailer);
+            PayloadItem::Field {
+                key,
+                value,
+                fill,
+                nested_comments,
+            } => {
+                // Paths in `nested_comments` are relative to this field's
+                // value, so the container path starts empty.
+                let path: Vec<CommentPathSegment> = Vec::new();
+                emit_field(
+                    out,
+                    key,
+                    value.as_json(),
+                    0,
+                    *fill,
+                    &path,
+                    nested_comments,
+                    trailer,
+                );
             }
             PayloadItem::Comment { text, .. } => {
                 out.push_str("# ");

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -94,7 +94,10 @@ pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadI
                 value: scalar_to_string(&key, value)?,
             },
             "$ext" => match value {
-                JsonValue::Object(map) => PayloadItem::Ext { value: map },
+                JsonValue::Object(map) => PayloadItem::Ext {
+                    value: map,
+                    nested_comments: Vec::new(),
+                },
                 other => {
                     return Err(ParseError::InvalidStructure(format!(
                         "Invalid `$ext` value — expected a mapping, got {}",

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -4,7 +4,8 @@
 //! YAML content. It carries — in source order, as variants of a single
 //! [`PayloadItem`] enum:
 //!
-//! - **System metadata** — typed `$quill` / `$kind` / `$id` entries.
+//! - **System metadata** — typed `$quill` / `$kind` / `$id` / `$ext`
+//!   entries.
 //! - **User fields** — `key: value` pairs with an optional `!fill` flag.
 //! - **Comments** — own-line or trailing inline, attached to whichever
 //!   item they immediately follow at emit time.
@@ -14,6 +15,16 @@
 //! line round-trips through the same mechanism as a comment adjacent to a
 //! user field. No "metadata region" vs "payload region" routing decision is
 //! ever made — there is only the source-ordered list.
+//!
+//! ## Comments at every level
+//!
+//! Top-level YAML comments (own-line and trailing inline) live as
+//! `PayloadItem::Comment` entries interleaved with fields and `$` items.
+//! Comments **inside** a structured value (mapping or sequence) live on
+//! the [`PayloadItem::Field`] / [`PayloadItem::Ext`] that owns that
+//! value, as a `nested_comments` slice with paths relative to the
+//! field's value tree. One storage surface, scoped to the item that
+//! "owns" each comment — no sidecar Vec hanging off `Payload`.
 //!
 //! ## Two faces
 //!
@@ -31,7 +42,7 @@
 use indexmap::IndexMap;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
-use super::prescan::NestedComment;
+use super::prescan::{CommentPathSegment, NestedComment};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
@@ -52,15 +63,26 @@ pub enum PayloadItem {
     /// `$ext` system metadata — an opaque mapping reserved for out-of-band
     /// extension data (UI editor state, agent annotations, …). Never
     /// emitted into the plate JSON, always round-trips through Markdown
-    /// and the storage DTO.
-    Ext { value: JsonMap<String, JsonValue> },
+    /// and the storage DTO. `nested_comments` carries YAML comments
+    /// inside the `$ext` mapping; paths are **relative** to the `$ext`
+    /// value tree (the `$ext` key itself is not part of the path).
+    Ext {
+        value: JsonMap<String, JsonValue>,
+        nested_comments: Vec<NestedComment>,
+    },
     /// A user-defined YAML field, optionally tagged `!fill`.
+    ///
+    /// `nested_comments` carries YAML comments inside the field's value
+    /// (only meaningful when the value is a mapping or sequence); paths
+    /// are **relative** to the field's value tree (the field's key is
+    /// not part of the path).
     Field {
         key: String,
         value: QuillValue,
         /// `true` when the field was written as `key: !fill <value>` or
         /// `key: !fill` in source.
         fill: bool,
+        nested_comments: Vec<NestedComment>,
     },
     /// A YAML comment. Text excludes the leading `#` and one optional space.
     ///
@@ -73,12 +95,27 @@ pub enum PayloadItem {
 }
 
 impl PayloadItem {
-    /// Build a plain (non-fill) field entry.
+    /// Build a plain (non-fill) field entry with no nested comments.
     pub fn field(key: impl Into<String>, value: QuillValue) -> Self {
         PayloadItem::Field {
             key: key.into(),
             value,
             fill: false,
+            nested_comments: Vec::new(),
+        }
+    }
+
+    /// Borrow the field/ext nested-comments slice. Returns `&[]` for
+    /// variants that don't carry nested comments.
+    pub fn nested_comments(&self) -> &[NestedComment] {
+        match self {
+            PayloadItem::Field {
+                nested_comments, ..
+            }
+            | PayloadItem::Ext {
+                nested_comments, ..
+            } => nested_comments,
+            _ => &[],
         }
     }
 
@@ -117,7 +154,6 @@ impl PayloadItem {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Payload {
     items: Vec<PayloadItem>,
-    nested_comments: Vec<NestedComment>,
 }
 
 impl Payload {
@@ -135,31 +171,105 @@ impl Payload {
                 key,
                 value,
                 fill: false,
+                nested_comments: Vec::new(),
             })
             .collect();
-        Self {
-            items,
-            nested_comments: Vec::new(),
-        }
+        Self { items }
     }
 
     /// Build from a pre-computed item list (parser and DTO entry point).
     pub fn from_items(items: Vec<PayloadItem>) -> Self {
-        Self {
-            items,
-            nested_comments: Vec::new(),
-        }
+        Self { items }
     }
 
-    /// Build from a pre-computed item list and nested comments.
-    pub fn from_items_with_nested(
-        items: Vec<PayloadItem>,
+    /// Build from a pre-computed item list plus a flat absolute-path
+    /// `nested_comments` Vec, partitioning the latter onto the matching
+    /// [`PayloadItem::Field`] / [`PayloadItem::Ext`] items.
+    ///
+    /// The first segment of each comment's `container_path` must be a
+    /// `Key(field)` matching a Field or Ext (`$ext`) entry in `items`;
+    /// that first segment is stripped and the remainder attached to the
+    /// owning item. Comments whose first segment matches nothing in
+    /// `items` are dropped silently — this can only arise from a
+    /// hand-crafted storage DTO that references a non-existent field.
+    pub(crate) fn from_items_with_flat_nested(
+        mut items: Vec<PayloadItem>,
         nested_comments: Vec<NestedComment>,
     ) -> Self {
-        Self {
-            items,
-            nested_comments,
+        for nc in nested_comments {
+            let Some((first, rest)) = nc.container_path.split_first() else {
+                // Empty path can't address any user field; drop.
+                continue;
+            };
+            let target_key = match first {
+                CommentPathSegment::Key(k) => k.clone(),
+                CommentPathSegment::Index(_) => continue,
+            };
+
+            let relative = NestedComment {
+                container_path: rest.to_vec(),
+                position: nc.position,
+                text: nc.text,
+                inline: nc.inline,
+            };
+
+            // `$ext` is encoded with the literal key "$ext" at the head of
+            // the path; everything else is a user field.
+            if target_key == "$ext" {
+                if let Some(slot) = items.iter_mut().find_map(|i| match i {
+                    PayloadItem::Ext {
+                        nested_comments, ..
+                    } => Some(nested_comments),
+                    _ => None,
+                }) {
+                    slot.push(relative);
+                }
+            } else if let Some(slot) = items.iter_mut().find_map(|i| match i {
+                PayloadItem::Field {
+                    key,
+                    nested_comments,
+                    ..
+                } if key == &target_key => Some(nested_comments),
+                _ => None,
+            }) {
+                slot.push(relative);
+            }
         }
+        Self { items }
+    }
+
+    /// Walk every Field/Ext item and yield each nested comment with its
+    /// path re-prefixed by the owning item's key (`$ext` for Ext, the
+    /// field key for Field). Used by the storage DTO conversion to
+    /// flatten the per-item storage back to the wire format's
+    /// payload-level sidecar.
+    pub(crate) fn flat_nested_comments(&self) -> Vec<NestedComment> {
+        let mut out = Vec::new();
+        for item in &self.items {
+            let (prefix, comments) = match item {
+                PayloadItem::Field {
+                    key,
+                    nested_comments,
+                    ..
+                } => (key.clone(), nested_comments),
+                PayloadItem::Ext {
+                    nested_comments, ..
+                } => ("$ext".to_string(), nested_comments),
+                _ => continue,
+            };
+            for nc in comments {
+                let mut path = Vec::with_capacity(nc.container_path.len() + 1);
+                path.push(CommentPathSegment::Key(prefix.clone()));
+                path.extend(nc.container_path.iter().cloned());
+                out.push(NestedComment {
+                    container_path: path,
+                    position: nc.position,
+                    text: nc.text.clone(),
+                    inline: nc.inline,
+                });
+            }
+        }
+        out
     }
 
     // ── Item-level access ───────────────────────────────────────────────────
@@ -170,18 +280,11 @@ impl Payload {
     }
 
     /// Mutable access to the raw item list. Callers must preserve the
-    /// invariants (at most one `Quill`/`Kind`/`Id`, no duplicate field
-    /// keys, every field name matches `[a-z_][a-z0-9_]*`) — use the
-    /// typed mutators when in doubt.
+    /// invariants (at most one `Quill`/`Kind`/`Id`/`Ext`, no duplicate
+    /// field keys, every field name matches `[a-z_][a-z0-9_]*`) — use
+    /// the typed mutators when in doubt.
     pub fn items_mut(&mut self) -> &mut [PayloadItem] {
         &mut self.items
-    }
-
-    /// Comments captured inside nested mappings/sequences. The emitter
-    /// re-injects these at the matching position when serialising the
-    /// value tree.
-    pub fn nested_comments(&self) -> &[NestedComment] {
-        &self.nested_comments
     }
 
     // ── Typed `$` access ────────────────────────────────────────────────────
@@ -214,7 +317,7 @@ impl Payload {
     /// interpret its contents and never emits them into the plate JSON.
     pub fn ext(&self) -> Option<&JsonMap<String, JsonValue>> {
         self.items.iter().find_map(|i| match i {
-            PayloadItem::Ext { value } => Some(value),
+            PayloadItem::Ext { value, .. } => Some(value),
             _ => None,
         })
     }
@@ -241,8 +344,15 @@ impl Payload {
     /// Set or replace the `$ext` entry. Same insertion rules as
     /// [`set_quill`](Self::set_quill); the canonical position is after
     /// `$quill` / `$kind` / `$id` and before any user field.
+    ///
+    /// Any nested comments previously attached to a replaced `$ext`
+    /// entry are dropped (the new value tree may not contain matching
+    /// positions).
     pub fn set_ext(&mut self, value: JsonMap<String, JsonValue>) {
-        self.upsert_meta(PayloadItem::Ext { value });
+        self.upsert_meta(PayloadItem::Ext {
+            value,
+            nested_comments: Vec::new(),
+        });
     }
 
     /// Remove the `$quill` entry, returning the previous value if any.
@@ -257,14 +367,15 @@ impl Payload {
         }
     }
 
-    /// Remove the `$ext` entry, returning the previous map if any.
+    /// Remove the `$ext` entry, returning the previous map if any. Any
+    /// nested comments attached to the entry are dropped.
     pub fn take_ext(&mut self) -> Option<JsonMap<String, JsonValue>> {
         let pos = self
             .items
             .iter()
             .position(|i| matches!(i, PayloadItem::Ext { .. }))?;
         match self.items.remove(pos) {
-            PayloadItem::Ext { value } => Some(value),
+            PayloadItem::Ext { value, .. } => Some(value),
             _ => unreachable!(),
         }
     }
@@ -355,7 +466,9 @@ impl Payload {
     /// Insert or update a user field. Always clears the `fill` marker
     /// (field is no longer a placeholder). Preserves position for existing
     /// keys; appends new keys at the end. `$` entries and comments are
-    /// untouched.
+    /// untouched. Replacing an existing field discards its
+    /// `nested_comments` because the new value tree may not contain
+    /// matching positions.
     pub fn insert(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
@@ -363,11 +476,13 @@ impl Payload {
                 key: k,
                 value: v,
                 fill,
+                nested_comments,
             } = item
             {
                 if k == &key {
                     let old = std::mem::replace(v, value);
                     *fill = false;
+                    nested_comments.clear();
                     return Some(old);
                 }
             }
@@ -376,12 +491,14 @@ impl Payload {
             key,
             value,
             fill: false,
+            nested_comments: Vec::new(),
         });
         None
     }
 
     /// Insert or update a user field and mark it as a `!fill` placeholder.
     /// Preserves position for existing keys; appends new keys at the end.
+    /// Replacing an existing field discards its `nested_comments`.
     pub fn insert_fill(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
@@ -389,11 +506,13 @@ impl Payload {
                 key: k,
                 value: v,
                 fill,
+                nested_comments,
             } = item
             {
                 if k == &key {
                     let old = std::mem::replace(v, value);
                     *fill = true;
+                    nested_comments.clear();
                     return Some(old);
                 }
             }
@@ -402,6 +521,7 @@ impl Payload {
             key,
             value,
             fill: true,
+            nested_comments: Vec::new(),
         });
         None
     }

--- a/crates/core/src/document/tests/emit_idempotence_tests.rs
+++ b/crates/core/src/document/tests/emit_idempotence_tests.rs
@@ -4,8 +4,6 @@
 //! canonicalise to the same in-memory document. This is the non-trivial
 //! consequence of byte-stable, lossless round-trips through both formats.
 
-use crate::document::Document;
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Collect all `.md` files reachable from `root`, walking recursively.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -50,7 +50,7 @@ pub const MAX_NESTING_DEPTH: usize = 100;
 /// Re-exported from [`crate::document::limits::MAX_YAML_DEPTH`].
 pub use crate::document::limits::MAX_YAML_DEPTH;
 
-/// Maximum number of CARD blocks allowed per document
+/// Maximum number of card blocks allowed per document
 pub const MAX_CARD_COUNT: usize = 1000;
 
 /// Maximum number of fields allowed per document

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -34,9 +34,6 @@ pub enum ValidationError {
     #[error("unknown card kind `{card}` at `{path}`")]
     UnknownCard { path: String, card: String },
 
-    #[error("card at `{path}` missing `CARD` discriminator")]
-    MissingCardDiscriminator { path: String },
-
     #[error(
         "card `{card}` at `{path}` has body content but the card kind declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card kind"
     )]
@@ -54,7 +51,6 @@ impl ValidationError {
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
             | ValidationError::UnknownCard { path, .. }
-            | ValidationError::MissingCardDiscriminator { path }
             | ValidationError::BodyDisabled { path, .. } => path,
         }
     }
@@ -68,9 +64,6 @@ impl ValidationError {
             ValidationError::EnumViolation { .. } => "validation::enum_violation",
             ValidationError::FormatViolation { .. } => "validation::format_violation",
             ValidationError::UnknownCard { .. } => "validation::unknown_card",
-            ValidationError::MissingCardDiscriminator { .. } => {
-                "validation::missing_card_discriminator"
-            }
             ValidationError::BodyDisabled { .. } => "validation::body_disabled",
         }
     }

--- a/docs/authoring/card-yaml.md
+++ b/docs/authoring/card-yaml.md
@@ -26,8 +26,8 @@ A card-yaml block has three parts, in order:
    string). No leading indentation. The info string alone identifies a
    metadata block.
 2. **YAML payload** — a standard YAML mapping. The reserved keys `$quill`,
-   `$kind`, and `$id` carry system metadata (see below); every other key is
-   a user-defined data field.
+   `$kind`, `$id`, and `$ext` carry system metadata (see below); every other
+   key is a user-defined data field.
 3. **Closing fence** — exactly `~~~`.
 
 The unstructured Markdown body begins immediately after the closing `~~~`
@@ -40,7 +40,7 @@ treated as an ordinary code block.
 
 ## System Metadata (`$`)
 
-The block's YAML payload may contain three reserved `$`-prefixed keys.
+The block's YAML payload may contain four reserved `$`-prefixed keys.
 After parsing, these keys are extracted from the user field set and exposed
 on the block's typed metadata.
 
@@ -53,10 +53,18 @@ on the block's typed metadata.
   `[a-z_][a-z0-9_]*` other than `main`.
 - **`$id: <value>`** is an opaque, optional identifier — plain metadata with
   no validation or uniqueness requirement, carried through the round-trip.
+- **`$ext: <mapping>`** is an opaque YAML mapping reserved for out-of-band
+  extension data — UI editor state, agent annotations, anything bespoke to a
+  consumer that should not reach the rendered output. Round-trips through
+  Markdown and the storage DTO; **never** appears in the plate JSON consumed
+  by backends. The value must be a mapping (scalars and sequences are
+  parse errors); an empty `$ext: {}` is preserved as a distinct, explicit
+  declaration.
 
 `$` metadata entries may appear anywhere in the block's payload (the
 canonical emission puts them first, in the order `$quill`, `$kind`,
-`$id`). Any other `$`-prefixed key is a parse error — the set is closed.
+`$id`, `$ext`). Any other `$`-prefixed key is a parse error — the set is
+closed.
 
 ### Version Selectors
 
@@ -139,9 +147,10 @@ YAML comments are supported in the payload and round-trip through
 title: My Document  # an inline comment
 ```
 
-Comments adjacent to a `$` metadata key (whether inline or own-line) are
-accepted by the YAML parser but **not preserved** through emit — the
-canonical form drops them.
+Comments adjacent to a `$` metadata key (whether inline trailing
+or own-line) round-trip through emit the same way comments on data fields
+do — the unified payload-item list attaches each comment to the adjacent
+item regardless of whether that item is a `$` entry or a user field.
 
 ## Placeholder Fields (`!fill`)
 
@@ -163,9 +172,9 @@ dropped with a warning.
 
 User field names match `[a-z_][a-z0-9_]*`. Uppercase, hyphens, and the
 `$` sigil are not allowed — the `$` prefix is reserved for system
-metadata that the engine projects onto the plate JSON (`$quill`,
-`$kind`, `$id`, `$body`, `$cards`). Keeping user fields lowercase
-guarantees they can never shadow that metadata.
+metadata (`$quill`, `$kind`, `$id`, `$ext`, plus the plate-JSON keys
+`$body` and `$cards`). Keeping user fields lowercase guarantees they
+can never shadow that metadata.
 
 ## Card Blocks
 
@@ -188,12 +197,14 @@ See [Cards](cards.md) for details on card syntax and usage.
 
 ## Emission
 
-`toMarkdown` always emits the canonical block form — a `~~~card-yaml` opener,
-the `$` metadata lines in the canonical order `$quill`, `$kind`, `$id`, the
-remaining data fields, and a `~~~` closer. The root block emits both
-`$quill` and `$kind: main`; composable cards emit `$kind: <kind>` plus any
-`$id` they declared. Fence markers, key ordering, and YAML quoting are
-normalised; `!fill` tags and data-field comments survive the round-trip.
+`toMarkdown` always emits the canonical block form — a `~~~card-yaml`
+opener, the `$` metadata lines in the canonical order `$quill`, `$kind`,
+`$id`, `$ext`, the remaining data fields, and a `~~~` closer. The root
+block emits both `$quill` and `$kind: main`; composable cards emit
+`$kind: <kind>` plus any `$id` / `$ext` they declared. Fence markers,
+key ordering, and YAML quoting are normalised; `!fill` tags and YAML
+comments (own-line and inline trailing, including those adjacent to `$`
+lines) survive the round-trip.
 
 The payload is coerced and validated against the schema declared in the
 Quill's `Quill.yaml` (`main.fields`). See the

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -53,9 +53,9 @@ All card blocks are collected into the plate JSON's `$cards` array.
 - A blank line is required immediately above every `~~~card-yaml` opener
   (unless the block is the very first line of the document). A `~~~card-yaml`
   line without a blank line above it is treated as an ordinary code block.
-- YAML comments adjacent to `$`-prefixed metadata keys are accepted on parse
-  but dropped from the canonical form. Comments on data fields round-trip
-  normally.
+- YAML comments round-trip through the canonical form. Own-line comments
+  and inline trailing comments are preserved on both `$` metadata lines
+  and data-field lines.
 
 The document is positional: the **first** `~~~card-yaml` block is the root
 block, and it must declare a `$quill: <name>@<version>` metadata line. Every
@@ -66,6 +66,27 @@ subsequent block is a card.
 Each card carries a `$body` value on the plate JSON containing the
 Markdown between that card's closing `~~~` fence and the next block's
 opening fence (or document end).
+
+## Out-of-band Metadata (`$ext`)
+
+A card may declare `$ext: <mapping>` — an opaque YAML map reserved for
+state that belongs with the card but should not reach the rendered
+output (UI editor renames, collapse flags, agent annotations,
+anything bespoke to a consumer). The map round-trips through Markdown
+and the storage DTO but is stripped from the plate JSON before backends
+see it, so template renders are unaffected. Consumers namespace inside
+the map (`$ext.presentation`, `$ext.agent`, …) to avoid collisions when
+more than one tool carries state on the same card.
+
+```
+~~~card-yaml
+$kind: indorsement
+$ext:
+  presentation:
+    title: "Cmdr's response"
+from: ORG/SYMBOL
+~~~
+```
 
 ## Emission
 

--- a/docs/format-designer/typst-backend.md
+++ b/docs/format-designer/typst-backend.md
@@ -54,7 +54,7 @@ Use Typst's `in` operator to check for optional fields:
 
 ### Body, arrays, and cards
 
-The document body is at `data.$body` (accessed via `data.at("$body")` because Typst identifiers exclude `$`). Arrays come through as Typst arrays. Cards live under `data.$cards`, each carrying its own `$kind` discriminator, fields, and `$body`:
+The document body is exposed under the `$body` key, accessed via `data.at("$body")` because Typst identifiers exclude `$`. Arrays come through as Typst arrays. Cards live under the `$cards` key, each carrying its own `$kind` discriminator, fields, and `$body`:
 
 ```typst
 #data.at("$body", default: "")

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -1,0 +1,50 @@
+# Bookmarks
+
+Notes on simplifications and refactors deliberately deferred. Each entry
+describes a known cleanup opportunity that isn't worth a separate
+proposal yet — a placeholder so the insight isn't lost between releases.
+
+When an entry is acted on, delete it (or promote it to a proper
+proposal in `proposals/`). When an entry has stayed here for a year
+without action and nobody can argue for it, delete it too.
+
+---
+
+## Plate JSON construction lives in one open-coded place
+
+**Where:** `Document::to_plate_json` in
+`crates/core/src/document/mod.rs:194-234`.
+
+**What:** The plate-JSON wire shape (the `$quill` / `$body` / `$cards`
++ flat user fields object) is hand-built with `serde_json::Map::insert`
+calls. After the 0.83.0 cleanup it's the **only** place in
+`quillmark-core` that produces this shape — the V0_82_0 storage DTO is
+unrelated, and the legacy synthetic `QUILL`/`CARD` discriminator
+fields are gone.
+
+**Why it might want unification:** the function is essentially a
+`From<&Document> for serde_json::Value` impl in disguise. Promoting it
+to a `From` impl (or a small dedicated type with a `Serialize` impl)
+would:
+
+- Make the contract type-level rather than positional.
+- Open the door to a typed `PlateJson` struct that backends could
+  consume directly without re-deriving the shape from `serde_json::Value`
+  lookups (cf. the Typst helper's `data.at("$cards")` /
+  `card.at("$kind")` accesses).
+- Let us share emit helpers between Document → plate-JSON and Card →
+  card-JSON without duplicating the field-loop.
+
+**Why we punted:** the shape is small (four `$` keys + a flat user
+spread) and is consumed by backend templates as opaque JSON anyway —
+turning it into a typed struct only pays off if more than one backend
+ends up needing typed access. Defer until the second canvas-capable
+backend lands, or until the `__meta__` shim in the Typst helper
+package is generalised.
+
+**Notes for the next implementer:** keep the `$`-key ordering
+(`$quill`, `$body`, `$cards`) deterministic — `to_plate_json`
+relies on `serde_json/preserve_order` and consumers may have started
+content-hashing the result. Touch `crates/backends/typst/src/lib.rs`
+(`transform_markdown_fields`) at the same time so the schema
+walker uses the same shape.

--- a/prose/README.md
+++ b/prose/README.md
@@ -8,5 +8,8 @@ Long-form project documentation, in two tiers by maturity:
   the code; it does not re-document implementation detail.
 - **`proposals/`** — fleshed-out proposed changes, not yet implemented. Each is
   a concrete plan. Removed once landed or abandoned.
+- **`BOOKMARKS.md`** — known simplifications and refactors deliberately
+  deferred. Lighter-weight than a proposal: just a placeholder so the
+  insight isn't lost between releases.
 
 Canonical docs never reference proposals or plans.

--- a/prose/canon/MARKDOWN.md
+++ b/prose/canon/MARKDOWN.md
@@ -173,7 +173,8 @@ data payload.
 
 - **Field names.** Every field name matches `/^[a-z_][a-z0-9_]*$/`. The
   pattern excludes `$` and uppercase, so a data field name can never collide
-  with the metadata sigil (`$quill`, `$kind`, `$id`, `$body`, `$cards`) and
+  with the metadata sigil (`$quill`, `$kind`, `$id`, `$ext`, `$body`,
+  `$cards`) and
   is consistently lowercase across the wire format.
 - **Whitespace-only payload.** A block whose payload (after metadata
   extraction) is only whitespace yields an empty field set.
@@ -385,8 +386,9 @@ normalised. `!fill` tags and YAML comments (own-line and inline, including
 those adjacent to `$` lines) survive the round-trip.
 
 Programmatically constructed metadata that does not have a source-order
-emits in the canonical key order `$quill`, `$kind`, `$id` — the typed
-mutators (`set_quill` / `set_kind` / `set_id`) insert at these positions.
+emits in the canonical key order `$quill`, `$kind`, `$id`, `$ext` — the
+typed mutators (`set_quill` / `set_kind` / `set_id` / `set_ext`) insert
+at these positions.
 
 ### 9.1 Canonical Idempotence
 
@@ -426,7 +428,7 @@ Parse errors include:
   `$kind: main` (which is reserved for the document root).
 - A duplicate `$key` within a single block (caught by the YAML parser as a
   duplicate mapping key).
-- An unknown `$key` outside the closed set `{quill, kind, id}`.
+- An unknown `$key` outside the closed set `{quill, kind, id, ext}`.
 - An invalid `$quill` reference.
 - A `$` metadata key whose value type is incompatible with the key.
 - A data-field name failing `/^[a-z_][a-z0-9_]*$/`.


### PR DESCRIPTION
## Summary

Refactor the storage and handling of nested YAML comments (comments inside structured values like mappings and sequences) to be attached directly to the `Field` and `Ext` items that own them, rather than kept in a separate payload-level sidecar. This simplifies the data model and makes comment ownership explicit.

## Key Changes

- **Payload item structure:** Added `nested_comments: Vec<NestedComment>` fields to both `PayloadItem::Field` and `PayloadItem::Ext` variants. Comments are now stored with paths **relative** to the owning item's value tree (the item's key is not part of the path).

- **Removed payload-level sidecar:** Deleted the `nested_comments: Vec<NestedComment>` field from the `Payload` struct itself. The unified item list now carries all comments (both top-level and nested) directly on the items they belong to.

- **Conversion methods:** 
  - Renamed `from_items_with_nested` to `from_items_with_flat_nested` and updated it to partition a flat absolute-path comment list onto matching Field/Ext items, stripping the first path segment (the field/`$ext` key).
  - Added `flat_nested_comments()` to re-flatten per-item comments back to the wire format by re-prefixing paths with the owning item's key.

- **Emission:** Updated `emit_payload_items` to pass each item's own `nested_comments` slice to child emitters (e.g., `emit_field`, `emit_ext_block`) with an empty initial container path, since paths are now relative to the value tree.

- **DTO round-trip:** Modified `From<&Payload> for PayloadV0_82_0` to call `flat_nested_comments()` when converting to the wire format, and `TryFrom<PayloadV0_82_0> for Payload` to call `from_items_with_flat_nested()` when deserializing.

- **Mutation safety:** Field and Ext mutation methods (`insert`, `insert_fill`, `set_ext`) now clear `nested_comments` when replacing values, since the new value tree may not contain matching comment positions.

## Notable Details

- The `nested_comments()` accessor method on `PayloadItem` returns the appropriate slice for Field/Ext variants and `&[]` for others, providing a uniform interface.
- Comment paths in the in-memory model are always relative to the owning item's value; absolute paths only exist in the wire format (storage DTO).
- Documentation updated to clarify that YAML comments adjacent to `$` metadata keys now round-trip the same way as comments on data fields (previously they were dropped).
- Added `BOOKMARKS.md` to track deferred simplification opportunities (e.g., unifying plate JSON construction into a single `From` impl).

https://claude.ai/code/session_0112MVFe2RaiHoJwZM3429oQ