### PR TITLE
Prune evolutionary information from comments and canon docs

### DIFF
--- a/.claude/skills/prune-evolutionary-info/SKILL.md
+++ b/.claude/skills/prune-evolutionary-info/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: prune-evolutionary-info
+description: Rewrite comments and docs to describe the current state, not how the project got there. Use when comments narrate change ("used to", "no longer", "renamed", "removed in 0.x", "legacy") instead of stating what is.
+---
+
+## Purpose
+
+Comments and docs should describe the **current state** of the project — not the
+path from older states to it. Evolutionary narration ("we used to X, now Y")
+adds words, ages badly, and makes a reader reconstruct history to understand the
+present. Prune it so prose stays semantically dense.
+
+## Scope
+
+| Surface | Rule |
+|---|---|
+| Code & test comments | Prune. State the present invariant. |
+| `prose/canon/` | Prune. Discuss the current high-level state. |
+| `prose/references/`, `prose/proposals/` | Leave. Specs and forward-looking proposals legitimately discuss other states. |
+| `docs/` (consumer-facing) | Leave unless the history is essential to *use* the feature. |
+| `docs/migrations/` | **Never touch.** Era-accurate and immutable. |
+
+## The judgment call
+
+Not every mention of the past is evolutionary cruft. Three buckets:
+
+1. **Pure narration → delete or restate.** "The heuristics that used to live
+   here couldn't keep pace" / "removed in 0.87.0" / "we switched to X". No
+   present-state value beyond what the current description already carries.
+
+2. **Current behavior wearing a historical costume → keep the fact, drop the
+   framing.** A backward-compat alias that is *still accepted* is current
+   behavior. Reframe rather than delete:
+   - "the legacy `~~~card-yaml` opener is still accepted but no longer canonical"
+     → "`~~~card-yaml` is also accepted as a non-canonical alias"
+   - "the `required` axis was removed; cell is implied by `default:`"
+     → "cell status is implied by `default:` presence"
+
+3. **Legacy load-bearing for the present → keep.** When understanding the old
+   pattern is *required* to understand the current one, the history is the
+   documentation. Example: a versioned-storage envelope whose whole purpose is
+   to load old formats — the legacy schema *is* current reader behavior.
+
+## Reframing moves
+
+- "used to X, now Y" → assert Y in the present tense.
+- "no longer / previously / formerly Z" → "is not Z" / "does not Z", or drop.
+- "as of 0.x / removed in 0.x" → state the current rule without the version.
+- Rejected-alternative rationale ("earlier API/drafts had X") → "the
+  alternative X would be justified only if…" — keeps the *why*, sheds the *when*.
+- Regression-test comments → state the invariant guarded, not the bug's history:
+  "X must not happen, which would cause Y" instead of "X used to happen".
+
+## Watch for
+
+- Leave **identifiers** alone (function/test names like `..._legacy_..._rejected`)
+  — they are out of scope and renaming them is churn.
+- Don't delete a fact a consumer still needs (an accepted alias, a tolerated
+  input) — reframe it.
+- `used to` often means "used in order to" — not evolutionary. Read before cutting.
+
+## Workflow
+
+1. **Sweep** — grep comments/docs for: `used to`, `no longer`, `previously`,
+   `formerly`, `historically`, `originally`, `renamed`, `migrated`, `replaced`,
+   `removed in`, `as of`, `legacy`, `deprecated`, `we dropped`, `we switched`.
+2. **Triage** each hit into the three buckets above.
+3. **Rewrite** in place — present tense, minimal, keep load-bearing facts.
+4. **Verify** — build/tests still pass; no test asserted the old wording.
+
+## Done when
+
+Comments and `prose/canon/` read as a description of what is. Backward-compat
+facts survive as current-state statements. Only `docs/migrations/` (and genuine
+load-bearing legacy explanations) still narrate the path here.

--- a/crates/backends/typst/src/convert.rs
+++ b/crates/backends/typst/src/convert.rs
@@ -1474,7 +1474,7 @@ mod tests {
         assert_eq!(typst, "== Code example: #raw(\"fn main()\")\n\n");
     }
 
-    // Tests for __ as CommonMark strong (no longer underline)
+    // Tests for __ as CommonMark strong
 
     #[test]
     fn test_double_underscore_is_strong() {
@@ -2324,7 +2324,7 @@ mod robustness_tests {
         assert_eq!(result, "a#linebreak()b#linebreak()c\n\n");
     }
 
-    // Word boundary handling (no longer needed with function syntax)
+    // Word boundary handling (not needed with function syntax)
 
     #[test]
     fn test_italic_before_number() {
@@ -2520,9 +2520,9 @@ More text with `inline code`."#;
     #[test]
     fn test_mismatched_asterisks_graceful_degradation() {
         // `*lethality**` has mismatched asterisks — pulldown_cmark parses `*lethality*`
-        // as emphasis and leaves the trailing `*` as literal text. Previously, the
-        // MarkdownFixer incorrectly consumed the trailing `*` as a closing event,
-        // producing an extra `]` bracket that caused a hard Typst compilation error.
+        // as emphasis and leaves the trailing `*` as literal text. The MarkdownFixer
+        // must not consume the trailing `*` as a closing event, which would produce
+        // an extra `]` bracket and a hard Typst compilation error.
         let result = mark_to_typst("Less formatting. More *lethality**.").unwrap();
         assert!(
             !result.contains("]]"),

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -124,7 +124,7 @@ def test_set_field_updates():
 
 
 def test_set_field_legacy_uppercase_rejected_matrix():
-    """set_field raises InvalidFieldName for the legacy uppercase sentinels."""
+    """set_field raises InvalidFieldName for uppercase field names."""
     for name in ("BODY", "CARDS", "QUILL", "CARD"):
         doc = Document.from_markdown(SIMPLE_MD)
         with pytest.raises(QuillmarkError, match="InvalidFieldName"):
@@ -132,7 +132,7 @@ def test_set_field_legacy_uppercase_rejected_matrix():
 
 
 def test_card_set_field_legacy_uppercase_rejected_matrix():
-    """Card update_card_field raises InvalidFieldName for legacy uppercase names."""
+    """Card update_card_field raises InvalidFieldName for uppercase field names."""
     for name in ("BODY", "CARDS", "QUILL", "CARD"):
         doc = Document.from_markdown(MD_WITH_CARDS)
         with pytest.raises(QuillmarkError, match="InvalidFieldName"):
@@ -169,7 +169,7 @@ def test_remove_field_absent():
 
 
 def test_remove_field_legacy_uppercase_rejected():
-    """remove_field raises InvalidFieldName for legacy uppercase names."""
+    """remove_field raises InvalidFieldName for uppercase field names."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(QuillmarkError, match="InvalidFieldName"):
         doc.remove_field("BODY")
@@ -306,7 +306,7 @@ def test_update_card_field():
 
 
 def test_update_card_field_legacy_uppercase_rejected():
-    """update_card_field raises InvalidFieldName for legacy uppercase names."""
+    """update_card_field raises InvalidFieldName for uppercase field names."""
     doc = Document.from_markdown(MD_WITH_CARDS)
     with pytest.raises(QuillmarkError, match="InvalidFieldName"):
         doc.update_card_field(0, "BODY", "value")

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -117,16 +117,16 @@ def test_blueprint_endorsed_delete_ok(tmp_path):
 
 
 def test_blueprint_no_legacy_required_optional_tags(tmp_path):
-    """Old `; required` / `; optional` role tags are gone from the grammar."""
+    """The blueprint grammar has no `; required` / `; optional` role tags."""
     quill = make_quill(tmp_path)
     bp = quill.blueprint
 
-    # The legacy role tags are dead — never emitted.
+    # Role tags are never emitted.
     assert "; required" not in bp, (
-        f"legacy `; required` tag must not appear in blueprint:\n{bp}"
+        f"`; required` tag must not appear in blueprint:\n{bp}"
     )
     assert "; optional" not in bp, (
-        f"legacy `; optional` tag must not appear in blueprint:\n{bp}"
+        f"`; optional` tag must not appear in blueprint:\n{bp}"
     )
 
 
@@ -194,15 +194,13 @@ def test_render_reports_must_fill_sentinel(tmp_path):
 
 
 def test_absent_unendorsed_does_not_emit_legacy_codes(tmp_path):
-    """The legacy ``validation::missing_required`` code must be gone.
+    """An absent Unendorsed field surfaces ``validation::field_absent``.
 
-    The same condition (absent Unendorsed field) must surface the new
-    ``validation::field_absent`` code instead. The intermediate codes
-    ``validation::required_field_absent`` and ``validation::unfilled_placeholder``
-    were also retired in favor of ``validation::field_absent`` and
-    ``validation::must_fill_sentinel``. Absence is a non-fatal signal (zero-filled
-    render — ``prose/canon/SCHEMAS.md``) carried by ``quill.validate``, so the
-    codes are checked there rather than on a render error.
+    Absence is a non-fatal signal (zero-filled render —
+    ``prose/canon/SCHEMAS.md``) carried by ``quill.validate``, so the code is
+    checked there rather than on a render error. The assertions also pin that
+    ``validation::missing_required``, ``validation::required_field_absent``, and
+    ``validation::unfilled_placeholder`` never appear.
     """
     quill = make_quill(tmp_path)
     md = (
@@ -217,22 +215,19 @@ def test_absent_unendorsed_does_not_emit_legacy_codes(tmp_path):
     result = quill.render(doc, OutputFormat.PDF)
     assert len(result.artifacts) > 0
 
-    # the validate surface carries the canonical code, never the legacy ones
+    # the validate surface carries only the canonical code
     codes = [d.get("code") for d in quill.validate(doc)]
     assert "validation::field_absent" in codes, (
         f"expected canonical field_absent; got: {codes}"
     )
     assert "validation::missing_required" not in codes, (
-        "legacy code `validation::missing_required` must no longer appear; "
-        f"got: {codes}"
+        f"`validation::missing_required` must not appear; got: {codes}"
     )
     assert "validation::required_field_absent" not in codes, (
-        "retired code `validation::required_field_absent` must no longer "
-        f"appear; got: {codes}"
+        f"`validation::required_field_absent` must not appear; got: {codes}"
     )
     assert "validation::unfilled_placeholder" not in codes, (
-        "retired code `validation::unfilled_placeholder` must no longer "
-        f"appear; got: {codes}"
+        f"`validation::unfilled_placeholder` must not appear; got: {codes}"
     )
 
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1127,13 +1127,13 @@ count: "nope"
 // Schema / blueprint / validation — Unendorsed vs Endorsed
 // ---------------------------------------------------------------------------
 //
-// Post-mcp-feedback the schema axis is implicit: a field with a `default:` is
-// Endorsed (the rendered default is shippable as-is and the blueprint emits
-// the value + `; delete-ok` annotation); a field without a `default:` is Must
-// Fill (the blueprint emits the `<must-fill>` sentinel).
+// The schema axis is implicit: a field with a `default:` is Endorsed (the
+// rendered default is shippable as-is and the blueprint emits the value +
+// `; delete-ok` annotation); a field without a `default:` is Must Fill (the
+// blueprint emits the `<must-fill>` sentinel).
 //
 // These tests pin the JS-facing contract:
-//   - `QuillFieldSchema` no longer carries a `required` axis.
+//   - `QuillFieldSchema` carries no `required` axis.
 //   - `quill.blueprint` carries `<must-fill>` and `; delete-ok` annotations.
 //   - `quill.render(doc)` *tolerates* an absent Unendorsed field: zero-filled
 //     render fills it with its type-empty value in the plate projection
@@ -1190,14 +1190,14 @@ main:
     )
   }
 
-  it('schema fields carry no legacy `required` axis', () => {
+  it('schema fields carry no `required` axis', () => {
     const quill = buildQuill()
     const fields = quill.schema.main.fields
 
     expect(fields.title).toBeDefined()
     expect(fields.subtitle).toBeDefined()
 
-    // The `required` axis was removed; cell is implied by `default:` presence.
+    // Cell status is implied by `default:` presence, not a `required` axis.
     expect('required' in fields.title).toBe(false)
     expect('required' in fields.subtitle).toBe(false)
 
@@ -1222,7 +1222,7 @@ main:
     // ambiguity), so the value cell is bare.
     expect(blueprint).toContain('subtitle: Untitled subtitle  # string; delete-ok')
 
-    // The legacy `; required` / `; optional` role tag must not appear anywhere.
+    // The `; required` / `; optional` role tag must not appear anywhere.
     expect(blueprint).not.toContain('; required')
     expect(blueprint).not.toContain('; optional')
   })
@@ -1233,8 +1233,8 @@ main:
     // Document omits `title`. Schema declares no default → Unendorsed. Under
     // zero-filled render this is merely *incomplete*, not malformed: render
     // fills `title` with its type-empty value in the plate projection and
-    // succeeds. Absence is no longer a hard error; `quill.validate` reports it
-    // as the non-fatal `validation::field_absent` doneness signal instead.
+    // succeeds. Absence is not a hard error; `quill.validate` reports it
+    // as the non-fatal `validation::field_absent` doneness signal.
     const md = `~~~card-yaml
 $quill: schema_test
 $kind: main

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -6,8 +6,8 @@ const enc = new TextEncoder()
 
 // Minimal font shipped with quillmark fixtures, loaded once. The Typst world
 // rejects compilation when no fonts are present, so every test quill needs at
-// least one — quills are responsible for shipping their own fonts now that
-// quillmark-typst no longer embeds a default fallback.
+// least one — quills are responsible for shipping their own fonts, since
+// quillmark-typst embeds no default fallback.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TEST_FONT_PATH = join(
   __dirname,

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -9,9 +9,9 @@
 //! `serde-saphyr` — the same library used for parsing. This makes the emit
 //! and parse sides of the wire symmetric by construction: anything saphyr
 //! decides to quote on emit, saphyr will read back as a string on parse.
-//! The hand-written quoting heuristics that used to live here couldn't
-//! keep pace with YAML 1.1 edge cases (`on`/`yes`/`off`, leading-zero
-//! integers, `1.0`-style numerics) — saphyr already handles them all.
+//! Delegation also covers the YAML 1.1 edge cases that ad-hoc quoting
+//! heuristics miss (`on`/`yes`/`off`, leading-zero integers, `1.0`-style
+//! numerics) — saphyr handles them all.
 //!
 //! `prefer_block_scalars: false` keeps multi-line strings inline as
 //! double-quoted scalars with `\n` escapes, so the emitter never produces

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -5,8 +5,8 @@
 //! code block is treated as literal content, not a card-yaml block. A
 //! column-zero `~~~` fence (three or more tildes, no info string) opens a
 //! card-yaml block; the canonical opener is three tildes (`to_markdown`
-//! always emits `~~~`) and the legacy `~~~card-yaml` info string is also
-//! accepted but is no longer canonical. To write a literal fenced *code* block
+//! always emits `~~~`), with the `~~~card-yaml` info string accepted as a
+//! non-canonical alias. To write a literal fenced *code* block
 //! in prose, use a backtick fence (or a `~~~` fence with a language info
 //! string).
 
@@ -15,9 +15,9 @@ use crate::{Diagnostic, Severity};
 
 use super::assemble::MetadataBlock;
 
-/// The legacy info string that also opens a card-yaml block. Accepted on input
-/// for backward compatibility but never emitted — canonical openers are bare
-/// `~~~` (see [`card_yaml_opener_run`]).
+/// The `card-yaml` info string that also opens a card-yaml block. Accepted on
+/// input as a non-canonical alias but never emitted — canonical openers are
+/// bare `~~~` (see [`card_yaml_opener_run`]).
 const CARD_YAML_INFO: &str = "card-yaml";
 
 /// Line-oriented view of the source, used for fence detection.
@@ -122,7 +122,7 @@ pub(super) fn code_fence_info(line: &str, run_len: usize) -> &str {
 ///
 /// A card-yaml opener is a tilde fence (three **or more** tildes) at **column
 /// zero** (spec §3.2) whose info string is empty (the canonical form) or
-/// exactly `card-yaml` (the accepted, non-canonical legacy alias). The
+/// exactly `card-yaml` (the accepted, non-canonical alias). The
 /// canonical opener is three tildes — `to_markdown` always emits `~~~` — but a
 /// longer run is accepted and normalised on emit; its closer must be at least
 /// as long (the run length is threaded into the closer scan to honour
@@ -225,7 +225,7 @@ pub(super) type FenceScan = (Vec<MetadataBlock>, Vec<Diagnostic>);
 
 /// Find all `~~~` card-yaml metadata blocks in the document.
 ///
-/// A card-yaml block opens with `~~~` (or the legacy `~~~card-yaml` alias),
+/// A card-yaml block opens with `~~~` (or the `~~~card-yaml` alias),
 /// requires a blank line above it (so body round-tripping stays stable), and
 /// closes with `~~~`. Openers inside ordinary fenced code blocks are ignored.
 pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseError> {

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -47,7 +47,7 @@ pub use wire::{CardWire, PayloadItemWire, WireError};
 /// rules. This is the single source of truth; bindings should call into it
 /// rather than re-stating the rules in their own glue.
 pub const FORMAT_RULES: &str = "Document format rules:
-\u{2022} Block opener and closer are EXACTLY `~~~` (three tildes, no info string). The legacy `~~~card-yaml` opener is still accepted but is no longer canonical.
+\u{2022} Block opener and closer are EXACTLY `~~~` (three tildes, no info string). The `~~~card-yaml` opener is also accepted as a non-canonical alias.
 \u{2022} A blank line must precede every `~~~` block opener (unless it is line 1), and the opener must be at column zero (no leading spaces). An indented `~~~` is an ordinary code block, not a card.
 \u{2022} The first block is the root and MUST contain `$quill: <name>@<version>` and `$kind: main`. Additional blocks declare composable cards via `$kind: <card_kind>`.
 \u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`. User fields use lowercase snake_case.

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -535,11 +535,10 @@ Item 1 body";
 
 #[test]
 fn test_uppercase_payload_keys_pass_parser() {
-    // Uppercase YAML keys (e.g. legacy `BODY`/`CARDS`) used to be rejected
-    // because they collided with the flat plate-JSON wire format. The wire
-    // format now namespaces metadata under `$`-prefixed keys, so user
-    // payload keys can be arbitrary — they're filtered downstream by the
-    // editor surface's `[a-z_][a-z0-9_]*` rule, not the parser.
+    // Uppercase YAML keys (e.g. `BODY`/`CARDS`) pass the parser: the wire
+    // format namespaces metadata under `$`-prefixed keys, so user payload
+    // keys can be arbitrary — they're filtered downstream by the editor
+    // surface's `[a-z_][a-z0-9_]*` rule, not the parser.
     let markdown = "~~~card-yaml
 $quill: test_quill
 $kind: main

--- a/crates/core/src/document/tests/card_fence_tests.rs
+++ b/crates/core/src/document/tests/card_fence_tests.rs
@@ -3,7 +3,7 @@
 //! Coverage:
 //! - Composable cards declared with `$kind:` parse to `Card`s; `$kind` is optional.
 //! - Every card round-trips to the canonical bare `~~~` form.
-//! - The legacy `~~~card-yaml` opener is still accepted on input.
+//! - The `~~~card-yaml` opener is accepted on input as a non-canonical alias.
 //! - Ordinary fenced code blocks and the blank-line rule for `~~~` openers.
 //!
 //! Parse-error and metadata-validation cases live in `assemble_tests.rs`.
@@ -109,7 +109,7 @@ fn card_fence_without_kind_is_allowed() {
 #[test]
 fn bare_tilde_fence_opens_a_card_yaml_block() {
     // The canonical opener is a bare `~~~` (no info string). It parses the
-    // same as the legacy `~~~card-yaml` alias.
+    // same as the `~~~card-yaml` alias.
     let src =
         "~~~\n$quill: q\n$kind: main\ntitle: Hi\n~~~\n\nBody.\n\n~~~\n$kind: note\nname: N\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -86,8 +86,8 @@ fn test_edit_error_display() {
 
 #[test]
 fn test_document_set_field_rejects_legacy_uppercase_names() {
-    // Names that used to be reserved sentinels — now rejected by the
-    // field-name regex like any other uppercase or `$`-prefixed input.
+    // Uppercase and `$`-prefixed names are rejected by the field-name regex
+    // like any other invalid input.
     for name in ["BODY", "CARDS", "QUILL", "CARD", "$body", "$cards"] {
         let mut doc = make_doc();
         let result = doc.main_mut().set_field(name, qv("value"));
@@ -141,8 +141,8 @@ fn test_document_remove_field_absent() {
 
 #[test]
 fn test_document_remove_field_legacy_uppercase_rejected() {
-    // Symmetric with set_field: the legacy uppercase sentinels are now
-    // rejected like any other invalid field name.
+    // Symmetric with set_field: uppercase names are rejected like any other
+    // invalid field name.
     let mut doc = make_doc();
     for name in ["BODY", "CARDS", "QUILL", "CARD"] {
         match doc.main_mut().remove_field(name) {

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -80,9 +80,9 @@ fn top_level_inline_comments_round_trip() {
 // ── Category: Block scalars ───────────────────────────────────────────────────
 
 /// A block-scalar value (markdown) whose content contains `#` heading lines
-/// round-trips intact. Regression: the prescan comment-stripper used to treat
-/// any `#`-leading line as a YAML comment, silently deleting markdown headings
-/// (and mis-reading `- ` / `key:` lines) inside literal blocks.
+/// round-trips intact. Regression guard: the prescan comment-stripper must not
+/// treat `#`-leading lines inside literal blocks as YAML comments, which would
+/// silently delete markdown headings (and mis-read `- ` / `key:` lines).
 #[test]
 fn block_scalar_with_markdown_headings_round_trips() {
     let src = "~~~card-yaml\n$quill: q\n$kind: main\nbio: |-\n  ## About me\n\n  - first point\n  Plain line.\ntitle: Resume\n~~~\n";

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1143,7 +1143,7 @@ ui:
 
 #[test]
 fn test_parse_card_field_type() {
-    // Test that FieldSchema no longer supports type = "card" (cards are in CardSchema now)
+    // FieldSchema does not support type = "card"; cards belong to CardSchema.
     let yaml = r#"
 type: "string"
 description: "A simple string field"
@@ -1330,7 +1330,7 @@ card_kinds:
 
 #[test]
 fn test_quill_config_ordering_with_cards() {
-    // Test that fields have proper UI ordering (cards no longer have card-level ordering)
+    // Test that fields have proper UI ordering (ordering is field-level, not card-level)
     let yaml_content = r#"
 quill:
   name: ordering_test
@@ -1884,8 +1884,8 @@ main:
 
 #[test]
 fn test_array_bare_properties_rejected() {
-    // A bare `properties` map on an array (the pre-`items` typed-table form)
-    // is no longer accepted — element typing goes under `items`.
+    // A bare `properties` map on an array is rejected — element typing goes
+    // under `items`.
     let yaml_content = r#"
 quill:
   name: array_bare_props
@@ -2592,7 +2592,7 @@ main:
 
 #[test]
 fn body_example_bare_triple_dash_is_not_a_fence() {
-    // A bare `---` thematic break is no longer a metadata fence — allowed.
+    // A bare `---` thematic break is not a metadata fence — allowed.
     let yaml = r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -2918,7 +2918,7 @@ fn markdown_type_mismatch_reports_markdown_not_string() {
 
 #[test]
 fn type_date_is_rejected() {
-    // `type: date` was removed in 0.87.0; schemas declaring it must fail to
+    // `type: date` is not a valid field type; schemas declaring it must fail to
     // load with a parse error, not silently accept or coerce the field.
     let yaml = r#"
 quill:

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -14,8 +14,6 @@ use std::ops::Deref;
 pub struct QuillValue(serde_json::Value);
 
 impl QuillValue {
-    // from_yaml removed as we use serde_json::Value directly
-
     /// Create a QuillValue from a YAML string
     pub fn from_yaml_str(yaml_str: &str) -> Result<Self, serde_saphyr::Error> {
         let json_val: serde_json::Value = serde_saphyr::from_str(yaml_str)?;

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -167,7 +167,7 @@ main:
         "~~~card-yaml\n$quill: test_quill\n$kind: main\nstatus: published\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
-    // Render no longer gates on absence.
+    // Render does not gate on absence.
     assert!(
         quill.dry_run(&parsed).is_ok(),
         "dry_run should tolerate an absent Unendorsed field (zero-filled)"

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -48,9 +48,9 @@ fn test_dry_run_success() {
 #[test]
 fn test_dry_run_missing_must_fill_field_is_tolerated() {
     // Zero-filled render: a merely *incomplete* document (Unendorsed `title`
-    // absent) is no longer a hard error — `title` is zero-filled in the plate
+    // absent) is not a hard error — `title` is zero-filled in the plate
     // projection. Only a *malformed* document (a surviving `<must-fill>`
-    // sentinel) still fails. See prose/canon/SCHEMAS.md.
+    // sentinel) fails. See prose/canon/SCHEMAS.md.
     let temp_dir = TempDir::new().unwrap();
     let quill_path = make_test_quill_path(&temp_dir, true);
 

--- a/crates/quillmark/tests/multibyte_regression_test.rs
+++ b/crates/quillmark/tests/multibyte_regression_test.rs
@@ -54,10 +54,9 @@ fn em_and_en_dashes_in_block_scalar_bullets_parse_without_panic() {
 
 #[test]
 fn multibyte_after_dash_marker_does_not_panic() {
-    // The previously-patched site (`prescan.rs:156`) sliced `trimmed[2..]`
-    // when it saw `- <content>`. If `<content>` started with a multibyte
-    // codepoint, the slice would land mid-character. Pin every known
-    // variant.
+    // Slicing a `- <content>` marker must respect char boundaries: a naive
+    // `trimmed[2..]` lands mid-character when `<content>` starts with a
+    // multibyte codepoint. Pin every known variant.
     let variants = [
         "~~~card-yaml\n$quill: q@0.1\n$kind: main\narr:\n  - \u{2013} en-dash leads\n~~~\n",
         "~~~card-yaml\n$quill: q@0.1\n$kind: main\narr:\n  - \u{2014} em-dash leads\n~~~\n",

--- a/crates/quillmark/tests/security_tests.rs
+++ b/crates/quillmark/tests/security_tests.rs
@@ -146,10 +146,9 @@ fn test_unknown_dollar_metadata_rejected() {
 
 /// Test that card kind validation prevents invalid names via the edit API.
 ///
-/// `$kind` is now opaque system metadata at parse time, so `from_markdown`
-/// no longer validates kind names. The `[a-z_][a-z0-9_]*` rule is still
-/// enforced by the structural edit API (`Card::new`), which is what this
-/// test now exercises.
+/// `$kind` is opaque system metadata at parse time, so `from_markdown` does
+/// not validate kind names. The `[a-z_][a-z0-9_]*` rule is enforced by the
+/// structural edit API (`Card::new`), which is what this test exercises.
 #[test]
 fn test_card_name_validation() {
     let invalid_names = vec!["Invalid-Name", "123start", "UPPERCASE", "spaces here"];

--- a/crates/quillmark/tests/validate_test.rs
+++ b/crates/quillmark/tests/validate_test.rs
@@ -1,5 +1,5 @@
 //! Tests for [`quillmark::Quill::validate`] — the editor-facing validation
-//! surface that replaced the schema-aware form view's `diagnostics` channel.
+//! surface.
 
 use std::collections::HashMap;
 

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -38,8 +38,8 @@ $kind: <card_kind>
 Write <card_kind> body here.
 ````
 
-Every block is a bare `~~~` block (the canonical card-yaml fence; the legacy
-`~~~card-yaml` opener is still accepted as an alias — see
+Every block is a bare `~~~` block (the canonical card-yaml fence; `~~~card-yaml`
+is also accepted as an alias — see
 [markdown-spec.md](../references/markdown-spec.md) §3): the root block carries
 the `$quill` system-metadata line; each composable card carries a
 `$kind: <card_kind>` metadata line.
@@ -280,9 +280,8 @@ rejected at `Quill.yaml` parse time (`quill::object_missing_properties`).
 `ui.order` controls field ordering within the document. Most other `ui:`
 keys (`ui.group`, `ui.compact`, `ui.multiline`, `ui.title`) are
 presentation-only and do not affect blueprint output. In particular,
-`ui.group` no longer emits `# ==== GROUPNAME ====` banner lines — the
-banners were visually confusable with field-description comments. Fields
-within the same `ui.group` still cluster together via `ui.order`.
+`ui.group` emits no banner lines; fields within the same `ui.group`
+cluster together via `ui.order`.
 
 ## Body markers
 
@@ -294,7 +293,7 @@ within the same `ui.group` still cluster together via `ui.order`.
 (e.g., a `skills` card whose data is purely structured).
 
 A `body.example` whose text contains a line that would parse as a
-card-yaml opener — a bare `~~~` (or the legacy `~~~card-yaml` alias) — is
+card-yaml opener — a bare `~~~` (or the `~~~card-yaml` alias) — is
 rejected at `Quill.yaml` parse time (`quill::body_example_contains_fence`)
 to prevent corrupting the blueprint's document structure.
 

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -78,8 +78,8 @@ card_kinds:
 
 ## Markdown Syntax
 
-A composable card is a `~~~` block (the legacy `~~~card-yaml` opener is
-still accepted but non-canonical), optionally led by a
+A composable card is a `~~~` block (`~~~card-yaml` is also accepted as a
+non-canonical alias), optionally led by a
 `$kind: <kind>` system-metadata line. The kind surfaces on the plate
 JSON as the card's `$kind` discriminator; the block's payload is the
 card's YAML data, and the markdown after the closing `~~~` fence is the

--- a/prose/canon/CLI.md
+++ b/prose/canon/CLI.md
@@ -11,7 +11,7 @@
 quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
 ```
 
-`QUILL_PATH` provides the local quill bundle used for rendering. `MARKDOWN_FILE` still requires a root bare `~~~` block (the legacy `~~~card-yaml` opener is also accepted) with a `$quill` system-metadata line because parsing enforces it.
+`QUILL_PATH` provides the local quill bundle used for rendering. `MARKDOWN_FILE` requires a root bare `~~~` block (`~~~card-yaml` is also accepted) with a `$quill` system-metadata line because parsing enforces it.
 
 Options:
 - `-o, --output <FILE>` — output file path (default: derived from input filename)

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -157,11 +157,10 @@ reports the actual backing dimensions in the result.
 
 ## Decisions and rationale
 
-- **Method on `RenderSession`, not a sub-handle.** Earlier drafts had a
-  `Preview` sub-handle returned by `session.preview()`. Justified only if
-  paint shipped with `click()` and `locate_cursor()` (they share state).
-  With paint alone, the sub-handle is ceremony — keep the verb on
-  `RenderSession`.
+- **Method on `RenderSession`, not a sub-handle.** A `Preview` sub-handle
+  returned by `session.preview()` would be justified only if paint shipped
+  with `click()` and `locate_cursor()` (they share state). With paint alone,
+  the sub-handle is ceremony — keep the verb on `RenderSession`.
 - **Not an `OutputFormat`.** Canvas is a side-effecting paint into a JS
   object, not a serializable byte stream. Forcing it into the enum
   either leaks `wasm_bindgen` into `core` or makes `Artifact` dishonest.
@@ -183,8 +182,8 @@ reports the actual backing dimensions in the result.
   `densityScale` ⇒ blurry retina, the benefit is a usable
   `paint(ctx, page)` for the simple case.
 - **Painter owns `canvas.width` / `canvas.height`; consumer owns
-  `canvas.style.*`.** Earlier API pushed backing-store math onto every
-  consumer ("size your canvas like X before calling paint"). That made
+  `canvas.style.*`.** The alternative — pushing backing-store math onto every
+  consumer ("size your canvas like X before calling paint") — makes
   `devicePixelRatio` and the rounding rule callable-side state, which
   means every consumer has to get them right. Folding the math into the
   painter eliminates a class of "blurry on retina" bugs and lets the

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -113,7 +113,7 @@ Metadata resolution:
 
 - Unknown keys in the `quill:` section error with `quill::unknown_key` (typos like `platefile` are not silently captured).
 - Unknown top-level sections error with `quill::unknown_section` (typos like `card_kind:` are not silently ignored). Root-level `fields:` gets a targeted hint pointing to `main.fields:`.
-- Field schemas that fail to parse (e.g. legacy `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
+- Field schemas that fail to parse (e.g. a bare `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
 - `object` fields without a `properties` map error with `quill::object_missing_properties`; an empty `properties` map errors with `quill::object_empty_properties`; an object nested inside another object errors with `quill::nested_object_not_supported`.
 - Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
 - Malformed `main.body` / `card_kinds.<name>.body` blocks error with `quill::invalid_body`.


### PR DESCRIPTION
Rewrite comments and prose/canon docs to describe the current state
rather than narrating how it changed from older states:

- Drop "used to"/"no longer"/"previously"/version-removal narration
  from code and test comments, restating each as a present-tense
  invariant.
- Reframe the `~~~card-yaml` opener mentions as a current non-canonical
  alias instead of a "legacy" form, across fences.rs, FORMAT_RULES,
  and canon (BLUEPRINT, CARDS, CLI).
- Convert rejected-alternative rationale in PREVIEW.md to current-state
  framing rather than "earlier API/drafts" history.

Schema-versioning docs (DOCUMENT_STORAGE.md, dto.rs) keep their
V0_81_0 discussion: the versioned-envelope design exists precisely to
load old formats, so the legacy schema is current reader behavior.