### PR TITLE
v0.87.0: Typed arrays via items, unified datetime, stricter schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,101 @@
 
 ## v0.87.0 - 2026-06-01
 
-- Consolidate schema literal validation into shared primitive (#680)
-- Remove FieldType::Date; unify datetime under YAML 1.1 timestamp grammar (#679)
-- Reject object fields with empty properties maps (#678)
-- Make object zero values shape-valid by recursively filling properties (#677)
-- Fix doc/comment nits from array-items review (#675)
-- docs: add overview index page to migration section (#674)
-- Collapse array/markdown handling into recursive passes (#673)
-- Make primitively typed arrays first-class via items (#672)
-- Migrate documentation hosting from Read the Docs to GitHub Pages (#671)
-- canon + docs: partial documents are first-class citizens (#670)
+Arrays become first-class typed fields via a required `items` element
+schema, datetime is unified under a single `type: datetime` accepting the
+full YAML-1.1-style timestamp range (`FieldType::Date` is gone), and object
+zero values are now shape-valid. This release tightens schema-load
+validation in several places — empty `properties` maps and deeper array
+nesting are now rejected — and consolidates the example/default conformance
+checks behind one shared primitive. Documentation now ships from GitHub
+Pages instead of Read the Docs.
+
+### Breaking changes
+
+- **Array fields now require an `items` element schema** (#672). Arrays
+  previously carried a single untyped `Array` type; scalar arrays were
+  never coerced or validated element-wise and were always annotated
+  `array<string>`. Every array field must now declare `items`, and schema
+  load rejects arrays without it. The bare-`properties`-on-an-array form
+  (the old "typed table") is **removed** in favor of
+  `items: { type: object, properties: … }`. Migration for a typed table:
+
+  ```yaml
+  # before
+  rows:
+    type: array
+    properties: { name: { type: string }, qty: { type: integer } }
+  # after
+  rows:
+    type: array
+    items:
+      type: object
+      properties: { name: { type: string }, qty: { type: integer } }
+  ```
+
+  A scalar array adds `items` directly, e.g.
+  `counts: { type: array, items: { type: integer } }`. Elements now coerce
+  and validate against `items` (failing at the indexed path, e.g.
+  `counts[1]`), and blueprint annotations reflect the element type
+  (`array<integer>`, `array<markdown>`, …). Bundled quills and the
+  `usaf_memo` golden schema are migrated.
+- **`FieldType::Date` removed; use `type: datetime`** (#679). `type: date`
+  no longer exists. `type: datetime` now accepts the full range from a bare
+  `YYYY-MM-DD` date through RFC 3339 with offset (seconds optional, `T` or
+  space separator). Datetime values gain calendar validation (e.g. Feb 30
+  is now rejected), and JSON Schema output emits `format: date-time` for
+  all datetime fields. The WASM `FieldType` union drops `"date"`. The
+  blueprint hint is now `datetime<YYYY-MM-DD[Thh:mm:ss]>`.
+- **Empty `properties: {}` on an object field is rejected** (#678). An
+  empty properties map carries no information (the only conforming value is
+  `{}`) and is almost always a mistake. It is now treated like a missing
+  `properties` key and surfaces `quill::object_empty_properties`.
+- **Deeper array nesting is rejected** (#673). The documented "one level of
+  nesting" contract is now enforced in a single recursive pass, closing a
+  gap where `array<object<array>>` and `object<array>` were silently
+  accepted. A typed table row and a typed dictionary may carry scalar
+  columns/properties only; deeper shapes fail with
+  `quill::nested_array_not_supported`.
+
+### Behavioral changes
+
+- **Object zero values are now shape-valid** (#677). `zero_value` returned
+  a bare `{}` for every object field, which failed validation on any object
+  with `properties` (each absent property reported as `MustFillUnset`), so
+  the zero-filled render path broke for object fields. An object with
+  `properties` now recurses, zero-filling each property to its own
+  type-empty leaf. `{}` remains the zero only for the property-less edge
+  case.
+- **`example:` values are now validated** (#680). The conformance check for
+  `example`/`default` literals recurses into array items and object
+  properties and validates datetime format — capabilities the old
+  load-time path lacked, so previously-unvalidated `example:` values are
+  now caught.
+
+### Documentation & infrastructure
+
+- **Docs hosting moved from Read the Docs to GitHub Pages** (#671). A new
+  `docs.yml` workflow builds MkDocs (strict build as a PR check) and
+  deploys to Pages on a published release; RCs are skipped. `.readthedocs.yaml`
+  is removed and homepage/User Guide links point at the Pages URL.
+- **Canon + docs: partial documents are first-class citizens** (#670). The
+  docs and binding READMEs no longer claim Must Fill fields must be supplied
+  before shipping. The only hard render gate is well-formedness (values
+  coerce, no surviving `<must-fill>` sentinel); completeness is a hint
+  surfaced by the form view. The `format-designer/` docs tree is renamed to
+  `quills/`.
+- A Migration section overview page was added and wired into the nav (#674).
+
+### Internal
+
+- Example/default validation is consolidated behind a single
+  `validate_schema_literal` conformance core shared by `quillmark-core`
+  config loading and the CLI `validate` command, with author-friendly
+  diagnostics preserved (#680).
+- Array and markdown handling collapse into recursive passes over the
+  schema in both schema-shape validation and the Typst markdown transform
+  (#673).
+- Doc/comment fixes from the array-items review (#675).
 
 
 ## v0.86.0 - 2026-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Pages instead of Read the Docs.
 
 ### Breaking changes
 
+These are schema-load cutovers for `Quill.yaml` authors; full before/after
+steps are in `docs/migrations/0.86-to-0.87.md`.
+
 - **Array fields now require an `items` element schema** (#672). Arrays
   previously carried a single untyped `Array` type; scalar arrays were
   never coerced or validated element-wise and were always annotated

--- a/docs/migrations/0.86-to-0.87.md
+++ b/docs/migrations/0.86-to-0.87.md
@@ -1,0 +1,155 @@
+# 0.86.0 → 0.87.0 — Typed arrays via `items`, unified `datetime`, stricter schema load
+
+`0.87.0` reshapes how array and datetime fields are declared in a
+`Quill.yaml` schema. The changes are **hard cutovers** at schema-load time:
+a schema that uses the old forms no longer loads, and the load diagnostics
+name the exact field and fix. The typed accessors, plate-JSON wire format,
+and document syntax are unchanged.
+
+If you only render documents against the **bundled** quills, no action is
+needed — they are already migrated. This guide is for anyone maintaining
+their own `Quill.yaml`, a stored golden schema, or a generator that emits
+schemas.
+
+## Array fields now require `items`
+
+Arrays previously carried a single untyped `Array` type. Scalar arrays were
+never coerced or validated element-wise and were always annotated
+`array<string>` regardless of contents; element typing was only possible for
+objects, via a bare `properties:` map directly on the array (the "typed
+table"). `0.87.0` makes every array carry an `items` **element schema**, and
+`items` is **required**.
+
+### Scalar arrays
+
+Add `items` with the element's type:
+
+```diff
+  counts:
+    type: array
++   items:
++     type: integer
+```
+
+Elements now coerce and validate against `items`, failing at the indexed
+path (e.g. `counts[1]`). The blueprint annotation reflects the element type
+(`array<integer>`), not a blanket `array<string>`.
+
+### Typed tables (the bare-`properties`-on-array form is removed)
+
+A typed table used to be an array with `properties:` set directly on it.
+That form is gone; wrap the object shape in `items` instead:
+
+```diff
+  rows:
+    type: array
+-   properties:
+-     name: { type: string }
+-     qty:  { type: integer }
++   items:
++     type: object
++     properties:
++       name: { type: string }
++       qty:  { type: integer }
+```
+
+### `markdown[]` and other element types
+
+The same `items` shape applies to any element type. A markdown list becomes:
+
+```yaml
+notes:
+  type: array
+  items:
+    type: markdown
+```
+
+`markdown[]` elements are converted to Typst markup on render, and the
+schema emits `contentMediaType: text/markdown` on the items recursively.
+
+### What the loader now rejects
+
+| Diagnostic | Cause | Fix |
+| --- | --- | --- |
+| `quill::array_missing_items` | `type: array` with no `items` | add an `items` element schema |
+| `quill::array_properties_not_supported` | `properties:` set directly on an array | move it under `items: { type: object, properties: … }` |
+| `quill::items_not_supported` | `items` on a non-array field | remove `items`, or change `type` to `array` |
+
+## `type: date` is gone — use `type: datetime`
+
+`FieldType::Date` is **removed**. There is now one temporal type,
+`datetime`, and it accepts the full range from a bare calendar date through
+a full timestamp with offset:
+
+- `YYYY-MM-DD` (bare date)
+- `YYYY-MM-DDThh:mm:ss` and the space-separated form
+- RFC 3339 with timezone offset; seconds and fractional seconds optional
+
+```diff
+  due:
+-   type: date
++   type: datetime
+```
+
+Knock-on effects:
+
+- **Calendar validation** — values are now parsed, so an impossible date
+  such as `2026-02-30` is rejected (it was previously accepted by the
+  format check).
+- **JSON Schema output** — every datetime field emits `format: date-time`.
+- **WASM `FieldType` union** — the `"date"` member is removed; use
+  `"datetime"`.
+- **Blueprint hint** — now `datetime<YYYY-MM-DD[Thh:mm:ss]>`.
+
+A value that was a valid `date` (`YYYY-MM-DD`) is still valid under
+`datetime`, so existing document values do not need editing — only the
+schema's `type:` keyword changes.
+
+## Empty `properties: {}` is rejected
+
+An object field with an empty `properties` map carries no information — the
+only conforming value is `{}` — and is almost always a mistake. It is now
+treated like a missing `properties` key and reported as
+`quill::object_empty_properties`. Either give the object real properties or
+drop the field.
+
+## Deeper array nesting is rejected
+
+The documented "one level of nesting" contract is now enforced in a single
+recursive pass, closing a gap where deeper shapes were silently accepted. A
+typed table row (`array<object>`) and a typed dictionary (`object`) may
+carry **scalar** columns/properties only. Shapes like `array<object<array>>`
+or `object<array>` now fail with `quill::nested_array_not_supported`.
+
+If you relied on a deeper shape, flatten it — e.g. lift the inner array to a
+top-level field, or model the data as a separate card kind.
+
+## `example:` values are now validated
+
+The conformance check for `example:` and `default:` literals now recurses
+into array items and object properties and validates datetime format —
+capabilities the old load-time path lacked. An `example:` value that does
+not match its field's type, enum, or datetime grammar is now caught at load
+(`quill::example_type_mismatch`, `quill::example_not_in_enum`,
+`quill::default_type_mismatch`). This surfaces latent mistakes in `example:`
+blocks that previously went unchecked; correct the literal to match the
+declared schema.
+
+## Migration checklist
+
+1. **Add `items` to every array field.** Scalar arrays get
+   `items: { type: <elem> }`; typed tables move `properties:` under
+   `items: { type: object, properties: … }`.
+2. **Replace `type: date` with `type: datetime`.** Document values need no
+   change; verify no value is an impossible calendar date.
+3. **Remove empty `properties: {}` maps.**
+4. **Flatten any array nested more than one level deep.**
+5. **Re-baseline stored golden schemas and blueprint goldens** — array
+   annotations (`array<integer>`, `array<markdown>`, …), the typed-table
+   shape, and datetime `format: date-time` output all change.
+6. **WASM consumers:** drop `"date"` from any code that branches on the
+   `FieldType` union.
+
+Load each migrated quill (`Quill::from_path` / the CLI `validate` command);
+the diagnostics above name the offending field and the corrective action
+directly.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -12,6 +12,9 @@ guides in order.
 
 ## Available guides
 
+- [0.86 → 0.87](0.86-to-0.87.md) — array fields require an `items` element
+  schema, `type: date` folds into a unified `type: datetime`, and schema load
+  rejects empty `properties` maps and deeper array nesting.
 - [0.85 → 0.86](0.85-to-0.86.md) — partial documents render without error, and
   the canonical card-yaml fence becomes a bare `~~~`.
 - [0.83 → 0.84](0.83-to-0.84.md) — the Must Fill / Endorsed schema model

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
+      - 0.86 → 0.87 (typed arrays via items, unified datetime): migrations/0.86-to-0.87.md
       - 0.85 → 0.86 (bare ~~~ card-yaml fence): migrations/0.85-to-0.86.md
       - 0.83 → 0.84 (Must Fill / Endorsed, Python parity): migrations/0.83-to-0.84.md
       - 0.82 → 0.83 ($-prefixed plate JSON): migrations/0.82-to-0.83.md


### PR DESCRIPTION
## Summary

This release introduces breaking schema-load changes that reshape how array and datetime fields are declared in `Quill.yaml` schemas. Arrays now require a first-class `items` element schema, `type: date` is removed in favor of a unified `type: datetime`, and schema validation is tightened to reject empty `properties` maps and deeper array nesting.

## Key Changes

- **Array fields now require `items` element schema** — Arrays previously carried a single untyped `Array` type with no element-wise coercion or validation. Every array field must now declare `items`, and the bare-`properties`-on-array form (typed tables) is removed in favor of `items: { type: object, properties: … }`. Elements now coerce and validate against `items` at the indexed path, and blueprint annotations reflect the actual element type (`array<integer>`, `array<markdown>`, etc.).

- **Unified datetime type** — `FieldType::Date` is removed; `type: datetime` now accepts the full range from bare `YYYY-MM-DD` dates through RFC 3339 timestamps with offset. Datetime values gain calendar validation (e.g., Feb 30 is rejected), JSON Schema output emits `format: date-time`, and the blueprint hint is `datetime<YYYY-MM-DD[Thh:mm:ss]>`.

- **Stricter schema validation** — Empty `properties: {}` maps on object fields are now rejected as `quill::object_empty_properties`. Deeper array nesting (e.g., `array<object<array>>`) is rejected with `quill::nested_array_not_supported`, enforcing the documented "one level of nesting" contract.

- **Object zero values are shape-valid** — `zero_value` now recurses into object properties, zero-filling each to its type-empty leaf, fixing validation failures on objects with properties.

- **Example/default validation consolidated** — `example:` and `default:` literals are now validated recursively into array items and object properties, with datetime format checks, surfacing previously-unvalidated mistakes.

- **Documentation hosting moved to GitHub Pages** — A new `docs.yml` workflow builds and deploys MkDocs on release; `.readthedocs.yaml` is removed.

- **Migration guide added** — `docs/migrations/0.86-to-0.87.md` provides detailed before/after steps and a checklist for schema authors.

## Implementation Details

- Schema load diagnostics name the exact field and corrective action for all rejections (`array_missing_items`, `array_properties_not_supported`, `items_not_supported`, `object_empty_properties`, `nested_array_not_supported`).
- Bundled quills and the `usaf_memo` golden schema are pre-migrated.
- The typed accessors, plate-JSON wire format, and document syntax remain unchanged; only schema declaration changes.
- WASM `FieldType` union drops the `"date"` member.

https://claude.ai/code/session_019crpfHgGrzb2Rzz3dcjumA