### PR TITLE
Resolve 0.88 API-feedback friction points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@
   authoring surface is `blueprint()`), so the projection collapses into the
   seed: internally the `FillSource` fork in blueprint emission is gone and the
   blueprint always renders `default:` else the `<must-fill>` sentinel.
+- **wasm:** lower the npm package `engines.node` floor from `>=24` to `>=22`.
+  The runtime never required 24 — `--weak-refs` needs only Node 14.6+, and the
+  `using` sugar that motivated the 24 floor is optional (a `try` / `finally`
+  fallback covers Node 22). The aggressive floor hard-blocked installs on Node
+  22 CI/dev images under `engine-strict`.
+- **wasm:** `Document.makeCard(kind, fields?, body?)` now types `fields` as
+  optional in the generated `.d.ts` (was required, contradicting its docs);
+  omitting it yields an empty field map, as before.
+- **docs:** fix the `Quill.schema` getter doc — the returned schema **includes**
+  `ui` hints (it never stripped them); the stale "ui hints stripped" wording is
+  corrected. The 0.87→0.88 migration guide now documents the `fill` flag's
+  `!fill`-placeholder semantics and clarifies that seeding is example-filled,
+  not a blank-form replacement.
 
 ## v0.87.3 - 2026-06-04
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -329,9 +329,10 @@ The wasm bindings are built with `--weak-refs`, so dropped `Document`,
 without manual `.free()` discipline. `.free()` is still emitted as an eager
 teardown hook for callers that want deterministic release.
 
-The package requires Node 24+ (`engines: { node: ">=24" }`) and current
-evergreen browsers; `--weak-refs` itself only needs Node 14.6+, but the
-published package floor is 24.
+The package floor is Node 22+ (`engines: { node: ">=22" }`) and current
+evergreen browsers; `--weak-refs` itself only needs Node 14.6+. The `using`
+sugar shown below ([explicit resource management][erm]) needs Node 24, but is
+optional — the `try` / `finally` fallback runs on the Node 22 floor.
 
 For environments where `using` (the [explicit resource management][erm]
 proposal) hasn't landed, use an explicit `try` / `finally`:

--- a/crates/bindings/wasm/package.template.json
+++ b/crates/bindings/wasm/package.template.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT OR Apache-2.0",
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -277,7 +277,10 @@ impl Quill {
         self.inner.source().config().blueprint()
     }
 
-    /// Document schema with `ui` hints stripped — for LLM/MCP consumers.
+    /// Document schema for the quill: the user-fillable fields plus their
+    /// `ui` hints (group / order / showWhen). The single field-metadata
+    /// surface — drives form editors and LLM/MCP consumers alike. Returns the
+    /// `QuillSchema` shape.
     #[wasm_bindgen(getter, js_name = schema, unchecked_return_type = "QuillSchema")]
     pub fn schema(&self) -> JsValue {
         let value = self.inner.source().config().schema();
@@ -757,18 +760,18 @@ impl Document {
     #[wasm_bindgen(js_name = makeCard, unchecked_return_type = "Card")]
     pub fn make_card(
         kind: String,
-        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: Option<JsValue>,
         body: Option<String>,
     ) -> Result<JsValue, JsValue> {
-        let field_map: serde_json::Map<String, serde_json::Value> =
-            if fields.is_undefined() || fields.is_null() {
-                serde_json::Map::new()
-            } else {
+        let field_map: serde_json::Map<String, serde_json::Value> = match fields {
+            Some(fields) if !fields.is_undefined() && !fields.is_null() => {
                 serde_wasm_bindgen::from_value(fields).map_err(|e| {
                     WasmError::from(format!("makeCard: `fields` must be an object: {e}"))
                         .to_js_value()
                 })?
-            };
+            }
+            _ => serde_json::Map::new(),
+        };
         let payload_items = field_map
             .into_iter()
             .map(|(key, value)| quillmark_core::PayloadItemWire::Field {

--- a/docs/migrations/0.87-to-0.88.md
+++ b/docs/migrations/0.87-to-0.88.md
@@ -128,6 +128,13 @@ There is no separate blank projection. To render an empty editor, drive it from
 `quill.schema` with no payload (every field falls back to its `default`, or is
 absent). For a pre-filled starter document, use `quill.seedDocument()`.
 
+These are **two distinct paths, not interchangeable**: `seedDocument` /
+`seedMain` / `seedCard` are *illustrative* — they commit each field's
+`example:` value, so a seeded card arrives full of placeholder content (e.g.
+`"ORG/SYMBOL"`), not blank. Reach for seeding when you want a worked example;
+drive the schema directly when you want an empty form. Do not substitute
+`seedDocument()` for the old `blankMain` / `blankCard` if you wanted *blank*.
+
 ### Unknown card kinds
 
 The `form::unknown_card_kind` diagnostic is now `validation::unknown_card`
@@ -258,6 +265,15 @@ doc.push_card(quill.seed_card("note"))
   (user fields + comments, in order). WASM uses camelCase `payloadItems`; Python
   uses snake_case `payload_items` (item entries — `type` / `key` / `value` /
   `fill` / `text` / `inline` — are identical across both).
+- The `fill` flag on a field item is the `!fill` *authoring* marker (`true`
+  ⇒ the source wrote `key: !fill <value>`), signalling a template placeholder
+  to be replaced rather than authored input. It defaults to `false` — an
+  ordinary committed value — and that is what `makeCard` and `seedCard` /
+  `seedDocument` emit: seeded `example:` values are committed as **ordinary
+  content**, not flagged placeholders. The engine does not track whether a
+  seeded value is still untouched, so a seeded field reads as authored content;
+  if you want "this is still the example, clear it on first edit" behaviour,
+  that provenance is the consumer's to layer on top — `fill` does not carry it.
 - **Rust:** `Document::push_card` now returns `Result<(), EditError>` and
   validates the card's composable kind (as `insert_card` does); the canonical
   card wire type is `quillmark_core::CardWire` (`From<&Card>` / `TryFrom`).
@@ -268,8 +284,10 @@ doc.push_card(quill.seed_card("note"))
 
 1. Replace every `quill.form(doc)` call with `quill.validate(doc)`; read
    diagnostics off the returned array directly (no `.diagnostics` wrapper).
-2. Replace `blankMain` / `blankCard` with a `quill.schema`-driven empty editor,
-   or `quill.seedDocument()` for a pre-filled starter.
+2. Replace `blankMain` / `blankCard` with a `quill.schema`-driven empty editor
+   (for a *blank* form), **or** `quill.seedDocument()` for an *example-filled*
+   starter — these are not interchangeable; seeding commits `example:` values,
+   it does not produce an empty document.
 3. Rebuild any field/value/order table from the `quill.schema` × `Document`
    join shown above; drop references to the removed `Form*` types.
 4. Update diagnostic routing: `validation::must_fill_absent` →


### PR DESCRIPTION
Address consumer feedback on the 0.88.0-rc bindings:

- wasm: fix the `Quill.schema` getter doc comment — it claimed `ui` hints
  are stripped, but the schema includes them (the sole field-metadata
  surface that form editors and LLM/MCP consumers both read).
- wasm: type `Document.makeCard`'s `fields` as `Option<JsValue>` so the
  generated `.d.ts` emits `fields?` to match its "optional" docs; the
  empty-map fallback behaviour is unchanged.
- wasm: lower the npm `engines.node` floor from `>=24` to `>=22`. The
  runtime never needed 24 (weak-refs need 14.6+; the `using` sugar is
  optional with a try/finally fallback), and the floor blocked installs
  on Node 22 under engine-strict.
- docs: document the `fill` flag's `!fill`-placeholder semantics and
  clarify that seedDocument/seedCard are example-filled illustrations,
  not blank-form replacements, in the 0.87->0.88 migration guide.

https://claude.ai/code/session_01BNW81oxNwXcfHDx99kBap4