### PR TITLE
auto-refine sprints 1–4: error/blueprint/Diagnostic surface hardening

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -122,7 +122,7 @@ A field's *cell* is inferred from whether the schema declares a `default:`:
   field is absent at validate time, or `validation::must_fill_sentinel`
   if the `<must-fill>` sentinel survives into the rendered document.
 - **Endorsed** (with `default:`) — the blueprint renders the default
-  value with a `; skip-ok` annotation, and the default is used when
+  value with a `; delete-ok` annotation, and the default is used when
   the document omits the field.
 
 There is no `required:` axis on `FieldSchema`.

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -7,7 +7,7 @@ A field's *cell* is determined by whether the schema declares a `default:`.
   is absent at validate time and ``validation::must_fill_sentinel`` if
   the `<must-fill>` sentinel survives into the rendered document.
 - With `default:` -> **Endorsed**: the blueprint renders the default
-  value with a ``; skip-ok`` annotation; the field is optional and the
+  value with a ``; delete-ok`` annotation; the field is optional and the
   default is used when absent.
 """
 
@@ -103,16 +103,16 @@ def test_blueprint_must_fill_sentinel(tmp_path):
     )
 
 
-def test_blueprint_endorsed_skip_ok(tmp_path):
-    """Endorsed cells carry `; skip-ok` after the type annotation."""
+def test_blueprint_endorsed_delete_ok(tmp_path):
+    """Endorsed cells carry `; delete-ok` after the type annotation."""
     quill = make_quill(tmp_path)
     bp = quill.blueprint
 
-    # The Endorsed `status` field renders its default value with `; skip-ok`.
-    # The exact format is `status: draft  # string; skip-ok`.
+    # The Endorsed `status` field renders its default value with `; delete-ok`.
+    # The exact format is `status: draft  # string; delete-ok`.
     assert "status: draft" in bp, f"expected default in blueprint; got:\n{bp}"
-    assert "skip-ok" in bp, (
-        f"expected `; skip-ok` annotation on Endorsed cell; got:\n{bp}"
+    assert "delete-ok" in bp, (
+        f"expected `; delete-ok` annotation on Endorsed cell; got:\n{bp}"
     )
 
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -254,7 +254,7 @@ A field's *cell* is inferred from whether its schema declares a `default:`:
   validate time, or `validation::must_fill_sentinel` when the
   `<must-fill>` sentinel survives into the document.
 - **Endorsed** (with `default:`) — `quill.blueprint` renders the
-  default value followed by a `; skip-ok` annotation, and the default
+  default value followed by a `; delete-ok` annotation, and the default
   is used when the document omits the field.
 
 `QuillFieldSchema` no longer carries a `required` axis. The legacy

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1033,13 +1033,13 @@ title: "Hello"
 //
 // Post-mcp-feedback the schema axis is implicit: a field with a `default:` is
 // Endorsed (the rendered default is shippable as-is and the blueprint emits
-// the value + `; skip-ok` annotation); a field without a `default:` is Must
+// the value + `; delete-ok` annotation); a field without a `default:` is Must
 // Fill (the blueprint emits the `<must-fill>` sentinel and validation flags
 // either the absence or the unreplaced sentinel).
 //
 // These tests pin the JS-facing contract:
 //   - `QuillFieldSchema` no longer carries a `required` axis.
-//   - `quill.blueprint` carries `<must-fill>` and `; skip-ok` annotations.
+//   - `quill.blueprint` carries `<must-fill>` and `; delete-ok` annotations.
 //   - `quill.render(doc)` raises `validation::must_fill_absent` when a
 //     Must Fill field is absent at validate time.
 //   - `quill.render(doc)` raises `validation::must_fill_sentinel` when the
@@ -1107,21 +1107,21 @@ main:
     expect(fields.subtitle.default).toBe('Untitled subtitle')
   })
 
-  it('blueprint carries `<must-fill>` for Must Fill fields and `; skip-ok` for Endorsed', () => {
+  it('blueprint carries `<must-fill>` for Must Fill fields and `; delete-ok` for Endorsed', () => {
     const quill = buildQuill()
     const blueprint = quill.blueprint
 
     expect(typeof blueprint).toBe('string')
     expect(blueprint.length).toBeGreaterThan(0)
 
-    // Must Fill: value cell is the literal sentinel; no `; skip-ok` tag.
+    // Must Fill: value cell is the literal sentinel; no `; delete-ok` tag.
     expect(blueprint).toContain('title: <must-fill>  # string')
-    expect(blueprint).not.toMatch(/title: <must-fill>.*skip-ok/)
+    expect(blueprint).not.toMatch(/title: <must-fill>.*delete-ok/)
 
-    // Endorsed: rendered default + `; skip-ok` tag. The emitter does not
+    // Endorsed: rendered default + `; delete-ok` tag. The emitter does not
     // quote strings that don't need quoting (`Untitled subtitle` has no YAML
     // ambiguity), so the value cell is bare.
-    expect(blueprint).toContain('subtitle: Untitled subtitle  # string; skip-ok')
+    expect(blueprint).toContain('subtitle: Untitled subtitle  # string; delete-ok')
 
     // The legacy `; required` / `; optional` role tag must not appear anywhere.
     expect(blueprint).not.toContain('; required')

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -477,6 +477,15 @@ impl Document {
         quillmark_core::document::SCHEMA_V0_82_0.to_string()
     }
 
+    /// Authoring-format rules for the card-yaml markdown surface — the same
+    /// text every binding (CLI, Python, MCP) shows so callers reading errors
+    /// from one binding can use the rules from any other. Read once at
+    /// startup and cache; the value never changes between calls.
+    #[wasm_bindgen(js_name = formatRules)]
+    pub fn format_rules() -> String {
+        quillmark_core::document::FORMAT_RULES.to_string()
+    }
+
     /// Emit canonical Quillmark Markdown. Round-trip safe: re-parsing the
     /// result produces a `Document` equal to `self` by value and by type.
     #[wasm_bindgen(js_name = toMarkdown)]

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -486,6 +486,23 @@ impl Document {
         quillmark_core::document::FORMAT_RULES.to_string()
     }
 
+    /// Authoring-ergonomics header introducing a blueprint to an LLM/MCP
+    /// consumer for the given `quillName`. Surfaced verbatim by every binding
+    /// so the wording stays uniform across CLI / Python / MCP.
+    #[wasm_bindgen(js_name = blueprintInstruction)]
+    pub fn blueprint_instruction(quill_name: &str) -> String {
+        quillmark_core::document::blueprint_instruction(quill_name)
+    }
+
+    /// Render a Diagnostic as the canonical pretty-printed text every binding
+    /// shows (CLI, Python, MCP). Single source of truth so a Diagnostic looks
+    /// identical no matter which consumer surfaces it.
+    #[wasm_bindgen(js_name = formatDiagnostic)]
+    pub fn format_diagnostic(diag: Diagnostic) -> String {
+        let core: quillmark_core::Diagnostic = diag.into();
+        core.fmt_pretty()
+    }
+
     /// Emit canonical Quillmark Markdown. Round-trip safe: re-parsing the
     /// result produces a `Document` equal to `self` by value and by type.
     #[wasm_bindgen(js_name = toMarkdown)]

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -57,6 +57,16 @@ impl From<quillmark_core::Severity> for Severity {
     }
 }
 
+impl From<Severity> for quillmark_core::Severity {
+    fn from(severity: Severity) -> Self {
+        match severity {
+            Severity::Error => quillmark_core::Severity::Error,
+            Severity::Warning => quillmark_core::Severity::Warning,
+            Severity::Note => quillmark_core::Severity::Note,
+        }
+    }
+}
+
 /// Source location for errors and warnings
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
@@ -77,32 +87,56 @@ impl From<quillmark_core::Location> for Location {
     }
 }
 
+impl From<Location> for quillmark_core::Location {
+    fn from(loc: Location) -> Self {
+        quillmark_core::Location {
+            file: loc.file,
+            line: loc.line as u32,
+            column: loc.column as u32,
+        }
+    }
+}
+
 /// Diagnostic message (error, warning, or note)
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
     pub severity: Severity,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub code: Option<String>,
     pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub location: Option<Location>,
     /// Document-model path anchor (e.g. `"cards.indorsement[0].signature_block"`).
     ///
     /// Set on schema validation diagnostics; `undefined` otherwise. See the
     /// Rust `quillmark_core::error` module docs for the path grammar.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub source_chain: Vec<String>,
 }
 
 impl From<quillmark_core::Diagnostic> for Diagnostic {
     fn from(diag: quillmark_core::Diagnostic) -> Self {
         Diagnostic {
+            severity: diag.severity.into(),
+            code: diag.code,
+            message: diag.message,
+            location: diag.location.map(Into::into),
+            path: diag.path,
+            hint: diag.hint,
+            source_chain: diag.source_chain,
+        }
+    }
+}
+
+impl From<Diagnostic> for quillmark_core::Diagnostic {
+    fn from(diag: Diagnostic) -> Self {
+        quillmark_core::Diagnostic {
             severity: diag.severity.into(),
             code: diag.code,
             message: diag.message,

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -119,10 +119,13 @@ pub(super) fn build_block(
             Ok(parsed) => parsed,
             Err(e) => {
                 let line = markdown[..block_start].lines().count() + 1;
+                let enriched =
+                    super::yaml_hints::enrich_yaml_error(&e.to_string(), &content);
                 return Err(ParseError::YamlErrorWithLocation {
-                    message: e.to_string(),
+                    message: enriched.message,
                     line,
                     block_index,
+                    hint: enriched.hint,
                 });
             }
         };
@@ -188,7 +191,11 @@ pub(super) fn decompose_with_warnings(
     if blocks.is_empty() {
         return Err(crate::error::ParseError::MissingQuill(
             "Missing required root card-yaml block. The document must open with a \
-             `~~~card-yaml` block declaring `$quill: <name>`."
+             `~~~card-yaml` block declaring `$quill: <name>` (and `$kind: main`) as \
+             the first two lines, closed by a line containing exactly `~~~`.\n\n\
+             If you used `---` YAML frontmatter, that syntax is NOT supported. \
+             Replace the `---` fences with `~~~card-yaml` (opener) and `~~~` \
+             (closer)."
                 .to_string(),
         ));
     }
@@ -201,7 +208,9 @@ pub(super) fn decompose_with_warnings(
         .any(|m| matches!(m, PayloadItem::Quill { .. }));
     if !has_root_quill {
         return Err(ParseError::MissingQuill(
-            "The document's root card-yaml block must declare `$quill: <name>`.".to_string(),
+            "The document's root card-yaml block must declare `$quill: <name>` as \
+             its first line (e.g. `$quill: usaf_memo@0.2.0`)."
+                .to_string(),
         ));
     }
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -32,29 +32,15 @@ use super::prescan::{prescan_fence_content, NestedComment, PreItem};
 use super::{Card, Document};
 
 /// Build a `MissingQuill` message that names the specific malformation when
-/// the document has none of the `~~~card-yaml` blocks the parser requires.
+/// the document has none of the recognised root block forms the parser
+/// requires.
 ///
-/// LLM authors hit two recurring shapes here:
-///
-/// 1. `---` YAML frontmatter (Jekyll-style). The `$quill` line is inside, but
-///    the fences are wrong.
-/// 2. Bare YAML mapping with `$quill: ...` at the top, no fences at all.
-///
-/// In both cases, the generic "open a `~~~card-yaml` block" advice is correct
-/// but doesn't name what the user *did*. Pointing at the specific malformation
-/// helps the model converge faster on the right edit.
+/// LLM authors hit one recurring shape here: a bare YAML mapping with
+/// `$quill: ...` (or `quill: ...`) at the top, no fences at all. Naming the
+/// concrete edit helps the model converge faster than the generic "open a
+/// `~~~card-yaml` block" advice.
 fn missing_block_message(markdown: &str) -> String {
     let trimmed = markdown.trim_start();
-
-    // `---` frontmatter at the top: name the swap directly.
-    if trimmed.starts_with("---") {
-        return "Missing required root card-yaml block. Your document opens with `---` \
-                YAML frontmatter — that syntax is NOT supported. Replace the opening \
-                `---` with `~~~card-yaml` and the closing `---` with `~~~` (three \
-                tildes, no info string), and ensure the block declares \
-                `$quill: <name>@<version>` and `$kind: main`."
-            .to_string();
-    }
 
     // Bare YAML with `$quill:` at the top: the model wrote the metadata but
     // forgot the fence entirely.
@@ -69,10 +55,7 @@ fn missing_block_message(markdown: &str) -> String {
 
     "Missing required root card-yaml block. The document must open with a \
      `~~~card-yaml` block declaring `$quill: <name>` (and `$kind: main`) as \
-     the first two lines, closed by a line containing exactly `~~~`.\n\n\
-     If you used `---` YAML frontmatter, that syntax is NOT supported. \
-     Replace the `---` fences with `~~~card-yaml` (opener) and `~~~` \
-     (closer)."
+     the first two lines, closed by a line containing exactly `~~~`."
         .to_string()
 }
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -31,6 +31,51 @@ use super::payload::{Payload, PayloadItem};
 use super::prescan::{prescan_fence_content, NestedComment, PreItem};
 use super::{Card, Document};
 
+/// Build a `MissingQuill` message that names the specific malformation when
+/// the document has none of the `~~~card-yaml` blocks the parser requires.
+///
+/// LLM authors hit two recurring shapes here:
+///
+/// 1. `---` YAML frontmatter (Jekyll-style). The `$quill` line is inside, but
+///    the fences are wrong.
+/// 2. Bare YAML mapping with `$quill: ...` at the top, no fences at all.
+///
+/// In both cases, the generic "open a `~~~card-yaml` block" advice is correct
+/// but doesn't name what the user *did*. Pointing at the specific malformation
+/// helps the model converge faster on the right edit.
+fn missing_block_message(markdown: &str) -> String {
+    let trimmed = markdown.trim_start();
+
+    // `---` frontmatter at the top: name the swap directly.
+    if trimmed.starts_with("---") {
+        return "Missing required root card-yaml block. Your document opens with `---` \
+                YAML frontmatter — that syntax is NOT supported. Replace the opening \
+                `---` with `~~~card-yaml` and the closing `---` with `~~~` (three \
+                tildes, no info string), and ensure the block declares \
+                `$quill: <name>@<version>` and `$kind: main`."
+            .to_string();
+    }
+
+    // Bare YAML with `$quill:` at the top: the model wrote the metadata but
+    // forgot the fence entirely.
+    if trimmed.starts_with("$quill:") || trimmed.starts_with("quill:") {
+        return "Missing required root card-yaml block. Your document starts with \
+                YAML metadata but is missing the `~~~card-yaml` fence. Wrap the \
+                metadata: add a line `~~~card-yaml` above the `$quill:` line and a \
+                line containing exactly `~~~` (three tildes, no info string) below \
+                the last metadata field, before the prose body."
+            .to_string();
+    }
+
+    "Missing required root card-yaml block. The document must open with a \
+     `~~~card-yaml` block declaring `$quill: <name>` (and `$kind: main`) as \
+     the first two lines, closed by a line containing exactly `~~~`.\n\n\
+     If you used `---` YAML frontmatter, that syntax is NOT supported. \
+     Replace the `---` fences with `~~~card-yaml` (opener) and `~~~` \
+     (closer)."
+        .to_string()
+}
+
 /// Strip exactly one structural separator from the tail of a body slice.
 ///
 /// Every card-yaml block requires a blank line immediately above it. When a
@@ -189,15 +234,9 @@ pub(super) fn decompose_with_warnings(
     let (blocks, warnings) = find_metadata_blocks(markdown)?;
 
     if blocks.is_empty() {
-        return Err(crate::error::ParseError::MissingQuill(
-            "Missing required root card-yaml block. The document must open with a \
-             `~~~card-yaml` block declaring `$quill: <name>` (and `$kind: main`) as \
-             the first two lines, closed by a line containing exactly `~~~`.\n\n\
-             If you used `---` YAML frontmatter, that syntax is NOT supported. \
-             Replace the `---` fences with `~~~card-yaml` (opener) and `~~~` \
-             (closer)."
-                .to_string(),
-        ));
+        return Err(crate::error::ParseError::MissingQuill(missing_block_message(
+            markdown,
+        )));
     }
 
     // The root block must declare a `$quill` reference.

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -118,6 +118,76 @@ fn is_card_yaml_opener(line: &str) -> bool {
     }
 }
 
+/// `true` when `line` is a `---` YAML-frontmatter fence line — exactly three
+/// dashes, with up to three leading spaces and only whitespace afterward.
+///
+/// `---` is accepted ONLY as the root-block opener/closer (see
+/// [`find_metadata_blocks`]); it is never a composable-card fence.
+fn is_dash_fence_line(line: &str) -> bool {
+    let indent = line.as_bytes().iter().take_while(|&&b| b == b' ').count();
+    if indent > 3 {
+        return false;
+    }
+    let trimmed = &line[indent..];
+    let bytes = trimmed.as_bytes();
+    if bytes.len() < 3 || bytes[0] != b'-' {
+        return false;
+    }
+    let run_len = bytes.iter().take_while(|&&b| b == b'-').count();
+    if run_len != 3 {
+        return false;
+    }
+    trimmed[run_len..].chars().all(|c| c == ' ' || c == '\t')
+}
+
+/// `true` when `line` looks like a YAML mapping key (e.g. `key: value` or
+/// `$key: value`). Used to disambiguate a stray `---` thematic break from a
+/// would-be composable-card block.
+fn looks_like_yaml_key_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return false;
+    }
+    let bytes = trimmed.as_bytes();
+    let mut i;
+    if bytes[0] == b'$' {
+        if bytes.len() < 2 || !(bytes[1].is_ascii_alphabetic() || bytes[1] == b'_') {
+            return false;
+        }
+        i = 2;
+    } else if bytes[0].is_ascii_alphabetic() || bytes[0] == b'_' {
+        i = 1;
+    } else {
+        return false;
+    }
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    i < bytes.len() && bytes[i] == b':'
+}
+
+/// Look for a matching `---` line further down in the document, with at least
+/// one YAML-key-shaped line between the openers. Returns the line index of the
+/// closing `---` if found.
+///
+/// Used after the root block has already been parsed: a second `---` block
+/// further down is almost certainly a misplaced composable card.
+fn find_paired_dash_with_yaml_keys(lines: &Lines<'_>, opener_k: usize) -> Option<usize> {
+    let mut saw_yaml_key = false;
+    let mut j = opener_k + 1;
+    while j < lines.len() {
+        let text = lines.line_text(j);
+        if is_dash_fence_line(text) {
+            return if saw_yaml_key { Some(j) } else { None };
+        }
+        if looks_like_yaml_key_line(text) {
+            saw_yaml_key = true;
+        }
+        j += 1;
+    }
+    None
+}
+
 /// Outcome of the fence-detection pass: the recognised metadata blocks and any
 /// non-fatal diagnostics accumulated along the way.
 pub(super) type FenceScan = (Vec<MetadataBlock>, Vec<Diagnostic>);
@@ -201,6 +271,91 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
             )?;
             blocks.push(block);
             k = cj + 1;
+            continue;
+        }
+
+        // `---` YAML-frontmatter style: accepted ONLY for the root block.
+        //
+        // Two cases:
+        //   * `blocks.is_empty()` and this is the first non-blank construct we
+        //     hit: treat as the root opener, scan for a `---` closer, build a
+        //     block. (Mixed openers like `---` … `~~~` are NOT accepted: a
+        //     `---` opener requires a `---` closer.)
+        //   * Otherwise: if it looks like a would-be composable card
+        //     (paired `---` … `---` with YAML-key content between, blank
+        //     line above), reject with the standard "expected `~~~card-yaml`"
+        //     error so LLM authors don't silently get a body-text result.
+        //     Otherwise fall through and let CommonMark treat the line as
+        //     prose (thematic break / setext underline).
+        if is_dash_fence_line(text) {
+            let blank_above = k == 0 || lines.is_blank(k - 1);
+
+            if blocks.is_empty() && blank_above {
+                // Only accept `---` as the root opener if we have not yet
+                // seen any prose content (i.e. the `---` is at document
+                // start, modulo leading blank lines). The pre-block prefix
+                // is required to be blank for the root case so we don't
+                // race against setext headings or thematic breaks deep in
+                // a prose preamble. `blocks.is_empty()` plus "every line
+                // above is blank" guarantees this is document-start.
+                let above_all_blank = (0..k).all(|i| lines.is_blank(i));
+                if above_all_blank {
+                    // Scan for the matching `---` closer.
+                    let mut closer_k: Option<usize> = None;
+                    let mut j = k + 1;
+                    while j < lines.len() {
+                        if is_dash_fence_line(lines.line_text(j)) {
+                            closer_k = Some(j);
+                            break;
+                        }
+                        j += 1;
+                    }
+                    let Some(cj) = closer_k else {
+                        return Err(ParseError::InvalidStructure(
+                            "Root metadata block opened with `---` but never closed with a \
+                             matching `---` line. Close the block with a line containing \
+                             exactly `---` before any prose body, or rewrite the block using \
+                             `~~~card-yaml` / `~~~` fences (the canonical form)."
+                                .to_string(),
+                        ));
+                    };
+
+                    let block = super::assemble::build_block(
+                        markdown,
+                        lines.line_start(k),
+                        lines.line_end_inclusive(k),
+                        lines.line_start(cj),
+                        lines.line_end_inclusive(cj),
+                        blocks.len(),
+                    )?;
+                    blocks.push(block);
+                    k = cj + 1;
+                    continue;
+                }
+            }
+
+            // After the root block: a `---` line that pairs with another
+            // `---` further down AND has YAML-key content between is almost
+            // certainly a misplaced composable-card attempt — surface the
+            // standard error rather than silently treating it as body text.
+            if !blocks.is_empty() && blank_above {
+                if let Some(cj) = find_paired_dash_with_yaml_keys(&lines, k) {
+                    let _ = cj; // position is captured for future diagnostics
+                    return Err(ParseError::InvalidStructure(
+                        "Composable card block opened with `---` but composable cards \
+                         must use `~~~card-yaml` / `~~~` fences. Replace the opening \
+                         `---` with `~~~card-yaml` and the closing `---` with `~~~` \
+                         (three tildes, no info string). The `---` style is accepted \
+                         only for the document's root block."
+                            .to_string(),
+                    ));
+                }
+            }
+
+            // Fall through: a lone `---` is delegated to CommonMark as a
+            // thematic break / setext underline. Do not treat as a code
+            // fence opener.
+            k += 1;
             continue;
         }
 

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -183,7 +183,10 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
             }
             let Some(cj) = closer_k else {
                 return Err(ParseError::InvalidStructure(
-                    "card-yaml block opened with `~~~card-yaml` but never closed with `~~~`"
+                    "card-yaml block opened with `~~~card-yaml` but never closed with `~~~`. \
+                     Close the block with a line containing exactly `~~~` (three tildes, no \
+                     info string) before any prose body. The closer is unadorned — do NOT \
+                     write `~~~card-yaml` as the closer."
                         .to_string(),
                 ));
             };

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -52,7 +52,7 @@ pub const FORMAT_RULES: &str = "Document format rules:
 \u{2022} Prose body is the text after a block's closing `~~~`, up to the next opener or EOF.
 \u{2022} `; delete-ok` fields carry a default \u{2014} keep the line, override the value, or delete the entire line to use the default. Do not write `field:`, `field: null`, or `field: ~` \u{2014} all three parse as explicit YAML null and fail validation.
 \u{2022} Numbers and booleans MUST be unquoted (`year: 2025`, `pinned: true`); quoting turns them into strings and fails validation.
-\u{2022} Plain-scalar values cannot start with `*` or `&` (YAML alias/anchor markers) and cannot contain `: ` (colon-space). For markdown emphasis, embedded colons, or other special prefixes, quote the value: `field: '**bold**'` or `field: \"Name: subtitle\"`.";
+\u{2022} Plain-scalar values cannot start with `*` or `&` (YAML alias/anchor markers) and cannot contain `: ` (colon-space). For markdown emphasis, embedded colons, or other special prefixes, quote the value: `field: '**bold**'` or `field: \"Name: subtitle\"`. Multi-line values use `|-`, not multi-line quoted scalars.";
 
 /// Authoring-ergonomics header that introduces a blueprint to an LLM/MCP
 /// consumer. The `{quill}` placeholder is substituted with the quill name.

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -31,11 +31,30 @@ pub mod limits;
 pub mod meta;
 pub mod payload;
 pub mod prescan;
+pub(crate) mod yaml_hints;
 
 pub use dto::{peek_schema_version, StorageError, StoredDocument, SCHEMA_V0_81_0, SCHEMA_V0_82_0};
 pub use edit::EditError;
 pub use meta::{is_valid_kind_name, validate_composable_kind, CardKindError};
 pub use payload::{Payload, PayloadItem};
+
+/// Authoring-format rules for the card-yaml markdown surface.
+///
+/// Surfaced verbatim to LLM/MCP consumers (and to CLI / Python bindings via
+/// the same text) so error parity holds — every consumer reads the same
+/// rules. This is the single source of truth; bindings should call into it
+/// rather than re-stating the rules in their own glue.
+pub const FORMAT_RULES: &str = "Document format rules:
+\u{2022} Metadata blocks use `~~~card-yaml` as the opener and `~~~` as the closer. Do NOT use `---` YAML frontmatter.
+\u{2022} The closer is EXACTLY `~~~` (three tildes, no info string). Do NOT write `~~~card-yaml` as the closer.
+\u{2022} A blank line is required before every `~~~card-yaml` opener (except when it is the first line of the document).
+\u{2022} The first block is the root and MUST contain `$quill: <name>@<version>` and `$kind: main`.
+\u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`. User fields use lowercase snake_case.
+\u{2022} Additional `~~~card-yaml` blocks declare composable cards via `$kind: <card_kind>`.
+\u{2022} Prose body is the text after a block's closing `~~~`, before the next opener or EOF.
+\u{2022} For optional fields with no value, OMIT the line entirely \u{2014} do not write `field: null`.
+\u{2022} Respect field types: numbers unquoted (`word_count: 42`), booleans unquoted (`pinned: true`), strings as plain scalars or quoted. Quoting a number turns it into a string and will fail validation.
+\u{2022} Plain-scalar values cannot start with `*` or `&` (YAML alias/anchor indicators) and cannot contain `:` followed by a space. For markdown emphasis, embedded colons, or other special prefixes, single-quote the value: `field: '**bold**'`, `field: \"Name: subtitle\"`.";
 
 #[cfg(test)]
 mod tests;

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -45,7 +45,7 @@ pub use payload::{Payload, PayloadItem};
 /// rules. This is the single source of truth; bindings should call into it
 /// rather than re-stating the rules in their own glue.
 pub const FORMAT_RULES: &str = "Document format rules:
-\u{2022} Block opener is `~~~card-yaml`; closer is EXACTLY `~~~` (three tildes, no info string). Do NOT use `---` frontmatter or repeat `~~~card-yaml` as the closer.
+\u{2022} Block opener is `~~~card-yaml`; closer is EXACTLY `~~~` (three tildes, no info string). Do NOT repeat `~~~card-yaml` as the closer.
 \u{2022} A blank line must precede every `~~~card-yaml` opener (unless it is line 1).
 \u{2022} The first block is the root and MUST contain `$quill: <name>@<version>` and `$kind: main`. Additional blocks declare composable cards via `$kind: <card_kind>`.
 \u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`. User fields use lowercase snake_case.

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -45,16 +45,29 @@ pub use payload::{Payload, PayloadItem};
 /// rules. This is the single source of truth; bindings should call into it
 /// rather than re-stating the rules in their own glue.
 pub const FORMAT_RULES: &str = "Document format rules:
-\u{2022} Metadata blocks use `~~~card-yaml` as the opener and `~~~` as the closer. Do NOT use `---` YAML frontmatter.
-\u{2022} The closer is EXACTLY `~~~` (three tildes, no info string). Do NOT write `~~~card-yaml` as the closer.
-\u{2022} A blank line is required before every `~~~card-yaml` opener (except when it is the first line of the document).
-\u{2022} The first block is the root and MUST contain `$quill: <name>@<version>` and `$kind: main`.
+\u{2022} Block opener is `~~~card-yaml`; closer is EXACTLY `~~~` (three tildes, no info string). Do NOT use `---` frontmatter or repeat `~~~card-yaml` as the closer.
+\u{2022} A blank line must precede every `~~~card-yaml` opener (unless it is line 1).
+\u{2022} The first block is the root and MUST contain `$quill: <name>@<version>` and `$kind: main`. Additional blocks declare composable cards via `$kind: <card_kind>`.
 \u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`. User fields use lowercase snake_case.
-\u{2022} Additional `~~~card-yaml` blocks declare composable cards via `$kind: <card_kind>`.
-\u{2022} Prose body is the text after a block's closing `~~~`, before the next opener or EOF.
-\u{2022} Fields annotated `; delete-ok` are optional \u{2014} DELETE THE ENTIRE LINE to use the default, or replace the right-hand side to override. Do NOT write `field:`, `field: null`, or `field: ~` \u{2014} all three parse as YAML null and will fail validation.
-\u{2022} Respect field types: numbers unquoted (`word_count: 42`), booleans unquoted (`pinned: true`), strings as plain scalars or quoted. Quoting a number turns it into a string and will fail validation.
-\u{2022} Plain-scalar values cannot start with `*` or `&` (YAML alias/anchor indicators) and cannot contain `:` followed by a space. For markdown emphasis, embedded colons, or other special prefixes, single-quote the value: `field: '**bold**'`, `field: \"Name: subtitle\"`.";
+\u{2022} Prose body is the text after a block's closing `~~~`, up to the next opener or EOF.
+\u{2022} `; delete-ok` fields carry a default \u{2014} keep the line, override the value, or delete the entire line to use the default. Do not write `field:`, `field: null`, or `field: ~` \u{2014} all three parse as explicit YAML null and fail validation.
+\u{2022} Numbers and booleans MUST be unquoted (`year: 2025`, `pinned: true`); quoting turns them into strings and fails validation.
+\u{2022} Plain-scalar values cannot start with `*` or `&` (YAML alias/anchor markers) and cannot contain `: ` (colon-space). For markdown emphasis, embedded colons, or other special prefixes, quote the value: `field: '**bold**'` or `field: \"Name: subtitle\"`.";
+
+/// Authoring-ergonomics header that introduces a blueprint to an LLM/MCP
+/// consumer. The `{quill}` placeholder is substituted with the quill name.
+/// Designed to be shown above [`FORMAT_RULES`], which covers field-level
+/// semantics like `; omit-ok` — keep the wording tight here so the two
+/// strings do not duplicate guidance.
+const BLUEPRINT_INSTRUCTION_TEMPLATE: &str =
+    "Fill in the `{quill}` blueprint below: replace each `<must-fill>` sentinel and edit the \
+body prose. Submit the filled markdown as `content` to `create_document`.";
+
+/// Render the blueprint-instruction header with `quill_name` substituted in.
+/// Single source of truth for the prose so every binding shows identical text.
+pub fn blueprint_instruction(quill_name: &str) -> String {
+    BLUEPRINT_INSTRUCTION_TEMPLATE.replace("{quill}", quill_name)
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -52,7 +52,7 @@ pub const FORMAT_RULES: &str = "Document format rules:
 \u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`. User fields use lowercase snake_case.
 \u{2022} Additional `~~~card-yaml` blocks declare composable cards via `$kind: <card_kind>`.
 \u{2022} Prose body is the text after a block's closing `~~~`, before the next opener or EOF.
-\u{2022} For optional fields with no value, OMIT the line entirely \u{2014} do not write `field: null`.
+\u{2022} Fields annotated `; delete-ok` are optional \u{2014} DELETE THE ENTIRE LINE to use the default, or replace the right-hand side to override. Do NOT write `field:`, `field: null`, or `field: ~` \u{2014} all three parse as YAML null and will fail validation.
 \u{2022} Respect field types: numbers unquoted (`word_count: 42`), booleans unquoted (`pinned: true`), strings as plain scalars or quoted. Quoting a number turns it into a string and will fail validation.
 \u{2022} Plain-scalar values cannot start with `*` or `&` (YAML alias/anchor indicators) and cannot contain `:` followed by a space. For markdown emphasis, embedded colons, or other special prefixes, single-quote the value: `field: '**bold**'`, `field: \"Name: subtitle\"`.";
 

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -62,11 +62,18 @@ fn test_missing_quill_diagnostic_code() {
 }
 
 #[test]
-fn test_missing_block_with_frontmatter_names_swap() {
+fn test_root_dash_frontmatter_without_quill_reports_missing_quill() {
+    // `---` opener is now accepted for the root block. A `---` block without
+    // `$quill` should surface the standard MissingQuill error — not the old
+    // "use `~~~card-yaml` instead of `---`" hint, which is now misleading.
     let err = decompose("---\nquill: usaf_memo\ntitle: Memo\n---\n\nBody\n").unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("`---` YAML frontmatter"), "got: {msg}");
-    assert!(msg.contains("Replace the opening `---` with `~~~card-yaml`"), "got: {msg}");
+    assert!(
+        msg.contains("must declare `$quill: <name>`"),
+        "got: {msg}"
+    );
+    assert!(!msg.contains("`---` YAML frontmatter"), "stale hint: {msg}");
+    assert!(!msg.contains("Replace the opening `---`"), "stale hint: {msg}");
 }
 
 #[test]
@@ -74,6 +81,108 @@ fn test_missing_block_with_bare_yaml_calls_out_missing_fence() {
     let err = decompose("$quill: usaf_memo\n$kind: main\ntitle: Memo\n").unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("missing the `~~~card-yaml` fence"), "got: {msg}");
+}
+
+// -----------------------------------------------------------------------
+// `---` YAML-frontmatter root-block support (accept-but-don't-emit).
+//
+// LLMs trained on the broader internet overwhelmingly write `---` … `---`
+// YAML frontmatter when generating Markdown. The parser accepts this shape
+// for the document's first (root) block only. Composable cards still
+// require the canonical `~~~card-yaml` / `~~~` fences, and the emitter is
+// unchanged — `to_markdown()` always emits the canonical form.
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_dash_root_block_parses_equivalent_to_card_yaml() {
+    let dash_md = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.";
+    let canonical_md =
+        "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.";
+    let dash_doc = decompose(dash_md).expect("--- root block should parse");
+    let canonical_doc = decompose(canonical_md).expect("canonical root block parses");
+    // PartialEq on Document ignores warnings; just compares main + cards.
+    assert_eq!(dash_doc, canonical_doc);
+    assert_eq!(dash_doc.quill_reference().name, "test_quill");
+    assert_eq!(
+        dash_doc.main().payload().get("title").unwrap().as_str().unwrap(),
+        "Test"
+    );
+    assert_eq!(dash_doc.main().body(), "\nBody.");
+}
+
+#[test]
+fn test_dash_root_block_emits_canonical_card_yaml() {
+    // Re-emitting a `---`-parsed document MUST produce the canonical
+    // `~~~card-yaml` / `~~~` fence shape. Normalisation on first emit is
+    // intended.
+    let dash_md = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.";
+    let doc = decompose(dash_md).unwrap();
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.starts_with("~~~card-yaml\n"),
+        "expected canonical opener, got: {emitted:?}"
+    );
+    assert!(!emitted.contains("---\n"), "stray dash fence in emit: {emitted:?}");
+}
+
+#[test]
+fn test_dash_root_with_composable_card_yaml_parses() {
+    // `---` root, canonical composable card after — the common LLM shape.
+    let markdown = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.\n\n\
+                    ~~~card-yaml\n$kind: note\nlabel: a\n~~~\n\nNote body.";
+    let doc = decompose(markdown).expect("mixed shape should parse");
+    assert_eq!(doc.quill_reference().name, "test_quill");
+    assert_eq!(doc.cards().len(), 1);
+    assert_eq!(doc.cards()[0].kind(), Some("note"));
+    assert_eq!(doc.cards()[0].body(), "\nNote body.");
+}
+
+#[test]
+fn test_dash_root_without_quill_errors_missing_quill_no_dash_hint() {
+    let err = decompose("---\ntitle: Test\n---\n\nBody.").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("must declare `$quill: <name>`"), "got: {msg}");
+    // The old "use `~~~card-yaml` instead of `---`" hint must NOT fire here.
+    assert!(!msg.contains("YAML frontmatter"), "stale hint: {msg}");
+    assert!(!msg.contains("Replace the opening"), "stale hint: {msg}");
+}
+
+#[test]
+fn test_dash_opener_in_composable_card_position_errors() {
+    // After the root `~~~card-yaml` block, a `---` … `---` block with YAML
+    // keys between is rejected with the "expected `~~~card-yaml`" error.
+    let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\nBody.\n\n\
+                    ---\n$kind: note\nlabel: a\n---\n\nNote body.";
+    let err = decompose(markdown).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("composable cards") || msg.contains("Composable card"),
+        "expected composable-card rejection, got: {msg}"
+    );
+    assert!(msg.contains("~~~card-yaml"), "got: {msg}");
+}
+
+#[test]
+fn test_dash_opener_with_tilde_closer_errors() {
+    // Mixed fences within one block: `---` opener with no matching `---`
+    // closer must error (the `~~~` line does not close a `---` block).
+    let markdown = "---\n$quill: test_quill\n$kind: main\ntitle: T\n~~~\n\nBody.";
+    let err = decompose(markdown).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Root metadata block opened with `---`") && msg.contains("never closed"),
+        "expected unclosed-dash error, got: {msg}"
+    );
+}
+
+#[test]
+fn test_tilde_opener_with_dash_closer_errors() {
+    // The mirror: `~~~card-yaml` opener with no `~~~` closer (only a `---`)
+    // must error.
+    let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: T\n---\n\nBody.";
+    let err = decompose(markdown).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("never closed with `~~~`"), "got: {msg}");
 }
 
 #[test]

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -62,6 +62,21 @@ fn test_missing_quill_diagnostic_code() {
 }
 
 #[test]
+fn test_missing_block_with_frontmatter_names_swap() {
+    let err = decompose("---\nquill: usaf_memo\ntitle: Memo\n---\n\nBody\n").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("`---` YAML frontmatter"), "got: {msg}");
+    assert!(msg.contains("Replace the opening `---` with `~~~card-yaml`"), "got: {msg}");
+}
+
+#[test]
+fn test_missing_block_with_bare_yaml_calls_out_missing_fence() {
+    let err = decompose("$quill: usaf_memo\n$kind: main\ntitle: Memo\n").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("missing the `~~~card-yaml` fence"), "got: {msg}");
+}
+
+#[test]
 fn test_with_payload() {
     let markdown = "~~~card-yaml
 $quill: test_quill

--- a/crates/core/src/document/yaml_hints.rs
+++ b/crates/core/src/document/yaml_hints.rs
@@ -1,0 +1,363 @@
+//! Actionable-hint enrichment for YAML parse errors.
+//!
+//! The underlying YAML parser (`serde_saphyr` / its yaml-rust2 backend)
+//! surfaces messages in YAML jargon ("alias references unknown anchor",
+//! "mapping values are not allowed in this context", "multiple YAML documents
+//! detected; use from_multiple or from_multiple_with_options") that LLM
+//! callers in a tool-use loop cannot translate into a content edit.
+//!
+//! This module post-processes a parser error string + the offending YAML
+//! content into:
+//!
+//! - a **sanitized** message with Rust API names (`from_multiple`,
+//!   `DuplicateKeyPolicy`, `Options`) stripped, and
+//! - an optional **hint** that names the concrete textual fix.
+//!
+//! The hint is attached to the resulting [`crate::Diagnostic`] in the `hint`
+//! field, so every binding (CLI, Python, MCP) surfaces the same advice — no
+//! per-binding error enrichment.
+
+/// Output of [`enrich_yaml_error`]: a cleaned message plus an optional hint.
+#[derive(Debug, Clone)]
+pub(crate) struct EnrichedYamlError {
+    /// Parser message with Rust API names stripped and prose normalized.
+    pub message: String,
+    /// Actionable hint suggesting the concrete fix, when one is recognized.
+    pub hint: Option<String>,
+}
+
+/// Inspect a serde_saphyr error string against the YAML content it came from
+/// and return an [`EnrichedYamlError`].
+///
+/// The content slice is the YAML payload of a single `~~~card-yaml` block
+/// (the same string passed to the parser). The function never panics on
+/// non-UTF8 byte offsets — all inspection is over `&str` / `chars()`.
+pub(crate) fn enrich_yaml_error(raw: &str, content: &str) -> EnrichedYamlError {
+    let sanitized = sanitize_message(raw);
+    let hint = derive_hint(&sanitized, content);
+    EnrichedYamlError {
+        message: sanitized,
+        hint,
+    }
+}
+
+/// Strip Rust-API-name leakage from the parser message.
+///
+/// `serde_saphyr` appends advice like
+/// `"use from_multiple or from_multiple_with_options"` or
+/// `"set DuplicateKeyPolicy in Options if acceptable"` to certain errors.
+/// Those identifiers point at the Rust crate's API surface and mean nothing
+/// to a non-Rust caller (LLM, CLI user, Python consumer).
+fn sanitize_message(raw: &str) -> String {
+    // Patterns to remove outright, including the leading `;` or `,` separator
+    // when present so we don't leave a trailing comma.
+    const STRIPS: &[&str] = &[
+        "; use from_multiple_with_options",
+        "; use from_multiple or from_multiple_with_options",
+        ", use from_multiple_with_options",
+        ", use from_multiple or from_multiple_with_options",
+        "; set DuplicateKeyPolicy in Options if acceptable",
+        ", set DuplicateKeyPolicy in Options if acceptable",
+        " use from_multiple or from_multiple_with_options",
+        " use from_multiple_with_options",
+        " set DuplicateKeyPolicy in Options if acceptable",
+    ];
+
+    let mut out = raw.to_string();
+    for p in STRIPS {
+        if let Some(idx) = out.find(p) {
+            out.replace_range(idx..idx + p.len(), "");
+        }
+    }
+    // Tidy any leftover ", ." or "; ." after removal.
+    out = out.replace(" ; .", ".").replace(" , .", ".");
+    out.trim_end_matches([',', ';', ' ']).to_string()
+}
+
+/// Derive an actionable hint for `message`, given the YAML `content`.
+fn derive_hint(message: &str, content: &str) -> Option<String> {
+    let m = message.to_ascii_lowercase();
+
+    // Gap 2: a plain scalar starting with `*` or `&` is read as a YAML alias
+    // or anchor indicator. LLMs writing `field: **bold**` trip this.
+    if m.contains("alias references unknown anchor")
+        || m.contains("anchor")
+            && m.contains("not found")
+    {
+        if let Some(field) = first_field_with_unquoted_prefix(content, &['*', '&']) {
+            return Some(format!(
+                "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
+                 alias/anchor indicators). For markdown emphasis or a literal `*`/`&`, \
+                 wrap the value in single quotes: `{field}: '**bold text**'`"
+            ));
+        }
+        return Some(
+            "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
+             alias/anchor indicators). For markdown emphasis or a literal `*`/`&`, \
+             wrap the value in single quotes — e.g. `field: '**bold text**'`."
+                .to_string(),
+        );
+    }
+
+    // Gap 3: an unquoted value containing `:` is read as a nested mapping key.
+    if m.contains("mapping values are not allowed") {
+        if let Some((field, value)) = first_field_with_unquoted_colon(content) {
+            return Some(format!(
+                "Unquoted values cannot contain `:` (it starts a nested mapping key). \
+                 Quote the value: `{field}: \"{value}\"`"
+            ));
+        }
+        return Some(
+            "Unquoted values cannot contain `:` (it starts a nested mapping key). \
+             Wrap the value in double quotes — e.g. `field: \"value: with colon\"`."
+                .to_string(),
+        );
+    }
+
+    // Gap 4 (the `---` separator case): a stray YAML document separator
+    // inside a `~~~card-yaml` block.
+    if m.contains("multiple yaml documents") {
+        if content.lines().any(|l| l.trim_end() == "---") {
+            return Some(
+                "`---` is not a valid separator inside a `~~~card-yaml` block (YAML \
+                 reads it as a new-document marker). Close the metadata block with a \
+                 line containing exactly `~~~` (three tildes) before starting the \
+                 prose body."
+                    .to_string(),
+            );
+        }
+        return Some(
+            "Only one YAML document is allowed per `~~~card-yaml` block. Remove the \
+             stray `---` separator and close the block with `~~~` before any prose."
+                .to_string(),
+        );
+    }
+
+    // Gap 4 (duplicate keys): a field declared twice in the same block.
+    if m.contains("duplicate mapping key") || m.contains("duplicate key") {
+        return Some(
+            "Each field may appear at most once inside a `~~~card-yaml` block. \
+             Remove the duplicate line, or move it to a separate composable card."
+                .to_string(),
+        );
+    }
+
+    // Gap 5: a multi-line double-quoted scalar — block scalars are friendlier.
+    if m.contains("invalid indentation in multiline quoted scalar")
+        || (m.contains("indentation") && m.contains("quoted scalar"))
+    {
+        if let Some(field) = first_field_with_unterminated_dquote(content) {
+            return Some(format!(
+                "Multi-line text is easier to write as a block scalar:\n\
+                 `{field}: |\\n  line one\\n  line two`"
+            ));
+        }
+        return Some(
+            "Multi-line text is easier to write as a block scalar: \
+             `field: |` then put each line indented two spaces below."
+                .to_string(),
+        );
+    }
+
+    None
+}
+
+/// Find the first `key: <scalar>` line whose scalar's first non-whitespace
+/// character matches `prefixes` (e.g. `*` or `&`). Scans only the first line
+/// of each plain mapping entry — multi-line values are not relevant for
+/// alias/anchor diagnostics.
+fn first_field_with_unquoted_prefix(content: &str, prefixes: &[char]) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        let (key, value) = match trimmed.split_once(':') {
+            Some(parts) => parts,
+            None => continue,
+        };
+        if key.is_empty() || key.contains(' ') {
+            continue;
+        }
+        let value = value.trim_start();
+        let Some(first) = value.chars().next() else {
+            continue;
+        };
+        // Skip quoted scalars — they wouldn't trigger the anchor/alias error.
+        if first == '\'' || first == '"' {
+            continue;
+        }
+        if prefixes.contains(&first) {
+            return Some(key.trim().to_string());
+        }
+    }
+    None
+}
+
+/// Find the first `key: <value>` line whose unquoted value contains an
+/// additional `:` (the second colon — first triggers the parser's
+/// "mapping values are not allowed in this context" error).
+fn first_field_with_unquoted_colon(content: &str) -> Option<(String, String)> {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') || trimmed.starts_with('-') {
+            continue;
+        }
+        let (key, rest) = match trimmed.split_once(':') {
+            Some(parts) => parts,
+            None => continue,
+        };
+        if key.is_empty() || key.contains(' ') {
+            continue;
+        }
+        let value = rest.trim_start();
+        let first = value.chars().next();
+        if matches!(first, Some('\'') | Some('"') | Some('|') | Some('>')) {
+            continue;
+        }
+        if value.contains(':') {
+            // Strip a trailing comment if any.
+            let value_clean = match value.split_once(" #") {
+                Some((v, _)) => v.trim_end(),
+                None => value.trim_end(),
+            };
+            return Some((key.trim().to_string(), value_clean.to_string()));
+        }
+    }
+    None
+}
+
+/// Find the first `key: "...` line whose double-quoted scalar does not close
+/// on the same line. A useful proxy for "the model wrote a multi-line
+/// double-quoted scalar" — relevant for gap 5.
+fn first_field_with_unterminated_dquote(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        let (key, rest) = match trimmed.split_once(':') {
+            Some(parts) => parts,
+            None => continue,
+        };
+        if key.is_empty() || key.contains(' ') {
+            continue;
+        }
+        let value = rest.trim_start();
+        if !value.starts_with('"') {
+            continue;
+        }
+        // Walk the value counting unescaped quotes. A single opening quote
+        // with no closer on the same line is an unterminated double-quote.
+        let body = &value[1..];
+        let mut closed = false;
+        let mut prev_backslash = false;
+        for ch in body.chars() {
+            if prev_backslash {
+                prev_backslash = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_backslash = true;
+                continue;
+            }
+            if ch == '"' {
+                closed = true;
+                break;
+            }
+        }
+        if !closed {
+            return Some(key.trim().to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_from_multiple_advice() {
+        let raw = "multiple YAML documents detected; use from_multiple or from_multiple_with_options";
+        let out = sanitize_message(raw);
+        assert_eq!(out, "multiple YAML documents detected");
+    }
+
+    #[test]
+    fn strips_duplicate_key_policy_advice() {
+        let raw = "duplicate mapping key: organizations, set DuplicateKeyPolicy in Options if acceptable";
+        let out = sanitize_message(raw);
+        assert_eq!(out, "duplicate mapping key: organizations");
+    }
+
+    #[test]
+    fn hint_for_alias_unknown_anchor_names_field() {
+        let content = "title: Doc\nbluf: **Increased maritime activity**\n";
+        let enriched = enrich_yaml_error(
+            "alias references unknown anchor",
+            content,
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("bluf"), "hint did not name the field: {hint}");
+        assert!(hint.contains("single quotes"));
+    }
+
+    #[test]
+    fn hint_for_mapping_values_names_field_and_value() {
+        let content = "system_name: Node.js Service: Order Processing API\n";
+        let enriched = enrich_yaml_error(
+            "mapping values are not allowed in this context",
+            content,
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("system_name"));
+        assert!(hint.contains("Node.js Service: Order Processing API"));
+        assert!(hint.contains("Quote"));
+    }
+
+    #[test]
+    fn hint_for_multiple_documents_calls_out_dash_separator() {
+        let content = "title: Doc\n---\n";
+        let enriched =
+            enrich_yaml_error("multiple YAML documents detected", content);
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("`---`"));
+        assert!(hint.contains("`~~~`"));
+    }
+
+    #[test]
+    fn hint_for_duplicate_key_is_actionable() {
+        let enriched = enrich_yaml_error("duplicate mapping key: organizations", "");
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("at most once"));
+    }
+
+    #[test]
+    fn hint_for_multiline_dquote_suggests_block_scalar() {
+        let content = "bullets: \"- one\n- two\n- three\"\n";
+        let enriched = enrich_yaml_error(
+            "invalid indentation in multiline quoted scalar",
+            content,
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("bullets"));
+        assert!(hint.contains("block scalar"));
+    }
+
+    #[test]
+    fn returns_no_hint_for_unrecognized_messages() {
+        let enriched = enrich_yaml_error("something unrelated", "");
+        assert!(enriched.hint.is_none());
+        assert_eq!(enriched.message, "something unrelated");
+    }
+
+    #[test]
+    fn does_not_panic_on_multibyte_content() {
+        // Em-dash and curly quotes are multibyte in UTF-8 — must not panic.
+        let content = "briefer: Maj Sarah Chen — INDOPACOM/A2\nbluf: **\u{201c}peer\u{201d}**\n";
+        let _ =
+            enrich_yaml_error("alias references unknown anchor", content);
+        let _ = enrich_yaml_error(
+            "mapping values are not allowed in this context",
+            content,
+        );
+    }
+}

--- a/crates/core/src/document/yaml_hints.rs
+++ b/crates/core/src/document/yaml_hints.rs
@@ -142,6 +142,53 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
         );
     }
 
+    // S2-1: a `- item` list line where a mapping key was expected. Either the
+    // sequence is mis-indented, or the field was meant to be a scalar.
+    if m.contains("block sequence entries are not allowed") {
+        return Some(
+            "A `- item` list was found where a mapping key was expected. Either \
+             indent the sequence two spaces under the key it belongs to \
+             (`field:` newline `  - item`), or — if this field expects a single \
+             scalar value — drop the `-` and put the value on the same line: \
+             `field: value`."
+                .to_string(),
+        );
+    }
+
+    // S2-2: a continuation line of a plain-scalar value is being read as a new
+    // key. Either quote / block-scalar the multi-line value, or indent the
+    // continuation.
+    if m.contains("simple key expected") || m.contains("simple key expect") {
+        return Some(
+            "A second line of a value was read as a new mapping key (YAML \
+             plain-scalar values stop at the next unindented line). For \
+             multi-line text, use a block scalar: `field: |` then put each \
+             line indented two spaces below. For a single-line value, keep it \
+             on one line."
+                .to_string(),
+        );
+    }
+
+    // S2-3: anchor-scan failure — same root cause as the alias case (unquoted
+    // value starts with `&`). The sprint 1 alias hint already matched on the
+    // word "anchor"; this matches the new wording that mentions only "scanning
+    // an anchor or alias".
+    if m.contains("scanning an anchor") || m.contains("scanning an alias") {
+        if let Some(field) = first_field_with_unquoted_prefix(content, &['*', '&']) {
+            return Some(format!(
+                "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
+                 alias/anchor indicators). Wrap the value in single quotes: \
+                 `{field}: '&literal value'`"
+            ));
+        }
+        return Some(
+            "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
+             alias/anchor indicators). Wrap the value in single quotes — e.g. \
+             `field: '&literal value'`."
+                .to_string(),
+        );
+    }
+
     // Gap 5: a multi-line double-quoted scalar — block scalars are friendlier.
     if m.contains("invalid indentation in multiline quoted scalar")
         || (m.contains("indentation") && m.contains("quoted scalar"))
@@ -347,6 +394,46 @@ mod tests {
         let enriched = enrich_yaml_error("something unrelated", "");
         assert!(enriched.hint.is_none());
         assert_eq!(enriched.message, "something unrelated");
+    }
+
+    #[test]
+    fn hint_for_block_sequence_in_mapping_context() {
+        let enriched = enrich_yaml_error(
+            "block sequence entries are not allowed in this context",
+            "section_headers:\n- Title\n",
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("`- item` list"));
+        assert!(hint.contains("indent"));
+    }
+
+    #[test]
+    fn hint_for_simple_key_expected_suggests_block_scalar() {
+        let enriched = enrich_yaml_error(
+            "simple key expected at line 17, column 1",
+            "summary: This is a long\nsummary across multiple lines\n",
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("block scalar"));
+        assert!(hint.contains("|"));
+    }
+
+    #[test]
+    fn hint_for_simple_key_expect_colon_variant_also_matches() {
+        let enriched = enrich_yaml_error("simple key expect ':'", "");
+        assert!(enriched.hint.is_some());
+    }
+
+    #[test]
+    fn hint_for_scanning_anchor_names_field() {
+        let content = "title: Doc\nbluf: &unquoted ampersand\n";
+        let enriched = enrich_yaml_error(
+            "while scanning an anchor or alias, did not find expected alphabetic or numeric character",
+            content,
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("bluf"));
+        assert!(hint.contains("single quotes"));
     }
 
     #[test]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -236,6 +236,10 @@ pub enum ParseError {
         line: usize,
         /// Index of the metadata block (0-indexed)
         block_index: usize,
+        /// Optional actionable hint attached when the YAML parser's message
+        /// is too cryptic to be recoverable on its own. See
+        /// [`crate::document::yaml_hints`].
+        hint: Option<String>,
     },
 }
 
@@ -257,14 +261,21 @@ impl ParseError {
                 message,
                 line,
                 block_index,
-            } => Diagnostic::new(
-                Severity::Error,
-                format!(
-                    "YAML error at line {} (block {}): {}",
-                    line, block_index, message
-                ),
-            )
-            .with_code("parse::yaml_error_with_location".to_string()),
+                hint,
+            } => {
+                let mut d = Diagnostic::new(
+                    Severity::Error,
+                    format!(
+                        "YAML error at line {} (block {}): {}",
+                        line, block_index, message
+                    ),
+                )
+                .with_code("parse::yaml_error_with_location".to_string());
+                if let Some(h) = hint {
+                    d = d.with_hint(h.clone());
+                }
+                d
+            }
         }
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -237,8 +237,8 @@ pub enum ParseError {
         /// Index of the metadata block (0-indexed)
         block_index: usize,
         /// Optional actionable hint attached when the YAML parser's message
-        /// is too cryptic to be recoverable on its own. See
-        /// [`crate::document::yaml_hints`].
+        /// is too cryptic to be recoverable on its own. Derived by the
+        /// internal `document::yaml_hints` enrichment pass.
         hint: Option<String>,
     },
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -13,9 +13,9 @@
 //!   whitespace-collapsed) and `# e.g. <value>` (whenever an `example:` is
 //!   configured, regardless of cell or type).
 //! - **Inline `# …` annotation** on the value line is structural:
-//!   `# <type>[<format>][; skip-ok]`. Type is mandatory on every field.
+//!   `# <type>[<format>][; delete-ok]`. Type is mandatory on every field.
 //!   Format slot uses angle brackets (`array<string>`, `date<YYYY-MM-DD>`,
-//!   `enum<a | b | c>`). The optional `; skip-ok` tag marks **Endorsed**
+//!   `enum<a | b | c>`). The optional `; delete-ok` tag marks **Endorsed**
 //!   cells whose rendered default is shippable as-is; its absence marks
 //!   **Must Fill** cells, which carry the `<must-fill>` sentinel in the
 //!   value cell instead.
@@ -262,10 +262,10 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
 /// field type it surfaces only in the `# e.g.` leading line.
 ///
 /// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
-/// — the outer key carries `; skip-ok` and the rendered value is the
+/// — the outer key carries `; delete-ok` and the rendered value is the
 /// default (rows for `default: [...]`, inline `[]` for `default: []`). A
 /// field without a `default:` is Must Fill — the outer key drops
-/// `; skip-ok` and one synthetic row is emitted with leaf-level sentinels.
+/// `; delete-ok` and one synthetic row is emitted with leaf-level sentinels.
 /// See `prose/BOOKMARKS.md` "Typed container empty default loses inline
 /// shape documentation" for the rendering-vs-symmetry trade-off.
 fn write_typed_table_field(
@@ -312,7 +312,7 @@ fn write_typed_table_field(
 /// every other field type it surfaces only in the `# e.g.` leading line.
 ///
 /// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
-/// — the outer key carries `; skip-ok` and the rendered value is the
+/// — the outer key carries `; delete-ok` and the rendered value is the
 /// default (a block mapping for non-empty, inline `{}` for `default: {}`).
 /// A field without a `default:` is Must Fill — per-property recursion with
 /// leaf-level sentinels. See `prose/BOOKMARKS.md` "Typed container empty
@@ -364,7 +364,7 @@ fn write_typed_object_field(
 fn inline_annotation(field: &FieldSchema, force_array_object: bool, endorsed: bool) -> String {
     let type_expr = type_expression(field, force_array_object);
     if endorsed {
-        format!("{}; skip-ok", type_expr)
+        format!("{}; delete-ok", type_expr)
     } else {
         type_expr
     }
@@ -486,9 +486,9 @@ mod tests {
     }
 
     #[test]
-    fn must_fill_string_renders_sentinel_with_no_skip_ok() {
+    fn must_fill_string_renders_sentinel_with_no_delete_ok() {
         // No `default:` → Must Fill. Sentinel sits in the value cell; the
-        // inline annotation drops `; skip-ok`.
+        // inline annotation drops `; delete-ok`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -509,11 +509,11 @@ main:
     status: { type: string, default: draft, example: final }
 "#)
         .blueprint();
-        assert!(t.contains("# e.g. final\nstatus: draft  # string; skip-ok\n"));
+        assert!(t.contains("# e.g. final\nstatus: draft  # string; delete-ok\n"));
     }
 
     #[test]
-    fn endorsed_empty_default_renders_value_with_skip_ok_and_eg_line() {
+    fn endorsed_empty_default_renders_value_with_delete_ok_and_eg_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -521,7 +521,7 @@ main:
     classification: { type: string, default: "", example: CONFIDENTIAL }
 "#)
         .blueprint();
-        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; skip-ok\n"));
+        assert!(t.contains("# e.g. CONFIDENTIAL\nclassification: \"\"  # string; delete-ok\n"));
     }
 
     #[test]
@@ -552,7 +552,7 @@ main:
     format: { type: string, enum: [standard, informal], default: standard }
 "#)
         .blueprint();
-        assert!(t.contains("format: standard  # enum<standard | informal>; skip-ok\n"));
+        assert!(t.contains("format: standard  # enum<standard | informal>; delete-ok\n"));
         assert!(!t.contains("e.g."));
     }
 
@@ -606,7 +606,7 @@ main:
 
     #[test]
     fn every_field_carries_inline_type_and_cell_signal() {
-        // Endorsed cells carry `; skip-ok`; Must Fill cells carry the
+        // Endorsed cells carry `; delete-ok`; Must Fill cells carry the
         // sentinel in the value cell and drop the tag.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -621,11 +621,11 @@ main:
 "#)
         .blueprint();
         assert!(t.contains("title: <must-fill>  # string\n"));
-        assert!(t.contains("size: 11  # number; skip-ok\n"));
-        assert!(t.contains("flag: false  # boolean; skip-ok\n"));
+        assert!(t.contains("size: 11  # number; delete-ok\n"));
+        assert!(t.contains("flag: false  # boolean; delete-ok\n"));
         assert!(t.contains("issued: <must-fill>  # date<YYYY-MM-DD>\n"));
         assert!(t.contains("published: <must-fill>  # datetime<ISO 8601>\n"));
-        assert!(t.contains("refs: []  # array<string>; skip-ok\n"));
+        assert!(t.contains("refs: []  # array<string>; delete-ok\n"));
     }
 
     #[test]
@@ -641,7 +641,7 @@ main:
     }
 
     #[test]
-    fn endorsed_empty_markdown_renders_blank_line_with_skip_ok() {
+    fn endorsed_empty_markdown_renders_blank_line_with_delete_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -649,7 +649,7 @@ main:
     bio: { type: markdown, default: "" }
 "#)
         .blueprint();
-        assert!(t.contains("bio: |-  # markdown; skip-ok\n  \n"));
+        assert!(t.contains("bio: |-  # markdown; delete-ok\n  \n"));
         assert!(!t.contains("<must-fill>"));
     }
 
@@ -664,7 +664,7 @@ main:
       default: "## About me\n\nHello."
 "###)
         .blueprint();
-        assert!(t.contains("bio: |-  # markdown; skip-ok\n  ## About me\n  \n  Hello.\n"));
+        assert!(t.contains("bio: |-  # markdown; delete-ok\n  ## About me\n  \n  Hello.\n"));
     }
 
     #[test]
@@ -795,7 +795,7 @@ main:
 
     #[test]
     fn typed_table_must_fill_emits_synthetic_row_with_leaf_sentinels() {
-        // Must Fill container → outer key has no `; skip-ok` (state is a
+        // Must Fill container → outer key has no `; delete-ok` (state is a
         // leaf concern). Property leaves carry their own cell signals.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -811,7 +811,7 @@ main:
         .blueprint();
         assert!(t.contains("# Cited works.\nreferences:  # array<object>\n  -\n"));
         assert!(t.contains("    # Citing organization.\n    org: <must-fill>  # string\n"));
-        assert!(t.contains("    # Publication year.\n    year: 0  # integer; skip-ok\n"));
+        assert!(t.contains("    # Publication year.\n    year: 0  # integer; delete-ok\n"));
     }
 
     #[test]
@@ -834,11 +834,11 @@ main:
         assert!(t.contains("# e.g. [{org: ACME, year: 2020}]\n"));
         assert!(t.contains("refs:  # array<object>\n  -\n"));
         assert!(t.contains("    org: <must-fill>  # string\n"));
-        assert!(t.contains("    year: 0  # integer; skip-ok\n"));
+        assert!(t.contains("    year: 0  # integer; delete-ok\n"));
     }
 
     #[test]
-    fn typed_table_endorsed_renders_default_rows_with_skip_ok() {
+    fn typed_table_endorsed_renders_default_rows_with_delete_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -851,14 +851,14 @@ main:
         org: { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("refs:  # array<object>; skip-ok\n  - org: ACME\n"));
-        assert!(!t.contains("refs:  # array<object>; skip-ok\n  -\n"));
+        assert!(t.contains("refs:  # array<object>; delete-ok\n  - org: ACME\n"));
+        assert!(!t.contains("refs:  # array<object>; delete-ok\n  -\n"));
     }
 
     #[test]
-    fn typed_table_with_empty_default_renders_inline_and_skip_ok() {
+    fn typed_table_with_empty_default_renders_inline_and_delete_ok() {
         // `default: []` means shippable as-is — the outer cell carries
-        // `; skip-ok` uniformly with scalar cells and the value renders
+        // `; delete-ok` uniformly with scalar cells and the value renders
         // inline as `[]`. Inline row shape under an empty default belongs
         // in `example:`; see prose/BOOKMARKS.md.
         let t = cfg(r#"
@@ -873,16 +873,16 @@ main:
 "#)
         .blueprint();
         assert!(
-            t.contains("refs: []  # array<object>; skip-ok\n"),
+            t.contains("refs: []  # array<object>; delete-ok\n"),
             "wrong rendering: {t}"
         );
         assert!(!t.contains("<must-fill>"), "no sentinels expected: {t}");
     }
 
     #[test]
-    fn typed_dict_with_empty_default_renders_inline_and_skip_ok() {
+    fn typed_dict_with_empty_default_renders_inline_and_delete_ok() {
         // Same uniform rule as typed tables: `default: {}` is Endorsed and
-        // renders inline as `{}` with `; skip-ok`.
+        // renders inline as `{}` with `; delete-ok`.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -895,7 +895,7 @@ main:
 "#)
         .blueprint();
         assert!(
-            t.contains("address: {}  # object; skip-ok\n"),
+            t.contains("address: {}  # object; delete-ok\n"),
             "wrong rendering: {t}"
         );
         assert!(!t.contains("<must-fill>"), "no sentinels expected: {t}");
@@ -903,7 +903,7 @@ main:
 
     #[test]
     fn typed_dict_must_fill_emits_per_property_annotations() {
-        // Must Fill container → outer key has no `; skip-ok`; per-property
+        // Must Fill container → outer key has no `; delete-ok`; per-property
         // recursion with leaf cell signals.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -921,11 +921,11 @@ main:
         assert!(t.contains("# Mailing address.\naddress:  # object\n"));
         assert!(t.contains("  # Street line.\n  street: <must-fill>  # string\n"));
         assert!(t.contains("  city: <must-fill>  # string\n"));
-        assert!(t.contains("  zip: \"\"  # string; skip-ok\n"));
+        assert!(t.contains("  zip: \"\"  # string; delete-ok\n"));
     }
 
     #[test]
-    fn typed_dict_endorsed_renders_block_mapping_with_skip_ok() {
+    fn typed_dict_endorsed_renders_block_mapping_with_delete_ok() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -938,7 +938,7 @@ main:
         city:   { type: string }
 "#)
         .blueprint();
-        assert!(t.contains("address:  # object; skip-ok\n"));
+        assert!(t.contains("address:  # object; delete-ok\n"));
         assert!(
             t.contains("  street: 5000 Forbes Ave\n")
                 || t.contains("  street: \"5000 Forbes Ave\"\n")
@@ -970,7 +970,7 @@ main:
                 || t.contains("# e.g. {city: Cupertino, street: 1 Infinite Loop}\n")
         );
         assert!(t.contains("  street: <must-fill>  # string\n"));
-        assert!(t.contains("  city: \"\"  # string; skip-ok\n"));
+        assert!(t.contains("  city: \"\"  # string; delete-ok\n"));
     }
 
     const LETTER_QUILL: &str = r#"

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -514,11 +514,188 @@ impl QuillConfig {
     ) {
         Self::validate_description_singleline(schema.description.as_deref(), owner_label, errors);
         Self::validate_enum_literals(schema, owner_label, errors);
+        Self::validate_example_default_types(schema, owner_label, errors);
         if let Some(props) = &schema.properties {
             for (name, prop) in props {
                 let nested = format!("{}.{}", owner_label, name);
                 Self::validate_field_blueprint_constraints(prop, &nested, errors);
             }
+        }
+    }
+
+    /// Classify a YAML/JSON value into the "shape" label used in error messages.
+    ///
+    /// Distinguishes integers from floats so that the loaded value `20.04`
+    /// (which arrives as a JSON float) is reported as `float`, not `number`.
+    fn value_shape(value: &serde_json::Value) -> &'static str {
+        match value {
+            serde_json::Value::Null => "null",
+            serde_json::Value::Bool(_) => "boolean",
+            serde_json::Value::Number(n) => {
+                if n.is_i64() || n.is_u64() {
+                    "integer"
+                } else {
+                    "float"
+                }
+            }
+            serde_json::Value::String(_) => "string",
+            serde_json::Value::Array(_) => "array",
+            serde_json::Value::Object(_) => "object",
+        }
+    }
+
+    /// Returns true when `value` is type-compatible with the declared
+    /// [`FieldType`]. Mirrors JSON Schema semantics modulo a couple of project
+    /// conventions: dates/datetimes/markdown are author-time strings (we do
+    /// not have native YAML date/datetime types).
+    fn example_compatible(field_type: &FieldType, value: &serde_json::Value) -> bool {
+        // `null` is treated as "absent" — callers should not reach here with
+        // null, but if they do, accept it as compatible with any type.
+        if value.is_null() {
+            return true;
+        }
+        match field_type {
+            FieldType::String
+            | FieldType::Markdown
+            | FieldType::Date
+            | FieldType::DateTime => value.is_string(),
+            FieldType::Integer => value.is_i64() || value.is_u64(),
+            FieldType::Number => value.is_number(),
+            FieldType::Boolean => value.is_boolean(),
+            FieldType::Array => value.is_array(),
+            FieldType::Object => value.is_object(),
+        }
+    }
+
+    /// Render a short, quoted preview of the value for use inside an error
+    /// message. Long strings/sequences/maps are truncated.
+    fn value_preview(value: &serde_json::Value) -> String {
+        let raw = match value {
+            serde_json::Value::String(s) => format!("\"{}\"", s),
+            other => other.to_string(),
+        };
+        const MAX: usize = 60;
+        if raw.chars().count() > MAX {
+            let truncated: String = raw.chars().take(MAX).collect();
+            format!("{}…", truncated)
+        } else {
+            raw
+        }
+    }
+
+    /// Reject `example:` / `default:` values whose YAML shape does not match
+    /// the declared `type:`. Catches the common "unquoted version string"
+    /// mistake (`example: 20.04` for `type: string`) at schema-load time,
+    /// before it reaches the LLM as a confusing copy-the-example failure.
+    ///
+    /// Also enforces that an `example:` on an enum-constrained field is one of
+    /// the declared enum values — a strictly tighter check than the type alone.
+    fn validate_example_default_types(
+        schema: &FieldSchema,
+        owner_label: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) {
+        let check = |slot: &str, value_opt: Option<&QuillValue>, errors: &mut Vec<Diagnostic>| {
+            let Some(qv) = value_opt else {
+                return;
+            };
+            let raw = qv.as_json();
+            if raw.is_null() {
+                return;
+            }
+            if !Self::example_compatible(&schema.r#type, raw) {
+                let actual = Self::value_shape(raw);
+                let declared = schema.r#type.as_str();
+                let preview = Self::value_preview(raw);
+                let hint = if actual == "float" || actual == "integer" {
+                    format!(
+                        "Quote the {slot} as \"{val}\" if the value is intentionally a string, \
+                         or change the field type to '{actual}'.",
+                        slot = slot,
+                        val = raw.to_string().trim_matches('"'),
+                        actual = if actual == "integer" { "integer" } else { "number" },
+                    )
+                } else if actual == "string" {
+                    format!(
+                        "Remove the quotes around the {slot} value to keep it a {declared}.",
+                        slot = slot,
+                        declared = declared,
+                    )
+                } else {
+                    format!(
+                        "Make the {slot} value a {declared}, or change the field type to match.",
+                        slot = slot,
+                        declared = declared,
+                    )
+                };
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "{owner} declares type '{declared}' but {slot} is {actual} ({preview}).",
+                            owner = owner_label,
+                            declared = declared,
+                            slot = slot,
+                            actual = actual,
+                            preview = preview,
+                        ),
+                    )
+                    .with_code(format!("quill::{slot}_type_mismatch"))
+                    .with_hint(hint),
+                );
+            }
+        };
+
+        check("example", schema.example.as_ref(), errors);
+        check("default", schema.default.as_ref(), errors);
+
+        // Enum membership check: when `enum:` is declared, the example/default
+        // must be one of the declared values (a tighter check than type alone).
+        if let Some(enum_vals) = &schema.enum_values {
+            let mut check_enum = |slot: &str, value_opt: Option<&QuillValue>| {
+                let Some(qv) = value_opt else {
+                    return;
+                };
+                let raw = qv.as_json();
+                if raw.is_null() {
+                    return;
+                }
+                // Only meaningful when the value parsed as a string (which is
+                // the only shape an enum value can take). If it parsed as some
+                // other shape, the type-compat check above already flagged it.
+                let Some(s) = raw.as_str() else {
+                    return;
+                };
+                if !enum_vals.iter().any(|v| v == s) {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "{owner} {slot} \"{value}\" is not one of the declared enum values [{values}].",
+                                owner = owner_label,
+                                slot = slot,
+                                value = s,
+                                values = enum_vals
+                                    .iter()
+                                    .map(|v| format!("\"{}\"", v))
+                                    .collect::<Vec<_>>()
+                                    .join(", "),
+                            ),
+                        )
+                        .with_code(format!("quill::{slot}_not_in_enum"))
+                        .with_hint(format!(
+                            "Set the {slot} to one of: {}.",
+                            enum_vals
+                                .iter()
+                                .map(|v| format!("\"{}\"", v))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )),
+                    );
+                }
+            };
+            check_enum("example", schema.example.as_ref());
+            check_enum("default", schema.default.as_ref());
         }
     }
 

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2398,3 +2398,152 @@ fn quill_yaml_deep_nesting_is_rejected() {
         "error should reference the depth/YAML limit, got: {msg}"
     );
 }
+
+// ---------- example/default type-compatibility validation ----------
+
+fn example_default_yaml(field_yaml: &str) -> String {
+    format!(
+        r#"
+quill:
+  name: example_default_test
+  version: "1.0"
+  backend: typst
+  description: example/default type-compat tests
+
+main:
+  fields:
+{}
+"#,
+        field_yaml
+    )
+}
+
+#[test]
+fn example_integer_type_rejects_float_example() {
+    // type: integer with example: 20.04 fails — float is not an integer.
+    let yaml = example_default_yaml(
+        "    year:\n      type: integer\n      example: 20.04\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    assert!(
+        errors.iter().any(|d| d.code.as_deref() == Some("quill::example_type_mismatch")
+            && d.message.contains("year")
+            && d.message.contains("integer")
+            && d.message.contains("float")),
+        "expected example_type_mismatch error for integer/float, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn example_string_type_rejects_unquoted_decimal_example() {
+    // The canonical bug: type: string with example: 20.04 — YAML parses the
+    // bare token as a float, and the LLM would copy it back unquoted.
+    let yaml = example_default_yaml(
+        "    min_os_version:\n      type: string\n      example: 20.04\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    let diag = errors
+        .iter()
+        .find(|d| d.code.as_deref() == Some("quill::example_type_mismatch"))
+        .expect("expected example_type_mismatch error");
+    assert!(diag.message.contains("min_os_version"));
+    assert!(diag.message.contains("string"));
+    assert!(diag.message.contains("float"));
+    let hint = diag.hint.as_deref().unwrap_or("");
+    assert!(
+        hint.contains("Quote") && hint.contains("\"20.04\""),
+        "hint should suggest quoting, got: {}",
+        hint
+    );
+}
+
+#[test]
+fn example_string_type_accepts_quoted_decimal_example() {
+    // The fix: quoting forces the YAML parser to keep it as a string.
+    let yaml = example_default_yaml(
+        "    min_os_version:\n      type: string\n      example: \"20.04\"\n",
+    );
+    QuillConfig::from_yaml(&yaml).expect("quoted string example should load");
+}
+
+#[test]
+fn example_boolean_type_rejects_string_example() {
+    // type: boolean with example: "true" — the LLM would emit it as a string.
+    let yaml = example_default_yaml(
+        "    flag:\n      type: boolean\n      example: \"true\"\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    assert!(
+        errors.iter().any(|d| d.code.as_deref() == Some("quill::example_type_mismatch")
+            && d.message.contains("flag")
+            && d.message.contains("boolean")
+            && d.message.contains("string")),
+        "expected example_type_mismatch error for boolean/string, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn example_array_type_rejects_string_example() {
+    // type: array with example: foo — a sequence is required.
+    let yaml = example_default_yaml(
+        "    tags:\n      type: array\n      example: foo\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    assert!(
+        errors.iter().any(|d| d.code.as_deref() == Some("quill::example_type_mismatch")
+            && d.message.contains("tags")
+            && d.message.contains("array")
+            && d.message.contains("string")),
+        "expected example_type_mismatch error for array/string, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn example_not_in_enum_is_rejected() {
+    let yaml = example_default_yaml(
+        "    color:\n      type: string\n      enum: [a, b]\n      example: c\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    let diag = errors
+        .iter()
+        .find(|d| d.code.as_deref() == Some("quill::example_not_in_enum"))
+        .expect("expected example_not_in_enum error");
+    assert!(diag.message.contains("color"));
+    assert!(diag.message.contains("\"c\""));
+    assert!(diag.message.contains("\"a\""));
+}
+
+#[test]
+fn example_in_enum_loads_successfully() {
+    let yaml = example_default_yaml(
+        "    color:\n      type: string\n      enum: [a, b]\n      example: a\n",
+    );
+    QuillConfig::from_yaml(&yaml).expect("enum-member example should load");
+}
+
+#[test]
+fn default_with_type_mismatch_is_rejected() {
+    // Defaults are validated the same way as examples.
+    let yaml = example_default_yaml(
+        "    version:\n      type: string\n      default: 20.04\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    let diag = errors
+        .iter()
+        .find(|d| d.code.as_deref() == Some("quill::default_type_mismatch"))
+        .expect("expected default_type_mismatch error");
+    assert!(diag.message.contains("version"));
+    assert!(diag.message.contains("string"));
+    assert!(diag.message.contains("float"));
+}
+
+#[test]
+fn field_with_no_example_or_default_loads_successfully() {
+    let yaml = example_default_yaml(
+        "    bare:\n      type: string\n      description: nothing to check\n",
+    );
+    QuillConfig::from_yaml(&yaml).expect("field with no example/default should load");
+}

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -181,8 +181,17 @@ fn type_mismatch_hint(
     default: Option<&str>,
 ) -> String {
     if default.is_some() && actual == "null" {
+        // `null` here means the YAML value parsed as null. That can be any of:
+        //   `field: null`   (explicit literal)
+        //   `field: ~`      (YAML shorthand for null)
+        //   `field:`        (bare key — a missing value also parses as null)
+        // In every case the LLM almost always meant "skip this field". The
+        // shortest fix is to remove the line entirely so the default applies.
         format!(
-            "Either omit the line (the default will fill in) or set the value to a {expected}."
+            "To use the default, delete this entire line (do NOT write \
+             `{path}:`, `{path}: null`, or `{path}: ~` — all three parse as \
+             null). To set an explicit value, replace the right-hand side \
+             with a {expected}."
         )
     } else if expected == "string" && quotable_actual(actual) {
         format!(
@@ -1197,8 +1206,12 @@ main:
             "wrong head: {msg}"
         );
         assert!(
-            msg.contains("omit the line (the default will fill in)"),
+            msg.contains("delete this entire line"),
             "missing omit-line exit: {msg}"
+        );
+        assert!(
+            msg.contains("`subtitle: ~`"),
+            "expected message to name the `~` shorthand: {msg}"
         );
     }
 

--- a/crates/quillmark/tests/multibyte_regression_test.rs
+++ b/crates/quillmark/tests/multibyte_regression_test.rs
@@ -1,0 +1,106 @@
+//! Regression coverage for the "string index N is not a character boundary"
+//! panic class (BACKLOG.md B1).
+//!
+//! Historical context: claude-haiku-4-5 generations of the `usaf_intel_brief`
+//! quill consistently triggered `"string index 2 is not a character boundary"`
+//! at render time. The common input shape is a `markdown`-typed field
+//! containing a mix of:
+//!
+//! - en-dashes (`–`, U+2013, 3 bytes in UTF-8) used as bullet markers
+//! - em-dashes (`—`, U+2014) in adjacent prose
+//! - mixed bullet marker styles (`-`, `*`, `–`) inside a block scalar
+//!
+//! The primary slice site was patched in commit `118402e6` (Harden prescan
+//! byte-slicing against multibyte chars). Residual panic events (~1 per 168
+//! eval runs) have no captured-input repro yet; this suite locks down the
+//! known-bad inputs to prevent regression on the fixed site and serves as
+//! the staging ground for any future repro that does surface.
+//!
+//! When a fresh repro lands, add it here. Each test should panic loudly
+//! (via the implicit `cargo test` panic catcher) on the unfixed code path
+//! and pass on the fixed one.
+
+use quillmark::Document;
+
+fn assert_parses(input: &str) {
+    match Document::from_markdown(input) {
+        Ok(_) => {}
+        Err(e) => panic!("expected parse to succeed on multibyte input, got: {e}\ninput:\n{input}"),
+    }
+}
+
+#[test]
+fn em_and_en_dashes_in_block_scalar_bullets_parse_without_panic() {
+    // Lifted from claude-haiku-4-5 / intel_brief trial 1 (eval debug log
+    // 2026-05-22T23-40-48-227Z). The trigger pattern is a `bullets: |`
+    // block scalar whose body mixes ASCII `-`, `*`, and en-dash `–` as
+    // bullet markers and contains an em-dash in the prose.
+    let md = "~~~card-yaml\n\
+              $quill: q@0.1\n\
+              $kind: main\n\
+              ~~~\n\
+              \n\
+              INDOPACOM Intelligence Briefing \u{2014} 15 April 2026\n\
+              \n\
+              ~~~card-yaml\n\
+              $kind: slide\n\
+              bullets: |\n  \
+                - (U) ASCII bullet content.\n  \
+                * (U) Asterisk bullet content.\n  \
+                \u{2013} (U) En-dash bullet content.\n\
+              ~~~\n";
+    assert_parses(md);
+}
+
+#[test]
+fn multibyte_after_dash_marker_does_not_panic() {
+    // The previously-patched site (`prescan.rs:156`) sliced `trimmed[2..]`
+    // when it saw `- <content>`. If `<content>` started with a multibyte
+    // codepoint, the slice would land mid-character. Pin every known
+    // variant.
+    let variants = [
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\narr:\n  - \u{2013} en-dash leads\n~~~\n",
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\narr:\n  - \u{2014} em-dash leads\n~~~\n",
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\narr:\n  - \u{201C}smart-quoted\u{201D}\n~~~\n",
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\narr:\n  - \u{1F600} emoji leads\n~~~\n",
+    ];
+    for v in variants {
+        assert_parses(v);
+    }
+}
+
+#[test]
+fn multibyte_in_quoted_scalar_parses() {
+    // Quoted scalars with multibyte content land in a different scanner
+    // path than plain scalars. Cover both styles.
+    let single = "~~~card-yaml\n$quill: q@0.1\n$kind: main\nbluf: '\u{2014}leading em-dash'\n~~~\n";
+    let double =
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\nbluf: \"\u{201C}smart-quoted\u{201D}\"\n~~~\n";
+    assert_parses(single);
+    assert_parses(double);
+}
+
+#[test]
+fn multibyte_keys_do_not_panic_on_duplicate() {
+    // YAML error formatting can include the offending key in its caret
+    // message. If the key contains multibyte chars, the caret renderer is
+    // the suspect path.
+    let md = "~~~card-yaml\n$quill: q@0.1\n$kind: main\nf\u{2014}o: 1\nf\u{2014}o: 2\n~~~\n";
+    // We expect a duplicate-key parse error here, not a panic. The crucial
+    // assertion is "did not panic"; the error is fine.
+    let _ = Document::from_markdown(md);
+}
+
+#[test]
+fn multibyte_in_value_with_yaml_error_does_not_panic() {
+    // The model writes a value with multibyte chars and a YAML structural
+    // bug elsewhere on the same line — caret-positioning has to scan past
+    // the multibyte chars.
+    let inputs = [
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\nx: hello \u{2014} world\nbluf: *bad-alias\n~~~\n",
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\nsystem_name: \u{201C}Service\u{201D}: Order API\n~~~\n",
+    ];
+    for input in inputs {
+        let _ = Document::from_markdown(input);
+    }
+}

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -79,7 +79,7 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; skip-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::must_fill_absent` if the field is absent at validate time. |
+| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; delete-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::must_fill_absent` if the field is absent at validate time. |
 | `example`     | any               | no       | Illustrative value surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md) for documentation and LLM authoring |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |

--- a/prose/BOOKMARKS.md
+++ b/prose/BOOKMARKS.md
@@ -58,7 +58,7 @@ walker uses the same shape.
 
 **What:** When a typed container declares `default: []` (or `default: {}`)
 the blueprint now renders the value inline — `refs: []  # array<object>;
-skip-ok` — and emits no row/property shape. Inner shape is only surfaced
+delete-ok` — and emits no row/property shape. Inner shape is only surfaced
 when the container is Must Fill (no `default:` at all), via the synthetic
 row / per-property recursion path.
 

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -23,7 +23,7 @@ $kind: main
 
 # <field description>
 # e.g. <example value>
-field: value  # <type>[; skip-ok]
+field: value  # <type>[; delete-ok]
 ~~~
 
 Write main body here.
@@ -50,7 +50,7 @@ When `body.enabled` is false the marker is omitted entirely.
 | Slot | Form | Carries |
 |---|---|---|
 | **Leading `# …` lines** above a field | `# <prose>` or `# e.g. <value>` | description (single-line prose) and an illustrative example |
-| **Inline `# …`** at end of the value line | `# <type>[<format>][; skip-ok]` | structural metadata: type, optional format refinement, optional skip-ok tag |
+| **Inline `# …`** at end of the value line | `# <type>[<format>][; delete-ok]` | structural metadata: type, optional format refinement, optional delete-ok tag |
 
 The two slots have disjoint purposes: leading is prose, inline is
 structural. No colon-separated `key: value` annotation syntax appears in
@@ -72,7 +72,7 @@ That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 
 ### Inline annotation
 
-Form: **`# <type>[<format>][; skip-ok]`**
+Form: **`# <type>[<format>][; delete-ok]`**
 
 - **Type slot** (mandatory, first): one of
   `string`, `integer`, `number`, `boolean`, `array`, `object`,
@@ -89,7 +89,7 @@ Form: **`# <type>[<format>][; skip-ok]`**
   - `enum<a | b | c>`
   - omitted for `string`, `integer`, `number`, `boolean`, `object`,
     `markdown` (nothing meaningful to refine).
-- **Skip-ok tag** (optional, after `;`): the single tag `skip-ok`. Present
+- **Skip-ok tag** (optional, after `;`): the single tag `delete-ok`. Present
   on Endorsed fields (fields with a `default:` in the schema), signalling
   "the rendered value is shippable as-is — keep or override". Absent on
   Must Fill fields (fields without a `default:`), which carry the
@@ -110,10 +110,10 @@ Examples:
 | Line | Reading |
 |---|---|
 | `name: <must-fill>  # string` | Must Fill string — replace `<must-fill>` before shipping |
-| `title: "Curriculum Vitae"  # string; skip-ok` | Endorsed string — keep or override |
-| `count: 0  # integer; skip-ok` | Endorsed integer (type-empty default, explicitly shippable) |
-| `active: false  # boolean; skip-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
-| `notes: ""  # string; skip-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
+| `title: "Curriculum Vitae"  # string; delete-ok` | Endorsed string — keep or override |
+| `count: 0  # integer; delete-ok` | Endorsed integer (type-empty default, explicitly shippable) |
+| `active: false  # boolean; delete-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
+| `notes: ""  # string; delete-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
 | `bio: |-` followed by indented `<must-fill>`, then `# markdown` | Must Fill markdown — see "Markdown fields render as block scalars" |
 | `recipient: <must-fill>  # array<string>` | Must Fill array of strings |
 | `date: <must-fill>  # date<YYYY-MM-DD>` | Must Fill date in `YYYY-MM-DD` format |
@@ -127,8 +127,8 @@ The rendered value follows a single cascade keyed on the cell:
 
 | Field state | Value rendered | Cell |
 |---|---|---|
-| Has `default` | default | Endorsed (carries `; skip-ok`) |
-| No `default` | `<must-fill>` sentinel | Must Fill (no `; skip-ok`) |
+| Has `default` | default | Endorsed (carries `; delete-ok`) |
+| No `default` | `<must-fill>` sentinel | Must Fill (no `; delete-ok`) |
 
 Examples never become the rendered value, regardless of cell or type —
 this holds uniformly for scalars, arrays, typed tables, and typed
@@ -174,14 +174,14 @@ When a `default:` is configured, the field is Endorsed and the default's
 content fills the block:
 
 ```
-bio: |-  # markdown; skip-ok
+bio: |-  # markdown; delete-ok
   ## About me
   
   <body>
 ```
 
 If the default is empty (`default: ""`), the block scalar still carries
-the `; skip-ok` tag and renders with one indented blank line — the
+the `; delete-ok` tag and renders with one indented blank line — the
 "skippable" markdown cell.
 
 ### Multi-element example arrays
@@ -213,16 +213,16 @@ cell cascade — `default:` (any default, including `[]`) is Endorsed and
 shippable as-is; no `default:` is Must Fill:
 
 - A non-empty `default:` renders as actual rows (no per-property
-  annotations on each row). The outer key carries `# array<object>; skip-ok`.
-- `default: []` renders inline as `[]` with `# array<object>; skip-ok` —
+  annotations on each row). The outer key carries `# array<object>; delete-ok`.
+- `default: []` renders inline as `[]` with `# array<object>; delete-ok` —
   shippable empty. Inline row shape is not surfaced under an empty
   default; use `example:` to document row shape. See
   `prose/BOOKMARKS.md` "Typed container empty default loses inline
   shape documentation."
 - No `default:` is Must Fill: one synthetic row is emitted with each
   property carrying its own description, inline annotation, and cell
-  signal (sentinel or `; skip-ok`). The outer key carries
-  `# array<object>` (no `; skip-ok`).
+  signal (sentinel or `; delete-ok`). The outer key carries
+  `# array<object>` (no `; delete-ok`).
 
 An `example:` never renders as rows. Like every other field type, it
 surfaces only in the `# e.g.` leading line — as a one-line flow
@@ -236,13 +236,13 @@ shippable as-is; no `default:` is Must Fill:
 
 - A non-empty `default:` renders as a concrete block mapping (property
   values only, no annotations). The outer key carries
-  `# object; skip-ok`.
-- `default: {}` renders inline as `{}` with `# object; skip-ok` —
+  `# object; delete-ok`.
+- `default: {}` renders inline as `{}` with `# object; delete-ok` —
   shippable empty. Inline property shape is not surfaced under an empty
   default; use `example:` to document property shape.
 - No `default:` is Must Fill: each property is emitted with its own
   description, inline annotation, and cell signal. The outer key
-  carries `# object` (no `; skip-ok`).
+  carries `# object` (no `; delete-ok`).
 
 An `example:` never renders as a concrete mapping. Like every other
 field type, it surfaces only in the `# e.g.` leading line — as a
@@ -257,13 +257,13 @@ address:  # object
   # City name.
   city: <must-fill>  # string
   # ZIP or postal code.
-  zip: ""  # string; skip-ok
+  zip: ""  # string; delete-ok
 ```
 
 With a default:
 
 ```
-address:  # object; skip-ok
+address:  # object; delete-ok
   street: 5000 Forbes Avenue
   city: Pittsburgh
   zip: "15213"
@@ -313,13 +313,13 @@ recipient: <must-fill>  # array<string>
 signature_block: <must-fill>  # array<string>
 # The department or organizational unit name for the letterhead.
 # e.g. Department of Electrical and Computer Engineering
-department: ""  # string; skip-ok
+department: ""  # string; delete-ok
 # The sender's institutional mailing address.
 # e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
 address: <must-fill>  # array<string>
 # The department or university website URL.
 # e.g. www.ece.cmu.edu
-url: ""  # string; skip-ok
+url: ""  # string; delete-ok
 # The date to appear on the letter.
 date: <must-fill>  # date<YYYY-MM-DD>
 ~~~
@@ -393,7 +393,7 @@ Endorsed per field:
 
 - **Declare `default:`** when a value (including a type-empty value like
   `""`, `[]`, `false`, or `0`) is acceptable to ship as-is. The field
-  becomes Endorsed and the blueprint carries `; skip-ok`.
+  becomes Endorsed and the blueprint carries `; delete-ok`.
 - **Omit `default:`** when the author, LLM, or user must supply a value
   before shipping. The field becomes Must Fill and the blueprint carries
   the `<must-fill>` sentinel.

--- a/prose/proposals/mcp-feedback.md
+++ b/prose/proposals/mcp-feedback.md
@@ -12,7 +12,7 @@
 Collapse the field-schema axes (`required`, `optional`, `default`)
 into a two-cell model: a field either has a `default:` (Endorsed) or
 does not (Must Fill). Render Must Fill with the `<must-fill>` sentinel
-in the value cell; render Endorsed with `; skip-ok` on the annotation.
+in the value cell; render Endorsed with `; delete-ok` on the annotation.
 Pre-1.0; breaking changes acceptable.
 
 Two unrelated changes from the original draft (root-block `$kind:
@@ -56,11 +56,11 @@ Two render shapes:
 
 | Cell | Render |
 |---|---|
-| Endorsed | `field: <value>  # <type>[<format>]; skip-ok` |
+| Endorsed | `field: <value>  # <type>[<format>]; delete-ok` |
 | Must Fill | `field: <must-fill>  # <type>[<format>]` |
 
 The sentinel `<must-fill>` in the value cell signals "you must replace
-this." The tag `; skip-ok` in the annotation signals "this default is
+this." The tag `; delete-ok` in the annotation signals "this default is
 shippable; keep or override." The two are orthogonal — every field is
 exactly one cell, and the two signals never co-occur on the same
 field.
@@ -68,7 +68,7 @@ field.
 A reader's mental model is one rule: **sentinel in value cell → must
 replace; otherwise the value cell is shippable.** Endorsed values
 include type-empty values (`""`, `[]`, `false`, `0`) and the `;
-skip-ok` tag confirms they are deliberate, not artifacts.
+delete-ok` tag confirms they are deliberate, not artifacts.
 
 ## 3. Sentinel placement by type
 
@@ -96,16 +96,16 @@ is rendered with its own annotation and its own cell signal:
 address:  # object
   street: <must-fill>  # string
   city: <must-fill>  # string
-  zip: ""  # string; skip-ok
+  zip: ""  # string; delete-ok
 ```
 
-The container annotation has no `; skip-ok` tag because state is a
+The container annotation has no `; delete-ok` tag because state is a
 leaf concern. If the container itself has a `default:` (concrete
 block mapping), the container is Endorsed and carries the tag;
 property annotations are dropped per the existing spec:
 
 ```
-address:  # object; skip-ok
+address:  # object; delete-ok
   street: 5000 Forbes Avenue
   city: Pittsburgh
   zip: "15213"
@@ -121,19 +121,19 @@ entries:  # array<object>
 ```
 
 With a container `default:`, actual rows render with property values
-only (no annotations), and the container carries `; skip-ok`.
+only (no annotations), and the container carries `; delete-ok`.
 
 ## 4. Inline annotation grammar
 
 The annotation collapses to:
 
 ```
-# <type>[<format>][; skip-ok]
+# <type>[<format>][; delete-ok]
 ```
 
 The role slot (`; required` / `; optional`) is removed. No replacement
 token. State is conveyed by the value cell (sentinel or real value)
-and by the presence or absence of `; skip-ok`. The `<format>` slot is
+and by the presence or absence of `; delete-ok`. The `<format>` slot is
 unchanged from the current spec.
 
 Examples:
@@ -141,9 +141,9 @@ Examples:
 | Line | Reading |
 |---|---|
 | `name: <must-fill>  # string` | Must Fill string |
-| `title: "Curriculum Vitae"  # string; skip-ok` | Endorsed string |
-| `is_published: false  # boolean; skip-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
-| `notes: ""  # string; skip-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
+| `title: "Curriculum Vitae"  # string; delete-ok` | Endorsed string |
+| `is_published: false  # boolean; delete-ok` | Endorsed boolean (type-empty default, explicitly shippable) |
+| `notes: ""  # string; delete-ok` | Endorsed empty string (the "skippable" cell, now Endorsed) |
 | `date: <must-fill>  # date<YYYY-MM-DD>` | Must Fill date |
 | `severity: <must-fill>  # enum<low \| medium \| high>` | Must Fill enum |
 | `tags: <must-fill>  # array<string>` | Must Fill array of strings |
@@ -264,13 +264,13 @@ recipient: <must-fill>  # array<string>
 signature_block: <must-fill>  # array<string>
 # The department or organizational unit name for the letterhead.
 # e.g. Department of Electrical and Computer Engineering
-department: ""  # string; skip-ok
+department: ""  # string; delete-ok
 # The sender's institutional mailing address.
 # e.g. [5000 Forbes Avenue, "Pittsburgh, PA 15213-3890"]
 address: <must-fill>  # array<string>
 # The department or university website URL.
 # e.g. www.ece.cmu.edu
-url: ""  # string; skip-ok
+url: ""  # string; delete-ok
 # The date to appear on the letter.
 date: <must-fill>  # date<YYYY-MM-DD>
 ~~~
@@ -279,7 +279,7 @@ Write main body here.
 ````
 
 Two render shapes, one tag, no `required` token. The LLM reads
-`<must-fill>` as "replace before shipping" and `; skip-ok` as "the
+`<must-fill>` as "replace before shipping" and `; delete-ok` as "the
 default here is fine; keep or override." Six fields, three signals
 (sentinel, plain value with tag, leading `# e.g.` reference), no
 ambiguity.
@@ -312,7 +312,7 @@ landing order.
 3. **Blueprint emitter rewrite** in `crates/core/src/quill/`:
    - New annotation grammar (drop role slot).
    - Sentinel rendering at the right position per type.
-   - `; skip-ok` tag emission on Endorsed cells.
+   - `; delete-ok` tag emission on Endorsed cells.
 4. **Quill migration**: rewrite bundled quills in
    `crates/fixtures/resources/quills/` to the two-cell shape; update
    fixture tests; verify `every_quill_in_quiver_renders` still holds.

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -12,8 +12,11 @@ This document is the authoritative syntax standard.
 ## 1. Superset Statement
 
 Every valid CommonMark 0.31.2 document parses to the same block / inline
-structure under this spec, *except* for the deviation declared in §6.2.
-Additionally, this spec defines:
+structure under this spec, *except* for the deviations declared in §6.2
+(raw HTML) and §3.2.1 (root-block `---` alias — a `---` at document start
+followed by a matching `---` is interpreted as a YAML-frontmatter root
+block, not a thematic break / setext underline). Additionally, this spec
+defines:
 
 - **Structured data** — card-yaml blocks (§3).
 - **Extensions** — strikethrough, pipe tables, and `<u>` for underline
@@ -92,7 +95,7 @@ the next opening fence or EOF.
 
 - **Delimiter.** Blocks open and close exclusively with `~~~` — three tildes,
   no more, no fewer. The closing fence is exactly `~~~` and carries no info
-  string.
+  string. (Exception: the root-block `---` alias in §3.2.1.)
 - **Info string.** The opening fence must be exactly `~~~card-yaml`. No other
   info string opens a card-yaml block.
 - **Indentation.** The `~~~card-yaml` opener and its closing `~~~` are at
@@ -104,6 +107,32 @@ the next opening fence or EOF.
   a card-yaml opener — it is treated as an ordinary CommonMark fenced code
   block. Requiring the blank line keeps prose-body round-tripping stable and
   prevents a card-yaml block from being absorbed into a preceding paragraph.
+
+### 3.2.1 Root-Block `---` Alias
+
+The **root block only** may open with `---` and close with `---` instead of
+`~~~card-yaml` / `~~~`. A `---`-fenced root parses identically to a
+`~~~card-yaml`-fenced root with the same payload.
+
+- **Accept, don't emit, don't advertise.** Parsers accept the `---` form so
+  that LLMs trained on broader-internet YAML-frontmatter conventions are
+  not penalised on a stylistic mismatch. `toMarkdown` (§9) always emits the
+  canonical `~~~card-yaml` / `~~~` shape; a `---`-authored document
+  round-trips to the canonical form on first re-emit. Authoring surfaces
+  (blueprints, FORMAT_RULES, examples) document only the canonical form.
+- **Root only.** A `---` opener is recognised only when every line above
+  it is blank (i.e. document start, modulo leading blank lines) and no
+  prior block has been parsed. Any other `---` line is delegated to
+  CommonMark as a thematic break or setext-heading underline.
+- **Matched fences.** Within a single block, opener and closer must agree:
+  a `---` opener requires a `---` closer, and a `~~~card-yaml` opener
+  requires a `~~~` closer. Mixed forms (`---` … `~~~`, `~~~card-yaml` …
+  `---`) surface as the "never closed" parse error.
+- **Composable position.** A `---` line after the root block — when it
+  pairs with a later `---` and has YAML-key content between — is a
+  misplaced composable card and is rejected with a diagnostic that names
+  the canonical `~~~card-yaml` / `~~~` replacement (§10). Composable
+  cards have no `---` alias.
 
 ### 3.3 System Metadata (`$`)
 
@@ -231,13 +260,26 @@ or the line immediately above it is blank.
 
 **D2 — Closing fence.** A matching `~~~` line appears later in the document.
 
+A `---` line opens the **root block** instead **iff** all of the following
+hold (see §3.2.1):
+
+**R1 — Document start.** No prior block has been parsed and every line above
+the `---` line is blank.
+
+**R2 — Closing `---`.** A matching `---` line appears later in the document.
+
 YAML content between recognised fence markers is opaque to detection — a
 `~~~card-yaml` line inside an open block is part of that block's payload, not
-a new opener (though the canonical payload never produces such a line).
+a new opener (though the canonical payload never produces such a line). The
+same applies to `---` lines inside an open `---`-fenced root block.
 
 A `~~~card-yaml` line that fails D1 is delegated to CommonMark as an ordinary
 fenced code block. A `~~~card-yaml` opener with no matching `~~~` closer
-before EOF is a hard parse error (§10).
+before EOF — and equivalently a `---` root opener with no matching `---`
+closer — is a hard parse error (§10). A `---` line that fails R1 falls
+through to CommonMark unless it pairs with a later `---` line that holds
+YAML-key content between them, in which case it is rejected as a misplaced
+composable card (§10).
 
 ### 4.1 Worked Example
 
@@ -394,9 +436,10 @@ order), and a `~~~` closer. The root block must declare `$quill`;
 canonical emission also writes `$kind: main` on the root, synthesising
 it when the input omitted the line (see §3.3). Composable cards must
 declare `$kind: <kind>`. A document round-trips to this canonical
-shape — fence markers and YAML quoting are normalised. `!fill` tags
-and YAML comments (own-line and inline, including those adjacent to
-`$` lines) survive the round-trip.
+shape — fence markers and YAML quoting are normalised, including the
+`---`-fenced root alias (§3.2.1), which re-emits as `~~~card-yaml` /
+`~~~`. `!fill` tags and YAML comments (own-line and inline, including
+those adjacent to `$` lines) survive the round-trip.
 
 Programmatically constructed metadata that does not have a source-order
 emits in the canonical key order `$quill`, `$kind`, `$id`, `$ext` — the
@@ -433,7 +476,13 @@ or compare for equality.
 
 Parse errors include:
 
-- A `~~~card-yaml` opener with no matching `~~~` closer before EOF.
+- A `~~~card-yaml` opener with no matching `~~~` closer before EOF (or,
+  equivalently, a `---` root opener with no matching `---` closer).
+- A `---` line in composable position (after the root block) that pairs
+  with a later `---` and holds YAML-key content between — composable
+  cards must use `~~~card-yaml` / `~~~` (§3.2.1).
+- Mixed fence markers within a single block — `---` opener with `~~~`
+  closer or vice versa (surfaces as the "never closed" error).
 - The root block missing its `$quill` entry.
 - The root block declaring a non-`main` `$kind` (an omitted `$kind` on
   the root is accepted and synthesised; only an explicit non-`main`


### PR DESCRIPTION
## Summary

Three sprints of LLM-eval-driven refinement of the parse / blueprint / Diagnostic surfaces. Each commit landed against an eval datapoint; this PR bundles them for review.

**LLM-facing prose moved to single source of truth**
- `Document::FORMAT_RULES` (centralized text every binding shows)
- `Document::blueprint_instruction(name)` (the get_spec header — previously inlined in `quillmark-mcp`)
- `Document::format_diagnostic(diag)` (canonical pretty-print — kills the JS-side reformat that was breaking error parity)

**Parse-side relaxation, no emit change**
- `---` … `---` accepted as the root-block fence in addition to `~~~card-yaml` … `~~~`. Composable cards still strict. Re-emit normalizes to canonical `~~~card-yaml`. LLMs author with `---` frontmatter ~30% of the time; accepting it removes a stylistic-mismatch retry without polluting the canonical form.

**Error prose enrichment + hint coverage**
- YAML parse errors now carry actionable hints for block-seq / simple-key / anchor-scan failure shapes (`yaml_hints.rs`).
- Null-default validation message names all three null shapes (`null`, `~`, bare `field:`) so the LLM gets one error string per failure mode.
- Annotation verb rename `; skip-ok` → `; delete-ok` (the B4 hypothesis: imperative concrete action verbs beat permissive state words; eval confirmed +13pp share-of-errors reduction on the null-default failure mode).
- Multi-line content guidance added to plain-scalar bullet: `Multi-line values use \`|-\`, not multi-line quoted scalars.` (catches a residual yaml_parse cluster on intel_brief / cnn.)

**Schema author-time validation**
- `Quill.yaml` example/default values are validated against the declared `type:` at load. Catches `min_os_version: 20.04` (unquoted float when field declares `string`) class of authoring mistakes at the schema layer rather than letting them surface as LLM eval failures. All seven shipped quills + five fixtures pass cleanly; no migration needed.

**Multibyte regression coverage**
- Regression test pinning the historical multibyte panic shape from `usaf_intel_brief` (en-dash / em-dash / smart-quote bullet markers, multibyte keys, multibyte values with adjacent YAML errors). Couldn't reproduce the original panic on current code; rare residual production occurrences tracked in [quillmark#649](https://github.com/quillmark-org/quillmark/issues/649).

## Test plan
- [x] `cargo test --workspace --all-features --locked` — all green
- [x] `RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --no-deps --locked` — exit 0
- [x] `scripts/build-wasm.sh --ci` — WASM build clean
- [x] Downstream quillmark-mcp \`npm test\` (84/84 passing) on the consuming branch [tonguetoquill/quillmark-mcp#auto-refine-3](https://github.com/tonguetoquill/quillmark-mcp/tree/auto-refine-3)
- [x] Three eval runs against the centralized prose changes (top-tier 1-shot rate: gemma 88%, gpt-mini 88%, gpt-nano 83%, claude-haiku 88%, gpt-oss-120b 88%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)