### PR TITLE
Expose form-field regions from stamped AcroForm backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +269,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1054,6 +1090,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
 dependencies = [
+ "brotli",
  "hayro-postscript",
 ]
 
@@ -2319,6 +2356,8 @@ dependencies = [
 name = "quillmark-pdfform"
 version = "0.92.1"
 dependencies = [
+ "hayro",
+ "hayro-svg",
  "lopdf",
  "quillmark",
  "quillmark-core",

--- a/crates/backends/pdfform/Cargo.toml
+++ b/crates/backends/pdfform/Cargo.toml
@@ -15,12 +15,14 @@ quillmark-core = { workspace = true }
 quillmark-pdf = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+hayro = { version = "0.7.1", optional = true }
+hayro-svg = { version = "0.7.0", optional = true }
 
 [features]
 default = []
-# Background-only preview (Svg / canvas raster via hayro). Off by default so the
-# form-filling-only build stays free of the raster tree. Deferred for V1.
-preview = []
+# PDF-flatten → hayro raster / SVG preview. Off by default so the
+# form-filling-only build stays free of the raster tree.
+preview = ["dep:hayro", "dep:hayro-svg"]
 
 [dev-dependencies]
 quillmark-fixtures = { workspace = true }

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -1,0 +1,465 @@
+//! Value-flatten path for the pdfform backend.
+//!
+//! Draws field values as PDF content stream operators instead of AcroForm
+//! widgets. The result is visible in ALL viewers including non-interactive
+//! rasterizers such as headless Chromium / pdfium or Ghostscript — unlike
+//! Technique A (AcroForm with `/NeedAppearances`), which requires an
+//! interactive viewer to synthesize appearances.
+//!
+//! Entry point: [`flatten`].
+
+use quillmark_pdf::{
+    reader::{
+        append_incremental_update, assert_traditional_xref, err, extract_outer_dict,
+        find_dict_value, find_object_bytes, find_startxref, find_trailer_dict, parse_indirect_ref,
+        resolve_page_ids, UpdatedObject,
+    },
+    regions_of, FieldSpec, FieldType, PdfError, StampOptions, StampResult, CHECKBOX_ON_STATE,
+};
+
+const CODE_PARSE: &str = "pdf::flatten_parse";
+
+/// Flatten `fields` onto `base` PDF by drawing values as PDF content stream
+/// operators. Unlike the stamp/Technique-A path, the result is visible in all
+/// rasterizers. Returns the flat PDF bytes and the same [`RenderedRegion`]
+/// sidecar the stamp path produces.
+pub fn flatten(
+    base: Vec<u8>,
+    fields: &[FieldSpec],
+    opts: &StampOptions,
+) -> Result<StampResult, PdfError> {
+    let regions = regions_of(fields);
+
+    if fields.is_empty() && opts.producer.is_none() {
+        return Ok(StampResult { pdf: base, regions });
+    }
+
+    let pdf = base;
+    let xref_offset = find_startxref(&pdf)?;
+    assert_traditional_xref(&pdf, xref_offset)?;
+    let trailer = find_trailer_dict(&pdf, xref_offset)?;
+
+    if find_dict_value(trailer, "Encrypt").is_some() {
+        return Err(err(
+            "pdf::encrypted",
+            "PDF is encrypted; the flatten path does not handle encrypted PDFs",
+        ));
+    }
+
+    let (catalog_id, _) = find_dict_value(trailer, "Root")
+        .and_then(parse_indirect_ref)
+        .ok_or_else(|| err(CODE_PARSE, "/Root missing or malformed in trailer"))?;
+    let size = find_dict_value(trailer, "Size")
+        .and_then(|v| std::str::from_utf8(v.trim_ascii()).ok())
+        .and_then(|s| s.parse::<u32>().ok())
+        .ok_or_else(|| err(CODE_PARSE, "/Size missing or malformed in trailer"))?;
+    let info_ref = find_dict_value(trailer, "Info").and_then(parse_indirect_ref);
+
+    let mut next_id = size;
+    let mut objects: Vec<UpdatedObject> = Vec::new();
+    let mut extra_info_ref: Option<u32> = None;
+
+    // ─── /Info /Producer (when requested) ────────────────────────────────────
+    if let Some(producer) = opts.producer.as_deref() {
+        let literal = pdf_text_string(producer);
+        match info_ref {
+            Some((info_id, _)) => {
+                let (s, e) = find_object_bytes(&pdf, info_id).ok_or_else(|| {
+                    err(CODE_PARSE, format!("/Info object {info_id} not found"))
+                })?;
+                let info_dict = extract_outer_dict(&pdf[s..e])
+                    .ok_or_else(|| err(CODE_PARSE, "/Info dict not parseable"))?;
+                objects.push(dict_object(info_id, &upsert_producer(info_dict, &literal)));
+            }
+            None => {
+                let info_id = alloc_id(&mut next_id)?;
+                let mut inner = b"/Producer ".to_vec();
+                inner.extend_from_slice(&literal);
+                objects.push(dict_object(info_id, &inner));
+                extra_info_ref = Some(info_id);
+            }
+        }
+    }
+
+    if fields.is_empty() {
+        let new_size = next_id;
+        let flat = append_incremental_update(
+            pdf,
+            xref_offset,
+            catalog_id,
+            new_size,
+            extra_info_ref,
+            &objects,
+        )?;
+        return Ok(StampResult { pdf: flat, regions });
+    }
+
+    let page_ids = resolve_page_ids(&pdf, catalog_id)?;
+    let page_count = page_ids.len();
+
+    for spec in fields {
+        if spec.page >= page_count {
+            return Err(err(
+                CODE_PARSE,
+                format!(
+                    "field {:?} targets page {} but the PDF has {page_count} page(s)",
+                    spec.name, spec.page
+                ),
+            ));
+        }
+    }
+
+    // Shared Helvetica Type1 font object (one of the 14 standard PDF fonts).
+    let font_id = alloc_id(&mut next_id)?;
+    objects.push(helvetica_font_object(font_id));
+
+    // Group fields by page.
+    let mut fields_by_page: Vec<Vec<&FieldSpec>> = vec![Vec::new(); page_count];
+    for spec in fields {
+        fields_by_page[spec.page].push(spec);
+    }
+
+    // For each page with drawable fields: emit a content stream and rewrite the page dict.
+    for (page_idx, page_fields) in fields_by_page.iter().enumerate() {
+        let drawable: Vec<&FieldSpec> = page_fields
+            .iter()
+            .copied()
+            .filter(|s| has_drawable_value(s))
+            .collect();
+        if drawable.is_empty() {
+            continue;
+        }
+
+        let stream_id = alloc_id(&mut next_id)?;
+        objects.push(content_stream_object(stream_id, &build_content_stream(&drawable)));
+
+        let page_obj_id = page_ids[page_idx];
+        let (s, e) = find_object_bytes(&pdf, page_obj_id)
+            .ok_or_else(|| err(CODE_PARSE, format!("page object {page_obj_id} not found")))?;
+        let pg_dict = extract_outer_dict(&pdf[s..e])
+            .ok_or_else(|| err(CODE_PARSE, "page dict not parseable"))?;
+
+        let new_pg = rewrite_page_for_flatten(pg_dict, font_id, stream_id)?;
+        objects.push(dict_object(page_obj_id, &new_pg));
+    }
+
+    let new_size = next_id;
+    let flat = append_incremental_update(
+        pdf,
+        xref_offset,
+        catalog_id,
+        new_size,
+        extra_info_ref,
+        &objects,
+    )?;
+    Ok(StampResult { pdf: flat, regions })
+}
+
+// ── Drawing helpers ───────────────────────────────────────────────────────────
+
+/// Whether a field has a value we render visually on the flat path.
+fn has_drawable_value(spec: &FieldSpec) -> bool {
+    match &spec.field_type {
+        FieldType::Signature => false,
+        FieldType::Checkbox => spec.value.as_deref() == Some(CHECKBOX_ON_STATE),
+        _ => spec.value.is_some(),
+    }
+}
+
+/// Build a PDF content stream drawing all `fields` for one page.
+fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for spec in fields {
+        let [x0, y0, x1, y1] = spec.rect;
+        let w = x1 - x0;
+        let h = y1 - y0;
+        match &spec.field_type {
+            FieldType::Signature => {}
+            FieldType::Checkbox => {
+                // Draw a centred "X" for a checked box.
+                let size = (h * 0.75).clamp(4.0, 12.0);
+                let glyph_w = size * 0.55;
+                let x_pos = x0 + (w - glyph_w) * 0.5;
+                let y_pos = y0 + (h - size) * 0.5 + size * 0.1;
+                write_text_block(&mut out, &["X"], x_pos, y_pos, size);
+            }
+            FieldType::Text { .. } => {
+                if let Some(value) = &spec.value {
+                    let size = (h * 0.65).clamp(4.0, 12.0);
+                    let x_pos = x0 + 2.0;
+                    // First baseline just inside the top edge.
+                    let y_top = y1 - size - 1.0;
+                    let lines: Vec<&str> = value.lines().collect();
+                    write_text_block(&mut out, &lines, x_pos, y_top, size);
+                }
+            }
+            FieldType::Choice { .. } => {
+                if let Some(value) = &spec.value {
+                    let size = (h * 0.65).clamp(4.0, 12.0);
+                    let x_pos = x0 + 2.0;
+                    let y_pos = y0 + (h - size) * 0.5;
+                    write_text_block(&mut out, &[value.as_str()], x_pos, y_pos, size);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Write a `q/Q`-wrapped `BT/ET` block for one or more lines of text using `/Helv`.
+fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32) {
+    if lines.is_empty() {
+        return;
+    }
+    let line_h = size * 1.2;
+    out.extend_from_slice(b"q\nBT\n/Helv ");
+    push_f32(out, size);
+    out.extend_from_slice(b" Tf\n");
+    push_f32(out, x);
+    out.push(b' ');
+    push_f32(out, y);
+    out.extend_from_slice(b" Td\n");
+    for (i, line) in lines.iter().enumerate() {
+        if i > 0 {
+            out.extend_from_slice(b"0 ");
+            push_f32(out, -line_h);
+            out.extend_from_slice(b" Td\n");
+        }
+        out.push(b'(');
+        pdf_escape(out, line.as_bytes());
+        out.extend_from_slice(b") Tj\n");
+    }
+    out.extend_from_slice(b"ET\nQ\n");
+}
+
+// ── Page dict rewriting ───────────────────────────────────────────────────────
+
+/// Rewrite the page's inner dict bytes to (a) add `/Helv` to `/Resources /Font`
+/// and (b) append `stream_id` to `/Contents`.
+fn rewrite_page_for_flatten(
+    pg_dict: &[u8],
+    font_id: u32,
+    stream_id: u32,
+) -> Result<Vec<u8>, PdfError> {
+    let with_stream = add_content_stream(pg_dict, stream_id)?;
+    add_font_resource(&with_stream, font_id)
+}
+
+/// Append `stream_id` to the page's `/Contents` (wrapping a bare ref in an array
+/// as needed, or creating `/Contents` when absent).
+fn add_content_stream(pg_dict: &[u8], stream_id: u32) -> Result<Vec<u8>, PdfError> {
+    let ref_str = format!("{stream_id} 0 R");
+    match find_dict_value(pg_dict, "Contents") {
+        None => {
+            let mut out = pg_dict.to_vec();
+            out.extend_from_slice(format!(" /Contents [{ref_str}]").as_bytes());
+            Ok(out)
+        }
+        Some(existing) => {
+            let trimmed = existing.trim_ascii();
+            let new_val = if trimmed.starts_with(b"[") {
+                let end = trimmed
+                    .iter()
+                    .rposition(|&b| b == b']')
+                    .ok_or_else(|| err(CODE_PARSE, "/Contents array missing ]"))?;
+                let inner = String::from_utf8_lossy(&trimmed[1..end]);
+                format!("[{} {ref_str}]", inner.trim())
+            } else {
+                // Single indirect ref — wrap in array.
+                format!("[{} {ref_str}]", String::from_utf8_lossy(trimmed).trim())
+            };
+            let key = b"/Contents";
+            let value_start = existing.as_ptr() as usize - pg_dict.as_ptr() as usize;
+            let key_at = value_start - key.len();
+            let value_end = value_start + existing.len();
+            let mut out = Vec::new();
+            out.extend_from_slice(&pg_dict[..key_at]);
+            out.extend_from_slice(b"/Contents ");
+            out.extend_from_slice(new_val.as_bytes());
+            out.extend_from_slice(&pg_dict[value_end..]);
+            Ok(out)
+        }
+    }
+}
+
+/// Inject `/Helv <font_id> 0 R` into the page's `/Resources /Font` dict,
+/// creating the intermediate dicts as needed.
+///
+/// When `/Resources` is an indirect reference (uncommon in our fixture
+/// contract), font injection is skipped — Helvetica is one of the 14 standard
+/// PDF fonts that conforming readers provide without explicit declaration.
+fn add_font_resource(pg_dict: &[u8], font_id: u32) -> Result<Vec<u8>, PdfError> {
+    let helv_entry = format!("/Helv {font_id} 0 R");
+
+    match find_dict_value(pg_dict, "Resources") {
+        None => {
+            let mut out = pg_dict.to_vec();
+            out.extend_from_slice(
+                format!(" /Resources << /Font << {helv_entry} >> >>").as_bytes(),
+            );
+            Ok(out)
+        }
+        Some(res_val) => {
+            if !res_val.trim_ascii().starts_with(b"<<") {
+                // Indirect resources ref — skip injection, rely on standard fonts.
+                return Ok(pg_dict.to_vec());
+            }
+            let res_inner = extract_outer_dict(res_val)
+                .ok_or_else(|| err(CODE_PARSE, "page /Resources dict not parseable"))?;
+
+            // Build new_res_inner with /Helv injected into /Font.
+            let new_res_inner: Vec<u8> = match find_dict_value(res_inner, "Font") {
+                None => {
+                    let mut out = res_inner.to_vec();
+                    out.extend_from_slice(format!(" /Font << {helv_entry} >>").as_bytes());
+                    out
+                }
+                Some(font_val) => {
+                    if !font_val.trim_ascii().starts_with(b"<<") {
+                        // Indirect font resources ref — rely on standard fonts.
+                        return Ok(pg_dict.to_vec());
+                    }
+                    let font_inner = extract_outer_dict(font_val).ok_or_else(|| {
+                        err(CODE_PARSE, "page /Resources /Font dict not parseable")
+                    })?;
+                    // Build new font dict value.
+                    let mut new_font_val = b"<< ".to_vec();
+                    new_font_val.extend_from_slice(font_inner);
+                    new_font_val.extend_from_slice(format!(" {helv_entry} >>").as_bytes());
+
+                    // Splice new_font_val into res_inner replacing /Font <font_val>.
+                    let fv_start = font_val.as_ptr() as usize - res_inner.as_ptr() as usize;
+                    let key_at = fv_start - b"/Font".len();
+                    let fv_end = fv_start + font_val.len();
+                    let mut out = Vec::new();
+                    out.extend_from_slice(&res_inner[..key_at]);
+                    out.extend_from_slice(b"/Font ");
+                    out.extend_from_slice(&new_font_val);
+                    out.extend_from_slice(&res_inner[fv_end..]);
+                    out
+                }
+            };
+
+            // Build new_res_val and splice it into pg_dict replacing /Resources <res_val>.
+            let mut new_res_val = b"<< ".to_vec();
+            new_res_val.extend_from_slice(&new_res_inner);
+            new_res_val.extend_from_slice(b" >>");
+
+            let rv_start = res_val.as_ptr() as usize - pg_dict.as_ptr() as usize;
+            let key_at = rv_start - b"/Resources".len();
+            let rv_end = rv_start + res_val.len();
+
+            let mut out = Vec::new();
+            out.extend_from_slice(&pg_dict[..key_at]);
+            out.extend_from_slice(b"/Resources ");
+            out.extend_from_slice(&new_res_val);
+            out.extend_from_slice(&pg_dict[rv_end..]);
+            Ok(out)
+        }
+    }
+}
+
+// ── PDF object builders ───────────────────────────────────────────────────────
+
+fn helvetica_font_object(id: u32) -> UpdatedObject {
+    UpdatedObject {
+        id,
+        bytes: format!(
+            "{id} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+        )
+        .into_bytes(),
+    }
+}
+
+fn content_stream_object(id: u32, content: &[u8]) -> UpdatedObject {
+    let mut bytes =
+        format!("{id} 0 obj\n<< /Length {} >>\nstream\n", content.len()).into_bytes();
+    bytes.extend_from_slice(content);
+    bytes.extend_from_slice(b"\nendstream\nendobj\n");
+    UpdatedObject { id, bytes }
+}
+
+fn dict_object(id: u32, inner: &[u8]) -> UpdatedObject {
+    let mut bytes = format!("{id} 0 obj\n<< ").into_bytes();
+    bytes.extend_from_slice(inner);
+    bytes.extend_from_slice(b" >>\nendobj\n");
+    UpdatedObject { id, bytes }
+}
+
+fn alloc_id(next: &mut u32) -> Result<u32, PdfError> {
+    let id = *next;
+    *next = id.checked_add(1).ok_or_else(|| {
+        err(
+            CODE_PARSE,
+            "PDF object id space exhausted (/Size too large)",
+        )
+    })?;
+    Ok(id)
+}
+
+// ── PDF text helpers ──────────────────────────────────────────────────────────
+
+/// Append `v` as a compact `%.2f` float, stripping trailing zeros and dot.
+fn push_f32(out: &mut Vec<u8>, v: f32) {
+    let s = format!("{v:.2}");
+    let s = s.trim_end_matches('0').trim_end_matches('.');
+    out.extend_from_slice(s.as_bytes());
+}
+
+/// Escape bytes for a PDF literal string `( … )`: `(`, `)`, `\` → `\x`.
+fn pdf_escape(out: &mut Vec<u8>, bytes: &[u8]) {
+    for &b in bytes {
+        if matches!(b, b'(' | b')' | b'\\') {
+            out.push(b'\\');
+        }
+        out.push(b);
+    }
+}
+
+/// Encode `s` as a PDF text string: ASCII → literal `(…)`, else UTF-16BE `<FEFF…>`.
+fn pdf_text_string(s: &str) -> Vec<u8> {
+    if s.is_ascii() {
+        let mut out = Vec::with_capacity(s.len() + 2);
+        out.push(b'(');
+        for &b in s.as_bytes() {
+            if matches!(b, b'(' | b')' | b'\\') {
+                out.push(b'\\');
+            }
+            out.push(b);
+        }
+        out.push(b')');
+        out
+    } else {
+        let mut out = Vec::new();
+        out.push(b'<');
+        out.extend_from_slice(b"FEFF");
+        for unit in s.encode_utf16() {
+            out.extend_from_slice(format!("{unit:04X}").as_bytes());
+        }
+        out.push(b'>');
+        out
+    }
+}
+
+fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
+    let key = b"/Producer";
+    match find_dict_value(info_dict, "Producer") {
+        None => {
+            let mut out = info_dict.to_vec();
+            out.extend_from_slice(b" /Producer ");
+            out.extend_from_slice(literal);
+            out
+        }
+        Some(value) => {
+            let value_start = value.as_ptr() as usize - info_dict.as_ptr() as usize;
+            let value_end = value_start + value.len();
+            let key_at = value_start - key.len();
+            let mut out = Vec::new();
+            out.extend_from_slice(&info_dict[..key_at]);
+            out.extend_from_slice(b"/Producer ");
+            out.extend_from_slice(literal);
+            out.extend_from_slice(&info_dict[value_end..]);
+            out
+        }
+    }
+}

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -109,9 +109,12 @@ pub fn flatten(
         }
     }
 
-    // Shared Helvetica Type1 font object (one of the 14 standard PDF fonts).
-    let font_id = alloc_id(&mut next_id)?;
-    objects.push(helvetica_font_object(font_id));
+    // Standard Type1 fonts: Helvetica for text/choice, ZapfDingbats for checkboxes.
+    // Both are among the 14 standard PDF fonts every conforming reader provides.
+    let helv_id = alloc_id(&mut next_id)?;
+    let zadb_id = alloc_id(&mut next_id)?;
+    objects.push(type1_font_object(helv_id, "Helvetica"));
+    objects.push(type1_font_object(zadb_id, "ZapfDingbats"));
 
     // Group fields by page.
     let mut fields_by_page: Vec<Vec<&FieldSpec>> = vec![Vec::new(); page_count];
@@ -139,7 +142,7 @@ pub fn flatten(
         let pg_dict = extract_outer_dict(&pdf[s..e])
             .ok_or_else(|| err(CODE_PARSE, "page dict not parseable"))?;
 
-        let new_pg = rewrite_page_for_flatten(pg_dict, font_id, stream_id)?;
+        let new_pg = rewrite_page_for_flatten(pg_dict, helv_id, zadb_id, stream_id)?;
         objects.push(dict_object(page_obj_id, &new_pg));
     }
 
@@ -176,12 +179,13 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
         match &spec.field_type {
             FieldType::Signature => {}
             FieldType::Checkbox => {
-                // Draw a centred "X" for a checked box.
+                // Glyph 0x34 ("4") in ZapfDingbats is the filled check mark — the
+                // same glyph the AcroForm stamp path declares via /MK /CA (4).
                 let size = (h * 0.75).clamp(4.0, 12.0);
-                let glyph_w = size * 0.55;
-                let x_pos = x0 + (w - glyph_w) * 0.5;
-                let y_pos = y0 + (h - size) * 0.5 + size * 0.1;
-                write_text_block(&mut out, &["X"], x_pos, y_pos, size);
+                // ZapfDingbats check glyphs are roughly square; centre in the box.
+                let x_pos = x0 + (w - size * 0.6) * 0.5;
+                let y_pos = y0 + (h - size) * 0.5;
+                write_zadb_char(&mut out, b'4', x_pos, y_pos, size);
             }
             FieldType::Text { .. } => {
                 if let Some(value) = &spec.value {
@@ -232,17 +236,37 @@ fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32
     out.extend_from_slice(b"ET\nQ\n");
 }
 
+/// Write a single ZapfDingbats character (as its raw byte code) in a `BT/ET` block.
+/// Glyph 0x34 (`'4'`) is the filled check mark — identical to the `/MK /CA (4)`
+/// glyph the AcroForm stamp path declares for checked checkboxes.
+fn write_zadb_char(out: &mut Vec<u8>, glyph: u8, x: f32, y: f32, size: f32) {
+    out.extend_from_slice(b"q\nBT\n/ZaDb ");
+    push_f32(out, size);
+    out.extend_from_slice(b" Tf\n");
+    push_f32(out, x);
+    out.push(b' ');
+    push_f32(out, y);
+    out.extend_from_slice(b" Td\n(");
+    if matches!(glyph, b'(' | b')' | b'\\') {
+        out.push(b'\\');
+    }
+    out.push(glyph);
+    out.extend_from_slice(b") Tj\nET\nQ\n");
+}
+
 // ── Page dict rewriting ───────────────────────────────────────────────────────
 
-/// Rewrite the page's inner dict bytes to (a) add `/Helv` to `/Resources /Font`
-/// and (b) append `stream_id` to `/Contents`.
+/// Rewrite the page's inner dict bytes to (a) add `/Helv` and `/ZaDb` to
+/// `/Resources /Font` and (b) append `stream_id` to `/Contents`.
 fn rewrite_page_for_flatten(
     pg_dict: &[u8],
-    font_id: u32,
+    helv_id: u32,
+    zadb_id: u32,
     stream_id: u32,
 ) -> Result<Vec<u8>, PdfError> {
     let with_stream = add_content_stream(pg_dict, stream_id)?;
-    add_font_resource(&with_stream, font_id)
+    let with_helv = add_font_resource(&with_stream, "Helv", helv_id)?;
+    add_font_resource(&with_helv, "ZaDb", zadb_id)
 }
 
 /// Append `stream_id` to the page's `/Contents` (wrapping a bare ref in an array
@@ -282,14 +306,14 @@ fn add_content_stream(pg_dict: &[u8], stream_id: u32) -> Result<Vec<u8>, PdfErro
     }
 }
 
-/// Inject `/Helv <font_id> 0 R` into the page's `/Resources /Font` dict,
-/// creating the intermediate dicts as needed.
+/// Inject `/<name> <font_id> 0 R` into the page's `/Resources /Font` dict,
+/// creating intermediate dicts as needed.
 ///
 /// When `/Resources` is an indirect reference (uncommon in our fixture
-/// contract), font injection is skipped — Helvetica is one of the 14 standard
-/// PDF fonts that conforming readers provide without explicit declaration.
-fn add_font_resource(pg_dict: &[u8], font_id: u32) -> Result<Vec<u8>, PdfError> {
-    let helv_entry = format!("/Helv {font_id} 0 R");
+/// contract), font injection is skipped — the 14 standard PDF Type1 fonts
+/// are available to conforming readers without explicit resource declaration.
+fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>, PdfError> {
+    let helv_entry = format!("/{name} {font_id} 0 R");
 
     match find_dict_value(pg_dict, "Resources") {
         None => {
@@ -361,11 +385,11 @@ fn add_font_resource(pg_dict: &[u8], font_id: u32) -> Result<Vec<u8>, PdfError> 
 
 // ── PDF object builders ───────────────────────────────────────────────────────
 
-fn helvetica_font_object(id: u32) -> UpdatedObject {
+fn type1_font_object(id: u32, base_font: &str) -> UpdatedObject {
     UpdatedObject {
         id,
         bytes: format!(
-            "{id} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+            "{id} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /{base_font} >>\nendobj\n"
         )
         .into_bytes(),
     }

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -28,13 +28,30 @@ use quillmark_core::{
     RenderSession, Severity,
 };
 use quillmark_pdf::{stamp, FieldSpec, PdfError, StampOptions};
+#[cfg(feature = "preview")]
+use quillmark_pdf::regions_of;
 use flatten::flatten as flatten_to_pdf;
+
+#[cfg(feature = "preview")]
+use {
+    hayro::hayro_interpret::{
+        InterpreterSettings,
+        font::{FontQuery, StandardFont},
+    },
+    hayro::hayro_syntax::Pdf as HayroPdf,
+    hayro::{RenderCache, RenderSettings, render as hayro_render},
+    hayro_svg::{RenderCache as SvgCache, SvgRenderSettings, convert as hayro_svg_convert},
+    std::sync::Arc,
+};
 
 /// Conventional filenames a `pdfform` quill ships at its root.
 const FORM_PDF: &str = "form.pdf";
 const FORM_JSON: &str = "form.json";
 
+#[cfg(not(feature = "preview"))]
 const SUPPORTED_FORMATS: &[OutputFormat] = &[OutputFormat::Pdf];
+#[cfg(feature = "preview")]
+const SUPPORTED_FORMATS: &[OutputFormat] = &[OutputFormat::Pdf, OutputFormat::Svg];
 
 /// The PDF-form backend.
 #[derive(Debug, Default)]
@@ -47,6 +64,11 @@ impl Backend for PdfformBackend {
 
     fn supported_formats(&self) -> &'static [OutputFormat] {
         SUPPORTED_FORMATS
+    }
+
+    #[cfg(feature = "preview")]
+    fn supports_canvas(&self) -> bool {
+        true
     }
 
     fn open(
@@ -95,10 +117,27 @@ impl Backend for PdfformBackend {
             field_specs.push(resolve::field_spec(field, media_box, json_data));
         }
 
+        // Under `preview`, pre-flatten once so render_rgba / SVG renders have
+        // a ready-to-rasterize flat PDF without re-running flatten on every
+        // paint call. The producer string only goes in the PDF Info dict and
+        // doesn't affect rasterisation, so None is fine here.
+        #[cfg(feature = "preview")]
+        let flat_pdf = flatten_to_pdf(
+            base_pdf.clone(),
+            &field_specs,
+            &StampOptions { producer: None },
+        )
+        .map(|r| r.pdf)
+        .map_err(map_pdf_err)?;
+
         Ok(RenderSession::new(Box::new(PdfformSession {
             base_pdf,
             field_specs,
             page_count,
+            #[cfg(feature = "preview")]
+            page_boxes,
+            #[cfg(feature = "preview")]
+            flat_pdf,
         })))
     }
 }
@@ -110,6 +149,14 @@ struct PdfformSession {
     base_pdf: Vec<u8>,
     field_specs: Vec<FieldSpec>,
     page_count: usize,
+    /// Page media-boxes from the background; used by `page_size_pt` under
+    /// `preview` without reparsing the PDF on every canvas-paint call.
+    #[cfg(feature = "preview")]
+    page_boxes: Vec<[f32; 4]>,
+    /// Pre-flattened PDF (values baked as content-stream operators) ready for
+    /// hayro rasterisation. Produced once at session-open time.
+    #[cfg(feature = "preview")]
+    flat_pdf: Vec<u8>,
 }
 
 impl SessionHandle for PdfformSession {
@@ -124,6 +171,12 @@ impl SessionHandle for PdfformSession {
                 .with_code("pdfform::format_not_supported".to_string())
                 .with_hint(format!("Supported formats: {SUPPORTED_FORMATS:?}"))],
             });
+        }
+
+        // SVG output: convert the pre-flattened PDF to SVG via hayro-svg.
+        #[cfg(feature = "preview")]
+        if format == OutputFormat::Svg {
+            return self.render_svg();
         }
 
         // The producer threads from the product layer, else the backend default.
@@ -152,6 +205,89 @@ impl SessionHandle for PdfformSession {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    /// Page dimensions in PDF points derived from the background's `/MediaBox`.
+    /// Available only under the `preview` feature; the default `None` satisfies
+    /// the canvas-capability contract when `preview` is off.
+    #[cfg(feature = "preview")]
+    fn page_size_pt(&self, page: usize) -> Option<(f32, f32)> {
+        let [x0, y0, x1, y1] = *self.page_boxes.get(page)?;
+        Some((x1 - x0, y1 - y0))
+    }
+
+    /// Rasterise `page` of the pre-flattened PDF via hayro. Field values are
+    /// baked into the flat PDF as content-stream operators, so they appear in
+    /// the raster without any regions-compositing by the caller.
+    #[cfg(feature = "preview")]
+    fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
+        use vello_cpu::color::palette::css::WHITE;
+
+        let pdf = HayroPdf::new(self.flat_pdf.clone()).ok()?;
+        let p = pdf.pages().get(page)?;
+        let cache = RenderCache::new();
+        let interp = standard_font_settings();
+        let render_settings = RenderSettings {
+            x_scale: scale,
+            y_scale: scale,
+            bg_color: WHITE,
+            ..Default::default()
+        };
+        let pixmap = hayro_render(p, &cache, &interp, &render_settings);
+        let w = pixmap.width() as u32;
+        let h = pixmap.height() as u32;
+        let bytes: Vec<u8> = pixmap
+            .take_unpremultiplied()
+            .into_iter()
+            .flat_map(|px| [px.r, px.g, px.b, px.a])
+            .collect();
+        Some((w, h, bytes))
+    }
+}
+
+#[cfg(feature = "preview")]
+impl PdfformSession {
+    /// Render all pages as SVG via hayro-svg, using the pre-flattened PDF.
+    fn render_svg(&self) -> Result<RenderResult, RenderError> {
+        let pdf = HayroPdf::new(self.flat_pdf.clone()).map_err(|_| {
+            engine_err(
+                "pdfform::svg_parse_failed",
+                "failed to parse pre-flattened PDF for SVG render",
+            )
+        })?;
+        let interp = standard_font_settings();
+        let svg_settings = SvgRenderSettings {
+            bg_color: [255, 255, 255, 255],
+        };
+        let artifacts: Vec<Artifact> = pdf
+            .pages()
+            .iter()
+            .map(|page| {
+                let cache = SvgCache::new();
+                let svg = hayro_svg_convert(page, &cache, &interp, &svg_settings);
+                Artifact {
+                    bytes: svg.into_bytes(),
+                    output_format: OutputFormat::Svg,
+                }
+            })
+            .collect();
+
+        let regions = regions_of(&self.field_specs);
+        Ok(RenderResult::new(artifacts, OutputFormat::Svg).with_regions(regions))
+    }
+}
+
+/// Build an `InterpreterSettings` that satisfies standard Type1 font queries
+/// (Helvetica, ZapfDingbats, etc.) using hayro's embedded font data.
+/// Required for rendering the flat PDF's Helv and ZaDb content streams.
+#[cfg(feature = "preview")]
+fn standard_font_settings() -> InterpreterSettings {
+    InterpreterSettings {
+        font_resolver: Arc::new(|query| match query {
+            FontQuery::Standard(s) => Some(s.get_font_data()),
+            FontQuery::Fallback(f) => Some(f.pick_standard_font().get_font_data()),
+        }),
+        ..Default::default()
     }
 }
 

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -14,6 +14,7 @@
 //! backends collapse to the same `&[FieldSpec]` seam; they differ only in where
 //! geometry and values come from.
 
+mod flatten;
 mod form;
 mod resolve;
 
@@ -27,6 +28,7 @@ use quillmark_core::{
     RenderSession, Severity,
 };
 use quillmark_pdf::{stamp, FieldSpec, PdfError, StampOptions};
+use flatten::flatten as flatten_to_pdf;
 
 /// Conventional filenames a `pdfform` quill ships at its root.
 const FORM_PDF: &str = "form.pdf";
@@ -126,11 +128,12 @@ impl SessionHandle for PdfformSession {
 
         // The producer threads from the product layer, else the backend default.
         let producer = Some(opts.producer.clone().unwrap_or_else(default_producer));
-        let stamped = stamp(
-            self.base_pdf.clone(),
-            &self.field_specs,
-            &StampOptions { producer },
-        )
+        let stamp_opts = StampOptions { producer };
+        let stamped = if opts.flatten {
+            flatten_to_pdf(self.base_pdf.clone(), &self.field_specs, &stamp_opts)
+        } else {
+            stamp(self.base_pdf.clone(), &self.field_specs, &stamp_opts)
+        }
         .map_err(map_pdf_err)?;
 
         Ok(RenderResult::new(

--- a/crates/backends/pdfform/tests/gov_form.rs
+++ b/crates/backends/pdfform/tests/gov_form.rs
@@ -220,12 +220,16 @@ fn flatten_pdf_contains_helv_font_and_content_streams() {
     let result = render_with(FILLED, true);
     let pdf = &result.artifacts[0].bytes;
 
-    // The flat PDF must contain a Helvetica font object and at least one new
-    // content stream with PDF text operators (BT/ET).
+    // The flat PDF must contain Helvetica and ZapfDingbats font objects and at
+    // least one content stream with PDF text operators.
     let pdf_text = String::from_utf8_lossy(pdf);
     assert!(
         pdf_text.contains("/Helvetica"),
         "flat PDF must declare Helvetica"
+    );
+    assert!(
+        pdf_text.contains("/ZapfDingbats"),
+        "flat PDF must declare ZapfDingbats (for checkbox glyph)"
     );
     assert!(
         pdf_text.contains("BT\n") || pdf_text.contains("BT "),

--- a/crates/backends/pdfform/tests/gov_form.rs
+++ b/crates/backends/pdfform/tests/gov_form.rs
@@ -6,6 +6,7 @@
 
 use lopdf::Document as PdfDoc;
 use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark_core::RegionKind;
 
 const FILLED: &str = "~~~\n\
 $quill: gov_form\n\
@@ -19,6 +20,10 @@ favorite_color: green\n\
 ~~~\n";
 
 fn render(markdown: &str) -> quillmark::RenderResult {
+    render_with(markdown, false)
+}
+
+fn render_with(markdown: &str, flatten: bool) -> quillmark::RenderResult {
     let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("gov_form"))
         .expect("load gov_form quill");
     let engine = Quillmark::new();
@@ -29,6 +34,7 @@ fn render(markdown: &str) -> quillmark::RenderResult {
             &doc,
             &RenderOptions {
                 output_format: Some(OutputFormat::Pdf),
+                flatten,
                 ..Default::default()
             },
         )
@@ -177,4 +183,61 @@ favorite_color: red\n\
     // Absent comments → blank multiline field.
     let comments = widget(&doc, af, "Comments");
     assert!(comments.get(b"V").is_err(), "absent array → no /V");
+}
+
+#[test]
+fn flatten_produces_no_acroform_and_structurally_valid_pdf() {
+    let result = render_with(FILLED, true);
+    assert_eq!(result.output_format, OutputFormat::Pdf);
+    let pdf = &result.artifacts[0].bytes;
+
+    let doc = PdfDoc::load_mem(pdf).expect("lopdf reparse — structurally valid");
+    let cat = doc.catalog().expect("catalog");
+
+    // Flatten path MUST NOT produce an AcroForm — values are in content streams.
+    assert!(
+        cat.get(b"AcroForm").is_err(),
+        "flat PDF must not contain /AcroForm"
+    );
+
+    // Regions sidecar still present (same geometry, same values).
+    assert_eq!(result.regions.len(), 5);
+    let r_full = result
+        .regions
+        .iter()
+        .find(|r| r.name == "FullName")
+        .unwrap();
+    match &r_full.kind {
+        RegionKind::Field { field_type, value } => {
+            assert_eq!(field_type, "text");
+            assert_eq!(value.as_deref(), Some("Ada Lovelace"));
+        }
+    }
+}
+
+#[test]
+fn flatten_pdf_contains_helv_font_and_content_streams() {
+    let result = render_with(FILLED, true);
+    let pdf = &result.artifacts[0].bytes;
+
+    // The flat PDF must contain a Helvetica font object and at least one new
+    // content stream with PDF text operators (BT/ET).
+    let pdf_text = String::from_utf8_lossy(pdf);
+    assert!(
+        pdf_text.contains("/Helvetica"),
+        "flat PDF must declare Helvetica"
+    );
+    assert!(
+        pdf_text.contains("BT\n") || pdf_text.contains("BT "),
+        "flat PDF must contain BT (begin text) operator"
+    );
+    assert!(
+        pdf_text.contains("Tj\n") || pdf_text.contains("Tj "),
+        "flat PDF must contain Tj (show text) operator"
+    );
+    // The field value must appear in the stream.
+    assert!(
+        pdf_text.contains("Ada Lovelace"),
+        "flat PDF must contain the FullName value"
+    );
 }

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -47,6 +47,7 @@ impl PyQuillmark {
             ppi,
             pages,
             producer,
+            flatten: false,
         };
         let start = Instant::now();
         let mut result = self

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -45,9 +45,10 @@ default = ["render"]
 # binding no longer depends on `quillmark-typst` directly.
 render = ["quillmark/typst", "dep:web-sys"]
 # pdfform build: add the Typst-free PDF-form backend so the engine can render
-# `pdfform` quills → PDF. Builds on `render` (the RenderSession surface); the
-# typst-free tiny bundle is a fast-follow.
-pdfform = ["render", "quillmark/pdfform"]
+# `pdfform` quills → PDF. Does NOT require `render` (Typst) — the engine /
+# RenderSession surface is available with `pdfform` alone, giving a tiny
+# Typst-free WASM bundle (core + quillmark-pdf only).
+pdfform = ["quillmark/pdfform"]
 # Core build = no features: Document + Quill (parse / load / validate / schema
 # / seed / blueprint). No engine, no Typst — ~0.34MB gzipped.
 

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # Direct path dep (not `workspace = true`) so `default-features = false` is
 # honoured — workspace inheritance forces the default `typst` feature on, which
 # would pull Typst into the core build. This crate is `publish = false`, so no
-# version pin is needed. `render` re-enables Typst via `quillmark/typst`.
+# version pin is needed. `typst` re-enables Typst via `quillmark/typst`.
 quillmark = { path = "../../quillmark", default-features = false }
 quillmark-core = { workspace = true }
 wasm-bindgen = "0.2"
@@ -38,14 +38,14 @@ web-sys = { version = "0.3", optional = true, features = [
 # Two artifacts from one crate. The boundary is *which types exist*, not
 # feature-gated methods inside a shared type (see
 # prose/proposals/wasm-bindings-split.md).
-default = ["render"]
-# Render build: the Typst-backed engine, RenderSession, and canvas preview.
+default = ["typst"]
+# Typst build: the Typst-backed engine, RenderSession, and canvas preview.
 # Strict API superset of core; ~8MB of Typst is ~96% of the artifact. The
 # canvas painter dispatches through the core `SessionHandle` seam, so the
 # binding no longer depends on `quillmark-typst` directly.
-render = ["quillmark/typst", "dep:web-sys"]
+typst = ["quillmark/typst", "dep:web-sys"]
 # pdfform build: add the Typst-free PDF-form backend so the engine can render
-# `pdfform` quills → PDF. Does NOT require `render` (Typst) — the engine /
+# `pdfform` quills → PDF. Does NOT require `typst` — the engine /
 # RenderSession surface is available with `pdfform` alone, giving a tiny
 # Typst-free WASM bundle (core + quillmark-pdf only).
 pdfform = ["quillmark/pdfform"]

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -416,6 +416,21 @@ describe('Quillmark.quill', () => {
     expect(svg.artifacts[0].mimeType).toBe('image/svg+xml')
   })
 
+  it('regions is always a non-null array on every render result', () => {
+    // Typst renders without AcroForm stamps → regions is empty, never undefined.
+    const engine = new Quillmark()
+    const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+
+    const pdf = engine.render(quill, doc, { format: 'pdf' })
+    expect(Array.isArray(pdf.regions)).toBe(true)
+    expect(pdf.regions.length).toBe(0)
+
+    const svg = engine.render(quill, doc, { format: 'svg' })
+    expect(Array.isArray(svg.regions)).toBe(true)
+    expect(svg.regions.length).toBe(0)
+  })
+
   it('should throw a quill::name_mismatch error when the document quill ref differs from the quill name', () => {
     const engine = new Quillmark()
     const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -134,6 +134,17 @@ describe('@quillmark/wasm/runtime — Engine (hidden core→backend crossing)', 
     expect(typeof (await engine.supportsCanvas(quill))).toBe('boolean')
   })
 
+  it('regions is always a non-null array on the Engine render path', async () => {
+    // Typst renders without AcroForm stamps → regions is empty, never undefined.
+    const engine = new Engine()
+    const quill = makeRuntimeQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+
+    const result = await engine.render(quill, doc, { format: 'pdf' })
+    expect(Array.isArray(result.regions)).toBe(true)
+    expect(result.regions.length).toBe(0)
+  })
+
   it('manifest-backed capability probes do NOT load the backend', async () => {
     // A descriptor-form counting loader: it carries the same manifest the
     // default registry uses, so probes answer from the manifest (no load),

--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -18,7 +18,9 @@ import type {
 	OutputFormat as CanonicalOutputFormat,
 	PageSize as CanonicalPageSize,
 	PaintOptions as CanonicalPaintOptions,
-	PaintResult as CanonicalPaintResult
+	PaintResult as CanonicalPaintResult,
+	FieldRegion as CanonicalFieldRegion,
+	FieldRegionKind as CanonicalFieldRegionKind
   // The BUILT copy (synced from `runtime/runtime.d.ts` by build-wasm.sh / the
   // cp step), because only there does the d.ts's own `../core/wasm.js` import
   // resolve to the generated `pkg/core` build. The two copies are byte-identical.
@@ -31,7 +33,9 @@ import type {
 	OutputFormat as TypstOutputFormat,
 	PageSize as TypstPageSize,
 	PaintOptions as TypstPaintOptions,
-	PaintResult as TypstPaintResult
+	PaintResult as TypstPaintResult,
+	FieldRegion as TypstFieldRegion,
+	FieldRegionKind as TypstFieldRegionKind
 } from '../../../pkg/backends/typst/wasm';
 
 // One mutual-assignability pair per hoisted type: typst → canonical and
@@ -72,3 +76,13 @@ const paintResultA: CanonicalPaintResult = {} as TypstPaintResult;
 const paintResultB: TypstPaintResult = {} as CanonicalPaintResult;
 void paintResultA;
 void paintResultB;
+
+const fieldRegionA: CanonicalFieldRegion = {} as TypstFieldRegion;
+const fieldRegionB: TypstFieldRegion = {} as CanonicalFieldRegion;
+void fieldRegionA;
+void fieldRegionB;
+
+const fieldRegionKindA: CanonicalFieldRegionKind = {} as TypstFieldRegionKind;
+const fieldRegionKindB: TypstFieldRegionKind = {} as CanonicalFieldRegionKind;
+void fieldRegionKindA;
+void fieldRegionKindB;

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -86,12 +86,38 @@ export interface RenderOptions {
 	producer?: string;
 }
 
+/** The kind and payload of a {@link FieldRegion}. Discriminated on `type`. */
+export type FieldRegionKind =
+	| { type: 'field'; fieldType: string; value?: string };
+
+/**
+ * A form-field region: geometry and bound value from a stamped AcroForm.
+ * Emitted by backends that stamp form fields (`pdfform`; Typst signature
+ * overlay). Consumers use `rect` for layout and `kind.value` to composite
+ * field values onto flat (non-interactive) render targets.
+ */
+export interface FieldRegion {
+	/** Fully-qualified field name (matches the AcroForm widget `/T`). */
+	name: string;
+	/** 0-based page index. */
+	page: number;
+	/** `[x0, y0, x1, y1]` in PDF points (1/72″), bottom-left origin. */
+	rect: [number, number, number, number];
+	kind: FieldRegionKind;
+}
+
 /** Canonical contract every backend build must satisfy. Result of one render. */
 export interface RenderResult {
 	artifacts: Artifact[];
 	warnings: Diagnostic[];
 	outputFormat: OutputFormat;
 	renderTimeMs: number;
+	/**
+	 * Form-field regions from stamped AcroForm backends. Always an array —
+	 * empty for backends / formats that produce no field geometry. The only
+	 * path to field values in non-interactive flat output.
+	 */
+	regions: FieldRegion[];
 }
 
 /** Canonical contract every backend build must satisfy. The emittable formats. */

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -84,6 +84,8 @@ export interface RenderOptions {
 	ppi?: number;
 	pages?: number[];
 	producer?: string;
+	/** Draw field values as content streams (visible in all rasterizers) instead of AcroForm widgets. Only the `pdfform` backend uses this; other backends ignore it. */
+	flatten?: boolean;
 }
 
 /** The kind and payload of a {@link FieldRegion}. Discriminated on `type`. */

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -265,6 +265,7 @@ impl Quillmark {
             warnings,
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
+            regions: result.regions.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -1296,6 +1297,7 @@ impl RenderSession {
             warnings: result.warnings.into_iter().map(Into::into).collect(),
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
+            regions: result.regions.into_iter().map(Into::into).collect(),
         })
     }
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2,7 +2,7 @@
 
 use crate::error::WasmError;
 use crate::types::Diagnostic;
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 use crate::types::{RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
 #[cfg(feature = "render")]
@@ -156,7 +156,7 @@ export interface Card {
 #[cfg(feature = "render")]
 const MAX_BACKING_DIMENSION: u32 = 16384;
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
     {
@@ -175,7 +175,7 @@ fn now_ms() -> f64 {
 
 /// Render engine: a backend registry and render dispatcher. Render build only —
 /// the core build constructs and validates quills without it.
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[wasm_bindgen]
 pub struct Quillmark {
     inner: quillmark::Quillmark,
@@ -192,7 +192,7 @@ pub struct Quill {
 /// (`pageCount === 0`); `paint(ctx, 0)` or `pageSize(0)` throws with
 /// `"page index 0 out of range (pageCount=0)"`. Branch on `pageCount === 0`
 /// rather than catching the error.
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[wasm_bindgen]
 pub struct RenderSession {
     inner: quillmark_core::RenderSession,
@@ -210,14 +210,14 @@ pub struct Document {
     parse_warnings: Vec<quillmark_core::Diagnostic>,
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl Default for Quillmark {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[wasm_bindgen]
 impl Quillmark {
     #[wasm_bindgen(constructor)]
@@ -1247,7 +1247,7 @@ export interface PaintResult {
 }
 "#;
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[wasm_bindgen]
 impl RenderSession {
     #[wasm_bindgen(getter, js_name = pageCount)]
@@ -1300,7 +1300,11 @@ impl RenderSession {
             regions: result.regions.into_iter().map(Into::into).collect(),
         })
     }
+}
 
+#[cfg(feature = "render")]
+#[wasm_bindgen]
+impl RenderSession {
     /// Page dimensions in Typst points (1 pt = 1/72 inch).
     /// Throws if the backend has no canvas painter or `page` is out of range.
     #[wasm_bindgen(js_name = pageSize, unchecked_return_type = "PageSize")]

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2,10 +2,10 @@
 
 use crate::error::WasmError;
 use crate::types::Diagnostic;
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 use crate::types::{RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -153,10 +153,10 @@ export interface Card {
 /// `densityScale` proportionally and surfaces the actual backing
 /// dimensions in the returned `PaintResult` so consumers can detect the
 /// clamp.
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 const MAX_BACKING_DIMENSION: u32 = 16384;
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 fn now_ms() -> f64 {
     #[cfg(target_arch = "wasm32")]
     {
@@ -175,7 +175,7 @@ fn now_ms() -> f64 {
 
 /// Render engine: a backend registry and render dispatcher. Render build only —
 /// the core build constructs and validates quills without it.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[wasm_bindgen]
 pub struct Quillmark {
     inner: quillmark::Quillmark,
@@ -192,7 +192,7 @@ pub struct Quill {
 /// (`pageCount === 0`); `paint(ctx, 0)` or `pageSize(0)` throws with
 /// `"page index 0 out of range (pageCount=0)"`. Branch on `pageCount === 0`
 /// rather than catching the error.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[wasm_bindgen]
 pub struct RenderSession {
     inner: quillmark_core::RenderSession,
@@ -210,14 +210,14 @@ pub struct Document {
     parse_warnings: Vec<quillmark_core::Diagnostic>,
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl Default for Quillmark {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[wasm_bindgen]
 impl Quillmark {
     #[wasm_bindgen(constructor)]
@@ -1174,7 +1174,7 @@ fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValu
 }
 
 /// TypeScript declarations for the canvas-preview surface.
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 #[wasm_bindgen(typescript_custom_section)]
 const CANVAS_PREVIEW_TS: &'static str = r#"
 /**
@@ -1247,7 +1247,7 @@ export interface PaintResult {
 }
 "#;
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[wasm_bindgen]
 impl RenderSession {
     #[wasm_bindgen(getter, js_name = pageCount)]
@@ -1302,7 +1302,7 @@ impl RenderSession {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 #[wasm_bindgen]
 impl RenderSession {
     /// Page dimensions in Typst points (1 pt = 1/72 inch).
@@ -1428,7 +1428,7 @@ impl RenderSession {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 impl RenderSession {
     /// Gate a canvas operation on the backend's honest canvas capability,
     /// captured at open time. The painter now dispatches generically through
@@ -1455,13 +1455,13 @@ impl RenderSession {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 enum CanvasCtx<'a> {
     OnScreen(&'a web_sys::CanvasRenderingContext2d),
     OffScreen(&'a web_sys::OffscreenCanvasRenderingContext2d),
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 impl<'a> CanvasCtx<'a> {
     fn from_js(ctx: &'a JsValue) -> Result<Self, JsValue> {
         if let Some(c) = ctx.dyn_ref::<web_sys::CanvasRenderingContext2d>() {
@@ -1503,7 +1503,7 @@ impl<'a> CanvasCtx<'a> {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 #[derive(Serialize)]
 struct PageSize {
     #[serde(rename = "widthPt")]
@@ -1512,7 +1512,7 @@ struct PageSize {
     height_pt: f32,
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 #[derive(Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PaintOptions {
@@ -1522,7 +1522,7 @@ struct PaintOptions {
     density_scale: Option<f32>,
 }
 
-#[cfg(feature = "render")]
+#[cfg(feature = "typst")]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PaintResult {

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -55,7 +55,7 @@ mod error;
 mod types;
 
 pub use engine::{Document, Quill};
-#[cfg(feature = "render")]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 pub use engine::{Quillmark, RenderSession};
 pub use error::WasmError;
 pub use types::*;

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::*;
 /// Gated behind the engine surface (`render` or `pdfform`) so tsify omits
 /// its `.d.ts` interface from the core bundle (`pkg/core/wasm.d.ts`), which
 /// has no rendering surface.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "lowercase")]
@@ -20,7 +20,7 @@ pub enum OutputFormat {
     Png,
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<OutputFormat> for quillmark_core::OutputFormat {
     fn from(format: OutputFormat) -> Self {
         match format {
@@ -32,7 +32,7 @@ impl From<OutputFormat> for quillmark_core::OutputFormat {
     }
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<quillmark_core::OutputFormat> for OutputFormat {
     fn from(format: quillmark_core::OutputFormat) -> Self {
         match format {
@@ -156,7 +156,7 @@ impl From<Diagnostic> for quillmark_core::Diagnostic {
 }
 
 /// Rendered artifact (PDF, SVG, etc.).
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -171,7 +171,7 @@ pub struct Artifact {
     pub mime_type: String,
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl Artifact {
     fn mime_type_for_format(format: OutputFormat) -> String {
         quillmark_core::OutputFormat::from(format)
@@ -180,7 +180,7 @@ impl Artifact {
     }
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<quillmark_core::Artifact> for Artifact {
     fn from(artifact: quillmark_core::Artifact) -> Self {
         let format = artifact.output_format.into();
@@ -193,7 +193,7 @@ impl From<quillmark_core::Artifact> for Artifact {
 }
 
 /// Result of a render operation.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -214,7 +214,7 @@ pub struct RenderResult {
 /// A form-field region: geometry and bound value from a stamped AcroForm.
 /// Emitted by backends that stamp form fields. Consumers use this to
 /// composite values onto flat (non-interactive) render targets.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -230,7 +230,7 @@ pub struct FieldRegion {
 
 /// The kind and payload of a [`FieldRegion`]. An open enum — future region
 /// types extend here without breaking existing consumers.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -246,7 +246,7 @@ pub enum FieldRegionKind {
     },
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<quillmark_core::RenderedRegion> for FieldRegion {
     fn from(r: quillmark_core::RenderedRegion) -> Self {
         FieldRegion {
@@ -258,7 +258,7 @@ impl From<quillmark_core::RenderedRegion> for FieldRegion {
     }
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<quillmark_core::RegionKind> for FieldRegionKind {
     fn from(k: quillmark_core::RegionKind) -> Self {
         match k {
@@ -270,7 +270,7 @@ impl From<quillmark_core::RegionKind> for FieldRegionKind {
 }
 
 /// Options for rendering.
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -301,7 +301,7 @@ pub struct RenderOptions {
     pub flatten: Option<bool>,
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl Default for RenderOptions {
     fn default() -> Self {
         RenderOptions {
@@ -314,7 +314,7 @@ impl Default for RenderOptions {
     }
 }
 
-#[cfg(any(feature = "render", feature = "pdfform"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<RenderOptions> for quillmark_core::RenderOptions {
     fn from(opts: RenderOptions) -> Self {
         Self {
@@ -334,7 +334,7 @@ mod tests {
     // ── OutputFormat ──────────────────────────────────────────────────────────
 
     #[test]
-    #[cfg(any(feature = "render", feature = "pdfform"))]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn test_output_format_serialization() {
         let pdf = OutputFormat::Pdf;
         let json_pdf = serde_json::to_string(&pdf).unwrap();
@@ -350,7 +350,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "render", feature = "pdfform"))]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn test_output_format_deserialization() {
         let pdf: OutputFormat = serde_json::from_str("\"pdf\"").unwrap();
         assert_eq!(pdf, OutputFormat::Pdf);
@@ -436,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "render", feature = "pdfform"))]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn test_render_options_with_format() {
         let options = RenderOptions {
             format: Some(OutputFormat::Pdf),
@@ -496,7 +496,7 @@ mod tests {
     // ── FieldRegion / FieldRegionKind ─────────────────────────────────────────
 
     #[test]
-    #[cfg(any(feature = "render", feature = "pdfform"))]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn field_region_serializes_to_expected_shape() {
         let region = FieldRegion {
             name: "FullName".to_string(),
@@ -517,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "render", feature = "pdfform"))]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn field_region_blank_value_omitted() {
         let region = FieldRegion {
             name: "Signature".to_string(),
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "render", feature = "pdfform"))]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn field_region_from_core_conversion() {
         use quillmark_core::{RegionKind, RenderedRegion};
 

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -201,6 +201,71 @@ pub struct RenderResult {
     pub warnings: Vec<Diagnostic>,
     pub output_format: OutputFormat,
     pub render_time_ms: f64,
+    /// Form-field regions from stamped AcroForm backends (`pdfform`;
+    /// Typst signature overlay). Ordered by page then field-spec order.
+    /// Always an array — empty for backends / formats that produce no
+    /// field geometry. The only path to field values in non-interactive
+    /// flat output; consumers composite values from here.
+    #[serde(default)]
+    pub regions: Vec<FieldRegion>,
+}
+
+/// A form-field region: geometry and bound value from a stamped AcroForm.
+/// Emitted by backends that stamp form fields. Consumers use this to
+/// composite values onto flat (non-interactive) render targets.
+#[cfg(feature = "render")]
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldRegion {
+    /// Fully-qualified field name (matches the AcroForm widget `/T`).
+    pub name: String,
+    /// 0-based page index.
+    pub page: usize,
+    /// `[x0, y0, x1, y1]` in PDF points (1/72″), bottom-left origin.
+    pub rect: [f32; 4],
+    pub kind: FieldRegionKind,
+}
+
+/// The kind and payload of a [`FieldRegion`]. An open enum — future region
+/// types extend here without breaking existing consumers.
+#[cfg(feature = "render")]
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum FieldRegionKind {
+    /// An interactive form field stamped onto the page.
+    Field {
+        /// Lowercase type id: `"text"`, `"checkbox"`, `"choice"`, or `"signature"`.
+        #[serde(rename = "fieldType")]
+        field_type: String,
+        /// The bound value, or `undefined` for a blank / unbound field.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
+    },
+}
+
+#[cfg(feature = "render")]
+impl From<quillmark_core::RenderedRegion> for FieldRegion {
+    fn from(r: quillmark_core::RenderedRegion) -> Self {
+        FieldRegion {
+            name: r.name,
+            page: r.page,
+            rect: r.rect,
+            kind: r.kind.into(),
+        }
+    }
+}
+
+#[cfg(feature = "render")]
+impl From<quillmark_core::RegionKind> for FieldRegionKind {
+    fn from(k: quillmark_core::RegionKind) -> Self {
+        match k {
+            quillmark_core::RegionKind::Field { field_type, value } => {
+                FieldRegionKind::Field { field_type, value }
+            }
+        }
+    }
 }
 
 /// Options for rendering.
@@ -417,5 +482,69 @@ mod tests {
 
         assert!(!js_value.is_undefined());
         assert!(!js_value.is_null());
+    }
+
+    // ── FieldRegion / FieldRegionKind ─────────────────────────────────────────
+
+    #[test]
+    #[cfg(feature = "render")]
+    fn field_region_serializes_to_expected_shape() {
+        let region = FieldRegion {
+            name: "FullName".to_string(),
+            page: 0,
+            rect: [180.0, 672.0, 520.0, 692.0],
+            kind: FieldRegionKind::Field {
+                field_type: "text".to_string(),
+                value: Some("Ada Lovelace".to_string()),
+            },
+        };
+        let json = serde_json::to_string(&region).unwrap();
+        assert!(json.contains("\"name\":\"FullName\""));
+        assert!(json.contains("\"page\":0"));
+        assert!(json.contains("\"rect\":[180.0,672.0,520.0,692.0]"));
+        assert!(json.contains("\"type\":\"field\""));
+        assert!(json.contains("\"fieldType\":\"text\""));
+        assert!(json.contains("\"value\":\"Ada Lovelace\""));
+    }
+
+    #[test]
+    #[cfg(feature = "render")]
+    fn field_region_blank_value_omitted() {
+        let region = FieldRegion {
+            name: "Signature".to_string(),
+            page: 0,
+            rect: [180.0, 422.0, 520.0, 462.0],
+            kind: FieldRegionKind::Field {
+                field_type: "signature".to_string(),
+                value: None,
+            },
+        };
+        let json = serde_json::to_string(&region).unwrap();
+        // value:None → absent from JSON (skip_serializing_if)
+        assert!(!json.contains("\"value\""));
+        assert!(json.contains("\"fieldType\":\"signature\""));
+    }
+
+    #[test]
+    #[cfg(feature = "render")]
+    fn field_region_from_core_conversion() {
+        use quillmark_core::{RegionKind, RenderedRegion};
+
+        let core_region = RenderedRegion {
+            name: "Agree".to_string(),
+            page: 0,
+            rect: [180.0, 538.0, 194.0, 552.0],
+            kind: RegionKind::Field {
+                field_type: "checkbox".to_string(),
+                value: Some("Yes".to_string()),
+            },
+        };
+        let wasm_region: FieldRegion = core_region.into();
+        assert_eq!(wasm_region.name, "Agree");
+        assert_eq!(wasm_region.page, 0);
+        assert_eq!(wasm_region.rect, [180.0, 538.0, 194.0, 552.0]);
+        let FieldRegionKind::Field { field_type, value } = wasm_region.kind;
+        assert_eq!(field_type, "checkbox");
+        assert_eq!(value.as_deref(), Some("Yes"));
     }
 }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -6,9 +6,10 @@ use wasm_bindgen::prelude::*;
 
 /// Output formats supported by backends.
 ///
-/// Gated behind `render` so tsify omits its `.d.ts` interface from the core
-/// bundle (`pkg/core/wasm.d.ts`), which has no rendering surface.
-#[cfg(feature = "render")]
+/// Gated behind the engine surface (`render` or `pdfform`) so tsify omits
+/// its `.d.ts` interface from the core bundle (`pkg/core/wasm.d.ts`), which
+/// has no rendering surface.
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "lowercase")]
@@ -19,7 +20,7 @@ pub enum OutputFormat {
     Png,
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl From<OutputFormat> for quillmark_core::OutputFormat {
     fn from(format: OutputFormat) -> Self {
         match format {
@@ -31,7 +32,7 @@ impl From<OutputFormat> for quillmark_core::OutputFormat {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl From<quillmark_core::OutputFormat> for OutputFormat {
     fn from(format: quillmark_core::OutputFormat) -> Self {
         match format {
@@ -155,7 +156,7 @@ impl From<Diagnostic> for quillmark_core::Diagnostic {
 }
 
 /// Rendered artifact (PDF, SVG, etc.).
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -170,7 +171,7 @@ pub struct Artifact {
     pub mime_type: String,
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl Artifact {
     fn mime_type_for_format(format: OutputFormat) -> String {
         quillmark_core::OutputFormat::from(format)
@@ -179,7 +180,7 @@ impl Artifact {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl From<quillmark_core::Artifact> for Artifact {
     fn from(artifact: quillmark_core::Artifact) -> Self {
         let format = artifact.output_format.into();
@@ -192,7 +193,7 @@ impl From<quillmark_core::Artifact> for Artifact {
 }
 
 /// Result of a render operation.
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -213,7 +214,7 @@ pub struct RenderResult {
 /// A form-field region: geometry and bound value from a stamped AcroForm.
 /// Emitted by backends that stamp form fields. Consumers use this to
 /// composite values onto flat (non-interactive) render targets.
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -229,7 +230,7 @@ pub struct FieldRegion {
 
 /// The kind and payload of a [`FieldRegion`]. An open enum — future region
 /// types extend here without breaking existing consumers.
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -245,7 +246,7 @@ pub enum FieldRegionKind {
     },
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl From<quillmark_core::RenderedRegion> for FieldRegion {
     fn from(r: quillmark_core::RenderedRegion) -> Self {
         FieldRegion {
@@ -257,7 +258,7 @@ impl From<quillmark_core::RenderedRegion> for FieldRegion {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl From<quillmark_core::RegionKind> for FieldRegionKind {
     fn from(k: quillmark_core::RegionKind) -> Self {
         match k {
@@ -269,7 +270,7 @@ impl From<quillmark_core::RegionKind> for FieldRegionKind {
 }
 
 /// Options for rendering.
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -300,7 +301,7 @@ pub struct RenderOptions {
     pub flatten: Option<bool>,
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl Default for RenderOptions {
     fn default() -> Self {
         RenderOptions {
@@ -313,7 +314,7 @@ impl Default for RenderOptions {
     }
 }
 
-#[cfg(feature = "render")]
+#[cfg(any(feature = "render", feature = "pdfform"))]
 impl From<RenderOptions> for quillmark_core::RenderOptions {
     fn from(opts: RenderOptions) -> Self {
         Self {
@@ -333,7 +334,7 @@ mod tests {
     // ── OutputFormat ──────────────────────────────────────────────────────────
 
     #[test]
-    #[cfg(feature = "render")]
+    #[cfg(any(feature = "render", feature = "pdfform"))]
     fn test_output_format_serialization() {
         let pdf = OutputFormat::Pdf;
         let json_pdf = serde_json::to_string(&pdf).unwrap();
@@ -349,7 +350,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "render")]
+    #[cfg(any(feature = "render", feature = "pdfform"))]
     fn test_output_format_deserialization() {
         let pdf: OutputFormat = serde_json::from_str("\"pdf\"").unwrap();
         assert_eq!(pdf, OutputFormat::Pdf);
@@ -435,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "render")]
+    #[cfg(any(feature = "render", feature = "pdfform"))]
     fn test_render_options_with_format() {
         let options = RenderOptions {
             format: Some(OutputFormat::Pdf),
@@ -495,7 +496,7 @@ mod tests {
     // ── FieldRegion / FieldRegionKind ─────────────────────────────────────────
 
     #[test]
-    #[cfg(feature = "render")]
+    #[cfg(any(feature = "render", feature = "pdfform"))]
     fn field_region_serializes_to_expected_shape() {
         let region = FieldRegion {
             name: "FullName".to_string(),
@@ -516,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "render")]
+    #[cfg(any(feature = "render", feature = "pdfform"))]
     fn field_region_blank_value_omitted() {
         let region = FieldRegion {
             name: "Signature".to_string(),
@@ -534,7 +535,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "render")]
+    #[cfg(any(feature = "render", feature = "pdfform"))]
     fn field_region_from_core_conversion() {
         use quillmark_core::{RegionKind, RenderedRegion};
 

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -293,6 +293,11 @@ pub struct RenderOptions {
     /// the default (`Quillmark <version>`). Applies to PDF output only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub producer: Option<String>,
+    /// Draw field values as PDF content streams (visible in all viewers,
+    /// including non-interactive rasterizers) instead of AcroForm widgets.
+    /// Only the `pdfform` backend uses this; other backends ignore it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flatten: Option<bool>,
 }
 
 #[cfg(feature = "render")]
@@ -303,6 +308,7 @@ impl Default for RenderOptions {
             ppi: None,
             pages: None,
             producer: None,
+            flatten: None,
         }
     }
 }
@@ -315,6 +321,7 @@ impl From<RenderOptions> for quillmark_core::RenderOptions {
             ppi: opts.ppi,
             pages: opts.pages,
             producer: opts.producer,
+            flatten: opts.flatten.unwrap_or(false),
         }
     }
 }
@@ -435,6 +442,7 @@ mod tests {
             ppi: None,
             pages: None,
             producer: None,
+            flatten: None,
         };
         let json = serde_json::to_string(&options).unwrap();
         assert!(json.contains("\"format\":\"pdf\""));

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -155,4 +155,8 @@ pub struct RenderOptions {
     /// the backend default (`Quillmark <version>` for the Typst backend).
     /// Applies to PDF output only; ignored by SVG/PNG/TXT.
     pub producer: Option<String>,
+    /// Draw field values as PDF content stream operators instead of AcroForm
+    /// widgets. Only the `pdfform` backend uses this; other backends ignore it.
+    /// When `false` (the default) the AcroForm / Technique A path is used.
+    pub flatten: bool,
 }

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -21,7 +21,7 @@
 //! `crate::reader`'s docs for the input contract the base PDF must satisfy.
 
 mod error;
-mod reader;
+pub mod reader;
 mod stamp;
 
 pub use error::PdfError;

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -20,12 +20,12 @@ const CODE_XREF_STREAM: &str = "pdf::xref_stream";
 
 /// Build a `PdfError` with `code`. Every fail site here just needs a code plus
 /// a message, so this is the whole error-construction surface.
-pub(crate) fn err(code: &'static str, msg: impl Into<String>) -> PdfError {
+pub fn err(code: &'static str, msg: impl Into<String>) -> PdfError {
     PdfError::new(code, msg)
 }
 
 /// The offset stored after the last `startxref` marker.
-pub(crate) fn find_startxref(pdf: &[u8]) -> Result<usize, PdfError> {
+pub fn find_startxref(pdf: &[u8]) -> Result<usize, PdfError> {
     let needle = b"startxref";
     let from = pdf.len().saturating_sub(1024);
     let tail = &pdf[from..];
@@ -52,7 +52,7 @@ pub(crate) fn find_startxref(pdf: &[u8]) -> Result<usize, PdfError> {
 }
 
 /// Bail if the base PDF stores an xref stream instead of a traditional table.
-pub(crate) fn assert_traditional_xref(pdf: &[u8], xref_offset: usize) -> Result<(), PdfError> {
+pub fn assert_traditional_xref(pdf: &[u8], xref_offset: usize) -> Result<(), PdfError> {
     if pdf.get(xref_offset..xref_offset + 4) != Some(b"xref") {
         return Err(err(
             CODE_XREF_STREAM,
@@ -65,7 +65,7 @@ pub(crate) fn assert_traditional_xref(pdf: &[u8], xref_offset: usize) -> Result<
 /// Return the trailer dictionary bytes for the xref section at `xref_offset`.
 /// The slice is the inner dict (between `<<` and `>>`) and may be queried with
 /// [`find_dict_value`].
-pub(crate) fn find_trailer_dict(pdf: &[u8], xref_offset: usize) -> Result<&[u8], PdfError> {
+pub fn find_trailer_dict(pdf: &[u8], xref_offset: usize) -> Result<&[u8], PdfError> {
     let needle = b"trailer";
     let pos = pdf[xref_offset..]
         .windows(needle.len())
@@ -92,7 +92,7 @@ fn write_preserved_trailer_keys(out: &mut Vec<u8>, prior_trailer: &[u8]) {
 
 /// One object emitted into an incremental update: its number and full
 /// serialized form (`<id> 0 obj … endobj`).
-pub(crate) struct UpdatedObject {
+pub struct UpdatedObject {
     pub id: u32,
     pub bytes: Vec<u8>,
 }
@@ -106,7 +106,7 @@ pub(crate) struct UpdatedObject {
 /// `/Info <id> 0 R` for the case where the prior trailer had none (a fresh
 /// `/Info` object was created). `new_size` is the updated `/Size` (highest
 /// object number + 1) and `root_id` the document catalog.
-pub(crate) fn append_incremental_update(
+pub fn append_incremental_update(
     mut pdf: Vec<u8>,
     prev_xref: usize,
     root_id: u32,
@@ -171,7 +171,7 @@ pub(crate) fn append_incremental_update(
 /// Matches only at a token boundary so `19 0 obj` isn't found inside `519 0
 /// obj`. Callers scan the original PDF before appending, so the first match is
 /// the only copy.
-pub(crate) fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
+pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
     let header = format!("{} 0 obj", id);
     let h = header.as_bytes();
     let mut i = 0;
@@ -191,7 +191,7 @@ pub(crate) fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
 /// Within a dict's inner bytes, locate `/Key` and return its raw value slice.
 /// Value-terminating tokenisation handles Name values like `/Pages` so they
 /// aren't mis-read as the next entry.
-pub(crate) fn find_dict_value<'a>(dict_bytes: &'a [u8], key: &str) -> Option<&'a [u8]> {
+pub fn find_dict_value<'a>(dict_bytes: &'a [u8], key: &str) -> Option<&'a [u8]> {
     let key_marker = format!("/{}", key);
     let km = key_marker.as_bytes();
     let mut i = 0;
@@ -387,7 +387,7 @@ fn is_pdf_delim(c: u8) -> bool {
     )
 }
 
-pub(crate) fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
+pub fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
     let s = skip_ws(s);
     let mut i = 0;
     while i < s.len() && s[i].is_ascii_digit() {
@@ -412,7 +412,7 @@ pub(crate) fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
 }
 
 /// Slice between the outermost `<< ... >>` of an indirect object's body.
-pub(crate) fn extract_outer_dict(obj_bytes: &[u8]) -> Option<&[u8]> {
+pub fn extract_outer_dict(obj_bytes: &[u8]) -> Option<&[u8]> {
     let open = obj_bytes.windows(2).position(|w| w == b"<<")?;
     let mut depth = 0i32;
     let mut i = open;
@@ -449,7 +449,7 @@ fn skip_ws(s: &[u8]) -> &[u8] {
 /// Resolve the catalog's `/Pages` tree into a flat list of page object IDs,
 /// in document order. The recursion is defensive and capped to prevent runaway
 /// on a pathological PDF.
-pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfError> {
+pub fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfError> {
     let root_pages_id = root_pages_id(pdf, catalog_id)?;
 
     const MAX_NODES: usize = 100_000;
@@ -567,7 +567,7 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
 /// full rect — not just width/height — is returned so a caller that owns
 /// page-relative top-left geometry can honour a non-zero page origin when
 /// flipping to bottom-left PDF user space.
-pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
+pub fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
     let xref_offset = find_startxref(pdf)?;
     assert_traditional_xref(pdf, xref_offset)?;
     let trailer = find_trailer_dict(pdf, xref_offset)?;

--- a/crates/quillmark/examples/pdfform_preview.rs
+++ b/crates/quillmark/examples/pdfform_preview.rs
@@ -1,0 +1,108 @@
+//! Visual preview harness for the `pdfform` backend.
+//!
+//! Renders `gov_form` → `gov_form_filled.pdf` and `taro` → `taro_preview.svg`,
+//! writes both to the fixtures output directory, and prints the regions sidecar
+//! for the filled form so field geometry can be cross-checked against a viewer.
+//!
+//! Run with:
+//!   cargo run --example pdfform_preview -p quillmark
+
+use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark_fixtures::{example_output_dir, quills_path, write_example_output};
+
+const GOV_FORM_MD: &str = "\
+~~~
+$quill: gov_form
+$kind: main
+full_name: Ada Lovelace
+comments:
+  - First comment line.
+  - Second comment line.
+agree: true
+favorite_color: green
+~~~
+";
+
+const TARO_MD: &str = "\
+~~~
+$quill: taro
+$kind: main
+author: Ada Lovelace
+title: Taro Preview
+ice_cream: taro
+~~~
+
+This is a preview document rendered for visual review of the SVG backend output.
+";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let engine = Quillmark::new();
+    let out_dir = example_output_dir();
+
+    // --- pdfform: gov_form → PDF ---
+    println!("=== pdfform backend: gov_form → PDF ===");
+    let gf_quill =
+        quillmark::quill_from_path(quills_path("gov_form")).expect("load gov_form quill");
+    let gf_doc = Document::from_markdown(GOV_FORM_MD).expect("parse gov_form markdown");
+    let gf_result = engine
+        .render(
+            &gf_quill,
+            &gf_doc,
+            &RenderOptions {
+                output_format: Some(OutputFormat::Pdf),
+                ..Default::default()
+            },
+        )
+        .expect("gov_form render");
+
+    write_example_output("gov_form_filled.pdf", &gf_result.artifacts[0].bytes)?;
+    println!(
+        "Written: {}",
+        out_dir.join("gov_form_filled.pdf").display()
+    );
+
+    println!("\nField regions sidecar ({} fields):", gf_result.regions.len());
+    for region in &gf_result.regions {
+        let quillmark_core::RegionKind::Field { field_type, value } = &region.kind;
+        let val_display = value.as_deref().unwrap_or("<blank>");
+        println!(
+            "  {:20}  page={:<2}  rect=[{:.1},{:.1},{:.1},{:.1}]  type={:<10}  value={:?}",
+            region.name,
+            region.page,
+            region.rect[0],
+            region.rect[1],
+            region.rect[2],
+            region.rect[3],
+            field_type,
+            val_display,
+        );
+    }
+
+    // --- Typst backend: taro → SVG ---
+    println!("\n=== Typst backend: taro → SVG ===");
+    let taro_quill = quillmark::quill_from_path(quills_path("taro")).expect("load taro quill");
+    let taro_doc = Document::from_markdown(TARO_MD).expect("parse taro markdown");
+    let taro_result = engine
+        .render(
+            &taro_quill,
+            &taro_doc,
+            &RenderOptions {
+                output_format: Some(OutputFormat::Svg),
+                ..Default::default()
+            },
+        )
+        .expect("taro SVG render");
+
+    write_example_output("taro_preview.svg", &taro_result.artifacts[0].bytes)?;
+    println!("Written: {}", out_dir.join("taro_preview.svg").display());
+    println!(
+        "SVG size: {} bytes",
+        taro_result.artifacts[0].bytes.len()
+    );
+
+    println!("\nDone. Open the files in the output directory to review:");
+    println!("  PDF: {}", out_dir.join("gov_form_filled.pdf").display());
+    println!("  SVG: {}", out_dir.join("taro_preview.svg").display());
+
+    Ok(())
+}

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -102,6 +102,7 @@ impl Quillmark {
             ppi: opts.ppi,
             pages: opts.pages.clone(),
             producer: opts.producer.clone(),
+            flatten: opts.flatten,
         };
         session.render(&resolved)
     }


### PR DESCRIPTION
## Summary

Adds support for exposing form-field geometry and bound values from backends that stamp AcroForm fields (currently `pdfform`). This enables consumers to composite field values onto flat (non-interactive) render targets by providing structured region metadata alongside rendered artifacts.

## Key Changes

- **New types in WASM bindings** (`crates/bindings/wasm/src/types.rs`):
  - `FieldRegion`: Represents a single form-field region with name, page, bounding rectangle, and kind
  - `FieldRegionKind`: Discriminated enum for field types (currently `Field` with `field_type` and optional `value`)
  - Conversion implementations from `quillmark_core::{RenderedRegion, RegionKind}`
  - Comprehensive unit tests for serialization, blank value handling, and core type conversion

- **Updated `RenderResult`** to include `regions: Vec<FieldRegion>` field (always present, empty for non-AcroForm backends)

- **TypeScript type definitions** (`runtime/runtime.d.ts`):
  - `FieldRegion` interface with fully-qualified field name, page index, PDF-point rectangle, and kind
  - `FieldRegionKind` discriminated union type
  - Updated `RenderResult` interface documentation

- **Type compatibility tests** (`runtime.types.test-d.ts`):
  - Bidirectional assignability checks between canonical and Typst backend types

- **Integration tests** (`basic.test.js`, `runtime.test.js`):
  - Verify `regions` is always a non-null array on render results
  - Confirm empty array for backends without AcroForm stamps

- **Example harness** (`pdfform_preview.rs`):
  - New example demonstrating `pdfform` backend rendering with field region output
  - Prints formatted region sidecar for visual cross-checking against PDF viewers

- **Engine integration** (`engine.rs`):
  - Maps core `RenderedRegion` objects into WASM `FieldRegion` types in render pipeline

## Implementation Details

- Regions are ordered by page then field-spec order
- Rectangle coordinates use PDF points (1/72″) with bottom-left origin: `[x0, y0, x1, y1]`
- Field values are optional (serialized with `skip_serializing_if` to omit `null`)
- Fully-qualified field names match AcroForm widget `/T` entries
- Design is extensible: `FieldRegionKind` is a tagged enum ready for future region types

https://claude.ai/code/session_01MnX3GcTqYCGFLbHjSdC2yf