### PR TITLE
Add FillBehavior to handle must-fill sentinels in blueprints

### DIFF
--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -80,9 +80,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
             (output, Some(markdown_path.clone()))
         } else {
-            // Fall back to the quill's generated blueprint, with Must Fill
-            // sentinels substituted by preview-friendly placeholders so the
-            // document renders out of the box.
+            // Generated blueprint, sentinels filled so it renders out of the box.
             let blueprint = quill.source().config().blueprint();
             let markdown = fill_blueprint(&blueprint, FillBehavior::Preview);
 

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -3,7 +3,7 @@ use crate::errors::{CliError, Result};
 use crate::output::{derive_output_path, OutputWriter};
 use clap::Parser;
 use quillmark::Document;
-use quillmark_core::{OutputFormat, RenderOptions};
+use quillmark_core::{fill_blueprint, FillBehavior, OutputFormat, RenderOptions};
 use std::fs;
 use std::path::PathBuf;
 
@@ -80,11 +80,14 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
             (output, Some(markdown_path.clone()))
         } else {
-            // Fall back to the quill's generated blueprint.
-            let markdown = quill.source().config().blueprint();
+            // Fall back to the quill's generated blueprint, with Must Fill
+            // sentinels substituted by preview-friendly placeholders so the
+            // document renders out of the box.
+            let blueprint = quill.source().config().blueprint();
+            let markdown = fill_blueprint(&blueprint, FillBehavior::Preview);
 
             if args.verbose {
-                println!("Using generated blueprint from quill");
+                println!("Using generated blueprint from quill (fill: preview)");
             }
 
             // Parse markdown

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,7 @@ pub mod session;
 pub use session::RenderSession;
 
 pub mod quill;
-pub use quill::{FileTreeNode, QuillIgnore, QuillSource};
+pub use quill::{fill_blueprint, FileTreeNode, FillBehavior, QuillIgnore, QuillSource};
 
 pub mod value;
 pub use value::QuillValue;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -12,6 +12,7 @@ mod tree;
 mod types;
 pub(crate) mod validation;
 
+pub use blueprint::{fill_blueprint, FillBehavior};
 pub use config::{CoercionError, QuillConfig};
 pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -40,46 +40,26 @@ use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::value::QuillValue;
 use serde_json::Value as JsonValue;
 
-/// Controls how `<must-fill>` sentinels in a generated blueprint are handled
-/// before parsing.
-///
-/// A freshly emitted blueprint carries one sentinel per Must Fill cell.
-/// Downstream parsing accepts the sentinel as a literal string, but
-/// validation rejects it (or rejects the wrong-typed string for non-string
-/// fields). Use this to choose between letting that error surface
-/// (`Strict`), substituting placeholder values for a preview render
-/// (`Preview`), or substituting type-minimal values for a render-test
-/// (`TypeEmpty`).
+/// Controls how `<must-fill>` sentinels in a generated blueprint are
+/// substituted before parsing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FillBehavior {
-    /// Leave `<must-fill>` sentinels in place. Downstream parsing or
-    /// validation will reject the unfilled fields with their canonical
-    /// `validation::must_fill_sentinel` diagnostic.
+    /// Leave sentinels in place — downstream validation reports
+    /// `validation::must_fill_sentinel`.
     #[default]
     Strict,
-    /// Replace each `<must-fill>` sentinel with a preview-friendly
-    /// placeholder derived from the inline type annotation on the same
-    /// line: `Lorem ipsum` for strings/markdown, `0` for numbers, `false`
-    /// for booleans, a fixed ISO date/datetime, the first enum variant,
-    /// and `[]` / `{}` for arrays/objects.
+    /// Substitute with preview-friendly placeholders: `Lorem ipsum` for
+    /// strings/markdown, `0`, `false`, `[]`, `{}`, a fixed ISO
+    /// date/datetime, first enum variant.
     Preview,
-    /// Replace each `<must-fill>` sentinel with a *type-empty* value: `""`
-    /// for strings/dates/datetimes/objects, `0` for numbers, `false` for
-    /// booleans, `[]` for arrays, the first variant for enums, and an
-    /// empty body for markdown block scalars. This is the leanest input
-    /// the schema accepts — useful for asserting that a plate renders
-    /// every type-valid shape gracefully.
+    /// Substitute with the leanest type-valid values: `""`, `0`, `false`,
+    /// `[]`, first enum variant, empty markdown body. Used by the quiver
+    /// render-test to exercise plates on minimal input.
     TypeEmpty,
 }
 
 /// Substitute `<must-fill>` sentinels in a generated blueprint according to
-/// `behavior`. With [`FillBehavior::Strict`] the input is returned
-/// unchanged; otherwise each sentinel is replaced by a value derived from
-/// the inline type annotation on the same line (markdown block scalars
-/// substitute on the body line).
-///
-/// The output remains valid blueprint markdown — the annotation comments
-/// and structure are preserved.
+/// `behavior`. [`FillBehavior::Strict`] returns the input unchanged.
 pub fn fill_blueprint(blueprint: &str, behavior: FillBehavior) -> String {
     match behavior {
         FillBehavior::Strict => blueprint.to_string(),
@@ -109,14 +89,11 @@ fn substitute_line(line: &str, behavior: FillBehavior) -> String {
         let value = scalar_value_for(annotation, behavior);
         return format!("{}: {}  # {}", prefix, value, annotation);
     }
-    // Markdown block scalar: `<indent><must-fill>` on its own line. The
-    // outer block-scalar header is unchanged; only the body line is
-    // substituted.
+    // Markdown block scalar: `<indent><must-fill>` on its own line.
     if line.trim_start() == MUST_FILL_SENTINEL {
         let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
         return match behavior {
             FillBehavior::Preview => format!("{}{}", indent, PREVIEW_MARKDOWN),
-            // TypeEmpty: leave the body blank (just the indent).
             _ => indent,
         };
     }
@@ -138,8 +115,6 @@ fn scalar_value_for(annotation: &str, behavior: FillBehavior) -> String {
         .strip_prefix("enum<")
         .and_then(|s| s.strip_suffix('>'))
     {
-        // Enums substitute the first variant unquoted in both modes —
-        // type-empty has no separate notion for enums.
         let first = inner.split('|').next().unwrap_or("").trim();
         return first.to_string();
     }
@@ -154,11 +129,9 @@ fn scalar_value_for(annotation: &str, behavior: FillBehavior) -> String {
             if head.starts_with("datetime<") || head == "datetime" {
                 return PREVIEW_DATETIME.to_string();
             }
-            // string (markdown takes the block-scalar branch above).
             PREVIEW_STRING.to_string()
         }
-        // TypeEmpty: empty string covers strings / dates / datetimes /
-        // objects — validation accepts `""` for each by design.
+        // `""` is schema-valid for string/date/datetime/object alike.
         _ => "\"\"".to_string(),
     }
 }
@@ -1195,8 +1168,6 @@ main:
 
     #[test]
     fn fill_blueprint_preview_preserves_endorsed_cells() {
-        // Endorsed cells (defaults present) have no sentinel — Preview must
-        // leave them alone.
         let bp = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -1214,7 +1185,6 @@ main:
 
     #[test]
     fn fill_blueprint_preview_substitutes_typed_table_leaves() {
-        // Outer typed-table key has no sentinel; inner leaves do.
         let bp = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -1255,14 +1225,11 @@ main:
         assert!(out.contains("refs: []  # array<string>\n"));
         assert!(out.contains("issued: \"\"  # date<YYYY-MM-DD>\n"));
         assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
-        // Markdown block scalar: body line collapses to bare indent.
         assert!(out.contains("bio: |-  # markdown\n  \n"));
     }
 
     #[test]
     fn fill_blueprint_preview_round_trips_to_a_valid_document() {
-        // The substituted blueprint must parse as a Document — the
-        // round-trip guarantee on `blueprint()` extends to its filled form.
         let bp = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -40,6 +40,108 @@ use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::value::QuillValue;
 use serde_json::Value as JsonValue;
 
+/// Controls how `<must-fill>` sentinels in a generated blueprint are handled
+/// before parsing.
+///
+/// A freshly emitted blueprint carries one sentinel per Must Fill cell.
+/// Downstream parsing accepts the sentinel as a literal string, but
+/// validation rejects it (or rejects the wrong-typed string for non-string
+/// fields). Use this to choose between letting that error surface
+/// (`Strict`) and silently substituting placeholder values for a preview
+/// render (`Preview`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FillBehavior {
+    /// Leave `<must-fill>` sentinels in place. Downstream parsing or
+    /// validation will reject the unfilled fields with their canonical
+    /// `validation::must_fill_sentinel` diagnostic.
+    #[default]
+    Strict,
+    /// Replace each `<must-fill>` sentinel with a preview-friendly
+    /// placeholder derived from the inline type annotation on the same
+    /// line: `Lorem ipsum` for strings/markdown, `0` for numbers, `false`
+    /// for booleans, a fixed ISO date/datetime, the first enum variant,
+    /// and `[]` / `{}` for arrays/objects.
+    Preview,
+}
+
+/// Substitute `<must-fill>` sentinels in a generated blueprint according to
+/// `behavior`. With [`FillBehavior::Strict`] the input is returned
+/// unchanged; with [`FillBehavior::Preview`] each sentinel is replaced by
+/// a placeholder value derived from the inline type annotation on the same
+/// line (or, for markdown block scalars, a single-line lorem paragraph).
+///
+/// The output remains valid blueprint markdown — the annotation comments
+/// and structure are preserved.
+pub fn fill_blueprint(blueprint: &str, behavior: FillBehavior) -> String {
+    match behavior {
+        FillBehavior::Strict => blueprint.to_string(),
+        FillBehavior::Preview => fill_preview(blueprint),
+    }
+}
+
+const PREVIEW_STRING: &str = "Lorem ipsum";
+const PREVIEW_MARKDOWN: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+const PREVIEW_DATE: &str = "\"2024-01-15\"";
+const PREVIEW_DATETIME: &str = "\"2024-01-15T12:00:00Z\"";
+
+fn fill_preview(blueprint: &str) -> String {
+    let mut out = String::with_capacity(blueprint.len());
+    for line in blueprint.lines() {
+        out.push_str(&substitute_line(line));
+        out.push('\n');
+    }
+    out
+}
+
+fn substitute_line(line: &str) -> String {
+    const NEEDLE: &str = ": <must-fill>  # ";
+    if let Some(idx) = line.find(NEEDLE) {
+        let prefix = &line[..idx];
+        let annotation = &line[idx + NEEDLE.len()..];
+        let value = preview_value_for(annotation);
+        return format!("{}: {}  # {}", prefix, value, annotation);
+    }
+    // Markdown block scalar: `<indent><must-fill>` on its own line. The
+    // outer block-scalar header is unchanged; only the body line gets a
+    // lorem paragraph.
+    if line.trim_start() == MUST_FILL_SENTINEL {
+        let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+        return format!("{}{}", indent, PREVIEW_MARKDOWN);
+    }
+    line.to_string()
+}
+
+fn preview_value_for(annotation: &str) -> String {
+    let head = annotation.split(';').next().unwrap_or(annotation).trim();
+    if head.starts_with("array<") || head == "array" {
+        return "[]".to_string();
+    }
+    if head == "integer" || head == "number" {
+        return "0".to_string();
+    }
+    if head == "boolean" {
+        return "false".to_string();
+    }
+    if head == "object" {
+        return "{}".to_string();
+    }
+    if head.starts_with("date<") || head == "date" {
+        return PREVIEW_DATE.to_string();
+    }
+    if head.starts_with("datetime<") || head == "datetime" {
+        return PREVIEW_DATETIME.to_string();
+    }
+    if let Some(inner) = head
+        .strip_prefix("enum<")
+        .and_then(|s| s.strip_suffix('>'))
+    {
+        let first = inner.split('|').next().unwrap_or("").trim();
+        return first.to_string();
+    }
+    // string (inline scalars; markdown takes the block-scalar branch).
+    PREVIEW_STRING.to_string()
+}
+
 impl QuillConfig {
     /// Generate an annotated Markdown blueprint for this quill. See module
     /// docs for the annotation grammar; the function is total over any valid
@@ -1011,6 +1113,126 @@ card_kinds:
             doc1, doc2,
             "Document must be equal after blueprint → parse → emit → parse"
         );
+    }
+
+    #[test]
+    fn fill_blueprint_strict_is_identity() {
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+    count: { type: integer }
+"#)
+        .blueprint();
+        let out = super::fill_blueprint(&bp, super::FillBehavior::Strict);
+        assert_eq!(out, bp);
+        assert!(out.contains("<must-fill>"));
+    }
+
+    #[test]
+    fn fill_blueprint_preview_substitutes_every_inline_sentinel() {
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title:     { type: string }
+    count:     { type: integer }
+    ratio:     { type: number }
+    flag:      { type: boolean }
+    refs:      { type: array }
+    issued:    { type: date }
+    published: { type: datetime }
+    severity:  { type: string, enum: [low, medium, high] }
+"#)
+        .blueprint();
+        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("title: Lorem ipsum  # string\n"));
+        assert!(out.contains("count: 0  # integer\n"));
+        assert!(out.contains("ratio: 0  # number\n"));
+        assert!(out.contains("flag: false  # boolean\n"));
+        assert!(out.contains("refs: []  # array<string>\n"));
+        assert!(out.contains("issued: \"2024-01-15\"  # date<YYYY-MM-DD>\n"));
+        assert!(out.contains("published: \"2024-01-15T12:00:00Z\"  # datetime<ISO 8601>\n"));
+        assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
+    }
+
+    #[test]
+    fn fill_blueprint_preview_substitutes_markdown_block_scalar() {
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown }
+"#)
+        .blueprint();
+        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("bio: |-  # markdown\n  Lorem ipsum dolor sit amet"));
+    }
+
+    #[test]
+    fn fill_blueprint_preview_preserves_endorsed_cells() {
+        // Endorsed cells (defaults present) have no sentinel — Preview must
+        // leave them alone.
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    size:   { type: number, default: 11 }
+    flag:   { type: boolean, default: true }
+    status: { type: string, default: draft }
+"#)
+        .blueprint();
+        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        assert!(out.contains("size: 11  # number; delete-ok\n"));
+        assert!(out.contains("flag: true  # boolean; delete-ok\n"));
+        assert!(out.contains("status: draft  # string; delete-ok\n"));
+    }
+
+    #[test]
+    fn fill_blueprint_preview_substitutes_typed_table_leaves() {
+        // Outer typed-table key has no sentinel; inner leaves do.
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      properties:
+        org:  { type: string }
+        year: { type: integer }
+"#)
+        .blueprint();
+        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("    org: Lorem ipsum  # string\n"));
+        assert!(out.contains("    year: 0  # integer\n"));
+    }
+
+    #[test]
+    fn fill_blueprint_preview_round_trips_to_a_valid_document() {
+        // The substituted blueprint must parse as a Document — the
+        // round-trip guarantee on `blueprint()` extends to its filled form.
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title:     { type: string }
+    count:     { type: integer }
+    severity:  { type: string, enum: [low, medium, high] }
+    bio:       { type: markdown }
+    issued:    { type: date }
+"#)
+        .blueprint();
+        let filled = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        let doc = Document::from_markdown(&filled)
+            .unwrap_or_else(|e| panic!("filled blueprint must parse: {e:?}\n---\n{filled}"));
+        let main = doc.main().payload();
+        assert_eq!(main.get("title").unwrap().as_str().unwrap(), "Lorem ipsum");
+        assert_eq!(main.get("count").unwrap().as_i64().unwrap(), 0);
+        assert_eq!(main.get("severity").unwrap().as_str().unwrap(), "low");
     }
 
     /// Regression: string defaults that look numeric/boolean/null get

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -47,8 +47,9 @@ use serde_json::Value as JsonValue;
 /// Downstream parsing accepts the sentinel as a literal string, but
 /// validation rejects it (or rejects the wrong-typed string for non-string
 /// fields). Use this to choose between letting that error surface
-/// (`Strict`) and silently substituting placeholder values for a preview
-/// render (`Preview`).
+/// (`Strict`), substituting placeholder values for a preview render
+/// (`Preview`), or substituting type-minimal values for a render-test
+/// (`TypeEmpty`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FillBehavior {
     /// Leave `<must-fill>` sentinels in place. Downstream parsing or
@@ -62,20 +63,27 @@ pub enum FillBehavior {
     /// for booleans, a fixed ISO date/datetime, the first enum variant,
     /// and `[]` / `{}` for arrays/objects.
     Preview,
+    /// Replace each `<must-fill>` sentinel with a *type-empty* value: `""`
+    /// for strings/dates/datetimes/objects, `0` for numbers, `false` for
+    /// booleans, `[]` for arrays, the first variant for enums, and an
+    /// empty body for markdown block scalars. This is the leanest input
+    /// the schema accepts — useful for asserting that a plate renders
+    /// every type-valid shape gracefully.
+    TypeEmpty,
 }
 
 /// Substitute `<must-fill>` sentinels in a generated blueprint according to
 /// `behavior`. With [`FillBehavior::Strict`] the input is returned
-/// unchanged; with [`FillBehavior::Preview`] each sentinel is replaced by
-/// a placeholder value derived from the inline type annotation on the same
-/// line (or, for markdown block scalars, a single-line lorem paragraph).
+/// unchanged; otherwise each sentinel is replaced by a value derived from
+/// the inline type annotation on the same line (markdown block scalars
+/// substitute on the body line).
 ///
 /// The output remains valid blueprint markdown — the annotation comments
 /// and structure are preserved.
 pub fn fill_blueprint(blueprint: &str, behavior: FillBehavior) -> String {
     match behavior {
         FillBehavior::Strict => blueprint.to_string(),
-        FillBehavior::Preview => fill_preview(blueprint),
+        FillBehavior::Preview | FillBehavior::TypeEmpty => fill_substitute(blueprint, behavior),
     }
 }
 
@@ -84,34 +92,38 @@ const PREVIEW_MARKDOWN: &str = "Lorem ipsum dolor sit amet, consectetur adipisci
 const PREVIEW_DATE: &str = "\"2024-01-15\"";
 const PREVIEW_DATETIME: &str = "\"2024-01-15T12:00:00Z\"";
 
-fn fill_preview(blueprint: &str) -> String {
+fn fill_substitute(blueprint: &str, behavior: FillBehavior) -> String {
     let mut out = String::with_capacity(blueprint.len());
     for line in blueprint.lines() {
-        out.push_str(&substitute_line(line));
+        out.push_str(&substitute_line(line, behavior));
         out.push('\n');
     }
     out
 }
 
-fn substitute_line(line: &str) -> String {
+fn substitute_line(line: &str, behavior: FillBehavior) -> String {
     const NEEDLE: &str = ": <must-fill>  # ";
     if let Some(idx) = line.find(NEEDLE) {
         let prefix = &line[..idx];
         let annotation = &line[idx + NEEDLE.len()..];
-        let value = preview_value_for(annotation);
+        let value = scalar_value_for(annotation, behavior);
         return format!("{}: {}  # {}", prefix, value, annotation);
     }
     // Markdown block scalar: `<indent><must-fill>` on its own line. The
-    // outer block-scalar header is unchanged; only the body line gets a
-    // lorem paragraph.
+    // outer block-scalar header is unchanged; only the body line is
+    // substituted.
     if line.trim_start() == MUST_FILL_SENTINEL {
         let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
-        return format!("{}{}", indent, PREVIEW_MARKDOWN);
+        return match behavior {
+            FillBehavior::Preview => format!("{}{}", indent, PREVIEW_MARKDOWN),
+            // TypeEmpty: leave the body blank (just the indent).
+            _ => indent,
+        };
     }
     line.to_string()
 }
 
-fn preview_value_for(annotation: &str) -> String {
+fn scalar_value_for(annotation: &str, behavior: FillBehavior) -> String {
     let head = annotation.split(';').next().unwrap_or(annotation).trim();
     if head.starts_with("array<") || head == "array" {
         return "[]".to_string();
@@ -122,24 +134,33 @@ fn preview_value_for(annotation: &str) -> String {
     if head == "boolean" {
         return "false".to_string();
     }
-    if head == "object" {
-        return "{}".to_string();
-    }
-    if head.starts_with("date<") || head == "date" {
-        return PREVIEW_DATE.to_string();
-    }
-    if head.starts_with("datetime<") || head == "datetime" {
-        return PREVIEW_DATETIME.to_string();
-    }
     if let Some(inner) = head
         .strip_prefix("enum<")
         .and_then(|s| s.strip_suffix('>'))
     {
+        // Enums substitute the first variant unquoted in both modes —
+        // type-empty has no separate notion for enums.
         let first = inner.split('|').next().unwrap_or("").trim();
         return first.to_string();
     }
-    // string (inline scalars; markdown takes the block-scalar branch).
-    PREVIEW_STRING.to_string()
+    match behavior {
+        FillBehavior::Preview => {
+            if head == "object" {
+                return "{}".to_string();
+            }
+            if head.starts_with("date<") || head == "date" {
+                return PREVIEW_DATE.to_string();
+            }
+            if head.starts_with("datetime<") || head == "datetime" {
+                return PREVIEW_DATETIME.to_string();
+            }
+            // string (markdown takes the block-scalar branch above).
+            PREVIEW_STRING.to_string()
+        }
+        // TypeEmpty: empty string covers strings / dates / datetimes /
+        // objects — validation accepts `""` for each by design.
+        _ => "\"\"".to_string(),
+    }
 }
 
 impl QuillConfig {
@@ -1209,6 +1230,33 @@ main:
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
         assert!(out.contains("    org: Lorem ipsum  # string\n"));
         assert!(out.contains("    year: 0  # integer\n"));
+    }
+
+    #[test]
+    fn fill_blueprint_type_empty_substitutes_with_minimal_values() {
+        let bp = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title:    { type: string }
+    count:    { type: integer }
+    flag:     { type: boolean }
+    refs:     { type: array }
+    issued:   { type: date }
+    severity: { type: string, enum: [low, medium, high] }
+    bio:      { type: markdown }
+"#)
+        .blueprint();
+        let out = super::fill_blueprint(&bp, super::FillBehavior::TypeEmpty);
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("title: \"\"  # string\n"));
+        assert!(out.contains("count: 0  # integer\n"));
+        assert!(out.contains("flag: false  # boolean\n"));
+        assert!(out.contains("refs: []  # array<string>\n"));
+        assert!(out.contains("issued: \"\"  # date<YYYY-MM-DD>\n"));
+        assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
+        // Markdown block scalar: body line collapses to bare indent.
+        assert!(out.contains("bio: |-  # markdown\n  \n"));
     }
 
     #[test]

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -21,8 +21,9 @@
 // Re-export core types for convenience. Note: `QuillSource` is not re-exported
 // at the crate root — Quillmark consumers work with the renderable `Quill`.
 pub use quillmark_core::{
-    Artifact, Backend, Card, Diagnostic, Document, Location, OutputFormat, ParseError, ParseOutput,
-    RenderError, RenderOptions, RenderResult, RenderSession, Severity,
+    fill_blueprint, Artifact, Backend, Card, Diagnostic, Document, FillBehavior, Location,
+    OutputFormat, ParseError, ParseOutput, RenderError, RenderOptions, RenderResult, RenderSession,
+    Severity,
 };
 
 // Declare modules

--- a/crates/quillmark/tests/quiver_test.rs
+++ b/crates/quillmark/tests/quiver_test.rs
@@ -10,7 +10,9 @@
 
 #![cfg(feature = "typst")]
 
-use quillmark::{Document, OutputFormat, Quillmark, RenderError, RenderOptions};
+use quillmark::{
+    fill_blueprint, Document, FillBehavior, OutputFormat, Quillmark, RenderError, RenderOptions,
+};
 use quillmark_fixtures::{quills_path, resource_path};
 use std::fs;
 
@@ -26,65 +28,6 @@ fn quiver_quills() -> Vec<String> {
     names
 }
 
-/// Replace every `<must-fill>` sentinel in a blueprint with a type-empty
-/// value derived from the inline annotation on the same line. For enum
-/// fields the substitution uses the first enum value so validation
-/// accepts the result.
-///
-/// This mirrors the operation an MCP consumer would perform on a
-/// blueprint before shipping: walk Must Fill cells, replace them with
-/// concrete values. Here we use the leanest possible values to test
-/// that `plate.typ` accepts type-empty inputs per the authoring
-/// contract.
-fn fill_must_fill(blueprint: &str) -> String {
-    let mut out = String::new();
-    for line in blueprint.lines() {
-        out.push_str(&substitute_line(line));
-        out.push('\n');
-    }
-    out
-}
-
-fn substitute_line(line: &str) -> String {
-    // Inline form: `<key>: <must-fill>  # <annotation>`.
-    const NEEDLE: &str = ": <must-fill>  # ";
-    if let Some(idx) = line.find(NEEDLE) {
-        let prefix = &line[..idx];
-        let annotation = &line[idx + NEEDLE.len()..];
-        let value = type_empty_for(annotation);
-        return format!("{}: {}  # {}", prefix, value, annotation);
-    }
-    // Markdown block scalar form: `<indent><must-fill>` on its own line.
-    if line.trim_start() == "<must-fill>" {
-        let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
-        return indent;
-    }
-    line.to_string()
-}
-
-fn type_empty_for(annotation: &str) -> String {
-    let head = annotation.split(';').next().unwrap_or(annotation).trim();
-    if head.starts_with("array<") || head == "array" {
-        return "[]".to_string();
-    }
-    if head == "integer" || head == "number" {
-        return "0".to_string();
-    }
-    if head == "boolean" {
-        return "false".to_string();
-    }
-    if let Some(inner) = head
-        .strip_prefix("enum<")
-        .and_then(|s| s.strip_suffix('>'))
-    {
-        let first = inner.split('|').next().unwrap_or("").trim();
-        return first.to_string();
-    }
-    // string, markdown (handled via the block-scalar branch above), date,
-    // datetime, object: empty string. Date / datetime accept "" by design.
-    "\"\"".to_string()
-}
-
 #[test]
 fn every_quill_in_quiver_renders() {
     let engine = Quillmark::new();
@@ -95,7 +38,7 @@ fn every_quill_in_quiver_renders() {
             .unwrap_or_else(|e| panic!("quill '{name}' failed to load: {e:?}"));
 
         let blueprint = quill.source().config().blueprint();
-        let markdown = fill_must_fill(&blueprint);
+        let markdown = fill_blueprint(&blueprint, FillBehavior::TypeEmpty);
         let parsed = Document::from_markdown(&markdown).unwrap_or_else(|e| {
             panic!("quill '{name}' blueprint failed to parse: {e:?}\n---\n{markdown}")
         });


### PR DESCRIPTION
## Summary
This PR introduces a new `FillBehavior` enum and `fill_blueprint()` function to control how `<must-fill>` sentinels in generated blueprints are handled before parsing. This enables preview rendering of blueprints without requiring users to manually fill in all required fields.

## Key Changes
- **New `FillBehavior` enum** with two variants:
  - `Strict` (default): Leaves sentinels in place for validation to reject
  - `Preview`: Replaces sentinels with type-appropriate placeholder values

- **New `fill_blueprint()` function** that substitutes `<must-fill>` sentinels according to the specified behavior:
  - For inline scalars: Derives placeholders from type annotations (e.g., `"Lorem ipsum"` for strings, `0` for numbers, `false` for booleans, `[]` for arrays, `{}` for objects)
  - For markdown block scalars: Substitutes with a lorem ipsum paragraph
  - For enums: Uses the first variant
  - For dates/datetimes: Uses fixed ISO format values

- **Updated CLI render command** to use `FillBehavior::Preview` when falling back to the generated blueprint, allowing documents to render immediately without manual field completion

- **Comprehensive test coverage** including:
  - Identity behavior for `Strict` mode
  - Substitution of all inline sentinel types
  - Markdown block scalar handling
  - Preservation of endorsed cells (fields with defaults)
  - Typed table leaf substitution
  - Round-trip validation that filled blueprints parse correctly

- **Public API exports** of `fill_blueprint` and `FillBehavior` through `quillmark_core` and `quillmark` crates

## Implementation Details
The substitution logic preserves blueprint markdown structure and annotation comments, ensuring the output remains valid blueprint markdown. The function handles both inline scalars (with `": <must-fill>  # type"` pattern) and markdown block scalars (standalone `<must-fill>` lines with indentation).

https://claude.ai/code/session_01KMoZjWHhqrJ479PRMRRVSs