### PR TITLE
Fold blueprint filling into generation; fix object/empty-container type-validity

### DIFF
--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -3,7 +3,7 @@ use crate::errors::{CliError, Result};
 use crate::output::{derive_output_path, OutputWriter};
 use clap::Parser;
 use quillmark::Document;
-use quillmark_core::{fill_blueprint, FillBehavior, OutputFormat, RenderOptions};
+use quillmark_core::{FillBehavior, OutputFormat, RenderOptions};
 use std::fs;
 use std::path::PathBuf;
 
@@ -80,9 +80,11 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
             (output, Some(markdown_path.clone()))
         } else {
-            // Generated blueprint, sentinels filled so it renders out of the box.
-            let blueprint = quill.source().config().blueprint();
-            let markdown = fill_blueprint(&blueprint, FillBehavior::Preview);
+            // Generated blueprint, Must Fill cells filled so it renders out of the box.
+            let markdown = quill
+                .source()
+                .config()
+                .blueprint_filled(FillBehavior::Preview);
 
             if args.verbose {
                 println!("Using generated blueprint from quill (fill: preview)");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,7 @@ pub mod session;
 pub use session::RenderSession;
 
 pub mod quill;
-pub use quill::{fill_blueprint, FileTreeNode, FillBehavior, QuillIgnore, QuillSource};
+pub use quill::{FileTreeNode, FillBehavior, QuillIgnore, QuillSource};
 
 pub mod value;
 pub use value::QuillValue;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -12,7 +12,7 @@ mod tree;
 mod types;
 pub(crate) mod validation;
 
-pub use blueprint::{fill_blueprint, FillBehavior};
+pub use blueprint::FillBehavior;
 pub use config::{CoercionError, QuillConfig};
 pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -40,31 +40,24 @@ use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::value::QuillValue;
 use serde_json::Value as JsonValue;
 
-/// Controls how `<must-fill>` sentinels in a generated blueprint are
-/// substituted before parsing.
+/// Controls how Must Fill cells (fields with no `default:`) are rendered in a
+/// generated blueprint. The value is chosen at generation time from the typed
+/// schema, so the placeholder never re-parses the annotation grammar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FillBehavior {
-    /// Leave sentinels in place — downstream validation reports
-    /// `validation::must_fill_sentinel`.
+    /// Render the `<must-fill>` sentinel in the value cell — downstream
+    /// validation reports `validation::must_fill_sentinel`. This is the
+    /// canonical authoring blueprint produced by [`QuillConfig::blueprint`].
     #[default]
     Strict,
-    /// Substitute with preview-friendly placeholders: `Lorem ipsum` for
+    /// Render preview-friendly placeholders: `Lorem ipsum` for
     /// strings/markdown, `0`, `false`, `[]`, `{}`, a fixed ISO
     /// date/datetime, first enum variant.
     Preview,
-    /// Substitute with the leanest type-valid values: `""`, `0`, `false`,
-    /// `[]`, first enum variant, empty markdown body. Used by the quiver
-    /// render-test to exercise plates on minimal input.
+    /// Render the leanest type-valid values: `""`, `0`, `false`, `[]`, first
+    /// enum variant, empty markdown body. Used by the quiver render-test to
+    /// exercise plates on minimal input.
     TypeEmpty,
-}
-
-/// Substitute `<must-fill>` sentinels in a generated blueprint according to
-/// `behavior`. [`FillBehavior::Strict`] returns the input unchanged.
-pub fn fill_blueprint(blueprint: &str, behavior: FillBehavior) -> String {
-    match behavior {
-        FillBehavior::Strict => blueprint.to_string(),
-        FillBehavior::Preview | FillBehavior::TypeEmpty => fill_substitute(blueprint, behavior),
-    }
 }
 
 const PREVIEW_STRING: &str = "Lorem ipsum";
@@ -72,80 +65,69 @@ const PREVIEW_MARKDOWN: &str = "Lorem ipsum dolor sit amet, consectetur adipisci
 const PREVIEW_DATE: &str = "\"2024-01-15\"";
 const PREVIEW_DATETIME: &str = "\"2024-01-15T12:00:00Z\"";
 
-fn fill_substitute(blueprint: &str, behavior: FillBehavior) -> String {
-    let mut out = String::with_capacity(blueprint.len());
-    for line in blueprint.lines() {
-        out.push_str(&substitute_line(line, behavior));
-        out.push('\n');
+/// The value cell rendered for a Must Fill scalar field under `behavior`.
+/// `Strict` keeps the `<must-fill>` sentinel; `Preview`/`TypeEmpty` substitute
+/// a type-valid placeholder so the blueprint parses (and, for `TypeEmpty`,
+/// satisfies the quill authoring contract). Markdown fields are handled
+/// separately in [`write_markdown_block`] and never reach this function.
+fn must_fill_value(field: &FieldSchema, behavior: FillBehavior) -> String {
+    if behavior == FillBehavior::Strict {
+        return MUST_FILL_SENTINEL.to_string();
     }
-    out
-}
-
-fn substitute_line(line: &str, behavior: FillBehavior) -> String {
-    const NEEDLE: &str = ": <must-fill>  # ";
-    if let Some(idx) = line.find(NEEDLE) {
-        let prefix = &line[..idx];
-        let annotation = &line[idx + NEEDLE.len()..];
-        let value = scalar_value_for(annotation, behavior);
-        return format!("{}: {}  # {}", prefix, value, annotation);
+    if field.enum_values.is_some() {
+        return first_enum(field);
     }
-    // Markdown block scalar: `<indent><must-fill>` on its own line.
-    if line.trim_start() == MUST_FILL_SENTINEL {
-        let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
-        return match behavior {
-            FillBehavior::Preview => format!("{}{}", indent, PREVIEW_MARKDOWN),
-            _ => indent,
-        };
-    }
-    line.to_string()
-}
-
-fn scalar_value_for(annotation: &str, behavior: FillBehavior) -> String {
-    let head = annotation.split(';').next().unwrap_or(annotation).trim();
-    if head.starts_with("array<") || head == "array" {
-        return "[]".to_string();
-    }
-    if head == "integer" || head == "number" {
-        return "0".to_string();
-    }
-    if head == "boolean" {
-        return "false".to_string();
-    }
-    if let Some(inner) = head
-        .strip_prefix("enum<")
-        .and_then(|s| s.strip_suffix('>'))
-    {
-        let first = inner.split('|').next().unwrap_or("").trim();
-        return first.to_string();
-    }
-    match behavior {
-        FillBehavior::Preview => {
-            if head == "object" {
-                return "{}".to_string();
-            }
-            if head.starts_with("date<") || head == "date" {
-                return PREVIEW_DATE.to_string();
-            }
-            if head.starts_with("datetime<") || head == "datetime" {
-                return PREVIEW_DATETIME.to_string();
-            }
+    match field.r#type {
+        FieldType::Array => "[]".to_string(),
+        FieldType::Integer | FieldType::Number => "0".to_string(),
+        FieldType::Boolean => "false".to_string(),
+        FieldType::Object if behavior == FillBehavior::Preview => "{}".to_string(),
+        FieldType::Date if behavior == FillBehavior::Preview => PREVIEW_DATE.to_string(),
+        FieldType::DateTime if behavior == FillBehavior::Preview => PREVIEW_DATETIME.to_string(),
+        FieldType::String | FieldType::Markdown if behavior == FillBehavior::Preview => {
             PREVIEW_STRING.to_string()
         }
-        // `""` is schema-valid for string/date/datetime/object alike.
+        // TypeEmpty for string/object/date/datetime: `""` is schema-valid for
+        // all of them.
         _ => "\"\"".to_string(),
     }
 }
 
+/// First variant of an `enum` field, rendered identically under `Preview` and
+/// `TypeEmpty`. An empty enum list yields the empty string.
+fn first_enum(field: &FieldSchema) -> String {
+    field
+        .enum_values
+        .as_ref()
+        .and_then(|v| v.first())
+        .cloned()
+        .unwrap_or_default()
+}
+
 impl QuillConfig {
-    /// Generate an annotated Markdown blueprint for this quill. See module
-    /// docs for the annotation grammar; the function is total over any valid
-    /// `QuillConfig`.
+    /// Generate the canonical annotated Markdown blueprint for this quill —
+    /// the authoring surface handed to LLMs and humans, with Must Fill cells
+    /// carrying the `<must-fill>` sentinel ([`FillBehavior::Strict`]). See
+    /// module docs for the annotation grammar; the function is total over any
+    /// valid `QuillConfig`.
     ///
     /// The result is guaranteed schema-valid and parseable (every key
     /// present, every value type-correct). It is *not* guaranteed to render
     /// — that is the quill authoring contract on `plate.typ`; see
     /// `prose/canon/BLUEPRINT.md` §Guarantees.
     pub fn blueprint(&self) -> String {
+        self.render_blueprint(FillBehavior::Strict)
+    }
+
+    /// Generate a blueprint with Must Fill cells filled per `behavior` — an
+    /// escape hatch producing a parseable (`Preview`) or render-exercising
+    /// (`TypeEmpty`) document without an authored input. `FillBehavior::Strict`
+    /// is equivalent to [`blueprint`](Self::blueprint).
+    pub fn blueprint_filled(&self, behavior: FillBehavior) -> String {
+        self.render_blueprint(behavior)
+    }
+
+    fn render_blueprint(&self, behavior: FillBehavior) -> String {
         let mut out = String::new();
         let main_desc = self
             .main
@@ -158,6 +140,7 @@ impl QuillConfig {
             &self.main,
             &format!("{}@{}", self.name, self.version),
             main_desc,
+            behavior,
         );
         if self.main.body_enabled() {
             let example = self.main.body.as_ref().and_then(|b| b.example.as_deref());
@@ -166,7 +149,7 @@ impl QuillConfig {
         }
         for card in &self.card_kinds {
             out.push('\n');
-            write_card_fence(&mut out, card);
+            write_card_fence(&mut out, card, behavior);
             if card.body_enabled() {
                 let example = card.body.as_ref().and_then(|b| b.example.as_deref());
                 let fallback = format!("Write {} body here.", card.name);
@@ -197,6 +180,7 @@ fn write_main_fence(
     card: &CardSchema,
     quill_ref: &str,
     description: Option<&str>,
+    behavior: FillBehavior,
 ) {
     out.push_str("~~~card-yaml\n");
     out.push_str("$quill: ");
@@ -209,14 +193,14 @@ fn write_main_fence(
     if let Some(desc) = description {
         write_comment(out, desc);
     }
-    write_card_fields(out, card);
+    write_card_fields(out, card, behavior);
     out.push_str("~~~\n");
 }
 
 /// Emit a composable card as a `~~~card-yaml` block declaring `$kind: <kind>`.
 /// The `composable (0..N)` role annotation and the optional description are
 /// emitted as own-line comments directly under the `$kind` header.
-fn write_card_fence(out: &mut String, card: &CardSchema) {
+fn write_card_fence(out: &mut String, card: &CardSchema, behavior: FillBehavior) {
     out.push_str("~~~card-yaml\n");
     out.push_str("$kind: ");
     out.push_str(&saphyr_emit_scalar(&JsonValue::String(card.name.clone())));
@@ -225,15 +209,15 @@ fn write_card_fence(out: &mut String, card: &CardSchema) {
     if let Some(desc) = &card.description {
         write_comment(out, desc);
     }
-    write_card_fields(out, card);
+    write_card_fields(out, card, behavior);
     out.push_str("~~~\n");
 }
 
 /// Emit a card's fields, clustered by `ui.group` and ordered by `ui.order`.
-fn write_card_fields(out: &mut String, card: &CardSchema) {
+fn write_card_fields(out: &mut String, card: &CardSchema, behavior: FillBehavior) {
     for (_, fields) in group_fields(card.fields.values()) {
         for field in fields {
-            write_field(out, field, 0);
+            write_field(out, field, 0, behavior);
         }
     }
 }
@@ -262,13 +246,13 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
     groups
 }
 
-fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
+fn write_field(out: &mut String, field: &FieldSchema, indent: usize, behavior: FillBehavior) {
     let pad = "  ".repeat(indent);
 
     // Typed table: array with a properties map directly on the field.
     if matches!(field.r#type, FieldType::Array) {
         if let Some(props) = &field.properties {
-            write_typed_table_field(out, field, props, indent);
+            write_typed_table_field(out, field, props, indent, behavior);
             return;
         }
     }
@@ -276,7 +260,7 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     // Typed dictionary: standalone object with defined properties.
     if matches!(field.r#type, FieldType::Object) {
         if let Some(props) = &field.properties {
-            write_typed_object_field(out, field, props, indent);
+            write_typed_object_field(out, field, props, indent, behavior);
             return;
         }
     }
@@ -288,12 +272,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize) {
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
         let inline = inline_annotation(field, false, field.default.is_some());
-        write_markdown_block(out, field, &pad, &inline);
+        write_markdown_block(out, field, &pad, &inline, behavior);
         return;
     }
 
     let inline = format!("  # {}", inline_annotation(field, false, field.default.is_some()));
-    let value = field_value(field);
+    let value = field_value(field, behavior);
     write_value(out, &field.name, &value, &inline, &pad);
 }
 
@@ -315,13 +299,20 @@ fn write_eg_comment(out: &mut String, field: &FieldSchema, pad: &str) {
     }
 }
 
-fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline: &str) {
+fn write_markdown_block(
+    out: &mut String,
+    field: &FieldSchema,
+    pad: &str,
+    inline: &str,
+    behavior: FillBehavior,
+) {
     out.push_str(&format!("{}{}: |-  # {}\n", pad, field.name, inline));
     let body_pad = format!("{}  ", pad);
     // Endorsed cell with content → render the default. Endorsed cell with
     // empty/absent string default → one indented blank line (the
-    // "skippable" markdown cell). Must Fill cell → the sentinel on one
-    // line inside the block scalar.
+    // "skippable" markdown cell). Must Fill cell → the sentinel (Strict),
+    // a preview paragraph (Preview), or an empty body line (TypeEmpty) on
+    // one line inside the block scalar.
     let content = field.default.as_ref().and_then(|v| match v.as_json() {
         serde_json::Value::String(s) => Some(s),
         _ => None,
@@ -336,7 +327,12 @@ fn write_markdown_block(out: &mut String, field: &FieldSchema, pad: &str, inline
             out.push_str(&format!("{}\n", body_pad));
         }
         None => {
-            out.push_str(&format!("{}{}\n", body_pad, MUST_FILL_SENTINEL));
+            let body = match behavior {
+                FillBehavior::Strict => MUST_FILL_SENTINEL,
+                FillBehavior::Preview => PREVIEW_MARKDOWN,
+                FillBehavior::TypeEmpty => "",
+            };
+            out.push_str(&format!("{}{}\n", body_pad, body));
         }
     }
 }
@@ -369,6 +365,7 @@ fn write_typed_table_field(
     field: &FieldSchema,
     item_props: &BTreeMap<String, Box<FieldSchema>>,
     indent: usize,
+    behavior: FillBehavior,
 ) {
     let pad = "  ".repeat(indent);
 
@@ -395,7 +392,7 @@ fn write_typed_table_field(
             let dash_pad = "  ".repeat(indent + 1);
             out.push_str(&format!("{}-\n", dash_pad));
             for prop in sort_props(item_props) {
-                write_field(out, prop, indent + 2);
+                write_field(out, prop, indent + 2, behavior);
             }
         }
     }
@@ -418,6 +415,7 @@ fn write_typed_object_field(
     field: &FieldSchema,
     props: &BTreeMap<String, Box<FieldSchema>>,
     indent: usize,
+    behavior: FillBehavior,
 ) {
     let pad = "  ".repeat(indent);
 
@@ -445,7 +443,7 @@ fn write_typed_object_field(
         None => {
             out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             for prop in sort_props(props) {
-                write_field(out, prop, indent + 1);
+                write_field(out, prop, indent + 1, behavior);
             }
         }
     }
@@ -497,14 +495,14 @@ enum FieldValue {
     Block(Vec<serde_json::Value>),
 }
 
-fn field_value(field: &FieldSchema) -> FieldValue {
+fn field_value(field: &FieldSchema, behavior: FillBehavior) -> FieldValue {
     if let Some(v) = field.default.as_ref() {
         return json_to_value(v.as_json());
     }
-    // No default → Must Fill cell. The sentinel sits in the value cell
-    // regardless of declared type (markdown is special-cased earlier and
-    // never reaches this code path).
-    FieldValue::Inline(MUST_FILL_SENTINEL.to_string())
+    // No default → Must Fill cell. Under `Strict` the sentinel sits in the
+    // value cell; under `Preview`/`TypeEmpty` a type-valid placeholder does
+    // (markdown is special-cased earlier and never reaches this code path).
+    FieldValue::Inline(must_fill_value(field, behavior))
 }
 
 fn json_to_value(val: &serde_json::Value) -> FieldValue {
@@ -1110,23 +1108,23 @@ card_kinds:
     }
 
     #[test]
-    fn fill_blueprint_strict_is_identity() {
-        let bp = cfg(r#"
+    fn blueprint_filled_strict_matches_blueprint() {
+        let config = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     title: { type: string }
     count: { type: integer }
-"#)
-        .blueprint();
-        let out = super::fill_blueprint(&bp, super::FillBehavior::Strict);
+"#);
+        let bp = config.blueprint();
+        let out = config.blueprint_filled(super::FillBehavior::Strict);
         assert_eq!(out, bp);
         assert!(out.contains("<must-fill>"));
     }
 
     #[test]
-    fn fill_blueprint_preview_substitutes_every_inline_sentinel() {
-        let bp = cfg(r#"
+    fn blueprint_filled_preview_substitutes_every_inline_sentinel() {
+        let out = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
@@ -1139,8 +1137,7 @@ main:
     published: { type: datetime }
     severity:  { type: string, enum: [low, medium, high] }
 "#)
-        .blueprint();
-        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        .blueprint_filled(super::FillBehavior::Preview);
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
         assert!(out.contains("title: Lorem ipsum  # string\n"));
         assert!(out.contains("count: 0  # integer\n"));
@@ -1153,22 +1150,21 @@ main:
     }
 
     #[test]
-    fn fill_blueprint_preview_substitutes_markdown_block_scalar() {
-        let bp = cfg(r#"
+    fn blueprint_filled_preview_substitutes_markdown_block_scalar() {
+        let out = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     bio: { type: markdown }
 "#)
-        .blueprint();
-        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        .blueprint_filled(super::FillBehavior::Preview);
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
         assert!(out.contains("bio: |-  # markdown\n  Lorem ipsum dolor sit amet"));
     }
 
     #[test]
-    fn fill_blueprint_preview_preserves_endorsed_cells() {
-        let bp = cfg(r#"
+    fn blueprint_filled_preview_preserves_endorsed_cells() {
+        let out = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
@@ -1176,16 +1172,15 @@ main:
     flag:   { type: boolean, default: true }
     status: { type: string, default: draft }
 "#)
-        .blueprint();
-        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        .blueprint_filled(super::FillBehavior::Preview);
         assert!(out.contains("size: 11  # number; delete-ok\n"));
         assert!(out.contains("flag: true  # boolean; delete-ok\n"));
         assert!(out.contains("status: draft  # string; delete-ok\n"));
     }
 
     #[test]
-    fn fill_blueprint_preview_substitutes_typed_table_leaves() {
-        let bp = cfg(r#"
+    fn blueprint_filled_preview_substitutes_typed_table_leaves() {
+        let out = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
@@ -1195,16 +1190,15 @@ main:
         org:  { type: string }
         year: { type: integer }
 "#)
-        .blueprint();
-        let out = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        .blueprint_filled(super::FillBehavior::Preview);
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
         assert!(out.contains("    org: Lorem ipsum  # string\n"));
         assert!(out.contains("    year: 0  # integer\n"));
     }
 
     #[test]
-    fn fill_blueprint_type_empty_substitutes_with_minimal_values() {
-        let bp = cfg(r#"
+    fn blueprint_filled_type_empty_substitutes_with_minimal_values() {
+        let out = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
@@ -1216,8 +1210,7 @@ main:
     severity: { type: string, enum: [low, medium, high] }
     bio:      { type: markdown }
 "#)
-        .blueprint();
-        let out = super::fill_blueprint(&bp, super::FillBehavior::TypeEmpty);
+        .blueprint_filled(super::FillBehavior::TypeEmpty);
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
         assert!(out.contains("title: \"\"  # string\n"));
         assert!(out.contains("count: 0  # integer\n"));
@@ -1229,8 +1222,8 @@ main:
     }
 
     #[test]
-    fn fill_blueprint_preview_round_trips_to_a_valid_document() {
-        let bp = cfg(r#"
+    fn blueprint_filled_preview_round_trips_to_a_valid_document() {
+        let filled = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
@@ -1240,8 +1233,7 @@ main:
     bio:       { type: markdown }
     issued:    { type: date }
 "#)
-        .blueprint();
-        let filled = super::fill_blueprint(&bp, super::FillBehavior::Preview);
+        .blueprint_filled(super::FillBehavior::Preview);
         let doc = Document::from_markdown(&filled)
             .unwrap_or_else(|e| panic!("filled blueprint must parse: {e:?}\n---\n{filled}"));
         let main = doc.main().payload();

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -79,16 +79,20 @@ fn must_fill_value(field: &FieldSchema, behavior: FillBehavior) -> String {
     }
     match field.r#type {
         FieldType::Array => "[]".to_string(),
+        // A bare object reaching this point would be schema-invalid (objects
+        // require a `properties` map and recurse through write_typed_object_field),
+        // so this arm is unreachable in practice. `{}` is the type-correct
+        // fallback regardless — `""` (a string) would fail object validation.
+        FieldType::Object => "{}".to_string(),
         FieldType::Integer | FieldType::Number => "0".to_string(),
         FieldType::Boolean => "false".to_string(),
-        FieldType::Object if behavior == FillBehavior::Preview => "{}".to_string(),
         FieldType::Date if behavior == FillBehavior::Preview => PREVIEW_DATE.to_string(),
         FieldType::DateTime if behavior == FillBehavior::Preview => PREVIEW_DATETIME.to_string(),
         FieldType::String | FieldType::Markdown if behavior == FillBehavior::Preview => {
             PREVIEW_STRING.to_string()
         }
-        // TypeEmpty for string/object/date/datetime: `""` is schema-valid for
-        // all of them.
+        // TypeEmpty string/date/datetime: `""` is schema-valid for all three
+        // (the validator accepts the empty string for date/datetime).
         _ => "\"\"".to_string(),
     }
 }
@@ -1219,6 +1223,41 @@ main:
         assert!(out.contains("issued: \"\"  # date<YYYY-MM-DD>\n"));
         assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
         assert!(out.contains("bio: |-  # markdown\n  \n"));
+    }
+
+    #[test]
+    fn blueprint_filled_type_empty_validates_clean() {
+        // The type-empty blueprint must be schema-*valid*, not merely
+        // parseable. Exercises every scalar Must Fill type plus the nested
+        // leaves of a typed dictionary and a typed table.
+        let config = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title:    { type: string }
+    count:    { type: integer }
+    flag:     { type: boolean }
+    refs:     { type: array }
+    issued:   { type: date }
+    severity: { type: string, enum: [low, medium, high] }
+    bio:      { type: markdown }
+    addr:
+      type: object
+      properties:
+        street: { type: string }
+        zip:    { type: integer }
+    rows:
+      type: array
+      properties:
+        org:  { type: string }
+        year: { type: integer }
+"#);
+        let filled = config.blueprint_filled(super::FillBehavior::TypeEmpty);
+        let doc = Document::from_markdown(&filled)
+            .unwrap_or_else(|e| panic!("filled blueprint must parse: {e:?}\n---\n{filled}"));
+        config.validate_document(&doc).unwrap_or_else(|errs| {
+            panic!("type-empty blueprint must validate: {errs:?}\n---\n{filled}")
+        });
     }
 
     #[test]

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -391,6 +391,11 @@ fn write_typed_table_field(
             out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             write_array_items(out, &items, &pad);
         }
+        None if item_props.is_empty() => {
+            // Row type declares no properties: emit an empty (type-valid)
+            // array rather than a null synthetic row.
+            out.push_str(&format!("{}{}: []  # {}\n", pad, field.name, inline));
+        }
         None => {
             out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             let dash_pad = "  ".repeat(indent + 1);
@@ -443,6 +448,11 @@ fn write_typed_object_field(
             for (k, v) in &map {
                 out.push_str(&format!("{}{}: {}\n", inner_pad, k, render_scalar(v)));
             }
+        }
+        None if props.is_empty() => {
+            // Empty typed object: no leaves to fill, so the value cell is an
+            // empty (type-valid) object rather than a bare null.
+            out.push_str(&format!("{}{}: {{}}  # {}\n", pad, field.name, inline));
         }
         None => {
             out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
@@ -1223,6 +1233,41 @@ main:
         assert!(out.contains("issued: \"\"  # date<YYYY-MM-DD>\n"));
         assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
         assert!(out.contains("bio: |-  # markdown\n  \n"));
+    }
+
+    #[test]
+    fn empty_typed_object_and_table_render_type_valid_and_validate() {
+        // `properties: {}` is a legal (if degenerate) schema — the rejection
+        // targets *absent* properties (freeform), not empty ones. With no
+        // leaves to fill, the value cell must be the empty container (`{}` /
+        // `[]`), not a bare null that fails the field's own validation.
+        let config = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    addr: { type: object, properties: {} }
+    rows: { type: array,  properties: {} }
+"#);
+        for behavior in [
+            super::FillBehavior::Strict,
+            super::FillBehavior::Preview,
+            super::FillBehavior::TypeEmpty,
+        ] {
+            let bp = config.blueprint_filled(behavior);
+            assert!(
+                bp.contains("addr: {}  # object\n"),
+                "{behavior:?} object cell:\n{bp}"
+            );
+            assert!(
+                bp.contains("rows: []  # array<object>\n"),
+                "{behavior:?} table cell:\n{bp}"
+            );
+            let doc = Document::from_markdown(&bp)
+                .unwrap_or_else(|e| panic!("{behavior:?} must parse: {e:?}\n---\n{bp}"));
+            config.validate_document(&doc).unwrap_or_else(|errs| {
+                panic!("{behavior:?} must validate: {errs:?}\n---\n{bp}")
+            });
+        }
     }
 
     #[test]

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -21,9 +21,8 @@
 // Re-export core types for convenience. Note: `QuillSource` is not re-exported
 // at the crate root — Quillmark consumers work with the renderable `Quill`.
 pub use quillmark_core::{
-    fill_blueprint, Artifact, Backend, Card, Diagnostic, Document, FillBehavior, Location,
-    OutputFormat, ParseError, ParseOutput, RenderError, RenderOptions, RenderResult, RenderSession,
-    Severity,
+    Artifact, Backend, Card, Diagnostic, Document, FillBehavior, Location, OutputFormat, ParseError,
+    ParseOutput, RenderError, RenderOptions, RenderResult, RenderSession, Severity,
 };
 
 // Declare modules

--- a/crates/quillmark/tests/quiver_test.rs
+++ b/crates/quillmark/tests/quiver_test.rs
@@ -11,7 +11,7 @@
 #![cfg(feature = "typst")]
 
 use quillmark::{
-    fill_blueprint, Document, FillBehavior, OutputFormat, Quillmark, RenderError, RenderOptions,
+    Document, FillBehavior, OutputFormat, Quillmark, RenderError, RenderOptions,
 };
 use quillmark_fixtures::{quills_path, resource_path};
 use std::fs;
@@ -37,8 +37,10 @@ fn every_quill_in_quiver_renders() {
             .quill_from_path(quills_path(&name))
             .unwrap_or_else(|e| panic!("quill '{name}' failed to load: {e:?}"));
 
-        let blueprint = quill.source().config().blueprint();
-        let markdown = fill_blueprint(&blueprint, FillBehavior::TypeEmpty);
+        let markdown = quill
+            .source()
+            .config()
+            .blueprint_filled(FillBehavior::TypeEmpty);
         let parsed = Document::from_markdown(&markdown).unwrap_or_else(|e| {
             panic!("quill '{name}' blueprint failed to parse: {e:?}\n---\n{markdown}")
         });

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -342,14 +342,15 @@ with a typed value.
 packages, which `blueprint()` does not control. That is a separate
 **quill authoring contract**:
 
-> A quill's `plate.typ` MUST render the quill's own blueprint — with all
-> `<must-fill>` cells replaced by type-empty values of the declared
-> type — to a successful (non-error) output.
+> A quill's `plate.typ` MUST render the quill's own blueprint — generated
+> with Must Fill cells filled by type-empty values of the declared type
+> (`blueprint_filled(FillBehavior::TypeEmpty)`) — to a successful
+> (non-error) output.
 
-The blueprint, after sentinel substitution, is by construction the
-*type-minimal valid input* — the worst-case-but-valid document. A plate
-that renders it has shown it degrades gracefully on every type-valid
-input shape. The contract requires:
+The type-empty blueprint is by construction the *type-minimal valid
+input* — the worst-case-but-valid document. A plate that renders it has
+shown it degrades gracefully on every type-valid input shape. The
+contract requires:
 
 - Templates treat type-empty values (`""`, `0`, `false`, `[]`, empty
   markdown body) as valid *present* input — read via `data.field`,
@@ -361,16 +362,29 @@ input shape. The contract requires:
   meaningful output." An empty-string title is a blank title — that is
   acceptable.
 
-The contract is enforced by a fixture test that fills sentinels with
-type-empty values, then renders every bundled quill's blueprint and
-asserts success
+The contract is enforced by a fixture test that generates each bundled
+quill's blueprint with type-empty fill, renders it, and asserts success
 (`crates/quillmark/tests/quiver_test.rs::every_quill_in_quiver_renders`).
+
+## Filled blueprints
+
+`blueprint()` emits the canonical authoring surface with `<must-fill>`
+sentinels. `QuillConfig::blueprint_filled(behavior)` is an escape hatch
+that fills Must Fill cells at generation time — from the typed schema, so
+no value re-parses the annotation grammar — producing a compile-able
+document without an authored input:
+
+| `FillBehavior` | Must Fill value | Used by |
+|---|---|---|
+| `Strict` | `<must-fill>` sentinel (identical to `blueprint()`) | authoring surface |
+| `Preview` | readable placeholders (`Lorem ipsum`, `0`, fixed ISO date, …) | CLI `render` with no input file |
+| `TypeEmpty` | leanest type-valid values (`""`, `0`, `false`, `[]`, first enum) | quiver authoring-contract test |
 
 ## Bindings surface
 
 | Binding | Accessor |
 |---|---|
-| Rust | `QuillConfig::blueprint() -> String` |
+| Rust | `QuillConfig::blueprint() -> String` (+ `blueprint_filled(behavior)`) |
 | Wasm | `Quill.blueprint` getter |
 | Python | `Quill.blueprint` property |
 | CLI | `quillmark blueprint <QUILL_PATH> [-o <FILE>]` |


### PR DESCRIPTION
## Summary

Replaces the post-hoc `fill_blueprint` string-transform with a `FillBehavior` threaded through blueprint generation, and fixes two type-validity bugs surfaced along the way.

The old transform scanned the generated blueprint text, found `: <must-fill>  # `, and **re-parsed the field type back out of the annotation comment** (`array<…>`, `enum<…>`, `date<…>`) to pick a substitute value. Choosing the value at generation time — where the typed `FieldType` is still in hand — removes that round trip and the fragile coupling to the annotation grammar. Since nothing fills a blueprint it didn't generate (the transform's only unique capability was unused), folding it in loses nothing.

## API changes

- **Removed** the public `fill_blueprint()` function and its internal helpers (`fill_substitute`, `substitute_line`, `scalar_value_for`), plus the re-exports from `quillmark_core` and `quillmark`.
- **`QuillConfig::blueprint()`** is unchanged — the canonical authoring surface with `<must-fill>` sentinels (`FillBehavior::Strict`).
- **`QuillConfig::blueprint_filled(behavior)`** is new — the escape hatch that fills Must Fill cells per `FillBehavior` to produce a compile-able document without an authored input (`Preview` for CLI render, `TypeEmpty` for the quiver contract test).

`FillBehavior` now drives generation directly rather than a post-processing pass. Output is byte-for-byte identical to the old transform; the existing fill tests (renamed `blueprint_filled_*`) assert the same strings.

## Correctness fixes

1. **Object Must Fill value was type-incorrect.** `TypeEmpty` filled an object cell with `""` (a string), which fails object validation. Now `{}`. In practice the arm is unreachable — a bare `type: object` (no `properties`) is a rejected schema, so objects always recurse through `write_typed_object_field` — but `{}` is the type-correct fallback rather than a latent landmine.

2. **Empty typed object/table emitted `null`.** `properties: {}` is a *legal* schema (the freeform rejection targets *absent* properties, not empty ones), but the Must Fill branch emitted a bare key (`addr:`) with no children → parsed as `null` → `TypeMismatch`, violating the `blueprint()` type-validity guarantee. Now emits the empty container (`{}` for object, `[]` for table), mirroring the Endorsed empty-default branch.

## Tests & docs

- Renamed and re-pointed the fill tests to `blueprint_filled_*`.
- Added `blueprint_filled_type_empty_validates_clean` — validates (not just parses) the `TypeEmpty` blueprint across every scalar type plus typed-dict and typed-table nested leaves.
- Added `empty_typed_object_and_table_render_type_valid_and_validate` — asserts exact output and clean validation across all three behaviors.
- Updated the quill authoring contract wording and added a "Filled blueprints" section in `prose/canon/BLUEPRINT.md`.

All 513 core tests, the quiver render-contract test, and the full workspace build are green.

https://claude.ai/code/session_01HL9FgqSwvSD8Mc5CJ6yfsF