### PR TITLE
Collapse array/markdown handling into recursive passes

### DIFF
--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -252,6 +252,51 @@ fn is_date_field(field_schema: &serde_json::Value) -> bool {
     is_string && is_date_format
 }
 
+/// Names of the markdown / `markdown[]` fields in a schema `properties` map —
+/// the fields whose values carry backend markup for the helper to `eval`.
+fn content_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+    properties
+        .iter()
+        .filter(|(_, fs)| is_markdown_field(fs) || is_markdown_array_field(fs))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// Names of the date fields in a schema `properties` map.
+fn date_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+    properties
+        .iter()
+        .filter(|(_, fs)| is_date_field(fs))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// Convert a content field's value to backend markup: a markdown string is
+/// converted in place; a `markdown[]` array converts each string element.
+/// Returns `None` when the value is neither (e.g. a string that fails to
+/// convert), leaving it untouched.
+fn convert_content_value(value: &QuillValue) -> Option<QuillValue> {
+    match value.as_json() {
+        serde_json::Value::String(s) => mark_to_typst(s)
+            .ok()
+            .map(|markup| QuillValue::from_json(serde_json::json!(markup))),
+        serde_json::Value::Array(arr) => {
+            let converted = arr
+                .iter()
+                .map(|elem| match elem.as_str() {
+                    Some(s) => match mark_to_typst(s) {
+                        Ok(markup) => serde_json::json!(markup),
+                        Err(_) => elem.clone(),
+                    },
+                    None => elem.clone(),
+                })
+                .collect();
+            Some(QuillValue::from_json(serde_json::Value::Array(converted)))
+        }
+        _ => None,
+    }
+}
+
 /// Transform markdown fields to Typst markup based on schema.
 ///
 /// Identifies fields with `contentMediaType = "text/markdown"` and converts
@@ -274,50 +319,18 @@ fn transform_markdown_fields(
         None => return result,
     };
 
-    // Transform each field based on schema, collecting converted field names
-    let mut content_field_names: Vec<&str> = Vec::new();
-    for (field_name, field_value) in fields {
-        if let Some(field_schema) = properties_obj.get(field_name) {
-            if is_markdown_field(field_schema) {
-                if let Some(content) = field_value.as_str() {
-                    if let Ok(typst_markup) = mark_to_typst(content) {
-                        result.insert(
-                            field_name.clone(),
-                            QuillValue::from_json(serde_json::json!(typst_markup)),
-                        );
-                        content_field_names.push(field_name);
-                    }
-                }
-            } else if is_markdown_array_field(field_schema) {
-                // `markdown[]`: convert each string element to backend markup.
-                // The helper package maps `eval(.., mode: "markup")` over the
-                // resulting array (see lib.typ.template).
-                if let Some(arr) = field_value.as_array() {
-                    let converted: Vec<serde_json::Value> = arr
-                        .iter()
-                        .map(|elem| match elem.as_str() {
-                            Some(s) => match mark_to_typst(s) {
-                                Ok(markup) => serde_json::json!(markup),
-                                Err(_) => elem.clone(),
-                            },
-                            None => elem.clone(),
-                        })
-                        .collect();
-                    result.insert(
-                        field_name.clone(),
-                        QuillValue::from_json(serde_json::Value::Array(converted)),
-                    );
-                    content_field_names.push(field_name);
-                }
+    // Convert every markdown / markdown[] field the schema declares; the
+    // helper package maps `eval(.., mode: "markup")` over these names.
+    let content_fields = content_field_names(properties_obj);
+    for field_name in &content_fields {
+        if let Some(value) = fields.get(field_name) {
+            if let Some(converted) = convert_content_value(value) {
+                result.insert(field_name.clone(), converted);
             }
         }
     }
 
-    let date_fields: Vec<&str> = properties_obj
-        .iter()
-        .filter(|(_, fs)| is_date_field(fs))
-        .map(|(name, _)| name.as_str())
-        .collect();
+    let date_fields = date_field_names(properties_obj);
 
     // Handle `$cards` array recursively
     if let Some(cards_value) = result.get("$cards") {
@@ -336,49 +349,28 @@ fn transform_markdown_fields(
     if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
         for (def_name, def_schema) in defs {
             if let Some(card_kind) = def_name.strip_suffix("_card") {
-                let card_fields: Vec<&str> = def_schema
-                    .get("properties")
-                    .and_then(|v| v.as_object())
-                    .map(|props| {
-                        props
-                            .iter()
-                            .filter(|(_, fs)| {
-                                is_markdown_field(fs) || is_markdown_array_field(fs)
-                            })
-                            .map(|(name, _)| name.as_str())
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let card_props = def_schema.get("properties").and_then(|v| v.as_object());
+                let card_fields = card_props.map(content_field_names).unwrap_or_default();
                 if !card_fields.is_empty() {
                     card_content_fields.insert(
                         card_kind.to_string(),
                         serde_json::Value::Array(
                             card_fields
                                 .into_iter()
-                                .map(|s| serde_json::Value::String(s.to_string()))
+                                .map(serde_json::Value::String)
                                 .collect(),
                         ),
                     );
                 }
 
-                let date_fields: Vec<&str> = def_schema
-                    .get("properties")
-                    .and_then(|v| v.as_object())
-                    .map(|props| {
-                        props
-                            .iter()
-                            .filter(|(_, fs)| is_date_field(fs))
-                            .map(|(name, _)| name.as_str())
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let date_fields = card_props.map(date_field_names).unwrap_or_default();
                 if !date_fields.is_empty() {
                     card_date_fields.insert(
                         card_kind.to_string(),
                         serde_json::Value::Array(
                             date_fields
                                 .into_iter()
-                                .map(|s| serde_json::Value::String(s.to_string()))
+                                .map(serde_json::Value::String)
                                 .collect(),
                         ),
                     );
@@ -391,7 +383,7 @@ fn transform_markdown_fields(
     result.insert(
         "__meta__".to_string(),
         QuillValue::from_json(serde_json::json!({
-            "content_fields": content_field_names,
+            "content_fields": content_fields,
             "card_content_fields": card_content_fields,
             "date_fields": date_fields,
             "card_date_fields": card_date_fields,

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -66,57 +66,46 @@
     card_date_fields: (:),
   ))
 
-  // Auto-eval top-level content fields. A markdown field is a string; a
-  // `markdown[]` field is an array whose string elements are each eval'd.
-  for key in meta.content_fields {
-    if key in d {
-      let val = d.at(key)
-      if type(val) == str and val != "" {
-        d.insert(key, eval(val, mode: "markup"))
-      } else if type(val) == array {
-        d.insert(key, val.map(v => if type(v) == str and v != "" { eval(v, mode: "markup") } else { v }))
+  // Eval the named content fields of `dict` into Typst content. A markdown
+  // field is a string; a `markdown[]` field is an array whose string elements
+  // are each eval'd. Used uniformly for the top-level data and for each card.
+  let eval-content(dict, keys) = {
+    for key in keys {
+      if key in dict {
+        let val = dict.at(key)
+        if type(val) == str and val != "" {
+          dict.insert(key, eval(val, mode: "markup"))
+        } else if type(val) == array {
+          dict.insert(key, val.map(v => if type(v) == str and v != "" { eval(v, mode: "markup") } else { v }))
+        }
       }
     }
+    dict
   }
 
-  // Auto-convert top-level date fields to datetime
-  for key in meta.date_fields {
-    if key in d {
-      let val = d.at(key)
-      if val != none {
-        d.insert(key, _parse-date(val))
+  // Parse the named date fields of `dict` into Typst datetimes.
+  let parse-dates(dict, keys) = {
+    for key in keys {
+      if key in dict {
+        let val = dict.at(key)
+        if val != none {
+          dict.insert(key, _parse-date(val))
+        }
       }
     }
+    dict
   }
 
-  // Auto-eval content fields within each card under `$cards`
+  d = eval-content(d, meta.content_fields)
+  d = parse-dates(d, meta.date_fields)
+
+  // Apply the same passes to each card under `$cards`, keyed by `$kind`.
   if "$cards" in d {
     let cards = ()
     for card in d.at("$cards") {
       let card-type = card.at("$kind", default: none)
-      let fields = meta.card_content_fields.at(card-type, default: ())
-      for key in fields {
-        if key in card {
-          let val = card.at(key)
-          if type(val) == str and val != "" {
-            card.insert(key, eval(val, mode: "markup"))
-          } else if type(val) == array {
-            card.insert(key, val.map(v => if type(v) == str and v != "" { eval(v, mode: "markup") } else { v }))
-          }
-        }
-      }
-
-      // Auto-convert date fields for this card type
-      let date-fields = meta.card_date_fields.at(card-type, default: ())
-      for key in date-fields {
-        if key in card {
-          let val = card.at(key)
-          if val != none {
-            card.insert(key, _parse-date(val))
-          }
-        }
-      }
-
+      card = eval-content(card, meta.card_content_fields.at(card-type, default: ()))
+      card = parse-dates(card, meta.card_date_fields.at(card-type, default: ()))
       cards.push(card)
     }
     d.insert("$cards", cards)

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -54,6 +54,19 @@ struct CardSchemaDef {
     pub body: Option<BodyCardSchema>,
 }
 
+/// Depth context for [`QuillConfig::validate_field_schema_shape`]. Encodes
+/// which shapes are legal at the current nesting level, so the one-level
+/// nesting contract is enforced by a single recursive walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShapePosition {
+    /// A field declared directly on a card: scalar, object, or array.
+    Top,
+    /// An array's `items`: scalar or object (typed-table row), not an array.
+    ArrayItem,
+    /// An object's property: scalar only.
+    Leaf,
+}
+
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum CoercionError {
     #[error("cannot coerce `{value}` to type `{target}` at `{path}`: {reason}")]
@@ -428,31 +441,118 @@ impl QuillConfig {
         Ok(out)
     }
 
-    fn has_disallowed_nested_object(schema: &FieldSchema, allow_object_here: bool) -> bool {
-        if schema.r#type == FieldType::Object {
-            if !allow_object_here {
-                return true;
-            }
-            if let Some(props) = &schema.properties {
-                for prop_schema in props.values() {
-                    if Self::has_disallowed_nested_object(prop_schema, false) {
-                        return true;
-                    }
-                }
-            }
+    /// Recursively validate a field's structural shape, enforcing the
+    /// one-level nesting contract in a single pass. The `position` records
+    /// what shapes are legal at the current depth:
+    ///
+    /// - [`ShapePosition::Top`] — a field declared directly on a card: scalar,
+    ///   `object` (typed dictionary), or `array` (primitive list or typed
+    ///   table).
+    /// - [`ShapePosition::ArrayItem`] — an array's `items`: a scalar or an
+    ///   `object` (the typed-table row), but **not** another array.
+    /// - [`ShapePosition::Leaf`] — an object's property (whether a top-level
+    ///   typed dictionary or a typed-table row): scalar only. No deeper
+    ///   containers, so `array<object<array>>` and `object<array>` are
+    ///   rejected here.
+    ///
+    /// Returns the first violation as a ready-to-push [`Diagnostic`] whose
+    /// message names `owner` (the field-name path, e.g. `rows[].tags`), or
+    /// `None` when the shape is valid.
+    fn validate_field_schema_shape(
+        schema: &FieldSchema,
+        owner: &str,
+        position: ShapePosition,
+    ) -> Option<Diagnostic> {
+        let err = |code: &str, message: String| {
+            Some(Diagnostic::new(Severity::Error, message).with_code(code.to_string()))
+        };
+
+        // `items` is only meaningful on arrays; `properties` only on objects.
+        if schema.r#type != FieldType::Array && schema.items.is_some() {
+            return err(
+                "quill::items_not_supported",
+                format!(
+                    "Field '{owner}' declares 'items' but is not type: array. \
+                     'items' (the element schema) is only valid on array fields."
+                ),
+            );
         }
 
-        if schema.r#type == FieldType::Array {
-            // The element schema may itself be an object (a typed table), which
-            // is allowed here; that object's own properties may not be objects.
-            if let Some(items) = &schema.items {
-                if Self::has_disallowed_nested_object(items, true) {
-                    return true;
+        match schema.r#type {
+            FieldType::Object => {
+                // An object nested inside another object (a Leaf position) is
+                // the classic "nested type: object" rejection.
+                if position == ShapePosition::Leaf {
+                    return err(
+                        "quill::nested_object_not_supported",
+                        format!(
+                            "Field '{owner}' uses a nested type: object, which is not supported. \
+                             An object's properties may only be scalars."
+                        ),
+                    );
                 }
+                let Some(props) = &schema.properties else {
+                    return err(
+                        "quill::object_missing_properties",
+                        format!(
+                            "Field '{owner}' has type: object but no properties defined. \
+                             Declare a properties map, or use type: array with \
+                             items: {{ type: object, properties: … }} for a list of objects."
+                        ),
+                    );
+                };
+                // Object properties are leaves — scalars only.
+                props.iter().find_map(|(name, prop)| {
+                    Self::validate_field_schema_shape(
+                        prop,
+                        &format!("{owner}.{name}"),
+                        ShapePosition::Leaf,
+                    )
+                })
             }
+            FieldType::Array => {
+                // An array may sit at the top level only; an array element may
+                // not itself be an array, and neither may an object property.
+                if position != ShapePosition::Top {
+                    return err(
+                        "quill::nested_array_not_supported",
+                        format!(
+                            "Field '{owner}' declares a nested array, which is not supported. \
+                             Array elements must be scalars or objects, and object properties \
+                             may only be scalars."
+                        ),
+                    );
+                }
+                if schema.properties.is_some() {
+                    return err(
+                        "quill::array_properties_not_supported",
+                        format!(
+                            "Field '{owner}' is type: array with a bare 'properties' map. \
+                             Declare the element type under 'items' instead — for a list \
+                             of objects use items: {{ type: object, properties: … }}."
+                        ),
+                    );
+                }
+                let Some(items) = &schema.items else {
+                    return err(
+                        "quill::array_missing_items",
+                        format!(
+                            "Field '{owner}' has type: array but no 'items' element schema. \
+                             Declare the element type, e.g. items: {{ type: string }} \
+                             for a list of strings or items: {{ type: object, \
+                             properties: … }} for a list of objects."
+                        ),
+                    );
+                };
+                Self::validate_field_schema_shape(
+                    items,
+                    &format!("{owner}[]"),
+                    ShapePosition::ArrayItem,
+                )
+            }
+            // Scalars are leaves; nothing further to validate.
+            _ => None,
         }
-
-        false
     }
 
     /// Reject multi-line descriptions. Single-line is required so the leading
@@ -753,138 +853,16 @@ impl QuillConfig {
             let quill_value = QuillValue::from_json(field_value.clone());
             match FieldSchema::from_quill_value(field_name.clone(), &quill_value) {
                 Ok(mut schema) => {
-                    // `items` is only meaningful on arrays; reject it elsewhere
-                    // so a misplaced element schema surfaces at load time.
-                    if schema.r#type != FieldType::Array && schema.items.is_some() {
-                        errors.push(
-                            Diagnostic::new(
-                                Severity::Error,
-                                format!(
-                                    "Field '{}' declares 'items' but is not type: array. \
-                                    'items' (the element schema) is only valid on array fields.",
-                                    field_name
-                                ),
-                            )
-                            .with_code("quill::items_not_supported".to_string()),
-                        );
-                        continue;
-                    }
-
-                    // Typed dictionaries (type: object with properties) are supported.
-                    // Freeform objects (no properties) and objects nested inside
-                    // typed-dictionary properties are not.
-                    if schema.r#type == FieldType::Object {
-                        if schema.properties.is_none() {
-                            errors.push(
-                                Diagnostic::new(
-                                    Severity::Error,
-                                    format!(
-                                        "Field '{}' has type: object but no properties defined. \
-                                        Declare a properties map, or use type: array with \
-                                        items: {{ type: object, properties: … }} for a list of objects.",
-                                        field_name
-                                    ),
-                                )
-                                .with_code("quill::object_missing_properties".to_string()),
-                            );
-                            continue;
-                        }
-                        // Properties of a typed dictionary may not themselves be objects.
-                        if Self::has_disallowed_nested_object(&schema, true) {
-                            errors.push(
-                                Diagnostic::new(
-                                    Severity::Error,
-                                    format!(
-                                        "Field '{}' contains a nested type: object property, \
-                                        which is not supported. Properties of a typed dictionary \
-                                        may not themselves be objects.",
-                                        field_name
-                                    ),
-                                )
-                                .with_code("quill::nested_object_not_supported".to_string()),
-                            );
-                            continue;
-                        }
-                        // Typed dictionary — fall through to normal processing.
-                    } else if schema.r#type == FieldType::Array {
-                        // Arrays declare their element type via `items` (not a
-                        // bare `properties` map). Every array must be typed.
-                        if schema.properties.is_some() {
-                            errors.push(
-                                Diagnostic::new(
-                                    Severity::Error,
-                                    format!(
-                                        "Field '{}' is type: array with a bare 'properties' map. \
-                                        Declare the element type under 'items' instead — for a list \
-                                        of objects use items: {{ type: object, properties: … }}.",
-                                        field_name
-                                    ),
-                                )
-                                .with_code("quill::array_properties_not_supported".to_string()),
-                            );
-                            continue;
-                        }
-                        let Some(items) = &schema.items else {
-                            errors.push(
-                                Diagnostic::new(
-                                    Severity::Error,
-                                    format!(
-                                        "Field '{}' has type: array but no 'items' element schema. \
-                                        Declare the element type, e.g. items: {{ type: string }} \
-                                        for a list of strings or items: {{ type: object, \
-                                        properties: … }} for a list of objects.",
-                                        field_name
-                                    ),
-                                )
-                                .with_code("quill::array_missing_items".to_string()),
-                            );
-                            continue;
-                        };
-                        // Nested arrays are not supported: an element may be a
-                        // scalar or an object, but not another array.
-                        if items.r#type == FieldType::Array {
-                            errors.push(
-                                Diagnostic::new(
-                                    Severity::Error,
-                                    format!(
-                                        "Field '{}' declares an array of arrays, which is not \
-                                        supported. Array elements must be scalars or objects.",
-                                        field_name
-                                    ),
-                                )
-                                .with_code("quill::nested_array_not_supported".to_string()),
-                            );
-                            continue;
-                        }
-                        // An object element's own properties may not be objects.
-                        if Self::has_disallowed_nested_object(&schema, false) {
-                            errors.push(
-                                Diagnostic::new(
-                                    Severity::Error,
-                                    format!(
-                                        "Field '{}' contains a nested type: object, which is not \
-                                        supported. An array element object's properties may not \
-                                        themselves be objects.",
-                                        field_name
-                                    ),
-                                )
-                                .with_code("quill::nested_object_not_supported".to_string()),
-                            );
-                            continue;
-                        }
-                    } else if Self::has_disallowed_nested_object(&schema, false) {
-                        errors.push(
-                            Diagnostic::new(
-                                Severity::Error,
-                                format!(
-                                    "Field '{}' uses nested type: object, which is not supported. \
-                                    Use type: array with items: {{ type: object, properties: … }} \
-                                    for a list of objects.",
-                                    field_name
-                                ),
-                            )
-                            .with_code("quill::nested_object_not_supported".to_string()),
-                        );
+                    // One recursive pass enforces the whole shape contract:
+                    // containers carry the right child schema (`object` →
+                    // `properties`, `array` → `items`), and nesting stops after
+                    // one structural level (a typed table is the deepest shape).
+                    if let Some(diag) = Self::validate_field_schema_shape(
+                        &schema,
+                        field_name,
+                        ShapePosition::Top,
+                    ) {
+                        errors.push(diag);
                         continue;
                     }
 

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1885,6 +1885,64 @@ main:
 }
 
 #[test]
+fn test_array_of_objects_with_array_property_rejected() {
+    // The one-level rule: a typed-table row may carry scalar columns only, so
+    // an array nested inside a table row is rejected.
+    let yaml_content = r#"
+quill:
+  name: table_with_array
+  version: "1.0"
+  backend: typst
+  description: Typed table row with an array column
+
+main:
+  fields:
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          tags:
+            type: array
+            items:
+              type: string
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_array_not_supported")
+            && d.message.contains("rows")));
+}
+
+#[test]
+fn test_object_with_array_property_rejected() {
+    // Symmetric rule for typed dictionaries: an object property may only be a
+    // scalar, so an array-valued property is rejected.
+    let yaml_content = r#"
+quill:
+  name: object_with_array
+  version: "1.0"
+  backend: typst
+  description: Typed dictionary with an array property
+
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        lines:
+          type: array
+          items:
+            type: string
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_array_not_supported")
+            && d.message.contains("address")));
+}
+
+#[test]
 fn test_config_coerce_cards_item_wise() {
     let yaml_content = r#"
 quill:


### PR DESCRIPTION
## Summary

Follow-up to #672 (primitive typed arrays via `items`). Two simplification cascades fall out of the new model — "an array's element is just another field" and "convert markdown wherever the schema says so" — replacing several special-cased code paths with single recursive passes. Also closes a real nesting gap.

## Schema-shape validation (quillmark-core)

Replaced the four ad-hoc load-time branches **and** `has_disallowed_nested_object` with one recursive `validate_field_schema_shape`, keyed on a `ShapePosition`:

- `Top` — a field on a card: scalar, object, or array
- `ArrayItem` — an array's `items`: scalar or object (typed-table row), **not** an array
- `Leaf` — an object's property: scalar only

This enforces the one-level nesting contract in a single pass and **closes a gap**: `array<object<array>>` and `object<array>` were previously accepted despite the documented "one level" limit. A typed-table row and a typed dictionary may now carry **scalar columns/properties only**; both are rejected with `quill::nested_array_not_supported`. Existing error codes (`object_missing_properties`, `array_missing_items`, `array_properties_not_supported`, `nested_object_not_supported`, `items_not_supported`) are preserved.

## Typst markdown transform (quillmark-typst + helper template)

- Extracted `content_field_names` / `date_field_names` / `convert_content_value` so top-level and per-card derivation share one definition instead of mirrored inline filters.
- Collapsed the helper template's four near-identical inline loops into two reusable closures (`eval-content`, `parse-dates`) applied uniformly to the top-level data and each card.

## Tests

- Added coverage for the newly-rejected shapes (`array<object<array>>`, `object<array>`).
- Full workspace suite green, including the end-to-end Typst render tests; clippy clean.

https://claude.ai/code/session_01Qmunf6M76JExVNR6xxcnti

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmunf6M76JExVNR6xxcnti)_