### PR TITLE
docs: reframe Quill.yaml default/example around author intent

### DIFF
--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -3,7 +3,7 @@ use crate::errors::{CliError, Result};
 use crate::output::{derive_output_path, OutputWriter};
 use clap::Parser;
 use quillmark::Document;
-use quillmark_core::{FillBehavior, OutputFormat, RenderOptions};
+use quillmark_core::{OutputFormat, RenderOptions};
 use std::fs;
 use std::path::PathBuf;
 
@@ -80,21 +80,20 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
             (output, Some(markdown_path.clone()))
         } else {
-            // Generated blueprint, Must Fill cells filled so it renders out of the box.
-            let markdown = quill
-                .source()
-                .config()
-                .blueprint_filled(FillBehavior::Preview);
+            // No input file: render the `example` reference document — the
+            // illustrative consolidation (example › default › zero), filled so
+            // it renders out of the box.
+            let markdown = quill.source().config().example();
 
             if args.verbose {
-                println!("Using generated blueprint from quill (fill: preview)");
+                println!("Using generated example document from quill");
             }
 
             // Parse markdown
             let output = Document::from_markdown_with_warnings(&markdown)?;
 
             if args.verbose {
-                println!("Blueprint parsed successfully");
+                println!("Example document parsed successfully");
             }
 
             (output, None)
@@ -180,7 +179,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             if let Some(ref path) = markdown_path_for_output {
                 derive_output_path(path, &args.format)
             } else {
-                PathBuf::from(format!("blueprint.{}", args.format))
+                PathBuf::from(format!("example.{}", args.format))
             }
         }))
     };

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -132,6 +132,14 @@ impl PyQuill {
         self.inner.source().config().blueprint()
     }
 
+    /// The `example` reference document — the illustrative "show me a
+    /// filled-out one": each field's `example:`, else `default:`, else the
+    /// type-empty zero value, with no `<must-fill>` sentinels.
+    #[getter]
+    fn example(&self) -> String {
+        self.inner.source().config().example()
+    }
+
     #[getter]
     fn supported_formats(&self) -> Vec<PyOutputFormat> {
         self.inner

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1034,17 +1034,20 @@ title: "Hello"
 // Post-mcp-feedback the schema axis is implicit: a field with a `default:` is
 // Endorsed (the rendered default is shippable as-is and the blueprint emits
 // the value + `; delete-ok` annotation); a field without a `default:` is Must
-// Fill (the blueprint emits the `<must-fill>` sentinel and validation flags
-// either the absence or the unreplaced sentinel).
+// Fill (the blueprint emits the `<must-fill>` sentinel).
 //
 // These tests pin the JS-facing contract:
 //   - `QuillFieldSchema` no longer carries a `required` axis.
 //   - `quill.blueprint` carries `<must-fill>` and `; delete-ok` annotations.
-//   - `quill.render(doc)` raises `validation::must_fill_absent` when a
-//     Must Fill field is absent at validate time.
+//   - `quill.render(doc)` *tolerates* an absent Must Fill field: zero-filled
+//     render fills it with its type-empty value in the plate projection
+//     (never persisted), so absence is not a render error.
 //   - `quill.render(doc)` raises `validation::must_fill_sentinel` when the
-//     `<must-fill>` sentinel is left in.
-//   - `quill.form(doc)` flags both situations under `diagnostics`.
+//     `<must-fill>` sentinel is left in (malformed, always fatal).
+//   - `quill.form(doc)` still flags both situations under `diagnostics`
+//     (the form view reports completeness independent of the render gate).
+//
+// See prose/proposals/zero-filled-render.md.
 
 describe('Must Fill / Endorsed schema model', () => {
   // The plate `unwrap`s `data.title` (Must Fill) and substitutes the optional
@@ -1128,10 +1131,14 @@ main:
     expect(blueprint).not.toContain('; optional')
   })
 
-  it('render throws `validation::must_fill_absent` when a Must Fill field is absent', () => {
+  it('render tolerates an absent Must Fill field (zero-filled, not an error)', () => {
     const quill = buildQuill()
 
-    // Document omits `title`. Schema declares no default → Must Fill.
+    // Document omits `title`. Schema declares no default → Must Fill. Under
+    // zero-filled render this is merely *incomplete*, not malformed: render
+    // fills `title` with its type-empty value in the plate projection and
+    // succeeds. Absence is no longer a hard error (the form's `source:
+    // "missing"` carries the doneness signal instead).
     const md = `~~~card-yaml
 $quill: schema_test
 $kind: main
@@ -1142,24 +1149,10 @@ subtitle: "Just a subtitle"
 `
     const doc = Document.fromMarkdown(md)
 
-    try {
-      quill.render(doc, { format: 'svg' })
-      throw new Error('render should have thrown ValidationFailed')
-    } catch (err) {
-      expect(Array.isArray(err.diagnostics)).toBe(true)
-      const codes = err.diagnostics.map((d) => d.code)
-      expect(codes).toContain('validation::must_fill_absent')
-      // The diagnostic must anchor to the offending field path.
-      const required = err.diagnostics.find(
-        (d) => d.code === 'validation::must_fill_absent',
-      )
-      expect(required.path).toBe('title')
-      expect(required.severity).toBe('error')
-      // The legacy codes must be gone.
-      expect(codes).not.toContain('validation::missing_required')
-      expect(codes).not.toContain('validation::required_field_absent')
-      expect(codes).not.toContain('validation::unfilled_placeholder')
-    }
+    const result = quill.render(doc, { format: 'svg' })
+    expect(result).toBeDefined()
+    expect(Array.isArray(result.artifacts)).toBe(true)
+    expect(result.artifacts.length).toBeGreaterThan(0)
   })
 
   it('render throws `validation::must_fill_sentinel` when the `<must-fill>` sentinel is left in', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -296,6 +296,15 @@ impl Quill {
         self.inner.source().config().blueprint()
     }
 
+    /// The `example` reference document — the illustrative "show me a
+    /// filled-out one." Each field renders its `example:`, else its
+    /// `default:`, else the type-empty zero value, with no `<must-fill>`
+    /// sentinels. See `prose/proposals/blueprint-example-split.md`.
+    #[wasm_bindgen(getter, js_name = example)]
+    pub fn example(&self) -> String {
+        self.inner.source().config().example()
+    }
+
     /// Document schema with `ui` hints stripped — for LLM/MCP consumers.
     #[wasm_bindgen(getter, js_name = schema, unchecked_return_type = "QuillSchema")]
     pub fn schema(&self) -> JsValue {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,7 @@ pub mod session;
 pub use session::RenderSession;
 
 pub mod quill;
-pub use quill::{FileTreeNode, FillBehavior, QuillIgnore, QuillSource};
+pub use quill::{zero_value, FileTreeNode, QuillIgnore, QuillSource};
 
 pub mod value;
 pub use value::QuillValue;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -2,6 +2,7 @@
 
 mod blueprint;
 mod config;
+mod fill;
 mod formats;
 mod ignore;
 mod load;
@@ -12,8 +13,8 @@ mod tree;
 mod types;
 pub(crate) mod validation;
 
-pub use blueprint::FillBehavior;
 pub use config::{CoercionError, QuillConfig};
+pub use fill::zero_value;
 pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -35,111 +35,78 @@
 use std::collections::BTreeMap;
 
 use super::validation::MUST_FILL_SENTINEL;
-use super::{CardSchema, FieldSchema, FieldType, QuillConfig};
+use super::{zero_value, CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::value::QuillValue;
 use serde_json::Value as JsonValue;
 
-/// Controls how Must Fill cells (fields with no `default:`) are rendered in a
-/// generated blueprint. The value is chosen at generation time from the typed
-/// schema, so the placeholder never re-parses the annotation grammar.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum FillBehavior {
-    /// Render the `<must-fill>` sentinel in the value cell — downstream
-    /// validation reports `validation::must_fill_sentinel`. This is the
-    /// canonical authoring blueprint produced by [`QuillConfig::blueprint`].
-    #[default]
-    Strict,
-    /// Fill each Must Fill cell from the field's `example:` when one is
-    /// configured, falling back to the leanest type-valid value (identical to
-    /// `TypeEmpty`: `""`, `0`, `false`, `[]`, `{}`, first enum variant, empty
-    /// markdown body) otherwise. Used by CLI `render` with no input file to
-    /// produce a representative document straight from the schema.
-    Preview,
-    /// Render the leanest type-valid values: `""`, `0`, `false`, `[]`, first
-    /// enum variant, empty markdown body. Used by the quiver render-test to
-    /// exercise plates on minimal input.
-    TypeEmpty,
+/// Internal strategy controlling how each field's value cell is rendered in a
+/// generated reference document. The value is chosen at generation time from
+/// the typed schema, so the document never re-parses the annotation grammar.
+///
+/// Two variants for the two named reference documents — no configurable
+/// precedence policy (see `prose/proposals/blueprint-example-split.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FillSource {
+    /// Render the `<must-fill>` sentinel in every Must Fill cell (a field with
+    /// no `default:`) — downstream validation reports
+    /// `validation::must_fill_sentinel`. The canonical authoring blueprint
+    /// produced by [`QuillConfig::blueprint`].
+    Sentinel,
+    /// Fill each cell with its illustrative value: `example:` › `default:` ›
+    /// the type-empty zero value. The `example` reference document produced by
+    /// [`QuillConfig::example`].
+    Example,
 }
 
-/// The value cell rendered for a Must Fill scalar field with no usable
-/// `example:` under `behavior`. `Strict` keeps the `<must-fill>` sentinel;
-/// `Preview`/`TypeEmpty` substitute the leanest type-valid placeholder so the
-/// blueprint parses (and, for `TypeEmpty`, satisfies the quill authoring
-/// contract). Markdown fields are handled separately in [`write_markdown_block`]
-/// and never reach this function.
-fn must_fill_value(field: &FieldSchema, behavior: FillBehavior) -> String {
-    if behavior == FillBehavior::Strict {
-        return MUST_FILL_SENTINEL.to_string();
+/// The value source for a field's rendered cell, by precedence:
+///
+/// - [`FillSource::Sentinel`] (blueprint): the endorsed `default:` only; a
+///   Must Fill cell falls through to the `<must-fill>` sentinel.
+/// - [`FillSource::Example`] (example document): the illustrative `example:`
+///   wins, then the `default:`; a cell with neither falls through to the
+///   type-empty zero value.
+///
+/// `None` means the cell falls back to sentinel / zero rendering in the
+/// caller. Endorsement (the `; delete-ok` tag) keys off `field.default` alone,
+/// never this source.
+fn fill_source(field: &FieldSchema, source: FillSource) -> Option<&QuillValue> {
+    match source {
+        FillSource::Sentinel => field.default.as_ref(),
+        FillSource::Example => field.example.as_ref().or(field.default.as_ref()),
     }
-    if field.enum_values.is_some() {
-        return first_enum(field);
-    }
-    match field.r#type {
-        FieldType::Array => "[]".to_string(),
-        // A bare object reaching this point would be schema-invalid (objects
-        // require a `properties` map and recurse through write_typed_object_field),
-        // so this arm is unreachable in practice. `{}` is the type-correct
-        // fallback regardless — `""` (a string) would fail object validation.
-        FieldType::Object => "{}".to_string(),
-        FieldType::Integer | FieldType::Number => "0".to_string(),
-        FieldType::Boolean => "false".to_string(),
-        // String/Markdown/Date/DateTime: `""` is schema-valid for all four
-        // (the validator accepts the empty string for date/datetime).
-        _ => "\"\"".to_string(),
-    }
-}
-
-/// The value source for a field's rendered cell: the endorsed `default:`, or —
-/// under `Preview` for a Must Fill field — the configured `example:`. Returns
-/// `None` when the cell must fall back to type-empty / synthetic rendering
-/// (`Strict`/`TypeEmpty`, or `Preview` with no example). Endorsement (the
-/// `; delete-ok` tag) keys off `field.default` alone, never this source.
-fn fill_source(field: &FieldSchema, behavior: FillBehavior) -> Option<&QuillValue> {
-    field.default.as_ref().or_else(|| {
-        if behavior == FillBehavior::Preview {
-            field.example.as_ref()
-        } else {
-            None
-        }
-    })
-}
-
-/// First variant of an `enum` field, rendered identically under `Preview` and
-/// `TypeEmpty`. An empty enum list yields the empty string.
-fn first_enum(field: &FieldSchema) -> String {
-    field
-        .enum_values
-        .as_ref()
-        .and_then(|v| v.first())
-        .cloned()
-        .unwrap_or_default()
 }
 
 impl QuillConfig {
     /// Generate the canonical annotated Markdown blueprint for this quill —
     /// the authoring surface handed to LLMs and humans, with Must Fill cells
-    /// carrying the `<must-fill>` sentinel ([`FillBehavior::Strict`]). See
-    /// module docs for the annotation grammar; the function is total over any
-    /// valid `QuillConfig`.
+    /// carrying the `<must-fill>` sentinel. Its illustrative counterpart is
+    /// [`example`](Self::example). See module docs for the annotation grammar;
+    /// the function is total over any valid `QuillConfig`.
     ///
     /// The result is guaranteed schema-valid and parseable (every key
     /// present, every value type-correct). It is *not* guaranteed to render
     /// — that is the quill authoring contract on `plate.typ`; see
     /// `prose/canon/BLUEPRINT.md` §Guarantees.
     pub fn blueprint(&self) -> String {
-        self.render_blueprint(FillBehavior::Strict)
+        self.render_blueprint(FillSource::Sentinel)
     }
 
-    /// Generate a blueprint with Must Fill cells filled per `behavior` — an
-    /// escape hatch producing a parseable (`Preview`) or render-exercising
-    /// (`TypeEmpty`) document without an authored input. `FillBehavior::Strict`
-    /// is equivalent to [`blueprint`](Self::blueprint).
-    pub fn blueprint_filled(&self, behavior: FillBehavior) -> String {
-        self.render_blueprint(behavior)
+    /// Generate the `example` reference document for this quill — the
+    /// illustrative consolidation "show me a filled-out one." Each field
+    /// renders its `example:`, else its `default:`, else the type-empty zero
+    /// value, with no `<must-fill>` sentinels. The document is example-*first*
+    /// but not guaranteed fully populated: a field with neither an `example:`
+    /// nor a `default:` renders at its zero value.
+    ///
+    /// See `prose/proposals/blueprint-example-split.md`. Like
+    /// [`blueprint`](Self::blueprint), the result is schema-valid and
+    /// parseable; rendering is the quill authoring contract on `plate.typ`.
+    pub fn example(&self) -> String {
+        self.render_blueprint(FillSource::Example)
     }
 
-    fn render_blueprint(&self, behavior: FillBehavior) -> String {
+    fn render_blueprint(&self, source: FillSource) -> String {
         let mut out = String::new();
         let main_desc = self
             .main
@@ -152,7 +119,7 @@ impl QuillConfig {
             &self.main,
             &format!("{}@{}", self.name, self.version),
             main_desc,
-            behavior,
+            source,
         );
         if self.main.body_enabled() {
             let example = self.main.body.as_ref().and_then(|b| b.example.as_deref());
@@ -161,7 +128,7 @@ impl QuillConfig {
         }
         for card in &self.card_kinds {
             out.push('\n');
-            write_card_fence(&mut out, card, behavior);
+            write_card_fence(&mut out, card, source);
             if card.body_enabled() {
                 let example = card.body.as_ref().and_then(|b| b.example.as_deref());
                 let fallback = format!("Write {} body here.", card.name);
@@ -192,7 +159,7 @@ fn write_main_fence(
     card: &CardSchema,
     quill_ref: &str,
     description: Option<&str>,
-    behavior: FillBehavior,
+    source: FillSource,
 ) {
     out.push_str("~~~\n");
     out.push_str("$quill: ");
@@ -205,14 +172,14 @@ fn write_main_fence(
     if let Some(desc) = description {
         write_comment(out, desc);
     }
-    write_card_fields(out, card, behavior);
+    write_card_fields(out, card, source);
     out.push_str("~~~\n");
 }
 
 /// Emit a composable card as a `~~~` block declaring `$kind: <kind>`.
 /// The `composable (0..N)` role annotation and the optional description are
 /// emitted as own-line comments directly under the `$kind` header.
-fn write_card_fence(out: &mut String, card: &CardSchema, behavior: FillBehavior) {
+fn write_card_fence(out: &mut String, card: &CardSchema, source: FillSource) {
     out.push_str("~~~\n");
     out.push_str("$kind: ");
     out.push_str(&saphyr_emit_scalar(&JsonValue::String(card.name.clone())));
@@ -221,15 +188,15 @@ fn write_card_fence(out: &mut String, card: &CardSchema, behavior: FillBehavior)
     if let Some(desc) = &card.description {
         write_comment(out, desc);
     }
-    write_card_fields(out, card, behavior);
+    write_card_fields(out, card, source);
     out.push_str("~~~\n");
 }
 
 /// Emit a card's fields, clustered by `ui.group` and ordered by `ui.order`.
-fn write_card_fields(out: &mut String, card: &CardSchema, behavior: FillBehavior) {
+fn write_card_fields(out: &mut String, card: &CardSchema, source: FillSource) {
     for (_, fields) in group_fields(card.fields.values()) {
         for field in fields {
-            write_field(out, field, 0, behavior);
+            write_field(out, field, 0, source);
         }
     }
 }
@@ -258,13 +225,13 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
     groups
 }
 
-fn write_field(out: &mut String, field: &FieldSchema, indent: usize, behavior: FillBehavior) {
+fn write_field(out: &mut String, field: &FieldSchema, indent: usize, source: FillSource) {
     let pad = "  ".repeat(indent);
 
     // Typed table: array with a properties map directly on the field.
     if matches!(field.r#type, FieldType::Array) {
         if let Some(props) = &field.properties {
-            write_typed_table_field(out, field, props, indent, behavior);
+            write_typed_table_field(out, field, props, indent, source);
             return;
         }
     }
@@ -272,7 +239,7 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize, behavior: F
     // Typed dictionary: standalone object with defined properties.
     if matches!(field.r#type, FieldType::Object) {
         if let Some(props) = &field.properties {
-            write_typed_object_field(out, field, props, indent, behavior);
+            write_typed_object_field(out, field, props, indent, source);
             return;
         }
     }
@@ -284,12 +251,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize, behavior: F
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
         let inline = inline_annotation(field, false, field.default.is_some());
-        write_markdown_block(out, field, &pad, &inline, behavior);
+        write_markdown_block(out, field, &pad, &inline, source);
         return;
     }
 
     let inline = format!("  # {}", inline_annotation(field, false, field.default.is_some()));
-    let value = field_value(field, behavior);
+    let value = field_value(field, source);
     write_value(out, &field.name, &value, &inline, &pad);
 }
 
@@ -316,7 +283,7 @@ fn write_markdown_block(
     field: &FieldSchema,
     pad: &str,
     inline: &str,
-    behavior: FillBehavior,
+    source: FillSource,
 ) {
     out.push_str(&format!("{}{}: |-  # {}\n", pad, field.name, inline));
     let body_pad = format!("{}  ", pad);
@@ -325,7 +292,7 @@ fn write_markdown_block(
     // cell with empty/absent string default (or empty example) → one indented
     // blank line (the "skippable" markdown cell). Otherwise a Must Fill cell
     // gets the sentinel (Strict) or an empty body line (Preview/TypeEmpty).
-    let content = fill_source(field, behavior).and_then(|v| match v.as_json() {
+    let content = fill_source(field, source).and_then(|v| match v.as_json() {
         serde_json::Value::String(s) => Some(s),
         _ => None,
     });
@@ -339,9 +306,9 @@ fn write_markdown_block(
             out.push_str(&format!("{}\n", body_pad));
         }
         None => {
-            let body = match behavior {
-                FillBehavior::Strict => MUST_FILL_SENTINEL,
-                FillBehavior::Preview | FillBehavior::TypeEmpty => "",
+            let body = match source {
+                FillSource::Sentinel => MUST_FILL_SENTINEL,
+                FillSource::Example => "",
             };
             out.push_str(&format!("{}{}\n", body_pad, body));
         }
@@ -360,16 +327,15 @@ fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
 
 /// Emit a typed-table field: description + `# e.g.` line (whenever an
 /// example is configured), then the field key with its `array<object>`
-/// inline annotation, then the rendered rows. Rows come from the declared
-/// default, the `example:` (under `Preview` only, when no default), or a
-/// synthetic template row otherwise.
+/// inline annotation, then the rendered rows. Rows come from [`fill_source`]
+/// (the `example:` › `default:` for the example document, the `default:` for
+/// the blueprint), or a synthetic template row otherwise.
 ///
 /// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
-/// — the outer key carries `; delete-ok` and the rendered value is the
-/// default (rows for `default: [...]`, inline `[]` for `default: []`). A
-/// field without a `default:` is Must Fill — the outer key drops
-/// `; delete-ok`. Such a cell renders the `example:` rows under `Preview`,
-/// otherwise one synthetic row with leaf-level sentinels. See
+/// — the outer key carries `; delete-ok`. A field without a `default:` is
+/// Must Fill — the outer key drops `; delete-ok`. When [`fill_source`] yields
+/// no value, the blueprint emits one synthetic row with leaf-level sentinels
+/// and the example document recurses to type-empty leaves. See
 /// `prose/BOOKMARKS.md` "Typed container empty default loses inline shape
 /// documentation" for the rendering-vs-symmetry trade-off.
 fn write_typed_table_field(
@@ -377,7 +343,7 @@ fn write_typed_table_field(
     field: &FieldSchema,
     item_props: &BTreeMap<String, Box<FieldSchema>>,
     indent: usize,
-    behavior: FillBehavior,
+    source: FillSource,
 ) {
     let pad = "  ".repeat(indent);
 
@@ -387,7 +353,7 @@ fn write_typed_table_field(
     // Endorsement keys off `default:` alone; the rendered rows come from the
     // default or — under `Preview` — the `example:`.
     let inline = inline_annotation(field, true, field.default.is_some());
-    let rows = fill_source(field, behavior).and_then(|v| match v.as_json() {
+    let rows = fill_source(field, source).and_then(|v| match v.as_json() {
         serde_json::Value::Array(items) => Some(items.clone()),
         _ => None,
     });
@@ -410,7 +376,7 @@ fn write_typed_table_field(
             let dash_pad = "  ".repeat(indent + 1);
             out.push_str(&format!("{}-\n", dash_pad));
             for prop in sort_props(item_props) {
-                write_field(out, prop, indent + 2, behavior);
+                write_field(out, prop, indent + 2, source);
             }
         }
     }
@@ -418,23 +384,23 @@ fn write_typed_table_field(
 
 /// Emit a typed-dictionary field: description + `# e.g.` line (whenever an
 /// example is configured), then the field key with its `object` inline
-/// annotation, then the rendered mapping. The mapping comes from the
-/// declared default, the `example:` (under `Preview` only, when no default),
-/// or per-property annotations otherwise.
+/// annotation, then the rendered mapping. The mapping comes from
+/// [`fill_source`] (the `example:` › `default:` for the example document, the
+/// `default:` for the blueprint), or per-property annotations otherwise.
 ///
 /// Cell rule (uniform with scalars): a field with a `default:` is Endorsed
 /// — the outer key carries `; delete-ok` and the rendered value is the
-/// default (a block mapping for non-empty, inline `{}` for `default: {}`).
-/// A field without a `default:` is Must Fill — it renders the `example:`
-/// mapping under `Preview`, otherwise per-property recursion with leaf-level
-/// sentinels. See `prose/BOOKMARKS.md` "Typed container empty default loses
-/// inline shape documentation" for the trade-off.
+/// resolved mapping (a block mapping for non-empty, inline `{}` for `{}`).
+/// A field without a `default:` is Must Fill — when [`fill_source`] yields no
+/// value, the blueprint recurses to per-property leaf-level sentinels and the
+/// example document to type-empty leaves. See `prose/BOOKMARKS.md` "Typed
+/// container empty default loses inline shape documentation" for the trade-off.
 fn write_typed_object_field(
     out: &mut String,
     field: &FieldSchema,
     props: &BTreeMap<String, Box<FieldSchema>>,
     indent: usize,
-    behavior: FillBehavior,
+    source: FillSource,
 ) {
     let pad = "  ".repeat(indent);
 
@@ -444,7 +410,7 @@ fn write_typed_object_field(
     // Endorsement keys off `default:` alone; the rendered mapping comes from
     // the default or — under `Preview` — the `example:`.
     let inline = inline_annotation(field, false, field.default.is_some());
-    let mapping = fill_source(field, behavior).and_then(|v| match v.as_json() {
+    let mapping = fill_source(field, source).and_then(|v| match v.as_json() {
         serde_json::Value::Object(map) => Some(map.clone()),
         _ => None,
     });
@@ -468,7 +434,7 @@ fn write_typed_object_field(
         None => {
             out.push_str(&format!("{}{}:  # {}\n", pad, field.name, inline));
             for prop in sort_props(props) {
-                write_field(out, prop, indent + 1, behavior);
+                write_field(out, prop, indent + 1, source);
             }
         }
     }
@@ -520,16 +486,19 @@ enum FieldValue {
     Block(Vec<serde_json::Value>),
 }
 
-fn field_value(field: &FieldSchema, behavior: FillBehavior) -> FieldValue {
-    // Endorsed cells render their default; under `Preview` a Must Fill cell is
-    // filled from its `example:` when present.
-    if let Some(v) = fill_source(field, behavior) {
+fn field_value(field: &FieldSchema, source: FillSource) -> FieldValue {
+    // Endorsed/illustrative value: the `default:` (blueprint), or `example:` ›
+    // `default:` (example document), when present.
+    if let Some(v) = fill_source(field, source) {
         return json_to_value(v.as_json());
     }
-    // Otherwise the value cell carries the `<must-fill>` sentinel (`Strict`) or a
-    // type-valid placeholder (`Preview`/`TypeEmpty`); markdown is special-cased
-    // earlier and never reaches this code path.
-    FieldValue::Inline(must_fill_value(field, behavior))
+    // Otherwise the cell falls through: the `<must-fill>` sentinel (blueprint)
+    // or the type-empty zero value (example document). Markdown is
+    // special-cased in `write_markdown_block` and never reaches this path.
+    match source {
+        FillSource::Sentinel => FieldValue::Inline(MUST_FILL_SENTINEL.to_string()),
+        FillSource::Example => json_to_value(zero_value(field).as_json()),
+    }
 }
 
 fn json_to_value(val: &serde_json::Value) -> FieldValue {
@@ -1135,24 +1104,33 @@ card_kinds:
     }
 
     #[test]
-    fn blueprint_filled_strict_matches_blueprint() {
+    fn example_prioritizes_example_over_default() {
+        // A field with BOTH a `default:` and an `example:`: the example
+        // document renders the illustrative example (example › default), while
+        // the blueprint renders the default. The `; delete-ok` tag keys off
+        // the default's presence in both.
         let config = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    title: { type: string }
-    count: { type: integer }
+    status: { type: string, default: draft, example: final }
 "#);
-        let bp = config.blueprint();
-        let out = config.blueprint_filled(super::FillBehavior::Strict);
-        assert_eq!(out, bp);
-        assert!(out.contains("<must-fill>"));
+        let example = config.example();
+        assert!(
+            example.contains("status: final  # string; delete-ok\n"),
+            "example should render the example value (example › default): {example}"
+        );
+        let blueprint = config.blueprint();
+        assert!(
+            blueprint.contains("status: draft  # string; delete-ok\n"),
+            "blueprint should render the default value: {blueprint}"
+        );
     }
 
     #[test]
-    fn blueprint_filled_preview_without_examples_falls_back_to_type_empty() {
-        // No `example:` on any field → Preview renders the leanest type-valid
-        // value, identical to TypeEmpty (no more `Lorem ipsum`/ISO-date stubs).
+    fn example_without_examples_falls_back_to_type_empty() {
+        // No `example:` and no `default:` on any field → the example document
+        // renders the leanest type-valid (zero) value.
         let out = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -1165,8 +1143,19 @@ main:
     issued:    { type: date }
     published: { type: datetime }
     severity:  { type: string, enum: [low, medium, high] }
+    bio:       { type: markdown }
+    addr:
+      type: object
+      properties:
+        street: { type: string }
+        zip:    { type: integer }
+    rows:
+      type: array
+      properties:
+        org:  { type: string }
+        year: { type: integer }
 "#)
-        .blueprint_filled(super::FillBehavior::Preview);
+        .example();
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
         assert!(!out.contains("Lorem ipsum"), "no stub strings expected: {out}");
         assert!(out.contains("title: \"\"  # string\n"));
@@ -1177,180 +1166,18 @@ main:
         assert!(out.contains("issued: \"\"  # date<YYYY-MM-DD>\n"));
         assert!(out.contains("published: \"\"  # datetime<ISO 8601>\n"));
         assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
-    }
-
-    #[test]
-    fn blueprint_filled_preview_fills_must_fill_cells_from_examples() {
-        // Each Must Fill field carries an `example:`; Preview renders it as the
-        // value cell (without `; delete-ok`, since the field is not endorsed).
-        let out = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    title:    { type: string, example: Quarterly Report }
-    count:    { type: integer, example: 7 }
-    issued:   { type: date, example: "2030-06-01" }
-    refs:     { type: array, example: [alpha, beta] }
-"#)
-        .blueprint_filled(super::FillBehavior::Preview);
-        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
-        assert!(out.contains("title: Quarterly Report  # string\n"), "{out}");
-        assert!(out.contains("count: 7  # integer\n"), "{out}");
-        assert!(out.contains("issued: 2030-06-01  # date<YYYY-MM-DD>\n"), "{out}");
-        assert!(out.contains("refs:  # array<string>\n  - alpha\n  - beta\n"), "{out}");
-    }
-
-    #[test]
-    fn blueprint_filled_preview_markdown_block_scalar() {
-        // No example → empty body (type-empty fallback). With an example →
-        // the example text, rendered verbatim inside the block scalar.
-        let bare = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    bio: { type: markdown }
-"#)
-        .blueprint_filled(super::FillBehavior::Preview);
-        assert!(!bare.contains("<must-fill>"), "no sentinels expected: {bare}");
-        assert!(!bare.contains("Lorem ipsum"), "no stub strings expected: {bare}");
-        assert!(bare.contains("bio: |-  # markdown\n  \n"), "{bare}");
-
-        let with_eg = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    bio: { type: markdown, example: "Hello there." }
-"#)
-        .blueprint_filled(super::FillBehavior::Preview);
-        assert!(with_eg.contains("bio: |-  # markdown\n  Hello there.\n"), "{with_eg}");
-    }
-
-    #[test]
-    fn blueprint_filled_preview_preserves_endorsed_cells() {
-        let out = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    size:   { type: number, default: 11 }
-    flag:   { type: boolean, default: true }
-    status: { type: string, default: draft }
-"#)
-        .blueprint_filled(super::FillBehavior::Preview);
-        assert!(out.contains("size: 11  # number; delete-ok\n"));
-        assert!(out.contains("flag: true  # boolean; delete-ok\n"));
-        assert!(out.contains("status: draft  # string; delete-ok\n"));
-    }
-
-    #[test]
-    fn blueprint_filled_preview_substitutes_typed_table_leaves() {
-        // No field-level example and no leaf examples → a synthetic row with
-        // type-empty leaves.
-        let out = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    refs:
-      type: array
-      properties:
-        org:  { type: string }
-        year: { type: integer }
-"#)
-        .blueprint_filled(super::FillBehavior::Preview);
-        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
-        assert!(out.contains("refs:  # array<object>\n  -\n"), "{out}");
-        assert!(out.contains("    org: \"\"  # string\n"), "{out}");
-        assert!(out.contains("    year: 0  # integer\n"), "{out}");
-    }
-
-    #[test]
-    fn blueprint_filled_preview_renders_typed_table_field_example_rows() {
-        // A field-level `example:` on a Must Fill typed table renders as rows
-        // under Preview (no `; delete-ok`, since there is no `default:`).
-        let out = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    refs:
-      type: array
-      example:
-        - { org: ACME, year: 2020 }
-      properties:
-        org:  { type: string }
-        year: { type: integer }
-"#)
-        .blueprint_filled(super::FillBehavior::Preview);
-        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
-        assert!(out.contains("refs:  # array<object>\n"), "{out}");
-        assert!(out.contains("  - org: ACME\n"), "{out}");
-        assert!(out.contains("    year: 2020\n"), "{out}");
-        assert!(!out.contains("; delete-ok"), "not endorsed: {out}");
-    }
-
-    #[test]
-    fn blueprint_filled_type_empty_substitutes_with_minimal_values() {
-        let out = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    title:    { type: string }
-    count:    { type: integer }
-    flag:     { type: boolean }
-    refs:     { type: array }
-    issued:   { type: date }
-    severity: { type: string, enum: [low, medium, high] }
-    bio:      { type: markdown }
-"#)
-        .blueprint_filled(super::FillBehavior::TypeEmpty);
-        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
-        assert!(out.contains("title: \"\"  # string\n"));
-        assert!(out.contains("count: 0  # integer\n"));
-        assert!(out.contains("flag: false  # boolean\n"));
-        assert!(out.contains("refs: []  # array<string>\n"));
-        assert!(out.contains("issued: \"\"  # date<YYYY-MM-DD>\n"));
-        assert!(out.contains("severity: low  # enum<low | medium | high>\n"));
         assert!(out.contains("bio: |-  # markdown\n  \n"));
+        // Typed object / table leaves fall through to type-empty too.
+        // (Object properties indent one level; typed-table rows two.)
+        assert!(out.contains("  street: \"\"  # string\n"), "{out}");
+        assert!(out.contains("    org: \"\"  # string\n"), "{out}");
     }
 
     #[test]
-    fn empty_typed_object_and_table_render_type_valid_and_validate() {
-        // `properties: {}` is a legal (if degenerate) schema — the rejection
-        // targets *absent* properties (freeform), not empty ones. With no
-        // leaves to fill, the value cell must be the empty container (`{}` /
-        // `[]`), not a bare null that fails the field's own validation.
-        let config = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    addr: { type: object, properties: {} }
-    rows: { type: array,  properties: {} }
-"#);
-        for behavior in [
-            super::FillBehavior::Strict,
-            super::FillBehavior::Preview,
-            super::FillBehavior::TypeEmpty,
-        ] {
-            let bp = config.blueprint_filled(behavior);
-            assert!(
-                bp.contains("addr: {}  # object\n"),
-                "{behavior:?} object cell:\n{bp}"
-            );
-            assert!(
-                bp.contains("rows: []  # array<object>\n"),
-                "{behavior:?} table cell:\n{bp}"
-            );
-            let doc = Document::from_markdown(&bp)
-                .unwrap_or_else(|e| panic!("{behavior:?} must parse: {e:?}\n---\n{bp}"));
-            config.validate_document(&doc).unwrap_or_else(|errs| {
-                panic!("{behavior:?} must validate: {errs:?}\n---\n{bp}")
-            });
-        }
-    }
-
-    #[test]
-    fn blueprint_filled_type_empty_validates_clean() {
-        // The type-empty blueprint must be schema-*valid*, not merely
-        // parseable. Exercises every scalar Must Fill type plus the nested
-        // leaves of a typed dictionary and a typed table.
+    fn example_without_examples_validates_clean() {
+        // The example document (zero-filled, no examples) must be schema-valid,
+        // not merely parseable. Exercises every scalar Must Fill type plus the
+        // nested leaves of a typed dictionary and a typed table.
         let config = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -1373,16 +1200,155 @@ main:
         org:  { type: string }
         year: { type: integer }
 "#);
-        let filled = config.blueprint_filled(super::FillBehavior::TypeEmpty);
+        let filled = config.example();
         let doc = Document::from_markdown(&filled)
-            .unwrap_or_else(|e| panic!("filled blueprint must parse: {e:?}\n---\n{filled}"));
+            .unwrap_or_else(|e| panic!("example document must parse: {e:?}\n---\n{filled}"));
         config.validate_document(&doc).unwrap_or_else(|errs| {
-            panic!("type-empty blueprint must validate: {errs:?}\n---\n{filled}")
+            panic!("example document must validate: {errs:?}\n---\n{filled}")
         });
     }
 
     #[test]
-    fn blueprint_filled_preview_round_trips_to_a_valid_document() {
+    fn example_fills_must_fill_cells_from_examples() {
+        // Each Must Fill field carries an `example:`; the example document
+        // renders it as the value cell (without `; delete-ok`, not endorsed).
+        let out = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title:    { type: string, example: Quarterly Report }
+    count:    { type: integer, example: 7 }
+    issued:   { type: date, example: "2030-06-01" }
+    refs:     { type: array, example: [alpha, beta] }
+"#)
+        .example();
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("title: Quarterly Report  # string\n"), "{out}");
+        assert!(out.contains("count: 7  # integer\n"), "{out}");
+        assert!(out.contains("issued: 2030-06-01  # date<YYYY-MM-DD>\n"), "{out}");
+        assert!(out.contains("refs:  # array<string>\n  - alpha\n  - beta\n"), "{out}");
+    }
+
+    #[test]
+    fn example_markdown_block_scalar() {
+        // No example → empty body (zero fallback). With an example → the
+        // example text, rendered verbatim inside the block scalar.
+        let bare = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown }
+"#)
+        .example();
+        assert!(!bare.contains("<must-fill>"), "no sentinels expected: {bare}");
+        assert!(bare.contains("bio: |-  # markdown\n  \n"), "{bare}");
+
+        let with_eg = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown, example: "Hello there." }
+"#)
+        .example();
+        assert!(with_eg.contains("bio: |-  # markdown\n  Hello there.\n"), "{with_eg}");
+    }
+
+    #[test]
+    fn example_renders_endorsed_default_when_no_example() {
+        // Fields with a `default:` and no `example:` → the example document
+        // renders the default (example › default, example absent).
+        let out = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    size:   { type: number, default: 11 }
+    flag:   { type: boolean, default: true }
+    status: { type: string, default: draft }
+"#)
+        .example();
+        assert!(out.contains("size: 11  # number; delete-ok\n"));
+        assert!(out.contains("flag: true  # boolean; delete-ok\n"));
+        assert!(out.contains("status: draft  # string; delete-ok\n"));
+    }
+
+    #[test]
+    fn example_substitutes_typed_table_leaves() {
+        // No field-level example and no leaf examples → a synthetic row with
+        // type-empty leaves.
+        let out = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      properties:
+        org:  { type: string }
+        year: { type: integer }
+"#)
+        .example();
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("refs:  # array<object>\n  -\n"), "{out}");
+        assert!(out.contains("    org: \"\"  # string\n"), "{out}");
+        assert!(out.contains("    year: 0  # integer\n"), "{out}");
+    }
+
+    #[test]
+    fn example_renders_typed_table_field_example_rows() {
+        // A field-level `example:` on a Must Fill typed table renders as rows
+        // in the example document (no `; delete-ok`, since there is no default).
+        let out = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    refs:
+      type: array
+      example:
+        - { org: ACME, year: 2020 }
+      properties:
+        org:  { type: string }
+        year: { type: integer }
+"#)
+        .example();
+        assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
+        assert!(out.contains("refs:  # array<object>\n"), "{out}");
+        assert!(out.contains("  - org: ACME\n"), "{out}");
+        assert!(out.contains("    year: 2020\n"), "{out}");
+        assert!(!out.contains("; delete-ok"), "not endorsed: {out}");
+    }
+
+    #[test]
+    fn empty_typed_object_and_table_render_type_valid_and_validate() {
+        // `properties: {}` is a legal (if degenerate) schema — the rejection
+        // targets *absent* properties (freeform), not empty ones. With no
+        // leaves to fill, the value cell must be the empty container (`{}` /
+        // `[]`), not a bare null that fails the field's own validation. Holds
+        // for both reference documents.
+        let config = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    addr: { type: object, properties: {} }
+    rows: { type: array,  properties: {} }
+"#);
+        for doc_md in [config.blueprint(), config.example()] {
+            assert!(
+                doc_md.contains("addr: {}  # object\n"),
+                "object cell:\n{doc_md}"
+            );
+            assert!(
+                doc_md.contains("rows: []  # array<object>\n"),
+                "table cell:\n{doc_md}"
+            );
+            let doc = Document::from_markdown(&doc_md)
+                .unwrap_or_else(|e| panic!("must parse: {e:?}\n---\n{doc_md}"));
+            config
+                .validate_document(&doc)
+                .unwrap_or_else(|errs| panic!("must validate: {errs:?}\n---\n{doc_md}"));
+        }
+    }
+
+    #[test]
+    fn example_round_trips_to_a_valid_document() {
         // Fields with examples render them; the example-less ones fall back to
         // type-empty. The result must parse and validate.
         let config = cfg(r#"
@@ -1396,11 +1362,11 @@ main:
     issued:    { type: date }
     refs:      { type: array, example: [first, second] }
 "#);
-        let filled = config.blueprint_filled(super::FillBehavior::Preview);
+        let filled = config.example();
         let doc = Document::from_markdown(&filled)
-            .unwrap_or_else(|e| panic!("filled blueprint must parse: {e:?}\n---\n{filled}"));
+            .unwrap_or_else(|e| panic!("example document must parse: {e:?}\n---\n{filled}"));
         config.validate_document(&doc).unwrap_or_else(|errs| {
-            panic!("preview blueprint must validate: {errs:?}\n---\n{filled}")
+            panic!("example document must validate: {errs:?}\n---\n{filled}")
         });
         let main = doc.main().payload();
         assert_eq!(main.get("title").unwrap().as_str().unwrap(), "My Title");

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -1,0 +1,41 @@
+//! The per-field **zero value** — the type-minimal valid value for a field.
+//!
+//! This is the single source of truth for "the zero value for this field,"
+//! shared by two callers (see `prose/proposals/`):
+//!
+//! - **blueprint/example emission** ([`super::blueprint`]) — the `example`
+//!   document's fallback, when a field carries neither an `example:` nor a
+//!   `default:`.
+//! - **zero-filled render** (the render path in `quillmark::orchestration`) —
+//!   each absent field is filled with its zero value in the plate-JSON
+//!   projection only, never in the persisted document.
+
+use serde_json::json;
+
+use super::{FieldSchema, FieldType};
+use crate::value::QuillValue;
+
+/// The type-empty (zero) value for `field`: the leanest value that satisfies
+/// the field's declared type.
+///
+/// Honestly blank for almost every type — `""` (string, markdown, date,
+/// datetime: the validator accepts the empty string for date/datetime), `0`,
+/// `false`, `[]`, `{}`. The lone seam is `enum`: there is no empty enum
+/// member, so the zero value is the first declared variant (`first_enum`).
+pub fn zero_value(field: &FieldSchema) -> QuillValue {
+    if let Some(values) = &field.enum_values {
+        let first = values.first().cloned().unwrap_or_default();
+        return QuillValue::from_json(json!(first));
+    }
+    let json = match field.r#type {
+        FieldType::Array => json!([]),
+        // A bare object reaching this point would be schema-invalid (objects
+        // require a `properties` map). `{}` is the type-correct zero regardless.
+        FieldType::Object => json!({}),
+        FieldType::Integer | FieldType::Number => json!(0),
+        FieldType::Boolean => json!(false),
+        // String / Markdown / Date / DateTime: `""` is schema-valid for all four.
+        _ => json!(""),
+    };
+    QuillValue::from_json(json)
+}

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -21,7 +21,7 @@
 // Re-export core types for convenience. Note: `QuillSource` is not re-exported
 // at the crate root — Quillmark consumers work with the renderable `Quill`.
 pub use quillmark_core::{
-    Artifact, Backend, Card, Diagnostic, Document, FillBehavior, Location, OutputFormat, ParseError,
+    Artifact, Backend, Card, Diagnostic, Document, Location, OutputFormat, ParseError,
     ParseOutput, RenderError, RenderOptions, RenderResult, RenderSession, Severity,
 };
 

--- a/crates/quillmark/src/orchestration/quill.rs
+++ b/crates/quillmark/src/orchestration/quill.rs
@@ -2,12 +2,12 @@
 //! [`QuillSource`] with a resolved backend.
 
 use indexmap::IndexMap;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use quillmark_core::{
-    normalize::normalize_document, Backend, Card, Diagnostic, Document, OutputFormat, Payload,
-    QuillSource, QuillValue, RenderError, RenderOptions, RenderResult, RenderSession, Severity,
+    normalize::normalize_document, quill::CardSchema, zero_value, Backend, Card, Diagnostic,
+    Document, OutputFormat, Payload, QuillSource, QuillValue, RenderError, RenderOptions,
+    RenderResult, RenderSession, Severity,
 };
 
 use crate::form::{self, Form, FormCard};
@@ -78,25 +78,29 @@ impl Quill {
     }
 
     /// Compile a document to JSON wire format for the backend.
-    /// Applies coercion, validation, normalization, and schema defaults.
+    ///
+    /// Applies coercion, validation, normalization, and **zero-filled render**:
+    /// every absent schema field is resolved to its authored value, else its
+    /// schema default, else its type-empty zero value — in this plate-JSON
+    /// projection only, never in the persisted document. A merely *incomplete*
+    /// document renders fine; only a *malformed* one (a surviving `<must-fill>`
+    /// sentinel or a value that won't coerce/validate) errors. See
+    /// `prose/proposals/zero-filled-render.md`.
     pub fn compile_data(&self, doc: &Document) -> Result<serde_json::Value, RenderError> {
         let coerced = self.coerce_and_validate(doc)?;
         let normalized = normalize_document(coerced)?;
-        let main_with_defaults = apply_defaults(
-            &normalized.main().payload().to_index_map(),
-            self.source.config().main.defaults(),
-        );
-        let cards_with_defaults: Vec<Card> = normalized
+        let config = self.source.config();
+
+        let main_resolved =
+            resolve_fields(&normalized.main().payload().to_index_map(), &config.main);
+        let cards_resolved: Vec<Card> = normalized
             .cards()
             .iter()
             .map(|card| {
-                let defaults = self
-                    .source
-                    .config()
-                    .card_kind(card.kind().unwrap_or(""))
-                    .map(|c| c.defaults())
-                    .unwrap_or_default();
-                let fields = apply_defaults(&card.payload().to_index_map(), defaults);
+                let fields = match config.card_kind(card.kind().unwrap_or("")) {
+                    Some(schema) => resolve_fields(&card.payload().to_index_map(), schema),
+                    None => card.payload().to_index_map(),
+                };
                 Card::from_parts(
                     rebuild_payload_with_meta(card, fields),
                     card.body().to_string(),
@@ -105,10 +109,10 @@ impl Quill {
             .collect();
 
         let final_main = Card::from_parts(
-            rebuild_payload_with_meta(normalized.main(), main_with_defaults),
+            rebuild_payload_with_meta(normalized.main(), main_resolved),
             normalized.main().body().to_string(),
         );
-        let final_doc = Document::from_main_and_cards(final_main, cards_with_defaults, Vec::new());
+        let final_doc = Document::from_main_and_cards(final_main, cards_resolved, Vec::new());
 
         Ok(final_doc.to_plate_json())
     }
@@ -195,14 +199,27 @@ impl Quill {
         match self.source.config().validate_document(doc) {
             Ok(_) => Ok(()),
             Err(errors) => {
-                // Each ValidationError gets its own Diagnostic so consumers
-                // can use `path` for UI navigation via `RenderError::diagnostics()`.
-                debug_assert!(
-                    !errors.is_empty(),
-                    "ValidationFailed must carry at least one diagnostic"
-                );
-                let diags: Vec<Diagnostic> = errors.iter().map(|e| e.to_diagnostic()).collect();
-                Err(RenderError::ValidationFailed { diags })
+                // Zero-filled render: a merely *incomplete* document (Must Fill
+                // fields absent) renders fine — each absent field is zero-filled
+                // in `resolve_fields`. Only *malformed* input is fatal: a
+                // surviving `<must-fill>` sentinel, or a value that won't
+                // coerce/validate. So `validation::must_fill_absent` is demoted
+                // (absence warnings are a deferred follow-up; today the form's
+                // `FormFieldSource::Missing` carries the doneness signal).
+                //
+                // Each surviving ValidationError gets its own Diagnostic so
+                // consumers can use `path` for UI navigation via
+                // `RenderError::diagnostics()`.
+                let diags: Vec<Diagnostic> = errors
+                    .iter()
+                    .filter(|e| e.code() != "validation::must_fill_absent")
+                    .map(|e| e.to_diagnostic())
+                    .collect();
+                if diags.is_empty() {
+                    Ok(())
+                } else {
+                    Err(RenderError::ValidationFailed { diags })
+                }
             }
         }
     }
@@ -218,14 +235,23 @@ fn coercion_error(e: impl std::fmt::Display) -> RenderError {
     }
 }
 
-/// Merge schema `defaults` into `fields`; existing fields win.
-fn apply_defaults(
+/// Resolve every schema field absent from `fields`, by precedence: an
+/// authored value wins; else the schema `default:`; else the type-empty
+/// [`zero_value`]. This is the zero-filled render projection — the fill lives
+/// only here and is never persisted (see
+/// `prose/proposals/zero-filled-render.md`). Non-schema fields already present
+/// are preserved untouched.
+fn resolve_fields(
     fields: &IndexMap<String, QuillValue>,
-    defaults: HashMap<String, QuillValue>,
+    schema: &CardSchema,
 ) -> IndexMap<String, QuillValue> {
     let mut result = fields.clone();
-    for (k, v) in defaults {
-        result.entry(k).or_insert(v);
+    for (name, field) in &schema.fields {
+        if result.contains_key(name) {
+            continue;
+        }
+        let value = field.default.clone().unwrap_or_else(|| zero_value(field));
+        result.insert(name.clone(), value);
     }
     result
 }

--- a/crates/quillmark/tests/common.rs
+++ b/crates/quillmark/tests/common.rs
@@ -1,16 +1,14 @@
 //! Shared test helpers for integration tests.
 
-use quillmark_core::FillBehavior;
 use quillmark_fixtures::{example_output_dir, quills_path, write_example_output};
 use std::error::Error;
 
-/// Load a quill, render its generated blueprint to PDF, and write the result
-/// to the demo output directory.
+/// Load a quill, render its generated `example` document to PDF, and write the
+/// result to the demo output directory.
 ///
-/// Fills the blueprint with [`FillBehavior::Preview`] so Must Fill cells (no
-/// `default:`) carry preview-friendly placeholders and the document renders
-/// out of the box; the plain `blueprint()` keeps the `<must-fill>` sentinel,
-/// which fails validation.
+/// Uses the `example` reference document (example › default › zero) so cells
+/// carry illustrative values and the document renders out of the box; the
+/// plain `blueprint()` keeps the `<must-fill>` sentinel, which is malformed.
 pub fn demo(
     quill_dir: &str,
     render_output: &str,
@@ -26,10 +24,7 @@ pub fn demo(
         .quill_from_path(quill_path.clone())
         .expect("Failed to load quill");
 
-    let markdown = quill
-        .source()
-        .config()
-        .blueprint_filled(FillBehavior::Preview);
+    let markdown = quill.source().config().example();
     let parsed = quillmark::Document::from_markdown(&markdown)?;
 
     let rendered = quill.render(

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -134,7 +134,10 @@ main:
 }
 
 #[test]
-fn test_validation_fails_without_defaults() {
+fn test_absent_must_fill_is_zero_filled() {
+    // Zero-filled render: an absent Must-Fill field (`title`) is tolerated and
+    // filled with its type-empty zero value (`""`) in the plate projection —
+    // never persisted. See prose/proposals/zero-filled-render.md.
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
@@ -164,21 +167,23 @@ main:
         "~~~card-yaml\n$quill: test_quill\n$kind: main\nstatus: published\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
-    let result = quill.dry_run(&parsed);
+    // Render no longer gates on absence.
     assert!(
-        result.is_err(),
-        "Should fail validation — `title` is Must-Fill and absent"
+        quill.dry_run(&parsed).is_ok(),
+        "dry_run should tolerate an absent Must-Fill field (zero-filled)"
     );
 
-    let err = result.unwrap_err();
-    let mentions_title = err
-        .diagnostics()
-        .iter()
-        .any(|d| d.message.contains("title") || d.path.as_deref() == Some("title"));
-    assert!(
-        mentions_title,
-        "Validation diagnostics should mention missing 'title' field; got {:?}",
-        err.diagnostics()
+    // The plate projection carries the zero value for the absent field.
+    let data = quill.compile_data(&parsed).expect("compile_data should succeed");
+    assert_eq!(
+        data.get("title").and_then(|v| v.as_str()),
+        Some(""),
+        "absent Must-Fill `title` should be zero-filled to \"\" in the projection: {data}"
+    );
+    assert_eq!(
+        data.get("status").and_then(|v| v.as_str()),
+        Some("published"),
+        "authored value should win over default"
     );
 }
 

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -46,7 +46,11 @@ fn test_dry_run_success() {
 }
 
 #[test]
-fn test_dry_run_missing_must_fill_field() {
+fn test_dry_run_missing_must_fill_field_is_tolerated() {
+    // Zero-filled render: a merely *incomplete* document (Must Fill `title`
+    // absent) is no longer a hard error — `title` is zero-filled in the plate
+    // projection. Only a *malformed* document (a surviving `<must-fill>`
+    // sentinel) still fails. See prose/proposals/zero-filled-render.md.
     let temp_dir = TempDir::new().unwrap();
     let quill_path = make_test_quill_path(&temp_dir, true);
 
@@ -61,16 +65,37 @@ fn test_dry_run_missing_must_fill_field() {
 
     let result = quill.dry_run(&parsed);
     assert!(
-        result.is_err(),
-        "dry_run should fail for missing Must-Fill field"
+        result.is_ok(),
+        "dry_run should tolerate an absent Must-Fill field (zero-filled): {:?}",
+        result
     );
+}
 
-    let err = result.unwrap_err();
-    let err_str = format!("{:?}", err);
+#[test]
+fn test_dry_run_surviving_sentinel_still_fails() {
+    // A surviving `<must-fill>` sentinel is *malformed* — it always errors,
+    // even though mere absence does not.
+    let temp_dir = TempDir::new().unwrap();
+    let quill_path = make_test_quill_path(&temp_dir, true);
+
+    let engine = Quillmark::new();
+    let quill = engine
+        .quill_from_path(&quill_path)
+        .expect("quill_from_path failed");
+
+    let markdown =
+        "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: <must-fill>\nauthor: Test\n~~~\n\n# Content\n";
+    let parsed = Document::from_markdown(markdown).expect("parse failed");
+
+    let result = quill.dry_run(&parsed);
     assert!(
-        err_str.contains("ValidationFailed") || err_str.contains("title"),
-        "Error should indicate validation failure: {}",
-        err_str
+        result.is_err(),
+        "dry_run should reject a surviving <must-fill> sentinel"
+    );
+    let err_str = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_str.contains("must_fill_sentinel") || err_str.contains("sentinel"),
+        "error should be the sentinel diagnostic: {err_str}"
     );
 }
 

--- a/crates/quillmark/tests/quiver_test.rs
+++ b/crates/quillmark/tests/quiver_test.rs
@@ -1,18 +1,18 @@
 //! Enforces the quill authoring contract from `prose/canon/BLUEPRINT.md`:
-//! every quill in the fixtures quiver loads, and its `plate.typ` renders the
-//! quill's own blueprint (with every `<must-fill>` cell replaced by a
-//! type-empty value) to a successful (non-error) output.
+//! every quill in the fixtures quiver loads, and its `plate.typ` renders an
+//! **empty document** (just `$quill` / `$kind: main`, no fields) to a
+//! successful (non-error) output.
 //!
-//! The blueprint, after sentinel substitution, is the type-minimal valid
-//! input — every field present, every value type-correct, enums at their
-//! first value. A plate that renders it has shown it degrades gracefully
-//! on every type-valid input shape.
+//! Under zero-filled render (see `prose/proposals/zero-filled-render.md`),
+//! every absent field is filled with its type-empty (zero) value in the plate
+//! projection. An empty document is therefore the type-minimal valid input —
+//! the worst-case-but-renderable shape — so a plate that renders it has shown
+//! it degrades gracefully on every type-valid input. No blueprint string is
+//! generated or re-parsed.
 
 #![cfg(feature = "typst")]
 
-use quillmark::{
-    Document, FillBehavior, OutputFormat, Quillmark, RenderError, RenderOptions,
-};
+use quillmark::{Document, OutputFormat, Quillmark, RenderError, RenderOptions};
 use quillmark_fixtures::{quills_path, resource_path};
 use std::fs;
 
@@ -37,12 +37,15 @@ fn every_quill_in_quiver_renders() {
             .quill_from_path(quills_path(&name))
             .unwrap_or_else(|e| panic!("quill '{name}' failed to load: {e:?}"));
 
-        let markdown = quill
-            .source()
-            .config()
-            .blueprint_filled(FillBehavior::TypeEmpty);
+        // An empty document — zero-filled render fills every absent field with
+        // its type-empty value in the plate projection.
+        let config = quill.source().config();
+        let markdown = format!(
+            "~~~\n$quill: {}@{}\n$kind: main\n~~~\n",
+            config.name, config.version
+        );
         let parsed = Document::from_markdown(&markdown).unwrap_or_else(|e| {
-            panic!("quill '{name}' blueprint failed to parse: {e:?}\n---\n{markdown}")
+            panic!("quill '{name}' empty document failed to parse: {e:?}\n---\n{markdown}")
         });
 
         let result = quill.render(

--- a/crates/quillmark/tests/usaf_memo_signature_test.rs
+++ b/crates/quillmark/tests/usaf_memo_signature_test.rs
@@ -10,7 +10,7 @@
 
 #![cfg(feature = "typst")]
 
-use quillmark::{Document, FillBehavior, OutputFormat, Quillmark, RenderError, RenderOptions};
+use quillmark::{Document, OutputFormat, Quillmark, RenderError, RenderOptions};
 use quillmark_fixtures::quills_path;
 
 const PT_PER_IN: f32 = 72.0;
@@ -59,13 +59,11 @@ fn usaf_memo_signature_widget_aligns_with_signature_block() {
         .quill_from_path(quills_path("usaf_memo"))
         .expect("usaf_memo should load");
 
-    // Preview fill exercises the main memo *and* a representative indorsement
-    // card, so both the `Signature` and `Ind_0_Signature` widgets are emitted.
-    let markdown = quill
-        .source()
-        .config()
-        .blueprint_filled(FillBehavior::Preview);
-    let parsed = Document::from_markdown(&markdown).expect("blueprint should parse");
+    // The `example` document exercises the main memo *and* a representative
+    // indorsement card, so both the `Signature` and `Ind_0_Signature` widgets
+    // are emitted.
+    let markdown = quill.source().config().example();
+    let parsed = Document::from_markdown(&markdown).expect("example document should parse");
 
     let result = quill.render(
         &parsed,

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -344,15 +344,16 @@ with a typed value.
 packages, which `blueprint()` does not control. That is a separate
 **quill authoring contract**:
 
-> A quill's `plate.typ` MUST render the quill's own blueprint — generated
-> with Must Fill cells filled by type-empty values of the declared type
-> (`blueprint_filled(FillBehavior::TypeEmpty)`) — to a successful
-> (non-error) output.
+> A quill's `plate.typ` MUST render an **empty document** (just `$quill` /
+> `$kind: main`, no fields) to a successful (non-error) output. Under
+> zero-filled render, every absent field is filled with its type-empty
+> (zero) value in the plate projection, so an empty document is by
+> construction the *type-minimal valid input*.
 
-The type-empty blueprint is by construction the *type-minimal valid
-input* — the worst-case-but-valid document. A plate that renders it has
-shown it degrades gracefully on every type-valid input shape. The
-contract requires:
+The zero-filled empty document is the *type-minimal valid input* — the
+worst-case-but-renderable document. A plate that renders it has shown it
+degrades gracefully on every type-valid input shape. The contract
+requires:
 
 - Templates treat type-empty values (`""`, `0`, `false`, `[]`, empty
   markdown body) as valid *present* input — read via `data.field`,
@@ -364,32 +365,47 @@ contract requires:
   meaningful output." An empty-string title is a blank title — that is
   acceptable.
 
-The contract is enforced by a fixture test that generates each bundled
-quill's blueprint with type-empty fill, renders it, and asserts success
+The contract is enforced by a fixture test that renders each bundled
+quill's empty document (zero-filled) and asserts success
 (`crates/quillmark/tests/quiver_test.rs::every_quill_in_quiver_renders`).
 
-## Filled blueprints
+## Two reference documents
 
-`blueprint()` emits the canonical authoring surface with `<must-fill>`
-sentinels. `QuillConfig::blueprint_filled(behavior)` is an escape hatch
-that fills Must Fill cells at generation time — from the typed schema, so
-no value re-parses the annotation grammar — producing a compile-able
-document without an authored input:
+A quill projects into two intent-named reference documents, each ordering
+its value sources for its own purpose (there is no cross-output "default
+always wins" rule). Both are annotated, parseable, and schema-valid; the
+fill strategy is an internal detail, not a public parameter.
 
-| `FillBehavior` | Must Fill value | Used by |
-|---|---|---|
-| `Strict` | `<must-fill>` sentinel (identical to `blueprint()`) | authoring surface |
-| `Preview` | the field's `example:` when configured, else the `TypeEmpty` value | CLI `render` with no input file |
-| `TypeEmpty` | leanest type-valid values (`""`, `0`, `false`, `[]`, first enum) | quiver authoring-contract test |
+| Output | Intent | Value precedence | Sentinels? |
+|---|---|---|---|
+| `blueprint` | *"give me the form to fill"* | `default:`, else `<must-fill>` | yes |
+| `example` | *"show me a filled-out one"* | `example:` › `default:` › type-empty zero | no |
+
+- The **blueprint** is the canonical authoring surface: an Endorsed field
+  (has a `default:`) renders its default; a Must Fill field carries the
+  `<must-fill>` sentinel.
+- The **example** document is the illustrative consolidation — each
+  field's `example:`, else its `default:`, else its zero value — with no
+  sentinels. It is example-*first* but not guaranteed fully populated
+  (a field with neither an `example:` nor a `default:` renders blank). A
+  field with *both* a default and an example shows its example here but
+  its default on the render path: the example optimizes for illustration,
+  render for fidelity.
+- The per-field **zero value** (`""`, `0`, `false`, `[]`, `{}`, first
+  enum variant; `quillmark_core::quill::zero_value`) is one shared
+  producer — the example fallback above *and* the render floor for
+  zero-filled render (see
+  [zero-filled-render.md](../proposals/zero-filled-render.md), pending
+  graduation into [SCHEMAS.md](SCHEMAS.md)).
 
 ## Bindings surface
 
 | Binding | Accessor |
 |---|---|
-| Rust | `QuillConfig::blueprint() -> String` (+ `blueprint_filled(behavior)`) |
-| Wasm | `Quill.blueprint` getter |
-| Python | `Quill.blueprint` property |
-| CLI | `quillmark blueprint <QUILL_PATH> [-o <FILE>]` |
+| Rust | `QuillConfig::blueprint() -> String`, `QuillConfig::example() -> String` |
+| Wasm | `Quill.blueprint` / `Quill.example` getters |
+| Python | `Quill.blueprint` / `Quill.example` properties |
+| CLI | `quillmark blueprint <QUILL_PATH> [-o <FILE>]`; `render` with no input file renders the `example` document |
 
 The Rust example `cargo run -p quillmark-core --example print_blueprint
 -- <quill_name> [<version>]` prints the blueprint for any bundled

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -15,6 +15,12 @@ Two types model a loaded quill:
 
 Bindings expose `Quill` only; `QuillSource` is a Rust-internal type.
 
+A **quiver** is a collection of quills. The bundled fixtures under
+`crates/fixtures/resources/quills/` are one quiver; the
+[quill authoring contract](BLUEPRINT.md#guarantees) is verified across the
+whole quiver by `every_quill_in_quiver_renders`
+(`crates/quillmark/tests/quiver_test.rs`).
+
 ## Internal File Structure
 
 ```rust

--- a/prose/proposals/blueprint-example-split.md
+++ b/prose/proposals/blueprint-example-split.md
@@ -10,12 +10,13 @@
 ## TL;DR
 
 A blueprint is **always** the canonical `<must-fill>` authoring document —
-no modes. Add a second named output, `example`, built from the field
-`example:` values (falling back to the zero value). Demote `FillBehavior`
-from a public parameter to an internal `FillSource` strategy. The pure-zero
-mode (today's `TypeEmpty` blueprint) is removed: its only consumer — the
-quiver authoring contract — instead zero-filled-renders an empty document
-(see [zero-filled-render.md](zero-filled-render.md)).
+no modes. Add a second named output, `example`, the illustrative
+consolidation of the schema: each field renders its `example:`, else its
+`default:`, else the zero value. Demote `FillBehavior` from a public
+parameter to an internal `FillSource` strategy. The pure-zero mode (today's
+`TypeEmpty` blueprint) is removed: its only consumer — the quiver authoring
+contract — instead zero-filled-renders an empty document (see
+[zero-filled-render.md](zero-filled-render.md)).
 
 Pre-1.0; not yet implemented. When built, graduates into
 [BLUEPRINT.md](../canon/BLUEPRINT.md).
@@ -46,18 +47,37 @@ Two problems:
 
 | Output | Intent | Fill source | Sentinels? |
 |---|---|---|---|
-| `blueprint` | *"give me the form to fill"* | `<must-fill>` | yes |
-| `example` | *"show me a filled-out one"* | example-else-zero | no |
+| `blueprint` | *"give me the form to fill"* | `default`, else `<must-fill>` | yes |
+| `example` | *"show me a filled-out one"* | `example` › `default` › zero | no |
 
-- `default:` always wins when present, in both outputs (an Endorsed field
-  renders its default, never a sentinel or example).
-- `example` is example-*else*-zero: a field without an `example:` renders at
-  its zero value. So it is "examples where defined, blank otherwise" — the
-  most illustrative document available, not a fully populated one. State
-  this in the contract so no one expects every field filled.
-- **Naming.** `example()` collides with the `example:` field-schema
-  property. Consider `sample`, `example_document`, or `demo` for the path.
-  The concept is settled; the label is open.
+- **Each artifact orders its value sources for its own purpose** — there is
+  no single cross-output "default always wins" rule. The blueprint shows an
+  Endorsed field's `default:` (and a `<must-fill>` sentinel otherwise); the
+  `example` document prioritizes the illustrative `example:`, falling back to
+  `default:`, then the zero value.
+- `example` is example-*first* but not fully populated: a field with neither
+  an `example:` nor a `default:` renders at its zero value. So it is
+  "examples where defined, defaults next, blank otherwise" — the most
+  illustrative document available, not a guaranteed-complete one. State this
+  in the contract so no one expects every field filled.
+- **The endorsed-field divergence is intentional.** A field carrying *both*
+  a `default:` and an `example:` shows its example in the `example` document
+  but its default on the render path — the example optimizes for
+  *illustration*, render optimizes for *fidelity* (and explicitly never
+  consults `example:`, see [zero-filled-render.md](zero-filled-render.md)).
+  The two artifacts serve different masters; this is by design, not an
+  exception bolted onto a shared rule. (In practice the divergence only fires
+  when a field has both, which is uncommon — examples earn their keep mostly
+  on Must Fill fields that have no default.)
+- **Naming.** The output is named `example`. It is the document-level
+  counterpart of the field-level `example:` property — literally the
+  consolidation of those field examples (and defaults). The shared word is a
+  faithful part-whole correspondence, not a namespace collision: a Rust
+  method / CLI subcommand and a schema key never clash as symbols. The one
+  mild surprise — `example` is example-*first*, not example-*only* — is
+  neutralized by canonizing the definition: *"a quill example is the
+  illustrative consolidation: each field's `example:`, else its `default:`,
+  else blank."*
 
 This is the same axis canonized at the field level — placeholder-to-fill
 (`<must-fill>` / no `default`) vs. illustrative value (`example:`) — lifted
@@ -66,16 +86,23 @@ to the document level.
 ## Internal unification — one emitter, a `FillSource` strategy
 
 The emitter already walks the schema and pulls a per-field value from a
-source. Demote `FillBehavior` to an **internal** `FillSource`:
+source. Demote `FillBehavior` to an **internal** `FillSource` with two
+variants, each composing the shared zero-value leaf with its own precedence:
 
-- `Sentinel` → `blueprint`
-- `ExampleElseZero` → `example`
+- `Sentinel` → `blueprint`: `default`, else `<must-fill>`.
+- `Example` → `example`: `example` › `default` › zero.
 
-`default:` wins across both. The per-field **zero value** (`must_fill_value`
-/ `first_enum`, factored into a `QuillValue` producer) is a shared leaf
-utility — called by the `ExampleElseZero` fallback here *and* by zero-filled
-render. The two proposals share one zero-value producer; this is the
-"unified internally" goal.
+The per-field **zero value** (`must_fill_value` / `first_enum`, factored into
+a `QuillValue` producer) is a shared leaf utility — called by the `Example`
+fallback here *and* by zero-filled render. The two proposals share one
+zero-value producer; this is the "unified internally" goal. Precedence lives
+*above* the leaf, composed per artifact, so the `example` document's
+example-first order is a local choice that never touches the producer or the
+render path.
+
+Two variants for two artifacts — no configurable precedence policy. If a
+third artifact ever appears, add a third variant then; generalizing now would
+invent meaningless combinations (a "blueprint with examples" nobody wants).
 
 ## The dead branch: pure-zero blueprint
 
@@ -92,8 +119,8 @@ has no reason to live:
   error), so "render the blueprint" was never the literal test.
 
 So the blueprint emitter keeps exactly two fill sources — `Sentinel` and
-`ExampleElseZero`. The pure-`Zero` *mode* leaves blueprint logic entirely;
-the zero *value* survives as the example fallback and the render floor.
+`Example`. The pure-`Zero` *mode* leaves blueprint logic entirely; the zero
+*value* survives as the example fallback and the render floor.
 
 `Preview` likewise stops being a blueprint mode: "render with no input"
 becomes "render the `example` document" (or a zero-filled render of an empty
@@ -102,21 +129,36 @@ doc, when blank is wanted).
 ## Bindings surface
 
 Replace the Rust `blueprint_filled(behavior)` escape hatch with `blueprint()`
-+ `example()` (or the chosen name). Wasm/Python/CLI already expose only
-`blueprint`; add the example accessor. CLI `render` with no input renders the
-`example` document.
++ `example()`. Wasm/Python/CLI already expose only `blueprint`; add the
+`example` accessor. CLI `render` with no input renders the `example`
+document.
+
+## Scope (this sprint)
+
+This proposal ships the public split (`blueprint()` + `example()`) and the
+internal `FillSource` demotion. The render-side companion
+([zero-filled-render.md](zero-filled-render.md)) ships zero-filled render and
+the malformed-sentinel error; its **warnings surface** and **standalone
+completeness query** are deferred to a follow-up sprint and are not part of
+this work.
 
 ## Rejected / open
 
 - **Keep `FillBehavior` public** — rejected. It is an internal strategy; the
   public surface should name *intents* (blueprint vs. example), not
   strategies.
-- **Open** — the second output's name (collision with the `example:` field
-  property).
+- **Generalize `FillSource` into a configurable precedence policy** —
+  rejected as overengineering. Two artifacts, two variants.
+- **(resolved) The second output's name** — decided: `example`. The
+  apparent collision with the `example:` field property is a faithful
+  part-whole correspondence, not a symbol clash, and is closed by canonizing
+  the definition above.
 
 ## Graduation
 
 Fold into [BLUEPRINT.md](../canon/BLUEPRINT.md): a "Two reference documents"
-section replaces "Filled blueprints" / the `FillBehavior` table, and the
-zero-value producer cross-links to the zero-filled-render section. Delete
-this proposal.
+section replaces "Filled blueprints" / the `FillBehavior` table, states the
+per-artifact precedence (blueprint: `default`-else-sentinel; example:
+`example` › `default` › zero), defines the quill example as the illustrative
+consolidation, and cross-links the zero-value producer to the
+zero-filled-render section. Delete this proposal.

--- a/prose/proposals/blueprint-example-split.md
+++ b/prose/proposals/blueprint-example-split.md
@@ -14,9 +14,9 @@ no modes. Add a second named output, `example`, the illustrative
 consolidation of the schema: each field renders its `example:`, else its
 `default:`, else the zero value. Demote `FillBehavior` from a public
 parameter to an internal `FillSource` strategy. The pure-zero mode (today's
-`TypeEmpty` blueprint) is removed: its only consumer — the quiver authoring
-contract — instead zero-filled-renders an empty document (see
-[zero-filled-render.md](zero-filled-render.md)).
+`TypeEmpty` blueprint) is removed: its only consumer — the quill authoring
+contract (`every_quill_in_quiver_renders`) — instead zero-filled-renders an
+empty document (see [zero-filled-render.md](zero-filled-render.md)).
 
 Pre-1.0; not yet implemented. When built, graduates into
 [BLUEPRINT.md](../canon/BLUEPRINT.md).
@@ -30,7 +30,7 @@ plus `blueprint_filled(FillBehavior)` with three variants:
 |---|---|---|
 | `Strict` | `<must-fill>` sentinel (identical to `blueprint()`) | authoring surface |
 | `Preview` | the field's `example:`, else the zero value | CLI `render` with no input file |
-| `TypeEmpty` | zero value everywhere (`""`, `0`, `false`, `[]`, `{}`, first enum) | quiver authoring-contract test |
+| `TypeEmpty` | zero value everywhere (`""`, `0`, `false`, `[]`, `{}`, first enum) | quill authoring-contract test (`every_quill_in_quiver_renders`) |
 
 Two problems:
 
@@ -107,7 +107,7 @@ invent meaningless combinations (a "blueprint with examples" nobody wants).
 ## The dead branch: pure-zero blueprint
 
 `blueprint_filled(TypeEmpty)` emits a document with every Must Fill field at
-its zero value. Its only caller is the quiver authoring-contract test
+its zero value. Its only caller is the quill authoring-contract test
 (`every_quill_in_quiver_renders`). Once zero-filled render exists, this mode
 has no reason to live:
 

--- a/prose/proposals/zero-filled-render.md
+++ b/prose/proposals/zero-filled-render.md
@@ -11,19 +11,32 @@
 
 ## TL;DR
 
-Render fill and completeness verdict are **orthogonal**. Both interfaces —
-UI form and MCP/LLM — use **zero-filled render**: each absent field is
-filled with its type-empty (zero) value, in the plate-JSON projection only,
-never in the persisted document. A document that is merely *incomplete*
-(Must Fill fields absent) renders fine; a *malformed* one — a value that
-won't coerce, or a surviving `<must-fill>` sentinel — always errors. Strict
-completeness ("every Must Fill present") is a separate **queryable
-verdict**, not a creation gate, answered identically for documents of
-either origin.
+Render fill and completeness verdict are **orthogonal**. The render path uses
+**zero-filled render**: each absent field is filled with its type-empty
+(zero) value, in the plate-JSON projection only, never in the persisted
+document. A document that is merely *incomplete* (Must Fill fields absent)
+renders fine; a *malformed* one — a value that won't coerce, or a surviving
+`<must-fill>` sentinel — always errors. Strict completeness ("every Must Fill
+present") is a separate concept, not a creation gate — and **in this sprint
+it is not a shipped API**: the web app applies the same lenient render
+everywhere, and the form's existing per-field state is the de-facto doneness
+signal.
 
 Pre-1.0; not yet implemented. When built, the conceptual model graduates
 into [SCHEMAS.md](../canon/SCHEMAS.md) with a pointer from
 [BLUEPRINT.md](../canon/BLUEPRINT.md).
+
+## Scope (this sprint)
+
+- **In:** zero-filled render (type-empty fill in the projection only) as the
+  single, uniform render behavior for both preview and export; the
+  malformed-sentinel and coercion-failure **hard errors**; the shared
+  zero-value producer (with [blueprint-example-split.md](blueprint-example-split.md)).
+- **Deferred:** a **warnings surface** for absent Must Fill fields (absence is
+  zero-filled *silently* for now). A **standalone strict-completeness query
+  API** — there is no finalize/publish gate in the web app, so nothing
+  consumes it; the form's `FormFieldSource::Missing` already answers "is it
+  done?" per field. Both remain in canon as concepts and future seams.
 
 ## Background
 
@@ -55,13 +68,14 @@ Two questions that are easy to conflate, kept separate:
 | Question | Mechanism | Fails when |
 |---|---|---|
 | *Show me something now* | **zero-filled render** | the document is **malformed** — a value that won't coerce, or a surviving `<must-fill>` sentinel. Never merely because it is incomplete. |
-| *Is this document complete?* | **strict completeness check** (a query) | any Must Fill field is **absent** |
+| *Is this document complete?* | **read the field provenance** (the form's `Document` / `Default` / `Missing` state) | any Must Fill field is **absent** |
 
-A document can be renderable (zero-filled) and incomplete (the completeness
-query says "not done") at the same time. "Always compiles" is a render
-guarantee; "complete" is a separate verdict. Naming the render by its
-*fill* — not by a validation posture — keeps the two axes from collapsing
-into one.
+A document can be renderable (zero-filled) and incomplete (a Must Fill field
+is `Missing`) at the same time. "Always compiles" is a render guarantee;
+"complete" is a separate verdict — surfaced this sprint by the form's
+per-field state, not wired to render or to any creation gate. Naming the
+render by its *fill* — not by a validation posture — keeps the two axes from
+collapsing into one.
 
 ## Malformed vs. incomplete
 
@@ -71,8 +85,10 @@ how much of it is filled:
 
 - **Incomplete** — a Must Fill field is **absent**. A coherent state: the
   author (human or LLM) simply did not provide the field. Zero-filled
-  render fills it with the type-empty value; the omission surfaces as a
-  **warning**, never a render error.
+  render fills it with the type-empty value; the omission is **not a render
+  error**. (Surfacing the omission back to the author — a warning — is a
+  deferred follow-up; today the form already shows it per-field via
+  `FormFieldSource::Missing`.)
 - **Malformed** — the document carries something that is **not a value**: a
   value that cannot coerce to its declared type, or a surviving
   `<must-fill>` **sentinel**. These always error, on every path.
@@ -95,10 +111,11 @@ the transcription accident happens — without any interface-specific
 special-casing.
 
 **Strict completeness** — *every* Must Fill field present — remains a
-well-defined verdict, answered identically regardless of origin. It is a
-**query** ("is this done?"), not a creation gate: wire it to the actions
-that need a finished document (publish, submit, finalize), not to render or
-to `create_document`.
+well-defined concept, answered identically regardless of origin. It is a
+**verdict** ("is this done?"), not a creation gate. This sprint reads it off
+the form's per-field provenance rather than a dedicated API; wiring a
+standalone query and any publish/submit/finalize gate is deferred (no such
+gate exists in the web app today).
 
 ## Zero-filled render — type-empty fill in the projection only
 
@@ -119,15 +136,17 @@ else.
   the document. A type-empty value is *indistinguishable from
   authored-empty*; persisting it collapses "field absent (untouched)" and
   "field present and empty" into one and destroys `must_fill_absent`
-  forever (it keys on absence). The fill is part of the render, never part
-  of the document.
+  forever (it keys on absence) — and, critically, leaves a future quill
+  schema migration unable to tell *author-never-touched* from
+  *author-set-blank*, so it would migrate fakes as if they were intent. The
+  fill is part of the render, never part of the document.
 
 ## The two interfaces
 
 Both produce documents in one shared model and run the **same** render +
 validation behavior (zero-fill absence; error on malformation). They differ
-only in how completeness is surfaced to the author — and in the practical
-fact that only the LLM path can emit a sentinel.
+only in how doneness is surfaced to the author — and in the practical fact
+that only the LLM path can emit a sentinel.
 
 ### UI form
 
@@ -137,29 +156,36 @@ fact that only the LLM path can emit a sentinel.
 - Emits **sparse** documents: an empty text box / unselected dropdown is
   *omitted* (treated as absent), so form-completeness and schema-presence
   coincide. The form's existing `FormFieldSource::Missing` / `Default`
-  state is the human-facing completeness signal.
+  state is the human-facing doneness signal — and, this sprint, the doneness
+  verdict itself.
 - **Persists the sparse authored truth**, never the fill.
-- The strict completeness query is the *"is it done?"* gate, wired to
-  submit / publish — not to preview or draft export.
+- No "is it done?" gate is wired to render or export — the web app renders
+  **uniformly throughout**. A finalize gate can read the form provenance if
+  and when one is needed.
 
-### MCP / LLM
+### MCP / LLM (future consumer)
 
-- `create_document(markdown)` also uses zero-filled render. Absent Must
-  Fill fields are zero-filled, not rejected — the LLM is **not** forced to
-  fill every field, so it never has to invent data it does not have.
+- `create_document(markdown)` would use the same zero-filled render. Absent
+  Must Fill fields are zero-filled, not rejected — the LLM is **not** forced
+  to fill every field, so it never has to invent data it does not have.
 - The one accident guard, beyond type-validity: a surviving `<must-fill>`
   **sentinel errors**. `create_document` rejects it with diagnostics and
   the LLM retries (per the MCP workflow). This targets the common LLM
   failure — echoing the blueprint placeholder — precisely, without a blunt
   completeness gate.
-- Absent Must Fill fields come back as **warnings** in the response, so the
-  LLM still learns what it left blank (guidance, not rejection).
+- *(Deferred)* returning absent Must Fill fields as **warnings** in the
+  response. Until the warnings surface ships, absence is zero-filled
+  silently; the LLM still learns shape from the `example` document and hints.
 - Contract for LLM authors: **fill each field or omit it — never leave
   `<must-fill>`.** The blueprint's sentinels mean "replace or delete," not
   content.
-- Semantic quality is steered by the blueprint's `# e.g.` example hints
-  (the `default`/`example` framing in [SCHEMAS.md](../canon/SCHEMAS.md)),
-  not by validation.
+- Semantic quality is steered by the `example` document and the blueprint's
+  `# e.g.` example hints (the `default`/`example` framing in
+  [SCHEMAS.md](../canon/SCHEMAS.md)), not by validation.
+
+This sprint lands the render behavior and the sentinel error on the shared
+render path — independent of whether `create_document` itself ships now. The
+MCP path is the future consumer that motivates the sentinel rule.
 
 ### Mixing the two
 
@@ -172,58 +198,67 @@ independent of origin. No two-class document semantics.
 - **Persist-time zero-fill** (the form populates type-empty into the
   *stored* document, so it is always complete-and-valid). Rejected: it
   makes `must_fill_absent` vacuous (every key always present), bakes the
-  enum first-variant value into storage as a silent fake choice, and
-  creates two-class document semantics in a mixed-author ecosystem — which
-  this project *is*, by design, because blueprints exist precisely so LLMs
-  author these documents too. Zero-fill must stay render-only.
+  enum first-variant value into storage as a silent fake choice, blinds
+  future schema migrations to author intent, and creates two-class document
+  semantics in a mixed-author ecosystem — which this project *is*, by
+  design, because blueprints exist precisely so LLMs author these documents
+  too. Zero-fill must stay render-only.
 - **Strict-gating the LLM on absence** (reject `create_document` when any
   Must Fill field is absent). Rejected in favor of erroring only on the
   malformed sentinel: absence is a coherent, zero-fillable state, and
   forcing the LLM to fill every field pushes it to invent data it does not
   have. The genuine accident worth rejecting is the placeholder
   transcription, which the sentinel rule targets exactly; completeness
-  stays a query for the finalize step.
+  stays a verdict for any future finalize step.
 - **Example-fallback render** (fill absent fields from `example:` instead
-  of the type-empty zero value). Rejected: an example is realistic but
-  *not the value most authors want* (the canonized framing), so it
-  camouflages incompleteness and risks leaking placeholder/PII content
+  of the type-empty zero value). Rejected for the render path: an example is
+  realistic but *not the value most authors want* (the canonized framing),
+  so it camouflages incompleteness and risks leaking placeholder/PII content
   through a complete-looking export. The zero value is honestly blank
-  everywhere except enum. `example` keeps its existing home — the `example`
-  reference document for LLM/no-input *generation* (see
-  [blueprint/example split](blueprint-example-split.md)), where a realistic
-  shape genuinely helps — and does not follow onto the render path.
+  everywhere except enum. `example:` stays on the *generation* side — the
+  `example` reference document (see
+  [blueprint/example split](blueprint-example-split.md)), which deliberately
+  prioritizes `example` › `default` › zero because **illustration** is its
+  job — and does not follow onto the render path, whose job is **fidelity**.
 
 ## Implementation sketch
 
 1. **Zero-value producer.** Factor the type-empty logic out of the
    blueprint string emitter (`must_fill_value` / `first_enum` in
    `crates/core/src/quill/`) into a per-field `QuillValue` producer shared
-   by blueprint emission and the render path — one source of truth for
-   "the zero value for this field." (Shared with the
+   by blueprint/example emission and the render path — one source of truth
+   for "the zero value for this field." (Shared with the
    [blueprint/example split](blueprint-example-split.md), which uses the
    same producer for the `example` document's fallback.)
-2. **Zero-filled render (the single render behavior).** On the render path
-   (`crates/quillmark/src/orchestration/`), after coercion: interpolate
-   each absent field's zero value (mirroring `apply_defaults`, "authored
-   value wins") and demote `must_fill_absent` to a **warning**. Keep
-   `must_fill_sentinel` and coercion failures as **hard errors**. The fill
-   goes into the `to_plate_json` projection only. Both the form path and
-   MCP `create_document` use this same behavior; absence warnings flow back
-   in the result.
-3. **Strict completeness query.** Expose the "every Must Fill present?"
-   check (the existing strict `validate_document`, or a thin wrapper over
-   it) as a separate API for finalize / publish gates — distinct from
-   render.
-4. **Surface.** Render returns artifact + warnings on every binding (Rust /
-   Wasm / Python / CLI); document that zero-filled output is preview/export,
-   not a completeness assertion, and that a surviving `<must-fill>` is the
-   one authoring accident render refuses to paper over.
+2. **One provenance-tagged field-resolution pass (the single render
+   behavior).** On the render path (`crates/quillmark/src/orchestration/`),
+   fold zero-fill into the existing default application: one pass resolving
+   each field as **`authored` › `default` › zero** and **tagging which tier
+   it came from**. The tags are exactly the form's trichotomy — `authored` =
+   `Document`, `default` = `Default`, zero = `Missing` — so render fill and
+   form provenance compute from one walk, not two. The resolved values go
+   into the `to_plate_json` projection only (authored value wins, never
+   persisted); the tier tags feed the form today and the deferred
+   completeness/warnings surface later. `must_fill_absent` stops being a hard
+   error (the zero tier handles it); `must_fill_sentinel` and coercion
+   failures stay **hard errors**, centralized and always-on on the render
+   path.
+3. **(Deferred) Warnings + completeness query.** Surfacing absent Must Fill
+   fields as render warnings, and exposing a standalone "every Must Fill
+   present?" query for any future finalize/publish gate, are **out of scope
+   this sprint** — the tier tags from step 2 already carry the information
+   when a consumer appears.
+4. **Surface.** Render returns the artifact on every binding (Rust / Wasm /
+   Python / CLI); document that zero-filled output is preview/export, not a
+   completeness assertion, and that a surviving `<must-fill>` is the one
+   authoring accident render refuses to paper over.
 
 ## Graduation
 
 Once implemented and tested, fold the conceptual model into
 [SCHEMAS.md](../canon/SCHEMAS.md) as a "Zero-filled render" section
-(render fill ⊥ completeness verdict; malformed vs. incomplete; the two
-interfaces), add a one-line pointer from
-[BLUEPRINT.md](../canon/BLUEPRINT.md)'s filled-blueprints section, and
-delete this proposal.
+(render fill ⊥ completeness verdict; malformed vs. incomplete; the
+provenance-tagged resolution; the two interfaces), add a one-line pointer
+from [BLUEPRINT.md](../canon/BLUEPRINT.md)'s filled-blueprints section, and
+delete this proposal. The deferred warnings surface and completeness-query
+API graduate with the follow-up sprint that builds them.


### PR DESCRIPTION
Reframe the `default` and `example` field-schema properties around author
intent rather than shippability:

- `default` is the value the majority of authors want; when omitted, the
  default is interpolated (an authored value always wins).
- `example` matches the semantic and type shape of the desired value but
  is not the value most authors want — it documents shape only and never
  renders as the value.

Update canon (SCHEMAS.md, BLUEPRINT.md), the Quill.yaml reference, and the
FieldSchema doc comments. No behavior change; the mechanical Must-Fill vs.
Endorsed consequences (delete-ok tag, must-fill sentinel) are unchanged.