### PR TITLE
Make the plate a Typst-backend concern, not a universal one

### DIFF
--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -69,7 +69,6 @@ impl Backend for PdfformBackend {
 
     fn open(
         &self,
-        _plate_content: &str,
         source: &Quill,
         json_data: &serde_json::Value,
     ) -> Result<RenderSession, RenderError> {

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -163,10 +163,11 @@ impl Backend for TypstBackend {
 
     fn open(
         &self,
-        plate_content: &str,
         source: &Quill,
         json_data: &serde_json::Value,
     ) -> Result<RenderSession, RenderError> {
+        let plate_content = read_plate(source)?;
+
         let fields = json_data.as_object().map_or_else(HashMap::new, |obj| {
             obj.iter()
                 .map(|(key, value)| (key.clone(), QuillValue::from_json(value.clone())))
@@ -193,7 +194,7 @@ impl Backend for TypstBackend {
                 )
                 .with_code("backend::data_serialization_failed".to_string())],
             })?;
-        let document = compile::compile_to_document(source, plate_content, &json_str)?;
+        let document = compile::compile_to_document(source, &plate_content, &json_str)?;
         let page_count = document.pages().len();
         let field_placements = overlay::extract(&document)?;
         let session = TypstSession {
@@ -209,6 +210,47 @@ impl Default for TypstBackend {
     /// Creates a new [`TypstBackend`] instance.
     fn default() -> Self {
         Self
+    }
+}
+
+/// Read the Typst plate (template) this quill renders through.
+///
+/// The plate is a Typst-only notion, not a universal backend input: its
+/// filename is declared under the `typst:` backend-config section as
+/// `plate_file`, and the source lives in the quill's file bundle. The backend
+/// resolves it here, the same way `pdfform` resolves its own `form.pdf` /
+/// `form.json`. A quill that declares no `plate_file` renders through an empty
+/// plate (`""`).
+fn read_plate(source: &Quill) -> Result<String, RenderError> {
+    let plate_file = source
+        .config()
+        .backend_config
+        .get("plate_file")
+        .and_then(|v| v.as_str());
+
+    let Some(plate_file) = plate_file else {
+        return Ok(String::new());
+    };
+
+    let bytes = source.files().get_file(plate_file).ok_or_else(|| {
+        engine_err(
+            "typst::plate_missing",
+            format!("plate file '{plate_file}' not found in the quill's file tree"),
+        )
+    })?;
+
+    String::from_utf8(bytes.to_vec()).map_err(|e| {
+        engine_err(
+            "typst::invalid_utf8",
+            format!("plate file '{plate_file}' is not valid UTF-8: {e}"),
+        )
+    })
+}
+
+/// A single-diagnostic [`RenderError::EngineCreation`] carrying `code`.
+fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
+    RenderError::EngineCreation {
+        diags: vec![Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string())],
     }
 }
 

--- a/crates/backends/typst/tests/eval_error_hint.rs
+++ b/crates/backends/typst/tests/eval_error_hint.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use quillmark_core::{Backend, FileTreeNode, OutputFormat, Quill, RenderOptions};
 use quillmark_typst::TypstBackend;
 
-fn host_source() -> Quill {
+fn host_tree() -> FileTreeNode {
     fn walk(dir: &Path) -> std::io::Result<FileTreeNode> {
         let mut files = HashMap::new();
         for entry in fs::read_dir(dir)? {
@@ -38,7 +38,22 @@ fn host_source() -> Quill {
         .join("quills")
         .join("usaf_memo")
         .join("0.2.0");
-    Quill::from_tree(walk(&quill_path).expect("walk fixture")).expect("load source")
+    walk(&quill_path).expect("walk fixture")
+}
+
+/// Build the host quill with its `plate.typ` replaced by `plate`; the fixture's
+/// `typst.plate_file: plate.typ` makes the backend read this override.
+fn source_with_plate(plate: &str) -> Quill {
+    let mut tree = host_tree();
+    if let FileTreeNode::Directory { files } = &mut tree {
+        files.insert(
+            "plate.typ".to_string(),
+            FileTreeNode::File {
+                contents: plate.as_bytes().to_vec(),
+            },
+        );
+    }
+    Quill::from_tree(tree).expect("load source")
 }
 
 /// `eval`s an unknown variable; the error resolves to the call site in
@@ -49,7 +64,7 @@ const EVAL_ERROR_PLATE: &str =
 /// Compilation happens during `open`, so the error may surface from either
 /// `open` or `render`.
 fn diagnostics_for(plate: &str) -> Vec<quillmark_core::Diagnostic> {
-    match TypstBackend.open(plate, &host_source(), &serde_json::json!({})) {
+    match TypstBackend.open(&source_with_plate(plate), &serde_json::json!({})) {
         Ok(session) => session
             .render(&RenderOptions {
                 output_format: Some(OutputFormat::Pdf),

--- a/crates/backends/typst/tests/plate_resolution.rs
+++ b/crates/backends/typst/tests/plate_resolution.rs
@@ -1,0 +1,62 @@
+//! The Typst backend resolves its own plate from the `typst.plate_file`
+//! setting in the quill's config, reading the file from the quill's bundle.
+//! Core no longer reads any template at load time, so a missing plate is a
+//! render-time (`open`) error rather than a load-time one.
+
+use std::collections::HashMap;
+
+use quillmark_core::{Backend, FileTreeNode, Quill};
+use quillmark_typst::TypstBackend;
+
+fn quill(yaml: &str, files: &[(&str, &[u8])]) -> Quill {
+    let mut map = HashMap::new();
+    map.insert(
+        "Quill.yaml".to_string(),
+        FileTreeNode::File {
+            contents: yaml.as_bytes().to_vec(),
+        },
+    );
+    for (name, bytes) in files {
+        map.insert(
+            (*name).to_string(),
+            FileTreeNode::File {
+                contents: bytes.to_vec(),
+            },
+        );
+    }
+    Quill::from_tree(FileTreeNode::Directory { files: map }).expect("load quill")
+}
+
+const YAML: &str = "quill:\n  name: t\n  version: \"1.0\"\n  backend: typst\n  \
+                    description: d\n\ntypst:\n  plate_file: plate.typ\n";
+
+#[test]
+fn plate_file_is_resolved_from_the_typst_section() {
+    let q = quill(
+        YAML,
+        &[("plate.typ", b"#set page(width: 100pt, height: 100pt)\n= Hi\n")],
+    );
+    let session = TypstBackend
+        .open(&q, &serde_json::json!({}))
+        .expect("open should resolve typst.plate_file and compile");
+    assert!(session.page_count() >= 1);
+}
+
+#[test]
+fn missing_plate_file_errors_at_open_not_load() {
+    // Loads fine: core reads no backend template at load time.
+    let q = quill(YAML, &[]);
+    // Opening resolves the plate and fails because the declared file is absent.
+    let err = match TypstBackend.open(&q, &serde_json::json!({})) {
+        Ok(_) => panic!("a missing plate file must fail at open"),
+        Err(e) => e,
+    };
+    let diags = err.into_diagnostics();
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code.as_deref() == Some("typst::plate_missing")),
+        "expected a typst::plate_missing diagnostic, got {:?}",
+        diags.iter().map(|d| d.code.as_deref()).collect::<Vec<_>>()
+    );
+}

--- a/crates/backends/typst/tests/producer_meta.rs
+++ b/crates/backends/typst/tests/producer_meta.rs
@@ -13,7 +13,7 @@ use lopdf::Object;
 use quillmark_core::{Backend, FileTreeNode, OutputFormat, Quill, RenderOptions};
 use quillmark_typst::TypstBackend;
 
-fn host_source() -> Quill {
+fn host_tree() -> FileTreeNode {
     fn walk(dir: &Path) -> std::io::Result<FileTreeNode> {
         let mut files = HashMap::new();
         for entry in fs::read_dir(dir)? {
@@ -43,15 +43,31 @@ fn host_source() -> Quill {
         .join("quills")
         .join("usaf_memo")
         .join("0.2.0");
-    Quill::from_tree(walk(&quill_path).expect("walk fixture")).expect("load source")
+    walk(&quill_path).expect("walk fixture")
+}
+
+/// Build the host quill with its `plate.typ` replaced by `plate`; the fixture's
+/// `typst.plate_file: plate.typ` makes the backend read this override.
+fn source_with_plate(plate: &str) -> Quill {
+    let mut tree = host_tree();
+    if let FileTreeNode::Directory { files } = &mut tree {
+        files.insert(
+            "plate.typ".to_string(),
+            FileTreeNode::File {
+                contents: plate.as_bytes().to_vec(),
+            },
+        );
+    }
+    Quill::from_tree(tree).expect("load source")
 }
 
 const PLATE: &str = "#set page(width: 400pt, height: 300pt)\n= Hello\n";
 
 /// Render a plate to PDF bytes via the public `Backend`/`RenderSession` path.
-fn render_pdf(source: &Quill, plate: &str) -> Vec<u8> {
+fn render_pdf(plate: &str) -> Vec<u8> {
+    let source = source_with_plate(plate);
     let session = TypstBackend
-        .open(plate, source, &serde_json::json!({}))
+        .open(&source, &serde_json::json!({}))
         .expect("open session");
     let result = session
         .render(&RenderOptions {
@@ -84,14 +100,14 @@ fn info_string(pdf: &[u8], key: &[u8]) -> Vec<u8> {
 
 #[test]
 fn default_producer_is_quillmark_version() {
-    let pdf = render_pdf(&host_source(), PLATE);
+    let pdf = render_pdf(PLATE);
     let expected = format!("Quillmark {}", env!("CARGO_PKG_VERSION"));
     assert_eq!(producer_of(&pdf), expected.as_bytes());
 }
 
 #[test]
 fn default_pass_preserves_typst_creator() {
-    let pdf = render_pdf(&host_source(), PLATE);
+    let pdf = render_pdf(PLATE);
     let creator = info_string(&pdf, b"Creator");
     assert!(
         creator.starts_with(b"Typst"),
@@ -102,10 +118,10 @@ fn default_pass_preserves_typst_creator() {
 
 #[test]
 fn producer_override_via_render_options() {
-    let source = host_source();
+    let source = source_with_plate(PLATE);
     let backend = TypstBackend;
     let session = backend
-        .open(PLATE, &source, &serde_json::json!({}))
+        .open(&source, &serde_json::json!({}))
         .expect("open session");
     // Includes (), and \\ to exercise PDF literal-string escaping.
     let override_str = r"ACME (PDF) \ Tool 2.0";
@@ -124,10 +140,10 @@ fn producer_override_via_render_options() {
 fn producer_override_non_ascii_roundtrips() {
     // A non-ASCII override takes the UTF-16BE+BOM hex-string branch of
     // pdf_text_string; assert it decodes back to the original.
-    let source = host_source();
+    let source = source_with_plate(PLATE);
     let backend = TypstBackend;
     let session = backend
-        .open(PLATE, &source, &serde_json::json!({}))
+        .open(&source, &serde_json::json!({}))
         .expect("open session");
     let override_str = "Quillmark 日本語 ✒";
     let result = session
@@ -156,7 +172,7 @@ fn producer_composes_with_signature_field() {
 #set page(width: 600pt, height: 400pt, margin: 50pt)
 #signature-field("a")
 "#;
-    let pdf = render_pdf(&host_source(), plate);
+    let pdf = render_pdf(plate);
 
     // /Producer present.
     let expected = format!("Quillmark {}", env!("CARGO_PKG_VERSION"));

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -16,7 +16,11 @@ use quillmark_typst::TypstBackend;
 /// — `signature-field` doesn't depend on any quill-specific config so we
 /// just need a valid quill skeleton, and `usaf_memo` is the fixture the
 /// spikes validated.
-fn host_source() -> Quill {
+/// Walk the `usaf_memo@0.2.0` fixture into an in-memory tree. Reused as a host
+/// — `signature-field` doesn't depend on any quill-specific config, so we just
+/// need a valid quill skeleton (fonts, packages), and `usaf_memo` is the
+/// fixture the spikes validated.
+fn host_tree() -> FileTreeNode {
     fn walk(dir: &Path) -> std::io::Result<FileTreeNode> {
         let mut files = HashMap::new();
         for entry in fs::read_dir(dir)? {
@@ -46,7 +50,21 @@ fn host_source() -> Quill {
         .join("quills")
         .join("usaf_memo")
         .join("0.2.0");
-    let tree = walk(&quill_path).expect("walk fixture");
+    walk(&quill_path).expect("walk fixture")
+}
+
+/// Build the host quill with its `plate.typ` replaced by `plate`. The fixture
+/// declares `typst.plate_file: plate.typ`, so the backend reads this override.
+fn source_with_plate(plate: &str) -> Quill {
+    let mut tree = host_tree();
+    if let FileTreeNode::Directory { files } = &mut tree {
+        files.insert(
+            "plate.typ".to_string(),
+            FileTreeNode::File {
+                contents: plate.as_bytes().to_vec(),
+            },
+        );
+    }
     Quill::from_tree(tree).expect("load source")
 }
 
@@ -58,8 +76,8 @@ fn compile(plate: &str) -> Result<Vec<u8>, RenderError> {
 /// Like [`compile`] but threads `json_data` to the plate's `data` binding, so a
 /// plate can exercise value binding via `data.*`.
 fn compile_with_data(plate: &str, json_data: &serde_json::Value) -> Result<Vec<u8>, RenderError> {
-    let source = host_source();
-    let session = TypstBackend.open(plate, &source, json_data)?;
+    let source = source_with_plate(plate);
+    let session = TypstBackend.open(&source, json_data)?;
     let result = session.render(&RenderOptions {
         output_format: Some(OutputFormat::Pdf),
         ..Default::default()
@@ -552,9 +570,9 @@ fn form_field_regions_carry_type_and_value() {
 #form-field("cho", type: "choice", options: ("A", "B"), value: "B")
 #form-field("sig", type: "signature")
 "#;
-    let source = host_source();
+    let source = source_with_plate(plate);
     let session = TypstBackend
-        .open(plate, &source, &serde_json::json!({}))
+        .open(&source, &serde_json::json!({}))
         .expect("open");
     let result = session
         .render(&RenderOptions {

--- a/crates/bindings/cli/src/commands/info.rs
+++ b/crates/bindings/cli/src/commands/info.rs
@@ -67,11 +67,6 @@ fn print_json(quill: &quillmark::Quill) -> Result<()> {
             serde_json::Value::Number(card_count.into()),
         );
     }
-    info.insert(
-        "has_plate".to_string(),
-        serde_json::Value::Bool(quill.plate().is_some()),
-    );
-
     // Add any additional metadata (excluding the standard fields already included)
     let mut extra_metadata = serde_json::Map::new();
     for (key, value) in metadata {
@@ -135,12 +130,6 @@ fn print_human_readable(quill: &quillmark::Quill) {
     if defaults_count > 0 {
         println!("  Defaults:    {}", defaults_count);
     }
-
-    // Plate
-    println!(
-        "  Has plate:   {}",
-        if quill.plate().is_some() { "yes" } else { "no" }
-    );
 
     // Additional metadata
     let extra_keys: Vec<&String> = metadata

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -183,12 +183,13 @@ fn validate_file_references(
     config: &QuillConfig,
     result: &mut ValidationResult,
 ) {
-    // Check plate_file reference. `plate_file` comes from the (untrusted)
-    // Quill.yaml, so reject anything that is not a simple relative filename
-    // before touching the filesystem: `Path::join` with an absolute path
-    // replaces the base entirely, and `..` escapes the quill root, either of
-    // which would turn `plate_path.exists()` into a host path-probing oracle.
-    if let Some(ref plate_file) = config.plate_file {
+    // Check a backend's `plate_file` reference (Typst declares it under its
+    // `typst:` section). It comes from the (untrusted) Quill.yaml, so reject
+    // anything that is not a simple relative filename before touching the
+    // filesystem: `Path::join` with an absolute path replaces the base
+    // entirely, and `..` escapes the quill root, either of which would turn
+    // `plate_path.exists()` into a host path-probing oracle.
+    if let Some(plate_file) = config.backend_config.get("plate_file").and_then(|v| v.as_str()) {
         let rel = Path::new(plate_file);
         if rel
             .components()

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -18,8 +18,10 @@ QUILL_YAML_CONTENT = """quill:
   name: py_schema_smoke
   version: "1.0"
   backend: typst
-  plate_file: plate.typ
   description: Python schema/blueprint smoke test
+
+typst:
+  plate_file: plate.typ
 
 main:
   fields:

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -949,8 +949,10 @@ describe('quill.metadata', () => {
   name: meta_test_quill
   version: "0.2.1"
   backend: typst
-  plate_file: plate.typ
   description: Metadata test
+
+typst:
+  plate_file: plate.typ
 
 main:
   description: The main card schema
@@ -1178,8 +1180,10 @@ describe('Unendorsed / Endorsed schema model', () => {
   name: schema_test
   version: "1.0"
   backend: typst
-  plate_file: plate.typ
   description: Unendorsed / Endorsed coverage
+
+typst:
+  plate_file: plate.typ
 
 main:
   fields:

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -25,8 +25,10 @@ export function makeQuill({
   name: ${name}
   version: "${version}"
   backend: typst
-  plate_file: plate.typ
   description: Test quill for smoke tests
+
+typst:
+  plate_file: plate.typ
 `
   return new Map([
     ['Quill.yaml', enc.encode(yaml)],

--- a/crates/bindings/wasm/tests/metadata.rs
+++ b/crates/bindings/wasm/tests/metadata.rs
@@ -8,7 +8,7 @@ fn test_quill_from_tree_with_ui_metadata() {
     let tree = common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: ui_test_quill\n  version: \"0.1\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for UI metadata\n\nmain:\n  fields:\n    my_field:\n      type: string\n      ui:\n        group: Personal Info\n",
+            b"quill:\n  name: ui_test_quill\n  version: \"0.1\"\n  backend: typst\n  description: Test quill for UI metadata\n\nmain:\n  fields:\n    my_field:\n      type: string\n      ui:\n        group: Personal Info\n",
         ),
         ("plate.typ", b"= Title"),
     ]);

--- a/crates/bindings/wasm/tests/resolve_quill.rs
+++ b/crates/bindings/wasm/tests/resolve_quill.rs
@@ -10,7 +10,7 @@ fn test_quill_from_tree_versioned() {
     let q1 = Quill::from_tree(common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.1.0\n",
+            b"quill:\n  name: usaf_memo\n  version: \"0.1.0\"\n  backend: typst\n  description: Version 0.1.0\n",
         ),
         ("plate.typ", b"hello 1"),
     ])).unwrap();
@@ -18,7 +18,7 @@ fn test_quill_from_tree_versioned() {
     let q2 = Quill::from_tree(common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Version 0.2.0\n",
+            b"quill:\n  name: usaf_memo\n  version: \"0.2.0\"\n  backend: typst\n  description: Version 0.2.0\n",
         ),
         ("plate.typ", b"hello 2"),
     ])).unwrap();

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -10,7 +10,7 @@ fn small_quill_tree() -> wasm_bindgen::JsValue {
     common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+            b"quill:\n  name: test_quill\n  backend: typst\n  description: Test quill for WASM bindings\n\ntypst:\n  plate_file: plate.typ\n",
         ),
         ("plate.typ", b"= Title\n\nThis is a test."),
     ])
@@ -220,7 +220,7 @@ fn test_quill_from_object_tree() {
     let entries: &[(&str, &[u8])] = &[
         (
             "Quill.yaml",
-            b"quill:\n  name: test_quill\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill for WASM bindings\n",
+            b"quill:\n  name: test_quill\n  backend: typst\n  description: Test quill for WASM bindings\n\ntypst:\n  plate_file: plate.typ\n",
         ),
         ("plate.typ", b"= Title\n\nThis is a test."),
     ];
@@ -256,7 +256,7 @@ fn test_quill_metadata_and_schemas() {
     let quill = Quill::from_tree(common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  plate_file: plate.typ\n  description: Metadata quill\nmain:\n  fields:\n    title:\n      type: string\n      ui:\n        group: Header\ncard_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n",
+            b"quill:\n  name: meta_quill\n  backend: typst\n  version: \"0.2.1\"\n  description: Metadata quill\nmain:\n  fields:\n    title:\n      type: string\n      ui:\n        group: Header\ncard_kinds:\n  indorsement:\n    fields:\n      signature_block:\n        type: string\n",
         ),
         ("plate.typ", b"= Title"),
     ]))
@@ -293,7 +293,7 @@ fn test_quill_seed_document() {
     let quill = Quill::from_tree(common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  plate_file: plate.typ\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\n    title:\n      type: string\n      default: Untitled\n",
+            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\n    title:\n      type: string\n      default: Untitled\n",
         ),
         ("plate.typ", b"= Title"),
     ]))
@@ -324,7 +324,7 @@ fn test_quill_seed_main_and_card() {
     let quill = Quill::from_tree(common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  plate_file: plate.typ\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\ncard_kinds:\n  note:\n    fields:\n      text:\n        type: string\n        example: NOTE EXAMPLE\n",
+            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\ncard_kinds:\n  note:\n    fields:\n      text:\n        type: string\n        example: NOTE EXAMPLE\n",
         ),
         ("plate.typ", b"= Title"),
     ]))
@@ -381,7 +381,7 @@ fn test_seed_overlay_round_trip() {
     let quill = Quill::from_tree(common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  plate_file: plate.typ\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\ncard_kinds:\n  note:\n    fields:\n      text:\n        type: string\n        example: NOTE EXAMPLE\n",
+            b"quill:\n  name: seed_quill\n  backend: typst\n  version: \"1.0\"\n  description: Seed quill\nmain:\n  fields:\n    byline:\n      type: string\n      example: FIRST LAST\ncard_kinds:\n  note:\n    fields:\n      text:\n        type: string\n        example: NOTE EXAMPLE\n",
         ),
         ("plate.typ", b"= Title"),
     ]))

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -12,10 +12,15 @@ pub trait Backend: Send + Sync + std::fmt::Debug {
     /// Get supported output formats.
     fn supported_formats(&self) -> &'static [OutputFormat];
 
-    /// Open an iterative render session from plate + compiled JSON data.
+    /// Open an iterative render session from a quill and compiled JSON data.
+    ///
+    /// The backend pulls whatever static inputs it needs straight from
+    /// `source` ([`Quill::files`] for assets, [`Quill::config`] for
+    /// backend-specific config). There is no universal "template" input: a
+    /// template/plate is one backend's private notion, read by that backend
+    /// from its own files, not a parameter every backend must accept.
     fn open(
         &self,
-        plate_content: &str,
         source: &Quill,
         json_data: &serde_json::Value,
     ) -> Result<RenderSession, RenderError>;

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -47,7 +47,6 @@ pub const STANDARD_METADATA_KEYS: &[&str] =
 #[derive(Clone)]
 pub struct Quill {
     pub(crate) metadata: HashMap<String, QuillValue>,
-    pub(crate) plate: Option<String>,
     pub(crate) config: QuillConfig,
     pub(crate) files: FileTreeNode,
 }
@@ -66,11 +65,6 @@ impl Quill {
     /// Quill-specific metadata parsed from Quill.yaml.
     pub fn metadata(&self) -> &HashMap<String, QuillValue> {
         &self.metadata
-    }
-
-    /// The plate template content, if the quill declares one.
-    pub fn plate(&self) -> Option<&str> {
-        self.plate.as_deref()
     }
 
     /// The parsed schema configuration.
@@ -98,10 +92,6 @@ impl std::fmt::Debug for Quill {
         f.debug_struct("Quill")
             .field("name", &self.config.name)
             .field("backend_id", &self.config.backend)
-            .field(
-                "plate",
-                &self.plate.as_ref().map(|s| format!("<{} bytes>", s.len())),
-            )
             .field("files", &"<FileTreeNode>")
             .finish()
     }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -46,8 +46,6 @@ pub struct QuillConfig {
     pub version: String,
     /// Author of the project
     pub author: String,
-    /// Plate file (template)
-    pub plate_file: Option<String>,
     /// Backend-specific configuration parsed from the top-level YAML section
     /// whose key matches `backend` (e.g. `[typst]`, `[html]`).
     #[serde(default)]
@@ -978,15 +976,8 @@ impl QuillConfig {
         };
 
         // Validate that no unknown keys appear in the [quill] section.
-        const KNOWN_QUILL_KEYS: &[&str] = &[
-            "name",
-            "backend",
-            "description",
-            "version",
-            "author",
-            "plate_file",
-            "ui",
-        ];
+        const KNOWN_QUILL_KEYS: &[&str] =
+            &["name", "backend", "description", "version", "author", "ui"];
         if let Some(quill_obj) = quill_section.as_object() {
             for key in quill_obj.keys() {
                 if !KNOWN_QUILL_KEYS.contains(&key.as_str()) {
@@ -1135,11 +1126,6 @@ impl QuillConfig {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .unwrap_or_else(|| "Unknown".to_string());
-
-        let plate_file = quill_section
-            .get("plate_file")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
 
         let ui_section: Option<UiCardSchema> = match quill_section.get("ui").cloned() {
             None => None,
@@ -1456,7 +1442,6 @@ impl QuillConfig {
                 backend,
                 version,
                 author,
-                plate_file,
                 backend_config,
             },
             warnings,

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -23,8 +23,8 @@ impl Quill {
     ///
     /// Returns a non-empty `Vec<Diagnostic>` describing every problem found.
     /// When `Quill.yaml` itself contains multiple errors they are all
-    /// reported together; subsequent failures (missing plate) surface as
-    /// single-element vectors.
+    /// reported together. Backend-specific assets (e.g. a Typst plate) are
+    /// not read here — a backend resolves its own inputs at render time.
     pub fn from_tree(root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
         let quill_yaml_bytes = root.get_file("Quill.yaml").ok_or_else(|| {
             vec![diag(
@@ -77,29 +77,8 @@ impl Quill {
             metadata.insert(format!("{}_{}", config.backend, key), value.clone());
         }
 
-        // Read the plate content from plate file (if specified)
-        let plate_content: Option<String> = if let Some(ref plate_file_name) = config.plate_file {
-            let plate_bytes = root.get_file(plate_file_name).ok_or_else(|| {
-                vec![diag(
-                    format!("Plate file '{}' not found in file tree", plate_file_name),
-                    "quill::plate_missing",
-                )]
-            })?;
-
-            let content = String::from_utf8(plate_bytes.to_vec()).map_err(|e| {
-                vec![diag(
-                    format!("Plate file '{}' is not valid UTF-8: {}", plate_file_name, e),
-                    "quill::invalid_utf8",
-                )]
-            })?;
-            Some(content)
-        } else {
-            None
-        };
-
         let source = Quill {
             metadata,
-            plate: plate_content,
             config,
             files: root,
         };

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -125,7 +125,7 @@ fn test_in_memory_file_system() {
     // Create test files
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "test plate").unwrap();
@@ -168,7 +168,7 @@ fn test_quillignore_integration() {
     // Create test files
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "test template").unwrap();
@@ -195,7 +195,7 @@ fn test_find_files_pattern() {
     // Create test directory structure
     fs::write(
             quill_dir.join("Quill.yaml"),
-            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test quill\"",
+            "quill:\n  name: \"test\"\n  version: \"1.0\"\n  backend: \"typst\"\n  description: \"Test quill\"",
         )
         .unwrap();
     fs::write(quill_dir.join("plate.typ"), "template").unwrap();
@@ -232,7 +232,6 @@ quill:
   name: my_custom_quill
   version: "1.0"
   backend: typst
-  plate_file: custom_plate.typ
   description: Test quill with new format
   author: Test Author
 "#;
@@ -268,9 +267,6 @@ quill:
             assert_eq!(version_str, "1.0");
         }
     }
-
-    // Test that plate template content is loaded correctly
-    assert!(quill.plate.unwrap().contains("Custom Template"));
 }
 
 #[test]
@@ -283,7 +279,6 @@ fn test_from_tree() {
   name: "test_from_tree"
   version: "1.0"
   backend: "typst"
-  plate_file: "plate.typ"
   description: "A test quill from tree"
 "#;
     root_files.insert(
@@ -309,7 +304,12 @@ fn test_from_tree() {
 
     // Validate the quill
     assert_eq!(quill.name(), "test_from_tree");
-    assert_eq!(quill.plate.unwrap(), plate_content);
+    // Non-manifest files (e.g. a backend's template) round-trip into the file
+    // tree verbatim; core no longer reads any of them at load time.
+    assert_eq!(
+        quill.files().get_file("plate.typ"),
+        Some(plate_content.as_bytes())
+    );
     assert!(quill.metadata.contains_key("backend"));
     assert!(quill.metadata.contains_key("description"));
 }
@@ -317,7 +317,7 @@ fn test_from_tree() {
 #[test]
 fn test_to_tree_round_trips_from_tree() {
     // Build a tree with a nested directory to exercise the recursive flatten.
-    let quill_yaml = b"quill:\n  name: roundtrip\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Round-trip test\n".to_vec();
+    let quill_yaml = b"quill:\n  name: roundtrip\n  version: \"1.0\"\n  backend: typst\n  description: Round-trip test\n".to_vec();
     let plate = b"= Plate".to_vec();
     let asset = b"\x00\x01\x02 binary asset".to_vec();
 
@@ -393,7 +393,7 @@ fn test_from_tree_structure_direct() {
             "Quill.yaml".to_string(),
             FileTreeNode::File {
                 contents:
-                    b"quill:\n  name: direct_tree\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Direct tree test\n"
+                    b"quill:\n  name: direct_tree\n  version: \"1.0\"\n  backend: typst\n  description: Direct tree test\n"
                         .to_vec(),
             },
         );
@@ -436,7 +436,7 @@ fn test_dir_exists_and_list_apis() {
     root_files.insert(
             "Quill.yaml".to_string(),
             FileTreeNode::File {
-                contents: b"quill:\n  name: test\n  version: \"1.0\"\n  backend: typst\n  plate_file: plate.typ\n  description: Test quill\n"
+                contents: b"quill:\n  name: test\n  version: \"1.0\"\n  backend: typst\n  description: Test quill\n"
                     .to_vec(),
             },
         );
@@ -542,7 +542,6 @@ fn test_field_schemas_parsing() {
   name: "taro"
   version: "1.0"
   backend: "typst"
-  plate_file: "plate.typ"
   description: "Test template for field schemas"
 
 main:
@@ -672,10 +671,11 @@ ui:
 
 #[test]
 fn test_quill_without_plate_file() {
-    // Test creating a Quill without specifying a plate file
+    // A quill that declares no backend template loads fine — plate selection is
+    // a backend's private concern, not a load-time requirement of core.
     let mut root_files = HashMap::new();
 
-    // Add Quill.yaml without plate field
+    // Add Quill.yaml with no backend section at all
     let quill_yaml = r#"quill:
   name: "test_no_plate"
   version: "1.0"
@@ -694,8 +694,8 @@ fn test_quill_without_plate_file() {
     // Create Quill from tree
     let quill = Quill::from_tree(root).unwrap();
 
-    // Validate that plate is null (will use auto plate)
-    assert!(quill.plate.clone().is_none());
+    // No `typst:` section means no `typst_plate_file` metadata surfaces.
+    assert!(!quill.metadata.contains_key("typst_plate_file"));
     assert_eq!(quill.name(), "test_no_plate");
 }
 
@@ -709,10 +709,10 @@ quill:
   backend: typst
   description: Test configuration parsing
   author: Test Author
-  plate_file: plate.typ
 
 typst:
-  packages: 
+  plate_file: plate.typ
+  packages:
     - "@preview/bubble:0.2.2"
 
 main:
@@ -739,9 +739,13 @@ main:
     // Verify optional fields
     assert_eq!(config.version, "1.0");
     assert_eq!(config.author, "Test Author");
-    assert_eq!(config.plate_file, Some("plate.typ".to_string()));
 
-    // Verify backend-specific config (parsed from the [typst] section).
+    // Verify backend-specific config (parsed from the [typst] section). The
+    // Typst plate now lives here alongside `packages`, not as a top-level key.
+    assert_eq!(
+        config.backend_config.get("plate_file").and_then(|v| v.as_str()),
+        Some("plate.typ")
+    );
     assert!(config.backend_config.contains_key("packages"));
 
     // Verify field schemas
@@ -2359,22 +2363,22 @@ main:
 
 #[test]
 fn test_unknown_key_in_quill_section_errors() {
-    // Typos like 'platefile' should fail loudly, not silently land in metadata.
+    // Typos like 'auther' should fail loudly, not silently land in metadata.
     let yaml_content = r#"
 quill:
   name: unk_key
   version: "1.0"
   backend: typst
   description: Unknown key test
-  platefile: foo.typ
+  auther: Jane Doe
 "#;
 
     let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
 
     assert_eq!(err.len(), 1);
     assert_eq!(err[0].code.as_deref(), Some("quill::unknown_key"));
-    assert!(err[0].message.contains("platefile"));
-    assert!(err[0].hint.as_deref().unwrap_or("").contains("plate_file"));
+    assert!(err[0].message.contains("auther"));
+    assert!(err[0].hint.as_deref().unwrap_or("").contains("author"));
 }
 
 #[test]

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -2,8 +2,10 @@ quill:
   name: classic_resume
   version: 0.1.0
   backend: typst
-  plate_file: plate.typ
   description: A clean and modern classic resume template.
+
+typst:
+  plate_file: plate.typ
 
 main:
   fields:

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -2,8 +2,10 @@ quill:
   name: cmu_letter
   version: 0.1.0
   backend: typst
-  plate_file: plate.typ
   description: Typeset letters that comply with Carnegie Mellon University letterhead standards.
+
+typst:
+  plate_file: plate.typ
 
 main:
   fields:

--- a/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/taro/0.1.0/Quill.yaml
@@ -2,8 +2,10 @@ quill:
   name: taro
   version: 0.1.0
   backend: typst
-  plate_file: plate.typ
   description: A simple document template for testing
+
+typst:
+  plate_file: plate.typ
 
 main:
   fields:

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -2,8 +2,10 @@ quill:
   name: usaf_memo
   version: 0.2.0
   backend: typst
-  plate_file: plate.typ
   description: U.S. Air Force and Space Force Official Memorandum
+
+typst:
+  plate_file: plate.typ
 
 main:
   body:

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -130,7 +130,6 @@ fn config_with_one_field(schema: FieldSchema) -> QuillConfig {
         backend: "typst".to_string(),
         version: "1.0".to_string(),
         author: String::new(),
-        plate_file: None,
         backend_config: HashMap::new(),
     }
 }

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -78,12 +78,7 @@ impl Quillmark {
         let backend = self.resolve_backend(quill)?;
         quill.check_quill_reference(doc)?;
         let json_data = quill.compile_data(doc)?;
-        let plate_content = quill
-            .plate()
-            .filter(|s| !s.is_empty())
-            .unwrap_or("")
-            .to_string();
-        backend.open(&plate_content, quill, &json_data)
+        backend.open(quill, &json_data)
     }
 
     /// Render `doc` against `quill` in one shot. Convenience over

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -21,12 +21,18 @@ impl Backend for MockBackend {
 
     fn open(
         &self,
-        plated: &str,
-        _source: &Quill,
+        source: &Quill,
         _json_data: &serde_json::Value,
     ) -> Result<quillmark::RenderSession, RenderError> {
+        // Like the real backends, the mock reads its own input from the quill's
+        // files — here a `plate.txt` it echoes back as the rendered bytes.
+        let plated = source
+            .files()
+            .get_file("plate.txt")
+            .map(|b| b.to_vec())
+            .unwrap_or_default();
         Ok(quillmark::RenderSession::new(Box::new(MockSession {
-            bytes: plated.as_bytes().to_vec(),
+            bytes: plated,
         })))
     }
 }
@@ -91,7 +97,7 @@ fn test_render_with_custom_backend() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        "quill:\n  name: \"custom_backend_quill\"\n  version: \"1.0\"\n  backend: \"mock-txt\"\n  plate_file: \"plate.txt\"\n  description: \"Test\"\n",
+        "quill:\n  name: \"custom_backend_quill\"\n  version: \"1.0\"\n  backend: \"mock-txt\"\n  description: \"Test\"\n",
     ).unwrap();
     fs::write(quill_path.join("plate.txt"), "Test template: {{ title }}").unwrap();
 

--- a/crates/quillmark/tests/default_values_test.rs
+++ b/crates/quillmark/tests/default_values_test.rs
@@ -28,7 +28,6 @@ fn test_nested_null_zero_fills_in_plate() {
   name: "test_quill"
   version: "1.0"
   backend: "typst"
-  plate_file: "plate.typ"
   description: "Nested null zero-fill"
 
 main:
@@ -84,7 +83,6 @@ fn test_defaults_applied_when_absent() {
   name: "test_quill"
   version: "1.0"
   backend: "typst"
-  plate_file: "plate.typ"
   description: "Test quill with defaults"
 
 main:
@@ -145,7 +143,6 @@ fn test_absent_must_fill_is_zero_filled() {
   name: "test_quill"
   version: "1.0"
   backend: "typst"
-  plate_file: "plate.typ"
   description: "Test quill with an Unendorsed field"
 
 main:

--- a/crates/quillmark/tests/dry_run_test.rs
+++ b/crates/quillmark/tests/dry_run_test.rs
@@ -19,7 +19,7 @@ fn make_test_quill_path(temp_dir: &TempDir, with_required_field: bool) -> std::p
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "quill:\n  name: \"test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n\n{}",
+            "quill:\n  name: \"test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  description: \"Test\"\n\ntypst:\n  plate_file: plate.typ\n\n{}",
             fields_section
         ),
     ).unwrap();

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -11,8 +11,8 @@ fn make_quill_dir(temp_dir: &TempDir, name: &str, backend: &str) -> std::path::P
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "quill:\n  name: \"{}\"\n  version: \"1.0\"\n  backend: \"{}\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
-            name, backend
+            "quill:\n  name: \"{}\"\n  version: \"1.0\"\n  backend: \"{}\"\n  description: \"Test\"\n\n{}:\n  plate_file: plate.typ\n",
+            name, backend, backend
         ),
     )
     .unwrap();
@@ -74,7 +74,7 @@ fn test_quill_engine_end_to_end() {
     fs::create_dir_all(&quill_path).unwrap();
     fs::write(
         quill_path.join("Quill.yaml"),
-        "quill:\n  name: \"my_test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
+        "quill:\n  name: \"my_test_quill\"\n  version: \"1.0\"\n  backend: \"typst\"\n  description: \"Test\"\n\ntypst:\n  plate_file: plate.typ\n",
     ).unwrap();
     fs::write(
         quill_path.join("plate.typ"),

--- a/crates/quillmark/tests/version_mismatch_test.rs
+++ b/crates/quillmark/tests/version_mismatch_test.rs
@@ -18,7 +18,7 @@ fn make_quill(temp_dir: &TempDir, version: &str) -> std::path::PathBuf {
     fs::write(
         quill_path.join("Quill.yaml"),
         format!(
-            "quill:\n  name: \"test_quill\"\n  version: \"{}\"\n  backend: \"typst\"\n  plate_file: \"plate.typ\"\n  description: \"Test\"\n",
+            "quill:\n  name: \"test_quill\"\n  version: \"{}\"\n  backend: \"typst\"\n  description: \"Test\"\n\ntypst:\n  plate_file: plate.typ\n",
             version
         ),
     )

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -53,7 +53,7 @@
 
     // A Quill is portable, declarative data — no engine needed to load it.
     const quill = Quill.fromTree(new Map([
-      ["Quill.yaml", enc.encode("quill:\n  name: my_quill\n  backend: typst\n  version: 1.0.0\n  description: Demo\n  plate_file: plate.typ\n")],
+      ["Quill.yaml", enc.encode("quill:\n  name: my_quill\n  backend: typst\n  version: 1.0.0\n  description: Demo\n\ntypst:\n  plate_file: plate.typ\n")],
       ["plate.typ", enc.encode("#import \"@local/quillmark-helper:0.1.0\": data\n#data.at(\"$body\")\n")],
     ]));
 

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -191,3 +191,45 @@ impl Backend for MyBackend {              impl Backend for MyBackend {
                                               fn render_rgba(&self, p, s) -> … { … }
                                           }
 ```
+
+## `plate_file` moves to the `typst:` section; `Backend::open` drops the plate parameter
+
+A plate is a Typst notion, not a universal one — the pdfform backend has no plate
+and ignored the parameter. The plate is no longer hoisted into core or the
+backend trait. Each backend now reads its own static inputs from the quill's file
+bundle, exactly as pdfform already read its `form.pdf` / `form.json`.
+
+**`Quill.yaml`: `plate_file` moves out of `quill:` into `typst:`.** It was always
+a Typst-only setting; it now lives under the backend-named section like
+`packages`. A `plate_file` left under `quill:` is now a hard `quill::unknown_key`
+error.
+
+```yaml
+# 0.92                          0.93
+quill:                          quill:
+  name: my_quill                  name: my_quill
+  backend: typst                  backend: typst
+  version: "1.0.0"                version: "1.0.0"
+  description: A format           description: A format
+  plate_file: plate.typ
+                                typst:
+                                  plate_file: plate.typ
+```
+
+It surfaces in `Quill.metadata()` as `typst_plate_file` (like any other
+`typst:` key), instead of the former dedicated handling.
+
+**Core drops the plate.** `Quill::plate()`, the `plate` field, and
+`QuillConfig::plate_file` are removed. Core no longer reads any template at load
+time, so a missing or non-UTF-8 plate is now a **render-time** error
+(`typst::plate_missing` / `typst::invalid_utf8`) rather than a load-time
+`quill::plate_missing`.
+
+**`Backend::open` loses its first parameter.** The signature is now
+`open(&self, source: &Quill, json_data: &serde_json::Value)`. A backend reads
+whatever it needs from `source.files()` / `source.config()`.
+
+**Action (out-of-tree backends):** drop the `plate_content` parameter from your
+`open` impl and read your own inputs from `source`. The Typst backend reads the
+file named by `source.config().backend_config["plate_file"]` (an empty plate when
+unset).

--- a/docs/quills/creating-quills.md
+++ b/docs/quills/creating-quills.md
@@ -22,6 +22,8 @@ quill:
   backend: typst
   version: "1.0.0"
   description: A simple letter format
+
+typst:
   plate_file: plate.typ
 
 main:

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -42,8 +42,11 @@ Every Quill.yaml must have a `quill` section with format metadata.
 | `description`    | string | yes      | Human-readable description of the quill itself (non-empty). Independent of `main.description`, which is the optional schema description authored under `main:`. |
 | `version`        | string | yes      | Semantic version (`MAJOR.MINOR` or `MAJOR.MINOR.PATCH`) |
 | `author`         | string | no       | Creator of the Quill (defaults to `"Unknown"`) |
-| `plate_file`     | string | no       | Path to the plate file |
 | `ui`             | object | no       | Document-level UI metadata |
+
+A backend's own settings live under its backend-named section, not in `quill:`.
+The Typst template, for example, is declared as `typst.plate_file` (see the
+[`typst` Section](#typst-section) below).
 
 ```yaml
 quill:
@@ -52,6 +55,8 @@ quill:
   backend: typst
   description: Typesetted USAF Official Memorandum
   author: TongueToQuill
+
+typst:
   plate_file: plate.typ
 ```
 
@@ -406,8 +411,14 @@ Card kinds defined here are authored as `~~~` blocks (with a `$kind: <kind>` lin
 
 Backend-specific configuration for the Typst renderer.
 
+| Key          | Type   | Required | Description |
+|--------------|--------|----------|-------------|
+| `plate_file` | string | no       | Path (relative to the quill root) to the Typst template the backend compiles |
+| `packages`   | array  | no       | Typst packages the template depends on |
+
 ```yaml
 typst:
+  plate_file: plate.typ
   packages:
     - "@preview/appreciated-letter:0.1.0"
 ```
@@ -438,6 +449,8 @@ quill:
   backend: typst
   description: Monthly project status report
   author: Engineering Team
+
+typst:
   plate_file: plate.typ
 
 main:

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Property-based fuzz tests (proptest): `parse_fuzz` (YAML/Markdown parsing), `con
 
 - **`Quillmark`** — Engine: a backend registry + render dispatcher. Auto-registers `TypstBackend` when the `typst` feature is enabled. Resolves a quill's declared backend at render time (erroring `UnsupportedBackend` on no match) and owns the backend-dependent surface — `render`, `open`, `supported_formats(&quill)`, `supports_canvas(&quill)`. It no longer constructs quills
 - **`Quill`** — The single quill type in `quillmark-core`: portable, declarative data (file bundle + config + metadata, tagged with a declared backend id). Held by value. Exposes the pure config-read operations: `dry_run`, `compile_data`, `backend_id`, plus `validate` (editor-facing: returns every schema diagnostic, including the non-fatal `validation::must_fill` warning raised for each `!must_fill` marker) and the `seed_document` / `seed_main` / `seed_card` starters that emit committed example documents and cards. Construct with `Quill::from_tree` or `quillmark::quill_from_path`
-- **`Backend`** — Trait for output formats (`Send + Sync`): `id()`, `supported_formats()`, `open(plate, &Quill, json)`. No canvas-capability method — capability is derived (`RenderSession::supports_canvas()` from the session seam; `formats_support_canvas()` as a pre-session hint)
+- **`Backend`** — Trait for output formats (`Send + Sync`): `id()`, `supported_formats()`, `open(&Quill, json)`. There is no universal template input: a backend reads whatever static inputs it needs (a Typst plate, a `form.pdf`) from the quill's own files. No canvas-capability method — capability is derived (`RenderSession::supports_canvas()` from the session seam; `formats_support_canvas()` as a pre-session hint)
 - **`RenderSession`** — Opaque handle returned by `Backend::open()`; call `render(opts)` to produce artifacts. Exposes `page_count()` and `warnings()` for consumers (e.g. canvas previews) that don't go through `render()`. The canvas-preview seam lives on `SessionHandle` itself (`page_size_pt`/`render_rgba`, default `None`); a canvas backend overrides both, and the WASM painter dispatches generically through them — no per-backend downcast (Typst and pdfform both ride this seam — see [PREVIEW.md](PREVIEW.md)). A backend with a different richer typed surface can still downcast via `RenderSession::handle()` + `SessionHandle::as_any`.
 - **`Document`** — Typed in-memory representation of a Quillmark Markdown file (root block, body, cards). Serializes via `serde` to a versioned JSON envelope (`StoredDocument`) for database persistence, decoupled from the evolving Markdown syntax — see [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md)
 - **`Diagnostic`** — Structured error with severity, code, message, location, hint, source chain
@@ -63,8 +63,7 @@ Property-based fuzz tests (proptest): `parse_fuzz` (YAML/Markdown parsing), `con
 ## Data Injection
 
 `Backend::open()` receives:
-- `plate_content` — raw plate string from `Quill.plate` (empty string for plate-less backends)
-- `source` — `&Quill` with static assets/packages, config, metadata
+- `source` — `&Quill` with static assets/packages, config, metadata. A backend reads its own inputs from here: the Typst backend reads the template named by `typst.plate_file` from `source.files()`; pdfform reads `form.pdf` / `form.json`
 - `json_data` — JSON object after coercion, defaults, normalization
 
 See [PLATE_DATA.md](PLATE_DATA.md) for the Typst helper package.

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -57,8 +57,12 @@ at the boundary.
 Validation rules:
 1. Root MUST be a directory node
 2. `Quill.yaml` MUST exist and be valid YAML
-3. The `plate_file` referenced in `Quill.yaml`, if specified, MUST exist
-4. File paths use `/` separators and are resolved relative to root
+3. File paths use `/` separators and are resolved relative to root
+
+Core reads no backend-specific assets at load time. A backend resolves its own
+inputs from the file bundle when it opens a session (the Typst backend reads its
+`typst.plate_file`; the pdfform backend reads `form.pdf` / `form.json`), so a
+missing or malformed template surfaces as a render-time error, not a load error.
 
 ## `Quill.yaml` Structure
 
@@ -71,7 +75,6 @@ quill:
   version: "1.0.0"        # required; semver (MAJOR.MINOR.PATCH or MAJOR.MINOR)
   description: A beautiful format  # required; non-empty
   author: Jane Doe        # optional; defaults to "Unknown"
-  plate_file: plate.typ   # optional; path to Typst template
   ui:                     # optional; fallback for main.ui when absent
     title: My Quill
 
@@ -97,6 +100,7 @@ card_kinds:
         description: Quote author
 
 typst:
+  plate_file: plate.typ   # optional; path to the Typst template, read by the backend
   packages:
     - "@preview/some-package:1.0.0"
 ```
@@ -105,7 +109,7 @@ Field names must be `snake_case` (match `[a-z][a-z0-9_]*`). Capitalized or `$`-p
 
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card kind.
-- `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, and `typst_*` keys from the `typst:` section. (Note: this identity `metadata` is pure config — the backend's `supportedFormats` is a resolved-backend capability read from the engine, not part of it.) The `quill:` section accepts only `name`, `backend`, `description`, `version`, `author`, `plate_file`, and `ui`; unknown keys produce a `quill::unknown_key` error rather than landing in `metadata`.
+- `metadata` on `Quill` stores `backend`, `description`, `version`, `author`, and `typst_*` keys from the `typst:` section (so a declared `typst.plate_file` surfaces as `typst_plate_file`). (Note: this identity `metadata` is pure config — the backend's `supportedFormats` is a resolved-backend capability read from the engine, not part of it.) The `quill:` section accepts only `name`, `backend`, `description`, `version`, `author`, and `ui`; unknown keys produce a `quill::unknown_key` error rather than landing in `metadata`. A backend's own settings (e.g. the Typst plate) live under the backend-named section, never in `quill:`.
 - `quill.ui` (a `UiCardSchema`, same shape as `card_kinds.<name>.ui`) is a fallback for `main.ui`: the `main` card uses `main.ui` when present, otherwise `quill.ui`.
 
 ## Strict Parsing

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -44,11 +44,13 @@ quill:
   backend: typst
   description: "Short description of this format"
   author: "..."          # optional
-  plate_file: "plate.typ" # optional; conventional name
   ui: { ... }            # optional
+
+typst:
+  plate_file: "plate.typ" # optional; the Typst template, read by the backend
 ```
 
-`name`, `backend`, `version`, and `description` are required. `author`, `plate_file`, and `ui` are optional. Unknown keys under `quill:` are a hard error. `version` must parse as `MAJOR.MINOR.PATCH` (or `MAJOR.MINOR`); an invalid or missing value fails at load.
+`name`, `backend`, `version`, and `description` are required. `author` and `ui` are optional. Unknown keys under `quill:` are a hard error. A backend's own settings (e.g. the Typst `plate_file`) live under the backend-named section, not in `quill:`. `version` must parse as `MAJOR.MINOR.PATCH` (or `MAJOR.MINOR`); an invalid or missing value fails at load.
 
 ## Error Handling
 


### PR DESCRIPTION
## Motivation

Adding the `pdfform` backend exposed that the **plate** was never a universal concept — it was hoisted into core and the `Backend` trait even though only Typst uses it. `pdfform::open` received `plate_content: &str` and ignored it, and that `&str` type could never carry pdfform's *binary* base PDF anyway. Core also special-cased the Typst template (eagerly reading + UTF-8 validating it at load time) while pdfform self-served its `form.pdf` / `form.json` from the file bundle. The plate is bespoke, not universal.

## What changed

This collapses the asymmetry so **every backend resolves its own inputs**:

- **`Backend::open` drops `plate_content`** — now `open(&self, source: &Quill, json_data: &serde_json::Value)`. Each backend reads what it needs from `source.files()` / `source.config()`.
- **`plate_file` moves out of `quill:` into the `typst:` section**, alongside `packages`. It surfaces as `typst_plate_file` metadata like any other backend-config key. A `plate_file` left under `quill:` is now a hard `quill::unknown_key` error.
- **Core stops knowing about plates** — removed `Quill::plate()`, the `plate` field, `QuillConfig::plate_file`, and the load-time read/validation. The Typst backend reads `typst.plate_file` from the bundle at open time, so a missing/non-UTF-8 template is now a **render-time** error (`typst::plate_missing` / `typst::invalid_utf8`) rather than a load-time `quill::plate_missing`.

On naming: since the field now lives under `typst:` where "plate" is literally accurate (it's the Typst source that imprints the page), the name stays `plate` — no need for a blander universal term, and `main` would have collided with the existing `main:` section.

## Scope

- Core: `backend.rs`, `quill.rs`, `quill/load.rs`, `quill/config.rs`, engine.
- Backends: Typst now resolves its own plate (new `read_plate` helper); pdfform drops the unused param.
- CLI: `info` drops the now-redundant generic `has_plate` line (it surfaces as `typst_plate_file` metadata automatically); `validate` keeps its plate-path safety check, sourced from `backend_config`.
- Fixtures (4 Quills), binding tests (Rust/JS/Python), a new `plate_resolution.rs` test locking the missing-template render-time error.
- Docs: canon (QUILL / ARCHITECTURE / VERSIONING), user docs, and a `0.92 → 0.93` migration entry.

## Testing

`cargo test --workspace` — all green (43 result groups, 0 failures); `cargo clippy` clean on the changed crates. WASM/Python binding YAML updated for their CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RB7fADX7qUeDtQEybK6eS8)_