### PR TITLE
wasm: pre-await handle snapshot in render/open; honest version stamps on from-source builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,20 @@ jobs:
 
       - name: Build WASM packages
         if: steps.wasm-cache.outputs.cache-hit != 'true'
-        run: ./scripts/build-wasm.sh
+        # --release-stamp: stamp the workspace version verbatim. This checkout
+        # is the bumped release tag, so the number is truthful here — and only
+        # here; every other build gets the script's default -dev.<sha> stamp.
+        run: ./scripts/build-wasm.sh --release-stamp
+
+      # A dev-stamped or stale-cached pkg/ must never reach npm: the stamp has
+      # to equal the tag being released.
+      - name: Assert pkg version matches the release tag
+        run: |
+          PKG_VERSION=$(jq -r .version pkg/package.json)
+          if [ "$PKG_VERSION" != "${{ needs.prepare.outputs.version }}" ]; then
+            echo "pkg/package.json is $PKG_VERSION, expected ${{ needs.prepare.outputs.version }} — refusing to publish." >&2
+            exit 1
+          fi
 
       - name: Install npm test dependencies
         working-directory: crates/bindings/wasm

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -397,6 +397,12 @@ The wasm bindings are built with `--weak-refs`, so dropped `Document`,
 without manual `.free()` discipline. `.free()` is still emitted as an eager
 teardown hook for callers that want deterministic release.
 
+`engine.render` and `engine.open` read the `quill` and `doc` handles
+synchronously, before their first await, so freeing a handle as soon as the
+call returns — `try { return engine.render(quill, doc); } finally
+{ doc.free(); }` — is safe even on the first render, while the backend
+binary is still loading.
+
 The package floor is Node 22+ (`engines: { node: ">=22" }`) and current
 evergreen browsers; `--weak-refs` itself only needs Node 14.6+. The `using`
 sugar shown below ([explicit resource management][erm]) needs Node 24, but is
@@ -406,7 +412,7 @@ For environments where `using` (the [explicit resource management][erm]
 proposal) hasn't landed, use an explicit `try` / `finally`:
 
 ```ts
-const session = engine.open(quill, doc);
+const session = await engine.open(quill, doc);
 try {
   for (let p = 0; p < session.pageCount; p++) {
     session.paint(ctx, p);

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -424,6 +424,36 @@ main:
     expect(loaded()).toBe(1)
   })
 
+  it('caller may free() its handles as soon as render/open returns (pre-await snapshot)', async () => {
+    // Both caller handles are snapshotted before the first await inside
+    // render/open (the backend load — a real suspension point on first call),
+    // so a synchronous free() right after the call cannot race the clone.
+    // Regression pin for the "null pointer passed to rust" panic (#782 §3):
+    // each engine below is fresh, so its first call has the load pending when
+    // free() runs.
+    const renderEngine = new Engine()
+    const renderQuill = makeRuntimeQuill()
+    const renderDoc = Document.fromMarkdown(TEST_MARKDOWN)
+    const pendingRender = renderEngine.render(renderQuill, renderDoc, { format: 'svg' })
+    renderDoc.free()
+    renderQuill.free()
+    const result = await pendingRender
+    expect(result.artifacts.length).toBeGreaterThan(0)
+
+    const openEngine = new Engine()
+    const openQuill = makeRuntimeQuill()
+    const openDoc = Document.fromMarkdown(TEST_MARKDOWN)
+    const pendingOpen = openEngine.open(openQuill, openDoc)
+    openDoc.free()
+    openQuill.free()
+    const session = await pendingOpen
+    try {
+      expect(session.pageCount).toBeGreaterThan(0)
+    } finally {
+      session.free()
+    }
+  })
+
   it('propagates a clone-construction failure (doc clone), leaving the quill clone cached', async () => {
     // Exercises the teardown path when the doc clone (Document.fromJson) throws:
     // the quill clone is already materialized and cached (NOT freed here — that

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -217,11 +217,18 @@ export interface EngineOptions {
 export declare class Engine {
 	constructor(options?: EngineOptions);
 
-	/** Render `doc` against `quill` in one shot. */
+	/**
+	 * Render `doc` against `quill` in one shot. Both handles are read
+	 * synchronously before the first await, so the caller may `free()` them as
+	 * soon as this call returns.
+	 */
 	render(quill: Quill, doc: Document, options?: RenderOptions): Promise<RenderResult>;
 
 	/**
 	 * Open a live render session (canvas preview / per-page paint / `apply`).
+	 * The `quill` and `doc` handles are read synchronously before the first
+	 * await, so the caller may `free()` them as soon as this call returns; the
+	 * caller owns the returned session and must `.free()` it.
 	 * @experimental Ships ahead of its first production consumer (the designed
 	 * canvas live-preview path — see `prose/canon/PREVIEW.md`). The session/paint
 	 * surface may change in any 0.x release; `render()` is the stable path.

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -217,16 +217,18 @@ export class Engine {
 
 	/**
 	 * Get (or materialize-and-cache) the backend-memory `Quill` clone for
-	 * `quill` under `backendId`. On a cache miss the clone is built via
-	 * `toTree`→`fromTree` and stored in the per-backend `WeakMap` keyed on the
+	 * `quill` under `backendId`. On a cache miss the clone is built from `tree`
+	 * — the caller's pre-await `toTree()` snapshot; the canonical handle may be
+	 * freed by now — and stored in the per-backend `WeakMap` keyed on the
 	 * canonical `Quill` instance, so a later call with the same instance reuses
 	 * it (the hot-path fix: no re-serialize / re-copy / re-validate per call).
 	 * @param {any} mod the backend build module
 	 * @param {string} backendId
-	 * @param {{ toTree(): Map<string, Uint8Array> }} quill
+	 * @param {object} quill the canonical instance (cache key only)
+	 * @param {Map<string, Uint8Array> | null} tree pre-await snapshot; `null` on a cache hit
 	 * @returns {any} the backend-memory quill clone
 	 */
-	#cachedQuillClone(mod, backendId, quill) {
+	#cachedQuillClone(mod, backendId, quill, tree) {
 		let perQuill = this.#quillClones.get(backendId);
 		if (!perQuill) {
 			perQuill = new WeakMap();
@@ -234,7 +236,7 @@ export class Engine {
 		}
 		let backendQuill = perQuill.get(quill);
 		if (!backendQuill) {
-			backendQuill = mod.Quill.fromTree(quill.toTree());
+			backendQuill = mod.Quill.fromTree(tree);
 			perQuill.set(quill, backendQuill);
 		}
 		return backendQuill;
@@ -244,6 +246,13 @@ export class Engine {
 	 * Materialize the backend-memory clones for `quill` + `doc` in `backendId`'s
 	 * memory and run `fn` against the backend engine. Only `render`/`open` call
 	 * this, so `doc` is always present.
+	 *
+	 * OWNERSHIP WINDOW: both caller handles are snapshotted (`doc.toJson()`, and
+	 * `quill.toTree()` on a clone-cache miss) BEFORE the first await. The backend
+	 * load below is a real suspension point — a multi-MB `import()` on first
+	 * render — so reading the handles after it would race a caller that
+	 * `free()`s them as soon as this call returns its promise ("null pointer
+	 * passed to rust"). The snapshot makes that natural calling pattern correct.
 	 *
 	 * Clone lifetimes differ by design: the `doc` clone is TRANSIENT — freed in
 	 * the `finally` of every call. The `quill` clone is CACHED per (engine,
@@ -258,6 +267,8 @@ export class Engine {
 	 * @param {(ctx: { mod: any, engine: any, quill: any, doc: any }) => any} fn
 	 */
 	async #withClones(backendId, quill, doc, fn) {
+		const docJson = doc.toJson();
+		const quillTree = this.#quillClones.get(backendId)?.has(quill) ? null : quill.toTree();
 		const { mod, engine } = await this.#resolveBackend(backendId);
 		// The quill clone is cached (see #cachedQuillClone); only the per-call doc
 		// clone is transient. Bring the doc clone + `fn` under one try so the doc
@@ -265,10 +276,10 @@ export class Engine {
 		// rejecting a cross-version DTO). The cached quill clone is intentionally
 		// NOT freed here. `fn` MUST be synchronous — the doc clone is freed as soon
 		// as it returns, so an async `fn` would have it freed mid-flight.
-		const backendQuill = this.#cachedQuillClone(mod, backendId, quill);
+		const backendQuill = this.#cachedQuillClone(mod, backendId, quill, quillTree);
 		let backendDoc = null;
 		try {
-			backendDoc = mod.Document.fromJson(doc.toJson());
+			backendDoc = mod.Document.fromJson(docJson);
 			return fn({ mod, engine, quill: backendQuill, doc: backendDoc });
 		} finally {
 			backendDoc?.free();
@@ -277,6 +288,8 @@ export class Engine {
 
 	/**
 	 * Render `doc` against `quill` in one shot, returning a `RenderResult`.
+	 * Both handles are read synchronously before the first await, so the caller
+	 * may `free()` them as soon as this call returns.
 	 * @param {Quill} quill
 	 * @param {Document} doc
 	 * @param {object} [options] render options (`{ format, ppi, pages, producer }`)
@@ -292,7 +305,9 @@ export class Engine {
 	 * Open a live render session (canvas preview / per-page paint / `apply`).
 	 * The session is self-contained (it retains what it needs for `apply`), so
 	 * the transient quill and document clones are freed before this returns;
-	 * the caller owns the returned session and must `.free()` it.
+	 * the caller owns the returned session and must `.free()` it. The `quill`
+	 * and `doc` handles are read synchronously before the first await, so the
+	 * caller may `free()` them as soon as this call returns.
 	 * @experimental Ships ahead of its first production consumer (the designed
 	 * canvas live-preview path); the session/paint surface may change in any
 	 * 0.x release. `render()` is the stable path.

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -29,15 +29,19 @@ set -o pipefail
 # cache namespacing in .github/workflows/{ci,release}.yml.
 PROFILE="wasm-release"
 MODE_LABEL="release (size-optimized)"
+RELEASE_STAMP=0
 for arg in "$@"; do
     case "$arg" in
         --ci)
             PROFILE="wasm-ci"
             MODE_LABEL="ci (fast compile, unoptimized)"
             ;;
+        --release-stamp)
+            RELEASE_STAMP=1
+            ;;
         *)
             echo "Unknown argument: $arg" >&2
-            echo "Usage: $0 [--ci]" >&2
+            echo "Usage: $0 [--ci] [--release-stamp]" >&2
             exit 2
             ;;
     esac
@@ -47,10 +51,19 @@ echo "Building WASM modules for @quillmark/wasm... [profile: $MODE_LABEL]"
 
 cd "$(dirname "$0")/.."
 
-# Check for required tools
+# Check for required tools. The CLI's version must match the wasm-bindgen
+# crate in Cargo.lock; wasm-bindgen itself only detects a mismatch when it
+# runs — after the multi-minute cargo build — so check it up front.
+LOCKED_WBG=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | sed -n 's/^version = "\(.*\)"/\1/p')
 if ! command -v wasm-bindgen &> /dev/null; then
-    echo "wasm-bindgen not found. Install it with:"
-    echo "  cargo install wasm-bindgen-cli --version 0.2.118"
+    echo "wasm-bindgen not found. Install it with:" >&2
+    echo "  cargo install wasm-bindgen-cli --version $LOCKED_WBG" >&2
+    exit 1
+fi
+CLI_WBG=$(wasm-bindgen --version | awk '{print $2}')
+if [ "$CLI_WBG" != "$LOCKED_WBG" ]; then
+    echo "ERROR: wasm-bindgen-cli $CLI_WBG does not match Cargo.lock's wasm-bindgen $LOCKED_WBG." >&2
+    echo "  cargo install wasm-bindgen-cli --version $LOCKED_WBG" >&2
     exit 1
 fi
 if ! command -v jq &> /dev/null; then
@@ -113,11 +126,23 @@ cp crates/bindings/wasm/runtime/runtime.d.ts pkg/runtime/runtime.d.ts
 # panic=abort, strip=true) it saves only ~15 KB raw / ~10 KB gzipped
 # (<0.1%) — not worth the build dependency or the extra build time.
 
-# Extract version and create package.json from template
+# Extract version and create package.json from template. Cargo.toml carries
+# the LAST RELEASED version, so a from-source build is ahead of the number it
+# would stamp. Default: mark it — next patch plus `-dev.<short-sha>` — so a
+# dev pkg/ can never pass for a published release (npm dedupe, peer ranges,
+# humans debugging read an honest number). `--release-stamp` stamps the
+# version verbatim; only release.yml passes it, from the bumped release tag,
+# and asserts the stamp equals the tag before `npm publish`.
 VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "quillmark-wasm") | .version')
 if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
     echo "ERROR: could not determine quillmark-wasm version from cargo metadata." >&2
     exit 1
+fi
+if [ "$RELEASE_STAMP" -ne 1 ]; then
+    BASE=${VERSION%%-*}
+    IFS=. read -r MAJOR MINOR PATCH <<< "$BASE"
+    SHA=$(git rev-parse --short HEAD 2>/dev/null || echo local)
+    VERSION="$MAJOR.$MINOR.$((PATCH + 1))-dev.$SHA"
 fi
 echo ""
 echo "Creating package.json..."


### PR DESCRIPTION
Resolves the two in-scope findings of #782 (3 and 5). Findings 2 and 4 are split out to #783 and #784; finding 1's compatibility-alias ask is rejected — pre-1.0 hard cutovers stand, and the `plate_file` move is already documented in the 0.92→0.93 migration guide.

## `Document`/`Quill` lifetime across `engine.render`/`open` (#782 §3)

`Engine.#withClones` read `doc.toJson()` only after awaiting the backend load — a real suspension point (multi-MB `import()`) on first render — so the natural pattern

```js
try { return engine.open(quill, doc); } finally { doc.free(); }
```

panicked with `null pointer passed to rust`. Both caller handles are now snapshotted before the first await (`doc.toJson()`, and `quill.toTree()` on a clone-cache miss), making a synchronous `free()` after the call safe. The ownership window is documented on `render`/`open` (JSDoc + `runtime.d.ts` + README), the README lifecycle example is fixed (it modeled the racy pattern: `engine.open` with no `await`), and a regression test frees both handles synchronously after first-call `render` and `open`.

## From-source builds claimed the last released version (#782 §5)

`build-wasm.sh` stamped the workspace version — by repo convention the *last released* number — onto every `pkg/`, so a dev build carrying unreleased semantics read as `0.92.1` to npm dedupe, peer ranges, and humans. Now:

- Default stamp is `<next-patch>-dev.<short-sha>` (e.g. `0.92.2-dev.ea7bd04`) — sorts above the last release and below any next one; an rc base strips its prerelease before the bump.
- `release.yml` passes the new `--release-stamp` flag from the bumped release tag (the one place the verbatim number is truthful) and asserts `pkg/package.json` equals the tag before `npm publish`, so a dev-stamped or stale-cached bundle can never reach npm.
- Folded in the spike's toolchain note: a `wasm-bindgen-cli`/`Cargo.lock` version mismatch now fails before the cargo build, with the pinned version read from `Cargo.lock` instead of hardcoded.

Closes #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrfGwtsq7ndxyMsoT1QH4Y