### PR TITLE
Remove APPEND_ONLY flag from empty signature fields

### DIFF
--- a/crates/backends/typst/src/sig_overlay/inject.rs
+++ b/crates/backends/typst/src/sig_overlay/inject.rs
@@ -87,8 +87,16 @@ pub(crate) fn inject(
     }
     {
         let mut form: Form<'_> = chunk.indirect(acroform_id).start::<Form>();
+        // Only `SIGNATURES_EXIST`: advertises that the document has signature
+        // fields so viewers list them in the signature panel. We deliberately
+        // do NOT set `APPEND_ONLY` — these fields are empty placeholders with
+        // no `/V` value, so nothing can be invalidated by a full save. Setting
+        // `APPEND_ONLY` makes Acrobat treat the file as signed and refuse all
+        // content edits ("This document cannot be edited because it has been
+        // signed"). Per PDF §12.7.4.5, `APPEND_ONLY` is only appropriate once a
+        // real signature value is present.
         form.fields(widget_ids.iter().copied())
-            .sig_flags(SigFlags::SIGNATURES_EXIST | SigFlags::APPEND_ONLY);
+            .sig_flags(SigFlags::SIGNATURES_EXIST);
         form.pair(Name(b"NeedAppearances"), true);
         form.finish();
     }

--- a/crates/backends/typst/src/sig_overlay/inject.rs
+++ b/crates/backends/typst/src/sig_overlay/inject.rs
@@ -87,14 +87,6 @@ pub(crate) fn inject(
     }
     {
         let mut form: Form<'_> = chunk.indirect(acroform_id).start::<Form>();
-        // Only `SIGNATURES_EXIST`: advertises that the document has signature
-        // fields so viewers list them in the signature panel. We deliberately
-        // do NOT set `APPEND_ONLY` — these fields are empty placeholders with
-        // no `/V` value, so nothing can be invalidated by a full save. Setting
-        // `APPEND_ONLY` makes Acrobat treat the file as signed and refuse all
-        // content edits ("This document cannot be edited because it has been
-        // signed"). Per PDF §12.7.4.5, `APPEND_ONLY` is only appropriate once a
-        // real signature value is present.
         form.fields(widget_ids.iter().copied())
             .sig_flags(SigFlags::SIGNATURES_EXIST);
         form.pair(Name(b"NeedAppearances"), true);

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -134,9 +134,6 @@ Page 2.
         .as_reference()
         .expect("AcroForm indirect");
     let af = doc.get_object(af_ref).unwrap().as_dict().unwrap();
-    // SigFlags must be 1 (SignaturesExist only), NOT 3. Setting bit 2
-    // (AppendOnly) would make Acrobat treat the document as signed and lock it
-    // against all content edits, even though the fields are empty placeholders.
     assert_eq!(af.get(b"SigFlags").unwrap().as_i64().unwrap(), 1);
     assert!(af.get(b"NeedAppearances").unwrap().as_bool().unwrap());
 

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -134,7 +134,10 @@ Page 2.
         .as_reference()
         .expect("AcroForm indirect");
     let af = doc.get_object(af_ref).unwrap().as_dict().unwrap();
-    assert_eq!(af.get(b"SigFlags").unwrap().as_i64().unwrap(), 3);
+    // SigFlags must be 1 (SignaturesExist only), NOT 3. Setting bit 2
+    // (AppendOnly) would make Acrobat treat the document as signed and lock it
+    // against all content edits, even though the fields are empty placeholders.
+    assert_eq!(af.get(b"SigFlags").unwrap().as_i64().unwrap(), 1);
     assert!(af.get(b"NeedAppearances").unwrap().as_bool().unwrap());
 
     let fields = af.get(b"Fields").unwrap().as_array().unwrap();


### PR DESCRIPTION
## Summary
This change removes the `APPEND_ONLY` flag from PDF signature fields that are empty placeholders. The flag is now only set to `SIGNATURES_EXIST`, which advertises that the document has signature fields without locking the document against edits.

## Key Changes
- **Removed `APPEND_ONLY` flag** from the `SigFlags` when injecting signature fields into the PDF AcroForm
- **Updated test assertion** to expect `SigFlags` value of 1 (SIGNATURES_EXIST only) instead of 3 (SIGNATURES_EXIST | APPEND_ONLY)
- **Added detailed comments** explaining why `APPEND_ONLY` should not be set for empty signature field placeholders

## Implementation Details
The `APPEND_ONLY` flag was causing Acrobat to treat documents as signed and refuse all content edits, even though the signature fields were empty placeholders with no actual signature values. Per PDF specification §12.7.4.5, `APPEND_ONLY` is only appropriate once a real signature value is present.

The `SIGNATURES_EXIST` flag alone is sufficient to advertise that the document has signature fields so viewers list them in the signature panel, without the unintended side effect of locking the document.

https://claude.ai/code/session_01L7RqCi5zQhHRZYRhyEbF1Y