### PR TITLE
Refactor array fields to use `items` schema for element typing

### DIFF
--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -214,6 +214,23 @@ fn is_markdown_field(field_schema: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
+/// Check if a field schema indicates an array of markdown elements.
+///
+/// True when the field is `{type: array, items: {contentMediaType:
+/// text/markdown}}` — i.e. a `markdown[]` field. Each element is markdown
+/// text that must be converted to backend markup individually.
+fn is_markdown_array_field(field_schema: &serde_json::Value) -> bool {
+    field_schema
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(|s| s == "array")
+        .unwrap_or(false)
+        && field_schema
+            .get("items")
+            .map(is_markdown_field)
+            .unwrap_or(false)
+}
+
 /// Check if a field schema indicates a date field.
 ///
 /// A field is considered a date if it has:
@@ -271,6 +288,27 @@ fn transform_markdown_fields(
                         content_field_names.push(field_name);
                     }
                 }
+            } else if is_markdown_array_field(field_schema) {
+                // `markdown[]`: convert each string element to backend markup.
+                // The helper package maps `eval(.., mode: "markup")` over the
+                // resulting array (see lib.typ.template).
+                if let Some(arr) = field_value.as_array() {
+                    let converted: Vec<serde_json::Value> = arr
+                        .iter()
+                        .map(|elem| match elem.as_str() {
+                            Some(s) => match mark_to_typst(s) {
+                                Ok(markup) => serde_json::json!(markup),
+                                Err(_) => elem.clone(),
+                            },
+                            None => elem.clone(),
+                        })
+                        .collect();
+                    result.insert(
+                        field_name.clone(),
+                        QuillValue::from_json(serde_json::Value::Array(converted)),
+                    );
+                    content_field_names.push(field_name);
+                }
             }
         }
     }
@@ -304,7 +342,9 @@ fn transform_markdown_fields(
                     .map(|props| {
                         props
                             .iter()
-                            .filter(|(_, fs)| is_markdown_field(fs))
+                            .filter(|(_, fs)| {
+                                is_markdown_field(fs) || is_markdown_array_field(fs)
+                            })
                             .map(|(name, _)| name.as_str())
                             .collect()
                     })
@@ -444,6 +484,56 @@ mod tests {
             "contentMediaType": "text/plain"
         });
         assert!(!is_markdown_field(&other_media_type));
+    }
+
+    #[test]
+    fn test_is_markdown_array_field() {
+        let md_array = json!({
+            "type": "array",
+            "items": { "type": "string", "contentMediaType": "text/markdown" }
+        });
+        assert!(is_markdown_array_field(&md_array));
+
+        let string_array = json!({
+            "type": "array",
+            "items": { "type": "string" }
+        });
+        assert!(!is_markdown_array_field(&string_array));
+
+        // A plain markdown scalar is not a markdown array.
+        let md_scalar = json!({ "type": "string", "contentMediaType": "text/markdown" });
+        assert!(!is_markdown_array_field(&md_scalar));
+    }
+
+    #[test]
+    fn test_transform_markdown_array_field() {
+        let schema = QuillValue::from_json(json!({
+            "type": "object",
+            "properties": {
+                "sections": {
+                    "type": "array",
+                    "items": { "type": "string", "contentMediaType": "text/markdown" }
+                }
+            }
+        }));
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "sections".to_string(),
+            QuillValue::from_json(json!(["This is **bold** text.", "Plain line."])),
+        );
+
+        let result = transform_markdown_fields(&fields, &schema);
+
+        // Each element is converted to Typst markup.
+        let sections = result.get("sections").unwrap().as_array().unwrap();
+        assert!(sections[0].as_str().unwrap().contains("#strong[bold]"));
+        assert!(sections[1].as_str().unwrap().contains("Plain line."));
+
+        // The field is registered for auto-eval in __meta__.
+        let meta = result.get("__meta__").unwrap().as_json();
+        let content_fields = meta["content_fields"].as_array().unwrap();
+        assert!(content_fields.iter().any(|v| v == "sections"));
     }
 
     #[test]

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -66,12 +66,15 @@
     card_date_fields: (:),
   ))
 
-  // Auto-eval top-level content fields
+  // Auto-eval top-level content fields. A markdown field is a string; a
+  // `markdown[]` field is an array whose string elements are each eval'd.
   for key in meta.content_fields {
     if key in d {
       let val = d.at(key)
       if type(val) == str and val != "" {
         d.insert(key, eval(val, mode: "markup"))
+      } else if type(val) == array {
+        d.insert(key, val.map(v => if type(v) == str and v != "" { eval(v, mode: "markup") } else { v }))
       }
     }
   }
@@ -97,6 +100,8 @@
           let val = card.at(key)
           if type(val) == str and val != "" {
             card.insert(key, eval(val, mode: "markup"))
+          } else if type(val) == array {
+            card.insert(key, val.map(v => if type(v) == str and v != "" { eval(v, mode: "markup") } else { v }))
           }
         }
       }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -228,11 +228,17 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 fn write_field(out: &mut String, field: &FieldSchema, indent: usize, source: FillSource) {
     let pad = "  ".repeat(indent);
 
-    // Typed table: array with a properties map directly on the field.
+    // Typed table: an array whose element is an object with properties.
+    // Scalar-element arrays (`string[]`, `integer[]`, `markdown[]`, …) fall
+    // through to the uniform scalar rendering below.
     if matches!(field.r#type, FieldType::Array) {
-        if let Some(props) = &field.properties {
-            write_typed_table_field(out, field, props, indent, source);
-            return;
+        if let Some(items) = &field.items {
+            if matches!(items.r#type, FieldType::Object) {
+                if let Some(props) = &items.properties {
+                    write_typed_table_field(out, field, props, indent, source);
+                    return;
+                }
+            }
         }
     }
 
@@ -250,12 +256,12 @@ fn write_field(out: &mut String, field: &FieldSchema, indent: usize, source: Fil
     // Markdown fields render as a YAML block scalar so multi-line content has
     // a consistent shape regardless of whether a default is configured.
     if matches!(field.r#type, FieldType::Markdown) {
-        let inline = inline_annotation(field, false, field.default.is_some());
+        let inline = inline_annotation(field, field.default.is_some());
         write_markdown_block(out, field, &pad, &inline, source);
         return;
     }
 
-    let inline = format!("  # {}", inline_annotation(field, false, field.default.is_some()));
+    let inline = format!("  # {}", inline_annotation(field, field.default.is_some()));
     let value = field_value(field, source);
     write_value(out, &field.name, &value, &inline, &pad);
 }
@@ -352,7 +358,7 @@ fn write_typed_table_field(
 
     // Endorsement keys off `default:` alone; the rendered rows come from the
     // default or — under `Preview` — the `example:`.
-    let inline = inline_annotation(field, true, field.default.is_some());
+    let inline = inline_annotation(field, field.default.is_some());
     let rows = fill_source(field, source).and_then(|v| match v.as_json() {
         serde_json::Value::Array(items) => Some(items.clone()),
         _ => None,
@@ -409,7 +415,7 @@ fn write_typed_object_field(
 
     // Endorsement keys off `default:` alone; the rendered mapping comes from
     // the default or — under `Preview` — the `example:`.
-    let inline = inline_annotation(field, false, field.default.is_some());
+    let inline = inline_annotation(field, field.default.is_some());
     let mapping = fill_source(field, source).and_then(|v| match v.as_json() {
         serde_json::Value::Object(map) => Some(map.clone()),
         _ => None,
@@ -446,8 +452,8 @@ fn write_typed_object_field(
 /// always render as `array<object>`; plain arrays render as `array<string>`.
 /// `endorsed` is uniformly `field.default.is_some()` — any `default:`
 /// (including type-empty `""`, `[]`, `{}`) means the cell is shippable.
-fn inline_annotation(field: &FieldSchema, force_array_object: bool, endorsed: bool) -> String {
-    let type_expr = type_expression(field, force_array_object);
+fn inline_annotation(field: &FieldSchema, endorsed: bool) -> String {
+    let type_expr = type_expression(field);
     if endorsed {
         format!("{}; delete-ok", type_expr)
     } else {
@@ -455,7 +461,7 @@ fn inline_annotation(field: &FieldSchema, force_array_object: bool, endorsed: bo
     }
 }
 
-fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
+fn type_expression(field: &FieldSchema) -> String {
     if let Some(values) = &field.enum_values {
         return format!("enum<{}>", values.join(" | "));
     }
@@ -468,12 +474,15 @@ fn type_expression(field: &FieldSchema, force_array_object: bool) -> String {
         FieldType::Markdown => "markdown".into(),
         FieldType::Date => "date<YYYY-MM-DD>".into(),
         FieldType::DateTime => "datetime<ISO 8601>".into(),
+        // The element type comes from `items`; a scalar element gives
+        // `array<string>`/`array<integer>`/`array<markdown>`, an object
+        // element gives `array<object>`.
         FieldType::Array => {
-            let item = if force_array_object {
-                "object"
-            } else {
-                "string"
-            };
+            let item = field
+                .items
+                .as_ref()
+                .map(|it| type_expression(it))
+                .unwrap_or_else(|| "string".into());
             format!("array<{}>", item)
         }
     }
@@ -622,6 +631,7 @@ main:
   fields:
     recipient:
       type: array
+      items: { type: string }
       example:
         - Mr. John Doe
         - 123 Main St
@@ -670,6 +680,7 @@ main:
   fields:
     memo_from:
       type: array
+      items: { type: string }
       example:
         - ORG/SYMBOL
         - City ST 12345
@@ -707,7 +718,7 @@ main:
     flag: { type: boolean, default: false }
     issued: { type: date }
     published: { type: datetime }
-    refs: { type: array, default: [] }
+    refs: { type: array, default: [], items: { type: string } }
 "#)
         .blueprint();
         assert!(t.contains("title: <must-fill>  # string\n"));
@@ -716,6 +727,24 @@ main:
         assert!(t.contains("issued: <must-fill>  # date<YYYY-MM-DD>\n"));
         assert!(t.contains("published: <must-fill>  # datetime<ISO 8601>\n"));
         assert!(t.contains("refs: []  # array<string>; delete-ok\n"));
+    }
+
+    #[test]
+    fn scalar_array_annotation_reflects_element_type() {
+        // The element type drives the format slot: `array<integer>`,
+        // `array<markdown>`, … rather than a hardcoded `array<string>`.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    counts:   { type: array, items: { type: integer } }
+    sections: { type: array, items: { type: markdown } }
+    tags:     { type: array, items: { type: string } }
+"#)
+        .blueprint();
+        assert!(t.contains("counts: <must-fill>  # array<integer>\n"), "{t}");
+        assert!(t.contains("sections: <must-fill>  # array<markdown>\n"), "{t}");
+        assert!(t.contains("tags: <must-fill>  # array<string>\n"), "{t}");
     }
 
     #[test]
@@ -802,7 +831,7 @@ card_kinds:
   skills:
     body: { enabled: false }
     fields:
-      items: { type: array }
+      items: { type: array, items: { type: string } }
 "#)
         .blueprint();
         let after = &t[t.find("$kind: skills").unwrap()..];
@@ -866,7 +895,7 @@ card_kinds:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    memo_for: { type: array, ui: { group: Addressing } }
+    memo_for: { type: array, items: { type: string }, ui: { group: Addressing } }
     subject: { type: string, ui: { group: Addressing } }
     letterhead_title: { type: string, default: HQ, ui: { group: Letterhead } }
     notes: { type: string }
@@ -894,9 +923,11 @@ main:
     references:
       type: array
       description: Cited works.
-      properties:
-        org: { type: string, description: Citing organization. }
-        year: { type: integer, default: 0, description: Publication year. }
+      items:
+        type: object
+        properties:
+          org: { type: string, description: Citing organization. }
+          year: { type: integer, default: 0, description: Publication year. }
 "#)
         .blueprint();
         assert!(t.contains("# Cited works.\nreferences:  # array<object>\n  -\n"));
@@ -916,9 +947,11 @@ main:
       type: array
       example:
         - { org: ACME, year: 2020 }
-      properties:
-        org: { type: string }
-        year: { type: integer, default: 0 }
+      items:
+        type: object
+        properties:
+          org: { type: string }
+          year: { type: integer, default: 0 }
 "#)
         .blueprint();
         assert!(t.contains("# e.g. [{org: ACME, year: 2020}]\n"));
@@ -937,8 +970,10 @@ main:
       type: array
       default:
         - { org: ACME }
-      properties:
-        org: { type: string }
+      items:
+        type: object
+        properties:
+          org: { type: string }
 "#)
         .blueprint();
         assert!(t.contains("refs:  # array<object>; delete-ok\n  - org: ACME\n"));
@@ -958,8 +993,10 @@ main:
     refs:
       type: array
       default: []
-      properties:
-        org: { type: string }
+      items:
+        type: object
+        properties:
+          org: { type: string }
 "#)
         .blueprint();
         assert!(
@@ -1080,6 +1117,7 @@ main:
       default: normal
     attachments:
       type: array
+      items: { type: string }
       default: []
       example:
         - report.pdf
@@ -1139,7 +1177,7 @@ main:
     count:     { type: integer }
     ratio:     { type: number }
     flag:      { type: boolean }
-    refs:      { type: array }
+    refs:      { type: array, items: { type: string } }
     issued:    { type: date }
     published: { type: datetime }
     severity:  { type: string, enum: [low, medium, high] }
@@ -1151,9 +1189,11 @@ main:
         zip:    { type: integer }
     rows:
       type: array
-      properties:
-        org:  { type: string }
-        year: { type: integer }
+      items:
+        type: object
+        properties:
+          org:  { type: string }
+          year: { type: integer }
 "#)
         .example();
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
@@ -1185,7 +1225,7 @@ main:
     title:    { type: string }
     count:    { type: integer }
     flag:     { type: boolean }
-    refs:     { type: array }
+    refs:     { type: array, items: { type: string } }
     issued:   { type: date }
     severity: { type: string, enum: [low, medium, high] }
     bio:      { type: markdown }
@@ -1196,9 +1236,11 @@ main:
         zip:    { type: integer }
     rows:
       type: array
-      properties:
-        org:  { type: string }
-        year: { type: integer }
+      items:
+        type: object
+        properties:
+          org:  { type: string }
+          year: { type: integer }
 "#);
         let filled = config.example();
         let doc = Document::from_markdown(&filled)
@@ -1219,7 +1261,7 @@ main:
     title:    { type: string, example: Quarterly Report }
     count:    { type: integer, example: 7 }
     issued:   { type: date, example: "2030-06-01" }
-    refs:     { type: array, example: [alpha, beta] }
+    refs:     { type: array, items: { type: string }, example: [alpha, beta] }
 "#)
         .example();
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
@@ -1281,9 +1323,11 @@ main:
   fields:
     refs:
       type: array
-      properties:
-        org:  { type: string }
-        year: { type: integer }
+      items:
+        type: object
+        properties:
+          org:  { type: string }
+          year: { type: integer }
 "#)
         .example();
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
@@ -1304,9 +1348,11 @@ main:
       type: array
       example:
         - { org: ACME, year: 2020 }
-      properties:
-        org:  { type: string }
-        year: { type: integer }
+      items:
+        type: object
+        properties:
+          org:  { type: string }
+          year: { type: integer }
 "#)
         .example();
         assert!(!out.contains("<must-fill>"), "no sentinels expected: {out}");
@@ -1328,7 +1374,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     addr: { type: object, properties: {} }
-    rows: { type: array,  properties: {} }
+    rows: { type: array,  items: { type: object, properties: {} } }
 "#);
         for doc_md in [config.blueprint(), config.example()] {
             assert!(
@@ -1360,7 +1406,7 @@ main:
     severity:  { type: string, enum: [low, medium, high] }
     bio:       { type: markdown }
     issued:    { type: date }
-    refs:      { type: array, example: [first, second] }
+    refs:      { type: array, items: { type: string }, example: [first, second] }
 "#);
         let filled = config.example();
         let doc = Document::from_markdown(&filled)

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -188,16 +188,19 @@ impl QuillConfig {
                     vec![json_value.clone()]
                 };
 
-                if let Some(props) = &field_schema.properties {
+                // Every array carries an element schema (`items`). Coerce each
+                // element against it: scalar items (`string[]`, `integer[]`,
+                // `markdown[]`) coerce element-wise; object items recurse into
+                // the element's `properties` via the Object branch.
+                if let Some(items) = &field_schema.items {
                     let mut out = Vec::with_capacity(arr.len());
                     for (idx, elem) in arr.iter().enumerate() {
-                        if let Some(obj) = elem.as_object() {
-                            let coerced_obj =
-                                Self::coerce_object_props(obj, props, &format!("{path}[{idx}]"))?;
-                            out.push(serde_json::Value::Object(coerced_obj));
-                        } else {
-                            out.push(elem.clone());
-                        }
+                        let coerced = Self::coerce_value_strict(
+                            &QuillValue::from_json(elem.clone()),
+                            items,
+                            &format!("{path}[{idx}]"),
+                        )?;
+                        out.push(coerced.into_json());
                     }
                     Ok(QuillValue::from_json(serde_json::Value::Array(out)))
                 } else {
@@ -440,11 +443,11 @@ impl QuillConfig {
         }
 
         if schema.r#type == FieldType::Array {
-            if let Some(props) = &schema.properties {
-                for prop_schema in props.values() {
-                    if Self::has_disallowed_nested_object(prop_schema, false) {
-                        return true;
-                    }
+            // The element schema may itself be an object (a typed table), which
+            // is allowed here; that object's own properties may not be objects.
+            if let Some(items) = &schema.items {
+                if Self::has_disallowed_nested_object(items, true) {
+                    return true;
                 }
             }
         }
@@ -520,6 +523,10 @@ impl QuillConfig {
                 let nested = format!("{}.{}", owner_label, name);
                 Self::validate_field_blueprint_constraints(prop, &nested, errors);
             }
+        }
+        if let Some(items) = &schema.items {
+            let nested = format!("{}[]", owner_label);
+            Self::validate_field_blueprint_constraints(items, &nested, errors);
         }
     }
 
@@ -746,6 +753,23 @@ impl QuillConfig {
             let quill_value = QuillValue::from_json(field_value.clone());
             match FieldSchema::from_quill_value(field_name.clone(), &quill_value) {
                 Ok(mut schema) => {
+                    // `items` is only meaningful on arrays; reject it elsewhere
+                    // so a misplaced element schema surfaces at load time.
+                    if schema.r#type != FieldType::Array && schema.items.is_some() {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!(
+                                    "Field '{}' declares 'items' but is not type: array. \
+                                    'items' (the element schema) is only valid on array fields.",
+                                    field_name
+                                ),
+                            )
+                            .with_code("quill::items_not_supported".to_string()),
+                        );
+                        continue;
+                    }
+
                     // Typed dictionaries (type: object with properties) are supported.
                     // Freeform objects (no properties) and objects nested inside
                     // typed-dictionary properties are not.
@@ -757,7 +781,7 @@ impl QuillConfig {
                                     format!(
                                         "Field '{}' has type: object but no properties defined. \
                                         Declare a properties map, or use type: array with \
-                                        a properties map for a list of objects.",
+                                        items: {{ type: object, properties: … }} for a list of objects.",
                                         field_name
                                     ),
                                 )
@@ -782,13 +806,80 @@ impl QuillConfig {
                             continue;
                         }
                         // Typed dictionary — fall through to normal processing.
+                    } else if schema.r#type == FieldType::Array {
+                        // Arrays declare their element type via `items` (not a
+                        // bare `properties` map). Every array must be typed.
+                        if schema.properties.is_some() {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Field '{}' is type: array with a bare 'properties' map. \
+                                        Declare the element type under 'items' instead — for a list \
+                                        of objects use items: {{ type: object, properties: … }}.",
+                                        field_name
+                                    ),
+                                )
+                                .with_code("quill::array_properties_not_supported".to_string()),
+                            );
+                            continue;
+                        }
+                        let Some(items) = &schema.items else {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Field '{}' has type: array but no 'items' element schema. \
+                                        Declare the element type, e.g. items: {{ type: string }} \
+                                        for a list of strings or items: {{ type: object, \
+                                        properties: … }} for a list of objects.",
+                                        field_name
+                                    ),
+                                )
+                                .with_code("quill::array_missing_items".to_string()),
+                            );
+                            continue;
+                        };
+                        // Nested arrays are not supported: an element may be a
+                        // scalar or an object, but not another array.
+                        if items.r#type == FieldType::Array {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Field '{}' declares an array of arrays, which is not \
+                                        supported. Array elements must be scalars or objects.",
+                                        field_name
+                                    ),
+                                )
+                                .with_code("quill::nested_array_not_supported".to_string()),
+                            );
+                            continue;
+                        }
+                        // An object element's own properties may not be objects.
+                        if Self::has_disallowed_nested_object(&schema, false) {
+                            errors.push(
+                                Diagnostic::new(
+                                    Severity::Error,
+                                    format!(
+                                        "Field '{}' contains a nested type: object, which is not \
+                                        supported. An array element object's properties may not \
+                                        themselves be objects.",
+                                        field_name
+                                    ),
+                                )
+                                .with_code("quill::nested_object_not_supported".to_string()),
+                            );
+                            continue;
+                        }
                     } else if Self::has_disallowed_nested_object(&schema, false) {
                         errors.push(
                             Diagnostic::new(
                                 Severity::Error,
                                 format!(
                                     "Field '{}' uses nested type: object, which is not supported. \
-                                    Use type: array with a properties map for a list of objects.",
+                                    Use type: array with items: {{ type: object, properties: … }} \
+                                    for a list of objects.",
                                     field_name
                                 ),
                             )

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -56,18 +56,12 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                     "type".to_string(),
                     serde_json::Value::String("array".to_string()),
                 );
-                if let Some(props) = &field.properties {
-                    let mut prop_schemas = serde_json::Map::new();
-                    for (name, prop) in props {
-                        prop_schemas.insert(name.clone(), field_to_schema(prop));
-                    }
-                    schema.insert(
-                        "items".to_string(),
-                        serde_json::json!({
-                            "type": "object",
-                            "properties": prop_schemas
-                        }),
-                    );
+                // The element schema is emitted recursively, so a scalar
+                // element yields `items: {type: string}` (and markdown carries
+                // its `contentMediaType`), while an object element yields
+                // `items: {type: object, properties: …}`.
+                if let Some(items) = &field.items {
+                    schema.insert("items".to_string(), field_to_schema(items));
                 }
             }
             FieldType::Object => {
@@ -163,9 +157,11 @@ main:
   fields:
     refs:
       type: array
-      properties:
-        org: { type: string }
-        year: { type: integer }
+      items:
+        type: object
+        properties:
+          org: { type: string }
+          year: { type: integer }
 "#;
         let schema = build_from_yaml(yaml);
         let json = schema.as_json();
@@ -174,6 +170,49 @@ main:
         assert_eq!(refs["items"]["type"], "object");
         assert_eq!(refs["items"]["properties"]["org"]["type"], "string");
         assert_eq!(refs["items"]["properties"]["year"]["type"], "integer");
+    }
+
+    #[test]
+    fn scalar_array_emits_items_with_element_type() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    counts:
+      type: array
+      items: { type: integer }
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let counts = &json["properties"]["counts"];
+        assert_eq!(counts["type"], "array");
+        assert_eq!(counts["items"]["type"], "integer");
+    }
+
+    #[test]
+    fn markdown_array_emits_items_with_content_media_type() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    sections:
+      type: array
+      items: { type: markdown }
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let sections = &json["properties"]["sections"];
+        assert_eq!(sections["type"], "array");
+        assert_eq!(sections["items"]["type"], "string");
+        assert_eq!(sections["items"]["contentMediaType"], "text/markdown");
     }
 
     #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1429,22 +1429,25 @@ main:
     my_list:
       type: array
       description: List of objects
-      properties:
-        sub_a:
-          type: string
-          description: Subfield A
-        sub_b:
-          type: number
-          description: Subfield B
+      items:
+        type: object
+        properties:
+          sub_a:
+            type: string
+            description: Subfield A
+          sub_b:
+            type: number
+            description: Subfield B
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
     let list_field = config.main.fields.get("my_list").unwrap();
     assert_eq!(list_field.r#type, FieldType::Array);
-    assert!(list_field.properties.is_some());
+    let items = list_field.items.as_ref().expect("array declares items");
+    assert_eq!(items.r#type, FieldType::Object);
 
-    let props = list_field.properties.as_ref().unwrap();
+    let props = items.properties.as_ref().unwrap();
     assert!(props.contains_key("sub_a"));
     assert!(props.contains_key("sub_b"));
     assert_eq!(props["sub_a"].r#type, FieldType::String);
@@ -1521,14 +1524,16 @@ main:
   fields:
     rows:
       type: array
-      properties:
-        score:
-          type: number
-        nested:
-          type: object
-          properties:
-            inner:
-              type: string
+      items:
+        type: object
+        properties:
+          score:
+            type: number
+          nested:
+            type: object
+            properties:
+              inner:
+                type: string
 "#;
 
     let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
@@ -1555,13 +1560,15 @@ main:
   fields:
     scores:
       type: array
-      properties:
-        name:
-          type: string
-        value:
-          type: number
-        active:
-          type: boolean
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          value:
+            type: number
+          active:
+            type: boolean
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
@@ -1711,11 +1718,13 @@ main:
   fields:
     items:
       type: array
-      properties:
-        score:
-          type: number
-        active:
-          type: boolean
+      items:
+        type: object
+        properties:
+          score:
+            type: number
+          active:
+            type: boolean
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
@@ -1736,6 +1745,143 @@ main:
     assert_eq!(first["active"], serde_json::json!(true));
     assert_eq!(second["score"], serde_json::json!(87.5));
     assert_eq!(second["active"], serde_json::json!(false));
+}
+
+#[test]
+fn test_coerce_scalar_array_elements() {
+    // A primitive `integer[]` coerces each element (string → integer), the
+    // same first-class treatment scalar fields already get.
+    let yaml_content = r#"
+quill:
+  name: scalar_array_coerce
+  version: "1.0"
+  backend: typst
+  description: Coerce primitive arrays element-wise
+
+main:
+  fields:
+    counts:
+      type: array
+      items:
+        type: integer
+"#;
+    let config = QuillConfig::from_yaml(yaml_content).unwrap();
+    let mut payload = indexmap::IndexMap::new();
+    payload.insert(
+        "counts".to_string(),
+        QuillValue::from_json(serde_json::json!(["1", "2", "3"])),
+    );
+    let coerced = config.coerce_payload(&payload).unwrap();
+    assert_eq!(
+        coerced.get("counts").unwrap().as_json(),
+        &serde_json::json!([1, 2, 3])
+    );
+}
+
+#[test]
+fn test_coerce_scalar_array_reports_bad_element_path() {
+    // An uncoercible element fails with the element's indexed path, just like
+    // a typed-table leaf does.
+    let yaml_content = r#"
+quill:
+  name: scalar_array_bad
+  version: "1.0"
+  backend: typst
+  description: Bad primitive array element
+
+main:
+  fields:
+    counts:
+      type: array
+      items:
+        type: integer
+"#;
+    let config = QuillConfig::from_yaml(yaml_content).unwrap();
+    let mut payload = indexmap::IndexMap::new();
+    payload.insert(
+        "counts".to_string(),
+        QuillValue::from_json(serde_json::json!([1, "nope"])),
+    );
+    let err = config.coerce_payload(&payload).unwrap_err();
+    assert!(matches!(
+        err,
+        super::CoercionError::Uncoercible { ref path, ref target, .. }
+        if path == "counts[1]" && target == "integer"
+    ));
+}
+
+#[test]
+fn test_array_missing_items_rejected() {
+    // Every array must declare its element type via `items`.
+    let yaml_content = r#"
+quill:
+  name: array_no_items
+  version: "1.0"
+  backend: typst
+  description: Array without items
+
+main:
+  fields:
+    tags:
+      type: array
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::array_missing_items")
+            && d.message.contains("tags")));
+}
+
+#[test]
+fn test_array_bare_properties_rejected() {
+    // A bare `properties` map on an array (the pre-`items` typed-table form)
+    // is no longer accepted — element typing goes under `items`.
+    let yaml_content = r#"
+quill:
+  name: array_bare_props
+  version: "1.0"
+  backend: typst
+  description: Array with bare properties
+
+main:
+  fields:
+    rows:
+      type: array
+      properties:
+        org:
+          type: string
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::array_properties_not_supported")
+            && d.message.contains("rows")));
+}
+
+#[test]
+fn test_nested_array_rejected() {
+    // Array elements may be scalars or objects, but not arrays.
+    let yaml_content = r#"
+quill:
+  name: nested_array
+  version: "1.0"
+  backend: typst
+  description: Array of arrays
+
+main:
+  fields:
+    grid:
+      type: array
+      items:
+        type: array
+        items:
+          type: integer
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_array_not_supported")
+            && d.message.contains("grid")));
 }
 
 #[test]
@@ -2260,7 +2406,7 @@ card_kinds:
       enabled: false
       example: This example is unused
     fields:
-      items: { type: array }
+      items: { type: array, items: { type: string } }
 "#;
     let (_config, warnings) = QuillConfig::from_yaml_with_warnings(yaml).unwrap();
     assert!(
@@ -2564,7 +2710,7 @@ fn example_boolean_type_rejects_string_example() {
 fn example_array_type_rejects_string_example() {
     // type: array with example: foo — a sequence is required.
     let yaml = example_default_yaml(
-        "    tags:\n      type: array\n      example: foo\n",
+        "    tags:\n      type: array\n      items:\n        type: string\n      example: foo\n",
     );
     let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
     assert!(

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -187,9 +187,16 @@ pub struct FieldSchema {
     /// Restricts valid values on string fields.
     #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<String>>,
-    /// Nested field schemas for dict/object types.
+    /// Nested field schemas for `object` types (the typed dictionary's
+    /// properties).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, Box<FieldSchema>>>,
+    /// Element schema for `array` types. Required on every `array` field:
+    /// the element type makes the array first-class (`string[]`, `integer[]`,
+    /// `markdown[]`, …). For a typed table the element is an `object` carrying
+    /// its own `properties`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<FieldSchema>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -204,6 +211,8 @@ struct FieldSchemaDef {
     pub enum_values: Option<Vec<String>>,
     // Nested schema support
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
+    // Element schema for arrays.
+    pub items: Option<serde_json::Value>,
 }
 
 impl FieldSchema {
@@ -217,6 +226,7 @@ impl FieldSchema {
             ui: None,
             enum_values: None,
             properties: None,
+            items: None,
         }
     }
 
@@ -224,7 +234,7 @@ impl FieldSchema {
         let def: FieldSchemaDef = serde_json::from_value(value.clone().into_json())
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
         Ok(Self {
-            name: key,
+            name: key.clone(),
             r#type: def.r#type,
             description: def.description,
             default: def.default,
@@ -243,6 +253,14 @@ impl FieldSchema {
                     );
                 }
                 Some(p)
+            } else {
+                None
+            },
+            items: if let Some(items) = def.items {
+                Some(Box::new(FieldSchema::from_quill_value(
+                    format!("{key}[]"),
+                    &QuillValue::from_json(items),
+                )?))
             } else {
                 None
             },

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -494,42 +494,20 @@ pub(crate) fn validate_field(
         }
         FieldType::Array => match value.as_array() {
             Some(items) => {
-                if let Some(properties) = &field.properties {
+                // Validate each element against the array's `items` schema.
+                // Scalar elements (`string[]`, `integer[]`, `markdown[]`, …)
+                // are type-checked element-wise; object elements recurse into
+                // their properties via the Object branch (a row collapsed to
+                // the `<must-fill>` sentinel surfaces a single Sentinel error
+                // at the row path through the sentinel detector above).
+                if let Some(item_schema) = &field.items {
                     for (idx, item) in items.iter().enumerate() {
                         let row_path = format!("{}[{}]", path, idx);
-                        // Hand-edited edge case: a row collapsed to the literal
-                        // sentinel string (the user replaced the synthetic row
-                        // with `<must-fill>` instead of expanding it). Report
-                        // it once against the row path rather than emitting an
-                        // Absent error per Must Fill property.
-                        if item.as_str() == Some(MUST_FILL_SENTINEL) {
-                            errors.push(ValidationError::MustFillUnset {
-                                path: row_path,
-                                expected: "object".to_string(),
-                                source: MustFillSource::Sentinel,
-                            });
-                            continue;
-                        }
-                        let obj = item.as_object();
-                        for (prop_name, prop_schema) in properties {
-                            let prop_path = format!("{}.{}", row_path, prop_name);
-                            match obj.and_then(|o| o.get(prop_name)) {
-                                Some(v) => errors.extend(validate_field(
-                                    prop_schema,
-                                    &QuillValue::from_json(v.clone()),
-                                    &prop_path,
-                                )),
-                                None if prop_schema.default.is_none() => {
-                                    errors.push(ValidationError::MustFillUnset {
-                                        path: prop_path,
-                                        expected: expected_type_name(&prop_schema.r#type)
-                                            .to_string(),
-                                        source: MustFillSource::Absent,
-                                    })
-                                }
-                                None => {}
-                            }
-                        }
+                        errors.extend(validate_field(
+                            item_schema,
+                            &QuillValue::from_json(item.clone()),
+                            &row_path,
+                        ));
                     }
                 }
                 true
@@ -887,7 +865,7 @@ main:
     #[test]
     fn validates_array_of_objects() {
         let config = config_with(
-            "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
+            "    recipients:\n      type: array\n      default: []\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n          org:\n            type: string\n            default: \"\"",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "name": "Sam", "org": "HQ" }]))]);
@@ -895,11 +873,38 @@ main:
     }
 
     #[test]
+    fn validates_scalar_array_elements() {
+        let config = config_with(
+            "    counts:\n      type: array\n      default: []\n      items:\n        type: integer",
+            "",
+        );
+        let ok = doc_from_fm(&[("counts", json!([1, 2, 3]))]);
+        assert!(validate_typed_document(&config, &ok).is_ok());
+    }
+
+    #[test]
+    fn rejects_scalar_array_element_type_mismatch() {
+        // A `string` element in an `integer[]` is reported at the element's
+        // indexed path — primitive arrays validate element-wise.
+        let config = config_with(
+            "    counts:\n      type: array\n      default: []\n      items:\n        type: integer",
+            "",
+        );
+        let doc = doc_from_fm(&[("counts", json!([1, "two"]))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| matches!(
+            e,
+            ValidationError::TypeMismatch { path, expected, .. }
+            if path == "counts[1]" && expected == "integer"
+        )));
+    }
+
+    #[test]
     fn reports_must_fill_property_absent_in_array_object() {
         // Property `name` is Must Fill (no default); `org` is Endorsed.
         // Missing `name` in a row → `MustFillUnset { source: Absent, .. }`.
         let config = config_with(
-            "    recipients:\n      type: array\n      default: []\n      properties:\n        name:\n          type: string\n        org:\n          type: string\n          default: \"\"",
+            "    recipients:\n      type: array\n      default: []\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n          org:\n            type: string\n            default: \"\"",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([{ "org": "HQ" }]))]);
@@ -916,7 +921,7 @@ main:
         // One Sentinel error at the row path beats N noisy Absent errors per
         // Must Fill property.
         let config = config_with(
-            "    recipients:\n      type: array\n      properties:\n        name:\n          type: string\n        org:\n          type: string",
+            "    recipients:\n      type: array\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n          org:\n            type: string",
             "",
         );
         let doc = doc_from_fm(&[("recipients", json!([MUST_FILL_SENTINEL]))]);
@@ -1047,7 +1052,7 @@ main:
     fn body_disabled_card_enforces_trim_boundary() {
         let config = config_with(
             "    title:\n      type: string\n      default: \"\"",
-            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        default: []",
+            "card_kinds:\n  skills:\n    body:\n      enabled: false\n    fields:\n      items:\n        type: array\n        items:\n          type: string\n        default: []",
         );
         // Prose triggers the error; whitespace-only does not.
         let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -15,6 +15,8 @@ main:
 
     contacts:
       type: array
+      items:
+        type: string
       example:
         - john.doe@example.com
         - 123-456-7890
@@ -56,11 +58,13 @@ card_kinds:
             skills: Python, Rust, C++
           - category: DevOps
             skills: Docker, Kubernetes
-        properties:
-          category:
-            type: string
-          skills:
-            type: string
+        items:
+          type: object
+          properties:
+            category:
+              type: string
+            skills:
+              type: string
 
   projects_section:
     description: A project entry with a name and optional URL.
@@ -85,6 +89,8 @@ card_kinds:
         default: Certifications
       cells:
         type: array
+        items:
+          type: string
         example:
           - AWS Certified Solutions Architect
           - CKA

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -9,6 +9,8 @@ main:
   fields:
     recipient:
       type: array
+      items:
+        type: string
       example:
         - Mr. John Doe
         - 123 Main St
@@ -19,6 +21,8 @@ main:
 
     signature_block:
       type: array
+      items:
+        type: string
       example:
         - First M. Last
         - Title
@@ -36,6 +40,8 @@ main:
 
     address:
       type: array
+      items:
+        type: string
       example:
         - 5000 Forbes Avenue
         - Pittsburgh, PA 15213-3890

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -14,6 +14,8 @@ main:
   fields:
     memo_for:
       type: array
+      items:
+        type: string
       default: []
       example:
         - ORG1/SYMBOL
@@ -24,6 +26,8 @@ main:
 
     memo_from:
       type: array
+      items:
+        type: string
       default: []
       example:
         - ORG/SYMBOL
@@ -44,6 +48,8 @@ main:
 
     signature_block:
       type: array
+      items:
+        type: string
       default: []
       example:
         - "FIRST M. LAST, Rank, USSF"
@@ -61,6 +67,8 @@ main:
 
     letterhead_caption:
       type: array
+      items:
+        type: string
       default:
         - HEADQUARTERS [UNIT NAME]
       ui:
@@ -104,6 +112,8 @@ main:
 
     references:
       type: array
+      items:
+        type: string
       default: []
       example:
         - "AFM 33-326, 31 July 2019, Preparing Official Communications"
@@ -113,6 +123,8 @@ main:
 
     cc:
       type: array
+      items:
+        type: string
       default: []
       example:
         - Rank and Name, ORG/SYMBOL
@@ -122,6 +134,8 @@ main:
 
     distribution:
       type: array
+      items:
+        type: string
       default: []
       example:
         - ORG1/SYMBOL
@@ -132,6 +146,8 @@ main:
 
     attachments:
       type: array
+      items:
+        type: string
       default: []
       example:
         - Attachment description, YYYY MMM DD
@@ -210,6 +226,8 @@ card_kinds:
         description: Office symbol or organization receiving the endorsed memo.
       signature_block:
         type: array
+        items:
+          type: string
         default:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title
@@ -242,12 +260,16 @@ card_kinds:
         description: "Action taken by the endorser. Leave blank to hide the Approve/Disapprove line entirely, 'undecided' to display the line with neither option circled, 'approve' or 'disapprove' to circle the selected option."
       attachments:
         type: array
+        items:
+          type: string
         default: []
         ui:
           group: Additional
         description: List of attachments specific to this endorsement.
       cc:
         type: array
+        items:
+          type: string
         default: []
         ui:
           group: Additional

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -11,6 +11,8 @@ main:
       ui:
         group: Additional
         order: 13
+      items:
+        type: string
     cc:
       type: array
       description: List office symbols of recipients to receive copies.
@@ -20,6 +22,8 @@ main:
       ui:
         group: Additional
         order: 11
+      items:
+        type: string
     classification:
       type: string
       description: >-
@@ -69,6 +73,8 @@ main:
       ui:
         group: Additional
         order: 12
+      items:
+        type: string
     font_size:
       type: number
       description: Font size for the memo text (pt). Decimal values (e.g. 11.5) are supported.
@@ -96,6 +102,8 @@ main:
       ui:
         group: Letterhead
         order: 5
+      items:
+        type: string
     letterhead_seal:
       type: string
       description: >-
@@ -137,6 +145,8 @@ main:
       ui:
         group: Addressing
         order: 0
+      items:
+        type: string
     memo_from:
       type: array
       description: >-
@@ -153,6 +163,8 @@ main:
       ui:
         group: Addressing
         order: 1
+      items:
+        type: string
     memo_style:
       type: string
       description: >-
@@ -175,6 +187,8 @@ main:
       ui:
         group: Additional
         order: 10
+      items:
+        type: string
     signature_block:
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
@@ -185,6 +199,8 @@ main:
       ui:
         group: Addressing
         order: 3
+      items:
+        type: string
     subject:
       type: string
       description: >-
@@ -237,6 +253,8 @@ card_kinds:
         ui:
           group: Additional
           order: 5
+        items:
+          type: string
       cc:
         type: array
         description: List of office symbols to receive copies of this endorsement.
@@ -244,6 +262,8 @@ card_kinds:
         ui:
           group: Additional
           order: 6
+        items:
+          type: string
       date:
         type: date
         description: >-
@@ -291,5 +311,7 @@ card_kinds:
         ui:
           group: Addressing
           order: 2
+        items:
+          type: string
     ui:
       title: Routing indorsement

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -43,9 +43,9 @@ fn arb_leaf_field_type() -> impl Strategy<Value = FieldType> {
     ]
 }
 
-/// `FieldSchema` of bounded depth. Both `Array` and `Object` carry a
-/// `properties` map applied to object-shaped children (the same way
-/// `coerce_value_strict` consumes it).
+/// `FieldSchema` of bounded depth. `Object` carries a `properties` map; an
+/// `Array` carries an `items` element schema (here, an object sharing that
+/// same property map) — the same way `coerce_value_strict` consumes them.
 fn arb_field_schema(max_depth: u32) -> impl Strategy<Value = FieldSchema> {
     let leaf = arb_leaf_field_type().prop_map(|ty| FieldSchema::new(String::new(), ty, None));
     leaf.prop_recursive(max_depth, 24, 3, |inner| {
@@ -66,8 +66,10 @@ fn arb_field_schema(max_depth: u32) -> impl Strategy<Value = FieldSchema> {
             }),
             // Array whose object-shaped elements share a 1-3 property schema
             props_map.prop_map(|props| {
+                let mut item = FieldSchema::new(String::new(), FieldType::Object, None);
+                item.properties = Some(props);
                 let mut schema = FieldSchema::new(String::new(), FieldType::Array, None);
-                schema.properties = Some(props);
+                schema.items = Some(Box::new(item));
                 schema
             }),
         ]
@@ -236,8 +238,10 @@ fn regression_t2_array_of_object_path() {
         "x".to_string(),
         Box::new(FieldSchema::new("x".to_string(), FieldType::Integer, None)),
     );
+    let mut item = FieldSchema::new("f[]".to_string(), FieldType::Object, None);
+    item.properties = Some(inner);
     let mut arr = FieldSchema::new(ROOT_FIELD.to_string(), FieldType::Array, None);
-    arr.properties = Some(inner);
+    arr.items = Some(Box::new(item));
     let config = config_with_one_field(arr);
 
     // [ { "x": "not-an-int" } ] — should fail at f[0].x

--- a/docs/authoring/card-yaml.md
+++ b/docs/authoring/card-yaml.md
@@ -140,7 +140,10 @@ author:
 ```
 
 Object-valued fields must be schematized in `Quill.yaml` with `type: object`
-and a `properties:` map. Nesting beyond one level is not supported. See
+and a `properties:` map; array-valued fields with `type: array` and an
+`items:` element schema (e.g. `items: { type: string }`, or `items: { type:
+object, properties: … }` for a list of objects). Nesting beyond one level is
+not supported. See
 [Quill.yaml Reference: Field Types](../quills/quill-yaml-reference.md#field-types).
 
 Field names must match `[a-z_][a-z0-9_]*`.

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -83,7 +83,8 @@ main:
 | `example`     | any               | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only — surfaced in the [blueprint](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BLUEPRINT.md)'s `# e.g.` line for documentation and LLM authoring, never rendered as the value. |
 | `enum`        | array of strings  | no       | Restrict to specific values |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
-| `properties`  | object            | no       | Nested field schemas (for `array` typed-table rows or `object` typed dictionaries) |
+| `items`       | object            | for `array` | Element schema for an `array` field (a nested field schema). Required on every array. |
+| `properties`  | object            | no       | Nested field schemas for an `object` typed dictionary (or an array's `object`-typed `items`) |
 
 ### Field Types
 
@@ -93,13 +94,13 @@ main:
 | `number`   | Numeric scalar (integers and decimals) |
 | `integer`  | Integer-only numeric scalar |
 | `boolean`  | `true` or `false` |
-| `array`    | Ordered list; add `properties:` for typed rows |
+| `array`    | Ordered list; requires an `items:` element schema |
 | `date`     | YYYY-MM-DD |
 | `datetime`  | ISO 8601 |
 | `markdown` | Rich text; backends convert to target format |
 | `object`   | Structured map; requires a `properties:` map |
 
-Use `type: array` with `properties:` when you need a **list** of structured rows. Use `type: object` with `properties:` for a single structured mapping. Nesting beyond one level is not supported.
+Every `array` declares its element type under `items:` — a nested field schema. Use a scalar element (`items: { type: string }`, `integer`, `markdown`, …) for a primitive list like `string[]`, and an `object` element (`items: { type: object, properties: … }`) for a **list** of structured rows (a typed table). Use `type: object` with `properties:` for a single structured mapping. Nesting beyond one level is not supported (an array element may not itself be an array).
 
 ### Enum Constraints
 
@@ -118,20 +119,41 @@ main:
       description: "Format style for the endorsement."
 ```
 
-### Typed Arrays and Typed Dictionaries
+### Primitive Arrays, Typed Tables, and Typed Dictionaries
 
-Add `properties:` to a `type: array` field to define a typed table — each element is a structured object. Coercion recurses into each element and converts property values to their declared types:
+Every array declares its element type under `items:`. For a **primitive list**, give `items` a scalar type — coercion and validation then apply element-wise (e.g. each element of an `integer[]` is coerced to an integer, and a bad element fails at its indexed path like `counts[1]`):
+
+```yaml
+main:
+  fields:
+    tags:
+      type: array
+      items:
+        type: string
+    counts:
+      type: array
+      items:
+        type: integer
+    sections:
+      type: array
+      items:
+        type: markdown   # each element is converted to backend markup
+```
+
+For a **typed table** — a list of structured rows — give `items` an `object` type with its own `properties:`. Coercion recurses into each element and converts property values to their declared types:
 
 ```yaml
 main:
   fields:
     cells:
       type: array
-      properties:
-        category:
-          type: string
-        score:
-          type: number
+      items:
+        type: object
+        properties:
+          category:
+            type: string
+          score:
+            type: number
 ```
 
 Use `type: object` with `properties:` for a single structured mapping:
@@ -163,6 +185,8 @@ main:
   fields:
     memo_for:
       type: array
+      items:
+        type: string
       ui:
         title: To       # "Memo For" would confuse users unfamiliar with memo conventions
 ```
@@ -180,11 +204,15 @@ main:
   fields:
     memo_for:
       type: array
+      items:
+        type: string
       ui:
         group: Addressing
 
     memo_from:
       type: array
+      items:
+        type: string
       ui:
         group: Addressing
 
@@ -480,6 +508,8 @@ main:
 
     team_members:
       type: array
+      items:
+        type: string
       default: []
       ui:
         group: Team

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -44,6 +44,8 @@ card_kinds:
         description: Office symbol receiving the endorsed memo.
       signature_block:
         type: array
+        items:
+          type: string
         ui:
           group: Addressing
         description: Name, grade, and duty title.
@@ -66,6 +68,8 @@ card_kinds:
         type: string
       signature_block:
         type: array
+        items:
+          type: string
         ui:
           group: Addressing
 ```

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -103,7 +103,7 @@ typst:
     - "@preview/some-package:1.0.0"
 ```
 
-Field names must be `snake_case` (match `[a-z_][a-z0-9_]*`). Capitalized or `$`-prefixed keys are rejected by the editor surface — document-level metadata sits on dedicated `$`-prefixed keys in the plate JSON (`$quill`, `$body`, `$cards`, `$kind`), and user fields stay lowercase so they cannot shadow it. Standalone `object` fields require a `properties` map; use `type: array` with `properties:` for a list of objects.
+Field names must be `snake_case` (match `[a-z_][a-z0-9_]*`). Capitalized or `$`-prefixed keys are rejected by the editor surface — document-level metadata sits on dedicated `$`-prefixed keys in the plate JSON (`$quill`, `$body`, `$cards`, `$kind`), and user fields stay lowercase so they cannot shadow it. Standalone `object` fields require a `properties` map. Every `array` field requires an `items:` element schema: use `items: { type: string }` (or `integer`, `markdown`, …) for a list of scalars, and `items: { type: object, properties: … }` for a list of objects.
 
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card kind.

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -22,7 +22,7 @@ Supported field types:
 | `number` | Numeric value (integers and decimals) |
 | `integer` | Integer-only numeric value |
 | `boolean` | `true` / `false` |
-| `array` | Ordered list; add `properties:` for typed rows |
+| `array` | Ordered list; requires an `items:` element schema (e.g. `items: { type: string }` for `string[]`, `items: { type: object, properties: … }` for a typed table) |
 | `object` | Structured map; requires `properties:` |
 | `date` | `YYYY-MM-DD` |
 | `datetime` | ISO 8601 |
@@ -35,7 +35,7 @@ Supported field types:
 - Returns `Result<IndexMap<String, QuillValue>, CoercionError>`
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
-- Coercion rules per type: array wrapping, boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
+- Coercion rules per type: array wrapping plus element-wise coercion against the `items` schema (a bad element fails at its indexed path, e.g. `counts[1]`), boolean from string/int/float, number/integer from string, string/markdown pass-through, date/datetime format validation, object property recursion
 - The Must-Fill sentinel string `<must-fill>` passes through coercion
   unchanged so the validation layer can surface a placeholder diagnostic
   rather than a type-coercion error
@@ -116,7 +116,7 @@ metadata, not schema fields, and do not appear in `fields`.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`ui`.
+Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`items`/`ui`. `items` (the element schema, itself a `FieldSchema`) is required on `array` fields and rejected elsewhere; `properties` is used by `object` fields (and by an array's `object`-typed `items`).
 
 ### `default` and `example`
 


### PR DESCRIPTION
## Summary

This change refactors how array fields declare their element types. Previously, arrays used a bare `properties` map to define typed-table rows. Now, all arrays must declare their element type via an `items` field containing a nested schema, enabling first-class support for primitive arrays (`string[]`, `integer[]`, `markdown[]`) alongside typed tables.

## Key Changes

- **Array element schema**: Introduced `items` field on `FieldSchema` to hold the element type schema. Every array now requires an `items` declaration.
  
- **Primitive array support**: Arrays can now have scalar element types (`integer`, `string`, `markdown`, etc.), not just objects. Element-wise coercion and validation apply to primitive arrays just like typed tables.

- **Typed table restructuring**: Object-typed array elements now nest their `properties` under `items: { type: object, properties: ... }` instead of directly on the array field.

- **Validation and coercion**: 
  - `coerce_payload()` now validates each array element against the `items` schema recursively
  - `validate_field()` validates array elements element-wise against `items`
  - Bare `properties` on arrays is rejected with error code `quill::array_properties_not_supported`
  - Arrays without `items` are rejected with error code `quill::array_missing_items`
  - Nested arrays (array of arrays) are rejected with error code `quill::nested_array_not_supported`

- **Blueprint generation**: Type annotations now reflect the actual element type (`array<integer>`, `array<markdown>`, etc.) by inspecting `items` instead of hardcoding `array<string>` or `array<object>`.

- **Markdown array support**: Added `is_markdown_array_field()` and `transform_markdown_array_field()` in the Typst backend to handle `markdown[]` fields by converting each element individually.

- **Schema generation**: The JSON schema builder now emits `items` recursively, preserving element type information (including `contentMediaType` for markdown arrays).

## Implementation Details

- All test fixtures and examples updated to use the new `items` syntax
- Error messages guide users to the correct syntax when they use the old `properties` approach
- The coercion path for array elements includes the index (e.g., `field[1]`) for precise error reporting
- Markdown arrays are auto-eval'd element-wise in the Typst template via the helper package

https://claude.ai/code/session_01Qmunf6M76JExVNR6xxcnti