### PR TITLE
docs(blueprint): fix $-line comment inaccuracies in canon

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -20,12 +20,13 @@
 //!   shippable as-is; an **Unendorsed** cell (no `default:`) carries the
 //!   `!must_fill` marker on the value line (`field: !must_fill`, or
 //!   `field: !must_fill <example>` when an example supplies a suggested value).
-//! - **Metadata annotation.** The `$quill` / `$kind` system-metadata lines
-//!   have no inline-annotation slot. The root block emits no role
-//!   annotation — the `$` sigil marks its lines as fixed system metadata,
-//!   and BLUEPRINT.md documents that `$quill` must not be modified. A
-//!   composable card emits its `composable (0..N)` role as an own-line
-//!   `# …` comment directly under the `$kind` line.
+//! - **Metadata annotation.** The root `$quill` line carries an inline
+//!   `# keep verbatim — do not drop` reminder: an in-band nudge against the
+//!   `parse::missing_quill` failure where an LLM author omits the line
+//!   (experimental — see issue #734). `$kind` carries no such reminder; an
+//!   omitted root `$kind: main` is synthesised at parse time, so it is not a
+//!   hard requirement. A composable card emits its `composable (0..N)` role
+//!   as an own-line `# …` comment directly under the `$kind` line.
 //! - **Body regions** are signalled by `Write main body here.` after the main
 //!   fence and `Write <card kind> body here.` after each card fence. When
 //!   `body.example` is set, the example text is embedded verbatim instead.
@@ -100,11 +101,12 @@ fn write_comment(out: &mut String, text: &str) {
 }
 
 /// Emit the root block:
-/// `~~~\n$quill: …\n$kind: main\n[# desc\n]<fields>~~~\n`.
+/// `~~~\n$quill: …  # keep verbatim — do not drop\n$kind: main\n[# desc\n]<fields>~~~\n`.
 ///
-/// The `$quill` system-metadata line leads the block; the optional
-/// description follows as an own-line comment. No role annotation is
-/// emitted — the `$` sigil marks the line as fixed system metadata.
+/// The `$quill` system-metadata line leads the block, carrying an inline
+/// `# keep verbatim — do not drop` reminder against the `parse::missing_quill`
+/// failure where an author drops it (experimental — see issue #734). The
+/// optional description follows as an own-line comment.
 fn write_main_fence(
     out: &mut String,
     card: &CardSchema,
@@ -116,7 +118,7 @@ fn write_main_fence(
     out.push_str(&saphyr_emit_scalar(&JsonValue::String(
         quill_ref.to_string(),
     )));
-    out.push('\n');
+    out.push_str("  # keep verbatim — do not drop\n");
     out.push_str("$kind: main\n");
     if let Some(desc) = description {
         write_comment(out, desc);
@@ -756,7 +758,7 @@ main:
     }
 
     #[test]
-    fn root_header_emits_no_role_comment() {
+    fn root_header_carries_quill_reminder_and_no_role_comment() {
         let t = cfg(r#"
 quill: { name: taro, version: 0.1.0, backend: typst, description: x }
 main:
@@ -764,10 +766,12 @@ main:
     flavor: { type: string, default: taro }
 "#)
         .blueprint();
-        // The root header goes straight from `$kind: main` to the
-        // description — no `# system metadata` role comment. The `$` sigil
-        // marks the lines as fixed; BLUEPRINT.md carries the instruction.
-        assert!(t.starts_with("~~~\n$quill: taro@0.1.0\n$kind: main\n# x\n"));
+        // The root `$quill` line carries the inline "keep verbatim" reminder
+        // (issue #734); `$kind: main` then goes straight to the description with
+        // no own-line role comment (the root has no `composable` cardinality).
+        assert!(t.starts_with(
+            "~~~\n$quill: taro@0.1.0  # keep verbatim — do not drop\n$kind: main\n# x\n"
+        ));
         assert!(t.contains("\nWrite main body here.\n"));
     }
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -21,12 +21,12 @@
 //!   `!must_fill` marker on the value line (`field: !must_fill`, or
 //!   `field: !must_fill <example>` when an example supplies a suggested value).
 //! - **Metadata annotation.** The root `$quill` line carries an inline
-//!   `# keep verbatim — do not drop` reminder: an in-band nudge against the
-//!   `parse::missing_quill` failure where an LLM author omits the line
-//!   (experimental — see issue #734). `$kind` carries no such reminder; an
-//!   omitted root `$kind: main` is synthesised at parse time, so it is not a
-//!   hard requirement. A composable card emits its `composable (0..N)` role
-//!   as an own-line `# …` comment directly under the `$kind` line.
+//!   `# keep verbatim — do not drop` reminder: an in-band guard against the
+//!   `parse::missing_quill` failure where an LLM author omits the line.
+//!   `$kind` carries no such reminder; an omitted root `$kind: main` is
+//!   synthesised at parse time, so it is not a hard requirement. A composable
+//!   card emits its `composable (0..N)` role as an own-line `# …` comment
+//!   directly under the `$kind` line.
 //! - **Body regions** are signalled by `Write main body here.` after the main
 //!   fence and `Write <card kind> body here.` after each card fence. When
 //!   `body.example` is set, the example text is embedded verbatim instead.
@@ -105,8 +105,8 @@ fn write_comment(out: &mut String, text: &str) {
 ///
 /// The `$quill` system-metadata line leads the block, carrying an inline
 /// `# keep verbatim — do not drop` reminder against the `parse::missing_quill`
-/// failure where an author drops it (experimental — see issue #734). The
-/// optional description follows as an own-line comment.
+/// failure where an author drops it. The optional description follows as an
+/// own-line comment.
 fn write_main_fence(
     out: &mut String,
     card: &CardSchema,
@@ -766,9 +766,9 @@ main:
     flavor: { type: string, default: taro }
 "#)
         .blueprint();
-        // The root `$quill` line carries the inline "keep verbatim" reminder
-        // (issue #734); `$kind: main` then goes straight to the description with
-        // no own-line role comment (the root has no `composable` cardinality).
+        // The root `$quill` line carries the inline "keep verbatim" reminder;
+        // `$kind: main` then goes straight to the description with no own-line
+        // role comment (the root has no `composable` cardinality).
         assert!(t.starts_with(
             "~~~\n$quill: taro@0.1.0  # keep verbatim — do not drop\n$kind: main\n# x\n"
         ));

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -21,7 +21,7 @@
 //!   `!must_fill` marker on the value line (`field: !must_fill`, or
 //!   `field: !must_fill <example>` when an example supplies a suggested value).
 //! - **Metadata annotation.** The root `$quill` line carries an inline
-//!   `# keep verbatim — do not drop` reminder: an in-band guard against the
+//!   `# keep verbatim` reminder: an in-band guard against the
 //!   `parse::missing_quill` failure where an LLM author omits the line.
 //!   `$kind` carries no such reminder; an omitted root `$kind: main` is
 //!   synthesised at parse time, so it is not a hard requirement. A composable
@@ -101,10 +101,10 @@ fn write_comment(out: &mut String, text: &str) {
 }
 
 /// Emit the root block:
-/// `~~~\n$quill: …  # keep verbatim — do not drop\n$kind: main\n[# desc\n]<fields>~~~\n`.
+/// `~~~\n$quill: …  # keep verbatim\n$kind: main\n[# desc\n]<fields>~~~\n`.
 ///
 /// The `$quill` system-metadata line leads the block, carrying an inline
-/// `# keep verbatim — do not drop` reminder against the `parse::missing_quill`
+/// `# keep verbatim` reminder against the `parse::missing_quill`
 /// failure where an author drops it. The optional description follows as an
 /// own-line comment.
 fn write_main_fence(
@@ -118,7 +118,7 @@ fn write_main_fence(
     out.push_str(&saphyr_emit_scalar(&JsonValue::String(
         quill_ref.to_string(),
     )));
-    out.push_str("  # keep verbatim — do not drop\n");
+    out.push_str("  # keep verbatim\n");
     out.push_str("$kind: main\n");
     if let Some(desc) = description {
         write_comment(out, desc);
@@ -770,7 +770,7 @@ main:
         // `$kind: main` then goes straight to the description with no own-line
         // role comment (the root has no `composable` cardinality).
         assert!(t.starts_with(
-            "~~~\n$quill: taro@0.1.0  # keep verbatim — do not drop\n$kind: main\n# x\n"
+            "~~~\n$quill: taro@0.1.0  # keep verbatim\n$kind: main\n# x\n"
         ));
         assert!(t.contains("\nWrite main body here.\n"));
     }

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -17,7 +17,7 @@ free.
 
 ````
 ~~~
-$quill: <name>@<version>
+$quill: <name>@<version>  # keep verbatim — do not drop
 $kind: main
 # <description>
 
@@ -108,19 +108,24 @@ inline type annotation — they are not user-defined data fields, so there
 is no `# <type>` slot to fill. (A `$` line *can* carry an ordinary YAML
 comment: both an inline trailing ` # comment` and an adjacent own-line
 comment parse and round-trip faithfully, exactly like comments on data
-fields — see [markdown-spec.md](../references/markdown-spec.md) §3.3. The
-blueprint emitter simply chooses not to attach one.) The root block's
-`$quill` line is emitted
-verbatim; its value is fixed and must not be modified. The root block
-emits **no role-annotation comment** of its own — the `$` sigil marks its
-lines as system metadata, and this document carries the "do not modify"
-rule, so a `# …` line in that slot would only read as a leading
-annotation for the field below it. A composable
-card's kind is carried in its `$kind: <card_kind>` metadata line. Its
-`composable (0..N)` role is emitted as an own-line `# composable (0..N)`
-comment directly under the `$kind` line, ahead of the card description —
-that comment carries the card's cardinality, which is structural
-information rather than a redundant instruction.
+fields — see [markdown-spec.md](../references/markdown-spec.md) §3.3.)
+
+The root block's `$quill` line is emitted verbatim and carries an inline
+**`# keep verbatim — do not drop`** reminder. This is an in-band nudge
+against the `parse::missing_quill` failure, where an LLM author omits the
+`$quill` line entirely and the document fails to bind to a quill. It is
+**experimental** — added under evaluation (issue #734) and kept only if it
+measurably reduces the omission rate; the eval is the gate, not this doc.
+The reminder rides only on `$quill`: it is the one line whose omission is
+a hard error. `$kind: main` carries no reminder — an omitted root
+`$kind` is synthesised at parse time, so dropping it is not an error, and
+a `# …` line in that slot would only read as a leading annotation for the
+field below it. A composable card's kind is carried in its
+`$kind: <card_kind>` metadata line. Its `composable (0..N)` role is
+emitted as an own-line `# composable (0..N)` comment directly under the
+`$kind` line, ahead of the card description — that comment carries the
+card's cardinality, which is structural information rather than a
+redundant instruction.
 
 Examples:
 
@@ -136,7 +141,7 @@ Examples:
 | `recipient: !must_fill  # array<string>` | Unendorsed array of strings |
 | `date: !must_fill  # datetime<YYYY-MM-DD[Thh:mm:ss]>` | Unendorsed datetime |
 | `severity: !must_fill  # enum<low \| medium \| high>` | Unendorsed enum |
-| `$quill: cmu_letter@0.1.0` | quill binding metadata, emitted verbatim, do not modify |
+| `$quill: cmu_letter@0.1.0  # keep verbatim — do not drop` | quill binding metadata, emitted verbatim; the inline reminder guards against dropping the line (issue #734) |
 | `$kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~` … `~~~` block per instance |
 
 ## Placeholder value precedence
@@ -326,7 +331,7 @@ to prevent corrupting the blueprint's document structure.
 
 ```
 ~~~
-$quill: cmu_letter@0.1.0
+$quill: cmu_letter@0.1.0  # keep verbatim — do not drop
 $kind: main
 # Typeset letters that comply with Carnegie Mellon University letterhead standards.
 

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -19,7 +19,6 @@ free.
 ~~~
 $quill: <name>@<version>
 $kind: main
-# system metadata; verbatim
 # <description>
 
 # <field description>
@@ -104,11 +103,14 @@ instead. The reader's single rule is: a `!must_fill` marker present → fill it;
 a concrete value present → shippable as-is (delete or blank the line to fall
 back to the default).
 
-The `$`-prefixed system-metadata keys (`$quill`, `$kind`, …) have no
-inline-annotation slot — they are not user-defined data fields. (The YAML
-parser accepts a trailing ` # comment` on a `$` line, but the blueprint
-emitter does not attach one, and the canonical form drops every comment
-attached to a `$` line.) The root block's `$quill` line is emitted
+The `$`-prefixed system-metadata keys (`$quill`, `$kind`, …) carry no
+inline type annotation — they are not user-defined data fields, so there
+is no `# <type>` slot to fill. (A `$` line *can* carry an ordinary YAML
+comment: both an inline trailing ` # comment` and an adjacent own-line
+comment parse and round-trip faithfully, exactly like comments on data
+fields — see [markdown-spec.md](../references/markdown-spec.md) §3.3. The
+blueprint emitter simply chooses not to attach one.) The root block's
+`$quill` line is emitted
 verbatim; its value is fixed and must not be modified. The root block
 emits **no role-annotation comment** of its own — the `$` sigil marks its
 lines as system metadata, and this document carries the "do not modify"
@@ -326,7 +328,6 @@ to prevent corrupting the blueprint's document structure.
 ~~~
 $quill: cmu_letter@0.1.0
 $kind: main
-# system metadata; verbatim
 # Typeset letters that comply with Carnegie Mellon University letterhead standards.
 
 # The recipient's name and full mailing address.

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -111,16 +111,13 @@ comment parse and round-trip faithfully, exactly like comments on data
 fields — see [markdown-spec.md](../references/markdown-spec.md) §3.3.)
 
 The root block's `$quill` line is emitted verbatim and carries an inline
-**`# keep verbatim — do not drop`** reminder. This is an in-band nudge
-against the `parse::missing_quill` failure, where an LLM author omits the
-`$quill` line entirely and the document fails to bind to a quill. It is
-**experimental** — added under evaluation (issue #734) and kept only if it
-measurably reduces the omission rate; the eval is the gate, not this doc.
-The reminder rides only on `$quill`: it is the one line whose omission is
-a hard error. `$kind: main` carries no reminder — an omitted root
-`$kind` is synthesised at parse time, so dropping it is not an error, and
-a `# …` line in that slot would only read as a leading annotation for the
-field below it. A composable card's kind is carried in its
+**`# keep verbatim — do not drop`** reminder — an in-band guard against the
+`parse::missing_quill` failure, where an LLM author omits the `$quill` line
+entirely and the document fails to bind to a quill. The reminder rides only
+on `$quill`: it is the one line whose omission is a hard error. `$kind: main`
+carries no reminder — an omitted root `$kind` is synthesised at parse time,
+so dropping it is not an error, and a `# …` line in that slot would only
+read as a leading annotation for the field below it. A composable card's kind is carried in its
 `$kind: <card_kind>` metadata line. Its `composable (0..N)` role is
 emitted as an own-line `# composable (0..N)` comment directly under the
 `$kind` line, ahead of the card description — that comment carries the
@@ -141,7 +138,7 @@ Examples:
 | `recipient: !must_fill  # array<string>` | Unendorsed array of strings |
 | `date: !must_fill  # datetime<YYYY-MM-DD[Thh:mm:ss]>` | Unendorsed datetime |
 | `severity: !must_fill  # enum<low \| medium \| high>` | Unendorsed enum |
-| `$quill: cmu_letter@0.1.0  # keep verbatim — do not drop` | quill binding metadata, emitted verbatim; the inline reminder guards against dropping the line (issue #734) |
+| `$quill: cmu_letter@0.1.0  # keep verbatim — do not drop` | quill binding metadata, emitted verbatim; the inline reminder guards against dropping the line |
 | `$kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~` … `~~~` block per instance |
 
 ## Placeholder value precedence

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -17,7 +17,7 @@ free.
 
 ````
 ~~~
-$quill: <name>@<version>  # keep verbatim — do not drop
+$quill: <name>@<version>  # keep verbatim
 $kind: main
 # <description>
 
@@ -111,7 +111,7 @@ comment parse and round-trip faithfully, exactly like comments on data
 fields — see [markdown-spec.md](../references/markdown-spec.md) §3.3.)
 
 The root block's `$quill` line is emitted verbatim and carries an inline
-**`# keep verbatim — do not drop`** reminder — an in-band guard against the
+**`# keep verbatim`** reminder — an in-band guard against the
 `parse::missing_quill` failure, where an LLM author omits the `$quill` line
 entirely and the document fails to bind to a quill. The reminder rides only
 on `$quill`: it is the one line whose omission is a hard error. `$kind: main`
@@ -138,7 +138,7 @@ Examples:
 | `recipient: !must_fill  # array<string>` | Unendorsed array of strings |
 | `date: !must_fill  # datetime<YYYY-MM-DD[Thh:mm:ss]>` | Unendorsed datetime |
 | `severity: !must_fill  # enum<low \| medium \| high>` | Unendorsed enum |
-| `$quill: cmu_letter@0.1.0  # keep verbatim — do not drop` | quill binding metadata, emitted verbatim; the inline reminder guards against dropping the line |
+| `$quill: cmu_letter@0.1.0  # keep verbatim` | quill binding metadata, emitted verbatim; the inline reminder guards against dropping the line |
 | `$kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~` … `~~~` block per instance |
 
 ## Placeholder value precedence
@@ -328,7 +328,7 @@ to prevent corrupting the blueprint's document structure.
 
 ```
 ~~~
-$quill: cmu_letter@0.1.0  # keep verbatim — do not drop
+$quill: cmu_letter@0.1.0  # keep verbatim
 $kind: main
 # Typeset letters that comply with Carnegie Mellon University letterhead standards.
 


### PR DESCRIPTION
Two related corrections in prose/canon/BLUEPRINT.md:

1. Remove the stale `# system metadata; verbatim` line from the
   "Output shape" and "Worked example" blocks. Neither the emitter
   (write_main_fence) nor the documented grammar produces this line;
   the test root_header_emits_no_role_comment asserts the header goes
   straight from `$kind: main` to the description.

2. Correct the false claim that "the canonical form drops every comment
   attached to a `$` line." Comments on `$` lines round-trip — confirmed
   by markdown-spec.md §3.3, emit_meta_line's trailer handling, and the
   comment_on_dollar_line_round_trips test. The blueprint emitter simply
   chooses not to attach one; the line carries no inline type-annotation
   slot, which is the actual (narrower) point.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SeNWp85SRLwCKSdVX3ZgEr