### PR TITLE
pdfform: collapse the flatten knob (PDF always AcroForm) + branch-review write-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@
   `regions` sidecar through `RenderResult` and generalize the raster-preview
   seam (#749, #750). See `prose/proposals/PDFFORM_BACKEND.md` §9 for the V1
   handover.
-- feat(core): add `RenderOptions.flatten` to drive the pdfform value-flattening
-  render path
-- fix(pdfform): flatten path transcodes values to WinAnsi (with a
-  `WinAnsiEncoding` font) so accented/Latin-1 text renders correctly in flat
-  output, and clips each value to its field box so long values can't overflow
+- refactor(pdfform): PDF output is always an interactive AcroForm (Technique A).
+  Value-flattening is now internal preview-only machinery (gated under the
+  `preview` feature) backing the SVG/PNG raster previews, never a PDF
+  deliverable. The public `RenderOptions.flatten` knob is removed across core and
+  all four bindings (it was wired only in wasm, hardcoded `false` in Python, and
+  ignored in .NET)
+- fix(pdfform): the preview flatten path transcodes values to WinAnsi (with a
+  `WinAnsiEncoding` font) so accented/Latin-1 text renders correctly in the
+  raster preview, and clips each value to its field box so long values can't
+  overflow
 - refactor(quillmark-pdf): hoist the shared PDF byte-serialization (object/text
   writers, `/Info /Producer` stamp) into `quillmark_pdf::writer`, consumed by
   both the stamp and flatten paths; `find_object_bytes` now matches any object

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -372,3 +372,184 @@ fn push_f32(out: &mut Vec<u8>, v: f32) {
     let s = s.trim_end_matches('0').trim_end_matches('.');
     out.extend_from_slice(s.as_bytes());
 }
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+//
+// This module inherits the whole file's `#[cfg(feature = "preview")]` gate, so
+// it only compiles/runs under `--features preview`. It restores the byte-level
+// coverage of the flatten output that the (now-removed) public `flatten: true`
+// integration tests used to provide, exercised here at the `flatten()` unit
+// level (plus the internal `build_content_stream` for the focused
+// transcoding/clipping byte windows) — no public render-option knob involved.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::Document as PdfDoc;
+    use quillmark_pdf::CHECKBOX_ON_STATE;
+
+    /// A stripped single-page US-Letter background PDF ([0 0 612 792], no
+    /// AcroForm, no annots) — the perfect flatten base.
+    const BASE: &[u8] =
+        include_bytes!("../../../fixtures/resources/quills/sample_form/0.1.0/form.pdf");
+
+    fn text_field(name: &str, value: &str) -> FieldSpec {
+        FieldSpec {
+            name: name.to_string(),
+            page: 0,
+            rect: [72.0, 700.0, 300.0, 720.0],
+            field_type: FieldType::Text { multiline: false },
+            value: Some(value.to_string()),
+            tooltip: None,
+        }
+    }
+
+    fn checkbox_field(name: &str, checked: bool) -> FieldSpec {
+        FieldSpec {
+            name: name.to_string(),
+            page: 0,
+            rect: [72.0, 660.0, 90.0, 678.0],
+            field_type: FieldType::Checkbox,
+            value: checked.then(|| CHECKBOX_ON_STATE.to_string()),
+            tooltip: None,
+        }
+    }
+
+    fn flatten_ok(fields: &[FieldSpec]) -> Vec<u8> {
+        flatten(BASE.to_vec(), fields, &StampOptions::default())
+            .expect("flatten succeeds")
+            .pdf
+    }
+
+    fn contains_window(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// 1. The flat output reparses cleanly and its catalog carries NO
+    ///    `/AcroForm` — values live in content streams, not widgets.
+    #[test]
+    fn flatten_produces_no_acroform() {
+        let pdf = flatten_ok(&[text_field("FullName", "Ada Lovelace")]);
+
+        let doc = PdfDoc::load_mem(&pdf).expect("lopdf reparse — structurally valid");
+        let cat = doc.catalog().expect("catalog");
+        assert!(
+            cat.get(b"AcroForm").is_err(),
+            "flat PDF must not contain /AcroForm"
+        );
+    }
+
+    /// 2. The flat output declares both standard fonts, a WinAnsi-encoded text
+    ///    font, the `BT`/`Tj` text operators, and the literal field value.
+    #[test]
+    fn flatten_has_fonts_and_text_operators() {
+        let pdf = flatten_ok(&[text_field("FullName", "Ada Lovelace")]);
+        let text = String::from_utf8_lossy(&pdf);
+
+        assert!(text.contains("/Helvetica"), "must declare Helvetica");
+        assert!(
+            text.contains("/ZapfDingbats"),
+            "must declare ZapfDingbats (checkbox glyph font)"
+        );
+        assert!(
+            text.contains("/Encoding /WinAnsiEncoding"),
+            "text font must declare WinAnsiEncoding"
+        );
+        assert!(
+            text.contains("BT\n") || text.contains("BT "),
+            "must contain BT (begin text) operator"
+        );
+        assert!(
+            text.contains("Tj\n") || text.contains("Tj "),
+            "must contain Tj (show text) operator"
+        );
+        assert!(
+            text.contains("Ada Lovelace"),
+            "must contain the field value literal"
+        );
+    }
+
+    /// 3. Each text value clips to its field rect (`re W n`) so it can't
+    ///    overflow over neighbouring content.
+    #[test]
+    fn flatten_clips_to_field_box() {
+        let pdf = flatten_ok(&[text_field("FullName", "Ada Lovelace")]);
+        let text = String::from_utf8_lossy(&pdf);
+        assert!(
+            text.contains(" re W n"),
+            "text must clip to the field box (re W n)"
+        );
+    }
+
+    /// 4. Non-ASCII CP1252 chars are transcoded to their WinAnsi bytes in the
+    ///    content stream (not drawn as raw UTF-8). Asserted directly on
+    ///    `build_content_stream` — the closest seam to the original byte-window
+    ///    test — and also that the value reaches the full `flatten()` output.
+    #[test]
+    fn build_content_stream_transcodes_non_ascii_to_winansi() {
+        // é(U+00E9) — (U+2014) ñ(U+00F1) ’(U+2019)
+        let value = "Caf\u{e9} \u{2014} Se\u{f1}or \u{2019}A\u{2019}";
+        let spec = text_field("FullName", value);
+        let stream = build_content_stream(&[&spec]);
+
+        // WinAnsi bytes: é→0xE9, —→0x97, ñ→0xF1, ’→0x92. Drawn literal:
+        // `Caf<E9> <97> Se<F1>or <92>A<92>`.
+        let want: &[u8] = &[
+            b'C', b'a', b'f', 0xE9, b' ', 0x97, b' ', b'S', b'e', 0xF1, b'o', b'r', b' ', 0x92,
+            b'A', 0x92,
+        ];
+        assert!(
+            contains_window(&stream, want),
+            "content stream must carry the WinAnsi-encoded value bytes"
+        );
+        // The raw UTF-8 sequence for é (0xC3 0xA9) must NOT appear as a drawn
+        // literal — that would be the pre-fix corruption.
+        assert!(
+            !contains_window(&stream, &[b'f', 0xC3, 0xA9, b' ']),
+            "value must not be drawn as raw UTF-8"
+        );
+
+        // And the same bytes survive the full flatten() envelope.
+        let pdf = flatten_ok(&[spec]);
+        assert!(
+            contains_window(&pdf, want),
+            "flat PDF must carry the WinAnsi-encoded value bytes"
+        );
+    }
+
+    /// 5. A checked checkbox wires the ZapfDingbats font and draws the check
+    ///    glyph via the `write_zadb_char` path (`/ZaDb` + the `'4'` glyph).
+    #[test]
+    fn flatten_checked_checkbox_emits_zapfdingbats_glyph() {
+        let spec = checkbox_field("Agree", true);
+        let stream = build_content_stream(&[&spec]);
+        let text = String::from_utf8_lossy(&stream);
+
+        assert!(
+            text.contains("/ZaDb"),
+            "checked checkbox must select the ZapfDingbats font (/ZaDb)"
+        );
+        // The check glyph is ZapfDingbats byte 0x34 ('4'), drawn as `(4) Tj`.
+        assert!(
+            contains_window(&stream, b"(4) Tj"),
+            "checked checkbox must draw the check glyph"
+        );
+
+        // The font object is wired in the full flatten() output.
+        let pdf = flatten_ok(&[spec]);
+        assert!(
+            String::from_utf8_lossy(&pdf).contains("/ZapfDingbats"),
+            "flat PDF must declare the ZapfDingbats font"
+        );
+
+        // Value-gating lives in flatten() (via `has_drawable_value`), not in
+        // `build_content_stream`: an unchecked checkbox is filtered out before
+        // it reaches the stream, so the check glyph is never drawn.
+        assert!(has_drawable_value(&checkbox_field("Agree", true)));
+        assert!(!has_drawable_value(&checkbox_field("Agree", false)));
+        let unchecked = flatten_ok(&[checkbox_field("Agree", false)]);
+        assert!(
+            !contains_window(&unchecked, b"(4) Tj"),
+            "unchecked checkbox must not draw the check glyph"
+        );
+    }
+}

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -14,15 +14,18 @@
 //! backends collapse to the same `&[FieldSpec]` seam; they differ only in where
 //! geometry and values come from.
 
+#[cfg(feature = "preview")]
 mod flatten;
 mod form;
 mod resolve;
+#[cfg(feature = "preview")]
 mod typography;
 
 pub use form::{FieldKind, FormField, FormParseError, FormSpec, Rect};
 
 use std::any::Any;
 
+#[cfg(feature = "preview")]
 use flatten::flatten as flatten_to_pdf;
 use quillmark_core::session::SessionHandle;
 use quillmark_core::{
@@ -178,14 +181,13 @@ impl SessionHandle for PdfformSession {
         }
 
         // The producer threads from the product layer, else the backend default.
+        // PDF output is always an interactive AcroForm (Technique A / `stamp`);
+        // value-flattening is internal preview-only machinery, never a PDF
+        // deliverable.
         let producer = Some(opts.producer.clone().unwrap_or_else(default_producer));
         let stamp_opts = StampOptions { producer };
-        let stamped = if opts.flatten {
-            flatten_to_pdf(self.base_pdf.clone(), &self.field_specs, &stamp_opts)
-        } else {
-            stamp(self.base_pdf.clone(), &self.field_specs, &stamp_opts)
-        }
-        .map_err(map_pdf_err)?;
+        let stamped =
+            stamp(self.base_pdf.clone(), &self.field_specs, &stamp_opts).map_err(map_pdf_err)?;
 
         Ok(RenderResult::new(
             vec![Artifact {

--- a/crates/backends/pdfform/tests/sample_form.rs
+++ b/crates/backends/pdfform/tests/sample_form.rs
@@ -6,7 +6,6 @@
 
 use lopdf::Document as PdfDoc;
 use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
-use quillmark_core::RegionKind;
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -20,10 +19,6 @@ favorite_color: green\n\
 ~~~\n";
 
 fn render(markdown: &str) -> quillmark::RenderResult {
-    render_with(markdown, false)
-}
-
-fn render_with(markdown: &str, flatten: bool) -> quillmark::RenderResult {
     let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("sample_form"))
         .expect("load sample_form quill");
     let engine = Quillmark::new();
@@ -34,7 +29,6 @@ fn render_with(markdown: &str, flatten: bool) -> quillmark::RenderResult {
             &doc,
             &RenderOptions {
                 output_format: Some(OutputFormat::Pdf),
-                flatten,
                 ..Default::default()
             },
         )
@@ -183,124 +177,4 @@ favorite_color: red\n\
     // Absent comments → blank multiline field.
     let comments = widget(&doc, af, "Comments");
     assert!(comments.get(b"V").is_err(), "absent array → no /V");
-}
-
-#[test]
-fn flatten_produces_no_acroform_and_structurally_valid_pdf() {
-    let result = render_with(FILLED, true);
-    assert_eq!(result.output_format, OutputFormat::Pdf);
-    let pdf = &result.artifacts[0].bytes;
-
-    let doc = PdfDoc::load_mem(pdf).expect("lopdf reparse — structurally valid");
-    let cat = doc.catalog().expect("catalog");
-
-    // Flatten path MUST NOT produce an AcroForm — values are in content streams.
-    assert!(
-        cat.get(b"AcroForm").is_err(),
-        "flat PDF must not contain /AcroForm"
-    );
-
-    // Regions sidecar still present (same geometry, same values).
-    assert_eq!(result.regions.len(), 5);
-    let r_full = result
-        .regions
-        .iter()
-        .find(|r| r.name == "FullName")
-        .unwrap();
-    match &r_full.kind {
-        RegionKind::Field { field_type, value } => {
-            assert_eq!(field_type, "text");
-            assert_eq!(value.as_deref(), Some("Ada Lovelace"));
-        }
-    }
-}
-
-#[test]
-fn flatten_pdf_contains_helv_font_and_content_streams() {
-    let result = render_with(FILLED, true);
-    let pdf = &result.artifacts[0].bytes;
-
-    // The flat PDF must contain Helvetica and ZapfDingbats font objects and at
-    // least one content stream with PDF text operators.
-    let pdf_text = String::from_utf8_lossy(pdf);
-    assert!(
-        pdf_text.contains("/Helvetica"),
-        "flat PDF must declare Helvetica"
-    );
-    assert!(
-        pdf_text.contains("/ZapfDingbats"),
-        "flat PDF must declare ZapfDingbats (for checkbox glyph)"
-    );
-    assert!(
-        pdf_text.contains("BT\n") || pdf_text.contains("BT "),
-        "flat PDF must contain BT (begin text) operator"
-    );
-    assert!(
-        pdf_text.contains("Tj\n") || pdf_text.contains("Tj "),
-        "flat PDF must contain Tj (show text) operator"
-    );
-    // The field value must appear in the stream.
-    assert!(
-        pdf_text.contains("Ada Lovelace"),
-        "flat PDF must contain the FullName value"
-    );
-    // The text font declares WinAnsiEncoding so the drawn bytes render correctly.
-    assert!(
-        pdf_text.contains("/Encoding /WinAnsiEncoding"),
-        "flat text font must declare WinAnsiEncoding"
-    );
-    // Text blocks clip to their field box (`re W n`) so values can't overflow.
-    assert!(
-        pdf_text.contains(" re W n"),
-        "flat text must clip to the field box"
-    );
-}
-
-#[test]
-fn flatten_transcodes_non_ascii_to_winansi() {
-    // Accented Latin-1, a CP1252-block em-dash, and a curly quote must reach the
-    // flat content stream as their WinAnsi bytes (not raw UTF-8), so a flat
-    // rasterizer renders them with the WinAnsi-encoded Helvetica.
-    let markdown = "~~~\n\
-        $quill: sample_form\n\
-        $kind: main\n\
-        full_name: \"Caf\u{e9} \u{2014} Se\u{f1}or \u{2019}A\u{2019}\"\n\
-        comments: []\n\
-        agree: false\n\
-        favorite_color: green\n\
-        ~~~\n";
-    let result = render_with(markdown, true);
-    let pdf = &result.artifacts[0].bytes;
-
-    // WinAnsi bytes: é→0xE9, —→0x97, ñ→0xF1, ’→0x92. The drawn literal is
-    // `Caf<E9> <97> Se<F1>or <92>A<92>`.
-    let want: &[u8] = &[
-        b'C', b'a', b'f', 0xE9, b' ', 0x97, b' ', b'S', b'e', 0xF1, b'o', b'r', b' ', 0x92, b'A',
-        0x92,
-    ];
-    assert!(
-        pdf.windows(want.len()).any(|w| w == want),
-        "flat PDF must contain the WinAnsi-encoded value bytes"
-    );
-    // The raw UTF-8 multi-byte sequence for é (0xC3 0xA9) must NOT appear in a
-    // drawn text literal — that would be the pre-fix corruption.
-    assert!(
-        !pdf.windows(4).any(|w| w == [b'f', 0xC3, 0xA9, b' ']),
-        "value must not be drawn as raw UTF-8"
-    );
-
-    // The region sidecar keeps the original Unicode value intact.
-    let r = result
-        .regions
-        .iter()
-        .find(|r| r.name == "FullName")
-        .unwrap();
-    match &r.kind {
-        RegionKind::Field { value, .. } => {
-            assert_eq!(
-                value.as_deref(),
-                Some("Caf\u{e9} \u{2014} Se\u{f1}or \u{2019}A\u{2019}")
-            );
-        }
-    }
 }

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -47,7 +47,6 @@ impl PyQuillmark {
             ppi,
             pages,
             producer,
-            flatten: false,
         };
         let start = Instant::now();
         let mut result = self

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -84,8 +84,6 @@ export interface RenderOptions {
 	ppi?: number;
 	pages?: number[];
 	producer?: string;
-	/** Draw field values as content streams (visible in all rasterizers) instead of AcroForm widgets. Only the `pdfform` backend uses this; other backends ignore it. */
-	flatten?: boolean;
 }
 
 /** The kind and payload of a {@link FieldRegion}. Discriminated on `type`. */

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -278,7 +278,7 @@ export class Engine {
 	 * Render `doc` against `quill` in one shot, returning a `RenderResult`.
 	 * @param {Quill} quill
 	 * @param {Document} doc
-	 * @param {object} [options] render options (`{ format, ppi, pages, producer, flatten }`)
+	 * @param {object} [options] render options (`{ format, ppi, pages, producer }`)
 	 * @returns {Promise<import('./runtime.js').RenderResult>}
 	 */
 	async render(quill, doc, options) {

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -295,11 +295,6 @@ pub struct RenderOptions {
     /// the default (`Quillmark <version>`). Applies to PDF output only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub producer: Option<String>,
-    /// Draw field values as PDF content streams (visible in all viewers,
-    /// including non-interactive rasterizers) instead of AcroForm widgets.
-    /// Only the `pdfform` backend uses this; other backends ignore it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub flatten: Option<bool>,
 }
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
@@ -310,7 +305,6 @@ impl Default for RenderOptions {
             ppi: None,
             pages: None,
             producer: None,
-            flatten: None,
         }
     }
 }
@@ -323,7 +317,6 @@ impl From<RenderOptions> for quillmark_core::RenderOptions {
             ppi: opts.ppi,
             pages: opts.pages,
             producer: opts.producer,
-            flatten: opts.flatten.unwrap_or(false),
         }
     }
 }
@@ -444,7 +437,6 @@ mod tests {
             ppi: None,
             pages: None,
             producer: None,
-            flatten: None,
         };
         let json = serde_json::to_string(&options).unwrap();
         assert!(json.contains("\"format\":\"pdf\""));

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -155,8 +155,4 @@ pub struct RenderOptions {
     /// the backend default (`Quillmark <version>` for the Typst backend).
     /// Applies to PDF output only; ignored by SVG/PNG/TXT.
     pub producer: Option<String>,
-    /// Draw field values as PDF content stream operators instead of AcroForm
-    /// widgets. Only the `pdfform` backend uses this; other backends ignore it.
-    /// When `false` (the default) the AcroForm / Technique A path is used.
-    pub flatten: bool,
 }

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -102,7 +102,6 @@ impl Quillmark {
             ppi: opts.ppi,
             pages: opts.pages.clone(),
             producer: opts.producer.clone(),
-            flatten: opts.flatten,
         };
         session.render(&resolved)
     }

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -183,7 +183,7 @@ The widget is unsigned: Quillmark performs no cryptography. To produce a signed 
 
 | Format | Support |
 |---|---|
-| **PDF** | Always — the deliverable. |
+| **PDF** | Always — the deliverable; always an interactive AcroForm (Technique A). |
 | **SVG** | Under the `preview` feature only. |
 | **PNG / canvas** | Under the `preview` feature only. |
 

--- a/prose/proposals/PDFFORM_BACKEND.md
+++ b/prose/proposals/PDFFORM_BACKEND.md
@@ -451,11 +451,13 @@ supports every field type, exercised through `pdfform`.
 
 ### Fast-follow / tooling backlog (deferred, not V1)
 
-- **Value flattening** for PNG/SVG-with-values (and an optional flattened-PDF):
-  draw values into page content via `pdf-writer` over the background, then
-  hayro/hayro-svg render them. This is the appearance-synthesis the issue
-  punted on (text layout, `0 Tf` auto-size emulation) — the single biggest *new*
-  piece of work. Lives in `pdfform`'s render feature, **never** in the spine.
+- **Value flattening** for PNG/SVG-with-values: draw values into page content
+  via `pdf-writer` over the background, then hayro/hayro-svg render them. This is
+  the appearance-synthesis the issue punted on (text layout, `0 Tf` auto-size
+  emulation) — the single biggest *new* piece of work. It is **internal
+  preview-only machinery, not a PDF-output deliverable**: PDF output is always an
+  interactive AcroForm (Technique A). Lives in `pdfform`'s `preview` feature,
+  **never** in the spine.
 - **Regions presentation enrichment** (font/size/align) — rides with flattening.
 - **Surface `regions` in the WASM typed API** (then Python/.NET) — opt-in,
   additive; wasm first as the GUI consumer.

--- a/prose/review/01-spine-nonzero-generation.md
+++ b/prose/review/01-spine-nonzero-generation.md
@@ -1,0 +1,62 @@
+# 01 — Spine re-emits overwritten objects at generation 0
+
+**Severity:** major **Category:** correctness **Status:** Open
+
+**Location:**
+- `crates/quillmark-pdf/src/writer.rs:16` (`dict_object`)
+- `crates/quillmark-pdf/src/stamp.rs:162` (trailer `/Root … 0 R`)
+- `crates/quillmark-pdf/src/reader.rs:178` (`find_object_bytes`, matches any generation)
+- test proving the reader accepts non-zero generations: `crates/quillmark-pdf/src/reader.rs:701` (`find_object_matches_nonzero_generation`)
+
+## Finding
+
+The incremental-update appender always re-emits an overwritten base object at
+**generation 0** and references it as gen 0 (`dict_object`, and the trailer's
+`/Root … 0 R`). But the reader deliberately matches an object header at **any**
+generation — there is even a passing test (`find_object_matches_nonzero_generation`)
+asserting the base may carry gen-2 objects.
+
+So a base PDF whose catalog / page / `/Info` object lives at a non-zero
+generation is **in-contract for the reader** (it parses fine) yet produces a
+**corrupt incremental update**: the new xref subsection lists the object at gen
+`00000` and `/Root` points to gen 0, while the prior xref still resolves the same
+object number at its true generation. A reader that honours generations sees an
+inconsistent document.
+
+This is a malformed-but-readable input that slips through the contract: the
+reader's permissiveness (any generation) and the writer's assumption (everything
+is gen 0) disagree.
+
+## Why it matters
+
+- It is a **silent corruption** path, not a clean rejection — the spine's whole
+  stated stance is "reject out-of-contract input cleanly" (xref streams,
+  encryption, indirect `/Annots`, near-`u32::MAX` `/Size` all hard-error). This
+  case is the one gap in that posture.
+- **Reachability is genuinely low.** The qualification layer emits gen-0
+  traditional-xref PDFs, and the hand-authored `sample_form` fixture is gen 0.
+  So no current producer hits this. It is a latent-robustness gap that would
+  surface only with a hand-supplied or third-party background.
+
+## Options
+
+1. **Hard-error (recommended).** When any object being overwritten
+   (catalog / page / `/Info`) has generation ≠ 0, return a `PdfError`. One small
+   check, consistent with the existing `assert_traditional_xref` / `/Encrypt`
+   rejections. Closes the gap by construction; adds no permanent complexity.
+2. **Carry the real generation** through `dict_object`, the xref entry, and the
+   `/Root`/ref serialization. Correct in full generality but adds generation
+   plumbing the contract was specifically designed to avoid.
+
+Recommendation: **(1)** — it matches the design's "normalize upstream, keep the
+runtime reader light, reject the rest" philosophy and is cheaper than (2).
+
+## Notes
+
+- Adjacent minor robustness item in the same module: `find_object_bytes` locates
+  the `endobj` terminator by raw byte search, which could truncate on an object
+  whose body legitimately contains the bytes `endobj` (e.g. inside a stream or
+  string). Safe for the dict-only objects this crate overwrites, but
+  `page_media_boxes` runs the scanner over arbitrary in-contract bases. Consider
+  matching `endobj` only at a token boundary. Track with this item or fold into
+  #07 coverage.

--- a/prose/review/02-canvas-capability-contract.md
+++ b/prose/review/02-canvas-capability-contract.md
@@ -1,0 +1,116 @@
+# 02 — Canvas capability contract not closed by construction
+
+**Severity:** major **Category:** architecture **Status:** Open — design proposed
+
+**Location:**
+- `crates/core/src/backend.rs:19-28` (`supports_canvas`, default `false`, with the
+  "must agree by construction" doc comment)
+- `crates/core/src/session.rs:22,51` (`page_size_pt` / `render_rgba`, default `None`)
+- `crates/bindings/wasm/src/engine.rs:240` (capability snapshot), `:1440`
+  (`ensure_canvas`), `:1405` (paint maps a `None` raster to `page_oob_error`)
+- pdfform's current canvas impls (the thing a shared path would subsume):
+  `crates/backends/pdfform/src/lib.rs:214` (`page_size_pt`), `:223` (`render_rgba`
+  over `flat_pdf` via hayro), `:251` (`render_svg`)
+
+## Finding
+
+Canvas capability is expressed in two independently-settable places: the static
+`Backend::supports_canvas()` (a hand-set `bool`) and the dynamic
+`SessionHandle::{page_size_pt, render_rgba}` (default `None`). The `backend.rs`
+doc comment claims "the two must agree by construction," but nothing in the type
+system enforces it — they are three separately-defaultable methods on two traits.
+For the two in-tree backends they agree by discipline; an out-of-tree backend can
+set `supports_canvas → true` while leaving `render_rgba` at its default `None`,
+reproducing exactly the paint-nothing failure the seam was meant to eliminate.
+
+The failure is worse than "paints nothing": with the capability snapshot true,
+`ensure_canvas` passes, and `paint` then treats the only remaining `None` from
+`render_rgba` as a bad page index (`engine.rs:1405`, `.ok_or_else(|| page_oob_error(...))`).
+So a disagreeing backend surfaces a **misleading "page index out of range"**
+error for a page that exists.
+
+This is the one place the implementation under-delivers on its own stated design
+goal (the proposal said to fold the flag and the impl "so the gap closes by
+construction").
+
+## Why it matters
+
+- The generalized canvas seam is a headline of this branch (it replaced the old
+  Typst-only `Any` downcast). Leaving the capability as a parallel hand-set flag
+  keeps the disagreement class alive for any third-party backend and mislabels
+  the failure when it occurs.
+- The static/dynamic split is deliberate and load-bearing: `supports_canvas` is a
+  **pre-session** query (so a GUI can decide whether to show a canvas affordance
+  before paying to open a session), while `render_rgba` needs an open session.
+  Any fix must preserve the cheap pre-session query.
+
+## Proposed design — automatic canvas for PDF-producing backends
+
+Origin: pdfform's three preview methods are already nothing but "rasterize/convert
+a PDF via hayro" — none is pdfform-specific except *which* PDF they read
+(`flat_pdf`). So generalize that into a shared, feature-gated engine capability
+and delete the per-backend copy.
+
+- **Shared PDF→canvas path** (feature-gated, hayro/vello): `pdf → rgba`,
+  `pdf → svg`, and page size via `quillmark_pdf::page_media_boxes`. Any backend
+  that can hand the engine a raster-ready PDF gets canvas/SVG/size for free.
+- **New session seam:** a default-`None` provider, e.g.
+  `fn raster_pdf(&self) -> Option<&[u8]> { None }`. A PDF-producing backend
+  returns its raster-ready bytes (pdfform returns `&self.flat_pdf`); a non-PDF
+  backend returns `None`.
+- **Dispatch, single predicate:**
+  ```
+  if let Some(px) = handle.render_rgba(page, scale) { px }            // native override (Typst)
+  else if cfg!(raster) { handle.raster_pdf().map(|pdf| pdf_raster(pdf, page, scale)) }
+  else { None }
+  ```
+- **`supports_canvas` becomes derived** from that same predicate (native override
+  present, or raster feature on and a raster PDF available) instead of a hand-set
+  bool — so capability and impl cannot disagree. A static pre-session form can be
+  derived from `SUPPORTED_FORMATS.contains(Pdf)` + the `cfg`, consistent with the
+  dynamic path.
+
+### How it honours both constraints (from discussion)
+
+- **Automatic canvas for PDF-output backends** — provide a raster PDF, get the
+  rest for free; no per-backend rasterizer code.
+- **No PDF mandate** — a non-PDF backend simply doesn't implement `raster_pdf`,
+  reports no canvas, and is never forced to produce PDF.
+- **Tiny/headless bundle preserved** — the rasterizer stays behind a feature;
+  with it off, `raster_pdf` is inert and `supports_canvas` derives to `false`.
+  The form-filling-only build links no rasterizer, as today.
+
+### Two correctness/placement points
+
+1. **Rasterize the *flattened* PDF, not the AcroForm deliverable.** Since PDF
+   output is now always AcroForm (commit `458064f`), the deliverable renders
+   blank in hayro (`NeedAppearances`). The seam is therefore "backend hands me a
+   *raster-ready* PDF" (pdfform's `flat_pdf`, produced by the now-internal
+   `flatten.rs`), not "engine grabs the deliverable bytes."
+2. **Keep Typst on native `typst-render`.** Typst→pixels directly is higher
+   fidelity than Typst→PDF→hayro, and Typst already owns that dep. The generic
+   PDF path is the default/fallback; the native `render_rgba` override is the only
+   remaining per-backend canvas knob, and it is purely additive (its absence just
+   means "fall back to generic," never a disagreement).
+
+### Open decision — where the shared hayro path lives
+
+- **`quillmark-pdf` behind a `raster` feature** — keeps the rasterizer next to the
+  PDF byte code it consumes (already has `page_media_boxes`); cost: widens the
+  crate's "Typst-free, `pdf-writer`-only leaf infra" charter.
+- **A sibling `quillmark-pdf-raster` crate** — keeps the spine pristine; the
+  rasterizer is its own opt-in leaf. Slight crate ceremony. *(Reviewer lean.)*
+
+## Cheaper fallback (if we don't do the shared path now)
+
+- **Downgrade the doc** at `backend.rs:22-25` to state the agreement is a
+  convention external backends must uphold, not a guarantee; and
+- **Fix the `paint` mislabel** (`engine.rs:1405`): a `None` from `render_rgba`
+  *after* `ensure_canvas` passed should be its own "backend reported canvas but
+  produced no raster" error, not `page_oob_error`. One line; correct regardless
+  of which larger path we choose.
+
+## Scope note
+
+The shared-path design is a real refactor (core seam + both backends + a dep
+move), larger than the other open items. Sequence it after the cheap cleanups.

--- a/prose/review/03-wasm-region-serde-roundtrip.md
+++ b/prose/review/03-wasm-region-serde-roundtrip.md
@@ -1,0 +1,44 @@
+# 03 — WASM region type: `skip_serializing_if` without `serde(default)`
+
+**Severity:** minor **Category:** correctness (latent) **Status:** Open
+
+**Location:** `crates/bindings/wasm/src/types.rs:245` (the `value` field on the
+`FieldRegionKind::Field` / `FieldRegion` Tsify type)
+
+## Finding
+
+The wasm `FieldRegion` kind carries
+`#[serde(skip_serializing_if = "Option::is_none")]` on its `value: Option<String>`
+field, but **no matching `#[serde(default)]`**. The type is annotated
+`#[tsify(into_wasm_abi, from_wasm_abi)]`, so Tsify generates a `from_wasm_abi`
+(JS→Rust) deserialization path as well as the serialization path.
+
+When `value` is `None`, serialization omits the key entirely. If that same JSON is
+ever fed back through `from_wasm_abi`, serde errors with `missing field 'value'`
+because there is no default to fall back on.
+
+## Why it matters
+
+- Today regions are **output-only** (Rust→JS), so this never fires in practice.
+- But the **bidirectional** Tsify annotation advertises a round-trip that is
+  silently broken for the blank-value case. Any future "accept/edit a region"
+  API that deserializes a `FieldRegion` back into Rust would hit
+  `missing field 'value'` for every unbound field — the common case.
+
+## Fix
+
+Add `#[serde(default)]` alongside the existing `skip_serializing_if` on the
+`value` field. One line; makes the declared round-trip actually total.
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub value: Option<String>,
+```
+
+## Notes
+
+- Mirrors a deliberate guard already present on the **core** side: the
+  `blank_field_value_is_null` test in `crates/core/src/region.rs` exists
+  specifically to keep core's `value` serializing as `null` (not omitted). The
+  wasm wrapper chose the opposite (omit) without the compensating `default`, so
+  the two layers treat blank values differently — worth aligning while here.

--- a/prose/review/04-region-kind-irrefutable-let.md
+++ b/prose/review/04-region-kind-irrefutable-let.md
@@ -1,0 +1,46 @@
+# 04 — Irrefutable `let` on the extensible `RegionKind`
+
+**Severity:** minor **Category:** smelly (future breakage) **Status:** Open
+
+**Location:** `crates/quillmark/examples/pdfform_preview.rs` — the
+`let quillmark_core::RegionKind::Field { field_type, value } = &region.kind;`
+destructuring (around line 66; verify current line).
+
+## Finding
+
+The example destructures `RegionKind` with an **irrefutable** `let`:
+
+```rust
+let RegionKind::Field { field_type, value } = &region.kind;
+```
+
+This compiles today only because `RegionKind` has exactly one variant. The moment
+a second variant is added, this becomes a hard compile error
+(`refutable pattern in local binding`).
+
+## Why it matters
+
+`RegionKind` was deliberately made an **enum from day one** (per the design doc)
+precisely so new region kinds can be added later. This `let` is a latent
+tripwire that will break the build on exactly the future the enum exists to
+support — and it sits in an example, which is the first code a new contributor
+reads and copies.
+
+## Fix
+
+Use a refutable form so adding a variant is non-breaking at this site:
+
+```rust
+if let RegionKind::Field { field_type, value } = &region.kind {
+    // …
+}
+```
+
+or a `match` with an explicit arm. Prefer `match` if the example should
+illustrate handling multiple kinds.
+
+## Notes
+
+- Cheap; bundle with the other low-risk cleanups (#05).
+- Worth a quick grep for the same pattern elsewhere
+  (`rg "let .*RegionKind::Field"`) in case other call sites copied it.

--- a/prose/review/05-stale-canvas-downcast-doc.md
+++ b/prose/review/05-stale-canvas-downcast-doc.md
@@ -1,0 +1,39 @@
+# 05 — Stale `as_any`/downcast doc on the canvas seam
+
+**Severity:** nit **Category:** smelly (stale doc) **Status:** Open
+
+**Location:** `crates/core/src/session.rs:73` (doc on `RenderSession::handle`)
+
+## Finding
+
+The doc comment on `RenderSession::handle` still says bindings reach
+backend-specific surfaces by downcasting via `SessionHandle::as_any` (the
+`typst_session_of` pattern). That was the *old* canvas mechanism. This branch
+generalized the canvas seam: the WASM painter now dispatches generically through
+`page_size_pt` / `render_rgba` on `RenderSession`, with **no downcast**.
+
+A grep confirms `typst_session_of` has **zero in-tree callers** — only its
+definition remains.
+
+## Why it matters
+
+- The whole point of the PREVIEW.md rework was to retire the "canvas is
+  Typst-only, downcast to reach it" premise. The doc still instructs the retired
+  pattern, so it actively misdirects a contributor wiring a new backend toward a
+  downcast they shouldn't need.
+- It is documentation drift, not a code bug — but it sits on the public seam that
+  the new design is most proud of.
+
+## Fix
+
+Update the comment to describe the generic seam as the canonical path
+(`page_size_pt` / `render_rgba` on the session), and reframe `as_any` as a
+last-resort escape hatch for a backend with a richer typed surface — not the
+default. Optionally note that `typst_session_of` is now callerless and a
+candidate for removal.
+
+## Notes
+
+- The ARCHITECTURE.md `RenderSession` entry (line ~50) already describes the new
+  generic seam correctly — so this is a localized rustdoc lag, and the canon is
+  ahead of the code comment. Aligning the rustdoc to the canon closes it.

--- a/prose/review/06-docs-and-canon-drift.md
+++ b/prose/review/06-docs-and-canon-drift.md
@@ -1,0 +1,80 @@
+# 06 — Docs & canon drift
+
+**Severity:** low **Category:** docs **Status:** Open
+
+A cluster of doc/code mismatches left after the branch (and after the
+`458064f` flatten collapse). Each sub-item is small and independently
+actionable; grouped because they're all "docs say X, code says Y."
+
+---
+
+## 6a — `pdfform-backend.md` conflates PNG (a format) with canvas (a paint surface)
+
+**Location:** `docs/quills/pdfform-backend.md:187-188`
+
+```
+| **SVG**        | Under the `preview` feature only. |
+| **PNG / canvas** | Under the `preview` feature only. |
+```
+
+`OutputFormat::Png` is **never** in pdfform's `SUPPORTED_FORMATS` — under
+`preview` it is `[Pdf, Svg]` (`crates/backends/pdfform/src/lib.rs`). A consumer
+calling `render` with `output_format: Some(Png)` gets `FormatNotSupported`.
+Canvas is a `paint()` raster surface (the WASM `render_rgba` path), **not** a
+`render()` output format. The table conflates the two.
+
+**Fix:** split the row — `SVG` as a real `render()` format under `preview`; a
+separate `Canvas (WASM paint)` row noting it is `paint()`, not `render()`, and
+not an `OutputFormat`.
+
+---
+
+## 6b — Canon crate inventory omits the two new crates
+
+**Location:** `prose/canon/ARCHITECTURE.md` (Crate Structure section);
+`prose/canon/INDEX.md:20-23` (Backends section)
+
+The branch adds two top-level crates — `quillmark-pdf` (the shared stamp spine)
+and `backends/quillmark-pdfform` (the second backend) — but:
+
+- ARCHITECTURE.md's crate-structure list still enumerates only core / typst /
+  fixtures / fuzz / bindings. (Note: its `RenderSession` entry *does* describe the
+  new canvas seam correctly — only the crate list lags.)
+- INDEX.md's Backends section still reads "Typst backend internals: see …" with no
+  `pdfform` / `quillmark-pdf` entry (though INDEX line 29 does reference pdfform via
+  the PREVIEW.md link).
+
+**Fix:** add `quillmark-pdf` and `quillmark-pdfform` subsections to ARCHITECTURE's
+crate structure (mirroring the `quillmark-typst` entry), and a `pdfform` backend
+entry to INDEX's Backends section linking `docs/quills/pdfform-backend.md` and
+naming the `quillmark-pdf` spine.
+
+---
+
+## 6c — PREVIEW.md overlay formula uses an undefined `y_pdf`
+
+**Location:** `prose/canon/PREVIEW.md:148`
+
+```
+y_canvas = (pageHeightPt − y_pdf) × renderScale
+x_canvas = x_pdf × renderScale
+```
+
+`y_pdf` is undefined relative to a region's `rect = [x0, y0, x1, y1]`. A consumer
+drawing an overlay box needs the **top** edge, which in bottom-left coordinates is
+`rect[3]` (`y1`); using `rect[1]` (`y0`) yields the canvas bottom. As written the
+formula is a correct generic scalar transform but is ambiguous/misleading for the
+actual rect.
+
+**Fix:** specify the component, e.g.
+`y_canvas_top = (pageHeightPt − rect[3]) × renderScale`, or expand to a full
+4-component rect-transform example.
+
+---
+
+## Already reconciled (no action)
+
+- The proposal's `§7` "optional flattened-PDF" deliverable contradiction and the
+  "value flattening" framing were fixed in `458064f` (flattening is now described
+  as internal preview-only machinery; PDF output is always an interactive
+  AcroForm).

--- a/prose/review/07-test-coverage-gaps.md
+++ b/prose/review/07-test-coverage-gaps.md
@@ -1,0 +1,87 @@
+# 07 — Test coverage gaps
+
+**Severity:** low–medium **Category:** coverage **Status:** Open
+
+Consolidated test/edge-case gaps surfaced across the review slices. None is a
+known live bug; each is an assertion that *would* have caught a class of
+regression and currently does not. Listed roughly by value.
+
+## Spine (`quillmark-pdf`)
+
+- **No non-zero-generation base test.** Directly tied to item #01 — the case that
+  silently corrupts output (overwriting a gen-≠-0 catalog/page) has no test. A
+  test stamping such a base would currently fail or emit a broken PDF.
+- **No xref-stream / encrypted-PDF rejection test.** `assert_traditional_xref` and
+  the `/Encrypt` check are core to the "hard-error on out-of-contract input"
+  promise, but no test asserts the clean error (unlike the `/Size` and
+  missing-page cases, which do).
+- **No non-zero `/MediaBox` origin integration test.** `page_media_boxes` returns
+  the full origin-bearing rect (a headline deviation), but `tests/stamp.rs` only
+  uses `[0 0 612 792]`; nothing asserts a non-zero `x0/y0` flows through.
+- **No multi-subsection xref test.** The run-coalescing loop that emits multiple
+  `<first> <count>` xref subsections is never exercised with a gap in allocated
+  object ids (e.g. overwrite id 1 plus new ids 7,8).
+- **No inline-`/Annots` merge test.** `rewrite_page_with_annots`'s array-splice
+  branch (base page already has inline `/Annots [...]`) is never hit; the
+  indirect-`/Annots` hard-error branch is also untested.
+- **`pdf_text_string` UTF-16BE branch untested.** The ASCII-escape path has a unit
+  test; the non-ASCII UTF-16BE-hex path (called out in the design as how multiline
+  `/V` serializes) does not.
+
+## Regions sidecar
+
+- **`RenderResult.regions` is never asserted non-empty in any integration test.**
+  The sidecar is "the only path to values in non-interactive output," yet no test
+  renders a fixture and checks `regions` content (name / page / rect / value).
+  Especially worth adding for the pdfform `sample_form` path.
+
+## Structural PDF validity
+
+- **Widgets validated only by a tolerant `lopdf` reparse** (which, per the test's
+  own comment, "silently tolerates" malformed dicts) plus a single
+  duplicate-`/Subtype` byte check on the **signature** widget. The new
+  text/checkbox/choice widgets get no byte-level duplicate-key check, and no
+  stricter validator (qpdf / MuPDF / pdfium) runs over multi-type output. A
+  qpdf/MuPDF lint would harden the regression fence across all four field types.
+- **`usaf_memo` multi-signature plate not exercised end-to-end** in `sig_field.rs`
+  (the real regression target uses several `Ind_<i>_Signature` widgets on a page;
+  the new tests cover one field per page).
+
+## Preview / canvas (`pdfform`, `preview` feature)
+
+- **Flatten byte-level coverage** — being restored at the `flatten()` unit level
+  as the finalization of the flatten collapse (no longer a public-path test).
+  Once landed, mark this sub-item closed.
+- **Multiline / auto-size layout untested.** Flatten tests assert presence of
+  `BT`/`Tj`/`re W n`/WinAnsi bytes but not the multiline line-advance
+  (`0 -line_h Td`) or the `0 Tf` auto-size clamp; a regression collapsing all
+  lines onto one baseline would pass.
+- **Canvas "complete raster" heuristic is too weak.** `canvas.test.js:284` asserts
+  `inkPixels > 0`, which the background's own borders/labels satisfy even if no
+  field value is painted — the single most important pdfform-canvas invariant.
+  Sample a known field coordinate (from `FieldRegion.rect` → device space) and
+  assert non-white, or floor `inkPixels` by expected glyph coverage.
+
+## Build matrix / bindings
+
+- **Headless `pdfform`-only build (no preview) untested.** The entire motivation
+  for the feature split — a Typst-free, raster-free form-filling bundle — has no
+  CI step. A break gated on `#[cfg(feature = "pdfform")]` without
+  `pdfform-preview` would go undetected. Add a `cargo check`/`test` matrix entry
+  (and ideally a wasm size-budget check for the pdfform artifact, analogous to the
+  existing `core` budget guard).
+- **Python `regions` accessibility unverified.** `PyRenderResult` wraps core's
+  `RenderResult`, but no `@property` exposing `regions` was observed; unclear
+  whether Python callers can read regions at all. Confirm and either expose or
+  document as pending.
+
+## Coercion / resolver (`pdfform`)
+
+- **`is_truthy` string variants** (`"yes"`/`"on"`/`"1"`/`"checked"`, non-zero
+  number) are unit-untested — only the JSON-bool path is exercised.
+- **`coerce_text` with mixed/non-string array elements** (`[null, "a", {}]`) and
+  the all-null-array→`None` path are not directly asserted.
+- **Numeric-`$kind` card addressing ambiguity** (`lookup_card` tries
+  `parse::<usize>()` first, so a card kind that is a numeric string can't be
+  addressed by kind) — untested; document the "kinds must be non-numeric"
+  expectation or disambiguate.

--- a/prose/review/README.md
+++ b/prose/review/README.md
@@ -1,0 +1,35 @@
+# Branch review — open items
+
+Findings from the swarm review of `claude/branch-review-agent-swarm-h9rbk4`
+(the `pdfform` backend + `quillmark-pdf` stamping spine work) relative to
+`origin/main`. Each file is a single, self-contained item we can discuss and
+action independently.
+
+The base of the review was commit `2baba0e` (`origin/main`); the branch HEAD at
+review time was `d2ff1cb`, plus the follow-up simplification `458064f`
+(flatten-flag collapse) landed during review.
+
+## Index
+
+| # | Item | Severity | Category | Status |
+|---|------|----------|----------|--------|
+| 01 | [Spine re-emits overwritten objects at generation 0](01-spine-nonzero-generation.md) | major | correctness | Open |
+| 02 | [Canvas capability contract not closed by construction](02-canvas-capability-contract.md) | major | architecture | Open — design proposed |
+| 03 | [WASM region type: `skip_serializing_if` without `serde(default)`](03-wasm-region-serde-roundtrip.md) | minor | correctness | Open |
+| 04 | [Irrefutable `let` on the extensible `RegionKind`](04-region-kind-irrefutable-let.md) | minor | smelly | Open |
+| 05 | [Stale `as_any`/downcast doc on the canvas seam](05-stale-canvas-downcast-doc.md) | nit | smelly | Open |
+| 06 | [Docs & canon drift](06-docs-and-canon-drift.md) | low | docs | Open |
+| 07 | [Test coverage gaps](07-test-coverage-gaps.md) | low–medium | coverage | Open |
+
+## Already resolved during review (not tracked here)
+
+- **Cross-binding `flatten` inconsistency** — dissolved by the flatten-flag
+  collapse (`458064f`): PDF output is now always AcroForm and the public
+  `flatten` knob is gone, so there is no longer an option for Python/.NET to be
+  missing.
+- **Proposal self-contradiction on flattening** (`§7` listing an "optional
+  flattened-PDF" deliverable while the body treated flattening as internal) —
+  reconciled in `458064f`.
+- **Direct flatten byte-level coverage** — the collapse deleted the public-path
+  flatten tests; restored at the `flatten()` unit level (preview-gated) as the
+  finalization of that change.


### PR DESCRIPTION
## Summary

Follow-up to the swarm review of the `pdfform` backend + `quillmark-pdf` spine work. Three commits:

1. **`refactor(pdfform)`: PDF output always AcroForm; remove the public `flatten` knob.** A simplification cascade — the `RenderOptions.flatten` field had exactly one consumer (the pdfform PDF render branch), so deciding "PDF output is always an interactive AcroForm" lets the entire public knob collapse across core + wasm + python + engine plumbing. The flattening machinery (`flatten.rs`/`typography.rs`) survives but is now `#[cfg(feature = "preview")]`-only, used solely to bake values into the SVG/canvas raster (non-interactive renderers show `NeedAppearances` fields blank). This also dissolves a known cross-binding inconsistency: `flatten` was wired in wasm but hardcoded `false` in Python and silently ignored in .NET — there's no longer an option to be missing.

2. **`test(pdfform)`: restore flatten byte-level coverage at the unit level (preview-gated).** The collapse deleted three public-path integration tests; their assertions are restored at the `flatten()` unit level (no public knob): no `/AcroForm` in output, Helvetica/ZapfDingbats fonts + `WinAnsiEncoding` + `BT`/`Tj`, field-box clipping (`re W n`), WinAnsi transcoding of non-ASCII (é→0xE9 etc. present, raw UTF-8 absent), and the checked-checkbox ZapfDingbats glyph (with the checked/unchecked gating asserted at its real seam, `has_drawable_value()`).

3. **`docs(review)`: write up unaddressed branch-review items.** Self-contained, individually-discussable docs under `prose/review/` for the findings not yet actioned.

## Open items captured in `prose/review/`

| # | Item | Severity |
|---|------|----------|
| 01 | Spine re-emits overwritten objects at generation 0 → corrupt incremental update for non-zero-gen (in-contract) bases | major |
| 02 | Canvas capability contract not closed by construction (`supports_canvas` vs `render_rgba` can disagree) — includes a proposed shared PDF→canvas design | major |
| 03 | WASM region type: `skip_serializing_if` without `serde(default)` breaks the advertised round-trip | minor |
| 04 | Irrefutable `let` on the extensible `RegionKind` (breaks when a 2nd variant lands) | minor |
| 05 | Stale `as_any`/downcast doc on the now-generic canvas seam | nit |
| 06 | Docs & canon drift (PNG/canvas table, missing crates in ARCHITECTURE/INDEX, PREVIEW overlay formula) | low |
| 07 | Consolidated test coverage gaps | low–medium |

These are intended for individual discussion, not all to land here.

## Validation

- `cargo test --workspace` green (flatten collapse).
- `cargo test -p quillmark-pdfform --features preview`: 23 passed; no-preview: 16 passed (new tests correctly excluded).
- Feature-gating verified: `cargo check -p quillmark-pdfform` and `--features preview` both compile; `cargo check -p quillmark --no-default-features` / `--features pdfform` clean.

## Notes

- Base is `feat/pdfform` (the integration branch), not `main`.
- Scope: 3 commits, no changes outside the flatten collapse, its test restoration, and the new `prose/review/` docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcFnkdtrFyt3naKX9c9znC)_