### PR TITLE
Address branch-review findings: spine robustness, coercion parity, doc accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   (pre-session hint, from output formats) replace it, so the capability can no
   longer disagree with what `paint` does. The engine and WASM `supportsCanvas`
   surfaces are unchanged in shape. See `docs/migrations/0.92-to-0.93.md`
+- build(wasm)!: rename the WASM engine feature `render` → `typst` (now the
+  default) and add `pdfform` / `pdfform-preview` build variants, so a Typst-free
+  PDF-form bundle can ship without Typst. From-source builders pass
+  `--features typst` where they used `--features render`; the published JS API is
+  unchanged. See `docs/migrations/0.92-to-0.93.md`
 
 ## v0.92.0 - 2026-06-22
 

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -11,6 +11,14 @@
 //! ([`winansi_encode`](quillmark_pdf::writer::winansi_encode)) and shown with a
 //! `WinAnsiEncoding` Helvetica, and each value is clipped to its field box.
 //!
+//! The drawing stream is appended last to the page `/Contents` and positions
+//! text with absolute `Td` coordinates, i.e. it assumes the **identity CTM** of
+//! the page default user space. A well-formed background restores its graphics
+//! state (balanced `q`/`Q`, no dangling `cm`), which the qualifier-produced and
+//! Typst-rendered bases this consumes always do; a base that left a non-identity
+//! CTM in effect would shift the flattened values. This path is preview-only, so
+//! the impact is confined to the raster preview, never a shipped deliverable.
+//!
 //! Entry point: [`flatten`].
 
 use quillmark_pdf::{
@@ -265,9 +273,13 @@ fn add_content_stream(pg_dict: &[u8], stream_id: u32) -> Result<Vec<u8>, PdfErro
 /// Inject `/<name> <font_id> 0 R` into the page's `/Resources /Font` dict,
 /// creating intermediate dicts as needed.
 ///
-/// When `/Resources` is an indirect reference (uncommon in our fixture
-/// contract), font injection is skipped — the 14 standard PDF Type1 fonts
-/// are available to conforming readers without explicit resource declaration.
+/// An indirect `/Resources` (or `/Font`) reference is a clean error: the flatten
+/// content stream selects `/Helv` and `/ZaDb` by *resource name*, and a `Tf`
+/// name must resolve through the page's `/Font` subdictionary — even the
+/// standard-14 fonts need a `/Font` entry mapping the name, so skipping
+/// injection would leave the value text unresolvable (blank). The reader's input
+/// contract produces inline resources, so this only rejects out-of-contract
+/// input rather than silently dropping it.
 fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>, PdfError> {
     let helv_entry = format!("/{name} {font_id} 0 R");
 
@@ -279,8 +291,12 @@ fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>
         }
         Some(res_val) => {
             if !res_val.trim_ascii().starts_with(b"<<") {
-                // Indirect resources ref — skip injection, rely on standard fonts.
-                return Ok(pg_dict.to_vec());
+                // Indirect /Resources ref: cannot inject the named font, and the
+                // emitted `/Helv`/`/ZaDb` Tf operators would not resolve.
+                return Err(err(
+                    CODE_PARSE,
+                    "page /Resources is an indirect reference; flatten requires inline resources",
+                ));
             }
             let res_inner = extract_outer_dict(res_val)
                 .ok_or_else(|| err(CODE_PARSE, "page /Resources dict not parseable"))?;
@@ -294,8 +310,12 @@ fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>
                 }
                 Some(font_val) => {
                     if !font_val.trim_ascii().starts_with(b"<<") {
-                        // Indirect font resources ref — rely on standard fonts.
-                        return Ok(pg_dict.to_vec());
+                        // Indirect /Font ref: same unresolvable-name problem.
+                        return Err(err(
+                            CODE_PARSE,
+                            "page /Resources /Font is an indirect reference; flatten requires \
+                             an inline /Font dict",
+                        ));
                     }
                     let font_inner = extract_outer_dict(font_val).ok_or_else(|| {
                         err(CODE_PARSE, "page /Resources /Font dict not parseable")

--- a/crates/backends/pdfform/src/form.rs
+++ b/crates/backends/pdfform/src/form.rs
@@ -72,6 +72,11 @@ pub enum FormParseError {
     Json(serde_json::Error),
     /// The `schema` tag is not a recognized `quillmark/form@…` string.
     BadSchema(String),
+    /// Two fields share the same `name`. AcroForm top-level field names must be
+    /// unique — duplicates would stamp two `/T`-colliding fields and render as a
+    /// single malformed field, so reject them at parse time (mirroring the
+    /// Typst producer, which rejects duplicate `form-field` names).
+    DuplicateField(String),
 }
 
 impl std::fmt::Display for FormParseError {
@@ -81,6 +86,10 @@ impl std::fmt::Display for FormParseError {
             FormParseError::BadSchema(s) => write!(
                 f,
                 "form.json `schema` is {s:?}, expected a \"{SCHEMA_PREFIX}<version>\" tag"
+            ),
+            FormParseError::DuplicateField(name) => write!(
+                f,
+                "form.json declares field name {name:?} more than once; field names must be unique"
             ),
         }
     }
@@ -92,6 +101,12 @@ impl FormSpec {
         let spec: FormSpec = serde_json::from_slice(bytes).map_err(FormParseError::Json)?;
         if !spec.schema.starts_with(SCHEMA_PREFIX) {
             return Err(FormParseError::BadSchema(spec.schema));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for field in &spec.fields {
+            if !seen.insert(field.name.as_str()) {
+                return Err(FormParseError::DuplicateField(field.name.clone()));
+            }
         }
         Ok(spec)
     }
@@ -144,5 +159,20 @@ mod tests {
             FormSpec::parse(json),
             Err(FormParseError::BadSchema(_))
         ));
+    }
+
+    #[test]
+    fn rejects_duplicate_field_names() {
+        let json = br#"{
+          "schema": "quillmark/form@0.1.0",
+          "fields": [
+            { "name": "Dup", "page": 0, "rect": { "x": 0, "y": 0, "w": 1, "h": 1 }, "type": "text" },
+            { "name": "Dup", "page": 0, "rect": { "x": 0, "y": 2, "w": 1, "h": 1 }, "type": "text" }
+          ]
+        }"#;
+        match FormSpec::parse(json) {
+            Err(FormParseError::DuplicateField(name)) => assert_eq!(name, "Dup"),
+            other => panic!("expected DuplicateField, got {other:?}"),
+        }
     }
 }

--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -141,12 +141,30 @@ where
     Some(cur)
 }
 
+/// Stringify a JSON number the same way the Typst producer does, so the two
+/// backends agree on the text they bind for the same value. `serde_json`'s own
+/// `Number::to_string` preserves the JSON literal form (`42.0` → `"42.0"`,
+/// `1e10` → `"10000000000.0"`), but the Typst side decodes the same JSON to a
+/// Typst `Int`/`Float` and prints via Rust's integer/`f64` `Display`, so an
+/// integral float renders without the trailing `.0`. Mirror that: float-backed
+/// numbers go through `f64` `Display`; integer-backed ones are already aligned.
+fn number_to_string(n: &serde_json::Number) -> String {
+    if n.is_f64() {
+        match n.as_f64() {
+            Some(f) => f.to_string(),
+            None => n.to_string(),
+        }
+    } else {
+        n.to_string()
+    }
+}
+
 /// Coerce a JSON value to display text. Empty results (empty string, all-null
 /// array) become `None` so the widget carries no `/V`.
 fn coerce_text(v: &Value) -> Option<String> {
     let s = match v {
         Value::String(s) => s.clone(),
-        Value::Number(n) => n.to_string(),
+        Value::Number(n) => number_to_string(n),
         Value::Bool(b) => b.to_string(),
         // An array (e.g. a `markdown[]` or `string[]` field) joins its string
         // elements with newlines — the multiline text fill.
@@ -154,7 +172,7 @@ fn coerce_text(v: &Value) -> Option<String> {
             .iter()
             .filter_map(|e| match e {
                 Value::String(s) => Some(s.clone()),
-                Value::Number(n) => Some(n.to_string()),
+                Value::Number(n) => Some(number_to_string(n)),
                 Value::Bool(b) => Some(b.to_string()),
                 _ => None,
             })
@@ -183,7 +201,7 @@ fn is_truthy(v: &Value) -> bool {
 fn coerce_choice(v: &Value, options: &[String]) -> Option<String> {
     let s = match v {
         Value::String(s) => s.clone(),
-        Value::Number(n) => n.to_string(),
+        Value::Number(n) => number_to_string(n),
         Value::Bool(b) => b.to_string(),
         _ => return None,
     };
@@ -224,6 +242,21 @@ mod tests {
             Some("line one\nline two".into())
         );
         assert_eq!(text("score"), Some("42".into()));
+    }
+
+    #[test]
+    fn number_stringification_matches_typst_producer() {
+        // Integral float literals drop the trailing `.0` (matching the Typst
+        // side's f64 Display), so the two backends bind identical text and a
+        // choice option like "42" matches a 42.0 value on both.
+        assert_eq!(coerce_text(&json!(42.0)), Some("42".into()));
+        assert_eq!(coerce_text(&json!(1e10)), Some("10000000000".into()));
+        // Integers and genuinely-fractional floats are unchanged.
+        assert_eq!(coerce_text(&json!(42)), Some("42".into()));
+        assert_eq!(coerce_text(&json!(42.5)), Some("42.5".into()));
+        // Choice matching uses the same rule.
+        let opts = vec!["42".to_string()];
+        assert_eq!(coerce_choice(&json!(42.0), &opts), Some("42".into()));
     }
 
     #[test]

--- a/crates/backends/pdfform/tests/sample_form.rs
+++ b/crates/backends/pdfform/tests/sample_form.rs
@@ -158,6 +158,46 @@ fn fixture_renders_structurally_valid_filled_pdf() {
 }
 
 #[test]
+fn non_ascii_value_round_trips_through_acroform_v() {
+    // A non-ASCII (accented / Latin-1 + smart-punctuation) text value must reach
+    // the AcroForm `/V` intact end-to-end: pdf-writer encodes it UTF-16BE, so
+    // the value decodes back to exactly what was authored.
+    let md = "~~~\n\
+$quill: sample_form\n\
+$kind: main\n\
+full_name: \"Café — Señor 'Ünïcøde'\"\n\
+agree: true\n\
+favorite_color: green\n\
+~~~\n";
+    let result = render(md);
+    let pdf = &result.artifacts[0].bytes;
+    let doc = PdfDoc::load_mem(pdf).expect("lopdf reparse");
+    let cat = doc.catalog().unwrap();
+    let af = doc
+        .get_object(cat.get(b"AcroForm").unwrap().as_reference().unwrap())
+        .unwrap()
+        .as_dict()
+        .unwrap();
+
+    let full = widget(&doc, af, "FullName");
+    assert_eq!(
+        decode_pdf_text(full.get(b"V").unwrap().as_str().unwrap()),
+        "Café — Señor 'Ünïcøde'"
+    );
+    // The regions sidecar carries the same value verbatim.
+    let r_full = result
+        .regions
+        .iter()
+        .find(|r| r.name == "FullName")
+        .unwrap();
+    match &r_full.kind {
+        quillmark_core::RegionKind::Field { value, .. } => {
+            assert_eq!(value.as_deref(), Some("Café — Señor 'Ünïcøde'"));
+        }
+    }
+}
+
+#[test]
 fn unchecked_and_unmatched_choice_render_blank() {
     let md = "~~~\n\
 $quill: sample_form\n\

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -6,8 +6,9 @@
 //! `prose/proposals/wasm-bindings-split.md`): a Typst-less **core**
 //! (`@quillmark/wasm/core`) for load / validate / schema / seed / blueprint, and
 //! a Typst-backed **backend** binary (`pkg/backends/typst/`) that adds the
-//! engine and canvas preview. The `render` cargo feature (default) gates the
-//! engine half.
+//! engine and canvas preview. The `typst` / `pdfform` cargo features gate the
+//! engine half (the default `typst` feature enables it; a no-feature build is
+//! the core).
 //!
 //! The Typst backend is a PRIVATE binary — it is not a public npm export. The
 //! package's public root (`@quillmark/wasm`) is a hand-written canonical layer

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 
 /// Output formats supported by backends.
 ///
-/// Gated behind the engine surface (`render` or `pdfform`) so tsify omits
+/// Gated behind the engine surface (`typst` or `pdfform`) so tsify omits
 /// its `.d.ts` interface from the core bundle (`pkg/core/wasm.d.ts`), which
 /// has no rendering surface.
 #[cfg(any(feature = "typst", feature = "pdfform"))]

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -35,8 +35,8 @@ pub trait Backend: Send + Sync + std::fmt::Debug {
 /// [`RenderSession::supports_canvas`](crate::RenderSession::supports_canvas),
 /// which is derived from the session's actual canvas seam
 /// ([`SessionHandle::page_size_pt`](crate::session::SessionHandle::page_size_pt))
-/// and so cannot disagree with what `paint` will do — there is no separately
-/// maintained capability flag to drift from the implementation.
+/// — there is no separately maintained capability flag to drift from the
+/// implementation (a canvas backend pairs `render_rgba` with `page_size_pt`).
 pub fn formats_support_canvas(formats: &[OutputFormat]) -> bool {
     formats
         .iter()

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -48,8 +48,9 @@ pub trait SessionHandle: Any + Send + Sync {
     /// A backend with no painter overrides neither this nor
     /// [`page_size_pt`](Self::page_size_pt); the defaults mark the session as
     /// non-canvas, which is exactly what [`RenderSession::supports_canvas`]
-    /// reports. Capability is derived from this seam, not declared separately,
-    /// so the two cannot disagree.
+    /// reports. Capability is derived from the `page_size_pt` half of this seam,
+    /// not declared as a separate flag — a canvas backend is contractually
+    /// expected to pair this method with `page_size_pt` over the same page set.
     fn render_rgba(&self, _page: usize, _scale: f32) -> Option<(u32, u32, Vec<u8>)> {
         None
     }
@@ -105,10 +106,10 @@ impl RenderSession {
     /// Whether this session can paint pages to a canvas — the authoritative,
     /// session-level capability. Derived directly from the canvas seam (a
     /// painter exposes [`page_size_pt`](SessionHandle::page_size_pt) for its
-    /// pages), so it cannot disagree with what [`render_rgba`](Self::render_rgba)
-    /// will do: there is no separate capability flag to keep in sync. A
-    /// canvas-capable backend with zero pages reports `false` (nothing to
-    /// paint).
+    /// pages), so there is no separate capability flag to keep in sync: a
+    /// canvas backend pairs [`render_rgba`](Self::render_rgba) with
+    /// `page_size_pt`, so this reflects what `paint` will do. A canvas-capable
+    /// backend with zero pages reports `false` (nothing to paint).
     ///
     /// For a pre-session estimate (no open session yet), see
     /// [`formats_support_canvas`](crate::formats_support_canvas).

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -13,6 +13,8 @@
 //! guarantee it. `hayro-syntax` is read-only and exposes no byte spans, so it
 //! cannot drive a byte-splice append — hence this bespoke scanner.
 
+use std::collections::HashSet;
+
 use crate::error::PdfError;
 
 const CODE_PARSE: &str = "pdf::parse";
@@ -178,7 +180,6 @@ pub fn append_incremental_update(
 pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
     let prefix = format!("{id} ");
     let p = prefix.as_bytes();
-    let needle = b"endobj";
     let mut last_start = None;
     let mut i = 0;
     while i + p.len() <= pdf.len() {
@@ -191,11 +192,28 @@ pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
         i += 1;
     }
     let start = last_start?;
-    let from = start + p.len();
-    let end_rel = pdf[from..]
-        .windows(needle.len())
-        .position(|w| w == needle)?;
-    Some((start, from + end_rel + needle.len()))
+    let end = find_endobj_end(pdf, start + p.len())?;
+    Some((start, end))
+}
+
+/// Find the `endobj` keyword that closes the object body starting at `from`,
+/// returning the index just past it. Literal `( … )` strings are skipped so a
+/// string value containing the bytes `endobj` (e.g. an `/Info` `/Title`) cannot
+/// truncate the object mid-string — the same string-aware skip
+/// [`extract_outer_dict`] already relies on.
+fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
+    let needle = b"endobj";
+    let mut i = from;
+    while i < pdf.len() {
+        if pdf[i] == b'(' {
+            i = skip_pdf_string(pdf, i);
+        } else if pdf[i..].starts_with(needle) {
+            return Some(i + needle.len());
+        } else {
+            i += 1;
+        }
+    }
+    None
 }
 
 /// The generation number in object `id`'s header (`<id> <gen> obj`), or `None`
@@ -521,10 +539,20 @@ pub fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfErro
     const MAX_NODES: usize = 100_000;
     let mut out = Vec::new();
     let mut stack = vec![root_pages_id];
-    let mut visited = 0usize;
+    // A node id reached twice means the `/Pages` tree is cyclic or shares a node
+    // across parents — malformed, and an amplification vector without this
+    // guard: every visit re-scans the whole file via `find_object_bytes`, so a
+    // tiny `/Kids` self-cycle would otherwise drive up to MAX_NODES full-file
+    // scans before the count cap trips.
+    let mut seen: HashSet<u32> = HashSet::new();
     while let Some(node_id) = stack.pop() {
-        visited += 1;
-        if visited > MAX_NODES {
+        if !seen.insert(node_id) {
+            return Err(err(
+                CODE_PARSE,
+                format!("page tree revisits node {node_id} (cycle or shared node)"),
+            ));
+        }
+        if seen.len() > MAX_NODES {
             return Err(err(CODE_PARSE, "page tree exceeds 100 000 nodes"));
         }
         let (s, e) = find_object_bytes(pdf, node_id)
@@ -564,6 +592,42 @@ fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
         .and_then(parse_indirect_ref)
         .map(|(id, _)| id)
         .ok_or_else(|| err(CODE_PARSE, "catalog /Pages reference not found"))
+}
+
+/// Reject a page with a non-zero `/Rotate` (its own value, else the inherited
+/// root `/Pages` value).
+///
+/// The stamp/flatten paths write widget and content geometry in *unrotated*
+/// user space and do not compensate for page rotation, so a rotated base page
+/// would display every widget rotated away from its intended box. `/Rotate` is
+/// not part of the Typst producer's output (its pages are always unrotated);
+/// this guard turns a rotated `pdfform` base into a clean rejection rather than
+/// silently mis-placed output, consistent with the reader's other hard
+/// rejections.
+pub fn assert_unrotated_page(pdf: &[u8], catalog_id: u32, page_id: u32) -> Result<(), PdfError> {
+    let read_rotate = |id: u32| -> Option<i64> {
+        let (s, e) = find_object_bytes(pdf, id)?;
+        let dict = extract_outer_dict(&pdf[s..e])?;
+        let raw = find_dict_value(dict, "Rotate")?;
+        std::str::from_utf8(raw.trim_ascii())
+            .ok()?
+            .trim()
+            .parse::<i64>()
+            .ok()
+    };
+    let rotate = read_rotate(page_id)
+        .or_else(|| root_pages_id(pdf, catalog_id).ok().and_then(read_rotate))
+        .unwrap_or(0);
+    if rotate.rem_euclid(360) != 0 {
+        return Err(err(
+            "pdf::rotated_page",
+            format!(
+                "page object {page_id} has /Rotate {rotate}; the stamp spine only \
+                 handles unrotated pages"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn parse_ref_array(bytes: &[u8]) -> Vec<(u32, u16)> {
@@ -768,5 +832,47 @@ mod tests {
         let pdf = b"%PDF\n4 0 obj\n<< /V (old) >>\nendobj\n4 0 obj\n<< /V (new) >>\nendobj\n";
         let (s, e) = find_object_bytes(pdf, 4).expect("found object 4");
         assert_eq!(&pdf[s..e], b"4 0 obj\n<< /V (new) >>\nendobj");
+    }
+
+    #[test]
+    fn endobj_inside_string_does_not_truncate_object() {
+        // A literal string value containing the bytes "endobj" (e.g. an /Info
+        // /Title) must not end the object at the in-string occurrence.
+        let pdf = b"%PDF\n3 0 obj\n<< /Title (My endobj report) /Author (X) >>\nendobj\n";
+        let (s, e) = find_object_bytes(pdf, 3).expect("found object 3");
+        assert_eq!(
+            &pdf[s..e],
+            b"3 0 obj\n<< /Title (My endobj report) /Author (X) >>\nendobj"
+        );
+        // …and the dict still extracts cleanly with the full /Title value.
+        let dict = extract_outer_dict(&pdf[s..e]).expect("dict parses");
+        let title = find_dict_value(dict, "Title").expect("/Title");
+        assert_eq!(title.trim_ascii(), b"(My endobj report)");
+    }
+
+    #[test]
+    fn page_tree_cycle_is_rejected() {
+        // A /Pages node whose /Kids references itself must error cleanly, not
+        // loop to the node cap re-scanning the whole file each visit.
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n";
+        let e = resolve_page_ids(pdf, 1).expect_err("cycle rejected");
+        assert_eq!(e.code, CODE_PARSE);
+        assert!(e.message.contains("revisits"), "{}", e.message);
+    }
+
+    #[test]
+    fn rotated_page_is_rejected() {
+        // /Rotate inherited from the root /Pages node is honoured.
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /Rotate 90 >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
+        let e = assert_unrotated_page(pdf, 1, 3).expect_err("rotated page rejected");
+        assert_eq!(e.code, "pdf::rotated_page");
+        // A page with no rotation (own or inherited) is accepted.
+        let flat = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                     2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
+                     3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
+        assert!(assert_unrotated_page(flat, 1, 3).is_ok());
     }
 }

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -10,9 +10,9 @@
 
 use crate::error::PdfError;
 use crate::reader::{
-    append_incremental_update, assert_overwrite_gen_zero, assert_traditional_xref, err,
-    find_dict_value, find_startxref, find_trailer_dict, parse_indirect_ref, resolve_page_ids,
-    UpdatedObject,
+    append_incremental_update, assert_overwrite_gen_zero, assert_traditional_xref,
+    assert_unrotated_page, err, find_dict_value, find_startxref, find_trailer_dict,
+    parse_indirect_ref, resolve_page_ids, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -109,6 +109,9 @@ impl PdfUpdate {
             // by every widget on it as gen 0, so a non-zero-generation page would
             // be silently corrupted.
             assert_overwrite_gen_zero(pdf, page_ids[spec.page], "page")?;
+            // Widget/content geometry is written in unrotated user space; a
+            // rotated target page would mis-place every field. Reject cleanly.
+            assert_unrotated_page(pdf, self.catalog_id, page_ids[spec.page])?;
         }
         Ok(page_ids)
     }

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -241,6 +241,83 @@ fn no_producer_no_fields_is_identity() {
 }
 
 #[test]
+fn producer_only_no_fields_stamps_info_producer() {
+    // producer=Some + no fields is NOT the identity short-circuit: it runs a
+    // minimal `/Info`-only incremental append (no AcroForm). Assert the success
+    // envelope reparses with the new /Producer and adds no /AcroForm.
+    let base = build_base_pdf(1);
+    let result = stamp(
+        base,
+        &[],
+        &StampOptions {
+            producer: Some("Quillmark test".into()),
+        },
+    )
+    .expect("stamp ok");
+    assert!(result.regions.is_empty());
+
+    let doc = lopdf::Document::load_mem(&result.pdf).expect("lopdf reparse");
+    assert!(
+        doc.catalog().unwrap().get(b"AcroForm").is_err(),
+        "producer-only stamp must not add an /AcroForm"
+    );
+    let info_ref = doc
+        .trailer
+        .get(b"Info")
+        .expect("trailer /Info")
+        .as_reference()
+        .expect("/Info indirect");
+    let info = doc.get_object(info_ref).unwrap().as_dict().unwrap();
+    assert_eq!(
+        info.get(b"Producer").unwrap().as_str().unwrap(),
+        b"Quillmark test"
+    );
+}
+
+#[test]
+fn rotated_page_rejected_cleanly() {
+    // A base whose target page carries a non-zero /Rotate is rejected rather
+    // than mis-stamped (widget geometry is written in unrotated user space).
+    let mut pdf = Pdf::new();
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    {
+        let mut pages = pdf.pages(page_tree_id);
+        pages
+            .kids([page_id])
+            .count(1)
+            .media_box(Rect::new(0.0, 0.0, 612.0, 792.0));
+    }
+    {
+        let mut page = pdf.page(page_id);
+        page.parent(page_tree_id)
+            .media_box(Rect::new(0.0, 0.0, 612.0, 792.0))
+            .rotate(90)
+            .contents(content_id);
+    }
+    let mut content = Content::new();
+    content.set_line_width(1.0);
+    content.rect(72.0, 700.0, 200.0, 20.0);
+    content.stroke();
+    pdf.stream(content_id, &content.finish());
+    let base = pdf.finish();
+
+    let fields = vec![FieldSpec {
+        name: "FullName".into(),
+        page: 0,
+        rect: [180.0, 700.0, 520.0, 720.0],
+        field_type: FieldType::Text { multiline: false },
+        value: Some("Ada".into()),
+        tooltip: None,
+    }];
+    let err = stamp(base, &fields, &StampOptions::default()).expect_err("rotated page rejected");
+    assert_eq!(err.code, "pdf::rotated_page");
+}
+
+#[test]
 fn implausible_size_errors_cleanly_without_panic() {
     // A base PDF whose trailer declares a near-u32::MAX /Size must yield a clean
     // PdfError (id space exhausted) rather than panic on overflow (debug) or

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -191,3 +191,20 @@ impl Backend for MyBackend {              impl Backend for MyBackend {
                                               fn render_rgba(&self, p, s) -> … { … }
                                           }
 ```
+
+## WASM build feature `render` → `typst` (plus new `pdfform` builds)
+
+The WASM crate's engine feature was renamed and split. The single `render`
+feature is gone; the engine half (the `Quillmark` / `RenderSession` types) is now
+gated on `typst` **or** `pdfform`:
+
+- **`typst`** (the new default) — the Typst-backed engine + canvas preview, the
+  exact surface the old `render` feature shipped.
+- **`pdfform`** — the Typst-free PDF-form backend alone (a tiny, Typst-less
+  engine bundle); reports `supportsCanvas == false`.
+- **`pdfform-preview`** — `pdfform` plus its hayro raster/SVG canvas seam;
+  reports `supportsCanvas == true`.
+
+**Action (from-source WASM builders only):** replace `--features render` with
+`--features typst` (or build the new `pdfform` / `pdfform-preview` variants). The
+published JS API surface and the canonical `Engine` runtime are unchanged.

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -192,8 +192,9 @@ build with a `{ formats, canvas }` manifest, drift-guarded by
 - **One generic painter over the `SessionHandle` seam, not a per-backend
   downcast.** `paint` calls `page_size_pt` / `render_rgba` on the opaque
   session; every canvas backend implements the same two methods. Adding a
-  canvas backend is overriding the seam + flipping `supports_canvas`, not
-  touching the binding.
+  canvas backend is overriding the two seam methods (`page_size_pt` /
+  `render_rgba`) — capability is then derived from the seam, with no separate
+  flag to flip and no binding to touch.
 - **Complete raster, never compose-from-regions.** Both backends hand back a
   finished page (Typst natively, pdfform by pre-flattening values into content
   streams before rasterizing). Regions are an overlay sidecar, not a

--- a/prose/review/07-test-coverage-gaps.md
+++ b/prose/review/07-test-coverage-gaps.md
@@ -40,9 +40,15 @@ assertion, or a binding surface) and is left open.
   `pdfform-preview` would go undetected. Add a `cargo check`/`test` matrix entry
   (and ideally a wasm size-budget check for the pdfform artifact, analogous to
   the `core` budget guard).
-- **Python `regions` accessibility unverified.** `PyRenderResult` wraps core's
-  `RenderResult`, but no `@property` exposing `regions` was observed. Confirm
-  and either expose or document as pending.
+- **Python `regions` not exposed (confirmed).** `PyRenderResult` exposes only
+  `artifacts` / `warnings` / `format` / `render_time_ms` — there is no `regions`
+  getter (`crates/bindings/python/src/types.rs`). Intentionally pending until
+  `pdfform` ships in the Python binding; expose it then.
+- **No non-ASCII value end-to-end through the `pdfform` backend.** The WinAnsi
+  transcode and the UTF-16BE `/V` encoding are unit-tested (`writer.rs`,
+  `flatten.rs`), but the integration tests (`sample_form.rs`,
+  `canvas_conformance.rs`) only use ASCII values, so no test drives an accented
+  value through the full backend render to the AcroForm `/V` (UTF-16BE decode).
 
 ## Closed (landed on `claude/prose-review-items-6svv5p`)
 
@@ -59,3 +65,14 @@ assertion, or a binding surface) and is left open.
   limitation (tested + documented on `lookup_card`).
 - **Flatten byte-level coverage** — restored at the `flatten()` unit level as
   the finalization of the flatten collapse.
+
+## Closed (landed on `claude/code-review-main-a3rokh`)
+
+- **Spine (`quillmark-pdf`)** — `endobj`-inside-a-string no longer truncates an
+  object (string-aware `find_object_bytes`); cyclic / shared-node `/Pages` trees
+  are rejected (visited-set, closing the O(nodes × file) amplification); a
+  non-zero page `/Rotate` is rejected rather than mis-stamped; and the
+  producer-only (no-fields) `/Info` `/Producer` success path is asserted.
+- **pdfform** — duplicate `form.json` field names are rejected at parse; JSON
+  number stringification matches the Typst producer (integral floats drop the
+  trailing `.0`), so the two backends bind identical text and choice options.


### PR DESCRIPTION
Follow-up fixes from a comprehensive adversarial review of the `pdfform` / `quillmark-pdf` work. This branch is exactly one commit ahead of `feat/pdfform`; everything here is a fix or test for issues surfaced by that review. Full `cargo test --workspace` is green (default + `pdfform`/`preview`), and clippy is clean on every crate touched.

## Correctness & robustness — `quillmark-pdf` spine

- **`endobj`-in-string truncation** — `find_object_bytes` now skips literal `( … )` strings while scanning for `endobj`, so an `/Info` `/Title` (or any string value) containing the bytes `endobj` no longer truncates the object and falsely rejects in-contract input. This was reachable on the common producer-stamp path.
- **Page-tree amplification / DoS** — `resolve_page_ids` tracks a visited-set and rejects cyclic / shared-node `/Pages` trees, closing an O(nodes × file) blow-up where a tiny `/Kids` self-cycle drove up to 100k full-file scans.
- **Page `/Rotate`** — a base page with a non-zero `/Rotate` (own or inherited) is now rejected cleanly instead of mis-placing widgets written in unrotated user space.

## `pdfform` backend

- **Duplicate field names** are rejected at `form.json` parse — AcroForm top-level `/T` names must be unique — mirroring the Typst producer's existing guard.
- **Number formatting parity** — JSON numbers stringify the way the Typst producer does (integral floats drop the trailing `.0`), so the two backends bind identical text and a `choice` option like `"42"` matches a `42.0` value on both.
- **flatten indirect `/Resources`/`/Font`** is now a clean error instead of silently emitting `/Helv`/`/ZaDb` operators that no `/Font` entry resolves (blank preview text). Corrected the inaccurate "standard fonts need no resource declaration" comment and documented the identity-CTM assumption (this path is preview-only).

## Docs

- WASM: fixed the stale `render` cargo-feature name (renamed to `typst` / `pdfform`) in `lib.rs` / `types.rs` doc comments.
- Softened the "capability cannot disagree" wording in `session.rs` / `backend.rs` to reflect that capability derives from the `page_size_pt` half of the seam.
- `PREVIEW.md`: dropped the deleted "flip `supports_canvas`" flag from the rationale.
- 0.92→0.93 migration guide + CHANGELOG: documented the WASM `render` → `typst` feature rename and the new `pdfform` / `pdfform-preview` build variants.
- `prose/review/07`: confirmed Python `regions` is not exposed; recorded the remaining non-ASCII end-to-end gap and the newly landed coverage.

## Tests

Added: `endobj`-in-string non-truncation, page-tree cycle rejection, `/Rotate` rejection, producer-only `/Info` success path, duplicate-field rejection, number-stringification parity, and a non-ASCII value round-trip through the AcroForm `/V`.

## Out of scope (reviewed and intentionally not changed)

Three review candidates were adversarially rejected as by-design and left alone: the `/DR` `/Helv` font having no `/Encoding` (moot under Technique A's `/NeedAppearances`), and the array-text-join / checkbox-truthiness "divergences" between the two producers (the resolver layer is per-backend by nature and never claimed to mirror there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ABkniCfwS8xiMV9rezYEM

---
_Generated by [Claude Code](https://claude.ai/code/session_014ABkniCfwS8xiMV9rezYEM)_