### PR TITLE
Ground #809/#810: memoize page checks, unify dict-splice + field-name filters

### DIFF
--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -22,7 +22,10 @@
 //! Entry point: [`flatten`].
 
 use quillmark_pdf::{
-    reader::{err, extract_outer_dict, find_dict_value, find_object_bytes, UpdatedObject},
+    reader::{
+        err, extract_outer_dict, find_dict_value, find_object_bytes, splice_dict_value,
+        UpdatedObject,
+    },
     writer::{alloc_id, dict_object, pdf_escape, winansi_encode},
     FieldSpec, FieldType, PdfError, PdfUpdate, StampOptions, CHECKBOX_ON_STATE,
 };
@@ -251,16 +254,12 @@ fn add_content_stream(pg_dict: &[u8], stream_id: u32) -> Result<Vec<u8>, PdfErro
                 // Single indirect ref — wrap in array.
                 format!("[{} {ref_str}]", String::from_utf8_lossy(trimmed).trim())
             };
-            let key = b"/Contents";
-            let value_start = existing.as_ptr() as usize - pg_dict.as_ptr() as usize;
-            let key_at = value_start - key.len();
-            let value_end = value_start + existing.len();
-            let mut out = Vec::new();
-            out.extend_from_slice(&pg_dict[..key_at]);
-            out.extend_from_slice(b"/Contents ");
-            out.extend_from_slice(new_val.as_bytes());
-            out.extend_from_slice(&pg_dict[value_end..]);
-            Ok(out)
+            Ok(splice_dict_value(
+                pg_dict,
+                b"/Contents",
+                existing,
+                new_val.as_bytes(),
+            ))
         }
     }
 }
@@ -321,15 +320,7 @@ fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>
                     new_font_val.extend_from_slice(format!(" {helv_entry} >>").as_bytes());
 
                     // Splice new_font_val into res_inner replacing /Font <font_val>.
-                    let fv_start = font_val.as_ptr() as usize - res_inner.as_ptr() as usize;
-                    let key_at = fv_start - b"/Font".len();
-                    let fv_end = fv_start + font_val.len();
-                    let mut out = Vec::new();
-                    out.extend_from_slice(&res_inner[..key_at]);
-                    out.extend_from_slice(b"/Font ");
-                    out.extend_from_slice(&new_font_val);
-                    out.extend_from_slice(&res_inner[fv_end..]);
-                    out
+                    splice_dict_value(res_inner, b"/Font", font_val, &new_font_val)
                 }
             };
 
@@ -338,16 +329,12 @@ fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>
             new_res_val.extend_from_slice(&new_res_inner);
             new_res_val.extend_from_slice(b" >>");
 
-            let rv_start = res_val.as_ptr() as usize - pg_dict.as_ptr() as usize;
-            let key_at = rv_start - b"/Resources".len();
-            let rv_end = rv_start + res_val.len();
-
-            let mut out = Vec::new();
-            out.extend_from_slice(&pg_dict[..key_at]);
-            out.extend_from_slice(b"/Resources ");
-            out.extend_from_slice(&new_res_val);
-            out.extend_from_slice(&pg_dict[rv_end..]);
-            Ok(out)
+            Ok(splice_dict_value(
+                pg_dict,
+                b"/Resources",
+                res_val,
+                &new_res_val,
+            ))
         }
     }
 }

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -40,6 +40,15 @@ fn render_options(pixel_per_pt: f32) -> RenderOptions {
 /// eviction — an editing loop (one compile per keystroke) leaks otherwise.
 /// 10 matches typst-cli's watch-loop policy: deep enough to keep everything a
 /// live document's recompile reuses, shallow enough to bound a long session.
+///
+/// Caveat: the "age" clock is also process-global, not per-`QuillWorld`. Two
+/// sessions compiling interleaved in one process share it, so a document that
+/// goes quiet for 10 compiles *summed across all sessions* has its entries
+/// evicted even when its own edit history is shorter — reuse degrades under
+/// concurrent-session use (WASM canvas-preview, a long-lived multi-session
+/// Python/CLI process). Never a wrong render (comemo entries are pure functions
+/// of input), only lost reuse. A true per-session bound needs an eviction
+/// counter scoped to the `World`, which comemo doesn't expose today.
 const COMEMO_EVICT_MAX_AGE: usize = 10;
 
 /// Compile the world, returning the paged document together with Typst's

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -616,21 +616,28 @@ fn is_date_field(field_schema: &serde_json::Value) -> bool {
 
 /// Names of the markdown / `markdown[]` fields in a schema `properties` map —
 /// the fields whose values carry backend markup for the helper to `eval`.
-fn content_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+/// Names of the schema `properties` whose field schema satisfies `predicate`,
+/// in map order. Shared spine of the field-class selectors below.
+fn field_names_where(
+    properties: &serde_json::Map<String, serde_json::Value>,
+    predicate: impl Fn(&serde_json::Value) -> bool,
+) -> Vec<String> {
     properties
         .iter()
-        .filter(|(_, fs)| is_markdown_field(fs) || is_markdown_array_field(fs))
+        .filter(|(_, fs)| predicate(fs))
         .map(|(name, _)| name.clone())
         .collect()
 }
 
+fn content_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+    field_names_where(properties, |fs| {
+        is_markdown_field(fs) || is_markdown_array_field(fs)
+    })
+}
+
 /// Names of the date fields in a schema `properties` map.
 fn date_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
-    properties
-        .iter()
-        .filter(|(_, fs)| is_date_field(fs))
-        .map(|(name, _)| name.clone())
-        .collect()
+    field_names_where(properties, is_date_field)
 }
 
 /// Names of the array-typed fields in a schema `properties` map — the fields
@@ -641,11 +648,9 @@ fn date_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> 
 /// the content codegen only *produces* eval sites for `markdown[]` elements,
 /// but a widget binding of a plain array element is a real, routable address.
 fn array_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
-    properties
-        .iter()
-        .filter(|(_, fs)| fs.get("type").and_then(|v| v.as_str()) == Some("array"))
-        .map(|(name, _)| name.clone())
-        .collect()
+    field_names_where(properties, |fs| {
+        fs.get("type").and_then(|v| v.as_str()) == Some("array")
+    })
 }
 
 /// Convert a content field's value to backend markup: a markdown string is

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -314,6 +314,29 @@ pub fn find_dict_value<'a>(dict_bytes: &'a [u8], key: &str) -> Option<&'a [u8]> 
     }
 }
 
+/// Replace `key`'s value in a flat dict, given the current `value` slice — which
+/// MUST be the subslice [`find_dict_value`] returned for that key. Its start
+/// locates the key span by pointer subtraction (`[value_start - key.len,
+/// value_end)`), not by re-scanning, so a `key` token appearing inside another
+/// value can't be matched by accident. The `key`+value span is rewritten as
+/// `key` + one space + `new_value`; the rest of `dict` is copied verbatim.
+///
+/// `key` is the on-page byte form including the leading slash (`b"/Producer"`).
+/// Callers that build the replacement value from `value`'s own bytes must do so
+/// before calling — `dict` is borrowed immutably here.
+pub fn splice_dict_value(dict: &[u8], key: &[u8], value: &[u8], new_value: &[u8]) -> Vec<u8> {
+    let value_start = value.as_ptr() as usize - dict.as_ptr() as usize;
+    let value_end = value_start + value.len();
+    let key_at = value_start - key.len();
+    let mut out = Vec::with_capacity(key_at + key.len() + 1 + new_value.len() + dict.len() - value_end);
+    out.extend_from_slice(&dict[..key_at]);
+    out.extend_from_slice(key);
+    out.push(b' ');
+    out.extend_from_slice(new_value);
+    out.extend_from_slice(&dict[value_end..]);
+    out
+}
+
 /// Skip PDF whitespace and `%`-comments (which run to end-of-line) starting at
 /// `start`; returns the index of the first significant byte at or after it.
 fn skip_ws_and_comments(b: &[u8], start: usize) -> usize {

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -21,7 +21,8 @@ use quillmark_core::RenderedRegion;
 
 use crate::error::PdfError;
 use crate::reader::{
-    err, extract_outer_dict, find_dict_value, find_object_bytes, parse_indirect_ref, UpdatedObject,
+    err, extract_outer_dict, find_dict_value, find_object_bytes, parse_indirect_ref,
+    splice_dict_value, UpdatedObject,
 };
 use crate::update::PdfUpdate;
 use crate::writer::{alloc_id, dict_object};
@@ -298,16 +299,12 @@ fn rewrite_page_with_annots(pg_dict: &[u8], widget_refs: &[u32]) -> Result<Vec<u
                     String::from_utf8_lossy(inner).trim(),
                     widgets_str
                 );
-                let key = b"/Annots";
-                let value_start = existing.as_ptr() as usize - pg_dict.as_ptr() as usize;
-                let key_at = value_start - key.len();
-                let value_end = value_start + existing.len();
-                let mut out = Vec::new();
-                out.extend_from_slice(&pg_dict[..key_at]);
-                out.extend_from_slice(b"/Annots ");
-                out.extend_from_slice(merged.as_bytes());
-                out.extend_from_slice(&pg_dict[value_end..]);
-                Ok(out)
+                Ok(splice_dict_value(
+                    pg_dict,
+                    b"/Annots",
+                    existing,
+                    merged.as_bytes(),
+                ))
             } else if parse_indirect_ref(existing).is_some() {
                 Err(err(
                     "pdf::indirect_annots",

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -95,6 +95,11 @@ impl PdfUpdate {
     pub fn resolve_pages(&self, pdf: &[u8], fields: &[FieldSpec]) -> Result<Vec<u32>, PdfError> {
         let page_ids = resolve_page_ids(pdf, self.catalog_id)?;
         let page_count = page_ids.len();
+        // Both assertions below re-scan the whole PDF byte buffer per call
+        // (`find_object_bytes` is linear), so a form with N fields on the same
+        // page would otherwise pay O(N × file_size). Validate each distinct page
+        // once; the bounds check still runs per field.
+        let mut checked = vec![false; page_count];
         for spec in fields {
             if spec.page >= page_count {
                 return Err(err(
@@ -105,6 +110,9 @@ impl PdfUpdate {
                     ),
                 ));
             }
+            if checked[spec.page] {
+                continue;
+            }
             // A targeted page node is overwritten (its `/Annots`) and referenced
             // by every widget on it as gen 0, so a non-zero-generation page would
             // be silently corrupted.
@@ -112,6 +120,7 @@ impl PdfUpdate {
             // Widget/content geometry is written in unrotated user space; a
             // rotated target page would mis-place every field. Reject cleanly.
             assert_unrotated_page(pdf, self.catalog_id, page_ids[spec.page])?;
+            checked[spec.page] = true;
         }
         Ok(page_ids)
     }

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -8,7 +8,7 @@
 use crate::error::PdfError;
 use crate::reader::{
     assert_overwrite_gen_zero, err, extract_outer_dict, find_dict_value, find_object_bytes,
-    UpdatedObject,
+    splice_dict_value, UpdatedObject,
 };
 
 const CODE_PARSE: &str = "pdf::write";
@@ -77,21 +77,7 @@ pub fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
             out.extend_from_slice(literal);
             out
         }
-        Some(value) => {
-            // `value` starts exactly after the matched `/Producer` key, so the
-            // key span is `[value_start - key.len, value_end)` — derived, not
-            // re-scanned, so a `/Producer` token inside another value can't be
-            // matched by accident.
-            let value_start = value.as_ptr() as usize - info_dict.as_ptr() as usize;
-            let value_end = value_start + value.len();
-            let key_at = value_start - key.len();
-            let mut out = Vec::new();
-            out.extend_from_slice(&info_dict[..key_at]);
-            out.extend_from_slice(b"/Producer ");
-            out.extend_from_slice(literal);
-            out.extend_from_slice(&info_dict[value_end..]);
-            out
-        }
+        Some(value) => splice_dict_value(info_dict, key, value, literal),
     }
 }
 


### PR DESCRIPTION
Addresses the actionable findings from issues #809 and #810.

#809.1 — PdfUpdate::resolve_pages validated each field's target page
independently, and both assertions re-scan the whole PDF buffer
(find_object_bytes is linear). N fields on one page paid O(N × file_size);
now each distinct page is checked once (bounds check still per field).

#809.2 — Document that comemo's eviction "age" clock is process-global, not
per-QuillWorld, so interleaved sessions share it and degrade reuse. No code
fix available (comemo exposes no per-World counter); caveat added.

#810.2 — Factor the five PDF dict-splice-by-pointer-arithmetic sites
(upsert_producer, rewrite_page_with_annots, add_content_stream, and both
splices in add_font_resource) onto one splice_dict_value helper in reader.rs,
shared across the quillmark-pdf and pdfform crates.

#810.3 — Collapse content/date/array_field_names onto one field_names_where
predicate helper in the Typst backend.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016w92WwssPraexhUcVK2jPY