### PR TITLE
Dead-code sweep from minimize-0.92.1-main review (#817–#821, #823, #825)

### DIFF
--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -27,7 +27,7 @@ use quillmark_pdf::{
         UpdatedObject,
     },
     writer::{alloc_id, dict_object, pdf_escape, winansi_encode},
-    FieldSpec, FieldType, PdfError, PdfUpdate, StampOptions, CHECKBOX_ON_STATE,
+    FieldSpec, FieldType, PdfError, PdfUpdate, CHECKBOX_ON_STATE,
 };
 
 use crate::typography;
@@ -37,19 +37,19 @@ const CODE_PARSE: &str = "pdf::flatten_parse";
 /// Flatten `fields` onto `base` PDF by drawing values as PDF content stream
 /// operators. Unlike the stamp/Technique-A path, the result is visible in all
 /// rasterizers. Returns the flat PDF bytes.
-pub fn flatten(
-    base: Vec<u8>,
-    fields: &[FieldSpec],
-    opts: &StampOptions,
-) -> Result<Vec<u8>, PdfError> {
-    if fields.is_empty() && opts.producer.is_none() {
+///
+/// Backs raster/vector output only (SVG/PNG/canvas), never a PDF deliverable,
+/// so it never stamps an `/Info /Producer` — that rides the interactive `stamp`
+/// path.
+pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError> {
+    if fields.is_empty() {
         return Ok(base);
     }
 
     let pdf = base;
     // Shared envelope: validate the input contract, read the trailer, seed the
-    // id counter, apply the optional `/Info` `/Producer` stamp.
-    let mut up = PdfUpdate::begin(&pdf, opts.producer.as_deref())?;
+    // id counter. No producer stamp on the flatten path.
+    let mut up = PdfUpdate::begin(&pdf, None)?;
 
     if !fields.is_empty() {
         let page_ids = up.resolve_pages(&pdf, fields)?;
@@ -132,7 +132,7 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                 // ZapfDingbats check glyphs are roughly square; centre in the box.
                 let x_pos = x0 + (w - size * typography::CHECK_GLYPH_WIDTH_FACTOR) * 0.5;
                 let y_pos = y0 + (h - size) * 0.5;
-                write_zadb_char(&mut out, b'4', x_pos, y_pos, size);
+                write_zadb_char(&mut out, x_pos, y_pos, size);
             }
             FieldType::Text { .. } => {
                 if let Some(value) = &spec.value {
@@ -198,22 +198,18 @@ fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32
     out.extend_from_slice(b"ET\nQ\n");
 }
 
-/// Write a single ZapfDingbats character (as its raw byte code) in a `BT/ET` block.
-/// Glyph 0x34 (`'4'`) is the filled check mark — identical to the `/MK /CA (4)`
-/// glyph the AcroForm stamp path declares for checked checkboxes.
-fn write_zadb_char(out: &mut Vec<u8>, glyph: u8, x: f32, y: f32, size: f32) {
+/// Write the ZapfDingbats checkmark in a `BT/ET` block. Glyph 0x34 (`'4'`) is
+/// the filled check mark — identical to the `/MK /CA (4)` glyph the AcroForm
+/// stamp path declares for checked checkboxes. It is the only glyph the flatten
+/// path draws, so it is written literally (no escape needed).
+fn write_zadb_char(out: &mut Vec<u8>, x: f32, y: f32, size: f32) {
     out.extend_from_slice(b"q\nBT\n/ZaDb ");
     push_f32(out, size);
     out.extend_from_slice(b" Tf\n");
     push_f32(out, x);
     out.push(b' ');
     push_f32(out, y);
-    out.extend_from_slice(b" Td\n(");
-    if matches!(glyph, b'(' | b')' | b'\\') {
-        out.push(b'\\');
-    }
-    out.push(glyph);
-    out.extend_from_slice(b") Tj\nET\nQ\n");
+    out.extend_from_slice(b" Td\n(4) Tj\nET\nQ\n");
 }
 
 // ── Page dict rewriting ───────────────────────────────────────────────────────
@@ -416,7 +412,7 @@ mod tests {
     }
 
     fn flatten_ok(fields: &[FieldSpec]) -> Vec<u8> {
-        flatten(BASE.to_vec(), fields, &StampOptions::default()).expect("flatten succeeds")
+        flatten(BASE.to_vec(), fields).expect("flatten succeeds")
     }
 
     fn contains_window(haystack: &[u8], needle: &[u8]) -> bool {

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -19,11 +19,8 @@ mod form;
 mod resolve;
 mod typography;
 
-pub use form::{FieldKind, FormField, FormParseError, FormSpec, Rect};
-
-use std::any::Any;
-
 use flatten::flatten as flatten_to_pdf;
+use form::FormSpec;
 use quillmark_core::session::SessionHandle;
 use quillmark_core::{
     Artifact, Backend, ChangeSet, Diagnostic, LiveSession, OutputFormat, Quill, RenderError,
@@ -98,20 +95,13 @@ impl Backend for PdfformBackend {
 
         // Pre-flatten once so render_rgba / SVG / PNG renders have a
         // ready-to-rasterize flat PDF without re-running flatten on every
-        // paint call. The producer string only goes in the PDF Info dict and
-        // doesn't affect rasterisation, so None is fine here.
-        let flat_pdf = flatten_to_pdf(
-            base_pdf.clone(),
-            &field_specs,
-            &StampOptions { producer: None },
-        )
-        .map_err(map_pdf_err)?;
+        // paint call.
+        let flat_pdf = flatten_to_pdf(base_pdf.clone(), &field_specs).map_err(map_pdf_err)?;
 
         Ok(LiveSession::new(Box::new(PdfformSession {
             base_pdf,
             spec,
             field_specs,
-            page_count: page_boxes.len(),
             page_boxes,
             flat_pdf,
         })))
@@ -151,9 +141,9 @@ struct PdfformSession {
     /// document data by each `apply`.
     spec: FormSpec,
     field_specs: Vec<FieldSpec>,
-    page_count: usize,
     /// Page media-boxes from the background; used by `page_size_pt` without
-    /// reparsing the PDF on every canvas-paint call.
+    /// reparsing the PDF on every canvas-paint call. Its length is the page
+    /// count (the background is fixed for the session).
     page_boxes: Vec<[f32; 4]>,
     /// Pre-flattened PDF (values baked as content-stream operators) ready for
     /// hayro rasterisation. Produced once at session-open time.
@@ -204,11 +194,7 @@ impl SessionHandle for PdfformSession {
     }
 
     fn page_count(&self) -> usize {
-        self.page_count
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
+        self.page_boxes.len()
     }
 
     /// Page dimensions in PDF points derived from the background's `/MediaBox`.
@@ -258,12 +244,7 @@ impl SessionHandle for PdfformSession {
     /// visible delta.
     fn apply(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
         let field_specs = resolve_field_specs(&self.spec, &self.page_boxes, json_data)?;
-        let flat_pdf = flatten_to_pdf(
-            self.base_pdf.clone(),
-            &field_specs,
-            &StampOptions { producer: None },
-        )
-        .map_err(map_pdf_err)?;
+        let flat_pdf = flatten_to_pdf(self.base_pdf.clone(), &field_specs).map_err(map_pdf_err)?;
 
         let mut dirty_pages: Vec<usize> = self
             .field_specs
@@ -279,7 +260,7 @@ impl SessionHandle for PdfformSession {
         self.flat_pdf = flat_pdf;
 
         Ok(ChangeSet {
-            page_count: self.page_count,
+            page_count: self.page_boxes.len(),
             dirty_pages,
         })
     }

--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -75,9 +75,6 @@ fn field_type(kind: &FieldKind) -> FieldType {
 /// (`schema_field: None`), an absent/null target, a signature, an empty text
 /// value, an unchecked checkbox, or a choice value matching no option.
 fn resolve_value(kind: &FieldKind, schema_field: Option<&str>, data: &Value) -> Option<String> {
-    if matches!(kind, FieldKind::Signature) {
-        return None;
-    }
     let raw = lookup(data, schema_field?)?;
     match kind {
         FieldKind::Text { .. } => coerce_text(raw),

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -27,7 +27,6 @@ use quillmark_core::{
     LiveSession, OutputFormat, Quill, QuillValue, RenderError, RenderOptions, RenderResult,
     Severity,
 };
-use std::any::Any;
 use std::collections::HashMap;
 
 /// Typst backend implementation for Quillmark.
@@ -42,9 +41,10 @@ const SUPPORTED_FORMATS: &[OutputFormat] =
 /// Holds the compiled `PagedDocument` *and* the `QuillWorld` it was compiled
 /// through. Persisting the world keeps fonts, packages, and assets parsed once
 /// per session rather than once per compile — the substrate for incremental
-/// recompiles. Exposes Typst-only operations (page geometry, raster rendering)
-/// used by the WASM canvas painter.
-pub struct TypstSession {
+/// recompiles. Typst-only operations (page geometry, raster rendering) are
+/// served generically through the `SessionHandle` trait; callers never name
+/// this type.
+struct TypstSession {
     world: world::QuillWorld,
     document: typst_layout::PagedDocument,
     page_count: usize,
@@ -303,10 +303,6 @@ impl SessionHandle for TypstSession {
 
     fn page_count(&self) -> usize {
         self.page_count
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     /// Incremental recompile against new document data. The persistent world

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -8,12 +8,6 @@
 // is `form-field` / `signature-field` (widget geometry + metadata hand-off)
 // and `_qm-known-path` (path validation); both read the generated `_qm-meta`.
 
-/// The backend always generates `_qm-meta` (below), so validation always has
-/// tables to check against. Kept as a binding — rather than inlined — so
-/// `_qm-known-path`'s permissive branch stays exercisable by hand-built test
-/// helpers that set it `false`.
-#let _qm-has-meta = true
-
 /// Backend-generated schema address tables (`fields`, `card_fields`,
 /// `array_fields`, `card_array_fields`) that validate `form-field` paths.
 /// A generated literal — never parsed from document data.
@@ -27,12 +21,10 @@
 /// `array_fields`/`card_array_fields`, not the broader `fields`/`card_fields`
 /// name tables, rejecting `subject.0` on a scalar `subject` even though the
 /// name itself is known: a scalar has no element for the address to resolve
-/// to. Permissive when `_qm-has-meta` is false — validation then has nothing
-/// to check against. Distinct from present-with-empty tables (e.g. a
-/// body-disabled main with no other fields and no cards), which validates
-/// against the empty set and so rejects every address.
+/// to. Distinct from present-with-empty tables (e.g. a body-disabled main with
+/// no other fields and no cards), which validates against the empty set and so
+/// rejects every address.
 #let _qm-known-path(path) = {
-  if not _qm-has-meta { return true }
   let fields = _qm-meta.at("fields", default: ())
   let card-fields = _qm-meta.at("card_fields", default: (:))
   let array-fields = _qm-meta.at("array_fields", default: ())

--- a/crates/backends/typst/src/overlay/extract.rs
+++ b/crates/backends/typst/src/overlay/extract.rs
@@ -96,7 +96,7 @@ fn read_field_kind(
 ) -> Result<FieldKind, RenderError> {
     match field_type {
         "text" => Ok(FieldKind::Text {
-            multiline: read_bool(d, "multiline")?.unwrap_or(false),
+            multiline: read_value_bool(d, "multiline")?.unwrap_or(false),
             value: read_value_str(d, "value")?,
         }),
         "checkbox" => Ok(FieldKind::Checkbox {
@@ -136,19 +136,6 @@ fn read_f64(d: &typst::foundations::Dict, key: &str) -> Result<f64, RenderError>
             format!("expected metadata.{key} to be float, got {}", other.ty()),
         )),
         Err(_) => Err(err(CODE_INTERNAL, format!("metadata.{key} missing"))),
-    }
-}
-
-/// Read an optional boolean key (`None` for a missing key, an error for a
-/// present-but-wrong-type key). Used for the `multiline` flag.
-fn read_bool(d: &typst::foundations::Dict, key: &str) -> Result<Option<bool>, RenderError> {
-    match d.get(key) {
-        Ok(Value::Bool(b)) => Ok(Some(*b)),
-        Ok(other) => Err(err(
-            CODE_INTERNAL,
-            format!("expected metadata.{key} to be bool, got {}", other.ty()),
-        )),
-        Err(_) => Ok(None),
     }
 }
 
@@ -220,18 +207,17 @@ fn read_value_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<Stri
     Ok((!s.is_empty()).then_some(s))
 }
 
-/// Read the polymorphic `value` key as a boolean (for checkbox fields). A
-/// `Bool` passes through; `None` (or a missing key) yields `None` (unchecked).
+/// Read an optional boolean key: a `Bool` passes through; `None` or a missing
+/// key yields `None`; any other present type errors. Used for the checkbox
+/// `value` binding and the text `multiline` flag — both treat a `none` as the
+/// unset default rather than an error.
 fn read_value_bool(d: &typst::foundations::Dict, key: &str) -> Result<Option<bool>, RenderError> {
     match d.get(key) {
         Ok(Value::Bool(b)) => Ok(Some(*b)),
         Ok(Value::None) | Err(_) => Ok(None),
         Ok(other) => Err(err(
             CODE_INTERNAL,
-            format!(
-                "expected checkbox metadata.{key} to be bool or none, got {}",
-                other.ty()
-            ),
+            format!("expected metadata.{key} to be bool or none, got {}", other.ty()),
         )),
     }
 }

--- a/crates/backends/typst/src/world.rs
+++ b/crates/backends/typst/src/world.rs
@@ -79,6 +79,14 @@ impl QuillWorld {
         // must be vendored under `packages/` in the quill tree.
         Self::load_packages_from_quill(source, &mut sources, &mut binaries)?;
 
+        // The helper package's typst.toml is constant for the session's
+        // lifetime, so insert it once here. Re-injecting the helper `lib.typ`
+        // per apply leaves it untouched.
+        binaries.insert(
+            Self::helper_fid("typst.toml"),
+            Bytes::new(helper::generate_typst_toml().into_bytes()),
+        );
+
         // Create main source
         let main_id = file_id(
             None,
@@ -116,49 +124,39 @@ impl QuillWorld {
         Ok((world, windows))
     }
 
-    /// The virtual `@local/quillmark-helper` package spec.
-    pub(crate) fn helper_spec() -> PackageSpec {
-        PackageSpec {
+    /// A [`FileId`] for `rel` inside the virtual `@local/quillmark-helper`
+    /// package (e.g. `lib.typ`).
+    pub(crate) fn helper_fid(rel: &str) -> FileId {
+        let spec = PackageSpec {
             namespace: helper::HELPER_NAMESPACE.into(),
             name: helper::HELPER_NAME.into(),
             version: helper::HELPER_VERSION
                 .parse()
                 .expect("Invalid helper version"),
-        }
-    }
-
-    /// A [`FileId`] for `rel` inside the helper package (e.g. `lib.typ`).
-    pub(crate) fn helper_fid(rel: &str) -> FileId {
-        file_id(
-            Some(Self::helper_spec()),
-            VirtualPath::new(rel).expect("valid helper vpath"),
-        )
+        };
+        file_id(Some(spec), VirtualPath::new(rel).expect("valid helper vpath"))
     }
 
     /// Replace-or-insert a source. An existing source is edited via
     /// [`Source::replace`] — a prefix/suffix diff reparses only the changed
     /// span, preserving spans on the untouched regions so `comemo` constraints
-    /// keep matching across an edit. A new source is inserted whole. Returns
-    /// the byte length of the reparsed range (0 on insert).
-    pub(crate) fn set_source(&mut self, id: FileId, text: &str) -> usize {
+    /// keep matching across an edit. A new source is inserted whole.
+    pub(crate) fn set_source(&mut self, id: FileId, text: &str) {
         match self.sources.get_mut(&id) {
-            Some(s) => s.replace(text).len(),
+            Some(s) => {
+                s.replace(text);
+            }
             None => {
                 self.sources.insert(id, Source::new(id, text.to_string()));
-                0
             }
         }
-    }
-
-    /// Set a binary file (e.g. the helper `typst.toml`).
-    pub(crate) fn set_binary(&mut self, id: FileId, bytes: Vec<u8>) {
-        self.binaries.insert(id, Bytes::new(bytes));
     }
 
     /// Inject the quillmark-helper package generated from the transformed
     /// document data plus the schema meta (see `helper::generate_lib_typ`).
     /// `set_source` on the helper `lib.typ` makes a repeat injection (a session
-    /// edit) an incremental reparse rather than a fresh parse. Returns each
+    /// edit) an incremental reparse rather than a fresh parse. The helper's
+    /// `typst.toml` is constant and set once at construction. Returns each
     /// generated content block's byte window, paired with the helper file's id
     /// — the span scan's classification table.
     pub(crate) fn inject_helper_package(
@@ -169,10 +167,6 @@ impl QuillWorld {
         let file = Self::helper_fid("lib.typ");
         let (src, windows) = helper::generate_lib_typ(data, meta);
         self.set_source(file, &src);
-        self.set_binary(
-            Self::helper_fid("typst.toml"),
-            helper::generate_typst_toml().into_bytes(),
-        );
         windows
             .into_iter()
             .map(|w| crate::overlay::FieldWindow {

--- a/crates/backends/typst/tests/sig_field.rs
+++ b/crates/backends/typst/tests/sig_field.rs
@@ -180,7 +180,6 @@ Page 2.
 #signature-field("b")
 "#;
     let pdf = compile(plate).expect("compile ok");
-    fs::write("/tmp/qm_sig_two_pages.pdf", &pdf).ok();
 
     let doc = lopdf::Document::load_mem(&pdf).expect("lopdf reparse");
     let cat = doc.catalog().expect("catalog");

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -32,7 +32,7 @@ impl PyQuillmark {
 
     /// Render `doc` against `quill` in one shot, resolving `quill`'s backend on
     /// this engine. The default `output_format` falls back to the backend's
-    /// first supported format. Raises `QuillmarkError` (`UnsupportedBackend`)
+    /// first supported format. Raises `QuillmarkError` (`engine::backend_not_found`)
     /// when the backend is not registered. Mirrors WASM `Engine.render`.
     #[pyo3(signature = (quill, doc, format=None, ppi=None, pages=None, producer=None, regions=false))]
     #[allow(clippy::too_many_arguments)] // kwargs mirror RenderOptions 1:1; the signature IS the Python API
@@ -69,7 +69,7 @@ impl PyQuillmark {
     }
 
     /// The output formats `quill`'s backend can emit. Raises `QuillmarkError`
-    /// (`UnsupportedBackend`) for an unregistered backend. Mirrors WASM
+    /// (`engine::backend_not_found`) for an unregistered backend. Mirrors WASM
     /// `Engine.supportedFormats`.
     fn supported_formats(&self, quill: &PyQuill) -> PyResult<Vec<PyOutputFormat>> {
         Ok(self

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -47,16 +47,11 @@ typst = ["quillmark/typst", "dep:web-sys"]
 # pdfform build: add the Typst-free PDF-form backend so the engine can render
 # `pdfform` quills → PDF (and SVG/PNG). Does NOT require `typst` — the engine /
 # LiveSession surface is available with `pdfform` alone, giving a Typst-free
-# WASM bundle. NO canvas painter (no `web-sys`): this build reports
-# `supportsCanvas == false`.
-pdfform = ["quillmark/pdfform"]
-# pdfform-preview build: pdfform plus the `web-sys` canvas surface. The pdfform
-# session already rasterizes pages via its always-linked hayro seam, so adding
-# `web-sys` ships the generic canvas painter (page_size / paint, dispatching
-# through the core `SessionHandle` seam) in the browser and reports
-# `supportsCanvas == true`. Strict superset of `pdfform`; mirrors how `typst`
-# enables the same canvas surface.
-pdfform-preview = ["pdfform", "dep:web-sys"]
+# WASM bundle. The pdfform session rasterizes pages via its always-linked hayro
+# seam, so `web-sys` ships the generic canvas painter (page_size / paint,
+# dispatching through the core `SessionHandle` seam) and this build reports
+# `supportsCanvas == true` — mirroring how `typst` enables the same surface.
+pdfform = ["quillmark/pdfform", "dep:web-sys"]
 # Core build = no features: Document + Quill (parse / load / validate / schema
 # / seed / blueprint). No engine, no Typst — ~0.34MB gzipped.
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -29,8 +29,8 @@ bash scripts/build-wasm.sh
 ```
 
 The script builds three variants — the core (no backend), the Typst backend
-(default features), and the Typst-free pdfform backend (`pdfform-preview`
-feature) — each with `--target bundler` and `--weak-refs` enabled (see
+(default features), and the Typst-free pdfform backend (`pdfform` feature) —
+each with `--target bundler` and `--weak-refs` enabled (see
 [Lifecycle](#lifecycle)).
 
 ## Test

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -72,7 +72,7 @@ beforeAll(() => {
 })
 
 const { Quillmark, Quill, Document } = await import('@quillmark-wasm')
-// The pdfform-preview backend bundle: same engine + LiveSession + canvas
+// The pdfform backend bundle: same engine + LiveSession + canvas
 // surface as the typst bundle, but a Typst-free PDF-form backend that paints by
 // rasterizing its pre-flattened page. SEPARATE WASM memory from the typst
 // bundle — its handles never mix with the typst ones.
@@ -248,7 +248,7 @@ describe('LiveSession canvas preview (pdfform backend)', () => {
 
   it('reports canvas support and page geometry for a pdfform quill', () => {
     const { engine, quill } = openPdfformQuill()
-    // The pdfform-preview backend rasterizes pre-flattened pages.
+    // The pdfform backend rasterizes pre-flattened pages.
     expect(engine.supportsCanvas(quill)).toBe(true)
 
     const session = engine.open(quill, PdfformDocument.fromMarkdown(SAMPLE_FORM_MARKDOWN))

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -5,7 +5,7 @@ use crate::types::Diagnostic;
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 use crate::types::{ChangeSet, FieldRegion, RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -152,7 +152,7 @@ export interface Card {
 /// `densityScale` proportionally and surfaces the actual backing
 /// dimensions in the returned `PaintResult` so consumers can detect the
 /// clamp.
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 const MAX_BACKING_DIMENSION: u32 = 16384;
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
@@ -272,7 +272,7 @@ impl Quillmark {
     }
 
     /// The output formats `quill`'s backend can emit. Static capability —
-    /// resolves the backend but compiles nothing. Throws `UnsupportedBackend`
+    /// resolves the backend but compiles nothing. Throws `engine::backend_not_found`
     /// if no registered backend matches the quill's declared backend.
     #[wasm_bindgen(js_name = supportedFormats, unchecked_return_type = "OutputFormat[]")]
     pub fn supported_formats(&self, quill: &Quill) -> Result<JsValue, JsValue> {
@@ -1261,7 +1261,7 @@ fn js_bytes_for_tree_entry(path: &str, value: JsValue) -> Result<Vec<u8>, JsValu
 }
 
 /// TypeScript declarations for the canvas-preview surface.
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[wasm_bindgen(typescript_custom_section)]
 const CANVAS_PREVIEW_TS: &'static str = r#"
 /**
@@ -1445,11 +1445,7 @@ impl LiveSession {
     pub fn field_at(&self, page: usize, x: f32, y: f32) -> Option<String> {
         self.inner.field_at(page, x, y)
     }
-}
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
-#[wasm_bindgen]
-impl LiveSession {
     /// Page dimensions in points (1 pt = 1/72 inch).
     /// Throws if the backend has no canvas painter or `page` is out of range.
     #[wasm_bindgen(js_name = pageSize, unchecked_return_type = "PageSize")]
@@ -1585,7 +1581,7 @@ impl LiveSession {
     }
 }
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl LiveSession {
     /// Gate a canvas operation on the session's canvas capability, derived from
     /// the core `SessionHandle` seam (`page_size_pt` / `render_rgba`) — the same
@@ -1612,13 +1608,13 @@ impl LiveSession {
     }
 }
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 enum CanvasCtx<'a> {
     OnScreen(&'a web_sys::CanvasRenderingContext2d),
     OffScreen(&'a web_sys::OffscreenCanvasRenderingContext2d),
 }
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 impl<'a> CanvasCtx<'a> {
     fn from_js(ctx: &'a JsValue) -> Result<Self, JsValue> {
         if let Some(c) = ctx.dyn_ref::<web_sys::CanvasRenderingContext2d>() {
@@ -1660,7 +1656,7 @@ impl<'a> CanvasCtx<'a> {
     }
 }
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Serialize)]
 struct PageSize {
     #[serde(rename = "widthPt")]
@@ -1669,7 +1665,7 @@ struct PageSize {
     height_pt: f32,
 }
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PaintOptions {
@@ -1679,7 +1675,7 @@ struct PaintOptions {
     density_scale: Option<f32>,
 }
 
-#[cfg(any(feature = "typst", feature = "pdfform-preview"))]
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PaintResult {

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -7,9 +7,8 @@
 //! (`pkg/core/`) for load / validate / schema / seed / blueprint, and two
 //! engine-carrying **backend** binaries — `pkg/backends/typst/` (Typst) and
 //! `pkg/backends/pdfform/` (Typst-free PDF-form) — each adding the engine and
-//! canvas preview. The `typst` / `pdfform` / `pdfform-preview` cargo features
-//! gate the engine half (the default `typst` feature enables it; a
-//! no-feature build is the core).
+//! canvas preview. The `typst` / `pdfform` cargo features gate the engine half
+//! (the default `typst` feature enables it; a no-feature build is the core).
 //!
 //! Both backend builds are PRIVATE binaries — neither is a public npm
 //! export. The package's public root (`@quillmark/wasm`) is a hand-written

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -39,7 +39,7 @@ typst:
 
 // The hand-authored `sample_form` fixture: a `pdfform`-backend quill shipping a
 // stripped background (`form.pdf`) and a value-free field spec (`form.json`).
-// Loaded as a tree so the canvas tests can drive the pdfform-preview backend
+// Loaded as a tree so the canvas tests can drive the pdfform backend
 // (which rasterizes the pre-flattened page) exactly like a typst quill.
 const SAMPLE_FORM_DIR = join(__dirname, '../../fixtures/resources/quills/sample_form/0.1.0')
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -397,10 +397,6 @@ impl RenderResult {
         }
     }
 
-    pub fn with_warning(mut self, warning: Diagnostic) -> Self {
-        self.warnings.push(warning);
-        self
-    }
 }
 
 pub fn print_errors(err: &RenderError) {
@@ -532,14 +528,4 @@ mod tests {
         assert!(output.contains("Underlying error"));
     }
 
-    #[test]
-    fn test_render_result_with_warnings() {
-        let artifacts = vec![];
-        let warning = Diagnostic::new(Severity::Warning, "Test warning".to_string());
-
-        let result = RenderResult::new(artifacts, OutputFormat::Pdf).with_warning(warning);
-
-        assert_eq!(result.warnings.len(), 1);
-        assert_eq!(result.warnings[0].message, "Test warning");
-    }
 }

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -22,8 +22,7 @@ pub use ignore::QuillIgnore;
 pub use schema::build_transform_schema;
 pub use tree::FileTreeNode;
 pub use types::{
-    field_key, ui_key, BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema,
-    UiFieldSchema,
+    BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -102,16 +102,14 @@ impl QuillConfig {
         );
         let coerced_doc = Document::from_main_and_cards(coerced_main, coerced_cards, Vec::new());
 
-        if let Err(errors) = self.validate_document(&coerced_doc) {
-            // Only *malformed* input is fatal (a value that won't
-            // coerce/validate). An incomplete document — absent fields or
-            // `!must_fill` placeholders — renders fine via zero-fill. Each
-            // error keeps its own `path` for UI navigation.
-            let diags: Vec<Diagnostic> = errors.iter().map(|e| e.to_diagnostic()).collect();
-            if !diags.is_empty() {
-                return Err(RenderError::new(diags));
-            }
-        }
+        // Only *malformed* input is fatal (a value that won't coerce/validate).
+        // An incomplete document — absent fields or `!must_fill` placeholders —
+        // renders fine via zero-fill. `validate_document` returns `Err` only
+        // with a non-empty error list; each error keeps its own `path` for UI
+        // navigation.
+        self.validate_document(&coerced_doc).map_err(|errors| {
+            RenderError::new(errors.iter().map(|e| e.to_diagnostic()).collect())
+        })?;
 
         Ok(coerced_doc)
     }

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -5,32 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::value::QuillValue;
 
-/// Semantic constants for field schema key names (`type`, `description`, …).
-/// Neither parsing (`FieldSchemaDef`) nor JSON Schema generation
-/// ([`build_transform_schema`](super::build_transform_schema)) consumes these constants —
-/// both use literal strings — but they're kept for downstream consumers that want the
-/// key names without stringly-typed literals, with the IDE support (find references,
-/// autocomplete) constants provide over bare literals.
-pub mod field_key {
-    pub const TYPE: &str = "type";
-    pub const DESCRIPTION: &str = "description";
-    pub const DEFAULT: &str = "default";
-    pub const EXAMPLE: &str = "example";
-    pub const UI: &str = "ui";
-    pub const ENUM: &str = "enum";
-    pub const FORMAT: &str = "format";
-}
-
-/// Semantic constants for UI schema keys
-pub mod ui_key {
-    pub const GROUP: &str = "group";
-    pub const ORDER: &str = "order";
-    /// May be a literal string or a `{field_name}` template interpolated per-instance by UI consumers.
-    pub const TITLE: &str = "title";
-    pub const COMPACT: &str = "compact";
-    pub const MULTILINE: &str = "multiline";
-}
-
 /// UI-specific metadata for field rendering
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{Diagnostic, RenderError, RenderOptions, RenderResult, RenderedRegion, Severity};
 
 /// What a committed [`LiveSession::apply`] changed.
@@ -15,14 +13,13 @@ pub struct ChangeSet {
 
 /// Backend-specific session implementation.
 ///
-/// Implementors must be `'static` (required by `Any`), `Send`, and `Sync`. The
-/// `'static` bound prevents borrowing source data — own anything you need to
-/// keep alive for the session's lifetime.
+/// Implementors must be `'static`, `Send`, and `Sync`. The `'static` bound
+/// prevents borrowing source data — own anything you need to keep alive for
+/// the session's lifetime.
 #[doc(hidden)]
-pub trait SessionHandle: Any + Send + Sync {
+pub trait SessionHandle: Send + Sync + 'static {
     fn render(&self, opts: &RenderOptions) -> Result<RenderResult, RenderError>;
     fn page_count(&self) -> usize;
-    fn as_any(&self) -> &dyn Any;
 
     /// Recompile the session against new document data.
     ///
@@ -154,21 +151,6 @@ impl LiveSession {
         Self { inner }
     }
 
-    /// Borrow the underlying [`SessionHandle`].
-    ///
-    /// The canonical canvas-preview path does **not** go through here: it
-    /// dispatches generically through [`page_size_pt`](LiveSession::page_size_pt)
-    /// / [`render_rgba`](LiveSession::render_rgba) on the session, with no
-    /// downcast. This accessor exists only as a last-resort escape hatch for a
-    /// backend that exposes a richer *typed* surface — reach it by downcasting
-    /// via [`SessionHandle::as_any`]. No in-tree caller does. Intentionally
-    /// `#[doc(hidden)]` — the shape of this accessor is not part of the stable
-    /// public API.
-    #[doc(hidden)]
-    pub fn handle(&self) -> &dyn SessionHandle {
-        &*self.inner
-    }
-
     pub fn page_count(&self) -> usize {
         self.inner.page_count()
     }
@@ -290,9 +272,6 @@ mod tests {
         fn page_count(&self) -> usize {
             self.pages
         }
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
         fn page_size_pt(&self, page: usize) -> Option<(f32, f32)> {
             (page < self.pages).then_some((612.0, 792.0))
         }
@@ -306,9 +285,6 @@ mod tests {
         }
         fn page_count(&self) -> usize {
             1
-        }
-        fn as_any(&self) -> &dyn Any {
-            self
         }
     }
 
@@ -324,9 +300,6 @@ mod tests {
         }
         fn page_count(&self) -> usize {
             1
-        }
-        fn as_any(&self) -> &dyn Any {
-            self
         }
         fn apply(&mut self, _: &serde_json::Value) -> Result<ChangeSet, RenderError> {
             self.applies += 1;

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -14,8 +14,9 @@
 //!
 //! The crate owns its own [`PdfError`]; each backend maps it to
 //! `quillmark_core::RenderError` at its boundary. It depends only on
-//! `quillmark-core` (for the [`RenderedRegion`] sidecar types) and `pdf-writer`
-//! (for typed object construction); it never depends on Typst.
+//! `quillmark-core` (for the [`RenderedRegion`](quillmark_core::RenderedRegion)
+//! sidecar types) and `pdf-writer` (for typed object construction); it never
+//! depends on Typst.
 //!
 //! See [`stamp`] for the operation, [`FieldSpec`] for the currency, and
 //! `crate::reader`'s docs for the input contract the base PDF must satisfy.
@@ -29,11 +30,6 @@ pub mod writer;
 pub use error::PdfError;
 pub use stamp::{regions_of, stamp, StampOptions, CHECKBOX_ON_STATE};
 pub use update::PdfUpdate;
-
-// The region sidecar lives in core, surfaced via `LiveSession::regions` (a
-// session-level query, not part of `RenderResult`); re-export so spine
-// consumers reach it without a second `quillmark-core` import.
-pub use quillmark_core::RenderedRegion;
 
 /// The `/MediaBox` of every page of `base`, normalized to `[x0, y0, x1, y1]`
 /// (lower-left, upper-right), in document order.
@@ -59,8 +55,9 @@ pub struct FieldSpec {
     pub name: String,
     /// The quill schema field address this widget maps to, if any. Opaque to
     /// the spine (it never interprets it), carried solely to key the region
-    /// sidecar: a field with `Some(path)` emits a [`RenderedRegion`], an unbound
-    /// widget (`None`) emits none.
+    /// sidecar: a field with `Some(path)` emits a
+    /// [`RenderedRegion`](quillmark_core::RenderedRegion), an unbound widget
+    /// (`None`) emits none.
     pub schema_field: Option<String>,
     /// 0-based page index.
     pub page: usize,
@@ -88,16 +85,4 @@ pub enum FieldType {
     Choice { options: Vec<String> },
     /// An unsigned signature field.
     Signature,
-}
-
-impl FieldType {
-    /// The lowercase type id used in the [`RenderedRegion`] sidecar.
-    pub fn type_id(&self) -> &'static str {
-        match self {
-            FieldType::Text { .. } => "text",
-            FieldType::Checkbox => "checkbox",
-            FieldType::Choice { .. } => "choice",
-            FieldType::Signature => "signature",
-        }
-    }
 }

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -27,7 +27,7 @@ pub fn err(code: &'static str, msg: impl Into<String>) -> PdfError {
 }
 
 /// The offset stored after the last `startxref` marker.
-pub fn find_startxref(pdf: &[u8]) -> Result<usize, PdfError> {
+pub(crate) fn find_startxref(pdf: &[u8]) -> Result<usize, PdfError> {
     let needle = b"startxref";
     let from = pdf.len().saturating_sub(1024);
     let tail = &pdf[from..];
@@ -54,7 +54,7 @@ pub fn find_startxref(pdf: &[u8]) -> Result<usize, PdfError> {
 }
 
 /// Bail if the base PDF stores an xref stream instead of a traditional table.
-pub fn assert_traditional_xref(pdf: &[u8], xref_offset: usize) -> Result<(), PdfError> {
+pub(crate) fn assert_traditional_xref(pdf: &[u8], xref_offset: usize) -> Result<(), PdfError> {
     if pdf.get(xref_offset..xref_offset + 4) != Some(b"xref") {
         return Err(err(
             CODE_XREF_STREAM,
@@ -67,7 +67,7 @@ pub fn assert_traditional_xref(pdf: &[u8], xref_offset: usize) -> Result<(), Pdf
 /// Return the trailer dictionary bytes for the xref section at `xref_offset`.
 /// The slice is the inner dict (between `<<` and `>>`) and may be queried with
 /// [`find_dict_value`].
-pub fn find_trailer_dict(pdf: &[u8], xref_offset: usize) -> Result<&[u8], PdfError> {
+pub(crate) fn find_trailer_dict(pdf: &[u8], xref_offset: usize) -> Result<&[u8], PdfError> {
     let needle = b"trailer";
     let pos = pdf[xref_offset..]
         .windows(needle.len())
@@ -108,7 +108,7 @@ pub struct UpdatedObject {
 /// `/Info <id> 0 R` for the case where the prior trailer had none (a fresh
 /// `/Info` object was created). `new_size` is the updated `/Size` (highest
 /// object number + 1) and `root_id` the document catalog.
-pub fn append_incremental_update(
+pub(crate) fn append_incremental_update(
     mut pdf: Vec<u8>,
     prev_xref: usize,
     root_id: u32,
@@ -221,7 +221,7 @@ fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
 /// The generation number in object `id`'s header (`<id> <gen> obj`), or `None`
 /// when the object is absent or its header is malformed. Reads the *live* copy
 /// (the last serialized revision), matching [`find_object_bytes`].
-pub fn object_generation(pdf: &[u8], id: u32) -> Option<u16> {
+pub(crate) fn object_generation(pdf: &[u8], id: u32) -> Option<u16> {
     let (start, _) = find_object_bytes(pdf, id)?;
     let after_id = start + format!("{id} ").len();
     let rest = &pdf[after_id..];
@@ -242,7 +242,7 @@ pub fn object_generation(pdf: &[u8], id: u32) -> Option<u16> {
 /// posture, consistent with the xref-stream / `/Encrypt` rejections.
 ///
 /// `None` (object absent) is left for the caller's own not-found error path.
-pub fn assert_overwrite_gen_zero(pdf: &[u8], id: u32, what: &str) -> Result<(), PdfError> {
+pub(crate) fn assert_overwrite_gen_zero(pdf: &[u8], id: u32, what: &str) -> Result<(), PdfError> {
     match object_generation(pdf, id) {
         Some(0) | None => Ok(()),
         Some(gen) => Err(err(
@@ -492,7 +492,7 @@ fn is_pdf_delim(c: u8) -> bool {
     )
 }
 
-pub fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
+pub(crate) fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
     let s = skip_ws(s);
     let mut i = 0;
     while i < s.len() && s[i].is_ascii_digit() {
@@ -554,7 +554,7 @@ fn skip_ws(s: &[u8]) -> &[u8] {
 /// Resolve the catalog's `/Pages` tree into a flat list of page object IDs,
 /// in document order. The recursion is defensive and capped to prevent runaway
 /// on a pathological PDF.
-pub fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfError> {
+pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfError> {
     let root_pages_id = root_pages_id(pdf, catalog_id)?;
 
     const MAX_NODES: usize = 100_000;
@@ -625,7 +625,11 @@ fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
 /// this guard turns a rotated `pdfform` base into a clean rejection rather than
 /// silently mis-placed output, consistent with the reader's other hard
 /// rejections.
-pub fn assert_unrotated_page(pdf: &[u8], catalog_id: u32, page_id: u32) -> Result<(), PdfError> {
+pub(crate) fn assert_unrotated_page(
+    pdf: &[u8],
+    catalog_id: u32,
+    page_id: u32,
+) -> Result<(), PdfError> {
     let read_rotate = |id: u32| -> Option<i64> {
         let (s, e) = find_object_bytes(pdf, id)?;
         let dict = extract_outer_dict(&pdf[s..e])?;
@@ -718,7 +722,7 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
 /// full rect — not just width/height — is returned so a caller that owns
 /// page-relative top-left geometry can honour a non-zero page origin when
 /// flipping to bottom-left PDF user space.
-pub fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
+pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
     let xref_offset = find_startxref(pdf)?;
     assert_traditional_xref(pdf, xref_offset)?;
     let trailer = find_trailer_dict(pdf, xref_offset)?;

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -48,7 +48,7 @@ pub fn pdf_escape(out: &mut Vec<u8>, bytes: &[u8]) {
 
 /// Encode `s` as a PDF text string. ASCII uses a literal `( … )` with `(`, `)`
 /// and `\` escaped; anything else uses a UTF-16BE hex string with a BOM.
-pub fn pdf_text_string(s: &str) -> Vec<u8> {
+pub(crate) fn pdf_text_string(s: &str) -> Vec<u8> {
     if s.is_ascii() {
         let mut out = Vec::with_capacity(s.len() + 2);
         out.push(b'(');
@@ -68,7 +68,7 @@ pub fn pdf_text_string(s: &str) -> Vec<u8> {
 }
 
 /// Replace `/Producer`'s value if present, else append the entry.
-pub fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
+pub(crate) fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
     let key = b"/Producer";
     match find_dict_value(info_dict, "Producer") {
         None => {
@@ -87,7 +87,7 @@ pub fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
 /// `info_ref` is the trailer's `/Info` reference, if any. Returns `Some(info_id)`
 /// when a *new* `/Info` object was allocated (the caller threads it into the
 /// trailer), or `None` when the existing `/Info` was updated in place.
-pub fn apply_producer_stamp(
+pub(crate) fn apply_producer_stamp(
     pdf: &[u8],
     info_ref: Option<(u32, u16)>,
     producer: &str,
@@ -124,7 +124,7 @@ pub fn apply_producer_stamp(
 /// flatten path draws text directly into a content stream, so it must commit to
 /// a byte encoding the font agrees with (unlike the stamp path, where the viewer
 /// synthesizes appearances from a UTF-16 `/V`).
-pub fn winansi_byte(c: char) -> Option<u8> {
+pub(crate) fn winansi_byte(c: char) -> Option<u8> {
     let cp = c as u32;
     match cp {
         // ASCII and the upper Latin-1 range are identity-mapped in WinAnsi.

--- a/crates/quillmark/examples/pdfform_preview.rs
+++ b/crates/quillmark/examples/pdfform_preview.rs
@@ -1,8 +1,8 @@
 //! Visual preview harness for the `pdfform` backend.
 //!
-//! Renders `sample_form` → `sample_form_filled.pdf` and `taro` → `taro_preview.svg`,
-//! writes both to the fixtures output directory, and prints the regions sidecar
-//! for the filled form so field geometry can be cross-checked against a viewer.
+//! Renders `sample_form` → `sample_form_filled.pdf`, writes it to the fixtures
+//! output directory, and prints the regions sidecar for the filled form so
+//! field geometry can be cross-checked against a viewer.
 //!
 //! Run with:
 //!   cargo run --example pdfform_preview -p quillmark
@@ -21,18 +21,6 @@ comments:
 agree: true
 favorite_color: green
 ~~~
-";
-
-const TARO_MD: &str = "\
-~~~
-$quill: taro
-$kind: main
-author: Ada Lovelace
-title: Taro Preview
-ice_cream: taro
-~~~
-
-This is a preview document rendered for visual review of the SVG backend output.
 ";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -82,31 +70,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    // --- Typst backend: taro → SVG ---
-    println!("\n=== Typst backend: taro → SVG ===");
-    let taro_quill = quillmark::quill_from_path(quills_path("taro")).expect("load taro quill");
-    let taro_doc = Document::from_markdown(TARO_MD).expect("parse taro markdown");
-    let taro_result = engine
-        .render(
-            &taro_quill,
-            &taro_doc,
-            &RenderOptions {
-                output_format: Some(OutputFormat::Svg),
-                ..Default::default()
-            },
-        )
-        .expect("taro SVG render");
-
-    write_example_output("taro_preview.svg", &taro_result.artifacts[0].bytes)?;
-    println!("Written: {}", out_dir.join("taro_preview.svg").display());
-    println!("SVG size: {} bytes", taro_result.artifacts[0].bytes.len());
-
-    println!("\nDone. Open the files in the output directory to review:");
+    println!("\nDone. Open the file in the output directory to review:");
     println!(
         "  PDF: {}",
         out_dir.join("sample_form_filled.pdf").display()
     );
-    println!("  SVG: {}", out_dir.join("taro_preview.svg").display());
 
     Ok(())
 }

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -52,7 +52,7 @@ impl Quillmark {
         self.backends.keys().map(|s| s.as_str()).collect()
     }
 
-    /// Resolve a quill's declared backend, erroring with `UnsupportedBackend`
+    /// Resolve a quill's declared backend, erroring with `engine::backend_not_found`
     /// when none is registered. The backend-existence check lives here — at
     /// render time, not load time — so a backend-less core can still load and
     /// validate quills.
@@ -94,12 +94,11 @@ impl Quillmark {
     ) -> Result<RenderResult, RenderError> {
         let default_format = self.supported_formats(quill)?.first().copied();
         let session = self.open(quill, doc)?;
+        // Struct-update so a new RenderOptions field is carried through by
+        // default; only `output_format` gets the backend-default fallback.
         let resolved = RenderOptions {
             output_format: opts.output_format.or(default_format),
-            ppi: opts.ppi,
-            pages: opts.pages.clone(),
-            producer: opts.producer.clone(),
-            regions: opts.regions,
+            ..opts.clone()
         };
         session.render(&resolved)
     }

--- a/crates/quillmark/tests/backend_registration_test.rs
+++ b/crates/quillmark/tests/backend_registration_test.rs
@@ -54,10 +54,6 @@ impl SessionHandle for MockSession {
     fn page_count(&self) -> usize {
         1
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[test]

--- a/crates/quillmark/tests/quill_engine_test.rs
+++ b/crates/quillmark/tests/quill_engine_test.rs
@@ -114,11 +114,6 @@ fn test_quill_render_succeeds_with_engine_loaded_quill() {
         },
     );
 
-    if let Err(e) = &result {
-        if e.diagnostics()[0].message.contains("No fonts found") {
-            return;
-        }
-    }
     assert!(
         result.is_ok(),
         "render should succeed for engine-loaded quill"

--- a/crates/quillmark/tests/quiver_test.rs
+++ b/crates/quillmark/tests/quiver_test.rs
@@ -59,15 +59,6 @@ fn every_quill_in_quiver_renders() {
             },
         );
 
-        // Font-less CI environments cannot exercise the renderer; skip rather
-        // than fail, matching the convention in quill_engine_test.rs.
-        if let Err(e) = &result {
-            if e.diagnostics()[0].message.contains("No fonts found") {
-                eprintln!("quill '{name}': skipping — no fonts available");
-                continue;
-            }
-        }
-
         let rendered = result
             .unwrap_or_else(|e| panic!("quill '{name}' failed to render: {e:?}\n---\n{markdown}"));
         assert!(
@@ -105,11 +96,6 @@ fn every_quill_blueprint_round_trips_and_renders() {
                 ..Default::default()
             },
         );
-        if let Err(e) = &result {
-            if e.diagnostics()[0].message.contains("No fonts found") {
-                continue;
-            }
-        }
         result.unwrap_or_else(|e| {
             panic!("quill '{name}' blueprint failed to render: {e:?}\n---\n{bp}")
         });

--- a/crates/quillmark/tests/usaf_memo_regions_test.rs
+++ b/crates/quillmark/tests/usaf_memo_regions_test.rs
@@ -26,15 +26,9 @@ fn usaf_memo_regions_cover_body_signature_and_cards() {
     // kind, so the indorsement addresses are present.
     let parsed = quill.seed_document();
 
-    let mut session = match engine.open(&quill, &parsed) {
-        // Font-less CI cannot exercise the renderer; skip rather than fail,
-        // matching the convention in quiver_test.rs.
-        Err(e) if e.diagnostics()[0].message.contains("No fonts found") => {
-            eprintln!("skipping — no fonts available");
-            return;
-        }
-        other => other.expect("usaf_memo should open a session"),
-    };
+    let mut session = engine
+        .open(&quill, &parsed)
+        .expect("usaf_memo should open a session");
 
     let regions = session.regions();
     let fields: HashSet<&str> = regions.iter().map(|r| r.field.as_str()).collect();

--- a/crates/quillmark/tests/usaf_memo_signature_test.rs
+++ b/crates/quillmark/tests/usaf_memo_signature_test.rs
@@ -72,15 +72,6 @@ fn usaf_memo_signature_widget_aligns_with_signature_block() {
         },
     );
 
-    // Font-less CI cannot exercise the renderer; skip rather than fail, matching
-    // the convention in quiver_test.rs.
-    if let Err(e) = &result {
-        if e.diagnostics()[0].message.contains("No fonts found") {
-            eprintln!("skipping — no fonts available");
-            return;
-        }
-    }
-
     let rendered = result.expect("usaf_memo should render to PDF");
     let pdf = &rendered.artifacts[0].bytes;
 

--- a/docs/migrations/0.92-to-0.93.md
+++ b/docs/migrations/0.92-to-0.93.md
@@ -375,14 +375,13 @@ gated on `typst` **or** `pdfform`:
 
 - **`typst`** (the new default) — the Typst-backed engine + canvas preview, the
   exact surface the old `render` feature shipped.
-- **`pdfform`** — the Typst-free PDF-form backend alone (a tiny, Typst-less
-  engine bundle); reports `supportsCanvas == false`.
-- **`pdfform-preview`** — `pdfform` plus its hayro raster/SVG canvas seam;
-  reports `supportsCanvas == true`.
+- **`pdfform`** — the Typst-free PDF-form backend (a tiny, Typst-less engine
+  bundle). It ships the `web-sys` canvas painter over its always-linked hayro
+  raster seam, so it reports `supportsCanvas == true`, mirroring `typst`.
 
 **Action (from-source WASM builders only):** replace `--features render` with
-`--features typst` (or build the new `pdfform` / `pdfform-preview` variants). The
-published JS API surface and the canonical `Engine` runtime are unchanged.
+`--features typst` (or build the new `pdfform` variant). The published JS API
+surface and the canonical `Engine` runtime are unchanged.
 
 ## `RenderSession` collapses into `LiveSession`; sessions gain `apply()`
 

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -46,10 +46,9 @@ session type:
 
 ```rust
 // quillmark-core
-pub trait SessionHandle: Any + Send + Sync {
+pub trait SessionHandle: Send + Sync + 'static {
     fn render(&self, opts: &RenderOptions) -> Result<RenderResult, RenderError>;
     fn page_count(&self) -> usize;
-    fn as_any(&self) -> &dyn Any;
 
     // Edit seam — default Err = "apply unsupported".
     fn apply(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> { ... }

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -13,8 +13,8 @@ set -o pipefail
 #   pkg/backends/typst/   — Typst-backed engine + LiveSession + canvas (a private
 #                           backend binary, NOT a public export)
 #   pkg/backends/pdfform/ — Typst-free PDF-form backend (engine + LiveSession +
-#                           canvas; the pdfform-preview feature adds the web-sys
-#                           canvas painter over the always-linked hayro raster;
+#                           canvas; the pdfform feature ships the web-sys canvas
+#                           painter over the always-linked hayro raster;
 #                           private backend binary, NOT a public export)
 #
 # These generated artifacts plus the hand-written canonical layer ship as one
@@ -50,6 +50,12 @@ done
 echo "Building WASM modules for @quillmark/wasm... [profile: $MODE_LABEL]"
 
 cd "$(dirname "$0")/.."
+
+# Start from a clean pkg/. CI restores a cached pkg/ from a previous build
+# (restore-keys partial-matches an older release), and this script only ever
+# mkdir/cp/sed *into* pkg/ — it never removes files. Without this, any file
+# dropped from the pkg layout between builds lingers and ships on `npm publish`.
+rm -rf pkg
 
 # Check for required tools. The CLI's version must match the wasm-bindgen
 # crate in Cargo.lock; wasm-bindgen itself only detects a mismatch when it
@@ -102,14 +108,14 @@ build_variant() {
 }
 
 # backends/typst   = default features (Typst).
-# backends/pdfform = the Typst-free PDF-form backend with its canvas preview
-#                    seam (pdfform-preview). Built like the typst variant: the
-#                    same cargo build + wasm-bindgen pass, sequentially (every
-#                    variant emits the same quillmark_wasm.wasm to the same
-#                    target path, so they must not run concurrently).
+# backends/pdfform = the Typst-free PDF-form backend with its web-sys canvas
+#                    painter. Built like the typst variant: the same cargo build
+#                    + wasm-bindgen pass, sequentially (every variant emits the
+#                    same quillmark_wasm.wasm to the same target path, so they
+#                    must not run concurrently).
 # core             = no features (Typst excluded).
 build_variant backends/typst
-build_variant backends/pdfform --no-default-features --features pdfform-preview
+build_variant backends/pdfform --no-default-features --features pdfform
 build_variant core --no-default-features
 
 # runtime = the canonical consumer API: a hand-written JS layer (NOT generated


### PR DESCRIPTION
Removes dead seams and narrows unreleased public surfaces flagged by the
review, plus a stale-pkg CI bug fix. All verified at HEAD 5869d30.

#825: `rm -rf pkg` at the top of build-wasm.sh so a cache-restored previous
release's pkg/ can't leak stale files into `npm publish` (the script only
ever mkdir/cp/sed into pkg/, never removes).

#823 (item 1): delete the five dead "No fonts found" skip guards — the only
producer of that string was removed pre-0.7 when Figtree became the embedded
fallback, so the guards can never fire.

#819: core dead code from the error/validation reworks — collapse the
unreachable emptiness guard in `coerce_and_validate` to `map_err(..)?`; drop
the orphaned `RenderResult::with_warning` builder + test; delete the unused
`field_key`/`ui_key` constant modules; struct-update `Quillmark::render` so a
new RenderOptions field carries through; fix four stale `UnsupportedBackend`
docstrings (the code is `engine::backend_not_found`).

#818: delete the `LiveSession::handle()` / `SessionHandle::as_any()` downcast
escape hatch (zero callers workspace-wide) and its six `as_any` impls; keep
`'static` via an explicit trait bound instead of the `Any` supertrait.

#820: typst backend leftover seams — delete the constant `_qm-has-meta` guard
in lib.typ.template; demote `pub struct TypstSession` to private; make
`set_source` return `()`; inject the constant helper `typst.toml` once at
world construction instead of per apply (inlining `helper_spec`/`set_binary`);
merge `read_bool` into the permissive `read_value_bool`; drop a `/tmp` debug
write in sig_field.rs.

#821: pdfform + quillmark-pdf surface narrowing (both crates unreleased) —
delete dead `FieldType::type_id`, the redundant `RenderedRegion` re-export,
the `pub use form::{..}` re-export, and the redundant `Signature` early-return;
drop the always-`None` `StampOptions` from `flatten()`; mark 14 reader/writer
items `pub(crate)`; hardcode `write_zadb_char`'s always-`'4'` glyph; derive
`page_count` from `page_boxes.len()`; strip the taro/Typst half of the
pdfform_preview example.

#817: collapse `pdfform-preview` into `pdfform` — the bare variant was unbuilt
and its `supportsCanvas` contract was false. Fold `web-sys` into `pdfform`,
delete `pdfform-preview`, unify the two split `LiveSession` impl blocks, and
collapse the `pdfform-preview` cfg predicates in engine.rs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y9Pc9PVhk9dVm2e2E1nigb