### PR TITLE
Region-contract hardening from the #788 review: form-field path validation, scalar index rejection, cached schema meta, WASM type sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,13 @@ jobs:
             pkg
           # Namespaced cache key: never share artifacts with the release
           # workflow, which builds with the size-optimized wasm-release
-          # profile and publishes pkg/ to npm.
-          key: wasm-ci-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs') }}
+          # profile and publishes pkg/ to npm. The key hashes every input
+          # baked into pkg/, not just Rust sources — the runtime sidecar and
+          # package.json template that build-wasm.sh copies in, plus the
+          # helper template and fonts embedded via include_str!/include_bytes!
+          # — so an edit to any of them rebuilds instead of serving a stale
+          # pkg/ to vitest and the typecheck drift guard.
+          key: wasm-ci-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/**/*.rs', 'crates/bindings/wasm/runtime/**', 'crates/bindings/wasm/package.template.json', 'crates/backends/typst/src/lib.typ.template', 'crates/backends/typst/src/fonts/**', 'scripts/build-wasm.sh') }}
 
       - name: Install wasm-bindgen-cli
         if: steps.wasm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,7 @@ jobs:
         working-directory: crates/bindings/wasm
         run: npx vitest run
 
+      - name: Typecheck WASM (canonical runtime.d.ts drift guard)
+        working-directory: crates/bindings/wasm
+        run: npm run typecheck
+

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -22,7 +22,9 @@ use quillmark_pdf::{stamp, PdfError, StampOptions};
 /// Map a stamp-spine [`PdfError`] to the backend's `RenderError`. The spine owns
 /// its own error type; this is the boundary translation.
 fn map_pdf_err(e: PdfError) -> RenderError {
-    RenderError::from_diag(Diagnostic::new(Severity::Error, e.message).with_code(e.code.to_string()))
+    RenderError::from_diag(
+        Diagnostic::new(Severity::Error, e.message).with_code(e.code.to_string()),
+    )
 }
 
 /// Build raster render options for a given pixels-per-point scale factor.
@@ -144,11 +146,8 @@ pub(crate) fn render_document_pages(
         OutputFormat::Pdf => {
             let pdf = typst_pdf::pdf(document, &PdfOptions::default()).map_err(|e| {
                 RenderError::from_diag(
-                    Diagnostic::new(
-                        Severity::Error,
-                        format!("PDF generation failed: {:?}", e),
-                    )
-                    .with_code("typst::pdf_generation".to_string()),
+                    Diagnostic::new(Severity::Error, format!("PDF generation failed: {:?}", e))
+                        .with_code("typst::pdf_generation".to_string()),
                 )
             })?;
             // Form-field placements → spine field specs (Typst top-left → PDF

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -63,10 +63,9 @@ pub struct TypstSession {
     /// data on `open` and every `apply`.
     transform_schema: QuillValue,
     /// `transform_schema`'s address/auto-eval tables, built once at `open`
-    /// (`None` only when the schema has no top-level `properties`) and reused
-    /// on every `apply` rather than rebuilt from `transform_schema`'s `$defs`
-    /// each time.
-    schema_meta: Option<SchemaMeta>,
+    /// and reused on every `apply` rather than rebuilt from
+    /// `transform_schema`'s `$defs` each time.
+    schema_meta: SchemaMeta,
     /// Per-page content fingerprints of the live compile; diffed against the
     /// next compile's to produce `ChangeSet::dirty_pages`.
     page_hashes: Vec<u128>,
@@ -124,11 +123,10 @@ fn page_hashes(document: &typst_layout::PagedDocument) -> Vec<u128> {
 
 /// Run the schema's markdown/date transform over raw document data and
 /// serialize it for helper-package injection. `meta` is the session's cached
-/// [`SchemaMeta`] (`None` only when the schema has no top-level `properties`
-/// — nothing to transform or validate against).
+/// [`SchemaMeta`].
 fn transformed_json_str(
     schema: &QuillValue,
-    meta: Option<&SchemaMeta>,
+    meta: &SchemaMeta,
     json_data: &serde_json::Value,
 ) -> Result<String, RenderError> {
     let fields = json_data.as_object().map_or_else(HashMap::new, |obj| {
@@ -137,10 +135,7 @@ fn transformed_json_str(
             .collect::<HashMap<_, _>>()
     });
 
-    let transformed_fields = match meta {
-        Some(meta) => transform_markdown_fields_with(&fields, schema, meta),
-        None => fields,
-    };
+    let transformed_fields = transform_markdown_fields(&fields, schema, meta);
     let transformed_json = serde_json::Value::Object(
         transformed_fields
             .into_iter()
@@ -204,8 +199,7 @@ impl SessionHandle for TypstSession {
     /// read keeps serving the last-good compile and its warnings (the world
     /// may hold the failed source; the next `apply` overwrites it).
     fn apply(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
-        let json_str =
-            transformed_json_str(&self.transform_schema, self.schema_meta.as_ref(), json_data)?;
+        let json_str = transformed_json_str(&self.transform_schema, &self.schema_meta, json_data)?;
         self.world.inject_helper_package(&json_str);
 
         let (document, compile_warnings) = compile::compile_document(&self.world)?;
@@ -306,7 +300,7 @@ impl Backend for TypstBackend {
 
         let transform_schema = build_transform_schema(source.config());
         let schema_meta = SchemaMeta::from_schema_json(transform_schema.as_json());
-        let json_str = transformed_json_str(&transform_schema, schema_meta.as_ref(), json_data)?;
+        let json_str = transformed_json_str(&transform_schema, &schema_meta, json_data)?;
         let world =
             world::QuillWorld::new_with_data(source, &plate_content, &json_str).map_err(|e| {
                 RenderError::from_diag(
@@ -439,16 +433,18 @@ fn date_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> 
         .collect()
 }
 
-/// Names of the `markdown[]` fields in a schema `properties` map — the subset
-/// of content fields the auto-tagger index-suffixes per element (`field.0`,
-/// `field.1`, ...). `tagged`'s path validator uses this to reject an index
-/// suffix on a scalar content field, which the auto-tagger never produces.
-fn markdown_array_field_names(
-    properties: &serde_json::Map<String, serde_json::Value>,
-) -> Vec<String> {
+/// Names of the array-typed fields in a schema `properties` map — the fields
+/// whose elements are addressable by index suffix (`field.0`, `field.1`, ...).
+/// `tagged`/`form-field`'s path validator uses this to reject an index suffix
+/// on a scalar field, where no element exists for the address to resolve to.
+/// Any array qualifies, matching the pdfform resolver's shallow-path grammar:
+/// the auto-tagger only *produces* indexed markers for `markdown[]` elements,
+/// but an explicit `tagged()` placement or widget binding of a plain array
+/// element is a real, routable address.
+fn array_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
     properties
         .iter()
-        .filter(|(_, fs)| is_markdown_array_field(fs))
+        .filter(|(_, fs)| fs.get("type").and_then(|v| v.as_str()) == Some("array"))
         .map(|(name, _)| name.clone())
         .collect()
 }
@@ -480,12 +476,17 @@ fn convert_content_value(value: &QuillValue) -> Option<QuillValue> {
 }
 
 /// Schema-derived tables backing `tagged`/`form-field` path validation and
-/// the helper's content/date auto-eval — pure functions of a transform
+/// the helper's content/date auto-eval — a pure function of a transform
 /// schema. `TypstSession` builds this once from `transform_schema` at `open`
 /// and reuses it on every `apply`, since the schema never changes for the
 /// session's lifetime; the recursive per-card pass in
 /// [`transform_cards_array`] still builds one fresh per call (each card's own
 /// schema is a different, and already cheap, computation).
+///
+/// A schema with no top-level `properties` yields the default (all tables
+/// empty) — `build_transform_schema` always emits `properties`, so that case
+/// only arises for hand-built schemas in tests. The template treats an empty
+/// `__meta__` the same as an absent one.
 #[derive(Default)]
 struct SchemaMeta {
     content_fields: Vec<String>,
@@ -499,14 +500,14 @@ struct SchemaMeta {
 }
 
 impl SchemaMeta {
-    /// `None` when `schema_json` has no top-level `properties` — nothing to
-    /// validate or auto-eval against.
-    fn from_schema_json(schema_json: &serde_json::Value) -> Option<Self> {
-        let properties_obj = schema_json.get("properties").and_then(|v| v.as_object())?;
+    fn from_schema_json(schema_json: &serde_json::Value) -> Self {
+        let Some(properties_obj) = schema_json.get("properties").and_then(|v| v.as_object()) else {
+            return Self::default();
+        };
 
         let content_fields = content_field_names(properties_obj);
         let date_fields = date_field_names(properties_obj);
-        let array_fields = markdown_array_field_names(properties_obj);
+        let array_fields = array_field_names(properties_obj);
         let fields = properties_obj.keys().cloned().collect();
 
         // Collect per-card-kind content/date/array field names from schema
@@ -548,13 +549,13 @@ impl SchemaMeta {
                     insert_names(
                         &mut card_array_fields,
                         card_kind,
-                        card_props.map(markdown_array_field_names).unwrap_or_default(),
+                        card_props.map(array_field_names).unwrap_or_default(),
                     );
                 }
             }
         }
 
-        Some(Self {
+        Self {
             content_fields,
             date_fields,
             array_fields,
@@ -563,7 +564,7 @@ impl SchemaMeta {
             card_field_names,
             card_array_fields,
             fields,
-        })
+        }
     }
 
     /// The `__meta__` object injected into document data for the helper
@@ -592,24 +593,10 @@ impl SchemaMeta {
 ///
 /// Also injects a `__meta__` key into the result containing the names of
 /// converted fields, which the quillmark-helper package uses to auto-evaluate
-/// markup strings into Typst content objects. Builds a fresh [`SchemaMeta`]
-/// from `schema` on every call — used for the recursive per-card pass; the
-/// top-level document pass uses [`transform_markdown_fields_with`] against a
-/// meta computed once at session open.
+/// markup strings into Typst content objects. `meta` is `schema`'s
+/// [`SchemaMeta`] — the session passes its per-open cache; the recursive
+/// per-card pass builds one fresh per card.
 fn transform_markdown_fields(
-    fields: &HashMap<String, QuillValue>,
-    schema: &QuillValue,
-) -> HashMap<String, QuillValue> {
-    match SchemaMeta::from_schema_json(schema.as_json()) {
-        Some(meta) => transform_markdown_fields_with(fields, schema, &meta),
-        None => fields.clone(),
-    }
-}
-
-/// Like [`transform_markdown_fields`], against a [`SchemaMeta`] already
-/// computed from `schema` rather than rebuilding it from the schema's
-/// `$defs` on every call.
-fn transform_markdown_fields_with(
     fields: &HashMap<String, QuillValue>,
     schema: &QuillValue,
     meta: &SchemaMeta,
@@ -677,10 +664,10 @@ fn transform_cards_array(
                     // drives card processing from the top-level `meta.card_*` maps and
                     // iterates each card directly, so strip the per-card `__meta__` rather
                     // than leak the sentinel into every card object plate authors see.
-                    let mut transformed_card_fields = transform_markdown_fields(
-                        &card_fields,
-                        &QuillValue::from_json(card_schema_json.clone()),
-                    );
+                    let card_schema = QuillValue::from_json(card_schema_json.clone());
+                    let card_meta = SchemaMeta::from_schema_json(card_schema.as_json());
+                    let mut transformed_card_fields =
+                        transform_markdown_fields(&card_fields, &card_schema, &card_meta);
                     transformed_card_fields.remove("__meta__");
 
                     // Convert back to JSON Value
@@ -706,6 +693,19 @@ fn transform_cards_array(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// [`transform_markdown_fields`] with `schema`'s meta built inline — the
+    /// session's cache is irrelevant to these unit cases.
+    fn transform(
+        fields: &HashMap<String, QuillValue>,
+        schema: &QuillValue,
+    ) -> HashMap<String, QuillValue> {
+        transform_markdown_fields(
+            fields,
+            schema,
+            &SchemaMeta::from_schema_json(schema.as_json()),
+        )
+    }
 
     #[test]
     fn test_backend_info() {
@@ -772,7 +772,7 @@ mod tests {
             QuillValue::from_json(json!(["This is **bold** text.", "Plain line."])),
         );
 
-        let result = transform_markdown_fields(&fields, &schema);
+        let result = transform(&fields, &schema);
 
         // Each element is converted to Typst markup.
         let sections = result.get("sections").unwrap().as_array().unwrap();
@@ -786,7 +786,10 @@ mod tests {
     }
 
     #[test]
-    fn schema_meta_array_fields_distinguish_scalar_from_markdown_array() {
+    fn schema_meta_array_fields_distinguish_scalar_from_array() {
+        // Any array is element-addressable (`field.N`) — markdown[] and plain
+        // string arrays alike, matching the pdfform resolver's grammar. Only
+        // scalars are excluded: no element exists for the address to resolve to.
         let schema = QuillValue::from_json(json!({
             "type": "object",
             "properties": {
@@ -794,6 +797,10 @@ mod tests {
                 "sections": {
                     "type": "array",
                     "items": { "type": "string", "contentMediaType": "text/markdown" }
+                },
+                "signature_block": {
+                    "type": "array",
+                    "items": { "type": "string" }
                 }
             },
             "$defs": {
@@ -803,16 +810,17 @@ mod tests {
                         "$body": { "type": "string", "contentMediaType": "text/markdown" },
                         "refs": {
                             "type": "array",
-                            "items": { "type": "string", "contentMediaType": "text/markdown" }
+                            "items": { "type": "string" }
                         }
                     }
                 }
             }
         }));
 
-        let meta = SchemaMeta::from_schema_json(schema.as_json()).expect("schema has properties");
+        let meta = SchemaMeta::from_schema_json(schema.as_json());
 
-        assert_eq!(meta.array_fields, vec!["sections".to_string()]);
+        assert!(meta.array_fields.contains(&"sections".to_string()));
+        assert!(meta.array_fields.contains(&"signature_block".to_string()));
         assert!(!meta.array_fields.contains(&"subject".to_string()));
 
         let card_arrays = meta.card_array_fields.get("indorsement").unwrap();
@@ -851,7 +859,7 @@ mod tests {
             QuillValue::from_json(json!("This is **bold** text.")),
         );
 
-        let result = transform_markdown_fields(&fields, &schema);
+        let result = transform(&fields, &schema);
 
         // title should be unchanged
         assert_eq!(result.get("title").unwrap().as_str(), Some("My Title"));
@@ -878,7 +886,7 @@ mod tests {
         );
         fields.insert("count".to_string(), QuillValue::from_json(json!(42)));
 
-        let result = transform_markdown_fields(&fields, &schema);
+        let result = transform(&fields, &schema);
 
         // All fields should be unchanged
         assert_eq!(result.get("title").unwrap().as_str(), Some("My Title"));
@@ -900,7 +908,7 @@ mod tests {
             QuillValue::from_json(json!("_italic_ text")),
         );
 
-        let result = transform_markdown_fields(&fields, &schema);
+        let result = transform(&fields, &schema);
 
         let body = result.get("$body").unwrap().as_str().unwrap();
         assert!(body.contains("#emph[italic]"));
@@ -923,7 +931,7 @@ mod tests {
             QuillValue::from_json(json!("My Title")),
         );
 
-        let result = transform_markdown_fields(&fields, &schema);
+        let result = transform(&fields, &schema);
         let meta = result.get("__meta__").expect("missing __meta__").as_json();
 
         let date_fields = meta["date_fields"].as_array().unwrap();
@@ -949,7 +957,7 @@ mod tests {
         }));
 
         let fields = HashMap::new();
-        let result = transform_markdown_fields(&fields, &schema);
+        let result = transform(&fields, &schema);
         let meta = result.get("__meta__").expect("missing __meta__").as_json();
 
         assert_eq!(

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -516,6 +516,15 @@ impl SchemaMeta {
         let mut card_date_fields = serde_json::Map::new();
         let mut card_field_names = serde_json::Map::new();
         let mut card_array_fields = serde_json::Map::new();
+        fn insert_names(
+            table: &mut serde_json::Map<String, serde_json::Value>,
+            kind: &str,
+            names: Vec<String>,
+        ) {
+            if !names.is_empty() {
+                table.insert(kind.to_string(), names.into());
+            }
+        }
         if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
             for (def_name, def_schema) in defs {
                 if let Some(card_kind) = def_name.strip_suffix("_card") {
@@ -523,45 +532,24 @@ impl SchemaMeta {
                     if let Some(props) = card_props {
                         card_field_names.insert(
                             card_kind.to_string(),
-                            serde_json::Value::Array(
-                                props
-                                    .keys()
-                                    .map(|k| serde_json::Value::String(k.clone()))
-                                    .collect(),
-                            ),
+                            props.keys().cloned().collect::<Vec<String>>().into(),
                         );
                     }
-                    let fields = card_props.map(content_field_names).unwrap_or_default();
-                    if !fields.is_empty() {
-                        card_content_fields.insert(
-                            card_kind.to_string(),
-                            serde_json::Value::Array(
-                                fields.into_iter().map(serde_json::Value::String).collect(),
-                            ),
-                        );
-                    }
-
-                    let dates = card_props.map(date_field_names).unwrap_or_default();
-                    if !dates.is_empty() {
-                        card_date_fields.insert(
-                            card_kind.to_string(),
-                            serde_json::Value::Array(
-                                dates.into_iter().map(serde_json::Value::String).collect(),
-                            ),
-                        );
-                    }
-
-                    let arrays = card_props
-                        .map(markdown_array_field_names)
-                        .unwrap_or_default();
-                    if !arrays.is_empty() {
-                        card_array_fields.insert(
-                            card_kind.to_string(),
-                            serde_json::Value::Array(
-                                arrays.into_iter().map(serde_json::Value::String).collect(),
-                            ),
-                        );
-                    }
+                    insert_names(
+                        &mut card_content_fields,
+                        card_kind,
+                        card_props.map(content_field_names).unwrap_or_default(),
+                    );
+                    insert_names(
+                        &mut card_date_fields,
+                        card_kind,
+                        card_props.map(date_field_names).unwrap_or_default(),
+                    );
+                    insert_names(
+                        &mut card_array_fields,
+                        card_kind,
+                        card_props.map(markdown_array_field_names).unwrap_or_default(),
+                    );
                 }
             }
         }

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -62,6 +62,11 @@ pub struct TypstSession {
     /// The quill schema's markdown/date transform, applied to the raw document
     /// data on `open` and every `apply`.
     transform_schema: QuillValue,
+    /// `transform_schema`'s address/auto-eval tables, built once at `open`
+    /// (`None` only when the schema has no top-level `properties`) and reused
+    /// on every `apply` rather than rebuilt from `transform_schema`'s `$defs`
+    /// each time.
+    schema_meta: Option<SchemaMeta>,
     /// Per-page content fingerprints of the live compile; diffed against the
     /// next compile's to produce `ChangeSet::dirty_pages`.
     page_hashes: Vec<u128>,
@@ -118,9 +123,12 @@ fn page_hashes(document: &typst_layout::PagedDocument) -> Vec<u128> {
 }
 
 /// Run the schema's markdown/date transform over raw document data and
-/// serialize it for helper-package injection.
+/// serialize it for helper-package injection. `meta` is the session's cached
+/// [`SchemaMeta`] (`None` only when the schema has no top-level `properties`
+/// — nothing to transform or validate against).
 fn transformed_json_str(
     schema: &QuillValue,
+    meta: Option<&SchemaMeta>,
     json_data: &serde_json::Value,
 ) -> Result<String, RenderError> {
     let fields = json_data.as_object().map_or_else(HashMap::new, |obj| {
@@ -129,7 +137,10 @@ fn transformed_json_str(
             .collect::<HashMap<_, _>>()
     });
 
-    let transformed_fields = transform_markdown_fields(&fields, schema);
+    let transformed_fields = match meta {
+        Some(meta) => transform_markdown_fields_with(&fields, schema, meta),
+        None => fields,
+    };
     let transformed_json = serde_json::Value::Object(
         transformed_fields
             .into_iter()
@@ -193,7 +204,8 @@ impl SessionHandle for TypstSession {
     /// read keeps serving the last-good compile and its warnings (the world
     /// may hold the failed source; the next `apply` overwrites it).
     fn apply(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
-        let json_str = transformed_json_str(&self.transform_schema, json_data)?;
+        let json_str =
+            transformed_json_str(&self.transform_schema, self.schema_meta.as_ref(), json_data)?;
         self.world.inject_helper_package(&json_str);
 
         let (document, compile_warnings) = compile::compile_document(&self.world)?;
@@ -293,7 +305,8 @@ impl Backend for TypstBackend {
         let plate_content = read_plate(source)?;
 
         let transform_schema = build_transform_schema(source.config());
-        let json_str = transformed_json_str(&transform_schema, json_data)?;
+        let schema_meta = SchemaMeta::from_schema_json(transform_schema.as_json());
+        let json_str = transformed_json_str(&transform_schema, schema_meta.as_ref(), json_data)?;
         let world =
             world::QuillWorld::new_with_data(source, &plate_content, &json_str).map_err(|e| {
                 RenderError::from_diag(
@@ -315,6 +328,7 @@ impl Backend for TypstBackend {
             page_count,
             field_placements,
             transform_schema,
+            schema_meta,
             page_hashes: hashes,
             compile_warnings,
         };
@@ -425,6 +439,20 @@ fn date_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> 
         .collect()
 }
 
+/// Names of the `markdown[]` fields in a schema `properties` map — the subset
+/// of content fields the auto-tagger index-suffixes per element (`field.0`,
+/// `field.1`, ...). `tagged`'s path validator uses this to reject an index
+/// suffix on a scalar content field, which the auto-tagger never produces.
+fn markdown_array_field_names(
+    properties: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<String> {
+    properties
+        .iter()
+        .filter(|(_, fs)| is_markdown_array_field(fs))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
 /// Convert a content field's value to backend markup: a markdown string is
 /// converted in place; a `markdown[]` array converts each string element.
 /// Returns `None` when the value is neither (e.g. a string that fails to
@@ -451,6 +479,123 @@ fn convert_content_value(value: &QuillValue) -> Option<QuillValue> {
     }
 }
 
+/// Schema-derived tables backing `tagged`/`form-field` path validation and
+/// the helper's content/date auto-eval — pure functions of a transform
+/// schema. `TypstSession` builds this once from `transform_schema` at `open`
+/// and reuses it on every `apply`, since the schema never changes for the
+/// session's lifetime; the recursive per-card pass in
+/// [`transform_cards_array`] still builds one fresh per call (each card's own
+/// schema is a different, and already cheap, computation).
+#[derive(Default)]
+struct SchemaMeta {
+    content_fields: Vec<String>,
+    date_fields: Vec<String>,
+    array_fields: Vec<String>,
+    card_content_fields: serde_json::Map<String, serde_json::Value>,
+    card_date_fields: serde_json::Map<String, serde_json::Value>,
+    card_field_names: serde_json::Map<String, serde_json::Value>,
+    card_array_fields: serde_json::Map<String, serde_json::Value>,
+    fields: Vec<String>,
+}
+
+impl SchemaMeta {
+    /// `None` when `schema_json` has no top-level `properties` — nothing to
+    /// validate or auto-eval against.
+    fn from_schema_json(schema_json: &serde_json::Value) -> Option<Self> {
+        let properties_obj = schema_json.get("properties").and_then(|v| v.as_object())?;
+
+        let content_fields = content_field_names(properties_obj);
+        let date_fields = date_field_names(properties_obj);
+        let array_fields = markdown_array_field_names(properties_obj);
+        let fields = properties_obj.keys().cloned().collect();
+
+        // Collect per-card-kind content/date/array field names from schema
+        // $defs, plus the full per-kind property-name lists that back
+        // `tagged`/`form-field` path validation.
+        let mut card_content_fields = serde_json::Map::new();
+        let mut card_date_fields = serde_json::Map::new();
+        let mut card_field_names = serde_json::Map::new();
+        let mut card_array_fields = serde_json::Map::new();
+        if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
+            for (def_name, def_schema) in defs {
+                if let Some(card_kind) = def_name.strip_suffix("_card") {
+                    let card_props = def_schema.get("properties").and_then(|v| v.as_object());
+                    if let Some(props) = card_props {
+                        card_field_names.insert(
+                            card_kind.to_string(),
+                            serde_json::Value::Array(
+                                props
+                                    .keys()
+                                    .map(|k| serde_json::Value::String(k.clone()))
+                                    .collect(),
+                            ),
+                        );
+                    }
+                    let fields = card_props.map(content_field_names).unwrap_or_default();
+                    if !fields.is_empty() {
+                        card_content_fields.insert(
+                            card_kind.to_string(),
+                            serde_json::Value::Array(
+                                fields.into_iter().map(serde_json::Value::String).collect(),
+                            ),
+                        );
+                    }
+
+                    let dates = card_props.map(date_field_names).unwrap_or_default();
+                    if !dates.is_empty() {
+                        card_date_fields.insert(
+                            card_kind.to_string(),
+                            serde_json::Value::Array(
+                                dates.into_iter().map(serde_json::Value::String).collect(),
+                            ),
+                        );
+                    }
+
+                    let arrays = card_props
+                        .map(markdown_array_field_names)
+                        .unwrap_or_default();
+                    if !arrays.is_empty() {
+                        card_array_fields.insert(
+                            card_kind.to_string(),
+                            serde_json::Value::Array(
+                                arrays.into_iter().map(serde_json::Value::String).collect(),
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+
+        Some(Self {
+            content_fields,
+            date_fields,
+            array_fields,
+            card_content_fields,
+            card_date_fields,
+            card_field_names,
+            card_array_fields,
+            fields,
+        })
+    }
+
+    /// The `__meta__` object injected into document data for the helper
+    /// package: content/date auto-eval field lists, plus the schema address
+    /// tables (`fields` / `card_fields` / `array_fields` / `card_array_fields`)
+    /// that `tagged`/`form-field` validate explicit region paths against.
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "content_fields": self.content_fields,
+            "card_content_fields": self.card_content_fields,
+            "date_fields": self.date_fields,
+            "card_date_fields": self.card_date_fields,
+            "fields": self.fields,
+            "card_fields": self.card_field_names,
+            "array_fields": self.array_fields,
+            "card_array_fields": self.card_array_fields,
+        })
+    }
+}
+
 /// Transform markdown fields to Typst markup based on schema.
 ///
 /// Identifies fields with `contentMediaType = "text/markdown"` and converts
@@ -459,32 +604,39 @@ fn convert_content_value(value: &QuillValue) -> Option<QuillValue> {
 ///
 /// Also injects a `__meta__` key into the result containing the names of
 /// converted fields, which the quillmark-helper package uses to auto-evaluate
-/// markup strings into Typst content objects.
+/// markup strings into Typst content objects. Builds a fresh [`SchemaMeta`]
+/// from `schema` on every call — used for the recursive per-card pass; the
+/// top-level document pass uses [`transform_markdown_fields_with`] against a
+/// meta computed once at session open.
 fn transform_markdown_fields(
     fields: &HashMap<String, QuillValue>,
     schema: &QuillValue,
 ) -> HashMap<String, QuillValue> {
-    let mut result = fields.clone();
-    let schema_json = schema.as_json();
+    match SchemaMeta::from_schema_json(schema.as_json()) {
+        Some(meta) => transform_markdown_fields_with(fields, schema, &meta),
+        None => fields.clone(),
+    }
+}
 
-    // Get the properties object from the schema
-    let properties_obj = match schema_json.get("properties").and_then(|v| v.as_object()) {
-        Some(obj) => obj,
-        None => return result,
-    };
+/// Like [`transform_markdown_fields`], against a [`SchemaMeta`] already
+/// computed from `schema` rather than rebuilding it from the schema's
+/// `$defs` on every call.
+fn transform_markdown_fields_with(
+    fields: &HashMap<String, QuillValue>,
+    schema: &QuillValue,
+    meta: &SchemaMeta,
+) -> HashMap<String, QuillValue> {
+    let mut result = fields.clone();
 
     // Convert every markdown / markdown[] field the schema declares; the
     // helper package maps `eval(.., mode: "markup")` over these names.
-    let content_fields = content_field_names(properties_obj);
-    for field_name in &content_fields {
+    for field_name in &meta.content_fields {
         if let Some(value) = fields.get(field_name) {
             if let Some(converted) = convert_content_value(value) {
                 result.insert(field_name.clone(), converted);
             }
         }
     }
-
-    let date_fields = date_field_names(properties_obj);
 
     // Handle `$cards` array recursively
     if let Some(cards_value) = result.get("$cards") {
@@ -497,68 +649,9 @@ fn transform_markdown_fields(
         }
     }
 
-    // Collect per-card-kind content field names from schema $defs, plus the
-    // full per-kind property-name lists that back `tagged` path validation.
-    let mut card_content_fields = serde_json::Map::new();
-    let mut card_date_fields = serde_json::Map::new();
-    let mut card_field_names = serde_json::Map::new();
-    if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
-        for (def_name, def_schema) in defs {
-            if let Some(card_kind) = def_name.strip_suffix("_card") {
-                let card_props = def_schema.get("properties").and_then(|v| v.as_object());
-                if let Some(props) = card_props {
-                    card_field_names.insert(
-                        card_kind.to_string(),
-                        serde_json::Value::Array(
-                            props
-                                .keys()
-                                .map(|k| serde_json::Value::String(k.clone()))
-                                .collect(),
-                        ),
-                    );
-                }
-                let card_fields = card_props.map(content_field_names).unwrap_or_default();
-                if !card_fields.is_empty() {
-                    card_content_fields.insert(
-                        card_kind.to_string(),
-                        serde_json::Value::Array(
-                            card_fields
-                                .into_iter()
-                                .map(serde_json::Value::String)
-                                .collect(),
-                        ),
-                    );
-                }
-
-                let date_fields = card_props.map(date_field_names).unwrap_or_default();
-                if !date_fields.is_empty() {
-                    card_date_fields.insert(
-                        card_kind.to_string(),
-                        serde_json::Value::Array(
-                            date_fields
-                                .into_iter()
-                                .map(serde_json::Value::String)
-                                .collect(),
-                        ),
-                    );
-                }
-            }
-        }
-    }
-
-    // Inject __meta__ so the helper package can auto-eval content fields.
-    // `fields` / `card_fields` are the full schema property-name tables the
-    // helper's `tagged` validates explicit region paths against.
     result.insert(
         "__meta__".to_string(),
-        QuillValue::from_json(serde_json::json!({
-            "content_fields": content_fields,
-            "card_content_fields": card_content_fields,
-            "date_fields": date_fields,
-            "card_date_fields": card_date_fields,
-            "fields": properties_obj.keys().collect::<Vec<_>>(),
-            "card_fields": card_field_names,
-        })),
+        QuillValue::from_json(meta.to_json()),
     );
 
     result
@@ -702,6 +795,40 @@ mod tests {
         let meta = result.get("__meta__").unwrap().as_json();
         let content_fields = meta["content_fields"].as_array().unwrap();
         assert!(content_fields.iter().any(|v| v == "sections"));
+    }
+
+    #[test]
+    fn schema_meta_array_fields_distinguish_scalar_from_markdown_array() {
+        let schema = QuillValue::from_json(json!({
+            "type": "object",
+            "properties": {
+                "subject": { "type": "string", "contentMediaType": "text/markdown" },
+                "sections": {
+                    "type": "array",
+                    "items": { "type": "string", "contentMediaType": "text/markdown" }
+                }
+            },
+            "$defs": {
+                "indorsement_card": {
+                    "type": "object",
+                    "properties": {
+                        "$body": { "type": "string", "contentMediaType": "text/markdown" },
+                        "refs": {
+                            "type": "array",
+                            "items": { "type": "string", "contentMediaType": "text/markdown" }
+                        }
+                    }
+                }
+            }
+        }));
+
+        let meta = SchemaMeta::from_schema_json(schema.as_json()).expect("schema has properties");
+
+        assert_eq!(meta.array_fields, vec!["sections".to_string()]);
+        assert!(!meta.array_fields.contains(&"subject".to_string()));
+
+        let card_arrays = meta.card_array_fields.get("indorsement").unwrap();
+        assert_eq!(card_arrays, &serde_json::json!(["refs"]));
     }
 
     #[test]

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -1,6 +1,51 @@
 // Auto-generated quillmark-helper package
 // Version: {version}
 
+/// Raw document JSON, including the `__meta__` sentinel the Rust backend
+/// injects. Parsed once; `data` strips the sentinel before plates see it.
+/// Must be defined before `form-field`/`tagged` — Typst does not hoist `#let`
+/// bindings, and both validate a `field:`/`field` path against `_qm-meta`.
+#let _qm-raw = json(bytes("{escaped_json}"))
+
+/// Backend-injected metadata: content/date field lists driving the auto
+/// passes, plus the schema address tables (`fields`, `card_fields`,
+/// `array_fields`, `card_array_fields`) that validate `tagged`/`form-field`
+/// paths.
+#let _qm-meta = _qm-raw.at("__meta__", default: (:))
+
+/// Whether `path` parses against the schema address tables: a top-level field
+/// (`subject`), a markdown[] element (`refs.2`), or a card address
+/// (`$cards.<kind>.<n>.<field>`, optional `.<i>` element suffix). An indexed
+/// suffix (`field.N`) is only ever a real address for a `markdown[]` field —
+/// the auto-tagger index-suffixes array elements and never a scalar — so it
+/// validates against `array_fields`/`card_array_fields`, not the broader
+/// `fields`/`card_fields` name tables, rejecting `subject.0` on a scalar
+/// `subject` even though the name itself is known. Permissive when the tables
+/// are absent (no `__meta__`) — validation then has nothing to check against.
+#let _qm-known-path(path) = {
+  let fields = _qm-meta.at("fields", default: ())
+  let card-fields = _qm-meta.at("card_fields", default: (:))
+  if fields.len() == 0 and card-fields.len() == 0 { return true }
+  let array-fields = _qm-meta.at("array_fields", default: ())
+  let card-array-fields = _qm-meta.at("card_array_fields", default: (:))
+  let is-index(s) = s.match(regex("^[0-9]+$")) != none
+  let parts = path.split(".")
+  if parts.at(0) == "$cards" {
+    if parts.len() < 4 or parts.len() > 5 { return false }
+    let kind = parts.at(1)
+    if not (kind in card-fields) { return false }
+    if not is-index(parts.at(2)) { return false }
+    let field = parts.at(3)
+    if parts.len() == 5 {
+      return field in card-array-fields.at(kind, default: ()) and is-index(parts.at(4))
+    }
+    return field in card-fields.at(kind)
+  }
+  if parts.len() == 1 { return path in fields }
+  if parts.len() == 2 { return parts.at(0) in array-fields and is-index(parts.at(1)) }
+  false
+}
+
 /// Emit an unsigned form field. PDF: a clickable AcroForm widget here (a text
 /// box, checkbox, dropdown, or signature). SVG/PNG: same invisible layout
 /// space.
@@ -50,6 +95,8 @@
     message: "form-field: type must be one of text/checkbox/choice/signature, got " + repr(type))
   assert(field == none or std.type(field) == str,
     message: "form-field: field must be a string or none, got " + repr(std.type(field)))
+  assert(field == none or _qm-known-path(field),
+    message: "form-field: " + repr(field) + " is not a schema field address; expected a field name, a markdown[] element like \"refs.2\", or a card path composed from the card's $path prefix")
   let abs-pt(field, l) = {
     let r = repr(l)
     assert(not (r.contains("em") or r.ends-with("%")),
@@ -102,15 +149,6 @@
   datetime(year: year, month: month, day: day)
 }
 
-/// Raw document JSON, including the `__meta__` sentinel the Rust backend
-/// injects. Parsed once; `data` strips the sentinel before plates see it.
-#let _qm-raw = json(bytes("{escaped_json}"))
-
-/// Backend-injected metadata: content/date field lists driving the auto
-/// passes, plus the schema address tables (`fields`, `card_fields`) that
-/// validate `tagged` paths.
-#let _qm-meta = _qm-raw.at("__meta__", default: (:))
-
 // Region tagging: wrap content between two zero-size `<__qm_region__>`
 // metadata markers carrying its schema-field `path`; the backend reads their
 // frame positions back into a region rect (`session.regions()`). Zero-size is
@@ -123,30 +161,6 @@
   [#metadata((kind: "qm-region", role: "start", field: path)) <__qm_region__>]
   body
   [#metadata((kind: "qm-region", role: "end", field: path)) <__qm_region__>]
-}
-
-/// Whether `path` parses against the schema address tables: a top-level field
-/// (`subject`), a markdown[] element (`refs.2`), or a card address
-/// (`$cards.<kind>.<n>.<field>`, optional `.<i>` element suffix). Permissive
-/// when the tables are absent (no `__meta__`) — validation then has nothing to
-/// check against.
-#let _qm-known-path(path) = {
-  let fields = _qm-meta.at("fields", default: ())
-  let card-fields = _qm-meta.at("card_fields", default: (:))
-  if fields.len() == 0 and card-fields.len() == 0 { return true }
-  let is-index(s) = s.match(regex("^[0-9]+$")) != none
-  let parts = path.split(".")
-  if parts.at(0) == "$cards" {
-    if parts.len() < 4 or parts.len() > 5 { return false }
-    if not (parts.at(1) in card-fields) { return false }
-    if not is-index(parts.at(2)) { return false }
-    let known = parts.at(3) in card-fields.at(parts.at(1))
-    if parts.len() == 5 { return known and is-index(parts.at(4)) }
-    return known
-  }
-  if parts.len() == 1 { return path in fields }
-  if parts.len() == 2 { return parts.at(0) in fields and is-index(parts.at(1)) }
-  false
 }
 
 /// Tag `body` as the placement of schema field `field`, so it surfaces a

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -14,14 +14,15 @@
 #let _qm-meta = _qm-raw.at("__meta__", default: (:))
 
 /// Whether `path` parses against the schema address tables: a top-level field
-/// (`subject`), a markdown[] element (`refs.2`), or a card address
+/// (`subject`), an array element (`refs.2`), or a card address
 /// (`$cards.<kind>.<n>.<field>`, optional `.<i>` element suffix). An indexed
-/// suffix (`field.N`) is only ever a real address for a `markdown[]` field —
-/// the auto-tagger index-suffixes array elements and never a scalar — so it
-/// validates against `array_fields`/`card_array_fields`, not the broader
-/// `fields`/`card_fields` name tables, rejecting `subject.0` on a scalar
-/// `subject` even though the name itself is known. Permissive when the tables
-/// are absent (no `__meta__`) — validation then has nothing to check against.
+/// suffix (`field.N`) is only a real address for an array-typed field — any
+/// array, matching the pdfform resolver's grammar — so it validates against
+/// `array_fields`/`card_array_fields`, not the broader `fields`/`card_fields`
+/// name tables, rejecting `subject.0` on a scalar `subject` even though the
+/// name itself is known: a scalar has no element for the address to resolve
+/// to. Permissive when the tables are absent (no `__meta__`) — validation
+/// then has nothing to check against.
 #let _qm-known-path(path) = {
   let fields = _qm-meta.at("fields", default: ())
   let card-fields = _qm-meta.at("card_fields", default: (:))
@@ -96,7 +97,7 @@
   assert(field == none or std.type(field) == str,
     message: "form-field: field must be a string or none, got " + repr(std.type(field)))
   assert(field == none or _qm-known-path(field),
-    message: "form-field: " + repr(field) + " is not a schema field address; expected a field name, a markdown[] element like \"refs.2\", or a card path composed from the card's $path prefix")
+    message: "form-field: " + repr(field) + " is not a schema field address; expected a field name, an array element like \"refs.2\", or a card path composed from the card's $path prefix")
   let abs-pt(field, l) = {
     let r = repr(l)
     assert(not (r.contains("em") or r.ends-with("%")),
@@ -174,7 +175,7 @@
 /// draws, package chrome included — where an auto-tag covers the field value's
 /// own ink.
 ///
-/// `field` must be a schema address: a field name (`"subject"`), a markdown[]
+/// `field` must be a schema address: a field name (`"subject"`), an array
 /// element (`"refs.2"`), or a card path (`"$cards.indorsement.1.from"`).
 /// Compose card paths from the card's injected `$path` prefix —
 /// `tagged(card.at("$path") + "from")[..]` — rather than hand-writing the
@@ -184,7 +185,7 @@
   assert(std.type(field) == str,
     message: "tagged: field must be a string, got " + repr(std.type(field)))
   assert(_qm-known-path(field),
-    message: "tagged: " + repr(field) + " is not a schema field address; expected a field name, a markdown[] element like \"refs.2\", or a card path composed from the card's $path prefix")
+    message: "tagged: " + repr(field) + " is not a schema field address; expected a field name, an array element like \"refs.2\", or a card path composed from the card's $path prefix")
   _qm-tag(field, body)
 }
 

--- a/crates/backends/typst/src/overlay/region_scan.rs
+++ b/crates/backends/typst/src/overlay/region_scan.rs
@@ -197,12 +197,10 @@ fn walk(frame: &Frame, ts: Transform, page_idx: usize, scan: &mut Scan) {
                         Role::Start => {
                             let next_instance = scan.instances.len();
                             let entry =
-                                scan.open
-                                    .entry(field.clone())
-                                    .or_insert_with(|| OpenField {
-                                        instance: next_instance,
-                                        depth: 0,
-                                    });
+                                scan.open.entry(field.clone()).or_insert_with(|| OpenField {
+                                    instance: next_instance,
+                                    depth: 0,
+                                });
                             if entry.depth == 0 {
                                 scan.instances.push(field.clone());
                             }

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -186,6 +186,58 @@ typst:
 }
 
 #[test]
+fn widget_and_tagged_content_both_surface_widget_ordered_first() {
+    // A field bound to both a `field:`-bound widget and a `tagged(..)`
+    // placement surfaces both (they route to the same field; a consumer
+    // groups by `field`), deterministically ordered widget-first — the
+    // contract documented on `SessionHandle::regions` and `TypstSession::regions`.
+    const YAML: &str = r#"
+quill:
+  name: widget_and_content
+  version: 0.1.0
+  backend: typst
+  description: widget-before-content ordering test
+main:
+  fields:
+    signature_block:
+      type: string
+      description: bound to both a widget and a tagged content placement
+typst:
+  plate_file: plate.typ
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged, signature-field
+#set page(width: 612pt, height: 792pt, margin: 72pt)
+
+#tagged("signature_block")[#data.signature_block]
+#signature-field("Signature", field: "signature_block")
+"#;
+    let data = serde_json::json!({ "signature_block": "FIRST M. LAST, Rank, USAF" });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let regions = session.regions();
+    let matches: Vec<_> = regions
+        .iter()
+        .filter(|r| r.field == "signature_block")
+        .collect();
+    assert_eq!(
+        matches.len(),
+        2,
+        "a widget-bound field with tagged content surfaces both: {regions:?}"
+    );
+
+    // The widget is a fixed-size box (200pt wide by default); the tagged
+    // content region is the ink of the placed string, distinguishing which
+    // entry is which without relying on a `source` field the type doesn't
+    // carry.
+    assert_eq!(
+        matches[0].rect[2] - matches[0].rect[0],
+        200.0,
+        "the widget region sorts first: {regions:?}"
+    );
+}
+
+#[test]
 fn nested_same_field_tags_collapse_into_one_placement() {
     // A plate that wraps an already-auto-tagged verbatim value in an explicit
     // `tagged(..)` double-tags one placement; the scan depth-counts and emits
@@ -252,6 +304,77 @@ main:
     assert!(
         msg.contains("subjcet"),
         "the compile error names the bad path: {msg}"
+    );
+}
+
+#[test]
+fn tagged_scalar_index_path_fails_the_compile() {
+    // `field.N` is only ever a real address for a markdown[] field — the
+    // auto-tagger index-suffixes array elements and never a scalar — so an
+    // index suffix on a known scalar field must fail validation too, not just
+    // an unknown name.
+    const YAML: &str = r#"
+quill:
+  name: tagged_scalar_index
+  version: 0.1.0
+  backend: typst
+  description: tagged array-type validation test
+main:
+  fields:
+    subject:
+      type: string
+      description: a scalar field, not markdown[]
+typst:
+  plate_file: plate.typ
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#tagged("subject.0")[#data.subject]
+"#;
+    let data = serde_json::json!({ "subject": "not an array" });
+
+    let err = TypstBackend
+        .open(&quill(YAML, PLATE), &data)
+        .err()
+        .expect("an index suffix on a scalar field must fail the compile");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("subject.0"),
+        "the compile error names the bad path: {msg}"
+    );
+}
+
+#[test]
+fn tagged_array_index_path_compiles_and_emits_region() {
+    // The positive counterpart: an index suffix on a genuine `markdown[]`
+    // field is a real address and must still validate.
+    const YAML: &str = r#"
+quill:
+  name: tagged_array_index
+  version: 0.1.0
+  backend: typst
+  description: tagged array-type validation positive test
+main:
+  fields:
+    refs:
+      type: array
+      items:
+        type: markdown
+      description: a markdown[] field
+typst:
+  plate_file: plate.typ
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#tagged("refs.0")[#data.refs.at(0)]
+"#;
+    let data = serde_json::json!({ "refs": ["First reference."] });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let regions = session.regions();
+    assert!(
+        regions.iter().any(|r| r.field == "refs.0"),
+        "a tagged markdown[] index path compiles and surfaces a region: {regions:?}"
     );
 }
 
@@ -399,7 +522,8 @@ fn form_field_region_needs_a_schema_binding() {
     // Only a schema-addressable widget surfaces a region. `field:` keys it on a
     // schema path (so a signature widget named "Signature" routes to
     // `signature_block`); a widget that binds none has only a `/T` name and
-    // exposes nothing.
+    // exposes nothing. `field:` validates against the schema like `tagged`, so
+    // `signature_block` must be a declared field.
     const YAML: &str = r#"
 quill:
   name: field_binding
@@ -409,7 +533,13 @@ quill:
 typst:
   plate_file: plate.typ
 main:
-  fields: {}
+  fields:
+    signature_block:
+      type: array
+      items:
+        type: string
+      default: []
+      description: the signer's name and title
 "#;
     const PLATE: &str = r#"
 #import "@local/quillmark-helper:0.1.0": form-field, signature-field

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -309,10 +309,9 @@ main:
 
 #[test]
 fn tagged_scalar_index_path_fails_the_compile() {
-    // `field.N` is only ever a real address for a markdown[] field — the
-    // auto-tagger index-suffixes array elements and never a scalar — so an
-    // index suffix on a known scalar field must fail validation too, not just
-    // an unknown name.
+    // `field.N` is only a real address for an array-typed field — a scalar
+    // has no element for the address to resolve to — so an index suffix on a
+    // known scalar field must fail validation too, not just an unknown name.
     const YAML: &str = r#"
 quill:
   name: tagged_scalar_index
@@ -323,7 +322,7 @@ main:
   fields:
     subject:
       type: string
-      description: a scalar field, not markdown[]
+      description: a scalar field, not an array
 typst:
   plate_file: plate.typ
 "#;
@@ -376,6 +375,45 @@ typst:
         regions.iter().any(|r| r.field == "refs.0"),
         "a tagged markdown[] index path compiles and surfaces a region: {regions:?}"
     );
+}
+
+#[test]
+fn plain_array_index_paths_validate_for_tagged_and_widgets() {
+    // Any array is element-addressable, not just markdown[] — the same
+    // shallow-path grammar the pdfform resolver binds (`field.0` into a plain
+    // string array). Both binding surfaces accept it: an explicit `tagged`
+    // placement and a `form-field` `field:` binding.
+    const YAML: &str = r#"
+quill:
+  name: plain_array_index
+  version: 0.1.0
+  backend: typst
+  description: plain-array element address test
+main:
+  fields:
+    signature_block:
+      type: array
+      items:
+        type: string
+      description: a plain string array, no markdown
+typst:
+  plate_file: plate.typ
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged, form-field
+#tagged("signature_block.0")[#data.signature_block.at(0)]
+#form-field("sig1", type: "text", value: "x", field: "signature_block.1")
+"#;
+    let data = serde_json::json!({ "signature_block": ["FIRST M. LAST", "Duty Title"] });
+
+    let session = TypstBackend.open(&quill(YAML, PLATE), &data).expect("open");
+    let regions = session.regions();
+    for expected in ["signature_block.0", "signature_block.1"] {
+        assert!(
+            regions.iter().any(|r| r.field == expected),
+            "plain-array element address {expected:?} validates and surfaces a region: {regions:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -210,7 +210,7 @@ typst:
 #set page(width: 612pt, height: 792pt, margin: 72pt)
 
 #tagged("signature_block")[#data.signature_block]
-#signature-field("Signature", field: "signature_block")
+#signature-field("Signature", field: "signature_block", width: 137pt)
 "#;
     let data = serde_json::json!({ "signature_block": "FIRST M. LAST, Rank, USAF" });
 
@@ -226,13 +226,13 @@ typst:
         "a widget-bound field with tagged content surfaces both: {regions:?}"
     );
 
-    // The widget is a fixed-size box (200pt wide by default); the tagged
-    // content region is the ink of the placed string, distinguishing which
-    // entry is which without relying on a `source` field the type doesn't
-    // carry.
+    // The widget is a fixed-size box at the test-owned 137pt width; the
+    // tagged content region is the ink of the placed string, distinguishing
+    // which entry is which without relying on a `source` field the type
+    // doesn't carry.
     assert_eq!(
         matches[0].rect[2] - matches[0].rect[0],
-        200.0,
+        137.0,
         "the widget region sorts first: {regions:?}"
     );
 }

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -553,20 +553,57 @@ fn form_field_value_binding_from_data() {
 /// keyed on that schema path (of any field type), each carrying page+geometry. A
 /// widget that binds no schema field has only a `/T` name — not a schema
 /// address — and surfaces nothing. A session-level query, not a render output.
-/// `field:` validates against the schema like `tagged`, so each binding below
-/// is a field the `usaf_memo` host fixture actually declares.
+/// `field:` validates against the schema like `tagged`, so the test owns its
+/// schema (declaring every bound field) rather than borrowing the host
+/// fixture's field inventory — a fixture edit cannot break a widget test.
 #[test]
 fn form_field_regions_key_on_bound_schema_field() {
+    const YAML: &str = r#"
+quill:
+  name: widget_regions
+  version: 0.1.0
+  backend: typst
+  description: form-field region binding test
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    f_txt:
+      type: string
+      description: text widget binding
+    f_chk:
+      type: boolean
+      description: checkbox widget binding
+    f_cho:
+      type: string
+      description: choice widget binding
+    f_sig:
+      type: string
+      description: signature widget binding
+"#;
     let plate = r#"
 #import "@local/quillmark-helper:0.1.0": form-field
 #set page(width: 600pt, height: 400pt, margin: 50pt)
-#form-field("txt", type: "text", value: "hi", field: "subject")
-#form-field("chk", type: "checkbox", value: true, field: "dissemination")
-#form-field("cho", type: "choice", options: ("A", "B"), value: "B", field: "memo_style")
-#form-field("sig", type: "signature", field: "tag_line")
+#form-field("txt", type: "text", value: "hi", field: "f_txt")
+#form-field("chk", type: "checkbox", value: true, field: "f_chk")
+#form-field("cho", type: "choice", options: ("A", "B"), value: "B", field: "f_cho")
+#form-field("sig", type: "signature", field: "f_sig")
 #form-field("unbound", type: "text", value: "x")
 "#;
-    let source = source_with_plate(plate);
+    let mut files = HashMap::new();
+    files.insert(
+        "Quill.yaml".to_string(),
+        FileTreeNode::File {
+            contents: YAML.as_bytes().to_vec(),
+        },
+    );
+    files.insert(
+        "plate.typ".to_string(),
+        FileTreeNode::File {
+            contents: plate.as_bytes().to_vec(),
+        },
+    );
+    let source = Quill::from_tree(FileTreeNode::Directory { files }).expect("load quill");
     let session = TypstBackend
         .open(&source, &serde_json::json!({}))
         .expect("open");
@@ -575,7 +612,7 @@ fn form_field_regions_key_on_bound_schema_field() {
     let fields: std::collections::HashMap<&str, &quillmark_core::RenderedRegion> =
         regions.iter().map(|r| (r.field.as_str(), r)).collect();
 
-    for field in ["subject", "dissemination", "memo_style", "tag_line"] {
+    for field in ["f_txt", "f_chk", "f_cho", "f_sig"] {
         let r = fields
             .get(field)
             .unwrap_or_else(|| panic!("region keyed on bound schema field {field:?}"));

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -553,15 +553,17 @@ fn form_field_value_binding_from_data() {
 /// keyed on that schema path (of any field type), each carrying page+geometry. A
 /// widget that binds no schema field has only a `/T` name — not a schema
 /// address — and surfaces nothing. A session-level query, not a render output.
+/// `field:` validates against the schema like `tagged`, so each binding below
+/// is a field the `usaf_memo` host fixture actually declares.
 #[test]
 fn form_field_regions_key_on_bound_schema_field() {
     let plate = r#"
 #import "@local/quillmark-helper:0.1.0": form-field
 #set page(width: 600pt, height: 400pt, margin: 50pt)
-#form-field("txt", type: "text", value: "hi", field: "f_txt")
-#form-field("chk", type: "checkbox", value: true, field: "f_chk")
-#form-field("cho", type: "choice", options: ("A", "B"), value: "B", field: "f_cho")
-#form-field("sig", type: "signature", field: "f_sig")
+#form-field("txt", type: "text", value: "hi", field: "subject")
+#form-field("chk", type: "checkbox", value: true, field: "dissemination")
+#form-field("cho", type: "choice", options: ("A", "B"), value: "B", field: "memo_style")
+#form-field("sig", type: "signature", field: "tag_line")
 #form-field("unbound", type: "text", value: "x")
 "#;
     let source = source_with_plate(plate);
@@ -573,7 +575,7 @@ fn form_field_regions_key_on_bound_schema_field() {
     let fields: std::collections::HashMap<&str, &quillmark_core::RenderedRegion> =
         regions.iter().map(|r| (r.field.as_str(), r)).collect();
 
-    for field in ["f_txt", "f_chk", "f_cho", "f_sig"] {
+    for field in ["subject", "dissemination", "memo_style", "tag_line"] {
         let r = fields
             .get(field)
             .unwrap_or_else(|| panic!("region keyed on bound schema field {field:?}"));

--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -39,6 +39,19 @@ import type {
 // One mutual-assignability pair per hoisted type: typst → canonical and
 // canonical → typst. `void` the bindings so "declared but never read" is not an
 // error under noUnusedLocals.
+//
+// Mutual assignability alone cannot catch a missing OPTIONAL member: for an
+// all-optional interface pair (RenderOptions, PaintOptions) both assignments
+// compile even when one side lacks a member entirely. The `KeysEqual`
+// assertions close that hole — `true` only when both sides declare exactly
+// the same property names.
+
+type KeysEqual<A, B> = [Exclude<keyof A, keyof B>, Exclude<keyof B, keyof A>] extends [
+	never,
+	never
+]
+	? true
+	: false;
 
 const renderResultA: CanonicalRenderResult = {} as TypstRenderResult;
 const renderResultB: TypstRenderResult = {} as CanonicalRenderResult;
@@ -79,3 +92,18 @@ const fieldRegionA: CanonicalFieldRegion = {} as TypstFieldRegion;
 const fieldRegionB: TypstFieldRegion = {} as CanonicalFieldRegion;
 void fieldRegionA;
 void fieldRegionB;
+
+const renderResultKeys: KeysEqual<CanonicalRenderResult, TypstRenderResult> = true;
+const renderOptionsKeys: KeysEqual<CanonicalRenderOptions, TypstRenderOptions> = true;
+const artifactKeys: KeysEqual<CanonicalArtifact, TypstArtifact> = true;
+const pageSizeKeys: KeysEqual<CanonicalPageSize, TypstPageSize> = true;
+const paintOptionsKeys: KeysEqual<CanonicalPaintOptions, TypstPaintOptions> = true;
+const paintResultKeys: KeysEqual<CanonicalPaintResult, TypstPaintResult> = true;
+const fieldRegionKeys: KeysEqual<CanonicalFieldRegion, TypstFieldRegion> = true;
+void renderResultKeys;
+void renderOptionsKeys;
+void artifactKeys;
+void pageSizeKeys;
+void paintOptionsKeys;
+void paintResultKeys;
+void fieldRegionKeys;

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -84,6 +84,13 @@ export interface RenderOptions {
 	ppi?: number;
 	pages?: number[];
 	producer?: string;
+	/**
+	 * Populate {@link RenderResult.regions} with the schema-field geometry
+	 * sidecar (the same entries {@link LiveSession.regions} serves), for
+	 * consumers without a live session — e.g. overlays over a one-shot SVG
+	 * export. Defaults to `false`: exports pay no introspection cost.
+	 */
+	regions?: boolean;
 }
 
 /**
@@ -136,6 +143,14 @@ export interface RenderResult {
 	warnings: Diagnostic[];
 	outputFormat: OutputFormat;
 	renderTimeMs: number;
+	/**
+	 * Schema-field geometry sidecar — populated only when
+	 * {@link RenderOptions.regions} requested it; empty otherwise. The same
+	 * entries {@link LiveSession.regions} serves, for consumers without a live
+	 * session. Page indices are document-space even under a `pages` subset
+	 * render.
+	 */
+	regions: FieldRegion[];
 }
 
 /** Canonical contract every backend build must satisfy. The emittable formats. */
@@ -287,11 +302,17 @@ export declare class LiveSession {
 	apply(doc: Document): ChangeSet;
 	render(options?: RenderOptions): RenderResult;
 	/**
-	 * Schema-field geometry for this compiled session — one {@link FieldRegion}
-	 * per schema-bound field, keyed on its quill schema field path. A
-	 * session-level query: no render, no byte artifact. Read it to place field
-	 * overlays / cross-navigation over a `paint`-ed canvas. Empty for backends
-	 * that place no schema fields.
+	 * Schema-field geometry for this compiled session, keyed on quill schema
+	 * field path. A session-level query: no render, no byte artifact. Read it
+	 * to place field overlays / cross-navigation over a `paint`-ed canvas.
+	 * Empty for backends that place no schema fields.
+	 *
+	 * `field` is **not** unique: this returns one {@link FieldRegion} per
+	 * (placement, page fragment). A field placed at several sites yields one
+	 * region each; a body breaking across pages yields one fragment per page
+	 * it touches (so a highlight covers continuation pages); tagged content
+	 * plus a `field:`-bound widget yields both, widget ordered first. Group by
+	 * `field` — every entry routes to that field.
 	 */
 	regions(): FieldRegion[];
 	/** Page geometry in points (1/72″). Report-only; the painter sizes the canvas. */

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -286,7 +286,8 @@ uses — with a lookup, not a guess. `RenderedRegion` (core) and the WASM
 `renderResult.regions`; read `region.field` where you read `region.name`; drop
 any use of `region.kind` / `fieldType` / `value`. Route a clicked region to the
 editor field named by `region.field` directly — no widget-name guessing.
-`region.field` is unique in the list (one region per logical field).
+`region.field` is **not** unique in the list — group entries by `field` before
+routing.
 
 **Action (out-of-tree backends):** override `SessionHandle::regions()` on your
 session (default empty) to return geometry. `FieldSpec` (the `quillmark-pdf`

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -258,10 +258,13 @@ uses — with a lookup, not a guess. `RenderedRegion` (core) and the WASM
   (`tagged("subject")[#data.subject]`) and markers wrapped *around* a package
   call's output survive the package's internal rebuild
   (`tagged("$body")[#mainmatter[#data.at("$body")]]`). Paths validate against
-  the schema at compile time — a typo'd field is a compile error. Each card
-  dict carries its canonical address prefix as `$path`, so plates compose card
-  paths (`tagged(card.at("$path") + "from")[..]`) without reimplementing the
-  kind+ordinal grammar.
+  the schema at compile time — a typo'd field is a compile error. An index
+  suffix (`refs.2`) is a valid address only on a `markdown[]` field, the one
+  field shape whose elements the auto-tagger addresses; `subject.0` on a
+  scalar `subject` is a compile error even though the name is declared. Each
+  card dict carries its canonical address prefix as `$path`, so plates compose
+  card paths (`tagged(card.at("$path") + "from")[..]`) without reimplementing
+  the kind+ordinal grammar.
 - **One region per (placement, page fragment) — `field` is not unique.** A
   field placed at two sites surfaces two independent regions; a page-spanning
   body surfaces one fragment per page it touches (so highlighting a focused
@@ -275,7 +278,11 @@ uses — with a lookup, not a guess. `RenderedRegion` (core) and the WASM
   `signature-field("Signature", field: "signature_block")`); a widget that binds
   none has only a `/T` name — a backend identifier, not a schema address — so it
   produces **no** region. (Same rule pdfform already follows: a widget with
-  `schema_field: null` is decorative and emits nothing.)
+  `schema_field: null` is decorative and emits nothing.) `field:` validates
+  against the schema at compile time under the same address grammar as
+  `tagged` — a widget bound to a name the schema doesn't declare (a 0.92-style
+  AcroForm `/T` string, say) is a compile error, not a silent no-region
+  widget. Bind `field:` to a declared schema field or omit it.
 - **`value` and `fieldType` are gone.** Regions are geometry for overlays and
   cross-navigation, not a compositing input — both canvas backends already bake
   values into a complete raster, so nothing read them. A field's value lives in

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -259,9 +259,10 @@ uses — with a lookup, not a guess. `RenderedRegion` (core) and the WASM
   call's output survive the package's internal rebuild
   (`tagged("$body")[#mainmatter[#data.at("$body")]]`). Paths validate against
   the schema at compile time — a typo'd field is a compile error. An index
-  suffix (`refs.2`) is a valid address only on a `markdown[]` field, the one
-  field shape whose elements the auto-tagger addresses; `subject.0` on a
-  scalar `subject` is a compile error even though the name is declared. Each
+  suffix (`refs.2`) is a valid address only on an array-typed field — any
+  array, the same shallow-path grammar the pdfform resolver binds; `subject.0`
+  on a scalar `subject` is a compile error even though the name is declared,
+  since a scalar has no element for the address to resolve to. Each
   card dict carries its canonical address prefix as `$path`, so plates compose
   card paths (`tagged(card.at("$path") + "from")[..]`) without reimplementing
   the kind+ordinal grammar.


### PR DESCRIPTION
Locked-in fixes from the post-merge review of #788 (the #783 implementation). Three commits:

## docs(migrations): fix stale region-uniqueness line

The consumer Action checklist still asserted `region.field` is unique, contradicting the rewritten contract two paragraphs above (one region per placement/page-fragment; group by field).

## feat(regions): validate form-field paths, reject scalar index-tagging, cache schema meta

- `form-field`/`signature-field`'s `field:` argument now validates against the schema like `tagged()` does, closing the typo-safety gap the tagged() helper was built for but left open on the older sibling API. A typo'd widget binding fails the compile instead of silently producing a region nothing routes to. Required reordering `_qm-raw`/`_qm-meta`/`_qm-known-path` before `form-field` in the generated helper — Typst doesn't hoist `#let` bindings.
- `tagged("field.N")` / `form-field(field: "field.N")` now reject an index suffix on a scalar field. The auto-tagger only index-suffixes `markdown[]` elements, so `subject.0` on a plain string field was a syntactically-plausible but never-real address that slipped past the old name-only check. Validates against new `array_fields`/`card_array_fields` tables in `__meta__`.
- Schema-derived address/auto-eval tables (`SchemaMeta`) are built once at `TypstSession::open` and reused on every `apply`, instead of rewalking the schema's `$defs` per edit in a live-preview session.
- New regression test pins the documented widget-before-content region ordering for a field bound to both a widget and tagged content (the ordering was doc-only, untested).
- Two existing tests bound widgets to field names absent from their schemas (fine before validation existed); updated to bind declared fields.

## fix(wasm): sync canonical runtime.d.ts, wire typecheck into CI

The hand-maintained canonical `RenderResult`/`RenderOptions` interfaces were missing the `regions` field #788 added to the generated Typst bindings, and `LiveSession.regions()`'s JSDoc still claimed field uniqueness. The existing drift guard (`runtime.types.test-d.ts` via `npm run typecheck`) would have caught this, but CI only ran `vitest run` — a typecheck step is now wired into the wasm CI job.

Verified: `cargo test --workspace` green, all 154 WASM vitest tests green, `npm run typecheck` green against a fresh WASM build, clippy clean.

Deferred by design (YAGNI, discussed in review): the double frame-walk on `regions: true` renders and the diverged `$cards` address grammar between the Typst validator and pdfform's resolver. The no-region detection probe is tracked as #789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzYekLj9DrdaS6LtRFpjYC