### PR TITLE
fix(quillmark-pdf): make find_dict_value key/value-position aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ## Unreleased
 
+- fix(quillmark-pdf): `find_dict_value` now walks the dict as strict
+  key→value pairs, so a Name in *value* position (e.g. `/Subtype /Producer`)
+  is no longer mis-matched as a key; the object/dict scanners also skip
+  `%`-comments, so `endobj` or a key token inside a comment can't derail
+  parsing of an untrusted base PDF
 - feat(pdfform): add the Typst-free `pdfform` backend + shared `quillmark-pdf`
   AcroForm stamping spine; rewire Typst signatures onto the spine; thread a
   `regions` sidecar through `RenderResult` and generalize the raster-preview

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -197,16 +197,18 @@ pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
 }
 
 /// Find the `endobj` keyword that closes the object body starting at `from`,
-/// returning the index just past it. Literal `( … )` strings are skipped so a
-/// string value containing the bytes `endobj` (e.g. an `/Info` `/Title`) cannot
-/// truncate the object mid-string — the same string-aware skip
-/// [`extract_outer_dict`] already relies on.
+/// returning the index just past it. Literal `( … )` strings and `%`-comments
+/// are skipped so the bytes `endobj` appearing inside a string value (e.g. an
+/// `/Info` `/Title`) or a comment cannot truncate the object early — the same
+/// string-aware skip [`extract_outer_dict`] already relies on.
 fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
     let needle = b"endobj";
     let mut i = from;
     while i < pdf.len() {
         if pdf[i] == b'(' {
             i = skip_pdf_string(pdf, i);
+        } else if pdf[i] == b'%' {
+            i = skip_ws_and_comments(pdf, i);
         } else if pdf[i..].starts_with(needle) {
             return Some(i + needle.len());
         } else {
@@ -273,65 +275,61 @@ fn is_obj_header_tail(rest: &[u8]) -> bool {
 }
 
 /// Within a dict's inner bytes, locate `/Key` and return its raw value slice.
-/// Value-terminating tokenisation handles Name values like `/Pages` so they
-/// aren't mis-read as the next entry.
+///
+/// `dict_bytes` is the *inner* content of one dict (between its `<<` / `>>`),
+/// where entries strictly alternate `key value key value …` and every key is a
+/// Name. The scan walks that key→value rhythm: at each step it reads the key
+/// Name, then consumes its value wholesale via [`read_value_end`] (which steps
+/// over nested `<<>>` / `[]` / `()` / `<>` as a unit). Because every value is
+/// consumed as a value, a Name that appears in *value* position (e.g.
+/// `/Subtype /Producer`) is never mistaken for a key — only keys are tested
+/// against `km`. The returned slice begins exactly after the matched key token
+/// (callers such as `upsert_producer` derive the key span by subtraction).
 pub fn find_dict_value<'a>(dict_bytes: &'a [u8], key: &str) -> Option<&'a [u8]> {
     let key_marker = format!("/{}", key);
     let km = key_marker.as_bytes();
     let mut i = 0;
-    let mut depth_dict = 0i32;
-    let mut depth_array = 0i32;
-    while i < dict_bytes.len() {
-        if dict_bytes[i] == b'(' {
-            i = skip_pdf_string(dict_bytes, i);
-            continue;
+    loop {
+        i = skip_ws_and_comments(dict_bytes, i);
+        // A well-formed flat dict yields a Name key here. Anything else (end of
+        // input, or a stray token) means there is no further key to match.
+        if dict_bytes.get(i) != Some(&b'/') {
+            return None;
         }
-        if dict_bytes[i..].starts_with(b"<<") {
-            depth_dict += 1;
-            i += 2;
-            continue;
+        let key_start = i;
+        i += 1;
+        while i < dict_bytes.len() && !is_pdf_delim(dict_bytes[i]) {
+            i += 1;
         }
-        if dict_bytes[i..].starts_with(b">>") {
-            depth_dict -= 1;
-            i += 2;
-            continue;
+        let after_key = i;
+        let matched = &dict_bytes[key_start..after_key] == km;
+        let value_start = skip_ws_and_comments(dict_bytes, after_key);
+        let value_end = read_value_end(dict_bytes, value_start)?;
+        if matched {
+            // Slice from immediately after the key (not `value_start`) so the
+            // key span is `[after_key - km.len, value_end)` by subtraction.
+            return Some(&dict_bytes[after_key..value_end]);
         }
-        if dict_bytes[i] == b'<' {
-            i = skip_pdf_hex_string(dict_bytes, i);
-            continue;
-        }
-        match dict_bytes[i] {
-            b'[' => {
-                depth_array += 1;
-                i += 1;
-            }
-            b']' => {
-                depth_array -= 1;
-                i += 1;
-            }
-            _ if depth_dict == 0 && depth_array == 0 && dict_bytes[i..].starts_with(km) => {
-                let next = dict_bytes.get(i + km.len()).copied();
-                if matches!(
-                    next,
-                    Some(b' ')
-                        | Some(b'\t')
-                        | Some(b'\n')
-                        | Some(b'\r')
-                        | Some(b'/')
-                        | Some(b'[')
-                        | Some(b'<')
-                        | Some(b'(')
-                ) {
-                    let start = i + km.len();
-                    let end = read_value_end(dict_bytes, start)?;
-                    return Some(&dict_bytes[start..end]);
-                }
-                i += 1;
-            }
-            _ => i += 1,
-        }
+        i = value_end;
     }
-    None
+}
+
+/// Skip PDF whitespace and `%`-comments (which run to end-of-line) starting at
+/// `start`; returns the index of the first significant byte at or after it.
+fn skip_ws_and_comments(b: &[u8], start: usize) -> usize {
+    let mut i = start;
+    loop {
+        while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r' | b'\x0c') {
+            i += 1;
+        }
+        if b.get(i) == Some(&b'%') {
+            while i < b.len() && b[i] != b'\n' && b[i] != b'\r' {
+                i += 1;
+            }
+            continue;
+        }
+        return i;
+    }
 }
 
 /// Find the byte index where a value beginning at `start` ends. Returns the
@@ -747,6 +745,43 @@ mod tests {
         let dict = b" /MediaBox [0 0 612 792] /Other 1 ";
         let v = find_dict_value(dict, "MediaBox").expect("found");
         assert_eq!(parse_rect_array(v), Some([0.0, 0.0, 612.0, 792.0]));
+    }
+
+    #[test]
+    fn dict_value_ignores_name_in_value_position() {
+        // A Name that appears as a *value* (`/Subtype /Producer`) must not be
+        // mistaken for the `/Producer` key. The real key wins.
+        let dict = b" /Subtype /Producer /Producer (real) /Creator (X) ";
+        let v = find_dict_value(dict, "Producer").expect("found the key, not the value");
+        assert_eq!(v.trim_ascii(), b"(real)");
+    }
+
+    #[test]
+    fn dict_value_absent_key_with_matching_name_value_is_none() {
+        // The key is genuinely absent; the only occurrence of the token is a
+        // value Name. The walk must report None, not the spurious value.
+        let dict = b" /Subtype /Producer /Creator (X) ";
+        assert!(find_dict_value(dict, "Producer").is_none());
+    }
+
+    #[test]
+    fn dict_value_skips_comments_between_entries() {
+        // A `%`-comment between entries must not derail the key→value walk, and
+        // a `/Producer` token sitting inside that comment must not be matched.
+        let dict = b" /A 1 %decoy /Producer (decoy)\n /Producer (real) ";
+        let v = find_dict_value(dict, "Producer").expect("found");
+        assert_eq!(v.trim_ascii(), b"(real)");
+    }
+
+    #[test]
+    fn endobj_inside_comment_does_not_truncate_object() {
+        // `endobj` appearing inside a `%`-comment must not close the object at
+        // the in-comment occurrence.
+        let pdf = b"%PDF\n3 0 obj\n<< /A 1 >> %endobj in a comment\n/B 2 >>\nendobj\n";
+        let (s, e) = find_object_bytes(pdf, 3).expect("found object 3");
+        assert_eq!(&pdf[e - 6..e], b"endobj");
+        // The real terminator is the standalone `endobj`, past the comment.
+        assert!(&pdf[s..e].ends_with(b"/B 2 >>\nendobj"));
     }
 
     #[test]

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -230,4 +230,31 @@ mod tests {
         // U+1F600 (😀) is outside the BMP → a UTF-16 surrogate pair D83D DE00.
         assert_eq!(pdf_text_string("😀"), b"<FEFFD83DDE00>");
     }
+
+    #[test]
+    fn upsert_producer_replaces_existing_value() {
+        let info = b"/Title (Hi) /Producer (Old) /Creator (X)";
+        let out = upsert_producer(info, b"(New)");
+        assert_eq!(&out, b"/Title (Hi) /Producer (New) /Creator (X)");
+    }
+
+    #[test]
+    fn upsert_producer_appends_when_absent() {
+        let info = b"/Title (Hi)";
+        let out = upsert_producer(info, b"(New)");
+        assert_eq!(&out, b"/Title (Hi) /Producer (New)");
+    }
+
+    #[test]
+    fn upsert_producer_ignores_producer_name_in_value_position() {
+        // A `/Producer` Name in *value* position (here as the value of
+        // `/Marker`) must not be overwritten as if it were the key — doing so
+        // would clobber the wrong token and drop a trailing entry. Regression
+        // for the key/value-position bug in `find_dict_value`.
+        let info = b"/Title (Hi) /Marker /Producer /Creator (X)";
+        let out = upsert_producer(info, b"(New)");
+        // No real /Producer key exists, so the entry is appended; the /Marker
+        // value and /Creator entry are left intact.
+        assert_eq!(&out, b"/Title (Hi) /Marker /Producer /Creator (X) /Producer (New)");
+    }
 }


### PR DESCRIPTION
## Motivation

A final code review of the `pdfform` + `quillmark-pdf` spine work surfaced one
real (latent) correctness bug in the spine's untrusted-PDF reader.

`find_dict_value` walked the dict's bytes at depth 0 and matched the search key
wherever its `/Name` appeared — **including in value position**. So
`find_dict_value(b" /Subtype /Producer /Foo 1 ", "Producer")` returned `/Foo`
(it matched the *value* of `/Subtype`). On an `/Info` dict carrying a Name value
equal to the searched key, `upsert_producer` then overwrote the wrong token and
dropped the trailing entry, producing a malformed `/Info` dict.

Impact is bounded (it can't bypass the `/Encrypt` rejection or pick a wrong
catalog — a false match there only over-triggers into a clean rejection), and
base PDFs come from the Quill bundle / Typst, so exploitability is low. But it's
a genuine defect in security-sensitive parsing of untrusted bytes, so worth
closing now while the spine is fresh.

## What changed

- **`find_dict_value` now walks the dict as the strict `key value key value …`
  pairs it is**: read each Name key, then consume its value wholesale via the
  existing `read_value_end` (which already steps over nested
  `<<>>` / `[]` / `()` / `<>`). Because every value is consumed *as a value*, a
  Name in value position is never tested as a key. The returned slice still
  begins exactly after the matched key token, so `upsert_producer`'s
  key-span-by-subtraction is preserved unchanged.
- **`%`-comment skipping** added to the dict walk and to `find_endobj_end`, so a
  key token or the bytes `endobj` sitting inside a comment in an untrusted base
  PDF can't derail parsing (the second, minor finding from the review).

No public API or behavior change for well-formed input; this only corrects
malformed/edge inputs.

## Testing

- New regression tests: a Name in value position (`reader.rs` +
  `upsert_producer` in `writer.rs`), the absent-key-with-matching-value-Name
  case, a comment-embedded decoy key, and an in-comment `endobj`.
- `cargo test -p quillmark-pdf` — 28 unit + 15 acceptance (lopdf-reparse) green.
- `cargo test -p quillmark-typst -p quillmark-pdfform` — direct consumers green.
- `cargo clippy -p quillmark-pdf --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbKVibzK9preVzpkxK3C5A)_