### PR TITLE
Replace required/optional role with Endorsed/Must Fill cell model

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -113,6 +113,20 @@ doc.push_card({"kind": "note", "fields": {"x": 1}, "body": "..."})
 # update_card_field, remove_card_field, update_card_body, ...
 ```
 
+## Schema model
+
+A field's *cell* is inferred from whether the schema declares a `default:`:
+
+- **Must Fill** (no `default:`) — the blueprint renders `<must-fill>`
+  and validation reports `validation::required_field_absent` if the
+  field is absent at validate time, or `validation::unfilled_placeholder`
+  if the `<must-fill>` sentinel survives into the rendered document.
+- **Endorsed** (with `default:`) — the blueprint renders the default
+  value with a `; skip-ok` annotation, and the default is used when
+  the document omits the field.
+
+There is no `required:` axis on `FieldSchema`.
+
 ## Error contract
 
 A single exception type — `QuillmarkError` — is raised for every failure

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -1,0 +1,231 @@
+"""Tests for the Must Fill / Endorsed schema surface.
+
+A field's *cell* is determined by whether the schema declares a `default:`.
+
+- No `default:` -> **Must Fill**: the blueprint renders `<must-fill>` and
+  validation reports ``validation::required_field_absent`` if the field
+  is absent at validate time and ``validation::unfilled_placeholder`` if
+  the `<must-fill>` sentinel survives into the rendered document.
+- With `default:` -> **Endorsed**: the blueprint renders the default
+  value with a ``; skip-ok`` annotation; the field is optional and the
+  default is used when absent.
+"""
+
+import pytest
+
+from quillmark import Document, OutputFormat, Quillmark, QuillmarkError
+
+
+QUILL_YAML_CONTENT = """quill:
+  name: py_schema_smoke
+  version: "1.0"
+  backend: typst
+  plate_file: plate.typ
+  description: Python schema/blueprint smoke test
+
+main:
+  fields:
+    title:
+      description: Document title
+      type: string
+    status:
+      description: Document status
+      type: string
+      default: draft
+    count:
+      type: integer
+"""
+
+PLATE_TYP = "Title: {{ title }} / Status: {{ status }} / Count: {{ count }}"
+
+
+def make_quill(tmp_path, yaml_content=QUILL_YAML_CONTENT, plate=PLATE_TYP):
+    quill_dir = tmp_path / "quill"
+    quill_dir.mkdir()
+    (quill_dir / "Quill.yaml").write_text(yaml_content)
+    (quill_dir / "plate.typ").write_text(plate)
+    engine = Quillmark()
+    return engine.quill_from_path(str(quill_dir))
+
+
+# ---------------------------------------------------------------------------
+# Schema surface — `required:` is gone; cells are inferred from `default:`.
+# ---------------------------------------------------------------------------
+
+def test_schema_has_no_required_key(tmp_path):
+    """The schema dict never carries a `required:` key on a field.
+
+    Cell is inferred from the presence/absence of `default:`.
+    """
+    quill = make_quill(tmp_path)
+    schema = quill.schema
+
+    fields = schema["main"]["fields"]
+    for name, field in fields.items():
+        assert "required" not in field, (
+            f"field {name!r} unexpectedly carries `required`; "
+            "the schema axis is now `default`-driven"
+        )
+
+
+def test_schema_default_marks_endorsed(tmp_path):
+    """Endorsed fields carry the `default` key; Must Fill fields don't."""
+    quill = make_quill(tmp_path)
+    fields = quill.schema["main"]["fields"]
+
+    # Must Fill: no `default`
+    assert "default" not in fields["title"], (
+        "title is Must Fill — no default should be reported"
+    )
+    assert "default" not in fields["count"], (
+        "count is Must Fill — no default should be reported"
+    )
+
+    # Endorsed: schema carries `default`
+    assert fields["status"]["default"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Blueprint surface — annotations and sentinels
+# ---------------------------------------------------------------------------
+
+def test_blueprint_must_fill_sentinel(tmp_path):
+    """Must Fill cells render the literal `<must-fill>` sentinel."""
+    quill = make_quill(tmp_path)
+    bp = quill.blueprint
+
+    # Must Fill fields carry the sentinel
+    assert "title: <must-fill>" in bp, (
+        f"expected `title: <must-fill>` in blueprint; got:\n{bp}"
+    )
+    assert "count: <must-fill>" in bp, (
+        f"expected `count: <must-fill>` in blueprint; got:\n{bp}"
+    )
+
+
+def test_blueprint_endorsed_skip_ok(tmp_path):
+    """Endorsed cells carry `; skip-ok` after the type annotation."""
+    quill = make_quill(tmp_path)
+    bp = quill.blueprint
+
+    # The Endorsed `status` field renders its default value with `; skip-ok`.
+    # The exact format is `status: draft  # string; skip-ok`.
+    assert "status: draft" in bp, f"expected default in blueprint; got:\n{bp}"
+    assert "skip-ok" in bp, (
+        f"expected `; skip-ok` annotation on Endorsed cell; got:\n{bp}"
+    )
+
+
+def test_blueprint_no_legacy_required_optional_tags(tmp_path):
+    """Old `; required` / `; optional` role tags are gone from the grammar."""
+    quill = make_quill(tmp_path)
+    bp = quill.blueprint
+
+    # The legacy role tags are dead — never emitted.
+    assert "; required" not in bp, (
+        f"legacy `; required` tag must not appear in blueprint:\n{bp}"
+    )
+    assert "; optional" not in bp, (
+        f"legacy `; optional` tag must not appear in blueprint:\n{bp}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation surface — new diagnostic codes
+# ---------------------------------------------------------------------------
+
+def _diag_codes(exc):
+    return [d.code for d in exc.diagnostics]
+
+
+def test_render_reports_required_field_absent(tmp_path):
+    """A Must Fill field absent from the document fails validation with
+    ``validation::required_field_absent``.
+    """
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "status: ready\n"          # Endorsed override
+        # title and count omitted — Must Fill, no defaults
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        quill.render(doc, OutputFormat.PDF)
+
+    codes = _diag_codes(exc_info.value)
+    assert "validation::required_field_absent" in codes, (
+        f"expected validation::required_field_absent; got: {codes}"
+    )
+
+
+def test_render_reports_unfilled_placeholder(tmp_path):
+    """A field whose value is still the literal `<must-fill>` sentinel
+    fails validation with ``validation::unfilled_placeholder``.
+    """
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "title: <must-fill>\n"      # sentinel left in place
+        "count: 1\n"
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        quill.render(doc, OutputFormat.PDF)
+
+    codes = _diag_codes(exc_info.value)
+    assert "validation::unfilled_placeholder" in codes, (
+        f"expected validation::unfilled_placeholder; got: {codes}"
+    )
+
+
+def test_render_does_not_emit_legacy_missing_required(tmp_path):
+    """The legacy ``validation::missing_required`` code must be gone.
+
+    Triggering the same condition (absent Must Fill field) must surface
+    the new ``validation::required_field_absent`` code instead.
+    """
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        quill.render(doc, OutputFormat.PDF)
+
+    codes = _diag_codes(exc_info.value)
+    assert "validation::missing_required" not in codes, (
+        "legacy code `validation::missing_required` must no longer appear; "
+        f"got: {codes}"
+    )
+
+
+def test_render_succeeds_when_must_fill_supplied(tmp_path):
+    """Filling every Must Fill field renders successfully — Endorsed
+    fields fall back to their declared default."""
+    quill = make_quill(tmp_path)
+    md = (
+        "~~~card-yaml\n"
+        "$quill: py_schema_smoke\n"
+        "$kind: main\n"
+        "title: Hello\n"
+        "count: 7\n"
+        # status omitted → falls back to its default "draft"
+        "~~~\n"
+    )
+    doc = Document.from_markdown(md)
+
+    result = quill.render(doc, OutputFormat.PDF)
+    assert len(result.artifacts) > 0
+    assert result.artifacts[0].format == OutputFormat.PDF

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -244,6 +244,25 @@ canvas.style.height = `${result.layoutHeight}px`;
   enforcement contract and includes the resolved `backendId` for
   debugging.
 
+### Schema model
+
+A field's *cell* is inferred from whether its schema declares a `default:`:
+
+- **Must Fill** (no `default:`) — `quill.blueprint` renders `<must-fill>`
+  in the value cell, and `quill.render(doc)` throws with
+  `validation::required_field_absent` when the field is absent at
+  validate time, or `validation::unfilled_placeholder` when the
+  `<must-fill>` sentinel survives into the document.
+- **Endorsed** (with `default:`) — `quill.blueprint` renders the
+  default value followed by a `; skip-ok` annotation, and the default
+  is used when the document omits the field.
+
+`QuillFieldSchema` no longer carries a `required` axis. The legacy
+`validation::missing_required` code has been replaced by
+`validation::required_field_absent`; the new
+`validation::unfilled_placeholder` code is added for unreplaced
+sentinels.
+
 ### Errors
 
 Every method that can fail throws a JS `Error` with `.diagnostics` attached:

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1026,3 +1026,227 @@ title: "Hello"
     expect(quill.blankCard('does_not_exist')).toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Schema / blueprint / validation — Must Fill vs Endorsed
+// ---------------------------------------------------------------------------
+//
+// Post-mcp-feedback the schema axis is implicit: a field with a `default:` is
+// Endorsed (the rendered default is shippable as-is and the blueprint emits
+// the value + `; skip-ok` annotation); a field without a `default:` is Must
+// Fill (the blueprint emits the `<must-fill>` sentinel and validation flags
+// either the absence or the unreplaced sentinel).
+//
+// These tests pin the JS-facing contract:
+//   - `QuillFieldSchema` no longer carries a `required` axis.
+//   - `quill.blueprint` carries `<must-fill>` and `; skip-ok` annotations.
+//   - `quill.render(doc)` raises `validation::required_field_absent` when a
+//     Must Fill field is absent at validate time.
+//   - `quill.render(doc)` raises `validation::unfilled_placeholder` when the
+//     `<must-fill>` sentinel is left in.
+//   - `quill.form(doc)` flags both situations under `diagnostics`.
+
+describe('Must Fill / Endorsed schema model', () => {
+  // The plate `unwrap`s `data.title` (Must Fill) and substitutes the optional
+  // `data.subtitle` if present. Authoring a quill with both Must Fill and
+  // Endorsed fields lets us exercise both validation codes without having to
+  // ship two separate test quills.
+  const SCHEMA_QUILL_YAML = `quill:
+  name: schema_test
+  version: "1.0"
+  backend: typst
+  plate_file: plate.typ
+  description: Must Fill / Endorsed coverage
+
+main:
+  fields:
+    title:
+      type: string
+      description: Document title (Must Fill — no default)
+    subtitle:
+      type: string
+      default: "Untitled subtitle"
+      description: Document subtitle (Endorsed — default shippable)
+`
+
+  const SCHEMA_PLATE = `#import "@local/quillmark-helper:0.1.0": data
+#let title = data.title
+#let subtitle = data.at("subtitle", default: "")
+#let body = data.at("$body")
+
+= #title
+
+#subtitle
+
+#body`
+
+  const buildQuill = () => {
+    const engine = new Quillmark()
+    return engine.quill(
+      makeQuill({
+        name: 'schema_test',
+        plate: SCHEMA_PLATE,
+        quillYaml: SCHEMA_QUILL_YAML,
+      }),
+    )
+  }
+
+  it('schema fields carry no legacy `required` axis', () => {
+    const quill = buildQuill()
+    const fields = quill.schema.main.fields
+
+    expect(fields.title).toBeDefined()
+    expect(fields.subtitle).toBeDefined()
+
+    // The `required` axis was removed; cell is implied by `default:` presence.
+    expect('required' in fields.title).toBe(false)
+    expect('required' in fields.subtitle).toBe(false)
+
+    // Must Fill fields have no `default`; Endorsed fields do.
+    expect(fields.title.default).toBeUndefined()
+    expect(fields.subtitle.default).toBe('Untitled subtitle')
+  })
+
+  it('blueprint carries `<must-fill>` for Must Fill fields and `; skip-ok` for Endorsed', () => {
+    const quill = buildQuill()
+    const blueprint = quill.blueprint
+
+    expect(typeof blueprint).toBe('string')
+    expect(blueprint.length).toBeGreaterThan(0)
+
+    // Must Fill: value cell is the literal sentinel; no `; skip-ok` tag.
+    expect(blueprint).toContain('title: <must-fill>  # string')
+    expect(blueprint).not.toMatch(/title: <must-fill>.*skip-ok/)
+
+    // Endorsed: rendered default + `; skip-ok` tag. The emitter does not
+    // quote strings that don't need quoting (`Untitled subtitle` has no YAML
+    // ambiguity), so the value cell is bare.
+    expect(blueprint).toContain('subtitle: Untitled subtitle  # string; skip-ok')
+
+    // The legacy `; required` / `; optional` role tag must not appear anywhere.
+    expect(blueprint).not.toContain('; required')
+    expect(blueprint).not.toContain('; optional')
+  })
+
+  it('render throws `validation::required_field_absent` when a Must Fill field is absent', () => {
+    const quill = buildQuill()
+
+    // Document omits `title`. Schema declares no default → Must Fill.
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+subtitle: "Just a subtitle"
+~~~
+
+# Body
+`
+    const doc = Document.fromMarkdown(md)
+
+    try {
+      quill.render(doc, { format: 'svg' })
+      throw new Error('render should have thrown ValidationFailed')
+    } catch (err) {
+      expect(Array.isArray(err.diagnostics)).toBe(true)
+      const codes = err.diagnostics.map((d) => d.code)
+      expect(codes).toContain('validation::required_field_absent')
+      // The diagnostic must anchor to the offending field path.
+      const required = err.diagnostics.find(
+        (d) => d.code === 'validation::required_field_absent',
+      )
+      expect(required.path).toBe('title')
+      expect(required.severity).toBe('error')
+      // The legacy code must be gone.
+      expect(codes).not.toContain('validation::missing_required')
+    }
+  })
+
+  it('render throws `validation::unfilled_placeholder` when the `<must-fill>` sentinel is left in', () => {
+    const quill = buildQuill()
+
+    // Document supplies the literal sentinel — the LLM forgot to fill it.
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+title: <must-fill>
+~~~
+
+# Body
+`
+    const doc = Document.fromMarkdown(md)
+
+    try {
+      quill.render(doc, { format: 'svg' })
+      throw new Error('render should have thrown ValidationFailed')
+    } catch (err) {
+      expect(Array.isArray(err.diagnostics)).toBe(true)
+      const codes = err.diagnostics.map((d) => d.code)
+      expect(codes).toContain('validation::unfilled_placeholder')
+      const placeholder = err.diagnostics.find(
+        (d) => d.code === 'validation::unfilled_placeholder',
+      )
+      expect(placeholder.path).toBe('title')
+      expect(placeholder.severity).toBe('error')
+      // Hint nudges the caller toward the action they need to take.
+      expect(placeholder.hint).toBeDefined()
+      expect(placeholder.hint).toMatch(/<must-fill>/)
+    }
+  })
+
+  it('render succeeds when every Must Fill field is supplied with a real value', () => {
+    const quill = buildQuill()
+
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+title: "A Real Title"
+~~~
+
+# Body
+`
+    const doc = Document.fromMarkdown(md)
+    const result = quill.render(doc, { format: 'svg' })
+    expect(result.artifacts.length).toBeGreaterThan(0)
+  })
+
+  it('form surfaces validation diagnostics for both absent and sentinel cases', () => {
+    const quill = buildQuill()
+
+    // Case 1: `title` absent — form should flag it.
+    const mdAbsent = `~~~card-yaml
+$quill: schema_test
+$kind: main
+subtitle: "Just a subtitle"
+~~~
+`
+    const formAbsent = quill.form(Document.fromMarkdown(mdAbsent))
+    // `title` is missing in the document, and the schema declares no default,
+    // so the form view marks the value as `missing`.
+    expect(formAbsent.main.values.title.source).toBe('missing')
+    expect(formAbsent.main.values.title.default).toBeNull()
+    // The validation error surfaces under `diagnostics` (form re-codes
+    // structured validation errors as `form::validation_error`).
+    expect(formAbsent.diagnostics.length).toBeGreaterThan(0)
+    expect(
+      formAbsent.diagnostics.some(
+        (d) => d.severity === 'error' && /title/.test(d.message),
+      ),
+    ).toBe(true)
+
+    // Case 2: sentinel left in — form should also flag it.
+    const mdSentinel = `~~~card-yaml
+$quill: schema_test
+$kind: main
+title: <must-fill>
+~~~
+`
+    const formSentinel = quill.form(Document.fromMarkdown(mdSentinel))
+    // The sentinel is a literal string value, so the source is `document`.
+    expect(formSentinel.main.values.title.source).toBe('document')
+    expect(formSentinel.main.values.title.value).toBe('<must-fill>')
+    expect(
+      formSentinel.diagnostics.some(
+        (d) => d.severity === 'error' && /<must-fill>/.test(d.message),
+      ),
+    ).toBe(true)
+  })
+})

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -32,13 +32,20 @@ export interface QuillCardBody {
     example?: string;
 }
 
-/** Schema entry for a single field declared in a quill's `Quill.yaml`. */
+/** Schema entry for a single field declared in a quill's `Quill.yaml`.
+ *
+ * A field's *cell* is determined by `default`: a field with a `default`
+ * is **Endorsed** (the rendered value is shippable as-is), while a field
+ * without a `default` is **Must Fill** (the blueprint carries a
+ * `<must-fill>` sentinel and validation reports
+ * `validation::required_field_absent` if the field is absent at validate
+ * time). There is no separate `required` axis.
+ */
 export interface QuillFieldSchema {
     type: "string" | "number" | "integer" | "boolean" | "array" | "object" | "date" | "datetime" | "markdown";
     description?: string;
     default?: unknown;
     example?: unknown;
-    required?: boolean;
     enum?: string[];
     ui?: QuillFieldUi;
     properties?: Record<string, QuillFieldSchema>;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -520,7 +520,7 @@ mod tests {
     #[test]
     fn test_diagnostic_with_path() {
         let diag = Diagnostic::new(Severity::Error, "Missing field".to_string())
-            .with_code("validation::missing_required".to_string())
+            .with_code("validation::required_field_absent".to_string())
             .with_path("cards.indorsement[0].signature_block".to_string());
 
         assert_eq!(

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -11,15 +11,17 @@
 //! Annotation grammar:
 //! - **Leading `# …` lines** carry prose: `# <description>` (single line,
 //!   whitespace-collapsed) and `# e.g. <value>` (whenever an `example:` is
-//!   configured, regardless of role or type).
+//!   configured, regardless of cell or type).
 //! - **Inline `# …` annotation** on the value line is structural:
-//!   `# <type>[<format>]; <role>[, <extras>...]`. Type is mandatory on every
-//!   field. Format slot uses angle brackets (`array<string>`,
-//!   `date<YYYY-MM-DD>`, `enum<a | b | c>`). Role is `required` or
-//!   `optional`.
+//!   `# <type>[<format>][; skip-ok]`. Type is mandatory on every field.
+//!   Format slot uses angle brackets (`array<string>`, `date<YYYY-MM-DD>`,
+//!   `enum<a | b | c>`). The optional `; skip-ok` tag marks **Endorsed**
+//!   cells whose rendered default is shippable as-is; its absence marks
+//!   **Must Fill** cells, which carry the `<must-fill>` sentinel in the
+//!   value cell instead.
 //! - **Metadata annotation.** The `$quill` / `$kind` system-metadata lines
 //!   have no inline-annotation slot, so their role annotation
-//!   (`system metadata; required, verbatim` for the root block,
+//!   (`system metadata; verbatim` for the root block,
 //!   `composable (0..N)` for cards) is emitted as an own-line `# …` comment
 //!   directly under the `$` line.
 //! - **Body regions** are signalled by `Write main body here.` after the main
@@ -32,6 +34,7 @@
 
 use std::collections::BTreeMap;
 
+use super::validation::MUST_FILL_SENTINEL;
 use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::value::QuillValue;
@@ -106,7 +109,7 @@ fn write_main_fence(
     )));
     out.push('\n');
     out.push_str("$kind: main\n");
-    write_comment(out, "system metadata; required, verbatim");
+    write_comment(out, "system metadata; verbatim");
     if let Some(desc) = description {
         write_comment(out, desc);
     }
@@ -188,12 +191,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     // Markdown fields render as a YAML block scalar so multi-line content has
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
-        let inline = inline_annotation(field, false);
+        let inline = inline_annotation(field, false, None);
         write_markdown_block(out, field, &pad, &inline);
         return;
     }
 
-    let inline = format!("  # {}", inline_annotation(field, false));
+    let inline = format!("  # {}", inline_annotation(field, false, None));
     let value = field_value(field);
     write_value(out, &field.name, &value, &inline, &pad);
 }
@@ -208,7 +211,7 @@ fn write_description(out: &mut String, field: &FieldSchema, pad: &str) {
 }
 
 /// `# e.g. <value>` — emitted whenever `example:` is configured on the field.
-/// Independent of role, type, or enum-ness; examples never become rendered
+/// Independent of cell, type, or enum-ness; examples never become rendered
 /// values.
 fn write_eg_comment(out: &mut String, field: &FieldSchema, pad: &str) {
     if let Some(eg) = field.example.as_ref().map(eg_hint) {
@@ -219,8 +222,10 @@ fn write_eg_comment(out: &mut String, field: &FieldSchema, pad: &str) {
 fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline: &str) {
     out.push_str(&format!("{}{}: |-  # {}\n", pad, field.name, inline));
     let body_pad = format!("{}  ", pad);
-    // Render default content if present; otherwise leave one indented blank
-    // line so the block scalar has a body for the author to fill in.
+    // Endorsed cell with content → render the default. Endorsed cell with
+    // empty/absent string default → one indented blank line (the
+    // "skippable" markdown cell). Must Fill cell → the sentinel on one
+    // line inside the block scalar.
     let content = field.default.as_ref().and_then(|v| match v.as_json() {
         serde_json::Value::String(s) => Some(s),
         _ => None,
@@ -231,8 +236,11 @@ fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline
                 out.push_str(&format!("{}{}\n", body_pad, line));
             }
         }
-        _ => {
+        Some(_) => {
             out.push_str(&format!("{}\n", body_pad));
+        }
+        None => {
+            out.push_str(&format!("{}{}\n", body_pad, MUST_FILL_SENTINEL));
         }
     }
 }
@@ -248,10 +256,16 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
 }
 
 /// Emit a typed-table field: description + `# e.g.` line (whenever an example
-/// is configured), then the field key with its `array<object>; <role>` inline
+/// is configured), then the field key with its `array<object>` inline
 /// annotation, then either default rows or a synthetic template row. An
 /// example never renders as rows — like every other field type it surfaces
 /// only in the `# e.g.` leading line.
+///
+/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
+/// `; skip-ok` on the outer key and renders concrete rows without
+/// per-property annotations. A Must Fill container (no default) drops
+/// `; skip-ok` from the outer key (state is a leaf concern) and recurses
+/// into one synthetic row whose leaves carry their own cell signals.
 fn write_typed_table_field(
     out: &mut String,
     field: &FieldSchema,
@@ -268,7 +282,8 @@ fn write_typed_table_field(
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let inline = inline_annotation(field, true);
+    let container_endorsed = concrete_rows.is_some();
+    let inline = inline_annotation(field, true, Some(container_endorsed));
     out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete_rows {
@@ -284,10 +299,17 @@ fn write_typed_table_field(
 }
 
 /// Emit a typed-dictionary field: description + `# e.g.` line (whenever an
-/// example is configured), then the field key with its `object; <role>` inline
+/// example is configured), then the field key with its `object` inline
 /// annotation, then either a concrete mapping from `default` or per-property
 /// annotations. An example never renders as a concrete mapping — like every
 /// other field type it surfaces only in the `# e.g.` leading line.
+///
+/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
+/// `; skip-ok` on the outer key and renders a concrete block mapping
+/// without per-property annotations. A Must Fill container (no default)
+/// drops `; skip-ok` from the outer key (state is a leaf concern) and
+/// recurses into per-property annotations whose leaves carry their own
+/// cell signals.
 fn write_typed_object_field(
     out: &mut String,
     field: &FieldSchema,
@@ -304,7 +326,8 @@ fn write_typed_object_field(
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let inline = inline_annotation(field, false);
+    let container_endorsed = concrete.is_some();
+    let inline = inline_annotation(field, false, Some(container_endorsed));
     out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete {
@@ -323,16 +346,32 @@ fn write_typed_object_field(
 }
 
 /// Build the inline annotation body (without the leading `# `).
-/// `force_array_object` is `true` for typed-table outer fields, which always
-/// renders as `array<object>`; plain arrays render as `array<string>`.
-fn inline_annotation(field: &FieldSchema, force_array_object: bool) -> String {
-    let role = if field.required {
-        "required"
-    } else {
-        "optional"
-    };
+///
+/// `force_array_object` is `true` for typed-table outer fields, which
+/// always render as `array<object>`; plain arrays render as `array<string>`.
+/// `endorsed_override` short-circuits the schema-driven cell decision —
+/// it's used for the typed-table / typed-dict outer key when the container
+/// is a leaf, or for property leaves whose cell decision differs from the
+/// container.
+fn inline_annotation(
+    field: &FieldSchema,
+    force_array_object: bool,
+    endorsed_override: Option<bool>,
+) -> String {
+    let endorsed = endorsed_override.unwrap_or_else(|| is_endorsed(field));
     let type_expr = type_expression(field, force_array_object);
-    format!("{}; {}", type_expr, role)
+    if endorsed {
+        format!("{}; skip-ok", type_expr)
+    } else {
+        type_expr
+    }
+}
+
+/// A field is **Endorsed** when its schema declares a `default:`. Otherwise
+/// it is **Must Fill** and the blueprint emits a `<must-fill>` sentinel in
+/// the value cell.
+fn is_endorsed(field: &FieldSchema) -> bool {
+    field.default.is_some()
 }
 
 fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
@@ -359,8 +398,8 @@ fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
     }
 }
 
-/// The value to render for a field. Single cascade independent of role:
-/// default → first enum value → type-empty.
+/// The value to render for a field. Endorsed cells render their default;
+/// Must Fill cells render the `<must-fill>` sentinel in the value cell.
 enum FieldValue {
     Inline(String),
     Block(Vec<serde_json::Value>),
@@ -370,22 +409,10 @@ fn field_value(field: &FieldSchema) -> FieldValue {
     if let Some(v) = field.default.as_ref() {
         return json_to_value(v.as_json());
     }
-    if let Some(first) = field.enum_values.as_ref().and_then(|v| v.first()) {
-        return FieldValue::Inline(first.clone());
-    }
-    type_empty(&field.r#type)
-}
-
-fn type_empty(t: &FieldType) -> FieldValue {
-    match t {
-        FieldType::Array => FieldValue::Inline("[]".into()),
-        FieldType::Boolean => FieldValue::Inline("false".into()),
-        FieldType::Number | FieldType::Integer => FieldValue::Inline("0".into()),
-        FieldType::Date | FieldType::DateTime => FieldValue::Inline("\"\"".into()),
-        // String, markdown, object: empty string. Markdown is special-cased
-        // earlier in `write_field` and never reaches this code path.
-        _ => FieldValue::Inline("\"\"".into()),
-    }
+    // No default → Must Fill cell. The sentinel sits in the value cell
+    // regardless of declared type (markdown is special-cased earlier and
+    // never reaches this code path).
+    FieldValue::Inline(MUST_FILL_SENTINEL.to_string())
 }
 
 fn json_to_value(val: &serde_json::Value) -> FieldValue {
@@ -463,32 +490,34 @@ mod tests {
     }
 
     #[test]
-    fn required_string_renders_empty_with_required_role() {
+    fn must_fill_string_renders_sentinel_with_no_skip_ok() {
+        // No `default:` → Must Fill. Sentinel sits in the value cell; the
+        // inline annotation drops `; skip-ok`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    author: { type: string, required: true }
+    author: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("author: \"\"  # string; required\n"));
+        assert!(t.contains("author: <must-fill>  # string\n"));
     }
 
     #[test]
-    fn required_field_with_example_does_not_use_example_as_value() {
+    fn endorsed_field_with_example_does_not_use_example_as_value() {
         // Examples never render as values — they always surface in `# e.g.`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    status: { type: string, required: true, default: draft, example: final }
+    status: { type: string, default: draft, example: final }
 "#)
         .blueprint();
-        assert!(t.contains("# e.g. final\nstatus: draft  # string; required\n"));
+        assert!(t.contains("# e.g. final\nstatus: draft  # string; skip-ok\n"));
     }
 
     #[test]
-    fn optional_field_default_renders_as_value_with_eg_line() {
+    fn endorsed_empty_default_renders_value_with_skip_ok_and_eg_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -496,11 +525,11 @@ main:
     classification: { type: string, default: "", example: CONFIDENTIAL }
 "#)
         .blueprint();
-        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; optional\n"));
+        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; skip-ok\n"));
     }
 
     #[test]
-    fn optional_array_example_renders_as_flow_sequence_with_context_quoting() {
+    fn must_fill_array_example_renders_as_flow_sequence_with_context_quoting() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -514,12 +543,12 @@ main:
 "#)
         .blueprint();
         assert!(t.contains(
-            "# e.g. [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\nrecipient: []  # array<string>; optional\n"
+            "# e.g. [Mr. John Doe, 123 Main St, \"Anytown, USA\"]\nrecipient: <must-fill>  # array<string>\n"
         ));
     }
 
     #[test]
-    fn enum_field_uses_enum_format_slot_and_no_eg() {
+    fn enum_endorsed_uses_enum_format_slot_and_no_eg() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -527,13 +556,27 @@ main:
     format: { type: string, enum: [standard, informal], default: standard }
 "#)
         .blueprint();
-        assert!(t.contains("format: standard  # enum<standard | informal>; optional\n"));
+        assert!(t.contains("format: standard  # enum<standard | informal>; skip-ok\n"));
         assert!(!t.contains("e.g."));
     }
 
     #[test]
-    fn required_array_with_example_renders_eg_only_not_value() {
-        // Plain (non-typed-table) required arrays render type-empty; the
+    fn enum_must_fill_renders_sentinel_in_value_cell() {
+        // An enum field with no `default:` renders `<must-fill>` rather than
+        // the first enum value — the cell is Must Fill regardless.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    severity: { type: string, enum: [low, medium, high] }
+"#)
+        .blueprint();
+        assert!(t.contains("severity: <must-fill>  # enum<low | medium | high>\n"));
+    }
+
+    #[test]
+    fn must_fill_array_with_example_renders_eg_only_not_value() {
+        // Plain (non-typed-table) Must Fill arrays render the sentinel; the
         // example surfaces in the leading `# e.g.` line.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -541,14 +584,13 @@ main:
   fields:
     memo_from:
       type: array
-      required: true
       example:
         - ORG/SYMBOL
         - City ST 12345
 "#)
         .blueprint();
         assert!(t.contains(
-            "# e.g. [ORG/SYMBOL, City ST 12345]\nmemo_from: []  # array<string>; required\n"
+            "# e.g. [ORG/SYMBOL, City ST 12345]\nmemo_from: <must-fill>  # array<string>\n"
         ));
     }
 
@@ -560,15 +602,16 @@ main:
   fields:
     subject:
       type: string
-      required: true
       description: Be brief and clear.
 "#)
         .blueprint();
-        assert!(t.contains("# Be brief and clear.\nsubject: \"\"  # string; required\n"));
+        assert!(t.contains("# Be brief and clear.\nsubject: <must-fill>  # string\n"));
     }
 
     #[test]
-    fn every_field_carries_inline_type_and_role() {
+    fn every_field_carries_inline_type_and_cell_signal() {
+        // Endorsed cells carry `; skip-ok`; Must Fill cells carry the
+        // sentinel in the value cell and drop the tag.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -578,19 +621,19 @@ main:
     flag: { type: boolean, default: false }
     issued: { type: date }
     published: { type: datetime }
-    refs: { type: array }
+    refs: { type: array, default: [] }
 "#)
         .blueprint();
-        assert!(t.contains("title: \"\"  # string; optional\n"));
-        assert!(t.contains("size: 11  # number; optional\n"));
-        assert!(t.contains("flag: false  # boolean; optional\n"));
-        assert!(t.contains("issued: \"\"  # date<YYYY-MM-DD>; optional\n"));
-        assert!(t.contains("published: \"\"  # datetime<ISO 8601>; optional\n"));
-        assert!(t.contains("refs: []  # array<string>; optional\n"));
+        assert!(t.contains("title: <must-fill>  # string\n"));
+        assert!(t.contains("size: 11  # number; skip-ok\n"));
+        assert!(t.contains("flag: false  # boolean; skip-ok\n"));
+        assert!(t.contains("issued: <must-fill>  # date<YYYY-MM-DD>\n"));
+        assert!(t.contains("published: <must-fill>  # datetime<ISO 8601>\n"));
+        assert!(t.contains("refs: []  # array<string>; skip-ok\n"));
     }
 
     #[test]
-    fn markdown_field_renders_as_block_scalar() {
+    fn must_fill_markdown_renders_sentinel_inside_block_scalar() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -598,11 +641,24 @@ main:
     bio: { type: markdown }
 "#)
         .blueprint();
-        assert!(t.contains("bio: |-  # markdown; optional\n  \n"));
+        assert!(t.contains("bio: |-  # markdown\n  <must-fill>\n"));
     }
 
     #[test]
-    fn markdown_field_with_default_fills_block() {
+    fn endorsed_empty_markdown_renders_blank_line_with_skip_ok() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown, default: "" }
+"#)
+        .blueprint();
+        assert!(t.contains("bio: |-  # markdown; skip-ok\n  \n"));
+        assert!(!t.contains("<must-fill>"));
+    }
+
+    #[test]
+    fn endorsed_markdown_default_fills_block() {
         let t = cfg(r###"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -612,11 +668,11 @@ main:
       default: "## About me\n\nHello."
 "###)
         .blueprint();
-        assert!(t.contains("bio: |-  # markdown; optional\n  ## About me\n  \n  Hello.\n"));
+        assert!(t.contains("bio: |-  # markdown; skip-ok\n  ## About me\n  \n  Hello.\n"));
     }
 
     #[test]
-    fn quill_metadata_line_is_required_verbatim() {
+    fn quill_metadata_line_is_verbatim() {
         let t = cfg(r#"
 quill: { name: taro, version: 0.1.0, backend: typst, description: x }
 main:
@@ -625,7 +681,7 @@ main:
 "#)
         .blueprint();
         assert!(t.starts_with(
-            "~~~card-yaml\n$quill: taro@0.1.0\n$kind: main\n# system metadata; required, verbatim\n# x\n"
+            "~~~card-yaml\n$quill: taro@0.1.0\n$kind: main\n# system metadata; verbatim\n# x\n"
         ));
         assert!(t.contains("\nWrite main body here.\n"));
     }
@@ -660,7 +716,7 @@ card_kinds:
   skills:
     body: { enabled: false }
     fields:
-      items: { type: array, required: true }
+      items: { type: array }
 "#)
         .blueprint();
         let after = &t[t.find("$kind: skills").unwrap()..];
@@ -724,8 +780,8 @@ card_kinds:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    memo_for: { type: array, required: true, ui: { group: Addressing } }
-    subject: { type: string, required: true, ui: { group: Addressing } }
+    memo_for: { type: array, ui: { group: Addressing } }
+    subject: { type: string, ui: { group: Addressing } }
     letterhead_title: { type: string, default: HQ, ui: { group: Letterhead } }
     notes: { type: string }
 "#)
@@ -742,7 +798,9 @@ main:
     }
 
     #[test]
-    fn typed_table_emits_synthetic_row_when_no_example() {
+    fn typed_table_must_fill_emits_synthetic_row_with_leaf_sentinels() {
+        // Must Fill container → outer key has no `; skip-ok` (state is a
+        // leaf concern). Property leaves carry their own cell signals.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -751,13 +809,13 @@ main:
       type: array
       description: Cited works.
       properties:
-        org: { type: string, required: true, description: Citing organization. }
-        year: { type: integer, description: Publication year. }
+        org: { type: string, description: Citing organization. }
+        year: { type: integer, default: 0, description: Publication year. }
 "#)
         .blueprint();
-        assert!(t.contains("# Cited works.\nreferences:  # array<object>; optional\n  -\n"));
-        assert!(t.contains("    # Citing organization.\n    org: \"\"  # string; required\n"));
-        assert!(t.contains("    # Publication year.\n    year: 0  # integer; optional\n"));
+        assert!(t.contains("# Cited works.\nreferences:  # array<object>\n  -\n"));
+        assert!(t.contains("    # Citing organization.\n    org: <must-fill>  # string\n"));
+        assert!(t.contains("    # Publication year.\n    year: 0  # integer; skip-ok\n"));
     }
 
     #[test]
@@ -773,18 +831,18 @@ main:
       example:
         - { org: ACME, year: 2020 }
       properties:
-        org: { type: string, required: true }
-        year: { type: integer }
+        org: { type: string }
+        year: { type: integer, default: 0 }
 "#)
         .blueprint();
         assert!(t.contains("# e.g. [{org: ACME, year: 2020}]\n"));
-        assert!(t.contains("refs:  # array<object>; optional\n  -\n"));
-        assert!(t.contains("    org: \"\"  # string; required\n"));
-        assert!(t.contains("    year: 0  # integer; optional\n"));
+        assert!(t.contains("refs:  # array<object>\n  -\n"));
+        assert!(t.contains("    org: <must-fill>  # string\n"));
+        assert!(t.contains("    year: 0  # integer; skip-ok\n"));
     }
 
     #[test]
-    fn typed_table_with_default_renders_default_rows() {
+    fn typed_table_endorsed_renders_default_rows_with_skip_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -794,15 +852,18 @@ main:
       default:
         - { org: ACME }
       properties:
-        org: { type: string, required: true }
+        org: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("refs:  # array<object>; optional\n  - org: ACME\n"));
-        assert!(!t.contains("refs:  # array<object>; optional\n  -\n"));
+        assert!(t.contains("refs:  # array<object>; skip-ok\n  - org: ACME\n"));
+        assert!(!t.contains("refs:  # array<object>; skip-ok\n  -\n"));
     }
 
     #[test]
     fn typed_table_with_empty_default_falls_through_to_synthetic_row() {
+        // An empty default array is treated like a Must Fill container
+        // for rendering purposes (we need a synthetic row to show the
+        // shape), and the outer key drops `; skip-ok`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -811,16 +872,18 @@ main:
       type: array
       default: []
       properties:
-        org: { type: string, required: true }
+        org: { type: string }
 "#)
         .blueprint();
         assert!(t.contains(
-            "refs:  # array<object>; optional\n  -\n    org: \"\"  # string; required\n"
+            "refs:  # array<object>\n  -\n    org: <must-fill>  # string\n"
         ));
     }
 
     #[test]
-    fn typed_dict_emits_per_property_annotations() {
+    fn typed_dict_must_fill_emits_per_property_annotations() {
+        // Must Fill container → outer key has no `; skip-ok`; per-property
+        // recursion with leaf cell signals.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -829,35 +892,19 @@ main:
       type: object
       description: Mailing address.
       properties:
-        street: { type: string, required: true, description: Street line. }
-        city:   { type: string, required: true }
-        zip:    { type: string }
+        street: { type: string, description: Street line. }
+        city:   { type: string }
+        zip:    { type: string, default: "" }
 "#)
         .blueprint();
-        assert!(t.contains("# Mailing address.\naddress:  # object; optional\n"));
-        assert!(t.contains("  # Street line.\n  street: \"\"  # string; required\n"));
-        assert!(t.contains("  city: \"\"  # string; required\n"));
-        assert!(t.contains("  zip: \"\"  # string; optional\n"));
+        assert!(t.contains("# Mailing address.\naddress:  # object\n"));
+        assert!(t.contains("  # Street line.\n  street: <must-fill>  # string\n"));
+        assert!(t.contains("  city: <must-fill>  # string\n"));
+        assert!(t.contains("  zip: \"\"  # string; skip-ok\n"));
     }
 
     #[test]
-    fn typed_dict_required_carries_role() {
-        let t = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    address:
-      type: object
-      required: true
-      properties:
-        street: { type: string, required: true }
-"#)
-        .blueprint();
-        assert!(t.contains("address:  # object; required\n"));
-    }
-
-    #[test]
-    fn typed_dict_with_default_renders_block_mapping_no_annotations() {
+    fn typed_dict_endorsed_renders_block_mapping_with_skip_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -866,18 +913,18 @@ main:
       type: object
       default: { street: "5000 Forbes Ave", city: Pittsburgh }
       properties:
-        street: { type: string, required: true }
-        city:   { type: string, required: true }
+        street: { type: string }
+        city:   { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("address:  # object; optional\n"));
+        assert!(t.contains("address:  # object; skip-ok\n"));
         assert!(
             t.contains("  street: 5000 Forbes Ave\n")
                 || t.contains("  street: \"5000 Forbes Ave\"\n")
         );
         assert!(t.contains("  city: Pittsburgh\n"));
         // No per-property annotations when concrete values are present.
-        assert!(!t.contains("# string; required"));
+        assert!(!t.contains("# string"));
     }
 
     #[test]
@@ -892,17 +939,17 @@ main:
       type: object
       example: { street: "1 Infinite Loop", city: Cupertino }
       properties:
-        street: { type: string, required: true }
-        city:   { type: string }
+        street: { type: string }
+        city:   { type: string, default: "" }
 "#)
         .blueprint();
-        assert!(t.contains("address:  # object; optional\n"));
+        assert!(t.contains("address:  # object\n"));
         assert!(
             t.contains("# e.g. {street: 1 Infinite Loop, city: Cupertino}\n")
                 || t.contains("# e.g. {city: Cupertino, street: 1 Infinite Loop}\n")
         );
-        assert!(t.contains("  street: \"\"  # string; required\n"));
-        assert!(t.contains("  city: \"\"  # string; optional\n"));
+        assert!(t.contains("  street: <must-fill>  # string\n"));
+        assert!(t.contains("  city: \"\"  # string; skip-ok\n"));
     }
 
     const LETTER_QUILL: &str = r#"
@@ -911,11 +958,9 @@ main:
   fields:
     to:
       type: string
-      required: true
       description: Recipient name.
     subject:
       type: string
-      required: true
     date:
       type: date
     priority:
@@ -924,13 +969,14 @@ main:
       default: normal
     attachments:
       type: array
+      default: []
       example:
         - report.pdf
 card_kinds:
   enclosure:
     description: An enclosure attached to the letter.
     fields:
-      label: { type: string, required: true }
+      label: { type: string }
       pages: { type: integer, default: 1 }
 "#;
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -163,6 +163,23 @@ impl QuillConfig {
         use super::FieldType;
 
         let json_value = value.as_json();
+
+        // Sentinel pass-through: the literal `<must-fill>` string survives
+        // coercion unchanged so the validation layer can surface a
+        // placeholder diagnostic instead of a type-coercion error. For
+        // markdown the sentinel sits inside the block scalar, which already
+        // decodes as a string, so the same comparison covers both cases.
+        if let Some(s) = json_value.as_str() {
+            let candidate = if matches!(field_schema.r#type, FieldType::Markdown) {
+                s.trim()
+            } else {
+                s
+            };
+            if candidate == super::validation::MUST_FILL_SENTINEL {
+                return Ok(value.clone());
+            }
+        }
+
         match field_schema.r#type {
             FieldType::Array => {
                 let arr = if let Some(a) = json_value.as_array() {

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -164,7 +164,7 @@ main:
     refs:
       type: array
       properties:
-        org: { type: string, required: true }
+        org: { type: string }
         year: { type: integer }
 "#;
         let schema = build_from_yaml(yaml);
@@ -189,7 +189,7 @@ main:
     address:
       type: object
       properties:
-        street: { type: string, required: true }
+        street: { type: string }
         city: { type: string }
 "#;
         let schema = build_from_yaml(yaml);

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1176,7 +1176,6 @@ card_kinds:
       name:
         type: string
         description: Name of the endorsing official
-        required: true
       org:
         type: string
         description: Endorser's organization
@@ -1197,7 +1196,8 @@ card_kinds:
 
     let name_field = card.fields.get("name").unwrap();
     assert_eq!(name_field.r#type, FieldType::String);
-    assert!(name_field.required);
+    // Must Fill: no default declared.
+    assert!(name_field.default.is_none());
 
     let org_field = card.fields.get("org").unwrap();
     assert_eq!(org_field.r#type, FieldType::String);
@@ -1471,10 +1471,8 @@ main:
       properties:
         street:
           type: string
-          required: true
         city:
           type: string
-          required: true
 "#;
 
     let (config, warnings) = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap();
@@ -2262,7 +2260,7 @@ card_kinds:
       enabled: false
       example: This example is unused
     fields:
-      items: { type: array, required: true }
+      items: { type: array }
 "#;
     let (_config, warnings) = QuillConfig::from_yaml_with_warnings(yaml).unwrap();
     assert!(

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -5,9 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::value::QuillValue;
 
-fn is_false(value: &bool) -> bool {
-    !*value
-}
 /// Semantic constants for field schema keys used in parsing and JSON Schema generation.
 /// Using constants provides IDE support (find references, autocomplete) and ensures
 /// consistency between parsing and output.
@@ -17,7 +14,6 @@ pub mod field_key {
     pub const DEFAULT: &str = "default";
     pub const EXAMPLE: &str = "example";
     pub const UI: &str = "ui";
-    pub const REQUIRED: &str = "required";
     pub const ENUM: &str = "enum";
     pub const FORMAT: &str = "format";
 }
@@ -156,7 +152,14 @@ impl FieldType {
     }
 }
 
-/// Schema definition for a template field
+/// Schema definition for a template field.
+///
+/// A field's *cell* is determined by `default`: a field with a `default:`
+/// is **Endorsed** (the rendered value is shippable as-is), while a field
+/// without a `default:` is **Must Fill** (the blueprint carries a
+/// `<must-fill>` sentinel and validation reports
+/// `validation::required_field_absent` if the field is missing at
+/// validate time). There is no separate `required:` axis.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FieldSchema {
     /// The map key carries this on the wire; skipped during serialization to avoid duplication.
@@ -172,9 +175,6 @@ pub struct FieldSchema {
     pub example: Option<QuillValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiFieldSchema>,
-    /// Fields are optional by default.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub required: bool,
     /// Restricts valid values on string fields.
     #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<String>>,
@@ -191,8 +191,6 @@ struct FieldSchemaDef {
     pub default: Option<QuillValue>,
     pub example: Option<QuillValue>,
     pub ui: Option<UiFieldSchema>,
-    #[serde(default)]
-    pub required: bool,
     #[serde(rename = "enum")]
     pub enum_values: Option<Vec<String>>,
     // Nested schema support
@@ -208,7 +206,6 @@ impl FieldSchema {
             default: None,
             example: None,
             ui: None,
-            required: false,
             enum_values: None,
             properties: None,
         }
@@ -224,7 +221,6 @@ impl FieldSchema {
             default: def.default,
             example: def.example,
             ui: def.ui,
-            required: def.required,
             enum_values: def.enum_values,
             properties: if let Some(props) = def.properties {
                 let mut p = BTreeMap::new();

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -8,11 +8,23 @@ use crate::quill::formats::DATE_FORMAT;
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
 
+/// Literal sentinel string the blueprint emitter writes into the value
+/// cell of every Must Fill field. Validation detects unreplaced sentinels
+/// and reports `validation::unfilled_placeholder`.
+pub const MUST_FILL_SENTINEL: &str = "<must-fill>";
+
 /// Validation error with a structured field path.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum ValidationError {
-    #[error("missing required field `{path}`")]
-    MissingRequired { path: String },
+    #[error(
+        "field `{path}` has no value and the schema declares no default; supply a value before shipping"
+    )]
+    RequiredFieldAbsent { path: String },
+
+    #[error(
+        "field `{path}` still carries the `<must-fill>` blueprint sentinel; replace it with a value of the declared type"
+    )]
+    UnfilledPlaceholder { path: String },
 
     #[error("field `{path}` has type `{actual}`, expected `{expected}`")]
     TypeMismatch {
@@ -46,7 +58,8 @@ impl ValidationError {
     /// See [`crate::error`] module docs for the path grammar and conventions.
     pub fn path(&self) -> &str {
         match self {
-            ValidationError::MissingRequired { path }
+            ValidationError::RequiredFieldAbsent { path }
+            | ValidationError::UnfilledPlaceholder { path }
             | ValidationError::TypeMismatch { path, .. }
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
@@ -59,7 +72,8 @@ impl ValidationError {
     /// instead of the message text.
     pub fn code(&self) -> &'static str {
         match self {
-            ValidationError::MissingRequired { .. } => "validation::missing_required",
+            ValidationError::RequiredFieldAbsent { .. } => "validation::required_field_absent",
+            ValidationError::UnfilledPlaceholder { .. } => "validation::unfilled_placeholder",
             ValidationError::TypeMismatch { .. } => "validation::type_mismatch",
             ValidationError::EnumViolation { .. } => "validation::enum_violation",
             ValidationError::FormatViolation { .. } => "validation::format_violation",
@@ -83,9 +97,13 @@ impl ValidationError {
 
     fn hint(&self) -> Option<String> {
         match self {
-            ValidationError::MissingRequired { .. } => {
+            ValidationError::RequiredFieldAbsent { .. } => {
                 Some("Add this field to the document.".to_string())
             }
+            ValidationError::UnfilledPlaceholder { .. } => Some(format!(
+                "Replace the `{}` sentinel with a value of the declared type.",
+                MUST_FILL_SENTINEL
+            )),
             ValidationError::TypeMismatch { expected, .. } => {
                 Some(format!("Provide a value of type `{}`.", expected))
             }
@@ -172,7 +190,9 @@ fn validate_fields_for_card_indexmap(
         let path = child_path(base_path, field_name);
         match fields.get(field_name) {
             Some(value) => errors.extend(validate_field(schema, value, &path)),
-            None if schema.required => errors.push(ValidationError::MissingRequired { path }),
+            None if schema.default.is_none() => {
+                errors.push(ValidationError::RequiredFieldAbsent { path })
+            }
             None => {}
         }
     }
@@ -188,6 +208,24 @@ pub(crate) fn validate_field(
     path: &str,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
+
+    // Sentinel detection runs before per-type coercion / validation.
+    // Scalar fields carry the sentinel in the value cell; markdown carries
+    // it as the trimmed content of the block scalar. On match, emit
+    // `UnfilledPlaceholder` and skip per-type checks for this field.
+    if let Some(text) = value.as_str() {
+        let candidate = if matches!(field.r#type, FieldType::Markdown) {
+            text.trim()
+        } else {
+            text
+        };
+        if candidate == MUST_FILL_SENTINEL {
+            errors.push(ValidationError::UnfilledPlaceholder {
+                path: path.to_string(),
+            });
+            return errors;
+        }
+    }
 
     let type_valid = match field.r#type {
         FieldType::String | FieldType::Markdown => value.as_str().is_some(),
@@ -252,8 +290,9 @@ pub(crate) fn validate_field(
                                     &QuillValue::from_json(v.clone()),
                                     &prop_path,
                                 )),
-                                None if prop_schema.required => errors
-                                    .push(ValidationError::MissingRequired { path: prop_path }),
+                                None if prop_schema.default.is_none() => errors.push(
+                                    ValidationError::RequiredFieldAbsent { path: prop_path },
+                                ),
                                 None => {}
                             }
                         }
@@ -277,8 +316,8 @@ pub(crate) fn validate_field(
                                 &QuillValue::from_json(property_value.clone()),
                                 &property_path,
                             )),
-                            None if property_schema.required => {
-                                errors.push(ValidationError::MissingRequired {
+                            None if property_schema.default.is_none() => {
+                                errors.push(ValidationError::RequiredFieldAbsent {
                                     path: property_path,
                                 })
                             }
@@ -421,14 +460,14 @@ main:
 
     #[test]
     fn validates_simple_string_field() {
-        let config = config_with("    title:\n      type: string\n      required: true", "");
+        let config = config_with("    title:\n      type: string", "");
         let doc = doc_from_fm(&[("title", json!("Memo"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_simple_string_type_mismatch() {
-        let config = config_with("    title:\n      type: string", "");
+        let config = config_with("    title:\n      type: string\n      default: \"\"", "");
         let doc = doc_from_fm(&[("title", json!(9))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -440,14 +479,14 @@ main:
 
     #[test]
     fn validates_integer_field_with_integer_value() {
-        let config = config_with("    count:\n      type: integer", "");
+        let config = config_with("    count:\n      type: integer\n      default: 0", "");
         let doc = doc_from_fm(&[("count", json!(9))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_integer_field_with_decimal_value() {
-        let config = config_with("    count:\n      type: integer", "");
+        let config = config_with("    count:\n      type: integer\n      default: 0", "");
         let doc = doc_from_fm(&[("count", json!(9.5))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -458,24 +497,70 @@ main:
     }
 
     #[test]
-    fn reports_missing_required_field() {
-        let config = config_with(
-            "    memo_for:\n      type: string\n      required: true",
-            "",
-        );
+    fn reports_absent_must_fill_field() {
+        // A field with no `default:` is Must Fill. Missing from the document
+        // → `required_field_absent`.
+        let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingRequired { path } if path == "memo_for")
+            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "memo_for")
         }));
     }
 
     #[test]
-    fn reports_required_field_wrong_type() {
+    fn missing_field_with_default_is_ok() {
+        // Endorsed field absent from document → no error; default applies.
         let config = config_with(
-            "    memo_for:\n      type: string\n      required: true",
+            "    memo_for:\n      type: string\n      default: \"\"",
             "",
         );
+        let doc = doc_from_fm(&[]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
+    }
+
+    #[test]
+    fn detects_unfilled_placeholder_sentinel() {
+        let config = config_with("    memo_for:\n      type: string", "");
+        let doc = doc_from_fm(&[("memo_for", json!(MUST_FILL_SENTINEL))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| {
+            matches!(e, ValidationError::UnfilledPlaceholder { path } if path == "memo_for")
+        }));
+    }
+
+    #[test]
+    fn detects_unfilled_placeholder_in_markdown_block() {
+        // Markdown block scalars carry the sentinel inside the block; the
+        // detector trims whitespace before comparing.
+        let config = config_with("    body:\n      type: markdown", "");
+        let doc = doc_from_fm(&[("body", json!(format!("  {}\n", MUST_FILL_SENTINEL)))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| {
+            matches!(e, ValidationError::UnfilledPlaceholder { path } if path == "body")
+        }));
+    }
+
+    #[test]
+    fn quoted_must_fill_string_is_content_not_sentinel() {
+        // Once parsed YAML decodes both forms to the same string, exact
+        // string equality is the detector. Document this expectation by
+        // confirming the literal sentinel always fires the placeholder
+        // error (no escape hatch besides quoting at the YAML layer, which
+        // produces the same decoded string and therefore still fires).
+        // The behavior is documented in BLUEPRINT.md authoring guidance.
+        let config = config_with("    name:\n      type: string", "");
+        let doc = doc_from_fm(&[("name", json!(MUST_FILL_SENTINEL))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| matches!(
+            e,
+            ValidationError::UnfilledPlaceholder { .. }
+        )));
+    }
+
+    #[test]
+    fn reports_wrong_type_on_must_fill_field() {
+        let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[("memo_for", json!(true))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -487,7 +572,7 @@ main:
     #[test]
     fn validates_enum_value() {
         let config = config_with(
-            "    status:\n      type: string\n      enum:\n        - draft\n        - final",
+            "    status:\n      type: string\n      default: draft\n      enum:\n        - draft\n        - final",
             "",
         );
         let doc = doc_from_fm(&[("status", json!("draft"))]);
@@ -497,7 +582,7 @@ main:
     #[test]
     fn rejects_invalid_enum_value() {
         let config = config_with(
-            "    status:\n      type: string\n      enum:\n        - draft\n        - final",
+            "    status:\n      type: string\n      default: draft\n      enum:\n        - draft\n        - final",
             "",
         );
         let doc = doc_from_fm(&[("status", json!("invalid"))]);
@@ -511,14 +596,14 @@ main:
 
     #[test]
     fn validates_date_format() {
-        let config = config_with("    signed_on:\n      type: date", "");
+        let config = config_with("    signed_on:\n      type: date\n      default: \"\"", "");
         let doc = doc_from_fm(&[("signed_on", json!("2026-04-13"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_invalid_date_format() {
-        let config = config_with("    signed_on:\n      type: date", "");
+        let config = config_with("    signed_on:\n      type: date\n      default: \"\"", "");
         let doc = doc_from_fm(&[("signed_on", json!("13-04-2026"))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
@@ -528,14 +613,20 @@ main:
 
     #[test]
     fn validates_datetime_format() {
-        let config = config_with("    created_at:\n      type: datetime", "");
+        let config = config_with(
+            "    created_at:\n      type: datetime\n      default: \"\"",
+            "",
+        );
         let doc = doc_from_fm(&[("created_at", json!("2026-04-13T19:24:55Z"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 
     #[test]
     fn rejects_invalid_datetime_format() {
-        let config = config_with("    created_at:\n      type: datetime", "");
+        let config = config_with(
+            "    created_at:\n      type: datetime\n      default: \"\"",
+            "",
+        );
         let doc = doc_from_fm(&[("created_at", json!("2026-04-13 19:24:55"))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -547,7 +638,7 @@ main:
 
     #[test]
     fn markdown_accepts_any_string() {
-        let config = config_with("    body:\n      type: markdown", "");
+        let config = config_with("    body:\n      type: markdown\n      default: \"\"", "");
         let doc = doc_from_fm(&[("body", json!("# Heading\n\nBody text"))]);
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
@@ -555,7 +646,7 @@ main:
     #[test]
     fn validates_array_of_objects() {
         let config = config_with(
-            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n          required: true\n        org:\n          type: string",
+            "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "name": "Sam", "org": "HQ" }]))]);
@@ -563,15 +654,17 @@ main:
     }
 
     #[test]
-    fn reports_missing_required_field_in_array_object() {
+    fn reports_must_fill_property_absent_in_array_object() {
+        // Property `name` is Must Fill (no default); `org` is Endorsed.
+        // Missing `name` in a row → `required_field_absent`.
         let config = config_with(
-            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n          required: true\n        org:\n          type: string",
+            "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingRequired { path } if path == "recipients[0].name")
+            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "recipients[0].name")
         }));
     }
 
@@ -581,9 +674,9 @@ main:
     // rejected at config parse time.
 
     #[test]
-    fn accumulates_multiple_missing_required_errors() {
+    fn accumulates_multiple_absent_must_fill_errors() {
         let config = config_with(
-            "    memo_for:\n      type: string\n      required: true\n    memo_from:\n      type: string\n      required: true",
+            "    memo_for:\n      type: string\n    memo_from:\n      type: string",
             "",
         );
         let doc = doc_from_fm(&[]);
@@ -591,7 +684,7 @@ main:
         let missing_paths: Vec<&str> = errors
             .iter()
             .filter_map(|e| match e {
-                ValidationError::MissingRequired { path } => Some(path.as_str()),
+                ValidationError::RequiredFieldAbsent { path } => Some(path.as_str()),
                 _ => None,
             })
             .collect();
@@ -602,8 +695,8 @@ main:
     #[test]
     fn validates_card_with_valid_discriminator() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -618,7 +711,7 @@ main:
     #[test]
     fn rejects_unknown_card_discriminator() {
         let config = config_with(
-            "    title:\n      type: string",
+            "    title:\n      type: string\n      default: \"\"",
             "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(&[], vec![typed_card("unknown", &[])]);
@@ -631,8 +724,8 @@ main:
     #[test]
     fn validates_multiple_card_instances_same_type() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -647,8 +740,8 @@ main:
     #[test]
     fn validates_multiple_card_kinds_mixed() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true\n  routing:\n    fields:\n      office:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n  routing:\n    fields:\n      office:\n        type: string",
         );
         let doc = doc_with_typed_cards(
             &[],
@@ -663,21 +756,21 @@ main:
     #[test]
     fn reports_card_field_paths_with_card_name_and_index() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string",
         );
         let doc = doc_with_typed_cards(&[], vec![typed_card("indorsement", &[])]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| {
-            matches!(e, ValidationError::MissingRequired { path } if path == "cards.indorsement[0].signature_block")
+            matches!(e, ValidationError::RequiredFieldAbsent { path } if path == "cards.indorsement[0].signature_block")
         }));
     }
 
     #[test]
     fn body_disabled_card_enforces_trim_boundary() {
         let config = config_with(
-            "    title:\n      type: string",
-            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        required: true",
+            "    title:\n      type: string\n      default: \"\"",
+            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        default: []",
         );
         // Prose triggers the error; whitespace-only does not.
         let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);
@@ -698,11 +791,14 @@ main:
 
     #[test]
     fn to_diagnostic_carries_path_and_code() {
-        let err = ValidationError::MissingRequired {
+        let err = ValidationError::RequiredFieldAbsent {
             path: "cards.indorsement[0].signature_block".to_string(),
         };
         let diag = err.to_diagnostic();
-        assert_eq!(diag.code.as_deref(), Some("validation::missing_required"));
+        assert_eq!(
+            diag.code.as_deref(),
+            Some("validation::required_field_absent")
+        );
         assert_eq!(
             diag.path.as_deref(),
             Some("cards.indorsement[0].signature_block")

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -9,14 +9,12 @@ main:
   fields:
     name:
       type: string
-      required: true
       example: John Doe
       ui:
         group: Personal Info
 
     contacts:
       type: array
-      required: true
       example:
         - john.doe@example.com
         - 123-456-7890
@@ -36,7 +34,6 @@ card_kinds:
         default: Experience
       heading_left:
         type: string
-        required: true
       heading_right:
         type: string
       subheading_left:
@@ -54,7 +51,6 @@ card_kinds:
         default: Skills
       cells:
         type: array
-        required: true
         example:
           - category: Languages
             skills: Python, Rust, C++
@@ -63,10 +59,8 @@ card_kinds:
         properties:
           category:
             type: string
-            required: true
           skills:
             type: string
-            required: true
 
   projects_section:
     description: A project entry with a name and optional URL.
@@ -78,7 +72,6 @@ card_kinds:
         default: Projects
       name:
         type: string
-        required: true
       url:
         type: string
 
@@ -92,7 +85,6 @@ card_kinds:
         default: Certifications
       cells:
         type: array
-        required: true
         example:
           - AWS Certified Solutions Architect
           - CKA

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -28,6 +28,7 @@ main:
 
     department:
       type: string
+      default: ""
       example: Department of Electrical and Computer Engineering
       ui:
         group: Letterhead
@@ -44,6 +45,7 @@ main:
 
     url:
       type: string
+      default: ""
       example: www.ece.cmu.edu
       ui:
         group: Letterhead

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/Quill.yaml
@@ -9,7 +9,6 @@ main:
   fields:
     memo_for:
       type: array
-      required: true
       example:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
@@ -19,7 +18,6 @@ main:
 
     memo_from:
       type: array
-      required: true
       example:
         - ORG/SYMBOL
         - Organization Name
@@ -31,7 +29,6 @@ main:
 
     subject:
       type: string
-      required: true
       example: Subject of the Memorandum
       ui:
         group: Addressing
@@ -39,7 +36,6 @@ main:
 
     signature_block:
       type: array
-      required: true
       example:
         - "FIRST M. LAST, Rank, USSF"
         - Duty Title
@@ -152,7 +148,6 @@ card_kinds:
         ui:
           group: Addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
-        required: true
         default:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title

--- a/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.1.0/__golden__/schema.yaml
@@ -83,7 +83,6 @@ main:
       ui:
         group: Addressing
         order: 0
-      required: true
     memo_from:
       type: array
       description: >-
@@ -98,7 +97,6 @@ main:
       ui:
         group: Addressing
         order: 1
-      required: true
     references:
       type: array
       description: Cite by organization, type, date, and title.
@@ -117,7 +115,6 @@ main:
       ui:
         group: Addressing
         order: 3
-      required: true
     subject:
       type: string
       description: >-
@@ -128,7 +125,6 @@ main:
       ui:
         group: Addressing
         order: 2
-      required: true
     tag_line:
       type: string
       description: Organizational motto at the bottom of the page.
@@ -197,4 +193,3 @@ card_kinds:
         ui:
           group: Addressing
           order: 2
-        required: true

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -9,7 +9,6 @@ main:
   fields:
     memo_for:
       type: array
-      required: true
       example:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
@@ -19,7 +18,6 @@ main:
 
     memo_from:
       type: array
-      required: true
       example:
         - ORG/SYMBOL
         - Organization Name
@@ -31,7 +29,6 @@ main:
 
     subject:
       type: string
-      required: true
       example: Subject of the Memorandum
       ui:
         group: Addressing
@@ -39,7 +36,6 @@ main:
 
     signature_block:
       type: array
-      required: true
       example:
         - "FIRST M. LAST, Rank, USSF"
         - Duty Title
@@ -154,7 +150,6 @@ card_kinds:
         ui:
           group: Addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
-        required: true
         default:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title

--- a/crates/quillmark/src/form/tests.rs
+++ b/crates/quillmark/src/form/tests.rs
@@ -86,7 +86,6 @@ main:
   fields:
     title:
       type: string
-      required: true
     status:
       type: string
       default: draft
@@ -95,19 +94,19 @@ main:
 "#,
     );
 
-    // `title` and `notes` are absent from the document.
-    // `title` is required — that produces a validation diagnostic.
-    // `status` is absent but has a default.
-    // `notes` is absent and has no default.
+    // `title` and `notes` are absent from the document and have no
+    // default → both produce validation diagnostics
+    // (`validation::required_field_absent`).
+    // `status` is absent but has a default — it falls back to the default.
     let md = "~~~card-yaml\n$quill: form_defaults_test\n$kind: main\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let form = quill.form(&doc);
 
-    // `title` is required and missing → validation diagnostic
+    // `title` is Must Fill and absent → validation diagnostic
     assert!(
         form.diagnostics.iter().any(|d| d.message.contains("title")),
-        "expected validation diagnostic for required 'title'; got: {:?}",
+        "expected validation diagnostic for absent Must-Fill 'title'; got: {:?}",
         form.diagnostics
     );
 
@@ -195,7 +194,6 @@ card_kinds:
     fields:
       signature_block:
         type: string
-        required: true
       office:
         type: string
         default: HQ
@@ -245,7 +243,6 @@ main:
   fields:
     count:
       type: integer
-      required: true
 "#,
     );
 

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -143,13 +143,12 @@ fn test_validation_fails_without_defaults() {
   version: "1.0"
   backend: "typst"
   plate_file: "plate.typ"
-  description: "Test quill with required field"
+  description: "Test quill with a Must-Fill field"
 
 main:
   fields:
     title:
       type: "string"
-      required: true
     status:
       type: "string"
       default: "draft"
@@ -168,7 +167,7 @@ main:
     let result = quill.dry_run(&parsed);
     assert!(
         result.is_err(),
-        "Should fail validation - title is required"
+        "Should fail validation — `title` is Must-Fill and absent"
     );
 
     let err = result.unwrap_err();

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -8,8 +8,10 @@ fn make_test_quill_path(temp_dir: &TempDir, with_required_field: bool) -> std::p
     let quill_path = temp_dir.path().join("test_quill");
     fs::create_dir_all(&quill_path).unwrap();
 
+    // `title` has no default → Must Fill. `author` has a default →
+    // Endorsed (absence is OK).
     let fields_section = if with_required_field {
-        "main:\n  fields:\n    title:\n      type: \"string\"\n      required: true\n    author:\n      type: \"string\"\n      required: false\n"
+        "main:\n  fields:\n    title:\n      type: \"string\"\n    author:\n      type: \"string\"\n      default: \"\"\n"
     } else {
         ""
     };
@@ -44,7 +46,7 @@ fn test_dry_run_success() {
 }
 
 #[test]
-fn test_dry_run_missing_required_field() {
+fn test_dry_run_missing_must_fill_field() {
     let temp_dir = TempDir::new().unwrap();
     let quill_path = make_test_quill_path(&temp_dir, true);
 
@@ -60,7 +62,7 @@ fn test_dry_run_missing_required_field() {
     let result = quill.dry_run(&parsed);
     assert!(
         result.is_err(),
-        "dry_run should fail for missing required field"
+        "dry_run should fail for missing Must-Fill field"
     );
 
     let err = result.unwrap_err();

--- a/crates/quillmark/tests/quiver_test.rs
+++ b/crates/quillmark/tests/quiver_test.rs
@@ -1,11 +1,12 @@
 //! Enforces the quill authoring contract from `prose/canon/BLUEPRINT.md`:
 //! every quill in the fixtures quiver loads, and its `plate.typ` renders the
-//! quill's own blueprint to a successful (non-error) output.
+//! quill's own blueprint (with every `<must-fill>` cell replaced by a
+//! type-empty value) to a successful (non-error) output.
 //!
-//! The blueprint is the type-minimal valid input — every required field
-//! present, every value type-correct, enums at their first value. A plate
-//! that renders it has shown it degrades gracefully on every type-valid
-//! input shape.
+//! The blueprint, after sentinel substitution, is the type-minimal valid
+//! input — every field present, every value type-correct, enums at their
+//! first value. A plate that renders it has shown it degrades gracefully
+//! on every type-valid input shape.
 
 #![cfg(feature = "typst")]
 
@@ -25,6 +26,65 @@ fn quiver_quills() -> Vec<String> {
     names
 }
 
+/// Replace every `<must-fill>` sentinel in a blueprint with a type-empty
+/// value derived from the inline annotation on the same line. For enum
+/// fields the substitution uses the first enum value so validation
+/// accepts the result.
+///
+/// This mirrors the operation an MCP consumer would perform on a
+/// blueprint before shipping: walk Must Fill cells, replace them with
+/// concrete values. Here we use the leanest possible values to test
+/// that `plate.typ` accepts type-empty inputs per the authoring
+/// contract.
+fn fill_must_fill(blueprint: &str) -> String {
+    let mut out = String::new();
+    for line in blueprint.lines() {
+        out.push_str(&substitute_line(line));
+        out.push('\n');
+    }
+    out
+}
+
+fn substitute_line(line: &str) -> String {
+    // Inline form: `<key>: <must-fill>  # <annotation>`.
+    const NEEDLE: &str = ": <must-fill>  # ";
+    if let Some(idx) = line.find(NEEDLE) {
+        let prefix = &line[..idx];
+        let annotation = &line[idx + NEEDLE.len()..];
+        let value = type_empty_for(annotation);
+        return format!("{}: {}  # {}", prefix, value, annotation);
+    }
+    // Markdown block scalar form: `<indent><must-fill>` on its own line.
+    if line.trim_start() == "<must-fill>" {
+        let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+        return indent;
+    }
+    line.to_string()
+}
+
+fn type_empty_for(annotation: &str) -> String {
+    let head = annotation.split(';').next().unwrap_or(annotation).trim();
+    if head.starts_with("array<") || head == "array" {
+        return "[]".to_string();
+    }
+    if head == "integer" || head == "number" {
+        return "0".to_string();
+    }
+    if head == "boolean" {
+        return "false".to_string();
+    }
+    if let Some(inner) = head
+        .strip_prefix("enum<")
+        .and_then(|s| s.strip_suffix('>'))
+    {
+        let first = inner.split('|').next().unwrap_or("").trim();
+        return first.to_string();
+    }
+    // string, markdown (handled via the block-scalar branch above), date,
+    // datetime, object: empty string. Date / datetime accept "" by design.
+    "\"\"".to_string()
+}
+
 #[test]
 fn every_quill_in_quiver_renders() {
     let engine = Quillmark::new();
@@ -34,9 +94,11 @@ fn every_quill_in_quiver_renders() {
             .quill_from_path(quills_path(&name))
             .unwrap_or_else(|e| panic!("quill '{name}' failed to load: {e:?}"));
 
-        let markdown = quill.source().config().blueprint();
-        let parsed = Document::from_markdown(&markdown)
-            .unwrap_or_else(|e| panic!("quill '{name}' blueprint failed to parse: {e:?}"));
+        let blueprint = quill.source().config().blueprint();
+        let markdown = fill_must_fill(&blueprint);
+        let parsed = Document::from_markdown(&markdown).unwrap_or_else(|e| {
+            panic!("quill '{name}' blueprint failed to parse: {e:?}\n---\n{markdown}")
+        });
 
         let result = quill.render(
             &parsed,

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -70,7 +70,6 @@ main:
   fields:
     subject:          # Field name (used as the card-yaml payload key)
       type: string
-      required: true
       description: Be brief and clear.
 ```
 
@@ -80,9 +79,8 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | any               | no       | Default value when not provided |
+| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; skip-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::required_field_absent` if the field is absent at validate time. |
 | `example`     | any               | no       | Illustrative value surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md) for documentation and LLM authoring |
-| `required`    | boolean           | no       | Whether the field must be present (default: `false`) |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
 | `properties`  | object            | no       | Nested field schemas (for `array` typed-table rows or `object` typed dictionaries) |
@@ -132,7 +130,6 @@ main:
       properties:
         category:
           type: string
-          required: true
         score:
           type: number
 ```
@@ -147,7 +144,6 @@ main:
       properties:
         street:
           type: string
-          required: true
         city:
           type: string
 ```
@@ -461,19 +457,18 @@ main:
   fields:
     project_name:
       type: string
-      required: true
       ui:
         group: Header
 
     status:
       type: string
-      required: true
       enum: [on_track, at_risk, blocked]
       ui:
         group: Header
 
     risk_description:
       type: string
+      default: ""
       ui:
         group: Header
       description: Describe the risk or blocker. Only needed when status is not on_track.
@@ -485,6 +480,7 @@ main:
 
     team_members:
       type: array
+      default: []
       ui:
         group: Team
 
@@ -500,7 +496,6 @@ card_kinds:
     fields:
       name:
         type: string
-        required: true
       target_date:
         type: date
       completed:

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -23,7 +23,7 @@ $kind: main
 
 # <field description>
 # e.g. <example value>
-field: value  # <type>; <role>
+field: value  # <type>[; skip-ok]
 ~~~
 
 Write main body here.
@@ -50,7 +50,7 @@ When `body.enabled` is false the marker is omitted entirely.
 | Slot | Form | Carries |
 |---|---|---|
 | **Leading `# …` lines** above a field | `# <prose>` or `# e.g. <value>` | description (single-line prose) and an illustrative example |
-| **Inline `# …`** at end of the value line | `# <type>[<format>]; <role>[, <extra>...]` | structural metadata: type, optional format refinement, role, optional extras |
+| **Inline `# …`** at end of the value line | `# <type>[<format>][; skip-ok]` | structural metadata: type, optional format refinement, optional skip-ok tag |
 
 The two slots have disjoint purposes: leading is prose, inline is
 structural. No colon-separated `key: value` annotation syntax appears in
@@ -64,15 +64,15 @@ Per field, in order:
    whitespace-collapsed. **Single line only**; multi-line descriptions are
    rejected at `Quill.yaml` parse time.
 2. `# e.g. <value>` — emitted whenever `example:` is configured on a
-   field. Independent of role and type. The example never becomes the
-   rendered value (see precedence below).
+   field. Independent of cell and type. The example never becomes the
+   rendered value.
 
 That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 `# type:` — those collapse into the inline.
 
 ### Inline annotation
 
-Form: **`# <type>[<format>]; <role>[, <extra>...]`**
+Form: **`# <type>[<format>][; skip-ok]`**
 
 - **Type slot** (mandatory, first): one of
   `string`, `integer`, `number`, `boolean`, `array`, `object`,
@@ -89,9 +89,11 @@ Form: **`# <type>[<format>]; <role>[, <extra>...]`**
   - `enum<a | b | c>`
   - omitted for `string`, `integer`, `number`, `boolean`, `object`,
     `markdown` (nothing meaningful to refine).
-- **Role slot** (mandatory, after `;`): `required` or `optional`.
-- **Extras** (optional, comma-separated, after the role): additional
-  qualifiers.
+- **Skip-ok tag** (optional, after `;`): the single tag `skip-ok`. Present
+  on Endorsed fields (fields with a `default:` in the schema), signalling
+  "the rendered value is shippable as-is — keep or override". Absent on
+  Must Fill fields (fields without a `default:`), which carry the
+  `<must-fill>` sentinel in the value cell instead.
 
 The `$`-prefixed system-metadata keys (`$quill`, `$kind`, …) have no
 inline-annotation slot — they are not user-defined data fields. (The YAML
@@ -107,70 +109,80 @@ Examples:
 
 | Line | Reading |
 |---|---|
-| `name: ""  # string; required` | required string field, no format refinement |
-| `count: 0  # integer; required` | required integer field |
-| `active: false  # boolean; optional` | optional boolean field |
-| `bio: |-` followed by indented block, then `# markdown; optional` | optional markdown field — see "Markdown fields render as block scalars" |
-| `recipient: []  # array<string>; optional` | optional array of strings |
-| `entries: [...]  # array<object>; required` | required array of objects (typed table follows) |
-| `date: ""  # date<YYYY-MM-DD>; required` | required date in `YYYY-MM-DD` format |
-| `published: ""  # datetime<ISO 8601>; required` | required datetime in ISO 8601 |
-| `level: low  # enum<low \| medium \| high>; optional` | optional enum, default is first value |
+| `name: <must-fill>  # string` | Must Fill string — replace `<must-fill>` before shipping |
+| `title: "Curriculum Vitae"  # string; skip-ok` | Endorsed string — keep or override |
+| `count: 0  # integer; skip-ok` | Endorsed integer (type-empty default, explicitly shippable) |
+| `active: false  # boolean; skip-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
+| `notes: ""  # string; skip-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
+| `bio: |-` followed by indented `<must-fill>`, then `# markdown` | Must Fill markdown — see "Markdown fields render as block scalars" |
+| `recipient: <must-fill>  # array<string>` | Must Fill array of strings |
+| `date: <must-fill>  # date<YYYY-MM-DD>` | Must Fill date in `YYYY-MM-DD` format |
+| `severity: <must-fill>  # enum<low \| medium \| high>` | Must Fill enum |
 | `$quill: cmu_letter@0.1.0` | quill binding metadata, emitted verbatim, do not modify |
 | `$kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~card-yaml` … `~~~` block per instance |
 
 ## Placeholder value precedence
 
-The rendered value is independent of the role (required vs. optional).
-Role drives "must fill"; the value rendering follows a single cascade:
+The rendered value follows a single cascade keyed on the cell:
 
-| Field state | Value rendered |
-|---|---|
-| Has `default` | default |
-| Has `enum` only | first enum value |
-| Otherwise | type-empty (`""`, `0`, `false`, `[]`, or block scalar for markdown — see below) |
+| Field state | Value rendered | Cell |
+|---|---|---|
+| Has `default` | default | Endorsed (carries `; skip-ok`) |
+| No `default` | `<must-fill>` sentinel | Must Fill (no `; skip-ok`) |
 
-Examples never become the rendered value, regardless of role or type —
+Examples never become the rendered value, regardless of cell or type —
 this holds uniformly for scalars, arrays, typed tables, and typed
 dictionaries. Examples are inherently illustrative and unsafe to ship;
 they always surface in the `# e.g.` leading line while the value follows
 the cascade above.
 
-All fields render as **live YAML** — no commented-out fields. The role
-tag (`; required` / `; optional`) is the sole "must fill" signal. The
-rendered value is the effective default: what the field will be if the
-author leaves it untouched.
+All fields render as **live YAML** — no commented-out fields. The
+sentinel in the value cell is the sole "must fill" signal: a reader's
+mental model is one rule — **`<must-fill>` in the value cell → replace
+before shipping; otherwise the value cell is shippable as-is**.
 
-`date` and `datetime` fields render `""` when no example or default is
-configured; the inline format slot (`<YYYY-MM-DD>` or `<ISO 8601>`)
-carries the shape hint.
+The sentinel lives where the LLM types the value:
 
-There is no string `"<name>"` placeholder — required strings render as
-`""` like every other type.
+| Type | Sentinel position | Example |
+|---|---|---|
+| `string`, `integer`, `number`, `boolean`, `date`, `datetime`, `enum` | Value cell | `name: <must-fill>  # string` |
+| `array<scalar>` | Value cell | `recipient: <must-fill>  # array<string>` |
+| `markdown` | Inside the block scalar | `bio: |-` then `<must-fill>` |
+| `object` (typed dict) | Per-property recursion | leaves carry sentinels |
+| `array<object>` (typed table) | Per-property recursion in one synthetic row | leaves carry sentinels |
 
 ### Markdown fields render as block scalars
 
-A `markdown` field renders as a YAML literal block scalar (`|-`), even
-when the type-empty case applies:
+A `markdown` field renders as a YAML literal block scalar (`|-`). The
+block-scalar shape is type-driven — it's the only YAML form that
+cleanly accommodates multi-line markdown content. By rendering it from
+the start, the LLM consumer writes into the indented block without
+needing to switch shapes mid-fill.
+
+For a Must Fill markdown field, the block's content is exactly one line
+containing the sentinel:
 
 ```
-bio: |-
-  
+bio: |-  # markdown
+  <must-fill>
 ```
 
-When a `default:` is configured, its content fills the block:
+The LLM replaces that single line with multi-line markdown; the block
+scalar's shape is unchanged.
+
+When a `default:` is configured, the field is Endorsed and the default's
+content fills the block:
 
 ```
-bio: |-
+bio: |-  # markdown; skip-ok
   ## About me
   
   <body>
 ```
 
-The block-scalar shape is type-driven — it's the only YAML form that
-cleanly accommodates multi-line markdown content. By rendering it from
-the start, the LLM consumer writes into the indented block without
-needing to switch shapes mid-fill.
+If the default is empty (`default: ""`), the block scalar still carries
+the `; skip-ok` tag and renders with one indented blank line — the
+"skippable" markdown cell.
 
 ### Multi-element example arrays
 
@@ -179,7 +191,7 @@ multi-element shape information is preserved:
 
 ```
 # e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
-recipient: []  # array<string>; optional
+recipient: <must-fill>  # array<string>
 ```
 
 Items containing flow indicators (`,`, `[`, `]`, `{`, `}`) get quoted so
@@ -199,15 +211,15 @@ fallback; authors needing these characters must reshape their values.
 A field of `type: array` with a `properties` map renders with full
 per-property annotations:
 
-- A non-empty `default:` renders as actual rows.
-- Otherwise one synthetic row is emitted, with each property carrying
-  its own description, inline type/format, and role.
+- A non-empty `default:` renders as actual rows (no per-property
+  annotations on each row). The outer key carries `# array<object>; skip-ok`.
+- Otherwise one synthetic row is emitted with each property carrying its
+  own description, inline annotation, and cell signal (sentinel or
+  `; skip-ok`). The outer key carries `# array<object>` (no `; skip-ok`).
 
 An `example:` never renders as rows. Like every other field type, it
 surfaces only in the `# e.g.` leading line — as a one-line flow
 sequence, e.g. `# e.g. [{org: ACME, year: 2020}]`.
-
-The outer field's inline annotation is `# array<object>; <role>`.
 
 ## Typed dictionaries
 
@@ -216,32 +228,32 @@ block mapping with per-property annotations — no outer value on the key
 line:
 
 - A non-empty `default:` renders as a concrete block mapping (property
-  values only, no annotations).
+  values only, no annotations). The outer key carries
+  `# object; skip-ok`.
 - Otherwise each property is emitted with its own description, inline
-  type/format, and role — the same annotation rules as any other field.
+  annotation, and cell signal — the same rules as any other field. The
+  outer key carries `# object` (no `; skip-ok`); state is a leaf concern.
 
 An `example:` never renders as a concrete mapping. Like every other
 field type, it surfaces only in the `# e.g.` leading line — as a
 one-line flow mapping, e.g. `# e.g. {street: 1 Infinite Loop, city:
 Cupertino}`.
 
-The outer field's inline annotation is `# object; <role>`.
-
 ```
 # The sender's mailing address.
-address:  # object; optional
+address:  # object
   # Street address line.
-  street: ""  # string; required
+  street: <must-fill>  # string
   # City name.
-  city: ""  # string; required
+  city: <must-fill>  # string
   # ZIP or postal code.
-  zip: ""  # string; optional
+  zip: ""  # string; skip-ok
 ```
 
 With a default:
 
 ```
-address:  # object; optional
+address:  # object; skip-ok
   street: 5000 Forbes Avenue
   city: Pittsburgh
   zip: "15213"
@@ -285,21 +297,21 @@ $kind: main
 
 # The recipient's name and full mailing address.
 # e.g. [Mr. John Doe, 123 Main St, "Anytown, USA"]
-recipient: []  # array<string>; optional
+recipient: <must-fill>  # array<string>
 # The signer's information. Line 1: Name. Line 2: Title.
 # e.g. [First M. Last, Title]
-signature_block: []  # array<string>; optional
+signature_block: <must-fill>  # array<string>
 # The department or organizational unit name for the letterhead.
 # e.g. Department of Electrical and Computer Engineering
-department: ""  # string; optional
+department: ""  # string; skip-ok
 # The sender's institutional mailing address.
 # e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
-address: []  # array<string>; optional
+address: <must-fill>  # array<string>
 # The department or university website URL.
 # e.g. www.ece.cmu.edu
-url: ""  # string; optional
+url: ""  # string; skip-ok
 # The date to appear on the letter.
-date: ""  # date<YYYY-MM-DD>; optional
+date: <must-fill>  # date<YYYY-MM-DD>
 ~~~
 
 Write main body here.
@@ -307,38 +319,41 @@ Write main body here.
 
 ## Guarantees
 
-`blueprint()` guarantees the emitted document is **schema-valid and
-parseable**: every field key is present, every value is type-correct,
-enums sit at their first value, dates render as `""`. Parsing the
-blueprint with `Document::from_markdown` and validating it against the
-quill schema always succeeds. This is the guarantee `blueprint()` itself
-is responsible for, and it is total over any valid `QuillConfig`.
+`blueprint()` guarantees the emitted document is **parseable**: every
+field key is present, every value is YAML-valid, the document round-trips
+through `Document::from_markdown` and back. Endorsed cells coerce and
+validate successfully; Must Fill cells carry the `<must-fill>` sentinel
+in the value cell (or inside a markdown block scalar), which validation
+reports as `validation::unfilled_placeholder` until the LLM replaces it
+with a typed value.
 
 `blueprint()` does **not**, on its own, guarantee the document
 *renders*. Rendering depends on the quill's `plate.typ` and its
 packages, which `blueprint()` does not control. That is a separate
 **quill authoring contract**:
 
-> A quill's `plate.typ` MUST render the quill's own blueprint to a
-> successful (non-error) output.
+> A quill's `plate.typ` MUST render the quill's own blueprint — with all
+> `<must-fill>` cells replaced by type-empty values of the declared
+> type — to a successful (non-error) output.
 
-The blueprint is, by construction, the *type-minimal valid input* — the
-worst-case-but-valid document. A plate that renders it has shown it
-degrades gracefully on every type-valid input shape. The contract
-requires:
+The blueprint, after sentinel substitution, is by construction the
+*type-minimal valid input* — the worst-case-but-valid document. A plate
+that renders it has shown it degrades gracefully on every type-valid
+input shape. The contract requires:
 
 - Templates treat type-empty values (`""`, `0`, `false`, `[]`, empty
   markdown body) as valid *present* input — read via `data.field`,
   `card.at("field", default: …)`, or guarded with `if "field" in data`.
-- No template asserts that a required field is *non-empty*. The schema
-  guarantees *presence*, not non-emptiness; `required` is an authoring
-  signal, not a render-time precondition.
+- No template asserts that a Must Fill field is *non-empty*. The schema
+  guarantees *presence*, not non-emptiness; the `<must-fill>` sentinel
+  is an authoring signal, not a render-time precondition.
 - "Renders successfully" means "compiles without error," not "produces
   meaningful output." An empty-string title is a blank title — that is
   acceptable.
 
-The contract is enforced by a fixture test that renders every bundled
-quill's blueprint and asserts success
+The contract is enforced by a fixture test that fills sentinels with
+type-empty values, then renders every bundled quill's blueprint and
+asserts success
 (`crates/quillmark/tests/quiver_test.rs::every_quill_in_quiver_renders`).
 
 ## Bindings surface
@@ -360,3 +375,27 @@ fixture.
 |---|---|
 | Validators, form builders, machine consumers | [SCHEMAS.md](SCHEMAS.md) — `schema()` |
 | LLM/MCP authoring, prompt-time reference document | this doc — `blueprint()` |
+
+## Authoring guidance
+
+When designing a `Quill.yaml` schema, choose between Must Fill and
+Endorsed per field:
+
+- **Declare `default:`** when a value (including a type-empty value like
+  `""`, `[]`, `false`, or `0`) is acceptable to ship as-is. The field
+  becomes Endorsed and the blueprint carries `; skip-ok`.
+- **Omit `default:`** when the author, LLM, or user must supply a value
+  before shipping. The field becomes Must Fill and the blueprint carries
+  the `<must-fill>` sentinel.
+- **Use `example:`** for illustrative reference values. `example:` is
+  orthogonal to the cell decision — it appears in the leading `# e.g.`
+  line for any cell, never rendering as the value.
+
+This is documentation, not enforcement.
+
+### Writing the literal string `<must-fill>` as content
+
+The blueprint emitter detects the unquoted form `<must-fill>` as the
+sentinel. To write the literal string as a field value, quote it:
+`"<must-fill>"`. Exact-string-equality detection treats the unquoted
+form as the sentinel and the quoted form as content.

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -44,7 +44,6 @@ card_kinds:
         description: Office symbol receiving the endorsed memo.
       signature_block:
         type: array
-        required: true
         ui:
           group: Addressing
         description: Name, grade, and duty title.
@@ -67,7 +66,6 @@ card_kinds:
         type: string
       signature_block:
         type: array
-        required: true
         ui:
           group: Addressing
 ```

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -36,6 +36,9 @@ Supported field types:
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
 - Coercion rules per type: array wrapping, boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
+- The Must-Fill sentinel string `<must-fill>` passes through coercion
+  unchanged so the validation layer can surface a placeholder diagnostic
+  rather than a type-coercion error
 
 ## Native validation
 
@@ -47,6 +50,13 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Emits path-aware errors for top-level fields and card fields
 - Validates each card's `$kind` matches a known card kind
 - Enforces `body.enabled: false` on the main card and on each card kind — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
+- **Sentinel detection runs first.** Before per-type checks, any value
+  equal to the literal string `<must-fill>` (for markdown, the trimmed
+  block-scalar content) fires `validation::unfilled_placeholder` and
+  skips the type check for that field.
+- **Required-field semantics**: a missing field with a `default:` accepts
+  the default (no error). A missing field without a `default:` fires
+  `validation::required_field_absent`.
 
 ## Schema emission
 
@@ -65,7 +75,22 @@ metadata, not schema fields, and do not appear in `fields`.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`, and optional `required` (omitted when false).
+Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`.
+
+### Must-Fill vs. Endorsed fields
+
+A field is **Must Fill** when no `default:` is declared; the schema author
+expects the LLM or user to supply a value before shipping. A missing
+Must Fill field at validate time fires `validation::required_field_absent`.
+
+A field is **Endorsed** when `default:` is declared; the rendered default
+is shippable as-is (the author can keep or override it). Endorsed
+defaults include type-empty values — `default: ""`, `default: []`,
+`default: false`, `default: 0` — which standardize the "skippable" cell.
+
+There is no separate `required:` axis; the presence or absence of
+`default:` is the sole author choice per field. See
+[BLUEPRINT.md](BLUEPRINT.md) for how the two cells render.
 
 Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata`; Python: `Quill.metadata` plus dedicated getters).
 


### PR DESCRIPTION
## Summary

This PR replaces the `required`/`optional` role-based field model with a new **Endorsed/Must Fill** cell-based model driven by the presence of a `default:` in the schema. Fields with defaults are "Endorsed" (shippable as-is) and carry `; skip-ok` in the blueprint; fields without defaults are "Must Fill" and render a `<must-fill>` sentinel in the value cell that validation detects and reports.

## Key Changes

- **Blueprint emission**: 
  - Removed `required` field from schema; cell state now determined by `default` presence
  - Endorsed fields (with `default:`) render their default value and carry `; skip-ok` tag
  - Must Fill fields (no `default:`) render `<must-fill>` sentinel in value cell, no `; skip-ok` tag
  - Markdown blocks render sentinel inside the block scalar for Must Fill fields
  - Typed tables/dicts: outer key carries `; skip-ok` only when container has non-empty default

- **Validation**:
  - Added `MUST_FILL_SENTINEL` constant (`"<must-fill>"`)
  - New error variant `UnfilledPlaceholder` detects unreplaced sentinels before type checking
  - Renamed `MissingRequired` → `RequiredFieldAbsent` (now triggered by missing field with no `default:`)
  - Sentinel detection runs first, skipping per-type validation on match
  - Coercion layer passes sentinel through unchanged for validation to catch

- **Documentation**:
  - Updated `BLUEPRINT.md` to explain Endorsed vs Must Fill cells
  - Removed role references; replaced with cell-based language
  - Clarified sentinel position for each type (value cell, block scalar, per-property recursion)
  - Updated examples to show `; skip-ok` and `<must-fill>` patterns

- **Test fixtures**:
  - Removed `required: true` declarations from all quill schemas
  - Added `default: ""` where needed to maintain Endorsed status
  - Updated test expectations to match new annotation format
  - Added tests for sentinel detection and Must Fill behavior

- **Test infrastructure**:
  - `quiver_test.rs`: Added `fill_must_fill()` helper to substitute sentinels with type-empty values before rendering, ensuring plates degrade gracefully on minimal valid input

## Implementation Details

- Cell determination is schema-driven: `field.default.is_some()` → Endorsed, else Must Fill
- Sentinel substitution in `inline_annotation()` uses `endorsed_override` parameter for typed containers where cell state differs from leaf properties
- Markdown block scalars always render as `|-` for consistent shape; Must Fill markdown contains exactly one line with the sentinel
- Validation sentinel detection handles both scalar fields (direct string match) and markdown (trimmed block content)
- Coercion preserves sentinel to avoid masking it with type-empty fallbacks

https://claude.ai/code/session_01Jd7FrCjaEm73PUh4dPnBka