### PR TITLE
Make $quill reference grammar a single source of truth

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -504,12 +504,11 @@ impl Document {
         quillmark_core::document::blueprint_instruction(quill_name)
     }
 
-    /// The canonical `$quill` reference grammar as author-facing text — the
-    /// same string every binding shows (CLI, Python, MCP) so a consumer's
-    /// schema `describe`, its validation messages, and the
-    /// `parse::invalid_quill_reference` diagnostic's `hint` all read from one
-    /// source rather than re-stating the rule. Read once at startup and cache;
-    /// the value never changes between calls.
+    /// The canonical `$quill` reference grammar as author-facing text. Single
+    /// source of truth (CLI, Python, MCP): drive schema `describe` and
+    /// validation messages from this instead of re-stating the rule — it
+    /// matches the `hint` on `parse::invalid_quill_reference`. Cache it; the
+    /// value never changes.
     #[wasm_bindgen(js_name = quillRefHint)]
     pub fn quill_ref_hint() -> String {
         quillmark_core::quill_ref_hint().to_string()
@@ -656,9 +655,7 @@ impl Document {
     #[wasm_bindgen(js_name = setQuillRef)]
     pub fn set_quill_ref(&mut self, ref_str: &str) -> Result<(), JsValue> {
         let qr: quillmark_core::QuillReference = ref_str.parse().map_err(|e| {
-            // Surface the same `parse::invalid_quill_reference` shape — code and
-            // canonical grammar `hint` — that document parsing emits, so the
-            // mutator and the parser never drift.
+            // Same shape document parsing emits, so mutator and parser don't drift.
             let diag = quillmark_core::Diagnostic::new(
                 quillmark_core::Severity::Error,
                 format!("setQuillRef: invalid reference '{}': {}", ref_str, e),

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -504,6 +504,17 @@ impl Document {
         quillmark_core::document::blueprint_instruction(quill_name)
     }
 
+    /// The canonical `$quill` reference grammar as author-facing text — the
+    /// same string every binding shows (CLI, Python, MCP) so a consumer's
+    /// schema `describe`, its validation messages, and the
+    /// `parse::invalid_quill_reference` diagnostic's `hint` all read from one
+    /// source rather than re-stating the rule. Read once at startup and cache;
+    /// the value never changes between calls.
+    #[wasm_bindgen(js_name = quillRefHint)]
+    pub fn quill_ref_hint() -> String {
+        quillmark_core::quill_ref_hint().to_string()
+    }
+
     /// Render a Diagnostic as the canonical pretty-printed text every binding
     /// shows (CLI, Python, MCP). Single source of truth so a Diagnostic looks
     /// identical no matter which consumer surfaces it.
@@ -645,10 +656,18 @@ impl Document {
     #[wasm_bindgen(js_name = setQuillRef)]
     pub fn set_quill_ref(&mut self, ref_str: &str) -> Result<(), JsValue> {
         let qr: quillmark_core::QuillReference = ref_str.parse().map_err(|e| {
-            WasmError::from(format!(
-                "setQuillRef: invalid reference '{}': {}",
-                ref_str, e
-            ))
+            // Surface the same `parse::invalid_quill_reference` shape — code and
+            // canonical grammar `hint` — that document parsing emits, so the
+            // mutator and the parser never drift.
+            let diag = quillmark_core::Diagnostic::new(
+                quillmark_core::Severity::Error,
+                format!("setQuillRef: invalid reference '{}': {}", ref_str, e),
+            )
+            .with_code("parse::invalid_quill_reference".to_string())
+            .with_hint(quillmark_core::quill_ref_hint().to_string());
+            WasmError {
+                diagnostics: vec![diag],
+            }
             .to_js_value()
         })?;
         self.inner.set_quill_ref(qr);

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -65,8 +65,11 @@ pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadI
         let meta = match key.as_str() {
             "$quill" => {
                 let s = require_string("$quill reference", value)?;
-                let reference = QuillReference::from_str(&s).map_err(|e| {
-                    ParseError::InvalidStructure(format!("Invalid $quill reference '{}': {}", s, e))
+                let reference = QuillReference::from_str(&s).map_err(|reason| {
+                    ParseError::InvalidQuillReference {
+                        value: s.clone(),
+                        reason,
+                    }
                 })?;
                 PayloadItem::Quill { reference }
             }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -63,10 +63,7 @@ fn test_missing_quill_diagnostic_code() {
 
 #[test]
 fn test_malformed_quill_reference_carries_code_and_grammar_hint() {
-    // An uppercase name violates the reference grammar. The parser surfaces a
-    // dedicated `parse::invalid_quill_reference` code and attaches the canonical
-    // grammar as the diagnostic `hint` (sourced from `quill_ref_hint`), so every
-    // binding renders identical guidance instead of re-stating the rule.
+    // Uppercase name → dedicated code plus the canonical grammar as `hint`.
     let err =
         decompose("~~~card-yaml\n$quill: Resume@2.1.0\n$kind: main\n~~~\n\nBody\n").unwrap_err();
     let diag = err.to_diagnostic();

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -62,6 +62,23 @@ fn test_missing_quill_diagnostic_code() {
 }
 
 #[test]
+fn test_malformed_quill_reference_carries_code_and_grammar_hint() {
+    // An uppercase name violates the reference grammar. The parser surfaces a
+    // dedicated `parse::invalid_quill_reference` code and attaches the canonical
+    // grammar as the diagnostic `hint` (sourced from `quill_ref_hint`), so every
+    // binding renders identical guidance instead of re-stating the rule.
+    let err =
+        decompose("~~~card-yaml\n$quill: Resume@2.1.0\n$kind: main\n~~~\n\nBody\n").unwrap_err();
+    let diag = err.to_diagnostic();
+    assert_eq!(diag.code.as_deref(), Some("parse::invalid_quill_reference"));
+    assert_eq!(
+        diag.hint.as_deref(),
+        Some(crate::version::quill_ref_hint()),
+        "the malformed-reference diagnostic must carry the canonical grammar hint"
+    );
+}
+
+#[test]
 fn test_root_dash_frontmatter_without_quill_reports_missing_quill() {
     // `---` opener is now accepted for the root block. A `---` block without
     // `$quill` should surface the standard MissingQuill error — not the old

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -229,17 +229,13 @@ pub enum ParseError {
     #[error("{0}")]
     MissingQuill(String),
 
-    /// A `$quill` reference string failed to parse against the reference
-    /// grammar (see [`crate::version::quill_ref_hint`]).
-    ///
-    /// Emitted as code `parse::invalid_quill_reference`; the canonical grammar
-    /// travels as the diagnostic's `hint` so the error and any binding's
-    /// schema `describe` text stay in lockstep with the parser.
+    /// A `$quill` reference failed to parse as a [`crate::version::QuillReference`].
+    /// Code `parse::invalid_quill_reference`; carries
+    /// [`crate::version::quill_ref_hint`] as its diagnostic hint.
     #[error("Invalid $quill reference '{value}': {reason}")]
     InvalidQuillReference {
-        /// The offending reference string, verbatim.
         value: String,
-        /// The specific violation reported by `QuillReference::from_str`.
+        /// The `from_str` violation.
         reason: String,
     },
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -229,6 +229,20 @@ pub enum ParseError {
     #[error("{0}")]
     MissingQuill(String),
 
+    /// A `$quill` reference string failed to parse against the reference
+    /// grammar (see [`crate::version::quill_ref_hint`]).
+    ///
+    /// Emitted as code `parse::invalid_quill_reference`; the canonical grammar
+    /// travels as the diagnostic's `hint` so the error and any binding's
+    /// schema `describe` text stay in lockstep with the parser.
+    #[error("Invalid $quill reference '{value}': {reason}")]
+    InvalidQuillReference {
+        /// The offending reference string, verbatim.
+        value: String,
+        /// The specific violation reported by `QuillReference::from_str`.
+        reason: String,
+    },
+
     #[error("YAML error at line {line}: {message}")]
     YamlErrorWithLocation {
         message: String,
@@ -257,6 +271,12 @@ impl ParseError {
                 .with_code("parse::empty_input".to_string()),
             ParseError::MissingQuill(msg) => Diagnostic::new(Severity::Error, msg.clone())
                 .with_code("parse::missing_quill".to_string()),
+            ParseError::InvalidQuillReference { value, reason } => Diagnostic::new(
+                Severity::Error,
+                format!("Invalid $quill reference '{}': {}", value, reason),
+            )
+            .with_code("parse::invalid_quill_reference".to_string())
+            .with_hint(crate::version::quill_ref_hint().to_string()),
             ParseError::YamlErrorWithLocation {
                 message,
                 line,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -67,4 +67,4 @@ pub use value::QuillValue;
 pub mod normalize;
 
 pub mod version;
-pub use version::{QuillReference, Version, VersionSelector};
+pub use version::{quill_ref_hint, QuillReference, Version, VersionSelector};

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -172,9 +172,8 @@ lowercase letters, digits, or underscores). The optional version selector is \
 (latest in that major series), or `@latest`; omitting the selector means latest.";
 
 /// The canonical `$quill` reference grammar as author-facing text. Single
-/// source of truth (see [`QUILL_REF_HINT`]) so every binding shows identical
-/// wording rather than re-stating the rule. The value never changes between
-/// calls.
+/// source of truth so every binding shows identical wording rather than
+/// re-stating the rule. The value never changes between calls.
 pub fn quill_ref_hint() -> &'static str {
     QUILL_REF_HINT
 }

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -156,24 +156,18 @@ impl fmt::Display for VersionSelector {
     }
 }
 
-/// Canonical, author-facing description of the `$quill` reference grammar
-/// enforced by [`QuillReference::from_str`].
-///
-/// This is the **single source of truth** for the grammar: bindings surface it
-/// verbatim (zod schema `describe`, CLI help, validation hints) instead of
-/// re-stating the rule in their own glue, and it travels as the `hint` on the
-/// `parse::invalid_quill_reference` diagnostic so a malformed reference's error
-/// and a schema's describe text never drift from the parser. Mirrors the
-/// `FORMAT_RULES` / `blueprint_instruction` pattern in `document`.
+/// Canonical, author-facing `$quill` reference grammar.
 const QUILL_REF_HINT: &str = "A $quill reference is `<name>` or `<name>@<selector>`. \
 The name must match `[a-z_][a-z0-9_]*` (start with a lowercase letter or underscore, then \
 lowercase letters, digits, or underscores). The optional version selector is \
 `@MAJOR.MINOR.PATCH` (exact), `@MAJOR.MINOR` (latest patch in that minor series), `@MAJOR` \
 (latest in that major series), or `@latest`; omitting the selector means latest.";
 
-/// The canonical `$quill` reference grammar as author-facing text. Single
-/// source of truth so every binding shows identical wording rather than
-/// re-stating the rule. The value never changes between calls.
+/// Single source of truth for the grammar [`QuillReference::from_str`] enforces:
+/// bindings surface it (schema `describe`, validation hints) and it rides as the
+/// `hint` on the `parse::invalid_quill_reference` diagnostic, so error and
+/// describe text can't drift from the parser. Sibling of `document`'s
+/// `FORMAT_RULES` / `blueprint_instruction`.
 pub fn quill_ref_hint() -> &'static str {
     QUILL_REF_HINT
 }
@@ -404,8 +398,7 @@ mod tests {
     fn test_quill_ref_hint_describes_the_grammar() {
         let hint = quill_ref_hint();
         assert!(!hint.is_empty());
-        // Names the charset and selector forms the parser actually enforces,
-        // so the single-source string can't silently drift from `from_str`.
+        // Pin the charset and selector forms so the hint can't drift from `from_str`.
         assert!(hint.contains("[a-z_][a-z0-9_]*"), "got: {hint}");
         assert!(hint.contains("@latest"), "got: {hint}");
         assert!(hint.contains("@MAJOR.MINOR.PATCH"), "got: {hint}");

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -156,6 +156,29 @@ impl fmt::Display for VersionSelector {
     }
 }
 
+/// Canonical, author-facing description of the `$quill` reference grammar
+/// enforced by [`QuillReference::from_str`].
+///
+/// This is the **single source of truth** for the grammar: bindings surface it
+/// verbatim (zod schema `describe`, CLI help, validation hints) instead of
+/// re-stating the rule in their own glue, and it travels as the `hint` on the
+/// `parse::invalid_quill_reference` diagnostic so a malformed reference's error
+/// and a schema's describe text never drift from the parser. Mirrors the
+/// `FORMAT_RULES` / `blueprint_instruction` pattern in `document`.
+const QUILL_REF_HINT: &str = "A $quill reference is `<name>` or `<name>@<selector>`. \
+The name must match `[a-z_][a-z0-9_]*` (start with a lowercase letter or underscore, then \
+lowercase letters, digits, or underscores). The optional version selector is \
+`@MAJOR.MINOR.PATCH` (exact), `@MAJOR.MINOR` (latest patch in that minor series), `@MAJOR` \
+(latest in that major series), or `@latest`; omitting the selector means latest.";
+
+/// The canonical `$quill` reference grammar as author-facing text. Single
+/// source of truth (see [`QUILL_REF_HINT`]) so every binding shows identical
+/// wording rather than re-stating the rule. The value never changes between
+/// calls.
+pub fn quill_ref_hint() -> &'static str {
+    QUILL_REF_HINT
+}
+
 /// Complete reference to a Quill template with name and version selector.
 ///
 /// Name charset: `[a-z_][a-z0-9_]*`. Selector defaults to `Latest` when omitted.
@@ -376,5 +399,16 @@ mod tests {
 
         let ref3 = QuillReference::new("resume".to_string(), VersionSelector::Latest);
         assert_eq!(ref3.to_string(), "resume");
+    }
+
+    #[test]
+    fn test_quill_ref_hint_describes_the_grammar() {
+        let hint = quill_ref_hint();
+        assert!(!hint.is_empty());
+        // Names the charset and selector forms the parser actually enforces,
+        // so the single-source string can't silently drift from `from_str`.
+        assert!(hint.contains("[a-z_][a-z0-9_]*"), "got: {hint}");
+        assert!(hint.contains("@latest"), "got: {hint}");
+        assert!(hint.contains("@MAJOR.MINOR.PATCH"), "got: {hint}");
     }
 }

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -10,7 +10,7 @@
 
 **`Diagnostic`**: severity, optional error code, message, primary location, optional hint, source error chain (omitted from serialization when empty)
 
-**`ParseError`**: parsing-stage error enum — input too large, YAML errors (with and without location), invalid structure; converts to `Diagnostic` via `to_diagnostic()`
+**`ParseError`**: parsing-stage error enum — input too large, YAML errors (with and without location), invalid structure, missing `$quill`, and invalid `$quill` reference; converts to `Diagnostic` via `to_diagnostic()`. The invalid-reference case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar — `quillmark_core::quill_ref_hint()` — as the diagnostic's `hint`. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule, mirroring `FORMAT_RULES` / `blueprint_instruction`.
 
 **`RenderError`**: main rendering error enum. Every variant carries the same
 payload — a non-empty `diags: Vec<Diagnostic>` — so all consumers (and all


### PR DESCRIPTION
## Summary

Establishes the canonical `$quill` reference grammar as a single source of truth that all bindings (CLI, Python, WASM, MCP) surface verbatim, preventing drift between parser validation, schema descriptions, and error messages.

## Key Changes

- **Added `QUILL_REF_HINT` constant and `quill_ref_hint()` function** in `crates/core/src/version.rs`
  - Defines the canonical author-facing grammar description for `$quill` references
  - Documents the name charset `[a-z_][a-z0-9_]*` and all version selector forms
  - Mirrors the `FORMAT_RULES` / `blueprint_instruction` pattern used elsewhere in the codebase

- **Created new `ParseError::InvalidQuillReference` variant** in `crates/core/src/error.rs`
  - Replaces generic `InvalidStructure` errors for malformed references
  - Emits diagnostic code `parse::invalid_quill_reference`
  - Automatically attaches the canonical grammar hint via `quill_ref_hint()` to all diagnostics

- **Updated WASM bindings** in `crates/bindings/wasm/src/engine.rs`
  - Exposed `quillRefHint()` method for JavaScript consumers to access the canonical grammar
  - Enhanced `setQuillRef()` error handling to emit the same diagnostic shape (code + hint) as the document parser, ensuring consistency

- **Updated reference parsing** in `crates/core/src/document/meta.rs`
  - Changed error handling to use the new `InvalidQuillReference` variant instead of generic `InvalidStructure`

- **Added comprehensive tests**
  - Test in `crates/core/src/version.rs` verifies the hint contains all grammar elements
  - Test in `crates/core/src/document/tests/assemble_tests.rs` confirms malformed references carry the code and hint

- **Updated public API** in `crates/core/src/lib.rs`
  - Exported `quill_ref_hint` function for use by bindings

- **Updated documentation** in `prose/canon/ERROR.md`
  - Clarified that invalid `$quill` reference errors include the canonical grammar as a hint

## Implementation Details

The grammar hint is a static string constant that travels through the diagnostic system, ensuring every binding (whether CLI, Python, WASM, or MCP) renders identical validation guidance. This prevents the common problem where error messages and schema descriptions drift from the actual parser implementation.

https://claude.ai/code/session_018gCmXSZCx6Kmnm2Q8zxNZB