### PR TITLE
MCP authoring-surface overhaul: cell model, uniform errors, structured diagnostics

### DIFF
--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -1689,7 +1689,7 @@ mod tests {
 
     #[test]
     fn test_table_br_tag_in_cell_is_stripped() {
-        // Per MARKDOWN.md §6.2 / §6.3, raw HTML (including <br>) produces no output.
+        // Per markdown-spec.md §6.2 / §6.3, raw HTML (including <br>) produces no output.
         let md = "| A |\n|---|\n| line1<br>line2 |";
         let out = mark_to_typst(md).unwrap();
         assert!(

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -113,6 +113,20 @@ doc.push_card({"kind": "note", "fields": {"x": 1}, "body": "..."})
 # update_card_field, remove_card_field, update_card_body, ...
 ```
 
+## Schema model
+
+A field's *cell* is inferred from whether the schema declares a `default:`:
+
+- **Must Fill** (no `default:`) — the blueprint renders `<must-fill>`
+  and validation reports `validation::required_field_absent` if the
+  field is absent at validate time, or `validation::unfilled_placeholder`
+  if the `<must-fill>` sentinel survives into the rendered document.
+- **Endorsed** (with `default:`) — the blueprint renders the default
+  value with a `; skip-ok` annotation, and the default is used when
+  the document omits the field.
+
+There is no `required:` axis on `FieldSchema`.
+
 ## Error contract
 
 A single exception type — `QuillmarkError` — is raised for every failure

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -118,8 +118,8 @@ doc.push_card({"kind": "note", "fields": {"x": 1}, "body": "..."})
 A field's *cell* is inferred from whether the schema declares a `default:`:
 
 - **Must Fill** (no `default:`) — the blueprint renders `<must-fill>`
-  and validation reports `validation::required_field_absent` if the
-  field is absent at validate time, or `validation::unfilled_placeholder`
+  and validation reports `validation::must_fill_absent` if the
+  field is absent at validate time, or `validation::must_fill_sentinel`
   if the `<must-fill>` sentinel survives into the rendered document.
 - **Endorsed** (with `default:`) — the blueprint renders the default
   value with a `; skip-ok` annotation, and the default is used when

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -3,8 +3,8 @@
 A field's *cell* is determined by whether the schema declares a `default:`.
 
 - No `default:` -> **Must Fill**: the blueprint renders `<must-fill>` and
-  validation reports ``validation::required_field_absent`` if the field
-  is absent at validate time and ``validation::unfilled_placeholder`` if
+  validation reports ``validation::must_fill_absent`` if the field
+  is absent at validate time and ``validation::must_fill_sentinel`` if
   the `<must-fill>` sentinel survives into the rendered document.
 - With `default:` -> **Endorsed**: the blueprint renders the default
   value with a ``; skip-ok`` annotation; the field is optional and the
@@ -138,9 +138,9 @@ def _diag_codes(exc):
     return [d.code for d in exc.diagnostics]
 
 
-def test_render_reports_required_field_absent(tmp_path):
+def test_render_reports_must_fill_absent(tmp_path):
     """A Must Fill field absent from the document fails validation with
-    ``validation::required_field_absent``.
+    ``validation::must_fill_absent``.
     """
     quill = make_quill(tmp_path)
     md = (
@@ -157,14 +157,14 @@ def test_render_reports_required_field_absent(tmp_path):
         quill.render(doc, OutputFormat.PDF)
 
     codes = _diag_codes(exc_info.value)
-    assert "validation::required_field_absent" in codes, (
-        f"expected validation::required_field_absent; got: {codes}"
+    assert "validation::must_fill_absent" in codes, (
+        f"expected validation::must_fill_absent; got: {codes}"
     )
 
 
-def test_render_reports_unfilled_placeholder(tmp_path):
+def test_render_reports_must_fill_sentinel(tmp_path):
     """A field whose value is still the literal `<must-fill>` sentinel
-    fails validation with ``validation::unfilled_placeholder``.
+    fails validation with ``validation::must_fill_sentinel``.
     """
     quill = make_quill(tmp_path)
     md = (
@@ -181,8 +181,8 @@ def test_render_reports_unfilled_placeholder(tmp_path):
         quill.render(doc, OutputFormat.PDF)
 
     codes = _diag_codes(exc_info.value)
-    assert "validation::unfilled_placeholder" in codes, (
-        f"expected validation::unfilled_placeholder; got: {codes}"
+    assert "validation::must_fill_sentinel" in codes, (
+        f"expected validation::must_fill_sentinel; got: {codes}"
     )
 
 
@@ -190,7 +190,10 @@ def test_render_does_not_emit_legacy_missing_required(tmp_path):
     """The legacy ``validation::missing_required`` code must be gone.
 
     Triggering the same condition (absent Must Fill field) must surface
-    the new ``validation::required_field_absent`` code instead.
+    the new ``validation::must_fill_absent`` code instead. The
+    intermediate codes ``validation::required_field_absent`` and
+    ``validation::unfilled_placeholder`` were also retired in favor of
+    ``validation::must_fill_absent`` and ``validation::must_fill_sentinel``.
     """
     quill = make_quill(tmp_path)
     md = (
@@ -208,6 +211,14 @@ def test_render_does_not_emit_legacy_missing_required(tmp_path):
     assert "validation::missing_required" not in codes, (
         "legacy code `validation::missing_required` must no longer appear; "
         f"got: {codes}"
+    )
+    assert "validation::required_field_absent" not in codes, (
+        "retired code `validation::required_field_absent` must no longer "
+        f"appear; got: {codes}"
+    )
+    assert "validation::unfilled_placeholder" not in codes, (
+        "retired code `validation::unfilled_placeholder` must no longer "
+        f"appear; got: {codes}"
     )
 
 

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -1,0 +1,231 @@
+"""Tests for the Must Fill / Endorsed schema surface.
+
+A field's *cell* is determined by whether the schema declares a `default:`.
+
+- No `default:` -> **Must Fill**: the blueprint renders `<must-fill>` and
+  validation reports ``validation::required_field_absent`` if the field
+  is absent at validate time and ``validation::unfilled_placeholder`` if
+  the `<must-fill>` sentinel survives into the rendered document.
+- With `default:` -> **Endorsed**: the blueprint renders the default
+  value with a ``; skip-ok`` annotation; the field is optional and the
+  default is used when absent.
+"""
+
+import pytest
+
+from quillmark import Document, OutputFormat, Quillmark, QuillmarkError
+
+
+QUILL_YAML_CONTENT = """quill:
+  name: py_schema_smoke
+  version: "1.0"
+  backend: typst
+  plate_file: plate.typ
+  description: Python schema/blueprint smoke test
+
+main:
+  fields:
+    title:
+      description: Document title
+      type: string
+    status:
+      description: Document status
+      type: string
+      default: draft
+    count:
+      type: integer
+"""
+
+PLATE_TYP = "Title: {{ title }} / Status: {{ status }} / Count: {{ count }}"
+
+
+def make_quill(tmp_path, yaml_content=QUILL_YAML_CONTENT, plate=PLATE_TYP):
+    quill_dir = tmp_path / "quill"
+    quill_dir.mkdir()
+    (quill_dir / "Quill.yaml").write_text(yaml_content)
+    (quill_dir / "plate.typ").write_text(plate)
+    engine = Quillmark()
+    return engine.quill_from_path(str(quill_dir))
+
+
+# ---------------------------------------------------------------------------
+# Schema surface — `required:` is gone; cells are inferred from `default:`.
+# ---------------------------------------------------------------------------
+
+def test_schema_has_no_required_key(tmp_path):
+    """The schema dict never carries a `required:` key on a field.
+
+    Cell is inferred from the presence/absence of `default:`.
+    """
+    quill = make_quill(tmp_path)
+    schema = quill.schema
+
+    fields = schema["main"]["fields"]
+    for name, field in fields.items():
+        assert "required" not in field, (
+            f"field {name!r} unexpectedly carries `required`; "
+            "the schema axis is now `default`-driven"
+        )
+
+
+def test_schema_default_marks_endorsed(tmp_path):
+    """Endorsed fields carry the `default` key; Must Fill fields don't."""
+    quill = make_quill(tmp_path)
+    fields = quill.schema["main"]["fields"]
+
+    # Must Fill: no `default`
+    assert "default" not in fields["title"], (
+        "title is Must Fill — no default should be reported"
+    )
+    assert "default" not in fields["count"], (
+        "count is Must Fill — no default should be reported"
+    )
+
+    # Endorsed: schema carries `default`
+    assert fields["status"]["default"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Blueprint surface — annotations and sentinels
+# ---------------------------------------------------------------------------
+
+def test_blueprint_must_fill_sentinel(tmp_path):
+    """Must Fill cells render the literal `<must-fill>` sentinel."""
+    quill = make_quill(tmp_path)
+    bp = quill.blueprint
+
+    # Must Fill fields carry the sentinel
+    assert "title: <must-fill>" in bp, (
+        f"expected `title: <must-fill>` in blueprint; got:\n{bp}"
+    )
+    assert "count: <must-fill>" in bp, (
+        f"expected `count: <must-fill>` in blueprint; got:\n{bp}"
+    )
+
+
+def test_blueprint_endorsed_skip_ok(tmp_path):
+    """Endorsed cells carry `; skip-ok` after the type annotation."""
+    quill = make_quill(tmp_path)
+    bp = quill.blueprint
+
+    # The Endorsed `status` field renders its default value with `; skip-ok`.
+    # The exact format is `status: draft  # string; skip-ok`.
+    assert "status: draft" in bp, f"expected default in blueprint; got:\n{bp}"
+    assert "skip-ok" in bp, (
+        f"expected `; skip-ok` annotation on Endorsed cell; got:\n{bp}"
+    )
+
+
+def test_blueprint_no_legacy_required_optional_tags(tmp_path):
+    """Old `; required` / `; optional` role tags are gone from the grammar."""
+    quill = make_quill(tmp_path)
+    bp = quill.blueprint
+
+    # The legacy role tags are dead — never emitted.
+    assert "; required" not in bp, (
+        f"legacy `; required` tag must not appear in blueprint:\n{bp}"
+    )
+    assert "; optional" not in bp, (
+        f"legacy `; optional` tag must not appear in blueprint:\n{bp}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation surface — new diagnostic codes
+# ---------------------------------------------------------------------------
+
+def _diag_codes(exc):
+    return [d.code for d in exc.diagnostics]
+
+
+def test_render_reports_required_field_absent(tmp_path):
+    """A Must Fill field absent from the document fails validation with
+    ``validation::required_field_absent``.
+    """
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "status: ready\n"          # Endorsed override
+        # title and count omitted — Must Fill, no defaults
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        quill.render(doc, OutputFormat.PDF)
+
+    codes = _diag_codes(exc_info.value)
+    assert "validation::required_field_absent" in codes, (
+        f"expected validation::required_field_absent; got: {codes}"
+    )
+
+
+def test_render_reports_unfilled_placeholder(tmp_path):
+    """A field whose value is still the literal `<must-fill>` sentinel
+    fails validation with ``validation::unfilled_placeholder``.
+    """
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "title: <must-fill>\n"      # sentinel left in place
+        "count: 1\n"
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        quill.render(doc, OutputFormat.PDF)
+
+    codes = _diag_codes(exc_info.value)
+    assert "validation::unfilled_placeholder" in codes, (
+        f"expected validation::unfilled_placeholder; got: {codes}"
+    )
+
+
+def test_render_does_not_emit_legacy_missing_required(tmp_path):
+    """The legacy ``validation::missing_required`` code must be gone.
+
+    Triggering the same condition (absent Must Fill field) must surface
+    the new ``validation::required_field_absent`` code instead.
+    """
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        quill.render(doc, OutputFormat.PDF)
+
+    codes = _diag_codes(exc_info.value)
+    assert "validation::missing_required" not in codes, (
+        "legacy code `validation::missing_required` must no longer appear; "
+        f"got: {codes}"
+    )
+
+
+def test_render_succeeds_when_must_fill_supplied(tmp_path):
+    """Filling every Must Fill field renders successfully — Endorsed
+    fields fall back to their declared default."""
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "title: Hello\n"
+        "count: 7\n"
+        # status omitted → falls back to its default "draft"
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    result = quill.render(doc, OutputFormat.PDF)
+    assert len(result.artifacts) > 0
+    assert result.artifacts[0].format == OutputFormat.PDF

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -244,6 +244,25 @@ canvas.style.height = `${result.layoutHeight}px`;
   enforcement contract and includes the resolved `backendId` for
   debugging.
 
+### Schema model
+
+A field's *cell* is inferred from whether its schema declares a `default:`:
+
+- **Must Fill** (no `default:`) — `quill.blueprint` renders `<must-fill>`
+  in the value cell, and `quill.render(doc)` throws with
+  `validation::required_field_absent` when the field is absent at
+  validate time, or `validation::unfilled_placeholder` when the
+  `<must-fill>` sentinel survives into the document.
+- **Endorsed** (with `default:`) — `quill.blueprint` renders the
+  default value followed by a `; skip-ok` annotation, and the default
+  is used when the document omits the field.
+
+`QuillFieldSchema` no longer carries a `required` axis. The legacy
+`validation::missing_required` code has been replaced by
+`validation::required_field_absent`; the new
+`validation::unfilled_placeholder` code is added for unreplaced
+sentinels.
+
 ### Errors
 
 Every method that can fail throws a JS `Error` with `.diagnostics` attached:

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -250,8 +250,8 @@ A field's *cell* is inferred from whether its schema declares a `default:`:
 
 - **Must Fill** (no `default:`) — `quill.blueprint` renders `<must-fill>`
   in the value cell, and `quill.render(doc)` throws with
-  `validation::required_field_absent` when the field is absent at
-  validate time, or `validation::unfilled_placeholder` when the
+  `validation::must_fill_absent` when the field is absent at
+  validate time, or `validation::must_fill_sentinel` when the
   `<must-fill>` sentinel survives into the document.
 - **Endorsed** (with `default:`) — `quill.blueprint` renders the
   default value followed by a `; skip-ok` annotation, and the default
@@ -259,9 +259,8 @@ A field's *cell* is inferred from whether its schema declares a `default:`:
 
 `QuillFieldSchema` no longer carries a `required` axis. The legacy
 `validation::missing_required` code has been replaced by
-`validation::required_field_absent`; the new
-`validation::unfilled_placeholder` code is added for unreplaced
-sentinels.
+`validation::must_fill_absent`; the `validation::must_fill_sentinel`
+code covers unreplaced sentinels.
 
 ### Errors
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1026,3 +1026,227 @@ title: "Hello"
     expect(quill.blankCard('does_not_exist')).toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Schema / blueprint / validation — Must Fill vs Endorsed
+// ---------------------------------------------------------------------------
+//
+// Post-mcp-feedback the schema axis is implicit: a field with a `default:` is
+// Endorsed (the rendered default is shippable as-is and the blueprint emits
+// the value + `; skip-ok` annotation); a field without a `default:` is Must
+// Fill (the blueprint emits the `<must-fill>` sentinel and validation flags
+// either the absence or the unreplaced sentinel).
+//
+// These tests pin the JS-facing contract:
+//   - `QuillFieldSchema` no longer carries a `required` axis.
+//   - `quill.blueprint` carries `<must-fill>` and `; skip-ok` annotations.
+//   - `quill.render(doc)` raises `validation::required_field_absent` when a
+//     Must Fill field is absent at validate time.
+//   - `quill.render(doc)` raises `validation::unfilled_placeholder` when the
+//     `<must-fill>` sentinel is left in.
+//   - `quill.form(doc)` flags both situations under `diagnostics`.
+
+describe('Must Fill / Endorsed schema model', () => {
+  // The plate `unwrap`s `data.title` (Must Fill) and substitutes the optional
+  // `data.subtitle` if present. Authoring a quill with both Must Fill and
+  // Endorsed fields lets us exercise both validation codes without having to
+  // ship two separate test quills.
+  const SCHEMA_QUILL_YAML = `quill:
+  name: schema_test
+  version: "1.0"
+  backend: typst
+  plate_file: plate.typ
+  description: Must Fill / Endorsed coverage
+
+main:
+  fields:
+    title:
+      type: string
+      description: Document title (Must Fill — no default)
+    subtitle:
+      type: string
+      default: "Untitled subtitle"
+      description: Document subtitle (Endorsed — default shippable)
+`
+
+  const SCHEMA_PLATE = `#import "@local/quillmark-helper:0.1.0": data
+#let title = data.title
+#let subtitle = data.at("subtitle", default: "")
+#let body = data.at("$body")
+
+= #title
+
+#subtitle
+
+#body`
+
+  const buildQuill = () => {
+    const engine = new Quillmark()
+    return engine.quill(
+      makeQuill({
+        name: 'schema_test',
+        plate: SCHEMA_PLATE,
+        quillYaml: SCHEMA_QUILL_YAML,
+      }),
+    )
+  }
+
+  it('schema fields carry no legacy `required` axis', () => {
+    const quill = buildQuill()
+    const fields = quill.schema.main.fields
+
+    expect(fields.title).toBeDefined()
+    expect(fields.subtitle).toBeDefined()
+
+    // The `required` axis was removed; cell is implied by `default:` presence.
+    expect('required' in fields.title).toBe(false)
+    expect('required' in fields.subtitle).toBe(false)
+
+    // Must Fill fields have no `default`; Endorsed fields do.
+    expect(fields.title.default).toBeUndefined()
+    expect(fields.subtitle.default).toBe('Untitled subtitle')
+  })
+
+  it('blueprint carries `<must-fill>` for Must Fill fields and `; skip-ok` for Endorsed', () => {
+    const quill = buildQuill()
+    const blueprint = quill.blueprint
+
+    expect(typeof blueprint).toBe('string')
+    expect(blueprint.length).toBeGreaterThan(0)
+
+    // Must Fill: value cell is the literal sentinel; no `; skip-ok` tag.
+    expect(blueprint).toContain('title: <must-fill>  # string')
+    expect(blueprint).not.toMatch(/title: <must-fill>.*skip-ok/)
+
+    // Endorsed: rendered default + `; skip-ok` tag. The emitter does not
+    // quote strings that don't need quoting (`Untitled subtitle` has no YAML
+    // ambiguity), so the value cell is bare.
+    expect(blueprint).toContain('subtitle: Untitled subtitle  # string; skip-ok')
+
+    // The legacy `; required` / `; optional` role tag must not appear anywhere.
+    expect(blueprint).not.toContain('; required')
+    expect(blueprint).not.toContain('; optional')
+  })
+
+  it('render throws `validation::required_field_absent` when a Must Fill field is absent', () => {
+    const quill = buildQuill()
+
+    // Document omits `title`. Schema declares no default → Must Fill.
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+subtitle: "Just a subtitle"
+~~~
+
+# Body
+`
+    const doc = Document.fromMarkdown(md)
+
+    try {
+      quill.render(doc, { format: 'svg' })
+      throw new Error('render should have thrown ValidationFailed')
+    } catch (err) {
+      expect(Array.isArray(err.diagnostics)).toBe(true)
+      const codes = err.diagnostics.map((d) => d.code)
+      expect(codes).toContain('validation::required_field_absent')
+      // The diagnostic must anchor to the offending field path.
+      const required = err.diagnostics.find(
+        (d) => d.code === 'validation::required_field_absent',
+      )
+      expect(required.path).toBe('title')
+      expect(required.severity).toBe('error')
+      // The legacy code must be gone.
+      expect(codes).not.toContain('validation::missing_required')
+    }
+  })
+
+  it('render throws `validation::unfilled_placeholder` when the `<must-fill>` sentinel is left in', () => {
+    const quill = buildQuill()
+
+    // Document supplies the literal sentinel — the LLM forgot to fill it.
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+title: <must-fill>
+~~~
+
+# Body
+`
+    const doc = Document.fromMarkdown(md)
+
+    try {
+      quill.render(doc, { format: 'svg' })
+      throw new Error('render should have thrown ValidationFailed')
+    } catch (err) {
+      expect(Array.isArray(err.diagnostics)).toBe(true)
+      const codes = err.diagnostics.map((d) => d.code)
+      expect(codes).toContain('validation::unfilled_placeholder')
+      const placeholder = err.diagnostics.find(
+        (d) => d.code === 'validation::unfilled_placeholder',
+      )
+      expect(placeholder.path).toBe('title')
+      expect(placeholder.severity).toBe('error')
+      // Hint nudges the caller toward the action they need to take.
+      expect(placeholder.hint).toBeDefined()
+      expect(placeholder.hint).toMatch(/<must-fill>/)
+    }
+  })
+
+  it('render succeeds when every Must Fill field is supplied with a real value', () => {
+    const quill = buildQuill()
+
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+title: "A Real Title"
+~~~
+
+# Body
+`
+    const doc = Document.fromMarkdown(md)
+    const result = quill.render(doc, { format: 'svg' })
+    expect(result.artifacts.length).toBeGreaterThan(0)
+  })
+
+  it('form surfaces validation diagnostics for both absent and sentinel cases', () => {
+    const quill = buildQuill()
+
+    // Case 1: `title` absent — form should flag it.
+    const mdAbsent = `~~~card-yaml
+$quill: schema_test
+$kind: main
+subtitle: "Just a subtitle"
+~~~
+`
+    const formAbsent = quill.form(Document.fromMarkdown(mdAbsent))
+    // `title` is missing in the document, and the schema declares no default,
+    // so the form view marks the value as `missing`.
+    expect(formAbsent.main.values.title.source).toBe('missing')
+    expect(formAbsent.main.values.title.default).toBeNull()
+    // The validation error surfaces under `diagnostics` (form re-codes
+    // structured validation errors as `form::validation_error`).
+    expect(formAbsent.diagnostics.length).toBeGreaterThan(0)
+    expect(
+      formAbsent.diagnostics.some(
+        (d) => d.severity === 'error' && /title/.test(d.message),
+      ),
+    ).toBe(true)
+
+    // Case 2: sentinel left in — form should also flag it.
+    const mdSentinel = `~~~card-yaml
+$quill: schema_test
+$kind: main
+title: <must-fill>
+~~~
+`
+    const formSentinel = quill.form(Document.fromMarkdown(mdSentinel))
+    // The sentinel is a literal string value, so the source is `document`.
+    expect(formSentinel.main.values.title.source).toBe('document')
+    expect(formSentinel.main.values.title.value).toBe('<must-fill>')
+    expect(
+      formSentinel.diagnostics.some(
+        (d) => d.severity === 'error' && /<must-fill>/.test(d.message),
+      ),
+    ).toBe(true)
+  })
+})

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1040,9 +1040,9 @@ title: "Hello"
 // These tests pin the JS-facing contract:
 //   - `QuillFieldSchema` no longer carries a `required` axis.
 //   - `quill.blueprint` carries `<must-fill>` and `; skip-ok` annotations.
-//   - `quill.render(doc)` raises `validation::required_field_absent` when a
+//   - `quill.render(doc)` raises `validation::must_fill_absent` when a
 //     Must Fill field is absent at validate time.
-//   - `quill.render(doc)` raises `validation::unfilled_placeholder` when the
+//   - `quill.render(doc)` raises `validation::must_fill_sentinel` when the
 //     `<must-fill>` sentinel is left in.
 //   - `quill.form(doc)` flags both situations under `diagnostics`.
 
@@ -1128,7 +1128,7 @@ main:
     expect(blueprint).not.toContain('; optional')
   })
 
-  it('render throws `validation::required_field_absent` when a Must Fill field is absent', () => {
+  it('render throws `validation::must_fill_absent` when a Must Fill field is absent', () => {
     const quill = buildQuill()
 
     // Document omits `title`. Schema declares no default → Must Fill.
@@ -1148,19 +1148,21 @@ subtitle: "Just a subtitle"
     } catch (err) {
       expect(Array.isArray(err.diagnostics)).toBe(true)
       const codes = err.diagnostics.map((d) => d.code)
-      expect(codes).toContain('validation::required_field_absent')
+      expect(codes).toContain('validation::must_fill_absent')
       // The diagnostic must anchor to the offending field path.
       const required = err.diagnostics.find(
-        (d) => d.code === 'validation::required_field_absent',
+        (d) => d.code === 'validation::must_fill_absent',
       )
       expect(required.path).toBe('title')
       expect(required.severity).toBe('error')
-      // The legacy code must be gone.
+      // The legacy codes must be gone.
       expect(codes).not.toContain('validation::missing_required')
+      expect(codes).not.toContain('validation::required_field_absent')
+      expect(codes).not.toContain('validation::unfilled_placeholder')
     }
   })
 
-  it('render throws `validation::unfilled_placeholder` when the `<must-fill>` sentinel is left in', () => {
+  it('render throws `validation::must_fill_sentinel` when the `<must-fill>` sentinel is left in', () => {
     const quill = buildQuill()
 
     // Document supplies the literal sentinel — the LLM forgot to fill it.
@@ -1180,15 +1182,15 @@ title: <must-fill>
     } catch (err) {
       expect(Array.isArray(err.diagnostics)).toBe(true)
       const codes = err.diagnostics.map((d) => d.code)
-      expect(codes).toContain('validation::unfilled_placeholder')
+      expect(codes).toContain('validation::must_fill_sentinel')
       const placeholder = err.diagnostics.find(
-        (d) => d.code === 'validation::unfilled_placeholder',
+        (d) => d.code === 'validation::must_fill_sentinel',
       )
       expect(placeholder.path).toBe('title')
       expect(placeholder.severity).toBe('error')
       // Hint nudges the caller toward the action they need to take.
       expect(placeholder.hint).toBeDefined()
-      expect(placeholder.hint).toMatch(/<must-fill>/)
+      expect(placeholder.hint).toContain('<must-fill>')
     }
   })
 
@@ -1223,12 +1225,13 @@ subtitle: "Just a subtitle"
     // so the form view marks the value as `missing`.
     expect(formAbsent.main.values.title.source).toBe('missing')
     expect(formAbsent.main.values.title.default).toBeNull()
-    // The validation error surfaces under `diagnostics` (form re-codes
-    // structured validation errors as `form::validation_error`).
+    // The validation error surfaces under `diagnostics` with its canonical
+    // `validation::*` code, path, and hint — the form view forwards the
+    // structured diagnostic verbatim.
     expect(formAbsent.diagnostics.length).toBeGreaterThan(0)
     expect(
       formAbsent.diagnostics.some(
-        (d) => d.severity === 'error' && /title/.test(d.message),
+        (d) => d.severity === 'error' && d.path === 'title',
       ),
     ).toBe(true)
 
@@ -1245,7 +1248,11 @@ title: <must-fill>
     expect(formSentinel.main.values.title.value).toBe('<must-fill>')
     expect(
       formSentinel.diagnostics.some(
-        (d) => d.severity === 'error' && /<must-fill>/.test(d.message),
+        (d) =>
+          d.severity === 'error' &&
+          d.path === 'title' &&
+          typeof d.hint === 'string' &&
+          d.hint.includes('<must-fill>'),
       ),
     ).toBe(true)
   })

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -38,7 +38,7 @@ export interface QuillCardBody {
  * is **Endorsed** (the rendered value is shippable as-is), while a field
  * without a `default` is **Must Fill** (the blueprint carries a
  * `<must-fill>` sentinel and validation reports
- * `validation::required_field_absent` if the field is absent at validate
+ * `validation::must_fill_absent` if the field is absent at validate
  * time). There is no separate `required` axis.
  */
 export interface QuillFieldSchema {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -32,13 +32,20 @@ export interface QuillCardBody {
     example?: string;
 }
 
-/** Schema entry for a single field declared in a quill's `Quill.yaml`. */
+/** Schema entry for a single field declared in a quill's `Quill.yaml`.
+ *
+ * A field's *cell* is determined by `default`: a field with a `default`
+ * is **Endorsed** (the rendered value is shippable as-is), while a field
+ * without a `default` is **Must Fill** (the blueprint carries a
+ * `<must-fill>` sentinel and validation reports
+ * `validation::required_field_absent` if the field is absent at validate
+ * time). There is no separate `required` axis.
+ */
 export interface QuillFieldSchema {
     type: "string" | "number" | "integer" | "boolean" | "array" | "object" | "date" | "datetime" | "markdown";
     description?: string;
     default?: unknown;
     example?: unknown;
-    required?: boolean;
     enum?: string[];
     ui?: QuillFieldUi;
     properties?: Record<string, QuillFieldSchema>;

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -205,36 +205,40 @@ pub(super) fn decompose_with_warnings(
         ));
     }
 
-    // The root block must declare `$kind: main`.
+    // The root block's `$kind` is `main` by position (MARKDOWN.md §3.3).
+    // An explicit `$kind: main` is accepted; an omitted `$kind` is accepted
+    // and synthesised below at the canonical position; any other value is a
+    // parse error.
     let root_kind = root_block.meta_items.iter().find_map(|m| match m {
         PayloadItem::Kind { value } => Some(value.as_str()),
         _ => None,
     });
-    match root_kind {
-        Some("main") => {}
-        Some(other) => {
+    if let Some(other) = root_kind {
+        if other != "main" {
             return Err(ParseError::InvalidStructure(format!(
-                "The document's root card-yaml block must declare `$kind: main`, \
-                 not `$kind: {}` — `main` is reserved for the document root.",
+                "The document's root card-yaml block has `$kind: {}`, but \
+                 `main` is reserved for the document root. Remove the line \
+                 (the root's kind is `main` by position) or change it to \
+                 `$kind: main`.",
                 other
             )));
         }
-        None => {
-            return Err(ParseError::InvalidStructure(
-                "The document's root card-yaml block must declare `$kind: main` \
-                 alongside `$quill:`."
-                    .to_string(),
-            ));
-        }
     }
 
-    // Build the root block's payload.
-    let main_payload = build_payload(
+    // Build the root block's payload, then synthesise `$kind: main` if the
+    // source omitted it. Using `set_kind` here inserts at the canonical
+    // position (after `$quill`, before any `$id`/`$ext`/user fields), so
+    // canonical input round-trips byte-equal and non-canonical input
+    // converges on first emit (MARKDOWN.md §9).
+    let mut main_payload = build_payload(
         &root_block.meta_items,
         &root_block.pre_items,
         &root_block.pre_nested_comments,
         &root_block.yaml_value,
     )?;
+    if main_payload.kind().is_none() {
+        main_payload.set_kind("main");
+    }
     let mut warnings = warnings;
     for w in &root_block.pre_warnings {
         warnings.push(w.clone());

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -205,7 +205,7 @@ pub(super) fn decompose_with_warnings(
         ));
     }
 
-    // The root block's `$kind` is `main` by position (MARKDOWN.md §3.3).
+    // The root block's `$kind` is `main` by position (markdown-spec.md §3.3).
     // An explicit `$kind: main` is accepted; an omitted `$kind` is accepted
     // and synthesised below at the canonical position; any other value is a
     // parse error.
@@ -229,7 +229,7 @@ pub(super) fn decompose_with_warnings(
     // source omitted it. Using `set_kind` here inserts at the canonical
     // position (after `$quill`, before any `$id`/`$ext`/user fields), so
     // canonical input round-trips byte-equal and non-canonical input
-    // converges on first emit (MARKDOWN.md §9).
+    // converges on first emit (markdown-spec.md §9).
     let mut main_payload = build_payload(
         &root_block.meta_items,
         &root_block.pre_items,

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -13,7 +13,7 @@
 //! [`Document::from_markdown`] returns errors for malformed YAML, unclosed
 //! fences, a missing root `$quill`, or unknown `$`-prefixed system keys.
 //!
-//! See [MARKDOWN.md](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/MARKDOWN.md)
+//! See [markdown-spec.md](https://github.com/quillmark-org/quillmark/blob/main/prose/references/markdown-spec.md)
 //! for the card-yaml format specification.
 
 use serde::{Deserialize, Serialize};

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -153,7 +153,10 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
                 stack.pop();
             }
 
-            let after_dash_full = if trimmed == "-" { "" } else { &trimmed[2..] };
+            // `trimmed` is either `"-"` or starts with `"- "` (case 2 guard).
+            // `strip_prefix` keeps this categorically free of byte-range
+            // slicing on user content even though `"- "` is two ASCII bytes.
+            let after_dash_full = trimmed.strip_prefix("- ").unwrap_or("");
             let (after_dash, trailing_comment) = split_trailing_comment(after_dash_full);
             let after_dash_trimmed = after_dash.trim_start();
             let inline_indent_offset = indent + 2 + (after_dash.len() - after_dash_trimmed.len());
@@ -684,6 +687,30 @@ mod tests {
                 fill: true,
             }]
         );
+    }
+
+    #[test]
+    fn sequence_with_multibyte_after_dash_does_not_panic() {
+        // En-dash (3 bytes), em-dash (3 bytes), smart quote (3 bytes), and emoji
+        // (4 bytes) appearing immediately after `- ` or as a sibling bullet
+        // marker. Earlier versions sliced `&trimmed[2..]` here; if that ever
+        // regresses to indexing inside a multi-byte codepoint, this test will
+        // panic with `"byte index 2 is not a char boundary"`.
+        let inputs = [
+            "arr:\n  - – en-dash\n  - — em-dash\n",
+            "arr:\n  - \u{2013}line\n  - \u{2014}line\n",
+            "arr:\n  - \u{201C}smart-quoted\u{201D}\n",
+            "arr:\n  - \u{1F600} emoji\n",
+            // A literal block scalar holding mixed dashes — mirrors the eval
+            // payload (`bullets: |` with `–` substituted for `-`).
+            "bullets: |\n  - (U) **A:** text\n  – (U) **B:** text\n",
+        ];
+        for input in inputs {
+            let out = prescan_fence_content(input);
+            // We don't care about the exact items; just that no panic occurred
+            // and that the cleaned YAML round-trips line count.
+            assert_eq!(out.cleaned_yaml.lines().count(), input.lines().count());
+        }
     }
 
     #[test]

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -735,6 +735,69 @@ Section 1 body.";
 }
 
 #[test]
+fn test_root_without_kind_is_accepted_and_synthesised() {
+    // MARKDOWN.md §3.3: the root's `$kind` is `main` by position. An omitted
+    // `$kind` parses successfully; the parser synthesises the entry at the
+    // canonical position so `doc.main().kind()` is always `Some("main")`
+    // and canonical emission writes `$kind: main` back out.
+    let markdown = "~~~card-yaml
+$quill: test_quill
+title: Test
+~~~
+
+Body content.";
+
+    let doc = decompose(markdown).expect("root without $kind should parse");
+    assert_eq!(doc.main().kind(), Some("main"));
+    assert_eq!(doc.main().quill().unwrap().name.as_str(), "test_quill");
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$kind: main"),
+        "canonical emission should synthesise $kind: main; got: {emitted}"
+    );
+
+    // The synthesised line lives in canonical position: after $quill, before
+    // any user field.
+    let quill_pos = emitted.find("$quill:").expect("emitted lacks $quill");
+    let kind_pos = emitted.find("$kind:").expect("emitted lacks $kind");
+    let title_pos = emitted.find("title:").expect("emitted lacks title");
+    assert!(
+        quill_pos < kind_pos && kind_pos < title_pos,
+        "canonical order is $quill < $kind < user fields; got: {emitted}"
+    );
+
+    // Round-trip the emitted form: it parses again and equals the original.
+    let reparsed = decompose(&emitted).expect("emitted form re-parses");
+    assert_eq!(doc, reparsed);
+}
+
+#[test]
+fn test_root_with_non_main_kind_is_error() {
+    // Only `$kind: main` is valid on the root. Other values still error.
+    let markdown = "~~~card-yaml
+$quill: test_quill
+$kind: other
+title: Test
+~~~";
+    let err = decompose(markdown).unwrap_err().to_string();
+    assert!(
+        err.contains("$kind: other") && err.contains("reserved for the document root"),
+        "expected non-main-root error, got: {err}"
+    );
+}
+
+#[test]
+fn test_canonical_root_with_kind_round_trips_byte_equal() {
+    // §9.1: a canonical document is a parse-emit fixed point. Adding the
+    // implicit-kind synthesis must not perturb canonical input — when
+    // `$kind: main` is already written, the emitter produces the same line.
+    let canonical = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.";
+    let doc = decompose(canonical).unwrap();
+    assert_eq!(doc.to_markdown(), canonical);
+}
+
+#[test]
 fn test_non_root_block_declaring_quill_is_error() {
     // Only the root block binds the document to a quill. A composable card
     // declaring `$quill` is a structural parse error.

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -736,7 +736,7 @@ Section 1 body.";
 
 #[test]
 fn test_root_without_kind_is_accepted_and_synthesised() {
-    // MARKDOWN.md §3.3: the root's `$kind` is `main` by position. An omitted
+    // markdown-spec.md §3.3: the root's `$kind` is `main` by position. An omitted
     // `$kind` parses successfully; the parser synthesises the entry at the
     // canonical position so `doc.main().kind()` is always `Some("main")`
     // and canonical emission writes `$kind: main` back out.
@@ -1927,7 +1927,7 @@ Body content.";
     assert_eq!(doc.main().body(), "\nBody content.");
 }
 
-/// Test the exact example from EXTENDED_MARKDOWN.md
+/// Test the exact example from markdown-spec.md
 #[test]
 fn test_spec_example() {
     let markdown = "~~~card-yaml

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -1725,7 +1725,7 @@ fn test_body_with_trailing_newlines() {
 }
 
 // ── Blank-line separator stripping: parse-side normalisation ─────────────────
-// See `assemble.rs::strip_blank_separator` and `MARKDOWN.md §4` (rule D1).
+// See `assemble.rs::strip_blank_separator` and `markdown-spec.md §4` (rule D1).
 
 #[test]
 fn test_blank_separator_strip_global_body_followed_by_card_lf() {

--- a/crates/core/src/document/tests/emit_idempotence_tests.rs
+++ b/crates/core/src/document/tests/emit_idempotence_tests.rs
@@ -22,7 +22,7 @@ fn collect_md_files(root: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
     }
 }
 
-// ── Markdown↔JSON canonical convergence (MARKDOWN.md §9.1) ────────────────────
+// ── Markdown↔JSON canonical convergence (markdown-spec.md §9.1) ──────────────
 
 /// `to_markdown(from_json(to_json(from_markdown(x)))) == to_markdown(from_markdown(x))`
 /// for every fixture: the markdown and JSON persistence paths canonicalise

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -520,7 +520,7 @@ mod tests {
     #[test]
     fn test_diagnostic_with_path() {
         let diag = Diagnostic::new(Severity::Error, "Missing field".to_string())
-            .with_code("validation::required_field_absent".to_string())
+            .with_code("validation::must_fill_absent".to_string())
             .with_path("cards.indorsement[0].signature_block".to_string());
 
         assert_eq!(

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -520,7 +520,7 @@ mod tests {
     #[test]
     fn test_diagnostic_with_path() {
         let diag = Diagnostic::new(Severity::Error, "Missing field".to_string())
-            .with_code("validation::missing_required".to_string())
+            .with_code("validation::required_field_absent".to_string())
             .with_path("cards.indorsement[0].signature_block".to_string());
 
         assert_eq!(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ## Further Reading
 //!
-//! - [MARKDOWN.md](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/MARKDOWN.md) - Quillmark Markdown parsing specification
+//! - [markdown-spec.md](https://github.com/quillmark-org/quillmark/blob/main/prose/references/markdown-spec.md) - Quillmark Markdown parsing specification
 //! - [Examples](https://github.com/quillmark-org/quillmark/tree/main/crates/core/examples) - Working examples
 
 pub mod document;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -6,7 +6,7 @@
 //!
 //! Every block is a `~~~card-yaml` fence: the root block declares
 //! `$quill: <name>@<version>` and each composable card declares
-//! `$kind: <kind>` (see `MARKDOWN.md`).
+//! `$kind: <kind>` (see `prose/references/markdown-spec.md`).
 //!
 //! Annotation grammar:
 //! - **Leading `# …` lines** carry prose: `# <description>` (single line,

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -11,15 +11,17 @@
 //! Annotation grammar:
 //! - **Leading `# …` lines** carry prose: `# <description>` (single line,
 //!   whitespace-collapsed) and `# e.g. <value>` (whenever an `example:` is
-//!   configured, regardless of role or type).
+//!   configured, regardless of cell or type).
 //! - **Inline `# …` annotation** on the value line is structural:
-//!   `# <type>[<format>]; <role>[, <extras>...]`. Type is mandatory on every
-//!   field. Format slot uses angle brackets (`array<string>`,
-//!   `date<YYYY-MM-DD>`, `enum<a | b | c>`). Role is `required` or
-//!   `optional`.
+//!   `# <type>[<format>][; skip-ok]`. Type is mandatory on every field.
+//!   Format slot uses angle brackets (`array<string>`, `date<YYYY-MM-DD>`,
+//!   `enum<a | b | c>`). The optional `; skip-ok` tag marks **Endorsed**
+//!   cells whose rendered default is shippable as-is; its absence marks
+//!   **Must Fill** cells, which carry the `<must-fill>` sentinel in the
+//!   value cell instead.
 //! - **Metadata annotation.** The `$quill` / `$kind` system-metadata lines
 //!   have no inline-annotation slot, so their role annotation
-//!   (`system metadata; required, verbatim` for the root block,
+//!   (`system metadata; verbatim` for the root block,
 //!   `composable (0..N)` for cards) is emitted as an own-line `# …` comment
 //!   directly under the `$` line.
 //! - **Body regions** are signalled by `Write main body here.` after the main
@@ -32,6 +34,7 @@
 
 use std::collections::BTreeMap;
 
+use super::validation::MUST_FILL_SENTINEL;
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::value::QuillValue;
@@ -106,7 +109,7 @@ fn write_main_fence(
     )));
     out.push('\n');
     out.push_str("$kind: main\n");
-    write_comment(out, "system metadata; required, verbatim");
+    write_comment(out, "system metadata; verbatim");
     if let Some(desc) = description {
         write_comment(out, desc);
     }
@@ -188,12 +191,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     // Markdown fields render as a YAML block scalar so multi-line content has
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
-        let inline = inline_annotation(field, false);
+        let inline = inline_annotation(field, false, None);
         write_markdown_block(out, field, &pad, &inline);
         return;
     }
 
-    let inline = format!("  # {}", inline_annotation(field, false));
+    let inline = format!("  # {}", inline_annotation(field, false, None));
     let value = field_value(field);
     write_value(out, &field.name, &value, &inline, &pad);
 }
@@ -208,7 +211,7 @@ fn write_description(out: &mut String, field: &FieldSchema, pad: &str) {
 }
 
 /// `# e.g. <value>` — emitted whenever `example:` is configured on the field.
-/// Independent of role, type, or enum-ness; examples never become rendered
+/// Independent of cell, type, or enum-ness; examples never become rendered
 /// values.
 fn write_eg_comment(out: &mut String, field: &FieldSchema, pad: &str) {
     if let Some(eg) = field.example.as_ref().map(eg_hint) {
@@ -219,8 +222,10 @@ fn write_eg_comment(out: &mut String, field: &FieldSchema, pad: &str) {
 fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline: &str) {
     out.push_str(&format!("{}{}: |-  # {}\n", pad, field.name, inline));
     let body_pad = format!("{}  ", pad);
-    // Render default content if present; otherwise leave one indented blank
-    // line so the block scalar has a body for the author to fill in.
+    // Endorsed cell with content → render the default. Endorsed cell with
+    // empty/absent string default → one indented blank line (the
+    // "skippable" markdown cell). Must Fill cell → the sentinel on one
+    // line inside the block scalar.
     let content = field.default.as_ref().and_then(|v| match v.as_json() {
         serde_json::Value::String(s) => Some(s),
         _ => None,
@@ -231,8 +236,11 @@ fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline
                 out.push_str(&format!("{}{}\n", body_pad, line));
             }
         }
-        _ => {
+        Some(_) => {
             out.push_str(&format!("{}\n", body_pad));
+        }
+        None => {
+            out.push_str(&format!("{}{}\n", body_pad, MUST_FILL_SENTINEL));
         }
     }
 }
@@ -248,10 +256,16 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
 }
 
 /// Emit a typed-table field: description + `# e.g.` line (whenever an example
-/// is configured), then the field key with its `array<object>; <role>` inline
+/// is configured), then the field key with its `array<object>` inline
 /// annotation, then either default rows or a synthetic template row. An
 /// example never renders as rows — like every other field type it surfaces
 /// only in the `# e.g.` leading line.
+///
+/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
+/// `; skip-ok` on the outer key and renders concrete rows without
+/// per-property annotations. A Must Fill container (no default) drops
+/// `; skip-ok` from the outer key (state is a leaf concern) and recurses
+/// into one synthetic row whose leaves carry their own cell signals.
 fn write_typed_table_field(
     out: &mut String,
     field: &FieldSchema,
@@ -268,7 +282,8 @@ fn write_typed_table_field(
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let inline = inline_annotation(field, true);
+    let container_endorsed = concrete_rows.is_some();
+    let inline = inline_annotation(field, true, Some(container_endorsed));
     out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete_rows {
@@ -284,10 +299,17 @@ fn write_typed_table_field(
 }
 
 /// Emit a typed-dictionary field: description + `# e.g.` line (whenever an
-/// example is configured), then the field key with its `object; <role>` inline
+/// example is configured), then the field key with its `object` inline
 /// annotation, then either a concrete mapping from `default` or per-property
 /// annotations. An example never renders as a concrete mapping — like every
 /// other field type it surfaces only in the `# e.g.` leading line.
+///
+/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
+/// `; skip-ok` on the outer key and renders a concrete block mapping
+/// without per-property annotations. A Must Fill container (no default)
+/// drops `; skip-ok` from the outer key (state is a leaf concern) and
+/// recurses into per-property annotations whose leaves carry their own
+/// cell signals.
 fn write_typed_object_field(
     out: &mut String,
     field: &FieldSchema,
@@ -304,7 +326,8 @@ fn write_typed_object_field(
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let inline = inline_annotation(field, false);
+    let container_endorsed = concrete.is_some();
+    let inline = inline_annotation(field, false, Some(container_endorsed));
     out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete {
@@ -323,16 +346,32 @@ fn write_typed_object_field(
 }
 
 /// Build the inline annotation body (without the leading `# `).
-/// `force_array_object` is `true` for typed-table outer fields, which always
-/// renders as `array<object>`; plain arrays render as `array<string>`.
-fn inline_annotation(field: &FieldSchema, force_array_object: bool) -> String {
-    let role = if field.required {
-        "required"
-    } else {
-        "optional"
-    };
+///
+/// `force_array_object` is `true` for typed-table outer fields, which
+/// always render as `array<object>`; plain arrays render as `array<string>`.
+/// `endorsed_override` short-circuits the schema-driven cell decision —
+/// it's used for the typed-table / typed-dict outer key when the container
+/// is a leaf, or for property leaves whose cell decision differs from the
+/// container.
+fn inline_annotation(
+    field: &FieldSchema,
+    force_array_object: bool,
+    endorsed_override: Option<bool>,
+) -> String {
+    let endorsed = endorsed_override.unwrap_or_else(|| is_endorsed(field));
     let type_expr = type_expression(field, force_array_object);
-    format!("{}; {}", type_expr, role)
+    if endorsed {
+        format!("{}; skip-ok", type_expr)
+    } else {
+        type_expr
+    }
+}
+
+/// A field is **Endorsed** when its schema declares a `default:`. Otherwise
+/// it is **Must Fill** and the blueprint emits a `<must-fill>` sentinel in
+/// the value cell.
+fn is_endorsed(field: &FieldSchema) -> bool {
+    field.default.is_some()
 }
 
 fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
@@ -359,8 +398,8 @@ fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
     }
 }
 
-/// The value to render for a field. Single cascade independent of role:
-/// default → first enum value → type-empty.
+/// The value to render for a field. Endorsed cells render their default;
+/// Must Fill cells render the `<must-fill>` sentinel in the value cell.
 enum FieldValue {
     Inline(String),
     Block(Vec<serde_json::Value>),
@@ -370,22 +409,10 @@ fn field_value(field: &FieldSchema) -> FieldValue {
     if let Some(v) = field.default.as_ref() {
         return json_to_value(v.as_json());
     }
-    if let Some(first) = field.enum_values.as_ref().and_then(|v| v.first()) {
-        return FieldValue::Inline(first.clone());
-    }
-    type_empty(&field.r#type)
-}
-
-fn type_empty(t: &FieldType) -> FieldValue {
-    match t {
-        FieldType::Array => FieldValue::Inline("[]".into()),
-        FieldType::Boolean => FieldValue::Inline("false".into()),
-        FieldType::Number | FieldType::Integer => FieldValue::Inline("0".into()),
-        FieldType::Date | FieldType::DateTime => FieldValue::Inline("\"\"".into()),
-        // String, markdown, object: empty string. Markdown is special-cased
-        // earlier in `write_field` and never reaches this code path.
-        _ => FieldValue::Inline("\"\"".into()),
-    }
+    // No default → Must Fill cell. The sentinel sits in the value cell
+    // regardless of declared type (markdown is special-cased earlier and
+    // never reaches this code path).
+    FieldValue::Inline(MUST_FILL_SENTINEL.to_string())
 }
 
 fn json_to_value(val: &serde_json::Value) -> FieldValue {
@@ -463,32 +490,34 @@ mod tests {
     }
 
     #[test]
-    fn required_string_renders_empty_with_required_role() {
+    fn must_fill_string_renders_sentinel_with_no_skip_ok() {
+        // No `default:` → Must Fill. Sentinel sits in the value cell; the
+        // inline annotation drops `; skip-ok`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    author: { type: string, required: true }
+    author: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("author: \"\"  # string; required\n"));
+        assert!(t.contains("author: <must-fill>  # string\n"));
     }
 
     #[test]
-    fn required_field_with_example_does_not_use_example_as_value() {
+    fn endorsed_field_with_example_does_not_use_example_as_value() {
         // Examples never render as values — they always surface in `# e.g.`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    status: { type: string, required: true, default: draft, example: final }
+    status: { type: string, default: draft, example: final }
 "#)
         .blueprint();
-        assert!(t.contains("# e.g. final\nstatus: draft  # string; required\n"));
+        assert!(t.contains("# e.g. final\nstatus: draft  # string; skip-ok\n"));
     }
 
     #[test]
-    fn optional_field_default_renders_as_value_with_eg_line() {
+    fn endorsed_empty_default_renders_value_with_skip_ok_and_eg_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -496,11 +525,11 @@ main:
     classification: { type: string, default: "", example: CONFIDENTIAL }
 "#)
         .blueprint();
-        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; optional\n"));
+        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; skip-ok\n"));
     }
 
     #[test]
-    fn optional_array_example_renders_as_flow_sequence_with_context_quoting() {
+    fn must_fill_array_example_renders_as_flow_sequence_with_context_quoting() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -514,12 +543,12 @@ main:
 "#)
         .blueprint();
         assert!(t.contains(
-            "# e.g. [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\nrecipient: []  # array<string>; optional\n"
+            "# e.g. [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\nrecipient: <must-fill>  # array<string>\n"
         ));
     }
 
     #[test]
-    fn enum_field_uses_enum_format_slot_and_no_eg() {
+    fn enum_endorsed_uses_enum_format_slot_and_no_eg() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -527,13 +556,27 @@ main:
     format: { type: string, enum: [standard, informal], default: standard }
 "#)
         .blueprint();
-        assert!(t.contains("format: standard  # enum<standard | informal>; optional\n"));
+        assert!(t.contains("format: standard  # enum<standard | informal>; skip-ok\n"));
         assert!(!t.contains("e.g."));
     }
 
     #[test]
-    fn required_array_with_example_renders_eg_only_not_value() {
-        // Plain (non-typed-table) required arrays render type-empty; the
+    fn enum_must_fill_renders_sentinel_in_value_cell() {
+        // An enum field with no `default:` renders `<must-fill>` rather than
+        // the first enum value — the cell is Must Fill regardless.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    severity: { type: string, enum: [low, medium, high] }
+"#)
+        .blueprint();
+        assert!(t.contains("severity: <must-fill>  # enum<low | medium | high>\n"));
+    }
+
+    #[test]
+    fn must_fill_array_with_example_renders_eg_only_not_value() {
+        // Plain (non-typed-table) Must Fill arrays render the sentinel; the
         // example surfaces in the leading `# e.g.` line.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -541,14 +584,13 @@ main:
   fields:
     memo_from:
       type: array
-      required: true
       example:
         - ORG/SYMBOL
         - City ST 12345
 "#)
         .blueprint();
         assert!(t.contains(
-            "# e.g. [ORG/SYMBOL, City ST 12345]\nmemo_from: []  # array<string>; required\n"
+            "# e.g. [ORG/SYMBOL, City ST 12345]\nmemo_from: <must-fill>  # array<string>\n"
         ));
     }
 
@@ -560,15 +602,16 @@ main:
   fields:
     subject:
       type: string
-      required: true
       description: Be brief and clear.
 "#)
         .blueprint();
-        assert!(t.contains("# Be brief and clear.\nsubject: \"\"  # string; required\n"));
+        assert!(t.contains("# Be brief and clear.\nsubject: <must-fill>  # string\n"));
     }
 
     #[test]
-    fn every_field_carries_inline_type_and_role() {
+    fn every_field_carries_inline_type_and_cell_signal() {
+        // Endorsed cells carry `; skip-ok`; Must Fill cells carry the
+        // sentinel in the value cell and drop the tag.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -578,19 +621,19 @@ main:
     flag: { type: boolean, default: false }
     issued: { type: date }
     published: { type: datetime }
-    refs: { type: array }
+    refs: { type: array, default: [] }
 "#)
         .blueprint();
-        assert!(t.contains("title: \"\"  # string; optional\n"));
-        assert!(t.contains("size: 11  # number; optional\n"));
-        assert!(t.contains("flag: false  # boolean; optional\n"));
-        assert!(t.contains("issued: \"\"  # date<YYYY-MM-DD>; optional\n"));
-        assert!(t.contains("published: \"\"  # datetime<ISO 8601>; optional\n"));
-        assert!(t.contains("refs: []  # array<string>; optional\n"));
+        assert!(t.contains("title: <must-fill>  # string\n"));
+        assert!(t.contains("size: 11  # number; skip-ok\n"));
+        assert!(t.contains("flag: false  # boolean; skip-ok\n"));
+        assert!(t.contains("issued: <must-fill>  # date<YYYY-MM-DD>\n"));
+        assert!(t.contains("published: <must-fill>  # datetime<ISO 8601>\n"));
+        assert!(t.contains("refs: []  # array<string>; skip-ok\n"));
     }
 
     #[test]
-    fn markdown_field_renders_as_block_scalar() {
+    fn must_fill_markdown_renders_sentinel_inside_block_scalar() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -598,11 +641,24 @@ main:
     bio: { type: markdown }
 "#)
         .blueprint();
-        assert!(t.contains("bio: |-  # markdown; optional\n  \n"));
+        assert!(t.contains("bio: |-  # markdown\n  <must-fill>\n"));
     }
 
     #[test]
-    fn markdown_field_with_default_fills_block() {
+    fn endorsed_empty_markdown_renders_blank_line_with_skip_ok() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown, default: "" }
+"#)
+        .blueprint();
+        assert!(t.contains("bio: |-  # markdown; skip-ok\n  \n"));
+        assert!(!t.contains("<must-fill>"));
+    }
+
+    #[test]
+    fn endorsed_markdown_default_fills_block() {
         let t = cfg(r###"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -612,11 +668,11 @@ main:
       default: "## About me\n\nHello."
 "###)
         .blueprint();
-        assert!(t.contains("bio: |-  # markdown; optional\n  ## About me\n  \n  Hello.\n"));
+        assert!(t.contains("bio: |-  # markdown; skip-ok\n  ## About me\n  \n  Hello.\n"));
     }
 
     #[test]
-    fn quill_metadata_line_is_required_verbatim() {
+    fn quill_metadata_line_is_verbatim() {
         let t = cfg(r#"
 quill: { name: taro, version: 0.1.0, backend: typst, description: x }
 main:
@@ -625,7 +681,7 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with(
-            "~~~card-yaml\n$quill: taro@0.1.0\n$kind: main\n# system metadata; required, verbatim\n# x\n"
+            "~~~card-yaml\n$quill: taro@0.1.0\n$kind: main\n# system metadata; verbatim\n# x\n"
         ));
         assert!(t.contains("\nWrite main body here.\n"));
     }
@@ -660,7 +716,7 @@ card_kinds:
   skills:
     body: { enabled: false }
     fields:
-      items: { type: array, required: true }
+      items: { type: array }
 "#)
         .blueprint();
         let after = &t[t.find("$kind: skills").unwrap()..];
@@ -724,8 +780,8 @@ card_kinds:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    memo_for: { type: array, required: true, ui: { group: Addressing } }
-    subject: { type: string, required: true, ui: { group: Addressing } }
+    memo_for: { type: array, ui: { group: Addressing } }
+    subject: { type: string, ui: { group: Addressing } }
     letterhead_title: { type: string, default: HQ, ui: { group: Letterhead } }
     notes: { type: string }
 "#)
@@ -742,7 +798,9 @@ main:
     }
 
     #[test]
-    fn typed_table_emits_synthetic_row_when_no_example() {
+    fn typed_table_must_fill_emits_synthetic_row_with_leaf_sentinels() {
+        // Must Fill container → outer key has no `; skip-ok` (state is a
+        // leaf concern). Property leaves carry their own cell signals.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -751,13 +809,13 @@ main:
       type: array
       description: Cited works.
       properties:
-        org: { type: string, required: true, description: Citing organization. }
-        year: { type: integer, description: Publication year. }
+        org: { type: string, description: Citing organization. }
+        year: { type: integer, default: 0, description: Publication year. }
 "#)
         .blueprint();
-        assert!(t.contains("# Cited works.\nreferences:  # array<object>; optional\n  -\n"));
-        assert!(t.contains("    # Citing organization.\n    org: \"\"  # string; required\n"));
-        assert!(t.contains("    # Publication year.\n    year: 0  # integer; optional\n"));
+        assert!(t.contains("# Cited works.\nreferences:  # array<object>\n  -\n"));
+        assert!(t.contains("    # Citing organization.\n    org: <must-fill>  # string\n"));
+        assert!(t.contains("    # Publication year.\n    year: 0  # integer; skip-ok\n"));
     }
 
     #[test]
@@ -773,18 +831,18 @@ main:
       example:
         - { org: ACME, year: 2020 }
       properties:
-        org: { type: string, required: true }
-        year: { type: integer }
+        org: { type: string }
+        year: { type: integer, default: 0 }
 "#)
         .blueprint();
         assert!(t.contains("# e.g. [{org: ACME, year: 2020}]\n"));
-        assert!(t.contains("refs:  # array<object>; optional\n  -\n"));
-        assert!(t.contains("    org: \"\"  # string; required\n"));
-        assert!(t.contains("    year: 0  # integer; optional\n"));
+        assert!(t.contains("refs:  # array<object>\n  -\n"));
+        assert!(t.contains("    org: <must-fill>  # string\n"));
+        assert!(t.contains("    year: 0  # integer; skip-ok\n"));
     }
 
     #[test]
-    fn typed_table_with_default_renders_default_rows() {
+    fn typed_table_endorsed_renders_default_rows_with_skip_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -794,15 +852,18 @@ main:
       default:
         - { org: ACME }
       properties:
-        org: { type: string, required: true }
+        org: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("refs:  # array<object>; optional\n  - org: ACME\n"));
-        assert!(!t.contains("refs:  # array<object>; optional\n  -\n"));
+        assert!(t.contains("refs:  # array<object>; skip-ok\n  - org: ACME\n"));
+        assert!(!t.contains("refs:  # array<object>; skip-ok\n  -\n"));
     }
 
     #[test]
     fn typed_table_with_empty_default_falls_through_to_synthetic_row() {
+        // An empty default array is treated like a Must Fill container
+        // for rendering purposes (we need a synthetic row to show the
+        // shape), and the outer key drops `; skip-ok`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -811,16 +872,18 @@ main:
       type: array
       default: []
       properties:
-        org: { type: string, required: true }
+        org: { type: string }
 "#)
         .blueprint();
         assert!(t.contains(
-            "refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"
+            "refs:  # array<object>\n  -\n    org: <must-fill>  # string\n"
         ));
     }
 
     #[test]
-    fn typed_dict_emits_per_property_annotations() {
+    fn typed_dict_must_fill_emits_per_property_annotations() {
+        // Must Fill container → outer key has no `; skip-ok`; per-property
+        // recursion with leaf cell signals.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -829,35 +892,19 @@ main:
       type: object
       description: Mailing address.
       properties:
-        street: { type: string, required: true, description: Street line. }
-        city:   { type: string, required: true }
-        zip:    { type: string }
+        street: { type: string, description: Street line. }
+        city:   { type: string }
+        zip:    { type: string, default: "" }
 "#)
         .blueprint();
-        assert!(t.contains("# Mailing address.\naddress:  # object; optional\n"));
-        assert!(t.contains("  # Street line.\n  street: \"\"  # string; required\n"));
-        assert!(t.contains("  city: \"\"  # string; required\n"));
-        assert!(t.contains("  zip: \"\"  # string; optional\n"));
+        assert!(t.contains("# Mailing address.\naddress:  # object\n"));
+        assert!(t.contains("  # Street line.\n  street: <must-fill>  # string\n"));
+        assert!(t.contains("  city: <must-fill>  # string\n"));
+        assert!(t.contains("  zip: \"\"  # string; skip-ok\n"));
     }
 
     #[test]
-    fn typed_dict_required_carries_role() {
-        let t = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    address:
-      type: object
-      required: true
-      properties:
-        street: { type: string, required: true }
-"#)
-        .blueprint();
-        assert!(t.contains("address:  # object; required\n"));
-    }
-
-    #[test]
-    fn typed_dict_with_default_renders_block_mapping_no_annotations() {
+    fn typed_dict_endorsed_renders_block_mapping_with_skip_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -866,18 +913,18 @@ main:
       type: object
       default: { street: "5000 Forbes Ave", city: Pittsburgh }
       properties:
-        street: { type: string, required: true }
-        city:   { type: string, required: true }
+        street: { type: string }
+        city:   { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("address:  # object; optional\n"));
+        assert!(t.contains("address:  # object; skip-ok\n"));
         assert!(
             t.contains("  street: 5000 Forbes Ave\n")
                 || t.contains("  street: \"5000 Forbes Ave\"\n")
         );
         assert!(t.contains("  city: Pittsburgh\n"));
         // No per-property annotations when concrete values are present.
-        assert!(!t.contains("# string; required"));
+        assert!(!t.contains("# string"));
     }
 
     #[test]
@@ -892,17 +939,17 @@ main:
       type: object
       example: { street: "1 Infinite Loop", city: Cupertino }
       properties:
-        street: { type: string, required: true }
-        city:   { type: string }
+        street: { type: string }
+        city:   { type: string, default: "" }
 "#)
         .blueprint();
-        assert!(t.contains("address:  # object; optional\n"));
+        assert!(t.contains("address:  # object\n"));
         assert!(
             t.contains("# e.g. {street: 1 Infinite Loop, city: Cupertino}\n")
                 || t.contains("# e.g. {city: Cupertino, street: 1 Infinite Loop}\n")
         );
-        assert!(t.contains("  street: \"\"  # string; required\n"));
-        assert!(t.contains("  city: \"\"  # string; optional\n"));
+        assert!(t.contains("  street: <must-fill>  # string\n"));
+        assert!(t.contains("  city: \"\"  # string; skip-ok\n"));
     }
 
     const LETTER_QUILL: &str = r#"
@@ -911,11 +958,9 @@ main:
   fields:
     to:
       type: string
-      required: true
       description: Recipient name.
     subject:
       type: string
-      required: true
     date:
       type: date
     priority:
@@ -924,13 +969,14 @@ main:
       default: normal
     attachments:
       type: array
+      default: []
       example:
         - report.pdf
 card_kinds:
   enclosure:
     description: An enclosure attached to the letter.
     fields:
-      label: { type: string, required: true }
+      label: { type: string }
       pages: { type: integer, default: 1 }
 "#;
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -191,12 +191,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     // Markdown fields render as a YAML block scalar so multi-line content has
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
-        let inline = inline_annotation(field, false, None);
+        let inline = inline_annotation(field, false, field.default.is_some());
         write_markdown_block(out, field, &pad, &inline);
         return;
     }
 
-    let inline = format!("  # {}", inline_annotation(field, false, None));
+    let inline = format!("  # {}", inline_annotation(field, false, field.default.is_some()));
     let value = field_value(field);
     write_value(out, &field.name, &value, &inline, &pad);
 }
@@ -255,17 +255,19 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
     v
 }
 
-/// Emit a typed-table field: description + `# e.g.` line (whenever an example
-/// is configured), then the field key with its `array<object>` inline
-/// annotation, then either default rows or a synthetic template row. An
-/// example never renders as rows — like every other field type it surfaces
-/// only in the `# e.g.` leading line.
+/// Emit a typed-table field: description + `# e.g.` line (whenever an
+/// example is configured), then the field key with its `array<object>`
+/// inline annotation, then either the declared default or a synthetic
+/// template row. An example never renders as rows — like every other
+/// field type it surfaces only in the `# e.g.` leading line.
 ///
-/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
-/// `; skip-ok` on the outer key and renders concrete rows without
-/// per-property annotations. A Must Fill container (no default) drops
-/// `; skip-ok` from the outer key (state is a leaf concern) and recurses
-/// into one synthetic row whose leaves carry their own cell signals.
+/// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
+/// — the outer key carries `; skip-ok` and the rendered value is the
+/// default (rows for `default: [...]`, inline `[]` for `default: []`). A
+/// field without a `default:` is Must Fill — the outer key drops
+/// `; skip-ok` and one synthetic row is emitted with leaf-level sentinels.
+/// See `prose/BOOKMARKS.md` "Typed container empty default loses inline
+/// shape documentation" for the rendering-vs-symmetry trade-off.
 fn write_typed_table_field(
     out: &mut String,
     field: &FieldSchema,
@@ -274,21 +276,26 @@ fn write_typed_table_field(
 ) {
     let pad = "  ".repeat(indent);
 
-    let concrete_rows = field.default.as_ref().and_then(|v| match v.as_json() {
-        serde_json::Value::Array(items) if !items.is_empty() => Some(items.clone()),
+    let default_items = field.default.as_ref().and_then(|v| match v.as_json() {
+        serde_json::Value::Array(items) => Some(items.clone()),
         _ => None,
     });
 
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let container_endorsed = concrete_rows.is_some();
-    let inline = inline_annotation(field, true, Some(container_endorsed));
-    out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+    let inline = inline_annotation(field, true, default_items.is_some());
 
-    match concrete_rows {
-        Some(items) => write_array_items(out, &items, &pad),
+    match default_items {
+        Some(items) if items.is_empty() => {
+            out.push_str(&format!("{}{}: []  # {}\n", pad, field.name, inline));
+        }
+        Some(items) => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+            write_array_items(out, &items, &pad);
+        }
         None => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             let dash_pad = "  ".repeat(indent + 1);
             out.push_str(&format!("{}-\n", dash_pad));
             for prop in sort_props(item_props) {
@@ -300,16 +307,16 @@ fn write_typed_table_field(
 
 /// Emit a typed-dictionary field: description + `# e.g.` line (whenever an
 /// example is configured), then the field key with its `object` inline
-/// annotation, then either a concrete mapping from `default` or per-property
-/// annotations. An example never renders as a concrete mapping — like every
-/// other field type it surfaces only in the `# e.g.` leading line.
+/// annotation, then either the declared default or per-property
+/// annotations. An example never renders as a concrete mapping — like
+/// every other field type it surfaces only in the `# e.g.` leading line.
 ///
-/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
-/// `; skip-ok` on the outer key and renders a concrete block mapping
-/// without per-property annotations. A Must Fill container (no default)
-/// drops `; skip-ok` from the outer key (state is a leaf concern) and
-/// recurses into per-property annotations whose leaves carry their own
-/// cell signals.
+/// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
+/// — the outer key carries `; skip-ok` and the rendered value is the
+/// default (a block mapping for non-empty, inline `{}` for `default: {}`).
+/// A field without a `default:` is Must Fill — per-property recursion with
+/// leaf-level sentinels. See `prose/BOOKMARKS.md` "Typed container empty
+/// default loses inline shape documentation" for the trade-off.
 fn write_typed_object_field(
     out: &mut String,
     field: &FieldSchema,
@@ -318,26 +325,29 @@ fn write_typed_object_field(
 ) {
     let pad = "  ".repeat(indent);
 
-    let concrete = field.default.as_ref().and_then(|v| match v.as_json() {
-        serde_json::Value::Object(map) if !map.is_empty() => Some(map.clone()),
+    let default_map = field.default.as_ref().and_then(|v| match v.as_json() {
+        serde_json::Value::Object(map) => Some(map.clone()),
         _ => None,
     });
 
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let container_endorsed = concrete.is_some();
-    let inline = inline_annotation(field, false, Some(container_endorsed));
-    out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+    let inline = inline_annotation(field, false, default_map.is_some());
 
-    match concrete {
+    match default_map {
+        Some(map) if map.is_empty() => {
+            out.push_str(&format!("{}{}: {{}}  # {}\n", pad, field.name, inline));
+        }
         Some(map) => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             let inner_pad = format!("{}  ", pad);
             for (k, v) in &map {
                 out.push_str(&format!("{}{}: {}\n", inner_pad, k, render_scalar(v)));
             }
         }
         None => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             for prop in sort_props(props) {
                 write_field(out, prop, indent + 1);
             }
@@ -349,29 +359,15 @@ fn write_typed_object_field(
 ///
 /// `force_array_object` is `true` for typed-table outer fields, which
 /// always render as `array<object>`; plain arrays render as `array<string>`.
-/// `endorsed_override` short-circuits the schema-driven cell decision —
-/// it's used for the typed-table / typed-dict outer key when the container
-/// is a leaf, or for property leaves whose cell decision differs from the
-/// container.
-fn inline_annotation(
-    field: &FieldSchema,
-    force_array_object: bool,
-    endorsed_override: Option<bool>,
-) -> String {
-    let endorsed = endorsed_override.unwrap_or_else(|| is_endorsed(field));
+/// `endorsed` is uniformly `field.default.is_some()` — any `default:`
+/// (including type-empty `""`, `[]`, `{}`) means the cell is shippable.
+fn inline_annotation(field: &FieldSchema, force_array_object: bool, endorsed: bool) -> String {
     let type_expr = type_expression(field, force_array_object);
     if endorsed {
         format!("{}; skip-ok", type_expr)
     } else {
         type_expr
     }
-}
-
-/// A field is **Endorsed** when its schema declares a `default:`. Otherwise
-/// it is **Must Fill** and the blueprint emits a `<must-fill>` sentinel in
-/// the value cell.
-fn is_endorsed(field: &FieldSchema) -> bool {
-    field.default.is_some()
 }
 
 fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
@@ -860,10 +856,11 @@ main:
     }
 
     #[test]
-    fn typed_table_with_empty_default_falls_through_to_synthetic_row() {
-        // An empty default array is treated like a Must Fill container
-        // for rendering purposes (we need a synthetic row to show the
-        // shape), and the outer key drops `; skip-ok`.
+    fn typed_table_with_empty_default_renders_inline_and_skip_ok() {
+        // `default: []` means shippable as-is — the outer cell carries
+        // `; skip-ok` uniformly with scalar cells and the value renders
+        // inline as `[]`. Inline row shape under an empty default belongs
+        // in `example:`; see prose/BOOKMARKS.md.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -875,9 +872,33 @@ main:
         org: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains(
-            "refs:  # array<object>\n  -\n    org: <must-fill>  # string\n"
-        ));
+        assert!(
+            t.contains("refs: []  # array<object>; skip-ok\n"),
+            "wrong rendering: {t}"
+        );
+        assert!(!t.contains("<must-fill>"), "no sentinels expected: {t}");
+    }
+
+    #[test]
+    fn typed_dict_with_empty_default_renders_inline_and_skip_ok() {
+        // Same uniform rule as typed tables: `default: {}` is Endorsed and
+        // renders inline as `{}` with `; skip-ok`.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      default: {}
+      properties:
+        street: { type: string }
+"#)
+        .blueprint();
+        assert!(
+            t.contains("address: {}  # object; skip-ok\n"),
+            "wrong rendering: {t}"
+        );
+        assert!(!t.contains("<must-fill>"), "no sentinels expected: {t}");
     }
 
     #[test]

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -163,6 +163,23 @@ impl QuillConfig {
         use super::FieldType;
 
         let json_value = value.as_json();
+
+        // Sentinel pass-through: the literal `<must-fill>` string survives
+        // coercion unchanged so the validation layer can surface a
+        // placeholder diagnostic instead of a type-coercion error. For
+        // markdown the sentinel sits inside the block scalar, which already
+        // decodes as a string, so the same comparison covers both cases.
+        if let Some(s) = json_value.as_str() {
+            let candidate = if matches!(field_schema.r#type, FieldType::Markdown) {
+                s.trim()
+            } else {
+                s
+            };
+            if candidate == super::validation::MUST_FILL_SENTINEL {
+                return Ok(value.clone());
+            }
+        }
+
         match field_schema.r#type {
             FieldType::Array => {
                 let arr = if let Some(a) = json_value.as_array() {

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -164,7 +164,7 @@ main:
     refs:
       type: array
       properties:
-        org: { type: string, required: true }
+        org: { type: string }
         year: { type: integer }
 "#;
         let schema = build_from_yaml(yaml);
@@ -189,7 +189,7 @@ main:
     address:
       type: object
       properties:
-        street: { type: string, required: true }
+        street: { type: string }
         city: { type: string }
 "#;
         let schema = build_from_yaml(yaml);

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1176,7 +1176,6 @@ card_kinds:
       name:
         type: string
         description: Name of the endorsing official
-        required: true
       org:
         type: string
         description: Endorser's organization
@@ -1197,7 +1196,8 @@ card_kinds:
 
     let name_field = card.fields.get("name").unwrap();
     assert_eq!(name_field.r#type, FieldType::String);
-    assert!(name_field.required);
+    // Must Fill: no default declared.
+    assert!(name_field.default.is_none());
 
     let org_field = card.fields.get("org").unwrap();
     assert_eq!(org_field.r#type, FieldType::String);
@@ -1471,10 +1471,8 @@ main:
       properties:
         street:
           type: string
-          required: true
         city:
           type: string
-          required: true
 "#;
 
     let (config, warnings) = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap();
@@ -2262,7 +2260,7 @@ card_kinds:
       enabled: false
       example: This example is unused
     fields:
-      items: { type: array, required: true }
+      items: { type: array }
 "#;
     let (_config, warnings) = QuillConfig::from_yaml_with_warnings(yaml).unwrap();
     assert!(

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -5,9 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::value::QuillValue;
 
-fn is_false(value: &bool) -> bool {
-    !*value
-}
 /// Semantic constants for field schema keys used in parsing and JSON Schema generation.
 /// Using constants provides IDE support (find references, autocomplete) and ensures
 /// consistency between parsing and output.
@@ -17,7 +14,6 @@ pub mod field_key {
     pub const DEFAULT: &str = "default";
     pub const EXAMPLE: &str = "example";
     pub const UI: &str = "ui";
-    pub const REQUIRED: &str = "required";
     pub const ENUM: &str = "enum";
     pub const FORMAT: &str = "format";
 }
@@ -156,7 +152,14 @@ impl FieldType {
     }
 }
 
-/// Schema definition for a template field
+/// Schema definition for a template field.
+///
+/// A field's *cell* is determined by `default`: a field with a `default:`
+/// is **Endorsed** (the rendered value is shippable as-is), while a field
+/// without a `default:` is **Must Fill** (the blueprint carries a
+/// `<must-fill>` sentinel and validation reports
+/// `validation::required_field_absent` if the field is missing at
+/// validate time). There is no separate `required:` axis.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FieldSchema {
     /// The map key carries this on the wire; skipped during serialization to avoid duplication.
@@ -172,9 +175,6 @@ pub struct FieldSchema {
     pub example: Option<QuillValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiFieldSchema>,
-    /// Fields are optional by default.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub required: bool,
     /// Restricts valid values on string fields.
     #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<String>>,
@@ -191,8 +191,6 @@ struct FieldSchemaDef {
     pub default: Option<QuillValue>,
     pub example: Option<QuillValue>,
     pub ui: Option<UiFieldSchema>,
-    #[serde(default)]
-    pub required: bool,
     #[serde(rename = "enum")]
     pub enum_values: Option<Vec<String>>,
     // Nested schema support
@@ -208,7 +206,6 @@ impl FieldSchema {
             default: None,
             example: None,
             ui: None,
-            required: false,
             enum_values: None,
             properties: None,
         }
@@ -224,7 +221,6 @@ impl FieldSchema {
             default: def.default,
             example: def.example,
             ui: def.ui,
-            required: def.required,
             enum_values: def.enum_values,
             properties: if let Some(props) = def.properties {
                 let mut p = BTreeMap::new();

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -158,7 +158,7 @@ impl FieldType {
 /// is **Endorsed** (the rendered value is shippable as-is), while a field
 /// without a `default:` is **Must Fill** (the blueprint carries a
 /// `<must-fill>` sentinel and validation reports
-/// `validation::required_field_absent` if the field is missing at
+/// `validation::must_fill_absent` if the field is missing at
 /// validate time). There is no separate `required:` axis.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FieldSchema {

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -10,46 +10,183 @@ use crate::value::QuillValue;
 
 /// Literal sentinel string the blueprint emitter writes into the value
 /// cell of every Must Fill field. Validation detects unreplaced sentinels
-/// and reports `validation::unfilled_placeholder`.
+/// and reports `validation::unfilled_placeholder` under the uniform
+/// validation message contract (see `ERROR.md`).
 pub const MUST_FILL_SENTINEL: &str = "<must-fill>";
 
 /// Validation error with a structured field path.
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+///
+/// Field-level type and presence errors (`RequiredFieldAbsent`,
+/// `UnfilledPlaceholder`, `TypeMismatch`) carry the field path, the
+/// verbatim YAML source token, the schema-declared type, and any default
+/// — enough for the `Display` impl to render the uniform diagnostic
+/// message described in `ERROR.md` ("Validation message contract"). The
+/// spinoff proposal's cross-reference clause retrofits the placeholder
+/// error to the uniform shape, so `RequiredFieldAbsent` and
+/// `UnfilledPlaceholder` both carry an `expected` slot for the
+/// declared-type line of the message.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
-    #[error(
-        "field `{path}` has no value and the schema declares no default; supply a value before shipping"
-    )]
-    RequiredFieldAbsent { path: String },
-
-    #[error(
-        "field `{path}` still carries the `<must-fill>` blueprint sentinel; replace it with a value of the declared type"
-    )]
-    UnfilledPlaceholder { path: String },
-
-    #[error("field `{path}` has type `{actual}`, expected `{expected}`")]
-    TypeMismatch {
+    /// A Must Fill field (no `default:`) is absent from the document.
+    RequiredFieldAbsent {
         path: String,
+        /// Schema-declared type (`string`, `integer`, …).
         expected: String,
-        actual: String,
     },
 
-    #[error("field `{path}` value `{value}` not in allowed set {allowed:?}")]
+    /// The blueprint sentinel `<must-fill>` survived into the document
+    /// and reached validation. Treated under the uniform format with
+    /// `<must-fill>` as the source token.
+    UnfilledPlaceholder {
+        path: String,
+        /// Schema-declared type (`string`, `integer`, …).
+        expected: String,
+    },
+
+    TypeMismatch {
+        path: String,
+        /// Schema-declared type (`string`, `integer`, …).
+        expected: String,
+        /// YAML-parsed type of the source token (`integer`, `number`,
+        /// `boolean`, `null`, `string`, `array`, `object`).
+        actual: String,
+        /// Verbatim YAML scalar that triggered the error, rendered in
+        /// its canonical YAML form (`42`, `null`, `"hello"`, `""`).
+        source_token: String,
+        /// Pre-rendered default token from the schema, when present.
+        /// Same canonical YAML form as `source_token`.
+        default: Option<String>,
+    },
+
     EnumViolation {
         path: String,
         value: String,
         allowed: Vec<String>,
     },
 
-    #[error("field `{path}` does not match expected format `{format}`")]
-    FormatViolation { path: String, format: String },
+    FormatViolation {
+        path: String,
+        format: String,
+    },
 
-    #[error("unknown card kind `{card}` at `{path}`")]
-    UnknownCard { path: String, card: String },
+    UnknownCard {
+        path: String,
+        card: String,
+    },
 
-    #[error(
-        "card `{card}` at `{path}` has body content but the card kind declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card kind"
-    )]
-    BodyDisabled { path: String, card: String },
+    BodyDisabled {
+        path: String,
+        card: String,
+    },
+}
+
+impl std::error::Error for ValidationError {}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::RequiredFieldAbsent { path, expected } => {
+                write!(
+                    f,
+                    "Field `{path}` is missing, schema declares `{expected}` with no default. \
+                     Provide a value of type `{expected}`."
+                )
+            }
+            ValidationError::UnfilledPlaceholder { path, expected } => {
+                // The mcp-feedback proposal's §5 routes this through the
+                // uniform format. The "either / or" pair collapses to one
+                // exit because there is no quote-or-omit alternative — the
+                // sentinel always means "replace me".
+                write!(
+                    f,
+                    "Field `{path}` still carries the `{MUST_FILL_SENTINEL}` blueprint sentinel, \
+                     schema declares `{expected}`. Replace `{MUST_FILL_SENTINEL}` with a value of type `{expected}`."
+                )
+            }
+            ValidationError::TypeMismatch {
+                path,
+                expected,
+                actual,
+                source_token,
+                default,
+            } => {
+                // Line 1: what we got vs what the schema says.
+                write!(f, "Field `{path}` got {actual} `{source_token}`, schema declares `{expected}`")?;
+                if let Some(d) = default {
+                    write!(f, " with default `{d}`")?;
+                }
+                write!(f, ". ")?;
+
+                // Exits depend on (expected, actual, has_default). The two
+                // patterns from `ERROR.md` cover the common LLM mistakes:
+                //   - null on a field with a default → omit the line, or
+                //     replace null with a real value of the declared type;
+                //   - string field receives an unquoted scalar → quote it,
+                //     or accept the scalar by changing the schema type.
+                if default.is_some() && actual == "null" {
+                    write!(
+                        f,
+                        "Either omit the line (the default will fill in) or set the value to a {expected}."
+                    )
+                } else if expected == "string" && quotable_actual(actual).is_some() {
+                    let bare = strip_string_quotes(source_token);
+                    write!(
+                        f,
+                        "Either quote the value (`{path}: \"{bare}\"`) or change the schema's `type:` to `{actual}`."
+                    )
+                } else if default.is_some() {
+                    write!(
+                        f,
+                        "Either omit the line (the default will fill in) or provide a value of type `{expected}`."
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Either provide a value of type `{expected}` or change the schema's `type:` to `{actual}`."
+                    )
+                }
+            }
+            ValidationError::EnumViolation { path, value, allowed } => {
+                write!(
+                    f,
+                    "field `{path}` value `{value}` not in allowed set {allowed:?}"
+                )
+            }
+            ValidationError::FormatViolation { path, format } => {
+                write!(
+                    f,
+                    "field `{path}` does not match expected format `{format}`"
+                )
+            }
+            ValidationError::UnknownCard { path, card } => {
+                write!(f, "unknown card kind `{card}` at `{path}`")
+            }
+            ValidationError::BodyDisabled { path, card } => {
+                write!(
+                    f,
+                    "card `{card}` at `{path}` has body content but the card kind declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card kind"
+                )
+            }
+        }
+    }
+}
+
+/// `Some(_)` when `actual` (a YAML-parsed type name) is a primitive scalar
+/// the author could lift to a string by quoting the source token. `null`
+/// is excluded — quoting `null` produces the literal string `"null"`,
+/// which is rarely what an LLM author intended.
+fn quotable_actual(actual: &str) -> Option<()> {
+    matches!(actual, "integer" | "number" | "boolean").then_some(())
+}
+
+/// Strip leading/trailing `"` from a verbatim string token; pass primitives
+/// through unchanged. Used to render the quoted-value exit cleanly when the
+/// token is already a string (we still re-quote in the suggested rewrite).
+fn strip_string_quotes(token: &str) -> &str {
+    token
+        .strip_prefix('"')
+        .and_then(|t| t.strip_suffix('"'))
+        .unwrap_or(token)
 }
 
 impl ValidationError {
@@ -58,8 +195,8 @@ impl ValidationError {
     /// See [`crate::error`] module docs for the path grammar and conventions.
     pub fn path(&self) -> &str {
         match self {
-            ValidationError::RequiredFieldAbsent { path }
-            | ValidationError::UnfilledPlaceholder { path }
+            ValidationError::RequiredFieldAbsent { path, .. }
+            | ValidationError::UnfilledPlaceholder { path, .. }
             | ValidationError::TypeMismatch { path, .. }
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
@@ -83,38 +220,44 @@ impl ValidationError {
     }
 
     /// Convert this error into a structured [`Diagnostic`] carrying the
-    /// stable code, the document-model `path`, and an optional hint.
+    /// stable code, the document-model `path`, and the canonical message.
     pub fn to_diagnostic(&self) -> Diagnostic {
-        let mut diag = Diagnostic::new(Severity::Error, self.to_string())
+        Diagnostic::new(Severity::Error, self.to_string())
             .with_code(self.code().to_string())
-            .with_path(self.path().to_string());
-
-        if let Some(hint) = self.hint() {
-            diag = diag.with_hint(hint);
-        }
-        diag
+            .with_path(self.path().to_string())
     }
+}
 
-    fn hint(&self) -> Option<String> {
-        match self {
-            ValidationError::RequiredFieldAbsent { .. } => {
-                Some("Add this field to the document.".to_string())
+/// Render a JSON scalar as the verbatim YAML token it would parse from.
+/// Primitives appear bare (`42`, `true`, `null`); strings appear quoted
+/// (`"hello"`, `""`); compound values render as a short placeholder.
+fn verbatim_yaml_scalar(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => format!("\"{s}\""),
+        serde_json::Value::Array(_) => "[…]".to_string(),
+        serde_json::Value::Object(_) => "{…}".to_string(),
+    }
+}
+
+/// YAML-parsed type name for a JSON value. Distinguishes `integer` from
+/// `number` (the proposal's example messages need that split).
+fn yaml_scalar_type(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(n) => {
+            if n.is_i64() || n.is_u64() {
+                "integer"
+            } else {
+                "number"
             }
-            ValidationError::UnfilledPlaceholder { .. } => Some(format!(
-                "Replace the `{}` sentinel with a value of the declared type.",
-                MUST_FILL_SENTINEL
-            )),
-            ValidationError::TypeMismatch { expected, .. } => {
-                Some(format!("Provide a value of type `{}`.", expected))
-            }
-            ValidationError::EnumViolation { allowed, .. } => {
-                Some(format!("Use one of: {}.", allowed.join(", ")))
-            }
-            ValidationError::FormatViolation { format, .. } => {
-                Some(format!("Use the `{}` format.", format))
-            }
-            _ => None,
         }
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 
@@ -191,7 +334,11 @@ fn validate_fields_for_card_indexmap(
         match fields.get(field_name) {
             Some(value) => errors.extend(validate_field(schema, value, &path)),
             None if schema.default.is_none() => {
-                errors.push(ValidationError::RequiredFieldAbsent { path })
+                // Must Fill (no `default:`) field absent from the document.
+                errors.push(ValidationError::RequiredFieldAbsent {
+                    path,
+                    expected: expected_type_name(&schema.r#type).to_string(),
+                })
             }
             None => {}
         }
@@ -222,6 +369,7 @@ pub(crate) fn validate_field(
         if candidate == MUST_FILL_SENTINEL {
             errors.push(ValidationError::UnfilledPlaceholder {
                 path: path.to_string(),
+                expected: expected_type_name(&field.r#type).to_string(),
             });
             return errors;
         }
@@ -290,9 +438,13 @@ pub(crate) fn validate_field(
                                     &QuillValue::from_json(v.clone()),
                                     &prop_path,
                                 )),
-                                None if prop_schema.default.is_none() => errors.push(
-                                    ValidationError::RequiredFieldAbsent { path: prop_path },
-                                ),
+                                None if prop_schema.default.is_none() => {
+                                    errors.push(ValidationError::RequiredFieldAbsent {
+                                        path: prop_path,
+                                        expected: expected_type_name(&prop_schema.r#type)
+                                            .to_string(),
+                                    })
+                                }
                                 None => {}
                             }
                         }
@@ -319,6 +471,8 @@ pub(crate) fn validate_field(
                             None if property_schema.default.is_none() => {
                                 errors.push(ValidationError::RequiredFieldAbsent {
                                     path: property_path,
+                                    expected: expected_type_name(&property_schema.r#type)
+                                        .to_string(),
                                 })
                             }
                             None => {}
@@ -340,7 +494,12 @@ pub(crate) fn validate_field(
         errors.push(ValidationError::TypeMismatch {
             path: path.to_string(),
             expected: expected_type_name(&field.r#type).to_string(),
-            actual: json_type_name(value.as_json()).to_string(),
+            actual: yaml_scalar_type(value.as_json()).to_string(),
+            source_token: verbatim_yaml_scalar(value.as_json()),
+            default: field
+                .default
+                .as_ref()
+                .map(|d| verbatim_yaml_scalar(d.as_json())),
         });
     }
 
@@ -375,17 +534,6 @@ fn expected_type_name(field_type: &FieldType) -> &'static str {
         FieldType::Boolean => "boolean",
         FieldType::Array => "array",
         FieldType::Object => "object",
-    }
-}
-
-fn json_type_name(value: &serde_json::Value) -> &'static str {
-    match value {
-        serde_json::Value::Null => "null",
-        serde_json::Value::Bool(_) => "boolean",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::Object(_) => "object",
     }
 }
 
@@ -472,8 +620,8 @@ main:
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
-            ValidationError::TypeMismatch { path, expected, actual }
-            if path == "title" && expected == "string" && actual == "number"
+            ValidationError::TypeMismatch { path, expected, actual, source_token, .. }
+            if path == "title" && expected == "string" && actual == "integer" && source_token == "9"
         )));
     }
 
@@ -491,8 +639,8 @@ main:
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,
-            ValidationError::TypeMismatch { path, expected, actual }
-            if path == "count" && expected == "integer" && actual == "number"
+            ValidationError::TypeMismatch { path, expected, actual, source_token, .. }
+            if path == "count" && expected == "integer" && actual == "number" && source_token == "9.5"
         )));
     }
 
@@ -504,7 +652,7 @@ main:
         let doc = doc_from_fm(&[]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "memo_for")
+            matches!(e, ValidationError::RequiredFieldAbsent { path, expected } if path == "memo_for" && expected == "string")
         }));
     }
 
@@ -525,7 +673,7 @@ main:
         let doc = doc_from_fm(&[("memo_for", json!(MUST_FILL_SENTINEL))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::UnfilledPlaceholder { path } if path == "memo_for")
+            matches!(e, ValidationError::UnfilledPlaceholder { path, expected } if path == "memo_for" && expected == "string")
         }));
     }
 
@@ -537,29 +685,36 @@ main:
         let doc = doc_from_fm(&[("body", json!(format!("  {}\n", MUST_FILL_SENTINEL)))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::UnfilledPlaceholder { path } if path == "body")
+            matches!(e, ValidationError::UnfilledPlaceholder { path, .. } if path == "body")
         }));
     }
 
     #[test]
-    fn quoted_must_fill_string_is_content_not_sentinel() {
-        // Once parsed YAML decodes both forms to the same string, exact
-        // string equality is the detector. Document this expectation by
-        // confirming the literal sentinel always fires the placeholder
-        // error (no escape hatch besides quoting at the YAML layer, which
-        // produces the same decoded string and therefore still fires).
-        // The behavior is documented in BLUEPRINT.md authoring guidance.
-        let config = config_with("    name:\n      type: string", "");
-        let doc = doc_from_fm(&[("name", json!(MUST_FILL_SENTINEL))]);
+    fn unfilled_placeholder_message_names_field_and_exit() {
+        // The mcp-feedback proposal's §5 routes this through the uniform
+        // format; assert the message names the field, shows the sentinel,
+        // and points at the exit.
+        let config = config_with("    memo_for:\n      type: string", "");
+        let doc = doc_from_fm(&[("memo_for", json!(MUST_FILL_SENTINEL))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
-        assert!(has_error(&errors, |e| matches!(
-            e,
-            ValidationError::UnfilledPlaceholder { .. }
-        )));
+        let msg = errors
+            .iter()
+            .find_map(|e| match e {
+                ValidationError::UnfilledPlaceholder { .. } => Some(e.to_string()),
+                _ => None,
+            })
+            .expect("expected UnfilledPlaceholder");
+        assert!(
+            msg.contains("Field `memo_for`")
+                && msg.contains(MUST_FILL_SENTINEL)
+                && msg.contains("schema declares `string`")
+                && msg.contains("Replace"),
+            "wrong message: {msg}"
+        );
     }
 
     #[test]
-    fn reports_wrong_type_on_must_fill_field() {
+    fn reports_must_fill_field_wrong_type() {
         let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[("memo_for", json!(true))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
@@ -664,7 +819,7 @@ main:
         let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "recipients[0].name")
+            matches!(e, ValidationError::RequiredFieldAbsent { path, .. } if path == "recipients[0].name")
         }));
     }
 
@@ -684,7 +839,7 @@ main:
         let missing_paths: Vec<&str> = errors
             .iter()
             .filter_map(|e| match e {
-                ValidationError::RequiredFieldAbsent { path } => Some(path.as_str()),
+                ValidationError::RequiredFieldAbsent { path, .. } => Some(path.as_str()),
                 _ => None,
             })
             .collect();
@@ -762,7 +917,7 @@ main:
         let doc = doc_with_typed_cards(&[], vec![typed_card("indorsement", &[])]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "cards.indorsement[0].signature_block")
+            matches!(e, ValidationError::RequiredFieldAbsent { path, .. } if path == "cards.indorsement[0].signature_block")
         }));
     }
 
@@ -793,6 +948,7 @@ main:
     fn to_diagnostic_carries_path_and_code() {
         let err = ValidationError::RequiredFieldAbsent {
             path: "cards.indorsement[0].signature_block".to_string(),
+            expected: "string".to_string(),
         };
         let diag = err.to_diagnostic();
         assert_eq!(
@@ -804,6 +960,81 @@ main:
             Some("cards.indorsement[0].signature_block")
         );
         assert_eq!(diag.severity, Severity::Error);
+    }
+
+    #[test]
+    fn type_mismatch_message_has_canonical_shape_quote_exit() {
+        // Integer source under a `string` schema → quote-the-value exit.
+        let config = config_with("    build_number:\n      type: string\n      default: \"\"", "");
+        let doc = doc_from_fm(&[("build_number", json!(42))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        let msg = errors
+            .iter()
+            .find_map(|e| match e {
+                ValidationError::TypeMismatch { .. } => Some(e.to_string()),
+                _ => None,
+            })
+            .expect("expected TypeMismatch");
+        assert!(
+            msg.contains("Field `build_number` got integer `42`, schema declares `string`"),
+            "wrong head: {msg}"
+        );
+        assert!(
+            msg.contains("quote the value (`build_number: \"42\"`)"),
+            "missing quote exit: {msg}"
+        );
+        assert!(
+            msg.contains("change the schema's `type:` to `integer`"),
+            "missing schema-change exit: {msg}"
+        );
+    }
+
+    #[test]
+    fn type_mismatch_message_has_canonical_shape_default_exit() {
+        // Null under a `string` schema with a default → omit-the-line exit.
+        let config = config_with(
+            "    subtitle:\n      type: string\n      default: \"My Subtitle\"",
+            "",
+        );
+        let doc = doc_from_fm(&[("subtitle", json!(null))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        let msg = errors
+            .iter()
+            .find_map(|e| match e {
+                ValidationError::TypeMismatch { .. } => Some(e.to_string()),
+                _ => None,
+            })
+            .expect("expected TypeMismatch");
+        assert!(
+            msg.contains(
+                "Field `subtitle` got null `null`, schema declares `string` with default `\"My Subtitle\"`"
+            ),
+            "wrong head: {msg}"
+        );
+        assert!(
+            msg.contains("omit the line (the default will fill in)"),
+            "missing omit-line exit: {msg}"
+        );
+    }
+
+    #[test]
+    fn required_field_absent_message_names_expected_type() {
+        let config = config_with("    memo_for:\n      type: string", "");
+        let doc = doc_from_fm(&[]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        let msg = errors
+            .iter()
+            .find_map(|e| match e {
+                ValidationError::RequiredFieldAbsent { .. } => Some(e.to_string()),
+                _ => None,
+            })
+            .expect("expected RequiredFieldAbsent");
+        assert!(
+            msg.contains("Field `memo_for` is missing")
+                && msg.contains("schema declares `string` with no default")
+                && msg.contains("Provide a value of type `string`"),
+            "wrong message: {msg}"
+        );
     }
 
     #[test]
@@ -821,6 +1052,7 @@ main:
   fields:
     title:
       type: string
+      default: ""
 "#,
         )
         .unwrap();

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -10,37 +10,46 @@ use crate::value::QuillValue;
 
 /// Literal sentinel string the blueprint emitter writes into the value
 /// cell of every Must Fill field. Validation detects unreplaced sentinels
-/// and reports `validation::unfilled_placeholder` under the uniform
+/// and reports `validation::must_fill_sentinel` under the uniform
 /// validation message contract (see `ERROR.md`).
 pub const MUST_FILL_SENTINEL: &str = "<must-fill>";
 
+/// Distinguishes the two ways a Must Fill field can be left unset.
+///
+/// Both routes mean "the field's Must Fill cell did not receive a value"
+/// and share the uniform diagnostic shape; they differ only in the
+/// failure mode and the recommended exit clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MustFillSource {
+    /// Schema field had no `default:` and the document omitted the line.
+    Absent,
+    /// The literal `<must-fill>` blueprint sentinel survived into the
+    /// document and reached validation.
+    Sentinel,
+}
+
 /// Validation error with a structured field path.
 ///
-/// Field-level type and presence errors (`RequiredFieldAbsent`,
-/// `UnfilledPlaceholder`, `TypeMismatch`) carry the field path, the
-/// verbatim YAML source token, the schema-declared type, and any default
-/// — enough for the `Display` impl to render the uniform diagnostic
-/// message described in `ERROR.md` ("Validation message contract"). The
-/// spinoff proposal's cross-reference clause retrofits the placeholder
-/// error to the uniform shape, so `RequiredFieldAbsent` and
-/// `UnfilledPlaceholder` both carry an `expected` slot for the
-/// declared-type line of the message.
+/// Field-level type and presence errors (`MustFillUnset`, `TypeMismatch`)
+/// carry the field path, the schema-declared type, and any verbatim YAML
+/// source token / default — enough for the `Display` impl to render the
+/// uniform diagnostic message described in `ERROR.md` ("Validation
+/// message contract"). `MustFillUnset` collapses the two Must Fill
+/// failure modes (omitted line vs. unreplaced `<must-fill>` sentinel)
+/// into one variant tagged by [`MustFillSource`]; both branches share
+/// the `expected` slot for the declared-type line of the message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
-    /// A Must Fill field (no `default:`) is absent from the document.
-    RequiredFieldAbsent {
+    /// A Must Fill cell did not receive a value. The `source` tag
+    /// distinguishes whether the document omitted the line entirely
+    /// (`Absent`) or left the blueprint `<must-fill>` sentinel in place
+    /// (`Sentinel`).
+    MustFillUnset {
         path: String,
         /// Schema-declared type (`string`, `integer`, …).
         expected: String,
-    },
-
-    /// The blueprint sentinel `<must-fill>` survived into the document
-    /// and reached validation. Treated under the uniform format with
-    /// `<must-fill>` as the source token.
-    UnfilledPlaceholder {
-        path: String,
-        /// Schema-declared type (`string`, `integer`, …).
-        expected: String,
+        /// How the Must Fill cell failed to receive a value.
+        source: MustFillSource,
     },
 
     TypeMismatch {
@@ -85,24 +94,23 @@ impl std::error::Error for ValidationError {}
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ValidationError::RequiredFieldAbsent { path, expected } => {
-                write!(
+            ValidationError::MustFillUnset { path, expected, source } => match source {
+                MustFillSource::Absent => write!(
                     f,
                     "Field `{path}` is missing, schema declares `{expected}` with no default. \
-                     Provide a value of type `{expected}`."
-                )
-            }
-            ValidationError::UnfilledPlaceholder { path, expected } => {
-                // The mcp-feedback proposal's §5 routes this through the
-                // uniform format. The "either / or" pair collapses to one
-                // exit because there is no quote-or-omit alternative — the
-                // sentinel always means "replace me".
-                write!(
+                     {hint}",
+                    hint = must_fill_hint(*source, expected),
+                ),
+                // The blueprint sentinel survived into the document. Single exit:
+                // there's no quote-or-omit alternative — the sentinel always means
+                // "replace me".
+                MustFillSource::Sentinel => write!(
                     f,
                     "Field `{path}` still carries the `{MUST_FILL_SENTINEL}` blueprint sentinel, \
-                     schema declares `{expected}`. Replace `{MUST_FILL_SENTINEL}` with a value of type `{expected}`."
-                )
-            }
+                     schema declares `{expected}`. {hint}",
+                    hint = must_fill_hint(*source, expected),
+                ),
+            },
             ValidationError::TypeMismatch {
                 path,
                 expected,
@@ -115,36 +123,7 @@ impl std::fmt::Display for ValidationError {
                 if let Some(d) = default {
                     write!(f, " with default `{d}`")?;
                 }
-                write!(f, ". ")?;
-
-                // Exits depend on (expected, actual, has_default). The two
-                // patterns from `ERROR.md` cover the common LLM mistakes:
-                //   - null on a field with a default → omit the line, or
-                //     replace null with a real value of the declared type;
-                //   - string field receives an unquoted scalar → quote it,
-                //     or accept the scalar by changing the schema type.
-                if default.is_some() && actual == "null" {
-                    write!(
-                        f,
-                        "Either omit the line (the default will fill in) or set the value to a {expected}."
-                    )
-                } else if expected == "string" && quotable_actual(actual).is_some() {
-                    let bare = strip_string_quotes(source_token);
-                    write!(
-                        f,
-                        "Either quote the value (`{path}: \"{bare}\"`) or change the schema's `type:` to `{actual}`."
-                    )
-                } else if default.is_some() {
-                    write!(
-                        f,
-                        "Either omit the line (the default will fill in) or provide a value of type `{expected}`."
-                    )
-                } else {
-                    write!(
-                        f,
-                        "Either provide a value of type `{expected}` or change the schema's `type:` to `{actual}`."
-                    )
-                }
+                write!(f, ". {hint}", hint = type_mismatch_hint(path, expected, actual, source_token, default.as_deref()))
             }
             ValidationError::EnumViolation { path, value, allowed } => {
                 write!(
@@ -164,29 +143,66 @@ impl std::fmt::Display for ValidationError {
             ValidationError::BodyDisabled { path, card } => {
                 write!(
                     f,
-                    "card `{card}` at `{path}` has body content but the card kind declares `body.enabled: false` — remove the body content or set `body.enabled: true` on the card kind"
+                    "card `{card}` at `{path}` has body content but the card kind declares `body.enabled: false` — {hint}",
+                    hint = body_disabled_hint(),
                 )
             }
         }
     }
 }
 
-/// `Some(_)` when `actual` (a YAML-parsed type name) is a primitive scalar
-/// the author could lift to a string by quoting the source token. `null`
-/// is excluded — quoting `null` produces the literal string `"null"`,
-/// which is rarely what an LLM author intended.
-fn quotable_actual(actual: &str) -> Option<()> {
-    matches!(actual, "integer" | "number" | "boolean").then_some(())
+/// Whether `actual` (a YAML-parsed type name) is a primitive scalar the
+/// author could lift to a string by quoting the source token. `null` is
+/// excluded — quoting `null` produces the literal string `"null"`, which
+/// is rarely what an LLM author intended.
+fn quotable_actual(actual: &str) -> bool {
+    matches!(actual, "integer" | "number" | "boolean")
 }
 
-/// Strip leading/trailing `"` from a verbatim string token; pass primitives
-/// through unchanged. Used to render the quoted-value exit cleanly when the
-/// token is already a string (we still re-quote in the suggested rewrite).
-fn strip_string_quotes(token: &str) -> &str {
-    token
-        .strip_prefix('"')
-        .and_then(|t| t.strip_suffix('"'))
-        .unwrap_or(token)
+/// Actionable exit clause for a Must Fill failure. Used by both `Display`
+/// and `hint()` so the recommended action lives in exactly one place.
+fn must_fill_hint(source: MustFillSource, expected: &str) -> String {
+    match source {
+        MustFillSource::Absent => format!("Provide a value of type `{expected}`."),
+        MustFillSource::Sentinel => format!(
+            "Replace `{MUST_FILL_SENTINEL}` with a value of type `{expected}`."
+        ),
+    }
+}
+
+/// Actionable exit clause for a TypeMismatch. Mirrors the (expected, actual,
+/// has_default) branching in `Display` so the structured hint and the prose
+/// message can never disagree.
+fn type_mismatch_hint(
+    path: &str,
+    expected: &str,
+    actual: &str,
+    source_token: &str,
+    default: Option<&str>,
+) -> String {
+    if default.is_some() && actual == "null" {
+        format!(
+            "Either omit the line (the default will fill in) or set the value to a {expected}."
+        )
+    } else if expected == "string" && quotable_actual(actual) {
+        format!(
+            "Either quote the value (`{path}: \"{source_token}\"`) or change the schema's `type:` to `{actual}`."
+        )
+    } else if default.is_some() {
+        format!(
+            "Either omit the line (the default will fill in) or provide a value of type `{expected}`."
+        )
+    } else {
+        format!(
+            "Either provide a value of type `{expected}` or change the schema's `type:` to `{actual}`."
+        )
+    }
+}
+
+/// Actionable exit clause for a `BodyDisabled` error. Same text in both the
+/// prose message and the structured hint.
+fn body_disabled_hint() -> &'static str {
+    "remove the body content or set `body.enabled: true` on the card kind"
 }
 
 impl ValidationError {
@@ -195,8 +211,7 @@ impl ValidationError {
     /// See [`crate::error`] module docs for the path grammar and conventions.
     pub fn path(&self) -> &str {
         match self {
-            ValidationError::RequiredFieldAbsent { path, .. }
-            | ValidationError::UnfilledPlaceholder { path, .. }
+            ValidationError::MustFillUnset { path, .. }
             | ValidationError::TypeMismatch { path, .. }
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
@@ -209,8 +224,14 @@ impl ValidationError {
     /// instead of the message text.
     pub fn code(&self) -> &'static str {
         match self {
-            ValidationError::RequiredFieldAbsent { .. } => "validation::required_field_absent",
-            ValidationError::UnfilledPlaceholder { .. } => "validation::unfilled_placeholder",
+            ValidationError::MustFillUnset {
+                source: MustFillSource::Absent,
+                ..
+            } => "validation::must_fill_absent",
+            ValidationError::MustFillUnset {
+                source: MustFillSource::Sentinel,
+                ..
+            } => "validation::must_fill_sentinel",
             ValidationError::TypeMismatch { .. } => "validation::type_mismatch",
             ValidationError::EnumViolation { .. } => "validation::enum_violation",
             ValidationError::FormatViolation { .. } => "validation::format_violation",
@@ -222,18 +243,36 @@ impl ValidationError {
     /// Actionable hint for this error, when one is well-defined for the
     /// variant. The hint restates the recommended exit so consumers (LLM
     /// agents, IDEs, MCP clients) can surface it next to the message
-    /// without re-parsing prose.
+    /// without re-parsing prose. The hint text is the same string the
+    /// `Display` impl bakes into the message.
     pub fn hint(&self) -> Option<String> {
         match self {
-            ValidationError::UnfilledPlaceholder { expected, .. } => Some(format!(
-                "Replace `{MUST_FILL_SENTINEL}` with a value of type `{expected}`."
+            ValidationError::MustFillUnset { expected, source, .. } => {
+                Some(must_fill_hint(*source, expected))
+            }
+            ValidationError::TypeMismatch {
+                path,
+                expected,
+                actual,
+                source_token,
+                default,
+            } => Some(type_mismatch_hint(
+                path,
+                expected,
+                actual,
+                source_token,
+                default.as_deref(),
             )),
-            _ => None,
+            ValidationError::BodyDisabled { .. } => Some(body_disabled_hint().to_string()),
+            ValidationError::EnumViolation { .. }
+            | ValidationError::FormatViolation { .. }
+            | ValidationError::UnknownCard { .. } => None,
         }
     }
 
     /// Convert this error into a structured [`Diagnostic`] carrying the
-    /// stable code, the document-model `path`, and the canonical message.
+    /// stable code, the document-model `path`, the canonical message, and
+    /// the actionable hint (when the variant defines one).
     pub fn to_diagnostic(&self) -> Diagnostic {
         let mut diag = Diagnostic::new(Severity::Error, self.to_string())
             .with_code(self.code().to_string())
@@ -352,9 +391,10 @@ fn validate_fields_for_card_indexmap(
             Some(value) => errors.extend(validate_field(schema, value, &path)),
             None if schema.default.is_none() => {
                 // Must Fill (no `default:`) field absent from the document.
-                errors.push(ValidationError::RequiredFieldAbsent {
+                errors.push(ValidationError::MustFillUnset {
                     path,
                     expected: expected_type_name(&schema.r#type).to_string(),
+                    source: MustFillSource::Absent,
                 })
             }
             None => {}
@@ -375,8 +415,8 @@ pub(crate) fn validate_field(
 
     // Sentinel detection runs before per-type coercion / validation.
     // Scalar fields carry the sentinel in the value cell; markdown carries
-    // it as the trimmed content of the block scalar. On match, emit
-    // `UnfilledPlaceholder` and skip per-type checks for this field.
+    // it as the trimmed content of the block scalar. On match, emit the
+    // sentinel-branch of `MustFillUnset` and skip per-type checks.
     if let Some(text) = value.as_str() {
         let candidate = if matches!(field.r#type, FieldType::Markdown) {
             text.trim()
@@ -384,9 +424,10 @@ pub(crate) fn validate_field(
             text
         };
         if candidate == MUST_FILL_SENTINEL {
-            errors.push(ValidationError::UnfilledPlaceholder {
+            errors.push(ValidationError::MustFillUnset {
                 path: path.to_string(),
                 expected: expected_type_name(&field.r#type).to_string(),
+                source: MustFillSource::Sentinel,
             });
             return errors;
         }
@@ -456,10 +497,11 @@ pub(crate) fn validate_field(
                                     &prop_path,
                                 )),
                                 None if prop_schema.default.is_none() => {
-                                    errors.push(ValidationError::RequiredFieldAbsent {
+                                    errors.push(ValidationError::MustFillUnset {
                                         path: prop_path,
                                         expected: expected_type_name(&prop_schema.r#type)
                                             .to_string(),
+                                        source: MustFillSource::Absent,
                                     })
                                 }
                                 None => {}
@@ -486,10 +528,11 @@ pub(crate) fn validate_field(
                                 &property_path,
                             )),
                             None if property_schema.default.is_none() => {
-                                errors.push(ValidationError::RequiredFieldAbsent {
+                                errors.push(ValidationError::MustFillUnset {
                                     path: property_path,
                                     expected: expected_type_name(&property_schema.r#type)
                                         .to_string(),
+                                    source: MustFillSource::Absent,
                                 })
                             }
                             None => {}
@@ -664,12 +707,12 @@ main:
     #[test]
     fn reports_absent_must_fill_field() {
         // A field with no `default:` is Must Fill. Missing from the document
-        // → `required_field_absent`.
+        // → `MustFillUnset { source: Absent, .. }`.
         let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::RequiredFieldAbsent { path, expected } if path == "memo_for" && expected == "string")
+            matches!(e, ValidationError::MustFillUnset { path, expected, source: MustFillSource::Absent } if path == "memo_for" && expected == "string")
         }));
     }
 
@@ -685,29 +728,29 @@ main:
     }
 
     #[test]
-    fn detects_unfilled_placeholder_sentinel() {
+    fn detects_must_fill_sentinel() {
         let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[("memo_for", json!(MUST_FILL_SENTINEL))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::UnfilledPlaceholder { path, expected } if path == "memo_for" && expected == "string")
+            matches!(e, ValidationError::MustFillUnset { path, expected, source: MustFillSource::Sentinel } if path == "memo_for" && expected == "string")
         }));
     }
 
     #[test]
-    fn detects_unfilled_placeholder_in_markdown_block() {
+    fn detects_must_fill_sentinel_in_markdown_block() {
         // Markdown block scalars carry the sentinel inside the block; the
         // detector trims whitespace before comparing.
         let config = config_with("    body:\n      type: markdown", "");
         let doc = doc_from_fm(&[("body", json!(format!("  {}\n", MUST_FILL_SENTINEL)))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::UnfilledPlaceholder { path, .. } if path == "body")
+            matches!(e, ValidationError::MustFillUnset { path, source: MustFillSource::Sentinel, .. } if path == "body")
         }));
     }
 
     #[test]
-    fn unfilled_placeholder_message_names_field_and_exit() {
+    fn must_fill_sentinel_message_names_field_and_exit() {
         // The mcp-feedback proposal's §5 routes this through the uniform
         // format; assert the message names the field, shows the sentinel,
         // and points at the exit.
@@ -717,10 +760,13 @@ main:
         let msg = errors
             .iter()
             .find_map(|e| match e {
-                ValidationError::UnfilledPlaceholder { .. } => Some(e.to_string()),
+                ValidationError::MustFillUnset {
+                    source: MustFillSource::Sentinel,
+                    ..
+                } => Some(e.to_string()),
                 _ => None,
             })
-            .expect("expected UnfilledPlaceholder");
+            .expect("expected MustFillUnset/Sentinel");
         assert!(
             msg.contains("Field `memo_for`")
                 && msg.contains(MUST_FILL_SENTINEL)
@@ -828,7 +874,7 @@ main:
     #[test]
     fn reports_must_fill_property_absent_in_array_object() {
         // Property `name` is Must Fill (no default); `org` is Endorsed.
-        // Missing `name` in a row → `required_field_absent`.
+        // Missing `name` in a row → `MustFillUnset { source: Absent, .. }`.
         let config = config_with(
             "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
             "",
@@ -836,7 +882,7 @@ main:
         let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::RequiredFieldAbsent { path, .. } if path == "recipients[0].name")
+            matches!(e, ValidationError::MustFillUnset { path, source: MustFillSource::Absent, .. } if path == "recipients[0].name")
         }));
     }
 
@@ -856,7 +902,11 @@ main:
         let missing_paths: Vec<&str> = errors
             .iter()
             .filter_map(|e| match e {
-                ValidationError::RequiredFieldAbsent { path, .. } => Some(path.as_str()),
+                ValidationError::MustFillUnset {
+                    path,
+                    source: MustFillSource::Absent,
+                    ..
+                } => Some(path.as_str()),
                 _ => None,
             })
             .collect();
@@ -934,7 +984,7 @@ main:
         let doc = doc_with_typed_cards(&[], vec![typed_card("indorsement", &[])]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::RequiredFieldAbsent { path, .. } if path == "cards.indorsement[0].signature_block")
+            matches!(e, ValidationError::MustFillUnset { path, source: MustFillSource::Absent, .. } if path == "cards.indorsement[0].signature_block")
         }));
     }
 
@@ -963,15 +1013,13 @@ main:
 
     #[test]
     fn to_diagnostic_carries_path_and_code() {
-        let err = ValidationError::RequiredFieldAbsent {
+        let err = ValidationError::MustFillUnset {
             path: "cards.indorsement[0].signature_block".to_string(),
             expected: "string".to_string(),
+            source: MustFillSource::Absent,
         };
         let diag = err.to_diagnostic();
-        assert_eq!(
-            diag.code.as_deref(),
-            Some("validation::required_field_absent")
-        );
+        assert_eq!(diag.code.as_deref(), Some("validation::must_fill_absent"));
         assert_eq!(
             diag.path.as_deref(),
             Some("cards.indorsement[0].signature_block")
@@ -980,18 +1028,77 @@ main:
     }
 
     #[test]
-    fn unfilled_placeholder_diagnostic_carries_actionable_hint() {
-        let err = ValidationError::UnfilledPlaceholder {
+    fn must_fill_absent_diagnostic_carries_actionable_hint() {
+        let err = ValidationError::MustFillUnset {
             path: "title".to_string(),
             expected: "string".to_string(),
+            source: MustFillSource::Absent,
         };
         let diag = err.to_diagnostic();
         let hint = diag
             .hint
             .as_deref()
-            .expect("unfilled_placeholder diagnostic should carry a hint");
+            .expect("must_fill_absent diagnostic should carry a hint");
+        assert!(hint.contains("string"), "hint missing expected type: {hint}");
+        assert!(
+            !hint.contains(MUST_FILL_SENTINEL),
+            "absent-branch hint must not mention the sentinel: {hint}"
+        );
+    }
+
+    #[test]
+    fn must_fill_sentinel_diagnostic_carries_actionable_hint() {
+        let err = ValidationError::MustFillUnset {
+            path: "title".to_string(),
+            expected: "string".to_string(),
+            source: MustFillSource::Sentinel,
+        };
+        let diag = err.to_diagnostic();
+        assert_eq!(
+            diag.code.as_deref(),
+            Some("validation::must_fill_sentinel")
+        );
+        let hint = diag
+            .hint
+            .as_deref()
+            .expect("must_fill_sentinel diagnostic should carry a hint");
         assert!(hint.contains(MUST_FILL_SENTINEL));
         assert!(hint.contains("string"));
+    }
+
+    #[test]
+    fn type_mismatch_diagnostic_carries_hint_matching_message() {
+        // The structured hint must equal the exit clause baked into the
+        // prose message, so consumers never need to re-parse.
+        let config = config_with(
+            "    build_number:\n      type: string\n      default: \"\"",
+            "",
+        );
+        let doc = doc_from_fm(&[("build_number", json!(42))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        let err = errors
+            .iter()
+            .find(|e| matches!(e, ValidationError::TypeMismatch { .. }))
+            .expect("expected TypeMismatch");
+        let diag = err.to_diagnostic();
+        let hint = diag.hint.expect("TypeMismatch diagnostic should carry a hint");
+        assert!(
+            err.to_string().ends_with(&hint),
+            "message tail must equal hint; msg={msg}, hint={hint}",
+            msg = err.to_string(),
+        );
+        assert!(hint.contains("quote the value"));
+    }
+
+    #[test]
+    fn body_disabled_diagnostic_carries_hint() {
+        let err = ValidationError::BodyDisabled {
+            path: "cards.skills[0].body".to_string(),
+            card: "skills".to_string(),
+        };
+        let diag = err.to_diagnostic();
+        let hint = diag.hint.expect("BodyDisabled diagnostic should carry a hint");
+        assert!(hint.contains("remove the body content"));
     }
 
     #[test]
@@ -1050,17 +1157,20 @@ main:
     }
 
     #[test]
-    fn required_field_absent_message_names_expected_type() {
+    fn must_fill_absent_message_names_expected_type() {
         let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         let msg = errors
             .iter()
             .find_map(|e| match e {
-                ValidationError::RequiredFieldAbsent { .. } => Some(e.to_string()),
+                ValidationError::MustFillUnset {
+                    source: MustFillSource::Absent,
+                    ..
+                } => Some(e.to_string()),
                 _ => None,
             })
-            .expect("expected RequiredFieldAbsent");
+            .expect("expected MustFillUnset/Absent");
         assert!(
             msg.contains("Field `memo_for` is missing")
                 && msg.contains("schema declares `string` with no default")

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -487,9 +487,23 @@ pub(crate) fn validate_field(
             Some(items) => {
                 if let Some(properties) = &field.properties {
                     for (idx, item) in items.iter().enumerate() {
+                        let row_path = format!("{}[{}]", path, idx);
+                        // Hand-edited edge case: a row collapsed to the literal
+                        // sentinel string (the user replaced the synthetic row
+                        // with `<must-fill>` instead of expanding it). Report
+                        // it once against the row path rather than emitting an
+                        // Absent error per Must Fill property.
+                        if item.as_str() == Some(MUST_FILL_SENTINEL) {
+                            errors.push(ValidationError::MustFillUnset {
+                                path: row_path,
+                                expected: "object".to_string(),
+                                source: MustFillSource::Sentinel,
+                            });
+                            continue;
+                        }
                         let obj = item.as_object();
                         for (prop_name, prop_schema) in properties {
-                            let prop_path = format!("{}[{}].{}", path, idx, prop_name);
+                            let prop_path = format!("{}.{}", row_path, prop_name);
                             match obj.and_then(|o| o.get(prop_name)) {
                                 Some(v) => errors.extend(validate_field(
                                     prop_schema,
@@ -884,6 +898,38 @@ main:
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::MustFillUnset { path, source: MustFillSource::Absent, .. } if path == "recipients[0].name")
         }));
+    }
+
+    #[test]
+    fn detects_must_fill_sentinel_as_typed_table_row() {
+        // Hand-edit edge case: the user collapses a synthetic row down to the
+        // literal sentinel string instead of expanding it into a mapping.
+        // One Sentinel error at the row path beats N noisy Absent errors per
+        // Must Fill property.
+        let config = config_with(
+            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n        org:\n          type: string",
+            "",
+        );
+        let doc = doc_from_fm(&[("recipients", json!([MUST_FILL_SENTINEL]))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(
+            has_error(&errors, |e| matches!(
+                e,
+                ValidationError::MustFillUnset { path, source: MustFillSource::Sentinel, .. }
+                if path == "recipients[0]"
+            )),
+            "expected sentinel error at row path; got {errors:?}"
+        );
+        // And no per-property Absent errors for that row — the row-level
+        // sentinel diagnostic supersedes them.
+        assert!(
+            !has_error(&errors, |e| matches!(
+                e,
+                ValidationError::MustFillUnset { path, source: MustFillSource::Absent, .. }
+                if path.starts_with("recipients[0].")
+            )),
+            "row-level sentinel should suppress per-property Absent errors; got {errors:?}"
+        );
     }
 
     // NOTE: top-level typed-dictionary fields (`type: object` with `properties`)

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -8,11 +8,23 @@ use crate::quill::formats::DATE_FORMAT;
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
 
+/// Literal sentinel string the blueprint emitter writes into the value
+/// cell of every Must Fill field. Validation detects unreplaced sentinels
+/// and reports `validation::unfilled_placeholder`.
+pub const MUST_FILL_SENTINEL: &str = "<must-fill>";
+
 /// Validation error with a structured field path.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum ValidationError {
-    #[error("missing required field `{path}`")]
-    MissingRequired { path: String },
+    #[error(
+        "field `{path}` has no value and the schema declares no default; supply a value before shipping"
+    )]
+    RequiredFieldAbsent { path: String },
+
+    #[error(
+        "field `{path}` still carries the `<must-fill>` blueprint sentinel; replace it with a value of the declared type"
+    )]
+    UnfilledPlaceholder { path: String },
 
     #[error("field `{path}` has type `{actual}`, expected `{expected}`")]
     TypeMismatch {
@@ -46,7 +58,8 @@ impl ValidationError {
     /// See [`crate::error`] module docs for the path grammar and conventions.
     pub fn path(&self) -> &str {
         match self {
-            ValidationError::MissingRequired { path }
+            ValidationError::RequiredFieldAbsent { path }
+            | ValidationError::UnfilledPlaceholder { path }
             | ValidationError::TypeMismatch { path, .. }
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
@@ -59,7 +72,8 @@ impl ValidationError {
     /// instead of the message text.
     pub fn code(&self) -> &'static str {
         match self {
-            ValidationError::MissingRequired { .. } => "validation::missing_required",
+            ValidationError::RequiredFieldAbsent { .. } => "validation::required_field_absent",
+            ValidationError::UnfilledPlaceholder { .. } => "validation::unfilled_placeholder",
             ValidationError::TypeMismatch { .. } => "validation::type_mismatch",
             ValidationError::EnumViolation { .. } => "validation::enum_violation",
             ValidationError::FormatViolation { .. } => "validation::format_violation",
@@ -83,9 +97,13 @@ impl ValidationError {
 
     fn hint(&self) -> Option<String> {
         match self {
-            ValidationError::MissingRequired { .. } => {
+            ValidationError::RequiredFieldAbsent { .. } => {
                 Some("Add this field to the document.".to_string())
             }
+            ValidationError::UnfilledPlaceholder { .. } => Some(format!(
+                "Replace the `{}` sentinel with a value of the declared type.",
+                MUST_FILL_SENTINEL
+            )),
             ValidationError::TypeMismatch { expected, .. } => {
                 Some(format!("Provide a value of type `{}`.", expected))
             }
@@ -172,7 +190,9 @@ fn validate_fields_for_card_indexmap(
         let path = child_path(base_path, field_name);
         match fields.get(field_name) {
             Some(value) => errors.extend(validate_field(schema, value, &path)),
-            None if schema.required => errors.push(ValidationError::MissingRequired { path }),
+            None if schema.default.is_none() => {
+                errors.push(ValidationError::RequiredFieldAbsent { path })
+            }
             None => {}
         }
     }
@@ -188,6 +208,24 @@ pub(crate) fn validate_field(
     path: &str,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
+
+    // Sentinel detection runs before per-type coercion / validation.
+    // Scalar fields carry the sentinel in the value cell; markdown carries
+    // it as the trimmed content of the block scalar. On match, emit
+    // `UnfilledPlaceholder` and skip per-type checks for this field.
+    if let Some(text) = value.as_str() {
+        let candidate = if matches!(field.r#type, FieldType::Markdown) {
+            text.trim()
+        } else {
+            text
+        };
+        if candidate == MUST_FILL_SENTINEL {
+            errors.push(ValidationError::UnfilledPlaceholder {
+                path: path.to_string(),
+            });
+            return errors;
+        }
+    }
 
     let type_valid = match field.r#type {
         FieldType::String | FieldType::Markdown => value.as_str().is_some(),
@@ -252,8 +290,9 @@ pub(crate) fn validate_field(
                                     &QuillValue::from_json(v.clone()),
                                     &prop_path,
                                 )),
-                                None if prop_schema.required => errors
-                                    .push(ValidationError::MissingRequired { path: prop_path }),
+                                None if prop_schema.default.is_none() => errors.push(
+                                    ValidationError::RequiredFieldAbsent { path: prop_path },
+                                ),
                                 None => {}
                             }
                         }
@@ -277,8 +316,8 @@ pub(crate) fn validate_field(
                                 &QuillValue::from_json(property_value.clone()),
                                 &property_path,
                             )),
-                            None if property_schema.required => {
-                                errors.push(ValidationError::MissingRequired {
+                            None if property_schema.default.is_none() => {
+                                errors.push(ValidationError::RequiredFieldAbsent {
                                     path: property_path,
                                 })
                             }
@@ -421,14 +460,14 @@ main:
 
     #[test]
     fn validates_simple_string_field() {
-        let config = config_with("    title:\n      type: string\n      required: true", "");
+        let config = config_with("    title:\n      type: string", "");
         let doc = doc_from_fm(&[("title", json!("Memo"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_simple_string_type_mismatch() {
-        let config = config_with("    title:\n      type: string", "");
+        let config = config_with("    title:\n      type: string\n      default: \"\"", "");
         let doc = doc_from_fm(&[("title", json!(9))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -440,14 +479,14 @@ main:
 
     #[test]
     fn validates_integer_field_with_integer_value() {
-        let config = config_with("    count:\n      type: integer", "");
+        let config = config_with("    count:\n      type: integer\n      default: 0", "");
         let doc = doc_from_fm(&[("count", json!(9))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_integer_field_with_decimal_value() {
-        let config = config_with("    count:\n      type: integer", "");
+        let config = config_with("    count:\n      type: integer\n      default: 0", "");
         let doc = doc_from_fm(&[("count", json!(9.5))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -458,24 +497,70 @@ main:
     }
 
     #[test]
-    fn reports_missing_required_field() {
-        let config = config_with(
-            "    memo_for:\n      type: string\n      required: true",
-            "",
-        );
+    fn reports_absent_must_fill_field() {
+        // A field with no `default:` is Must Fill. Missing from the document
+        // → `required_field_absent`.
+        let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingRequired { path } if path == "memo_for")
+            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "memo_for")
         }));
     }
 
     #[test]
-    fn reports_required_field_wrong_type() {
+    fn missing_field_with_default_is_ok() {
+        // Endorsed field absent from document → no error; default applies.
         let config = config_with(
-            "    memo_for:\n      type: string\n      required: true",
+            "    memo_for:\n      type: string\n      default: \"\"",
             "",
         );
+        let doc = doc_from_fm(&[]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
+    }
+
+    #[test]
+    fn detects_unfilled_placeholder_sentinel() {
+        let config = config_with("    memo_for:\n      type: string", "");
+        let doc = doc_from_fm(&[("memo_for", json!(MUST_FILL_SENTINEL))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| {
+            matches!(e, ValidationError::UnfilledPlaceholder { path } if path == "memo_for")
+        }));
+    }
+
+    #[test]
+    fn detects_unfilled_placeholder_in_markdown_block() {
+        // Markdown block scalars carry the sentinel inside the block; the
+        // detector trims whitespace before comparing.
+        let config = config_with("    body:\n      type: markdown", "");
+        let doc = doc_from_fm(&[("body", json!(format!("  {}\n", MUST_FILL_SENTINEL)))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| {
+            matches!(e, ValidationError::UnfilledPlaceholder { path } if path == "body")
+        }));
+    }
+
+    #[test]
+    fn quoted_must_fill_string_is_content_not_sentinel() {
+        // Once parsed YAML decodes both forms to the same string, exact
+        // string equality is the detector. Document this expectation by
+        // confirming the literal sentinel always fires the placeholder
+        // error (no escape hatch besides quoting at the YAML layer, which
+        // produces the same decoded string and therefore still fires).
+        // The behavior is documented in BLUEPRINT.md authoring guidance.
+        let config = config_with("    name:\n      type: string", "");
+        let doc = doc_from_fm(&[("name", json!(MUST_FILL_SENTINEL))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| matches!(
+            e,
+            ValidationError::UnfilledPlaceholder { .. }
+        )));
+    }
+
+    #[test]
+    fn reports_wrong_type_on_must_fill_field() {
+        let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[("memo_for", json!(true))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -487,7 +572,7 @@ main:
     #[test]
     fn validates_enum_value() {
         let config = config_with(
-            "    status:\n      type: string\n      enum:\n        - draft\n        - final",
+            "    status:\n      type: string\n      default: draft\n      enum:\n        - draft\n        - final",
             "",
         );
         let doc = doc_from_fm(&[("status", json!("draft"))]);
@@ -497,7 +582,7 @@ main:
     #[test]
     fn rejects_invalid_enum_value() {
         let config = config_with(
-            "    status:\n      type: string\n      enum:\n        - draft\n        - final",
+            "    status:\n      type: string\n      default: draft\n      enum:\n        - draft\n        - final",
             "",
         );
         let doc = doc_from_fm(&[("status", json!("invalid"))]);
@@ -511,14 +596,14 @@ main:
 
     #[test]
     fn validates_date_format() {
-        let config = config_with("    signed_on:\n      type: date", "");
+        let config = config_with("    signed_on:\n      type: date\n      default: \"\"", "");
         let doc = doc_from_fm(&[("signed_on", json!("2026-04-13"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_invalid_date_format() {
-        let config = config_with("    signed_on:\n      type: date", "");
+        let config = config_with("    signed_on:\n      type: date\n      default: \"\"", "");
         let doc = doc_from_fm(&[("signed_on", json!("13-04-2026"))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
@@ -528,14 +613,20 @@ main:
 
     #[test]
     fn validates_datetime_format() {
-        let config = config_with("    created_at:\n      type: datetime", "");
+        let config = config_with(
+            "    created_at:\n      type: datetime\n      default: \"\"",
+            "",
+        );
         let doc = doc_from_fm(&[("created_at", json!("2026-04-13T19:24:55Z"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_invalid_datetime_format() {
-        let config = config_with("    created_at:\n      type: datetime", "");
+        let config = config_with(
+            "    created_at:\n      type: datetime\n      default: \"\"",
+            "",
+        );
         let doc = doc_from_fm(&[("created_at", json!("2026-04-13 19:24:55"))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -547,7 +638,7 @@ main:
 
     #[test]
     fn markdown_accepts_any_string() {
-        let config = config_with("    body:\n      type: markdown", "");
+        let config = config_with("    body:\n      type: markdown\n      default: \"\"", "");
         let doc = doc_from_fm(&[("body", json!("# Heading\n\nBody text"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
@@ -555,7 +646,7 @@ main:
     #[test]
     fn validates_array_of_objects() {
         let config = config_with(
-            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n          required: true\n        org:\n          type: string",
+            "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "name": "Sam", "org": "HQ" }]))]);
@@ -563,15 +654,17 @@ main:
     }
 
     #[test]
-    fn reports_missing_required_field_in_array_object() {
+    fn reports_must_fill_property_absent_in_array_object() {
+        // Property `name` is Must Fill (no default); `org` is Endorsed.
+        // Missing `name` in a row → `required_field_absent`.
         let config = config_with(
-            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n          required: true\n        org:\n          type: string",
+            "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingRequired { path } if path == "recipients[0].name")
+            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "recipients[0].name")
         }));
     }
 
@@ -581,9 +674,9 @@ main:
     // rejected at config parse time.
 
     #[test]
-    fn accumulates_multiple_missing_required_errors() {
+    fn accumulates_multiple_absent_must_fill_errors() {
         let config = config_with(
-            "    memo_for:\n      type: string\n      required: true\n    memo_from:\n      type: string\n      required: true",
+            "    memo_for:\n      type: string\n    memo_from:\n      type: string",
             "",
         );
         let doc = doc_from_fm(&[]);
@@ -591,7 +684,7 @@ main:
         let missing_paths: Vec<&str> = errors
             .iter()
             .filter_map(|e| match e {
-                ValidationError::MissingRequired { path } => Some(path.as_str()),
+                ValidationError::RequiredFieldAbsent { path } => Some(path.as_str()),
                 _ => None,
             })
             .collect();
@@ -602,8 +695,8 @@ main:
     #[test]
     fn validates_card_with_valid_discriminator() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -618,7 +711,7 @@ main:
     #[test]
     fn rejects_unknown_card_discriminator() {
         let config = config_with(
-            "    title:\n      type: string",
+            "    title:\n      type: string\n      default: \"\"",
             "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(&[], vec![typed_card("unknown", &[])]);
@@ -631,8 +724,8 @@ main:
     #[test]
     fn validates_multiple_card_instances_same_type() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -647,8 +740,8 @@ main:
     #[test]
     fn validates_multiple_card_kinds_mixed() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true\n  routing:\n    fields:\n      office:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n  routing:\n    fields:\n      office:\n        type: string",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -663,21 +756,21 @@ main:
     #[test]
     fn reports_card_field_paths_with_card_name_and_index() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(&[], vec![typed_card("indorsement", &[])]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingRequired { path } if path == "cards.indorsement[0].signature_block")
+            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "cards.indorsement[0].signature_block")
         }));
     }
 
     #[test]
     fn body_disabled_card_enforces_trim_boundary() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        default: []",
         );
         // Prose triggers the error; whitespace-only does not.
         let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);
@@ -698,11 +791,14 @@ main:
 
     #[test]
     fn to_diagnostic_carries_path_and_code() {
-        let err = ValidationError::MissingRequired {
+        let err = ValidationError::RequiredFieldAbsent {
             path: "cards.indorsement[0].signature_block".to_string(),
         };
         let diag = err.to_diagnostic();
-        assert_eq!(diag.code.as_deref(), Some("validation::missing_required"));
+        assert_eq!(
+            diag.code.as_deref(),
+            Some("validation::required_field_absent")
+        );
         assert_eq!(
             diag.path.as_deref(),
             Some("cards.indorsement[0].signature_block")

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -219,12 +219,29 @@ impl ValidationError {
         }
     }
 
+    /// Actionable hint for this error, when one is well-defined for the
+    /// variant. The hint restates the recommended exit so consumers (LLM
+    /// agents, IDEs, MCP clients) can surface it next to the message
+    /// without re-parsing prose.
+    pub fn hint(&self) -> Option<String> {
+        match self {
+            ValidationError::UnfilledPlaceholder { expected, .. } => Some(format!(
+                "Replace `{MUST_FILL_SENTINEL}` with a value of type `{expected}`."
+            )),
+            _ => None,
+        }
+    }
+
     /// Convert this error into a structured [`Diagnostic`] carrying the
     /// stable code, the document-model `path`, and the canonical message.
     pub fn to_diagnostic(&self) -> Diagnostic {
-        Diagnostic::new(Severity::Error, self.to_string())
+        let mut diag = Diagnostic::new(Severity::Error, self.to_string())
             .with_code(self.code().to_string())
-            .with_path(self.path().to_string())
+            .with_path(self.path().to_string());
+        if let Some(hint) = self.hint() {
+            diag = diag.with_hint(hint);
+        }
+        diag
     }
 }
 
@@ -960,6 +977,21 @@ main:
             Some("cards.indorsement[0].signature_block")
         );
         assert_eq!(diag.severity, Severity::Error);
+    }
+
+    #[test]
+    fn unfilled_placeholder_diagnostic_carries_actionable_hint() {
+        let err = ValidationError::UnfilledPlaceholder {
+            path: "title".to_string(),
+            expected: "string".to_string(),
+        };
+        let diag = err.to_diagnostic();
+        let hint = diag
+            .hint
+            .as_deref()
+            .expect("unfilled_placeholder diagnostic should carry a hint");
+        assert!(hint.contains(MUST_FILL_SENTINEL));
+        assert!(hint.contains("string"));
     }
 
     #[test]

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -1,5 +1,5 @@
 //! Independent spec conformance probes for the card-yaml metadata syntax
-//! described in `prose/canon/MARKDOWN.md`.
+//! described in `prose/references/markdown-spec.md`.
 //!
 //! These tests exercise concrete spec requirements that are most likely to
 //! diverge between the parser and the written standard.

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -9,14 +9,12 @@ main:
   fields:
     name:
       type: string
-      required: true
       example: John Doe
       ui:
         group: Personal Info
 
     contacts:
       type: array
-      required: true
       example:
         - john.doe@example.com
         - 123-456-7890
@@ -36,7 +34,6 @@ card_kinds:
         default: Experience
       heading_left:
         type: string
-        required: true
       heading_right:
         type: string
       subheading_left:
@@ -54,7 +51,6 @@ card_kinds:
         default: Skills
       cells:
         type: array
-        required: true
         example:
           - category: Languages
             skills: Python, Rust, C++
@@ -63,10 +59,8 @@ card_kinds:
         properties:
           category:
             type: string
-            required: true
           skills:
             type: string
-            required: true
 
   projects_section:
     description: A project entry with a name and optional URL.
@@ -78,7 +72,6 @@ card_kinds:
         default: Projects
       name:
         type: string
-        required: true
       url:
         type: string
 
@@ -92,7 +85,6 @@ card_kinds:
         default: Certifications
       cells:
         type: array
-        required: true
         example:
           - AWS Certified Solutions Architect
           - CKA

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -28,6 +28,7 @@ main:
 
     department:
       type: string
+      default: ""
       example: Department of Electrical and Computer Engineering
       ui:
         group: Letterhead
@@ -44,6 +45,7 @@ main:
 
     url:
       type: string
+      default: ""
       example: www.ece.cmu.edu
       ui:
         group: Letterhead

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -9,7 +9,6 @@ main:
   fields:
     memo_for:
       type: array
-      required: true
       example:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
@@ -19,7 +18,6 @@ main:
 
     memo_from:
       type: array
-      required: true
       example:
         - ORG/SYMBOL
         - Organization Name
@@ -31,7 +29,6 @@ main:
 
     subject:
       type: string
-      required: true
       example: Subject of the Memorandum
       ui:
         group: Addressing
@@ -39,7 +36,6 @@ main:
 
     signature_block:
       type: array
-      required: true
       example:
         - "FIRST M. LAST, Rank, USSF"
         - Duty Title
@@ -152,7 +148,6 @@ card_kinds:
         ui:
           group: Addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
-        required: true
         default:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -83,7 +83,6 @@ main:
       ui:
         group: Addressing
         order: 0
-      required: true
     memo_from:
       type: array
       description: >-
@@ -98,7 +97,6 @@ main:
       ui:
         group: Addressing
         order: 1
-      required: true
     references:
       type: array
       description: Cite by organization, type, date, and title.
@@ -117,7 +115,6 @@ main:
       ui:
         group: Addressing
         order: 3
-      required: true
     subject:
       type: string
       description: >-
@@ -128,7 +125,6 @@ main:
       ui:
         group: Addressing
         order: 2
-      required: true
     tag_line:
       type: string
       description: Organizational motto at the bottom of the page.
@@ -197,4 +193,3 @@ card_kinds:
         ui:
           group: Addressing
           order: 2
-        required: true

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -9,7 +9,6 @@ main:
   fields:
     memo_for:
       type: array
-      required: true
       example:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
@@ -19,7 +18,6 @@ main:
 
     memo_from:
       type: array
-      required: true
       example:
         - ORG/SYMBOL
         - Organization Name
@@ -31,7 +29,6 @@ main:
 
     subject:
       type: string
-      required: true
       example: Subject of the Memorandum
       ui:
         group: Addressing
@@ -39,7 +36,6 @@ main:
 
     signature_block:
       type: array
-      required: true
       example:
         - "FIRST M. LAST, Rank, USSF"
         - Duty Title
@@ -154,7 +150,6 @@ card_kinds:
         ui:
           group: Addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
-        required: true
         default:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title

--- a/crates/quillmark/src/form.rs
+++ b/crates/quillmark/src/form.rs
@@ -106,11 +106,13 @@ pub(crate) fn build_form(quill: &Quill, doc: &Document) -> Form {
     }
 
     if let Err(validation_errors) = quill.source().config().validate_document(doc) {
+        // Forward the structured diagnostic produced by `ValidationError`
+        // verbatim — same `validation::*` code, same path, same hint —
+        // instead of wrapping in `form::validation_error` and dropping
+        // those fields. Consumers can route on the code without parsing
+        // the message text.
         for err in validation_errors {
-            diagnostics.push(
-                Diagnostic::new(Severity::Error, err.to_string())
-                    .with_code("form::validation_error".to_string()),
-            );
+            diagnostics.push(err.to_diagnostic());
         }
     }
 

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -96,7 +96,7 @@ main:
 
     // `title` and `notes` are absent from the document and have no
     // default → both produce validation diagnostics
-    // (`validation::required_field_absent`).
+    // (`validation::must_fill_absent`).
     // `status` is absent but has a default — it falls back to the default.
     let md = "~~~card-yaml\n$quill: form_defaults_test\n$kind: main\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
@@ -253,15 +253,26 @@ main:
 
     let form = quill.form(&doc);
 
+    // Validation errors now surface with their canonical `validation::*`
+    // codes — same diagnostic the engine emits — so consumers can route
+    // without parsing the message text.
     let val_diag = form
         .diagnostics
         .iter()
-        .find(|d| d.code.as_deref() == Some("form::validation_error"))
+        .find(|d| {
+            d.code
+                .as_deref()
+                .is_some_and(|c| c.starts_with("validation::"))
+        })
         .expect("expected a validation diagnostic");
+    assert_eq!(
+        val_diag.code.as_deref(),
+        Some("validation::type_mismatch")
+    );
+    assert_eq!(val_diag.path.as_deref(), Some("count"));
     assert!(
-        val_diag.message.contains("count"),
-        "diagnostic should mention field name; got: {:?}",
-        val_diag.message
+        val_diag.hint.is_some(),
+        "structured hint should be populated for type_mismatch"
     );
 }
 

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -86,7 +86,6 @@ main:
   fields:
     title:
       type: string
-      required: true
     status:
       type: string
       default: draft
@@ -95,19 +94,19 @@ main:
 "#,
     );
 
-    // `title` and `notes` are absent from the document.
-    // `title` is required — that produces a validation diagnostic.
-    // `status` is absent but has a default.
-    // `notes` is absent and has no default.
+    // `title` and `notes` are absent from the document and have no
+    // default → both produce validation diagnostics
+    // (`validation::required_field_absent`).
+    // `status` is absent but has a default — it falls back to the default.
     let md = "~~~card-yaml\n$quill: form_defaults_test\n$kind: main\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
 
-    // `title` is required and missing → validation diagnostic
+    // `title` is Must Fill and absent → validation diagnostic
     assert!(
         form.diagnostics.iter().any(|d| d.message.contains("title")),
-        "expected validation diagnostic for required 'title'; got: {:?}",
+        "expected validation diagnostic for absent Must-Fill 'title'; got: {:?}",
         form.diagnostics
     );
 
@@ -195,7 +194,6 @@ card_kinds:
     fields:
       signature_block:
         type: string
-        required: true
       office:
         type: string
         default: HQ
@@ -245,7 +243,6 @@ main:
   fields:
     count:
       type: integer
-      required: true
 "#,
     );
 

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -171,7 +171,9 @@ impl Quill {
 
     /// Schema-aware form view of `doc`. Read-only snapshot — re-call after edits.
     /// Unknown card kinds surface as `form::unknown_card_kind` diagnostics;
-    /// validation errors as `form::validation_error` diagnostics.
+    /// validation errors forward through with their canonical
+    /// `validation::*` codes, paths, and hints (same as
+    /// [`Quill::render`]'s `RenderError::diagnostics`).
     pub fn form(&self, doc: &Document) -> Form {
         form::build_form(self, doc)
     }

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -143,13 +143,12 @@ fn test_validation_fails_without_defaults() {
   version: "1.0"
   backend: "typst"
   plate_file: "plate.typ"
-  description: "Test quill with required field"
+  description: "Test quill with a Must-Fill field"
 
 main:
   fields:
     title:
       type: "string"
-      required: true
     status:
       type: "string"
       default: "draft"
@@ -168,7 +167,7 @@ main:
     let result = quill.dry_run(&parsed);
     assert!(
         result.is_err(),
-        "Should fail validation - title is required"
+        "Should fail validation — `title` is Must-Fill and absent"
     );
 
     let err = result.unwrap_err();

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -8,8 +8,10 @@ fn make_test_quill_path(temp_dir: &TempDir, with_required_field: bool) -> std::p
     let quill_path = temp_dir.path().join("test_quill");
     fs::create_dir_all(&quill_path).unwrap();
 
+    // `title` has no default → Must Fill. `author` has a default →
+    // Endorsed (absence is OK).
     let fields_section = if with_required_field {
-        "main:\n  fields:\n    title:\n      type: \"string\"\n      required: true\n    author:\n      type: \"string\"\n      required: false\n"
+        "main:\n  fields:\n    title:\n      type: \"string\"\n    author:\n      type: \"string\"\n      default: \"\"\n"
     } else {
         ""
     };
@@ -44,7 +46,7 @@ fn test_dry_run_success() {
 }
 
 #[test]
-fn test_dry_run_missing_required_field() {
+fn test_dry_run_missing_must_fill_field() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = make_test_quill_path(&temp_dir, true);
 
@@ -60,7 +62,7 @@ fn test_dry_run_missing_required_field() {
     let result = quill.dry_run(&parsed);
     assert!(
         result.is_err(),
-        "dry_run should fail for missing required field"
+        "dry_run should fail for missing Must-Fill field"
     );
 
     let err = result.unwrap_err();

--- a/crates/quillmark/tests/quiver_test.rs
+++ b/crates/quillmark/tests/quiver_test.rs
@@ -1,11 +1,12 @@
 //! Enforces the quill authoring contract from `prose/canon/BLUEPRINT.md`:
 //! every quill in the fixtures quiver loads, and its `plate.typ` renders the
-//! quill's own blueprint to a successful (non-error) output.
+//! quill's own blueprint (with every `<must-fill>` cell replaced by a
+//! type-empty value) to a successful (non-error) output.
 //!
-//! The blueprint is the type-minimal valid input — every required field
-//! present, every value type-correct, enums at their first value. A plate
-//! that renders it has shown it degrades gracefully on every type-valid
-//! input shape.
+//! The blueprint, after sentinel substitution, is the type-minimal valid
+//! input — every field present, every value type-correct, enums at their
+//! first value. A plate that renders it has shown it degrades gracefully
+//! on every type-valid input shape.
 
 #![cfg(feature = "typst")]
 
@@ -25,6 +26,65 @@ fn quiver_quills() -> Vec<String> {
     names
 }
 
+/// Replace every `<must-fill>` sentinel in a blueprint with a type-empty
+/// value derived from the inline annotation on the same line. For enum
+/// fields the substitution uses the first enum value so validation
+/// accepts the result.
+///
+/// This mirrors the operation an MCP consumer would perform on a
+/// blueprint before shipping: walk Must Fill cells, replace them with
+/// concrete values. Here we use the leanest possible values to test
+/// that `plate.typ` accepts type-empty inputs per the authoring
+/// contract.
+fn fill_must_fill(blueprint: &str) -> String {
+    let mut out = String::new();
+    for line in blueprint.lines() {
+        out.push_str(&substitute_line(line));
+        out.push('\n');
+    }
+    out
+}
+
+fn substitute_line(line: &str) -> String {
+    // Inline form: `<key>: <must-fill>  # <annotation>`.
+    const NEEDLE: &str = ": <must-fill>  # ";
+    if let Some(idx) = line.find(NEEDLE) {
+        let prefix = &line[..idx];
+        let annotation = &line[idx + NEEDLE.len()..];
+        let value = type_empty_for(annotation);
+        return format!("{}: {}  # {}", prefix, value, annotation);
+    }
+    // Markdown block scalar form: `<indent><must-fill>` on its own line.
+    if line.trim_start() == "<must-fill>" {
+        let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+        return indent;
+    }
+    line.to_string()
+}
+
+fn type_empty_for(annotation: &str) -> String {
+    let head = annotation.split(';').next().unwrap_or(annotation).trim();
+    if head.starts_with("array<") || head == "array" {
+        return "[]".to_string();
+    }
+    if head == "integer" || head == "number" {
+        return "0".to_string();
+    }
+    if head == "boolean" {
+        return "false".to_string();
+    }
+    if let Some(inner) = head
+        .strip_prefix("enum<")
+        .and_then(|s| s.strip_suffix('>'))
+    {
+        let first = inner.split('|').next().unwrap_or("").trim();
+        return first.to_string();
+    }
+    // string, markdown (handled via the block-scalar branch above), date,
+    // datetime, object: empty string. Date / datetime accept "" by design.
+    "\"\"".to_string()
+}
+
 #[test]
 fn every_quill_in_quiver_renders() {
     let engine = Quillmark::new();
@@ -34,9 +94,11 @@ fn every_quill_in_quiver_renders() {
             .quill_from_path(quills_path(&name))
             .unwrap_or_else(|e| panic!("quill '{name}' failed to load: {e:?}"));
 
-        let markdown = quill.source().config().blueprint();
-        let parsed = Document::from_markdown(&markdown)
-            .unwrap_or_else(|e| panic!("quill '{name}' blueprint failed to parse: {e:?}"));
+        let blueprint = quill.source().config().blueprint();
+        let markdown = fill_must_fill(&blueprint);
+        let parsed = Document::from_markdown(&markdown).unwrap_or_else(|e| {
+            panic!("quill '{name}' blueprint failed to parse: {e:?}\n---\n{markdown}")
+        });
 
         let result = quill.render(
             &parsed,

--- a/docs/authoring/markdown-syntax.md
+++ b/docs/authoring/markdown-syntax.md
@@ -2,7 +2,7 @@
 
 Quillmark Markdown is a **strict superset of [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/)** with a small set of [GitHub Flavored Markdown](https://github.github.com/gfm/) extensions and **one declared deviation**. If you already know CommonMark, you only need to learn what is on this page.
 
-For the authoritative grammar, block-detection rules, normalization, and limits, see the formal specification: [prose/canon/MARKDOWN.md](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/MARKDOWN.md).
+For the authoritative grammar, block-detection rules, normalization, and limits, see the formal [Markdown specification](../reference/markdown-spec.md).
 
 ## Foundation
 
@@ -70,7 +70,7 @@ Because metadata lives inside `~~~card-yaml` fences, ordinary Markdown markers
 keep their CommonMark meaning. A `---` line in body content is a thematic
 break or a setext heading underline, exactly as CommonMark defines it — it has
 no special role in Quillmark. The full block-detection rules are in
-[§4 of the spec](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/MARKDOWN.md#4-block-detection).
+[§4 of the spec](../reference/markdown-spec.md#4-block-detection).
 
 ## Next steps
 

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -79,7 +79,7 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; skip-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::required_field_absent` if the field is absent at validate time. |
+| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; skip-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::must_fill_absent` if the field is absent at validate time. |
 | `example`     | any               | no       | Illustrative value surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md) for documentation and LLM authoring |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -70,7 +70,6 @@ main:
   fields:
     subject:          # Field name (used as the card-yaml payload key)
       type: string
-      required: true
       description: Be brief and clear.
 ```
 
@@ -80,9 +79,8 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | any               | no       | Default value when not provided |
+| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; skip-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::required_field_absent` if the field is absent at validate time. |
 | `example`     | any               | no       | Illustrative value surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md) for documentation and LLM authoring |
-| `required`    | boolean           | no       | Whether the field must be present (default: `false`) |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
 | `properties`  | object            | no       | Nested field schemas (for `array` typed-table rows or `object` typed dictionaries) |
@@ -132,7 +130,6 @@ main:
       properties:
         category:
           type: string
-          required: true
         score:
           type: number
 ```
@@ -147,7 +144,6 @@ main:
       properties:
         street:
           type: string
-          required: true
         city:
           type: string
 ```
@@ -461,19 +457,18 @@ main:
   fields:
     project_name:
       type: string
-      required: true
       ui:
         group: Header
 
     status:
       type: string
-      required: true
       enum: [on_track, at_risk, blocked]
       ui:
         group: Header
 
     risk_description:
       type: string
+      default: ""
       ui:
         group: Header
       description: Describe the risk or blocker. Only needed when status is not on_track.
@@ -485,6 +480,7 @@ main:
 
     team_members:
       type: array
+      default: []
       ui:
         group: Team
 
@@ -500,7 +496,6 @@ card_kinds:
     fields:
       name:
         type: string
-        required: true
       target_date:
         type: date
       completed:

--- a/docs/migrations/0.82-to-0.83.md
+++ b/docs/migrations/0.82-to-0.83.md
@@ -128,7 +128,7 @@ title: Hi
 ~~~
 ```
 
-Rules at a glance — see [MARKDOWN.md §3.3](../../prose/canon/MARKDOWN.md)
+Rules at a glance — see [markdown-spec.md §3.3](../reference/markdown-spec.md)
 for the full specification:
 
 - Value **must** be a YAML mapping; scalars and sequences are parse

--- a/docs/reference/markdown-spec.md
+++ b/docs/reference/markdown-spec.md
@@ -1,0 +1,1 @@
+--8<-- "prose/references/markdown-spec.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,8 @@ nav:
       - Versioning: format-designer/versioning.md
   - CLI:
       - Reference: cli/reference.md
+  - Reference:
+      - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - 0.82 → 0.83 ($-prefixed plate JSON): migrations/0.82-to-0.83.md
       - 0.81 → 0.82 (card-yaml): migrations/0.81-to-0.82.md
@@ -57,7 +59,11 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path:
+        - .
+        - docs
+      check_paths: true
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -48,3 +48,42 @@ relies on `serde_json/preserve_order` and consumers may have started
 content-hashing the result. Touch `crates/backends/typst/src/lib.rs`
 (`transform_markdown_fields`) at the same time so the schema
 walker uses the same shape.
+
+---
+
+## Typed container empty default loses inline shape documentation
+
+**Where:** `write_typed_table_field` / `write_typed_object_field` in
+`crates/core/src/quill/blueprint.rs`.
+
+**What:** When a typed container declares `default: []` (or `default: {}`)
+the blueprint now renders the value inline — `refs: []  # array<object>;
+skip-ok` — and emits no row/property shape. Inner shape is only surfaced
+when the container is Must Fill (no `default:` at all), via the synthetic
+row / per-property recursion path.
+
+**Why we accepted the loss:** prior to this, an empty container default
+asymmetrically forced a synthetic row with leaf sentinels — the field's
+own cell signal said "Must Fill" even though `default: []` is a fully
+shippable value per `prose/canon/SCHEMAS.md`. The asymmetry leaked into
+the rendering code (an override parameter on `inline_annotation`) and
+disagreed with the canonical "type-empty defaults are Endorsed" rule.
+Removing the asymmetry was a one-rule simplification — uniform cascade:
+`default.is_some()` → Endorsed → render the default; `default` absent →
+Must Fill → render the shape with sentinels.
+
+**What's left for a future pass:** schema authors who want both "shippable
+empty" *and* inline shape documentation now have no single knob. Options
+when this comes up:
+
+- Add a leading `# rows shaped like: {…}` comment for typed containers
+  with an empty default, derived from `properties:`. Cheap to emit, no
+  semantic conflict (it's a comment).
+- Promote `example:` rendering for typed containers so an `example:
+  [{…}]` under an empty default actually shows a shape sketch — today
+  the example collapses to a single-line `# e.g. …` regardless.
+- Add an explicit `ui.show_shape: true` flag on the field.
+
+Defer until a real authoring case asks for it. The canon update lives
+in `prose/canon/BLUEPRINT.md` "Typed tables" / "Typed dictionaries"
+which already point readers here.

--- a/prose/README.md
+++ b/prose/README.md
@@ -6,10 +6,15 @@ Long-form project documentation, in two tiers by maturity:
   codebase's systems, specifications, and intent. The settled truth. Start at
   [`canon/INDEX.md`](canon/INDEX.md). Canon describes *what is* and points into
   the code; it does not re-document implementation detail.
+- **`references/`** — authoritative, standalone specifications. Each
+  reference is self-contained: it makes no outbound links to other prose
+  docs, so it can be cited freely from canon, user docs, and code comments
+  without forming a cycle.
 - **`proposals/`** — fleshed-out proposed changes, not yet implemented. Each is
   a concrete plan. Removed once landed or abandoned.
 - **`BOOKMARKS.md`** — known simplifications and refactors deliberately
   deferred. Lighter-weight than a proposal: just a placeholder so the
   insight isn't lost between releases.
 
-Canonical docs never reference proposals or plans.
+Canonical docs never reference proposals or plans. References never link
+out to other prose docs.

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -38,7 +38,7 @@ $kind: <card_kind>
 Write <card_kind> body here.
 ````
 
-Every block is a `~~~card-yaml` block (see [MARKDOWN.md](MARKDOWN.md) §3):
+Every block is a `~~~card-yaml` block (see [markdown-spec.md](../references/markdown-spec.md) §3):
 the root block carries the `$quill` system-metadata line; each composable
 card carries a `$kind: <card_kind>` metadata line.
 

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -208,14 +208,21 @@ fallback; authors needing these characters must reshape their values.
 
 ## Typed tables
 
-A field of `type: array` with a `properties` map renders with full
-per-property annotations:
+A field of `type: array` with a `properties` map follows the uniform
+cell cascade — `default:` (any default, including `[]`) is Endorsed and
+shippable as-is; no `default:` is Must Fill:
 
 - A non-empty `default:` renders as actual rows (no per-property
   annotations on each row). The outer key carries `# array<object>; skip-ok`.
-- Otherwise one synthetic row is emitted with each property carrying its
-  own description, inline annotation, and cell signal (sentinel or
-  `; skip-ok`). The outer key carries `# array<object>` (no `; skip-ok`).
+- `default: []` renders inline as `[]` with `# array<object>; skip-ok` —
+  shippable empty. Inline row shape is not surfaced under an empty
+  default; use `example:` to document row shape. See
+  `prose/BOOKMARKS.md` "Typed container empty default loses inline
+  shape documentation."
+- No `default:` is Must Fill: one synthetic row is emitted with each
+  property carrying its own description, inline annotation, and cell
+  signal (sentinel or `; skip-ok`). The outer key carries
+  `# array<object>` (no `; skip-ok`).
 
 An `example:` never renders as rows. Like every other field type, it
 surfaces only in the `# e.g.` leading line — as a one-line flow
@@ -223,16 +230,19 @@ sequence, e.g. `# e.g. [{org: ACME, year: 2020}]`.
 
 ## Typed dictionaries
 
-A field of `type: object` with a `properties` map renders as an indented
-block mapping with per-property annotations — no outer value on the key
-line:
+A field of `type: object` with a `properties` map follows the uniform
+cell cascade — `default:` (any default, including `{}`) is Endorsed and
+shippable as-is; no `default:` is Must Fill:
 
 - A non-empty `default:` renders as a concrete block mapping (property
   values only, no annotations). The outer key carries
   `# object; skip-ok`.
-- Otherwise each property is emitted with its own description, inline
-  annotation, and cell signal — the same rules as any other field. The
-  outer key carries `# object` (no `; skip-ok`); state is a leaf concern.
+- `default: {}` renders inline as `{}` with `# object; skip-ok` —
+  shippable empty. Inline property shape is not surfaced under an empty
+  default; use `example:` to document property shape.
+- No `default:` is Must Fill: each property is emitted with its own
+  description, inline annotation, and cell signal. The outer key
+  carries `# object` (no `; skip-ok`).
 
 An `example:` never renders as a concrete mapping. Like every other
 field type, it surfaces only in the `# e.g.` leading line — as a

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -324,7 +324,7 @@ field key is present, every value is YAML-valid, the document round-trips
 through `Document::from_markdown` and back. Endorsed cells coerce and
 validate successfully; Must Fill cells carry the `<must-fill>` sentinel
 in the value cell (or inside a markdown block scalar), which validation
-reports as `validation::unfilled_placeholder` until the LLM replaces it
+reports as `validation::must_fill_sentinel` until the LLM replaces it
 with a typed value.
 
 `blueprint()` does **not**, on its own, guarantee the document

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -23,7 +23,7 @@ $kind: main
 
 # <field description>
 # e.g. <example value>
-field: value  # <type>; <role>
+field: value  # <type>[; skip-ok]
 ~~~
 
 Write main body here.
@@ -50,7 +50,7 @@ When `body.enabled` is false the marker is omitted entirely.
 | Slot | Form | Carries |
 |---|---|---|
 | **Leading `# …` lines** above a field | `# <prose>` or `# e.g. <value>` | description (single-line prose) and an illustrative example |
-| **Inline `# …`** at end of the value line | `# <type>[<format>]; <role>[, <extra>...]` | structural metadata: type, optional format refinement, role, optional extras |
+| **Inline `# …`** at end of the value line | `# <type>[<format>][; skip-ok]` | structural metadata: type, optional format refinement, optional skip-ok tag |
 
 The two slots have disjoint purposes: leading is prose, inline is
 structural. No colon-separated `key: value` annotation syntax appears in
@@ -64,15 +64,15 @@ Per field, in order:
    whitespace-collapsed. **Single line only**; multi-line descriptions are
    rejected at `Quill.yaml` parse time.
 2. `# e.g. <value>` — emitted whenever `example:` is configured on a
-   field. Independent of role and type. The example never becomes the
-   rendered value (see precedence below).
+   field. Independent of cell and type. The example never becomes the
+   rendered value.
 
 That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 `# type:` — those collapse into the inline.
 
 ### Inline annotation
 
-Form: **`# <type>[<format>]; <role>[, <extra>...]`**
+Form: **`# <type>[<format>][; skip-ok]`**
 
 - **Type slot** (mandatory, first): one of
   `string`, `integer`, `number`, `boolean`, `array`, `object`,
@@ -89,9 +89,11 @@ Form: **`# <type>[<format>]; <role>[, <extra>...]`**
   - `enum<a | b | c>`
   - omitted for `string`, `integer`, `number`, `boolean`, `object`,
     `markdown` (nothing meaningful to refine).
-- **Role slot** (mandatory, after `;`): `required` or `optional`.
-- **Extras** (optional, comma-separated, after the role): additional
-  qualifiers.
+- **Skip-ok tag** (optional, after `;`): the single tag `skip-ok`. Present
+  on Endorsed fields (fields with a `default:` in the schema), signalling
+  "the rendered value is shippable as-is — keep or override". Absent on
+  Must Fill fields (fields without a `default:`), which carry the
+  `<must-fill>` sentinel in the value cell instead.
 
 The `$`-prefixed system-metadata keys (`$quill`, `$kind`, …) have no
 inline-annotation slot — they are not user-defined data fields. (The YAML
@@ -107,70 +109,80 @@ Examples:
 
 | Line | Reading |
 |---|---|
-| `name: ""  # string; required` | required string field, no format refinement |
-| `count: 0  # integer; required` | required integer field |
-| `active: false  # boolean; optional` | optional boolean field |
-| `bio: |-` followed by indented block, then `# markdown; optional` | optional markdown field — see "Markdown fields render as block scalars" |
-| `recipient: []  # array<string>; optional` | optional array of strings |
-| `entries: [...]  # array<object>; required` | required array of objects (typed table follows) |
-| `date: ""  # date<YYYY-MM-DD>; required` | required date in `YYYY-MM-DD` format |
-| `published: ""  # datetime<ISO 8601>; required` | required datetime in ISO 8601 |
-| `level: low  # enum<low \| medium \| high>; optional` | optional enum, default is first value |
+| `name: <must-fill>  # string` | Must Fill string — replace `<must-fill>` before shipping |
+| `title: "Curriculum Vitae"  # string; skip-ok` | Endorsed string — keep or override |
+| `count: 0  # integer; skip-ok` | Endorsed integer (type-empty default, explicitly shippable) |
+| `active: false  # boolean; skip-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
+| `notes: ""  # string; skip-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
+| `bio: |-` followed by indented `<must-fill>`, then `# markdown` | Must Fill markdown — see "Markdown fields render as block scalars" |
+| `recipient: <must-fill>  # array<string>` | Must Fill array of strings |
+| `date: <must-fill>  # date<YYYY-MM-DD>` | Must Fill date in `YYYY-MM-DD` format |
+| `severity: <must-fill>  # enum<low \| medium \| high>` | Must Fill enum |
 | `$quill: cmu_letter@0.1.0` | quill binding metadata, emitted verbatim, do not modify |
 | `$kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~card-yaml` … `~~~` block per instance |
 
 ## Placeholder value precedence
 
-The rendered value is independent of the role (required vs. optional).
-Role drives "must fill"; the value rendering follows a single cascade:
+The rendered value follows a single cascade keyed on the cell:
 
-| Field state | Value rendered |
-|---|---|
-| Has `default` | default |
-| Has `enum` only | first enum value |
-| Otherwise | type-empty (`""`, `0`, `false`, `[]`, or block scalar for markdown — see below) |
+| Field state | Value rendered | Cell |
+|---|---|---|
+| Has `default` | default | Endorsed (carries `; skip-ok`) |
+| No `default` | `<must-fill>` sentinel | Must Fill (no `; skip-ok`) |
 
-Examples never become the rendered value, regardless of role or type —
+Examples never become the rendered value, regardless of cell or type —
 this holds uniformly for scalars, arrays, typed tables, and typed
 dictionaries. Examples are inherently illustrative and unsafe to ship;
 they always surface in the `# e.g.` leading line while the value follows
 the cascade above.
 
-All fields render as **live YAML** — no commented-out fields. The role
-tag (`; required` / `; optional`) is the sole "must fill" signal. The
-rendered value is the effective default: what the field will be if the
-author leaves it untouched.
+All fields render as **live YAML** — no commented-out fields. The
+sentinel in the value cell is the sole "must fill" signal: a reader's
+mental model is one rule — **`<must-fill>` in the value cell → replace
+before shipping; otherwise the value cell is shippable as-is**.
 
-`date` and `datetime` fields render `""` when no example or default is
-configured; the inline format slot (`<YYYY-MM-DD>` or `<ISO 8601>`)
-carries the shape hint.
+The sentinel lives where the LLM types the value:
 
-There is no string `"<name>"` placeholder — required strings render as
-`""` like every other type.
+| Type | Sentinel position | Example |
+|---|---|---|
+| `string`, `integer`, `number`, `boolean`, `date`, `datetime`, `enum` | Value cell | `name: <must-fill>  # string` |
+| `array<scalar>` | Value cell | `recipient: <must-fill>  # array<string>` |
+| `markdown` | Inside the block scalar | `bio: |-` then `<must-fill>` |
+| `object` (typed dict) | Per-property recursion | leaves carry sentinels |
+| `array<object>` (typed table) | Per-property recursion in one synthetic row | leaves carry sentinels |
 
 ### Markdown fields render as block scalars
 
-A `markdown` field renders as a YAML literal block scalar (`|-`), even
-when the type-empty case applies:
+A `markdown` field renders as a YAML literal block scalar (`|-`). The
+block-scalar shape is type-driven — it's the only YAML form that
+cleanly accommodates multi-line markdown content. By rendering it from
+the start, the LLM consumer writes into the indented block without
+needing to switch shapes mid-fill.
+
+For a Must Fill markdown field, the block's content is exactly one line
+containing the sentinel:
 
 ```
-bio: |-
-  
+bio: |-  # markdown
+  <must-fill>
 ```
 
-When a `default:` is configured, its content fills the block:
+The LLM replaces that single line with multi-line markdown; the block
+scalar's shape is unchanged.
+
+When a `default:` is configured, the field is Endorsed and the default's
+content fills the block:
 
 ```
-bio: |-
+bio: |-  # markdown; skip-ok
   ## About me
   
   <body>
 ```
 
-The block-scalar shape is type-driven — it's the only YAML form that
-cleanly accommodates multi-line markdown content. By rendering it from
-the start, the LLM consumer writes into the indented block without
-needing to switch shapes mid-fill.
+If the default is empty (`default: ""`), the block scalar still carries
+the `; skip-ok` tag and renders with one indented blank line — the
+"skippable" markdown cell.
 
 ### Multi-element example arrays
 
@@ -179,7 +191,7 @@ multi-element shape information is preserved:
 
 ```
 # e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
-recipient: []  # array<string>; optional
+recipient: <must-fill>  # array<string>
 ```
 
 Items containing flow indicators (`,`, `[`, `]`, `{`, `}`) get quoted so
@@ -199,15 +211,15 @@ fallback; authors needing these characters must reshape their values.
 A field of `type: array` with a `properties` map renders with full
 per-property annotations:
 
-- A non-empty `default:` renders as actual rows.
-- Otherwise one synthetic row is emitted, with each property carrying
-  its own description, inline type/format, and role.
+- A non-empty `default:` renders as actual rows (no per-property
+  annotations on each row). The outer key carries `# array<object>; skip-ok`.
+- Otherwise one synthetic row is emitted with each property carrying its
+  own description, inline annotation, and cell signal (sentinel or
+  `; skip-ok`). The outer key carries `# array<object>` (no `; skip-ok`).
 
 An `example:` never renders as rows. Like every other field type, it
 surfaces only in the `# e.g.` leading line — as a one-line flow
 sequence, e.g. `# e.g. [{org: ACME, year: 2020}]`.
-
-The outer field's inline annotation is `# array<object>; <role>`.
 
 ## Typed dictionaries
 
@@ -216,32 +228,32 @@ block mapping with per-property annotations — no outer value on the key
 line:
 
 - A non-empty `default:` renders as a concrete block mapping (property
-  values only, no annotations).
+  values only, no annotations). The outer key carries
+  `# object; skip-ok`.
 - Otherwise each property is emitted with its own description, inline
-  type/format, and role — the same annotation rules as any other field.
+  annotation, and cell signal — the same rules as any other field. The
+  outer key carries `# object` (no `; skip-ok`); state is a leaf concern.
 
 An `example:` never renders as a concrete mapping. Like every other
 field type, it surfaces only in the `# e.g.` leading line — as a
 one-line flow mapping, e.g. `# e.g. {street: 1 Infinite Loop, city:
 Cupertino}`.
 
-The outer field's inline annotation is `# object; <role>`.
-
 ```
 # The sender's mailing address.
-address:  # object; optional
+address:  # object
   # Street address line.
-  street: ""  # string; required
+  street: <must-fill>  # string
   # City name.
-  city: ""  # string; required
+  city: <must-fill>  # string
   # ZIP or postal code.
-  zip: ""  # string; optional
+  zip: ""  # string; skip-ok
 ```
 
 With a default:
 
 ```
-address:  # object; optional
+address:  # object; skip-ok
   street: 5000 Forbes Avenue
   city: Pittsburgh
   zip: "15213"
@@ -285,21 +297,21 @@ $kind: main
 
 # The recipient's name and full mailing address.
 # e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
-recipient: []  # array<string>; optional
+recipient: <must-fill>  # array<string>
 # The signer's information. Line 1: Name. Line 2: Title.
 # e.g. [First M. Last, Title]
-signature_block: []  # array<string>; optional
+signature_block: <must-fill>  # array<string>
 # The department or organizational unit name for the letterhead.
 # e.g. Department of Electrical and Computer Engineering
-department: ""  # string; optional
+department: ""  # string; skip-ok
 # The sender's institutional mailing address.
 # e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
-address: []  # array<string>; optional
+address: <must-fill>  # array<string>
 # The department or university website URL.
 # e.g. www.ece.cmu.edu
-url: ""  # string; optional
+url: ""  # string; skip-ok
 # The date to appear on the letter.
-date: ""  # date<YYYY-MM-DD>; optional
+date: <must-fill>  # date<YYYY-MM-DD>
 ~~~
 
 Write main body here.
@@ -307,38 +319,41 @@ Write main body here.
 
 ## Guarantees
 
-`blueprint()` guarantees the emitted document is **schema-valid and
-parseable**: every field key is present, every value is type-correct,
-enums sit at their first value, dates render as `""`. Parsing the
-blueprint with `Document::from_markdown` and validating it against the
-quill schema always succeeds. This is the guarantee `blueprint()` itself
-is responsible for, and it is total over any valid `QuillConfig`.
+`blueprint()` guarantees the emitted document is **parseable**: every
+field key is present, every value is YAML-valid, the document round-trips
+through `Document::from_markdown` and back. Endorsed cells coerce and
+validate successfully; Must Fill cells carry the `<must-fill>` sentinel
+in the value cell (or inside a markdown block scalar), which validation
+reports as `validation::unfilled_placeholder` until the LLM replaces it
+with a typed value.
 
 `blueprint()` does **not**, on its own, guarantee the document
 *renders*. Rendering depends on the quill's `plate.typ` and its
 packages, which `blueprint()` does not control. That is a separate
 **quill authoring contract**:
 
-> A quill's `plate.typ` MUST render the quill's own blueprint to a
-> successful (non-error) output.
+> A quill's `plate.typ` MUST render the quill's own blueprint — with all
+> `<must-fill>` cells replaced by type-empty values of the declared
+> type — to a successful (non-error) output.
 
-The blueprint is, by construction, the *type-minimal valid input* — the
-worst-case-but-valid document. A plate that renders it has shown it
-degrades gracefully on every type-valid input shape. The contract
-requires:
+The blueprint, after sentinel substitution, is by construction the
+*type-minimal valid input* — the worst-case-but-valid document. A plate
+that renders it has shown it degrades gracefully on every type-valid
+input shape. The contract requires:
 
 - Templates treat type-empty values (`""`, `0`, `false`, `[]`, empty
   markdown body) as valid *present* input — read via `data.field`,
   `card.at("field", default: …)`, or guarded with `if "field" in data`.
-- No template asserts that a required field is *non-empty*. The schema
-  guarantees *presence*, not non-emptiness; `required` is an authoring
-  signal, not a render-time precondition.
+- No template asserts that a Must Fill field is *non-empty*. The schema
+  guarantees *presence*, not non-emptiness; the `<must-fill>` sentinel
+  is an authoring signal, not a render-time precondition.
 - "Renders successfully" means "compiles without error," not "produces
   meaningful output." An empty-string title is a blank title — that is
   acceptable.
 
-The contract is enforced by a fixture test that renders every bundled
-quill's blueprint and asserts success
+The contract is enforced by a fixture test that fills sentinels with
+type-empty values, then renders every bundled quill's blueprint and
+asserts success
 (`crates/quillmark/tests/quiver_test.rs::every_quill_in_quiver_renders`).
 
 ## Bindings surface
@@ -360,3 +375,27 @@ fixture.
 |---|---|
 | Validators, form builders, machine consumers | [SCHEMAS.md](SCHEMAS.md) — `schema()` |
 | LLM/MCP authoring, prompt-time reference document | this doc — `blueprint()` |
+
+## Authoring guidance
+
+When designing a `Quill.yaml` schema, choose between Must Fill and
+Endorsed per field:
+
+- **Declare `default:`** when a value (including a type-empty value like
+  `""`, `[]`, `false`, or `0`) is acceptable to ship as-is. The field
+  becomes Endorsed and the blueprint carries `; skip-ok`.
+- **Omit `default:`** when the author, LLM, or user must supply a value
+  before shipping. The field becomes Must Fill and the blueprint carries
+  the `<must-fill>` sentinel.
+- **Use `example:`** for illustrative reference values. `example:` is
+  orthogonal to the cell decision — it appears in the leading `# e.g.`
+  line for any cell, never rendering as the value.
+
+This is documentation, not enforcement.
+
+### Writing the literal string `<must-fill>` as content
+
+The blueprint emitter detects the unquoted form `<must-fill>` as the
+sentinel. To write the literal string as a field value, quote it:
+`"<must-fill>"`. Exact-string-equality detection treats the unquoted
+form as the sentinel and the quoted form as content.

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -93,7 +93,7 @@ signature_block:
 Indorsement body content.
 ````
 
-See [`MARKDOWN.md`](./MARKDOWN.md) §3 for the full syntax specification.
+See [`markdown-spec.md`](../references/markdown-spec.md) §3 for the full syntax specification.
 
 ## Backend Consumption
 
@@ -110,4 +110,4 @@ stripped from `Document::to_plate_json()` before backends see it, so
 template renders are not affected by editor state. Consumers
 namespace inside the map (`$ext.presentation`, `$ext.agent`, …) to avoid
 collisions when more than one tool carries state on the same card. See
-[MARKDOWN.md §3.3](./MARKDOWN.md) for the full specification.
+[markdown-spec.md §3.3](../references/markdown-spec.md) for the full specification.

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -44,7 +44,6 @@ card_kinds:
         description: Office symbol receiving the endorsed memo.
       signature_block:
         type: array
-        required: true
         ui:
           group: Addressing
         description: Name, grade, and duty title.
@@ -67,7 +66,6 @@ card_kinds:
         type: string
       signature_block:
         type: array
-        required: true
         ui:
           group: Addressing
 ```

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -162,6 +162,6 @@ by any past version always loads.
 ## Links
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — `Document` in the core type overview
-- [MARKDOWN.md](MARKDOWN.md) — Markdown syntax and the in-memory data model
+- [markdown-spec.md](../references/markdown-spec.md) — Markdown syntax and the in-memory data model
 - [VERSIONING.md](VERSIONING.md) — quill version resolution (a separate concern)
 - [QUILL_VALUE.md](QUILL_VALUE.md) — value type stored inside payload fields

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -53,8 +53,8 @@ See `crates/backends/typst/src/error_mapping.rs`.
 ## Validation message contract
 
 Field-level validation diagnostics — `validation::type_mismatch`,
-`validation::required_field_absent`, and
-`validation::unfilled_placeholder` — emit a single canonical shape:
+`validation::must_fill_absent`, and
+`validation::must_fill_sentinel` — emit a single canonical shape:
 
 - **Field path** — the document-model anchor of the offending field
   (`recipient`, `cards[2].author`).

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -50,6 +50,51 @@ Typst diagnostics mapped via `map_typst_errors()`:
 
 See `crates/backends/typst/src/error_mapping.rs`.
 
+## Validation message contract
+
+Field-level validation diagnostics — `validation::type_mismatch`,
+`validation::required_field_absent`, and
+`validation::unfilled_placeholder` — emit a single canonical shape:
+
+- **Field path** — the document-model anchor of the offending field
+  (`recipient`, `cards[2].author`).
+- **Source token** — the YAML scalar that triggered the error, rendered
+  verbatim in its YAML-canonical form (`42`, `null`, `true`, `""`). The
+  Must-Fill sentinel renders as `<must-fill>`. Strings appear quoted;
+  primitives appear bare. (Absent fields have no source token.)
+- **Schema declaration** — the field's declared type and, when present,
+  its default. Defaults render with the same verbatim formatting.
+- **Both exits when applicable** — the message names two ways out. The
+  parser does not silently coerce; the message is the lever.
+
+Example messages:
+
+```
+Field `build_number` got integer `42`, schema declares `string`.
+Either quote the value (`build_number: "42"`) or change the schema's
+`type:` to `integer`.
+```
+
+```
+Field `subtitle` got `null`, schema declares `string` with default
+`"My Subtitle"`. Either omit the line (the default will fill in) or
+set the value to a string.
+```
+
+```
+Field `memo_for` is missing, schema declares `string` with no default.
+Provide a value of type `string`.
+```
+
+```
+Field `name` still carries the `<must-fill>` blueprint sentinel,
+schema declares `string`. Replace `<must-fill>` with a value of type
+`string`.
+```
+
+Implementation: `crates/core/src/quill/validation.rs` (the
+`ValidationError` `Display` impl).
+
 ## Error Presentation
 
 **Pretty printing** (`Diagnostic::fmt_pretty()`):

--- a/prose/canon/INDEX.md
+++ b/prose/canon/INDEX.md
@@ -7,7 +7,7 @@
 
 ## Components
 
-- **[MARKDOWN.md](MARKDOWN.md)** - Quillmark Markdown specification (superset of CommonMark)
+- **[../references/markdown-spec.md](../references/markdown-spec.md)** - Quillmark Markdown specification (superset of CommonMark)
 - **[DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md)** - Versioned JSON serialization of `Document` for database persistence
 - **[QUILL.md](QUILL.md)** - Quill bundle structure and file tree API
 - **[QUILL_VALUE.md](QUILL_VALUE.md)** - Unified value type for YAML/JSON conversions

--- a/prose/canon/MARKDOWN.md
+++ b/prose/canon/MARKDOWN.md
@@ -122,7 +122,10 @@ accessors — `card.quill()`, `card.kind()`, `card.id()`, `card.ext()` —
 which return `Option<…>`. On a successfully parsed document the root
 card always returns `Some(_)` for both `quill()` and `kind()` (with
 `kind() == "main"`); composable cards return `None` for `quill()` and
-`Some(_)` for `kind()` (any value other than `"main"`).
+`Some(_)` for `kind()` (any value other than `"main"`). The root's
+`$kind: main` is synthesised when omitted in source (see §3.3 rules),
+so the typed-accessor invariant holds regardless of whether the
+author wrote the line.
 
 - **`$quill: <name>@<version>`** — binds the document to a quill (see §3.5
   for the version-selector forms). The root block (the first block) must
@@ -130,8 +133,12 @@ card always returns `Some(_)` for both `quill()` and `kind()` (with
   reference as the block is read.
 - **`$kind: <value>`** — identifies a card's kind. The value is
   name-validated at parse time and must match `[a-z_][a-z0-9_]*`. The kind
-  `main` is **reserved for the document root**: the root block must declare
-  `$kind: main`, and no composable card may declare `$kind: main`.
+  `main` is **reserved for the document root**: the root block's kind is
+  `main` by virtue of position. An explicit `$kind: main` on the root is
+  accepted and round-trips byte-equal; omitting it is also accepted, in
+  which case the parser synthesises the entry at the canonical position
+  so the in-memory model is uniform. A non-`main` `$kind` on the root is
+  a parse error, and no composable card may declare `$kind: main`.
 - **`$id: <value>`** — an opaque, optional identifier. Plain metadata: no
   validation, no uniqueness requirement; carried through round-trip
   unchanged.
@@ -146,9 +153,12 @@ card always returns `Some(_)` for both `quill()` and `kind()` (with
 
 Rules:
 
-- The root block must declare both `$quill: <ref>` and `$kind: main`. A
-  composable (non-root) block must declare `$kind: <kind>` for some
-  `<kind>` other than `main`, and must not declare `$quill`.
+- The root block must declare `$quill: <ref>`. Its `$kind` is `main`
+  by position: an explicit `$kind: main` is accepted, an omitted `$kind`
+  is accepted (and synthesised on parse), and any other `$kind` value
+  is a parse error. A composable (non-root) block must declare
+  `$kind: <kind>` for some `<kind>` other than `main`, and must not
+  declare `$quill`.
 - `$` metadata entries may appear at any position within the payload, and
   may be interleaved with data fields. The emitter preserves source order
   (see §9); newly constructed metadata that does not have a source-order
@@ -379,11 +389,13 @@ error when any is exceeded:
 
 That is: a `~~~card-yaml` opener, the YAML payload (typed `$` system
 metadata, user data fields, and YAML comments interleaved in source
-order), and a `~~~` closer. The root block must declare `$quill` and
-`$kind: main`; composable cards must declare `$kind: <kind>`. A document
-round-trips to this canonical shape — fence markers and YAML quoting are
-normalised. `!fill` tags and YAML comments (own-line and inline, including
-those adjacent to `$` lines) survive the round-trip.
+order), and a `~~~` closer. The root block must declare `$quill`;
+canonical emission also writes `$kind: main` on the root, synthesising
+it when the input omitted the line (see §3.3). Composable cards must
+declare `$kind: <kind>`. A document round-trips to this canonical
+shape — fence markers and YAML quoting are normalised. `!fill` tags
+and YAML comments (own-line and inline, including those adjacent to
+`$` lines) survive the round-trip.
 
 Programmatically constructed metadata that does not have a source-order
 emits in the canonical key order `$quill`, `$kind`, `$id`, `$ext` — the
@@ -422,8 +434,9 @@ Parse errors include:
 
 - A `~~~card-yaml` opener with no matching `~~~` closer before EOF.
 - The root block missing its `$quill` entry.
-- The root block missing its `$kind: main` entry, or declaring a
-  non-`main` `$kind`.
+- The root block declaring a non-`main` `$kind` (an omitted `$kind` on
+  the root is accepted and synthesised; only an explicit non-`main`
+  value is rejected).
 - A composable (non-root) block declaring `$quill`, or declaring
   `$kind: main` (which is reserved for the document root).
 - A duplicate `$key` within a single block (caught by the YAML parser as a

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -58,6 +58,10 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   the default (no error). A missing field without a `default:` fires
   `validation::required_field_absent`.
 
+Field-level type and presence errors render under a uniform shape —
+field path, verbatim source token, schema declaration, and both exits
+when applicable. See `ERROR.md` § "Validation message contract".
+
 ## Schema emission
 
 `QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -52,11 +52,11 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Enforces `body.enabled: false` on the main card and on each card kind — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
 - **Sentinel detection runs first.** Before per-type checks, any value
   equal to the literal string `<must-fill>` (for markdown, the trimmed
-  block-scalar content) fires `validation::unfilled_placeholder` and
+  block-scalar content) fires `validation::must_fill_sentinel` and
   skips the type check for that field.
 - **Required-field semantics**: a missing field with a `default:` accepts
   the default (no error). A missing field without a `default:` fires
-  `validation::required_field_absent`.
+  `validation::must_fill_absent`.
 
 Field-level type and presence errors render under a uniform shape —
 field path, verbatim source token, schema declaration, and both exits
@@ -85,7 +85,7 @@ Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `
 
 A field is **Must Fill** when no `default:` is declared; the schema author
 expects the LLM or user to supply a value before shipping. A missing
-Must Fill field at validate time fires `validation::required_field_absent`.
+Must Fill field at validate time fires `validation::must_fill_absent`.
 
 A field is **Endorsed** when `default:` is declared; the rendered default
 is shippable as-is (the author can keep or override it). Endorsed

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -36,6 +36,9 @@ Supported field types:
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
 - Coercion rules per type: array wrapping, boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
+- The Must-Fill sentinel string `<must-fill>` passes through coercion
+  unchanged so the validation layer can surface a placeholder diagnostic
+  rather than a type-coercion error
 
 ## Native validation
 
@@ -47,6 +50,13 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Emits path-aware errors for top-level fields and card fields
 - Validates each card's `$kind` matches a known card kind
 - Enforces `body.enabled: false` on the main card and on each card kind — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
+- **Sentinel detection runs first.** Before per-type checks, any value
+  equal to the literal string `<must-fill>` (for markdown, the trimmed
+  block-scalar content) fires `validation::unfilled_placeholder` and
+  skips the type check for that field.
+- **Required-field semantics**: a missing field with a `default:` accepts
+  the default (no error). A missing field without a `default:` fires
+  `validation::required_field_absent`.
 
 ## Schema emission
 
@@ -65,7 +75,22 @@ metadata, not schema fields, and do not appear in `fields`.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`, and optional `required` (omitted when false).
+Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`.
+
+### Must-Fill vs. Endorsed fields
+
+A field is **Must Fill** when no `default:` is declared; the schema author
+expects the LLM or user to supply a value before shipping. A missing
+Must Fill field at validate time fires `validation::required_field_absent`.
+
+A field is **Endorsed** when `default:` is declared; the rendered default
+is shippable as-is (the author can keep or override it). Endorsed
+defaults include type-empty values — `default: ""`, `default: []`,
+`default: false`, `default: 0` — which standardize the "skippable" cell.
+
+There is no separate `required:` axis; the presence or absence of
+`default:` is the sole author choice per field. See
+[BLUEPRINT.md](BLUEPRINT.md) for how the two cells render.
 
 Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters).
 

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -15,7 +15,7 @@ Semantic versioning: `MAJOR.MINOR.PATCH` (two-segment `MAJOR.MINOR` also accepte
 ## Document Syntax
 
 The version selector is carried on the root block's `$quill` system-metadata
-line (see [MARKDOWN.md](MARKDOWN.md) §3.3):
+line (see [markdown-spec.md](../references/markdown-spec.md) §3.3):
 
 ```
 $quill: my_format@2.1.0    # exact version

--- a/prose/proposals/mcp-feedback.md
+++ b/prose/proposals/mcp-feedback.md
@@ -251,33 +251,26 @@ main:
       # no default → Must Fill
 ```
 
-Blueprint:
+Rough example:
 
 ````
 ~~~card-yaml
 $quill: cmu_letter@0.1.0
-# Typeset letters that comply with Carnegie Mellon University letterhead standards.
-
 # The recipient's name and full mailing address.
 # e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
 recipient: <must-fill>  # array<string>
-
 # The signer's information. Line 1: Name. Line 2: Title.
 # e.g. [First M. Last, Title]
 signature_block: <must-fill>  # array<string>
-
 # The department or organizational unit name for the letterhead.
 # e.g. Department of Electrical and Computer Engineering
 department: ""  # string; skip-ok
-
 # The sender's institutional mailing address.
 # e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
 address: <must-fill>  # array<string>
-
 # The department or university website URL.
 # e.g. www.ece.cmu.edu
 url: ""  # string; skip-ok
-
 # The date to appear on the letter.
 date: <must-fill>  # date<YYYY-MM-DD>
 ~~~

--- a/prose/proposals/mcp-feedback.md
+++ b/prose/proposals/mcp-feedback.md
@@ -1,106 +1,42 @@
-# MCP Authoring-Surface Cleanup
+# MCP Field-Schema and Blueprint Redesign
 
-> **Motivation**: friction observed in an MCP consumer's eval, where LLM
-> authors of Quillmark Markdown made systematic mistakes the consumer had
-> to bandage with prompt-side rules. This proposal addresses the subset
-> of that friction whose fixes do not break the CommonMark-superset
-> guarantee or introduce silent coercion.
+> **Motivation**: friction in an MCP consumer's eval, where LLM authors
+> writing Quillmark Markdown systematically misunderstood the
+> `required` / `optional` / `default` axes on field schemas. This
+> proposal collapses the field-schema surface to a single author choice
+> and gives the blueprint two visually distinct render shapes for the
+> two cells.
 
 ## TL;DR
 
-Three changes: drop the redundant `$kind: main` requirement on the root
-block; give validation errors a uniform field-path / source-token /
-both-exits format; and collapse the field-schema axes (`required`,
-`optional`, `default`) into a two-cell model where a field either has a
-`default:` (Endorsed) or does not (Must Fill). Pre-1.0; breaking changes
-acceptable.
+Collapse the field-schema axes (`required`, `optional`, `default`)
+into a two-cell model: a field either has a `default:` (Endorsed) or
+does not (Must Fill). Render Must Fill with the `<must-fill>` sentinel
+in the value cell; render Endorsed with `; skip-ok` on the annotation.
+Pre-1.0; breaking changes acceptable.
+
+Two unrelated changes from the original draft (root-block `$kind:
+main` drop and the uniform validation-error format) are spun off into
+a separate effort.
 
 ## Background
 
-A consumer building an MCP server over Quillmark surfaced friction
-points where LLM authors made systematic mistakes. Three of them
-(asymmetric fences, tildes-only, `---` frontmatter as sugar) defend
-invariants worth more than the friction they cost and are not addressed
-here. The remaining ones — root-block redundancy, type-mismatch error
-quality, and the muddled `required`/`optional`/`default` schema axes —
-are addressed below.
+The `required` / `optional` axis on field schemas was overpromising a
+validation gate the system did not implement: the blueprint pre-fills
+every field and absence never reaches validation through the blueprint
+pathway. Authors and LLMs read `required: true` as "this field will be
+rejected if empty" — and the system never delivered.
 
-The field-schema collapse below resolves an overpromise: the
-`required` / `optional` axis advertised a validation gate the system did
-not implement, because the blueprint pre-fills every field and absence
-never reaches validation through the blueprint pathway. The new model
-replaces the overpromise with a single author choice (`default:` or not)
-and a visible blueprint signal (sentinel value or real value) per cell.
+The two-cell collapse replaces the overpromise with a single author
+choice (`default:` or not) and a visible blueprint signal per cell.
+The schema author makes one choice per field. The LLM reads one of
+two render shapes per field. Validation enforces type correctness and
+flags surviving sentinels.
 
-## Change 1: Drop `$kind: main` requirement on the root block
+## 1. Schema cells
 
-The root block is identified by position (MARKDOWN.md §2). Requiring
-`$kind: main` on the root is double bookkeeping that LLMs forget to
-satisfy and that adds no validation power.
-
-**Parsing.** Root block with `$kind: main` continues to validate. Root
-block without `$kind` validates as well; `main` is the implicit kind by
-virtue of position.
-
-**Canonical emission.** Canonical emission auto-injects `$kind: main`
-on the root, so the canonical form is unchanged and existing canonical
-documents round-trip byte-equal. Non-canonical input (omitted `$kind`
-on root) converges to the canonical form on first emit.
-
-**Rejected:** a composable block declaring `$kind: main` is still a
-parse error. The reservation of `main` for the root holds.
-
-**Spec touches:** MARKDOWN.md §3.3 (rules block), §9 (emission
-contract), §10 (errors).
-
-**Implementation:** `crates/core/src/document/`.
-
-## Change 2: Uniform validation-error format
-
-Validation errors that fire when a YAML scalar's parsed type does not
-match the schema's declared type — or when a sentinel survives to
-validation — emit a single canonical shape:
-
-- Names the field by its path (`recipient`, `cards[2].author`).
-- Shows the source token verbatim (`42`, `null`, `true`, `""`,
-  `<must-fill>`).
-- Offers both exits when applicable: quote the value, change the
-  schema's declared type, or replace the sentinel.
-
-No silent coercion. The error message is the lever; the parser stays
-strict.
-
-Example messages:
-
-```
-Field `build_number` got integer `42`, schema declares `string`.
-Either quote the value (`build_number: "42"`) or change the schema's
-`type:` to `integer`.
-```
-
-```
-Field `subtitle` got `null`, schema declares `string` with default
-`"My Subtitle"`. Either omit the line (the default will fill in) or
-set the value to a string.
-```
-
-```
-Field `recipient` still contains the placeholder `<must-fill>`.
-Replace it with a value of type `array<string>`.
-```
-
-**Spec touches:** SCHEMAS.md (Native validation section), ERROR.md
-(new code `validation::unfilled_placeholder`).
-
-**Implementation:** `crates/core/src/quill/` (validation walker; error
-construction).
-
-## Change 3: Two-cell field model
-
-### 3.1 Schema cells
-
-The `required:` key is removed from `Quill.yaml`. The `optional:` key is
-removed. The `default:` key alone determines a field's cell:
+The `required:` key is removed from `Quill.yaml`. The `optional:` key
+is removed. The `default:` key alone determines a field's cell:
 
 | Schema | Author intent | Omission semantic |
 |---|---|---|
@@ -109,12 +45,12 @@ removed. The `default:` key alone determines a field's cell:
 
 There is no third cell. "Skippable" use cases (the field may be left
 empty in the document) are expressed as Endorsed with a type-empty
-default — `default: ""`, `default: []`, `default: false`, etc. The plate
-contract (BLUEPRINT.md) already requires plates to accept type-empty
-values; this collapse standardizes the encoding rather than introducing
-new burden.
+default — `default: ""`, `default: []`, `default: false`, etc. The
+plate contract (BLUEPRINT.md) already requires plates to accept
+type-empty values; this collapse standardizes the encoding rather than
+introducing new burden.
 
-### 3.2 Blueprint rendering
+## 2. Blueprint rendering
 
 Two render shapes:
 
@@ -126,14 +62,15 @@ Two render shapes:
 The sentinel `<must-fill>` in the value cell signals "you must replace
 this." The tag `; skip-ok` in the annotation signals "this default is
 shippable; keep or override." The two are orthogonal — every field is
-exactly one cell, and the two signals never co-occur on the same field.
+exactly one cell, and the two signals never co-occur on the same
+field.
 
 A reader's mental model is one rule: **sentinel in value cell → must
 replace; otherwise the value cell is shippable.** Endorsed values
-include type-empty values (`""`, `[]`, `false`, `0`) and the `; skip-ok`
-tag confirms they are deliberate, not artifacts.
+include type-empty values (`""`, `[]`, `false`, `0`) and the `;
+skip-ok` tag confirms they are deliberate, not artifacts.
 
-### 3.3 Sentinel placement by type
+## 3. Sentinel placement by type
 
 The sentinel lives where the LLM types the value:
 
@@ -145,14 +82,15 @@ The sentinel lives where the LLM types the value:
 | `object` (typed dict) | Per-property recursion | leaves carry sentinels |
 | `array<object>` (typed table) | Per-property recursion in one synthetic row | leaves carry sentinels |
 
-**Markdown.** The block-scalar wrapper (`|-`) is preserved. The scalar's
-content is exactly `<must-fill>`, one line. Coercion reads the scalar's
-content as a string, compares to the sentinel literal, fires the
-placeholder error. When the LLM fills, it replaces the single line with
-multi-line markdown; the block-scalar shape is unchanged.
+**Markdown.** The block-scalar wrapper (`|-`) is preserved. The
+scalar's content is exactly `<must-fill>`, one line. Coercion reads
+the scalar's content as a string, compares to the sentinel literal,
+fires the placeholder error. When the LLM fills, it replaces the
+single line with multi-line markdown; the block-scalar shape is
+unchanged.
 
-**Typed object.** The container key has no value cell. Each property is
-rendered with its own annotation and its own cell signal:
+**Typed object.** The container key has no value cell. Each property
+is rendered with its own annotation and its own cell signal:
 
 ```
 address:  # object
@@ -161,10 +99,10 @@ address:  # object
   zip: ""  # string; skip-ok
 ```
 
-The container annotation has no `; skip-ok` tag because state is a leaf
-concern. If the container itself has a `default:` (concrete block
-mapping), the container is Endorsed and carries the tag; property
-annotations are dropped per the existing spec:
+The container annotation has no `; skip-ok` tag because state is a
+leaf concern. If the container itself has a `default:` (concrete
+block mapping), the container is Endorsed and carries the tag;
+property annotations are dropped per the existing spec:
 
 ```
 address:  # object; skip-ok
@@ -185,7 +123,7 @@ entries:  # array<object>
 With a container `default:`, actual rows render with property values
 only (no annotations), and the container carries `; skip-ok`.
 
-### 3.4 Inline annotation grammar
+## 4. Inline annotation grammar
 
 The annotation collapses to:
 
@@ -194,8 +132,8 @@ The annotation collapses to:
 ```
 
 The role slot (`; required` / `; optional`) is removed. No replacement
-token. State is conveyed by the value cell (sentinel or real value) and
-by the presence or absence of `; skip-ok`. The `<format>` slot is
+token. State is conveyed by the value cell (sentinel or real value)
+and by the presence or absence of `; skip-ok`. The `<format>` slot is
 unchanged from the current spec.
 
 Examples:
@@ -210,51 +148,50 @@ Examples:
 | `severity: <must-fill>  # enum<low \| medium \| high>` | Must Fill enum |
 | `tags: <must-fill>  # array<string>` | Must Fill array of strings |
 
-### 3.5 Validation
+## 5. Validation
 
 `QuillConfig::coerce_payload` and `validate_document`:
 
 - **Sentinel detection first.** Before per-type coercion runs, the raw
   YAML value is compared against the literal `<must-fill>`. For block
   scalars (markdown), the trimmed content is compared. On match: emit
-  `validation::unfilled_placeholder` with the field path; skip per-type
-  coercion for this field.
-- **Type-only coercion otherwise.** Every present value that is not the
-  sentinel is coerced to its declared type. Type mismatch fires
-  `validation::type_mismatch` per Change 2.
-- **Type-empty values are accepted.** No asymmetric rule for strings or
-  markdown. `""`, `[]`, `0`, `false`, empty block scalars all coerce
-  successfully for their declared types. The `default: ""` cell is fully
-  valid.
-- **Absence falls back.** A missing field with a `default:` accepts the
-  default. A missing field without a `default:` fires
+  `validation::unfilled_placeholder` with the field path; skip
+  per-type coercion for this field.
+- **Type-only coercion otherwise.** Every present value that is not
+  the sentinel is coerced to its declared type. Type mismatch fires
+  `validation::type_mismatch`.
+- **Type-empty values are accepted.** No asymmetric rule for strings
+  or markdown. `""`, `[]`, `0`, `false`, empty block scalars all
+  coerce successfully for their declared types. The `default: ""`
+  cell is fully valid.
+- **Absence falls back.** A missing field with a `default:` accepts
+  the default. A missing field without a `default:` fires
   `validation::required_field_absent`. (Blueprint flow never produces
   absence; this branch matters for non-blueprint authoring paths.)
 - **Errors accumulate.** The walker collects all errors per pass; it
   does not short-circuit on the first placeholder.
 
-### 3.6 Plate contract
+The `validation::unfilled_placeholder` error consumes the uniform
+error format defined by the spun-off document-parser proposal. Its
+message names the field path, shows the literal `<must-fill>` source
+token, and points at the exit (replace with a value of the declared
+type).
+
+## 6. Plate contract
 
 Unchanged. Plates must handle type-empty values (`""`, `[]`, `0`,
 `false`, empty markdown bodies) per BLUEPRINT.md's existing rendering
-contract. Plates never see `<must-fill>` — validation rejects it before
-render. The "every quill renders its own blueprint" fixture
+contract. Plates never see `<must-fill>` — validation rejects it
+before render. The "every quill renders its own blueprint" fixture
 (`every_quill_in_quiver_renders`) tightens to "the blueprint after
-all `<must-fill>` cells are replaced (or after migration converts them
-to Endorsed defaults)" — the bundled quills' blueprints are valid input
-once migrated.
+all `<must-fill>` cells are replaced (or after migration converts
+them to Endorsed defaults)" — the bundled quills' blueprints are
+valid input once migrated.
 
-**Spec touches:** SCHEMAS.md (field schema definition, validation
-section), BLUEPRINT.md (annotation grammar, placeholder cascade,
-sentinel rules, worked examples).
+## 7. Authoring guidance
 
-**Implementation:** `crates/core/src/quill/` (schema model, validator,
-blueprint emitter).
-
-## Change 4: Authoring guidance
-
-BLUEPRINT.md gains a short authoring-guidance section recommending that
-schema authors:
+BLUEPRINT.md gains a short authoring-guidance section recommending
+that schema authors:
 
 - Declare `default:` on a field when a value (including a type-empty
   value) is acceptable to ship as-is.
@@ -264,8 +201,6 @@ schema authors:
   line for any cell, never rendering as the value.
 
 This is documentation, not enforcement.
-
-**Spec touches:** BLUEPRINT.md (new authoring-guidance section).
 
 ## Migration
 
@@ -358,14 +293,6 @@ ambiguity.
 
 ## What this proposal does not do
 
-- Does not change fence syntax (`~~~card-yaml` stays asymmetric;
-  tildes-only stays).
-- Does not accept `---` frontmatter as sugar.
-- Does not add type coercion at the parser boundary.
-- Does not add a `field_name_type_mismatch` lint — naming-convention
-  heuristics produce false positives (`is_a_test`, `count` as unit
-  suffix) and Change 2's boundary error surfaces the real bug
-  per-document.
 - Does not add a `min_items:` or `non_empty:` constraint for arrays.
   "Required non-empty array" remains unrepresentable — the schema
   author who needs it documents the expectation in the field
@@ -379,41 +306,42 @@ ambiguity.
 
 ## Implementation order
 
-Each step is a separate commit; the order below is also a safe landing
-order.
+Each step is a separate commit; the order below is also a safe
+landing order.
 
-1. **Spec edits** to MARKDOWN.md, SCHEMAS.md, BLUEPRINT.md, and
-   ERROR.md reflecting the changes above. Spec edits go first so the
-   implementation has a target.
-2. **`$kind: main` relaxation** in the document parser and emitter
-   (Change 1). Smallest change; lands independently.
-3. **Boundary-error format** in the validation walker (Change 2).
-   Independent of Change 3.
-4. **Two-cell schema model** in `QuillConfig` and downstream consumers
-   (Change 3). Includes:
-   - Removal of `required:` / `optional:` from `FieldSchema`.
-   - Sentinel detection in the coercion path.
-   - `validation::unfilled_placeholder` error code.
-   - Blueprint-emitter rewrite: new annotation grammar, sentinel
-     rendering, `; skip-ok` tag emission.
-5. **Quill migration**: rewrite bundled quills in
+1. **Spec edits** to SCHEMAS.md and BLUEPRINT.md reflecting the new
+   two-cell model, sentinel rules, and annotation grammar. Spec edits
+   go first so the implementation has a target.
+2. **Schema model refactor** in `crates/core/src/quill/`:
+   - Remove `required:` / `optional:` from `FieldSchema`.
+   - Add sentinel detection in the coercion path.
+   - Add `validation::unfilled_placeholder` error code.
+3. **Blueprint emitter rewrite** in `crates/core/src/quill/`:
+   - New annotation grammar (drop role slot).
+   - Sentinel rendering at the right position per type.
+   - `; skip-ok` tag emission on Endorsed cells.
+4. **Quill migration**: rewrite bundled quills in
    `crates/fixtures/resources/quills/` to the two-cell shape; update
-   fixture tests; verify `every_quill_in_quiver_renders` still holds
-   (now over migrated blueprints).
-6. **Documentation guidance** added to BLUEPRINT.md (Change 4).
+   fixture tests; verify `every_quill_in_quiver_renders` still holds.
+5. **Documentation guidance** added to BLUEPRINT.md.
 
 ## Open questions
 
 - **Migration script for row 3 of the migration table.** The judgment
-  call between "keep default as Endorsed" and "move to example as Must
-  Fill" cannot be automated. Decision: the script flags these fields,
-  emits a comment, and a human reviewer makes the call per field.
-  Tooling, not design.
+  call between "keep default as Endorsed" and "move to example as
+  Must Fill" cannot be automated. Decision: the script flags these
+  fields, emits a comment, and a human reviewer makes the call per
+  field. Tooling, not design.
 - **Sentinel name collision.** `<must-fill>` is unlikely to appear as
   legitimate content. If a future use case needs to write the literal
   string `<must-fill>` as a value, the workaround is quoting
   (`"<must-fill>"`) — exact-string-equality detection treats the
-  unquoted form as the sentinel and the quoted form as content. Not a
-  design question; documented in BLUEPRINT.md and ERROR.md.
-- **Required non-empty arrays.** Deferred (see "What this proposal does
-  not do"). Revisit if migration surfaces material need.
+  unquoted form as the sentinel and the quoted form as content. Not
+  a design question; documented in BLUEPRINT.md and ERROR.md.
+- **Required non-empty arrays.** Deferred (see "What this proposal
+  does not do"). Revisit if migration surfaces material need.
+- **Dependency on the spun-off uniform error format.** The
+  `validation::unfilled_placeholder` error uses that format. If the
+  spinoff lands first, the new code drops in cleanly. If this
+  proposal lands first, the placeholder error uses a predecessor
+  format and gets retrofitted later. Either order is safe.

--- a/prose/proposals/mcp-feedback.md
+++ b/prose/proposals/mcp-feedback.md
@@ -1,54 +1,51 @@
 # MCP Authoring-Surface Cleanup
 
 > **Motivation**: friction observed in an MCP consumer's eval, where LLM
-> authors of Quillmark Markdown needed a written rulebook to compensate
-> for spec choices that fought their priors. This proposal addresses the
-> subset of that friction whose fixes do not break the CommonMark-superset
+> authors of Quillmark Markdown made systematic mistakes the consumer had
+> to bandage with prompt-side rules. This proposal addresses the subset
+> of that friction whose fixes do not break the CommonMark-superset
 > guarantee or introduce silent coercion.
 
 ## TL;DR
 
-Four locked-in changes: drop the redundant `$kind: main` requirement
-on the root block, give validation errors a uniform name-field /
-show-token / offer-both-exits format, collapse the
-`required`/`optional` schema axis into `default`-presence, and add
-authoring guidance favouring non-empty defaults. Pre-1.0; breaking
-changes acceptable.
+Three changes: drop the redundant `$kind: main` requirement on the root
+block; give validation errors a uniform field-path / source-token /
+both-exits format; and collapse the field-schema axes (`required`,
+`optional`, `default`) into a two-cell model where a field either has a
+`default:` (Endorsed) or does not (Must Fill). Pre-1.0; breaking changes
+acceptable.
 
 ## Background
 
-A consumer building an MCP server over Quillmark surfaced six friction
-points where LLM authors made systematic mistakes the consumer had to
-bandage with prompt-side rules. Three of the six (asymmetric fences,
-tildes-only, `---` frontmatter as sugar) defend invariants worth more
-than the friction they cost and are not addressed here. The remaining
-three are addressed below — two directly via grammar collapses, one
-via a uniform validation-error format that subsumes a class of LLM
-failures.
+A consumer building an MCP server over Quillmark surfaced friction
+points where LLM authors made systematic mistakes. Three of them
+(asymmetric fences, tildes-only, `---` frontmatter as sugar) defend
+invariants worth more than the friction they cost and are not addressed
+here. The remaining ones — root-block redundancy, type-mismatch error
+quality, and the muddled `required`/`optional`/`default` schema axes —
+are addressed below.
 
-A separate observation from the same review: the `role: required |
-optional` axis on field schemas was overpromising a validation gate
-the system did not implement, because the blueprint pre-fills every
-field and absence never reaches validation through the blueprint
-pathway. The collapse below removes that overpromise.
+The field-schema collapse below resolves an overpromise: the
+`required` / `optional` axis advertised a validation gate the system did
+not implement, because the blueprint pre-fills every field and absence
+never reaches validation through the blueprint pathway. The new model
+replaces the overpromise with a single author choice (`default:` or not)
+and a visible blueprint signal (sentinel value or real value) per cell.
 
-## Locked-in changes
-
-### 1. Drop `$kind: main` requirement on the root block
+## Change 1: Drop `$kind: main` requirement on the root block
 
 The root block is identified by position (MARKDOWN.md §2). Requiring
 `$kind: main` on the root is double bookkeeping that LLMs forget to
 satisfy and that adds no validation power.
 
-**Parsing.** Root block with `$kind: main` continues to validate.
-Root block without `$kind` validates as well; `main` is the implicit
-kind by virtue of position.
+**Parsing.** Root block with `$kind: main` continues to validate. Root
+block without `$kind` validates as well; `main` is the implicit kind by
+virtue of position.
 
 **Canonical emission.** Canonical emission auto-injects `$kind: main`
-on the root, so the canonical form is unchanged and existing
-canonical documents round-trip byte-equal. Non-canonical input
-(omitted `$kind` on root) converges to the canonical form on first
-emit.
+on the root, so the canonical form is unchanged and existing canonical
+documents round-trip byte-equal. Non-canonical input (omitted `$kind`
+on root) converges to the canonical form on first emit.
 
 **Rejected:** a composable block declaring `$kind: main` is still a
 parse error. The reservation of `main` for the root holds.
@@ -58,132 +55,306 @@ contract), §10 (errors).
 
 **Implementation:** `crates/core/src/document/`.
 
-### 2. Boundary-error uniform format
+## Change 2: Uniform validation-error format
 
 Validation errors that fire when a YAML scalar's parsed type does not
-match the schema's declared type — or when a no-default field arrives
-absent / type-empty — emit a single canonical shape:
+match the schema's declared type — or when a sentinel survives to
+validation — emit a single canonical shape:
 
 - Names the field by its path (`recipient`, `cards[2].author`).
-- Shows the source token verbatim (`42`, `null`, `true`, `""`).
-- Offers both exits when applicable: quote the value, or change the
-  schema's declared type.
+- Shows the source token verbatim (`42`, `null`, `true`, `""`,
+  `<must-fill>`).
+- Offers both exits when applicable: quote the value, change the
+  schema's declared type, or replace the sentinel.
 
 No silent coercion. The error message is the lever; the parser stays
-strict. This subsumes complaint #6 (string-typed fields receiving
-integer/boolean shapes) and complaint #5 (`null` on default-bearing
-fields — the message points the LLM at "omit the line").
+strict.
 
 Example messages:
 
 ```
 Field `build_number` got integer `42`, schema declares `string`.
-Either quote the value (`build_number: "42"`) or change the
-schema's `type:` to `integer`.
+Either quote the value (`build_number: "42"`) or change the schema's
+`type:` to `integer`.
 ```
 
 ```
 Field `subtitle` got `null`, schema declares `string` with default
-`"My Subtitle"`. Either omit the line (the default will fill in)
-or set the value to a string.
+`"My Subtitle"`. Either omit the line (the default will fill in) or
+set the value to a string.
+```
+
+```
+Field `recipient` still contains the placeholder `<must-fill>`.
+Replace it with a value of type `array<string>`.
 ```
 
 **Spec touches:** SCHEMAS.md (Native validation section), ERROR.md
-(diagnostic format if a new error code is introduced).
+(new code `validation::unfilled_placeholder`).
 
-**Implementation:** `crates/core/src/quill/` (validation walker;
-error construction).
+**Implementation:** `crates/core/src/quill/` (validation walker; error
+construction).
 
-### 3. Collapse `required`/`optional` into `default`-presence
+## Change 3: Two-cell field model
 
-The `role: required | optional` axis in `Quill.yaml` is removed. A
-field's required-ness is derived from whether a `default` is declared:
+### 3.1 Schema cells
 
-| `default` in schema | Field state |
+The `required:` key is removed from `Quill.yaml`. The `optional:` key is
+removed. The `default:` key alone determines a field's cell:
+
+| Schema | Author intent | Omission semantic |
+|---|---|---|
+| `default: <value>` | Endorsed — the rendered value is shippable; LLM may keep or override | pass `<value>` |
+| (no `default:`) | Must Fill — LLM must provide content before shipping | `validation::required_field_absent` error |
+
+There is no third cell. "Skippable" use cases (the field may be left
+empty in the document) are expressed as Endorsed with a type-empty
+default — `default: ""`, `default: []`, `default: false`, etc. The plate
+contract (BLUEPRINT.md) already requires plates to accept type-empty
+values; this collapse standardizes the encoding rather than introducing
+new burden.
+
+### 3.2 Blueprint rendering
+
+Two render shapes:
+
+| Cell | Render |
 |---|---|
-| absent | required — validation rejects absence; for `string` and `markdown`, additionally rejects type-empty values |
-| present (any value, including type-empty) | optional — absence is accepted (default substitutes); any present value is accepted |
+| Endorsed | `field: <value>  # <type>[<format>]; skip-ok` |
+| Must Fill | `field: <must-fill>  # <type>[<format>]` |
 
-**Why two type categories.** For strings and markdown, the type-empty
-value (`""`, empty block scalar) is the natural "unset" marker — an
-LLM leaving it untouched is the failure case the rule catches. For
-booleans, integers, numbers, arrays, and objects, the type-empty
-value (`false`, `0`, `[]`, `{}`) is a legitimate domain value, not an
-unset marker; rejecting it would reject valid authoring choices.
-Schema authors are expected to declare a `default` for these types,
-since omitting the field defaults to the type-empty value at
-validation anyway — making the no-default state behaviourally
-identical to `default: <type-empty>`. A schema lint can warn on
-no-default boolean / integer / array / object fields if this becomes
-common.
+The sentinel `<must-fill>` in the value cell signals "you must replace
+this." The tag `; skip-ok` in the annotation signals "this default is
+shippable; keep or override." The two are orthogonal — every field is
+exactly one cell, and the two signals never co-occur on the same field.
 
-**Blueprint rendering.** The inline annotation slot loses its
-mandatory role token. The grammar becomes
-`# <type>[<format>][; <extra>...]` where the role slot is gone and
-no other token replaces it. Required-vs-optional is conveyed by the
-rendered value itself: an empty string field reads as "fill me," a
-non-empty string field reads as "value present." For non-string types,
-the visual signal is absent and the LLM gets disambiguation from the
-schema (presented separately or implied by context) and from the
-validation feedback loop in #2.
+A reader's mental model is one rule: **sentinel in value cell → must
+replace; otherwise the value cell is shippable.** Endorsed values
+include type-empty values (`""`, `[]`, `false`, `0`) and the `; skip-ok`
+tag confirms they are deliberate, not artifacts.
 
-**Migration.** Pre-1.0; breaking change accepted.
+### 3.3 Sentinel placement by type
 
-- Existing quills declaring `required: true` and no `default`: drop
-  the `required` declaration; behaviour is preserved.
-- Existing quills declaring `required: true` and a `default`: drop
-  `required`; field becomes optional. The "must customize this
-  starting point" semantic is not preserved; if the author wants a
-  customize-mandatory placeholder, move the value to `example` and
-  remove the default.
-- Existing quills declaring `required: false` (or omitting `required`)
-  with no `default`: add `default: ""` (or appropriate type-empty
-  literal) to preserve optional semantics.
-- Existing quills declaring `required: false` (or omitting `required`)
-  with a `default`: no change.
+The sentinel lives where the LLM types the value:
 
-A one-shot migration script reads the old form and emits the new
-form deterministically.
+| Type | Sentinel position | Example |
+|---|---|---|
+| `string`, `integer`, `number`, `boolean`, `date`, `datetime`, `enum` | Value cell | `name: <must-fill>  # string` |
+| `array<scalar>` | Value cell | `recipient: <must-fill>  # array<string>` |
+| `markdown` | Inside the block scalar | `bio: \|-\n  <must-fill>` |
+| `object` (typed dict) | Per-property recursion | leaves carry sentinels |
+| `array<object>` (typed table) | Per-property recursion in one synthetic row | leaves carry sentinels |
 
-**Cells lost.** The old four-cell cross-product of
-`{required, optional} × {has_default, no_default}` collapses to
-three:
+**Markdown.** The block-scalar wrapper (`|-`) is preserved. The scalar's
+content is exactly `<must-fill>`, one line. Coercion reads the scalar's
+content as a string, compares to the sentinel literal, fires the
+placeholder error. When the LLM fills, it replaces the single line with
+multi-line markdown; the block-scalar shape is unchanged.
 
-- required + no default (was: required + empty default)
-- optional + empty default (was: optional + empty default)
-- optional + non-empty default (was: optional + non-empty default OR
-  required + non-empty default)
+**Typed object.** The container key has no value cell. Each property is
+rendered with its own annotation and its own cell signal:
 
-The last collapse — "required + non-empty default" merging into
-"optional + non-empty default" — is the only behavioural shift.
-Real-world cases in this cell were predominantly shippable defaults
-("Curriculum Vitae" CV title, today's date) rather than
-must-customize placeholders, so the loss is mostly nominal. The rare
-must-customize case is reachable via `example:` without a `default`.
+```
+address:  # object
+  street: <must-fill>  # string
+  city: <must-fill>  # string
+  zip: ""  # string; skip-ok
+```
+
+The container annotation has no `; skip-ok` tag because state is a leaf
+concern. If the container itself has a `default:` (concrete block
+mapping), the container is Endorsed and carries the tag; property
+annotations are dropped per the existing spec:
+
+```
+address:  # object; skip-ok
+  street: 5000 Forbes Avenue
+  city: Pittsburgh
+  zip: "15213"
+```
+
+**Typed table.** Same recursion. Without a container `default:`, one
+synthetic row is emitted with leaf-level sentinels:
+
+```
+entries:  # array<object>
+  - org: <must-fill>  # string
+    year: <must-fill>  # integer
+```
+
+With a container `default:`, actual rows render with property values
+only (no annotations), and the container carries `; skip-ok`.
+
+### 3.4 Inline annotation grammar
+
+The annotation collapses to:
+
+```
+# <type>[<format>][; skip-ok]
+```
+
+The role slot (`; required` / `; optional`) is removed. No replacement
+token. State is conveyed by the value cell (sentinel or real value) and
+by the presence or absence of `; skip-ok`. The `<format>` slot is
+unchanged from the current spec.
+
+Examples:
+
+| Line | Reading |
+|---|---|
+| `name: <must-fill>  # string` | Must Fill string |
+| `title: "Curriculum Vitae"  # string; skip-ok` | Endorsed string |
+| `is_published: false  # boolean; skip-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
+| `notes: ""  # string; skip-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
+| `date: <must-fill>  # date<YYYY-MM-DD>` | Must Fill date |
+| `severity: <must-fill>  # enum<low \| medium \| high>` | Must Fill enum |
+| `tags: <must-fill>  # array<string>` | Must Fill array of strings |
+
+### 3.5 Validation
+
+`QuillConfig::coerce_payload` and `validate_document`:
+
+- **Sentinel detection first.** Before per-type coercion runs, the raw
+  YAML value is compared against the literal `<must-fill>`. For block
+  scalars (markdown), the trimmed content is compared. On match: emit
+  `validation::unfilled_placeholder` with the field path; skip per-type
+  coercion for this field.
+- **Type-only coercion otherwise.** Every present value that is not the
+  sentinel is coerced to its declared type. Type mismatch fires
+  `validation::type_mismatch` per Change 2.
+- **Type-empty values are accepted.** No asymmetric rule for strings or
+  markdown. `""`, `[]`, `0`, `false`, empty block scalars all coerce
+  successfully for their declared types. The `default: ""` cell is fully
+  valid.
+- **Absence falls back.** A missing field with a `default:` accepts the
+  default. A missing field without a `default:` fires
+  `validation::required_field_absent`. (Blueprint flow never produces
+  absence; this branch matters for non-blueprint authoring paths.)
+- **Errors accumulate.** The walker collects all errors per pass; it
+  does not short-circuit on the first placeholder.
+
+### 3.6 Plate contract
+
+Unchanged. Plates must handle type-empty values (`""`, `[]`, `0`,
+`false`, empty markdown bodies) per BLUEPRINT.md's existing rendering
+contract. Plates never see `<must-fill>` — validation rejects it before
+render. The "every quill renders its own blueprint" fixture
+(`every_quill_in_quiver_renders`) tightens to "the blueprint after
+all `<must-fill>` cells are replaced (or after migration converts them
+to Endorsed defaults)" — the bundled quills' blueprints are valid input
+once migrated.
 
 **Spec touches:** SCHEMAS.md (field schema definition, validation
-section), BLUEPRINT.md (inline annotation grammar, placeholder
-cascade).
+section), BLUEPRINT.md (annotation grammar, placeholder cascade,
+sentinel rules, worked examples).
 
 **Implementation:** `crates/core/src/quill/` (schema model, validator,
 blueprint emitter).
 
-### 4. Authoring guidance: prefer shippable defaults
+## Change 4: Authoring guidance
 
-BLUEPRINT.md gains a short authoring-guidance section recommending
-that schema authors:
+BLUEPRINT.md gains a short authoring-guidance section recommending that
+schema authors:
 
-- Declare `default` on a field when the default value is acceptable
-  to ship as-is.
-- Omit `default` when the author / LLM / user must supply a value.
-- Use `example` (not `default`) for illustrative values that should
-  not pre-fill the document — e.g., when the value must be
-  customised per document and no shippable default exists.
+- Declare `default:` on a field when a value (including a type-empty
+  value) is acceptable to ship as-is.
+- Omit `default:` when the author / LLM / user must supply a value.
+- Use `example:` for illustrative reference values. `example:` is
+  orthogonal to the cell decision — it appears in the leading `# e.g.`
+  line for any cell, never rendering as the value.
 
-This is documentation, not enforcement. No warning fires from missing
-defaults.
+This is documentation, not enforcement.
 
 **Spec touches:** BLUEPRINT.md (new authoring-guidance section).
+
+## Migration
+
+The transformation is largely mechanical:
+
+| Current schema | New schema | Notes |
+|---|---|---|
+| `required: true`, no `default:` | drop `required:`; no `default:` | Was Must Fill, stays Must Fill |
+| `required: false` (or omitted), no `default:` | drop `required:`; add `default: <type-empty>` | Old "implicit optional" becomes Endorsed empty |
+| `required: true`, `default: <value>` | drop `required:`; keep `default:` OR drop both and add `example:` | One judgment call: was the default shippable (keep) or a must-customize placeholder (move to `example`)? |
+| `required: false` (or omitted), `default: <value>` | drop `required:`; keep `default:` | Unchanged behavior |
+
+A migration script handles rows 1, 2, and 4 deterministically. Row 3
+requires per-field author judgment; the script flags these for review.
+
+Bundled quills in `crates/fixtures/resources/quills/` are migrated as
+part of the implementation.
+
+## Worked example
+
+`cmu_letter` after migration:
+
+```yaml
+main:
+  fields:
+    recipient:
+      type: array
+      example: [Mr. John Doe, 123 Main St, "Anytown, USA"]
+      # no default → Must Fill
+    signature_block:
+      type: array
+      example: [First M. Last, Title]
+      # no default → Must Fill
+    department:
+      type: string
+      default: ""
+      example: Department of Electrical and Computer Engineering
+    address:
+      type: array
+      example: [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
+      # no default → Must Fill
+    url:
+      type: string
+      default: ""
+      example: www.ece.cmu.edu
+    date:
+      type: date
+      # no default → Must Fill
+```
+
+Blueprint:
+
+````
+~~~card-yaml
+$quill: cmu_letter@0.1.0
+# Typeset letters that comply with Carnegie Mellon University letterhead standards.
+
+# The recipient's name and full mailing address.
+# e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
+recipient: <must-fill>  # array<string>
+
+# The signer's information. Line 1: Name. Line 2: Title.
+# e.g. [First M. Last, Title]
+signature_block: <must-fill>  # array<string>
+
+# The department or organizational unit name for the letterhead.
+# e.g. Department of Electrical and Computer Engineering
+department: ""  # string; skip-ok
+
+# The sender's institutional mailing address.
+# e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
+address: <must-fill>  # array<string>
+
+# The department or university website URL.
+# e.g. www.ece.cmu.edu
+url: ""  # string; skip-ok
+
+# The date to appear on the letter.
+date: <must-fill>  # date<YYYY-MM-DD>
+~~~
+
+Write main body here.
+````
+
+Two render shapes, one tag, no `required` token. The LLM reads
+`<must-fill>` as "replace before shipping" and `; skip-ok` as "the
+default here is fine; keep or override." Six fields, three signals
+(sentinel, plain value with tag, leading `# e.g.` reference), no
+ambiguity.
 
 ## What this proposal does not do
 
@@ -191,42 +362,58 @@ defaults.
   tildes-only stays).
 - Does not accept `---` frontmatter as sugar.
 - Does not add type coercion at the parser boundary.
-- Does not add a `field_name_type_mismatch` lint. This was considered
-  and demoted — naming-convention heuristics produce false positives
-  on legitimate fields (`is_a_test`, `count` as a unit suffix) and
-  the boundary error in #2 surfaces the real bug per-document.
-- Does not add visual signalling of optionality beyond the
-  empty-vs-filled placeholder shape. Non-string-type ambiguity is
-  resolved reactively via #2's error feedback loop.
+- Does not add a `field_name_type_mismatch` lint — naming-convention
+  heuristics produce false positives (`is_a_test`, `count` as unit
+  suffix) and Change 2's boundary error surfaces the real bug
+  per-document.
+- Does not add a `min_items:` or `non_empty:` constraint for arrays.
+  "Required non-empty array" remains unrepresentable — the schema
+  author who needs it documents the expectation in the field
+  description and relies on plate-side handling. Deferred; revisit
+  after migration if real cases accumulate.
+- Does not change `example:` semantics. `example:` is illustrative
+  reference flavor, orthogonal to cell choice. The `# e.g.` leading
+  line is unchanged.
+- Does not introduce a "must customize this default" cell. The closest
+  expression is no-default + `example:` (Must Fill with reference).
 
 ## Implementation order
 
-1. **Spec edits** to MARKDOWN.md, SCHEMAS.md, BLUEPRINT.md, and ERROR.md
-   reflecting the changes above. Spec edits go first so the
+Each step is a separate commit; the order below is also a safe landing
+order.
+
+1. **Spec edits** to MARKDOWN.md, SCHEMAS.md, BLUEPRINT.md, and
+   ERROR.md reflecting the changes above. Spec edits go first so the
    implementation has a target.
 2. **`$kind: main` relaxation** in the document parser and emitter
-   (#1). Smallest change; lands independently.
-3. **Boundary-error format** in the validation walker (#2). Independent
-   of #3.
-4. **`role` axis removal** in `QuillConfig` and downstream consumers
-   (#3). Largest change; includes blueprint-emitter rewrite of the
-   inline annotation grammar and the placeholder cascade.
-5. **Quill migration**: rewrite bundled quills (`crates/quillmark/quiver/`)
-   to the new schema shape; update fixture tests; verify the
-   `every_quill_in_quiver_renders` invariant still holds.
-6. **Documentation guidance** added to BLUEPRINT.md (#4).
-
-Each step is a separate commit; the order above is also a safe
-landing order (later steps depend on earlier ones for the spec
-contract).
+   (Change 1). Smallest change; lands independently.
+3. **Boundary-error format** in the validation walker (Change 2).
+   Independent of Change 3.
+4. **Two-cell schema model** in `QuillConfig` and downstream consumers
+   (Change 3). Includes:
+   - Removal of `required:` / `optional:` from `FieldSchema`.
+   - Sentinel detection in the coercion path.
+   - `validation::unfilled_placeholder` error code.
+   - Blueprint-emitter rewrite: new annotation grammar, sentinel
+     rendering, `; skip-ok` tag emission.
+5. **Quill migration**: rewrite bundled quills in
+   `crates/fixtures/resources/quills/` to the two-cell shape; update
+   fixture tests; verify `every_quill_in_quiver_renders` still holds
+   (now over migrated blueprints).
+6. **Documentation guidance** added to BLUEPRINT.md (Change 4).
 
 ## Open questions
 
-- **Schema lint for no-default non-string fields.** Worth adding as a
-  warning, or leave to authoring convention? Deferred — revisit after
-  the migration shakes out which fields actually omit defaults in
-  practice.
-- **Error code namespace.** The boundary errors in #2 may need new
-  error codes (`validation::type_mismatch`,
-  `validation::required_field_empty`, `validation::required_field_absent`).
-  Decided during implementation; not a design question.
+- **Migration script for row 3 of the migration table.** The judgment
+  call between "keep default as Endorsed" and "move to example as Must
+  Fill" cannot be automated. Decision: the script flags these fields,
+  emits a comment, and a human reviewer makes the call per field.
+  Tooling, not design.
+- **Sentinel name collision.** `<must-fill>` is unlikely to appear as
+  legitimate content. If a future use case needs to write the literal
+  string `<must-fill>` as a value, the workaround is quoting
+  (`"<must-fill>"`) — exact-string-equality detection treats the
+  unquoted form as the sentinel and the quoted form as content. Not a
+  design question; documented in BLUEPRINT.md and ERROR.md.
+- **Required non-empty arrays.** Deferred (see "What this proposal does
+  not do"). Revisit if migration surfaces material need.

--- a/prose/proposals/mcp-feedback.md
+++ b/prose/proposals/mcp-feedback.md
@@ -41,7 +41,7 @@ is removed. The `default:` key alone determines a field's cell:
 | Schema | Author intent | Omission semantic |
 |---|---|---|
 | `default: <value>` | Endorsed — the rendered value is shippable; LLM may keep or override | pass `<value>` |
-| (no `default:`) | Must Fill — LLM must provide content before shipping | `validation::required_field_absent` error |
+| (no `default:`) | Must Fill — LLM must provide content before shipping | `validation::must_fill_absent` error |
 
 There is no third cell. "Skippable" use cases (the field may be left
 empty in the document) are expressed as Endorsed with a type-empty
@@ -155,7 +155,7 @@ Examples:
 - **Sentinel detection first.** Before per-type coercion runs, the raw
   YAML value is compared against the literal `<must-fill>`. For block
   scalars (markdown), the trimmed content is compared. On match: emit
-  `validation::unfilled_placeholder` with the field path; skip
+  `validation::must_fill_sentinel` with the field path; skip
   per-type coercion for this field.
 - **Type-only coercion otherwise.** Every present value that is not
   the sentinel is coerced to its declared type. Type mismatch fires
@@ -166,12 +166,12 @@ Examples:
   cell is fully valid.
 - **Absence falls back.** A missing field with a `default:` accepts
   the default. A missing field without a `default:` fires
-  `validation::required_field_absent`. (Blueprint flow never produces
+  `validation::must_fill_absent`. (Blueprint flow never produces
   absence; this branch matters for non-blueprint authoring paths.)
 - **Errors accumulate.** The walker collects all errors per pass; it
   does not short-circuit on the first placeholder.
 
-The `validation::unfilled_placeholder` error consumes the uniform
+The `validation::must_fill_sentinel` error consumes the uniform
 error format defined by the spun-off document-parser proposal. Its
 message names the field path, shows the literal `<must-fill>` source
 token, and points at the exit (replace with a value of the declared
@@ -308,7 +308,7 @@ landing order.
 2. **Schema model refactor** in `crates/core/src/quill/`:
    - Remove `required:` / `optional:` from `FieldSchema`.
    - Add sentinel detection in the coercion path.
-   - Add `validation::unfilled_placeholder` error code.
+   - Add `validation::must_fill_sentinel` error code.
 3. **Blueprint emitter rewrite** in `crates/core/src/quill/`:
    - New annotation grammar (drop role slot).
    - Sentinel rendering at the right position per type.
@@ -334,7 +334,7 @@ landing order.
 - **Required non-empty arrays.** Deferred (see "What this proposal
   does not do"). Revisit if migration surfaces material need.
 - **Dependency on the spun-off uniform error format.** The
-  `validation::unfilled_placeholder` error uses that format. If the
+  `validation::must_fill_sentinel` error uses that format. If the
   spinoff lands first, the new code drops in cleanly. If this
   proposal lands first, the placeholder error uses a predecessor
   format and gets retrofitted later. Either order is safe.

--- a/prose/proposals/mcp-feedback.md
+++ b/prose/proposals/mcp-feedback.md
@@ -1,0 +1,232 @@
+# MCP Authoring-Surface Cleanup
+
+> **Motivation**: friction observed in an MCP consumer's eval, where LLM
+> authors of Quillmark Markdown needed a written rulebook to compensate
+> for spec choices that fought their priors. This proposal addresses the
+> subset of that friction whose fixes do not break the CommonMark-superset
+> guarantee or introduce silent coercion.
+
+## TL;DR
+
+Four locked-in changes: drop the redundant `$kind: main` requirement
+on the root block, give validation errors a uniform name-field /
+show-token / offer-both-exits format, collapse the
+`required`/`optional` schema axis into `default`-presence, and add
+authoring guidance favouring non-empty defaults. Pre-1.0; breaking
+changes acceptable.
+
+## Background
+
+A consumer building an MCP server over Quillmark surfaced six friction
+points where LLM authors made systematic mistakes the consumer had to
+bandage with prompt-side rules. Three of the six (asymmetric fences,
+tildes-only, `---` frontmatter as sugar) defend invariants worth more
+than the friction they cost and are not addressed here. The remaining
+three are addressed below — two directly via grammar collapses, one
+via a uniform validation-error format that subsumes a class of LLM
+failures.
+
+A separate observation from the same review: the `role: required |
+optional` axis on field schemas was overpromising a validation gate
+the system did not implement, because the blueprint pre-fills every
+field and absence never reaches validation through the blueprint
+pathway. The collapse below removes that overpromise.
+
+## Locked-in changes
+
+### 1. Drop `$kind: main` requirement on the root block
+
+The root block is identified by position (MARKDOWN.md §2). Requiring
+`$kind: main` on the root is double bookkeeping that LLMs forget to
+satisfy and that adds no validation power.
+
+**Parsing.** Root block with `$kind: main` continues to validate.
+Root block without `$kind` validates as well; `main` is the implicit
+kind by virtue of position.
+
+**Canonical emission.** Canonical emission auto-injects `$kind: main`
+on the root, so the canonical form is unchanged and existing
+canonical documents round-trip byte-equal. Non-canonical input
+(omitted `$kind` on root) converges to the canonical form on first
+emit.
+
+**Rejected:** a composable block declaring `$kind: main` is still a
+parse error. The reservation of `main` for the root holds.
+
+**Spec touches:** MARKDOWN.md §3.3 (rules block), §9 (emission
+contract), §10 (errors).
+
+**Implementation:** `crates/core/src/document/`.
+
+### 2. Boundary-error uniform format
+
+Validation errors that fire when a YAML scalar's parsed type does not
+match the schema's declared type — or when a no-default field arrives
+absent / type-empty — emit a single canonical shape:
+
+- Names the field by its path (`recipient`, `cards[2].author`).
+- Shows the source token verbatim (`42`, `null`, `true`, `""`).
+- Offers both exits when applicable: quote the value, or change the
+  schema's declared type.
+
+No silent coercion. The error message is the lever; the parser stays
+strict. This subsumes complaint #6 (string-typed fields receiving
+integer/boolean shapes) and complaint #5 (`null` on default-bearing
+fields — the message points the LLM at "omit the line").
+
+Example messages:
+
+```
+Field `build_number` got integer `42`, schema declares `string`.
+Either quote the value (`build_number: "42"`) or change the
+schema's `type:` to `integer`.
+```
+
+```
+Field `subtitle` got `null`, schema declares `string` with default
+`"My Subtitle"`. Either omit the line (the default will fill in)
+or set the value to a string.
+```
+
+**Spec touches:** SCHEMAS.md (Native validation section), ERROR.md
+(diagnostic format if a new error code is introduced).
+
+**Implementation:** `crates/core/src/quill/` (validation walker;
+error construction).
+
+### 3. Collapse `required`/`optional` into `default`-presence
+
+The `role: required | optional` axis in `Quill.yaml` is removed. A
+field's required-ness is derived from whether a `default` is declared:
+
+| `default` in schema | Field state |
+|---|---|
+| absent | required — validation rejects absence; for `string` and `markdown`, additionally rejects type-empty values |
+| present (any value, including type-empty) | optional — absence is accepted (default substitutes); any present value is accepted |
+
+**Why two type categories.** For strings and markdown, the type-empty
+value (`""`, empty block scalar) is the natural "unset" marker — an
+LLM leaving it untouched is the failure case the rule catches. For
+booleans, integers, numbers, arrays, and objects, the type-empty
+value (`false`, `0`, `[]`, `{}`) is a legitimate domain value, not an
+unset marker; rejecting it would reject valid authoring choices.
+Schema authors are expected to declare a `default` for these types,
+since omitting the field defaults to the type-empty value at
+validation anyway — making the no-default state behaviourally
+identical to `default: <type-empty>`. A schema lint can warn on
+no-default boolean / integer / array / object fields if this becomes
+common.
+
+**Blueprint rendering.** The inline annotation slot loses its
+mandatory role token. The grammar becomes
+`# <type>[<format>][; <extra>...]` where the role slot is gone and
+no other token replaces it. Required-vs-optional is conveyed by the
+rendered value itself: an empty string field reads as "fill me," a
+non-empty string field reads as "value present." For non-string types,
+the visual signal is absent and the LLM gets disambiguation from the
+schema (presented separately or implied by context) and from the
+validation feedback loop in #2.
+
+**Migration.** Pre-1.0; breaking change accepted.
+
+- Existing quills declaring `required: true` and no `default`: drop
+  the `required` declaration; behaviour is preserved.
+- Existing quills declaring `required: true` and a `default`: drop
+  `required`; field becomes optional. The "must customize this
+  starting point" semantic is not preserved; if the author wants a
+  customize-mandatory placeholder, move the value to `example` and
+  remove the default.
+- Existing quills declaring `required: false` (or omitting `required`)
+  with no `default`: add `default: ""` (or appropriate type-empty
+  literal) to preserve optional semantics.
+- Existing quills declaring `required: false` (or omitting `required`)
+  with a `default`: no change.
+
+A one-shot migration script reads the old form and emits the new
+form deterministically.
+
+**Cells lost.** The old four-cell cross-product of
+`{required, optional} × {has_default, no_default}` collapses to
+three:
+
+- required + no default (was: required + empty default)
+- optional + empty default (was: optional + empty default)
+- optional + non-empty default (was: optional + non-empty default OR
+  required + non-empty default)
+
+The last collapse — "required + non-empty default" merging into
+"optional + non-empty default" — is the only behavioural shift.
+Real-world cases in this cell were predominantly shippable defaults
+("Curriculum Vitae" CV title, today's date) rather than
+must-customize placeholders, so the loss is mostly nominal. The rare
+must-customize case is reachable via `example:` without a `default`.
+
+**Spec touches:** SCHEMAS.md (field schema definition, validation
+section), BLUEPRINT.md (inline annotation grammar, placeholder
+cascade).
+
+**Implementation:** `crates/core/src/quill/` (schema model, validator,
+blueprint emitter).
+
+### 4. Authoring guidance: prefer shippable defaults
+
+BLUEPRINT.md gains a short authoring-guidance section recommending
+that schema authors:
+
+- Declare `default` on a field when the default value is acceptable
+  to ship as-is.
+- Omit `default` when the author / LLM / user must supply a value.
+- Use `example` (not `default`) for illustrative values that should
+  not pre-fill the document — e.g., when the value must be
+  customised per document and no shippable default exists.
+
+This is documentation, not enforcement. No warning fires from missing
+defaults.
+
+**Spec touches:** BLUEPRINT.md (new authoring-guidance section).
+
+## What this proposal does not do
+
+- Does not change fence syntax (`~~~card-yaml` stays asymmetric;
+  tildes-only stays).
+- Does not accept `---` frontmatter as sugar.
+- Does not add type coercion at the parser boundary.
+- Does not add a `field_name_type_mismatch` lint. This was considered
+  and demoted — naming-convention heuristics produce false positives
+  on legitimate fields (`is_a_test`, `count` as a unit suffix) and
+  the boundary error in #2 surfaces the real bug per-document.
+- Does not add visual signalling of optionality beyond the
+  empty-vs-filled placeholder shape. Non-string-type ambiguity is
+  resolved reactively via #2's error feedback loop.
+
+## Implementation order
+
+1. **Spec edits** to MARKDOWN.md, SCHEMAS.md, BLUEPRINT.md, and ERROR.md
+   reflecting the changes above. Spec edits go first so the
+   implementation has a target.
+2. **`$kind: main` relaxation** in the document parser and emitter
+   (#1). Smallest change; lands independently.
+3. **Boundary-error format** in the validation walker (#2). Independent
+   of #3.
+4. **`role` axis removal** in `QuillConfig` and downstream consumers
+   (#3). Largest change; includes blueprint-emitter rewrite of the
+   inline annotation grammar and the placeholder cascade.
+5. **Quill migration**: rewrite bundled quills (`crates/quillmark/quiver/`)
+   to the new schema shape; update fixture tests; verify the
+   `every_quill_in_quiver_renders` invariant still holds.
+6. **Documentation guidance** added to BLUEPRINT.md (#4).
+
+Each step is a separate commit; the order above is also a safe
+landing order (later steps depend on earlier ones for the spec
+contract).
+
+## Open questions
+
+- **Schema lint for no-default non-string fields.** Worth adding as a
+  warning, or leave to authoring convention? Deferred — revisit after
+  the migration shakes out which fields actually omit defaults in
+  practice.
+- **Error code namespace.** The boundary errors in #2 may need new
+  error codes (`validation::type_mismatch`,
+  `validation::required_field_empty`, `validation::required_field_absent`).
+  Decided during implementation; not a design question.

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -1,6 +1,6 @@
-# Quillmark Markdown
+# Quillmark Markdown Specification
 
-> **Status**: Draft specification
+> **Status**: Authoritative specification
 > **Base**: [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/)
 > **Implementation**: `crates/core/src/document/`
 
@@ -217,8 +217,9 @@ of:
 | `name@latest` | latest overall (explicit) |
 | `name` | latest overall (default — `@version` omitted) |
 
-Quill names match `/^[a-z][a-z0-9_]*$/`. See [VERSIONING.md](./VERSIONING.md)
-for resolution semantics.
+Quill names match `/^[a-z][a-z0-9_]*$/`. Resolution of partial selectors to
+concrete versions is performed by the quill registry; this spec fixes only
+the surface syntax accepted on the `$quill` line.
 
 ## 4. Block Detection
 
@@ -236,7 +237,7 @@ a new opener (though the canonical payload never produces such a line).
 
 A `~~~card-yaml` line that fails D1 is delegated to CommonMark as an ordinary
 fenced code block. A `~~~card-yaml` opener with no matching `~~~` closer
-before EOF is a hard parse error (§9).
+before EOF is a hard parse error (§10).
 
 ### 4.1 Worked Example
 
@@ -451,7 +452,5 @@ Parse errors include:
 ## 11. References
 
 - [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/)
-- [GitHub Flavored Markdown](https://github.github.com/gfm/) (pipe tables,
-  strikethrough)
-- [`VERSIONING.md`](./VERSIONING.md) — quill version-selector resolution
-- [`CARDS.md`](./CARDS.md) — downstream card-handling semantics
+- [GitHub Flavored Markdown](https://github.github.com/gfm/) — pipe tables
+  and strikethrough.


### PR DESCRIPTION
## Summary

Implements the `prose/proposals/mcp-feedback.md` proposal end-to-end, plus a follow-on simplification cascade that fell out of the new schema model. Together these reduce LLM-authoring friction and let consumers route on structured diagnostic fields instead of regex-parsing message text.

## What landed

**Schema / authoring model**
- **Drop `$kind: main` on the root block** (#638). Root kind is implicit by position; the canonical emitter re-injects `$kind: main` so round-trips stay byte-equal.
- **Collapse `required` / `optional` into the `default`-presence axis** (#637). A field is **Must Fill** when it has no `default:` and **Endorsed** when it does — no separate `role` field. The blueprint emitter writes a `<must-fill>` sentinel for Must Fill cells and a `; skip-ok` tag on Endorsed cells.
- **Promote `MARKDOWN.md` to authoritative reference docs** at `prose/references/markdown-spec.md` (#639), removing the old canon vs. reference ambiguity.

**Validation / diagnostics**
- **Uniform boundary-error format** (#638). Every field-level error names the field path, shows the source token verbatim, declares the schema-expected type, and offers concrete exit clauses ("quote the value or change the schema type", "omit the line or set a real value").
- **`MustFillUnset` variant** collapses the two Must Fill failure modes (omitted line vs. unreplaced `<must-fill>` sentinel) into one shape tagged by `MustFillSource::{Absent, Sentinel}`, surfaced under two diagnostic codes: `validation::must_fill_absent` and `validation::must_fill_sentinel`.
- **Structured `hint` on every diagnostic with an actionable exit** — `MustFillUnset` (both branches), `TypeMismatch`, `BodyDisabled`. The hint text is sourced from the same private helpers as the prose message, so `Display` and `hint()` can never drift.
- **`Form::diagnostics` forwards validation errors verbatim** with their `validation::*` codes, paths, and hints — no more `form::validation_error` wrapper that dropped structure.

**Cleanup**
- Dead `strip_string_quotes` helper deleted; `quotable_actual` simplified to `bool`.
- Stale `MARKDOWN.md` / `EXTENDED_MARKDOWN.md` doc references repointed at `markdown-spec.md`.
- Multibyte-safe prescan: replaces a `&trimmed[2..]` byte-slice with `strip_prefix("- ")` (regression test covers en-dash / em-dash / smart quotes / emoji bullets).

## Breaking changes

Pre-1.0 — all observable for consumers of the diagnostic API:

| Removed | Replacement |
|---|---|
| `validation::required_field_absent` code | `validation::must_fill_absent` |
| `validation::unfilled_placeholder` code | `validation::must_fill_sentinel` |
| `validation::missing_required` code (already gone, asserted dead) | `validation::must_fill_absent` |
| `form::validation_error` wrapper code | Underlying `validation::*` codes flow through |
| `required: true` / `required: false` field schema key | Declare or omit `default:` |
| `$kind: main` required on root block | Implicit; emitter re-injects on canonical write |

Routing on the `validation::must_fill_*` prefix is the recommended way to handle both Must Fill failure modes uniformly.

## Verification

- `cargo test --workspace`: 0 failures (471 + 217 + 83 + 22 + others across crates)
- `npx vitest run` (wasm bindings): 100/100
- CI green on `4efcb3a` (lint / test / wasm)

## Scope deferred

Flagged in the sanity-check review but explicitly out of scope for this PR:
- `is_endorsed` override-parameter shrink on `inline_annotation`
- Sentinel detection on non-string container fields (hand-edited edge case; blueprint never emits the shape)

https://claude.ai/code/session_01H5MrfvQsGUMreVhgFbqqG2