### PR TITLE
Tidy deferred backlog: dedup error-summary, pdfform flatten-limit docs, cleanup (#804, #807, #810, #812)

### DIFF
--- a/crates/backends/typst/tests/eval_error_hint.rs
+++ b/crates/backends/typst/tests/eval_error_hint.rs
@@ -1,5 +1,7 @@
-//! Issue #745: a Typst error whose span *does* resolve must be left unchanged
-//! by the eval-hint fallback.
+//! Issue #745: a Typst error raised from inside `#eval` whose span *does*
+//! resolve keeps its real source location. (The former eval-specific synthetic
+//! hint is retired — that no-synthetic-hint contract is covered directly by
+//! `error_mapping`'s `unresolvable_span_without_typst_hint_carries_no_hint`.)
 
 use std::collections::HashMap;
 use std::fs;
@@ -76,7 +78,7 @@ fn diagnostics_for(plate: &str) -> Vec<quillmark_core::Diagnostic> {
     }
 }
 
-/// A resolvable diagnostic keeps its location and does not get the generic hint.
+/// A resolvable eval error keeps its real source location.
 #[test]
 fn resolvable_eval_error_is_unchanged() {
     let diags = diagnostics_for(EVAL_ERROR_PLATE);
@@ -93,12 +95,5 @@ fn resolvable_eval_error_is_unchanged() {
     assert!(
         diag.location.is_some(),
         "this eval error resolves to the call site; expected a location, got None"
-    );
-    assert!(
-        diag.hint
-            .as_deref()
-            .is_none_or(|h| !h.contains("dynamically evaluated content")),
-        "a resolvable diagnostic must not receive the generic eval hint, got: {:?}",
-        diag.hint
     );
 }

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -86,8 +86,8 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         } else {
             // No input file: render the seeded document — the committed
             // "filled-out one" (each field's `example:`, with `default:`/zero
-            // interpolated at the render floor), which renders without
-            // field-filling.
+            // interpolated at the render floor), so the quill renders out of
+            // the box without the caller supplying any field values.
             if args.verbose {
                 println!("Using seeded document from quill");
             }

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -35,10 +35,7 @@ pub fn convert_edit_errors(errors: Vec<(String, EditError)>) -> PyErr {
             .with_path(name)
         })
         .collect();
-    let message = match diags.as_slice() {
-        [only] => only.message.clone(),
-        _ => format!("{} error(s): {}", diags.len(), diags[0].message),
-    };
+    let message = RenderError::summary_message(&diags);
     raise_with_diagnostics(diags, message)
 }
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1066,10 +1066,7 @@ fn pydict_to_field_batch(
         }
     }
     if !diags.is_empty() {
-        let message = match diags.as_slice() {
-            [only] => only.message.clone(),
-            _ => format!("{} error(s): {}", diags.len(), diags[0].message),
-        };
+        let message = quillmark_core::RenderError::summary_message(&diags);
         return Err(raise_with_diagnostics(diags, message));
     }
     Ok(batch)

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -11,6 +11,8 @@ A field's *cell* is determined by whether the schema declares a `default:`.
   the default is used when absent.
 """
 
+import pytest
+
 from quillmark import Document, OutputFormat, Quill
 
 
@@ -134,34 +136,49 @@ def test_blueprint_no_legacy_required_optional_tags(tmp_path):
 # Validation surface — new diagnostic codes
 # ---------------------------------------------------------------------------
 
-def test_absent_unendorsed_is_nonfatal(engine, tmp_path):
-    """An absent Unendorsed field is not a render gate.
+@pytest.mark.parametrize(
+    "supplied_fields",
+    [
+        # Partial: an Endorsed override present, both Unendorsed fields omitted.
+        pytest.param("status: ready\n", id="partial"),
+        # Empty: nothing supplied at all.
+        pytest.param("", id="empty"),
+    ],
+)
+def test_absent_unendorsed_emits_no_completeness_codes(engine, tmp_path, supplied_fields):
+    """An absent Unendorsed field is not a render gate, and its absence is silent.
 
     Per the zero-filled-render contract (``prose/canon/SCHEMAS.md``), render
     succeeds — each absent field is zero-filled in the ephemeral plate
-    projection. Absence is silent: ``validation::field_absent`` is not emitted by
-    ``quill.validate``.
+    projection — and ``quill.validate`` surfaces neither the removed
+    ``validation::field_absent`` nor any legacy ``required`` code, whether the
+    document is partially filled or fully empty.
     """
     quill = make_quill(tmp_path)
     md = (
         "~~~card-yaml\n"
         "$quill: py_schema_smoke\n"
         "$kind: main\n"
-        "status: ready\n"          # Endorsed override
-        # title and count omitted — Unendorsed, no defaults
+        f"{supplied_fields}"
         "~~~\n"
     )
     doc = Document.from_markdown(md)
 
-    # Absence does not gate render: a merely incomplete document renders fine.
+    # Absence does not gate render: an incomplete (or empty) document renders fine.
     result = engine.render(quill, doc, OutputFormat.PDF)
     assert len(result.artifacts) > 0
 
-    # Absence is silent — field_absent is removed and never surfaced.
+    # Absence is silent — none of the removed/legacy completeness codes surface.
     codes = [d.get("code") for d in quill.validate(doc)]
-    assert "validation::field_absent" not in codes, (
-        f"field_absent is removed and must not be surfaced; got: {codes}"
-    )
+    for legacy in (
+        "validation::field_absent",
+        "validation::missing_required",
+        "validation::required_field_absent",
+        "validation::unfilled_placeholder",
+    ):
+        assert legacy not in codes, (
+            f"`{legacy}` must not be surfaced; got: {codes}"
+        )
 
 
 def test_render_tolerates_must_fill_marker(engine, tmp_path):
@@ -194,45 +211,6 @@ def test_render_tolerates_must_fill_marker(engine, tmp_path):
     )
     assert all(d.get("severity") == "warning" for d in fill), (
         f"validation::must_fill must be a non-fatal warning; got: {fill}"
-    )
-
-
-def test_absent_unendorsed_does_not_emit_legacy_codes(engine, tmp_path):
-    """An absent Unendorsed field emits no completeness/required codes.
-
-    Absence is silent under zero-filled render (``prose/canon/SCHEMAS.md``):
-    render succeeds and ``quill.validate`` surfaces no ``field_absent`` or
-    legacy ``required`` codes. The removed ``validation::field_absent`` and
-    the legacy ``validation::missing_required``,
-    ``validation::required_field_absent``, and
-    ``validation::unfilled_placeholder`` codes never appear.
-    """
-    quill = make_quill(tmp_path)
-    md = (
-        "~~~card-yaml\n"
-        "$quill: py_schema_smoke\n"
-        "$kind: main\n"
-        "~~~\n"
-    )
-    doc = Document.from_markdown(md)
-
-    # render zero-fills absent fields and succeeds
-    result = engine.render(quill, doc, OutputFormat.PDF)
-    assert len(result.artifacts) > 0
-
-    # the validate surface carries none of these codes
-    codes = [d.get("code") for d in quill.validate(doc)]
-    assert "validation::field_absent" not in codes, (
-        f"`validation::field_absent` is removed; got: {codes}"
-    )
-    assert "validation::missing_required" not in codes, (
-        f"`validation::missing_required` must not appear; got: {codes}"
-    )
-    assert "validation::required_field_absent" not in codes, (
-        f"`validation::required_field_absent` must not appear; got: {codes}"
-    )
-    assert "validation::unfilled_placeholder" not in codes, (
-        f"`validation::unfilled_placeholder` must not appear; got: {codes}"
     )
 
 

--- a/crates/bindings/wasm/src/error.rs
+++ b/crates/bindings/wasm/src/error.rs
@@ -28,10 +28,9 @@ impl WasmError {
     /// `"… N error(s)"` summary; callers should iterate `diagnostics` for
     /// the per-error details.
     pub fn message(&self) -> String {
-        match self.diagnostics.len() {
-            0 => "Unknown error".to_string(),
-            1 => self.diagnostics[0].message.clone(),
-            n => format!("{} error(s): {}", n, self.diagnostics[0].message),
+        match self.diagnostics.as_slice() {
+            [] => "Unknown error".to_string(),
+            diags => RenderError::summary_message(diags),
         }
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -341,6 +341,20 @@ impl RenderError {
     pub fn into_diagnostics(self) -> Vec<Diagnostic> {
         self.diags
     }
+
+    /// The count-based summary line shared by `Display` and every binding's
+    /// exception message: the sole diagnostic's `message` for one, an
+    /// `"<N> error(s): <first message>"` aggregate for more. The single source
+    /// of truth for this rule — bindings delegate here rather than re-deriving
+    /// it. An empty slice yields `"render error"` defensively (see
+    /// [`RenderError::new`]'s debug-only non-empty invariant).
+    pub fn summary_message(diags: &[Diagnostic]) -> String {
+        match diags {
+            [d] => d.message.clone(),
+            [first, ..] => format!("{} error(s): {}", diags.len(), first.message),
+            [] => "render error".to_string(),
+        }
+    }
 }
 
 /// The primary message for a single diagnostic; an
@@ -348,11 +362,7 @@ impl RenderError {
 /// WASM binding applies to thrown `Error.message`.
 impl std::fmt::Display for RenderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.diags.as_slice() {
-            [d] => write!(f, "{}", d.message),
-            [first, ..] => write!(f, "{} error(s): {}", self.diags.len(), first.message),
-            [] => write!(f, "render error"),
-        }
+        write!(f, "{}", Self::summary_message(&self.diags))
     }
 }
 

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -198,6 +198,15 @@ The PDF is the real deliverable. By design (Technique A — real fields plus `Ne
 
 To get values into the SVG/PNG/canvas output, the backend pre-flattens them: it bakes each value into the page content stream (via a raster tree, hayro) so the raster is complete rather than background-only. This flattening backs the SVG/PNG/canvas surfaces only — never the AcroForm PDF deliverable, which is always stamped.
 
+### Flatten fidelity limits
+
+The stamped PDF is always faithful; the **flattened preview surfaces (SVG/PNG/canvas) are a lossy approximation** in two cases, because the flatten path bakes a fixed Helvetica appearance clipped to the field box rather than deferring to a viewer's form renderer. In both, the delivered PDF is correct — only the preview differs, and no diagnostic is raised.
+
+- **Non-WinAnsi characters render as `?`.** The flatten path encodes text as WinAnsi (CP1252). Any code point outside that range — CJK, emoji, and many symbols — is substituted with `?` in the preview, while the stamped PDF keeps full Unicode (UTF-16BE `/V`). A field whose value is `日本語` shows correctly in Acrobat but as `???` in the SVG/PNG/canvas.
+- **Multi-line overflow is clipped.** A multi-line value taller than its field box has its overflow lines clipped in the preview (the content is masked to the box), whereas the stamped PDF keeps the full value and lets the viewer wrap or scroll it. A preview can therefore look truncated where the delivered PDF is complete.
+
+Treat the stamped PDF, not the raster preview, as the source of truth for what a field actually contains.
+
 ### Regions sidecar
 
 Field geometry is a session-level query, not part of `RenderResult`: open a session and call `regions()` to get one entry per schema-bound field, keyed on its schema field path:


### PR DESCRIPTION
Follow-up to #814, clearing the cheap, low-risk half of the deferred `v0.92.1..HEAD` review backlog. No behavior changes to the render path.

## #810-1 — remove error-summary drift
Extracted `RenderError::summary_message(&[Diagnostic])` in core as the single source of truth for the `"<N> error(s): <first>"` aggregate rule. `RenderError::Display`, `WasmError::message`, and both Python exception paths (`convert_edit_errors`, `pydict_to_field_batch`) now delegate to it instead of hand-duplicating the formula in four places. Behavior is unchanged — WASM keeps its `"Unknown error"` empty sentinel; the core empty case stays `"render error"`.

## #804 / #807 — document pdfform flatten fidelity limits
New "Flatten fidelity limits" subsection in `docs/quills/pdfform-backend.md`. The stamped PDF is always faithful, but the flattened preview surfaces (SVG/PNG/canvas) are lossy in two cases: non-WinAnsi characters (CJK, emoji, many symbols) render as `?`, and multi-line values taller than their box are clipped. The delivered PDF is correct in both — only the preview differs. Docs only.

## #812 — three cleanups
- **CLI comment** (`render.rs`): fixed the self-contradicting no-input-file comment. The seeded document renders out of the box *because* it carries example values, not "without field-filling".
- **Vestigial test assertion** (`eval_error_hint.rs`): dropped the `"dynamically evaluated content"` hint assertion — it checked for a synthetic-hint mechanism that no longer exists (retired in `error_mapping`, already covered by its `unresolvable_span_without_typst_hint_carries_no_hint` unit test). Kept the real location-resolution check.
- **Near-duplicate Python tests** (`test_schema.py`): folded `test_absent_unendorsed_is_nonfatal` and `test_absent_unendorsed_does_not_emit_legacy_codes` into one parametrized test over partial/empty payloads, asserting all legacy/removed codes in both.

## Verification
- `cargo build --workspace` clean (no warnings)
- 610 core lib tests pass; `eval_error_hint` integration test passes
- `cargo doc -p quillmark-core` no broken links; `test_schema.py` `py_compile`s
- Full Python/WASM binding tests run on CI per project convention

## Still deferred (need real care, out of scope here)
- #806 — Typst widget hit-testing z-order (behavioral correctness)
- #809 — perf: per-field PDF re-scans, process-global comemo clock
- #810 parts 2–4 — dict-splice / field-name-filter / y-flip dedup (larger refactors; the issue recommends bundling with other work in those files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvDosvW8vJXfzW3ZBfLsvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvDosvW8vJXfzW3ZBfLsvK)_