### PR TITLE
Complete $ext mutator matrix with namespace-scoped removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- Complete the `$ext` mutator matrix with namespace-scoped removal and
+  card-indexed namespace ops: `remove_ext_namespace` (Rust `Card`,
+  `removeExtNamespace` WASM, `remove_ext_namespace` Python) plus
+  `setCardExtNamespace` / `removeCardExtNamespace`. Deleting a sub-namespace
+  is now the preferred way to clear `$ext` state — it preserves sibling
+  consumers' slots and drops `$ext` entirely once empty, where `removeExt`
+  remains a blunt clear-everything escape hatch.
+- **Breaking (bindings):** the whole-map card mutator `updateCardExt` /
+  `update_card_ext` is renamed `setCardExt` / `set_card_ext` for naming
+  consistency with `setExt` on the main card.
+
 ## v0.87.2 - 2026-06-03
 
 - Expose $ext write path through the editor surface and bindings (#687)

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -426,8 +426,10 @@ impl PyDocument {
         Ok(())
     }
 
-    /// Remove the `$ext` map from the main card, returning the previous map or
-    /// `None`.
+    /// Remove the `$ext` map from the main card *entirely*, returning the
+    /// previous map or `None`. This is a blunt escape hatch that discards every
+    /// namespace at once — prefer `remove_ext_namespace` to clear only your own
+    /// slot while leaving sibling consumers' state intact.
     fn remove_ext<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         ext_map_to_py(py, self.inner.main_mut().remove_ext())
     }
@@ -441,30 +443,65 @@ impl PyDocument {
         Ok(())
     }
 
-    /// Replace the `$ext` map on the card at `index`. Raises on out-of-range
-    /// index or non-dict value.
-    fn update_card_ext(&mut self, index: usize, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let map = py_to_object(&value, "update_card_ext")?;
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        card.set_ext(map);
+    /// Remove `namespace` from the main card's `$ext` map, returning the value
+    /// stored there or `None`. This is the recommended way to clear `$ext`
+    /// state: sibling namespaces survive, and when the last namespace is removed
+    /// the `$ext` entry is dropped entirely (not left as `$ext: {}`).
+    fn remove_ext_namespace<'py>(
+        &mut self,
+        py: Python<'py>,
+        namespace: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        ext_value_to_py(py, self.inner.main_mut().remove_ext_namespace(namespace))
+    }
+
+    /// Replace the `$ext` map on the composable card at `index`. Raises on
+    /// out-of-range index or non-dict value. Named to mirror `set_ext` on the
+    /// main card; `set_card_ext_namespace` is the sibling-safe alternative.
+    fn set_card_ext(&mut self, index: usize, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let map = py_to_object(&value, "set_card_ext")?;
+        self.card_mut_or_raise(index)?.set_ext(map);
         Ok(())
     }
 
-    /// Remove the `$ext` map from the card at `index`, returning the previous
-    /// map or `None`. Raises if `index` is out of range.
+    /// Remove the `$ext` map from the composable card at `index` *entirely*,
+    /// returning the previous map or `None`. Raises if `index` is out of range.
+    /// Prefer `remove_card_ext_namespace` to clear only one consumer's slot.
     fn remove_card_ext<'py>(
         &mut self,
         py: Python<'py>,
         index: usize,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        ext_map_to_py(py, card.remove_ext())
+        let prev = self.card_mut_or_raise(index)?.remove_ext();
+        ext_map_to_py(py, prev)
+    }
+
+    /// Merge `value` into the composable card's `$ext` map under `namespace`,
+    /// preserving sibling namespaces. The card-indexed twin of
+    /// `set_ext_namespace`. Raises if `index` is out of range.
+    fn set_card_ext_namespace(
+        &mut self,
+        index: usize,
+        namespace: &str,
+        value: Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        let json = py_to_json(&value)?;
+        self.card_mut_or_raise(index)?
+            .set_ext_namespace(namespace, json);
+        Ok(())
+    }
+
+    /// Remove `namespace` from the composable card's `$ext` map, returning the
+    /// value stored there or `None`; clears `$ext` entirely once empty. The
+    /// card-indexed twin of `remove_ext_namespace`. Raises if out of range.
+    fn remove_card_ext_namespace<'py>(
+        &mut self,
+        py: Python<'py>,
+        index: usize,
+        namespace: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let removed = self.card_mut_or_raise(index)?.remove_ext_namespace(namespace);
+        ext_value_to_py(py, removed)
     }
 
     fn set_quill_ref(&mut self, ref_str: &str) -> PyResult<()> {
@@ -522,11 +559,9 @@ impl PyDocument {
         value: Bound<'_, PyAny>,
     ) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        card.set_field(name, qv).map_err(convert_edit_error)
+        self.card_mut_or_raise(index)?
+            .set_field(name, qv)
+            .map_err(convert_edit_error)
     }
 
     fn remove_card_field<'py>(
@@ -535,23 +570,31 @@ impl PyDocument {
         index: usize,
         name: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        match card.remove_field(name).map_err(convert_edit_error)? {
+        match self
+            .card_mut_or_raise(index)?
+            .remove_field(name)
+            .map_err(convert_edit_error)?
+        {
             Some(v) => quillvalue_to_py(py, &v),
             None => py.None().into_bound_py_any(py),
         }
     }
 
     fn update_card_body(&mut self, index: usize, body: &str) -> PyResult<()> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        card.replace_body(body);
+        self.card_mut_or_raise(index)?.replace_body(body);
         Ok(())
+    }
+}
+
+impl PyDocument {
+    /// Resolve a mutable composable card by index, raising the same
+    /// `IndexOutOfRange` error the other card mutators raise. Shared by the
+    /// card-indexed `$ext` mutators so they don't each re-spell the bounds check.
+    fn card_mut_or_raise(&mut self, index: usize) -> PyResult<&mut quillmark_core::Card> {
+        let len = self.inner.cards().len();
+        self.inner.card_mut(index).ok_or_else(|| {
+            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
+        })
     }
 }
 
@@ -914,15 +957,24 @@ fn py_to_object(
     }
 }
 
+/// Convert an optional JSON value to a Python object, or `None`. Backs both the
+/// namespaced reads (any value) and the whole-map reads (via `ext_map_to_py`).
+fn ext_value_to_py<'py>(
+    py: Python<'py>,
+    value: Option<serde_json::Value>,
+) -> PyResult<Bound<'py, PyAny>> {
+    match value {
+        Some(v) => json_to_py(py, &v),
+        None => py.None().into_bound_py_any(py),
+    }
+}
+
 /// Convert an optional `$ext` map to a Python dict, or `None`.
 fn ext_map_to_py<'py>(
     py: Python<'py>,
     map: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    match map {
-        Some(map) => json_to_py(py, &serde_json::Value::Object(map)),
-        None => py.None().into_bound_py_any(py),
-    }
+    ext_value_to_py(py, map.map(serde_json::Value::Object))
 }
 
 fn py_dict_to_card(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::Card> {

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -329,6 +329,21 @@ def test_set_ext_namespace_preserves_siblings():
     }
 
 
+def test_remove_ext_namespace_clears_one_slot_and_drops_when_empty():
+    """remove_ext_namespace clears one slot; the last one drops $ext."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    doc.set_ext_namespace("presentation", {"title": "A"})
+    doc.set_ext_namespace("tutorial", ["step-1", "step-2"])
+    # Returns the removed value; siblings survive.
+    assert doc.remove_ext_namespace("tutorial") == ["step-1", "step-2"]
+    assert doc.main["ext"] == {"presentation": {"title": "A"}}
+    # Removing the last namespace clears $ext entirely.
+    doc.remove_ext_namespace("presentation")
+    assert doc.main["ext"] is None
+    # Absent namespace is a no-op returning None.
+    assert doc.remove_ext_namespace("nope") is None
+
+
 def test_remove_ext_returns_previous_and_clears():
     """remove_ext returns the previous map, then None."""
     doc = Document.from_markdown(SIMPLE_MD)
@@ -339,11 +354,22 @@ def test_remove_ext_returns_previous_and_clears():
 
 
 def test_card_ext_mutators():
-    """update_card_ext / remove_card_ext target the card at index."""
+    """set_card_ext / remove_card_ext target the card at index."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.update_card_ext(0, {"agent": {"note": "y"}})
+    doc.set_card_ext(0, {"agent": {"note": "y"}})
     assert doc.cards[0]["ext"] == {"agent": {"note": "y"}}
     assert doc.remove_card_ext(0) == {"agent": {"note": "y"}}
+    assert doc.cards[0]["ext"] is None
+
+
+def test_card_ext_namespace_mutators():
+    """set/remove_card_ext_namespace preserve siblings and clear when empty."""
+    doc = Document.from_markdown(MD_WITH_CARDS)
+    doc.set_card_ext_namespace(0, "presentation", {"title": "A"})
+    doc.set_card_ext_namespace(0, "tutorial", ["step-1"])
+    assert doc.remove_card_ext_namespace(0, "tutorial") == ["step-1"]
+    assert doc.cards[0]["ext"] == {"presentation": {"title": "A"}}
+    doc.remove_card_ext_namespace(0, "presentation")
     assert doc.cards[0]["ext"] is None
 
 
@@ -351,9 +377,13 @@ def test_card_ext_mutators_out_of_range():
     """Card ext mutators raise IndexOutOfRange for a bad index."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.update_card_ext(0, {})
+        doc.set_card_ext(0, {})
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         doc.remove_card_ext(0)
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.set_card_ext_namespace(0, "a", {})
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.remove_card_ext_namespace(0, "a")
 
 
 def test_mutators_do_not_touch_warnings():

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -785,6 +785,21 @@ describe('Document editor surface — $ext mutators', () => {
     expect(doc.main.ext.agent.pinned).toBe(true)
   })
 
+  it('removeExtNamespace clears one slot and drops $ext once empty', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setExtNamespace('presentation', { title: 'A' })
+    doc.setExtNamespace('tutorial', ['step-1', 'step-2'])
+    // Returns the removed value; siblings survive.
+    expect(doc.removeExtNamespace('tutorial')).toEqual(['step-1', 'step-2'])
+    expect(doc.main.ext.presentation.title).toBe('A')
+    expect(doc.main.ext.tutorial).toBeUndefined()
+    // Removing the last namespace clears $ext entirely.
+    doc.removeExtNamespace('presentation')
+    expect(doc.main.ext == null).toBe(true)
+    // Absent namespace is a no-op returning undefined.
+    expect(doc.removeExtNamespace('nope')).toBeUndefined()
+  })
+
   it('removeExt returns the previous map and clears it', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.setExt({ agent: { n: 1 } })
@@ -796,16 +811,29 @@ describe('Document editor surface — $ext mutators', () => {
   it('card-level ext mutators target the card at index', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.pushCard({ kind: 'note', body: 'x' })
-    doc.updateCardExt(0, { agent: { note: 'y' } })
+    doc.setCardExt(0, { agent: { note: 'y' } })
     expect(doc.cards[0].ext.agent.note).toBe('y')
     expect(doc.removeCardExt(0).agent.note).toBe('y')
     expect(doc.cards[0].ext == null).toBe(true)
   })
 
+  it('card-level namespace mutators preserve siblings and clear when empty', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.pushCard({ kind: 'note', body: 'x' })
+    doc.setCardExtNamespace(0, 'presentation', { title: 'A' })
+    doc.setCardExtNamespace(0, 'tutorial', ['step-1'])
+    expect(doc.removeCardExtNamespace(0, 'tutorial')).toEqual(['step-1'])
+    expect(doc.cards[0].ext.presentation.title).toBe('A')
+    doc.removeCardExtNamespace(0, 'presentation')
+    expect(doc.cards[0].ext == null).toBe(true)
+  })
+
   it('card-level ext mutators throw IndexOutOfRange', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.updateCardExt(5, {})).toThrow(/IndexOutOfRange/)
+    expect(() => doc.setCardExt(5, {})).toThrow(/IndexOutOfRange/)
     expect(() => doc.removeCardExt(5)).toThrow(/IndexOutOfRange/)
+    expect(() => doc.setCardExtNamespace(5, 'a', {})).toThrow(/IndexOutOfRange/)
+    expect(() => doc.removeCardExtNamespace(5, 'a')).toThrow(/IndexOutOfRange/)
   })
 })
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -662,8 +662,10 @@ impl Document {
         Ok(())
     }
 
-    /// Remove the `$ext` map from the main card, returning the previous map or
-    /// `undefined`.
+    /// Remove the `$ext` map from the main card *entirely*, returning the
+    /// previous map or `undefined`. This is a blunt escape hatch that discards
+    /// every namespace at once — prefer `removeExtNamespace` to clear only your
+    /// own slot while leaving sibling consumers' state intact.
     #[wasm_bindgen(js_name = removeExt, unchecked_return_type = "Record<string, unknown> | undefined")]
     pub fn remove_ext(&mut self) -> JsValue {
         ext_map_to_js(self.inner.main_mut().remove_ext())
@@ -675,35 +677,67 @@ impl Document {
     /// `$ext.agent`, …) don't clobber each other.
     #[wasm_bindgen(js_name = setExtNamespace)]
     pub fn set_ext_namespace(&mut self, namespace: &str, value: JsValue) -> Result<(), JsValue> {
-        let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
-            WasmError::from(format!("setExtNamespace: invalid value: {}", e)).to_js_value()
-        })?;
+        let json = js_value_to_json(value, "setExtNamespace")?;
         self.inner.main_mut().set_ext_namespace(namespace, json);
         Ok(())
     }
 
-    /// Replace the `$ext` map on the card at `index`. Throws if out of range or
-    /// `value` is not a plain object.
-    #[wasm_bindgen(js_name = updateCardExt)]
-    pub fn update_card_ext(&mut self, index: usize, value: JsValue) -> Result<(), JsValue> {
-        let map = js_value_to_object(&value, "updateCardExt")?;
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        card.set_ext(map);
+    /// Remove `namespace` from the main card's `$ext` map, returning the value
+    /// stored there or `undefined`. This is the recommended way to clear `$ext`
+    /// state: sibling namespaces survive, and when the last namespace is removed
+    /// the `$ext` entry is dropped entirely (not left as `$ext: {}`).
+    #[wasm_bindgen(js_name = removeExtNamespace)]
+    pub fn remove_ext_namespace(&mut self, namespace: &str) -> JsValue {
+        json_value_to_js(self.inner.main_mut().remove_ext_namespace(namespace))
+    }
+
+    /// Replace the `$ext` map on the composable card at `index`. Throws if out
+    /// of range or `value` is not a plain object. Named to mirror `setExt` on
+    /// the main card; `setCardExtNamespace` is the sibling-safe alternative.
+    #[wasm_bindgen(js_name = setCardExt)]
+    pub fn set_card_ext(&mut self, index: usize, value: JsValue) -> Result<(), JsValue> {
+        let map = js_value_to_object(&value, "setCardExt")?;
+        self.card_mut_or_throw(index)?.set_ext(map);
         Ok(())
     }
 
-    /// Remove the `$ext` map from the card at `index`, returning the previous
-    /// map or `undefined`. Throws if out of range.
+    /// Remove the `$ext` map from the composable card at `index` *entirely*,
+    /// returning the previous map or `undefined`. Throws if out of range.
+    /// Prefer `removeCardExtNamespace` to clear only one consumer's slot.
     #[wasm_bindgen(js_name = removeCardExt, unchecked_return_type = "Record<string, unknown> | undefined")]
     pub fn remove_card_ext(&mut self, index: usize) -> Result<JsValue, JsValue> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        Ok(ext_map_to_js(card.remove_ext()))
+        Ok(ext_map_to_js(self.card_mut_or_throw(index)?.remove_ext()))
+    }
+
+    /// Merge `value` into the composable card's `$ext` map under `namespace`,
+    /// preserving sibling namespaces. The card-indexed twin of `setExtNamespace`.
+    /// Throws if out of range or `value` cannot be serialized.
+    #[wasm_bindgen(js_name = setCardExtNamespace)]
+    pub fn set_card_ext_namespace(
+        &mut self,
+        index: usize,
+        namespace: &str,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
+        let json = js_value_to_json(value, "setCardExtNamespace")?;
+        self.card_mut_or_throw(index)?
+            .set_ext_namespace(namespace, json);
+        Ok(())
+    }
+
+    /// Remove `namespace` from the composable card's `$ext` map, returning the
+    /// value stored there or `undefined`; clears `$ext` entirely once empty.
+    /// The card-indexed twin of `removeExtNamespace`. Throws if out of range.
+    #[wasm_bindgen(js_name = removeCardExtNamespace)]
+    pub fn remove_card_ext_namespace(
+        &mut self,
+        index: usize,
+        namespace: &str,
+    ) -> Result<JsValue, JsValue> {
+        Ok(json_value_to_js(
+            self.card_mut_or_throw(index)?
+                .remove_ext_namespace(namespace),
+        ))
     }
 
     /// Replace the QUILL reference string. Throws if `ref_str` is invalid.
@@ -796,26 +830,21 @@ impl Document {
         name: &str,
         value: JsValue,
     ) -> Result<(), JsValue> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
-            WasmError::from(format!("updateCardField: invalid value: {}", e)).to_js_value()
-        })?;
+        let json = js_value_to_json(value, "updateCardField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
-        card.set_field(name, qv).map_err(|e| edit_error_to_js(&e))
+        self.card_mut_or_throw(index)?
+            .set_field(name, qv)
+            .map_err(|e| edit_error_to_js(&e))
     }
 
     /// Remove a field on the card at `index`. Returns the removed value or
     /// `undefined`. Throws if `index` is out of range or `name` is invalid.
     #[wasm_bindgen(js_name = removeCardField)]
     pub fn remove_card_field(&mut self, index: usize, name: &str) -> Result<JsValue, JsValue> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        let removed = card.remove_field(name).map_err(|e| edit_error_to_js(&e))?;
+        let removed = self
+            .card_mut_or_throw(index)?
+            .remove_field(name)
+            .map_err(|e| edit_error_to_js(&e))?;
         Ok(match removed {
             Some(v) => {
                 let serializer =
@@ -831,12 +860,21 @@ impl Document {
     /// Replace the body of the card at `index`. Throws if out of range.
     #[wasm_bindgen(js_name = updateCardBody)]
     pub fn update_card_body(&mut self, index: usize, body: &str) -> Result<(), JsValue> {
-        let len = self.inner.cards().len();
-        let card = self.inner.card_mut(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
-        })?;
-        card.replace_body(body);
+        self.card_mut_or_throw(index)?.replace_body(body);
         Ok(())
+    }
+}
+
+impl Document {
+    /// Resolve a mutable composable card by index, mapping out-of-range to the
+    /// same `IndexOutOfRange` JS error the other card mutators throw. Shared by
+    /// the card-indexed `$ext` mutators so they don't each re-spell the bounds
+    /// check.
+    fn card_mut_or_throw(&mut self, index: usize) -> Result<&mut quillmark_core::Card, JsValue> {
+        let len = self.inner.cards().len();
+        self.inner.card_mut(index).ok_or_else(|| {
+            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+        })
     }
 }
 
@@ -853,31 +891,42 @@ fn edit_error_to_js(err: &quillmark_core::EditError) -> JsValue {
     WasmError::from(format!("[EditError::{}] {}", variant, err)).to_js_value()
 }
 
-/// Deserialize a JS value into a JSON object map, rejecting non-objects. Used
-/// by the `$ext` mutators, whose value must be a plain object.
+/// Deserialize a JS value into an arbitrary JSON value. The namespaced `$ext`
+/// mutators take any shape (the consumer's slot may hold an array, scalar, or
+/// map); `js_value_to_object` adds the object constraint on top.
+fn js_value_to_json(value: JsValue, ctx: &str) -> Result<serde_json::Value, JsValue> {
+    serde_wasm_bindgen::from_value(value)
+        .map_err(|e| WasmError::from(format!("{}: invalid value: {}", ctx, e)).to_js_value())
+}
+
+/// Deserialize a JS value into a JSON object map, rejecting non-objects. Used by
+/// the whole-map `$ext` mutators, whose value must be a plain object.
 fn js_value_to_object(
     value: &JsValue,
     ctx: &str,
 ) -> Result<serde_json::Map<String, serde_json::Value>, JsValue> {
-    let json: serde_json::Value = serde_wasm_bindgen::from_value(value.clone())
-        .map_err(|e| WasmError::from(format!("{}: invalid value: {}", ctx, e)).to_js_value())?;
-    match json {
+    match js_value_to_json(value.clone(), ctx)? {
         serde_json::Value::Object(map) => Ok(map),
         _ => Err(WasmError::from(format!("{}: $ext must be a plain object", ctx)).to_js_value()),
     }
 }
 
-/// Serialize an optional `$ext` map to a JS object, or `undefined` when `None`.
-fn ext_map_to_js(map: Option<serde_json::Map<String, serde_json::Value>>) -> JsValue {
-    match map {
-        Some(map) => {
+/// Serialize an optional JSON value to JS, or `undefined` when `None`. Backs
+/// both the namespaced reads (any value) and the whole-map reads (via
+/// `ext_map_to_js`).
+fn json_value_to_js(value: Option<serde_json::Value>) -> JsValue {
+    match value {
+        Some(v) => {
             let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-            serde_json::Value::Object(map)
-                .serialize(&serializer)
-                .unwrap_or(JsValue::UNDEFINED)
+            v.serialize(&serializer).unwrap_or(JsValue::UNDEFINED)
         }
         None => JsValue::UNDEFINED,
     }
+}
+
+/// Serialize an optional `$ext` map to a JS object, or `undefined` when `None`.
+fn ext_map_to_js(map: Option<serde_json::Map<String, serde_json::Value>>) -> JsValue {
+    json_value_to_js(map.map(serde_json::Value::Object))
 }
 
 fn js_value_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -8,8 +8,8 @@
 //!
 //! Payload/body mutators live on [`Card`] (`set_field`, `set_fill`,
 //! `remove_field`, `set_ext`, `remove_ext`, `set_ext_namespace`,
-//! `replace_body`); [`Document`] keeps document-level ops (quill-ref,
-//! push/insert/remove/move card).
+//! `remove_ext_namespace`, `replace_body`); [`Document`] keeps
+//! document-level ops (quill-ref, push/insert/remove/move card).
 //!
 //! The `$ext` mutators are unguarded: `$ext` is an opaque mapping that
 //! never reaches the plate JSON backends consume, so there is no field-name
@@ -191,9 +191,11 @@ impl Card {
         self.payload_mut().set_ext(value);
     }
 
-    /// Remove the card's `$ext` map entirely, returning the previous map if
-    /// present. To clear a single namespace while keeping the rest, read
-    /// [`Card::ext`], drop the key, and [`Card::set_ext`] the result.
+    /// Remove the card's `$ext` map *entirely*, returning the previous map if
+    /// present. This is a blunt escape hatch — it discards every namespace
+    /// (`$ext.presentation`, `$ext.agent`, …) at once. To clear consumer
+    /// state, prefer [`Card::remove_ext_namespace`], which drops only your
+    /// own slot and leaves sibling consumers' state intact.
     pub fn remove_ext(&mut self) -> Option<serde_json::Map<String, serde_json::Value>> {
         self.payload_mut().take_ext()
     }
@@ -208,6 +210,25 @@ impl Card {
         let mut map = self.payload_mut().take_ext().unwrap_or_default();
         map.insert(namespace.into(), value);
         self.payload_mut().set_ext(map);
+    }
+
+    /// Remove `namespace` from the card's `$ext` map, returning the value
+    /// that was stored there (or `None` when the map or the key was absent).
+    ///
+    /// This is the recommended way to clear `$ext` state: it is the
+    /// namespace-scoped inverse of [`Card::set_ext_namespace`] and preserves
+    /// sibling namespaces, where [`Card::remove_ext`] would wipe them all.
+    /// When removing the last namespace empties the map, the `$ext` entry is
+    /// dropped entirely (not left as `$ext: {}`), so
+    /// `set_ext_namespace(ns, v)` followed by `remove_ext_namespace(ns)`
+    /// restores a card that had no `$ext` to its original state.
+    pub fn remove_ext_namespace(&mut self, namespace: &str) -> Option<serde_json::Value> {
+        let mut map = self.payload_mut().take_ext()?;
+        let removed = map.remove(namespace);
+        if !map.is_empty() {
+            self.payload_mut().set_ext(map);
+        }
+        removed
     }
 
     pub fn replace_body(&mut self, body: impl Into<String>) {

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -614,6 +614,52 @@ fn test_set_ext_namespace_preserves_siblings() {
 }
 
 #[test]
+fn test_remove_ext_namespace_preserves_siblings() {
+    let mut doc = make_doc();
+    doc.main_mut()
+        .set_ext_namespace("presentation", serde_json::json!({ "title": "A" }));
+    doc.main_mut()
+        .set_ext_namespace("tutorial", serde_json::json!(["step-1", "step-2"]));
+
+    // Dropping one namespace returns its value and leaves the rest intact.
+    let removed = doc.main_mut().remove_ext_namespace("tutorial").unwrap();
+    assert_eq!(removed, serde_json::json!(["step-1", "step-2"]));
+    let ext = doc.main().ext().unwrap();
+    assert_eq!(ext["presentation"]["title"].as_str(), Some("A"));
+    assert!(!ext.contains_key("tutorial"));
+}
+
+#[test]
+fn test_remove_ext_namespace_drops_ext_when_empty() {
+    let mut doc = make_doc();
+    doc.main_mut()
+        .set_ext_namespace("tutorial", serde_json::json!(["step-1"]));
+
+    // Removing the last namespace clears `$ext` entirely — set/remove of a
+    // single namespace is a clean inverse for a card that had no `$ext`.
+    let removed = doc.main_mut().remove_ext_namespace("tutorial").unwrap();
+    assert_eq!(removed, serde_json::json!(["step-1"]));
+    assert!(doc.main().ext().is_none());
+}
+
+#[test]
+fn test_remove_ext_namespace_is_noop_when_absent() {
+    let mut doc = make_doc();
+    // No `$ext` at all.
+    assert!(doc.main_mut().remove_ext_namespace("tutorial").is_none());
+
+    // `$ext` present but without the requested key.
+    doc.main_mut()
+        .set_ext_namespace("presentation", serde_json::json!({ "title": "A" }));
+    assert!(doc.main_mut().remove_ext_namespace("tutorial").is_none());
+    // The unrelated namespace is untouched.
+    assert_eq!(
+        doc.main().ext().unwrap()["presentation"]["title"].as_str(),
+        Some("A")
+    );
+}
+
+#[test]
 fn test_set_empty_ext_is_preserved() {
     let mut doc = make_doc();
     doc.main_mut().set_ext(serde_json::Map::new());
@@ -632,4 +678,9 @@ fn test_ext_mutators_work_on_composable_cards() {
         doc.cards()[0].ext().unwrap()["agent"]["note"].as_str(),
         Some("x")
     );
+
+    // Namespace removal targets the same card and clears `$ext` once empty.
+    let removed = doc.card_mut(0).unwrap().remove_ext_namespace("agent");
+    assert_eq!(removed, Some(serde_json::json!({ "note": "x" })));
+    assert!(doc.cards()[0].ext().is_none());
 }


### PR DESCRIPTION
Adds namespace-scoped removal and card-indexed namespace operations to the `$ext` mutator API, completing the matrix of extension state management options.

## Summary

This change introduces `remove_ext_namespace` (and its card-indexed variants) as the recommended way to clear `$ext` state. Unlike the blunt `remove_ext` which discards all namespaces at once, the new namespace-scoped removal preserves sibling consumers' slots and drops the `$ext` entry entirely once empty—making it a clean inverse of `set_ext_namespace`.

## Key Changes

- **Core (`crates/core/src/document/edit.rs`):**
  - Add `Card::remove_ext_namespace()` to remove a single namespace from `$ext`, returning its value or `None`
  - Clears the entire `$ext` entry when the last namespace is removed (not left as `$ext: {}`)
  - Update docstrings to clarify that `remove_ext` is a blunt escape hatch; namespace removal is preferred

- **WASM bindings (`crates/bindings/wasm/src/engine.rs`):**
  - Add `removeExtNamespace()` on main card
  - Rename `updateCardExt` → `setCardExt` for consistency with `setExt`
  - Add `setCardExtNamespace()` and `removeCardExtNamespace()` for card-indexed namespace ops
  - Refactor common card-bounds-checking into `card_mut_or_throw()` helper
  - Extract `js_value_to_json()` helper for arbitrary JSON deserialization (vs. object-only)
  - Generalize `json_value_to_js()` to handle any JSON value, backing both namespace and whole-map reads

- **Python bindings (`crates/bindings/python/src/types.rs`):**
  - Add `remove_ext_namespace()` on main card
  - Rename `update_card_ext` → `set_card_ext` for consistency
  - Add `set_card_ext_namespace()` and `remove_card_ext_namespace()` for card-indexed namespace ops
  - Refactor common card-bounds-checking into `card_mut_or_raise()` helper
  - Extract `py_to_json()` helper and generalize `ext_value_to_py()` for arbitrary JSON values

- **Tests:**
  - Add core tests for `remove_ext_namespace` covering sibling preservation, empty-map cleanup, and no-op behavior
  - Add Python and WASM tests for both main-card and card-indexed namespace removal
  - Update existing card-ext tests to use renamed `set_card_ext` method

## Breaking Changes

- **Bindings only:** `updateCardExt` (WASM) / `update_card_ext` (Python) renamed to `setCardExt` / `set_card_ext` for naming consistency with the main card's `setExt` / `set_ext`.

## Implementation Details

- Namespace removal is implemented by extracting the `$ext` map, removing the key, and re-setting only if non-empty
- Both bindings extract common card-bounds-checking logic to avoid duplication across the new namespace mutators
- JSON serialization helpers are generalized to support both scalar and object values in namespace slots (not just objects)

https://claude.ai/code/session_01ECXtSmvM3vd3EjwzDVcK8y