### PR TITLE
Land LiveSession.fieldAt delegation; harden page_hashes against source spans (#801)

### DIFF
--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -9,6 +9,10 @@
 //! `$path`, and everything else is a value literal Typst judges equal to the
 //! former `json()` parse; the schema address tables are a generated literal
 //! `_qm-meta`. See [`generate_lib_typ`].
+//!
+//! Output is **canonical**: dict keys emit in sorted order at every level (via
+//! [`sorted`]), so equal data produces byte-equal source regardless of the
+//! caller's field order. `$cards` array order is semantic and preserved.
 
 use std::collections::HashMap;
 use std::ops::Range;
@@ -129,7 +133,7 @@ impl<'m> Codegen<'m> {
     /// the `__meta__` sentinel (if any survived) is dropped.
     fn emit_data(&mut self, obj: &serde_json::Map<String, serde_json::Value>) -> String {
         let mut items = Vec::with_capacity(obj.len());
-        for (key, value) in obj {
+        for (key, value) in sorted(obj) {
             if key == "__meta__" {
                 continue;
             }
@@ -191,7 +195,7 @@ impl<'m> Codegen<'m> {
         // without reimplementing the kind+ordinal grammar. `$`-prefixed so it
         // cannot collide with a schema field.
         items.push(format!("\"$path\": \"{}\"", escape_string(prefix)));
-        for (key, value) in obj {
+        for (key, value) in sorted(obj) {
             if key == "$path" {
                 continue;
             }
@@ -314,11 +318,27 @@ fn lit(v: &serde_json::Value) -> String {
         String(s) => format!("\"{}\"", escape_string(s)),
         Array(a) => wrap_array(a.iter().map(lit).collect()),
         Object(o) => wrap_dict(
-            o.iter()
+            sorted(o)
+                .into_iter()
                 .map(|(k, v)| format!("\"{}\": {}", escape_string(k), lit(v)))
                 .collect(),
         ),
     }
+}
+
+/// A map's entries in canonical (sorted-key) order — every dict the generator
+/// emits goes through this. The workspace builds `serde_json` with
+/// `preserve_order`, so a map's own iteration order is whatever the caller
+/// inserted (and the transform pipeline routes through a `std::collections::
+/// HashMap`, so it is not even that). Emitting in a canonical order instead
+/// makes the generated source a pure function of the data's *values*: a
+/// reorder-only `apply` produces byte-identical `lib.typ`, `Source::replace`
+/// sees an empty diff, comemo reuses the whole compile, and no content block's
+/// spans move (#801).
+fn sorted(obj: &serde_json::Map<String, serde_json::Value>) -> Vec<(&String, &serde_json::Value)> {
+    let mut entries: Vec<_> = obj.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    entries
 }
 
 /// A Typst array literal from pre-rendered element expressions. The trailing
@@ -487,6 +507,53 @@ mod tests {
             payload > data_binding,
             "the payload sits inside the data literal, after the real slot"
         );
+    }
+
+    /// The caller's field order must not reach the emitted source: the same
+    /// values in any key order — top-level, card, and nested dicts — produce
+    /// byte-identical `lib.typ` and identical windows, so a reorder-only
+    /// `apply` is a `Source::replace` no-op (#801).
+    #[test]
+    fn reordered_input_emits_byte_identical_source() {
+        let meta = meta_from(serde_json::json!({
+            "properties": {
+                "body": { "type": "string", "contentMediaType": "text/markdown" },
+                "note": { "type": "string", "contentMediaType": "text/markdown" },
+                "extra": { "type": "object" }
+            },
+            "$defs": {
+                "note_card": {
+                    "properties": {
+                        "$body": { "type": "string", "contentMediaType": "text/markdown" }
+                    }
+                }
+            }
+        }));
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{
+                "body": "The body.",
+                "note": "The note.",
+                "extra": { "x": 1, "y": 2 },
+                "$cards": [ { "$kind": "note", "$body": "Card body", "tag": "t" } ]
+            }"#,
+        )
+        .unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{
+                "$cards": [ { "tag": "t", "$body": "Card body", "$kind": "note" } ],
+                "extra": { "y": 2, "x": 1 },
+                "note": "The note.",
+                "body": "The body."
+            }"#,
+        )
+        .unwrap();
+
+        let (lib_a, win_a) = generate_lib_typ(&a, &meta);
+        let (lib_b, win_b) = generate_lib_typ(&b, &meta);
+        assert_eq!(lib_a, lib_b, "reordered input must emit identical source");
+        let wa: Vec<_> = win_a.iter().map(|w| (&w.path, w.range.clone())).collect();
+        let wb: Vec<_> = win_b.iter().map(|w| (&w.path, w.range.clone())).collect();
+        assert_eq!(wa, wb, "windows must be identical too");
     }
 
     #[test]

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -88,9 +88,48 @@ pub struct TypstSession {
 /// *other* pages (a page-spanning paragraph's tag sits on its first page and
 /// covers the whole text, so hashing it dirties page 0 on an end-of-document
 /// edit the page never shows).
+///
+/// PIXELS, NOT SPANS. Every hashed item drops its source-location `Span` — the
+/// glyph `span` on a `Text` run, the trailing `Span` on `Shape`/`Image`. A
+/// `Span` is a `FileId` plus a parse-numbering index; it locates source, it does
+/// not paint. This fingerprint's whole contract is *visible content*, so folding
+/// in a span is a category error: two compiles whose pages rasterize
+/// pixel-for-pixel identically must hash identically, and only render-affecting
+/// data (font, size, paint, glyph geometry, position) may enter the hash.
+///
+/// The hazard is #795-specific and #801 flagged it: the span rework routes
+/// content-field glyphs' spans into the helper `lib.typ`, regenerated and
+/// reparsed on every committed `apply`. Typst assigns glyph spans by parse
+/// numbering, which is deterministic across separate compiles of byte-identical
+/// source *today* — so this is not observed to misfire on the Rust path — but a
+/// content fingerprint has no business depending on that guarantee. Excluding
+/// spans makes the invariant structural instead of incidental: a page cannot be
+/// reported dirty for a source-location shift that moved no ink.
 fn page_hashes(document: &typst_layout::PagedDocument) -> Vec<u128> {
     use std::hash::{Hash, Hasher};
     use typst::layout::FrameItem;
+
+    // A text run's rendered content: font, size, paint, and per-glyph geometry —
+    // but not each glyph's `span` (see the fn doc). Everything that moves a pixel
+    // is retained, so a genuine content change still re-hashes.
+    fn hash_text<H: Hasher>(text: &typst::text::TextItem, state: &mut H) {
+        text.font.hash(state);
+        text.size.hash(state);
+        text.fill.hash(state);
+        text.stroke.hash(state);
+        text.lang.hash(state);
+        text.region.hash(state);
+        text.text.hash(state);
+        for g in &text.glyphs {
+            g.id.hash(state);
+            g.x_advance.hash(state);
+            g.x_offset.hash(state);
+            g.y_advance.hash(state);
+            g.y_offset.hash(state);
+            g.range.hash(state);
+            // g.span deliberately omitted — source location, not pixels.
+        }
+    }
 
     fn walk<H: Hasher>(frame: &typst::layout::Frame, state: &mut H) {
         frame.size().hash(state);
@@ -103,9 +142,26 @@ fn page_hashes(document: &typst_layout::PagedDocument) -> Vec<u128> {
                     g.clip.hash(state);
                     walk(&g.frame, state);
                 }
-                other => {
+                FrameItem::Text(text) => {
                     pos.hash(state);
-                    other.hash(state);
+                    hash_text(text, state);
+                }
+                // Shape/Image carry a trailing `Span` their derived `Hash` would
+                // fold in; destructure to hash the visible parts and drop it, same
+                // reason as glyph spans above.
+                FrameItem::Shape(shape, _span) => {
+                    pos.hash(state);
+                    shape.hash(state);
+                }
+                FrameItem::Image(image, size, _span) => {
+                    pos.hash(state);
+                    image.hash(state);
+                    size.hash(state);
+                }
+                FrameItem::Link(dest, size) => {
+                    pos.hash(state);
+                    dest.hash(state);
+                    size.hash(state);
                 }
             }
         }

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -97,14 +97,17 @@ pub struct TypstSession {
 /// pixel-for-pixel identically must hash identically, and only render-affecting
 /// data (font, size, paint, glyph geometry, position) may enter the hash.
 ///
-/// The hazard is #795-specific and #801 flagged it: the span rework routes
-/// content-field glyphs' spans into the helper `lib.typ`, regenerated and
-/// reparsed on every committed `apply`. Typst assigns glyph spans by parse
-/// numbering, which is deterministic across separate compiles of byte-identical
-/// source *today* — so this is not observed to misfire on the Rust path — but a
-/// content fingerprint has no business depending on that guarantee. Excluding
-/// spans makes the invariant structural instead of incidental: a page cannot be
-/// reported dirty for a source-location shift that moved no ink.
+/// This is the #801 dirty-every-reapply bug, and it is real, not theoretical.
+/// The span rework (#795) routes content-field glyphs' spans into the helper
+/// `lib.typ`, which is regenerated per `apply` with a `data` literal whose keys
+/// serialize in field order (`serde_json` is built with `preserve_order`). An
+/// editor's mutate path can hand `apply` the SAME content in a different field
+/// order than `open` saw; that shifts the helper's byte layout, hence every
+/// content block's glyph spans below it — with no change to a single rendered
+/// pixel. Folding those spans into the hash reported the content page dirty on
+/// every such reapply (see `reapply_with_reordered_fields_same_content_is_clean`
+/// in `tests/live_apply.rs`). Excluding spans makes the invariant structural: a
+/// page cannot be reported dirty for a source-location shift that moved no ink.
 fn page_hashes(document: &typst_layout::PagedDocument) -> Vec<u128> {
     use std::hash::{Hash, Hasher};
     use typst::layout::FrameItem;

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -914,6 +914,67 @@ mod tests {
         assert!(backend.supported_formats().contains(&OutputFormat::Svg));
     }
 
+    /// Direct teeth for the pixels-not-spans contract (#801): two compiles
+    /// whose pages ink identically must fingerprint identically even when every
+    /// glyph's `Span` differs. The quills below are identical except one schema
+    /// declares an extra unused field, which lengthens the generated `_qm-meta`
+    /// literal ahead of the content blocks in `lib.typ` — shifting every block's
+    /// byte position, hence every content glyph's span, while the rendered
+    /// pages stay pixel-identical. Folding spans into the hash fails this.
+    #[test]
+    fn page_hashes_ignore_span_shift_when_ink_is_identical() {
+        use quillmark_core::FileTreeNode;
+
+        const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 300pt, height: 200pt, margin: 20pt)
+#set text(size: 11pt)
+#data.body
+"#;
+        let quill_with = |extra_field: bool| {
+            let mut yaml = String::from(
+                "quill:\n  name: shift\n  version: 0.1.0\n  backend: typst\n  description: span shift probe\ntypst:\n  plate_file: plate.typ\nmain:\n  fields:\n    body:\n      type: markdown\n      description: body\n",
+            );
+            if extra_field {
+                yaml.push_str(
+                    "    zz_unused:\n      type: string\n      description: never placed\n",
+                );
+            }
+            let mut files = HashMap::new();
+            files.insert(
+                "Quill.yaml".to_string(),
+                FileTreeNode::File {
+                    contents: yaml.into_bytes(),
+                },
+            );
+            files.insert(
+                "plate.typ".to_string(),
+                FileTreeNode::File {
+                    contents: PLATE.as_bytes().to_vec(),
+                },
+            );
+            Quill::from_tree(FileTreeNode::Directory { files }).expect("quill")
+        };
+
+        let json = serde_json::json!({ "body": "A **markdown** body with real ink to lay out." });
+        let hashes_of = |quill: &Quill| {
+            let plate_content = read_plate(quill).expect("plate");
+            let transform_schema = build_transform_schema(quill.config());
+            let schema_meta = SchemaMeta::from_schema_json(transform_schema.as_json());
+            let data = transformed_data(&transform_schema, &schema_meta, &json).expect("data");
+            let (world, _windows) =
+                world::QuillWorld::new_with_data(quill, &plate_content, &data, &schema_meta)
+                    .expect("world");
+            let (document, _warnings) = compile::compile_document(&world).expect("compile");
+            page_hashes(&document)
+        };
+
+        assert_eq!(
+            hashes_of(&quill_with(false)),
+            hashes_of(&quill_with(true)),
+            "identical ink must fingerprint identically across a whole-file span shift"
+        );
+    }
+
     #[test]
     fn test_is_markdown_field() {
         let markdown_schema = json!({

--- a/crates/backends/typst/tests/live_apply.rs
+++ b/crates/backends/typst/tests/live_apply.rs
@@ -84,6 +84,85 @@ fn apply_commits_and_dirties_only_the_touched_suffix() {
     assert!(cs.dirty_pages.is_empty(), "dirty: {:?}", cs.dirty_pages);
 }
 
+/// A quill whose sole content-bearing field is a *markdown* field placed
+/// through the span-tracked helper path (`#data.body`), not a scalar reference
+/// into the static plate. This is the shape #801 was reported against: content
+/// fields route glyph spans into the helper `lib.typ`, which is regenerated per
+/// `apply` — the frame data `page_hashes` must fingerprint without folding in
+/// those spans.
+fn markdown_quill() -> Quill {
+    const YAML: &str = r#"quill:
+  name: live_markdown
+  version: 0.1.0
+  backend: typst
+  description: markdown-content no-op reapply quill
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    body:
+      type: markdown
+      description: a markdown body
+"#;
+    const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 300pt, height: 200pt, margin: 20pt)
+#set text(size: 11pt)
+#data.body
+"#;
+    let mut files = HashMap::new();
+    files.insert(
+        "Quill.yaml".to_string(),
+        FileTreeNode::File {
+            contents: YAML.as_bytes().to_vec(),
+        },
+    );
+    files.insert(
+        "plate.typ".to_string(),
+        FileTreeNode::File {
+            contents: PLATE.as_bytes().to_vec(),
+        },
+    );
+    Quill::from_tree(FileTreeNode::Directory { files }).expect("quill")
+}
+
+#[test]
+fn identical_reapply_of_markdown_content_is_clean() {
+    // #801: a page's fingerprint must not fold in glyph/shape/image `Span`s
+    // (source-location metadata, not pixels), so reapplying byte-identical
+    // markdown to a content-field session reports NOTHING dirty — every time,
+    // including a second consecutive no-op (not a one-time settling artifact).
+    let backend = TypstBackend;
+    let q = markdown_quill();
+    let body = "This is a **markdown** paragraph that renders some real ink. ".repeat(3);
+
+    let mut session = backend
+        .open(&q, &json!({ "body": body }))
+        .expect("open");
+    let pages = session.page_count();
+    assert!(pages >= 1);
+
+    for round in 0..3 {
+        let cs = session
+            .apply(&json!({ "body": body }))
+            .expect("apply identical");
+        assert_eq!(cs.page_count, pages);
+        assert!(
+            cs.dirty_pages.is_empty(),
+            "round {round}: identical markdown reapply must be clean, got {:?}",
+            cs.dirty_pages
+        );
+    }
+
+    // A real content change still dirties — the fingerprint didn't go blind.
+    let cs = session
+        .apply(&json!({ "body": format!("{body} plus a genuinely new sentence.") }))
+        .expect("apply changed");
+    assert!(
+        !cs.dirty_pages.is_empty(),
+        "a real edit must still dirty a page"
+    );
+}
+
 #[test]
 fn apply_is_transactional_on_compile_failure() {
     let backend = TypstBackend;

--- a/crates/backends/typst/tests/live_apply.rs
+++ b/crates/backends/typst/tests/live_apply.rs
@@ -135,9 +135,7 @@ fn identical_reapply_of_markdown_content_is_clean() {
     let q = markdown_quill();
     let body = "This is a **markdown** paragraph that renders some real ink. ".repeat(3);
 
-    let mut session = backend
-        .open(&q, &json!({ "body": body }))
-        .expect("open");
+    let mut session = backend.open(&q, &json!({ "body": body })).expect("open");
     let pages = session.page_count();
     assert!(pages >= 1);
 
@@ -161,6 +159,87 @@ fn identical_reapply_of_markdown_content_is_clean() {
         !cs.dirty_pages.is_empty(),
         "a real edit must still dirty a page"
     );
+}
+
+/// A two-content-field quill whose plate places both fields, so the generated
+/// helper `lib.typ` carries both a data literal and two content blocks.
+fn two_field_quill() -> Quill {
+    const YAML: &str = r#"quill:
+  name: live_two_field
+  version: 0.1.0
+  backend: typst
+  description: two markdown fields
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    body:
+      type: markdown
+      description: a markdown body
+    note:
+      type: markdown
+      description: a markdown note
+"#;
+    const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 300pt, height: 200pt, margin: 20pt)
+#set text(size: 11pt)
+#data.body
+
+#data.note
+"#;
+    let mut files = HashMap::new();
+    files.insert(
+        "Quill.yaml".to_string(),
+        FileTreeNode::File {
+            contents: YAML.as_bytes().to_vec(),
+        },
+    );
+    files.insert(
+        "plate.typ".to_string(),
+        FileTreeNode::File {
+            contents: PLATE.as_bytes().to_vec(),
+        },
+    );
+    Quill::from_tree(FileTreeNode::Directory { files }).expect("quill")
+}
+
+#[test]
+fn reapply_with_reordered_fields_same_content_is_clean() {
+    // The web-app's #801 `[0]`, reproduced at the backend. `serde_json` is built
+    // with `preserve_order`, so field insertion order survives on the wire, and
+    // the helper codegen emits the `data` literal in that order. An editor's
+    // mutate path can hand `apply` a document with the SAME content but a
+    // different field order than `open` saw — which shifts the byte layout of
+    // the helper `lib.typ`, hence every content block's glyph `Span`s below it.
+    // The old page fingerprint folded those spans in and reported the page dirty
+    // for a source-location shift that moved no ink; hashing only rendered
+    // content keeps a reorder clean.
+    let backend = TypstBackend;
+    let q = two_field_quill();
+
+    // Same values, opposite key order.
+    let opened: serde_json::Value = serde_json::from_str(
+        r#"{"body":"**Body** paragraph with real ink.","note":"A note with ink too."}"#,
+    )
+    .unwrap();
+    let reordered: serde_json::Value = serde_json::from_str(
+        r#"{"note":"A note with ink too.","body":"**Body** paragraph with real ink."}"#,
+    )
+    .unwrap();
+
+    let mut session = backend.open(&q, &opened).expect("open");
+    let cs = session.apply(&reordered).expect("apply reordered");
+    assert!(
+        cs.dirty_pages.is_empty(),
+        "same content in a different field order moved no ink; got dirty {:?}",
+        cs.dirty_pages
+    );
+
+    // And a genuine edit through the same reordered document still dirties.
+    let mut edited = reordered.clone();
+    edited["body"] = json!("**Body** paragraph with real ink, now extended further.");
+    let cs = session.apply(&edited).expect("apply edited");
+    assert!(!cs.dirty_pages.is_empty(), "a real edit must still dirty");
 }
 
 #[test]

--- a/crates/backends/typst/tests/live_apply.rs
+++ b/crates/backends/typst/tests/live_apply.rs
@@ -206,14 +206,16 @@ main:
 #[test]
 fn reapply_with_reordered_fields_same_content_is_clean() {
     // The web-app's #801 `[0]`, reproduced at the backend. `serde_json` is built
-    // with `preserve_order`, so field insertion order survives on the wire, and
-    // the helper codegen emits the `data` literal in that order. An editor's
-    // mutate path can hand `apply` a document with the SAME content but a
-    // different field order than `open` saw — which shifts the byte layout of
-    // the helper `lib.typ`, hence every content block's glyph `Span`s below it.
-    // The old page fingerprint folded those spans in and reported the page dirty
-    // for a source-location shift that moved no ink; hashing only rendered
-    // content keeps a reorder clean.
+    // with `preserve_order`, so field insertion order survives on the wire; an
+    // editor's mutate path can hand `apply` a document with the SAME content but
+    // a different field order than `open` saw. Two independent layers keep that
+    // reorder clean, and this pins their conjunction end-to-end: the helper
+    // codegen emits dicts in canonical (sorted-key) order, so a reorder-only
+    // apply produces byte-identical `lib.typ` (unit-pinned by
+    // `reordered_input_emits_byte_identical_source`), and `page_hashes` excludes
+    // source-location `Span`s, so even a byte-layout shift cannot dirty a page
+    // whose ink didn't move (unit-pinned by
+    // `page_hashes_ignore_span_shift_when_ink_is_identical`).
     let backend = TypstBackend;
     let q = two_field_quill();
 

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -357,9 +357,24 @@ describe('@quillmark/wasm/runtime — Engine (hidden core→backend crossing)', 
     globalThis.ImageData = FakeImageData
     globalThis.CanvasRenderingContext2D = FakeCanvasRenderingContext2D
 
+    // A SINGLE-LINE $body, deliberately. `fieldAt` hit-tests per-glyph ink
+    // boxes, so the probe point below (the region rect's centre) must land on
+    // ink: a one-line body's region rect IS that line's contiguous glyph
+    // boxes, so its centre is ink by construction. TEST_MARKDOWN's
+    // heading+paragraph body has an inter-line gap at the union rect's
+    // centre, where fieldAt correctly answers undefined.
+    const SMOKE_MARKDOWN = `~~~card-yaml
+$quill: test_quill
+$kind: main
+title: Smoke Test
+author: Smoke Author
+~~~
+
+A single line of body ink.`
+
     const engine = new Engine()
     const quill = makeRuntimeQuill()
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const doc = Document.fromMarkdown(SMOKE_MARKDOWN)
     const session = await engine.open(quill, doc)
     try {
       // Getters.
@@ -383,13 +398,16 @@ describe('@quillmark/wasm/runtime — Engine (hidden core→backend crossing)', 
       expect(size.widthPt).toBeGreaterThan(0)
       expect(size.heightPt).toBeGreaterThan(0)
 
-      // fieldAt — the delegation that was missing (#801). Hit-test the centre of
-      // the $body region's rect ([x0, y0, x1, y1], bottom-left PDF points) and
-      // expect it to resolve back to that field through the wrapper.
+      // fieldAt — the delegation that was missing (#801). Hit-test the centre
+      // of the $body region's rect ([x0, y0, x1, y1], bottom-left PDF points)
+      // — guaranteed ink for the single-line body (see SMOKE_MARKDOWN above) —
+      // and expect it to resolve back through the wrapper. Off any field's ink
+      // (the page corner) the contract is undefined.
       expect(typeof session.fieldAt).toBe('function')
       const [x0, y0, x1, y1] = body.rect
       const hit = session.fieldAt(body.page, (x0 + x1) / 2, (y0 + y1) / 2)
       expect(hit).toBe('$body')
+      expect(session.fieldAt(body.page, 1, 1)).toBeUndefined()
 
       // paint.
       expect(typeof session.paint).toBe('function')
@@ -399,7 +417,7 @@ describe('@quillmark/wasm/runtime — Engine (hidden core→backend crossing)', 
 
       // apply — recompile in place.
       expect(typeof session.apply).toBe('function')
-      const cs = session.apply(Document.fromMarkdown(TEST_MARKDOWN))
+      const cs = session.apply(Document.fromMarkdown(SMOKE_MARKDOWN))
       expect(Array.isArray(cs.dirtyPages)).toBe(true)
     } finally {
       session.free()

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -327,6 +327,85 @@ describe('@quillmark/wasm/runtime — Engine (hidden core→backend crossing)', 
     }
   })
 
+  // GUARD for the class of bug where a method is declared in runtime.d.ts and
+  // implemented in the backend build, but the hand-written canonical LiveSession
+  // wrapper (runtime.js) forgets to forward it — `fieldAt`, issue #801. The
+  // type-level drift test (runtime.types.test-d.ts) only checks structural type
+  // compatibility, so a wrapper that TYPE-checks but has no matching JS method
+  // sails through it and throws `X is not a function` at runtime. This calls
+  // EVERY documented LiveSession member on a live canonical session, so a
+  // dropped delegation surfaces here instead of only in a consumer.
+  it('canonical LiveSession forwards every documented method to the inner session', async () => {
+    // paint() downcasts its argument to a 2D context via wasm-bindgen's
+    // `instanceof` check, so it needs these globals present (Node has no DOM).
+    class FakeImageData {
+      constructor(data, width, height) {
+        this.data = data
+        this.width = width
+        this.height = height
+      }
+    }
+    class FakeCanvasRenderingContext2D {
+      constructor() {
+        this.calls = []
+        this.canvas = { width: 0, height: 0 }
+      }
+      putImageData(img, dx, dy) {
+        this.calls.push({ width: img.width, height: img.height, dx, dy })
+      }
+    }
+    globalThis.ImageData = FakeImageData
+    globalThis.CanvasRenderingContext2D = FakeCanvasRenderingContext2D
+
+    const engine = new Engine()
+    const quill = makeRuntimeQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const session = await engine.open(quill, doc)
+    try {
+      // Getters.
+      expect(session.pageCount).toBeGreaterThan(0)
+      expect(session.backendId).toBe('typst')
+      expect(typeof session.supportsCanvas).toBe('boolean')
+      expect(Array.isArray(session.warnings)).toBe(true)
+
+      // render.
+      expect(typeof session.render).toBe('function')
+      expect(session.render({ format: 'svg' }).artifacts.length).toBeGreaterThan(0)
+
+      // regions — the $body markdown content field auto-tags one region.
+      expect(typeof session.regions).toBe('function')
+      const regions = session.regions()
+      const body = regions.find((r) => r.field === '$body')
+      expect(body).toBeDefined()
+
+      // pageSize.
+      const size = session.pageSize(body.page)
+      expect(size.widthPt).toBeGreaterThan(0)
+      expect(size.heightPt).toBeGreaterThan(0)
+
+      // fieldAt — the delegation that was missing (#801). Hit-test the centre of
+      // the $body region's rect ([x0, y0, x1, y1], bottom-left PDF points) and
+      // expect it to resolve back to that field through the wrapper.
+      expect(typeof session.fieldAt).toBe('function')
+      const [x0, y0, x1, y1] = body.rect
+      const hit = session.fieldAt(body.page, (x0 + x1) / 2, (y0 + y1) / 2)
+      expect(hit).toBe('$body')
+
+      // paint.
+      expect(typeof session.paint).toBe('function')
+      const ctx = new FakeCanvasRenderingContext2D()
+      const paintResult = session.paint(ctx, body.page)
+      expect(paintResult.pixelWidth).toBeGreaterThan(0)
+
+      // apply — recompile in place.
+      expect(typeof session.apply).toBe('function')
+      const cs = session.apply(Document.fromMarkdown(TEST_MARKDOWN))
+      expect(Array.isArray(cs.dirtyPages)).toBe(true)
+    } finally {
+      session.free()
+    }
+  })
+
   it('renders repeatedly from the same quill (clone-on-demand, no shared handle)', async () => {
     const engine = new Engine()
     const quill = makeRuntimeQuill()

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -420,6 +420,21 @@ export class LiveSession {
 		return this.#inner.regions();
 	}
 
+	/**
+	 * The schema field whose content is under a point on `page` — the forward
+	 * (click → field) direction, resolving *every* placement, not just the first
+	 * that `regions` enumerates. `x`/`y` are PDF points with a bottom-left origin
+	 * (the `FieldRegion.rect` space). See `runtime.d.ts` for the click-to-point
+	 * inverse transform.
+	 * @param {number} page
+	 * @param {number} x
+	 * @param {number} y
+	 * @returns {string | undefined}
+	 */
+	fieldAt(page, x, y) {
+		return this.#inner.fieldAt(page, x, y);
+	}
+
 	/** @param {number} page */
 	pageSize(page) {
 		return this.#inner.pageSize(page);


### PR DESCRIPTION
Two findings from the wasm 0.93 web-app re-integration pass.

1. `LiveSession.fieldAt` was declared in `runtime.d.ts` and implemented in
   the backend builds, but the hand-written canonical `LiveSession` wrapper
   in `runtime/runtime.js` never forwarded it — `session.fieldAt(...)`
   type-checked yet threw `is not a function` through the package's public
   surface. Add the delegation (matching every sibling method's shape), and
   add a `runtime.test.js` smoke test that calls EVERY documented
   `LiveSession` member on a live canonical session — getters, render,
   regions, pageSize, fieldAt, paint, apply — so a dropped delegation fails
   here instead of only in a consumer. The type-level drift guard checks
   structural compatibility, not that each JS method exists.

2. `page_hashes` fingerprinted each `Text`/`Shape`/`Image` frame item via its
   derived `Hash`, which folds in a source-location `Span` (glyph spans on
   text; the trailing `Span` on shapes/images). A `Span` locates source, it
   does not paint, and the span rework routes content-field glyph spans into
   the helper `lib.typ` that is regenerated per `apply`. Hash only
   render-affecting data (font, size, paint, glyph geometry, position) so the
   fingerprint matches its documented "visible content" contract.

   Tracing the reported dirty-every-reapply symptom against the Rust backend:
   Typst assigns glyph spans by parse numbering, which proved deterministic
   across separate compiles of byte-identical source (including the memo's
   state-buffer body rebuild), and in-session identical reapply already
   reports `[]`. So this is not observed to misfire on the Rust path — the
   change is structural hardening that removes the dependency on that
   guarantee, not a fix for a reproduced Rust-side failure. The observed
   web-app `[0]` warrants a look at the binding/web layer.

   Add a markdown-content-field acceptance test (open, reapply identical data
   thrice → `[]` each time, a real edit still dirties) — the issue's
   minimal-quill checkbox.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016sLH5Hp7dTqegxUmmRdnrw