### PR TITLE
Accept uppercase field names; reserve only `$`-prefixed keys

### DIFF
--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -125,20 +125,13 @@ def test_set_field_updates():
     assert field(doc.main, "title") == "New Title"
 
 
-def test_set_field_legacy_uppercase_rejected_matrix():
-    """set_field raises InvalidFieldName for uppercase field names."""
-    for name in ("BODY", "CARDS", "QUILL", "CARD"):
-        doc = Document.from_markdown(SIMPLE_MD)
-        with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-            doc.set_field(name, "value")
-
-
-def test_card_set_field_legacy_uppercase_rejected_matrix():
-    """Card update_card_field raises InvalidFieldName for uppercase field names."""
-    for name in ("BODY", "CARDS", "QUILL", "CARD"):
-        doc = Document.from_markdown(MD_WITH_CARDS)
-        with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-            doc.update_card_field(0, name, "value")
+def test_set_field_uppercase_accepted():
+    """set_field accepts uppercase field names verbatim (lowercase is canonical
+    but not enforced); only `$`-prefixed keys stay reserved."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    for name in ("BODY", "CARDS", "Title", "MixedCase_1"):
+        doc.set_field(name, "value")
+        assert field(doc.main, name) == "value"
 
 
 def test_set_field_dollar_prefix_rejected_matrix():
@@ -150,10 +143,10 @@ def test_set_field_dollar_prefix_rejected_matrix():
 
 
 def test_set_field_invalid_field_name():
-    """set_field raises EditError for an uppercase/invalid name."""
+    """set_field raises EditError for an invalid name (hyphen not allowed)."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-        doc.set_field("Title", "value")
+        doc.set_field("bad-name", "value")
 
 
 def test_remove_field_existing():
@@ -168,13 +161,6 @@ def test_remove_field_absent():
     """remove_field returns None when the field doesn't exist."""
     doc = Document.from_markdown(SIMPLE_MD)
     assert doc.remove_field("nonexistent") is None
-
-
-def test_remove_field_legacy_uppercase_rejected():
-    """remove_field raises InvalidFieldName for uppercase field names."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-        doc.remove_field("BODY")
 
 
 def test_set_quill_ref():
@@ -305,13 +291,6 @@ def test_update_card_field():
     doc = Document.from_markdown(MD_WITH_CARDS)
     doc.update_card_field(0, "content", "hello")
     assert field(doc.cards[0], "content") == "hello"
-
-
-def test_update_card_field_legacy_uppercase_rejected():
-    """update_card_field raises InvalidFieldName for uppercase field names."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-        doc.update_card_field(0, "BODY", "value")
 
 
 def test_update_card_field_out_of_range():
@@ -453,7 +432,7 @@ def test_invariants_after_mutation_sequence():
     doc.remove_field("extra_author")
 
     # Assertions: every payload key passes the user-field regex.
-    field_name_re = re.compile(r"^[a-z_][a-z0-9_]*$")
+    field_name_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
     for key in field_keys(doc.main):
         assert field_name_re.match(key), f"invalid key '{key}' found in payload"
 

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -298,18 +298,6 @@ def test_remove_card_field_out_of_range():
         doc.remove_card_field(0, "foo")
 
 
-def test_remove_card_field_legacy_uppercase_rejected():
-    """remove_card_field rejects legacy uppercase names as InvalidFieldName."""
-
-    md = (
-        "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\nBody.\n\n"
-        "~~~card-yaml\n$kind: note\n~~~\n"
-    )
-    doc = Document.from_markdown(md)
-    with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-        doc.remove_card_field(0, "BODY")
-
-
 def test_diagnostic_str_is_canonical_pretty_text():
     """str(diagnostic) is the canonical pretty-printed text; repr is concise."""
     warn_md = (

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -263,6 +263,16 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     expect(restored.warnings.length).toBe(0)
   })
 
+  it('fromJson accepts a stored DTO with an uppercase field name', () => {
+    // Regression: uppercase data-field names (e.g. PRESENTATION) are valid
+    // user fields — only `$`-prefixed keys are reserved — so a stored DTO
+    // carrying one must deserialize and round-trip verbatim.
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setField('PRESENTATION', 'deck')
+    const restored = Document.fromJson(doc.toJson())
+    expect(field(restored.main, 'PRESENTATION')).toBe('deck')
+  })
+
   it('fromJson rejects an unknown schema version', () => {
     expect(() =>
       Document.fromJson('{"schema":"quillmark/document@0.99.0","main":{}}'),
@@ -447,10 +457,11 @@ describe('Document editor surface — setField / removeField', () => {
     expect(field(doc.main, 'title')).toBe('Updated')
   })
 
-  it('setField throws EditError::InvalidFieldName for uppercase field names (BODY, CARDS, QUILL, CARD)', () => {
+  it('setField accepts uppercase field names verbatim (lowercase is canonical, not enforced)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    for (const name of ['BODY', 'CARDS', 'QUILL', 'CARD']) {
-      expect(() => doc.setField(name, 'x')).toThrow(/InvalidFieldName/)
+    for (const name of ['BODY', 'CARDS', 'Title', 'MixedCase_1']) {
+      doc.setField(name, 'x')
+      expect(field(doc.main, name)).toBe('x')
     }
   })
 
@@ -461,9 +472,9 @@ describe('Document editor surface — setField / removeField', () => {
     }
   })
 
-  it('setField throws EditError::InvalidFieldName for uppercase name', () => {
+  it('setField throws EditError::InvalidFieldName for an invalid name (hyphen)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setField('Title', 'x')).toThrow(/InvalidFieldName/)
+    expect(() => doc.setField('bad-name', 'x')).toThrow(/InvalidFieldName/)
   })
 
   it('removeField returns the removed value', () => {
@@ -478,23 +489,11 @@ describe('Document editor surface — setField / removeField', () => {
     expect(doc.removeField('nonexistent')).toBeUndefined()
   })
 
-  it('removeField throws EditError::InvalidFieldName for uppercase field names (BODY, CARDS, QUILL, CARD)', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    for (const name of ['BODY', 'CARDS', 'QUILL', 'CARD']) {
-      expect(() => doc.removeField(name)).toThrow(/InvalidFieldName/)
-    }
-  })
-
   it('removeField throws EditError::InvalidFieldName for `$`-prefixed names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     for (const name of ['$body', '$cards', '$quill', '$kind']) {
       expect(() => doc.removeField(name)).toThrow(/InvalidFieldName/)
     }
-  })
-
-  it('removeField throws EditError::InvalidFieldName for uppercase name', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.removeField('Title')).toThrow(/InvalidFieldName/)
   })
 })
 
@@ -732,9 +731,10 @@ Card body.
     expect(field(doc.cards[0], 'content')).toBe('hello')
   })
 
-  it('updateCardField throws EditError::InvalidFieldName for uppercase names', () => {
+  it('updateCardField accepts uppercase names verbatim', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    expect(() => doc.updateCardField(0, 'BODY', 'x')).toThrow(/InvalidFieldName/)
+    doc.updateCardField(0, 'BODY', 'x')
+    expect(field(doc.cards[0], 'BODY')).toBe('x')
   })
 
   it('updateCardField throws IndexOutOfRange when card absent', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -659,7 +659,7 @@ impl Document {
 
     /// Update a payload field on the main card. Clears any existing `!must_fill` marker.
     ///
-    /// Throws if `name` does not match `[a-z_][a-z0-9_]*`.
+    /// Throws if `name` does not match `[A-Za-z_][A-Za-z0-9_]*`.
     #[wasm_bindgen(js_name = setField)]
     pub fn set_field(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
         let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
@@ -686,7 +686,7 @@ impl Document {
     }
 
     /// Remove a payload field on the main card, returning the removed value or
-    /// `undefined`. Throws if `name` does not match `[a-z_][a-z0-9_]*`.
+    /// `undefined`. Throws if `name` does not match `[A-Za-z_][A-Za-z0-9_]*`.
     #[wasm_bindgen(js_name = removeField)]
     pub fn remove_field(&mut self, name: &str) -> Result<JsValue, JsValue> {
         let removed = self

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -393,7 +393,7 @@ fn validate_parsed_field(key: &str, value: &serde_json::Value) -> Result<(), Par
     use crate::document::edit::{validate_field, FieldViolation};
     validate_field(key, value).map_err(|v| match v {
         FieldViolation::InvalidName => ParseError::InvalidStructure(format!(
-            "invalid data-field name `{}`: field names must match [a-z_][a-z0-9_]*",
+            "invalid data-field name `{}`: field names must match [A-Za-z_][A-Za-z0-9_]*",
             key
         )),
         FieldViolation::TooDeep => ParseError::InvalidStructure(format!(

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -538,7 +538,7 @@ impl TryFrom<PayloadItemV0_92_0> for PayloadItem {
                 validate_field(&key, &value).map_err(|v| {
                     StorageError::Malformed(match v {
                         FieldViolation::InvalidName => {
-                            format!("invalid field name {key:?}: must match [a-z_][a-z0-9_]*")
+                            format!("invalid field name {key:?}: must match [A-Za-z_][A-Za-z0-9_]*")
                         }
                         FieldViolation::TooDeep => format!(
                             "field {key:?} nests deeper than the maximum of {} levels",

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -1,7 +1,7 @@
 //! Typed mutators for [`Document`] and [`Card`] with invariant enforcement.
 //!
 //! Every successful mutator leaves the document with every user field name
-//! matching `[a-z_][a-z0-9_]*` and every composable `$kind` passing
+//! matching `[A-Za-z_][A-Za-z0-9_]*` and every composable `$kind` passing
 //! `meta::is_valid_kind_name`, so the result is safely serializable via
 //! [`Document::to_plate_json`]. Mutators never modify `warnings` — those
 //! are immutable parse-time observations.
@@ -23,7 +23,12 @@ use crate::document::{Card, Document, Payload};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
-/// `true` if `name` matches `[a-z_][a-z0-9_]*` after NFC normalisation.
+/// `true` if `name` matches `[A-Za-z_][A-Za-z0-9_]*` after NFC normalisation.
+///
+/// Lowercase is the recommended (canonical) convention, but uppercase ASCII
+/// letters are accepted and preserved verbatim. Collision-safety with system
+/// metadata comes entirely from the `$`-prefix exclusion — `$`-prefixed keys
+/// are reserved, so a user field can never shadow one regardless of case.
 pub fn is_valid_field_name(name: &str) -> bool {
     let normalized: String = name.nfc().collect();
     if normalized.is_empty() {
@@ -31,11 +36,11 @@ pub fn is_valid_field_name(name: &str) -> bool {
     }
     let mut chars = normalized.chars();
     let first = chars.next().unwrap();
-    if !first.is_ascii_lowercase() && first != '_' {
+    if !first.is_ascii_alphabetic() && first != '_' {
         return false;
     }
     for ch in chars {
-        if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '_' {
+        if !ch.is_ascii_alphanumeric() && ch != '_' {
             return false;
         }
     }
@@ -45,7 +50,7 @@ pub fn is_valid_field_name(name: &str) -> bool {
 /// Errors returned by document and card mutators.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum EditError {
-    #[error("invalid field name '{0}': must match [a-z_][a-z0-9_]*")]
+    #[error("invalid field name '{0}': must match [A-Za-z_][A-Za-z0-9_]*")]
     InvalidFieldName(String),
 
     #[error("invalid card kind '{0}': must match [a-z_][a-z0-9_]*")]
@@ -80,12 +85,12 @@ impl EditError {
 ///
 /// Each boundary maps it to its own error type (`ParseError`,
 /// `StorageError`, `WireError`, `EditError`), so the invariant — every user
-/// field name matches `[a-z_][a-z0-9_]*` and no value nests past the §8
+/// field name matches `[A-Za-z_][A-Za-z0-9_]*` and no value nests past the §8
 /// depth limit — is enforced once, here, and a constructed `Document` can
 /// never violate it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FieldViolation {
-    /// The field name does not match `[a-z_][a-z0-9_]*` (spec §3.4 / §10).
+    /// The field name does not match `[A-Za-z_][A-Za-z0-9_]*` (spec §3.4 / §10).
     InvalidName,
     /// The value nests deeper than [`MAX_YAML_DEPTH`](crate::document::limits::MAX_YAML_DEPTH)
     /// (spec §8).
@@ -237,7 +242,7 @@ impl Card {
     /// Set a payload field, clearing any `!must_fill` marker on that key.
     ///
     /// Returns [`EditError::InvalidFieldName`] when `name` does not match
-    /// `[a-z_][a-z0-9_]*`.
+    /// `[A-Za-z_][A-Za-z0-9_]*`.
     pub fn set_field(&mut self, name: &str, value: QuillValue) -> Result<(), EditError> {
         check_field(name, value.as_json())?;
         self.payload_mut().insert(name.to_string(), value);

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -659,7 +659,7 @@ fn emit_key(out: &mut String, key: &str) {
 }
 
 /// Emit a mapping key at `indent`. Top-level field names (indent 0) are emitted
-/// verbatim: the line-oriented prescan accepts only bare `[a-z_][a-z0-9_]*`
+/// verbatim: the line-oriented prescan accepts only bare `[A-Za-z_][A-Za-z0-9_]*`
 /// field names there, so quoting one would make it unparseable. Nested keys
 /// (indent > 0) route through [`emit_key`] for correct YAML quoting.
 fn emit_key_at(out: &mut String, key: &str, indent: usize) {

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -280,8 +280,8 @@ impl Document {
     ///
     /// `$`-prefixed keys carry document-level metadata (quill ref, body
     /// text, card list, card kind). User payload fields stay flat at the
-    /// root — they cannot collide with `$` keys because field names must
-    /// match `[a-z_][a-z0-9_]*`.
+    /// root — they cannot collide with `$` keys because user field names are
+    /// never `$`-prefixed (they match `[A-Za-z_][A-Za-z0-9_]*`).
     pub fn to_plate_json(&self) -> serde_json::Value {
         let mut map = serde_json::Map::new();
 

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -338,7 +338,7 @@ impl Payload {
 
     /// Mutable access to the raw item list. Callers must preserve the
     /// invariants (at most one `Quill`/`Kind`/`Id`/`Ext`, no duplicate
-    /// field keys, every field name matches `[a-z_][a-z0-9_]*`) — use
+    /// field keys, every field name matches `[A-Za-z_][A-Za-z0-9_]*`) — use
     /// the typed mutators when in doubt.
     pub fn items_mut(&mut self) -> &mut [PayloadItem] {
         &mut self.items

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -534,11 +534,12 @@ Item 1 body";
 }
 
 #[test]
-fn test_uppercase_payload_keys_rejected_at_parse() {
-    // Spec §3.4/§10: data-field names must match [a-z_][a-z0-9_]*, enforced
-    // at parse time — the same invariant the mutators and DTO/wire paths
-    // enforce, so a constructed Document can never hold a non-conforming
-    // name (which would also break the bare-key emit round-trip).
+fn test_uppercase_payload_keys_accepted_at_parse() {
+    // Spec §3.4: data-field names match [A-Za-z_][A-Za-z0-9_]*. The legacy
+    // uppercase reservation is gone (only `$`-prefixed keys are system
+    // metadata since the 0.83 plate-JSON cutover), so uppercase user fields
+    // parse, are preserved verbatim (case is significant), and round-trip
+    // bare through emit.
     let markdown = "~~~card-yaml
 $quill: test_quill
 $kind: main
@@ -549,10 +550,20 @@ $kind: section
 BODY: Test
 ~~~";
 
-    let err = decompose(markdown).unwrap_err();
+    let doc = decompose(markdown).unwrap();
+    assert_eq!(
+        doc.cards()[0]
+            .payload()
+            .get("BODY")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        "Test"
+    );
+    // Verbatim, no lowercasing: the uppercase key survives emit unquoted.
     assert!(
-        err.to_string().contains("BODY"),
-        "non-conforming field name is a parse error naming the key: {err}"
+        doc.to_markdown().contains("BODY: Test"),
+        "uppercase field name must round-trip bare and verbatim"
     );
 }
 
@@ -1481,7 +1492,8 @@ fn test_payload_at_eof_no_trailing_newline() {
 #[test]
 fn test_unicode_in_yaml_keys() {
     // Unicode is welcome in *values* (next test); field *names* are
-    // restricted to [a-z_][a-z0-9_]* (spec §3.4) and rejected at parse.
+    // restricted to ASCII [A-Za-z_][A-Za-z0-9_]* (spec §3.4), so a non-ASCII
+    // name is rejected at parse.
     let markdown =
         "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitre: Bonjour\nタイトル: こんにちは\n~~~\n\nBody.";
     let err = decompose(markdown).unwrap_err();

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -42,17 +42,19 @@ fn test_valid_field_names() {
     assert!(is_valid_field_name("a1b2c3"));
     assert!(is_valid_field_name("x"));
     assert!(is_valid_field_name("_"));
+    // Uppercase is accepted (lowercase is canonical but not enforced); case
+    // is significant. The legacy uppercase metadata keys are ordinary fields.
+    assert!(is_valid_field_name("Title"));
+    assert!(is_valid_field_name("BODY"));
+    assert!(is_valid_field_name("MixedCase_1"));
 }
 
 #[test]
 fn test_invalid_field_names() {
     assert!(!is_valid_field_name(""));
-    assert!(!is_valid_field_name("Title")); // uppercase
     assert!(!is_valid_field_name("123abc")); // starts with digit
     assert!(!is_valid_field_name("my-field")); // hyphen not allowed
     assert!(!is_valid_field_name("my field")); // space not allowed
-    assert!(!is_valid_field_name("BODY")); // uppercase
-    assert!(!is_valid_field_name("CARDS")); // uppercase
     assert!(!is_valid_field_name("$body")); // $-prefix reserved for metadata
 }
 
@@ -82,13 +84,13 @@ fn test_edit_error_display() {
         .contains("3"));
 }
 
-// ── Uppercase/`$`-prefixed names: Document::set_field ────────────────────────
+// ── `$`-prefixed names: Document::set_field ──────────────────────────────────
 
 #[test]
-fn test_document_set_field_rejects_legacy_uppercase_names() {
-    // Uppercase and `$`-prefixed names are rejected by the field-name regex
-    // like any other invalid input.
-    for name in ["BODY", "CARDS", "QUILL", "CARD", "$body", "$cards"] {
+fn test_document_set_field_rejects_dollar_prefixed_names() {
+    // `$`-prefixed keys are reserved for system metadata — the surviving
+    // field-name reservation (uppercase is now accepted).
+    for name in ["$body", "$cards", "$quill", "$kind"] {
         let mut doc = make_doc();
         let result = doc.main_mut().set_field(name, qv("value"));
         assert_eq!(
@@ -140,15 +142,18 @@ fn test_document_remove_field_absent() {
 }
 
 #[test]
-fn test_document_remove_field_legacy_uppercase_rejected() {
-    // Symmetric with set_field: uppercase names are rejected like any other
-    // invalid field name.
+fn test_document_field_legacy_uppercase_accepted() {
+    // The legacy uppercase metadata keys are now ordinary valid field names:
+    // set them, read them back verbatim, and remove them. Only `$`-prefixed
+    // keys remain reserved.
     let mut doc = make_doc();
     for name in ["BODY", "CARDS", "QUILL", "CARD"] {
-        match doc.main_mut().remove_field(name) {
-            Err(EditError::InvalidFieldName(got)) => assert_eq!(got, name),
-            other => panic!("expected InvalidFieldName for {name}, got {other:?}"),
-        }
+        doc.main_mut()
+            .set_field(name, qv("v"))
+            .unwrap_or_else(|e| panic!("expected {name} to be accepted, got {e:?}"));
+        assert_eq!(doc.main().payload().get(name).unwrap().as_str().unwrap(), "v");
+        let removed = doc.main_mut().remove_field(name).unwrap();
+        assert_eq!(removed.unwrap().as_str().unwrap(), "v");
     }
 }
 
@@ -377,10 +382,10 @@ fn test_card_set_field_valid() {
 #[test]
 fn test_card_set_field_invalid_name() {
     let mut card = Card::new("note").unwrap();
-    let result = card.set_field("Content", qv("text"));
+    let result = card.set_field("bad-name", qv("text"));
     assert_eq!(
         result,
-        Err(EditError::InvalidFieldName("Content".to_string()))
+        Err(EditError::InvalidFieldName("bad-name".to_string()))
     );
 }
 
@@ -400,17 +405,6 @@ fn test_card_remove_field_existing() {
 fn test_card_remove_field_absent() {
     let mut card = Card::new("note").unwrap();
     assert!(card.remove_field("nonexistent").unwrap().is_none());
-}
-
-#[test]
-fn test_card_remove_field_legacy_uppercase_rejected() {
-    let mut card = Card::new("note").unwrap();
-    for name in ["BODY", "CARDS", "QUILL", "CARD"] {
-        match card.remove_field(name) {
-            Err(EditError::InvalidFieldName(got)) => assert_eq!(got, name),
-            other => panic!("expected InvalidFieldName for {name}, got {other:?}"),
-        }
-    }
 }
 
 #[test]
@@ -761,7 +755,7 @@ fn wire_card_rejects_value_past_depth_limit_and_bad_names() {
     .unwrap();
     let err = crate::document::Card::try_from(wire).unwrap_err();
     assert!(
-        err.to_string().contains("[a-z_]"),
+        err.to_string().contains("[A-Za-z_]"),
         "expected name error, got {err}"
     );
 }

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -151,7 +151,10 @@ fn test_document_field_legacy_uppercase_accepted() {
         doc.main_mut()
             .set_field(name, qv("v"))
             .unwrap_or_else(|e| panic!("expected {name} to be accepted, got {e:?}"));
-        assert_eq!(doc.main().payload().get(name).unwrap().as_str().unwrap(), "v");
+        assert_eq!(
+            doc.main().payload().get(name).unwrap().as_str().unwrap(),
+            "v"
+        );
         let removed = doc.main_mut().remove_field(name).unwrap();
         assert_eq!(removed.unwrap().as_str().unwrap(), "v");
     }

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -134,7 +134,7 @@ pub enum WireError {
     /// The `quill` string is not a valid `name@version` reference.
     InvalidQuillReference { value: String, reason: String },
     /// A field violates the payload invariant: a name failing
-    /// `[a-z_][a-z0-9_]*`, or a value (including `$ext`) nesting past the
+    /// `[A-Za-z_][A-Za-z0-9_]*`, or a value (including `$ext`) nesting past the
     /// §8 depth limit.
     InvalidField { key: String, reason: String },
 }
@@ -299,7 +299,7 @@ fn validate_wire_field(key: &str, value: &JsonValue) -> Result<(), WireError> {
     validate_field(key, value).map_err(|v| WireError::InvalidField {
         key: key.to_string(),
         reason: match v {
-            FieldViolation::InvalidName => "field names must match [a-z_][a-z0-9_]*".to_string(),
+            FieldViolation::InvalidName => "field names must match [A-Za-z_][A-Za-z0-9_]*".to_string(),
             FieldViolation::TooDeep => format!(
                 "nests deeper than the maximum of {} levels",
                 crate::document::limits::MAX_YAML_DEPTH

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -299,7 +299,9 @@ fn validate_wire_field(key: &str, value: &JsonValue) -> Result<(), WireError> {
     validate_field(key, value).map_err(|v| WireError::InvalidField {
         key: key.to_string(),
         reason: match v {
-            FieldViolation::InvalidName => "field names must match [A-Za-z_][A-Za-z0-9_]*".to_string(),
+            FieldViolation::InvalidName => {
+                "field names must match [A-Za-z_][A-Za-z0-9_]*".to_string()
+            }
             FieldViolation::TooDeep => format!(
                 "nests deeper than the maximum of {} levels",
                 crate::document::limits::MAX_YAML_DEPTH

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -16,12 +16,12 @@
 //!
 //! ```text
 //! path        := segment ( "." field_name | "[" index "]" )*
-//! field_name  := [a-z_][a-z0-9_]*       // same charset enforced for fields/kinds
+//! field_name  := [A-Za-z_][A-Za-z0-9_]*  // card kinds use lowercase-only [a-z_][a-z0-9_]*
 //! index       := [0-9]+
 //! ```
 //!
-//! Because field names and card kinds are validated to that charset (no `.`,
-//! `[`, `]`, or whitespace), the dotted form round-trips unambiguously.
+//! Because field names and card kinds are validated to charsets that exclude
+//! `.`, `[`, `]`, and whitespace, the dotted form round-trips unambiguously.
 //!
 //! | Anchor                     | Path                                      |
 //! |----------------------------|-------------------------------------------|

--- a/crates/fixtures/resources/extended_metadata_demo.md
+++ b/crates/fixtures/resources/extended_metadata_demo.md
@@ -59,5 +59,5 @@ Ideal for content-heavy sites where each item needs its own metadata (price, cat
 - **Card kind pattern**: `[a-z_][a-z0-9_]*`
 - **Blank lines**: Allowed within card-yaml blocks
 - **Card syntax**: a `~~~` block declaring `$kind: <kind>`, preceded by a blank line
-- **Field names**: must match `[a-z_][a-z0-9_]*` — uppercase and `$`-prefixed keys are rejected so user payload can never shadow the `$`-prefixed plate-JSON metadata (`$quill`, `$body`, `$cards`, `$kind`)
+- **Field names**: must match `[A-Za-z_][A-Za-z0-9_]*` — only `$`-prefixed keys are rejected, so user payload can never shadow the `$`-prefixed plate-JSON metadata (`$quill`, `$body`, `$cards`, `$kind`); lowercase is canonical but uppercase is accepted and preserved verbatim
 - **Collections**: The same card kind creates an array of objects

--- a/docs/authoring/card-yaml.md
+++ b/docs/authoring/card-yaml.md
@@ -147,7 +147,9 @@ object, properties: … }` for a list of objects). Nesting beyond one level is
 not supported. See
 [Quill.yaml Reference: Field Types](../quills/quill-yaml-reference.md#field-types).
 
-Field names must match `[a-z_][a-z0-9_]*`.
+Field names must match `[A-Za-z_][A-Za-z0-9_]*`. Lowercase is the canonical,
+recommended convention, but uppercase is accepted and preserved verbatim (case
+is significant). Only `$`-prefixed keys are reserved for system metadata.
 
 ## Comments
 

--- a/docs/authoring/cards.md
+++ b/docs/authoring/cards.md
@@ -50,8 +50,10 @@ All card blocks are collected into the plate JSON's `$cards` array.
   card kind. The kind must match `[a-z_][a-z0-9_]*` and must not be `main`
   (reserved for the document root). Invalid examples: `BadCard`, `my-card`,
   `2nd_card`, `main`.
-- Field names must match `[a-z_][a-z0-9_]*`. Uppercase and `$`-prefixed
-  keys are reserved for system metadata and cannot be used as user fields.
+- Field names must match `[A-Za-z_][A-Za-z0-9_]*`. Lowercase is the canonical
+  convention, but uppercase is accepted and preserved verbatim; only
+  `$`-prefixed keys are reserved for system metadata and cannot be used as
+  user fields.
 - A blank line is required immediately above every `~~~` opener
   (unless the block is the very first line of the document). A `~~~`
   line without a blank line above it is treated as an ordinary code block.

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -233,10 +233,11 @@ User-defined fields sit in the same YAML payload as the `$` metadata keys
 (§3.3); after metadata extraction, the remaining mapping entries are the
 data payload.
 
-- **Field names.** Every field name matches `/^[a-z_][a-z0-9_]*$/`. The
-  pattern excludes `$` and uppercase, so a data field name can never collide
-  with any `$`-prefixed system key and is consistently lowercase across the
-  wire format.
+- **Field names.** Every field name matches `/^[A-Za-z_][A-Za-z0-9_]*$/`. The
+  pattern excludes `$`, so a data field name can never collide with any
+  `$`-prefixed system key. Lowercase is the canonical, recommended convention,
+  but uppercase ASCII letters are accepted and preserved verbatim; case is
+  significant, so `title` and `Title` are distinct fields.
 - **Whitespace-only payload.** A block whose payload (after metadata
   extraction) is only whitespace yields an empty field set.
 - **YAML comments.** Both own-line comments (`# …` on their own line) and


### PR DESCRIPTION
## Summary

This change relaxes the field-name validation to accept uppercase ASCII letters in user-defined field names. Previously, field names were restricted to lowercase `[a-z_][a-z0-9_]*`; they now match `[A-Za-z_][A-Za-z0-9_]*`. The legacy uppercase metadata keys (`BODY`, `CARDS`, `QUILL`, `CARD`) are now treated as ordinary user fields. Only `$`-prefixed keys remain reserved for system metadata.

## Key Changes

- **Field-name validation** (`crate::document::edit::is_valid_field_name`):
  - Updated regex from `[a-z_][a-z0-9_]*` to `[A-Za-z_][A-Za-z0-9_]*`
  - Uppercase letters are now accepted and preserved verbatim
  - Case is significant: `title` and `Title` are distinct fields
  - Lowercase remains the canonical, recommended convention

- **Test updates**:
  - Removed tests that expected uppercase names to be rejected
  - Added tests confirming uppercase names are accepted and round-trip verbatim
  - Updated field-name regex patterns in test assertions across Rust, Python, and WASM bindings

- **Documentation updates**:
  - Updated markdown spec (§3.4) to reflect new field-name pattern
  - Updated card authoring guides to clarify that uppercase is accepted but lowercase is canonical
  - Updated error messages and docstrings to reference the new pattern

- **Binding updates**:
  - Python: Replaced tests rejecting uppercase with tests accepting them
  - WASM: Updated test expectations and added regression test for uppercase field round-tripping
  - Updated JSDoc and docstrings in WASM engine

## Implementation Details

- The change is backward-compatible: existing lowercase field names continue to work unchanged
- Collision safety with system metadata now depends entirely on the `$`-prefix exclusion, not on case restrictions
- Field names are normalized via NFC before validation, consistent with existing behavior
- The uppercase acceptance applies uniformly across all mutation paths: `Document::set_field`, `Card::set_field`, parsing, DTO deserialization, and wire format validation

https://claude.ai/code/session_018i1HLJF9kLtNRS3m3fQzQ9