### PR TITLE
refactor(core)!: rework field regions — schema-keyed and session-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@
 
 ## Unreleased
 
-- refactor(core)!: `RenderResult.regions` is keyed on the quill schema field
-  path, not the backend widget. `RenderedRegion` (and the WASM `FieldRegion`)
-  drop `name`/`kind`/`fieldType`/`value` for a single `field` carrying the
-  schema address (e.g. `signature_block`); the pdfform AcroForm widget name no
-  longer leaks. A region is emitted only for a field with a schema address — an
-  unbound widget produces none. `RegionKind` is removed; `quillmark-pdf`'s
-  `FieldSpec` gains `schema_field`. Regions are geometry for overlays and
-  canvas↔editor cross-navigation, never a compositing input (#773). See
+- refactor(core)!: field regions move from `RenderResult` to a session-level
+  query, `RenderSession::regions()` (WASM `session.regions()`), and are keyed on
+  the quill schema field path, not the backend widget. Only the interactive
+  preview path wants region geometry; a one-shot byte render (PDF/PNG/SVG) does
+  not, so `RenderResult.regions` is removed and the geometry is read once off the
+  compiled session without a render. `RenderedRegion` (and the WASM
+  `FieldRegion`) drop `name`/`kind`/`fieldType`/`value` for a single `field`
+  carrying the schema address (e.g. `signature_block`); the pdfform AcroForm
+  widget name no longer leaks. A region is emitted only for a schema-bound field
+  — an unbound widget produces none. `RegionKind` is removed; the `quillmark-pdf`
+  `FieldSpec` gains `schema_field` and `stamp`/`flatten` return plain bytes
+  (`StampResult` is gone). Regions are geometry for overlays and canvas↔editor
+  cross-navigation, never a compositing input (#773). See
   `docs/migrations/0.92-to-0.93.md`
 - feat(pdfform)!: the `pdfform` backend now exports PNG and SVG as first-class
   `render()` output formats (`SUPPORTED_FORMATS == [Pdf, Svg, Png]`); PNG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ## Unreleased
 
+- refactor(core)!: `RenderResult.regions` is keyed on the quill schema field
+  path, not the backend widget. `RenderedRegion` (and the WASM `FieldRegion`)
+  drop `name`/`kind`/`fieldType`/`value` for a single `field` carrying the
+  schema address (e.g. `signature_block`); the pdfform AcroForm widget name no
+  longer leaks. A region is emitted only for a field with a schema address — an
+  unbound widget produces none. `RegionKind` is removed; `quillmark-pdf`'s
+  `FieldSpec` gains `schema_field`. Regions are geometry for overlays and
+  canvas↔editor cross-navigation, never a compositing input (#773). See
+  `docs/migrations/0.92-to-0.93.md`
 - feat(pdfform)!: the `pdfform` backend now exports PNG and SVG as first-class
   `render()` output formats (`SUPPORTED_FORMATS == [Pdf, Svg, Png]`); PNG
   rasters at `RenderOptions::ppi` (default 144). The `preview` cargo feature is

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -23,9 +23,8 @@
 
 use quillmark_pdf::{
     reader::{err, extract_outer_dict, find_dict_value, find_object_bytes, UpdatedObject},
-    regions_of,
     writer::{alloc_id, dict_object, pdf_escape, winansi_encode},
-    FieldSpec, FieldType, PdfError, PdfUpdate, StampOptions, StampResult, CHECKBOX_ON_STATE,
+    FieldSpec, FieldType, PdfError, PdfUpdate, StampOptions, CHECKBOX_ON_STATE,
 };
 
 use crate::typography;
@@ -34,17 +33,10 @@ const CODE_PARSE: &str = "pdf::flatten_parse";
 
 /// Flatten `fields` onto `base` PDF by drawing values as PDF content stream
 /// operators. Unlike the stamp/Technique-A path, the result is visible in all
-/// rasterizers. Returns the flat PDF bytes and the same [`RenderedRegion`]
-/// sidecar the stamp path produces.
-pub fn flatten(
-    base: Vec<u8>,
-    fields: &[FieldSpec],
-    opts: &StampOptions,
-) -> Result<StampResult, PdfError> {
-    let regions = regions_of(fields);
-
+/// rasterizers. Returns the flat PDF bytes.
+pub fn flatten(base: Vec<u8>, fields: &[FieldSpec], opts: &StampOptions) -> Result<Vec<u8>, PdfError> {
     if fields.is_empty() && opts.producer.is_none() {
-        return Ok(StampResult { pdf: base, regions });
+        return Ok(base);
     }
 
     let pdf = base;
@@ -103,8 +95,7 @@ pub fn flatten(
         }
     }
 
-    let flat = up.finish(pdf)?;
-    Ok(StampResult { pdf: flat, regions })
+    up.finish(pdf)
 }
 
 // ── Drawing helpers ───────────────────────────────────────────────────────────
@@ -434,9 +425,7 @@ mod tests {
     }
 
     fn flatten_ok(fields: &[FieldSpec]) -> Vec<u8> {
-        flatten(BASE.to_vec(), fields, &StampOptions::default())
-            .expect("flatten succeeds")
-            .pdf
+        flatten(BASE.to_vec(), fields, &StampOptions::default()).expect("flatten succeeds")
     }
 
     fn contains_window(haystack: &[u8], needle: &[u8]) -> bool {

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -412,6 +412,7 @@ mod tests {
     fn text_field(name: &str, value: &str) -> FieldSpec {
         FieldSpec {
             name: name.to_string(),
+            schema_field: Some(name.to_string()),
             page: 0,
             rect: [72.0, 700.0, 300.0, 720.0],
             field_type: FieldType::Text { multiline: false },
@@ -423,6 +424,7 @@ mod tests {
     fn checkbox_field(name: &str, checked: bool) -> FieldSpec {
         FieldSpec {
             name: name.to_string(),
+            schema_field: Some(name.to_string()),
             page: 0,
             rect: [72.0, 660.0, 90.0, 678.0],
             field_type: FieldType::Checkbox,

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -27,7 +27,7 @@ use flatten::flatten as flatten_to_pdf;
 use quillmark_core::session::SessionHandle;
 use quillmark_core::{
     Artifact, Backend, Diagnostic, OutputFormat, Quill, RenderError, RenderOptions, RenderResult,
-    RenderSession, Severity,
+    RenderSession, RenderedRegion, Severity,
 };
 use quillmark_pdf::regions_of;
 use quillmark_pdf::{stamp, FieldSpec, PdfError, StampOptions};
@@ -113,13 +113,8 @@ impl Backend for PdfformBackend {
         // ready-to-rasterize flat PDF without re-running flatten on every
         // paint call. The producer string only goes in the PDF Info dict and
         // doesn't affect rasterisation, so None is fine here.
-        let flat_pdf = flatten_to_pdf(
-            base_pdf.clone(),
-            &field_specs,
-            &StampOptions { producer: None },
-        )
-        .map(|r| r.pdf)
-        .map_err(map_pdf_err)?;
+        let flat_pdf = flatten_to_pdf(base_pdf.clone(), &field_specs, &StampOptions { producer: None })
+            .map_err(map_pdf_err)?;
 
         Ok(RenderSession::new(Box::new(PdfformSession {
             base_pdf,
@@ -182,12 +177,11 @@ impl SessionHandle for PdfformSession {
 
         Ok(RenderResult::new(
             vec![Artifact {
-                bytes: stamped.pdf,
+                bytes: stamped,
                 output_format: OutputFormat::Pdf,
             }],
             OutputFormat::Pdf,
-        )
-        .with_regions(stamped.regions))
+        ))
     }
 
     fn page_count(&self) -> usize {
@@ -230,6 +224,12 @@ impl SessionHandle for PdfformSession {
             .collect();
         Some((w, h, bytes))
     }
+
+    /// Schema-field geometry from the resolved specs — keyed on the schema path,
+    /// skipping unbound widgets. Computed from cached state, no rasterization.
+    fn regions(&self) -> Vec<RenderedRegion> {
+        regions_of(&self.field_specs)
+    }
 }
 
 impl PdfformSession {
@@ -258,8 +258,7 @@ impl PdfformSession {
             })
             .collect();
 
-        let regions = regions_of(&self.field_specs);
-        Ok(RenderResult::new(artifacts, OutputFormat::Svg).with_regions(regions))
+        Ok(RenderResult::new(artifacts, OutputFormat::Svg))
     }
 
     /// Render all pages as PNG via hayro, using the pre-flattened PDF. `scale`
@@ -298,8 +297,7 @@ impl PdfformSession {
             });
         }
 
-        let regions = regions_of(&self.field_specs);
-        Ok(RenderResult::new(artifacts, OutputFormat::Png).with_regions(regions))
+        Ok(RenderResult::new(artifacts, OutputFormat::Png))
     }
 }
 

--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -37,6 +37,7 @@ use crate::form::{FieldKind, FormField, Rect};
 pub fn field_spec(field: &FormField, media_box: [f32; 4], data: &Value) -> FieldSpec {
     FieldSpec {
         name: field.name.clone(),
+        schema_field: field.schema_field.clone(),
         page: field.page,
         rect: flip_rect(field.rect, media_box),
         field_type: field_type(&field.kind),

--- a/crates/backends/pdfform/src/typography.rs
+++ b/crates/backends/pdfform/src/typography.rs
@@ -11,16 +11,16 @@
 //!
 //! ## On regions presentation enrichment (#752)
 //!
-//! Surfacing this typography on [`RegionKind::Field`](quillmark_core::RegionKind)
-//! (resolved font/size/align) was the deferred half of value flattening. It is
-//! deliberately **not** done: the unified flatten technique makes *both* canvas
-//! backends produce a **complete** raster (the pdfform session pre-flattens
-//! values into the page content, then rasterizes), so no consumer ever
-//! composites a value from a region — the trigger the enrichment was waiting on
-//! ("font-accurate client-side compositing") never occurs. Were such a consumer
-//! to materialize, it reads sizes from *this* module and adding the optional
-//! `RegionKind` fields is a clean, additive change. Until then, surfacing it
-//! would be public API (carried across all four bindings) with no caller.
+//! Surfacing this typography on the region sidecar (resolved font/size/align)
+//! was the deferred half of value flattening. It is deliberately **not** done:
+//! the unified flatten technique makes *both* canvas backends produce a
+//! **complete** raster (the pdfform session pre-flattens values into the page
+//! content, then rasterizes), so no consumer ever composites a value from a
+//! region — the trigger the enrichment was waiting on ("font-accurate
+//! client-side compositing") never occurs. The region carries only geometry +
+//! the schema field address for cross-navigation; it intentionally carries no
+//! value or typography. Were a font-accurate-compositing consumer to
+//! materialize, it reads sizes from *this* module.
 
 /// House text font — PDF base-14 Helvetica, registered as `/Helv`. Used for
 /// text and choice values.

--- a/crates/backends/pdfform/tests/canvas_conformance.rs
+++ b/crates/backends/pdfform/tests/canvas_conformance.rs
@@ -18,7 +18,7 @@
 //! top-left origin in device pixels, so the test applies the canonical
 //! `y_canvas = (pageHeightPt - y_pdf) × scale` flip to locate a field box.
 
-use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark::{Document, Quillmark};
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -70,19 +70,14 @@ fn pdfform_canvas_raster_is_complete() {
         "RGBA buffer must be w*h*4 bytes"
     );
 
-    // 2. Field-value ink: locate a bound text field via the regions sidecar and
-    //    prove the flat raster has non-white opaque pixels inside its rect.
-    let result = session
-        .render(&RenderOptions {
-            output_format: Some(OutputFormat::Pdf),
-            ..Default::default()
-        })
-        .expect("render to obtain regions geometry");
+    // 2. Field-value ink: locate a bound text field via the session's region
+    //    geometry and prove the flat raster has non-white opaque pixels inside
+    //    its rect. Geometry is a session-level query — no second byte render.
+    let regions = session.regions();
 
     // Pick the bound text field (schema path `full_name` = "Ada Lovelace") on
-    // page 0 via the regions sidecar, keyed on the schema path.
-    let region = result
-        .regions
+    // page 0, keyed on the schema path.
+    let region = regions
         .iter()
         .find(|r| r.page == 0 && r.field == "full_name")
         .expect("a region for the bound text field on page 0");

--- a/crates/backends/pdfform/tests/canvas_conformance.rs
+++ b/crates/backends/pdfform/tests/canvas_conformance.rs
@@ -19,7 +19,6 @@
 //! `y_canvas = (pageHeightPt - y_pdf) × scale` flip to locate a field box.
 
 use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
-use quillmark_core::RegionKind;
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -80,19 +79,13 @@ fn pdfform_canvas_raster_is_complete() {
         })
         .expect("render to obtain regions geometry");
 
-    // Pick a bound text field (FullName = "Ada Lovelace") on page 0.
+    // Pick the bound text field (schema path `full_name` = "Ada Lovelace") on
+    // page 0 via the regions sidecar, keyed on the schema path.
     let region = result
         .regions
         .iter()
-        .find(|r| {
-            r.page == 0
-                && matches!(
-                    &r.kind,
-                    RegionKind::Field { field_type, value }
-                        if field_type == "text" && value.is_some()
-                )
-        })
-        .expect("a bound text field region on page 0");
+        .find(|r| r.page == 0 && r.field == "full_name")
+        .expect("a region for the bound text field on page 0");
 
     // PDF points (bottom-left origin) → canvas pixels (top-left origin), the
     // canonical transform from PREVIEW.md: y_canvas = (pageHeightPt - y_pdf) × scale.

--- a/crates/backends/pdfform/tests/sample_form.rs
+++ b/crates/backends/pdfform/tests/sample_form.rs
@@ -35,6 +35,16 @@ fn render(markdown: &str) -> quillmark::RenderResult {
         .expect("render ok")
 }
 
+/// Open a compiled session — the surface that carries schema-field geometry
+/// (`session.regions()`), independent of any byte render.
+fn open_session(markdown: &str) -> quillmark::RenderSession {
+    let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("sample_form"))
+        .expect("load sample_form quill");
+    let engine = Quillmark::new();
+    let doc = Document::from_markdown(markdown).expect("parse markdown");
+    engine.open(&quill, &doc).expect("open ok")
+}
+
 /// Decode a PDF text string: UTF-16BE when it carries a BOM (pdf-writer picks
 /// this for values with characters outside the literal-safe set, e.g. a
 /// newline in a multiline field), else treat the bytes as Latin-1/ASCII.
@@ -122,19 +132,17 @@ fn fixture_renders_structurally_valid_filled_pdf() {
     assert_eq!(sig.get(b"FT").unwrap().as_name().unwrap(), b"Sig");
     assert!(sig.get(b"V").is_err());
 
-    // Regions sidecar: one per *schema-bound* field, keyed on the schema path.
-    // The fixture's Signature widget carries no `schema_field`, so it is a
+    // Region geometry is a session-level query (`session.regions()`), not on the
+    // render result: one per *schema-bound* field, keyed on the schema path. The
+    // fixture's Signature widget carries no `schema_field`, so it is a
     // backend-only artifact and emits no region — four regions, not five.
-    assert_eq!(result.regions.len(), 4);
+    let regions = open_session(FILLED).regions();
+    assert_eq!(regions.len(), 4);
     assert!(
-        result.regions.iter().all(|r| r.field != "Signature"),
+        regions.iter().all(|r| r.field != "Signature"),
         "the unbound signature widget produces no region"
     );
-    let r_full = result
-        .regions
-        .iter()
-        .find(|r| r.field == "full_name")
-        .unwrap();
+    let r_full = regions.iter().find(|r| r.field == "full_name").unwrap();
     // Geometry rides the sidecar: a real page and a non-degenerate rect.
     assert!(r_full.page < doc.get_pages().len().max(1));
     assert!(
@@ -184,10 +192,10 @@ favorite_color: green\n\
         decode_pdf_text(full.get(b"V").unwrap().as_str().unwrap()),
         "Café — Señor 'Ünïcøde'"
     );
-    // The regions sidecar carries geometry keyed on the schema path, not the
-    // bound value (the value lives in the AcroForm `/V`, asserted above).
+    // The session's region geometry is keyed on the schema path, not the bound
+    // value (the value lives in the AcroForm `/V`, asserted above).
     assert!(
-        result.regions.iter().any(|r| r.field == "full_name"),
+        open_session(md).regions().iter().any(|r| r.field == "full_name"),
         "a region is keyed on the schema path"
     );
 }

--- a/crates/backends/pdfform/tests/sample_form.rs
+++ b/crates/backends/pdfform/tests/sample_form.rs
@@ -122,20 +122,20 @@ fn fixture_renders_structurally_valid_filled_pdf() {
     assert_eq!(sig.get(b"FT").unwrap().as_name().unwrap(), b"Sig");
     assert!(sig.get(b"V").is_err());
 
-    // Regions sidecar: one per field, carrying bound values.
-    assert_eq!(result.regions.len(), 5);
+    // Regions sidecar: one per *schema-bound* field, keyed on the schema path.
+    // The fixture's Signature widget carries no `schema_field`, so it is a
+    // backend-only artifact and emits no region — four regions, not five.
+    assert_eq!(result.regions.len(), 4);
+    assert!(
+        result.regions.iter().all(|r| r.field != "Signature"),
+        "the unbound signature widget produces no region"
+    );
     let r_full = result
         .regions
         .iter()
-        .find(|r| r.name == "FullName")
+        .find(|r| r.field == "full_name")
         .unwrap();
-    match &r_full.kind {
-        quillmark_core::RegionKind::Field { field_type, value } => {
-            assert_eq!(field_type, "text");
-            assert_eq!(value.as_deref(), Some("Ada Lovelace"));
-        }
-    }
-    // Geometry rides the sidecar too: a real page and a non-degenerate rect.
+    // Geometry rides the sidecar: a real page and a non-degenerate rect.
     assert!(r_full.page < doc.get_pages().len().max(1));
     assert!(
         r_full.rect[2] > r_full.rect[0] && r_full.rect[3] > r_full.rect[1],
@@ -184,17 +184,12 @@ favorite_color: green\n\
         decode_pdf_text(full.get(b"V").unwrap().as_str().unwrap()),
         "Café — Señor 'Ünïcøde'"
     );
-    // The regions sidecar carries the same value verbatim.
-    let r_full = result
-        .regions
-        .iter()
-        .find(|r| r.name == "FullName")
-        .unwrap();
-    match &r_full.kind {
-        quillmark_core::RegionKind::Field { value, .. } => {
-            assert_eq!(value.as_deref(), Some("Café — Señor 'Ünïcøde'"));
-        }
-    }
+    // The regions sidecar carries geometry keyed on the schema path, not the
+    // bound value (the value lives in the AcroForm `/V`, asserted above).
+    assert!(
+        result.regions.iter().any(|r| r.field == "full_name"),
+        "a region is keyed on the schema path"
+    );
 }
 
 #[test]

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -132,12 +132,6 @@ pub(crate) fn render_document_pages(
         None => (0..page_count).collect(),
     };
 
-    // Form-field placements → spine field specs (Typst top-left → PDF
-    // bottom-left). Regions ride on every render regardless of format, so the
-    // GUI overlay has the geometry whether it shows the PDF or a raster.
-    let field_specs = overlay::build_field_specs(document, field_placements)?;
-    let regions = quillmark_pdf::regions_of(&field_specs);
-
     match format {
         OutputFormat::Svg => {
             let artifacts = selected_indices
@@ -148,7 +142,7 @@ pub(crate) fn render_document_pages(
                     output_format: OutputFormat::Svg,
                 })
                 .collect();
-            Ok(RenderResult::new(artifacts, OutputFormat::Svg).with_regions(regions))
+            Ok(RenderResult::new(artifacts, OutputFormat::Svg))
         }
         OutputFormat::Png => {
             let scale = ppi.unwrap_or(DEFAULT_PPI) / 72.0;
@@ -170,7 +164,7 @@ pub(crate) fn render_document_pages(
                     output_format: OutputFormat::Png,
                 });
             }
-            Ok(RenderResult::new(artifacts, OutputFormat::Png).with_regions(regions))
+            Ok(RenderResult::new(artifacts, OutputFormat::Png))
         }
         OutputFormat::Pdf => {
             let pdf = typst_pdf::pdf(document, &PdfOptions::default()).map_err(|e| {
@@ -182,6 +176,11 @@ pub(crate) fn render_document_pages(
                     .with_code("typst::pdf_generation".to_string())],
                 }
             })?;
+            // Form-field placements → spine field specs (Typst top-left → PDF
+            // bottom-left), stamped as AcroForm widgets. Only the PDF path needs
+            // them; SVG/PNG render the pages directly, and field geometry is a
+            // session-level query (`TypstSession::regions`), not a render output.
+            let field_specs = overlay::build_field_specs(document, field_placements)?;
             // The producer is always stamped (the always-on `/Info` pass); the
             // override threads from the product layer, else the backend default.
             let producer = Some(
@@ -193,12 +192,11 @@ pub(crate) fn render_document_pages(
                 stamp(pdf, &field_specs, &StampOptions { producer }).map_err(map_pdf_err)?;
             Ok(RenderResult::new(
                 vec![Artifact {
-                    bytes: stamped.pdf,
+                    bytes: stamped,
                     output_format: OutputFormat::Pdf,
                 }],
                 OutputFormat::Pdf,
-            )
-            .with_regions(stamped.regions))
+            ))
         }
         OutputFormat::Txt => Err(RenderError::FormatNotSupported {
             diags: vec![Diagnostic::new(

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -125,6 +125,16 @@ impl SessionHandle for TypstSession {
         }
         Some((width, height, rgba))
     }
+
+    /// Schema-field geometry for the compiled document — the placements resolved
+    /// to bottom-left PDF-point rects, keyed on the plate-authored field name.
+    /// Geometry math over the laid-out frames, no rasterization. Empty if the
+    /// placements fail to resolve (a render would surface the same error).
+    fn regions(&self) -> Vec<quillmark_core::RenderedRegion> {
+        overlay::build_field_specs(&self.document, &self.field_placements)
+            .map(|specs| quillmark_pdf::regions_of(&specs))
+            .unwrap_or_default()
+    }
 }
 
 /// Borrow the [`TypstSession`] underlying a [`RenderSession`], if the session

--- a/crates/backends/typst/src/overlay/mod.rs
+++ b/crates/backends/typst/src/overlay/mod.rs
@@ -131,6 +131,10 @@ pub(crate) fn build_field_specs(
             };
             Ok(FieldSpec {
                 name: p.name.clone(),
+                // A Typst form-field has no separate widget-vs-schema split: the
+                // plate-authored name is the author's field address, so it is
+                // both the `/T` and the region key.
+                schema_field: Some(p.name.clone()),
                 page: p.page,
                 // Typst top-left → PDF bottom-left.
                 rect: [x0, page_h - y1, x1, page_h - y0],

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -556,10 +556,10 @@ fn form_field_value_binding_from_data() {
     );
 }
 
-/// case: the `RenderResult.regions` sidecar carries the right `field_type` and
-/// case: the `RenderResult.regions` sidecar is keyed on the plate-authored field
-/// address (a Typst form-field's name is its schema address — no widget/schema
-/// split), one region per field of any type, each carrying page+geometry.
+/// case: `session.regions()` is keyed on the plate-authored field address (a
+/// Typst form-field's name is its schema address — no widget/schema split), one
+/// region per field of any type, each carrying page+geometry. A session-level
+/// query, not a render output.
 #[test]
 fn form_field_regions_key_on_field_address() {
     let plate = r#"
@@ -574,15 +574,10 @@ fn form_field_regions_key_on_field_address() {
     let session = TypstBackend
         .open(&source, &serde_json::json!({}))
         .expect("open");
-    let result = session
-        .render(&RenderOptions {
-            output_format: Some(OutputFormat::Pdf),
-            ..Default::default()
-        })
-        .expect("render");
+    let regions = session.regions();
 
     let fields: std::collections::HashMap<&str, &quillmark_core::RenderedRegion> =
-        result.regions.iter().map(|r| (r.field.as_str(), r)).collect();
+        regions.iter().map(|r| (r.field.as_str(), r)).collect();
 
     for name in ["txt", "chk", "cho", "sig"] {
         let r = fields

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -557,11 +557,11 @@ fn form_field_value_binding_from_data() {
 }
 
 /// case: the `RenderResult.regions` sidecar carries the right `field_type` and
-/// `value` per field, for every type.
+/// case: the `RenderResult.regions` sidecar is keyed on the plate-authored field
+/// address (a Typst form-field's name is its schema address — no widget/schema
+/// split), one region per field of any type, each carrying page+geometry.
 #[test]
-fn form_field_regions_carry_type_and_value() {
-    use quillmark_core::RegionKind;
-
+fn form_field_regions_key_on_field_address() {
     let plate = r#"
 #import "@local/quillmark-helper:0.1.0": form-field
 #set page(width: 600pt, height: 400pt, margin: 50pt)
@@ -581,29 +581,18 @@ fn form_field_regions_carry_type_and_value() {
         })
         .expect("render");
 
-    let mut got: std::collections::HashMap<String, (String, Option<String>)> =
-        std::collections::HashMap::new();
-    for r in &result.regions {
-        // Refutable `if let` (not an irrefutable `let`) so a future `RegionKind`
-        // variant stays non-breaking here; the `allow` covers the
-        // single-variant-today warning and lapses once a second variant exists.
-        #[allow(irrefutable_let_patterns)]
-        if let RegionKind::Field { field_type, value } = &r.kind {
-            got.insert(r.name.clone(), (field_type.clone(), value.clone()));
-        }
-    }
+    let fields: std::collections::HashMap<&str, &quillmark_core::RenderedRegion> =
+        result.regions.iter().map(|r| (r.field.as_str(), r)).collect();
 
-    assert_eq!(
-        got.get("txt"),
-        Some(&("text".to_string(), Some("hi".to_string())))
-    );
-    assert_eq!(
-        got.get("chk"),
-        Some(&("checkbox".to_string(), Some("Yes".to_string())))
-    );
-    assert_eq!(
-        got.get("cho"),
-        Some(&("choice".to_string(), Some("B".to_string())))
-    );
-    assert_eq!(got.get("sig"), Some(&("signature".to_string(), None)));
+    for name in ["txt", "chk", "cho", "sig"] {
+        let r = fields
+            .get(name)
+            .unwrap_or_else(|| panic!("region keyed on field address {name:?}"));
+        assert_eq!(r.page, 0);
+        assert!(
+            r.rect[2] > r.rect[0] && r.rect[3] > r.rect[1],
+            "region {name:?} rect is a proper box: {:?}",
+            r.rect
+        );
+    }
 }

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -416,19 +416,18 @@ describe('Quillmark.quill', () => {
     expect(svg.artifacts[0].mimeType).toBe('image/svg+xml')
   })
 
-  it('regions is always a non-null array on every render result', () => {
-    // Typst renders without AcroForm stamps → regions is empty, never undefined.
+  it('session.regions() is always a non-null array', () => {
+    // Regions are a session-level query, not on the render result. A Typst plate
+    // with no form-fields has no schema-field regions → empty, never undefined.
     const engine = new Quillmark()
     const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
 
-    const pdf = engine.render(quill, doc, { format: 'pdf' })
-    expect(Array.isArray(pdf.regions)).toBe(true)
-    expect(pdf.regions.length).toBe(0)
-
-    const svg = engine.render(quill, doc, { format: 'svg' })
-    expect(Array.isArray(svg.regions)).toBe(true)
-    expect(svg.regions.length).toBe(0)
+    const session = engine.open(quill, doc)
+    const regions = session.regions()
+    expect(Array.isArray(regions)).toBe(true)
+    expect(regions.length).toBe(0)
+    session.free()
   })
 
   it('should throw a quill::name_mismatch error when the document quill ref differs from the quill name', () => {

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -134,15 +134,18 @@ describe('@quillmark/wasm/runtime — Engine (hidden core→backend crossing)', 
     expect(typeof (await engine.supportsCanvas(quill))).toBe('boolean')
   })
 
-  it('regions is always a non-null array on the Engine render path', async () => {
-    // Typst renders without AcroForm stamps → regions is empty, never undefined.
+  it('session.regions() is always a non-null array', async () => {
+    // Regions are a session-level query, not on the render result. A Typst plate
+    // with no form-fields has no schema-field regions → empty, never undefined.
     const engine = new Engine()
     const quill = makeRuntimeQuill()
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
 
-    const result = await engine.render(quill, doc, { format: 'pdf' })
-    expect(Array.isArray(result.regions)).toBe(true)
-    expect(result.regions.length).toBe(0)
+    const session = await engine.open(quill, doc)
+    const regions = session.regions()
+    expect(Array.isArray(regions)).toBe(true)
+    expect(regions.length).toBe(0)
+    session.free()
   })
 
   it('manifest-backed capability probes do NOT load the backend', async () => {

--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -19,8 +19,7 @@ import type {
 	PageSize as CanonicalPageSize,
 	PaintOptions as CanonicalPaintOptions,
 	PaintResult as CanonicalPaintResult,
-	FieldRegion as CanonicalFieldRegion,
-	FieldRegionKind as CanonicalFieldRegionKind
+	FieldRegion as CanonicalFieldRegion
   // The BUILT copy (synced from `runtime/runtime.d.ts` by build-wasm.sh / the
   // cp step), because only there does the d.ts's own `../core/wasm.js` import
   // resolve to the generated `pkg/core` build. The two copies are byte-identical.
@@ -34,8 +33,7 @@ import type {
 	PageSize as TypstPageSize,
 	PaintOptions as TypstPaintOptions,
 	PaintResult as TypstPaintResult,
-	FieldRegion as TypstFieldRegion,
-	FieldRegionKind as TypstFieldRegionKind
+	FieldRegion as TypstFieldRegion
 } from '../../../pkg/backends/typst/wasm';
 
 // One mutual-assignability pair per hoisted type: typst → canonical and
@@ -81,8 +79,3 @@ const fieldRegionA: CanonicalFieldRegion = {} as TypstFieldRegion;
 const fieldRegionB: TypstFieldRegion = {} as CanonicalFieldRegion;
 void fieldRegionA;
 void fieldRegionB;
-
-const fieldRegionKindA: CanonicalFieldRegionKind = {} as TypstFieldRegionKind;
-const fieldRegionKindB: TypstFieldRegionKind = {} as CanonicalFieldRegionKind;
-void fieldRegionKindA;
-void fieldRegionKindB;

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -136,13 +136,6 @@ export interface RenderResult {
 	warnings: Diagnostic[];
 	outputFormat: OutputFormat;
 	renderTimeMs: number;
-	/**
-	 * Schema-field regions, each keyed on the quill schema field path. Always
-	 * an array — empty for backends / formats that produce no field geometry,
-	 * and for fields with no schema address. Geometry for overlays /
-	 * cross-navigation, never a compositing input.
-	 */
-	regions: FieldRegion[];
 }
 
 /** Canonical contract every backend build must satisfy. The emittable formats. */
@@ -249,9 +242,10 @@ export declare class Engine {
  * pixels, with NO compositing required by the caller. Both backends that
  * support canvas satisfy this: Typst rasterizes its laid-out page natively;
  * pdfform pre-flattens bound field values into the page content and rasterizes
- * that, so field values appear in the raster on their own. The
- * {@link FieldRegion} sidecar carries field geometry for interactive overlays
- * drawn on top of the raster; it is never needed to complete the picture.
+ * that, so field values appear in the raster on their own.
+ * {@link RenderSession.regions} carries schema-field geometry for interactive
+ * overlays / cross-navigation drawn on top of the raster; it is never needed to
+ * complete the picture.
  *
  * @experimental The whole session/canvas-paint surface (`Engine.open`,
  * `RenderSession`, `PaintOptions`, `PaintResult`, `PageSize`) ships ahead of
@@ -265,6 +259,14 @@ export declare class RenderSession {
 	readonly supportsCanvas: boolean;
 	readonly warnings: Diagnostic[];
 	render(options?: RenderOptions): RenderResult;
+	/**
+	 * Schema-field geometry for this compiled session — one {@link FieldRegion}
+	 * per schema-bound field, keyed on its quill schema field path. A
+	 * session-level query: no render, no byte artifact. Read it to place field
+	 * overlays / cross-navigation over a `paint`-ed canvas. Empty for backends
+	 * that place no schema fields.
+	 */
+	regions(): FieldRegion[];
 	/** Page geometry in points (1/72″). Report-only; the painter sizes the canvas. */
 	pageSize(page: number): PageSize;
 	/**

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -86,41 +86,48 @@ export interface RenderOptions {
 	producer?: string;
 }
 
-/** The kind and payload of a {@link FieldRegion}. Discriminated on `type`. */
-export type FieldRegionKind =
-	| { type: 'field'; fieldType: string; value?: string };
-
 /**
- * A form-field region: geometry and bound value from a stamped AcroForm.
- * Emitted by backends that stamp form fields (`pdfform`; Typst signature
- * overlay). Consumers use `rect` for *overlay* layout (e.g. positioning an
- * input box over a canvas) and `kind.value` to read the bound value.
+ * A rendered field region: the quill schema field address (`field`) plus its
+ * geometry (`rect`) on the page. Emitted by backends that place schema fields
+ * (`pdfform` AcroForm widgets; Typst form-fields). Only fields with a schema
+ * address produce a region — a backend-only widget produces none, and the
+ * backend widget name never appears.
  *
- * Regions are NOT needed to make a canvas paint complete: `RenderSession.paint`
- * already bakes every field value into the raster (see {@link RenderSession}).
- * They exist for interactive overlays drawn on top of that raster.
+ * Use it to map between a place on the page and a field in the editor: click a
+ * rendered field → focus `field` in the editor, or highlight the rect for the
+ * focused field. Geometry only — `RenderSession.paint` already bakes every
+ * value into the raster (see {@link RenderSession}), so a region is never a
+ * compositing input.
  *
- * COORDINATE TRANSFORM. `rect` is in PDF points with a **bottom-left** origin;
- * a canvas is **top-left** origin in device pixels. To place an overlay from a
- * region onto a canvas painted at `renderScale` (= `layoutScale × densityScale`)
- * for a page `pageHeightPt` tall (from {@link PageSize}.heightPt):
+ * COORDINATE TRANSFORM. `rect` is in PDF points with a **bottom-left** origin.
+ *
+ * For an **HTML/CSS overlay** on a `width:100%` canvas, position hotspots as
+ * percentages of the page — they track the displayed size across DPI and pane
+ * resize for free, and only the Y axis flips:
  *
  * ```js
- * const [x0, y0, x1, y1] = region.rect;       // PDF pt, bottom-left origin
+ * const [x0, y0, x1, y1] = region.rect;            // PDF pt, bottom-left origin
+ * const left   = (x0 / pageWidthPt) * 100;         // % of page (from PageSize.widthPt)
+ * const top    = (1 - y1 / pageHeightPt) * 100;    // % — flip Y (from PageSize.heightPt)
+ * const width  = ((x1 - x0) / pageWidthPt) * 100;
+ * const height = ((y1 - y0) / pageHeightPt) * 100;
+ * ```
+ *
+ * For painting **into a raster** at `renderScale` (= `layoutScale × densityScale`),
+ * use the device-pixel form instead:
+ *
+ * ```js
  * const left   = x0 * renderScale;
- * const right  = x1 * renderScale;
  * const top    = (pageHeightPt - y1) * renderScale;  // flip Y
- * const bottom = (pageHeightPt - y0) * renderScale;  // y_canvas = (pageHeightPt - y_pdf) × renderScale
  * ```
  */
 export interface FieldRegion {
-	/** Fully-qualified field name (matches the AcroForm widget `/T`). */
-	name: string;
+	/** Quill schema field path (e.g. `"signature_block"`), not a backend widget name. */
+	field: string;
 	/** 0-based page index. */
 	page: number;
 	/** `[x0, y0, x1, y1]` in PDF points (1/72″), bottom-left origin. */
 	rect: [number, number, number, number];
-	kind: FieldRegionKind;
 }
 
 /** Canonical contract every backend build must satisfy. Result of one render. */
@@ -130,9 +137,10 @@ export interface RenderResult {
 	outputFormat: OutputFormat;
 	renderTimeMs: number;
 	/**
-	 * Form-field regions from stamped AcroForm backends. Always an array —
-	 * empty for backends / formats that produce no field geometry. The only
-	 * path to field values in non-interactive flat output.
+	 * Schema-field regions, each keyed on the quill schema field path. Always
+	 * an array — empty for backends / formats that produce no field geometry,
+	 * and for fields with no schema address. Geometry for overlays /
+	 * cross-navigation, never a compositing input.
 	 */
 	regions: FieldRegion[];
 }

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -345,7 +345,7 @@ export class Engine {
  * natively; pdfform rasterizes its pre-flattened page). See `runtime.d.ts`.
  */
 export class RenderSession {
-	/** @param {{ pageCount: number, backendId: string, supportsCanvas: boolean, warnings: any[], render: Function, pageSize: Function, paint: Function, free: Function }} inner backend-build RenderSession (typst or pdfform) */
+	/** @param {{ pageCount: number, backendId: string, supportsCanvas: boolean, warnings: any[], render: Function, regions: Function, pageSize: Function, paint: Function, free: Function }} inner backend-build RenderSession (typst or pdfform) */
 	constructor(inner) {
 		this.#inner = inner;
 	}
@@ -367,6 +367,17 @@ export class RenderSession {
 	/** @param {object} [options] */
 	render(options) {
 		return this.#inner.render(options ?? undefined);
+	}
+
+	/**
+	 * Schema-field geometry for this compiled session — one region per
+	 * schema-bound field, keyed on its quill schema field path. A session-level
+	 * query (no render); read it to place field overlays / cross-navigation over
+	 * a `paint`-ed canvas.
+	 * @returns {import('./runtime.d.ts').FieldRegion[]}
+	 */
+	regions() {
+		return this.#inner.regions();
 	}
 
 	/** @param {number} page */

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -3,7 +3,7 @@
 use crate::error::WasmError;
 use crate::types::Diagnostic;
 #[cfg(any(feature = "typst", feature = "pdfform"))]
-use crate::types::{RenderOptions, RenderResult};
+use crate::types::{FieldRegion, RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
 #[cfg(any(feature = "typst", feature = "pdfform-preview"))]
 use serde::Deserialize;
@@ -261,7 +261,6 @@ impl Quillmark {
             warnings,
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
-            regions: result.regions.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -1298,8 +1297,18 @@ impl RenderSession {
             warnings: result.warnings.into_iter().map(Into::into).collect(),
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
-            regions: result.regions.into_iter().map(Into::into).collect(),
         })
+    }
+
+    /// Schema-field geometry for this compiled session — one region per
+    /// schema-bound field, keyed on its quill schema field path. A session-level
+    /// query: no render, no byte artifact. An interactive preview reads it to
+    /// place field overlays / cross-navigation over a `paint`-ed canvas. Empty
+    /// for backends that place no schema fields.
+    #[wasm_bindgen(js_name = regions, unchecked_return_type = "FieldRegion[]")]
+    pub fn regions(&self) -> Result<JsValue, JsValue> {
+        let regions: Vec<FieldRegion> = self.inner.regions().into_iter().map(Into::into).collect();
+        serialize_or_throw(&regions, "regions")
     }
 }
 

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -202,14 +202,6 @@ pub struct RenderResult {
     pub warnings: Vec<Diagnostic>,
     pub output_format: OutputFormat,
     pub render_time_ms: f64,
-    /// Schema-field regions (`pdfform` AcroForm widgets; Typst form-fields),
-    /// each keyed on the quill schema field path. Ordered by page then
-    /// field-spec order. Always an array — empty for backends / formats that
-    /// produce no field geometry, and for fields with no schema address.
-    /// Geometry for interactive overlays / cross-navigation drawn on top of the
-    /// complete raster; never a compositing input.
-    #[serde(default)]
-    pub regions: Vec<FieldRegion>,
 }
 
 /// A rendered field region: the quill schema field address plus its geometry on

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -202,74 +202,43 @@ pub struct RenderResult {
     pub warnings: Vec<Diagnostic>,
     pub output_format: OutputFormat,
     pub render_time_ms: f64,
-    /// Form-field regions from stamped AcroForm backends (`pdfform`;
-    /// Typst signature overlay). Ordered by page then field-spec order.
-    /// Always an array — empty for backends / formats that produce no
-    /// field geometry. Geometry for interactive overlays drawn on top of
-    /// the complete raster; consumers never need them to composite a value
-    /// (the canvas backends pre-flatten values into the page).
+    /// Schema-field regions (`pdfform` AcroForm widgets; Typst form-fields),
+    /// each keyed on the quill schema field path. Ordered by page then
+    /// field-spec order. Always an array — empty for backends / formats that
+    /// produce no field geometry, and for fields with no schema address.
+    /// Geometry for interactive overlays / cross-navigation drawn on top of the
+    /// complete raster; never a compositing input.
     #[serde(default)]
     pub regions: Vec<FieldRegion>,
 }
 
-/// A form-field region: geometry and bound value from a stamped AcroForm.
-/// Emitted by backends that stamp form fields. Consumers use this geometry
-/// to position interactive overlays on top of an already-complete raster.
+/// A rendered field region: the quill schema field address plus its geometry on
+/// the page. Emitted by backends that place schema fields (pdfform AcroForm
+/// widgets, Typst form-fields). Consumers use it to map between a place on the
+/// page and a field in the editor — click a rendered field to focus it, or
+/// highlight the page rectangle for the focused field. Geometry only: the
+/// raster is already complete, so a region is never a compositing input.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldRegion {
-    /// Fully-qualified field name (matches the AcroForm widget `/T`).
-    pub name: String,
+    /// Quill schema field path (e.g. `"signature_block"`), not any backend
+    /// widget name. The address the editor uses for this field.
+    pub field: String,
     /// 0-based page index.
     pub page: usize,
     /// `[x0, y0, x1, y1]` in PDF points (1/72″), bottom-left origin.
     pub rect: [f32; 4],
-    pub kind: FieldRegionKind,
-}
-
-/// The kind and payload of a [`FieldRegion`]. An open enum — future region
-/// types extend here without breaking existing consumers.
-#[cfg(any(feature = "typst", feature = "pdfform"))]
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum FieldRegionKind {
-    /// An interactive form field stamped onto the page.
-    Field {
-        /// Lowercase type id: `"text"`, `"checkbox"`, `"choice"`, or `"signature"`.
-        #[serde(rename = "fieldType")]
-        field_type: String,
-        /// The bound value, or `undefined` for a blank / unbound field.
-        /// `default` pairs with `skip_serializing_if` so the declared
-        /// `from_wasm_abi` round-trip is total: a blank field omits the key on
-        /// the way out and deserializes back to `None` rather than erroring with
-        /// `missing field 'value'`.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        value: Option<String>,
-    },
 }
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 impl From<quillmark_core::RenderedRegion> for FieldRegion {
     fn from(r: quillmark_core::RenderedRegion) -> Self {
         FieldRegion {
-            name: r.name,
+            field: r.field,
             page: r.page,
             rect: r.rect,
-            kind: r.kind.into(),
-        }
-    }
-}
-
-#[cfg(any(feature = "typst", feature = "pdfform"))]
-impl From<quillmark_core::RegionKind> for FieldRegionKind {
-    fn from(k: quillmark_core::RegionKind) -> Self {
-        match k {
-            quillmark_core::RegionKind::Field { field_type, value } => {
-                FieldRegionKind::Field { field_type, value }
-            }
         }
     }
 }
@@ -490,108 +459,53 @@ mod tests {
         assert!(!js_value.is_null());
     }
 
-    // ── FieldRegion / FieldRegionKind ─────────────────────────────────────────
+    // ── FieldRegion ───────────────────────────────────────────────────────────
 
     #[test]
     #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn field_region_serializes_to_expected_shape() {
         let region = FieldRegion {
-            name: "FullName".to_string(),
+            field: "full_name".to_string(),
             page: 0,
             rect: [180.0, 672.0, 520.0, 692.0],
-            kind: FieldRegionKind::Field {
-                field_type: "text".to_string(),
-                value: Some("Ada Lovelace".to_string()),
-            },
         };
         let json = serde_json::to_string(&region).unwrap();
-        assert!(json.contains("\"name\":\"FullName\""));
+        assert!(json.contains("\"field\":\"full_name\""));
         assert!(json.contains("\"page\":0"));
         assert!(json.contains("\"rect\":[180.0,672.0,520.0,692.0]"));
-        assert!(json.contains("\"type\":\"field\""));
-        assert!(json.contains("\"fieldType\":\"text\""));
-        assert!(json.contains("\"value\":\"Ada Lovelace\""));
+        // No backend widget name or kind/value leaks into the wire shape.
+        assert!(!json.contains("\"name\""));
+        assert!(!json.contains("\"kind\""));
     }
 
     #[test]
     #[cfg(any(feature = "typst", feature = "pdfform"))]
-    fn field_region_blank_value_omitted() {
+    fn field_region_round_trips() {
+        // The `from_wasm_abi` (JS→Rust) path uses the same serde derive.
         let region = FieldRegion {
-            name: "Signature".to_string(),
+            field: "signature_block".to_string(),
             page: 0,
             rect: [180.0, 422.0, 520.0, 462.0],
-            kind: FieldRegionKind::Field {
-                field_type: "signature".to_string(),
-                value: None,
-            },
         };
         let json = serde_json::to_string(&region).unwrap();
-        // value:None → absent from JSON (skip_serializing_if)
-        assert!(!json.contains("\"value\""));
-        assert!(json.contains("\"fieldType\":\"signature\""));
-    }
-
-    #[test]
-    #[cfg(any(feature = "typst", feature = "pdfform"))]
-    fn field_region_blank_value_round_trips() {
-        // The `from_wasm_abi` (JS→Rust) path uses the same serde derive. A blank
-        // value omits the key on the way out, so deserializing that JSON back
-        // must default to `None` rather than error with `missing field 'value'`.
-        // (Regression guard for the `#[serde(default)]` on `value`.)
-        let region = FieldRegion {
-            name: "Signature".to_string(),
-            page: 0,
-            rect: [180.0, 422.0, 520.0, 462.0],
-            kind: FieldRegionKind::Field {
-                field_type: "signature".to_string(),
-                value: None,
-            },
-        };
-        let json = serde_json::to_string(&region).unwrap();
-        let back: FieldRegion = serde_json::from_str(&json).expect("blank value round-trips");
-        #[allow(irrefutable_let_patterns)]
-        let FieldRegionKind::Field { value, .. } = back.kind else {
-            panic!("expected a Field region kind");
-        };
-        assert_eq!(value, None);
-
-        // Also accept JSON that omits `value` outright (the shape a JS caller
-        // would hand back for an unbound field).
-        let bare = r#"{"name":"Sig","page":0,"rect":[0.0,0.0,1.0,1.0],"kind":{"type":"field","fieldType":"signature"}}"#;
-        let parsed: FieldRegion = serde_json::from_str(bare).expect("missing value defaults");
-        #[allow(irrefutable_let_patterns)]
-        let FieldRegionKind::Field { value, .. } = parsed.kind else {
-            panic!("expected a Field region kind");
-        };
-        assert_eq!(value, None);
+        let back: FieldRegion = serde_json::from_str(&json).expect("round-trips");
+        assert_eq!(back.field, "signature_block");
+        assert_eq!(back.rect, [180.0, 422.0, 520.0, 462.0]);
     }
 
     #[test]
     #[cfg(any(feature = "typst", feature = "pdfform"))]
     fn field_region_from_core_conversion() {
-        use quillmark_core::{RegionKind, RenderedRegion};
+        use quillmark_core::RenderedRegion;
 
         let core_region = RenderedRegion {
-            name: "Agree".to_string(),
+            field: "agree".to_string(),
             page: 0,
             rect: [180.0, 538.0, 194.0, 552.0],
-            kind: RegionKind::Field {
-                field_type: "checkbox".to_string(),
-                value: Some("Yes".to_string()),
-            },
         };
         let wasm_region: FieldRegion = core_region.into();
-        assert_eq!(wasm_region.name, "Agree");
+        assert_eq!(wasm_region.field, "agree");
         assert_eq!(wasm_region.page, 0);
         assert_eq!(wasm_region.rect, [180.0, 538.0, 194.0, 552.0]);
-        // Refutable form so adding a `FieldRegionKind` variant is non-breaking
-        // here; the `allow` covers the single-variant-today warning and lapses
-        // once a second variant exists.
-        #[allow(irrefutable_let_patterns)]
-        let FieldRegionKind::Field { field_type, value } = wasm_region.kind else {
-            panic!("expected a Field region kind");
-        };
-        assert_eq!(field_type, "checkbox");
-        assert_eq!(value.as_deref(), Some("Yes"));
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -441,10 +441,6 @@ pub struct RenderResult {
     pub artifacts: Vec<crate::Artifact>,
     pub warnings: Vec<Diagnostic>,
     pub output_format: OutputFormat,
-    /// Field placements on the rendered pages (geometry + bound values),
-    /// defaulted empty. Populated by backends that stamp form fields; the only
-    /// path to field values in non-interactive output. See [`crate::region`].
-    pub regions: Vec<crate::RenderedRegion>,
 }
 
 impl RenderResult {
@@ -453,18 +449,11 @@ impl RenderResult {
             artifacts,
             warnings: Vec::new(),
             output_format,
-            regions: Vec::new(),
         }
     }
 
     pub fn with_warning(mut self, warning: Diagnostic) -> Self {
         self.warnings.push(warning);
-        self
-    }
-
-    /// Attach the rendered-region sidecar (replacing any prior value).
-    pub fn with_regions(mut self, regions: Vec<crate::RenderedRegion>) -> Self {
-        self.regions = regions;
         self
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,7 +40,7 @@ pub mod types;
 pub use types::{Artifact, OutputFormat, RenderOptions};
 
 pub mod region;
-pub use region::{RegionKind, RenderedRegion};
+pub use region::RenderedRegion;
 
 pub mod session;
 pub use session::RenderSession;

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -1,4 +1,6 @@
-//! Rendered-region sidecar carried on every [`RenderResult`](crate::RenderResult).
+//! Schema-field geometry, queried from a compiled
+//! [`RenderSession`](crate::RenderSession) via
+//! [`regions`](crate::RenderSession::regions).
 //!
 //! A region ties a rectangle on the rendered page to the **quill schema field**
 //! that produced it — the address the document author already uses to refer to
@@ -14,12 +16,14 @@
 //! (`Signature`). A region is emitted only for a field with a schema address —
 //! an unbound decorative widget produces none.
 //!
-//! Regions ride on *every* render regardless of output format — a GUI overlay
-//! needs the geometry whether it shows the PDF or a rastered background — and
-//! default to empty for backends that produce none. They are an overlay
-//! sidecar, never a compositing input: both canvas backends hand back a
-//! complete page raster, so nothing about the picture depends on reading a
-//! region.
+//! Regions are a session-level query, not a render output: the geometry is a
+//! property of the compiled snapshot, read once from the session without
+//! producing any byte artifact. Only the interactive-preview path wants it (to
+//! lay out overlays over a `paint`-ed canvas); a one-shot byte render
+//! (PDF/PNG/SVG) never does. They are an overlay sidecar, never a compositing
+//! input: both canvas backends hand back a complete page raster, so nothing
+//! about the picture depends on reading a region. Empty for backends that place
+//! no schema fields.
 
 /// One schema field's placement on a rendered page.
 ///

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -1,60 +1,42 @@
 //! Rendered-region sidecar carried on every [`RenderResult`](crate::RenderResult).
 //!
-//! A region records *where a named field landed* on the rendered page —
-//! geometry plus the kind of field and its bound value. It is the only path to
-//! field values in non-interactive output: under the stamping engine's
-//! Technique A (real AcroForm fields + `/NeedAppearances`, no baked appearance
-//! streams), a flat rasterizer renders the widgets blank, so a consumer that
-//! must composite values (a canvas preview, a server-side flattener) reads them
-//! from here.
+//! A region ties a rectangle on the rendered page to the **quill schema field**
+//! that produced it — the address the document author already uses to refer to
+//! that field (the same address the Typst plate reads as `data.*` and the
+//! pdfform binder resolves against `compile_data`). It exists so a consumer can
+//! map between a place on the page and a field in the editor: click a rendered
+//! field → focus it in the editor, or highlight the page rectangle for the
+//! focused field.
+//!
+//! Backend-internal identifiers never appear here. A pdfform AcroForm widget
+//! name (`/T`) is an implementation detail of the stamp spine; the region
+//! carries the schema path it maps to (`signature_block`), not the widget name
+//! (`Signature`). A region is emitted only for a field with a schema address —
+//! an unbound decorative widget produces none.
 //!
 //! Regions ride on *every* render regardless of output format — a GUI overlay
 //! needs the geometry whether it shows the PDF or a rastered background — and
-//! default to empty for backends that produce none.
+//! default to empty for backends that produce none. They are an overlay
+//! sidecar, never a compositing input: both canvas backends hand back a
+//! complete page raster, so nothing about the picture depends on reading a
+//! region.
 
-/// One field's placement on a rendered page.
+/// One schema field's placement on a rendered page.
 ///
 /// `rect` is `[x0, y0, x1, y1]` in PDF points with a **bottom-left** origin —
 /// the same final geometry the stamp spine writes to the widget `/Rect`, so the
-/// region and the stamped widget describe the identical box.
+/// region and the rendered field describe the identical box.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderedRegion {
-    /// Fully-qualified field name (matches the widget `/T`).
-    pub name: String,
+    /// Quill schema field path, e.g. `"signature_block"` or
+    /// `"$cards.indorsement.1.from"` — the author-facing field address, not any
+    /// backend widget name.
+    pub field: String,
     /// 0-based page index.
     pub page: usize,
     /// `[x0, y0, x1, y1]`, PDF points, bottom-left origin.
     pub rect: [f32; 4],
-    /// What kind of region this is, plus its kind-specific payload.
-    pub kind: RegionKind,
-}
-
-/// The kind of a [`RenderedRegion`] and its payload.
-///
-/// An enum from day one (rather than a bare string) so future region kinds —
-/// e.g. a flattened-value glyph run carrying resolved typography — extend it
-/// additively without reshaping the sidecar.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum RegionKind {
-    /// An interactive form field. `field_type` is the lowercase field-type id
-    /// (`"text"`, `"checkbox"`, `"choice"`, `"signature"`); `value` is the bound
-    /// value, `None` for a blank/unbound field.
-    ///
-    /// Carries geometry + value but **not** resolved typography (font/size/
-    /// align), by design: both canvas backends produce a *complete* raster (the
-    /// pdfform session pre-flattens values into the page before rasterizing), so
-    /// no consumer composites a value from a region — there is nothing to
-    /// typeset client-side. The one place that decides a flattened value's
-    /// font/size is `quillmark-pdfform`'s `typography` module; a
-    /// font-accurate-compositing consumer would read sizes from there, and these
-    /// fields would become an additive extension.
-    Field {
-        #[serde(rename = "fieldType")]
-        field_type: String,
-        value: Option<String>,
-    },
 }
 
 #[cfg(test)]
@@ -64,34 +46,13 @@ mod tests {
     #[test]
     fn region_round_trips_through_json() {
         let region = RenderedRegion {
-            name: "FullName".to_string(),
+            field: "full_name".to_string(),
             page: 0,
             rect: [180.0, 715.0, 520.0, 735.0],
-            kind: RegionKind::Field {
-                field_type: "text".to_string(),
-                value: Some("Ada Lovelace".to_string()),
-            },
         };
         let json = serde_json::to_string(&region).unwrap();
-        // camelCase field names and the internally-tagged kind.
-        assert!(json.contains("\"fieldType\":\"text\""), "{json}");
-        assert!(json.contains("\"type\":\"field\""), "{json}");
+        assert!(json.contains("\"field\":\"full_name\""), "{json}");
         let back: RenderedRegion = serde_json::from_str(&json).unwrap();
         assert_eq!(back, region);
-    }
-
-    #[test]
-    fn blank_field_value_is_null() {
-        let region = RenderedRegion {
-            name: "Signature".to_string(),
-            page: 0,
-            rect: [0.0, 0.0, 10.0, 10.0],
-            kind: RegionKind::Field {
-                field_type: "signature".to_string(),
-                value: None,
-            },
-        };
-        let json = serde_json::to_string(&region).unwrap();
-        assert!(json.contains("\"value\":null"), "{json}");
     }
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{Diagnostic, RenderError, RenderOptions, RenderResult};
+use crate::{Diagnostic, RenderError, RenderOptions, RenderResult, RenderedRegion};
 
 /// Backend-specific session implementation.
 ///
@@ -41,10 +41,9 @@ pub trait SessionHandle: Any + Send + Sync {
     ///   streams at session-open, then rasterizes that flat PDF — so field
     ///   values appear in the raster without the caller drawing them.
     ///
-    /// The `regions` sidecar on [`RenderResult`](crate::RenderResult) carries
-    /// per-field geometry keyed on the quill schema field path, for *overlay* /
-    /// cross-navigation UIs regardless; it is never required to make the raster
-    /// complete.
+    /// The [`regions`](Self::regions) accessor carries per-field geometry keyed
+    /// on the quill schema field path, for *overlay* / cross-navigation UIs
+    /// regardless; it is never required to make the raster complete.
     ///
     /// A backend with no painter overrides neither this nor
     /// [`page_size_pt`](Self::page_size_pt); the defaults mark the session as
@@ -54,6 +53,19 @@ pub trait SessionHandle: Any + Send + Sync {
     /// expected to pair this method with `page_size_pt` over the same page set.
     fn render_rgba(&self, _page: usize, _scale: f32) -> Option<(u32, u32, Vec<u8>)> {
         None
+    }
+
+    /// Schema-field geometry for the compiled session — one [`RenderedRegion`]
+    /// per field that carries a quill schema address, keyed on that address.
+    ///
+    /// A session-level query, not a render output: the geometry is a property of
+    /// the compiled snapshot, computed from already-resolved field placements
+    /// with no rasterization and no byte artifact. An interactive preview reads
+    /// it to lay out overlays / field cross-navigation over a `paint`-ed canvas;
+    /// a one-shot byte render never needs it. Default empty — a backend that
+    /// places schema fields overrides this.
+    fn regions(&self) -> Vec<RenderedRegion> {
+        Vec::new()
     }
 }
 
@@ -132,6 +144,16 @@ impl RenderSession {
     /// [`SessionHandle::render_rgba`].
     pub fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
         self.inner.render_rgba(page, scale)
+    }
+
+    /// Schema-field geometry for the compiled session — one [`RenderedRegion`]
+    /// per schema-bound field, keyed on its quill schema field path. A
+    /// session-level query computed without rendering bytes; an interactive
+    /// preview reads it to place overlays / field cross-navigation over a
+    /// `paint`-ed canvas. Empty for backends that place no schema fields. See
+    /// [`SessionHandle::regions`].
+    pub fn regions(&self) -> Vec<RenderedRegion> {
+        self.inner.regions()
     }
 
     /// Session-level warnings attached at `Backend::open` time, also appended

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -42,8 +42,9 @@ pub trait SessionHandle: Any + Send + Sync {
     ///   values appear in the raster without the caller drawing them.
     ///
     /// The `regions` sidecar on [`RenderResult`](crate::RenderResult) carries
-    /// per-field geometry (and bound value) for *overlay* UIs regardless; it is
-    /// never required to make the raster complete.
+    /// per-field geometry keyed on the quill schema field path, for *overlay* /
+    /// cross-navigation UIs regardless; it is never required to make the raster
+    /// complete.
     ///
     /// A backend with no painter overrides neither this nor
     /// [`page_size_pt`](Self::page_size_pt); the defaults mark the session as

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -27,7 +27,7 @@ mod update;
 pub mod writer;
 
 pub use error::PdfError;
-pub use stamp::{regions_of, stamp, StampOptions, StampResult, CHECKBOX_ON_STATE};
+pub use stamp::{regions_of, stamp, StampOptions, CHECKBOX_ON_STATE};
 pub use update::PdfUpdate;
 
 // The region sidecar lives in core (it rides on `RenderResult`); re-export so

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -32,7 +32,7 @@ pub use update::PdfUpdate;
 
 // The region sidecar lives in core (it rides on `RenderResult`); re-export so
 // spine consumers reach it without a second `quillmark-core` import.
-pub use quillmark_core::{RegionKind, RenderedRegion};
+pub use quillmark_core::RenderedRegion;
 
 /// The `/MediaBox` of every page of `base`, normalized to `[x0, y0, x1, y1]`
 /// (lower-left, upper-right), in document order.
@@ -53,8 +53,14 @@ pub fn page_media_boxes(base: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
 /// whoever owns the geometry source converts before constructing the spec.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldSpec {
-    /// Fully-qualified field name, written to `/T`.
+    /// Fully-qualified field name, written to `/T`. A spine-internal AcroForm
+    /// identifier — never surfaced to a region consumer.
     pub name: String,
+    /// The quill schema field address this widget maps to, if any. Opaque to
+    /// the spine (it never interprets it), carried solely to key the region
+    /// sidecar: a field with `Some(path)` emits a [`RenderedRegion`], an unbound
+    /// widget (`None`) emits none.
+    pub schema_field: Option<String>,
     /// 0-based page index.
     pub page: usize,
     /// `[x0, y0, x1, y1]` in PDF points, bottom-left origin.

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -47,16 +47,10 @@ pub struct StampOptions {
     pub producer: Option<String>,
 }
 
-/// Result of [`stamp`](crate::stamp): the stamped PDF and the region sidecar.
-#[derive(Debug, Clone)]
-pub struct StampResult {
-    pub pdf: Vec<u8>,
-    pub regions: Vec<RenderedRegion>,
-}
-
 /// Stamp `fields` onto `base` as a fresh AcroForm via one incremental update,
-/// optionally stamping `/Info` `/Producer`. Returns the stamped bytes plus a
-/// [`RenderedRegion`] per field.
+/// optionally stamping `/Info` `/Producer`. Returns the stamped bytes. Field
+/// geometry is not produced here — it is a session-level query (see
+/// [`regions_of`]).
 ///
 /// `base` must satisfy the reader's input contract (traditional-xref,
 /// unencrypted, inline-annots, flat-tree). Each field's `rect` is final
@@ -66,13 +60,11 @@ pub fn stamp(
     base: Vec<u8>,
     fields: &[FieldSpec],
     opts: &StampOptions,
-) -> Result<StampResult, PdfError> {
-    let regions = regions_of(fields);
-
+) -> Result<Vec<u8>, PdfError> {
     // Nothing to write: no producer stamp and no fields. Return the base as-is
     // rather than append an empty revision.
     if opts.producer.is_none() && fields.is_empty() {
-        return Ok(StampResult { pdf: base, regions });
+        return Ok(base);
     }
 
     let pdf = base;
@@ -167,11 +159,7 @@ pub fn stamp(
         }
     }
 
-    let stamped = up.finish(pdf)?;
-    Ok(StampResult {
-        pdf: stamped,
-        regions,
-    })
+    up.finish(pdf)
 }
 
 /// Build the [`RenderedRegion`] geometry sidecar — one region per field that

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -17,7 +17,7 @@ use pdf_writer::types::{AnnotationFlags, FieldFlags, FieldType as PwFieldType, S
 use pdf_writer::writers::Form;
 use pdf_writer::{Chunk, Finish, Name, Rect, Ref, Str, TextStr};
 
-use quillmark_core::{RegionKind, RenderedRegion};
+use quillmark_core::RenderedRegion;
 
 use crate::error::PdfError;
 use crate::reader::{
@@ -174,20 +174,20 @@ pub fn stamp(
     })
 }
 
-/// Build a [`RenderedRegion`] per field — the geometry+value sidecar that is the
-/// only path to values in non-interactive output. Shared by `stamp` and any
-/// no-stamp render path so the region geometry always matches the widget.
+/// Build the [`RenderedRegion`] geometry sidecar — one region per field that
+/// carries a schema address, keyed on that address. A widget with no schema
+/// field (`schema_field: None`) is a backend-only artifact and emits nothing.
+/// Shared by `stamp` and any no-stamp render path so the region geometry always
+/// matches the widget.
 pub fn regions_of(fields: &[FieldSpec]) -> Vec<RenderedRegion> {
     fields
         .iter()
-        .map(|f| RenderedRegion {
-            name: f.name.clone(),
-            page: f.page,
-            rect: f.rect,
-            kind: RegionKind::Field {
-                field_type: f.field_type.type_id().to_string(),
-                value: f.value.clone(),
-            },
+        .filter_map(|f| {
+            Some(RenderedRegion {
+                field: f.schema_field.clone()?,
+                page: f.page,
+                rect: f.rect,
+            })
         })
         .collect()
 }

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -4,7 +4,7 @@
 //! land in `/V` and the viewer synthesizes appearances.
 
 use pdf_writer::{Content, Pdf, Rect, Ref};
-use quillmark_pdf::{stamp, FieldSpec, FieldType, StampOptions};
+use quillmark_pdf::{regions_of, stamp, FieldSpec, FieldType, StampOptions};
 
 /// Build an `n`-page base PDF (612×792, traditional xref) with a trivial
 /// content stream per page. This is exactly the input contract the spine
@@ -108,7 +108,7 @@ fn stamps_all_four_field_types_into_valid_acroform() {
     )
     .expect("stamp ok");
 
-    let doc = lopdf::Document::load_mem(&result.pdf).expect("lopdf reparse");
+    let doc = lopdf::Document::load_mem(&result).expect("lopdf reparse");
     let cat = doc.catalog().expect("catalog");
     let af_ref = cat
         .get(b"AcroForm")
@@ -174,20 +174,21 @@ fn stamps_all_four_field_types_into_valid_acroform() {
         let r = f.as_reference().unwrap();
         let header = format!("{} 0 obj", r.0);
         let start = result
-            .pdf
             .windows(header.len())
             .position(|w| w == header.as_bytes())
             .expect("widget header");
-        let after = &result.pdf[start..];
+        let after = &result[start..];
         let endobj = after.windows(6).position(|w| w == b"endobj").unwrap();
         let body = &after[..endobj];
         let count = body.windows(8).filter(|w| *w == b"/Subtype").count();
         assert_eq!(count, 1, "exactly one /Subtype in widget {}", r.0);
     }
 
-    // Regions sidecar: one per field, keyed on the schema path, geometry matches.
-    assert_eq!(result.regions.len(), 4);
-    let agree_region = result.regions.iter().find(|r| r.field == "agree").unwrap();
+    // Region geometry (a session-level query over the same specs): one per
+    // field, keyed on the schema path, geometry matches.
+    let regions = regions_of(&all_four_fields());
+    assert_eq!(regions.len(), 4);
+    let agree_region = regions.iter().find(|r| r.field == "agree").unwrap();
     assert_eq!(agree_region.rect, [180.0, 560.0, 194.0, 574.0]);
 }
 
@@ -205,7 +206,7 @@ fn signature_field_sets_sigflags() {
     }];
     let result = stamp(base, &fields, &StampOptions::default()).expect("stamp ok");
 
-    let doc = lopdf::Document::load_mem(&result.pdf).expect("reparse");
+    let doc = lopdf::Document::load_mem(&result).expect("reparse");
     let cat = doc.catalog().unwrap();
     let af = doc
         .get_object(cat.get(b"AcroForm").unwrap().as_reference().unwrap())
@@ -241,8 +242,8 @@ fn no_producer_no_fields_is_identity() {
     let base = build_base_pdf(1);
     let before = base.clone();
     let result = stamp(base, &[], &StampOptions::default()).expect("stamp ok");
-    assert_eq!(result.pdf, before, "no-op stamp returns base unchanged");
-    assert!(result.regions.is_empty());
+    assert_eq!(result, before, "no-op stamp returns base unchanged");
+    assert!(regions_of(&[]).is_empty(), "no fields → no regions");
 }
 
 #[test]
@@ -259,9 +260,8 @@ fn producer_only_no_fields_stamps_info_producer() {
         },
     )
     .expect("stamp ok");
-    assert!(result.regions.is_empty());
 
-    let doc = lopdf::Document::load_mem(&result.pdf).expect("lopdf reparse");
+    let doc = lopdf::Document::load_mem(&result).expect("lopdf reparse");
     assert!(
         doc.catalog().unwrap().get(b"AcroForm").is_err(),
         "producer-only stamp must not add an /AcroForm"
@@ -573,7 +573,7 @@ fn inline_annots_are_merged_not_replaced() {
     }];
     let result = stamp(base, &fields, &StampOptions::default()).expect("stamp ok");
 
-    let doc = lopdf::Document::load_mem(&result.pdf).expect("reparse");
+    let doc = lopdf::Document::load_mem(&result).expect("reparse");
     let pages = doc.get_pages();
     let page = doc
         .get_object(*pages.get(&1).unwrap())
@@ -659,13 +659,12 @@ fn xref_emits_multiple_subsections_when_ids_have_gaps() {
     // (two numeric tokens) up to the trailer; entries have three tokens.
     let table_marker = b"\nxref\n";
     let pos = result
-        .pdf
         .windows(table_marker.len())
         .rposition(|w| w == table_marker)
         .expect("appended xref")
         + table_marker.len();
-    let section_end = pos + find_sub(&result.pdf[pos..], b"trailer");
-    let headers = result.pdf[pos..section_end]
+    let section_end = pos + find_sub(&result[pos..], b"trailer");
+    let headers = result[pos..section_end]
         .split(|&b| b == b'\n')
         .filter(|line| {
             let toks: Vec<&[u8]> = line.split(|&b| b == b' ').filter(|t| !t.is_empty()).collect();

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -57,6 +57,7 @@ fn all_four_fields() -> Vec<FieldSpec> {
     vec![
         FieldSpec {
             name: "FullName".into(),
+            schema_field: Some("full_name".into()),
             page: 0,
             rect: [180.0, 700.0, 520.0, 720.0],
             field_type: FieldType::Text { multiline: false },
@@ -65,6 +66,7 @@ fn all_four_fields() -> Vec<FieldSpec> {
         },
         FieldSpec {
             name: "Comments".into(),
+            schema_field: Some("comments".into()),
             page: 0,
             rect: [180.0, 600.0, 520.0, 680.0],
             field_type: FieldType::Text { multiline: true },
@@ -73,6 +75,7 @@ fn all_four_fields() -> Vec<FieldSpec> {
         },
         FieldSpec {
             name: "Agree".into(),
+            schema_field: Some("agree".into()),
             page: 0,
             rect: [180.0, 560.0, 194.0, 574.0],
             field_type: FieldType::Checkbox,
@@ -81,6 +84,7 @@ fn all_four_fields() -> Vec<FieldSpec> {
         },
         FieldSpec {
             name: "FavoriteColor".into(),
+            schema_field: Some("favorite_color".into()),
             page: 0,
             rect: [180.0, 520.0, 520.0, 540.0],
             field_type: FieldType::Choice {
@@ -181,9 +185,9 @@ fn stamps_all_four_field_types_into_valid_acroform() {
         assert_eq!(count, 1, "exactly one /Subtype in widget {}", r.0);
     }
 
-    // Regions sidecar: one per field, geometry matches.
+    // Regions sidecar: one per field, keyed on the schema path, geometry matches.
     assert_eq!(result.regions.len(), 4);
-    let agree_region = result.regions.iter().find(|r| r.name == "Agree").unwrap();
+    let agree_region = result.regions.iter().find(|r| r.field == "agree").unwrap();
     assert_eq!(agree_region.rect, [180.0, 560.0, 194.0, 574.0]);
 }
 
@@ -192,6 +196,7 @@ fn signature_field_sets_sigflags() {
     let base = build_base_pdf(2);
     let fields = vec![FieldSpec {
         name: "Signature".into(),
+        schema_field: Some("signature".into()),
         page: 1,
         rect: [180.0, 100.0, 520.0, 140.0],
         field_type: FieldType::Signature,
@@ -307,6 +312,7 @@ fn rotated_page_rejected_cleanly() {
 
     let fields = vec![FieldSpec {
         name: "FullName".into(),
+        schema_field: Some("full_name".into()),
         page: 0,
         rect: [180.0, 700.0, 520.0, 720.0],
         field_type: FieldType::Text { multiline: false },
@@ -348,6 +354,7 @@ fn field_targeting_missing_page_errors() {
     let base = build_base_pdf(1);
     let fields = vec![FieldSpec {
         name: "X".into(),
+        schema_field: Some("x".into()),
         page: 5,
         rect: [0.0, 0.0, 10.0, 10.0],
         field_type: FieldType::Signature,
@@ -493,6 +500,7 @@ fn nonzero_generation_page_rejected_cleanly() {
     replace_first(&mut base, b"3 0 obj", b"3 4 obj");
     let fields = vec![FieldSpec {
         name: "X".into(),
+        schema_field: Some("x".into()),
         page: 0,
         rect: [10.0, 10.0, 100.0, 30.0],
         field_type: FieldType::Text { multiline: false },
@@ -556,6 +564,7 @@ fn inline_annots_are_merged_not_replaced() {
     let (base, existing) = build_base_with_inline_annot();
     let fields = vec![FieldSpec {
         name: "X".into(),
+        schema_field: Some("x".into()),
         page: 0,
         rect: [10.0, 10.0, 100.0, 30.0],
         field_type: FieldType::Text { multiline: false },
@@ -618,6 +627,7 @@ fn indirect_annots_rejected_cleanly() {
     }
     let fields = vec![FieldSpec {
         name: "X".into(),
+        schema_field: Some("x".into()),
         page: 0,
         rect: [10.0, 10.0, 100.0, 30.0],
         field_type: FieldType::Text { multiline: false },

--- a/crates/quillmark/examples/pdfform_preview.rs
+++ b/crates/quillmark/examples/pdfform_preview.rs
@@ -58,11 +58,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     write_example_output("sample_form_filled.pdf", &gf_result.artifacts[0].bytes)?;
     println!("Written: {}", out_dir.join("sample_form_filled.pdf").display());
 
-    println!(
-        "\nField regions sidecar ({} fields):",
-        gf_result.regions.len()
-    );
-    for region in &gf_result.regions {
+    // Region geometry is a session-level query, not on the render result: open
+    // a session and read it without producing another byte artifact.
+    let gf_session = engine.open(&gf_quill, &gf_doc).expect("open sample_form session");
+    let regions = gf_session.regions();
+    println!("\nField regions ({} fields):", regions.len());
+    for region in &regions {
         // A region carries the schema field address + geometry, for mapping a
         // page rectangle to the editor field (cross-navigation).
         println!(

--- a/crates/quillmark/examples/pdfform_preview.rs
+++ b/crates/quillmark/examples/pdfform_preview.rs
@@ -63,26 +63,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         gf_result.regions.len()
     );
     for region in &gf_result.regions {
-        // `RegionKind` is an enum so new kinds can be added later; use a
-        // refutable `if let` (not an irrefutable `let`) so a future variant is
-        // non-breaking at this site. The `allow` silences the
-        // single-variant-today warning; it lapses on its own once a second
-        // variant exists.
-        #[allow(irrefutable_let_patterns)]
-        if let quillmark_core::RegionKind::Field { field_type, value } = &region.kind {
-            let val_display = value.as_deref().unwrap_or("<blank>");
-            println!(
-                "  {:20}  page={:<2}  rect=[{:.1},{:.1},{:.1},{:.1}]  type={:<10}  value={:?}",
-                region.name,
-                region.page,
-                region.rect[0],
-                region.rect[1],
-                region.rect[2],
-                region.rect[3],
-                field_type,
-                val_display,
-            );
-        }
+        // A region carries the schema field address + geometry, for mapping a
+        // page rectangle to the editor field (cross-navigation).
+        println!(
+            "  {:20}  page={:<2}  rect=[{:.1},{:.1},{:.1},{:.1}]",
+            region.field,
+            region.page,
+            region.rect[0],
+            region.rect[1],
+            region.rect[2],
+            region.rect[3],
+        );
     }
 
     // --- Typst backend: taro → SVG ---

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -192,14 +192,34 @@ impl Backend for MyBackend {              impl Backend for MyBackend {
                                           }
 ```
 
-## `RenderResult.regions` is keyed on the quill schema field, not the backend widget
+## Field regions move to `RenderSession::regions()` and key on the quill schema field
 
-The `regions` sidecar is reshaped so a consumer maps a rendered field back to
-the **quill schema field** — the address the editor uses — with a lookup, not a
-guess. Backend-internal identifiers no longer leak.
+Two changes to the region sidecar, both narrowing it to what the interactive
+preview path actually uses.
 
-`RenderedRegion` (core) and the WASM `FieldRegion` lose `name`, `kind`,
-`fieldType`, and `value`, and gain a single `field`:
+**1. Regions are a session query, not a render output.** Only a canvas/SVG
+preview wants field geometry; a one-shot byte render (PDF/PNG/SVG) never does.
+So `RenderResult.regions` is **removed**, and the geometry is read once off the
+compiled session — no render, no discarded artifact:
+
+```js
+// 0.92                                      0.93
+const r = await engine.render(quill, doc);  const session = await engine.open(quill, doc);
+const regions = r.regions;                  const regions = session.regions();
+```
+
+```rust
+// 0.92                                      0.93
+let regions = session.render(&opts)?.regions;   let regions = session.regions();
+```
+
+An interactive consumer already holds a session (it `paint()`s), so this is the
+surface it wants; an export-only consumer drops region handling entirely.
+
+**2. Regions key on the quill schema field, not the backend widget.** A region
+maps a rendered field back to the **quill schema field** — the address the editor
+uses — with a lookup, not a guess. `RenderedRegion` (core) and the WASM
+`FieldRegion` lose `name`, `kind`, `fieldType`, and `value` for a single `field`:
 
 ```jsonc
 // 0.92                                          0.93
@@ -215,22 +235,25 @@ guess. Backend-internal identifiers no longer leak.
 
 - **`field`** is the quill schema field path (e.g. `signature_block`,
   `$cards.indorsement.1.from`) — never the pdfform AcroForm widget name.
-- **A region is emitted only for a field with a schema address.** An unbound
-  decorative widget (pdfform `schema_field: null`) now produces **no** region.
+- **A region is emitted only for a schema-bound field.** An unbound decorative
+  widget (pdfform `schema_field: null`) produces **no** region.
 - **`value` and `fieldType` are gone.** Regions are geometry for overlays and
   cross-navigation, not a compositing input — both canvas backends already bake
   values into a complete raster, so nothing read them. A field's value lives in
   the editor (and, for PDF output, the AcroForm `/V`); its type lives in the
   quill schema.
 
-**Action (consumers):** read `region.field` where you read `region.name`, and
-drop any use of `region.kind` / `fieldType` / `value`. Route a clicked region to
-the editor field named by `region.field` directly — no widget-name guessing.
+**Action (consumers):** get regions from `session.regions()` instead of
+`renderResult.regions`; read `region.field` where you read `region.name`; drop
+any use of `region.kind` / `fieldType` / `value`. Route a clicked region to the
+editor field named by `region.field` directly — no widget-name guessing.
 
-**Action (out-of-tree backends):** `FieldSpec` (the `quillmark-pdf` stamp spine)
-gains a `schema_field: Option<String>` carrying the schema address; set it when
-you build specs (a field with `None` emits no region). `RegionKind` is removed
-from `quillmark_core`.
+**Action (out-of-tree backends):** override `SessionHandle::regions()` on your
+session (default empty) to return geometry. `FieldSpec` (the `quillmark-pdf`
+stamp spine) gains a `schema_field: Option<String>`; set it when you build specs
+(a field with `None` emits no region). `stamp`/`flatten` now return plain
+`Vec<u8>` (`StampResult` is removed), and `RegionKind` is removed from
+`quillmark_core`.
 
 ## `plate_file` moves to the `typst:` section; `Backend::open` drops the plate parameter
 

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -192,6 +192,46 @@ impl Backend for MyBackend {              impl Backend for MyBackend {
                                           }
 ```
 
+## `RenderResult.regions` is keyed on the quill schema field, not the backend widget
+
+The `regions` sidecar is reshaped so a consumer maps a rendered field back to
+the **quill schema field** — the address the editor uses — with a lookup, not a
+guess. Backend-internal identifiers no longer leak.
+
+`RenderedRegion` (core) and the WASM `FieldRegion` lose `name`, `kind`,
+`fieldType`, and `value`, and gain a single `field`:
+
+```jsonc
+// 0.92                                          0.93
+{                                                {
+  "name": "Signature",        // AcroForm /T       "field": "signature_block",  // schema path
+  "page": 0,                                       "page": 0,
+  "rect": [324, 490.5, 524, 540.5],                "rect": [324, 490.5, 524, 540.5]
+  "kind": { "type": "field",                     }
+           "fieldType": "signature",
+           "value": null }
+}
+```
+
+- **`field`** is the quill schema field path (e.g. `signature_block`,
+  `$cards.indorsement.1.from`) — never the pdfform AcroForm widget name.
+- **A region is emitted only for a field with a schema address.** An unbound
+  decorative widget (pdfform `schema_field: null`) now produces **no** region.
+- **`value` and `fieldType` are gone.** Regions are geometry for overlays and
+  cross-navigation, not a compositing input — both canvas backends already bake
+  values into a complete raster, so nothing read them. A field's value lives in
+  the editor (and, for PDF output, the AcroForm `/V`); its type lives in the
+  quill schema.
+
+**Action (consumers):** read `region.field` where you read `region.name`, and
+drop any use of `region.kind` / `fieldType` / `value`. Route a clicked region to
+the editor field named by `region.field` directly — no widget-name guessing.
+
+**Action (out-of-tree backends):** `FieldSpec` (the `quillmark-pdf` stamp spine)
+gains a `schema_field: Option<String>` carrying the schema address; set it when
+you build specs (a field with `None` emits no region). `RegionKind` is removed
+from `quillmark_core`.
+
 ## `plate_file` moves to the `typst:` section; `Backend::open` drops the plate parameter
 
 A plate is a Typst notion, not a universal one — the pdfform backend has no plate

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -72,12 +72,15 @@ compositing of its own. Backends satisfy it differently:
   values appear in the raster on their own, with no regions-compositing by the
   caller.
 
-The `regions` sidecar (on `RenderResult`, see [SCHEMAS.md](SCHEMAS.md) and the
-region type in `crates/core/src/region.rs`) carries per-field geometry keyed on
-the **quill schema field path** — the address the editor uses — for interactive
-**overlays** and **cross-navigation** (click a rendered field → focus it in the
-editor, or highlight the page rectangle for the focused field). It carries
-geometry only, never a value or a backend widget name, and is never needed to
+Field geometry is a **session-level query**, `RenderSession::regions()` (see
+[SCHEMAS.md](SCHEMAS.md) and the region type in `crates/core/src/region.rs`) —
+not a field on `RenderResult`. Only the interactive-preview path wants it, and
+that path holds a session; a one-shot byte render (PDF/PNG/SVG) never does, so it
+is read once off the compiled session with no render. Each region carries
+per-field geometry keyed on the **quill schema field path** — the address the
+editor uses — for **overlays** and **cross-navigation** (click a rendered field →
+focus it in the editor, or highlight the page rectangle for the focused field).
+Geometry only, never a value or a backend widget name, and never needed to
 complete the picture.
 
 ## TypeScript surface
@@ -100,6 +103,7 @@ class RenderSession {
   readonly warnings: Diagnostic[];
 
   render(opts?: RenderOptions): RenderResult;
+  regions(): FieldRegion[];             // schema-field geometry; session query, no render
   pageSize(page: number): PageSize;     // { widthPt, heightPt } in pt; report-only
   paint(
     ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
@@ -241,6 +245,14 @@ sequentially; `runtime/runtime.js` maps each backend id to its build with a
 - **`warnings` accessor on `RenderSession`.** Session-level diagnostics attached
   at `Backend::open` are otherwise invisible to canvas consumers (only surfaced
   via `render()`'s `RenderResult`).
+- **`regions()` on `RenderSession`, not `RenderResult`.** Field geometry is a
+  property of the compiled snapshot, and only the interactive-preview path wants
+  it — that path holds a session (it `paint()`s) and produces no byte artifact.
+  Hanging regions off `RenderResult` forced an export-only consumer to receive
+  geometry it never reads, and forced a paint-only consumer to run a throwaway
+  byte render just to harvest the sidecar. A session method computes it from
+  already-resolved placements with no rasterization, serving both the canvas and
+  SVG-overlay previews from the one handle they already hold.
 
 ## Lifecycle and consumer flow
 

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -73,9 +73,12 @@ compositing of its own. Backends satisfy it differently:
   caller.
 
 The `regions` sidecar (on `RenderResult`, see [SCHEMAS.md](SCHEMAS.md) and the
-region type in `crates/core/src/region.rs`) carries per-field geometry and
-bound value for interactive **overlays** drawn on top of the raster. It is
-never needed to complete the picture.
+region type in `crates/core/src/region.rs`) carries per-field geometry keyed on
+the **quill schema field path** — the address the editor uses — for interactive
+**overlays** and **cross-navigation** (click a rendered field → focus it in the
+editor, or highlight the page rectangle for the focused field). It carries
+geometry only, never a value or a backend widget name, and is never needed to
+complete the picture.
 
 ## TypeScript surface
 
@@ -157,6 +160,20 @@ width_canvas  = (rect[2] − rect[0]) × renderScale
 height_canvas = (rect[3] − rect[1]) × renderScale
 ```
 
+For an **HTML/CSS overlay** on a `width:100%` canvas, prefer percentages of the
+page over device pixels — they track the displayed size across DPI and
+pane-resize for free, with no `renderScale` to thread; only the Y axis flips:
+
+```
+left%   = rect[0] / pageWidthPt  × 100
+top%    = (pageHeightPt − rect[3]) / pageHeightPt × 100
+width%  = (rect[2] − rect[0]) / pageWidthPt  × 100
+height% = (rect[3] − rect[1]) / pageHeightPt × 100
+```
+
+The device-pixel form above is still the right one for painting an overlay
+*into* a raster.
+
 ## Feature / build mapping
 
 Canvas ships per-backend, compile-time aligned so the capability flag and the
@@ -183,8 +200,10 @@ sequentially; `runtime/runtime.js` maps each backend id to its build with a
 - Native (CLI / Python) exposure. Capability is WASM-only.
 - Text selection, find-in-page, accessibility. Canvas has none of these by
   design — if you need them, keep an SVG/PDF export path alongside.
-- Click-to-jump or cursor-to-region mapping. Not supported; the preview does
-  not require it.
+- Built-in click→region hit-testing in the painter. The painter is a dumb
+  blit; it maps no clicks itself. A consumer builds field cross-navigation on
+  top, hit-testing a click against the `regions` sidecar (keyed on the schema
+  field path) — see [SCHEMAS.md](SCHEMAS.md).
 
 ## Decisions and rationale
 


### PR DESCRIPTION
Reworks the field-region surface (`RenderResult.regions` → `RenderSession::regions()`) so it carries what an interactive preview actually needs, and nothing else. Two related changes, landed as two commits. Closes #773 (all four asks).

## 1. Regions key on the quill schema field, not the backend widget

A region maps a rendered field back to the **quill schema field** — the address the editor uses — with a lookup, not a guess at the pdfform AcroForm widget name. Backend-internal identifiers no longer leak.

`RenderedRegion` (core) and the WASM `FieldRegion` lose `name`, `kind`, `fieldType`, and `value` for a single `field` carrying the schema address (e.g. `signature_block`):

```jsonc
// before                                    after
{ "name": "Signature",      // AcroForm /T   { "field": "signature_block",  // schema path
  "page": 0,                                   "page": 0,
  "rect": [324, 490.5, 524, 540.5],            "rect": [324, 490.5, 524, 540.5] }
  "kind": { "type": "field",
           "fieldType": "signature", "value": null } }
```

- A region is emitted only for a **schema-bound** field; an unbound decorative widget produces none.
- `value`/`fieldType` are dropped: regions are geometry for overlays and cross-navigation, never a compositing input (both canvas backends already bake values into a complete raster, so nothing read them). A value lives in the editor (and the AcroForm `/V`); a type lives in the quill schema.
- Typst form-fields have no widget/schema split — the plate-authored name is the field address, so it keys the region directly.

## 2. Regions move from `RenderResult` to a session-level query

Only the interactive-preview path wants field geometry, and that path holds a session (it `paint()`s) and produces no byte artifact. A one-shot byte render (PDF/PNG/SVG) never reads regions. So `RenderResult.regions` is removed and the geometry is read once off the compiled session, with no render:

```js
// before                                  after
const r = await engine.render(quill, doc); const session = await engine.open(quill, doc);
const regions = r.regions;                 const regions = session.regions();
```

This is the simplification that subsumes #773's "geometry-only accessor" ask: `regions()` is the *only* home, not a supplement. As a knock-on, the `quillmark-pdf` stamp spine stops threading regions through every render path — `stamp`/`flatten` return plain `Vec<u8>` and `StampResult` is gone.

## API surface

- **core**: add `SessionHandle::regions()` (default empty) + `RenderSession::regions()`; remove `RenderResult.regions` / `with_regions`; remove `RegionKind`.
- **quillmark-pdf**: `FieldSpec` gains `schema_field`; `stamp` returns `Vec<u8>`; `StampResult` removed.
- **pdfform / typst**: override `regions()` from cached specs / placements; drop `.with_regions` from all render paths.
- **wasm**: `session.regions()` accessor (Rust + runtime wrapper + `runtime.d.ts`); `FieldRegion` reshaped; `regions` removed from the WASM `RenderResult`.

## Docs

Migration guide (`docs/migrations/0.92-to-0.93.md`), CHANGELOG, and the `PREVIEW.md` canon — including the recommended percentage-overlay transform for HTML/CSS consumers (ask 3) and the statement that regions are schema-field-only (ask 4).

## Scope / compatibility

Unreleased 0.93 surface, so no released migration is broken. Canvas/regions are WASM-only by design; native bindings (Python/.NET) never surfaced regions, so they're untouched.

## Testing

`cargo test --workspace` green; wasm Rust compiles across core-only / typst / pdfform-preview; clippy clean on touched crates. WASM/binding JS suites run on CI. The canvas-conformance test, which previously ran a throwaway `render()` purely to harvest the sidecar, now calls `session.regions()` directly — the waste the issue named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)