### PR TITLE
Make object zero values shape-valid by recursively filling properties

### DIFF
--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -20,8 +20,14 @@ use crate::value::QuillValue;
 ///
 /// Honestly blank for almost every type — `""` (string, markdown, date,
 /// datetime: the validator accepts the empty string for date/datetime), `0`,
-/// `false`, `[]`, `{}`. The lone seam is `enum`: there is no empty enum
+/// `false`, `[]`. The lone seam is `enum`: there is no empty enum
 /// member, so the zero value is the first declared variant (`first_enum`).
+///
+/// An `object` with `properties` is *shape-valid only when every property is
+/// present*, so its zero value is the object whose each property carries that
+/// property's zero value (recursively). A bare `{}` would fail validation —
+/// the validator reports every absent property as a `MustFillUnset`. Only a
+/// property-less object (schema-invalid in practice) degrades to `{}`.
 pub fn zero_value(field: &FieldSchema) -> QuillValue {
     if let Some(values) = &field.enum_values {
         let first = values.first().cloned().unwrap_or_default();
@@ -29,13 +35,83 @@ pub fn zero_value(field: &FieldSchema) -> QuillValue {
     }
     let json = match field.r#type {
         FieldType::Array => json!([]),
-        // A bare object reaching this point would be schema-invalid (objects
-        // require a `properties` map). `{}` is the type-correct zero regardless.
-        FieldType::Object => json!({}),
+        FieldType::Object => match &field.properties {
+            // Recurse so each property is zero-filled to its own type-empty
+            // leaf — the result is a shape-valid object, not a bare `{}`.
+            Some(properties) => serde_json::Value::Object(
+                properties
+                    .iter()
+                    .map(|(name, schema)| (name.clone(), zero_value(schema).into_json()))
+                    .collect(),
+            ),
+            // A property-less object is schema-invalid; `{}` is its only
+            // type-correct zero.
+            None => json!({}),
+        },
         FieldType::Integer | FieldType::Number => json!(0),
         FieldType::Boolean => json!(false),
         // String / Markdown / Date / DateTime: `""` is schema-valid for all four.
         _ => json!(""),
     };
     QuillValue::from_json(json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(yaml: &str) -> FieldSchema {
+        let value = QuillValue::from_yaml_str(yaml).unwrap();
+        FieldSchema::from_quill_value("field".to_string(), &value).unwrap()
+    }
+
+    #[test]
+    fn object_with_properties_zero_fills_each_scalar_leaf() {
+        let schema = field(
+            r#"
+type: object
+properties:
+  street: { type: string }
+  zip: { type: integer }
+  active: { type: boolean }
+"#,
+        );
+
+        assert_eq!(
+            zero_value(&schema).into_json(),
+            json!({ "street": "", "zip": 0, "active": false })
+        );
+    }
+
+    #[test]
+    fn nested_object_recurses_to_type_empty_leaves() {
+        let schema = field(
+            r#"
+type: object
+properties:
+  name: { type: string }
+  address:
+    type: object
+    properties:
+      city: { type: string }
+      tags: { type: array, items: { type: string } }
+"#,
+        );
+
+        assert_eq!(
+            zero_value(&schema).into_json(),
+            json!({
+                "name": "",
+                "address": { "city": "", "tags": [] }
+            })
+        );
+    }
+
+    #[test]
+    fn property_less_object_degrades_to_empty_object() {
+        // A property-less object is schema-invalid in practice; `{}` is the
+        // only type-correct zero it can carry.
+        let schema = field("type: object\n");
+        assert_eq!(zero_value(&schema).into_json(), json!({}));
+    }
 }

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -391,10 +391,12 @@ fill strategy is an internal detail, not a public parameter.
   field with *both* a default and an example shows its example here but
   its default on the render path: the example optimizes for illustration,
   render for fidelity.
-- The per-field **zero value** (`""`, `0`, `false`, `[]`, `{}`, first
-  enum variant; `quillmark_core::quill::zero_value`) is one shared
-  producer — the example fallback above *and* the render floor for
-  zero-filled render (see [SCHEMAS.md](SCHEMAS.md) § "Zero-filled render").
+- The per-field **zero value** (`""`, `0`, `false`, `[]`, first enum
+  variant; an `object` with `properties` recurses to a shape-valid object
+  whose every property is zero-filled, while a property-less object degrades
+  to `{}`; `quillmark_core::quill::zero_value`) is one shared producer — the
+  example fallback above *and* the render floor for zero-filled render (see
+  [SCHEMAS.md](SCHEMAS.md) § "Zero-filled render").
 
 ## Bindings surface
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -94,10 +94,12 @@ projection that feeds the backend **only, never in the persisted document**.
   `must_fill_absent` (which keys on absence) vacuous and blind a future
   schema migration to author intent.
 
-The per-field zero value is honestly blank for every type except `enum`,
-whose zero is the first declared variant; it is the one shared producer
-behind both this render floor and the `example` document's fallback (see
-[BLUEPRINT.md](BLUEPRINT.md)).
+The per-field zero value is honestly blank for every scalar type except
+`enum`, whose zero is the first declared variant. An `object` with
+`properties` is shape-valid only when every property is present, so its zero
+is the object whose each property carries that property's zero (recursively),
+not a bare `{}`. It is the one shared producer behind both this render floor
+and the `example` document's fallback (see [BLUEPRINT.md](BLUEPRINT.md)).
 
 ## Schema emission
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -97,8 +97,7 @@ projection that feeds the backend **only, never in the persisted document**.
 The per-field zero value is honestly blank for every scalar type except
 `enum`, whose zero is the first declared variant. An `object` with
 `properties` is shape-valid only when every property is present, so its zero
-is the object whose each property carries that property's zero (recursively),
-not a bare `{}`. It is the one shared producer behind both this render floor
+is the object whose each property carries that property's zero (recursively). It is the one shared producer behind both this render floor
 and the `example` document's fallback (see [BLUEPRINT.md](BLUEPRINT.md)).
 
 ## Schema emission


### PR DESCRIPTION
## Summary
Updated the `zero_value` function to generate shape-valid zero values for objects with properties, rather than returning bare `{}` which would fail validation. Objects now recursively zero-fill each property to its own type-empty value.

## Key Changes
- **Modified `zero_value()` logic for objects**: When an object schema has `properties`, the function now recursively generates zero values for each property and constructs a complete object. Only property-less objects (schema-invalid in practice) degrade to `{}`.
- **Added comprehensive test coverage**: Three new tests validate the behavior:
  - Scalar properties are filled with their type-correct zeros (string → `""`, integer → `0`, boolean → `false`)
  - Nested objects recurse properly to reach type-empty leaves
  - Property-less objects correctly fall back to `{}`
- **Updated documentation**: Clarified in both BLUEPRINT.md and SCHEMAS.md that object zero values are shape-valid and recursively filled, distinguishing them from the simple scalar zero values.

## Implementation Details
The change replaces a simple `json!({})` with a conditional that:
1. Checks if the object schema defines `properties`
2. If present: iterates through properties, recursively calls `zero_value()` on each schema, and collects results into a `serde_json::Value::Object`
3. If absent: falls back to `{}` as the only type-correct zero for schema-invalid property-less objects

This ensures that zero-filled renders produce documents that pass schema validation, addressing the validator's `MustFillUnset` errors for absent required properties.

https://claude.ai/code/session_015PtKHDrKJ1zFTKQLNfDZeg