### PR TITLE
Add $ext mutators for opaque consumer metadata

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -416,6 +416,57 @@ impl PyDocument {
         }
     }
 
+    /// Replace the opaque `$ext` map on the main card. `value` must be a dict;
+    /// raises `ValueError` otherwise. `$ext` carries out-of-band consumer state
+    /// and never reaches the rendered output. Pass `{}` for an explicit empty
+    /// `$ext`.
+    fn set_ext(&mut self, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let map = py_to_object(&value, "set_ext")?;
+        self.inner.main_mut().set_ext(map);
+        Ok(())
+    }
+
+    /// Remove the `$ext` map from the main card, returning the previous map or
+    /// `None`.
+    fn remove_ext<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        ext_map_to_py(py, self.inner.main_mut().remove_ext())
+    }
+
+    /// Merge `value` into the main card's `$ext` map under `namespace`, creating
+    /// the map when absent and replacing any existing value at that key. Sibling
+    /// namespaces are preserved so independent consumers don't clobber each other.
+    fn set_ext_namespace(&mut self, namespace: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let json = py_to_json(&value)?;
+        self.inner.main_mut().set_ext_namespace(namespace, json);
+        Ok(())
+    }
+
+    /// Replace the `$ext` map on the card at `index`. Raises on out-of-range
+    /// index or non-dict value.
+    fn update_card_ext(&mut self, index: usize, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let map = py_to_object(&value, "update_card_ext")?;
+        let len = self.inner.cards().len();
+        let card = self.inner.card_mut(index).ok_or_else(|| {
+            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
+        })?;
+        card.set_ext(map);
+        Ok(())
+    }
+
+    /// Remove the `$ext` map from the card at `index`, returning the previous
+    /// map or `None`. Raises if `index` is out of range.
+    fn remove_card_ext<'py>(
+        &mut self,
+        py: Python<'py>,
+        index: usize,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let len = self.inner.cards().len();
+        let card = self.inner.card_mut(index).ok_or_else(|| {
+            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
+        })?;
+        ext_map_to_py(py, card.remove_ext())
+    }
+
     fn set_quill_ref(&mut self, ref_str: &str) -> PyResult<()> {
         let qr: quillmark_core::QuillReference = ref_str.parse().map_err(|e| {
             PyValueError::new_err(format!("invalid QuillReference '{}': {}", ref_str, e))
@@ -846,6 +897,32 @@ fn py_to_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
     }
     let s = value.str()?.to_string();
     Ok(serde_json::Value::String(s))
+}
+
+/// Convert a Python value into a JSON object map, rejecting non-objects. Used
+/// by the `$ext` mutators, whose value must be a dict.
+fn py_to_object(
+    value: &Bound<'_, PyAny>,
+    ctx: &str,
+) -> PyResult<serde_json::Map<String, serde_json::Value>> {
+    match py_to_json(value)? {
+        serde_json::Value::Object(map) => Ok(map),
+        _ => Err(PyValueError::new_err(format!(
+            "{}: $ext must be a dict",
+            ctx
+        ))),
+    }
+}
+
+/// Convert an optional `$ext` map to a Python dict, or `None`.
+fn ext_map_to_py<'py>(
+    py: Python<'py>,
+    map: Option<serde_json::Map<String, serde_json::Value>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    match map {
+        Some(map) => json_to_py(py, &serde_json::Value::Object(map)),
+        None => py.None().into_bound_py_any(py),
+    }
 }
 
 fn py_dict_to_card(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::Card> {

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -295,6 +295,67 @@ def test_update_card_body_out_of_range():
         doc.update_card_body(0, "x")
 
 
+def test_set_ext_adds_map():
+    """set_ext stores an opaque map readable via card['ext']."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    doc.set_ext({"presentation": {"title": "Greeting"}})
+    assert doc.main["ext"] == {"presentation": {"title": "Greeting"}}
+
+
+def test_set_ext_rejects_non_dict():
+    """set_ext raises for non-dict values."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    with pytest.raises(ValueError, match="must be a dict"):
+        doc.set_ext("nope")
+
+
+def test_ext_round_trips_through_markdown():
+    """$ext survives emit → re-parse."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    doc.set_ext({"agent": {"pinned": True}})
+    reparsed = Document.from_markdown(doc.to_markdown())
+    assert reparsed.main["ext"]["agent"]["pinned"] is True
+
+
+def test_set_ext_namespace_preserves_siblings():
+    """set_ext_namespace merges without clobbering other namespaces."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    doc.set_ext_namespace("presentation", {"title": "A"})
+    doc.set_ext_namespace("agent", {"pinned": True})
+    doc.set_ext_namespace("presentation", {"title": "B"})
+    assert doc.main["ext"] == {
+        "presentation": {"title": "B"},
+        "agent": {"pinned": True},
+    }
+
+
+def test_remove_ext_returns_previous_and_clears():
+    """remove_ext returns the previous map, then None."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    doc.set_ext({"agent": {"n": 1}})
+    assert doc.remove_ext() == {"agent": {"n": 1}}
+    assert doc.main["ext"] is None
+    assert doc.remove_ext() is None
+
+
+def test_card_ext_mutators():
+    """update_card_ext / remove_card_ext target the card at index."""
+    doc = Document.from_markdown(MD_WITH_CARDS)
+    doc.update_card_ext(0, {"agent": {"note": "y"}})
+    assert doc.cards[0]["ext"] == {"agent": {"note": "y"}}
+    assert doc.remove_card_ext(0) == {"agent": {"note": "y"}}
+    assert doc.cards[0]["ext"] is None
+
+
+def test_card_ext_mutators_out_of_range():
+    """Card ext mutators raise IndexOutOfRange for a bad index."""
+    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.update_card_ext(0, {})
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.remove_card_ext(0)
+
+
 def test_mutators_do_not_touch_warnings():
     """Mutators must not modify the warnings list."""
     doc = Document.from_markdown(SIMPLE_MD)

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -756,6 +756,59 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
   })
 })
 
+describe('Document editor surface — $ext mutators', () => {
+  it('setExt adds an opaque map readable via card.ext', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setExt({ presentation: { title: 'Greeting' } })
+    expect(doc.main.ext.presentation.title).toBe('Greeting')
+  })
+
+  it('setExt rejects non-object values', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(() => doc.setExt('nope')).toThrow(/must be a plain object/)
+    expect(() => doc.setExt(42)).toThrow(/must be a plain object/)
+  })
+
+  it('$ext round-trips through toMarkdown', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setExt({ agent: { pinned: true } })
+    const reparsed = Document.fromMarkdown(doc.toMarkdown())
+    expect(reparsed.main.ext.agent.pinned).toBe(true)
+  })
+
+  it('setExtNamespace preserves sibling namespaces', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setExtNamespace('presentation', { title: 'A' })
+    doc.setExtNamespace('agent', { pinned: true })
+    doc.setExtNamespace('presentation', { title: 'B' })
+    expect(doc.main.ext.presentation.title).toBe('B')
+    expect(doc.main.ext.agent.pinned).toBe(true)
+  })
+
+  it('removeExt returns the previous map and clears it', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setExt({ agent: { n: 1 } })
+    expect(doc.removeExt().agent.n).toBe(1)
+    expect(doc.main.ext == null).toBe(true)
+    expect(doc.removeExt()).toBeUndefined()
+  })
+
+  it('card-level ext mutators target the card at index', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.pushCard({ kind: 'note', body: 'x' })
+    doc.updateCardExt(0, { agent: { note: 'y' } })
+    expect(doc.cards[0].ext.agent.note).toBe('y')
+    expect(doc.removeCardExt(0).agent.note).toBe('y')
+    expect(doc.cards[0].ext == null).toBe(true)
+  })
+
+  it('card-level ext mutators throw IndexOutOfRange', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(() => doc.updateCardExt(5, {})).toThrow(/IndexOutOfRange/)
+    expect(() => doc.removeCardExt(5)).toThrow(/IndexOutOfRange/)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // open + session.render
 // ---------------------------------------------------------------------------

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -651,6 +651,61 @@ impl Document {
         })
     }
 
+    /// Replace the opaque `$ext` map on the main card. `value` must be a plain
+    /// object; throws otherwise. `$ext` carries out-of-band consumer state and
+    /// never reaches the rendered output. Pass `{}` to record an explicit
+    /// empty `$ext`.
+    #[wasm_bindgen(js_name = setExt)]
+    pub fn set_ext(&mut self, value: JsValue) -> Result<(), JsValue> {
+        let map = js_value_to_object(&value, "setExt")?;
+        self.inner.main_mut().set_ext(map);
+        Ok(())
+    }
+
+    /// Remove the `$ext` map from the main card, returning the previous map or
+    /// `undefined`.
+    #[wasm_bindgen(js_name = removeExt, unchecked_return_type = "Record<string, unknown> | undefined")]
+    pub fn remove_ext(&mut self) -> JsValue {
+        ext_map_to_js(self.inner.main_mut().remove_ext())
+    }
+
+    /// Merge `value` into the main card's `$ext` map under `namespace`, creating
+    /// the map when absent and replacing any existing value at that key. Sibling
+    /// namespaces are preserved, so independent consumers (`$ext.presentation`,
+    /// `$ext.agent`, …) don't clobber each other.
+    #[wasm_bindgen(js_name = setExtNamespace)]
+    pub fn set_ext_namespace(&mut self, namespace: &str, value: JsValue) -> Result<(), JsValue> {
+        let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
+            WasmError::from(format!("setExtNamespace: invalid value: {}", e)).to_js_value()
+        })?;
+        self.inner.main_mut().set_ext_namespace(namespace, json);
+        Ok(())
+    }
+
+    /// Replace the `$ext` map on the card at `index`. Throws if out of range or
+    /// `value` is not a plain object.
+    #[wasm_bindgen(js_name = updateCardExt)]
+    pub fn update_card_ext(&mut self, index: usize, value: JsValue) -> Result<(), JsValue> {
+        let map = js_value_to_object(&value, "updateCardExt")?;
+        let len = self.inner.cards().len();
+        let card = self.inner.card_mut(index).ok_or_else(|| {
+            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+        })?;
+        card.set_ext(map);
+        Ok(())
+    }
+
+    /// Remove the `$ext` map from the card at `index`, returning the previous
+    /// map or `undefined`. Throws if out of range.
+    #[wasm_bindgen(js_name = removeCardExt, unchecked_return_type = "Record<string, unknown> | undefined")]
+    pub fn remove_card_ext(&mut self, index: usize) -> Result<JsValue, JsValue> {
+        let len = self.inner.cards().len();
+        let card = self.inner.card_mut(index).ok_or_else(|| {
+            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+        })?;
+        Ok(ext_map_to_js(card.remove_ext()))
+    }
+
     /// Replace the QUILL reference string. Throws if `ref_str` is invalid.
     #[wasm_bindgen(js_name = setQuillRef)]
     pub fn set_quill_ref(&mut self, ref_str: &str) -> Result<(), JsValue> {
@@ -796,6 +851,33 @@ fn edit_error_to_js(err: &quillmark_core::EditError) -> JsValue {
         quillmark_core::EditError::IndexOutOfRange { .. } => "IndexOutOfRange",
     };
     WasmError::from(format!("[EditError::{}] {}", variant, err)).to_js_value()
+}
+
+/// Deserialize a JS value into a JSON object map, rejecting non-objects. Used
+/// by the `$ext` mutators, whose value must be a plain object.
+fn js_value_to_object(
+    value: &JsValue,
+    ctx: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, JsValue> {
+    let json: serde_json::Value = serde_wasm_bindgen::from_value(value.clone())
+        .map_err(|e| WasmError::from(format!("{}: invalid value: {}", ctx, e)).to_js_value())?;
+    match json {
+        serde_json::Value::Object(map) => Ok(map),
+        _ => Err(WasmError::from(format!("{}: $ext must be a plain object", ctx)).to_js_value()),
+    }
+}
+
+/// Serialize an optional `$ext` map to a JS object, or `undefined` when `None`.
+fn ext_map_to_js(map: Option<serde_json::Map<String, serde_json::Value>>) -> JsValue {
+    match map {
+        Some(map) => {
+            let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+            serde_json::Value::Object(map)
+                .serialize(&serializer)
+                .unwrap_or(JsValue::UNDEFINED)
+        }
+        None => JsValue::UNDEFINED,
+    }
 }
 
 fn js_value_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -7,8 +7,14 @@
 //! are immutable parse-time observations.
 //!
 //! Payload/body mutators live on [`Card`] (`set_field`, `set_fill`,
-//! `remove_field`, `replace_body`); [`Document`] keeps document-level ops
-//! (quill-ref, push/insert/remove/move card).
+//! `remove_field`, `set_ext`, `remove_ext`, `set_ext_namespace`,
+//! `replace_body`); [`Document`] keeps document-level ops (quill-ref,
+//! push/insert/remove/move card).
+//!
+//! The `$ext` mutators are unguarded: `$ext` is an opaque mapping that
+//! never reaches the plate JSON backends consume, so there is no field-name
+//! or kind invariant to enforce — only that the value is a mapping, which
+//! the types already guarantee.
 
 use unicode_normalization::UnicodeNormalization;
 
@@ -171,6 +177,37 @@ impl Card {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
         Ok(self.payload_mut().remove(name))
+    }
+
+    /// Replace the card's opaque `$ext` map wholesale, inserting it at the
+    /// canonical position (after `$quill`/`$kind`/`$id`, before user fields)
+    /// when none existed. Passing an empty map records an explicit `$ext: {}`.
+    ///
+    /// `$ext` carries out-of-band consumer state (editor renames, agent
+    /// annotations, …) and is stripped from [`Document::to_plate_json`], so a
+    /// write here can never affect a render. Any nested comments attached to a
+    /// replaced `$ext` are dropped.
+    pub fn set_ext(&mut self, value: serde_json::Map<String, serde_json::Value>) {
+        self.payload_mut().set_ext(value);
+    }
+
+    /// Remove the card's `$ext` map entirely, returning the previous map if
+    /// present. To clear a single namespace while keeping the rest, read
+    /// [`Card::ext`], drop the key, and [`Card::set_ext`] the result.
+    pub fn remove_ext(&mut self) -> Option<serde_json::Map<String, serde_json::Value>> {
+        self.payload_mut().take_ext()
+    }
+
+    /// Merge `value` into the card's `$ext` map under `namespace`, creating
+    /// the map when absent and replacing any existing value at that key.
+    ///
+    /// This is the recommended way to write `$ext`: it preserves sibling
+    /// namespaces, so independent consumers keying on their own slot
+    /// (`$ext.presentation`, `$ext.agent`, …) don't clobber each other.
+    pub fn set_ext_namespace(&mut self, namespace: impl Into<String>, value: serde_json::Value) {
+        let mut map = self.payload_mut().take_ext().unwrap_or_default();
+        map.insert(namespace.into(), value);
+        self.payload_mut().set_ext(map);
     }
 
     pub fn replace_body(&mut self, body: impl Into<String>) {

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -539,3 +539,97 @@ fn test_invariants_after_mutation_sequence() {
     );
     assert!(doc.main().payload().get("version").is_none());
 }
+
+// ── $ext mutators ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_ext_adds_map_and_strips_from_plate() {
+    let mut doc = make_doc();
+    let mut ext = serde_json::Map::new();
+    ext.insert(
+        "presentation".to_string(),
+        serde_json::json!({ "title": "Greeting" }),
+    );
+    doc.main_mut().set_ext(ext);
+
+    // Surfaced through the typed accessor.
+    assert_eq!(
+        doc.main().ext().unwrap()["presentation"]["title"].as_str(),
+        Some("Greeting")
+    );
+
+    // Never reaches the plate JSON backends consume.
+    let json = doc.to_plate_json();
+    assert!(json.get("$ext").is_none());
+    assert!(!json.as_object().unwrap().contains_key("$ext"));
+}
+
+#[test]
+fn test_set_ext_round_trips_through_markdown() {
+    let mut doc = make_doc();
+    let mut ext = serde_json::Map::new();
+    ext.insert("agent".to_string(), serde_json::json!({ "pinned": true }));
+    doc.main_mut().set_ext(ext);
+
+    let md = doc.to_markdown();
+    let reparsed = Document::from_markdown(&md).unwrap();
+    assert_eq!(
+        reparsed.main().ext().unwrap()["agent"]["pinned"].as_bool(),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_remove_ext_returns_previous_and_clears() {
+    let mut doc = make_doc();
+    let mut ext = serde_json::Map::new();
+    ext.insert("agent".to_string(), serde_json::json!(1));
+    doc.main_mut().set_ext(ext);
+
+    let removed = doc.main_mut().remove_ext().unwrap();
+    assert_eq!(removed["agent"].as_i64(), Some(1));
+    assert!(doc.main().ext().is_none());
+    // Removing again is a no-op.
+    assert!(doc.main_mut().remove_ext().is_none());
+}
+
+#[test]
+fn test_set_ext_namespace_preserves_siblings() {
+    let mut doc = make_doc();
+    doc.main_mut()
+        .set_ext_namespace("presentation", serde_json::json!({ "title": "A" }));
+    doc.main_mut()
+        .set_ext_namespace("agent", serde_json::json!({ "pinned": true }));
+
+    let ext = doc.main().ext().unwrap();
+    assert_eq!(ext["presentation"]["title"].as_str(), Some("A"));
+    assert_eq!(ext["agent"]["pinned"].as_bool(), Some(true));
+
+    // Replacing one namespace leaves the other intact.
+    doc.main_mut()
+        .set_ext_namespace("presentation", serde_json::json!({ "title": "B" }));
+    let ext = doc.main().ext().unwrap();
+    assert_eq!(ext["presentation"]["title"].as_str(), Some("B"));
+    assert_eq!(ext["agent"]["pinned"].as_bool(), Some(true));
+}
+
+#[test]
+fn test_set_empty_ext_is_preserved() {
+    let mut doc = make_doc();
+    doc.main_mut().set_ext(serde_json::Map::new());
+    assert!(doc.main().ext().is_some());
+    let md = doc.to_markdown();
+    assert!(md.contains("$ext: {}"), "got: {md}");
+}
+
+#[test]
+fn test_ext_mutators_work_on_composable_cards() {
+    let mut doc = make_doc_with_cards();
+    doc.card_mut(0)
+        .unwrap()
+        .set_ext_namespace("agent", serde_json::json!({ "note": "x" }));
+    assert_eq!(
+        doc.cards()[0].ext().unwrap()["agent"]["note"].as_str(),
+        Some("x")
+    );
+}


### PR DESCRIPTION
Adds a complete set of mutators for the `$ext` field, which carries out-of-band consumer state (editor renames, agent annotations, etc.) that never reaches rendered output.

## Summary

Implements `set_ext`, `remove_ext`, and `set_ext_namespace` methods on `Card` to allow mutation of the opaque `$ext` metadata map. These methods are exposed across all three language bindings (Rust core, Python, and WebAssembly) with consistent semantics.

## Key Changes

- **Core (`crates/core/src/document/edit.rs`)**:
  - Added `set_ext()` to replace the `$ext` map wholesale
  - Added `remove_ext()` to clear `$ext` and return the previous value
  - Added `set_ext_namespace()` to merge values under a namespace key without clobbering siblings
  - Updated module documentation to clarify that `$ext` mutators are unguarded (no field-name or kind invariants apply)

- **Python bindings (`crates/bindings/python/src/types.rs`)**:
  - Exposed all three `$ext` mutators on `PyDocument`
  - Added card-level variants: `update_card_ext()` and `remove_card_ext()`
  - Implemented `py_to_object()` helper to validate dict inputs
  - Implemented `ext_map_to_py()` helper to convert optional maps to Python dicts or `None`

- **WebAssembly bindings (`crates/bindings/wasm/src/engine.rs`)**:
  - Exposed all three `$ext` mutators on the `Document` class
  - Added card-level variants: `updateCardExt()` and `removeCardExt()`
  - Implemented `js_value_to_object()` helper to validate plain object inputs
  - Implemented `ext_map_to_js()` helper to convert optional maps to JS objects or `undefined`

- **Tests**:
  - Added 6 comprehensive Rust tests covering set/remove/namespace operations, round-tripping through markdown, and composable cards
  - Added 7 Python tests covering basic operations, error cases, and card-level mutations
  - Added 5 WebAssembly tests with equivalent coverage

## Implementation Details

- `$ext` is intentionally unguarded: since it never reaches plate JSON output, there are no field-name or kind invariants to enforce
- `set_ext_namespace()` is the recommended API for independent consumers, as it preserves sibling namespaces
- Empty `$ext: {}` is explicitly preserved through serialization (not treated as absent)
- All bindings validate that `$ext` values are plain objects/dicts, rejecting primitives and arrays

https://claude.ai/code/session_01YMfTofb1zuZemjKAMa2M7c