### PR TITLE
Fix makeCard fields/body typed as required in WASM .d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Fix (WASM bindings):** `Document.makeCard`'s generated TypeScript now marks
+  `fields` (and `body`) as optional (`fields?: Record<string, unknown>`,
+  `body?: string`), matching the doc comment and runtime behavior. They were
+  typed as required because `unchecked_param_type` drops the `?` marker; the
+  bindings now use `unchecked_optional_param_type`. Callers can build a bare
+  card with `Document.makeCard('kind')`.
+
 ## v0.88.0 - 2026-06-05
 
 - **Breaking (bindings + Rust API):** a single canonical **`Card` wire shape** now

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -576,6 +576,16 @@ Card two.
     expect(() => doc.pushCard(bad)).toThrow(/InvalidKindName/) // insertion rejects
   })
 
+  it('makeCard treats fields and body as optional', () => {
+    // Both `fields` and `body` are omittable; a bare kind yields an empty card.
+    // The `.d.ts` marks them `fields?` / `body?` to match (see makeCard's
+    // unchecked_optional_param_type bindings).
+    const bare = Document.makeCard('note')
+    expect(bare.kind).toBe('note')
+    expect(bare.payloadItems).toEqual([])
+    expect(bare.body).toBe('')
+  })
+
   it('a stale { kind, fields } object is a loud error, not a silent empty card', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     expect(() => doc.pushCard({ kind: 'note', fields: { x: 1 } })).toThrow()

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -760,8 +760,9 @@ impl Document {
     #[wasm_bindgen(js_name = makeCard, unchecked_return_type = "Card")]
     pub fn make_card(
         kind: String,
-        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: Option<JsValue>,
-        body: Option<String>,
+        #[wasm_bindgen(unchecked_optional_param_type = "Record<string, unknown>")]
+        fields: Option<JsValue>,
+        #[wasm_bindgen(unchecked_optional_param_type = "string")] body: Option<String>,
     ) -> Result<JsValue, JsValue> {
         let field_map: serde_json::Map<String, serde_json::Value> = match fields {
             Some(fields) if !fields.is_undefined() && !fields.is_null() => {


### PR DESCRIPTION
makeCard's TypeScript signature marked `fields` as a required positional
parameter while the doc comment described it as optional. The override
attribute `unchecked_param_type` drops the `?` optional marker even when
the Rust type is `Option<JsValue>`, so callers were forced to pass an
explicit {} for a bare card.

Switch `fields` (and `body`, which follows it and must also be optional
per wasm-bindgen's positional rule) to `unchecked_optional_param_type`,
which preserves the type override and emits `fields?` / `body?`. Now
`Document.makeCard('kind')` type-checks, matching the doc comment and
runtime behavior.

https://claude.ai/code/session_01AqX5z8v39ZJtboZZEWHurF