### PR TITLE
Add migration guides overview page

### DIFF
--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -1,0 +1,29 @@
+# Migration Guides
+
+Quillmark evolves through deliberate, documented releases. When a release
+changes the document syntax, the plate-JSON wire format, or a public API in a
+way that is not backward compatible, it ships with a migration guide describing
+exactly what changed and how to update your documents, quills, and host code.
+
+Many of these are **hard cutovers** — the old form stops parsing or compiling,
+so a guide is the path forward, not an optional read. Each guide is scoped to a
+single version step; to cross several versions, work through the relevant
+guides in order.
+
+## Available guides
+
+- [0.85 → 0.86](0.85-to-0.86.md) — partial documents render without error, and
+  the canonical card-yaml fence becomes a bare `~~~`.
+- [0.83 → 0.84](0.83-to-0.84.md) — the Must Fill / Endorsed schema model
+  replaces `required:`, with Python ↔ WASM parity.
+- [0.82 → 0.83](0.82-to-0.83.md) — `$`-prefixed plate JSON wire format retires
+  the legacy uppercase reserved keys.
+- [0.81 → 0.82](0.81-to-0.82.md) — the card-yaml metadata syntax replaces the
+  `---`/`QUILL:` frontmatter and fenced cards.
+- [`@quillmark/wasm` 0.77 → 0.80](wasm-0.77-to-0.80.md) — migration notes for
+  WASM consumers crossing the card-syntax release.
+
+## Related
+
+For how Quills themselves are versioned and how authors target a version, see
+[Quill Versioning](../quills/versioning.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Reference:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
+      - Overview: migrations/index.md
       - 0.85 → 0.86 (bare ~~~ card-yaml fence): migrations/0.85-to-0.86.md
       - 0.83 → 0.84 (Must Fill / Endorsed, Python parity): migrations/0.83-to-0.84.md
       - 0.82 → 0.83 ($-prefixed plate JSON): migrations/0.82-to-0.83.md


### PR DESCRIPTION
## Summary
Added a new overview page for migration guides that introduces the migration documentation structure and provides a centralized index of all available migration guides.

## Changes
- **New file**: `docs/migrations/index.md` — Overview page explaining Quillmark's migration guide philosophy and linking to all available version migration guides
- **Updated**: `mkdocs.yml` — Added the new overview page as the first item under the Migration section in the documentation navigation

## Details
The new overview page establishes context for users about how Quillmark handles breaking changes across releases. It explains that migration guides are provided for non-backward-compatible changes and that guides should be followed sequentially when crossing multiple versions. The page then lists all five available migration guides with brief descriptions of what changed in each version step, plus a link to related Quill versioning documentation.

This provides better discoverability and navigation for users who need to migrate their documents, quills, or host code across Quillmark versions.

https://claude.ai/code/session_017D2qCtwoD1QLvPMNG98525