### PR TITLE
docs: canonize $ext.editor.title as per-card display name slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- docs(canon): canonize `$ext.editor.title` as the slot for a per-card display name
+
 ## v0.92.0 - 2026-06-22
 
 - 0.92 technical-debt sweep: correctness, $seed hardening, de-duplication (#727)

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -800,8 +800,8 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
 describe('Document editor surface — $ext mutators', () => {
   it('setExt adds an opaque map readable via card.ext', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExt({ presentation: { title: 'Greeting' } })
-    expect(doc.main.ext.presentation.title).toBe('Greeting')
+    doc.setExt({ editor: { title: 'Greeting' } })
+    expect(doc.main.ext.editor.title).toBe('Greeting')
   })
 
   it('setExt rejects non-object values', () => {
@@ -819,23 +819,23 @@ describe('Document editor surface — $ext mutators', () => {
 
   it('setExtNamespace preserves sibling namespaces', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExtNamespace('presentation', { title: 'A' })
+    doc.setExtNamespace('editor', { title: 'A' })
     doc.setExtNamespace('agent', { pinned: true })
-    doc.setExtNamespace('presentation', { title: 'B' })
-    expect(doc.main.ext.presentation.title).toBe('B')
+    doc.setExtNamespace('editor', { title: 'B' })
+    expect(doc.main.ext.editor.title).toBe('B')
     expect(doc.main.ext.agent.pinned).toBe(true)
   })
 
   it('removeExtNamespace clears one slot and drops $ext once empty', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExtNamespace('presentation', { title: 'A' })
+    doc.setExtNamespace('editor', { title: 'A' })
     doc.setExtNamespace('tutorial', ['step-1', 'step-2'])
     // Returns the removed value; siblings survive.
     expect(doc.removeExtNamespace('tutorial')).toEqual(['step-1', 'step-2'])
-    expect(doc.main.ext.presentation.title).toBe('A')
+    expect(doc.main.ext.editor.title).toBe('A')
     expect(doc.main.ext.tutorial).toBeUndefined()
     // Removing the last namespace clears $ext entirely.
-    doc.removeExtNamespace('presentation')
+    doc.removeExtNamespace('editor')
     expect(doc.main.ext == null).toBe(true)
     // Absent namespace is a no-op returning undefined.
     expect(doc.removeExtNamespace('nope')).toBeUndefined()
@@ -861,11 +861,11 @@ describe('Document editor surface — $ext mutators', () => {
   it('card-level namespace mutators preserve siblings and clear when empty', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.pushCard({ kind: 'note', body: 'x' })
-    doc.setCardExtNamespace(0, 'presentation', { title: 'A' })
+    doc.setCardExtNamespace(0, 'editor', { title: 'A' })
     doc.setCardExtNamespace(0, 'tutorial', ['step-1'])
     expect(doc.removeCardExtNamespace(0, 'tutorial')).toEqual(['step-1'])
-    expect(doc.cards[0].ext.presentation.title).toBe('A')
-    doc.removeCardExtNamespace(0, 'presentation')
+    expect(doc.cards[0].ext.editor.title).toBe('A')
+    doc.removeCardExtNamespace(0, 'editor')
     expect(doc.cards[0].ext == null).toBe(true)
   })
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -725,7 +725,7 @@ impl Document {
 
     /// Merge `value` into the main card's `$ext` map under `namespace`, creating
     /// the map when absent and replacing any existing value at that key. Sibling
-    /// namespaces are preserved, so independent consumers (`$ext.presentation`,
+    /// namespaces are preserved, so independent consumers (`$ext.editor`,
     /// `$ext.agent`, …) don't clobber each other.
     #[wasm_bindgen(js_name = setExtNamespace)]
     pub fn set_ext_namespace(&mut self, namespace: &str, value: JsValue) -> Result<(), JsValue> {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -273,7 +273,9 @@ impl Card {
     /// Returns [`EditError::ValueTooDeep`] when the map nests past the §8
     /// depth limit — `$ext` never reaches the plate JSON, but it does flow
     /// through the recursive emit and DTO paths, so it carries the same
-    /// depth bound as user fields.
+    /// depth bound as user fields. By convention each consumer keys its
+    /// state under its own namespace (`$ext.editor`, `$ext.agent`, …);
+    /// `$ext.editor.title` is the canonical slot for a per-card display name.
     pub fn set_ext(
         &mut self,
         value: serde_json::Map<String, serde_json::Value>,
@@ -285,7 +287,7 @@ impl Card {
 
     /// Remove the card's `$ext` map *entirely*, returning the previous map if
     /// present. This is a blunt escape hatch — it discards every namespace
-    /// (`$ext.presentation`, `$ext.agent`, …) at once. To clear consumer
+    /// (`$ext.editor`, `$ext.agent`, …) at once. To clear consumer
     /// state, prefer [`Card::remove_ext_namespace`], which drops only your
     /// own slot and leaves sibling consumers' state intact.
     pub fn remove_ext(&mut self) -> Option<serde_json::Map<String, serde_json::Value>> {
@@ -297,7 +299,7 @@ impl Card {
     ///
     /// This is the recommended way to write `$ext`: it preserves sibling
     /// namespaces, so independent consumers keying on their own slot
-    /// (`$ext.presentation`, `$ext.agent`, …) don't clobber each other.
+    /// (`$ext.editor`, `$ext.agent`, …) don't clobber each other.
     /// Returns [`EditError::ValueTooDeep`] when the merged map nests past
     /// the §8 depth limit (see [`Card::set_ext`]); the card's `$ext` is
     /// unchanged on error.

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -273,9 +273,7 @@ impl Card {
     /// Returns [`EditError::ValueTooDeep`] when the map nests past the §8
     /// depth limit — `$ext` never reaches the plate JSON, but it does flow
     /// through the recursive emit and DTO paths, so it carries the same
-    /// depth bound as user fields. By convention each consumer keys its
-    /// state under its own namespace (`$ext.editor`, `$ext.agent`, …);
-    /// `$ext.editor.title` is the canonical slot for a per-card display name.
+    /// depth bound as user fields.
     pub fn set_ext(
         &mut self,
         value: serde_json::Map<String, serde_json::Value>,

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -77,15 +77,17 @@ A card may declare `$ext: <mapping>` — an opaque YAML map reserved for
 state that belongs with the card but should not reach the rendered
 output. The map round-trips through Markdown and the storage DTO but is
 stripped from the plate JSON before backends see it, so template renders
-are unaffected. Consumers namespace inside the map (`$ext.presentation`,
+are unaffected. Consumers namespace inside the map (`$ext.editor`,
 `$ext.agent`, …) to avoid collisions when more than one tool carries
-state on the same card.
+state on the same card. `$ext.editor.title` is the canonical slot for a
+per-card display name — the label an editing surface shows when a user
+renames a single card.
 
 ```
 ~~~
 $kind: indorsement
 $ext:
-  presentation:
+  editor:
     title: "Cmdr's response"
 from: ORG/SYMBOL
 ~~~

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -80,8 +80,7 @@ stripped from the plate JSON before backends see it, so template renders
 are unaffected. Consumers namespace inside the map (`$ext.editor`,
 `$ext.agent`, …) to avoid collisions when more than one tool carries
 state on the same card. `$ext.editor.title` is the canonical slot for a
-per-card display name — the label an editing surface shows when a user
-renames a single card.
+per-card display name (an editor-side rename).
 
 ```
 ~~~

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -117,17 +117,10 @@ namespace inside the map (`$ext.editor`, `$ext.agent`, …) to avoid
 collisions when more than one tool carries state on the same card. See
 [markdown-spec.md §3.3](../references/markdown-spec.md) for the full specification.
 
-**`$ext.editor.title`** is the canonical home for a per-card display
-name — the human-readable label an editing surface shows for a single
-card instance, set when a user renames a card in the UI. It is distinct
-from `ui.title` (the schema-level, per-*kind* label, optionally a
-`{field}` template) and from any user field: a display rename is editor
-state, so it lives in `$ext` and never reaches the backend. A consumer
-that needs a card's display name reads `$ext.editor.title` and falls
-back to the kind's `ui.title` when absent. The `editor` namespace is the
-blessed slot for the editing surface's state; the broader
-`$ext.<namespace>` convention still holds, so other tools keep their own
-namespaces.
+`$ext.editor.title` is the canonical slot for a per-card display name —
+the label an editing surface shows when a user renames one card
+instance. It overrides the per-*kind* `ui.title` and, being editor
+state, never reaches the backend.
 
 ## Per-kind Seed Overlays (`$seed`)
 

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -113,9 +113,21 @@ annotations, anything bespoke to a UI consumer — belongs in the card's
 mapping that round-trips through Markdown and the storage DTO but is
 stripped from `Document::to_plate_json()` before backends see it, so
 template renders are not affected by editor state. Consumers
-namespace inside the map (`$ext.presentation`, `$ext.agent`, …) to avoid
+namespace inside the map (`$ext.editor`, `$ext.agent`, …) to avoid
 collisions when more than one tool carries state on the same card. See
 [markdown-spec.md §3.3](../references/markdown-spec.md) for the full specification.
+
+**`$ext.editor.title`** is the canonical home for a per-card display
+name — the human-readable label an editing surface shows for a single
+card instance, set when a user renames a card in the UI. It is distinct
+from `ui.title` (the schema-level, per-*kind* label, optionally a
+`{field}` template) and from any user field: a display rename is editor
+state, so it lives in `$ext` and never reaches the backend. A consumer
+that needs a card's display name reads `$ext.editor.title` and falls
+back to the kind's `ui.title` when absent. The `editor` namespace is the
+blessed slot for the editing surface's state; the broader
+`$ext.<namespace>` convention still holds, so other tools keep their own
+namespaces.
 
 ## Per-kind Seed Overlays (`$seed`)
 

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -196,7 +196,8 @@ author wrote the line.
   rejected. Contents are carried verbatim through Markdown and storage
   DTO round-trips, and **never** appear in the plate JSON consumed by
   backends (§5). Bespoke consumers namespace their state inside the
-  map — e.g. `$ext.presentation.title` for an editor-side card rename.
+  map — e.g. `$ext.editor.title` for an editor-side card rename (the
+  canonical slot for a per-card display name).
   An empty `$ext: {}` is preserved as a distinct, explicit declaration.
 - **`$seed: <mapping>`** — an optional **mapping keyed by composable
   card-kind**, present on the **root block only**; a composable block carrying

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -196,8 +196,8 @@ author wrote the line.
   rejected. Contents are carried verbatim through Markdown and storage
   DTO round-trips, and **never** appear in the plate JSON consumed by
   backends (§5). Bespoke consumers namespace their state inside the
-  map — e.g. `$ext.editor.title` for an editor-side card rename (the
-  canonical slot for a per-card display name).
+  map — e.g. `$ext.editor.title`, the canonical slot for a per-card
+  display name (an editor-side rename).
   An empty `$ext: {}` is preserved as a distinct, explicit declaration.
 - **`$seed: <mapping>`** — an optional **mapping keyed by composable
   card-kind**, present on the **root block only**; a composable block carrying


### PR DESCRIPTION
## Summary

Standardizes the `$ext.editor.title` namespace as the canonical slot for per-card display names (editor-side renames), replacing the previous `$ext.presentation` example throughout the codebase and documentation.

## Changes

- **Test updates**: Changed all test cases in `basic.test.js` from `presentation` to `editor` namespace to reflect the new standard
- **Documentation**: Updated references across multiple docs:
  - `docs/authoring/cards.md`: Added explicit note that `$ext.editor.title` is the canonical slot for per-card display names
  - `prose/canon/CARDS.md`: Documented `$ext.editor.title` as the standard for editor-side card renames, with clarification that it overrides per-kind `ui.title` and never reaches the backend
  - `prose/references/markdown-spec.md`: Updated example to use `$ext.editor.title` as the canonical per-card display name slot
- **Code comments**: Updated Rust documentation in `crates/core/src/document/edit.rs` and `crates/bindings/wasm/src/engine.rs` to reference `$ext.editor` instead of `$ext.presentation`
- **Changelog**: Added entry documenting the canonization of `$ext.editor.title`

## Implementation Details

This is a documentation and naming standardization change with no functional code modifications. The `$ext` namespace mechanism itself remains unchanged; this PR simply establishes `editor` as the reserved namespace for editor-side state and `title` as the standard key for per-card display names, making the API contract explicit and consistent across all documentation and examples.

https://claude.ai/code/session_017ZokDhzY7JAv1vJkoHzRrf