### PR TITLE
Fix silent-data-loss regression and blueprint/error/docs gaps (#803, #805, #808, #811)

### DIFF
--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -275,10 +275,11 @@ pub struct RenderOptions {
     pub ppi: Option<f32>,
     /// Optional 0-based page indices to render (e.g., `[0, 2]` for the
     /// first and third pages). `undefined` renders all pages. Any index
-    /// `>= pageCount` causes the render to throw — read
-    /// `LiveSession.pageCount` first if validation is needed.
+    /// `>= pageCount` throws with the `typst::page_index_out_of_bounds`
+    /// code — read `LiveSession.pageCount` first if validation is needed.
     /// **Not supported for PDF output** — passing `pages` with
-    /// `format: "pdf"` yields a `FormatNotSupported` error.
+    /// `format: "pdf"` throws with the
+    /// `typst::pdf_page_selection_not_supported` code.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pages: Option<Vec<usize>>,
     /// Override for the PDF `/Info` `/Producer` metadata string. Omit to use

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -313,7 +313,11 @@ pub struct RenderError {
 }
 
 impl RenderError {
-    /// Wrap `diags` as a failure. `diags` must be non-empty.
+    /// Wrap `diags` as a failure. `diags` should be non-empty; the invariant is
+    /// enforced only by `debug_assert!`, so a release build can construct an
+    /// empty `RenderError`. That is deliberately non-fatal: the `Display` impl
+    /// carries an `[]` fallback branch rather than promising the invariant is
+    /// load-bearing. Every internal caller passes a non-empty vec.
     pub fn new(diags: Vec<Diagnostic>) -> Self {
         debug_assert!(
             !diags.is_empty(),
@@ -327,7 +331,8 @@ impl RenderError {
         Self { diags: vec![diag] }
     }
 
-    /// Returns all diagnostics for this error. Always non-empty.
+    /// Returns all diagnostics for this error. Non-empty by construction (see
+    /// [`RenderError::new`]'s debug-asserted invariant).
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diags
     }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -221,7 +221,8 @@ fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool
 /// The cell's `(value, fill)` for a scalar/array/markdown leaf, per the value
 /// cascade. Endorsed → the default, no marker. Unendorsed → the `example` (when
 /// present) carried by the marker, else a bare null marker. Markdown never
-/// inlines an example: an Unendorsed markdown leaf is always a bare marker.
+/// inlines an example: an Unendorsed markdown leaf is always a bare marker, but
+/// its `example:` still surfaces as a `# e.g.` hint (see `append_scalar`).
 fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
     if let Some(default) = &field.default {
         return (default.as_json().clone(), false);
@@ -238,7 +239,11 @@ fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
 /// Append a scalar / scalar-array / markdown field as a single payload field
 /// plus its trailing inline type annotation.
 fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
-    push_leading(items, field, field.default.is_some());
+    // Markdown never inlines its `example:` as the marker value, so — unlike
+    // other Unendorsed scalars — the example would vanish entirely. Surface it
+    // as a `# e.g.` hint instead (the hint no-ops when no `example:` is set).
+    let eg_when = field.default.is_some() || matches!(field.r#type, FieldType::Markdown);
+    push_leading(items, field, eg_when);
     let (json, fill) = scalar_cell(field);
     items.push(PayloadItem::Field {
         key: field.name.clone(),
@@ -457,6 +462,20 @@ main:
 "#)
         .blueprint();
         assert!(t.contains("author: !must_fill # string\n"));
+    }
+
+    #[test]
+    fn must_fill_markdown_example_surfaces_as_eg_hint_not_inline_value() {
+        // Markdown never inlines its example as the marker value, but the
+        // `example:` must still surface as a `# e.g.` hint (regression: #805).
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: markdown, example: "Hello world" }
+"#)
+        .blueprint();
+        assert!(t.contains("# e.g. Hello world\nbio: !must_fill # markdown\n"));
     }
 
     #[test]

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -345,6 +345,10 @@ fn resolve_fields(
 ///   [`zero_value`].
 /// - A present **typed dictionary** is rebuilt from its declared properties so a
 ///   null/absent property zero-fills and the projection matches the schema shape.
+///   Source keys the schema does not declare pass through verbatim, matching
+///   `config::coerce_object_props`'s coercion-time behavior — the schema is a
+///   floor, not an allowlist, so an undeclared `note:` on a typed dict reaches
+///   the plate instead of being silently dropped.
 /// - A present **typed array** resolves each element against the item schema, so
 ///   a null element zero-fills in place.
 /// - Any other present value is returned unchanged.
@@ -365,6 +369,16 @@ fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue 
                     pname.clone(),
                     resolve_value(pv.as_ref(), pschema).into_json(),
                 );
+            }
+            // Preserve undeclared keys verbatim; only rebuild the ones the
+            // schema names. Skips keys already emitted above so a declared
+            // property keeps its resolved (zero-filled) value.
+            if let Some(o) = obj {
+                for (k, v) in o {
+                    if !props.contains_key(k) {
+                        out.insert(k.clone(), v.clone());
+                    }
+                }
             }
             QuillValue::from_json(serde_json::Value::Object(out))
         }
@@ -462,4 +476,57 @@ fn fill_warning(path: &str) -> Diagnostic {
          current value is intended."
             .to_string(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn field(yaml: &str) -> FieldSchema {
+        let value = QuillValue::from_yaml_str(yaml).unwrap();
+        FieldSchema::from_quill_value("field".to_string(), &value).unwrap()
+    }
+
+    // A typed dictionary carrying a key the schema does not declare keeps that
+    // key in the resolved projection (regression guard for #803: the schema is
+    // a floor, not an allowlist). Declared-but-absent properties still zero-fill.
+    #[test]
+    fn typed_dict_preserves_undeclared_keys() {
+        let schema = field(
+            r#"
+type: object
+properties:
+  street: { type: string }
+  zip: { type: integer }
+"#,
+        );
+        let input = QuillValue::from_json(json!({ "street": "1 Infinite Loop", "note": "extra" }));
+
+        let resolved = resolve_value(Some(&input), &schema).into_json();
+
+        assert_eq!(
+            resolved,
+            json!({ "street": "1 Infinite Loop", "zip": 0, "note": "extra" })
+        );
+    }
+
+    // Same pass-through inside a typed-table row (the Array→Object recursion).
+    #[test]
+    fn typed_table_row_preserves_undeclared_keys() {
+        let schema = field(
+            r#"
+type: array
+items:
+  type: object
+  properties:
+    name: { type: string }
+"#,
+        );
+        let input = QuillValue::from_json(json!([{ "name": "ACME", "year": 2020 }]));
+
+        let resolved = resolve_value(Some(&input), &schema).into_json();
+
+        assert_eq!(resolved, json!([{ "name": "ACME", "year": 2020 }]));
+    }
 }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -146,10 +146,12 @@ pub struct RenderOptions {
     pub ppi: Option<f32>,
     /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
     /// the first and third pages). `None` renders all pages. Any index
-    /// `>= page_count` causes a `ValidationFailed` error — call
+    /// `>= page_count` fails with a `RenderError` carrying the
+    /// `typst::page_index_out_of_bounds` code — call
     /// `LiveSession::page_count()` first if validation is needed.
-    /// Backends that do not support page selection (notably PDF) return
-    /// a `FormatNotSupported` error when this is `Some`.
+    /// Backends that do not support page selection (notably PDF) fail with a
+    /// `RenderError` carrying `typst::pdf_page_selection_not_supported` when
+    /// this is `Some`.
     pub pages: Option<Vec<usize>>,
     /// Override for the PDF `/Info` `/Producer` metadata string. `None` uses
     /// the backend default (`Quillmark <version>` for the Typst backend).

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -159,6 +159,77 @@ The label `<__qm_field__>` and metadata `kind: "__qm_field__"` are reserved for 
 > `query(metadata)`, filter to your own elements rather than assuming a single
 > or last metadata element.
 
+## Form Fields
+
+`signature-field` is a thin wrapper over the general `form-field` primitive, which backs all four widget kinds — text inputs, checkboxes, choice dropdowns, and signature boxes. Import it from the same helper package:
+
+```typst
+#import "@local/quillmark-helper:0.1.0": form-field
+```
+
+Each call drops an AcroForm widget at its call site (a clickable field in PDF; reserved invisible layout space in SVG/PNG, same as `signature-field`). Value binding is the plate author's job — pass `value:` straight from your data; there is no resolver on the Typst side.
+
+### Parameters
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `name` | `str` | required (positional) | Widget `/T` name — unique within the document, matching `[A-Za-z0-9_.]+`. Shares one uniqueness domain with `signature-field`. |
+| `type` | `str` | `"text"` | One of `"text"`, `"checkbox"`, `"choice"`, `"signature"`. |
+| `value` | per type | `none` | The delivered field value; interpretation depends on `type` (see below). |
+| `options` | `array` of `str` | `()` | Display strings for `type: "choice"`; ignored otherwise. |
+| `multiline` | `bool` | `false` | Toggles the multi-line flag for `type: "text"`; ignored otherwise. |
+| `width` | `length` | `200pt` | Absolute length (`pt`/`mm`/`cm`/`in`); relative lengths (`2em`, `50%`) are rejected. |
+| `height` | `length` | `20pt` | Same constraint as `width`. |
+| `field` | `str` or `none` | `none` | Schema-field address this widget's region is keyed on (see "Binding to a schema field"). |
+
+Positioning works exactly as for `signature-field` (in-flow reserves space; wrap in `#place(...)` to overlay without displacement) — see the "Positioning" notes above.
+
+### The four field types
+
+`value:` is forwarded verbatim; the Rust adapter maps it to the AcroForm value per `type`:
+
+**Text** — `value` is a string (numbers stringify). A blank value emits no `/V`. Set `multiline: true` for a multi-line box.
+
+```typst
+#form-field("full_name", type: "text", value: data.name)
+#form-field("bio", type: "text", value: data.bio, multiline: true, height: 80pt)
+```
+
+**Checkbox** — `value` is a bool; `true` renders checked.
+
+```typst
+#form-field("agree", type: "checkbox", value: data.agree)
+```
+
+**Choice** — `value` is a string, bound only if it matches an entry in `options`.
+
+```typst
+#form-field("size", type: "choice", options: ("S", "M", "L"), value: data.size)
+```
+
+**Signature** — `value` is ignored; the widget is an unsigned SigField (Quillmark performs no cryptography — sign the output with pyHanko, Acrobat, endesive, etc.). `signature-field(name, ...)` is exactly `form-field(name, type: "signature", ...)`.
+
+```typst
+#form-field("approver", type: "signature", height: 50pt)
+```
+
+### Binding to a schema field
+
+By default a widget's only identity is its `/T` name. Pass `field:` to additionally key the widget's region on a schema-field address, so it surfaces in the geometry sidecar (`session.regions()`) and resolves under `session.fieldAt(...)`:
+
+```typst
+#form-field("Signature", type: "signature", field: "signature_block")
+```
+
+`field:` is **region-only** — the `/T` widget name stays `name`; only the sidecar entry keys on `field:`. The address must be a real schema field: a bare field name, an array element like `"refs.2"`, or a card path built from the card's `$path` prefix (a bad address raises a Typst assert). Omit `field:` and the widget exposes no region — a click has no schema field to route to.
+
+### Errors
+
+- Duplicate `name` across any `form-field`/`signature-field` calls → `typst::duplicate_form_field`.
+- A non-absolute `width`/`height`, a `type` outside the four values, a name violating `[A-Za-z0-9_.]+`, or a `field:` that is not a known schema address → a Typst assert pointing at `form-field`.
+
+The label `<__qm_field__>` and metadata `kind: "__qm_field__"` are reserved for this hand-off — the same `query(metadata)` caveat noted for `signature-field` applies.
+
 ## Output Formats
 
 PDF and SVG render as a single artifact. PNG renders one artifact per page.

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -84,9 +84,12 @@ Per field, in order:
 2. `# e.g. <value>` — emitted on an **Endorsed** field whenever `example:`
    is configured. Independent of type. On an Endorsed field the example
    never becomes the rendered value, so it surfaces as a hint. On an
-   **Unendorsed** field there is no `# e.g.` line: the example inlines
+   **Unendorsed** field there is normally no `# e.g.` line: the example inlines
    directly as the `!must_fill` marker's suggested value (see "Placeholder
-   value precedence"), so a separate hint would be redundant.
+   value precedence"), so a separate hint would be redundant. The one exception
+   is `markdown`, which never inlines its example as the value — an Unendorsed
+   markdown field with an `example:` therefore keeps the `# e.g.` line (see
+   "Markdown fields").
 
 That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 `# type:` — those collapse into the inline.
@@ -179,7 +182,9 @@ signal on its own.
 An `example` on an **Endorsed** field never becomes the rendered value — it
 surfaces in the `# e.g.` leading line instead. Only **Unendorsed** fields
 inline the example as the marker's suggested value. This holds uniformly for
-scalars, arrays, typed tables, and typed dictionaries.
+scalars, arrays, typed tables, and typed dictionaries — **except `markdown`**,
+which never inlines its example as a value in either endorsement state; its
+`example:` always surfaces as the `# e.g.` line (see "Markdown fields").
 
 All fields render as **live YAML** — no commented-out fields. The `!must_fill`
 marker is the sole "must fill" signal: a reader's mental model is one rule —
@@ -209,6 +214,15 @@ bio: !must_fill # markdown
 
 The LLM replaces the marked field with its markdown content (a quoted scalar
 or a block scalar, the consumer's choice); the marker signals "fill me."
+
+Unlike other scalars, markdown never inlines its `example:` as the marker's
+suggested value (a block-scalar placeholder would be indistinguishable from
+real content). Instead the `example:` surfaces as a `# e.g.` leading hint:
+
+```
+# e.g. Hello world
+bio: !must_fill # markdown
+```
 
 When a `default:` is configured, the field is **Endorsed** and renders its
 default as an **inline double-quoted scalar** with `\n` escapes — the canonical


### PR DESCRIPTION
#803: resolve_value's Object branch rebuilt typed-dict/typed-table objects
strictly from schema-declared properties, silently dropping undeclared source
keys before they reached the plate — a regression from the nested-null
zero-fill rework. Restore verbatim pass-through of undeclared keys, matching
config::coerce_object_props. Add compose unit tests.

#805: an Unendorsed markdown field with an example: emitted neither an inline
value (intentional) nor a # e.g. hint (the bug), so the example vanished. Gate
the hint on markdown as well as default-present. Update BLUEPRINT.md's
placeholder-precedence and Markdown-fields sections to carve out the exception.
Add a blueprint unit test.

#808: RenderOptions::pages docs (core + wasm) named the removed ValidationFailed
/ FormatNotSupported error variants; reword to the actual code strings
(typst::page_index_out_of_bounds, typst::pdf_page_selection_not_supported).
Document RenderError::new's non-empty invariant as debug-only with the Display
[] branch as the deliberate release-mode fallback.

#811: document the generalized form-field() primitive in typst-backend.md — a
Form Fields section with a parameter table, the four type: values each with a
worked example, and the field: schema-region binding.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UvDosvW8vJXfzW3ZBfLsvK