### PR TITLE
Unify typed container defaults with scalar cell endorsement

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -191,12 +191,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     // Markdown fields render as a YAML block scalar so multi-line content has
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
-        let inline = inline_annotation(field, false, None);
+        let inline = inline_annotation(field, false, field.default.is_some());
         write_markdown_block(out, field, &pad, &inline);
         return;
     }
 
-    let inline = format!("  # {}", inline_annotation(field, false, None));
+    let inline = format!("  # {}", inline_annotation(field, false, field.default.is_some()));
     let value = field_value(field);
     write_value(out, &field.name, &value, &inline, &pad);
 }
@@ -282,8 +282,7 @@ fn write_typed_table_field(
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let container_endorsed = concrete_rows.is_some();
-    let inline = inline_annotation(field, true, Some(container_endorsed));
+    let inline = inline_annotation(field, true, concrete_rows.is_some());
     out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete_rows {
@@ -326,8 +325,7 @@ fn write_typed_object_field(
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let container_endorsed = concrete.is_some();
-    let inline = inline_annotation(field, false, Some(container_endorsed));
+    let inline = inline_annotation(field, false, concrete.is_some());
     out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
 
     match concrete {
@@ -347,31 +345,19 @@ fn write_typed_object_field(
 
 /// Build the inline annotation body (without the leading `# `).
 ///
-/// `force_array_object` is `true` for typed-table outer fields, which
-/// always render as `array<object>`; plain arrays render as `array<string>`.
-/// `endorsed_override` short-circuits the schema-driven cell decision —
-/// it's used for the typed-table / typed-dict outer key when the container
-/// is a leaf, or for property leaves whose cell decision differs from the
-/// container.
-fn inline_annotation(
-    field: &FieldSchema,
-    force_array_object: bool,
-    endorsed_override: Option<bool>,
-) -> String {
-    let endorsed = endorsed_override.unwrap_or_else(|| is_endorsed(field));
+/// `force_array_object` is `true` for typed-table outer fields, which always
+/// render as `array<object>`; plain arrays render as `array<string>`.
+/// `endorsed` carries the cell decision: scalars use `field.default.is_some()`
+/// (any default, even `""`, is shippable); containers (typed-table /
+/// typed-dict) use "default present AND non-empty" so an empty default
+/// still recurses into the synthetic row / per-property shape.
+fn inline_annotation(field: &FieldSchema, force_array_object: bool, endorsed: bool) -> String {
     let type_expr = type_expression(field, force_array_object);
     if endorsed {
         format!("{}; skip-ok", type_expr)
     } else {
         type_expr
     }
-}
-
-/// A field is **Endorsed** when its schema declares a `default:`. Otherwise
-/// it is **Must Fill** and the blueprint emits a `<must-fill>` sentinel in
-/// the value cell.
-fn is_endorsed(field: &FieldSchema) -> bool {
-    field.default.is_some()
 }
 
 fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -255,17 +255,19 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
     v
 }
 
-/// Emit a typed-table field: description + `# e.g.` line (whenever an example
-/// is configured), then the field key with its `array<object>` inline
-/// annotation, then either default rows or a synthetic template row. An
-/// example never renders as rows — like every other field type it surfaces
-/// only in the `# e.g.` leading line.
+/// Emit a typed-table field: description + `# e.g.` line (whenever an
+/// example is configured), then the field key with its `array<object>`
+/// inline annotation, then either the declared default or a synthetic
+/// template row. An example never renders as rows — like every other
+/// field type it surfaces only in the `# e.g.` leading line.
 ///
-/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
-/// `; skip-ok` on the outer key and renders concrete rows without
-/// per-property annotations. A Must Fill container (no default) drops
-/// `; skip-ok` from the outer key (state is a leaf concern) and recurses
-/// into one synthetic row whose leaves carry their own cell signals.
+/// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
+/// — the outer key carries `; skip-ok` and the rendered value is the
+/// default (rows for `default: [...]`, inline `[]` for `default: []`). A
+/// field without a `default:` is Must Fill — the outer key drops
+/// `; skip-ok` and one synthetic row is emitted with leaf-level sentinels.
+/// See `prose/BOOKMARKS.md` "Typed container empty default loses inline
+/// shape documentation" for the rendering-vs-symmetry trade-off.
 fn write_typed_table_field(
     out: &mut String,
     field: &FieldSchema,
@@ -274,20 +276,26 @@ fn write_typed_table_field(
 ) {
     let pad = "  ".repeat(indent);
 
-    let concrete_rows = field.default.as_ref().and_then(|v| match v.as_json() {
-        serde_json::Value::Array(items) if !items.is_empty() => Some(items.clone()),
+    let default_items = field.default.as_ref().and_then(|v| match v.as_json() {
+        serde_json::Value::Array(items) => Some(items.clone()),
         _ => None,
     });
 
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let inline = inline_annotation(field, true, concrete_rows.is_some());
-    out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+    let inline = inline_annotation(field, true, default_items.is_some());
 
-    match concrete_rows {
-        Some(items) => write_array_items(out, &items, &pad),
+    match default_items {
+        Some(items) if items.is_empty() => {
+            out.push_str(&format!("{}{}: []  # {}\n", pad, field.name, inline));
+        }
+        Some(items) => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+            write_array_items(out, &items, &pad);
+        }
         None => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             let dash_pad = "  ".repeat(indent + 1);
             out.push_str(&format!("{}-\n", dash_pad));
             for prop in sort_props(item_props) {
@@ -299,16 +307,16 @@ fn write_typed_table_field(
 
 /// Emit a typed-dictionary field: description + `# e.g.` line (whenever an
 /// example is configured), then the field key with its `object` inline
-/// annotation, then either a concrete mapping from `default` or per-property
-/// annotations. An example never renders as a concrete mapping — like every
-/// other field type it surfaces only in the `# e.g.` leading line.
+/// annotation, then either the declared default or per-property
+/// annotations. An example never renders as a concrete mapping — like
+/// every other field type it surfaces only in the `# e.g.` leading line.
 ///
-/// Cell rule: an Endorsed container (with a non-empty `default:`) carries
-/// `; skip-ok` on the outer key and renders a concrete block mapping
-/// without per-property annotations. A Must Fill container (no default)
-/// drops `; skip-ok` from the outer key (state is a leaf concern) and
-/// recurses into per-property annotations whose leaves carry their own
-/// cell signals.
+/// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
+/// — the outer key carries `; skip-ok` and the rendered value is the
+/// default (a block mapping for non-empty, inline `{}` for `default: {}`).
+/// A field without a `default:` is Must Fill — per-property recursion with
+/// leaf-level sentinels. See `prose/BOOKMARKS.md` "Typed container empty
+/// default loses inline shape documentation" for the trade-off.
 fn write_typed_object_field(
     out: &mut String,
     field: &FieldSchema,
@@ -317,25 +325,29 @@ fn write_typed_object_field(
 ) {
     let pad = "  ".repeat(indent);
 
-    let concrete = field.default.as_ref().and_then(|v| match v.as_json() {
-        serde_json::Value::Object(map) if !map.is_empty() => Some(map.clone()),
+    let default_map = field.default.as_ref().and_then(|v| match v.as_json() {
+        serde_json::Value::Object(map) => Some(map.clone()),
         _ => None,
     });
 
     write_description(out, field, &pad);
     write_eg_comment(out, field, &pad);
 
-    let inline = inline_annotation(field, false, concrete.is_some());
-    out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
+    let inline = inline_annotation(field, false, default_map.is_some());
 
-    match concrete {
+    match default_map {
+        Some(map) if map.is_empty() => {
+            out.push_str(&format!("{}{}: {{}}  # {}\n", pad, field.name, inline));
+        }
         Some(map) => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             let inner_pad = format!("{}  ", pad);
             for (k, v) in &map {
                 out.push_str(&format!("{}{}: {}\n", inner_pad, k, render_scalar(v)));
             }
         }
         None => {
+            out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             for prop in sort_props(props) {
                 write_field(out, prop, indent + 1);
             }
@@ -345,12 +357,10 @@ fn write_typed_object_field(
 
 /// Build the inline annotation body (without the leading `# `).
 ///
-/// `force_array_object` is `true` for typed-table outer fields, which always
-/// render as `array<object>`; plain arrays render as `array<string>`.
-/// `endorsed` carries the cell decision: scalars use `field.default.is_some()`
-/// (any default, even `""`, is shippable); containers (typed-table /
-/// typed-dict) use "default present AND non-empty" so an empty default
-/// still recurses into the synthetic row / per-property shape.
+/// `force_array_object` is `true` for typed-table outer fields, which
+/// always render as `array<object>`; plain arrays render as `array<string>`.
+/// `endorsed` is uniformly `field.default.is_some()` — any `default:`
+/// (including type-empty `""`, `[]`, `{}`) means the cell is shippable.
 fn inline_annotation(field: &FieldSchema, force_array_object: bool, endorsed: bool) -> String {
     let type_expr = type_expression(field, force_array_object);
     if endorsed {
@@ -846,10 +856,11 @@ main:
     }
 
     #[test]
-    fn typed_table_with_empty_default_falls_through_to_synthetic_row() {
-        // An empty default array is treated like a Must Fill container
-        // for rendering purposes (we need a synthetic row to show the
-        // shape), and the outer key drops `; skip-ok`.
+    fn typed_table_with_empty_default_renders_inline_and_skip_ok() {
+        // `default: []` means shippable as-is — the outer cell carries
+        // `; skip-ok` uniformly with scalar cells and the value renders
+        // inline as `[]`. Inline row shape under an empty default belongs
+        // in `example:`; see prose/BOOKMARKS.md.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -861,9 +872,33 @@ main:
         org: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains(
-            "refs:  # array<object>\n  -\n    org: <must-fill>  # string\n"
-        ));
+        assert!(
+            t.contains("refs: []  # array<object>; skip-ok\n"),
+            "wrong rendering: {t}"
+        );
+        assert!(!t.contains("<must-fill>"), "no sentinels expected: {t}");
+    }
+
+    #[test]
+    fn typed_dict_with_empty_default_renders_inline_and_skip_ok() {
+        // Same uniform rule as typed tables: `default: {}` is Endorsed and
+        // renders inline as `{}` with `; skip-ok`.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      default: {}
+      properties:
+        street: { type: string }
+"#)
+        .blueprint();
+        assert!(
+            t.contains("address: {}  # object; skip-ok\n"),
+            "wrong rendering: {t}"
+        );
+        assert!(!t.contains("<must-fill>"), "no sentinels expected: {t}");
     }
 
     #[test]

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -487,9 +487,23 @@ pub(crate) fn validate_field(
             Some(items) => {
                 if let Some(properties) = &field.properties {
                     for (idx, item) in items.iter().enumerate() {
+                        let row_path = format!("{}[{}]", path, idx);
+                        // Hand-edited edge case: a row collapsed to the literal
+                        // sentinel string (the user replaced the synthetic row
+                        // with `<must-fill>` instead of expanding it). Report
+                        // it once against the row path rather than emitting an
+                        // Absent error per Must Fill property.
+                        if item.as_str() == Some(MUST_FILL_SENTINEL) {
+                            errors.push(ValidationError::MustFillUnset {
+                                path: row_path,
+                                expected: "object".to_string(),
+                                source: MustFillSource::Sentinel,
+                            });
+                            continue;
+                        }
                         let obj = item.as_object();
                         for (prop_name, prop_schema) in properties {
-                            let prop_path = format!("{}[{}].{}", path, idx, prop_name);
+                            let prop_path = format!("{}.{}", row_path, prop_name);
                             match obj.and_then(|o| o.get(prop_name)) {
                                 Some(v) => errors.extend(validate_field(
                                     prop_schema,
@@ -884,6 +898,38 @@ main:
         assert!(has_error(&errors, |e| {
             matches!(e, ValidationError::MustFillUnset { path, source: MustFillSource::Absent, .. } if path == "recipients[0].name")
         }));
+    }
+
+    #[test]
+    fn detects_must_fill_sentinel_as_typed_table_row() {
+        // Hand-edit edge case: the user collapses a synthetic row down to the
+        // literal sentinel string instead of expanding it into a mapping.
+        // One Sentinel error at the row path beats N noisy Absent errors per
+        // Must Fill property.
+        let config = config_with(
+            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n        org:\n          type: string",
+            "",
+        );
+        let doc = doc_from_fm(&[("recipients", json!([MUST_FILL_SENTINEL]))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(
+            has_error(&errors, |e| matches!(
+                e,
+                ValidationError::MustFillUnset { path, source: MustFillSource::Sentinel, .. }
+                if path == "recipients[0]"
+            )),
+            "expected sentinel error at row path; got {errors:?}"
+        );
+        // And no per-property Absent errors for that row — the row-level
+        // sentinel diagnostic supersedes them.
+        assert!(
+            !has_error(&errors, |e| matches!(
+                e,
+                ValidationError::MustFillUnset { path, source: MustFillSource::Absent, .. }
+                if path.starts_with("recipients[0].")
+            )),
+            "row-level sentinel should suppress per-property Absent errors; got {errors:?}"
+        );
     }
 
     // NOTE: top-level typed-dictionary fields (`type: object` with `properties`)

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -48,3 +48,42 @@ relies on `serde_json/preserve_order` and consumers may have started
 content-hashing the result. Touch `crates/backends/typst/src/lib.rs`
 (`transform_markdown_fields`) at the same time so the schema
 walker uses the same shape.
+
+---
+
+## Typed container empty default loses inline shape documentation
+
+**Where:** `write_typed_table_field` / `write_typed_object_field` in
+`crates/core/src/quill/blueprint.rs`.
+
+**What:** When a typed container declares `default: []` (or `default: {}`)
+the blueprint now renders the value inline — `refs: []  # array<object>;
+skip-ok` — and emits no row/property shape. Inner shape is only surfaced
+when the container is Must Fill (no `default:` at all), via the synthetic
+row / per-property recursion path.
+
+**Why we accepted the loss:** prior to this, an empty container default
+asymmetrically forced a synthetic row with leaf sentinels — the field's
+own cell signal said "Must Fill" even though `default: []` is a fully
+shippable value per `prose/canon/SCHEMAS.md`. The asymmetry leaked into
+the rendering code (an override parameter on `inline_annotation`) and
+disagreed with the canonical "type-empty defaults are Endorsed" rule.
+Removing the asymmetry was a one-rule simplification — uniform cascade:
+`default.is_some()` → Endorsed → render the default; `default` absent →
+Must Fill → render the shape with sentinels.
+
+**What's left for a future pass:** schema authors who want both "shippable
+empty" *and* inline shape documentation now have no single knob. Options
+when this comes up:
+
+- Add a leading `# rows shaped like: {…}` comment for typed containers
+  with an empty default, derived from `properties:`. Cheap to emit, no
+  semantic conflict (it's a comment).
+- Promote `example:` rendering for typed containers so an `example:
+  [{…}]` under an empty default actually shows a shape sketch — today
+  the example collapses to a single-line `# e.g. …` regardless.
+- Add an explicit `ui.show_shape: true` flag on the field.
+
+Defer until a real authoring case asks for it. The canon update lives
+in `prose/canon/BLUEPRINT.md` "Typed tables" / "Typed dictionaries"
+which already point readers here.

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -208,14 +208,21 @@ fallback; authors needing these characters must reshape their values.
 
 ## Typed tables
 
-A field of `type: array` with a `properties` map renders with full
-per-property annotations:
+A field of `type: array` with a `properties` map follows the uniform
+cell cascade — `default:` (any default, including `[]`) is Endorsed and
+shippable as-is; no `default:` is Must Fill:
 
 - A non-empty `default:` renders as actual rows (no per-property
   annotations on each row). The outer key carries `# array<object>; skip-ok`.
-- Otherwise one synthetic row is emitted with each property carrying its
-  own description, inline annotation, and cell signal (sentinel or
-  `; skip-ok`). The outer key carries `# array<object>` (no `; skip-ok`).
+- `default: []` renders inline as `[]` with `# array<object>; skip-ok` —
+  shippable empty. Inline row shape is not surfaced under an empty
+  default; use `example:` to document row shape. See
+  `prose/BOOKMARKS.md` "Typed container empty default loses inline
+  shape documentation."
+- No `default:` is Must Fill: one synthetic row is emitted with each
+  property carrying its own description, inline annotation, and cell
+  signal (sentinel or `; skip-ok`). The outer key carries
+  `# array<object>` (no `; skip-ok`).
 
 An `example:` never renders as rows. Like every other field type, it
 surfaces only in the `# e.g.` leading line — as a one-line flow
@@ -223,16 +230,19 @@ sequence, e.g. `# e.g. [{org: ACME, year: 2020}]`.
 
 ## Typed dictionaries
 
-A field of `type: object` with a `properties` map renders as an indented
-block mapping with per-property annotations — no outer value on the key
-line:
+A field of `type: object` with a `properties` map follows the uniform
+cell cascade — `default:` (any default, including `{}`) is Endorsed and
+shippable as-is; no `default:` is Must Fill:
 
 - A non-empty `default:` renders as a concrete block mapping (property
   values only, no annotations). The outer key carries
   `# object; skip-ok`.
-- Otherwise each property is emitted with its own description, inline
-  annotation, and cell signal — the same rules as any other field. The
-  outer key carries `# object` (no `; skip-ok`); state is a leaf concern.
+- `default: {}` renders inline as `{}` with `# object; skip-ok` —
+  shippable empty. Inline property shape is not surfaced under an empty
+  default; use `example:` to document property shape.
+- No `default:` is Must Fill: each property is emitted with its own
+  description, inline annotation, and cell signal. The outer key
+  carries `# object` (no `; skip-ok`).
 
 An `example:` never renders as a concrete mapping. Like every other
 field type, it surfaces only in the `# e.g.` leading line — as a


### PR DESCRIPTION
## Summary

Simplifies the blueprint rendering logic for typed containers (arrays and objects with `properties`) by applying a uniform cell endorsement rule: any field with a `default:` value is Endorsed and shippable as-is, regardless of whether the default is empty. This eliminates special-case handling that previously forced synthetic rows/properties for empty defaults.

## Key Changes

- **Uniform endorsement rule**: Changed `inline_annotation()` signature to accept a boolean `endorsed` parameter (derived from `field.default.is_some()`) instead of an `endorsed_override` option. Removed the `is_endorsed()` helper function entirely.

- **Typed table rendering**: 
  - `default: []` now renders inline as `refs: []  # array<object>; skip-ok` instead of emitting a synthetic row with sentinels
  - Non-empty defaults continue to render as actual rows
  - No default still renders a synthetic row with per-property annotations

- **Typed object rendering**:
  - `default: {}` now renders inline as `address: {}  # object; skip-ok` instead of per-property recursion
  - Non-empty defaults continue to render as concrete block mappings
  - No default still recurses into per-property annotations

- **Validation improvement**: Added detection for hand-edited edge case where users replace a synthetic row with the literal `<must-fill>` sentinel string. Reports a single row-level error instead of N per-property Absent errors.

- **Documentation updates**: Updated `prose/canon/BLUEPRINT.md` and added a new bookmark in `prose/BOOKMARKS.md` explaining the trade-off (inline shape documentation is lost for empty defaults; authors should use `example:` to document shape).

## Implementation Details

- The change simplifies the rendering code by removing conditional branches that treated empty defaults differently from non-empty ones
- All three match arms in `write_typed_table_field` and `write_typed_object_field` now explicitly write the field key line, making the logic more uniform
- Tests updated to verify inline rendering with `; skip-ok` for empty defaults, and new test added for the sentinel detection edge case

https://claude.ai/code/session_01S3xkZkPs2cneQ48qJtTGSE