### PR TITLE
review(0.93.0): fix stale comments, document scalar coercion, cover card markers

### DIFF
--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -137,8 +137,8 @@ def test_absent_unendorsed_is_nonfatal(engine, tmp_path):
 
     Per the zero-filled-render contract (``prose/canon/SCHEMAS.md``), render
     succeeds — each absent field is zero-filled in the ephemeral plate
-    projection. Absence is silent: ``validation::field_absent`` is no longer
-    emitted by ``quill.validate``.
+    projection. Absence is silent: ``validation::field_absent`` is not emitted by
+    ``quill.validate``.
     """
     quill = make_quill(tmp_path)
     md = (
@@ -155,10 +155,10 @@ def test_absent_unendorsed_is_nonfatal(engine, tmp_path):
     result = engine.render(quill, doc, OutputFormat.PDF)
     assert len(result.artifacts) > 0
 
-    # Absence is silent — field_absent is deferred and no longer surfaced.
+    # Absence is silent — field_absent is removed and never surfaced.
     codes = [d.get("code") for d in quill.validate(doc)]
     assert "validation::field_absent" not in codes, (
-        f"field_absent is deferred and must not be surfaced; got: {codes}"
+        f"field_absent is removed and must not be surfaced; got: {codes}"
     )
 
 
@@ -200,7 +200,7 @@ def test_absent_unendorsed_does_not_emit_legacy_codes(engine, tmp_path):
 
     Absence is silent under zero-filled render (``prose/canon/SCHEMAS.md``):
     render succeeds and ``quill.validate`` surfaces no ``field_absent`` or
-    legacy ``required`` codes. The deferred ``validation::field_absent`` and
+    legacy ``required`` codes. The removed ``validation::field_absent`` and
     the legacy ``validation::missing_required``,
     ``validation::required_field_absent``, and
     ``validation::unfilled_placeholder`` codes never appear.
@@ -221,7 +221,7 @@ def test_absent_unendorsed_does_not_emit_legacy_codes(engine, tmp_path):
     # the validate surface carries none of these codes
     codes = [d.get("code") for d in quill.validate(doc)]
     assert "validation::field_absent" not in codes, (
-        f"`validation::field_absent` is deferred; got: {codes}"
+        f"`validation::field_absent` is removed; got: {codes}"
     )
     assert "validation::missing_required" not in codes, (
         f"`validation::missing_required` must not appear; got: {codes}"

--- a/crates/bindings/python/tests/test_validate.py
+++ b/crates/bindings/python/tests/test_validate.py
@@ -110,15 +110,15 @@ def test_validate_reports_unknown_card_kind(tmp_path):
 
 
 def test_validate_omits_field_absent(tmp_path):
-    """Absent Unendorsed fields zero-fill silently — the deferred
-    ``validation::field_absent`` code is no longer surfaced by validate."""
+    """Absent Unendorsed fields zero-fill silently — the removed
+    ``validation::field_absent`` code is never surfaced by validate."""
     quill = make_quill(tmp_path)
     doc = Document.from_markdown(_md())  # empty main card
 
     diags = quill.validate(doc)
     codes = [d.get("code") for d in diags]
     assert "validation::field_absent" not in codes, (
-        f"field_absent is deferred and must not be surfaced; got: {codes}"
+        f"field_absent is removed and must not be surfaced; got: {codes}"
     )
 
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1104,7 +1104,7 @@ body: "B"
     expect(diags.some((d) => d.code === 'validation::unknown_card')).toBe(true)
   })
 
-  it('does not emit field_absent for absent Unendorsed fields (deferred signal)', () => {
+  it('does not emit field_absent for absent Unendorsed fields (removed signal)', () => {
     const quill = buildQuill()
     const md = `~~~card-yaml
 $quill: validate_smoke_test

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -559,8 +559,8 @@ mod tests {
 
     #[test]
     fn test_diagnostic_with_path() {
-        let diag = Diagnostic::new(Severity::Error, "Missing field".to_string())
-            .with_code("validation::field_absent".to_string())
+        let diag = Diagnostic::new(Severity::Error, "Type mismatch".to_string())
+            .with_code("validation::type_mismatch".to_string())
             .with_path("cards.indorsement[0].signature_block".to_string());
 
         assert_eq!(

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -237,9 +237,6 @@ fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
 /// Append a scalar / scalar-array / markdown field as a single payload field
 /// plus its trailing inline type annotation.
 fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
-    // Scalars surface `# e.g.` only when Endorsed — an Unendorsed example
-    // inlines as the marker's suggested value, so a separate hint would
-    // duplicate it.
     push_leading(items, field, field.default.is_some());
     let (json, fill) = scalar_cell(field);
     items.push(PayloadItem::Field {
@@ -279,8 +276,7 @@ fn build_property_mapping(
                 inline: false,
             });
         }
-        // A leaf surfaces `# e.g.` under the same rule as a top-level scalar:
-        // only when Endorsed (an Unendorsed example inlines as the marker).
+        // `# e.g.` only when Endorsed (see `push_leading`).
         if prop.default.is_some() {
             if let Some(eg) = prop.example.as_ref() {
                 nested.push(NestedComment {

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -248,7 +248,7 @@ fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
         fill,
         nested_comments: Vec::new(),
     });
-    items.push(PayloadItem::comment_inline(inline_annotation(field)));
+    items.push(PayloadItem::comment_inline(type_expression(field)));
 }
 
 fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
@@ -301,7 +301,7 @@ fn build_property_mapping(
         nested.push(NestedComment {
             container_path: prefix.to_vec(),
             position: slot,
-            text: inline_annotation(prop),
+            text: type_expression(prop),
             inline: true,
         });
     }
@@ -392,17 +392,13 @@ fn push_container_field(
         fill: false,
         nested_comments,
     });
-    items.push(PayloadItem::comment_inline(inline_annotation(field)));
+    items.push(PayloadItem::comment_inline(type_expression(field)));
 }
 
 /// Build the inline annotation body (without the leading `# `): purely the
 /// structural type expression `<type>[<format>]`. Shippability is carried by
 /// the value cell alone — a concrete value is shippable as-is, a `!must_fill`
 /// marker asks to be filled — so the annotation needs no cell-state tag.
-fn inline_annotation(field: &FieldSchema) -> String {
-    type_expression(field)
-}
-
 fn type_expression(field: &FieldSchema) -> String {
     if let Some(values) = &field.enum_values {
         return format!("enum<{}>", values.join(" | "));

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -157,9 +157,9 @@ fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
 }
 
 /// Order fields by `ui.group` (ungrouped lead, then groups in first-appearance
-/// order) with `ui.order` sorting within each cluster. The grouping is purely
-/// positional now — no banner is emitted — so the clusters are flattened into a
-/// single field stream.
+/// order) with `ui.order` sorting within each cluster. Grouping is purely
+/// positional (no banner); the clusters are flattened into a single field
+/// stream.
 fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(fields: I) -> Vec<&'a FieldSchema> {
     let mut sorted: Vec<&FieldSchema> = fields.into_iter().collect();
     sorted.sort_by_key(|f| f.ui_order());

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -135,22 +135,16 @@ impl Quill {
     /// Validate `doc` against this quill's schema, returning every diagnostic
     /// (an empty `Vec` when the document is valid).
     ///
-    /// This is the editor-facing validation surface. It forwards the canonical
-    /// `validation::*` diagnostics verbatim — same code, `path`, and `hint` the
-    /// engine emits — so consumers can route on the code and navigate by path
-    /// without parsing message text. It covers type mismatches, unknown card
-    /// kinds (`validation::unknown_card`), body-on-disabled-body, and the
-    /// non-fatal `validation::must_fill` placeholder warning.
-    ///
-    /// Field absence is not surfaced: an absent Unendorsed field zero-fills at
-    /// render and raises nothing here. The `validation::must_fill` warning is
-    /// the one non-fatal diagnostic this surface emits; the remaining
-    /// `error`-severity diagnostics are blockers.
+    /// The editor-facing validation surface. Forwards the canonical
+    /// `validation::*` diagnostics verbatim (same code, `path`, `hint`) so
+    /// consumers route on the code without parsing message text: type
+    /// mismatches, unknown card kinds, body-on-disabled-body, and the non-fatal
+    /// `validation::must_fill` warning — the only non-fatal one; the rest are
+    /// blockers. Field absence is not surfaced (it zero-fills at render).
     ///
     /// Field values, defaults, and presentation order are not part of this
-    /// surface: a consumer reads them directly from the [`Document`] payload and
-    /// the quill schema (`quill.config().schema()`), where fields carry their
-    /// `ui.order` as the presentation-ordering signal.
+    /// surface — read them from the [`Document`] payload and the quill schema
+    /// (`quill.config().schema()`, carrying each field's `ui.order`).
     pub fn validate(&self, doc: &Document) -> Vec<Diagnostic> {
         let mut diags = match self.config().validate_document(doc) {
             Ok(()) => Vec::new(),
@@ -262,14 +256,10 @@ impl Quill {
         match self.config().validate_document(doc) {
             Ok(_) => Ok(()),
             Err(errors) => {
-                // Zero-filled render: a merely *incomplete* document (Unendorsed
-                // fields absent, or `!must_fill` placeholders) renders fine —
-                // each absent/null field is zero-filled in `resolve_fields`, and
-                // the placeholder marker is render-irrelevant. Only *malformed*
-                // input is fatal: a value that won't coerce/validate.
-                //
-                // Each ValidationError gets its own Diagnostic so consumers can
-                // use `path` for UI navigation via `RenderError::diagnostics()`.
+                // Only *malformed* input is fatal (a value that won't
+                // coerce/validate). An incomplete document — absent fields or
+                // `!must_fill` placeholders — renders fine via zero-fill. Each
+                // error keeps its own `path` for UI navigation.
                 let diags: Vec<Diagnostic> = errors.iter().map(|e| e.to_diagnostic()).collect();
                 if diags.is_empty() {
                     Ok(())
@@ -393,15 +383,12 @@ fn rebuild_payload_with_meta(source: &Card, fields: IndexMap<String, QuillValue>
     payload
 }
 
-/// Surface every `!must_fill` placeholder marker as a non-fatal **warning**.
+/// Surface every `!must_fill` marker as a non-fatal **warning**, root-and-nested
+/// across the main card and every composable card.
 ///
-/// The marker is the explicit "fill me" flag a blueprint stamps (and an author
-/// may write by hand). It is orthogonal to the value layer — it fires whether
-/// the cell is empty/null or carries a suggested value (`!must_fill <value>`) —
-/// and it never gates render: a marked document still renders (the cell
-/// zero-fills, or uses its suggested value). A strict consumer (e.g. an LLM
-/// authoring loop) treats any outstanding marker as "not done". Markers are
-/// reported root-and-nested, across the main card and every composable card.
+/// The marker fires whether or not the cell carries a suggested value, and never
+/// gates render (the cell zero-fills or uses its suggested value). A strict
+/// consumer treats any outstanding marker as "not done".
 fn validate_fills(doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
     collect_fill_diags(doc.main(), "", &mut diags);

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -142,10 +142,9 @@ impl Quill {
     /// kinds (`validation::unknown_card`), body-on-disabled-body, and the
     /// non-fatal `validation::must_fill` placeholder warning.
     ///
-    /// The per-field completeness signal (`validation::field_absent`) is
-    /// currently **deferred** (an absent Unendorsed field zero-fills at render
-    /// and raises nothing here). The `validation::must_fill` warning is the one
-    /// non-fatal diagnostic this surface emits today; the remaining
+    /// Field absence is not surfaced: an absent Unendorsed field zero-fills at
+    /// render and raises nothing here. The `validation::must_fill` warning is
+    /// the one non-fatal diagnostic this surface emits; the remaining
     /// `error`-severity diagnostics are blockers.
     ///
     /// Field values, defaults, and presentation order are not part of this
@@ -269,14 +268,9 @@ impl Quill {
                 // the placeholder marker is render-irrelevant. Only *malformed*
                 // input is fatal: a value that won't coerce/validate.
                 //
-                // Each surviving ValidationError gets its own Diagnostic so
-                // consumers can use `path` for UI navigation via
-                // `RenderError::diagnostics()`.
-                let diags: Vec<Diagnostic> = errors
-                    .iter()
-                    .filter(|e| e.code() != "validation::field_absent")
-                    .map(|e| e.to_diagnostic())
-                    .collect();
+                // Each ValidationError gets its own Diagnostic so consumers can
+                // use `path` for UI navigation via `RenderError::diagnostics()`.
+                let diags: Vec<Diagnostic> = errors.iter().map(|e| e.to_diagnostic()).collect();
                 if diags.is_empty() {
                     Ok(())
                 } else {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -11,15 +11,12 @@ use crate::value::QuillValue;
 
 use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
 
-/// Canonical string text for a bare scalar that is unambiguously representable
-/// as a string: a boolean (`true`/`false`) or a number (`47`, `1.0`). Returns
-/// `None` for everything else — `null` (≡ absent), strings (already a string),
-/// and collections (structurally not a scalar).
+/// Canonical string text for a bare scalar unambiguously representable as a
+/// string — a boolean (`true`/`false`) or number (`47`, `1.0`). `None` for
+/// `null` (≡ absent), strings (already strings), and collections.
 ///
-/// This is the single source of truth for the gracious scalar→string rule:
-/// [`QuillConfig::coerce_value_strict`] uses the returned text to adopt the
-/// value, and `validation::validate_value` calls it (via this same function) to
-/// decide that such a value is type-valid — so coercion and validation can
+/// Shared by [`QuillConfig::coerce_value_strict`] (to adopt the value) and
+/// `validation::validate_value` (to accept it), so coercion and validation
 /// never disagree about which bare scalars a `string` field accepts.
 pub(crate) fn scalar_as_string(value: &serde_json::Value) -> Option<String> {
     match value {
@@ -352,13 +349,10 @@ impl QuillConfig {
                         }
                     }
                 }
-                // Gracious scalar→string: a bare boolean/integer/number written
-                // where a string is expected is unambiguous — adopt its
-                // canonical scalar text (`true`, `47`, `1.0`) as the string
-                // value rather than rejecting it. Helps authors (LLMs
-                // especially) who write `verified: true` or `build_number: 47`
-                // for a `string` field. Null (≡ absent) is handled above;
-                // collections fall through unchanged.
+                // Gracious scalar→string: adopt a bare bool/number's canonical
+                // text rather than reject it (an author writing `verified: true`
+                // for a `string` field). Null is handled above; collections fall
+                // through.
                 if let Some(text) = scalar_as_string(json_value) {
                     return Ok(QuillValue::from_json(serde_json::Value::String(text)));
                 }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -359,7 +359,7 @@ impl QuillConfig {
                 // especially) who write `verified: true` or `build_number: 47`
                 // for a `string` field. Null (≡ absent) is handled above;
                 // collections fall through unchanged.
-                if let Some(text) = scalar_as_string(&json_value) {
+                if let Some(text) = scalar_as_string(json_value) {
                     return Ok(QuillValue::from_json(serde_json::Value::String(text)));
                 }
                 Ok(value.clone())
@@ -761,7 +761,7 @@ impl QuillConfig {
                 )
                 .with_code(format!("quill::{slot}_format_violation"))
                 .with_hint(format!("Provide a valid {format} value for the {slot}.")),
-                // FieldAbsent, UnknownCard, BodyDisabled do not apply to schema literals.
+                // UnknownCard, BodyDisabled do not apply to schema literals.
                 _ => continue,
             };
             errors.push(diag);

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -15,19 +15,15 @@ use serde_json::json;
 use super::{FieldSchema, FieldType};
 use crate::value::QuillValue;
 
-/// The type-empty (zero) value for `field`: the leanest value that satisfies
-/// the field's declared type.
+/// The type-empty (zero) value for `field`: the leanest value satisfying its
+/// declared type.
 ///
-/// Honestly blank for almost every type — `""` (string, markdown, datetime:
-/// the validator accepts the empty string for datetime), `0`, `false`, `[]`.
-/// The lone seam is `enum`: there is no empty enum
-/// member, so the zero value is the first declared variant (`first_enum`).
-///
-/// An `object` with `properties` is *shape-valid only when every property is
-/// present*, so its zero value is the object whose each property carries that
-/// property's zero value (recursively). A bare `{}` would omit the declared
-/// properties, leaving the projection out of shape; only a property-less object
-/// (schema-invalid in practice) degrades to `{}`.
+/// Blank for most types — `""` (string/markdown/datetime), `0`, `false`, `[]`.
+/// `enum` has no empty member, so it zeroes to the first declared variant. An
+/// `object` with `properties` is shape-valid only when every property is
+/// present, so it zeroes (recursively) to an object with every property at its
+/// own zero value, not a bare `{}` (which only a property-less object degrades
+/// to).
 pub fn zero_value(field: &FieldSchema) -> QuillValue {
     if let Some(values) = &field.enum_values {
         let first = values.first().cloned().unwrap_or_default();

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -25,9 +25,9 @@ use crate::value::QuillValue;
 ///
 /// An `object` with `properties` is *shape-valid only when every property is
 /// present*, so its zero value is the object whose each property carries that
-/// property's zero value (recursively). A bare `{}` would fail validation —
-/// the validator reports every absent property as a `FieldAbsent`. Only a
-/// property-less object (schema-invalid in practice) degrades to `{}`.
+/// property's zero value (recursively). A bare `{}` would omit the declared
+/// properties, leaving the projection out of shape; only a property-less object
+/// (schema-invalid in practice) degrades to `{}`.
 pub fn zero_value(field: &FieldSchema) -> QuillValue {
     if let Some(values) = &field.enum_values {
         let first = values.first().cloned().unwrap_or_default();

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -159,11 +159,9 @@ impl ValidationError {
         }
     }
 
-    /// Actionable hint for this error, when one is well-defined for the
-    /// variant. The hint restates the recommended exit so consumers (LLM
-    /// agents, IDEs, MCP clients) can surface it next to the message
-    /// without re-parsing prose. The hint text is the same string the
-    /// `Display` impl bakes into the message.
+    /// Actionable hint for this error, when defined for the variant — the same
+    /// string the `Display` impl bakes in, exposed so consumers can surface it
+    /// without re-parsing prose.
     pub fn hint(&self) -> Option<String> {
         match self {
             ValidationError::TypeMismatch {
@@ -331,10 +329,9 @@ fn validate_value(
     path: &str,
     ctx: ValueContext,
 ) -> Vec<ValidationError> {
-    // Null ≡ absent: a present-null value carries no data, so in a document it
-    // is treated exactly like an omitted field — no type error. The `!must_fill`
-    // placeholder marker (when present) is surfaced separately as a non-fatal
-    // warning by `Quill::validate`; it is not a value-layer concern here.
+    // Null ≡ absent: a present-null value in a document is treated as omitted
+    // (no type error). The `!must_fill` marker is surfaced separately as a
+    // warning by `Quill::validate`, not here.
     if ctx == ValueContext::Document && value.as_json().is_null() {
         return vec![];
     }
@@ -342,13 +339,10 @@ fn validate_value(
     let mut errors = Vec::new();
 
     let type_valid = match field.r#type {
-        // In a *document*, a bare boolean/integer/number is unambiguously
-        // representable as a string, so the coercion layer adopts its canonical
-        // text and the value is type-valid here too — kept in lockstep with
-        // `coerce_value_strict` via the shared `scalar_as_string` predicate.
-        // Schema literals (a quill author's own `default:`/`example:`) stay
-        // strict: they are never coerced, and the blueprint relies on ambiguous
-        // string literals being quoted at authoring time.
+        // In a document a bare bool/number is type-valid as a string (the
+        // coercion layer adopts it) — in lockstep with `coerce_value_strict`
+        // via `scalar_as_string`. Schema literals stay strict so the blueprint
+        // keeps quoting ambiguous string literals.
         FieldType::String | FieldType::Markdown => {
             value.as_str().is_some()
                 || (ctx == ValueContext::Document

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -13,23 +13,12 @@ use crate::value::QuillValue;
 /// enough for the `Display` impl to render the uniform diagnostic message
 /// described in `ERROR.md` ("Validation message contract").
 ///
-/// `Placeholder` (the `!must_fill` marker) is **not** a well-formedness error
-/// and so is absent here — it is surfaced as a non-fatal warning by
-/// `Quill::validate`, independent of the value-layer checks below.
+/// Two concerns are deliberately *not* well-formedness errors and so have no
+/// variant here: the `!must_fill` marker (surfaced as a non-fatal warning by
+/// `Quill::validate`) and field absence (an absent or present-null field
+/// zero-fills at render). Both are handled outside the value-layer checks below.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
-    /// A schema field with no `default:` was absent from the document.
-    ///
-    /// A non-fatal *completeness* signal, **not** a fill requirement: the render
-    /// floor zero-fills the field (see `prose/canon/SCHEMAS.md`, "Zero-filled
-    /// render"). Emission is currently **deferred** pending the authoring-feedback
-    /// design; the variant is retained for when that surface returns.
-    FieldAbsent {
-        path: String,
-        /// Schema-declared type (`string`, `integer`, …).
-        expected: String,
-    },
-
     TypeMismatch {
         path: String,
         /// Schema-declared type (`string`, `integer`, …).
@@ -72,12 +61,6 @@ impl std::error::Error for ValidationError {}
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ValidationError::FieldAbsent { path, expected } => write!(
-                f,
-                "Field `{path}` is missing, schema declares `{expected}` with no default. \
-                 {hint}",
-                hint = field_absent_hint(expected),
-            ),
             ValidationError::TypeMismatch {
                 path,
                 expected,
@@ -129,12 +112,6 @@ impl std::fmt::Display for ValidationError {
     }
 }
 
-/// Actionable exit clause for an absent field. Used by both `Display` and
-/// `hint()` so the recommended action lives in exactly one place.
-fn field_absent_hint(expected: &str) -> String {
-    format!("Provide a value of type `{expected}`.")
-}
-
 /// Actionable exit clause for a TypeMismatch. Mirrors the (expected, actual,
 /// has_default) branching in `Display` so the structured hint and the prose
 /// message can never disagree.
@@ -162,8 +139,7 @@ impl ValidationError {
     /// See [`crate::error`] module docs for the path grammar and conventions.
     pub fn path(&self) -> &str {
         match self {
-            ValidationError::FieldAbsent { path, .. }
-            | ValidationError::TypeMismatch { path, .. }
+            ValidationError::TypeMismatch { path, .. }
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
             | ValidationError::UnknownCard { path, .. }
@@ -175,7 +151,6 @@ impl ValidationError {
     /// instead of the message text.
     pub fn code(&self) -> &'static str {
         match self {
-            ValidationError::FieldAbsent { .. } => "validation::field_absent",
             ValidationError::TypeMismatch { .. } => "validation::type_mismatch",
             ValidationError::EnumViolation { .. } => "validation::enum_violation",
             ValidationError::FormatViolation { .. } => "validation::format_violation",
@@ -191,7 +166,6 @@ impl ValidationError {
     /// `Display` impl bakes into the message.
     pub fn hint(&self) -> Option<String> {
         match self {
-            ValidationError::FieldAbsent { expected, .. } => Some(field_absent_hint(expected)),
             ValidationError::TypeMismatch {
                 expected,
                 actual,
@@ -322,11 +296,9 @@ fn validate_fields_for_card_indexmap(
     for field_name in field_names {
         let schema = &card.fields[field_name];
         let path = child_path(base_path, field_name);
-        // Absence is a completeness concern, not a well-formedness one. The
-        // per-field completeness signal (`FieldAbsent`) is deferred until the
-        // authoring-feedback surface is designed per author type (LLM, GUI,
-        // markdown); for now an absent field — like a present-null one — is
-        // simply zero-filled at render and raises nothing here.
+        // Absence is a completeness concern, not a well-formedness one: an
+        // absent field — like a present-null one — is zero-filled at render and
+        // raises nothing here.
         if let Some(value) = fields.get(field_name) {
             errors.extend(validate_field(schema, value, &path));
         }
@@ -380,7 +352,7 @@ fn validate_value(
         FieldType::String | FieldType::Markdown => {
             value.as_str().is_some()
                 || (ctx == ValueContext::Document
-                    && super::config::scalar_as_string(&value.as_json()).is_some())
+                    && super::config::scalar_as_string(value.as_json()).is_some())
         }
         FieldType::Integer => {
             let json = value.as_json();
@@ -439,9 +411,8 @@ fn validate_value(
                         let property_schema = &properties[property_name];
                         let property_path = child_path(path, property_name);
                         // Absent object property: completeness, not
-                        // well-formedness. Like a top-level absent field, the
-                        // `FieldAbsent` signal is deferred (see
-                        // `validate_fields_for_card_indexmap`).
+                        // well-formedness. Like a top-level absent field, it
+                        // zero-fills at render and raises nothing here.
                         if let Some(property_value) = object.get(property_name) {
                             errors.extend(validate_value(
                                 property_schema,
@@ -645,8 +616,8 @@ main:
     #[test]
     fn absent_unendorsed_field_raises_nothing() {
         // A field with no `default:` absent from the document is a completeness
-        // concern, not a well-formedness one. `FieldAbsent` emission is deferred,
-        // so validation is clean; the field zero-fills at render.
+        // concern, not a well-formedness one: validation is clean and the field
+        // zero-fills at render.
         let config = config_with("    memo_for:\n      type: string", "");
         let doc = doc_from_fm(&[]);
         assert!(validate_typed_document(&config, &doc).is_ok());
@@ -675,7 +646,7 @@ main:
     #[test]
     fn absent_object_property_raises_nothing() {
         // Property `name` is Unendorsed and absent from the row. Like a
-        // top-level absent field, this is a deferred completeness concern, not a
+        // top-level absent field, this is a completeness concern, not a
         // validation error.
         let config = config_with(
             "    recipients:\n      type: array\n      default: []\n      items:\n        type: object\n        properties:\n          name:\n            type: string\n          org:\n            type: string\n            default: \"\"",
@@ -692,8 +663,8 @@ main:
 
     #[test]
     fn multiple_absent_fields_raise_nothing() {
-        // Completeness (`FieldAbsent`) is deferred, so several absent Unendorsed
-        // fields produce no validation errors.
+        // Absence is a completeness concern, not a well-formedness one, so
+        // several absent Unendorsed fields produce no validation errors.
         let config = config_with(
             "    memo_for:\n      type: string\n    memo_from:\n      type: string",
             "",
@@ -806,35 +777,26 @@ main:
     }
 
     #[test]
-    fn to_diagnostic_carries_path_and_code() {
-        let err = ValidationError::FieldAbsent {
+    fn to_diagnostic_carries_path_code_and_hint() {
+        let err = ValidationError::TypeMismatch {
             path: "cards.indorsement[0].signature_block".to_string(),
             expected: "string".to_string(),
+            actual: "integer".to_string(),
+            source_token: "42".to_string(),
+            default: None,
         };
         let diag = err.to_diagnostic();
-        assert_eq!(diag.code.as_deref(), Some("validation::field_absent"));
+        assert_eq!(diag.code.as_deref(), Some("validation::type_mismatch"));
         assert_eq!(
             diag.path.as_deref(),
             Some("cards.indorsement[0].signature_block")
         );
         assert_eq!(diag.severity, Severity::Error);
-    }
-
-    #[test]
-    fn field_absent_diagnostic_carries_actionable_hint() {
-        let err = ValidationError::FieldAbsent {
-            path: "title".to_string(),
-            expected: "string".to_string(),
-        };
-        let diag = err.to_diagnostic();
         let hint = diag
             .hint
             .as_deref()
-            .expect("field_absent diagnostic should carry a hint");
-        assert!(
-            hint.contains("string"),
-            "hint missing expected type: {hint}"
-        );
+            .expect("type_mismatch diagnostic should carry a hint");
+        assert!(hint.contains("string"), "hint missing expected type: {hint}");
     }
 
     #[test]

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -64,7 +64,11 @@ main:
 }
 
 #[test]
-fn test_default_values_applied_via_dry_run() {
+fn test_defaults_applied_when_absent() {
+    // An absent Endorsed field (one with a `default:`) resolves to its default
+    // in the plate projection — across string and number types — while an
+    // authored value still wins over the default. dry_run tolerates the
+    // partially-authored document (nothing gates on absence).
     let temp_dir = TempDir::new().unwrap();
     let quill_path = create_test_quill(
         &temp_dir,
@@ -79,6 +83,7 @@ main:
   fields:
     title:
       type: "string"
+      default: "Untitled"
     status:
       type: "string"
       default: "draft"
@@ -90,84 +95,33 @@ main:
 
     let quill = quillmark::quill_from_path(&quill_path).expect("from_path failed");
 
+    // `status` is authored; `title` and `version` fall back to their defaults.
     let markdown =
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: My Document\n~~~\n\n# Content\n";
+        "~~~card-yaml\n$quill: test_quill\n$kind: main\nstatus: published\n~~~\n\n# Content\n";
     let parsed = Document::from_markdown(markdown).expect("parse failed");
 
-    let result = quill.dry_run(&parsed);
     assert!(
-        result.is_ok(),
-        "Dry run should succeed - optional fields have defaults"
-    );
-}
-
-#[test]
-fn test_default_values_not_overriding_existing_fields() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_path = create_test_quill(
-        &temp_dir,
-        r#"quill:
-  name: "test_quill"
-  version: "1.0"
-  backend: "typst"
-  plate_file: "plate.typ"
-  description: "Test quill with defaults"
-
-main:
-  fields:
-    title:
-      type: "string"
-    status:
-      type: "string"
-      default: "draft"
-"#,
+        quill.dry_run(&parsed).is_ok(),
+        "dry_run should tolerate absent Endorsed fields (defaults apply)"
     );
 
-    let quill = quillmark::quill_from_path(&quill_path).expect("from_path failed");
-
-    let markdown =
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: My Document\nstatus: published\n~~~\n\n# Content\n";
-    let parsed = Document::from_markdown(markdown).expect("parse failed");
-
-    let result = quill.dry_run(&parsed);
-    assert!(
-        result.is_ok(),
-        "Dry run should succeed with explicit values"
+    let data = quill
+        .compile_data(&parsed)
+        .expect("compile_data should succeed");
+    assert_eq!(
+        data.get("title").and_then(|v| v.as_str()),
+        Some("Untitled"),
+        "absent Endorsed `title` should resolve to its default: {data}"
     );
-}
-
-#[test]
-fn test_validation_with_defaults() {
-    let temp_dir = TempDir::new().unwrap();
-    let quill_path = create_test_quill(
-        &temp_dir,
-        r#"quill:
-  name: "test_quill"
-  version: "1.0"
-  backend: "typst"
-  plate_file: "plate.typ"
-  description: "Test quill with optional fields"
-
-main:
-  fields:
-    title:
-      type: "string"
-      default: "Untitled"
-    status:
-      type: "string"
-      default: "draft"
-"#,
+    assert_eq!(
+        data.get("version").and_then(|v| v.as_f64()),
+        Some(1.0),
+        "absent Endorsed `version` should resolve to its numeric default: {data}"
     );
-
-    let quill = quillmark::quill_from_path(&quill_path).expect("from_path failed");
-
-    let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\n# Content";
-    let parsed = Document::from_markdown(markdown).expect("parse failed");
-
-    let dry_run_result = quill.dry_run(&parsed);
-    assert!(
-        dry_run_result.is_ok(),
-        "Dry run should pass - fields have defaults"
+    assert_eq!(
+        data.get("status").and_then(|v| v.as_str()),
+        Some("published"),
+        "authored value should win over the default: {data}"
     );
 }
 

--- a/crates/quillmark/tests/validate_test.rs
+++ b/crates/quillmark/tests/validate_test.rs
@@ -95,17 +95,17 @@ fn validate_reports_unknown_card_kind() {
 }
 
 #[test]
-fn validate_defers_field_absent_completeness_signal() {
+fn validate_does_not_surface_field_absence() {
     let quill = quill_from_yaml(SIMPLE);
-    // `title` and `count` are Unendorsed (no default) and absent. The
-    // completeness signal is deferred pending the authoring-feedback design, so
-    // an incomplete-but-well-formed document produces no diagnostics.
+    // `title` and `count` are Unendorsed (no default) and absent. Field absence
+    // is not a well-formedness error — it zero-fills at render — so an
+    // incomplete-but-well-formed document produces no diagnostics.
     let md = "~~~card-yaml\n$quill: validate_test\n$kind: main\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     assert!(
         quill.validate(&doc).is_empty(),
-        "absence is no longer surfaced; an incomplete document validates clean"
+        "absence is not surfaced; an incomplete document validates clean"
     );
 }
 

--- a/crates/quillmark/tests/validate_test.rs
+++ b/crates/quillmark/tests/validate_test.rs
@@ -39,7 +39,7 @@ main:
 card_kinds:
   note:
     fields:
-      body:
+      label:
         type: string
 "#;
 
@@ -113,9 +113,11 @@ fn validate_defers_field_absent_completeness_signal() {
 fn validate_warns_on_must_fill_marker() {
     let quill = quill_from_yaml(SIMPLE);
     // The `!must_fill` placeholder surfaces as a non-fatal warning, regardless
-    // of whether it carries a suggested value.
+    // of whether it carries a suggested value — and across the main card and
+    // every composable card (the contract is "root and nested, main and cards").
     let md = "~~~card-yaml\n$quill: validate_test\n$kind: main\n\
-              title: !must_fill Draft\ncount: !must_fill\n~~~\n";
+              title: !must_fill Draft\ncount: !must_fill\n~~~\n\n\
+              ~~~card-yaml\n$kind: note\nlabel: !must_fill\n~~~\n";
     let doc = Document::from_markdown(md).unwrap();
 
     let diags = quill.validate(&doc);
@@ -126,7 +128,10 @@ fn validate_warns_on_must_fill_marker() {
         .filter_map(|d| d.path.clone())
         .collect();
     assert!(
-        marked.contains(&"title".to_string()) && marked.contains(&"count".to_string()),
-        "both !must_fill markers should warn; got paths: {marked:?}"
+        marked.contains(&"title".to_string())
+            && marked.contains(&"count".to_string())
+            && marked.contains(&"cards.note[0].label".to_string()),
+        "main-card and composable-card !must_fill markers should all warn; \
+         got paths: {marked:?}"
     );
 }

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -133,17 +133,17 @@ the coercion sentinel pass-through are all **retired**. In their place:
 for the literal `<must-fill>` string, should switch to the non-fatal
 `validation::must_fill` warning and stop gating render on it.
 
-## `validation::field_absent` is no longer emitted
+## `validation::field_absent` is removed
 
-The completeness signal `validation::field_absent` is **deferred**:
-`Quill::validate` no longer emits it. (The variant is retained in the code for
-when the per-author-type authoring-feedback surface — LLM / GUI / markdown — is
-designed.) A merely incomplete document, or one with present-null fields, now
-validates clean.
+The completeness signal `validation::field_absent` is **gone** — the
+`ValidationError::FieldAbsent` variant, its code, and its diagnostic machinery
+are removed. Field absence is no longer a validation concern: a merely
+incomplete document, or one with present-null fields, validates clean and
+zero-fills at render.
 
 **Action:** consumers that read `validation::field_absent` as a doneness hint
-should expect it to be absent for now; use the `!must_fill` markers (via
-`validation::must_fill`) as the outstanding-work signal instead.
+should drop it; use the `!must_fill` markers (via `validation::must_fill`) as
+the outstanding-work signal instead.
 
 ## No literal-string escape hatch
 

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -97,6 +97,23 @@ treated **exactly like an omitted field**: null ≡ absent. It validates clean
 type-zero). The previous behavior — where a present-null fired a
 `TypeMismatch` whose message told you to "delete this entire line" — is gone.
 
+## Bare scalars stringify into `string` fields
+
+A bare boolean, integer, or number written where a `string` is expected is now
+**coerced to its canonical scalar token** (`true`, `47`, `1.0`) instead of
+firing a `TypeMismatch`. It is unambiguously representable as text, and this
+helps authors — LLMs especially — who naturally write `verified: true` or
+`build_number: 47` for a string-typed field. Null and collections are
+excluded.
+
+The leniency is scoped to **document** payloads. A quill author's own
+`default:`/`example:` literals stay strict, so the blueprint keeps quoting
+ambiguous string literals.
+
+**Action:** consumers that relied on a `TypeMismatch` to catch a bare scalar in
+a string field (the "quote the value" hint) should expect the value to coerce
+instead. The `quotable_actual` / "quote the value" diagnostic branch is gone.
+
 ## `validation::must_fill_sentinel` (fatal) → `validation::must_fill` (non-fatal)
 
 The fatal `MustFillSentinel` diagnostic, the `<must-fill>` string constant, and

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -17,8 +17,8 @@ guides in order.
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now
   falls back to default/zero instead of failing. The fatal
   `validation::must_fill_sentinel` becomes the non-fatal `validation::must_fill`
-  warning (it never gates render), and `validation::field_absent` is no longer
-  emitted for now.
+  warning (it never gates render), `validation::field_absent` is removed, and
+  bare scalars (`true`, `47`, `1.0`) coerce into `string` fields.
 - [0.91 → 0.92](0.91-to-0.92.md) — the additive `$seed` system key carries
   per-card-kind seed overlays (`seedCard` gains an optional overlay argument);
   **and** the placeholder tag `!fill` is renamed to `!must_fill` with no alias —

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -92,8 +92,10 @@ no diagnostic. The completeness signal `validation::field_absent` is
 currently deferred (see [SCHEMAS.md](SCHEMAS.md) § "Native validation"), so a
 merely incomplete document also produces no field-level diagnostic.
 
-Implementation: `crates/core/src/quill/validation.rs` (the
-`ValidationError` `Display` impl).
+Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
+`Display` impl, for `validation::type_mismatch`) and
+`crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning`, for
+`validation::must_fill`).
 
 ## Error Presentation
 

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -88,9 +88,9 @@ value).
 A present-null value (`subtitle:`, `subtitle: null`, `subtitle: ~`) is
 treated exactly like an omitted field — null ≡ absent. It validates clean
 and zero-fills at render (authored › `default:` › type-zero), so it produces
-no diagnostic. The completeness signal `validation::field_absent` is
-currently deferred (see [SCHEMAS.md](SCHEMAS.md) § "Native validation"), so a
-merely incomplete document also produces no field-level diagnostic.
+no diagnostic. Field absence is likewise not surfaced as a diagnostic (see
+[SCHEMAS.md](SCHEMAS.md) § "Native validation"), so a merely incomplete
+document also produces no field-level diagnostic.
 
 Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -72,11 +72,10 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   outstanding marker as "not done."
 - **Absence semantics**: a missing (or present-null) field with a `default:`
   accepts the default; without a `default:` it zero-fills. Either way it
-  validates clean. The completeness signal `validation::field_absent` is
-  **deferred** — `Quill::validate` no longer emits it (the variant is
-  retained in code for when the authoring-feedback surface is designed per
-  author type — LLM / GUI / markdown). So a merely incomplete (or
-  present-null) document validates clean.
+  validates clean. Field absence is **not surfaced as a diagnostic** —
+  `Quill::validate` raises no completeness/`field_absent` code — so a merely
+  incomplete (or present-null) document validates clean. The only authoring
+  signal it raises is the non-fatal `validation::must_fill` warning.
 
 Field-level type and presence errors render under a uniform shape —
 field path, verbatim source token, schema declaration, and both exits
@@ -132,9 +131,9 @@ complete to render — render success is not a completeness signal.
 Shippability is the author's judgment; the engine's only hard requirement
 is that the document be *well-formed* (values coerce). A `!must_fill` marker
 and a present-null cell are both renderable — neither gates render.
-Completeness is not currently surfaced as a diagnostic: `validation::field_absent`
-is deferred (see [Native validation](#native-validation)); the only authoring
-signal `Quill::validate` raises is the non-fatal `validation::must_fill`
+Completeness is not surfaced as a diagnostic — `Quill::validate` raises no
+completeness/`field_absent` code (see [Native validation](#native-validation));
+the only authoring signal it raises is the non-fatal `validation::must_fill`
 warning for each outstanding marker.
 
 Rendering and the *completeness verdict* are orthogonal. The render path
@@ -147,7 +146,7 @@ backend **only, never in the persisted document**.
 - **Incomplete is renderable.** A document that merely omits an Unendorsed
   field — or leaves it present-null — renders fine: the field is zero-filled
   in the projection. Such a document validates clean; completeness is not
-  currently surfaced (`validation::field_absent` is deferred).
+  surfaced as a diagnostic.
 - **Malformed is fatal.** The only malformed case is a value that cannot
   coerce to (or validate against) its declared type. Placeholders and null
   are *not* malformed: a `!must_fill` marker renders (using its suggested
@@ -155,8 +154,8 @@ backend **only, never in the persisted document**.
   warning, and a present-null cell zero-fills like an absent field.
 - **Non-persist invariant.** The zero-fill lives only in the ephemeral
   projection and must never be written back. A type-empty value is
-  indistinguishable from authored-empty, so persisting it would make
-  `field_absent` (which keys on absence) vacuous and blind a future
+  indistinguishable from authored-empty, so persisting it would erase the
+  absence signal (which keys on a field being unwritten) and blind a future
   schema migration to author intent.
 
 The per-field zero value is honestly blank for every scalar type except

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -40,6 +40,13 @@ Supported field types:
   it carries no data to coerce. The value reaches the render floor and
   zero-fills (authored › `default:` › type-zero) exactly like an omitted
   field
+- **Bare scalars stringify into `string`/`markdown` fields.** A bare boolean,
+  integer, or number written where a `string` is expected adopts its canonical
+  scalar token (`true`, `47`, `1.0`) instead of failing — it is unambiguously
+  text (null and collections are excluded). The leniency is scoped to
+  *document* payloads via the shared `scalar_as_string` predicate; a quill
+  author's own `default:`/`example:` literals stay strict, so the blueprint
+  keeps quoting ambiguous string literals
 
 ## Native validation
 


### PR DESCRIPTION
Release-prep review fixes for 0.93.0:

- fill.rs: zero_value doc no longer claims a bare `{}` fails validation as
  FieldAbsent — #732 retired that emission; state the current shape rationale.
- ERROR.md: attribute `validation::must_fill` to compose.rs (validate_fills/
  fill_warning), not validation.rs, which only carries the type_mismatch Display.
- SCHEMAS.md + 0.92-to-0.93 migration guide: document the previously-undocumented
  bare-scalar→string coercion (#733), including the document-vs-schema-literal
  strictness boundary.
- blueprint.rs: drop change-narration ("purely positional now — no banner")
  from group_fields doc; state current behavior.
- validate_test: extend the must_fill warning test to a composable-card field
  (cards.note[0].label), closing the gap on the documented "main and cards"
  contract.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015HoerhwyNYYp1SxLG4MFHA