### PR TITLE
Reject object fields with empty properties map

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -1363,33 +1363,30 @@ main:
     }
 
     #[test]
-    fn empty_typed_object_and_table_render_type_valid_and_validate() {
-        // `properties: {}` is a legal (if degenerate) schema — the rejection
-        // targets *absent* properties (freeform), not empty ones. With no
-        // leaves to fill, the value cell must be the empty container (`{}` /
-        // `[]`), not a bare null that fails the field's own validation. Holds
-        // for both reference documents.
-        let config = cfg(r#"
+    fn empty_typed_object_and_table_rejected() {
+        // `properties: {}` is rejected — an object with no properties is
+        // useless and almost certainly a mistake.
+        for yaml in [
+            r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     addr: { type: object, properties: {} }
-    rows: { type: array,  items: { type: object, properties: {} } }
-"#);
-        for doc_md in [config.blueprint(), config.example()] {
+"#,
+            r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    rows: { type: array, items: { type: object, properties: {} } }
+"#,
+        ] {
+            let errs = QuillConfig::from_yaml_with_warnings(yaml)
+                .expect_err("expected error for empty properties");
             assert!(
-                doc_md.contains("addr: {}  # object\n"),
-                "object cell:\n{doc_md}"
+                errs.iter()
+                    .any(|e| e.code.as_deref() == Some("quill::object_empty_properties")),
+                "expected quill::object_empty_properties, got: {errs:?}"
             );
-            assert!(
-                doc_md.contains("rows: []  # array<object>\n"),
-                "table cell:\n{doc_md}"
-            );
-            let doc = Document::from_markdown(&doc_md)
-                .unwrap_or_else(|e| panic!("must parse: {e:?}\n---\n{doc_md}"));
-            config
-                .validate_document(&doc)
-                .unwrap_or_else(|errs| panic!("must validate: {errs:?}\n---\n{doc_md}"));
         }
     }
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -504,6 +504,15 @@ impl QuillConfig {
                         ),
                     );
                 };
+                if props.is_empty() {
+                    return err(
+                        "quill::object_empty_properties",
+                        format!(
+                            "Field '{owner}' has type: object with an empty properties map. \
+                             Declare at least one property, or remove the field entirely."
+                        ),
+                    );
+                }
                 // Object properties are leaves — scalars only.
                 props.iter().find_map(|(name, prop)| {
                     Self::validate_field_schema_shape(

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1512,6 +1512,56 @@ main:
 }
 
 #[test]
+fn test_empty_properties_object_rejected() {
+    for (label, yaml_content) in [
+        (
+            "top-level object",
+            r#"
+quill:
+  name: obj_test
+  version: "1.0"
+  backend: typst
+  description: Test empty properties rejection
+
+main:
+  fields:
+    metadata:
+      type: object
+      properties: {}
+"#,
+        ),
+        (
+            "array items object",
+            r#"
+quill:
+  name: obj_test
+  version: "1.0"
+  backend: typst
+  description: Test empty properties rejection in array items
+
+main:
+  fields:
+    rows:
+      type: array
+      items:
+        type: object
+        properties: {}
+"#,
+        ),
+    ] {
+        let err = QuillConfig::from_yaml_with_warnings(yaml_content)
+            .expect_err(&format!("{label}: expected error for empty properties"));
+        assert_eq!(err.len(), 1, "{label}");
+        assert_eq!(err[0].severity, Severity::Error, "{label}");
+        assert_eq!(
+            err[0].code.as_deref(),
+            Some("quill::object_empty_properties"),
+            "{label}"
+        );
+    }
+}
+
+#[test]
 fn test_nested_object_in_typed_table_rejected_with_error() {
     let yaml_content = r#"
 quill:


### PR DESCRIPTION
## Summary
Add validation to reject object fields that have an empty `properties` map, as they are useless and likely indicate a configuration error.

## Key Changes
- Added validation in `QuillConfig` to detect and reject object fields with empty `properties` maps with error code `quill::object_empty_properties`
- The validation applies to both top-level object fields and objects nested in array items
- Updated existing test in `blueprint.rs` that previously expected empty properties to be valid; now expects validation errors instead
- Added comprehensive test coverage in `tests.rs` with two test cases: empty properties in top-level objects and in array item objects

## Implementation Details
- The validation check is performed during schema shape validation in `config.rs`
- When an empty properties map is detected, a clear error message is returned instructing users to either declare at least one property or remove the field entirely
- The error code `quill::object_empty_properties` allows for targeted error handling by consumers

https://claude.ai/code/session_01RRWJp71LsMk2mpDKU3gPcg