### PR TITLE
docs: reframe Quill.yaml default/example around author intent

### DIFF
--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -154,6 +154,11 @@ impl FieldType {
 
 /// Schema definition for a template field.
 ///
+/// `default` and `example` are both type-valid values with opposite intent:
+/// `default` is the value most authors want (interpolated when the field is
+/// omitted), while `example` matches the desired type and shape but is not
+/// the value most authors want (it documents shape only, never rendering).
+///
 /// A field's *cell* is determined by `default`: a field with a `default:`
 /// is **Endorsed** (the rendered value is shippable as-is), while a field
 /// without a `default:` is **Must Fill** (the blueprint carries a
@@ -168,9 +173,12 @@ pub struct FieldSchema {
     pub r#type: FieldType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// The value most authors want; interpolated when the field is omitted.
+    /// Its presence makes the field Endorsed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<QuillValue>,
-    /// Single value; used as template placeholder.
+    /// A value matching the desired type and shape but not the value most
+    /// authors want; documents shape only and never renders as the value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<QuillValue>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/docs/format-designer/creating-quills.md
+++ b/docs/format-designer/creating-quills.md
@@ -39,6 +39,11 @@ main:
 
 `name`, `backend`, `version`, and `description` are all required. `name` must be `snake_case`. Define your document's expected root-block fields under `main.fields`. Each field has a `type`, optional `default`, `description`, and validation constraints. Use `integer` for whole numbers only and `number` for values that may include decimals. For the full list of field types, UI hints, typed arrays, and enum constraints, see the [Quill.yaml Reference](quill-yaml-reference.md).
 
+When choosing field values, keep `default` and `example` distinct by author intent:
+
+- **`default`** is the value the *majority of authors want*. Declaring it lets authors omit the field entirely — the default is interpolated for them — so reach for a `default` whenever one value is the right answer most of the time (including a type-empty value like `""`, `[]`, `false`, or `0` when "blank" is an acceptable ship).
+- **`example`** matches the *type and shape* of what the author wants but is *not* the value they'd want most of the time. It documents the expected shape only — surfacing in the blueprint's `# e.g.` line — and never renders as the value. Use it when there is no single right answer but you still want to show authors what a well-formed value looks like.
+
 ## 3. Write `plate.typ`
 
 Your first plate template:

--- a/docs/format-designer/quill-yaml-reference.md
+++ b/docs/format-designer/quill-yaml-reference.md
@@ -79,8 +79,8 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | any               | no       | Default value when not provided. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; delete-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::must_fill_absent` if the field is absent at validate time. |
-| `example`     | any               | no       | Illustrative value surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md) for documentation and LLM authoring |
+| `default`     | any               | no       | The value the **majority of authors want**. When the field is omitted, the default is interpolated. **Declaring `default` makes the field Endorsed**: the blueprint renders the default plus a `; delete-ok` tag. Omitting `default` makes the field **Must Fill**: the blueprint renders the `<must-fill>` sentinel and validation fires `validation::must_fill_absent` if the field is absent at validate time. |
+| `example`     | any               | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only — surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md)'s `# e.g.` line for documentation and LLM authoring, never rendered as the value. |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
 | `properties`  | object            | no       | Nested field schemas (for `array` typed-table rows or `object` typed dictionaries) |

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -134,9 +134,9 @@ The rendered value follows a single cascade keyed on the cell:
 
 Examples never become the rendered value, regardless of cell or type —
 this holds uniformly for scalars, arrays, typed tables, and typed
-dictionaries. Examples are inherently illustrative and unsafe to ship;
-they always surface in the `# e.g.` leading line while the value follows
-the cascade above.
+dictionaries. An example matches the *shape* of the desired value but is
+not the value most authors want, so it always surfaces in the `# e.g.`
+leading line while the value follows the cascade above.
 
 All fields render as **live YAML** — no commented-out fields. The
 sentinel in the value cell is the sole "must fill" signal: a reader's
@@ -407,15 +407,19 @@ fixture.
 When designing a `Quill.yaml` schema, choose between Must Fill and
 Endorsed per field:
 
-- **Declare `default:`** when a value (including a type-empty value like
-  `""`, `[]`, `false`, or `0`) is acceptable to ship as-is. The field
-  becomes Endorsed and the blueprint carries `; delete-ok`.
-- **Omit `default:`** when the author, LLM, or user must supply a value
-  before shipping. The field becomes Must Fill and the blueprint carries
-  the `<must-fill>` sentinel.
-- **Use `example:`** for illustrative reference values. `example:` is
-  orthogonal to the cell decision — it appears in the leading `# e.g.`
-  line for any cell, never rendering as the value.
+- **Declare `default:`** when the value is what the *majority* of authors
+  want — including a type-empty value like `""`, `[]`, `false`, or `0`.
+  Most authors want it, so the field can be omitted and the default is
+  interpolated for them. The field becomes Endorsed and the blueprint
+  carries `; delete-ok`.
+- **Omit `default:`** when there is no value most authors want — the
+  author, LLM, or user must supply one before shipping. The field becomes
+  Must Fill and the blueprint carries the `<must-fill>` sentinel.
+- **Use `example:`** when a value matches the semantic and type shape of
+  what the author wants but is *not* the value they'd want most of the
+  time. It documents shape, not the choice — orthogonal to the cell
+  decision, it appears in the leading `# e.g.` line for any cell and never
+  renders as the value.
 
 This is documentation, not enforcement.
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -81,16 +81,33 @@ For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits 
 
 Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`.
 
+### `default` and `example`
+
+`default` and `example` are both type- and shape-valid values, but they
+encode opposite author intents:
+
+- **`default`** is the value the *majority* of authors want. Because most
+  authors want it, the field can be omitted entirely: at render time the
+  default is interpolated for any field the document leaves out (an
+  authored value always wins — `apply_defaults` in
+  `quill/orchestration`). A field with a `default:` is **Endorsed** — the
+  rendered value is shippable as-is — and the blueprint tags it
+  `; delete-ok`. Type-empty defaults (`default: ""`, `[]`, `false`, `0`)
+  are the canonical way to mark a "skippable" cell.
+- **`example`** matches the semantic and type *shape* of the desired
+  value but is *not* the value most authors want. It documents shape, not
+  the choice — so it never becomes the rendered value; it only surfaces in
+  the blueprint's `# e.g.` line.
+
 ### Must-Fill vs. Endorsed fields
 
-A field is **Must Fill** when no `default:` is declared; the schema author
-expects the LLM or user to supply a value before shipping. A missing
-Must Fill field at validate time fires `validation::must_fill_absent`.
+A field is **Must Fill** when no `default:` is declared — there is no value
+most authors want, so the LLM or user must supply one before shipping. A
+missing Must Fill field at validate time fires
+`validation::must_fill_absent`.
 
 A field is **Endorsed** when `default:` is declared; the rendered default
-is shippable as-is (the author can keep or override it). Endorsed
-defaults include type-empty values — `default: ""`, `default: []`,
-`default: false`, `default: 0` — which standardize the "skippable" cell.
+is shippable as-is (the author can keep or override it).
 
 There is no separate `required:` axis; the presence or absence of
 `default:` is the sole author choice per field. See

--- a/prose/proposals/blueprint-example-split.md
+++ b/prose/proposals/blueprint-example-split.md
@@ -1,0 +1,122 @@
+# Blueprint / Example — Two Named Reference Documents
+
+> **Motivation**: `blueprint_filled(FillBehavior)` exposes an internal fill
+> strategy as a public enum, overloading what a "blueprint" *is*. Split the
+> public surface into two intent-named reference documents — `blueprint`
+> (canonical `<must-fill>`) and `example` (illustrative) — demote the fill
+> strategy to an internal detail, and retire the pure-zero blueprint mode as
+> a dead branch.
+
+## TL;DR
+
+A blueprint is **always** the canonical `<must-fill>` authoring document —
+no modes. Add a second named output, `example`, built from the field
+`example:` values (falling back to the zero value). Demote `FillBehavior`
+from a public parameter to an internal `FillSource` strategy. The pure-zero
+mode (today's `TypeEmpty` blueprint) is removed: its only consumer — the
+quiver authoring contract — instead zero-filled-renders an empty document
+(see [zero-filled-render.md](zero-filled-render.md)).
+
+Pre-1.0; not yet implemented. When built, graduates into
+[BLUEPRINT.md](../canon/BLUEPRINT.md).
+
+## Background
+
+The current public surface (in `crates/core/src/quill/`) is `blueprint()`
+plus `blueprint_filled(FillBehavior)` with three variants:
+
+| `FillBehavior` | Fills Must Fill cells with | Consumer |
+|---|---|---|
+| `Strict` | `<must-fill>` sentinel (identical to `blueprint()`) | authoring surface |
+| `Preview` | the field's `example:`, else the zero value | CLI `render` with no input file |
+| `TypeEmpty` | zero value everywhere (`""`, `0`, `false`, `[]`, `{}`, first enum) | quiver authoring-contract test |
+
+Two problems:
+
+- **"Blueprint" is overloaded.** A consumer must understand three fill
+  strategies to know what a blueprint even is. The canonical authoring
+  surface and a populated sample are not the same artifact, yet both are
+  "a blueprint."
+- **It leaks an internal concern as a public flavor.** `TypeEmpty` is the
+  render *floor* (the type-minimal valid input), not a document anyone
+  authors from. Exposing it as a blueprint variant conflates "document I
+  fill in" with "minimal render input."
+
+## Two named reference documents
+
+| Output | Intent | Fill source | Sentinels? |
+|---|---|---|---|
+| `blueprint` | *"give me the form to fill"* | `<must-fill>` | yes |
+| `example` | *"show me a filled-out one"* | example-else-zero | no |
+
+- `default:` always wins when present, in both outputs (an Endorsed field
+  renders its default, never a sentinel or example).
+- `example` is example-*else*-zero: a field without an `example:` renders at
+  its zero value. So it is "examples where defined, blank otherwise" — the
+  most illustrative document available, not a fully populated one. State
+  this in the contract so no one expects every field filled.
+- **Naming.** `example()` collides with the `example:` field-schema
+  property. Consider `sample`, `example_document`, or `demo` for the path.
+  The concept is settled; the label is open.
+
+This is the same axis canonized at the field level — placeholder-to-fill
+(`<must-fill>` / no `default`) vs. illustrative value (`example:`) — lifted
+to the document level.
+
+## Internal unification — one emitter, a `FillSource` strategy
+
+The emitter already walks the schema and pulls a per-field value from a
+source. Demote `FillBehavior` to an **internal** `FillSource`:
+
+- `Sentinel` → `blueprint`
+- `ExampleElseZero` → `example`
+
+`default:` wins across both. The per-field **zero value** (`must_fill_value`
+/ `first_enum`, factored into a `QuillValue` producer) is a shared leaf
+utility — called by the `ExampleElseZero` fallback here *and* by zero-filled
+render. The two proposals share one zero-value producer; this is the
+"unified internally" goal.
+
+## The dead branch: pure-zero blueprint
+
+`blueprint_filled(TypeEmpty)` emits a document with every Must Fill field at
+its zero value. Its only caller is the quiver authoring-contract test
+(`every_quill_in_quiver_renders`). Once zero-filled render exists, this mode
+has no reason to live:
+
+- The contract — *"the plate renders type-minimal valid input"* — is more
+  directly expressed as **zero-filled render of an empty document** for each
+  quill. No blueprint string is generated or re-parsed.
+- The canonical blueprint can't serve as that fixture anyway: its
+  `<must-fill>` sentinels are **malformed** under zero-filled render (they
+  error), so "render the blueprint" was never the literal test.
+
+So the blueprint emitter keeps exactly two fill sources — `Sentinel` and
+`ExampleElseZero`. The pure-`Zero` *mode* leaves blueprint logic entirely;
+the zero *value* survives as the example fallback and the render floor.
+
+`Preview` likewise stops being a blueprint mode: "render with no input"
+becomes "render the `example` document" (or a zero-filled render of an empty
+doc, when blank is wanted).
+
+## Bindings surface
+
+Replace the Rust `blueprint_filled(behavior)` escape hatch with `blueprint()`
++ `example()` (or the chosen name). Wasm/Python/CLI already expose only
+`blueprint`; add the example accessor. CLI `render` with no input renders the
+`example` document.
+
+## Rejected / open
+
+- **Keep `FillBehavior` public** — rejected. It is an internal strategy; the
+  public surface should name *intents* (blueprint vs. example), not
+  strategies.
+- **Open** — the second output's name (collision with the `example:` field
+  property).
+
+## Graduation
+
+Fold into [BLUEPRINT.md](../canon/BLUEPRINT.md): a "Two reference documents"
+section replaces "Filled blueprints" / the `FillBehavior` table, and the
+zero-value producer cross-links to the zero-filled-render section. Delete
+this proposal.

--- a/prose/proposals/non-strict-render.md
+++ b/prose/proposals/non-strict-render.md
@@ -1,0 +1,179 @@
+# Non-Strict Render & the Two Authoring Interfaces
+
+> **Motivation**: a live-editing web app wants documents to preview and
+> export while still in progress — without forcing authors to fill every
+> unendorsed field or writing boilerplate to satisfy validation. At the
+> same time, LLM/MCP authoring must stay held to a completeness bar. This
+> proposal adds a non-strict *render* path and pins down how the two
+> interfaces — UI form and MCP/LLM — share one document model without
+> either one weakening the other.
+
+## TL;DR
+
+Render mode and validation verdict are **orthogonal**. Keep one validity
+notion — strict validation answers *"is this document complete?"* — and
+add a non-strict **render** path that type-empty-interpolates absent
+fields into the plate-JSON projection only, never into the persisted
+document. UI forms render non-strict and persist the sparse authored
+truth; MCP/LLM `create_document` gates on strict. The same strict verdict
+applies uniformly to documents of either origin.
+
+Pre-1.0; not yet implemented. When built, the conceptual model graduates
+into [SCHEMAS.md](../canon/SCHEMAS.md) with a pointer from
+[BLUEPRINT.md](../canon/BLUEPRINT.md).
+
+## Background
+
+Today the render path (`compile_data` in `crates/quillmark/src/orchestration/`)
+runs `coerce_and_validate`, which **hard-fails** on `must_fill_absent`: a
+document that omits any field without a `default:` cannot render at all.
+That is correct for a finished-document pipeline but wrong for a live form
+editor, where the natural state of a document is *in progress*.
+
+Two facts already in the codebase make the fix small:
+
+- The quill **authoring contract** guarantees every quill renders its own
+  type-empty blueprint (`blueprint_filled(FillBehavior::TypeEmpty)`,
+  enforced by `every_quill_in_quiver_renders`). Type-empty input is the
+  type-minimal valid document — the worst-case-but-renderable shape.
+- `apply_defaults` already builds a throwaway `final_doc` for the plate
+  JSON and does not persist it. The render projection is already the right
+  place to inject values that never touch storage.
+
+## The orthogonality principle
+
+Two questions that are easy to conflate, kept separate:
+
+| Question | Answered by | Always succeeds? |
+|---|---|---|
+| *Show me something now* | **render mode** (strict / non-strict) | non-strict: yes |
+| *Is this document complete?* | **strict validation** | no — that's the point |
+
+A document can be renderable (non-strict) and incomplete (fails strict) at
+the same time. "Always compiles" is a render guarantee; "always valid" is
+a validation verdict. They are not the same claim, and the design depends
+on not fusing them.
+
+## Strict validation — the single completeness verdict
+
+Strict validation checks **structural completeness**, uniformly regardless
+of who authored the document:
+
+- every Must Fill field (no `default:`) is **present**;
+- no `<must-fill>` sentinel survives;
+- every value coerces to its declared type.
+
+It does **not** check non-emptiness or semantics. A present `""` for a
+Must Fill string passes strict. Semantic quality is steered by the
+blueprint's `# e.g.` example hints (see the `default`/`example` framing in
+[SCHEMAS.md](../canon/SCHEMAS.md)), not by the validator.
+
+Consequence worth internalizing: a document in which **every** field is
+present at its type-empty value (`""`, `0`, `false`, `[]`, `{}`,
+first-enum) *passes strict* — present, non-sentinel, type-valid. A
+**sparse** document (Must Fill fields absent) *fails strict*. The
+difference between the two is exactly presence, which is what strict keys
+on.
+
+## Non-strict render — type-empty fill in the projection only
+
+A non-strict render fills every absent field with its **type-empty**
+value, in the plate-JSON projection that feeds the backend — and nowhere
+else.
+
+- Type-empty is honestly blank for almost every type: `""` (string,
+  markdown, **date**, **datetime** — the validator accepts the empty
+  string for both), `0`, `false`, `[]`, `{}`.
+- The lone seam is `enum`: there is no empty enum member, so type-empty is
+  `first_enum` — a real, meaningful variant. Because the fill lives only
+  in the ephemeral projection, this appears **only in preview pixels**: the
+  persisted document keeps the enum absent, and a form reload shows the
+  dropdown unselected. The "looks-chosen-but-wasn't" value never hardens
+  into storage or form state.
+- **Non-persist invariant.** The type-empty fill must never be written
+  back to the document. Type-empty is *indistinguishable from
+  authored-empty*; persisting it collapses "field absent (untouched)" and
+  "field present and empty" into one and destroys `must_fill_absent`
+  forever (it keys on absence). The fill is part of the render, never part
+  of the document.
+
+## The two interfaces
+
+Both produce documents in one shared model; they differ only in what they
+gate on.
+
+### UI form (non-strict)
+
+- Renders non-strict for **both** preview and artifact export (PDF/SVG/PNG)
+  — a blank form always produces a renderable result, no boilerplate.
+- Emits **sparse** documents: an empty text box / unselected dropdown is
+  *omitted* (treated as absent), so form-completeness and schema-presence
+  coincide. The form's existing `FormFieldSource::Missing` / `Default`
+  state remains the human-facing completeness signal — the analog of the
+  `<must-fill>` sentinel for LLMs.
+- **Persists the sparse authored truth**, never the fill.
+- Strict validation is available as the *"is it done?"* gate, wired to the
+  actions that need completeness (submit / publish), not to preview or
+  draft export.
+
+### MCP / LLM (strict)
+
+- `create_document(markdown)` **gates on strict validation**. The LLM is
+  handed the blueprint and must return a complete document: every Must
+  Fill field present, no surviving `<must-fill>` sentinel.
+- Strict enforces *structural* completeness; the blueprint's `# e.g.`
+  hints carry the *semantic* guidance. "The LLM writes a semantically
+  valid document" is guaranteed by **blueprint guidance + strict structural
+  check together**, not by strict alone.
+
+### Mixing the two
+
+Both interfaces write into the same document model, so a document's strict
+verdict is a uniform signal of "came from a finished process": LLM docs
+pass, in-progress form docs fail, regardless of origin. No two-class
+document semantics.
+
+## Rejected alternatives
+
+- **Option X — form populates type-empty at persist time** (document is
+  always complete-and-valid). Rejected: it makes `must_fill_absent`
+  vacuous (every key always present), bakes the enum first-variant value
+  into storage as a silent fake choice, and creates two-class document
+  semantics in a mixed-author ecosystem — which this project *is*, by
+  design, because blueprints exist precisely so LLMs author these
+  documents too.
+- **Example-fallback in non-strict render** (fill absent fields from
+  `example:` instead of type-empty). Rejected: an example is realistic but
+  *not the value most authors want* (the canonized framing), so it
+  camouflages incompleteness and risks leaking placeholder/PII content
+  through a complete-looking export. Type-empty is honestly blank
+  everywhere except enum. `example` keeps its existing home — blueprint
+  `FillBehavior::Preview` for LLM/no-input *generation*, where a realistic
+  shape genuinely helps — and does not follow onto the form render path.
+
+## Implementation sketch
+
+1. **Type-empty value producer.** Factor the type-empty logic out of the
+   blueprint string emitter (`must_fill_value` / `first_enum` in
+   `crates/core/src/quill/`) into a per-field `QuillValue` producer shared
+   by blueprint emission and the render path — one source of truth for
+   "the empty value for this field."
+2. **Non-strict render mode.** On the render path
+   (`crates/quillmark/src/orchestration/`), add a mode that, after
+   coercion, interpolates type-empty `QuillValue`s for absent fields
+   (mirroring `apply_defaults`, "authored value wins") and demotes
+   `must_fill_absent` from a hard error to a warning. The fill goes into
+   the `to_plate_json` projection only.
+3. **Strict path unchanged.** `coerce_and_validate` keeps hard-failing on
+   `must_fill_absent`; MCP `create_document` uses it as today.
+4. **Surface.** Expose mode selection on the render bindings (Rust / Wasm /
+   Python / CLI) and document that non-strict output is preview/export, not
+   a completeness assertion.
+
+## Graduation
+
+Once implemented and tested, fold the conceptual model into
+[SCHEMAS.md](../canon/SCHEMAS.md) as a "Strict vs. non-strict" section
+(render mode ⊥ validation verdict; the two interfaces), add a one-line
+pointer from [BLUEPRINT.md](../canon/BLUEPRINT.md)'s filled-blueprints
+section, and delete this proposal.

--- a/prose/proposals/zero-filled-render.md
+++ b/prose/proposals/zero-filled-render.md
@@ -2,21 +2,24 @@
 
 > **Motivation**: a live-editing web app wants documents to preview and
 > export while still in progress — without forcing authors to fill every
-> unendorsed field or writing boilerplate to satisfy validation. At the
-> same time, LLM/MCP authoring must stay held to a completeness bar. This
+> unendorsed field or writing boilerplate to satisfy validation. The same
+> leniency should serve LLM/MCP authoring, with one guard: a copied
+> `<must-fill>` placeholder is an accident and must be rejected. This
 > proposal adds a **zero-filled** *render* path and pins down how the two
-> interfaces — UI form and MCP/LLM — share one document model without
-> either one weakening the other.
+> interfaces — UI form and MCP/LLM — share one document model and one
+> validation behavior.
 
 ## TL;DR
 
-Render fill and validation verdict are **orthogonal**. Keep one validity
-notion — strict validation answers *"is this document complete?"* — and
-add a **zero-filled render** path that fills each absent field with its
-type-empty (zero) value, in the plate-JSON projection only, never in the
-persisted document. UI forms use zero-filled render and persist the sparse
-authored truth; MCP/LLM `create_document` gates on strict validation. The
-same strict verdict applies uniformly to documents of either origin.
+Render fill and completeness verdict are **orthogonal**. Both interfaces —
+UI form and MCP/LLM — use **zero-filled render**: each absent field is
+filled with its type-empty (zero) value, in the plate-JSON projection only,
+never in the persisted document. A document that is merely *incomplete*
+(Must Fill fields absent) renders fine; a *malformed* one — a value that
+won't coerce, or a surviving `<must-fill>` sentinel — always errors. Strict
+completeness ("every Must Fill present") is a separate **queryable
+verdict**, not a creation gate, answered identically for documents of
+either origin.
 
 Pre-1.0; not yet implemented. When built, the conceptual model graduates
 into [SCHEMAS.md](../canon/SCHEMAS.md) with a pointer from
@@ -28,7 +31,8 @@ Today the render path (`compile_data` in `crates/quillmark/src/orchestration/`)
 runs `coerce_and_validate`, which **hard-fails** on `must_fill_absent`: a
 document that omits any field without a `default:` cannot render at all.
 That is correct for a finished-document pipeline but wrong for a live form
-editor, where the natural state of a document is *in progress*.
+editor — and, as it turns out, wrong for LLM drafting too — where the
+natural state of a document is *in progress*.
 
 Two facts already in the codebase make the fix small:
 
@@ -44,37 +48,53 @@ Two facts already in the codebase make the fix small:
 
 Two questions that are easy to conflate, kept separate:
 
-| Question | Answered by | Always succeeds? |
+| Question | Mechanism | Fails when |
 |---|---|---|
-| *Show me something now* | **render fill** (plain / zero-filled) | zero-filled: yes |
-| *Is this document complete?* | **strict validation** | no — that's the point |
+| *Show me something now* | **zero-filled render** | the document is **malformed** — a value that won't coerce, or a surviving `<must-fill>` sentinel. Never merely because it is incomplete. |
+| *Is this document complete?* | **strict completeness check** (a query) | any Must Fill field is **absent** |
 
-A document can be renderable (zero-filled) and incomplete (fails strict)
-at the same time. "Always compiles" is a render guarantee; "always valid"
-is a validation verdict. They are not the same claim, and the design
-depends on not fusing them. Naming the render by its *fill* — not by a
-validation posture — keeps the two axes from collapsing into one.
+A document can be renderable (zero-filled) and incomplete (the completeness
+query says "not done") at the same time. "Always compiles" is a render
+guarantee; "complete" is a separate verdict. Naming the render by its
+*fill* — not by a validation posture — keeps the two axes from collapsing
+into one.
 
-## Strict validation — the single completeness verdict
+## Malformed vs. incomplete
 
-Strict validation checks **structural completeness**, uniformly regardless
-of who authored the document:
+Zero-filled render tolerates a document that is *incomplete* but rejects
+one that is *malformed*. The line is about what the document **says**, not
+how much of it is filled:
 
-- every Must Fill field (no `default:`) is **present**;
-- no `<must-fill>` sentinel survives;
-- every value coerces to its declared type.
+- **Incomplete** — a Must Fill field is **absent**. A coherent state: the
+  author (human or LLM) simply did not provide the field. Zero-filled
+  render fills it with the type-empty value; the omission surfaces as a
+  **warning**, never a render error.
+- **Malformed** — the document carries something that is **not a value**: a
+  value that cannot coerce to its declared type, or a surviving
+  `<must-fill>` **sentinel**. These always error, on every path.
 
-It does **not** check non-emptiness or semantics. A present `""` for a
-Must Fill string passes strict. Semantic quality is steered by the
-blueprint's `# e.g.` example hints (see the `default`/`example` framing in
-[SCHEMAS.md](../canon/SCHEMAS.md)), not by the validator.
+The sentinel is the sharp case, and the reason this proposal treats LLM
+input the same as form input. `<must-fill>` is the system's own
+placeholder — stamped *"this is not a real value; replace it."* Leaving it
+in the document is therefore provably an accident, almost always a verbatim
+**transcription** of the blueprint that the author forgot to fill. Unlike
+an absent field (a deliberate-looking omission), a surviving sentinel is
+scaffolding leaked into content, and rendering it literally — `<must-fill>`
+printed into a PDF — is never what anyone wants. So it earns a hard error
+with a precise correction ("you left these fields as placeholders"), while
+mere absence does not.
 
-Consequence worth internalizing: a document in which **every** field is
-present at its type-empty value (`""`, `0`, `false`, `[]`, `{}`,
-first-enum) *passes strict* — present, non-sentinel, type-valid. A
-**sparse** document (Must Fill fields absent) *fails strict*. The
-difference between the two is exactly presence, which is what strict keys
-on.
+A human form never produces the sentinel: widgets emit values, and a user
+who literally types `<must-fill>` yields the quoted, escaped string, not
+the sentinel. So this rule fires **only on the LLM path** — exactly where
+the transcription accident happens — without any interface-specific
+special-casing.
+
+**Strict completeness** — *every* Must Fill field present — remains a
+well-defined verdict, answered identically regardless of origin. It is a
+**query** ("is this done?"), not a creation gate: wire it to the actions
+that need a finished document (publish, submit, finalize), not to render or
+to `create_document`.
 
 ## Zero-filled render — type-empty fill in the projection only
 
@@ -100,10 +120,12 @@ else.
 
 ## The two interfaces
 
-Both produce documents in one shared model; they differ only in what they
-gate on.
+Both produce documents in one shared model and run the **same** render +
+validation behavior (zero-fill absence; error on malformation). They differ
+only in how completeness is surfaced to the author — and in the practical
+fact that only the LLM path can emit a sentinel.
 
-### UI form (zero-filled render)
+### UI form
 
 - Uses zero-filled render for **both** preview and artifact export
   (PDF/SVG/PNG) — a blank form always produces a renderable result, no
@@ -111,29 +133,35 @@ gate on.
 - Emits **sparse** documents: an empty text box / unselected dropdown is
   *omitted* (treated as absent), so form-completeness and schema-presence
   coincide. The form's existing `FormFieldSource::Missing` / `Default`
-  state remains the human-facing completeness signal — the analog of the
-  `<must-fill>` sentinel for LLMs.
+  state is the human-facing completeness signal.
 - **Persists the sparse authored truth**, never the fill.
-- Strict validation is available as the *"is it done?"* gate, wired to the
-  actions that need completeness (submit / publish), not to preview or
-  draft export.
+- The strict completeness query is the *"is it done?"* gate, wired to
+  submit / publish — not to preview or draft export.
 
-### MCP / LLM (strict validation)
+### MCP / LLM
 
-- `create_document(markdown)` **gates on strict validation**. The LLM is
-  handed the blueprint and must return a complete document: every Must
-  Fill field present, no surviving `<must-fill>` sentinel.
-- Strict enforces *structural* completeness; the blueprint's `# e.g.`
-  hints carry the *semantic* guidance. "The LLM writes a semantically
-  valid document" is guaranteed by **blueprint guidance + strict structural
-  check together**, not by strict alone.
+- `create_document(markdown)` also uses zero-filled render. Absent Must
+  Fill fields are zero-filled, not rejected — the LLM is **not** forced to
+  fill every field, so it never has to invent data it does not have.
+- The one accident guard, beyond type-validity: a surviving `<must-fill>`
+  **sentinel errors**. `create_document` rejects it with diagnostics and
+  the LLM retries (per the MCP workflow). This targets the common LLM
+  failure — echoing the blueprint placeholder — precisely, without a blunt
+  completeness gate.
+- Absent Must Fill fields come back as **warnings** in the response, so the
+  LLM still learns what it left blank (guidance, not rejection).
+- Contract for LLM authors: **fill each field or omit it — never leave
+  `<must-fill>`.** The blueprint's sentinels mean "replace or delete," not
+  content.
+- Semantic quality is steered by the blueprint's `# e.g.` example hints
+  (the `default`/`example` framing in [SCHEMAS.md](../canon/SCHEMAS.md)),
+  not by validation.
 
 ### Mixing the two
 
-Both interfaces write into the same document model, so a document's strict
-verdict is a uniform signal of "came from a finished process": LLM docs
-pass, in-progress form docs fail, regardless of origin. No two-class
-document semantics.
+One document model, one render + validation behavior. A document's strict
+completeness verdict is a uniform signal of "came from a finished process,"
+independent of origin. No two-class document semantics.
 
 ## Rejected alternatives
 
@@ -144,6 +172,13 @@ document semantics.
   creates two-class document semantics in a mixed-author ecosystem — which
   this project *is*, by design, because blueprints exist precisely so LLMs
   author these documents too. Zero-fill must stay render-only.
+- **Strict-gating the LLM on absence** (reject `create_document` when any
+  Must Fill field is absent). Rejected in favor of erroring only on the
+  malformed sentinel: absence is a coherent, zero-fillable state, and
+  forcing the LLM to fill every field pushes it to invent data it does not
+  have. The genuine accident worth rejecting is the placeholder
+  transcription, which the sentinel rule targets exactly; completeness
+  stays a query for the finalize step.
 - **Example-fallback render** (fill absent fields from `example:` instead
   of the type-empty zero value). Rejected: an example is realistic but
   *not the value most authors want* (the canonized framing), so it
@@ -151,7 +186,7 @@ document semantics.
   through a complete-looking export. The zero value is honestly blank
   everywhere except enum. `example` keeps its existing home — blueprint
   `FillBehavior::Preview` for LLM/no-input *generation*, where a realistic
-  shape genuinely helps — and does not follow onto the form render path.
+  shape genuinely helps — and does not follow onto the render path.
 
 ## Implementation sketch
 
@@ -160,23 +195,28 @@ document semantics.
    `crates/core/src/quill/`) into a per-field `QuillValue` producer shared
    by blueprint emission and the render path — one source of truth for
    "the zero value for this field."
-2. **Zero-filled render mode.** On the render path
-   (`crates/quillmark/src/orchestration/`), add a mode that, after
-   coercion, interpolates each absent field's zero value (mirroring
-   `apply_defaults`, "authored value wins") and demotes `must_fill_absent`
-   from a hard error to a warning. The fill goes into the `to_plate_json`
-   projection only.
-3. **Strict validation path unchanged.** `coerce_and_validate` keeps
-   hard-failing on `must_fill_absent`; MCP `create_document` uses it as
-   today.
-4. **Surface.** Expose render-fill selection on the bindings (Rust / Wasm /
-   Python / CLI) and document that zero-filled output is preview/export,
-   not a completeness assertion.
+2. **Zero-filled render (the single render behavior).** On the render path
+   (`crates/quillmark/src/orchestration/`), after coercion: interpolate
+   each absent field's zero value (mirroring `apply_defaults`, "authored
+   value wins") and demote `must_fill_absent` to a **warning**. Keep
+   `must_fill_sentinel` and coercion failures as **hard errors**. The fill
+   goes into the `to_plate_json` projection only. Both the form path and
+   MCP `create_document` use this same behavior; absence warnings flow back
+   in the result.
+3. **Strict completeness query.** Expose the "every Must Fill present?"
+   check (the existing strict `validate_document`, or a thin wrapper over
+   it) as a separate API for finalize / publish gates — distinct from
+   render.
+4. **Surface.** Render returns artifact + warnings on every binding (Rust /
+   Wasm / Python / CLI); document that zero-filled output is preview/export,
+   not a completeness assertion, and that a surviving `<must-fill>` is the
+   one authoring accident render refuses to paper over.
 
 ## Graduation
 
 Once implemented and tested, fold the conceptual model into
-[SCHEMAS.md](../canon/SCHEMAS.md) as a "Zero-filled render" section (render
-fill ⊥ validation verdict; the two interfaces), add a one-line pointer from
+[SCHEMAS.md](../canon/SCHEMAS.md) as a "Zero-filled render" section
+(render fill ⊥ completeness verdict; malformed vs. incomplete; the two
+interfaces), add a one-line pointer from
 [BLUEPRINT.md](../canon/BLUEPRINT.md)'s filled-blueprints section, and
 delete this proposal.

--- a/prose/proposals/zero-filled-render.md
+++ b/prose/proposals/zero-filled-render.md
@@ -36,10 +36,14 @@ natural state of a document is *in progress*.
 
 Two facts already in the codebase make the fix small:
 
-- The quill **authoring contract** guarantees every quill renders its own
-  type-empty blueprint (`blueprint_filled(FillBehavior::TypeEmpty)`,
-  enforced by `every_quill_in_quiver_renders`). Type-empty input is the
-  type-minimal valid document — the worst-case-but-renderable shape.
+- The quill **authoring contract** guarantees every quill renders
+  type-minimal valid input — today via the type-empty blueprint, and under
+  this proposal expressed directly as a **zero-filled render of an empty
+  document** (`every_quill_in_quiver_renders`). Type-empty input is the
+  worst-case-but-renderable shape, so that test doubles as the proof that
+  zero-filled render always compiles. (The companion
+  [blueprint/example split](blueprint-example-split.md) retires the
+  standalone type-empty *blueprint* mode in favor of this.)
 - `apply_defaults` already builds a throwaway `final_doc` for the plate
   JSON and does not persist it. The render projection is already the right
   place to inject values that never touch storage.
@@ -184,8 +188,9 @@ independent of origin. No two-class document semantics.
   *not the value most authors want* (the canonized framing), so it
   camouflages incompleteness and risks leaking placeholder/PII content
   through a complete-looking export. The zero value is honestly blank
-  everywhere except enum. `example` keeps its existing home — blueprint
-  `FillBehavior::Preview` for LLM/no-input *generation*, where a realistic
+  everywhere except enum. `example` keeps its existing home — the `example`
+  reference document for LLM/no-input *generation* (see
+  [blueprint/example split](blueprint-example-split.md)), where a realistic
   shape genuinely helps — and does not follow onto the render path.
 
 ## Implementation sketch
@@ -194,7 +199,9 @@ independent of origin. No two-class document semantics.
    blueprint string emitter (`must_fill_value` / `first_enum` in
    `crates/core/src/quill/`) into a per-field `QuillValue` producer shared
    by blueprint emission and the render path — one source of truth for
-   "the zero value for this field."
+   "the zero value for this field." (Shared with the
+   [blueprint/example split](blueprint-example-split.md), which uses the
+   same producer for the `example` document's fallback.)
 2. **Zero-filled render (the single render behavior).** On the render path
    (`crates/quillmark/src/orchestration/`), after coercion: interpolate
    each absent field's zero value (mirroring `apply_defaults`, "authored

--- a/prose/proposals/zero-filled-render.md
+++ b/prose/proposals/zero-filled-render.md
@@ -1,22 +1,22 @@
-# Non-Strict Render & the Two Authoring Interfaces
+# Zero-Filled Render & the Two Authoring Interfaces
 
 > **Motivation**: a live-editing web app wants documents to preview and
 > export while still in progress — without forcing authors to fill every
 > unendorsed field or writing boilerplate to satisfy validation. At the
 > same time, LLM/MCP authoring must stay held to a completeness bar. This
-> proposal adds a non-strict *render* path and pins down how the two
+> proposal adds a **zero-filled** *render* path and pins down how the two
 > interfaces — UI form and MCP/LLM — share one document model without
 > either one weakening the other.
 
 ## TL;DR
 
-Render mode and validation verdict are **orthogonal**. Keep one validity
+Render fill and validation verdict are **orthogonal**. Keep one validity
 notion — strict validation answers *"is this document complete?"* — and
-add a non-strict **render** path that type-empty-interpolates absent
-fields into the plate-JSON projection only, never into the persisted
-document. UI forms render non-strict and persist the sparse authored
-truth; MCP/LLM `create_document` gates on strict. The same strict verdict
-applies uniformly to documents of either origin.
+add a **zero-filled render** path that fills each absent field with its
+type-empty (zero) value, in the plate-JSON projection only, never in the
+persisted document. UI forms use zero-filled render and persist the sparse
+authored truth; MCP/LLM `create_document` gates on strict validation. The
+same strict verdict applies uniformly to documents of either origin.
 
 Pre-1.0; not yet implemented. When built, the conceptual model graduates
 into [SCHEMAS.md](../canon/SCHEMAS.md) with a pointer from
@@ -46,13 +46,14 @@ Two questions that are easy to conflate, kept separate:
 
 | Question | Answered by | Always succeeds? |
 |---|---|---|
-| *Show me something now* | **render mode** (strict / non-strict) | non-strict: yes |
+| *Show me something now* | **render fill** (plain / zero-filled) | zero-filled: yes |
 | *Is this document complete?* | **strict validation** | no — that's the point |
 
-A document can be renderable (non-strict) and incomplete (fails strict) at
-the same time. "Always compiles" is a render guarantee; "always valid" is
-a validation verdict. They are not the same claim, and the design depends
-on not fusing them.
+A document can be renderable (zero-filled) and incomplete (fails strict)
+at the same time. "Always compiles" is a render guarantee; "always valid"
+is a validation verdict. They are not the same claim, and the design
+depends on not fusing them. Naming the render by its *fill* — not by a
+validation posture — keeps the two axes from collapsing into one.
 
 ## Strict validation — the single completeness verdict
 
@@ -75,23 +76,23 @@ first-enum) *passes strict* — present, non-sentinel, type-valid. A
 difference between the two is exactly presence, which is what strict keys
 on.
 
-## Non-strict render — type-empty fill in the projection only
+## Zero-filled render — type-empty fill in the projection only
 
-A non-strict render fills every absent field with its **type-empty**
+A zero-filled render fills every absent field with its **type-empty (zero)**
 value, in the plate-JSON projection that feeds the backend — and nowhere
 else.
 
-- Type-empty is honestly blank for almost every type: `""` (string,
+- The zero value is honestly blank for almost every type: `""` (string,
   markdown, **date**, **datetime** — the validator accepts the empty
   string for both), `0`, `false`, `[]`, `{}`.
-- The lone seam is `enum`: there is no empty enum member, so type-empty is
-  `first_enum` — a real, meaningful variant. Because the fill lives only
+- The lone seam is `enum`: there is no empty enum member, so the zero value
+  is `first_enum` — a real, meaningful variant. Because the fill lives only
   in the ephemeral projection, this appears **only in preview pixels**: the
   persisted document keeps the enum absent, and a form reload shows the
   dropdown unselected. The "looks-chosen-but-wasn't" value never hardens
   into storage or form state.
-- **Non-persist invariant.** The type-empty fill must never be written
-  back to the document. Type-empty is *indistinguishable from
+- **Non-persist invariant.** The zero-fill must never be written back to
+  the document. A type-empty value is *indistinguishable from
   authored-empty*; persisting it collapses "field absent (untouched)" and
   "field present and empty" into one and destroys `must_fill_absent`
   forever (it keys on absence). The fill is part of the render, never part
@@ -102,10 +103,11 @@ else.
 Both produce documents in one shared model; they differ only in what they
 gate on.
 
-### UI form (non-strict)
+### UI form (zero-filled render)
 
-- Renders non-strict for **both** preview and artifact export (PDF/SVG/PNG)
-  — a blank form always produces a renderable result, no boilerplate.
+- Uses zero-filled render for **both** preview and artifact export
+  (PDF/SVG/PNG) — a blank form always produces a renderable result, no
+  boilerplate.
 - Emits **sparse** documents: an empty text box / unselected dropdown is
   *omitted* (treated as absent), so form-completeness and schema-presence
   coincide. The form's existing `FormFieldSource::Missing` / `Default`
@@ -116,7 +118,7 @@ gate on.
   actions that need completeness (submit / publish), not to preview or
   draft export.
 
-### MCP / LLM (strict)
+### MCP / LLM (strict validation)
 
 - `create_document(markdown)` **gates on strict validation**. The LLM is
   handed the blueprint and must return a complete document: every Must
@@ -135,45 +137,46 @@ document semantics.
 
 ## Rejected alternatives
 
-- **Option X — form populates type-empty at persist time** (document is
-  always complete-and-valid). Rejected: it makes `must_fill_absent`
-  vacuous (every key always present), bakes the enum first-variant value
-  into storage as a silent fake choice, and creates two-class document
-  semantics in a mixed-author ecosystem — which this project *is*, by
-  design, because blueprints exist precisely so LLMs author these
-  documents too.
-- **Example-fallback in non-strict render** (fill absent fields from
-  `example:` instead of type-empty). Rejected: an example is realistic but
+- **Persist-time zero-fill** (the form populates type-empty into the
+  *stored* document, so it is always complete-and-valid). Rejected: it
+  makes `must_fill_absent` vacuous (every key always present), bakes the
+  enum first-variant value into storage as a silent fake choice, and
+  creates two-class document semantics in a mixed-author ecosystem — which
+  this project *is*, by design, because blueprints exist precisely so LLMs
+  author these documents too. Zero-fill must stay render-only.
+- **Example-fallback render** (fill absent fields from `example:` instead
+  of the type-empty zero value). Rejected: an example is realistic but
   *not the value most authors want* (the canonized framing), so it
   camouflages incompleteness and risks leaking placeholder/PII content
-  through a complete-looking export. Type-empty is honestly blank
+  through a complete-looking export. The zero value is honestly blank
   everywhere except enum. `example` keeps its existing home — blueprint
   `FillBehavior::Preview` for LLM/no-input *generation*, where a realistic
   shape genuinely helps — and does not follow onto the form render path.
 
 ## Implementation sketch
 
-1. **Type-empty value producer.** Factor the type-empty logic out of the
+1. **Zero-value producer.** Factor the type-empty logic out of the
    blueprint string emitter (`must_fill_value` / `first_enum` in
    `crates/core/src/quill/`) into a per-field `QuillValue` producer shared
    by blueprint emission and the render path — one source of truth for
-   "the empty value for this field."
-2. **Non-strict render mode.** On the render path
+   "the zero value for this field."
+2. **Zero-filled render mode.** On the render path
    (`crates/quillmark/src/orchestration/`), add a mode that, after
-   coercion, interpolates type-empty `QuillValue`s for absent fields
-   (mirroring `apply_defaults`, "authored value wins") and demotes
-   `must_fill_absent` from a hard error to a warning. The fill goes into
-   the `to_plate_json` projection only.
-3. **Strict path unchanged.** `coerce_and_validate` keeps hard-failing on
-   `must_fill_absent`; MCP `create_document` uses it as today.
-4. **Surface.** Expose mode selection on the render bindings (Rust / Wasm /
-   Python / CLI) and document that non-strict output is preview/export, not
-   a completeness assertion.
+   coercion, interpolates each absent field's zero value (mirroring
+   `apply_defaults`, "authored value wins") and demotes `must_fill_absent`
+   from a hard error to a warning. The fill goes into the `to_plate_json`
+   projection only.
+3. **Strict validation path unchanged.** `coerce_and_validate` keeps
+   hard-failing on `must_fill_absent`; MCP `create_document` uses it as
+   today.
+4. **Surface.** Expose render-fill selection on the bindings (Rust / Wasm /
+   Python / CLI) and document that zero-filled output is preview/export,
+   not a completeness assertion.
 
 ## Graduation
 
 Once implemented and tested, fold the conceptual model into
-[SCHEMAS.md](../canon/SCHEMAS.md) as a "Strict vs. non-strict" section
-(render mode ⊥ validation verdict; the two interfaces), add a one-line
-pointer from [BLUEPRINT.md](../canon/BLUEPRINT.md)'s filled-blueprints
-section, and delete this proposal.
+[SCHEMAS.md](../canon/SCHEMAS.md) as a "Zero-filled render" section (render
+fill ⊥ validation verdict; the two interfaces), add a one-line pointer from
+[BLUEPRINT.md](../canon/BLUEPRINT.md)'s filled-blueprints section, and
+delete this proposal.


### PR DESCRIPTION
Reframe the `default` and `example` field-schema properties around author
intent rather than shippability:

- `default` is the value the majority of authors want; when omitted, the
  default is interpolated (an authored value always wins).
- `example` matches the semantic and type shape of the desired value but
  is not the value most authors want — it documents shape only and never
  renders as the value.

Update canon (SCHEMAS.md, BLUEPRINT.md), the Quill.yaml reference, and the
FieldSchema doc comments. No behavior change; the mechanical Must-Fill vs.
Endorsed consequences (delete-ok tag, must-fill sentinel) are unchanged.