### PR TITLE
Automate changelog management in release workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -85,6 +85,38 @@ jobs:
             --no-confirm \
             --execute
 
+      - name: Seed changelog entry
+        run: |
+          VERSION="${{ steps.version.outputs.next }}"
+          DATE=$(date +%Y-%m-%d)
+
+          # Changelog baseline: latest strict semver X.Y.Z tag (optional v
+          # prefix). Pre-release tags (e.g. v0.85.0-rc.1) are skipped so the
+          # commit range covers everything since the last final release.
+          LAST=$(git tag -l --sort=-v:refname \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+
+          # Build the seed section: a commit list maintainers refine in the PR.
+          {
+            echo "## v${VERSION} - ${DATE}"
+            echo
+            if [ -n "$LAST" ]; then
+              git log --no-merges --pretty='- %s' "${LAST}..HEAD"
+            else
+              git log --no-merges --pretty='- %s'
+            fi
+            echo
+          } > entry.md
+
+          # Splice the new section in directly after the "# Changelog" title.
+          [ -f CHANGELOG.md ] || printf '# Changelog\n\n' > CHANGELOG.md
+          { head -n1 CHANGELOG.md; echo; cat entry.md; tail -n +2 CHANGELOG.md; } \
+            > CHANGELOG.new && mv CHANGELOG.new CHANGELOG.md
+          rm entry.md
+
+          echo "Seeded changelog entry for v${VERSION}:"
+          cat CHANGELOG.md
+
       - name: Push branch and open PR
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -101,6 +133,10 @@ jobs:
 
           gh pr create \
             --title "chore(release): v${VERSION}" \
-            --body "Automated version bump to \`v${VERSION}\`. Merging this PR will tag and publish the release." \
+            --body "Automated version bump to \`v${VERSION}\`.
+
+          **Before merging:** review and edit the \`v${VERSION}\` section at the top of \`CHANGELOG.md\` on this branch — it is seeded with the raw commit list. The final section becomes the GitHub Release notes.
+
+          Merging this PR will tag and publish the release." \
             --base main \
             --head "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push origin "v${VERSION}"
 
+      - name: Extract release notes
+        run: |
+          VERSION="${{ steps.version.outputs.next }}"
+          # Pull the section for this version out of CHANGELOG.md: everything
+          # between its "## v<version>" heading and the next "## " heading.
+          awk -v v="## v${VERSION}" \
+            '$0 ~ "^"v {f=1; next} /^## / && f {exit} f {print}' \
+            CHANGELOG.md > notes.md || true
+          # Fall back to a generic note if the section is missing or empty
+          # (e.g. an RC with no curated changelog).
+          [ -s notes.md ] || echo "Release v${VERSION}" > notes.md
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
@@ -62,12 +74,12 @@ jobs:
           if [[ "$VERSION" == *-* ]]; then
             gh release create "v${VERSION}" \
               --title "v${VERSION}" \
-              --notes "Pre-release v${VERSION}" \
+              --notes-file notes.md \
               --prerelease
           else
             gh release create "v${VERSION}" \
               --title "v${VERSION}" \
-              --notes "Release v${VERSION}" \
+              --notes-file notes.md \
               --latest
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog


### PR DESCRIPTION
## Summary
This change automates changelog management in the release process by seeding changelog entries during release preparation and extracting them for GitHub Release notes during the actual release.

## Key Changes

- **Release Preparation (`release-prepare.yml`)**
  - Added "Seed changelog entry" step that generates a new changelog section with the version, date, and commit list since the last release
  - Automatically inserts the seeded section into `CHANGELOG.md` right after the "# Changelog" title
  - Updated PR description to prompt maintainers to review and refine the changelog entry before merging

- **Release Publishing (`release.yml`)**
  - Added "Extract release notes" step that parses `CHANGELOG.md` to pull the curated changelog section for the version being released
  - Falls back to a generic note if no curated section exists (useful for pre-releases)
  - Updated GitHub Release creation to use the extracted notes instead of generic hardcoded messages

- **Added `CHANGELOG.md`**
  - Created initial changelog file with standard header

## Implementation Details

The changelog seeding uses `git log` to extract commit messages since the last strict semver tag (skipping pre-release tags), providing maintainers with a raw list to refine. The extraction step uses `awk` to parse the markdown structure, making it robust to varying changelog formats. This approach keeps the changelog as the single source of truth for release notes while maintaining a smooth maintainer workflow.

https://claude.ai/code/session_013UgDHWUEMm9MeDoMpRfdSC