### PR TITLE
feat(core): first-class $seed key for per-card-kind seed overlays

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -297,7 +297,7 @@ impl PyDocument {
     /// Schema version this build writes.
     #[staticmethod]
     fn current_schema_version() -> &'static str {
-        quillmark_core::document::SCHEMA_V0_82_0
+        quillmark_core::document::SCHEMA_V0_92_0
     }
 
     /// Canonical card-yaml authoring rules — the core text every surface shows.

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -212,15 +212,24 @@ impl PyQuill {
     }
 
     /// Seed a starter composable card of the given kind (carries `$kind`),
-    /// committing its fields' `example` values and leaving every other field
-    /// absent; `None` if `card_kind` is not declared. Returns the same dict
-    /// shape as `Document.cards` / `remove_card`. Mirrors WASM `seedCard`.
+    /// layering an optional per-kind seed `overlay` over the schema-example
+    /// base (`overlay › example › absent`); `None` if `card_kind` is not
+    /// declared. Returns the same dict shape as `Document.cards` /
+    /// `remove_card`. Pass `document.seed(card_kind)` as `overlay` so a card
+    /// added to a template-derived document inherits its curated starting
+    /// values; omit it for the bare schema seed. Mirrors WASM `seedCard`.
+    #[pyo3(signature = (card_kind, overlay=None))]
     fn seed_card<'py>(
         &self,
         py: Python<'py>,
         card_kind: &str,
+        overlay: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
-        match self.inner.seed_card(card_kind) {
+        let overlay = match overlay {
+            Some(value) => quillmark_core::SeedOverlay::from_json(&py_to_json(&value)?),
+            None => None,
+        };
+        match self.inner.seed_card(card_kind, overlay.as_ref()) {
             Some(card) => Ok(Some(card_to_pydict(py, &card)?)),
             None => Ok(None),
         }
@@ -471,6 +480,42 @@ impl PyDocument {
         ext_value_to_py(py, self.inner.main_mut().remove_ext_namespace(namespace))
     }
 
+    /// The raw `$seed[card_kind]` overlay (sparse fields plus an optional
+    /// `$body`) on the main card, or `None`. Hand the result to
+    /// `quill.seed_card(card_kind, …)` so a newly-added card inherits the
+    /// document's curated starting values. A read — it never mutates the doc.
+    fn seed<'py>(&self, py: Python<'py>, card_kind: &str) -> PyResult<Bound<'py, PyAny>> {
+        let entry = self
+            .inner
+            .main()
+            .seed()
+            .and_then(|m| m.get(card_kind).cloned());
+        ext_value_to_py(py, entry)
+    }
+
+    /// Merge a card-kind's seed `overlay` into the main card's `$seed` map
+    /// under `card_kind`, preserving sibling kinds. Sets the starting values
+    /// new cards of that kind spawn with.
+    fn set_seed_namespace(&mut self, card_kind: &str, overlay: Bound<'_, PyAny>) -> PyResult<()> {
+        let json = py_to_json(&overlay)?;
+        self.inner
+            .main_mut()
+            .set_seed_namespace(card_kind, json)
+            .map_err(convert_edit_error)?;
+        Ok(())
+    }
+
+    /// Remove `card_kind` from the main card's `$seed` map, returning its
+    /// overlay or `None`; drops `$seed` entirely once empty. Sibling kinds
+    /// survive.
+    fn remove_seed_namespace<'py>(
+        &mut self,
+        py: Python<'py>,
+        card_kind: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        ext_value_to_py(py, self.inner.main_mut().remove_seed_namespace(card_kind))
+    }
+
     /// Replace the `$ext` map on the composable card at `index`. Raises on
     /// out-of-range index or non-dict value. Named to mirror `set_ext` on the
     /// main card; `set_card_ext_namespace` is the sibling-safe alternative.
@@ -566,6 +611,7 @@ impl PyDocument {
             quill: None,
             id: None,
             ext: None,
+            seed: None,
             payload_items,
             body: body.unwrap_or_default(),
         };
@@ -874,6 +920,16 @@ fn card_to_pydict<'py>(
             )?;
         }
         None => d.set_item("ext", py.None())?,
+    }
+
+    match &wire.seed {
+        Some(seed_map) => {
+            d.set_item(
+                "seed",
+                json_to_py(py, &serde_json::Value::Object(seed_map.clone()))?,
+            )?;
+        }
+        None => d.set_item("seed", py.None())?,
     }
 
     d.set_item("body", &wire.body)?;

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -117,7 +117,7 @@ def test_json_dto_round_trip(taro_md):
 
     dto = doc.to_json()
     assert isinstance(dto, str)
-    assert "quillmark/document@0.82.0" in dto
+    assert "quillmark/document@0.92.0" in dto
 
     restored = Document.from_json(dto)
     assert restored.quill_ref == doc.quill_ref
@@ -165,7 +165,7 @@ def test_schema_version_of_reads_dto(taro_md):
     doc = Document.from_markdown(taro_md)
     dto = doc.to_json()
 
-    assert Document.schema_version_of(dto) == "quillmark/document@0.82.0"
+    assert Document.schema_version_of(dto) == "quillmark/document@0.92.0"
 
 
 def test_schema_version_of_returns_unknown_future_versions():

--- a/crates/bindings/python/tests/test_validate.py
+++ b/crates/bindings/python/tests/test_validate.py
@@ -166,3 +166,47 @@ def test_seed_main_and_card(tmp_path):
     assert "NOTE TAG" in json.dumps(note), "tag example must be committed"
 
     assert quill.seed_card("missing") is None, "unknown kind must be None"
+
+
+def test_seed_card_with_overlay_layers_over_example(tmp_path):
+    """seed_card(kind, overlay) layers the overlay over the schema example
+    (overlay > example); without an overlay the bare example is used."""
+    quill = make_quill(tmp_path)
+
+    # Override `tag`; pin `body` (a default-only field with no example).
+    card = quill.seed_card("note", {"tag": "PINNED", "body": "Pinned body"})
+    blob = json.dumps(card)
+    assert "PINNED" in blob, "overlay value wins over the example"
+    assert "Pinned body" in blob, "overlay can pin a default-only field"
+
+    bare = json.dumps(quill.seed_card("note"))
+    assert "NOTE TAG" in bare and "PINNED" not in bare
+
+
+def test_document_seed_and_set_seed_namespace_round_trip(tmp_path):
+    """Document.seed(kind) reads what set_seed_namespace wrote; the overlay
+    feeds straight back into seed_card; remove_seed_namespace clears it."""
+    quill = make_quill(tmp_path)
+    doc = Document.from_markdown(_md())  # empty main card
+
+    assert doc.seed("note") is None
+    doc.set_seed_namespace("note", {"tag": "WRITTEN"})
+    assert doc.seed("note")["tag"] == "WRITTEN"
+
+    card = quill.seed_card("note", doc.seed("note"))
+    assert "WRITTEN" in json.dumps(card)
+
+    doc.remove_seed_namespace("note")
+    assert doc.seed("note") is None
+
+
+def test_seed_overlay_validation_is_advisory(tmp_path):
+    """A type-mismatched overlay surfaces a WARNING rooted at its seed path —
+    seed overlays are advisory and never gate render."""
+    quill = make_quill(tmp_path)
+    doc = Document.from_markdown(_md("$seed:", "  note:", "    tag: 123"))
+
+    diags = quill.validate(doc)
+    seed_diags = [d for d in diags if (d.get("path") or "").startswith("$seed")]
+    assert seed_diags, f"expected a seed-rooted diagnostic; got: {diags}"
+    assert all(d.get("severity") == "warning" for d in seed_diags)

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -223,7 +223,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const dto = doc.toJson()
     expect(typeof dto).toBe('string')
-    expect(dto).toContain('quillmark/document@0.82.0')
+    expect(dto).toContain('quillmark/document@0.92.0')
   })
 
   it('round-trips losslessly: fromJson(toJson(doc)) equals doc', () => {
@@ -249,7 +249,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
   it('toJson output is standard JSON parseable by the JSON global', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const parsed = JSON.parse(doc.toJson())
-    expect(parsed.schema).toBe('quillmark/document@0.82.0')
+    expect(parsed.schema).toBe('quillmark/document@0.92.0')
   })
 
   it('drops parse-time warnings on reconstruction', () => {

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -83,6 +83,48 @@ describe('@quillmark/wasm/core surface', () => {
     expect(Array.isArray(diags)).toBe(true)
   })
 
+  it('seedCard layers a $seed overlay over the schema example', () => {
+    const yaml = `quill:
+  name: seed_core
+  version: "1.0.0"
+  backend: typst
+  description: Seed overlay smoke test
+main:
+  fields:
+    title:
+      type: string
+      example: T
+card_kinds:
+  note:
+    fields:
+      author:
+        type: string
+        example: A. Author
+`
+    const quill = Quill.fromTree(new Map([['Quill.yaml', enc.encode(yaml)]]))
+
+    const doc = Document.fromMarkdown(
+      '~~~\n$quill: seed_core@1.0.0\n$kind: main\n$seed:\n  note:\n    author: Custom Author\n~~~\n',
+    )
+
+    // Document.seed(kind) reads the per-kind overlay (undefined for unknown).
+    const overlay = doc.seed('note')
+    expect(overlay.author).toBe('Custom Author')
+    expect(doc.seed('missing')).toBeUndefined()
+
+    // seedCard layers it over the example (overlay › example); omitting the
+    // overlay yields the bare schema example.
+    expect(field(quill.seedCard('note', overlay), 'author')).toBe('Custom Author')
+    expect(field(quill.seedCard('note'), 'author')).toBe('A. Author')
+
+    // setSeedNamespace writes an overlay; seed() reads it back; remove clears.
+    const doc2 = Document.fromMarkdown('~~~\n$quill: seed_core@1.0.0\n$kind: main\n~~~\n')
+    doc2.setSeedNamespace('note', { author: 'Written' })
+    expect(doc2.seed('note').author).toBe('Written')
+    doc2.removeSeedNamespace('note')
+    expect(doc2.seed('note')).toBeUndefined()
+  })
+
   it('loads even when the declared backend is unknown (resolved at render time)', () => {
     const yaml = `quill:
   name: no_backend

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -525,7 +525,7 @@ impl Document {
     /// the tag advances only when the wire format changes, not on every release.
     #[wasm_bindgen(js_name = currentSchemaVersion)]
     pub fn current_schema_version() -> String {
-        quillmark_core::document::SCHEMA_V0_82_0.to_string()
+        quillmark_core::document::SCHEMA_V0_92_0.to_string()
     }
 
     /// Authoring-format rules for the card-yaml markdown surface. The canonical

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -114,14 +114,16 @@ export type PayloadItem =
  *
  * `$` system entries are hoisted to named fields: `kind` (the `$kind`, empty
  * string when none), optional `quill` (the `$quill` `name@version`, main card
- * only), optional `id` (`$id`), and optional `ext` (`$ext`). `payloadItems`
- * carries user fields and comments in order.
+ * only), optional `id` (`$id`), optional `ext` (`$ext`), and optional `seed`
+ * (the `$seed` per-kind overlay map, main card only). `payloadItems` carries
+ * user fields and comments in order.
  */
 export interface Card {
     kind: string;
     quill?: string;
     id?: string;
     ext?: Record<string, unknown>;
+    seed?: Record<string, unknown>;
     payloadItems: PayloadItem[];
     body: string;
 }
@@ -431,13 +433,28 @@ impl Quill {
     }
 
     /// Seed a starter composable `Card` of the given kind (carries `$kind`),
-    /// committing its fields' `example:` values and leaving every other field
-    /// absent. Returns `undefined` if `cardKind` is not declared in this
-    /// quill's schema, else a `Card` that feeds straight into
-    /// `Document.pushCard` / `insertCard`.
+    /// layering an optional per-kind seed `overlay` over the schema-example
+    /// base (`overlay › example › absent`). Returns `undefined` if `cardKind`
+    /// is not declared in this quill's schema, else a `Card` that feeds
+    /// straight into `Document.pushCard` / `insertCard`.
+    ///
+    /// Pass `document.seed(cardKind)` as `overlay` so a card added to a
+    /// template-derived document inherits its curated starting values; omit it
+    /// (or pass `undefined` / `null`) for the bare schema seed. `overlay` is a
+    /// plain object — this reads the document, it does not mutate it.
     #[wasm_bindgen(js_name = seedCard, unchecked_return_type = "Card | undefined")]
-    pub fn seed_card(&self, card_kind: &str) -> Result<JsValue, JsValue> {
-        match self.inner.seed_card(card_kind) {
+    pub fn seed_card(
+        &self,
+        card_kind: &str,
+        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown> | undefined")] overlay: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let overlay = if overlay.is_undefined() || overlay.is_null() {
+            None
+        } else {
+            let json = js_value_to_json(overlay, "seedCard")?;
+            quillmark_core::SeedOverlay::from_json(&json)
+        };
+        match self.inner.seed_card(card_kind, overlay.as_ref()) {
             Some(core_card) => card_to_js(&core_card),
             None => Ok(JsValue::UNDEFINED),
         }
@@ -714,6 +731,43 @@ impl Document {
         json_value_to_js(self.inner.main_mut().remove_ext_namespace(namespace))
     }
 
+    /// The raw `$seed[cardKind]` overlay object on the main card (the sparse
+    /// fields plus an optional `$body`), or `undefined`. Hand the result to
+    /// `quill.seedCard(cardKind, …)` so a newly-added card inherits the
+    /// document's curated starting values. This is a read — it never mutates
+    /// the document.
+    #[wasm_bindgen(js_name = seed, unchecked_return_type = "Record<string, unknown> | undefined")]
+    pub fn seed(&self, card_kind: &str) -> Result<JsValue, JsValue> {
+        let entry = self
+            .inner
+            .main()
+            .seed()
+            .and_then(|m| m.get(card_kind).cloned());
+        json_value_to_js(entry)
+    }
+
+    /// Merge a card-kind's seed `overlay` into the main card's `$seed` map
+    /// under `cardKind`, preserving sibling kinds. Sets the starting values
+    /// new cards of that kind spawn with. Throws if `overlay` cannot be
+    /// serialized or nests too deep.
+    #[wasm_bindgen(js_name = setSeedNamespace)]
+    pub fn set_seed_namespace(&mut self, card_kind: &str, overlay: JsValue) -> Result<(), JsValue> {
+        let json = js_value_to_json(overlay, "setSeedNamespace")?;
+        self.inner
+            .main_mut()
+            .set_seed_namespace(card_kind, json)
+            .map_err(|e| edit_error_to_js(&e))?;
+        Ok(())
+    }
+
+    /// Remove `cardKind` from the main card's `$seed` map, returning its
+    /// overlay or `undefined`; drops `$seed` entirely once empty. Sibling
+    /// kinds survive.
+    #[wasm_bindgen(js_name = removeSeedNamespace)]
+    pub fn remove_seed_namespace(&mut self, card_kind: &str) -> Result<JsValue, JsValue> {
+        json_value_to_js(self.inner.main_mut().remove_seed_namespace(card_kind))
+    }
+
     /// Replace the `$ext` map on the composable card at `index`. Throws if out
     /// of range or `value` is not a plain object. Named to mirror `setExt` on
     /// the main card; `setCardExtNamespace` is the sibling-safe alternative.
@@ -825,6 +879,7 @@ impl Document {
             quill: None,
             id: None,
             ext: None,
+            seed: None,
             payload_items,
             body: body.unwrap_or_default(),
         };
@@ -1024,7 +1079,7 @@ fn js_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
     // a flat `{ kind, fields }` object fails loudly instead of yielding a
     // silently-empty card.
     if let Some(obj) = value.dyn_ref::<js_sys::Object>() {
-        const ALLOWED: &[&str] = &["kind", "quill", "id", "ext", "payloadItems", "body"];
+        const ALLOWED: &[&str] = &["kind", "quill", "id", "ext", "seed", "payloadItems", "body"];
         for key in js_sys::Object::keys(obj).iter() {
             if let Some(k) = key.as_string() {
                 if !ALLOWED.contains(&k.as_str()) {

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -163,7 +163,7 @@ fn test_json_dto_round_trip() {
     // toJson yields a string carrying the schema version.
     let dto = doc.to_json();
     assert!(
-        dto.contains("\"quillmark/document@0.82.0\""),
+        dto.contains("\"quillmark/document@0.92.0\""),
         "DTO string must carry the schema version, got: {dto}"
     );
 

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -359,6 +359,59 @@ fn test_quill_seed_main_and_card() {
     );
 }
 
+/// `$seed` overlays: `Document.seed(kind)` reads the per-kind overlay,
+/// `Quill.seedCard(kind, overlay)` layers it over the schema example
+/// (overlay › example), and `setSeedNamespace` / `removeSeedNamespace`
+/// write and clear it.
+#[wasm_bindgen_test]
+fn test_seed_overlay_round_trip() {
+    use wasm_bindgen::JsValue;
+
+    let json = |v: &JsValue| js_sys::JSON::stringify(v).unwrap().as_string().unwrap();
+
+    let quill = Quill::from_tree(common::tree(&[
+        (
+            "Quill.yaml",
+            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  plate_file: plate.typ\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\ncard_kinds:\n  note:\n    fields:\n      text:\n        type: string\n        example: NOTE EXAMPLE\n",
+        ),
+        ("plate.typ", b"= Title"),
+    ]))
+    .expect("quill load");
+
+    let md = "~~~card-yaml\n$quill: seed_quill@1.0\n$kind: main\n$seed:\n  note:\n    text: OVERLAY TEXT\n~~~\n";
+    let doc = Document::from_markdown(md).expect("fromMarkdown failed");
+
+    // Document.seed(kind) returns the per-kind overlay object (or undefined).
+    let overlay = doc.seed("note").unwrap();
+    assert!(json(&overlay).contains("OVERLAY TEXT"));
+    assert!(doc.seed("missing").unwrap().is_undefined());
+
+    // seedCard with the overlay layers it over the example; without it the
+    // bare schema example is used.
+    let with_overlay = quill.seed_card("note", overlay).unwrap();
+    assert!(
+        json(&with_overlay).contains("OVERLAY TEXT"),
+        "overlay value must win: {}",
+        json(&with_overlay)
+    );
+    let bare = quill.seed_card("note", JsValue::UNDEFINED).unwrap();
+    assert!(
+        json(&bare).contains("NOTE EXAMPLE"),
+        "bare seed uses the example: {}",
+        json(&bare)
+    );
+
+    // setSeedNamespace writes an overlay; seed() reads it back; remove clears.
+    let mut doc2 =
+        Document::from_markdown("~~~card-yaml\n$quill: seed_quill@1.0\n$kind: main\n~~~\n")
+            .expect("fromMarkdown failed");
+    let overlay_in = js_sys::JSON::parse("{\"text\":\"WRITTEN\"}").unwrap();
+    doc2.set_seed_namespace("note", overlay_in).unwrap();
+    assert!(json(&doc2.seed("note").unwrap()).contains("WRITTEN"));
+    doc2.remove_seed_namespace("note").unwrap();
+    assert!(doc2.seed("note").unwrap().is_undefined());
+}
+
 /// `doc.clone()` returns an independent handle: mutations on the clone
 /// must not affect the original, and parse-time warnings must survive.
 #[wasm_bindgen_test]

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -342,7 +342,8 @@ fn test_quill_seed_main_and_card() {
     );
 
     // seed_card: a known kind seeds its example; an unknown kind is undefined.
-    let note = quill.seed_card("note").unwrap();
+    // `None`/undefined overlay → the bare schema seed.
+    let note = quill.seed_card("note", JsValue::UNDEFINED).unwrap();
     assert_eq!(get(&note, "kind").as_string().as_deref(), Some("note"));
     assert!(
         json(&note).contains("NOTE EXAMPLE"),
@@ -350,7 +351,10 @@ fn test_quill_seed_main_and_card() {
         json(&note)
     );
     assert!(
-        quill.seed_card("missing").unwrap().is_undefined(),
+        quill
+            .seed_card("missing", JsValue::UNDEFINED)
+            .unwrap()
+            .is_undefined(),
         "unknown kind must be undefined"
     );
 }

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -323,6 +323,19 @@ pub(super) fn decompose_with_warnings(
             ));
         }
 
+        // Seeding overlays live on the document root only (like `$quill`).
+        if block
+            .meta_items
+            .iter()
+            .any(|m| matches!(m, PayloadItem::Seed { .. }))
+        {
+            return Err(ParseError::InvalidStructure(
+                "A composable card-yaml block must not carry `$seed` — only the \
+                 document's root block carries seeding overlays."
+                    .to_string(),
+            ));
+        }
+
         let card_payload = build_payload(
             &block.meta_items,
             &block.pre_items,

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1049,4 +1049,74 @@ title: Hi
         assert!(err.to_string().contains("invalid quill reference"));
     }
 
+    #[test]
+    fn v0_82_0_payload_loads_via_migration() {
+        // A 0.82.0 blob (no `$seed`) migrates forward (0.82 → 0.92) to the live
+        // model, then re-serializes under the current tag.
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "usaf_memo@0.1"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "field", "key": "title", "value": "Hello"}
+                ]},
+                "body": "Body."
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.main().kind(), Some("main"));
+        assert_eq!(
+            doc.main().payload().get("title").unwrap().as_str(),
+            Some("Hello")
+        );
+        let reser = serde_json::to_string(&doc).unwrap();
+        assert_eq!(peek_schema_version(&reser).as_deref(), Some(SCHEMA_V0_92_0));
+    }
+
+    #[test]
+    fn v0_82_0_blob_with_seed_item_is_rejected() {
+        // Proves the schema bump was necessary: `{"type":"seed"}` is not a legal
+        // V0_82_0 payload item, so a blob claiming the 0.82.0 tag must fail
+        // rather than silently load.
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "seed", "value": {"indorsement": {"from": "X"}}}
+                ]},
+                "body": ""
+            },
+            "cards": []
+        }"#;
+        assert!(serde_json::from_str::<Document>(json).is_err());
+    }
+
+    #[test]
+    fn v0_92_0_seed_item_round_trips() {
+        let json = r#"{
+            "schema": "quillmark/document@0.92.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "seed", "value": {"indorsement": {"from": "49 FW/CC"}}}
+                ]},
+                "body": ""
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        let overlay = doc.seed("indorsement").expect("overlay present");
+        assert_eq!(
+            overlay.fields.get("from").and_then(|v| v.as_str()),
+            Some("49 FW/CC")
+        );
+        let reser: Document =
+            serde_json::from_str(&serde_json::to_string(&doc).unwrap()).unwrap();
+        assert_eq!(doc, reser);
+    }
 }

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -429,6 +429,11 @@ impl TryFrom<DocumentV0_92_0> for Document {
                     "composable cards must not carry a $quill entry".into(),
                 ));
             }
+            if card.seed().is_some() {
+                return Err(StorageError::Malformed(
+                    "composable cards must not carry a $seed entry".into(),
+                ));
+            }
             if let Some(kind) = card.kind() {
                 match validate_composable_kind(kind) {
                     Ok(()) => {}
@@ -1093,6 +1098,32 @@ title: Hi
             "cards": []
         }"#;
         assert!(serde_json::from_str::<Document>(json).is_err());
+    }
+
+    #[test]
+    fn rejects_composable_card_with_seed() {
+        // `$seed` is root-only (like `$quill`): a stored composable card
+        // carrying it fails to load.
+        let json = r#"{
+            "schema": "quillmark/document@0.92.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"}
+                ]},
+                "body": ""
+            },
+            "cards": [
+                {"payload": {"items": [
+                    {"type": "kind", "value": "indorsement"},
+                    {"type": "seed", "value": {"note": {"from": "X"}}}
+                ]}, "body": ""}
+            ]
+        }"#;
+        let err = serde_json::from_str::<Document>(json).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("composable cards must not carry a $seed entry"));
     }
 
     #[test]

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -12,10 +12,12 @@
 //!
 //! ## Schema versions
 //!
-//! - **`quillmark/document@0.82.0`** — current. Encodes the unified
-//!   [`Payload`] item list (typed `$` entries, user fields, and comments
-//!   interleaved in source order). This is the format newly serialized
-//!   documents use.
+//! - **`quillmark/document@0.92.0`** — current. Identical to V0_82_0 plus the
+//!   `$seed` payload-item variant (per-card-kind seed overlays). This is the
+//!   format newly serialized documents use.
+//! - **`quillmark/document@0.82.0`** — prior. The unified [`Payload`] item
+//!   list (typed `$` entries, user fields, and comments interleaved in source
+//!   order) without `$seed`. Read-only; migrated forward on read.
 //! - **`quillmark/document@0.81.0`** — legacy. Encodes the pre-unification
 //!   shape with a separate `sentinel` (the typed `$quill` / `$kind`) and a
 //!   `frontmatter` item list (user fields + comments only). Kept read-only
@@ -45,9 +47,14 @@ use crate::version::QuillReference;
 /// read.
 pub const SCHEMA_V0_81_0: &str = "quillmark/document@0.81.0";
 
-/// Schema version for the V0_82_0 wire format. Newly serialized documents
-/// carry this tag.
+/// Schema version for the V0_82_0 wire format. Read-only: documents written
+/// by `0.82.x` carry this tag and are migrated forward on read.
 pub const SCHEMA_V0_82_0: &str = "quillmark/document@0.82.0";
+
+/// Schema version for the V0_92_0 wire format. Newly serialized documents
+/// carry this tag. V0_92_0 adds the `$seed` payload-item variant; it is
+/// otherwise identical to V0_82_0.
+pub const SCHEMA_V0_92_0: &str = "quillmark/document@0.92.0";
 
 /// Read the `schema` field from a raw storage DTO payload without
 /// performing full deserialization.
@@ -73,7 +80,11 @@ pub fn peek_schema_version(json: &str) -> Option<String> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "schema")]
 pub enum StoredDocument {
-    /// Current (V0_82_0) document model — unified payload items.
+    /// Current (V0_92_0) document model — unified payload items with `$seed`.
+    #[serde(rename = "quillmark/document@0.92.0")]
+    V0_92_0(DocumentV0_92_0),
+    /// Prior (V0_82_0) document model — unified payload items, no `$seed`.
+    /// Read-only; migrated forward on reconstruction.
     #[serde(rename = "quillmark/document@0.82.0")]
     V0_82_0(DocumentV0_82_0),
     /// Legacy (V0_81_0) document model — separate sentinel + frontmatter.
@@ -117,7 +128,7 @@ impl std::fmt::Display for StorageError {
 
 impl std::error::Error for StorageError {}
 
-// ─── V0_82_0 wire format (current) ────────────────────────────────────────────
+// ─── V0_82_0 wire format (frozen; read + migrate forward only) ────────────────
 
 /// Frozen `0.82.0` representation of a [`Document`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -195,33 +206,112 @@ pub enum CommentPathSegmentV0_82_0 {
     Index(usize),
 }
 
-// ─── Document ↔ V0_82_0 (live conversion) ─────────────────────────────────────
+// ─── V0_92_0 wire format (current) ────────────────────────────────────────────
+
+/// Frozen `0.92.0` representation of a [`Document`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentV0_92_0 {
+    pub main: CardV0_92_0,
+    #[serde(default)]
+    pub cards: Vec<CardV0_92_0>,
+}
+
+/// Frozen `0.92.0` representation of a [`Card`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardV0_92_0 {
+    pub payload: PayloadV0_92_0,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// Frozen `0.92.0` representation of a [`Payload`].
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PayloadV0_92_0 {
+    #[serde(default)]
+    pub items: Vec<PayloadItemV0_92_0>,
+    #[serde(default)]
+    pub nested_comments: Vec<NestedCommentV0_92_0>,
+}
+
+/// Frozen `0.92.0` representation of a unified payload item. Identical to
+/// V0_82_0 plus the `Seed` variant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum PayloadItemV0_92_0 {
+    /// `$quill` system metadata — the quill reference string.
+    Quill { value: String },
+    /// `$kind` system metadata.
+    Kind { value: String },
+    /// `$id` system metadata.
+    Id { value: String },
+    /// `$ext` system metadata — an opaque mapping carrying out-of-band
+    /// extension data. Never emitted into the plate JSON.
+    Ext {
+        value: serde_json::Map<String, serde_json::Value>,
+    },
+    /// `$seed` system metadata — a mapping keyed by card-kind carrying the
+    /// per-kind seed overlays. Never emitted into the plate JSON.
+    Seed {
+        value: serde_json::Map<String, serde_json::Value>,
+    },
+    /// A user-defined field.
+    Field {
+        key: String,
+        value: serde_json::Value,
+        #[serde(default)]
+        fill: bool,
+    },
+    /// A YAML comment.
+    Comment {
+        text: String,
+        #[serde(default)]
+        inline: bool,
+    },
+}
+
+/// Frozen `0.92.0` representation of a [`NestedComment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NestedCommentV0_92_0 {
+    pub container_path: Vec<CommentPathSegmentV0_92_0>,
+    pub position: usize,
+    pub text: String,
+    pub inline: bool,
+}
+
+/// Frozen `0.92.0` representation of a [`CommentPathSegment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommentPathSegmentV0_92_0 {
+    Key(String),
+    Index(usize),
+}
+
+// ─── Document ↔ V0_92_0 (live conversion) ─────────────────────────────────────
 
 impl From<Document> for StoredDocument {
     fn from(doc: Document) -> Self {
-        StoredDocument::V0_82_0(DocumentV0_82_0::from(&doc))
+        StoredDocument::V0_92_0(DocumentV0_92_0::from(&doc))
     }
 }
 
-impl From<&Document> for DocumentV0_82_0 {
+impl From<&Document> for DocumentV0_92_0 {
     fn from(doc: &Document) -> Self {
-        DocumentV0_82_0 {
-            main: CardV0_82_0::from(doc.main()),
-            cards: doc.cards().iter().map(CardV0_82_0::from).collect(),
+        DocumentV0_92_0 {
+            main: CardV0_92_0::from(doc.main()),
+            cards: doc.cards().iter().map(CardV0_92_0::from).collect(),
         }
     }
 }
 
-impl From<&Card> for CardV0_82_0 {
+impl From<&Card> for CardV0_92_0 {
     fn from(card: &Card) -> Self {
-        CardV0_82_0 {
-            payload: PayloadV0_82_0::from(card.payload()),
+        CardV0_92_0 {
+            payload: PayloadV0_92_0::from(card.payload()),
             body: card.body().to_string(),
         }
     }
 }
 
-impl From<&Payload> for PayloadV0_82_0 {
+impl From<&Payload> for PayloadV0_92_0 {
     fn from(payload: &Payload) -> Self {
         // The wire format keeps `nested_comments` as a flat sidecar at
         // the payload level. The in-memory model carries them per-item
@@ -229,48 +319,48 @@ impl From<&Payload> for PayloadV0_82_0 {
         let nested_comments = payload
             .flat_nested_comments()
             .iter()
-            .map(NestedCommentV0_82_0::from)
+            .map(NestedCommentV0_92_0::from)
             .collect();
-        PayloadV0_82_0 {
+        PayloadV0_92_0 {
             items: payload
                 .items()
                 .iter()
-                .map(PayloadItemV0_82_0::from)
+                .map(PayloadItemV0_92_0::from)
                 .collect(),
             nested_comments,
         }
     }
 }
 
-impl From<&PayloadItem> for PayloadItemV0_82_0 {
+impl From<&PayloadItem> for PayloadItemV0_92_0 {
     fn from(item: &PayloadItem) -> Self {
         match item {
-            PayloadItem::Quill { reference } => PayloadItemV0_82_0::Quill {
+            PayloadItem::Quill { reference } => PayloadItemV0_92_0::Quill {
                 value: reference.to_string(),
             },
-            PayloadItem::Kind { value } => PayloadItemV0_82_0::Kind {
+            PayloadItem::Kind { value } => PayloadItemV0_92_0::Kind {
                 value: value.clone(),
             },
-            PayloadItem::Id { value } => PayloadItemV0_82_0::Id {
+            PayloadItem::Id { value } => PayloadItemV0_92_0::Id {
                 value: value.clone(),
             },
-            // The wire `Ext` variant has no `nested_comments` field —
-            // its comments live in the payload-level sidecar after
-            // `flat_nested_comments` re-prefixes them with `$ext`.
-            PayloadItem::Ext { value, .. } => PayloadItemV0_82_0::Ext {
+            // `Ext` / `Seed` wire variants carry no `nested_comments` field —
+            // their comments live in the payload-level sidecar after
+            // `flat_nested_comments` re-prefixes them with `$ext` / `$seed`.
+            PayloadItem::Ext { value, .. } => PayloadItemV0_92_0::Ext {
                 value: value.clone(),
             },
-            // Same story for `Field` — the per-item `nested_comments`
-            // are flattened onto the payload-level sidecar with the
-            // field's key as the leading path segment.
+            PayloadItem::Seed { value, .. } => PayloadItemV0_92_0::Seed {
+                value: value.clone(),
+            },
             PayloadItem::Field {
                 key, value, fill, ..
-            } => PayloadItemV0_82_0::Field {
+            } => PayloadItemV0_92_0::Field {
                 key: key.clone(),
                 value: value.as_json().clone(),
                 fill: *fill,
             },
-            PayloadItem::Comment { text, inline } => PayloadItemV0_82_0::Comment {
+            PayloadItem::Comment { text, inline } => PayloadItemV0_92_0::Comment {
                 text: text.clone(),
                 inline: *inline,
             },
@@ -278,13 +368,13 @@ impl From<&PayloadItem> for PayloadItemV0_82_0 {
     }
 }
 
-impl From<&NestedComment> for NestedCommentV0_82_0 {
+impl From<&NestedComment> for NestedCommentV0_92_0 {
     fn from(nc: &NestedComment) -> Self {
-        NestedCommentV0_82_0 {
+        NestedCommentV0_92_0 {
             container_path: nc
                 .container_path
                 .iter()
-                .map(CommentPathSegmentV0_82_0::from)
+                .map(CommentPathSegmentV0_92_0::from)
                 .collect(),
             position: nc.position,
             text: nc.text.clone(),
@@ -293,11 +383,11 @@ impl From<&NestedComment> for NestedCommentV0_82_0 {
     }
 }
 
-impl From<&CommentPathSegment> for CommentPathSegmentV0_82_0 {
+impl From<&CommentPathSegment> for CommentPathSegmentV0_92_0 {
     fn from(seg: &CommentPathSegment) -> Self {
         match seg {
-            CommentPathSegment::Key(k) => CommentPathSegmentV0_82_0::Key(k.clone()),
-            CommentPathSegment::Index(i) => CommentPathSegmentV0_82_0::Index(*i),
+            CommentPathSegment::Key(k) => CommentPathSegmentV0_92_0::Key(k.clone()),
+            CommentPathSegment::Index(i) => CommentPathSegmentV0_92_0::Index(*i),
         }
     }
 }
@@ -306,17 +396,22 @@ impl TryFrom<StoredDocument> for Document {
     type Error = StorageError;
 
     fn try_from(stored: StoredDocument) -> Result<Self, Self::Error> {
+        // Only the newest DTO converts to the live `Document`; older versions
+        // migrate forward through the chain (V0_81 → V0_82 → V0_92).
         match stored {
-            StoredDocument::V0_82_0(payload) => Document::try_from(payload),
-            StoredDocument::V0_81_0(payload) => Document::try_from(DocumentV0_82_0::from(payload)),
+            StoredDocument::V0_92_0(payload) => Document::try_from(payload),
+            StoredDocument::V0_82_0(payload) => Document::try_from(DocumentV0_92_0::from(payload)),
+            StoredDocument::V0_81_0(payload) => {
+                Document::try_from(DocumentV0_92_0::from(DocumentV0_82_0::from(payload)))
+            }
         }
     }
 }
 
-impl TryFrom<DocumentV0_82_0> for Document {
+impl TryFrom<DocumentV0_92_0> for Document {
     type Error = StorageError;
 
-    fn try_from(payload: DocumentV0_82_0) -> Result<Self, Self::Error> {
+    fn try_from(payload: DocumentV0_92_0) -> Result<Self, Self::Error> {
         let main = Card::try_from(payload.main)?;
         if main.quill().is_none() {
             return Err(StorageError::Malformed(
@@ -355,20 +450,20 @@ impl TryFrom<DocumentV0_82_0> for Document {
     }
 }
 
-impl TryFrom<CardV0_82_0> for Card {
+impl TryFrom<CardV0_92_0> for Card {
     type Error = StorageError;
 
-    fn try_from(card: CardV0_82_0) -> Result<Self, Self::Error> {
+    fn try_from(card: CardV0_92_0) -> Result<Self, Self::Error> {
         let payload = Payload::try_from(card.payload)?;
         validate_dto_payload(&payload)?;
         Ok(Card::from_parts(payload, card.body))
     }
 }
 
-impl TryFrom<PayloadV0_82_0> for Payload {
+impl TryFrom<PayloadV0_92_0> for Payload {
     type Error = StorageError;
 
-    fn try_from(p: PayloadV0_82_0) -> Result<Self, Self::Error> {
+    fn try_from(p: PayloadV0_92_0) -> Result<Self, Self::Error> {
         let mut items = Vec::with_capacity(p.items.len());
         for item in p.items {
             items.push(PayloadItem::try_from(item)?);
@@ -379,17 +474,17 @@ impl TryFrom<PayloadV0_82_0> for Payload {
             .map(NestedComment::from)
             .collect();
         // Partition the flat wire-format sidecar onto the matching
-        // Field / Ext items (paths become relative to the owning value).
+        // Field / Ext / Seed items (paths become relative to the owning value).
         Ok(Payload::from_items_with_flat_nested(items, nested))
     }
 }
 
-impl TryFrom<PayloadItemV0_82_0> for PayloadItem {
+impl TryFrom<PayloadItemV0_92_0> for PayloadItem {
     type Error = StorageError;
 
-    fn try_from(item: PayloadItemV0_82_0) -> Result<Self, Self::Error> {
+    fn try_from(item: PayloadItemV0_92_0) -> Result<Self, Self::Error> {
         Ok(match item {
-            PayloadItemV0_82_0::Quill { value } => {
+            PayloadItemV0_92_0::Quill { value } => {
                 let reference = QuillReference::from_str(&value).map_err(|reason| {
                     StorageError::InvalidQuillReference {
                         value: value.clone(),
@@ -398,28 +493,23 @@ impl TryFrom<PayloadItemV0_82_0> for PayloadItem {
                 })?;
                 PayloadItem::Quill { reference }
             }
-            PayloadItemV0_82_0::Kind { value } => PayloadItem::Kind { value },
-            PayloadItemV0_82_0::Id { value } => PayloadItem::Id { value },
-            PayloadItemV0_82_0::Ext { value } => {
-                let as_value = serde_json::Value::Object(value);
-                if crate::value::json_depth_exceeds(
-                    &as_value,
-                    crate::document::limits::MAX_YAML_DEPTH,
-                ) {
-                    return Err(StorageError::Malformed(format!(
-                        "$ext nests deeper than the maximum of {} levels",
-                        crate::document::limits::MAX_YAML_DEPTH
-                    )));
-                }
-                let serde_json::Value::Object(value) = as_value else {
-                    unreachable!("constructed as Object above")
-                };
+            PayloadItemV0_92_0::Kind { value } => PayloadItem::Kind { value },
+            PayloadItemV0_92_0::Id { value } => PayloadItem::Id { value },
+            PayloadItemV0_92_0::Ext { value } => {
+                let value = depth_check_meta_map(value, "$ext")?;
                 PayloadItem::Ext {
                     value,
                     nested_comments: Vec::new(),
                 }
             }
-            PayloadItemV0_82_0::Field { key, value, fill } => {
+            PayloadItemV0_92_0::Seed { value } => {
+                let value = depth_check_meta_map(value, "$seed")?;
+                PayloadItem::Seed {
+                    value,
+                    nested_comments: Vec::new(),
+                }
+            }
+            PayloadItemV0_92_0::Field { key, value, fill } => {
                 use super::edit::{validate_field, FieldViolation};
                 validate_field(&key, &value).map_err(|v| {
                     StorageError::Malformed(match v {
@@ -439,13 +529,32 @@ impl TryFrom<PayloadItemV0_82_0> for PayloadItem {
                     nested_comments: Vec::new(),
                 }
             }
-            PayloadItemV0_82_0::Comment { text, inline } => PayloadItem::Comment { text, inline },
+            PayloadItemV0_92_0::Comment { text, inline } => PayloadItem::Comment { text, inline },
         })
     }
 }
 
-impl From<NestedCommentV0_82_0> for NestedComment {
-    fn from(nc: NestedCommentV0_82_0) -> Self {
+/// Depth-bound a `$ext` / `$seed` mapping at the storage boundary; both flow
+/// through the recursive emit/DTO paths and carry the §8 value-depth limit.
+fn depth_check_meta_map(
+    value: serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, StorageError> {
+    let as_value = serde_json::Value::Object(value);
+    if crate::value::json_depth_exceeds(&as_value, crate::document::limits::MAX_YAML_DEPTH) {
+        return Err(StorageError::Malformed(format!(
+            "{key} nests deeper than the maximum of {} levels",
+            crate::document::limits::MAX_YAML_DEPTH
+        )));
+    }
+    let serde_json::Value::Object(value) = as_value else {
+        unreachable!("constructed as Object above")
+    };
+    Ok(value)
+}
+
+impl From<NestedCommentV0_92_0> for NestedComment {
+    fn from(nc: NestedCommentV0_92_0) -> Self {
         NestedComment {
             container_path: nc
                 .container_path
@@ -459,11 +568,88 @@ impl From<NestedCommentV0_82_0> for NestedComment {
     }
 }
 
-impl From<CommentPathSegmentV0_82_0> for CommentPathSegment {
+impl From<CommentPathSegmentV0_92_0> for CommentPathSegment {
+    fn from(seg: CommentPathSegmentV0_92_0) -> Self {
+        match seg {
+            CommentPathSegmentV0_92_0::Key(k) => CommentPathSegment::Key(k),
+            CommentPathSegmentV0_92_0::Index(i) => CommentPathSegment::Index(i),
+        }
+    }
+}
+
+// ─── V0_82_0 → V0_92_0 migration ──────────────────────────────────────────────
+//
+// Purely structural: V0_82_0 has no `$seed`, so every variant maps 1:1 and the
+// new `Seed` variant is simply never produced.
+
+impl From<DocumentV0_82_0> for DocumentV0_92_0 {
+    fn from(d: DocumentV0_82_0) -> Self {
+        DocumentV0_92_0 {
+            main: CardV0_92_0::from(d.main),
+            cards: d.cards.into_iter().map(CardV0_92_0::from).collect(),
+        }
+    }
+}
+
+impl From<CardV0_82_0> for CardV0_92_0 {
+    fn from(c: CardV0_82_0) -> Self {
+        CardV0_92_0 {
+            payload: PayloadV0_92_0::from(c.payload),
+            body: c.body,
+        }
+    }
+}
+
+impl From<PayloadV0_82_0> for PayloadV0_92_0 {
+    fn from(p: PayloadV0_82_0) -> Self {
+        PayloadV0_92_0 {
+            items: p.items.into_iter().map(PayloadItemV0_92_0::from).collect(),
+            nested_comments: p
+                .nested_comments
+                .into_iter()
+                .map(NestedCommentV0_92_0::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<PayloadItemV0_82_0> for PayloadItemV0_92_0 {
+    fn from(item: PayloadItemV0_82_0) -> Self {
+        match item {
+            PayloadItemV0_82_0::Quill { value } => PayloadItemV0_92_0::Quill { value },
+            PayloadItemV0_82_0::Kind { value } => PayloadItemV0_92_0::Kind { value },
+            PayloadItemV0_82_0::Id { value } => PayloadItemV0_92_0::Id { value },
+            PayloadItemV0_82_0::Ext { value } => PayloadItemV0_92_0::Ext { value },
+            PayloadItemV0_82_0::Field { key, value, fill } => {
+                PayloadItemV0_92_0::Field { key, value, fill }
+            }
+            PayloadItemV0_82_0::Comment { text, inline } => {
+                PayloadItemV0_92_0::Comment { text, inline }
+            }
+        }
+    }
+}
+
+impl From<NestedCommentV0_82_0> for NestedCommentV0_92_0 {
+    fn from(nc: NestedCommentV0_82_0) -> Self {
+        NestedCommentV0_92_0 {
+            container_path: nc
+                .container_path
+                .into_iter()
+                .map(CommentPathSegmentV0_92_0::from)
+                .collect(),
+            position: nc.position,
+            text: nc.text,
+            inline: nc.inline,
+        }
+    }
+}
+
+impl From<CommentPathSegmentV0_82_0> for CommentPathSegmentV0_92_0 {
     fn from(seg: CommentPathSegmentV0_82_0) -> Self {
         match seg {
-            CommentPathSegmentV0_82_0::Key(k) => CommentPathSegment::Key(k),
-            CommentPathSegmentV0_82_0::Index(i) => CommentPathSegment::Index(i),
+            CommentPathSegmentV0_82_0::Key(k) => CommentPathSegmentV0_92_0::Key(k),
+            CommentPathSegmentV0_82_0::Index(i) => CommentPathSegmentV0_92_0::Index(i),
         }
     }
 }
@@ -692,10 +878,10 @@ This body and the metadata above are an indorsement card.
     }
 
     #[test]
-    fn serialization_uses_v0_82_0_schema() {
+    fn serialization_uses_v0_92_0_schema() {
         let doc = sample();
         let value: serde_json::Value = serde_json::to_value(&doc).unwrap();
-        assert_eq!(value["schema"], SCHEMA_V0_82_0);
+        assert_eq!(value["schema"], SCHEMA_V0_92_0);
     }
 
     #[test]
@@ -735,7 +921,7 @@ This body and the metadata above are an indorsement card.
     fn peek_schema_version_reads_field_without_full_parse() {
         let doc = sample();
         let json = serde_json::to_string(&doc).unwrap();
-        assert_eq!(peek_schema_version(&json).as_deref(), Some(SCHEMA_V0_82_0));
+        assert_eq!(peek_schema_version(&json).as_deref(), Some(SCHEMA_V0_92_0));
 
         // Unknown future version: peek still succeeds.
         let future = r#"{"schema":"quillmark/document@0.99.0","main":{}}"#;

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -98,6 +98,12 @@ fn check_ext_depth(map: &serde_json::Map<String, serde_json::Value>) -> Result<(
     Ok(())
 }
 
+/// Depth-bound a `$seed` map. Mirrors [`check_ext_depth`]: `$seed` rides the
+/// same recursive emit/DTO paths, so it carries the same §8 depth bound.
+fn check_seed_depth(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), EditError> {
+    check_ext_depth(map)
+}
+
 /// Validate a user field at the payload boundary: name conformance and
 /// value-depth bound. See [`FieldViolation`] for the invariant.
 pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldViolation> {
@@ -317,6 +323,46 @@ impl Card {
         let removed = map.remove(namespace);
         if !map.is_empty() {
             self.payload_mut().set_ext(map);
+        }
+        removed
+    }
+
+    /// The raw `$seed` map (keyed by card-kind), or `None`. For a parsed,
+    /// per-kind overlay use [`crate::Document::seed`]. Only the main card
+    /// carries `$seed`.
+    pub fn seed(&self) -> Option<&serde_json::Map<String, serde_json::Value>> {
+        self.payload().seed()
+    }
+
+    /// Merge a card-kind's seed overlay `value` into the card's `$seed` map
+    /// under `card_kind`, creating the map when absent and replacing any
+    /// existing overlay for that kind. Sibling kinds are preserved — this is
+    /// the per-kind-safe writer, the seed analogue of
+    /// [`Card::set_ext_namespace`]. Returns [`EditError::ValueTooDeep`] when
+    /// the merged map nests past the §8 depth limit; the card is unchanged on
+    /// error.
+    pub fn set_seed_namespace(
+        &mut self,
+        card_kind: impl Into<String>,
+        value: serde_json::Value,
+    ) -> Result<(), EditError> {
+        let mut map = self.payload_mut().seed().cloned().unwrap_or_default();
+        map.insert(card_kind.into(), value);
+        check_seed_depth(&map)?;
+        self.payload_mut().take_seed();
+        self.payload_mut().set_seed(map);
+        Ok(())
+    }
+
+    /// Remove `card_kind` from the card's `$seed` map, returning the overlay
+    /// stored there (or `None`). When removing the last kind empties the map,
+    /// the `$seed` entry is dropped entirely (not left as `$seed: {}`).
+    /// The seed analogue of [`Card::remove_ext_namespace`].
+    pub fn remove_seed_namespace(&mut self, card_kind: &str) -> Option<serde_json::Value> {
+        let mut map = self.payload_mut().take_seed()?;
+        let removed = map.remove(card_kind);
+        if !map.is_empty() {
+            self.payload_mut().set_seed(map);
         }
         removed
     }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -153,6 +153,28 @@ fn emit_ext_block(
     emit_mapping_children(out, value, 2, &path, nested);
 }
 
+/// Emit the `$seed: …` block. Same shape as [`emit_ext_block`]: an empty map
+/// emits inline as `$seed: {}`, a non-empty map as a `$seed:` header followed
+/// by indented block-style children.
+fn emit_seed_block(
+    out: &mut String,
+    value: &serde_json::Map<String, JsonValue>,
+    trailer: Option<&str>,
+    nested: &[NestedComment],
+) {
+    if value.is_empty() {
+        out.push_str("$seed: {}");
+        push_trailer(out, trailer);
+        out.push('\n');
+        return;
+    }
+    out.push_str("$seed:");
+    push_trailer(out, trailer);
+    out.push('\n');
+    let path: Vec<CommentPathSegment> = Vec::new();
+    emit_mapping_children(out, value, 2, &path, nested);
+}
+
 fn emit_block(out: &mut String, card: &Card) {
     out.push_str("~~~\n");
     emit_payload_items(out, card.payload().items());
@@ -190,6 +212,12 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                 nested_comments,
             } => {
                 emit_ext_block(out, value, trailer, nested_comments);
+            }
+            PayloadItem::Seed {
+                value,
+                nested_comments,
+            } => {
+                emit_seed_block(out, value, trailer, nested_comments);
             }
             PayloadItem::Field {
                 key,

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -1,7 +1,7 @@
 //! Validation helpers for card-yaml `$`-prefixed system metadata.
 //!
-//! The closed set of `$` keys (`$quill`, `$kind`, `$id`, `$ext`) and their
-//! typed values are stored as variants of [`super::PayloadItem`] inside a
+//! The closed set of `$` keys (`$quill`, `$kind`, `$id`, `$ext`, `$seed`) and
+//! their typed values are stored as variants of [`super::PayloadItem`] inside a
 //! card's unified [`super::Payload`] item list — they sit alongside user
 //! fields and comments in source order, which is what makes inline-comment
 //! preservation symmetric across the `$`/non-`$` boundary.
@@ -32,6 +32,7 @@ pub(super) fn meta_key(item: &PayloadItem) -> Option<&'static str> {
         PayloadItem::Kind { .. } => Some("$kind"),
         PayloadItem::Id { .. } => Some("$id"),
         PayloadItem::Ext { .. } => Some("$ext"),
+        PayloadItem::Seed { .. } => Some("$seed"),
         PayloadItem::Field { .. } | PayloadItem::Comment { .. } => None,
     }
 }
@@ -41,14 +42,15 @@ pub(super) fn meta_key(item: &PayloadItem) -> Option<&'static str> {
 /// in source order. The keys are removed from `payload` so the caller can
 /// build the user-field portion from what remains.
 ///
-/// The accepted keys are the closed set `{$quill, $kind, $id, $ext}`. Any
-/// other `$`-prefixed key is a parse error. Duplicate keys cannot arise
+/// The accepted keys are the closed set `{$quill, $kind, $id, $ext, $seed}`.
+/// Any other `$`-prefixed key is a parse error. Duplicate keys cannot arise
 /// here — the YAML parser rejects them as duplicate mapping keys before
 /// this function runs.
 ///
 /// `$quill` and `$kind` require string scalars (non-string YAML types are
-/// rejected). `$id` accepts any scalar and stringifies it. `$ext` requires
-/// a YAML mapping (object) — its contents are carried opaquely.
+/// rejected). `$id` accepts any scalar and stringifies it. `$ext` and `$seed`
+/// each require a YAML mapping (object); `$ext` contents are carried opaquely,
+/// while `$seed` is a map keyed by card-kind interpreted by the seeding layer.
 pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadItem>, ParseError> {
     let map = match payload {
         JsonValue::Object(m) => m,
@@ -108,10 +110,22 @@ pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadI
                     )));
                 }
             },
+            "$seed" => match value {
+                JsonValue::Object(map) => PayloadItem::Seed {
+                    value: map,
+                    nested_comments: Vec::new(),
+                },
+                other => {
+                    return Err(ParseError::InvalidStructure(format!(
+                        "Invalid `$seed` value — expected a mapping, got {}",
+                        yaml_type_name(&other)
+                    )));
+                }
+            },
             other => {
                 return Err(ParseError::InvalidStructure(format!(
                     "Unknown `{}` system-metadata key — the card-yaml block \
-                     accepts only `$quill`, `$kind`, `$id`, and `$ext`",
+                     accepts only `$quill`, `$kind`, `$id`, `$ext`, and `$seed`",
                     other
                 )));
             }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -206,6 +206,10 @@ impl Document {
             cards.iter().all(|c| c.quill().is_none()),
             "composable cards must not carry `$quill`"
         );
+        debug_assert!(
+            cards.iter().all(|c| c.seed().is_none()),
+            "composable cards must not carry `$seed`"
+        );
         Self {
             main,
             cards,

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -34,7 +34,10 @@ pub mod prescan;
 pub(crate) mod yaml_hints;
 pub mod wire;
 
-pub use dto::{peek_schema_version, StorageError, StoredDocument, SCHEMA_V0_81_0, SCHEMA_V0_82_0};
+pub use dto::{
+    peek_schema_version, StorageError, StoredDocument, SCHEMA_V0_81_0, SCHEMA_V0_82_0,
+    SCHEMA_V0_92_0,
+};
 pub use edit::EditError;
 pub use meta::{is_valid_kind_name, validate_composable_kind, CardKindError};
 pub use payload::{Payload, PayloadItem};
@@ -50,7 +53,7 @@ pub const FORMAT_RULES: &str = "Document format rules:
 \u{2022} Block opener and closer are EXACTLY `~~~` (three tildes, no info string). The `~~~card-yaml` opener is also accepted as a non-canonical alias.
 \u{2022} A blank line must precede every `~~~` block opener (unless it is line 1), and the opener must be at column zero (no leading spaces). An indented `~~~` is an ordinary code block, not a card.
 \u{2022} The first block is the root and MUST contain `$quill: <name>@<version>` and `$kind: main`. Additional blocks declare composable cards via `$kind: <card_kind>`.
-\u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`. User fields use lowercase snake_case.
+\u{2022} Reserved `$`-keys: `$quill`, `$kind`, `$id`, `$ext`, `$seed`. User fields use lowercase snake_case.
 \u{2022} Prose body is the text after a block's closing `~~~`, up to the next opener or EOF. To include a literal fenced code block in prose, use a backtick fence (```); any column-zero `~~~` block is parsed as card metadata.
 \u{2022} `; delete-ok` fields carry a default \u{2014} keep the line, override the value, or delete the entire line to use the default. Do not write `field:`, `field: null`, or `field: ~` \u{2014} all three parse as explicit YAML null and fail validation.
 \u{2022} Numbers and booleans MUST be unquoted (`year: 2025`, `pinned: true`); quoting turns them into strings and fails validation.
@@ -133,6 +136,49 @@ impl Card {
     }
 }
 
+/// A parsed, per-kind **seed overlay**: the sparse fields (and optional body)
+/// a newly-added card of a given kind starts with. Read from the main card's
+/// `$seed` map by [`Document::seed`], and layered over the quill's
+/// schema-example seed by [`crate::Quill::seed_card`] (overlay › example ›
+/// absent). The reserved inner key `$body` carries the body override; every
+/// other key is a user field.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct SeedOverlay {
+    /// Field-value overrides, keyed by field name.
+    pub fields: indexmap::IndexMap<String, crate::value::QuillValue>,
+    /// Body override, when the overlay declares a `$body` string.
+    pub body: Option<String>,
+}
+
+impl SeedOverlay {
+    /// Parse an overlay from a `$seed[<kind>]` JSON value, or `None` when it is
+    /// not a mapping. Bindings use this to turn the raw overlay object a
+    /// consumer reads from `$seed` (e.g. via [`Document::seed`]) back into a
+    /// typed overlay to hand to [`crate::Quill::seed_card`].
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        value.as_object().map(Self::from_json_map)
+    }
+
+    /// Build an overlay from a single `$seed[<kind>]` JSON map: the reserved
+    /// `$body` string becomes [`body`](Self::body); every other entry becomes
+    /// a field. A non-string `$body` is ignored here (the editor-surface
+    /// validator flags it).
+    fn from_json_map(map: &serde_json::Map<String, serde_json::Value>) -> Self {
+        let mut fields = indexmap::IndexMap::new();
+        let mut body = None;
+        for (key, value) in map {
+            if key == "$body" {
+                if let Some(s) = value.as_str() {
+                    body = Some(s.to_string());
+                }
+            } else {
+                fields.insert(key.clone(), crate::value::QuillValue::from_json(value.clone()));
+            }
+        }
+        SeedOverlay { fields, body }
+    }
+}
+
 /// A fully-parsed Quillmark document. Serde routes through [`StoredDocument`];
 /// for the plate wire shape see [`Document::to_plate_json`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -194,6 +240,16 @@ impl Document {
 
     pub fn cards(&self) -> &[Card] {
         &self.cards
+    }
+
+    /// The parsed [`SeedOverlay`] for `card_kind`, read from the main card's
+    /// `$seed` map, or `None` when no overlay is declared for that kind (or
+    /// the entry is not a mapping). This is the read-only input to
+    /// [`crate::Quill::seed_card`]: the document supplies the overlay, the
+    /// quill composes it over the schema-example seed.
+    pub fn seed(&self, card_kind: &str) -> Option<SeedOverlay> {
+        let entry = self.main.payload().seed()?.get(card_kind)?.as_object()?;
+        Some(SeedOverlay::from_json_map(entry))
     }
 
     pub fn cards_mut(&mut self) -> &mut [Card] {

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -73,9 +73,11 @@ pub enum PayloadItem {
     /// `$seed` system metadata — a mapping keyed by composable card-kind,
     /// each entry a sparse "overlay" (the user fields, plus an optional
     /// `$body` string, that a newly-added card of that kind starts with).
-    /// Carried on the main card only. Like `$ext` it never reaches the plate
-    /// JSON and always round-trips through Markdown and the storage DTO;
-    /// unlike `$ext` the seeding layer interprets it (see
+    /// The seeding layer reads it from the **main card** only
+    /// ([`crate::Document::seed`]); like `$ext`, the parser accepts it on any
+    /// card, but a `$seed` outside the main card is inert. Like `$ext` it never
+    /// reaches the plate JSON and always round-trips through Markdown and the
+    /// storage DTO; unlike `$ext` the seeding layer interprets it (see
     /// [`crate::Quill::seed_card`]). `nested_comments` carries YAML comments
     /// inside the `$seed` mapping, with paths **relative** to the `$seed`
     /// value tree.

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -70,6 +70,19 @@ pub enum PayloadItem {
         value: JsonMap<String, JsonValue>,
         nested_comments: Vec<NestedComment>,
     },
+    /// `$seed` system metadata — a mapping keyed by composable card-kind,
+    /// each entry a sparse "overlay" (the user fields, plus an optional
+    /// `$body` string, that a newly-added card of that kind starts with).
+    /// Carried on the main card only. Like `$ext` it never reaches the plate
+    /// JSON and always round-trips through Markdown and the storage DTO;
+    /// unlike `$ext` the seeding layer interprets it (see
+    /// [`crate::Quill::seed_card`]). `nested_comments` carries YAML comments
+    /// inside the `$seed` mapping, with paths **relative** to the `$seed`
+    /// value tree.
+    Seed {
+        value: JsonMap<String, JsonValue>,
+        nested_comments: Vec<NestedComment>,
+    },
     /// A user-defined YAML field, optionally tagged `!fill`.
     ///
     /// `nested_comments` carries YAML comments inside the field's value
@@ -114,6 +127,9 @@ impl PayloadItem {
             }
             | PayloadItem::Ext {
                 nested_comments, ..
+            }
+            | PayloadItem::Seed {
+                nested_comments, ..
             } => nested_comments,
             _ => &[],
         }
@@ -134,14 +150,15 @@ impl PayloadItem {
     }
 
     /// Canonical sort rank for typed `$` entries: `$quill` < `$kind` <
-    /// `$id` < `$ext`. Returns `None` for user fields and comments, which
-    /// are positioned by source order and never reshuffled.
+    /// `$id` < `$ext` < `$seed`. Returns `None` for user fields and comments,
+    /// which are positioned by source order and never reshuffled.
     fn meta_rank(&self) -> Option<u8> {
         match self {
             PayloadItem::Quill { .. } => Some(0),
             PayloadItem::Kind { .. } => Some(1),
             PayloadItem::Id { .. } => Some(2),
             PayloadItem::Ext { .. } => Some(3),
+            PayloadItem::Seed { .. } => Some(4),
             _ => None,
         }
     }
@@ -213,11 +230,20 @@ impl Payload {
                 inline: nc.inline,
             };
 
-            // `$ext` is encoded with the literal key "$ext" at the head of
-            // the path; everything else is a user field.
+            // `$ext` / `$seed` are encoded with their literal key at the head
+            // of the path; everything else is a user field.
             if target_key == "$ext" {
                 if let Some(slot) = items.iter_mut().find_map(|i| match i {
                     PayloadItem::Ext {
+                        nested_comments, ..
+                    } => Some(nested_comments),
+                    _ => None,
+                }) {
+                    slot.push(relative);
+                }
+            } else if target_key == "$seed" {
+                if let Some(slot) = items.iter_mut().find_map(|i| match i {
+                    PayloadItem::Seed {
                         nested_comments, ..
                     } => Some(nested_comments),
                     _ => None,
@@ -255,6 +281,9 @@ impl Payload {
                 PayloadItem::Ext {
                     nested_comments, ..
                 } => ("$ext".to_string(), nested_comments),
+                PayloadItem::Seed {
+                    nested_comments, ..
+                } => ("$seed".to_string(), nested_comments),
                 _ => continue,
             };
             for nc in comments {
@@ -322,6 +351,16 @@ impl Payload {
         })
     }
 
+    /// The raw `$seed` map (keyed by card-kind), if declared. The seeding
+    /// layer interprets it; it never reaches the plate JSON. For a parsed,
+    /// per-kind view use [`crate::Document::seed`].
+    pub fn seed(&self) -> Option<&JsonMap<String, JsonValue>> {
+        self.items.iter().find_map(|i| match i {
+            PayloadItem::Seed { value, .. } => Some(value),
+            _ => None,
+        })
+    }
+
     /// Set or replace the `$quill` entry. Inserts at canonical position
     /// (before any `$kind` / `$id` / `$ext`) when adding. Comments are
     /// untouched.
@@ -355,6 +394,17 @@ impl Payload {
         });
     }
 
+    /// Set or replace the `$seed` entry. Inserted at the canonical position
+    /// (after `$quill` / `$kind` / `$id` / `$ext`, before any user field).
+    /// Nested comments on a replaced `$seed` are dropped, like
+    /// [`set_ext`](Self::set_ext).
+    pub fn set_seed(&mut self, value: JsonMap<String, JsonValue>) {
+        self.upsert_meta(PayloadItem::Seed {
+            value,
+            nested_comments: Vec::new(),
+        });
+    }
+
     /// Remove the `$quill` entry, returning the previous value if any.
     pub fn take_quill(&mut self) -> Option<QuillReference> {
         let pos = self
@@ -376,6 +426,19 @@ impl Payload {
             .position(|i| matches!(i, PayloadItem::Ext { .. }))?;
         match self.items.remove(pos) {
             PayloadItem::Ext { value, .. } => Some(value),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Remove the `$seed` entry, returning the previous map if any. Any
+    /// nested comments attached to the entry are dropped.
+    pub fn take_seed(&mut self) -> Option<JsonMap<String, JsonValue>> {
+        let pos = self
+            .items
+            .iter()
+            .position(|i| matches!(i, PayloadItem::Seed { .. }))?;
+        match self.items.remove(pos) {
+            PayloadItem::Seed { value, .. } => Some(value),
             _ => unreachable!(),
         }
     }

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -73,9 +73,9 @@ pub enum PayloadItem {
     /// `$seed` system metadata — a mapping keyed by composable card-kind,
     /// each entry a sparse "overlay" (the user fields, plus an optional
     /// `$body` string, that a newly-added card of that kind starts with).
-    /// The seeding layer reads it from the **main card** only
-    /// ([`crate::Document::seed`]); like `$ext`, the parser accepts it on any
-    /// card, but a `$seed` outside the main card is inert. Like `$ext` it never
+    /// **Root-only** (like `$quill`): carried on the main card and read by the
+    /// seeding layer ([`crate::Document::seed`]); a composable card carrying
+    /// `$seed` is rejected at parse and on storage load. Like `$ext` it never
     /// reaches the plate JSON and always round-trips through Markdown and the
     /// storage DTO; unlike `$ext` the seeding layer interprets it (see
     /// [`crate::Quill::seed_card`]). `nested_comments` carries YAML comments

--- a/crates/core/src/document/tests/mod.rs
+++ b/crates/core/src/document/tests/mod.rs
@@ -9,3 +9,4 @@ mod ext_tests;
 mod fence_conformance_tests;
 mod lossiness_tests;
 mod number_edge_tests;
+mod seed_tests;

--- a/crates/core/src/document/tests/seed_tests.rs
+++ b/crates/core/src/document/tests/seed_tests.rs
@@ -1,0 +1,343 @@
+//! End-to-end tests for the `$seed` system-metadata key.
+//!
+//! `$seed` is the per-card-kind seed-overlay map: parsers accept it, the
+//! emitter preserves it, the storage DTO round-trips it, and the plate JSON
+//! consumed by backends strips it. Unlike `$ext` the seeding layer interprets
+//! it — see `crate::Quill::seed_card` and the `quill::seed` tests for layering.
+
+use serde_json::json;
+
+use crate::document::{Document, PayloadItem};
+
+fn parse(src: &str) -> Document {
+    Document::from_markdown(src).expect("source should parse")
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn seed_with_mapping_value_is_accepted() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  indorsement:
+    from: 49 FW/CC
+    signature_block:
+      - \"JANE A. DOE, Col, USAF\"
+      - Commander
+title: Hi
+~~~
+",
+    );
+    let seed = doc.main().payload().seed().expect("$seed present");
+    let ind = seed.get("indorsement").and_then(|v| v.as_object()).unwrap();
+    assert_eq!(ind.get("from").and_then(|v| v.as_str()), Some("49 FW/CC"));
+}
+
+#[test]
+fn seed_with_empty_mapping_is_preserved() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed: {}
+~~~
+",
+    );
+    let seed = doc.main().payload().seed().expect("$seed present");
+    assert!(seed.is_empty());
+}
+
+#[test]
+fn seed_with_scalar_value_is_rejected() {
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed: just-a-string
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("Invalid `$seed`") && err.contains("mapping"),
+        "expected $seed-must-be-mapping rejection, got: {err}",
+    );
+}
+
+#[test]
+fn seed_with_sequence_value_is_rejected() {
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  - foo
+  - bar
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("Invalid `$seed`") && err.contains("mapping"),
+        "expected $seed-must-be-mapping rejection, got: {err}",
+    );
+}
+
+#[test]
+fn unknown_dollar_key_message_lists_seed() {
+    // The closed-set rejection now advertises `$seed` as accepted.
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$bogus: x
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("$seed"), "closed-set message should list $seed: {err}");
+}
+
+// ── Emit / round-trip ──────────────────────────────────────────────────────
+
+#[test]
+fn seed_round_trips_through_markdown() {
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  indorsement:
+    from: 49 FW/CC
+title: Body
+~~~
+
+Body content.
+";
+    let doc = parse(src);
+    let emitted = doc.to_markdown();
+    let reparsed = parse(&emitted);
+    assert_eq!(doc, reparsed);
+    assert!(
+        emitted.contains("$seed:\n  indorsement:\n    from: 49 FW/CC\n"),
+        "unexpected emit:\n{emitted}",
+    );
+}
+
+#[test]
+fn empty_seed_emits_as_inline_braces() {
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed: {}
+~~~
+";
+    let doc = parse(src);
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$seed: {}\n"),
+        "expected `$seed: {{}}` literal in emit, got:\n{emitted}",
+    );
+    let reparsed = parse(&emitted);
+    assert_eq!(doc, reparsed);
+}
+
+#[test]
+fn comments_inside_seed_round_trip() {
+    // Exercises the `$seed` branches of the nested-comment machinery
+    // (parse → per-item nested_comments → emit, and the storage-DTO flatten).
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  indorsement:
+    # pin the squadron office symbol
+    from: 49 FW/CC
+~~~
+";
+    let doc = parse(src);
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("# pin the squadron office symbol"),
+        "nested $seed comment must survive emit:\n{emitted}",
+    );
+    assert_eq!(doc, parse(&emitted));
+
+    // And it survives the storage DTO round-trip too.
+    let json = serde_json::to_string(&doc).unwrap();
+    let restored: Document = serde_json::from_str(&json).unwrap();
+    assert_eq!(doc, restored);
+}
+
+#[test]
+fn seed_emit_is_idempotent() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  note:
+    a: 1
+~~~
+",
+    );
+    let once = doc.to_markdown();
+    let twice = parse(&once).to_markdown();
+    assert_eq!(once, twice);
+}
+
+// ── Programmatic construction ──────────────────────────────────────────────
+
+#[test]
+fn set_seed_inserts_after_ext_and_before_user_fields() {
+    let mut doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$id: rev-1
+$ext:
+  a: 1
+title: Hi
+~~~
+",
+    );
+    let mut seed = serde_json::Map::new();
+    seed.insert("indorsement".into(), json!({ "from": "X" }));
+    doc.main_mut().payload_mut().set_seed(seed);
+
+    let items = doc.main().payload().items();
+    // Canonical order: $quill, $kind, $id, $ext, $seed, then user fields.
+    assert!(matches!(items[0], PayloadItem::Quill { .. }));
+    assert!(matches!(items[1], PayloadItem::Kind { .. }));
+    assert!(matches!(items[2], PayloadItem::Id { .. }));
+    assert!(matches!(items[3], PayloadItem::Ext { .. }));
+    assert!(matches!(items[4], PayloadItem::Seed { .. }));
+    assert!(matches!(items[5], PayloadItem::Field { .. }));
+}
+
+#[test]
+fn document_seed_parses_overlay_with_body() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  indorsement:
+    from: 49 FW/CC
+    $body: \"Standard endorsement text.\"
+~~~
+",
+    );
+    let overlay = doc.seed("indorsement").expect("overlay present");
+    assert_eq!(
+        overlay.fields.get("from").and_then(|v| v.as_str()),
+        Some("49 FW/CC"),
+    );
+    assert_eq!(overlay.body.as_deref(), Some("Standard endorsement text."));
+    // `$body` is the body override, not a field.
+    assert!(!overlay.fields.contains_key("$body"));
+    // An undeclared kind yields no overlay.
+    assert!(doc.seed("missing").is_none());
+}
+
+#[test]
+fn seed_namespace_mutators_preserve_siblings() {
+    let mut doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+~~~
+",
+    );
+    let card = doc.main_mut();
+    card.set_seed_namespace("indorsement", json!({ "from": "A" }))
+        .unwrap();
+    card.set_seed_namespace("attachment", json!({ "label": "B" }))
+        .unwrap();
+    assert_eq!(card.seed().map(|m| m.len()), Some(2));
+
+    // Removing one kind leaves the sibling intact.
+    let removed = card.remove_seed_namespace("indorsement").unwrap();
+    assert_eq!(removed.get("from").and_then(|v| v.as_str()), Some("A"));
+    assert_eq!(card.seed().map(|m| m.len()), Some(1));
+    assert!(card.seed().unwrap().contains_key("attachment"));
+
+    // Removing the last kind drops `$seed` entirely (not `$seed: {}`).
+    card.remove_seed_namespace("attachment");
+    assert!(card.seed().is_none());
+}
+
+// ── Plate JSON ─────────────────────────────────────────────────────────────
+
+#[test]
+fn seed_is_stripped_from_plate_json() {
+    // Backends must never see `$seed` — it is curation data, not template data.
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  indorsement:
+    from: \"Should not reach the backend\"
+title: Hi
+~~~
+",
+    );
+    let plate = doc.to_plate_json();
+    let obj = plate.as_object().expect("plate is an object");
+    assert!(!obj.contains_key("$seed"), "plate must not contain `$seed`: {plate}");
+    assert!(!obj.contains_key("seed"), "plate must not contain `seed`: {plate}");
+    assert_eq!(obj.get("title").and_then(|v| v.as_str()), Some("Hi"));
+    assert!(obj.contains_key("$quill"));
+    assert!(obj.contains_key("$cards"));
+}
+
+// ── Storage DTO ────────────────────────────────────────────────────────────
+
+#[test]
+fn seed_round_trips_through_serde_json() {
+    let doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$seed:
+  indorsement:
+    from: 49 FW/CC
+    $body: \"Body override.\"
+title: Hi
+~~~
+
+Body.
+",
+    );
+    let json = serde_json::to_string(&doc).unwrap();
+    let restored: Document = serde_json::from_str(&json).unwrap();
+    assert_eq!(doc, restored);
+    assert_eq!(doc.to_markdown(), restored.to_markdown());
+
+    // The DTO carries `"type": "seed"` under the current 0.92.0 schema tag.
+    assert!(json.contains("\"type\":\"seed\""), "expected seed variant in DTO: {json}");
+    assert!(
+        json.contains("quillmark/document@0.92.0"),
+        "expected 0.92.0 schema tag: {json}",
+    );
+}

--- a/crates/core/src/document/tests/seed_tests.rs
+++ b/crates/core/src/document/tests/seed_tests.rs
@@ -109,6 +109,33 @@ $bogus: x
     assert!(err.contains("$seed"), "closed-set message should list $seed: {err}");
 }
 
+#[test]
+fn seed_on_composable_card_is_rejected() {
+    // `$seed` is root-only (like `$quill`): a composable block carrying it is a
+    // parse error, not silently-inert data.
+    let err = Document::from_markdown(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+~~~
+
+~~~card-yaml
+$kind: indorsement
+$seed:
+  note:
+    from: X
+~~~
+",
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("must not carry `$seed`"),
+        "expected composable-$seed rejection, got: {err}",
+    );
+}
+
 // ── Emit / round-trip ──────────────────────────────────────────────────────
 
 #[test]

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -77,6 +77,10 @@ pub struct CardWire {
     /// The block's opaque `$ext` map, if declared. Omitted when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<JsonMap<String, JsonValue>>,
+    /// The block's `$seed` map (keyed by card-kind), if declared. Present on
+    /// the main card only. Omitted when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<JsonMap<String, JsonValue>>,
     /// User fields and comments, in source order.
     #[serde(default, alias = "payload_items")]
     pub payload_items: Vec<PayloadItemWire>,
@@ -118,6 +122,7 @@ impl From<&Card> for CardWire {
             quill: None,
             id: None,
             ext: None,
+            seed: None,
             payload_items: Vec::new(),
             body: card.body().to_string(),
         };
@@ -127,6 +132,7 @@ impl From<&Card> for CardWire {
                 PayloadItem::Kind { value } => wire.kind = value.clone(),
                 PayloadItem::Id { value } => wire.id = Some(value.clone()),
                 PayloadItem::Ext { value, .. } => wire.ext = Some(value.clone()),
+                PayloadItem::Seed { value, .. } => wire.seed = Some(value.clone()),
                 PayloadItem::Field {
                     key, value, fill, ..
                 } => wire.payload_items.push(PayloadItemWire::Field {
@@ -201,6 +207,23 @@ impl TryFrom<CardWire> for Card {
             };
             payload.set_ext(ext);
         }
+        if let Some(seed) = wire.seed {
+            let as_value = JsonValue::Object(seed);
+            if crate::value::json_depth_exceeds(&as_value, crate::document::limits::MAX_YAML_DEPTH)
+            {
+                return Err(WireError::InvalidField {
+                    key: "$seed".to_string(),
+                    reason: format!(
+                        "nests deeper than the maximum of {} levels",
+                        crate::document::limits::MAX_YAML_DEPTH
+                    ),
+                });
+            }
+            let JsonValue::Object(seed) = as_value else {
+                unreachable!("constructed as Object above")
+            };
+            payload.set_seed(seed);
+        }
         Ok(Card::from_parts(payload, wire.body))
     }
 }
@@ -273,6 +296,7 @@ mod tests {
             quill: None,
             id: None,
             ext: None,
+            seed: None,
             payload_items: vec![PayloadItemWire::Field {
                 key: "x".to_string(),
                 value: json!(1),
@@ -296,6 +320,7 @@ mod tests {
             quill: Some("@nope".to_string()),
             id: None,
             ext: None,
+            seed: None,
             payload_items: Vec::new(),
             body: String::new(),
         })

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,7 +46,7 @@
 pub mod document;
 pub use document::{
     Card, CardWire, Document, EditError, ParseOutput, Payload, PayloadItem, PayloadItemWire,
-    WireError,
+    SeedOverlay, WireError,
 };
 
 pub mod backend;

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -9,7 +9,9 @@ use indexmap::IndexMap;
 use super::{seed, CardSchema, Quill};
 use crate::normalize::normalize_document;
 use crate::quill::zero_value;
-use crate::{Card, Diagnostic, Document, Payload, QuillValue, RenderError, Severity, Version};
+use crate::{
+    Card, Diagnostic, Document, Payload, QuillValue, RenderError, SeedOverlay, Severity, Version,
+};
 
 impl Quill {
     /// Applies coercion, validation, normalization, and **zero-filled render**:
@@ -149,10 +151,82 @@ impl Quill {
     /// the quill schema (`quill.config().schema()`), where fields carry their
     /// `ui.order` as the presentation-ordering signal.
     pub fn validate(&self, doc: &Document) -> Vec<Diagnostic> {
-        match self.config().validate_document(doc) {
+        let mut diags = match self.config().validate_document(doc) {
             Ok(()) => Vec::new(),
             Err(errors) => errors.iter().map(|e| e.to_diagnostic()).collect(),
+        };
+        diags.extend(self.validate_seed(doc));
+        diags
+    }
+
+    /// Advisory validation of the main card's `$seed` overlays.
+    ///
+    /// Seed overlays are editor-surface only: they never gate render
+    /// (`compile_data` / `dry_run` ignore `$seed`), so every diagnostic here is
+    /// a **warning** rooted at `$seed.<kind>[.<field>]`. An overlay keyed by a
+    /// name that is not a declared `card_kind` is flagged; otherwise each
+    /// overlaid field is checked against that kind's schema with the same
+    /// conformance core the schema's own `example:` / `default:` literals use
+    /// (partial values allowed, no `<must-fill>` sentinel or absence gating).
+    /// The reserved `$body` key is the body override, not a field, and is
+    /// skipped.
+    fn validate_seed(&self, doc: &Document) -> Vec<Diagnostic> {
+        let Some(seed_map) = doc.main().payload().seed() else {
+            return Vec::new();
+        };
+        let config = self.config();
+        let mut diags = Vec::new();
+        for (kind, overlay) in seed_map {
+            let Some(card_schema) = config.card_kind(kind) else {
+                diags.push(
+                    Diagnostic::new(
+                        Severity::Warning,
+                        format!("`$seed` overlay targets unknown card kind `{kind}`"),
+                    )
+                    .with_code("validation::seed_unknown_kind".to_string())
+                    .with_path(format!("$seed.{kind}"))
+                    .with_hint(format!(
+                        "Remove the `{kind}` overlay, or rename it to a declared card kind."
+                    )),
+                );
+                continue;
+            };
+            let Some(obj) = overlay.as_object() else {
+                diags.push(
+                    Diagnostic::new(
+                        Severity::Warning,
+                        format!("`$seed.{kind}` must be a mapping of field overrides"),
+                    )
+                    .with_code("validation::seed_overlay_shape".to_string())
+                    .with_path(format!("$seed.{kind}")),
+                );
+                continue;
+            };
+            for (field, value) in obj {
+                if field == "$body" {
+                    continue;
+                }
+                let field_path = format!("$seed.{kind}.{field}");
+                let Some(field_schema) = card_schema.fields.get(field) else {
+                    diags.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            format!("`$seed.{kind}.{field}` is not a field of card kind `{kind}`"),
+                        )
+                        .with_code("validation::seed_unknown_field".to_string())
+                        .with_path(field_path),
+                    );
+                    continue;
+                };
+                let qv = QuillValue::from_json(value.clone());
+                for violation in
+                    super::validation::validate_schema_literal(field_schema, &qv, &field_path)
+                {
+                    diags.push(seed_violation_diagnostic(&violation));
+                }
+            }
         }
+        diags
     }
 
     /// Seed a starter [`Document`]: the main card plus one instance of each
@@ -171,10 +245,14 @@ impl Quill {
         seed::seed_main(self)
     }
 
-    /// Seed a starter composable [`Card`] of the given kind (carries `$kind`);
-    /// `None` if the kind is not declared. Use to add a new card to a document.
-    pub fn seed_card(&self, card_kind: &str) -> Option<Card> {
-        seed::seed_card_for_kind(self, card_kind)
+    /// Seed a starter composable [`Card`] of the given kind (carries `$kind`),
+    /// layering an optional per-kind [`SeedOverlay`] over the schema-example
+    /// base (`overlay › example › absent`); `None` if the kind is not declared.
+    /// Use to add a new card to a document — pass `doc.seed(card_kind)` as the
+    /// overlay so a card spawned into a template-derived document inherits its
+    /// curated starting values, and `None` for the bare schema seed.
+    pub fn seed_card(&self, card_kind: &str, overlay: Option<&SeedOverlay>) -> Option<Card> {
+        seed::seed_card_for_kind(self, card_kind, overlay)
     }
 
     fn validate_document(&self, doc: &Document) -> Result<(), RenderError> {
@@ -215,6 +293,19 @@ fn quill_mismatch(message: String, code: &str, hint: &str) -> RenderError {
             .with_code(code.to_string())
             .with_hint(hint.to_string())],
     }
+}
+
+/// Render a seed-overlay validation error as a **warning**-severity diagnostic
+/// — seed overlays are advisory and never gate render. The error's `path` is
+/// already rooted at `$seed.<kind>.<field>` by the caller.
+fn seed_violation_diagnostic(v: &super::validation::ValidationError) -> Diagnostic {
+    let mut diag = Diagnostic::new(Severity::Warning, v.to_string())
+        .with_code(v.code().to_string())
+        .with_path(v.path().to_string());
+    if let Some(hint) = v.hint() {
+        diag = diag.with_hint(hint);
+    }
+    diag
 }
 
 /// Wrap a coercion error into `RenderError::ValidationFailed`.

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -31,30 +31,51 @@ use indexmap::IndexMap;
 
 use super::Quill;
 use crate::quill::CardSchema;
-use crate::{Card, Document, Payload, QuillReference, QuillValue};
+use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 
-/// Build the seeded `(payload, body)` for one card schema: each field that
-/// declares an `example` is committed, ordered by `ui.order` (matching the
-/// blueprint); fields without an `example` are omitted. The `$quill` /
-/// `$kind` system metadata is attached by the caller.
-fn seed_parts(schema: &CardSchema) -> (Payload, String) {
-    let mut names: Vec<&str> = schema.fields.keys().map(String::as_str).collect();
-    names.sort_by_key(|name| schema.fields[*name].ui_order());
-
-    let mut fields: IndexMap<String, QuillValue> = IndexMap::new();
-    for name in names {
-        if let Some(example) = &schema.fields[name].example {
-            fields.insert(name.to_string(), example.clone());
+/// Build the seeded `(payload, body)` for one card schema, layering an optional
+/// [`SeedOverlay`] over the schema-example base. Per field the precedence is
+/// `overlay › example › absent`; the overlay may also add a field the base
+/// omits (a `default`-only field with no `example`). The final fields are
+/// ordered by `ui.order` (matching the blueprint). Only fields declared on the
+/// schema are included — an overlay key naming no schema field is ignored here
+/// (the editor-surface validator flags it). Body: `overlay › body.example ›
+/// empty`, honored only when the kind enables bodies. The `$quill` / `$kind`
+/// system metadata is attached by the caller.
+fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, String) {
+    // Merge the example base with the overlay (schema-declared fields only).
+    let mut merged: IndexMap<String, QuillValue> = IndexMap::new();
+    for (name, field) in &schema.fields {
+        if let Some(example) = &field.example {
+            merged.insert(name.clone(), example.clone());
+        }
+    }
+    if let Some(overlay) = overlay {
+        for (name, value) in &overlay.fields {
+            if schema.fields.contains_key(name) {
+                merged.insert(name.clone(), value.clone());
+            }
         }
     }
 
-    // Body region carries `body.example` when declared and bodies are enabled,
-    // mirroring the blueprint; otherwise it is empty.
-    let body = if schema.body_enabled() {
+    // Order by `ui.order`. Every key is a declared field here, so the lookup
+    // always resolves; the `i32::MAX` fallback is defensive.
+    let mut entries: Vec<(String, QuillValue)> = merged.into_iter().collect();
+    entries.sort_by_key(|(name, _)| {
         schema
-            .body
-            .as_ref()
-            .and_then(|b| b.example.clone())
+            .fields
+            .get(name)
+            .map(|f| f.ui_order())
+            .unwrap_or(i32::MAX)
+    });
+    let fields: IndexMap<String, QuillValue> = entries.into_iter().collect();
+
+    // Body region: an overlay body wins, else `body.example`, else empty —
+    // and only when bodies are enabled for the kind.
+    let body = if schema.body_enabled() {
+        overlay
+            .and_then(|o| o.body.clone())
+            .or_else(|| schema.body.as_ref().and_then(|b| b.example.clone()))
             .unwrap_or_default()
     } else {
         String::new()
@@ -74,7 +95,9 @@ fn main_reference(quill: &Quill) -> QuillReference {
 }
 
 pub(crate) fn seed_main(quill: &Quill) -> Card {
-    let (mut payload, body) = seed_parts(&quill.config().main);
+    // The main card is never seeded from an overlay — `$seed` keys range over
+    // composable `card_kinds`, and `main` is not one of them.
+    let (mut payload, body) = seed_parts(&quill.config().main, None);
     payload.set_quill(main_reference(quill));
     // The root block carries `$kind: main` alongside `$quill` (see the
     // markdown spec); set it so a seeded main card round-trips through
@@ -83,25 +106,32 @@ pub(crate) fn seed_main(quill: &Quill) -> Card {
     Card::from_parts(payload, body)
 }
 
-pub(crate) fn seed_card_for_kind(quill: &Quill, card_kind: &str) -> Option<Card> {
+pub(crate) fn seed_card_for_kind(
+    quill: &Quill,
+    card_kind: &str,
+    overlay: Option<&SeedOverlay>,
+) -> Option<Card> {
     let schema = quill.config().card_kind(card_kind)?;
-    Some(seed_composable(schema))
+    Some(seed_composable(schema, overlay))
 }
 
-/// Seed a single composable card from its schema (sets `$kind`, never `$quill`).
-fn seed_composable(schema: &CardSchema) -> Card {
-    let (mut payload, body) = seed_parts(schema);
+/// Seed a single composable card from its schema and an optional overlay (sets
+/// `$kind`, never `$quill`).
+fn seed_composable(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> Card {
+    let (mut payload, body) = seed_parts(schema, overlay);
     payload.set_kind(schema.name.clone());
     Card::from_parts(payload, body)
 }
 
 pub(crate) fn seed_document(quill: &Quill) -> Document {
+    // A fresh document carries no `$seed`, so every kind seeds from its schema
+    // example base (overlay = `None`).
     let main = seed_main(quill);
     let cards = quill
         .config()
         .card_kinds
         .iter()
-        .map(seed_composable)
+        .map(|schema| seed_composable(schema, None))
         .collect();
     Document::from_main_and_cards(main, cards, Vec::new())
 }

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -3,9 +3,16 @@
 
 use std::collections::HashMap;
 
+use serde_json::json;
+
 use crate::quill::FileTreeNode;
 
-use crate::Quill;
+use crate::{Document, Quill, SeedOverlay, Severity};
+
+/// Build a [`SeedOverlay`] from a JSON object (the `$seed[<kind>]` shape).
+fn overlay(value: serde_json::Value) -> SeedOverlay {
+    SeedOverlay::from_json(&value).expect("overlay json must be an object")
+}
 
 /// Build a minimal [`Quill`] from inline YAML with no filesystem dependencies.
 fn quill_from_yaml(yaml: &str) -> Quill {
@@ -175,6 +182,67 @@ fn seed_card_for_known_and_unknown_kind() {
     );
 }
 
+// ── Overlay layering (overlay › example › absent) ───────────────────────────
+
+#[test]
+fn overlay_overrides_example_and_falls_through_for_untouched_fields() {
+    let quill = quill_from_yaml(QUILL);
+    // Override only `author`; leave the rest to the schema seed.
+    let ov = overlay(json!({ "author": "Custom Author" }));
+    let card = quill.seed_card("note", Some(&ov)).expect("known kind");
+    assert_eq!(
+        card.payload().get("author").and_then(|v| v.as_str()),
+        Some("Custom Author"),
+        "overlay value wins over the example",
+    );
+}
+
+#[test]
+fn overlay_adds_a_field_the_base_omits() {
+    let quill = quill_from_yaml(QUILL);
+    // `tag` has no example, so the bare seed omits it; the overlay adds it.
+    assert!(quill
+        .seed_card("note", None)
+        .unwrap()
+        .payload()
+        .get("tag")
+        .is_none());
+    let ov = overlay(json!({ "tag": "pinned" }));
+    let card = quill.seed_card("note", Some(&ov)).expect("known kind");
+    assert_eq!(card.payload().get("tag").and_then(|v| v.as_str()), Some("pinned"));
+    // `author` still flows from its example (sparse fall-through).
+    assert_eq!(
+        card.payload().get("author").and_then(|v| v.as_str()),
+        Some("A. Author"),
+    );
+}
+
+#[test]
+fn overlay_fields_are_ordered_by_ui_order() {
+    let quill = quill_from_yaml(QUILL);
+    // Overlay touches `tag` (declared 2nd) and `author` (declared 1st); the
+    // result must still be ordered by ui.order, not overlay insertion order.
+    let ov = overlay(json!({ "tag": "pinned", "author": "Custom" }));
+    let card = quill.seed_card("note", Some(&ov)).expect("known kind");
+    let keys: Vec<&str> = card.payload().keys().map(String::as_str).collect();
+    assert_eq!(keys, vec!["author", "tag"]);
+}
+
+#[test]
+fn overlay_body_overrides_and_non_schema_keys_are_ignored() {
+    let quill = quill_from_yaml(QUILL);
+    // `note` has no body.example, so the bare seed body is empty.
+    assert_eq!(quill.seed_card("note", None).unwrap().body(), "");
+    // An overlay `$body` wins; a non-schema field is ignored.
+    let ov = overlay(json!({ "author": "X", "$body": "Overlay body.", "bogus": "drop me" }));
+    let card = quill.seed_card("note", Some(&ov)).expect("known kind");
+    assert_eq!(card.body(), "Overlay body.");
+    assert!(
+        card.payload().get("bogus").is_none(),
+        "a key naming no schema field must not land on the card",
+    );
+}
+
 /// `body.example` is only seeded when bodies are enabled for the kind.
 #[test]
 fn seed_omits_body_when_body_disabled() {
@@ -210,5 +278,62 @@ card_kinds:
     assert_eq!(
         card.payload().get("value").and_then(|v| v.as_str()),
         Some("V"),
+    );
+}
+
+// ── Advisory `$seed` validation (editor surface only; never gates render) ────
+
+/// A minimal `seed_test` document carrying a raw `$seed` YAML block.
+fn doc_with_seed(seed_block: &str) -> Document {
+    let md = format!("~~~card-yaml\n$quill: seed_test@1.0\n$kind: main\n{seed_block}~~~\n");
+    Document::from_markdown(&md).expect("doc should parse")
+}
+
+#[test]
+fn seed_overlay_type_mismatch_is_advisory_and_does_not_gate_render() {
+    let quill = quill_from_yaml(QUILL);
+    // `author` is a string; an integer overlay value is a type mismatch.
+    let doc = doc_with_seed("$seed:\n  note:\n    author: 123\n");
+
+    let diags = quill.validate(&doc);
+    let seed_diag = diags
+        .iter()
+        .find(|d| d.path.as_deref() == Some("$seed.note.author"))
+        .expect("a diagnostic rooted at the seed field");
+    assert_eq!(
+        seed_diag.severity,
+        Severity::Warning,
+        "seed diagnostics are advisory, not errors",
+    );
+
+    // The malformed overlay never blocks render — `$seed` is stripped.
+    assert!(quill.compile_data(&doc).is_ok(), "compile_data must ignore $seed");
+    assert!(quill.dry_run(&doc).is_ok(), "dry_run must ignore $seed");
+}
+
+#[test]
+fn seed_overlay_unknown_kind_is_flagged_but_renders() {
+    let quill = quill_from_yaml(QUILL);
+    let doc = doc_with_seed("$seed:\n  bogus_kind:\n    x: 1\n");
+    let diags = quill.validate(&doc);
+    let d = diags
+        .iter()
+        .find(|d| d.code.as_deref() == Some("validation::seed_unknown_kind"))
+        .expect("unknown-kind advisory");
+    assert_eq!(d.path.as_deref(), Some("$seed.bogus_kind"));
+    assert_eq!(d.severity, Severity::Warning);
+    assert!(quill.compile_data(&doc).is_ok());
+}
+
+#[test]
+fn well_formed_seed_overlay_yields_no_seed_diagnostics() {
+    let quill = quill_from_yaml(QUILL);
+    let doc = doc_with_seed("$seed:\n  note:\n    author: Custom\n");
+    let diags = quill.validate(&doc);
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.path.as_deref().is_some_and(|p| p.starts_with("$seed"))),
+        "a well-formed overlay should produce no seed diagnostics: {diags:?}",
     );
 }

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -162,7 +162,7 @@ fn seeded_document_compiles_with_default_then_zero_for_absent_fields() {
 fn seed_card_for_known_and_unknown_kind() {
     let quill = quill_from_yaml(QUILL);
 
-    let note = quill.seed_card("note").expect("known kind");
+    let note = quill.seed_card("note", None).expect("known kind");
     assert_eq!(note.kind(), Some("note"));
     assert_eq!(
         note.payload().get("author").and_then(|v| v.as_str()),
@@ -170,7 +170,7 @@ fn seed_card_for_known_and_unknown_kind() {
     );
 
     assert!(
-        quill.seed_card("missing").is_none(),
+        quill.seed_card("missing", None).is_none(),
         "unknown kind must return None"
     );
 }
@@ -201,7 +201,7 @@ card_kinds:
 "#,
     );
 
-    let card = quill.seed_card("data").expect("known kind");
+    let card = quill.seed_card("data", None).expect("known kind");
     assert_eq!(
         card.body(),
         "",

--- a/docs/migrations/0.91-to-0.92.md
+++ b/docs/migrations/0.91-to-0.92.md
@@ -59,9 +59,10 @@ card = quill.seed_card(kind, doc.seed(kind))   # overlay defaults to None
 
 **Rust (core)** — the one breaking signature: `Quill::seed_card(&self, kind)`
 becomes `Quill::seed_card(&self, kind, overlay: Option<&SeedOverlay>)`. Pass
-`None` for the bare schema seed, or `doc.seed(kind)` for the overlay-aware seed.
-The document-less variant is intentionally not exposed — a card is always seeded
-*into* a document — which makes it impossible to silently bypass an overlay.
+`None` for the bare schema seed (the historical behavior), or `doc.seed(kind)` to
+layer a document's overlay. Making the overlay an explicit argument keeps it
+discoverable: `doc.seed(kind)` is the obvious value to pass when adding a card to
+a template-derived document.
 
 ## New accessors
 

--- a/docs/migrations/0.91-to-0.92.md
+++ b/docs/migrations/0.91-to-0.92.md
@@ -31,7 +31,7 @@ while every untouched field still flows from the quill's schema `example:`
 (`overlay › example › absent`). Like `$ext`, `$seed` round-trips through Markdown
 and storage and is **stripped before backends** — it never appears in rendered
 output. It is validated only advisorily (`Quill::validate`, warning severity)
-and never gates render. See [CARDS.md](../../prose/canon/CARDS.md) for the model.
+and never gates render. The model lives in the `prose/canon/CARDS.md` design doc.
 
 ## `seedCard` takes an optional overlay
 

--- a/docs/migrations/0.91-to-0.92.md
+++ b/docs/migrations/0.91-to-0.92.md
@@ -8,10 +8,11 @@ loading.
 
 ## What `$seed` is
 
-`$seed` is a `$`-prefixed system key on the **root block only**, a mapping keyed
-by composable card-kind. Each entry is a *sparse overlay* — the user fields
-(plus an optional reserved `$body` string) a freshly-added card of that kind
-should start with:
+`$seed` is a `$`-prefixed system key on the **root block only** — like `$quill`,
+a composable card carrying `$seed` is rejected at parse and on storage load. It
+is a mapping keyed by composable card-kind; each entry is a *sparse overlay* —
+the user fields (plus an optional reserved `$body` string) a freshly-added card
+of that kind should start with:
 
 ```
 ~~~

--- a/docs/migrations/0.91-to-0.92.md
+++ b/docs/migrations/0.91-to-0.92.md
@@ -1,0 +1,84 @@
+# 0.91.0 → 0.92.0 — per-card-kind seed overlays (`$seed`)
+
+An additive release: a new system-metadata key, `$seed`, lets a document carry
+the curated starting values that newly-added cards spawn with. Existing
+documents and quills are unaffected — the only code change is one optional
+argument on `seedCard`. Stored documents written by `0.82.x`–`0.91.x` keep
+loading.
+
+## What `$seed` is
+
+`$seed` is a `$`-prefixed system key on the **root block only**, a mapping keyed
+by composable card-kind. Each entry is a *sparse overlay* — the user fields
+(plus an optional reserved `$body` string) a freshly-added card of that kind
+should start with:
+
+```
+~~~
+$quill: usaf_memo@0.2.0
+$kind: main
+$seed:
+  indorsement:
+    from: 49 FW/CC
+    signature_block:
+      - "JANE A. DOE, Col, USAF"
+      - "Commander"
+~~~
+```
+
+Adding a new `indorsement` now seeds `from` / `signature_block` from the overlay
+while every untouched field still flows from the quill's schema `example:`
+(`overlay › example › absent`). Like `$ext`, `$seed` round-trips through Markdown
+and storage and is **stripped before backends** — it never appears in rendered
+output. It is validated only advisorily (`Quill::validate`, warning severity)
+and never gates render. See [CARDS.md](../../prose/canon/CARDS.md) for the model.
+
+## `seedCard` takes an optional overlay
+
+`seedCard` now accepts the per-kind overlay so a card added to a
+template-derived document inherits its curated values. Read the overlay from the
+document and hand it to the quill:
+
+**WASM / TypeScript**
+
+```js
+// before
+const card = quill.seedCard(kind);
+// after — pass the document's overlay (a read; it does not mutate the doc)
+const card = quill.seedCard(kind, doc.seed(kind));
+```
+
+`quill.seedCard(kind)` (omitting the overlay) still works and yields the bare
+schema seed, so unmodified call sites compile and behave as before.
+
+**Python**
+
+```python
+card = quill.seed_card(kind, doc.seed(kind))   # overlay defaults to None
+```
+
+**Rust (core)** — the one breaking signature: `Quill::seed_card(&self, kind)`
+becomes `Quill::seed_card(&self, kind, overlay: Option<&SeedOverlay>)`. Pass
+`None` for the bare schema seed, or `doc.seed(kind)` for the overlay-aware seed.
+The document-less variant is intentionally not exposed — a card is always seeded
+*into* a document — which makes it impossible to silently bypass an overlay.
+
+## New accessors
+
+- **`Document.seed(cardKind)`** — the per-kind overlay (or `undefined`/`None`);
+  feed it straight to `seedCard`.
+- **`Document.setSeedNamespace(cardKind, overlay)`** /
+  **`removeSeedNamespace(cardKind)`** — write/clear one kind's overlay, preserving
+  sibling kinds (the seed analogue of `setExtNamespace`). This is how a template
+  author sets the values new cards spawn with.
+
+The `Card` shape gains an optional `seed` field (hoisted from `$seed`, main card
+only), mirroring `ext`.
+
+## Storage: schema `quillmark/document@0.92.0`
+
+The `StoredDocument` wire format gains a `seed` payload-item variant, so newly
+serialized documents carry the tag `quillmark/document@0.92.0`. This is
+transparent: `0.81.x` / `0.82.x`–`0.91.x` blobs migrate forward losslessly on
+read (`V0_81_0 → V0_82_0 → V0_92_0`), and re-serialization upgrades the tag. No
+action is required for persisted documents.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -12,6 +12,9 @@ guides in order.
 
 ## Available guides
 
+- [0.91 → 0.92](0.91-to-0.92.md) — the additive `$seed` system key carries
+  per-card-kind seed overlays; `seedCard` gains an optional overlay argument and
+  the storage schema bumps to `quillmark/document@0.92.0` (old blobs migrate).
 - [0.90 → 0.91](0.90-to-0.91.md) — the closing `~~~` of a card-yaml block must
   be at column zero (an indented `~~~` is payload, fixing silent truncation of
   block-scalar values containing tilde fences); data-field names

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -116,3 +116,41 @@ template renders are not affected by editor state. Consumers
 namespace inside the map (`$ext.presentation`, `$ext.agent`, …) to avoid
 collisions when more than one tool carries state on the same card. See
 [markdown-spec.md §3.3](../references/markdown-spec.md) for the full specification.
+
+## Per-kind Seed Overlays (`$seed`)
+
+`$seed` is the structural twin of `$ext` — a system-metadata mapping carried on
+the **main card only**, round-tripping through Markdown and the storage DTO and
+stripped before backends — but the seeding layer *interprets* it. It answers
+"what does a *new* card of kind K start with in this document": each entry,
+keyed by composable card-kind, is a **sparse overlay** of the user fields (plus
+an optional reserved `$body` string) a freshly-added card of that kind inherits.
+
+````markdown
+~~~
+$quill: usaf_memo@0.2.0
+$kind: main
+$seed:
+  indorsement:                 # keyed by card-kind; never "main"
+    from: 49 FW/CC
+    signature_block:
+      - "JANE A. DOE, Col, USAF"
+      - "Commander"
+~~~
+````
+
+`Quill::seed_card(kind, overlay)` layers the overlay over the quill's
+schema-`example:` seed, per field `overlay › example › absent`, ordered by
+`ui.order` (see [SCHEMAS.md](SCHEMAS.md) "Document seeding"). The overlay is
+*sparse*: fields it omits keep flowing from the live quill seed, so it tracks
+the quill rather than freezing a snapshot. `Document::seed(kind)` reads the
+parsed overlay; the consumer passes it to `seed_card` (`quill.seedCard(kind,
+doc.seed(kind))`) — a read of the document, never a mutation of it.
+
+The main card **carries** `$seed` but is never a *subject* of it: its keys range
+over `card_kinds`, and `main ∉ card_kinds` (a `$seed.main` entry is an advisory
+unknown-kind). Overlays are validated only on the editor surface
+(`Quill::validate`, warning-severity, rooted at `$seed.<kind>[.<field>]`) and
+**never gate render** — `compile_data` / `dry_run` ignore `$seed` entirely. A
+malformed overlay surfaces enforcement only when a card is actually spawned from
+it, as an ordinary card diagnostic on that card.

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -121,7 +121,9 @@ collisions when more than one tool carries state on the same card. See
 
 `$seed` is the structural twin of `$ext` — a system-metadata mapping carried on
 the **main card only**, round-tripping through Markdown and the storage DTO and
-stripped before backends — but the seeding layer *interprets* it. It answers
+stripped before backends — but the seeding layer *interprets* it. It is
+**root-only** like `$quill`: a composable card carrying `$seed` is rejected at
+parse and on storage load. It answers
 "what does a *new* card of kind K start with in this document": each entry,
 keyed by composable card-kind, is a **sparse overlay** of the user fields (plus
 an optional reserved `$body` string) a freshly-added card of that kind inherits.

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -38,7 +38,7 @@ bindings) and never a storage option.
 
 ## The Format
 
-The current schema (`quillmark/document@0.82.0`) carries each card's full
+The current schema (`quillmark/document@0.92.0`) carries each card's full
 ordered payload — typed `$` system metadata, user fields, and YAML
 comments interleaved in source order — as a single discriminated-union
 item list. This is what makes inline-comment preservation symmetric across
@@ -46,7 +46,7 @@ the `$`/non-`$` boundary.
 
 ```json
 {
-  "schema": "quillmark/document@0.82.0",
+  "schema": "quillmark/document@0.92.0",
   "main": {
     "payload": {
       "items": [
@@ -67,8 +67,9 @@ each variant carries a frozen DTO tree. Quill references are stored as
 strings (parsed back via `QuillReference::from_str`). The discriminator on
 payload items is `type` (not `kind`) to keep it unambiguous next to the
 `$kind` metadata semantic. The full variant set is `quill | kind | id |
-ext | field | comment`; the `ext` variant carries the opaque `$ext` map
-verbatim and is stripped from `to_plate_json()` before backends see it.
+ext | seed | field | comment`; the `ext` and `seed` variants carry the
+`$ext` / `$seed` maps verbatim and are stripped from `to_plate_json()`
+before backends see it.
 Parse-time warnings live on `Document` (`warnings: Vec<Diagnostic>`) but
 are excluded from `PartialEq` and not serialized, so they never reach this
 format.
@@ -105,22 +106,25 @@ change the byte layout.
 
 The schema version is tied to the **crate version at which the `Document`
 wire format was last changed** — not the running crate version. The
-current format was fixed in `0.82.0`, so the version tag is
-`quillmark/document@0.82.0`; every `0.82.x` patch release writes that same
-value, because patches do not change the format.
+current format was fixed in `0.92.0`, so the version tag is
+`quillmark/document@0.92.0`; every later patch writes that same value,
+because patches do not change the format.
 
 The first schema version was `0.81.0`. `0.82.0` migrated `Document` to a
 unified payload-item list (typed `$` entries living alongside user fields
 and comments in a single `Vec<PayloadItem>` instead of a separate
-`sentinel + frontmatter` pair). The migration is structural: the V0_81_0
-sentinel becomes a prelude of typed `$` items, then user fields and
-comments append in their original order.
+`sentinel + frontmatter` pair). `0.92.0` added the `seed` payload-item
+variant (the `$seed` per-card-kind overlay map); it is otherwise identical
+to `0.82.0`. Both migrations are structural — old payload items map 1:1 and
+the new variant is simply never produced from an older blob — and chain
+forward (`V0_81_0 → V0_82_0 → V0_92_0`), with only the newest DTO
+converting to the live `Document`.
 
 ## Adding a Schema Version
 
 When the `Document` wire format changes again:
 
-1. **Freeze** the current `DocumentV0_82_0` type tree — leave its struct
+1. **Freeze** the current `DocumentV0_92_0` type tree — leave its struct
    /enum definitions and serde derives untouched so existing rows still parse.
 2. **Remove** the conversions binding the old DTO to the *live* `Document`
    (`From<&Document>` and `TryFrom<… for Document>`); they no longer compile
@@ -129,23 +133,25 @@ When the `Document` wire format changes again:
    plus its `From<&Document>` and `TryFrom<… for Document>` conversions.
 4. **Add** the `StoredDocument::V0_NN_0` variant, tagged
    `#[serde(rename = "quillmark/document@0.NN.0")]`.
-5. **Write the migration** — `From<DocumentV0_82_0> for DocumentV0_NN_0`.
+5. **Write the migration** — `From<DocumentV0_92_0> for DocumentV0_NN_0`.
    This is the only real labor: it encodes how old fields map to the new
    model (renames, restructures, defaults for new fields).
-6. **Extend** the reader:
+6. **Extend** the reader (each older blob migrates one hop, then chains):
    ```rust
    match stored {
        StoredDocument::V0_NN_0(p) => Document::try_from(p),
-       StoredDocument::V0_82_0(p) => Document::try_from(DocumentV0_NN_0::from(p)),
-       StoredDocument::V0_81_0(p) => {
-           let v82 = DocumentV0_82_0::from(p);
-           Document::try_from(DocumentV0_NN_0::from(v82))
+       StoredDocument::V0_92_0(p) => Document::try_from(DocumentV0_NN_0::from(p)),
+       StoredDocument::V0_82_0(p) => {
+           Document::try_from(DocumentV0_NN_0::from(DocumentV0_92_0::from(p)))
        }
+       StoredDocument::V0_81_0(p) => Document::try_from(DocumentV0_NN_0::from(
+           DocumentV0_92_0::from(DocumentV0_82_0::from(p)),
+       )),
    }
    ```
 
 Old and new DTOs **coexist permanently** in `dto.rs`. Migrations chain
-(`V0_81_0 → V0_82_0 → V0_NN_0 → …`); only the newest DTO converts to the
+(`V0_81_0 → V0_82_0 → V0_92_0 → V0_NN_0 → …`); only the newest DTO converts to the
 live `Document`, so each migration step stays small as versions accumulate.
 The cost of this design is one frozen type tree per schema version plus
 one migration function per version bump; the benefit is that a row written
@@ -153,7 +159,7 @@ by any past version always loads.
 
 ## Gotchas
 
-- The schema version is a hand-set constant (`SCHEMA_V0_82_0`), **not**
+- The schema version is a hand-set constant (`SCHEMA_V0_92_0`), **not**
   `CARGO_PKG_VERSION` — bumping it is a deliberate act tied to a model change.
 - Unknown schema versions are rejected on read, never silently ignored.
 - DTO type names carry version suffixes with underscores

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -94,6 +94,7 @@ floor, `FieldSchema::ui_order` for ordering):
 | render (fidelity) | authored › `default:` › zero | zero | plate JSON — [Zero-filled render](#zero-filled-render) |
 | `blueprint` document | `default:` › `<must-fill>` | sentinel | annotated string — [BLUEPRINT.md](BLUEPRINT.md) |
 | seeding | `example:` › absent | (deferred to render floor) | committed `Document` — [Document seeding](#document-seeding) |
+| add-card (into a document) | `$seed` overlay › `example:` › absent | (deferred to render floor) | a new composable `Card` — [Document seeding](#document-seeding) |
 | editor (consumer-side) | authored / `default:` / missing (uncollapsed; `example:` as guidance) | — | a `Document`-payload × schema join the UI consumer performs directly (no engine projection); completeness comes from `Quill::validate` |
 
 Two seams are deliberate, not uniform: the floor is `zero` on every projection
@@ -184,6 +185,22 @@ hands back a committed `Document` already carrying the `example:` values, the
 rest deferred to the render floor for fidelity. It is the only "filled-out"
 projection — there is no annotated `example` string. Implemented by
 `Quill::seed_document` (with `seed_main` / `seed_card`) in `quillmark`.
+
+### Per-document seed overlays (`$seed`)
+
+Seeding a *new card into an existing document* — `Quill::seed_card(kind,
+overlay)` — adds one more rung above `example:`: a curated, per-document
+**overlay** read from the main card's `$seed` map. Per field the precedence is
+**`$seed` overlay › `example:` › absent** (ordered by `ui.order`), and `default`
+/ `zero` stay deferred to the render floor exactly as everywhere else, so the
+"never persist a `default`" invariant holds. The overlay is *sparse* — fields it
+omits keep flowing from the schema seed, so it tracks an evolving quill rather
+than freezing a snapshot. This is how a template author customizes the values
+new cards spawn with; it lives in the document (a template *is* a document), so
+markdown writers and MCP agents see the same source. See
+[CARDS.md](CARDS.md) "Per-kind Seed Overlays" for the `$seed` mechanics. The
+`example: → absent` document-seeding above is the `overlay = None` case (a fresh
+document carries no `$seed`).
 
 ## Schema emission
 

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -206,7 +206,7 @@ author wrote the line.
   mapping; scalars and sequences are rejected. Like `$ext` it carries verbatim
   through Markdown and storage DTO round-trips and **never** appears in the
   plate JSON consumed by backends; unlike `$ext` the seeding layer interprets
-  it (see [CARDS.md](../canon/CARDS.md)). Overlays are validated advisorily by
+  it. Overlays are validated advisorily by
   `Quill::validate` and never gate render. An empty `$seed: {}` is preserved.
 
 - `$` metadata entries may appear at any position within the payload, and

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -199,7 +199,8 @@ author wrote the line.
   map — e.g. `$ext.presentation.title` for an editor-side card rename.
   An empty `$ext: {}` is preserved as a distinct, explicit declaration.
 - **`$seed: <mapping>`** — an optional **mapping keyed by composable
-  card-kind**, present on the **root block only**. Each entry is a *sparse
+  card-kind**, present on the **root block only**; a composable block carrying
+  `$seed` is a parse error, exactly like `$quill`. Each entry is a *sparse
   overlay* — the user fields (plus an optional reserved `$body` string) that a
   newly-added card of that kind starts with, layered over the quill's
   schema-`example:` seed (`overlay › example › absent`). Required to be a YAML

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -157,18 +157,18 @@ with the same payload.
 ### 3.3 System Metadata (`$`)
 
 A block's YAML payload may contain **`$`-prefixed reserved keys** that carry
-system metadata. The set is **closed**: only `$quill`, `$kind`, `$id`, and
-`$ext` are accepted. Any other `$`-prefixed key is a parse error. These
+system metadata. The set is **closed**: only `$quill`, `$kind`, `$id`,
+`$ext`, and `$seed` are accepted. Any other `$`-prefixed key is a parse error. These
 keys are ordinary YAML — they are read by the same YAML parser that handles
 the rest of the payload — but they are **extracted** from the user field
 set after parsing; they are not part of the data model's field map (§3.4).
 
 In the typed model, the `$` entries live as typed variants of the
 unified payload-item list (`PayloadItem::Quill`, `PayloadItem::Kind`,
-`PayloadItem::Id`, `PayloadItem::Ext`), interleaved in source order with
-user fields and YAML comments. They are surfaced through typed
-accessors — `card.quill()`, `card.kind()`, `card.id()`, `card.ext()` —
-which return `Option<…>`. On a successfully parsed document the root
+`PayloadItem::Id`, `PayloadItem::Ext`, `PayloadItem::Seed`), interleaved in
+source order with user fields and YAML comments. They are surfaced through typed
+accessors — `card.quill()`, `card.kind()`, `card.id()`, `card.ext()`,
+`card.seed()` — which return `Option<…>`. On a successfully parsed document the root
 card always returns `Some(_)` for both `quill()` and `kind()` (with
 `kind() == "main"`); composable cards return `None` for `quill()` and
 `Some(_)` for `kind()` (any value other than `"main"`). The root's
@@ -198,16 +198,24 @@ author wrote the line.
   backends (§5). Bespoke consumers namespace their state inside the
   map — e.g. `$ext.presentation.title` for an editor-side card rename.
   An empty `$ext: {}` is preserved as a distinct, explicit declaration.
-
-Rules:
+- **`$seed: <mapping>`** — an optional **mapping keyed by composable
+  card-kind**, present on the **root block only**. Each entry is a *sparse
+  overlay* — the user fields (plus an optional reserved `$body` string) that a
+  newly-added card of that kind starts with, layered over the quill's
+  schema-`example:` seed (`overlay › example › absent`). Required to be a YAML
+  mapping; scalars and sequences are rejected. Like `$ext` it carries verbatim
+  through Markdown and storage DTO round-trips and **never** appears in the
+  plate JSON consumed by backends; unlike `$ext` the seeding layer interprets
+  it (see [CARDS.md](../canon/CARDS.md)). Overlays are validated advisorily by
+  `Quill::validate` and never gate render. An empty `$seed: {}` is preserved.
 
 - `$` metadata entries may appear at any position within the payload, and
   may be interleaved with data fields. The emitter preserves source order
   (see §9); newly constructed metadata that does not have a source-order
-  is emitted in the canonical key order `$quill`, `$kind`, `$id`, `$ext`.
+  is emitted in the canonical key order `$quill`, `$kind`, `$id`, `$ext`, `$seed`.
 - A duplicate `$key` within a single block is a parse error (a YAML mapping
   cannot carry two entries under the same key).
-- An unknown `$key` (anything outside `{quill, kind, id, ext}`) is a parse
+- An unknown `$key` (anything outside `{quill, kind, id, ext, seed}`) is a parse
   error.
 - An invalid `$quill` reference is a parse error.
 - A `$`-prefixed key whose value type is wrong for the key (e.g. a sequence
@@ -466,9 +474,9 @@ alias and the `---`-fenced root alias (§3.2.1) both re-emit as bare `~~~`.
 round-trip.
 
 Programmatically constructed metadata that does not have a source-order
-emits in the canonical key order `$quill`, `$kind`, `$id`, `$ext` — the
-typed mutators (`set_quill` / `set_kind` / `set_id` / `set_ext`) insert
-at these positions.
+emits in the canonical key order `$quill`, `$kind`, `$id`, `$ext`, `$seed` — the
+typed mutators (`set_quill` / `set_kind` / `set_id` / `set_ext` / `set_seed`)
+insert at these positions.
 
 ### 9.1 Canonical Idempotence
 


### PR DESCRIPTION
## Summary

Adds **`$seed`**, a first-class system-metadata key that lets a document carry the curated values newly-added cards spawn with. A `$seed` map on the main card, keyed by composable card-kind, holds a *sparse overlay* (the fields plus an optional `$body`) that `Quill::seed_card(kind, overlay)` layers over the quill's schema-`example:` seed (`overlay › example › absent`). It is the structural twin of `$ext` — round-trips Markdown + storage, stripped before backends — but the seeding layer interprets it. This closes the gap where a web-app "template" (a saved `Document`) could curate the *initial* document but not what *later-added* cards look like.

## What's included (engine only)

- **Core:** `$seed` joins the closed `$`-key set; `Quill::seed_card` takes an optional `SeedOverlay`; `Document::seed(kind)` reads it; advisory validation (`Quill::validate`, warning severity, rooted at `$seed.<kind>[.<field>]`) that never gates render (`compile_data`/`dry_run` ignore `$seed`).
- **Storage:** new schema `quillmark/document@0.92.0` with a chained forward migration — every `0.81`–`0.91` blob still loads losslessly. A test asserts a `0.82.0` blob carrying a `seed` item is rejected (proving the version bump was load-bearing).
- **Bindings:** WASM + Python `seedCard(kind, overlay)`, `Document.seed(kind)`, `set`/`removeSeedNamespace`.
- **Docs:** markdown-spec §3.3, CARDS/SCHEMAS/DOCUMENT_STORAGE canon, and `docs/migrations/0.91-to-0.92.md`.

`airmark-quiver` / usaf_memo need no changes — seeds are document-level; the existing `example:` values are the base.

## Design notes

- **Sparse overlay, not a snapshot:** fields the overlay omits keep flowing from the live quill seed, so it tracks an evolving quill rather than freezing a copy. `default`/`zero` stay deferred to the render floor (never persisted).
- **`main` carries `$seed` but is never a subject of it** — keys range over `card_kinds`, and a non-`card_kinds` key is an advisory unknown-kind.
- **Footgun closed:** there is no public document-less `seed_card`; bypassing the overlay requires passing an explicit `None`.

## Verification

Run locally (CI-equivalent):

- Core: **577** Rust tests (`cargo test --workspace --all-features --locked`)
- Lint: `cargo doc -Dwarnings` clean
- WASM: build (wasm-bindgen 0.2.118) + **138** vitest, incl. a new `$seed` overlay round-trip test
- Python: maturin build + **111** pytest, incl. new `$seed` tests

## Out of scope

Web-app wiring — a one-line `makeSeedCard` change (`quill.seedCard(kind, doc.seed(kind))`) plus the "Starting values for new &lt;kind&gt;" authoring panel — is a deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln2gZetC38M4Q8BHU29311

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ln2gZetC38M4Q8BHU29311)_