### PR TITLE
feat(regions): per-placement regions, public tagged() helper, one-shot sidecar

### DIFF
--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -60,6 +60,11 @@ mod tests {
         assert!(!lib.contains("#let parse-date(s)"));
         assert!(lib.contains("meta.date_fields"));
         assert!(lib.contains("meta.card_date_fields"));
+        // Public explicit-tagging surface: `tagged` (validated) over the
+        // private `_qm-tag` emitter; cards carry their `$path` prefix.
+        assert!(lib.contains("#let tagged(field, body)"));
+        assert!(lib.contains("#let _qm-tag(path, body)"));
+        assert!(lib.contains("card.insert(\"$path\", prefix)"));
     }
 
     #[test]

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -245,16 +245,17 @@ impl SessionHandle for TypstSession {
     }
 
     /// Schema-field geometry for the compiled document — bottom-left PDF-point
-    /// rects keyed on the schema-field path. Two sources, ordered: form-field
-    /// widgets (one fixed-size box each) first, then auto-tagged content fields
-    /// (markdown bodies, geometry read from the laid-out frames). The
-    /// widgets-first order sets the precedence for the one-region-per-field
-    /// dedup that [`LiveSession::regions`](quillmark_core::LiveSession::regions)
-    /// applies: an explicit `field:`-bound widget wins over a content auto-tag of
-    /// the same path, and a page-spanning body keeps its first page-fragment
-    /// (content arrives sorted by `(page, field)`, so the lowest page leads).
-    /// Geometry math over the frames, no rasterization. Widget regions are empty
-    /// if the placements fail to resolve (a render would surface the same error).
+    /// rects keyed on the schema-field path, one per (placement, page
+    /// fragment). Two sources, deterministically ordered: form-field widgets
+    /// (one fixed-size box each) first, then marker-tagged content (auto-tagged
+    /// fields and explicit `tagged(..)` placements, geometry read from the
+    /// laid-out frames) in (page, field, placement) order. Entries pass through
+    /// [`LiveSession::regions`](quillmark_core::LiveSession::regions) as-is —
+    /// a field appearing several times (multiple placements, page fragments, or
+    /// tagged content plus a bound widget) surfaces every appearance; consumers
+    /// group by field. Geometry math over the frames, no rasterization. Widget
+    /// regions are empty if the placements fail to resolve (a render would
+    /// surface the same error).
     fn regions(&self) -> Vec<quillmark_core::RenderedRegion> {
         let mut regions = overlay::build_field_specs(&self.document, &self.field_placements)
             .map(|specs| quillmark_pdf::regions_of(&specs))
@@ -484,13 +485,26 @@ fn transform_markdown_fields(
         }
     }
 
-    // Collect per-card-kind content field names from schema $defs
+    // Collect per-card-kind content field names from schema $defs, plus the
+    // full per-kind property-name lists that back `tagged` path validation.
     let mut card_content_fields = serde_json::Map::new();
     let mut card_date_fields = serde_json::Map::new();
+    let mut card_field_names = serde_json::Map::new();
     if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
         for (def_name, def_schema) in defs {
             if let Some(card_kind) = def_name.strip_suffix("_card") {
                 let card_props = def_schema.get("properties").and_then(|v| v.as_object());
+                if let Some(props) = card_props {
+                    card_field_names.insert(
+                        card_kind.to_string(),
+                        serde_json::Value::Array(
+                            props
+                                .keys()
+                                .map(|k| serde_json::Value::String(k.clone()))
+                                .collect(),
+                        ),
+                    );
+                }
                 let card_fields = card_props.map(content_field_names).unwrap_or_default();
                 if !card_fields.is_empty() {
                     card_content_fields.insert(
@@ -520,7 +534,9 @@ fn transform_markdown_fields(
         }
     }
 
-    // Inject __meta__ so the helper package can auto-eval content fields
+    // Inject __meta__ so the helper package can auto-eval content fields.
+    // `fields` / `card_fields` are the full schema property-name tables the
+    // helper's `tagged` validates explicit region paths against.
     result.insert(
         "__meta__".to_string(),
         QuillValue::from_json(serde_json::json!({
@@ -528,6 +544,8 @@ fn transform_markdown_fields(
             "card_content_fields": card_content_fields,
             "date_fields": date_fields,
             "card_date_fields": card_date_fields,
+            "fields": properties_obj.keys().collect::<Vec<_>>(),
+            "card_fields": card_field_names,
         })),
     );
 

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -102,33 +102,92 @@
   datetime(year: year, month: month, day: day)
 }
 
+/// Raw document JSON, including the `__meta__` sentinel the Rust backend
+/// injects. Parsed once; `data` strips the sentinel before plates see it.
+#let _qm-raw = json(bytes("{escaped_json}"))
+
+/// Backend-injected metadata: content/date field lists driving the auto
+/// passes, plus the schema address tables (`fields`, `card_fields`) that
+/// validate `tagged` paths.
+#let _qm-meta = _qm-raw.at("__meta__", default: (:))
+
+// Region tagging: wrap content between two zero-size `<__qm_region__>`
+// metadata markers carrying its schema-field `path`; the backend reads their
+// frame positions back into a region rect (`session.regions()`). Zero-size is
+// layout-neutral — the same property the form-field metadata relies on. Like
+// `form-field`, this emits `metadata`; a plate/package reading its own config
+// via an unfiltered `query(metadata)` must filter by label or an owned key.
+// Private: emits markers with no path validation — the auto-tagging pass
+// constructs its paths itself. Plates use `tagged`, which validates.
+#let _qm-tag(path, body) = {
+  [#metadata((kind: "qm-region", role: "start", field: path)) <__qm_region__>]
+  body
+  [#metadata((kind: "qm-region", role: "end", field: path)) <__qm_region__>]
+}
+
+/// Whether `path` parses against the schema address tables: a top-level field
+/// (`subject`), a markdown[] element (`refs.2`), or a card address
+/// (`$cards.<kind>.<n>.<field>`, optional `.<i>` element suffix). Permissive
+/// when the tables are absent (no `__meta__`) — validation then has nothing to
+/// check against.
+#let _qm-known-path(path) = {
+  let fields = _qm-meta.at("fields", default: ())
+  let card-fields = _qm-meta.at("card_fields", default: (:))
+  if fields.len() == 0 and card-fields.len() == 0 { return true }
+  let is-index(s) = s.match(regex("^[0-9]+$")) != none
+  let parts = path.split(".")
+  if parts.at(0) == "$cards" {
+    if parts.len() < 4 or parts.len() > 5 { return false }
+    if not (parts.at(1) in card-fields) { return false }
+    if not is-index(parts.at(2)) { return false }
+    let known = parts.at(3) in card-fields.at(parts.at(1))
+    if parts.len() == 5 { return known and is-index(parts.at(4)) }
+    return known
+  }
+  if parts.len() == 1 { return path in fields }
+  if parts.len() == 2 { return parts.at(0) in fields and is-index(parts.at(1)) }
+  false
+}
+
+/// Tag `body` as the placement of schema field `field`, so it surfaces a
+/// region (`session.regions()`) at whatever geometry it lays out to. The
+/// explicit counterpart of content auto-tagging, for the two cases auto-tags
+/// cannot reach: a scalar (`tagged("subject")[#data.subject]` — a plain string
+/// carries no tag of its own) and content placed through a package that
+/// rebuilds it (`tagged("$body")[#render(data.at("$body"))]` — the markers
+/// bracket the package's *output*, so its internal reconstruction cannot drop
+/// them). The region covers the ink of this placement — everything `body`
+/// draws, package chrome included — where an auto-tag covers the field value's
+/// own ink.
+///
+/// `field` must be a schema address: a field name (`"subject"`), a markdown[]
+/// element (`"refs.2"`), or a card path (`"$cards.indorsement.1.from"`).
+/// Compose card paths from the card's injected `$path` prefix —
+/// `tagged(card.at("$path") + "from")[..]` — rather than hand-writing the
+/// kind+ordinal grammar. An unknown address is a compile error, so a typo'd
+/// path fails loudly instead of producing a region nothing routes to.
+#let tagged(field, body) = {
+  assert(std.type(field) == str,
+    message: "tagged: field must be a string, got " + repr(std.type(field)))
+  assert(_qm-known-path(field),
+    message: "tagged: " + repr(field) + " is not a schema field address; expected a field name, a markdown[] element like \"refs.2\", or a card path composed from the card's $path prefix")
+  _qm-tag(field, body)
+}
+
 /// Document data as a dictionary.
 /// Markdown fields are automatically converted to Typst content objects.
 /// The `__meta__` key (injected by the Rust backend) is consumed here and
 /// never exposed to plate authors.
 #let data = {
-  let d = json(bytes("{escaped_json}"))
+  let d = _qm-raw
 
-  // Read and consume __meta__ (injected by transform_fields)
+  // Strip and read __meta__ (injected by transform_fields)
   let meta = d.remove("__meta__", default: (
     content_fields: (),
     card_content_fields: (:),
     date_fields: (),
     card_date_fields: (:),
   ))
-
-  // Auto-region tagging: wrap content between two zero-size `<__qm_region__>`
-  // metadata markers carrying its schema-field `path`; the backend reads their
-  // frame positions back into a region rect (`session.regions()`). Zero-size is
-  // layout-neutral — the same property the form-field metadata relies on — so a
-  // content field tags its own page geometry with no plate-author effort. Like
-  // `form-field`, this emits `metadata`; a plate/package reading its own config
-  // via an unfiltered `query(metadata)` must filter by label or an owned key.
-  let qm-region(path, body) = {
-    [#metadata((kind: "qm-region", role: "start", field: path)) <__qm_region__>]
-    body
-    [#metadata((kind: "qm-region", role: "end", field: path)) <__qm_region__>]
-  }
 
   // Eval the named content fields of `dict` into Typst content. A markdown
   // field is a string; a `markdown[]` field is an array whose string elements
@@ -141,9 +200,9 @@
       if key in dict {
         let val = dict.at(key)
         if type(val) == str and val != "" {
-          dict.insert(key, qm-region(prefix + key, eval(val, mode: "markup")))
+          dict.insert(key, _qm-tag(prefix + key, eval(val, mode: "markup")))
         } else if type(val) == array {
-          dict.insert(key, val.enumerate().map(((i, v)) => if type(v) == str and v != "" { qm-region(prefix + key + "." + str(i), eval(v, mode: "markup")) } else { v }))
+          dict.insert(key, val.enumerate().map(((i, v)) => if type(v) == str and v != "" { _qm-tag(prefix + key + "." + str(i), eval(v, mode: "markup")) } else { v }))
         }
       }
     }
@@ -182,6 +241,13 @@
         let n = kind-ordinals.at(card-type, default: 0)
         kind-ordinals.insert(card-type, n + 1)
         prefix = "$cards." + card-type + "." + str(n) + "."
+        // The card's canonical address prefix, injected so plates compose
+        // region paths — `tagged(card.at("$path") + "from")[..]` — without
+        // reimplementing the kind+ordinal grammar (an absolute enumerate()
+        // index is NOT the ordinal once kinds interleave). `$`-prefixed like
+        // the other system keys ($kind, $body), so it cannot collide with a
+        // schema field.
+        card.insert("$path", prefix)
       }
       card = eval-content(card, meta.card_content_fields.at(card-type, default: ()), prefix)
       card = parse-dates(card, meta.card_date_fields.at(card-type, default: ()))

--- a/crates/backends/typst/src/overlay/region_scan.rs
+++ b/crates/backends/typst/src/overlay/region_scan.rs
@@ -1,33 +1,40 @@
-//! Recover schema-field regions for *auto-tagged content* by walking the
+//! Recover schema-field regions for *marker-tagged content* — auto-tagged
+//! content fields and explicit `tagged(..)` placements — by walking the
 //! compiled frame tree, not by reading a fixed-size widget box.
 //!
 //! Where [`extract`](super::extract) handles `form-field` widgets — each a
 //! single fixed-size box whose rect is `marker_position + (width, height)` — a
-//! content field (a markdown body) has no declared size and may wrap across
-//! many lines and break across pages. Its geometry can only be read from the
-//! laid-out frames.
+//! tagged body has no declared size and may wrap across many lines and break
+//! across pages. Its geometry can only be read from the laid-out frames.
 //!
-//! The helper (`lib.typ`'s `qm-region`) brackets each auto-tagged content field
-//! between two zero-size `<__qm_region__>` metadata markers (`role: start` /
-//! `role: end`, carrying the schema `field` path). The walk, mirroring
-//! `typst_layout::introspect::discover_frame` (the same transform composition
-//! Typst uses to place elements):
+//! The helper (`lib.typ`'s `_qm-tag`, reached via auto-tagging or the public
+//! `tagged`) brackets each placement between two zero-size `<__qm_region__>`
+//! metadata markers (`role: start` / `role: end`, carrying the schema `field`
+//! path). The walk, mirroring `typst_layout::introspect::discover_frame` (the
+//! same transform composition Typst uses to place elements):
 //!   1. Query the markers → `location → (role, field)`.
 //!   2. Walk every page frame in document order, composing the group-transform
-//!      stack. A `start` tag opens a field; an `end` tag closes it. Every drawn
-//!      leaf (text/shape/image) seen while a field is open contributes its
-//!      transformed bbox to that field's running union, partitioned by page.
-//!   3. Flip each page-space (top-left) union to the PDF bottom-left origin the
-//!      region model uses.
+//!      stack. A `start` marker opens a **placement** of its field; the
+//!      matching `end` marker closes it. Every drawn leaf (text/shape/image)
+//!      seen while a placement is open contributes its transformed bbox to
+//!      that placement's running union, partitioned by page.
+//!   3. Flip each page-space (top-left) union to the PDF bottom-left origin
+//!      the region model uses.
 //!
-//! A field that crosses a page boundary yields one box per page it touches, in
-//! page order (the open-field set persists across pages: a field opened on one
-//! page stays open until its `end` marker, which may live on a later page). The
-//! session keeps only the first — the field's lowest-page anchor — so callers
-//! see one region per logical field; the per-page boxes are produced here so the
-//! anchor is the page where the field actually starts.
+//! **One region per (placement, page).** A field placed twice yields two
+//! independent regions — a spanning union would claim the ink of whatever sits
+//! between the placements. A placement that crosses a page boundary yields one
+//! region per page it touches, in page order (a placement opened on one page
+//! stays open until its `end` marker, which may live on a later page) — every
+//! fragment surfaces, so a consumer highlighting a field covers its
+//! continuation pages too. Consumers group by `field`.
+//!
+//! Nested markers for the *same* field collapse into the outer placement
+//! (depth-counted): a plate that wraps an already-auto-tagged verbatim body in
+//! an explicit `tagged(..)` is double-tagging one placement, not placing the
+//! field twice, and gets one region for it.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use typst::foundations::{Label, Selector, Value};
 use typst::introspection::{Introspector, Tag};
@@ -78,8 +85,30 @@ enum Role {
     End,
 }
 
+/// Per-field open state: the placement instance leaves currently accrue to,
+/// and the marker nesting depth that keeps same-field markers collapsed into
+/// it.
+struct OpenField {
+    instance: usize,
+    depth: usize,
+}
+
+/// Walk state threaded through the frame recursion.
+struct Scan<'a> {
+    /// Marker location hash → (role, field), from the introspector query.
+    by_loc: &'a HashMap<u128, (Role, String)>,
+    /// field → its open placement. Persists across pages: a placement opened
+    /// on one page stays open until its `end` marker, which may live on a
+    /// later page — resetting per page would drop the continuation fragments.
+    open: HashMap<String, OpenField>,
+    /// instance id → field. Allocation order is document order.
+    instances: Vec<String>,
+    /// (instance, page) → union box, in page-space top-left pt.
+    boxes: HashMap<(usize, usize), Aabb>,
+}
+
 /// Walk the compiled document and return one [`RenderedRegion`] per
-/// (auto-tagged content field, page it occupies). Best-effort: a malformed
+/// (placement of a tagged field, page it occupies). Best-effort: a malformed
 /// marker is skipped rather than failing the whole scan, since this rides
 /// alongside the (already-validated) form-field path and a render would surface
 /// any real compilation error first.
@@ -94,7 +123,7 @@ pub(crate) fn scan(doc: &PagedDocument) -> Vec<RenderedRegion> {
     }
 
     // location id → (role, field). Keyed by the marker's location so the frame
-    // walk can recognise a tag without re-reading the metadata dict.
+    // walk can recognise a marker without re-reading the metadata dict.
     let mut by_loc: HashMap<u128, (Role, String)> = HashMap::new();
     for c in markers.iter() {
         let Ok(Value::Dict(dict)) = c.get_by_name("value") else {
@@ -113,98 +142,100 @@ pub(crate) fn scan(doc: &PagedDocument) -> Vec<RenderedRegion> {
         }
     }
 
-    // (field, page) → union box, in page-space top-left pt.
-    let mut boxes: HashMap<(String, usize), Aabb> = HashMap::new();
-    // `active` persists across pages: a field opened on one page stays open
-    // until its `end` marker, which may live on a later page. Resetting per
-    // page would drop the continuation fragments.
-    let mut active: HashSet<String> = HashSet::new();
+    let mut scan = Scan {
+        by_loc: &by_loc,
+        open: HashMap::new(),
+        instances: Vec::new(),
+        boxes: HashMap::new(),
+    };
     for (page_idx, page) in doc.pages().iter().enumerate() {
-        walk(
-            &page.frame,
-            Transform::identity(),
-            page_idx,
-            &by_loc,
-            &mut active,
-            &mut boxes,
-        );
+        walk(&page.frame, Transform::identity(), page_idx, &mut scan);
     }
 
-    // Flip each page-space box to PDF bottom-left and emit. Sort for stable output.
-    let mut out: Vec<RenderedRegion> = boxes
+    // Flip each page-space box to PDF bottom-left and emit. Sort for stable
+    // output: page order, then field, then placement document order (two
+    // same-field placements on one page keep the order they were opened in).
+    let mut out: Vec<(RenderedRegion, usize)> = scan
+        .boxes
         .into_iter()
         .filter(|(_, b)| !b.is_empty())
-        .filter_map(|((field, page), b)| {
+        .filter_map(|((instance, page), b)| {
             let page_h = doc.pages().get(page)?.frame.size().y.to_pt();
-            Some(RenderedRegion {
-                field,
-                page,
-                rect: [
-                    b.min_x as f32,
-                    (page_h - b.max_y) as f32,
-                    b.max_x as f32,
-                    (page_h - b.min_y) as f32,
-                ],
-            })
+            Some((
+                RenderedRegion {
+                    field: scan.instances[instance].clone(),
+                    page,
+                    rect: [
+                        b.min_x as f32,
+                        (page_h - b.max_y) as f32,
+                        b.max_x as f32,
+                        (page_h - b.min_y) as f32,
+                    ],
+                },
+                instance,
+            ))
         })
         .collect();
-    out.sort_by(|a, b| (a.page, &a.field).cmp(&(b.page, &b.field)));
-    out
+    out.sort_by(|(a, ai), (b, bi)| (a.page, &a.field, *ai).cmp(&(b.page, &b.field, *bi)));
+    out.into_iter().map(|(r, _)| r).collect()
 }
 
 /// Recursive frame walk. `ts` maps this frame's local coordinates to page space;
 /// composed exactly as `discover_frame` does (translate by item pos, then the
 /// group's own transform).
-fn walk(
-    frame: &Frame,
-    ts: Transform,
-    page_idx: usize,
-    by_loc: &HashMap<u128, (Role, String)>,
-    active: &mut HashSet<String>,
-    boxes: &mut HashMap<(String, usize), Aabb>,
-) {
+fn walk(frame: &Frame, ts: Transform, page_idx: usize, scan: &mut Scan) {
     for (pos, item) in frame.items() {
         match item {
-            // Each `metadata` element emits both a `Tag::Start` and a `Tag::End`
-            // with the *same* location hash, so every marker fires twice here.
-            // `insert`/`remove` are idempotent and the body is zero-size (the two
-            // tags are adjacent), so the double-fire is a no-op.
-            FrameItem::Tag(tag) => {
-                if let Some((role, field)) = by_loc.get(&tag_loc(tag)) {
+            // Each `metadata` element contributes a `Tag::Start` and a
+            // `Tag::End` frame item with the *same* location. Reacting to
+            // `Tag::Start` only fires exactly once per marker, in document
+            // order — required now that a `role: start` marker allocates a
+            // placement instance (a double fire would open two).
+            FrameItem::Tag(tag @ Tag::Start(..)) => {
+                if let Some((role, field)) = scan.by_loc.get(&tag.location().hash()) {
                     match role {
                         Role::Start => {
-                            active.insert(field.clone());
+                            let next_instance = scan.instances.len();
+                            let entry =
+                                scan.open
+                                    .entry(field.clone())
+                                    .or_insert_with(|| OpenField {
+                                        instance: next_instance,
+                                        depth: 0,
+                                    });
+                            if entry.depth == 0 {
+                                scan.instances.push(field.clone());
+                            }
+                            entry.depth += 1;
                         }
                         Role::End => {
-                            active.remove(field);
+                            if let Some(entry) = scan.open.get_mut(field) {
+                                entry.depth -= 1;
+                                if entry.depth == 0 {
+                                    scan.open.remove(field);
+                                }
+                            }
                         }
                     }
                 }
             }
+            FrameItem::Tag(Tag::End(..)) => {}
             FrameItem::Group(group) => {
                 let ts = ts
                     .pre_concat(Transform::translate(pos.x, pos.y))
                     .pre_concat(group.transform);
-                walk(&group.frame, ts, page_idx, by_loc, active, boxes);
+                walk(&group.frame, ts, page_idx, scan);
             }
-            FrameItem::Text(text) if !active.is_empty() => {
+            FrameItem::Text(text) if !scan.open.is_empty() => {
                 let bb = text.bbox();
-                add_rect(active, page_idx, boxes, *pos, bb.min, bb.max, ts);
+                add_rect(scan, page_idx, *pos, bb.min, bb.max, ts);
             }
-            FrameItem::Shape(shape, _) if !active.is_empty() => {
+            FrameItem::Shape(shape, _) if !scan.open.is_empty() => {
                 let bb = shape.geometry.bbox(shape.stroke.as_ref());
-                add_rect(active, page_idx, boxes, *pos, bb.min, bb.max, ts);
+                add_rect(scan, page_idx, *pos, bb.min, bb.max, ts);
             }
-            FrameItem::Image(_, size, _) if !active.is_empty() => {
-                add_rect(
-                    active,
-                    page_idx,
-                    boxes,
-                    *pos,
-                    Point::zero(),
-                    size.to_point(),
-                    ts,
-                );
+            FrameItem::Image(_, size, _) if !scan.open.is_empty() => {
+                add_rect(scan, page_idx, *pos, Point::zero(), size.to_point(), ts);
             }
             _ => {}
         }
@@ -212,17 +243,9 @@ fn walk(
 }
 
 /// Union a leaf item's box (corners `lo`..`hi`, relative to the item anchor
-/// `pos`, in this frame's local space) into every currently-open field, after
-/// mapping to page space via `ts`.
-fn add_rect(
-    active: &HashSet<String>,
-    page_idx: usize,
-    boxes: &mut HashMap<(String, usize), Aabb>,
-    pos: Point,
-    lo: Point,
-    hi: Point,
-    ts: Transform,
-) {
+/// `pos`, in this frame's local space) into every currently-open placement,
+/// after mapping to page space via `ts`.
+fn add_rect(scan: &mut Scan, page_idx: usize, pos: Point, lo: Point, hi: Point, ts: Transform) {
     // Transform all four corners (ts may rotate/scale), take the AABB.
     let corners = [
         Point::new(pos.x + lo.x, pos.y + lo.y),
@@ -230,16 +253,13 @@ fn add_rect(
         Point::new(pos.x + lo.x, pos.y + hi.y),
         Point::new(pos.x + hi.x, pos.y + hi.y),
     ];
-    for field in active.iter() {
-        let entry = boxes
-            .entry((field.clone(), page_idx))
+    for open in scan.open.values() {
+        let entry = scan
+            .boxes
+            .entry((open.instance, page_idx))
             .or_insert_with(Aabb::empty);
         for c in corners {
             entry.add(c.transform(ts));
         }
     }
-}
-
-fn tag_loc(tag: &Tag) -> u128 {
-    tag.location().hash()
 }

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -1,9 +1,12 @@
-//! Auto-tagged content fields produce schema-path-keyed regions read from the
-//! laid-out frame tree: a top-level markdown field, the multi-rect-per-field
-//! shape when content breaks across pages, and the canonical card address
-//! `$cards.<kind>.<n>.<field>` (per-kind 0-based ordinal, surviving interleaved
-//! kinds). Plus the `form-field` `field:` schema-path binding, which keys a
-//! widget region on a schema path rather than its `/T` name.
+//! Marker-tagged content produces schema-path-keyed regions read from the
+//! laid-out frame tree — one region per (placement, page fragment): a
+//! top-level markdown field, per-page fragments when content breaks across
+//! pages, independent regions for a field placed twice, and the canonical card
+//! address `$cards.<kind>.<n>.<field>` (per-kind 0-based ordinal, surviving
+//! interleaved kinds). Plus the explicit `tagged(..)` placement path (scalars,
+//! nested-tag collapse, schema-address validation, the card `$path` prefix)
+//! and the `form-field` `field:` schema-path binding, which keys a widget
+//! region on a schema path rather than its `/T` name.
 
 use std::collections::HashMap;
 
@@ -70,15 +73,8 @@ main:
     let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
     let regions = session.regions();
 
-    // One region per logical field — `field` is unique across the result.
-    let mut seen = std::collections::HashSet::new();
-    assert!(
-        regions.iter().all(|r| seen.insert(r.field.clone())),
-        "each field appears at most once: {:?}",
-        regions.iter().map(|r| &r.field).collect::<Vec<_>>()
-    );
-
-    // intro: one region, keyed on the schema path (not a widget name).
+    // intro: one placement, one page — exactly one region, keyed on the schema
+    // path (not a widget name).
     let intro: Vec<_> = regions.iter().filter(|r| r.field == "intro").collect();
     assert_eq!(intro.len(), 1, "intro is one region");
     let [x0, y0, x1, y1] = intro[0].rect;
@@ -88,15 +84,174 @@ main:
         intro[0].rect
     );
 
-    // body spans four pages but collapses to a single region anchored to the
-    // first page it occupies (page 0).
+    // body spans several pages: one fragment per page it touches, in page
+    // order starting at the page it opens on, each page at most once.
     let body: Vec<_> = regions.iter().filter(|r| r.field == "body").collect();
-    assert_eq!(body.len(), 1, "page-spanning body collapses to one region");
-    assert_eq!(body[0].page, 0, "anchored to the first page it occupies");
     assert!(
-        body[0].rect[2] - body[0].rect[0] > 200.0,
-        "body anchor spans most of the text column: {:?}",
-        body[0].rect
+        body.len() >= 2,
+        "page-spanning body surfaces one fragment per page: {body:?}"
+    );
+    assert_eq!(body[0].page, 0, "first fragment on the page the body opens");
+    let pages: Vec<usize> = body.iter().map(|r| r.page).collect();
+    let mut sorted_pages = pages.clone();
+    sorted_pages.sort();
+    sorted_pages.dedup();
+    assert_eq!(pages, sorted_pages, "fragments in page order, one per page");
+    for r in &body {
+        assert!(
+            r.rect[2] - r.rect[0] > 200.0,
+            "each body fragment spans most of the text column: {:?}",
+            r.rect
+        );
+    }
+}
+
+#[test]
+fn field_placed_twice_yields_independent_regions() {
+    const YAML: &str = r#"
+quill:
+  name: two_placements
+  version: 0.1.0
+  backend: typst
+  description: per-placement region test
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    intro:
+      type: markdown
+      description: a short paragraph placed twice
+"#;
+    // The auto-tagged value is placed at two sites with unrelated ink between
+    // them; each placement must surface independently rather than as one
+    // spanning union that would claim the middle content.
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 612pt, height: 792pt, margin: 72pt)
+
+#data.intro
+
+#lorem(40)
+
+#data.intro
+"#;
+    let data = serde_json::json!({ "intro": "The same intro, placed twice." });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let regions = session.regions();
+    let intro: Vec<_> = regions.iter().filter(|r| r.field == "intro").collect();
+    assert_eq!(intro.len(), 2, "two placements, two regions: {regions:?}");
+    // Disjoint vertically (bottom-left origin: the later placement sits lower).
+    assert!(
+        intro[0].rect[1] > intro[1].rect[3] || intro[1].rect[1] > intro[0].rect[3],
+        "placements do not union into a spanning rect: {:?} vs {:?}",
+        intro[0].rect,
+        intro[1].rect
+    );
+}
+
+#[test]
+fn tagged_scalar_placement_emits_region() {
+    const YAML: &str = r#"
+quill:
+  name: tagged_scalar
+  version: 0.1.0
+  backend: typst
+  description: explicit scalar tagging test
+main:
+  fields:
+    subject:
+      type: string
+      description: a plain scalar the plate tags at its placement site
+typst:
+  plate_file: plate.typ
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#set page(width: 612pt, height: 792pt, margin: 72pt)
+
+#tagged("subject")[*#data.subject*]
+"#;
+    let data = serde_json::json!({ "subject": "Request for Quarters" });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let regions = session.regions();
+    let subject: Vec<_> = regions.iter().filter(|r| r.field == "subject").collect();
+    assert_eq!(
+        subject.len(),
+        1,
+        "a tagged scalar placement surfaces one region: {regions:?}"
+    );
+    assert!(subject[0].rect[2] > subject[0].rect[0]);
+}
+
+#[test]
+fn nested_same_field_tags_collapse_into_one_placement() {
+    // A plate that wraps an already-auto-tagged verbatim value in an explicit
+    // `tagged(..)` double-tags one placement; the scan depth-counts and emits
+    // one region, not two overlapping ones.
+    const YAML: &str = r#"
+quill:
+  name: nested_tags
+  version: 0.1.0
+  backend: typst
+  description: nested same-field tag collapse test
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    intro:
+      type: markdown
+      description: an auto-tagged value wrapped in an explicit tag
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#set page(width: 612pt, height: 792pt, margin: 72pt)
+
+#tagged("intro")[#data.intro]
+"#;
+    let data = serde_json::json!({ "intro": "A defensively double-tagged intro." });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let regions = session.regions();
+    let intro: Vec<_> = regions.iter().filter(|r| r.field == "intro").collect();
+    assert_eq!(
+        intro.len(),
+        1,
+        "nested same-field tags collapse into the outer placement: {regions:?}"
+    );
+}
+
+#[test]
+fn tagged_unknown_path_fails_the_compile() {
+    const YAML: &str = r#"
+quill:
+  name: tagged_typo
+  version: 0.1.0
+  backend: typst
+  description: tagged path validation test
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    subject:
+      type: string
+      description: the only schema field
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#tagged("subjcet")[#data.subject]
+"#;
+    let data = serde_json::json!({ "subject": "typo'd path" });
+
+    let err = TypstBackend
+        .open(&quill(YAML, PLATE), &data)
+        .err()
+        .expect("a typo'd tagged path must fail the compile");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("subjcet"),
+        "the compile error names the bad path: {msg}"
     );
 }
 
@@ -175,6 +330,68 @@ card_kinds:
             || f.starts_with("$cards.2.")),
         "card regions must use kind+ordinal, not positional index: {fields:?}"
     );
+}
+
+#[test]
+fn card_path_prefix_composes_tagged_addresses() {
+    // Each card dict carries its canonical `$path` prefix, so a plate tags a
+    // card scalar without reimplementing the kind+ordinal grammar — and gets
+    // the per-kind ordinal right where an absolute enumerate() index would
+    // drift once kinds interleave.
+    const YAML: &str = r#"
+quill:
+  name: card_path
+  version: 0.1.0
+  backend: typst
+  description: card $path prefix test
+typst:
+  plate_file: plate.typ
+main:
+  fields: {}
+card_kinds:
+  alpha:
+    description: alpha card
+    fields:
+      title:
+        type: string
+        description: a scalar card field
+  beta:
+    description: beta card
+    fields:
+      title:
+        type: string
+        description: a scalar card field
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#set page(width: 612pt, height: 792pt, margin: 72pt)
+
+#for card in data.at("$cards", default: ()) {
+  tagged(card.at("$path") + "title")[#card.at("title")]
+  parbreak()
+}
+"#;
+    let data = serde_json::json!({
+        "$cards": [
+            {"$kind": "alpha", "title": "Alpha one"},
+            {"$kind": "beta",  "title": "Beta one"},
+            {"$kind": "alpha", "title": "Alpha two"},
+        ],
+    });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let fields: std::collections::HashSet<String> =
+        session.regions().into_iter().map(|r| r.field).collect();
+    for expected in [
+        "$cards.alpha.0.title",
+        "$cards.beta.0.title",
+        "$cards.alpha.1.title",
+    ] {
+        assert!(
+            fields.contains(expected),
+            "expected a region keyed {expected:?}; got {fields:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -34,7 +34,7 @@ impl PyQuillmark {
     /// this engine. The default `output_format` falls back to the backend's
     /// first supported format. Raises `QuillmarkError` (`UnsupportedBackend`)
     /// when the backend is not registered. Mirrors WASM `Engine.render`.
-    #[pyo3(signature = (quill, doc, format=None, ppi=None, pages=None, producer=None))]
+    #[pyo3(signature = (quill, doc, format=None, ppi=None, pages=None, producer=None, regions=false))]
     fn render(
         &self,
         quill: &PyQuill,
@@ -43,12 +43,14 @@ impl PyQuillmark {
         ppi: Option<f32>,
         pages: Option<Vec<usize>>,
         producer: Option<String>,
+        regions: bool,
     ) -> PyResult<PyRenderResult> {
         let opts = quillmark_core::RenderOptions {
             output_format: format.map(OutputFormat::from),
             ppi,
             pages,
             producer,
+            regions,
         };
         let start = Instant::now();
         let mut result = self
@@ -769,6 +771,26 @@ impl PyRenderResult {
     #[getter]
     fn render_time_ms(&self) -> f64 {
         self.render_time_ms
+    }
+
+    /// Schema-field geometry sidecar — populated only when `render(...,
+    /// regions=True)` requested it; empty otherwise. One dict per (placement,
+    /// page fragment): `{"field": str, "page": int, "rect": [x0, y0, x1, y1]}`
+    /// with rect in PDF points, bottom-left origin, page indices
+    /// document-space. A field may appear more than once; group by `field`.
+    #[getter]
+    fn regions<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        self.inner
+            .regions
+            .iter()
+            .map(|r| {
+                let d = PyDict::new(py);
+                d.set_item("field", &r.field)?;
+                d.set_item("page", r.page)?;
+                d.set_item("rect", r.rect.to_vec())?;
+                Ok(d)
+            })
+            .collect()
     }
 }
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -35,6 +35,7 @@ impl PyQuillmark {
     /// first supported format. Raises `QuillmarkError` (`UnsupportedBackend`)
     /// when the backend is not registered. Mirrors WASM `Engine.render`.
     #[pyo3(signature = (quill, doc, format=None, ppi=None, pages=None, producer=None, regions=false))]
+    #[allow(clippy::too_many_arguments)] // kwargs mirror RenderOptions 1:1; the signature IS the Python API
     fn render(
         &self,
         quill: &PyQuill,

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -267,6 +267,7 @@ impl Quillmark {
             warnings,
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
+            regions: result.regions.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -1411,14 +1412,16 @@ impl LiveSession {
             warnings: result.warnings.into_iter().map(Into::into).collect(),
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
+            regions: result.regions.into_iter().map(Into::into).collect(),
         })
     }
 
     /// Schema-field geometry for this compiled session — one region per
-    /// schema-bound field, keyed on its quill schema field path. A session-level
-    /// query: no render, no byte artifact. An interactive preview reads it to
-    /// place field overlays / cross-navigation over a `paint`-ed canvas. Empty
-    /// for backends that place no schema fields.
+    /// (placement, page fragment), keyed on the quill schema field path; a
+    /// field may appear more than once (group by `field`, see `FieldRegion`).
+    /// A session-level query: no render, no byte artifact. An interactive
+    /// preview reads it to place field overlays / cross-navigation over a
+    /// `paint`-ed canvas. Empty for backends that place no schema fields.
     #[wasm_bindgen(js_name = regions, unchecked_return_type = "FieldRegion[]")]
     pub fn regions(&self) -> Result<JsValue, JsValue> {
         let regions: Vec<FieldRegion> = self.inner.regions().into_iter().map(Into::into).collect();

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -202,6 +202,11 @@ pub struct RenderResult {
     pub warnings: Vec<Diagnostic>,
     pub output_format: OutputFormat,
     pub render_time_ms: f64,
+    /// Schema-field geometry sidecar — populated only when
+    /// `RenderOptions.regions` requested it; empty otherwise. The same entries
+    /// `LiveSession.regions()` serves, for consumers without a live session.
+    /// Page indices are document-space even under a `pages` subset render.
+    pub regions: Vec<FieldRegion>,
 }
 
 /// What a committed `LiveSession.apply` changed. `dirtyPages` lists the pages
@@ -218,18 +223,18 @@ pub struct ChangeSet {
 }
 
 /// A rendered field region: the quill schema field address plus its geometry on
-/// the page. Emitted for schema-bound fields — auto-tagged content (markdown
-/// bodies) and form-field widgets (pdfform AcroForm, Typst `form-field`).
-/// Consumers use it to map between a place on the page and a field in the editor
-/// — click a rendered field to focus it, or highlight the page rectangle for the
-/// focused field. Geometry only: the raster is already complete, so a region is
-/// never a compositing input.
+/// the page. Emitted for schema-bound fields — marker-tagged content (auto-tagged
+/// markdown bodies and explicit `tagged(..)` placements) and form-field widgets
+/// (pdfform AcroForm, Typst `form-field`). Consumers use it to map between a
+/// place on the page and a field in the editor — click a rendered field to focus
+/// it, or highlight the page rectangle for the focused field. Geometry only: the
+/// raster is already complete, so a region is never a compositing input.
 ///
-/// `field` is unique: `regions()` returns one entry per logical schema field. A
-/// field that would otherwise arise from several page-fragments, or from both a
-/// content auto-tag and a `field:`-bound widget, is collapsed to a single region
-/// by the session (the bound widget wins; a page-spanning body anchors to its
-/// first page).
+/// `field` is **not** unique: `regions()` returns one entry per (placement,
+/// page fragment). A field placed at several sites yields one region each; a
+/// body breaking across pages yields one fragment per page it touches (so a
+/// highlight covers continuation pages); tagged content plus a `field:`-bound
+/// widget yields both. Group by `field` — every entry routes to that field.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
@@ -281,6 +286,14 @@ pub struct RenderOptions {
     /// the default (`Quillmark <version>`). Applies to PDF output only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub producer: Option<String>,
+    /// Populate `RenderResult.regions` with the schema-field geometry sidecar
+    /// (the same entries `LiveSession.regions()` serves), for consumers
+    /// without a live session — e.g. overlays over a one-shot SVG export.
+    /// Defaults to `false`: exports pay no introspection cost. The sidecar
+    /// always describes the whole document — page indices are document-space
+    /// even when `pages` selects a subset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regions: Option<bool>,
 }
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
@@ -291,6 +304,7 @@ impl Default for RenderOptions {
             ppi: None,
             pages: None,
             producer: None,
+            regions: None,
         }
     }
 }
@@ -303,6 +317,7 @@ impl From<RenderOptions> for quillmark_core::RenderOptions {
             ppi: opts.ppi,
             pages: opts.pages,
             producer: opts.producer,
+            regions: opts.regions.unwrap_or(false),
         }
     }
 }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -438,6 +438,7 @@ mod tests {
             ppi: None,
             pages: None,
             producer: None,
+            regions: None,
         };
         let json = serde_json::to_string(&options).unwrap();
         assert!(json.contains("\"format\":\"pdf\""));

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -452,6 +452,12 @@ pub struct RenderResult {
     pub artifacts: Vec<crate::Artifact>,
     pub warnings: Vec<Diagnostic>,
     pub output_format: OutputFormat,
+    /// Schema-field geometry sidecar, populated only when
+    /// [`RenderOptions::regions`](crate::RenderOptions) is set (empty
+    /// otherwise). The same entries [`LiveSession::regions`](crate::LiveSession::regions)
+    /// serves, for consumers without a live session. Whole-document geometry:
+    /// page indices are document-space even under a `pages` subset render.
+    pub regions: Vec<crate::RenderedRegion>,
 }
 
 impl RenderResult {
@@ -460,6 +466,7 @@ impl RenderResult {
             artifacts,
             warnings: Vec::new(),
             output_format,
+            regions: Vec::new(),
         }
     }
 

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -10,15 +10,25 @@
 //! field → focus it in the editor, or highlight the page rectangle for the
 //! focused field.
 //!
-//! Two producers feed regions, both keyed on the schema path:
+//! Three producers feed regions, all keyed on the schema path:
 //!
 //! - **Content fields** (a markdown body) auto-tag from their content — the
-//!   Typst eval site brackets each one with its schema address, so the key is
-//!   carried by construction with no plate-author effort. Two cases produce no
-//!   region: a computed scalar (`data.from + ", " + rank`) cannot be tagged at
-//!   all (a string has no label), and a field that is blank or draws nothing
-//!   (an empty or whitespace-only body) is tagged but has no inked extent to
-//!   bound — present-but-empty is not the same as placed.
+//!   Typst eval site brackets each one's *value* with its schema address, so
+//!   the key is carried by construction when the plate places the value
+//!   verbatim. Three cases produce no region: a computed scalar (`data.from +
+//!   ", " + rank`) cannot be tagged at all (a string has no label); a field
+//!   that is blank or draws nothing (an empty or whitespace-only body) is
+//!   tagged but has no inked extent to bound — present-but-empty is not the
+//!   same as placed; and a value passed through a package that **rebuilds its
+//!   content** (a `show`-rule pass that captures paragraphs into a state
+//!   buffer and re-emits them) loses the markers in the reconstruction — the
+//!   auto-tag contract is *content placed verbatim*, not arbitrary Typst.
+//! - **Explicit `tagged(field)[..]` placements** bracket whatever a plate
+//!   places at that site — the recovery for both auto-tag gaps: a scalar
+//!   becomes taggable as content at its placement site, and markers wrapped
+//!   *around* a package call's output survive whatever the package does
+//!   internally. The region covers the ink of the placement (package chrome
+//!   included), where an auto-tag covers the value's own ink.
 //! - **Form-field widgets** carry a schema path explicitly: pdfform binds it
 //!   from the form mapping; a Typst `form-field` binds it from its `field:`
 //!   argument. A widget that binds none produces **no** region — its backend
@@ -26,34 +36,39 @@
 //!   nothing for a consumer to route to. Only schema-addressable fields surface
 //!   a region.
 //!
-//! **One region per logical field.** A field can arise from more than one
-//! source — a content auto-tag *and* a `field:`-bound widget — or as several
-//! page-fragments of a body that breaks across pages. [`LiveSession::regions`](crate::LiveSession::regions)
-//! collapses these to one entry per `field`: a bound widget wins over a content
-//! tag (the explicit binding is the author's deliberate mapping), and a
-//! page-spanning body keeps the first page it occupies as its anchor. A consumer
-//! looks a field up and gets exactly one rectangle.
+//! **One region per (placement, page fragment).** A field placed at two sites
+//! surfaces two independent regions — a spanning union would claim the ink of
+//! whatever sits between them — and a body that breaks across pages surfaces
+//! one fragment per page it touches, so highlighting a focused field covers
+//! its continuation pages. A field arising from both tagged content and a
+//! bound widget surfaces both (overlapping rects that route to the same
+//! field). [`LiveSession::regions`](crate::LiveSession::regions) passes the
+//! backend's entries through; consumers group by `field`. Nested markers for
+//! the same field collapse into their outer placement — double-tagging one
+//! placement is not placing it twice.
 //!
-//! Regions are a session-level query, not a render output: the geometry is a
-//! property of the current compile, re-read from the session per edit without
-//! producing any byte artifact. Only the interactive-preview path wants it (to
-//! lay out overlays over a `paint`-ed canvas); a one-shot byte render
-//! (PDF/PNG/SVG) never does. They are an overlay sidecar, never a compositing
-//! input: both canvas backends hand back a complete page raster, so nothing
-//! about the picture depends on reading a region. Empty for backends that place
-//! no schema fields.
+//! Regions are primarily a session-level query: the geometry is a property of
+//! the current compile, re-read from the session per edit without producing
+//! any byte artifact — the interactive-preview path (overlays over a
+//! `paint`-ed canvas) reads it that way. A one-shot byte render carries the
+//! same sidecar only on request ([`RenderOptions::regions`](crate::RenderOptions))
+//! for consumers without a live session (static SVG overlays, PDF
+//! post-processing, CI coverage probes). Either way regions are an overlay
+//! sidecar, never a compositing input: every canvas backend hands back a
+//! complete page raster, so nothing about the picture depends on reading a
+//! region. Empty for backends that place no schema fields.
 
-/// One schema field's placement on a rendered page.
+/// One schema field placement's extent on a rendered page.
 ///
 /// `rect` is `[x0, y0, x1, y1]` in PDF points with a **bottom-left** origin —
 /// the same final geometry the stamp spine writes to the widget `/Rect`, so the
 /// region and the rendered field describe the identical box.
 ///
-/// `field` is unique within the `Vec` that [`LiveSession::regions`](crate::LiveSession::regions) returns —
-/// one region per logical schema field. (A backend's
-/// [`SessionHandle::regions`](crate::session::SessionHandle::regions) may emit a
-/// field more than once in precedence order; the session wrapper keeps the
-/// first.)
+/// `field` is **not** unique within the `Vec` that
+/// [`LiveSession::regions`](crate::LiveSession::regions) returns: a field
+/// placed at several sites, breaking across pages, or arising from both
+/// tagged content and a bound widget yields one entry per (placement, page
+/// fragment). Consumers group by `field`; every entry routes to that field.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderedRegion {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -91,13 +91,16 @@ pub trait SessionHandle: Any + Send + Sync {
     /// the current compile, computed from already-resolved field placements
     /// with no rasterization and no byte artifact. An interactive preview reads
     /// it to lay out overlays / field cross-navigation over a `paint`-ed canvas;
-    /// a one-shot byte render never needs it. Default empty — a backend that
-    /// places schema fields overrides this.
+    /// a one-shot byte render carries it only on request
+    /// ([`RenderOptions::regions`](crate::RenderOptions)). Default empty — a
+    /// backend that places schema fields overrides this.
     ///
-    /// A backend may return a field more than once (several page-fragments, or a
-    /// content tag plus a bound widget); emit them in precedence order, as
-    /// [`LiveSession::regions`] keeps the first per `field` to present one
-    /// region per logical field.
+    /// Emit one region per **(placement, page fragment)**: a field may appear
+    /// more than once — placed twice, breaking across pages, or arising from
+    /// both tagged content and a bound widget — and every appearance surfaces
+    /// independently ([`LiveSession::regions`] passes them through; consumers
+    /// group by `field`). Order deterministically: widget regions first, then
+    /// content regions in (page, field, placement) order.
     fn regions(&self) -> Vec<RenderedRegion> {
         Vec::new()
     }
@@ -184,23 +187,19 @@ impl LiveSession {
     }
 
     /// Schema-field geometry for the compiled session — **one
-    /// [`RenderedRegion`] per logical schema field**, keyed on its quill schema
-    /// field path. A session-level query computed without rendering bytes; an
-    /// interactive preview reads it to place overlays / field cross-navigation
-    /// over a `paint`-ed canvas. Empty for backends that place no schema fields.
+    /// [`RenderedRegion`] per (placement, page fragment)**, keyed on the quill
+    /// schema field path. A session-level query computed without rendering
+    /// bytes; an interactive preview reads it to place overlays / field
+    /// cross-navigation over a `paint`-ed canvas. Empty for backends that
+    /// place no schema fields.
     ///
-    /// The backend ([`SessionHandle::regions`]) may surface a field from more
-    /// than one source (a content auto-tag and a bound widget) or as several
-    /// page-fragments; this keeps the first per `field` in the backend's order
-    /// — the backend orders its output to set that precedence — so a consumer
-    /// looks a field up and gets exactly one rectangle.
+    /// A field may appear more than once: placed at several sites, breaking
+    /// across pages (one fragment per page it touches, so a highlight covers
+    /// continuation pages), or arising from both tagged content and a
+    /// `field:`-bound widget (overlapping rects that route to the same field).
+    /// Group by `field`; every entry routes to that field in the editor.
     pub fn regions(&self) -> Vec<RenderedRegion> {
-        let mut seen = std::collections::HashSet::new();
-        self.inner
-            .regions()
-            .into_iter()
-            .filter(|r| seen.insert(r.field.clone()))
-            .collect()
+        self.inner.regions()
     }
 
     /// Session-level warnings attached at `Backend::open` time, also appended
@@ -213,6 +212,12 @@ impl LiveSession {
     pub fn render(&self, opts: &RenderOptions) -> Result<RenderResult, RenderError> {
         let mut result = self.inner.render(opts)?;
         result.warnings.extend(self.warnings.iter().cloned());
+        // The regions sidecar is attached here, at the wrapper, so every
+        // backend's one-shot render carries it without implementing anything
+        // beyond the `regions` accessor it already has.
+        if opts.regions {
+            result.regions = self.inner.regions();
+        }
         Ok(result)
     }
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -155,4 +155,15 @@ pub struct RenderOptions {
     /// the backend default (`Quillmark <version>` for the Typst backend).
     /// Applies to PDF output only; ignored by SVG/PNG/TXT.
     pub producer: Option<String>,
+    /// Populate [`RenderResult::regions`](crate::RenderResult) with the
+    /// schema-field geometry sidecar (the same entries
+    /// [`LiveSession::regions`](crate::LiveSession::regions) serves), for
+    /// consumers without a live session — static overlays over exported SVG,
+    /// PDF post-processing, CI coverage probes. Default `false`: exports pay
+    /// no introspection cost, and the sidecar stays a request, not a promise.
+    ///
+    /// The sidecar always describes the **whole document** — page indices are
+    /// document-space and unaffected by a `pages` subset selection — so it
+    /// never disagrees with the geometry of the compile it came from.
+    pub regions: bool,
 }

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, signature-field
+#import "@local/quillmark-helper:0.1.0": data, signature-field, tagged
 #import "@local/tonguetoquill-usaf-memo:3.0.0": backmatter, frontmatter, indorsement, mainmatter
 
 // Frontmatter configuration
@@ -53,16 +53,19 @@
   memo_for_cols: 1,
 )
 
-// Mainmatter configuration
-#mainmatter[
+// Mainmatter configuration. `tagged` brackets the package *output*: the
+// package's render-body rebuilds paragraphs through a state buffer (AFH
+// 33-337 auto-numbering), which drops the value-level auto-tag markers, so
+// the body regions only when tagged here, outside the rebuild.
+#tagged("$body")[#mainmatter[
   #data.at("$body")
-]
+]]
 
 // Backmatter
 #backmatter(
   // Signature block
   signature_block: data.signature_block,
-  signing_field: signature-field("Signature"),
+  signing_field: signature-field("Signature", field: "signature_block"),
 
   // Optional cc
   ..if "cc" in data { (cc: data.cc) },
@@ -92,17 +95,27 @@
     } else {
       card_date
     }
-    indorsement(
+    // The card's `$path` prefix composes its canonical region addresses
+    // (`$cards.indorsement.<n>.…`, per-kind ordinal) — the absolute loop
+    // index `i` is NOT that ordinal once kinds interleave, so it stays a
+    // widget-name suffix only. `tagged` wraps the indorsement's *output*
+    // (the package rebuilds body paragraphs, dropping value-level markers),
+    // keyed on the card's body: clicking anywhere in the indorsement block
+    // routes to that card in the editor.
+    tagged(card.at("$path") + "$body")[#indorsement(
       from: card.at("from", default: ""),
       to: card.at("for", default: ""),
       signature_block: card.signature_block,
-      signing_field: signature-field("Ind_" + str(i) + "_Signature"),
+      signing_field: signature-field(
+        "Ind_" + str(i) + "_Signature",
+        field: card.at("$path") + "signature_block",
+      ),
       ..if "attachments" in card { (attachments: card.attachments) },
       ..if "cc" in card { (cc: card.cc) },
       format: card.at("format", default: "standard"),
       date: resolved_date,
       ..if "action" in card { (action: card.action) },
       body_content,
-    )
+    )]
   }
 }

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -97,6 +97,7 @@ impl Quillmark {
             ppi: opts.ppi,
             pages: opts.pages.clone(),
             producer: opts.producer.clone(),
+            regions: opts.regions,
         };
         session.render(&resolved)
     }

--- a/crates/quillmark/tests/usaf_memo_regions_test.rs
+++ b/crates/quillmark/tests/usaf_memo_regions_test.rs
@@ -1,0 +1,89 @@
+//! Region coverage on the flagship `usaf_memo` quill (#783).
+//!
+//! The memo package's `render-body` rebuilds body paragraphs through a state
+//! buffer (AFH 33-337 auto-numbering), which drops value-level auto-tag
+//! markers — `$body` was the field a user most wants to click and produced no
+//! region. The plate now brackets the package *output* with `tagged(..)` and
+//! binds the signature widgets to schema paths, so the cross-navigation
+//! surface is live on the shipped catalog. This renders the real plate
+//! end-to-end and pins that coverage, plus the one-shot regions sidecar.
+
+#![cfg(feature = "typst")]
+
+use std::collections::HashSet;
+
+use quillmark::{OutputFormat, Quillmark, RenderError, RenderOptions};
+use quillmark_fixtures::quills_path;
+
+#[test]
+fn usaf_memo_regions_cover_body_signature_and_cards() {
+    let engine = Quillmark::new();
+    let quill =
+        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
+
+    // The seeded document exercises the main memo and one card per declared
+    // kind, so the indorsement addresses are present.
+    let parsed = quill.seed_document();
+
+    let session = match engine.open(&quill, &parsed) {
+        // Font-less CI cannot exercise the renderer; skip rather than fail,
+        // matching the convention in quiver_test.rs.
+        Err(RenderError::EngineCreation { diags })
+            if diags[0].message.contains("No fonts found") =>
+        {
+            eprintln!("skipping — no fonts available");
+            return;
+        }
+        other => other.expect("usaf_memo should open a session"),
+    };
+
+    let regions = session.regions();
+    let fields: HashSet<&str> = regions.iter().map(|r| r.field.as_str()).collect();
+
+    // The body regions *through* the package's paragraph rebuild — the case
+    // that was inert under value-level auto-tagging alone.
+    for expected in [
+        "$body",
+        "signature_block",
+        "$cards.indorsement.0.$body",
+        "$cards.indorsement.0.signature_block",
+    ] {
+        assert!(
+            fields.contains(expected),
+            "expected a region keyed {expected:?}; got {fields:?}"
+        );
+    }
+
+    // The one-shot sidecar serves the same geometry without a session in the
+    // consumer's hands, and stays empty unless requested.
+    let with_regions = engine
+        .render(
+            &quill,
+            &parsed,
+            &RenderOptions {
+                output_format: Some(OutputFormat::Pdf),
+                regions: true,
+                ..Default::default()
+            },
+        )
+        .expect("usaf_memo should render to PDF");
+    assert_eq!(
+        with_regions.regions, regions,
+        "one-shot sidecar matches the session query"
+    );
+
+    let without_regions = engine
+        .render(
+            &quill,
+            &parsed,
+            &RenderOptions {
+                output_format: Some(OutputFormat::Pdf),
+                ..Default::default()
+            },
+        )
+        .expect("usaf_memo should render to PDF");
+    assert!(
+        without_regions.regions.is_empty(),
+        "the sidecar is opt-in; exports carry no regions by default"
+    );
+}

--- a/crates/quillmark/tests/usaf_memo_regions_test.rs
+++ b/crates/quillmark/tests/usaf_memo_regions_test.rs
@@ -1,12 +1,12 @@
-//! Region coverage on the flagship `usaf_memo` quill (#783).
+//! Region coverage on the flagship `usaf_memo` quill.
 //!
 //! The memo package's `render-body` rebuilds body paragraphs through a state
 //! buffer (AFH 33-337 auto-numbering), which drops value-level auto-tag
-//! markers — `$body` was the field a user most wants to click and produced no
-//! region. The plate now brackets the package *output* with `tagged(..)` and
-//! binds the signature widgets to schema paths, so the cross-navigation
-//! surface is live on the shipped catalog. This renders the real plate
-//! end-to-end and pins that coverage, plus the one-shot regions sidecar.
+//! markers, so the plate brackets the package's *output* with `tagged(..)`
+//! and binds the signature widgets to schema paths — keeping `$body` and
+//! `signature_block` addressable for cross-navigation across the shipped
+//! catalog. This renders the real plate end-to-end and pins that coverage,
+//! plus the one-shot regions sidecar.
 
 #![cfg(feature = "typst")]
 

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -192,29 +192,37 @@ impl Backend for MyBackend {              impl Backend for MyBackend {
                                           }
 ```
 
-## Field regions move to `LiveSession::regions()` and key on the quill schema field
+## Field regions become a session query (opt-in on renders) and key on the quill schema field
 
-Two changes to the region sidecar, both narrowing it to what the interactive
-preview path actually uses.
+Two changes to the region sidecar.
 
-**1. Regions are a session query, not a render output.** Only a canvas/SVG
-preview wants field geometry; a one-shot byte render (PDF/PNG/SVG) never does.
-So `RenderResult.regions` is **removed**, and the geometry is read once off the
-compiled session — no render, no discarded artifact:
+**1. Regions are primarily a session query; a render carries them only on
+request.** An interactive canvas/SVG preview holds a session (it `paint()`s)
+and reads the geometry off the compiled session — no render, no discarded
+artifact — re-reading it after each committed `apply`. A one-shot render's
+`RenderResult.regions` is now **empty unless `RenderOptions` asks**
+(`regions: true`), for consumers without a session in hand — static overlays
+over an exported SVG, PDF post-processing, coverage probes. The sidecar always
+describes the whole document: page indices are document-space even under a
+`pages` subset render.
 
 ```js
-// 0.92                                      0.93
+// 0.92                                      0.93 — interactive preview
 const r = await engine.render(quill, doc);  const session = await engine.open(quill, doc);
 const regions = r.regions;                  const regions = session.regions();
+
+                                            // 0.93 — one-shot consumer, no session
+                                            const r = await engine.render(quill, doc, { regions: true });
+                                            const regions = r.regions;
 ```
 
 ```rust
-// 0.92                                      0.93
-let regions = session.render(&opts)?.regions;   let regions = session.regions();
+// 0.92                                          0.93
+let regions = session.render(&opts)?.regions;    let regions = session.regions();
 ```
 
-An interactive consumer already holds a session (it `paint()`s), so this is the
-surface it wants; an export-only consumer drops region handling entirely.
+An export-only consumer that never read regions now pays nothing for them by
+default.
 
 **2. Regions key on the quill schema field, not the backend widget.** A region
 maps a rendered field back to the **quill schema field** — the address the editor
@@ -236,17 +244,32 @@ uses — with a lookup, not a guess. `RenderedRegion` (core) and the WASM
 - **`field`** is the quill schema field path (e.g. `signature_block`,
   `$cards.indorsement.1.from` — the card form is kind + 0-based ordinal,
   `$cards.<kind>.<n>.<field>`).
-- **Content fields are now covered, auto-tagged.** A markdown body carries its
-  schema address from the Typst eval site with no plate-author effort, and its
-  page geometry is recovered from the laid-out frames (true rendered extent, not
-  a declared size). A computed scalar (`data.from + ", " + rank`) cannot be
-  tagged — a string has no label — so it produces no region.
-- **One region per logical field.** A field that arises from both a content
-  auto-tag and a `field:`-bound widget, or from several page-fragments of a
-  page-spanning body, is collapsed to a single region: the bound widget wins over
-  the content tag, and a page-spanning body anchors to the first page it
-  occupies. So `field` is unique in the returned list — look a field up, get one
-  rectangle.
+- **Content fields are covered, auto-tagged — when placed verbatim.** A
+  markdown body carries its schema address from the Typst eval site, and its
+  page geometry is recovered from the laid-out frames (true rendered extent,
+  not a declared size). Three cases produce no auto-tag region: a computed
+  scalar (`data.from + ", " + rank`) cannot be tagged — a string has no label;
+  an empty/whitespace-only body draws nothing to bound; and a value passed
+  through a package that **rebuilds its content** (a `show`-rule pass that
+  buffers and re-emits paragraphs) loses the markers in the reconstruction.
+- **Explicit tagging covers what auto-tags cannot.** The generated helper
+  exports `tagged(field)[..]`: it brackets whatever the plate places at that
+  site, so a scalar regions as content at its placement
+  (`tagged("subject")[#data.subject]`) and markers wrapped *around* a package
+  call's output survive the package's internal rebuild
+  (`tagged("$body")[#mainmatter[#data.at("$body")]]`). Paths validate against
+  the schema at compile time — a typo'd field is a compile error. Each card
+  dict carries its canonical address prefix as `$path`, so plates compose card
+  paths (`tagged(card.at("$path") + "from")[..]`) without reimplementing the
+  kind+ordinal grammar.
+- **One region per (placement, page fragment) — `field` is not unique.** A
+  field placed at two sites surfaces two independent regions; a page-spanning
+  body surfaces one fragment per page it touches (so highlighting a focused
+  field covers continuation pages); tagged content plus a `field:`-bound
+  widget surfaces both, overlapping rects that route to the same field. Group
+  by `field` — a 0.92-style unique-key lookup must become a group-by. Nested
+  markers for the same field collapse into the outer placement, so
+  defensively double-tagging one placement does not duplicate it.
 - **Only schema-addressable fields surface a region.** A Typst `form-field`
   emits a region only when it binds a schema path via `field:` (e.g.
   `signature-field("Signature", field: "signature_block")`); a widget that binds

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -124,25 +124,46 @@ compositing of its own. Backends satisfy it differently:
   flat PDF via hayro — so field values appear in the raster on their own, with
   no regions-compositing by the caller.
 
-Field geometry is a **session-level query**, `LiveSession::regions()` (see
-[SCHEMAS.md](SCHEMAS.md) and the region type in `crates/core/src/region.rs`) —
-not a field on `RenderResult`. Only the interactive-preview path wants it, and
-that path holds a session; a one-shot byte render (PDF/PNG/SVG) never does, so
-it is read off the current compile with no render — re-read it after each
-committed `apply`. Each region carries per-field geometry keyed on the **quill
-schema field path** — the address the editor uses — for **overlays** and
+Field geometry is primarily a **session-level query**, `LiveSession::regions()`
+(see the region type in `crates/core/src/region.rs`): the interactive-preview
+path holds a session and reads geometry off the current compile with no render
+— re-read it after each committed `apply`. A one-shot byte render carries the
+same sidecar only on request (`RenderOptions::regions` → `RenderResult::regions`),
+for consumers without a live session — static overlays over an exported SVG,
+PDF post-processing, CI coverage probes. The sidecar always describes the
+whole document: page indices are document-space even under a `pages` subset
+render. Each region carries per-field geometry keyed on the **quill schema
+field path** — the address the editor uses — for **overlays** and
 **cross-navigation** (click a rendered field → focus it in the editor, or
 highlight the page rectangle for the focused field).
-Two producers: **content fields** (a markdown body) auto-tag from their content
-at the Typst eval site and recover their true rendered extent from the laid-out
-frames; **form-field widgets** carry the path explicitly (pdfform from the form
-mapping, a Typst `form-field` from its `field:` argument) and surface a region
-only when they bind one — a widget with no schema field is a backend artifact,
-not a routable field. The session returns **one region per logical field**: a
-field arising from both a content tag and a bound widget, or from several
-page-fragments, is collapsed (the bound widget wins; a page-spanning body anchors
-to its first page), so a consumer looks a field up and gets one rectangle.
-Geometry only, never a value, and never needed to complete the picture.
+
+Three producers: **content fields** (a markdown body) auto-tag from their
+*value* at the Typst eval site and recover their rendered extent from the
+laid-out frames — carried by construction when the plate places the value
+verbatim, and lost when a package rebuilds the content (a `show`-rule pass
+that buffers and re-emits paragraphs drops the markers; the auto-tag contract
+is *verbatim placement*, not arbitrary Typst). **Explicit `tagged(field)[..]`
+placements** bracket whatever the plate places at that site — the recovery for
+both auto-tag gaps: scalars (a plain string carries no tag of its own) and
+package-rebuilt content (markers around the package's *output* survive its
+internals); the region covers the placement's ink, package chrome included,
+and an unknown path is a compile error (validated against schema address
+tables baked into the generated helper; cards carry their canonical prefix as
+`$path`, so plates compose card addresses without reimplementing the
+kind+ordinal grammar). **Form-field widgets** carry the path explicitly
+(pdfform from the form mapping, a Typst `form-field` from its `field:`
+argument) and surface a region only when they bind one — a widget with no
+schema field is a backend artifact, not a routable field.
+
+The result is **one region per (placement, page fragment)**, not one per
+field: a field placed at two sites surfaces two regions (a spanning union
+would claim the ink between them); a page-spanning body surfaces one fragment
+per page it touches, so highlighting a focused field covers its continuation
+pages; tagged content plus a bound widget surfaces both, overlapping rects
+that route to the same field. Consumers group by `field`. Nested markers for
+the same field collapse into their outer placement — double-tagging one
+placement is not placing it twice. Geometry only, never a value, and never
+needed to complete the picture.
 
 ## TypeScript surface
 
@@ -323,14 +344,17 @@ sequentially; `runtime/runtime.js` maps each backend id to its build with a
 - **`warnings` accessor on `LiveSession`.** Session-level diagnostics attached
   at `Backend::open` are otherwise invisible to canvas consumers (only surfaced
   via `render()`'s `RenderResult`).
-- **`regions()` on `LiveSession`, not `RenderResult`.** Field geometry is a
-  property of the current compile, and only the interactive-preview path wants
-  it — that path holds a session (it `paint()`s) and produces no byte artifact.
-  Hanging regions off `RenderResult` forced an export-only consumer to receive
-  geometry it never reads, and forced a paint-only consumer to run a throwaway
-  byte render just to harvest the sidecar. A session method computes it from
-  already-resolved placements with no rasterization, serving both the canvas and
-  SVG-overlay previews from the one handle they already hold.
+- **`regions()` render-free on the session; opt-in on one-shot renders.** The
+  invariants are that geometry never composites (the raster is complete
+  without it) and that the edit loop reads it without producing bytes — a
+  paint-only consumer must never run a throwaway byte render to harvest the
+  sidecar. Session exclusivity was never the invariant: there is exactly one
+  producer (the frame scan over the current compile), so `RenderOptions::regions`
+  attaches the same entries to `RenderResult` for consumers with no session in
+  hand (static SVG overlays, PDF post-processing, CI coverage probes — and the
+  native bindings, which expose no session surface at all). Off by default:
+  exports pay no introspection cost, and best-effort geometry stays a request,
+  not a promise attached to every artifact.
 
 ## Lifecycle and consumer flow
 


### PR DESCRIPTION
Design agreed in #783 discussion. Three coordinated changes:

- Helper package exports tagged(field, body) — explicit region tagging at
  the placement site, covering the two auto-tag gaps (scalars; content
  placed through packages that rebuild it). Paths validate against
  schema address tables embedded in __meta__ (fields / card_fields), so
  a typo'd path fails the compile. Cards carry their canonical address
  prefix as $path, so plates compose card paths without reimplementing
  the kind+ordinal grammar.

- Region scan emits one region per (placement, page fragment) instead of
  a per-field spanning union: marker pairs are instance-scoped
  (depth-counted, so nested same-field tags collapse into the outer
  placement), a field placed twice surfaces independently, and a
  page-spanning body surfaces every continuation fragment (previously
  the session kept only the first page's box). LiveSession::regions
  passes backend entries through; consumers group by field.

- RenderOptions.regions opt-in populates RenderResult.regions on
  one-shot renders (attached at the LiveSession wrapper, so every
  backend gets it via its existing regions accessor). Whole-document,
  document-space page indices regardless of `pages` subset. Exposed in
  the WASM (RenderOptions.regions / RenderResult.regions) and Python
  (render(regions=True) / RenderResult.regions) bindings.

Region contract docs (region.rs) now name the package-rebuild no-region
case for auto-tags: the auto-tag contract is content placed verbatim.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EKExYpA5uoZDmKpiboEmMN