### PR TITLE
Clarify array validation and add defensive fallback comment

### DIFF
--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -217,6 +217,9 @@ impl QuillConfig {
                     }
                     Ok(QuillValue::from_json(serde_json::Value::Array(out)))
                 } else {
+                    // Defensive fallback: schema-load rejects any array without
+                    // `items` (quill::array_missing_items), so a validated
+                    // config never reaches here — pass the array through as-is.
                     Ok(QuillValue::from_json(serde_json::Value::Array(arr)))
                 }
             }
@@ -608,8 +611,8 @@ impl QuillConfig {
         }
     }
 
-    /// Recursively validate field-level blueprint constraints across the field
-    /// and any nested object properties.
+    /// Recursively validate field-level blueprint constraints across the field,
+    /// any nested object properties, and an array's element schema (`items`).
     fn validate_field_blueprint_constraints(
         schema: &FieldSchema,
         owner_label: &str,


### PR DESCRIPTION
## Summary
This PR improves code clarity and documentation around array validation in the Quill configuration system by adding a defensive fallback comment and updating the docstring for the field blueprint constraint validation method.

## Key Changes
- Added a clarifying comment explaining the defensive fallback behavior when processing arrays without an `items` schema. The comment documents that schema validation (via `quill::array_missing_items`) ensures validated configs never reach this code path, so the array is passed through as-is.
- Updated the docstring for `validate_field_blueprint_constraints()` to explicitly mention that it validates array element schemas (`items`), making the method's scope clearer to future maintainers.

## Implementation Details
The changes are purely documentation-focused and do not alter any runtime behavior. The defensive fallback comment provides context for why the code handles arrays without `items` definitions, clarifying that this is a safety measure rather than a primary code path.

https://claude.ai/code/session_018KVQq4MsvdUUnKM7L9TvSd