### PR TITLE
Omit $body from the transform schema for body-disabled kinds

### DIFF
--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -11,6 +11,7 @@
 /// passes, plus the schema address tables (`fields`, `card_fields`,
 /// `array_fields`, `card_array_fields`) that validate `tagged`/`form-field`
 /// paths.
+#let _qm-has-meta = "__meta__" in _qm-raw
 #let _qm-meta = _qm-raw.at("__meta__", default: (:))
 
 /// Whether `path` parses against the schema address tables: a top-level field
@@ -21,12 +22,14 @@
 /// `array_fields`/`card_array_fields`, not the broader `fields`/`card_fields`
 /// name tables, rejecting `subject.0` on a scalar `subject` even though the
 /// name itself is known: a scalar has no element for the address to resolve
-/// to. Permissive when the tables are absent (no `__meta__`) — validation
-/// then has nothing to check against.
+/// to. Permissive when `__meta__` itself is absent — validation then has
+/// nothing to check against. Distinct from `__meta__` present with empty
+/// tables (e.g. a body-disabled main with no other fields and no cards),
+/// which validates against the empty set and so rejects every address.
 #let _qm-known-path(path) = {
+  if not _qm-has-meta { return true }
   let fields = _qm-meta.at("fields", default: ())
   let card-fields = _qm-meta.at("card_fields", default: (:))
-  if fields.len() == 0 and card-fields.len() == 0 { return true }
   let array-fields = _qm-meta.at("array_fields", default: ())
   let card-array-fields = _qm-meta.at("card_array_fields", default: (:))
   let is-index(s) = s.match(regex("^[0-9]+$")) != none

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -308,6 +308,80 @@ main:
 }
 
 #[test]
+fn tagged_body_on_body_disabled_kind_fails_the_compile() {
+    // `body.enabled: false` drops `$body` from the transform schema, so it's
+    // absent from the `__meta__` address tables and `tagged("$body")` must be
+    // rejected the same as any other unknown path.
+    const YAML: &str = r#"
+quill:
+  name: body_disabled_tagged
+  version: 0.1.0
+  backend: typst
+  description: tagged $body-on-disabled-kind validation test
+typst:
+  plate_file: plate.typ
+main:
+  body:
+    enabled: false
+  fields:
+    title:
+      type: string
+      description: the only schema field
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, tagged
+#tagged("$body")[#data.title]
+"#;
+    let data = serde_json::json!({ "title": "a title" });
+
+    let err = TypstBackend
+        .open(&quill(YAML, PLATE), &data)
+        .err()
+        .expect("tagging $body on a body-disabled kind must fail the compile");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("$body"),
+        "the compile error names the bad path: {msg}"
+    );
+}
+
+#[test]
+fn tagged_unknown_path_rejected_when_body_disabled_main_has_no_other_fields() {
+    // A body-disabled main with no other fields and no cards yields
+    // `__meta__` address tables that are present but empty (`fields: ()`,
+    // `card_fields: (:)`) — distinct from `__meta__` being absent entirely.
+    // The former must still validate (and reject every address); only the
+    // latter is permissive.
+    const YAML: &str = r#"
+quill:
+  name: body_disabled_empty_main
+  version: 0.1.0
+  backend: typst
+  description: known-path permissive-vs-empty guard test
+typst:
+  plate_file: plate.typ
+main:
+  body:
+    enabled: false
+"#;
+    const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": tagged
+#tagged("subject")[nothing here]
+"#;
+    let data = serde_json::json!({});
+
+    let err = TypstBackend
+        .open(&quill(YAML, PLATE), &data)
+        .err()
+        .expect("an unknown path must still fail when the address tables are empty, not absent");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("subject"),
+        "the compile error names the bad path: {msg}"
+    );
+}
+
+#[test]
 fn tagged_scalar_index_path_fails_the_compile() {
     // `field.N` is only a real address for an array-typed field — a scalar
     // has no element for the address to resolve to — so an index suffix on a

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -13,6 +13,13 @@ use crate::value::QuillValue;
 ///
 /// The descriptor marks markdown fields with `contentMediaType: "text/markdown"`
 /// and date/date-time fields with the corresponding JSON Schema `format`.
+///
+/// `$body` is injected into a kind's `properties` only when that kind's
+/// `body.enabled` is not `false`. A body-disabled kind's `$body` is absent,
+/// not present-and-empty: absence cascades through the `__meta__` address
+/// tables so `tagged()`/`form-field(field:)` reject `$body` addresses on that
+/// kind at compile time, matching `Quill::validate`'s hard error on authored
+/// body content for the same kind.
 pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     fn field_to_schema(field: &FieldSchema) -> serde_json::Value {
         let mut schema = serde_json::Map::new();
@@ -95,10 +102,12 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     for (name, field) in &config.main.fields {
         properties.insert(name.clone(), field_to_schema(field));
     }
-    properties.insert(
-        "$body".to_string(),
-        serde_json::json!({ "type": "string", "contentMediaType": "text/markdown" }),
-    );
+    if config.main.body_enabled() {
+        properties.insert(
+            "$body".to_string(),
+            serde_json::json!({ "type": "string", "contentMediaType": "text/markdown" }),
+        );
+    }
 
     let mut defs = serde_json::Map::new();
     for card in &config.card_kinds {
@@ -106,10 +115,12 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
         for (name, field) in &card.fields {
             card_properties.insert(name.clone(), field_to_schema(field));
         }
-        card_properties.insert(
-            "$body".to_string(),
-            serde_json::json!({ "type": "string", "contentMediaType": "text/markdown" }),
-        );
+        if card.body_enabled() {
+            card_properties.insert(
+                "$body".to_string(),
+                serde_json::json!({ "type": "string", "contentMediaType": "text/markdown" }),
+            );
+        }
         defs.insert(
             format!("{}_card", card.name),
             serde_json::json!({
@@ -272,5 +283,55 @@ card_kinds:
                 "{def_name} $body should be markdown"
             );
         }
+    }
+
+    #[test]
+    fn body_disabled_kind_omits_body_from_schema() {
+        let yaml = r#"
+quill:
+  name: example
+  version: 0.1.0
+  backend: typst
+  description: example
+
+main:
+  body:
+    enabled: false
+  fields:
+    title:
+      type: string
+
+card_kinds:
+  indorsement:
+    body:
+      enabled: false
+    fields:
+      signature_block:
+        type: string
+  note:
+    fields:
+      author:
+        type: string
+"#;
+
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+
+        assert!(
+            json["properties"].get("$body").is_none(),
+            "body-disabled main should not carry $body"
+        );
+        assert!(
+            json["$defs"]["indorsement_card"]["properties"]
+                .get("$body")
+                .is_none(),
+            "body-disabled card kind should not carry $body"
+        );
+        assert!(
+            json["$defs"]["note_card"]["properties"]
+                .get("$body")
+                .is_some(),
+            "body-enabled card kind should still carry $body"
+        );
     }
 }

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -462,6 +462,22 @@ The `.NET` binding is **dropped entirely**. The supported bindings are now
 Python, WASM, and the CLI. There is no C#/.NET surface to migrate; a consumer on
 the .NET binding must move to one of the remaining bindings.
 
+## `$body` is absent from the transform schema for a body-disabled kind
+
+`build_transform_schema` no longer injects `$body` into `properties` for a
+kind (main or a card kind) that declares `body.enabled: false`. Previously
+`$body` was always present — an address the system promised could never hold
+content, yet still validated and compiled as a `tagged`/`form-field` target.
+Absence now cascades: `$body` drops out of the `__meta__` address tables, so
+`tagged("$body")` / `form-field(field: "$body")` on a body-disabled kind is a
+**compile-time error**, matching `Quill::validate`'s existing hard error on
+authored body content for the same kind.
+
+**Action:** a plate that does
+`tagged(card.at("$path") + "$body")[..]` (or the main-level equivalent) on a
+kind with `body.enabled: false` must drop the `$body` placement — there is no
+address for it to route to. No in-tree plate did this.
+
 ## New: programmatic construction surface
 
 Additive; nothing to migrate. A document can be built in memory without

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -58,6 +58,7 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
 - Emits path-aware errors for top-level fields and card fields
 - Validates each card's `$kind` matches a known card kind
 - Enforces `body.enabled: false` on the main card and on each card kind — body content for a body-disabled card emits `ValidationError::BodyDisabled` (whitespace-only bodies are treated as empty)
+- `body.enabled: false` also drops `$body` from `build_transform_schema`'s `properties` for that kind — absent, not present-and-empty. This cascades into the Typst helper's `__meta__` address tables, so `tagged`/`form-field(field:)` reject a `$body` address on that kind at compile time (see `PLATE_DATA.md`)
 - **Null ≡ absent.** A present-null value (`field:`, `field: null`,
   `field: ~`) carries no data: it is treated exactly like an omitted field.
   It validates clean (no `TypeMismatch`) and zero-fills at render


### PR DESCRIPTION
build_transform_schema now skips injecting $body into properties for
main/card kinds with body.enabled: false, so the address is absent
rather than present-and-inert. Absence cascades into the Typst
helper's __meta__ tables, so tagged()/form-field(field:) reject a
$body address on a body-disabled kind at compile time.

Companion guard: the template's _qm-known-path distinguished
"no __meta__" from "tables present but empty" by checking whether
fields/card_fields were empty, which the schema change makes
reachable for a legitimate case (body-disabled main, zero other
fields, no cards). It now checks for __meta__'s literal presence on
the raw document instead, so an empty-but-present address table
still rejects every path.

Fixes #793

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01So1PLe6TVHbb5MRZQrupjc