### PR TITLE
docs(richtext): open integration HQ plan for the content-model rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "quillmark-richtext"
+version = "0.92.1"
+dependencies = [
+ "indexmap",
+ "proptest",
+ "pulldown-cmark",
+ "quillmark-core",
+ "quillmark-fixtures",
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "quillmark-typst"
 version = "0.92.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/quillmark-pdf",
     "crates/backends/typst",
     "crates/backends/pdfform",
+    "crates/richtext",
     "crates/fixtures",
     "crates/bindings/wasm",
     "crates/fuzz",
@@ -63,6 +64,7 @@ typst-svg = "0.15.0"
 
 # Intra-project dependencies
 quillmark-core = { version = "0.92.1", path = "crates/core" }
+quillmark-richtext = { version = "0.92.1", path = "crates/richtext" }
 quillmark-pdf = { version = "0.92.1", path = "crates/quillmark-pdf" }
 quillmark-typst = { version = "0.92.1", path = "crates/backends/typst", default-features = false }
 quillmark-pdfform = { version = "0.92.1", path = "crates/backends/pdfform", default-features = false }

--- a/crates/richtext/Cargo.toml
+++ b/crates/richtext/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "quillmark-richtext"
+version.workspace = true
+edition.workspace = true
+include.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository = "https://github.com/quillmark-org/quillmark"
+description = "RichText corpus content model and markdown codecs for Quillmark (issue #831, phase 1)"
+# Phase 1 is engine-off: the model + codecs are exercised in isolation and no
+# engine crate consumes them yet. Kept out of the default publish set until
+# phase 2 wires storage/backends to it. Tracked in prose/plans/richtext/.
+publish = false
+
+[dependencies]
+quillmark-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+indexmap = { workspace = true }
+unicode-normalization = { workspace = true }
+# The markdown projection's parser. Core stays markdown-engine-free (pulldown is
+# dev-only there); the codecs that need a CommonMark parser live in this crate.
+pulldown-cmark = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+quillmark-fixtures = { workspace = true }

--- a/crates/richtext/src/delta.rs
+++ b/crates/richtext/src/delta.rs
@@ -1,0 +1,369 @@
+//! The per-field edit surface: a [`Delta`] (Quill-Delta semantics) over the USV
+//! corpus, plus the **stale-text writer** path — cold-parse a full new markdown
+//! document, char-diff it against the base, and rebase the base's identity marks
+//! (anchors/comments) through the diff so annotations survive an LLM
+//! full-document rewrite with no preservation contract on the LLM.
+//!
+//! Phase 1 delivers the diff + rebase + a **move detector**; the live delta
+//! transport (revision, bounded change log) is phase 3. Position mapping follows
+//! CodeMirror's `ChangeDesc.mapPos` / ProseMirror mapping semantics.
+//!
+//! ## The move weak spot (documented limit)
+//!
+//! A paragraph reorder is delete-here + insert-there to any char differ, so a
+//! naive rebase collapses an anchor in the moved text to the deletion point. The
+//! detector re-homes an anchor onto a **single, verbatim block move** by locating
+//! the moved text in the new corpus. Text both *moved and rewritten* in one round
+//! (the match is lost) drops the anchor — the accepted residual, stated not
+//! hidden. Tightening verbatim → fuzzy (longest-common-substring) is a hardening
+//! follow-up.
+
+use crate::model::{Mark, MarkKind, RichText};
+
+/// A per-field edit against a base corpus. Ops apply left-to-right, consuming
+/// base positions; `Retain`/`Delete` advance the base cursor, `Insert` adds new
+/// text. USV throughout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Delta {
+    pub ops: Vec<Op>,
+}
+
+/// One delta operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    /// Keep `n` chars of the base unchanged.
+    Retain(usize),
+    /// Insert this text at the cursor.
+    Insert(String),
+    /// Drop `n` chars of the base.
+    Delete(usize),
+}
+
+/// Which side of a same-position insertion a mapped point lands on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Assoc {
+    /// Stay before inserted text.
+    Before,
+    /// Move after inserted text.
+    After,
+}
+
+impl Delta {
+    /// Apply to `base`, producing the new text. Ignores over-long
+    /// `Retain`/`Delete` gracefully (clamps), so a mismatched delta cannot
+    /// panic.
+    pub fn apply(&self, base: &str) -> String {
+        let chars: Vec<char> = base.chars().collect();
+        let mut out = String::new();
+        let mut i = 0usize;
+        for op in &self.ops {
+            match op {
+                Op::Retain(n) => {
+                    let end = (i + n).min(chars.len());
+                    out.extend(&chars[i..end]);
+                    i = end;
+                }
+                Op::Delete(n) => {
+                    i = (i + n).min(chars.len());
+                }
+                Op::Insert(s) => out.push_str(s),
+            }
+        }
+        out.extend(&chars[i.min(chars.len())..]);
+        out
+    }
+
+    /// Map a base char position to its new position. `assoc` decides the side of
+    /// a same-position insertion (`After` moves past it).
+    pub fn map_pos(&self, pos: usize, assoc: Assoc) -> usize {
+        let mut old = 0usize;
+        let mut new = 0usize;
+        for op in &self.ops {
+            match op {
+                Op::Retain(n) => {
+                    if pos <= old + n {
+                        return new + (pos - old);
+                    }
+                    old += n;
+                    new += n;
+                }
+                Op::Delete(n) => {
+                    if pos < old + n {
+                        // Inside (or at the start of) the deletion — collapse to
+                        // the deletion point.
+                        return new;
+                    }
+                    old += n;
+                }
+                Op::Insert(s) => {
+                    let len = s.chars().count();
+                    if pos == old {
+                        match assoc {
+                            Assoc::Before => return new,
+                            Assoc::After => new += len, // fall through past insert
+                        }
+                    } else {
+                        new += len;
+                    }
+                }
+            }
+        }
+        new
+    }
+
+    /// Whether base position `pos` sits strictly inside a deleted span (used to
+    /// detect a collapsed zero-width anchor).
+    fn is_deleted(&self, pos: usize) -> bool {
+        let mut old = 0usize;
+        for op in &self.ops {
+            match op {
+                Op::Retain(n) => old += n,
+                Op::Delete(n) => {
+                    if pos >= old && pos < old + n {
+                        return true;
+                    }
+                    old += n;
+                }
+                Op::Insert(_) => {}
+            }
+        }
+        false
+    }
+}
+
+/// Char-level diff via common-prefix / common-suffix trim: the change is one
+/// `Delete` of the differing base middle and one `Insert` of the new middle.
+/// Coarse but valid — the move detector recovers relocations from the new text
+/// directly, so a finer diff is not needed for phase-1 anchor rebase.
+pub fn diff(base: &str, new: &str) -> Delta {
+    let a: Vec<char> = base.chars().collect();
+    let b: Vec<char> = new.chars().collect();
+
+    let mut p = 0usize;
+    while p < a.len() && p < b.len() && a[p] == b[p] {
+        p += 1;
+    }
+    let mut s = 0usize;
+    while s < a.len() - p && s < b.len() - p && a[a.len() - 1 - s] == b[b.len() - 1 - s] {
+        s += 1;
+    }
+
+    let mut ops = Vec::new();
+    if p > 0 {
+        ops.push(Op::Retain(p));
+    }
+    let del = a.len() - p - s;
+    if del > 0 {
+        ops.push(Op::Delete(del));
+    }
+    let ins: String = b[p..b.len() - s].iter().collect();
+    if !ins.is_empty() {
+        ops.push(Op::Insert(ins));
+    }
+    if s > 0 {
+        ops.push(Op::Retain(s));
+    }
+    Delta { ops }
+}
+
+/// The stale-text writer path: cold-parse `new_markdown`, char-diff it against
+/// `base`, and carry `base`'s identity marks (anchors) forward, rebased through
+/// the diff (re-homing verbatim block moves). The returned corpus is `new_rt`
+/// (structure/marks/islands from the fresh import) plus the surviving anchors.
+///
+/// Returns the new corpus and the [`Delta`] used (the change log entry a phase-3
+/// revision would record).
+pub fn diff_import(
+    base: &RichText,
+    new_markdown: &str,
+) -> Result<(RichText, Delta), crate::import::ImportError> {
+    let mut new_rt = crate::import::from_markdown(new_markdown)?;
+    let delta = diff(&base.text, &new_rt.text);
+
+    let new_chars: Vec<char> = new_rt.text.chars().collect();
+    for m in &base.marks {
+        // Only identity marks live in the corpus but not in markdown; formatting
+        // marks are re-derived by the fresh import, so we do not carry them.
+        let MarkKind::Anchor { .. } = &m.kind else {
+            continue;
+        };
+        if let Some((ns, ne)) = rebase_anchor(&base.text, &delta, &new_chars, m) {
+            new_rt.marks.push(Mark {
+                start: ns,
+                end: ne,
+                kind: m.kind.clone(),
+            });
+        }
+        // else: detached — the accepted residual drop.
+    }
+    new_rt.normalize();
+    Ok((new_rt, delta))
+}
+
+/// Rebase one anchor through the delta. Returns its new range, or `None` if it
+/// detaches (its text was deleted and no verbatim move re-homes it).
+fn rebase_anchor(
+    base_text: &str,
+    delta: &Delta,
+    new_chars: &[char],
+    m: &Mark,
+) -> Option<(usize, usize)> {
+    if m.start == m.end {
+        // Zero-width point anchor.
+        if !delta.is_deleted(m.start) {
+            return Some((
+                delta.map_pos(m.start, Assoc::Before),
+                delta.map_pos(m.start, Assoc::Before),
+            ));
+        }
+        // Context relocation: place it at the same offset inside its
+        // surrounding text if that context survived the move.
+        return relocate_point(base_text, new_chars, m.start);
+    }
+
+    let ns = delta.map_pos(m.start, Assoc::After);
+    let ne = delta.map_pos(m.end, Assoc::Before);
+    if ns < ne {
+        return Some((ns, ne)); // survived a surrounding edit
+    }
+    // Collapsed — try a verbatim block move: find the annotated span in the new
+    // corpus.
+    relocate_span(base_text, new_chars, m.start, m.end)
+}
+
+fn relocate_span(
+    base_text: &str,
+    new_chars: &[char],
+    start: usize,
+    end: usize,
+) -> Option<(usize, usize)> {
+    let base_chars: Vec<char> = base_text.chars().collect();
+    if end > base_chars.len() {
+        return None;
+    }
+    let needle = &base_chars[start..end];
+    find_subslice(new_chars, needle).map(|pos| (pos, pos + needle.len()))
+}
+
+fn relocate_point(base_text: &str, new_chars: &[char], pos: usize) -> Option<(usize, usize)> {
+    const K: usize = 24;
+    let base_chars: Vec<char> = base_text.chars().collect();
+    // Prefer left context (text immediately before the point); fall back to
+    // right context. The point lands at the boundary between them.
+    let l0 = pos.saturating_sub(K);
+    let left = &base_chars[l0..pos];
+    if !left.is_empty() {
+        if let Some(p) = find_subslice(new_chars, left) {
+            return Some((p + left.len(), p + left.len()));
+        }
+    }
+    let r1 = (pos + K).min(base_chars.len());
+    let right = &base_chars[pos..r1];
+    if !right.is_empty() {
+        if let Some(p) = find_subslice(new_chars, right) {
+            return Some((p, p));
+        }
+    }
+    None
+}
+
+/// First index where `needle` occurs in `hay` (char slices). `None` if absent or
+/// empty needle.
+fn find_subslice(hay: &[char], needle: &[char]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > hay.len() {
+        return None;
+    }
+    (0..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import::from_markdown;
+    use crate::model::MarkKind;
+
+    #[test]
+    fn diff_apply_round_trips() {
+        let d = diff("the quick brown fox", "the slow brown fox");
+        assert_eq!(d.apply("the quick brown fox"), "the slow brown fox");
+    }
+
+    #[test]
+    fn map_pos_insertion() {
+        // Insert "XY" at position 3 of "abcdef".
+        let d = diff("abcdef", "abcXYdef");
+        assert_eq!(d.apply("abcdef"), "abcXYdef");
+        // A point before the insert is unmoved; after it shifts by 2.
+        assert_eq!(d.map_pos(2, Assoc::After), 2);
+        assert_eq!(d.map_pos(4, Assoc::Before), 6);
+    }
+
+    #[test]
+    fn anchor_survives_edit_elsewhere() {
+        // Anchor on "target" (chars 7..13); edit happens before it.
+        let mut base = from_markdown("hello, target word").unwrap();
+        base.marks.push(Mark {
+            start: 7,
+            end: 13,
+            kind: MarkKind::Anchor { id: "c1".into() },
+        });
+        base.normalize();
+        let (new_rt, _) = diff_import(&base, "why hello, target word").unwrap();
+        let anchor = new_rt
+            .marks
+            .iter()
+            .find(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1"))
+            .expect("anchor preserved");
+        assert_eq!(
+            new_rt.text[byte(&new_rt.text, anchor.start)..byte(&new_rt.text, anchor.end)].to_string(),
+            "target"
+        );
+    }
+
+    #[test]
+    fn anchor_rehomed_on_block_move() {
+        // Two paragraphs; anchor on the first; the rewrite swaps their order.
+        let mut base = from_markdown("first para here\n\nsecond para here").unwrap();
+        // "first para here" is chars 0..15
+        base.marks.push(Mark {
+            start: 0,
+            end: 15,
+            kind: MarkKind::Anchor { id: "c1".into() },
+        });
+        base.normalize();
+        let (new_rt, _) = diff_import(&base, "second para here\n\nfirst para here").unwrap();
+        let anchor = new_rt
+            .marks
+            .iter()
+            .find(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1"))
+            .expect("anchor re-homed onto moved block");
+        assert_eq!(
+            new_rt.text[byte(&new_rt.text, anchor.start)..byte(&new_rt.text, anchor.end)].to_string(),
+            "first para here"
+        );
+    }
+
+    #[test]
+    fn anchor_dropped_when_text_deleted() {
+        let mut base = from_markdown("keep this and drop that").unwrap();
+        // Anchor on "drop that" (14..23).
+        base.marks.push(Mark {
+            start: 14,
+            end: 23,
+            kind: MarkKind::Anchor { id: "c1".into() },
+        });
+        base.normalize();
+        let (new_rt, _) = diff_import(&base, "keep this").unwrap();
+        assert!(
+            !new_rt
+                .marks
+                .iter()
+                .any(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1")),
+            "anchor on deleted text detaches (accepted residual)"
+        );
+    }
+
+    fn byte(s: &str, char_idx: usize) -> usize {
+        crate::usv::char_to_byte(s, char_idx)
+    }
+}

--- a/crates/richtext/src/delta.rs
+++ b/crates/richtext/src/delta.rs
@@ -81,7 +81,10 @@ impl Delta {
         for op in &self.ops {
             match op {
                 Op::Retain(n) => {
-                    if pos <= old + n {
+                    // Strictly inside the retain resolves here; the right
+                    // boundary (pos == old + n) falls through, so a following
+                    // Insert can apply its `assoc`.
+                    if pos < old + n {
                         return new + (pos - old);
                     }
                     old += n;
@@ -108,18 +111,19 @@ impl Delta {
                 }
             }
         }
-        new
+        new + pos.saturating_sub(old)
     }
 
-    /// Whether base position `pos` sits strictly inside a deleted span (used to
-    /// detect a collapsed zero-width anchor).
+    /// Whether base position `pos` sits strictly inside a deleted span. The
+    /// deletion's left edge (`pos == old`) survives — a point anchor there stays
+    /// put — so only `old < pos < old + n` counts as deleted.
     fn is_deleted(&self, pos: usize) -> bool {
         let mut old = 0usize;
         for op in &self.ops {
             match op {
                 Op::Retain(n) => old += n,
                 Op::Delete(n) => {
-                    if pos >= old && pos < old + n {
+                    if pos > old && pos < old + n {
                         return true;
                     }
                     old += n;
@@ -129,12 +133,44 @@ impl Delta {
         }
         false
     }
+
+    /// New-text char ranges covered by `Insert` ops — the only regions an anchor
+    /// may be re-homed into (moved text must have been *inserted*, not merely
+    /// present in surviving text elsewhere).
+    fn inserted_spans(&self) -> Vec<(usize, usize)> {
+        let mut spans = Vec::new();
+        let mut new = 0usize;
+        for op in &self.ops {
+            match op {
+                Op::Retain(n) => new += n,
+                Op::Insert(s) => {
+                    let len = s.chars().count();
+                    if len > 0 {
+                        spans.push((new, new + len));
+                    }
+                    new += len;
+                }
+                Op::Delete(_) => {}
+            }
+        }
+        spans
+    }
 }
+
+/// A relocation match shorter than this many chars is too weak to trust — the
+/// verbatim-move detector's length floor (mirrors the spike's `MIN_MOVE`).
+const MIN_MOVE: usize = 4;
 
 /// Char-level diff via common-prefix / common-suffix trim: the change is one
 /// `Delete` of the differing base middle and one `Insert` of the new middle.
-/// Coarse but valid — the move detector recovers relocations from the new text
-/// directly, so a finer diff is not needed for phase-1 anchor rebase.
+///
+/// Coarse by design for phase 1. A consequence: two disjoint edits collapse the
+/// whole span between them into one delete+insert, so an anchor sitting between
+/// them collapses and must relocate via the move detector. Anchor *survival*
+/// still holds (relocation recovers moved text; unrelated edits keep the
+/// surrounding retain), but the returned `Delta` is not a minimal edit script.
+/// Phase 3 (the real edit surface + change log) replaces this with a Myers/LCS
+/// diff; phase-1 anchor rebase does not need one.
 pub fn diff(base: &str, new: &str) -> Delta {
     let a: Vec<char> = base.chars().collect();
     let b: Vec<char> = new.chars().collect();
@@ -180,14 +216,16 @@ pub fn diff_import(
     let mut new_rt = crate::import::from_markdown(new_markdown)?;
     let delta = diff(&base.text, &new_rt.text);
 
+    let base_chars: Vec<char> = base.text.chars().collect();
     let new_chars: Vec<char> = new_rt.text.chars().collect();
+    let inserted = delta.inserted_spans();
     for m in &base.marks {
         // Only identity marks live in the corpus but not in markdown; formatting
         // marks are re-derived by the fresh import, so we do not carry them.
         let MarkKind::Anchor { .. } = &m.kind else {
             continue;
         };
-        if let Some((ns, ne)) = rebase_anchor(&base.text, &delta, &new_chars, m) {
+        if let Some((ns, ne)) = rebase_anchor(&delta, &base_chars, &new_chars, &inserted, m) {
             new_rt.marks.push(Mark {
                 start: ns,
                 end: ne,
@@ -203,22 +241,21 @@ pub fn diff_import(
 /// Rebase one anchor through the delta. Returns its new range, or `None` if it
 /// detaches (its text was deleted and no verbatim move re-homes it).
 fn rebase_anchor(
-    base_text: &str,
     delta: &Delta,
+    base_chars: &[char],
     new_chars: &[char],
+    inserted: &[(usize, usize)],
     m: &Mark,
 ) -> Option<(usize, usize)> {
     if m.start == m.end {
         // Zero-width point anchor.
         if !delta.is_deleted(m.start) {
-            return Some((
-                delta.map_pos(m.start, Assoc::Before),
-                delta.map_pos(m.start, Assoc::Before),
-            ));
+            let p = delta.map_pos(m.start, Assoc::Before);
+            return Some((p, p));
         }
-        // Context relocation: place it at the same offset inside its
-        // surrounding text if that context survived the move.
-        return relocate_point(base_text, new_chars, m.start);
+        // Its surrounding text was deleted — relocate only if that text was
+        // re-inserted verbatim elsewhere (a move).
+        return relocate_point(base_chars, new_chars, inserted, m.start);
     }
 
     let ns = delta.map_pos(m.start, Assoc::After);
@@ -226,54 +263,68 @@ fn rebase_anchor(
     if ns < ne {
         return Some((ns, ne)); // survived a surrounding edit
     }
-    // Collapsed — try a verbatim block move: find the annotated span in the new
-    // corpus.
-    relocate_span(base_text, new_chars, m.start, m.end)
+    // Collapsed — try a verbatim block move: the annotated span must reappear
+    // inside inserted text (not merely somewhere in the surviving corpus).
+    relocate_span(base_chars, new_chars, inserted, m.start, m.end)
 }
 
+/// Find the annotated span `base[start..end]` inside an inserted region of the
+/// new text. Requires a length floor and containment in inserted text, so an
+/// unrelated surviving occurrence of the same words cannot capture the anchor.
 fn relocate_span(
-    base_text: &str,
+    base_chars: &[char],
     new_chars: &[char],
+    inserted: &[(usize, usize)],
     start: usize,
     end: usize,
 ) -> Option<(usize, usize)> {
-    let base_chars: Vec<char> = base_text.chars().collect();
     if end > base_chars.len() {
         return None;
     }
     let needle = &base_chars[start..end];
-    find_subslice(new_chars, needle).map(|pos| (pos, pos + needle.len()))
+    find_in_spans(new_chars, needle, inserted).map(|pos| (pos, pos + needle.len()))
 }
 
-fn relocate_point(base_text: &str, new_chars: &[char], pos: usize) -> Option<(usize, usize)> {
+/// Relocate a point anchor by its left context (text immediately before it),
+/// but only if that context reappears inside inserted text — the same
+/// move-only, length-floored discipline as [`relocate_span`].
+fn relocate_point(
+    base_chars: &[char],
+    new_chars: &[char],
+    inserted: &[(usize, usize)],
+    pos: usize,
+) -> Option<(usize, usize)> {
     const K: usize = 24;
-    let base_chars: Vec<char> = base_text.chars().collect();
-    // Prefer left context (text immediately before the point); fall back to
-    // right context. The point lands at the boundary between them.
     let l0 = pos.saturating_sub(K);
     let left = &base_chars[l0..pos];
-    if !left.is_empty() {
-        if let Some(p) = find_subslice(new_chars, left) {
-            return Some((p + left.len(), p + left.len()));
-        }
+    if let Some(p) = find_in_spans(new_chars, left, inserted) {
+        return Some((p + left.len(), p + left.len()));
     }
     let r1 = (pos + K).min(base_chars.len());
     let right = &base_chars[pos..r1];
-    if !right.is_empty() {
-        if let Some(p) = find_subslice(new_chars, right) {
-            return Some((p, p));
-        }
+    if let Some(p) = find_in_spans(new_chars, right, inserted) {
+        return Some((p, p));
     }
     None
 }
 
-/// First index where `needle` occurs in `hay` (char slices). `None` if absent or
-/// empty needle.
-fn find_subslice(hay: &[char], needle: &[char]) -> Option<usize> {
-    if needle.is_empty() || needle.len() > hay.len() {
+/// First index where `needle` occurs in `hay` while *overlapping* an inserted
+/// span — i.e. the match touches text the rewrite actually inserted, not purely
+/// surviving text. Overlap (not full containment) is required because a coarse
+/// diff can split a moved block across an inserted region and the retained
+/// suffix; demanding containment would miss real moves, while demanding overlap
+/// still rejects an unrelated occurrence sitting entirely in retained text.
+/// Enforces [`MIN_MOVE`].
+fn find_in_spans(hay: &[char], needle: &[char], spans: &[(usize, usize)]) -> Option<usize> {
+    if needle.len() < MIN_MOVE || needle.len() > hay.len() {
         return None;
     }
-    (0..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
+    (0..=hay.len() - needle.len()).find(|&i| {
+        &hay[i..i + needle.len()] == needle
+            && spans
+                .iter()
+                .any(|&(s, e)| i < e && i + needle.len() > s)
+    })
 }
 
 #[cfg(test)]
@@ -361,6 +412,46 @@ mod tests {
                 .any(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1")),
             "anchor on deleted text detaches (accepted residual)"
         );
+    }
+
+    #[test]
+    fn anchor_not_rehomed_onto_unrelated_survivor() {
+        // Regression (review finding 5): an anchor on deleted text must NOT
+        // capture an unrelated *surviving* occurrence of the same words.
+        let mut base = from_markdown("target one to drop\n\nkeep the target two").unwrap();
+        base.marks.push(Mark {
+            start: 0,
+            end: 6, // "target" in the first (deleted) paragraph
+            kind: MarkKind::Anchor { id: "c1".into() },
+        });
+        base.normalize();
+        // First paragraph deleted; the second (with its own "target") survives
+        // as retained text — the anchor must drop, not jump to it.
+        let (new_rt, _) = diff_import(&base, "keep the target two").unwrap();
+        assert!(
+            !new_rt
+                .marks
+                .iter()
+                .any(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1")),
+            "anchor wrongly re-homed onto surviving unrelated text"
+        );
+    }
+
+    #[test]
+    fn map_pos_after_moves_past_boundary_insertion() {
+        // Regression (finding 7): a point at a retain|insert boundary with
+        // Assoc::After lands after the inserted text.
+        let d = diff("abcdef", "abcXYdef");
+        assert_eq!(d.map_pos(3, Assoc::After), 5);
+        assert_eq!(d.map_pos(3, Assoc::Before), 3);
+    }
+
+    #[test]
+    fn point_anchor_at_deletion_left_edge_survives() {
+        // Regression (finding 13): the deletion's left edge is not "deleted".
+        let d = diff("abcdef", "abef"); // delete "cd" (span [2,4))
+        assert!(!d.is_deleted(2), "left edge of deletion survives");
+        assert!(d.is_deleted(3), "interior of deletion is deleted");
     }
 
     fn byte(s: &str, char_idx: usize) -> usize {

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -1,0 +1,618 @@
+//! Markdown export: corpus → markdown, per island loss class.
+//!
+//! The projection back to markdown. Marks become syntax; islands are emitted per
+//! their [`Loss`] class; identity ([`MarkKind::Anchor`]) marks are **omitted** —
+//! they survive across edits via diff-rebase, not the projection (issue #831
+//! § Codecs). Anchors carry no markdown encoding, so dropping them here is by
+//! design, not loss.
+//!
+//! The contract phase 1 pins is the **corpus fixed point**: for a corpus `rt`
+//! obtained from [`crate::import::from_markdown`],
+//! `from_markdown(to_markdown(rt)) == rt` modulo island loss class — markdown
+//! source is not canonical, but the corpus is, so round-trip is defined at the
+//! corpus, not the string.
+
+use crate::model::{Container, Island, LineKind, Loss, MarkKind, RichText, ISLAND_SLOT};
+
+/// Render a corpus to markdown. Lossless/degraded islands emit their markdown;
+/// unrepresentable islands emit a placeholder comment.
+pub fn to_markdown(rt: &RichText) -> String {
+    // Per-line char ranges, so global marks can be clipped to a line.
+    let segments = line_segments(rt);
+    let ctx = Ctx {
+        rt,
+        segments: &segments,
+    };
+    let mut out = String::new();
+    emit_block(&ctx, 0..rt.lines.len(), 0, &mut out);
+    // Collapse any trailing blank lines to a single newline.
+    while out.ends_with("\n\n") {
+        out.pop();
+    }
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+struct Ctx<'a> {
+    rt: &'a RichText,
+    segments: &'a [Segment],
+}
+
+/// One line's char range `[start, end)` into the corpus.
+struct Segment {
+    start: usize,
+    end: usize,
+}
+
+fn line_segments(rt: &RichText) -> Vec<Segment> {
+    let mut segs = Vec::with_capacity(rt.lines.len());
+    let mut start = 0usize;
+    let mut pos = 0usize;
+    for c in rt.text.chars() {
+        if c == '\n' {
+            segs.push(Segment { start, end: pos });
+            start = pos + 1;
+        }
+        pos += 1;
+    }
+    segs.push(Segment { start, end: pos });
+    // Defensive: a malformed corpus (lines.len() != segments) still gets one
+    // segment per line so indexing never panics.
+    while segs.len() < rt.lines.len() {
+        segs.push(Segment { start: pos, end: pos });
+    }
+    segs
+}
+
+/// Emit the lines in `range`, all sharing the container prefix of length
+/// `depth`. Leaf lines (containers.len() == depth) render at this level;
+/// deeper lines are grouped by their `depth`-th container and recursed into.
+fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut String) {
+    let lines = &ctx.rt.lines;
+    let mut i = range.start;
+    let mut first_block = true;
+    while i < range.end {
+        let line = &lines[i];
+        if line.containers.len() > depth {
+            // A nested container starts here; gather its run and recurse.
+            let key = &line.containers[depth];
+            let mut j = i + 1;
+            while j < range.end
+                && lines[j].containers.len() > depth
+                && &lines[j].containers[depth] == key
+            {
+                j += 1;
+            }
+            block_separator(out, first_block);
+            emit_container(ctx, key, i..j, depth, out);
+            first_block = false;
+            i = j;
+        } else {
+            // Leaf block at this depth. Code lines coalesce into one fence.
+            if let LineKind::Code { lang } = &line.kind {
+                let mut j = i + 1;
+                while j < range.end
+                    && lines[j].containers.len() == depth
+                    && matches!(&lines[j].kind, LineKind::Code { lang: l } if l == lang)
+                {
+                    j += 1;
+                }
+                block_separator(out, first_block);
+                emit_code(ctx, i..j, lang.as_deref(), out);
+                first_block = false;
+                i = j;
+            } else {
+                block_separator(out, first_block);
+                emit_leaf(ctx, i, out);
+                first_block = false;
+                i += 1;
+            }
+        }
+    }
+}
+
+fn block_separator(out: &mut String, first_block: bool) {
+    if !first_block {
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+}
+
+/// Emit a container run (a list item's block, or a quote's block) by prefixing
+/// each produced line. The inner blocks are emitted into a scratch buffer, then
+/// each of its lines is prefixed.
+fn emit_container(
+    ctx: &Ctx,
+    key: &Container,
+    range: std::ops::Range<usize>,
+    depth: usize,
+    out: &mut String,
+) {
+    let mut inner = String::new();
+    emit_block(ctx, range, depth + 1, &mut inner);
+
+    match key {
+        Container::ListItem {
+            ordered,
+            start,
+            ordinal,
+        } => {
+            let marker = if *ordered {
+                format!("{}. ", start + ordinal)
+            } else {
+                "- ".to_string()
+            };
+            let indent = " ".repeat(marker.len());
+            prefix_lines(&inner, &marker, &indent, out);
+        }
+        Container::Quote => {
+            // `> ` on content lines, `>` on blank lines so paragraphs stay in
+            // one quote on re-import.
+            prefix_quote(&inner, out);
+        }
+    }
+}
+
+/// Prefix the first produced line with `first`, the rest with `cont`.
+fn prefix_lines(inner: &str, first: &str, cont: &str, out: &mut String) {
+    for (idx, line) in inner.split('\n').enumerate() {
+        if idx == 0 {
+            out.push_str(first);
+            out.push_str(line);
+        } else {
+            out.push('\n');
+            if line.is_empty() {
+                // blank continuation line: no trailing indent
+            } else {
+                out.push_str(cont);
+                out.push_str(line);
+            }
+        }
+    }
+}
+
+fn prefix_quote(inner: &str, out: &mut String) {
+    for (idx, line) in inner.split('\n').enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        if line.is_empty() {
+            out.push('>');
+        } else {
+            out.push_str("> ");
+            out.push_str(line);
+        }
+    }
+}
+
+fn emit_code(ctx: &Ctx, range: std::ops::Range<usize>, lang: Option<&str>, out: &mut String) {
+    // Choose a fence long enough to not collide with backtick runs in content.
+    let mut max_ticks = 0usize;
+    for i in range.clone() {
+        let s = seg_str(ctx, i);
+        let mut run = 0usize;
+        for c in s.chars() {
+            if c == '`' {
+                run += 1;
+                max_ticks = max_ticks.max(run);
+            } else {
+                run = 0;
+            }
+        }
+    }
+    let fence = "`".repeat(max_ticks.max(2) + 1);
+    out.push_str(&fence);
+    if let Some(l) = lang {
+        out.push_str(l);
+    }
+    out.push('\n');
+    for i in range {
+        out.push_str(seg_str(ctx, i));
+        out.push('\n');
+    }
+    out.push_str(&fence);
+}
+
+fn emit_leaf(ctx: &Ctx, i: usize, out: &mut String) {
+    let line = &ctx.rt.lines[i];
+    match &line.kind {
+        LineKind::Heading { level } => {
+            for _ in 0..*level {
+                out.push('#');
+            }
+            out.push(' ');
+            out.push_str(&render_inline(ctx, i, false));
+        }
+        LineKind::Island => {
+            // A block island: the segment is a single slot. Resolve and emit.
+            let island = slot_island(ctx, i);
+            if let Some(isl) = island {
+                emit_island(isl, out);
+            }
+        }
+        LineKind::Code { .. } => {
+            // Handled by emit_code; a lone code line still renders as a fence.
+            emit_code(ctx, i..i + 1, None, out);
+        }
+        LineKind::Para => {
+            out.push_str(&render_inline(ctx, i, true));
+        }
+    }
+}
+
+fn seg_str<'a>(ctx: &'a Ctx, i: usize) -> &'a str {
+    let seg = &ctx.segments[i];
+    let bstart = crate::usv::char_to_byte(&ctx.rt.text, seg.start);
+    let bend = crate::usv::char_to_byte(&ctx.rt.text, seg.end);
+    &ctx.rt.text[bstart..bend]
+}
+
+/// The island backing the single slot on a block-island line `i`.
+fn slot_island<'a>(ctx: &'a Ctx, i: usize) -> Option<&'a Island> {
+    // Count slots before this line to find the island index.
+    let seg = &ctx.segments[i];
+    let before = ctx
+        .rt
+        .text
+        .chars()
+        .take(seg.start)
+        .filter(|c| *c == ISLAND_SLOT)
+        .count();
+    ctx.rt.islands.get(before)
+}
+
+fn emit_island(isl: &Island, out: &mut String) {
+    match (isl.island_type.as_str(), isl.loss) {
+        ("table", _) => emit_table(isl, out),
+        ("image", _) => emit_image(isl, out),
+        (_, Loss::Unrepresentable) | (_, _) => {
+            // Unknown island / unrepresentable: a comment placeholder that
+            // survives round-trip as no corpus text (HTML comments are stripped
+            // on re-import). The island itself is preserved via storage, not the
+            // projection.
+            out.push_str(&format!("<!-- island:{} -->", isl.island_type));
+        }
+    }
+}
+
+fn emit_table(isl: &Island, out: &mut String) {
+    let header = isl.props.get("header").and_then(|v| v.as_array());
+    let rows = isl.props.get("rows").and_then(|v| v.as_array());
+    let aligns = isl.props.get("aligns").and_then(|v| v.as_array());
+    let cols = header.map(|h| h.len()).unwrap_or(0);
+    if cols == 0 {
+        return;
+    }
+    let cell = |v: &serde_json::Value| v.as_str().unwrap_or("").replace('|', "\\|");
+
+    // header row
+    out.push_str("| ");
+    if let Some(h) = header {
+        out.push_str(
+            &h.iter()
+                .map(&cell)
+                .collect::<Vec<_>>()
+                .join(" | "),
+        );
+    }
+    out.push_str(" |\n|");
+    for k in 0..cols {
+        let a = aligns
+            .and_then(|a| a.get(k))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none");
+        out.push_str(match a {
+            "left" => " :--- |",
+            "center" => " :---: |",
+            "right" => " ---: |",
+            _ => " --- |",
+        });
+    }
+    if let Some(rs) = rows {
+        for row in rs {
+            if let Some(r) = row.as_array() {
+                out.push_str("\n| ");
+                out.push_str(&r.iter().map(&cell).collect::<Vec<_>>().join(" | "));
+                out.push_str(" |");
+            }
+        }
+    }
+}
+
+fn emit_image(isl: &Island, out: &mut String) {
+    let url = isl.props.get("url").and_then(|v| v.as_str()).unwrap_or("");
+    let alt = isl.props.get("alt").and_then(|v| v.as_str()).unwrap_or("");
+    out.push_str(&format!("![{}]({})", alt, url));
+}
+
+// ---------------------------------------------------------------------------
+// Inline rendering: marks -> syntax, over one line's char range.
+// ---------------------------------------------------------------------------
+
+fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
+    let seg = &ctx.segments[i];
+    let line_start = seg.start;
+    let text = seg_str(ctx, i);
+    let chars: Vec<char> = text.chars().collect();
+    let n = chars.len();
+
+    // Clip marks to this line, split into code (atomic) and formatting (nested).
+    let mut code_ranges: Vec<(usize, usize)> = Vec::new();
+    let mut fmt: Vec<(usize, usize, &MarkKind)> = Vec::new();
+    let mut links: Vec<(usize, usize, &str)> = Vec::new();
+    for m in &ctx.rt.marks {
+        let s = m.start.saturating_sub(line_start);
+        let e = m.end.saturating_sub(line_start);
+        if m.end <= line_start || m.start >= line_start + n {
+            continue; // outside this line
+        }
+        let s = s.min(n);
+        let e = e.min(n);
+        match &m.kind {
+            MarkKind::Anchor { .. } => {} // omitted from the projection
+            MarkKind::Code => code_ranges.push((s, e)),
+            MarkKind::Link { url } => links.push((s, e, url)),
+            _ => fmt.push((s, e, &m.kind)),
+        }
+    }
+
+    let mut out = String::new();
+    let island_at = |pos_local: usize| -> Option<&Island> {
+        let global = line_start + pos_local;
+        let before = ctx
+            .rt
+            .text
+            .chars()
+            .take(global)
+            .filter(|c| *c == ISLAND_SLOT)
+            .count();
+        ctx.rt.islands.get(before)
+    };
+
+    // Formatting delimiter open/close order at each boundary (proper nesting):
+    // open longer marks first, close shorter marks first.
+    let mut stack: Vec<(usize, &MarkKind)> = Vec::new(); // (end, kind)
+    let mut pos = 0usize;
+    while pos <= n {
+        // Close marks ending here (innermost first).
+        while let Some(&(end, kind)) = stack.last() {
+            if end == pos {
+                out.push_str(&delim_close(kind));
+                stack.pop();
+            } else {
+                break;
+            }
+        }
+        // Open formatting marks starting here, longest span (outer) first —
+        // BEFORE any atomic run, so a formatting mark that begins at the same
+        // position as inline code/link still wraps it (`**` + code at 457 →
+        // `**`code`…**`, not a dropped strong).
+        let mut opening: Vec<(usize, &MarkKind)> = fmt
+            .iter()
+            .filter(|(s, _, _)| *s == pos)
+            .map(|(_, e, k)| (*e, *k))
+            .collect();
+        opening.sort_by(|a, b| b.0.cmp(&a.0));
+        for (end, kind) in opening {
+            out.push_str(&delim_open(kind));
+            stack.push((end, kind));
+        }
+        // A link is emitted atomically as [text](url); its display text carries
+        // plain content (nested marks in link text are out of scope for phase 1).
+        if let Some(&(ls, le, url)) = links.iter().find(|(s, _, _)| *s == pos) {
+            out.push('[');
+            out.push_str(&escape_run(&chars[ls..le]));
+            out.push_str("](");
+            out.push_str(url);
+            out.push(')');
+            pos = le;
+            continue;
+        }
+        // A code range is atomic.
+        if let Some(&(cs, ce)) = code_ranges.iter().find(|(s, _)| *s == pos) {
+            let content: String = chars[cs..ce].iter().collect();
+            let ticks = longest_backtick_run(&content) + 1;
+            let fence = "`".repeat(ticks.max(1));
+            out.push_str(&fence);
+            out.push_str(&content);
+            out.push_str(&fence);
+            pos = ce;
+            continue;
+        }
+        if pos < n {
+            let c = chars[pos];
+            if c == ISLAND_SLOT {
+                if let Some(isl) = island_at(pos) {
+                    let mut tmp = String::new();
+                    emit_island(isl, &mut tmp);
+                    out.push_str(&tmp);
+                }
+            } else {
+                out.push_str(&escape_char(
+                    c,
+                    pos == 0 && escape_leading_block,
+                ));
+            }
+        }
+        pos += 1;
+    }
+    out
+}
+
+fn delim_open(kind: &MarkKind) -> String {
+    match kind {
+        MarkKind::Strong => "**".into(),
+        MarkKind::Emph => "_".into(),
+        MarkKind::Underline => "<u>".into(),
+        MarkKind::Strike => "~~".into(),
+        MarkKind::Unknown { .. } => String::new(),
+        // Code/Link/Anchor handled elsewhere.
+        _ => String::new(),
+    }
+}
+
+fn delim_close(kind: &MarkKind) -> String {
+    match kind {
+        MarkKind::Strong => "**".into(),
+        MarkKind::Emph => "_".into(),
+        MarkKind::Underline => "</u>".into(),
+        MarkKind::Strike => "~~".into(),
+        _ => String::new(),
+    }
+}
+
+fn escape_run(chars: &[char]) -> String {
+    let mut s = String::new();
+    for (i, c) in chars.iter().enumerate() {
+        s.push_str(&escape_char(*c, i == 0));
+    }
+    s
+}
+
+/// Escape a char so it re-imports as literal text. `leading` also escapes
+/// block-starter chars that would otherwise open a heading/list/quote.
+fn escape_char(c: char, leading: bool) -> String {
+    match c {
+        '\\' => "\\\\".into(),
+        '*' => "\\*".into(),
+        '_' => "\\_".into(),
+        '`' => "\\`".into(),
+        '[' => "\\[".into(),
+        ']' => "\\]".into(),
+        '<' => "\\<".into(),
+        '~' => "\\~".into(),
+        '#' if leading => "\\#".into(),
+        '>' if leading => "\\>".into(),
+        '-' if leading => "\\-".into(),
+        '+' if leading => "\\+".into(),
+        other => other.to_string(),
+    }
+}
+
+fn longest_backtick_run(s: &str) -> usize {
+    let mut max = 0;
+    let mut run = 0;
+    for c in s.chars() {
+        if c == '`' {
+            run += 1;
+            max = max.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    max
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import::from_markdown;
+    use crate::model::Mark;
+
+    /// The phase-1 contract: export∘import is the identity on the corpus (modulo
+    /// island loss class, which our test islands don't trigger).
+    fn round_trips(md: &str) {
+        let rt = from_markdown(md).unwrap();
+        let md2 = to_markdown(&rt);
+        let rt2 = from_markdown(&md2).unwrap();
+        assert_eq!(
+            rt, rt2,
+            "corpus not a fixed point.\n  in:  {md:?}\n  mid: {md2:?}"
+        );
+    }
+
+    #[test]
+    fn paragraph() {
+        round_trips("Hello world");
+    }
+
+    #[test]
+    fn two_paragraphs() {
+        round_trips("one\n\ntwo");
+    }
+
+    #[test]
+    fn marks() {
+        round_trips("a **b** _c_ ~~d~~ <u>e</u>");
+    }
+
+    #[test]
+    fn nested_marks() {
+        round_trips("**bold _and italic_**");
+    }
+
+    #[test]
+    fn heading() {
+        round_trips("## Title here");
+    }
+
+    #[test]
+    fn inline_code() {
+        round_trips("run `cargo test` now");
+    }
+
+    #[test]
+    fn code_block() {
+        round_trips("```rust\nfn a() {}\nfn b() {}\n```");
+    }
+
+    #[test]
+    fn bullet_list() {
+        round_trips("- a\n- b\n- c");
+    }
+
+    #[test]
+    fn ordered_list() {
+        round_trips("3. a\n4. b");
+    }
+
+    #[test]
+    fn multi_paragraph_item() {
+        round_trips("- first\n\n  second");
+    }
+
+    #[test]
+    fn blockquote() {
+        round_trips("> quoted text");
+    }
+
+    #[test]
+    fn link() {
+        round_trips("see [our site](https://example.com) now");
+    }
+
+    #[test]
+    fn table() {
+        round_trips("| a | b |\n| --- | --- |\n| 1 | 2 |");
+    }
+
+    #[test]
+    fn image() {
+        round_trips("see ![a cat](cat.png) here");
+    }
+
+    #[test]
+    fn literal_asterisks_escaped() {
+        round_trips("2 * 3 = 6 and a_b_c");
+    }
+
+    #[test]
+    fn anchor_marks_omitted_but_text_survives() {
+        let mut rt = from_markdown("comment target here").unwrap();
+        rt.marks.push(Mark {
+            start: 8,
+            end: 14,
+            kind: MarkKind::Anchor { id: "c1".into() },
+        });
+        rt.normalize();
+        let md = to_markdown(&rt);
+        // No anchor syntax in the projection, but the text round-trips.
+        let rt2 = from_markdown(&md).unwrap();
+        assert_eq!(rt2.text, "comment target here");
+        assert!(!md.contains("c1"));
+    }
+}

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -11,6 +11,21 @@
 //! `from_markdown(to_markdown(rt)) == rt` modulo island loss class — markdown
 //! source is not canonical, but the corpus is, so round-trip is defined at the
 //! corpus, not the string.
+//!
+//! ## Documented codec limits (degenerate, non-authorable corpora)
+//!
+//! The fixed point holds for corpora a well-behaved producer emits. Two
+//! degenerate shapes markdown cannot represent do **not** round-trip, and are
+//! recorded here rather than hidden (see `tests::known_hard_break_limits`):
+//!
+//! - **A mark spanning a hard break** — per-line rendering splits it into two
+//!   per-line marks (they do not re-union across the `\n`).
+//! - **An empty first line in a hard-break block** — markdown has no
+//!   blank-then-forced-break syntax, so the leading empty line is dropped.
+//!
+//! Both arise only from adversarial delimiter/break placement, never from clean
+//! markdown or a form editor. Hardening them is deferred (a phase-3 concern once
+//! a live editor defines what it can even produce).
 
 use crate::model::{Container, Island, LineKind, Loss, MarkKind, RichText, ISLAND_SLOT};
 
@@ -90,25 +105,16 @@ fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut 
             first_block = false;
             i = j;
         } else {
-            // Leaf block at this depth. Code lines coalesce into one fence.
-            if let LineKind::Code { lang } = &line.kind {
-                let mut j = i + 1;
-                while j < range.end
-                    && lines[j].containers.len() == depth
-                    && matches!(&lines[j].kind, LineKind::Code { lang: l } if l == lang)
-                {
-                    j += 1;
-                }
-                block_separator(out, first_block);
-                emit_code(ctx, i..j, lang.as_deref(), out);
-                first_block = false;
-                i = j;
-            } else {
-                block_separator(out, first_block);
-                emit_leaf(ctx, i, out);
-                first_block = false;
-                i += 1;
+            // A leaf block: this line (continues == false) plus every following
+            // line that continues it (a hard-break run, or a code fence's lines).
+            let mut j = i + 1;
+            while j < range.end && lines[j].containers.len() == depth && lines[j].continues {
+                j += 1;
             }
+            block_separator(out, first_block);
+            emit_leaf_block(ctx, i..j, out);
+            first_block = false;
+            i = j;
         }
     }
 }
@@ -217,29 +223,35 @@ fn emit_code(ctx: &Ctx, range: std::ops::Range<usize>, lang: Option<&str>, out: 
     out.push_str(&fence);
 }
 
-fn emit_leaf(ctx: &Ctx, i: usize, out: &mut String) {
-    let line = &ctx.rt.lines[i];
-    match &line.kind {
+/// Emit one leaf block: the lines `range.start` (a block start) plus any
+/// continuation lines. A paragraph block joins its lines with a markdown hard
+/// break (`\` + newline); a code block renders one fence; a heading/island is a
+/// single line.
+fn emit_leaf_block(ctx: &Ctx, range: std::ops::Range<usize>, out: &mut String) {
+    let first = &ctx.rt.lines[range.start];
+    match &first.kind {
+        LineKind::Code { lang } => emit_code(ctx, range, lang.as_deref(), out),
+        LineKind::Island => {
+            // A block island: the segment is a single slot. Resolve and emit.
+            if let Some(isl) = slot_island(ctx, range.start) {
+                emit_island(isl, out);
+            }
+        }
         LineKind::Heading { level } => {
             for _ in 0..*level {
                 out.push('#');
             }
             out.push(' ');
-            out.push_str(&render_inline(ctx, i, false));
-        }
-        LineKind::Island => {
-            // A block island: the segment is a single slot. Resolve and emit.
-            let island = slot_island(ctx, i);
-            if let Some(isl) = island {
-                emit_island(isl, out);
-            }
-        }
-        LineKind::Code { .. } => {
-            // Handled by emit_code; a lone code line still renders as a fence.
-            emit_code(ctx, i..i + 1, None, out);
+            // Headings never carry continuations (import maps a hard break in a
+            // heading to a space), so only the first line contributes.
+            out.push_str(&render_inline(ctx, range.start, false));
         }
         LineKind::Para => {
-            out.push_str(&render_inline(ctx, i, true));
+            // Join continuation lines with a backslash hard break.
+            let parts: Vec<String> = range
+                .map(|i| render_inline(ctx, i, true))
+                .collect();
+            out.push_str(&parts.join("\\\n"));
         }
     }
 }
@@ -287,7 +299,10 @@ fn emit_table(isl: &Island, out: &mut String) {
     if cols == 0 {
         return;
     }
-    let cell = |v: &serde_json::Value| v.as_str().unwrap_or("").replace('|', "\\|");
+    // Cells are stored as raw markdown source slices (pipes already escaped as
+    // `\|` at import), so emit them verbatim — re-escaping would double the
+    // backslash and split the cell on re-import.
+    let cell = |v: &serde_json::Value| v.as_str().unwrap_or("").to_string();
 
     // header row
     out.push_str("| ");
@@ -360,6 +375,22 @@ fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
         }
     }
 
+    // Leading ordered-list marker: a line whose text starts `<digits>.` or
+    // `<digits>)` would re-import as an ordered list, so escape that punctuation.
+    let escape_punct_at = if escape_leading_block {
+        let lead_digits = chars.iter().take_while(|c| c.is_ascii_digit()).count();
+        if lead_digits > 0
+            && lead_digits < n
+            && matches!(chars[lead_digits], '.' | ')')
+        {
+            Some(lead_digits)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     let mut out = String::new();
     let island_at = |pos_local: usize| -> Option<&Island> {
         let global = line_start + pos_local;
@@ -431,11 +462,11 @@ fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
                     emit_island(isl, &mut tmp);
                     out.push_str(&tmp);
                 }
+            } else if Some(pos) == escape_punct_at {
+                out.push('\\');
+                out.push(c);
             } else {
-                out.push_str(&escape_char(
-                    c,
-                    pos == 0 && escape_leading_block,
-                ));
+                out.push_str(&escape_char(c, pos == 0 && escape_leading_block));
             }
         }
         pos += 1;
@@ -446,7 +477,9 @@ fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
 fn delim_open(kind: &MarkKind) -> String {
     match kind {
         MarkKind::Strong => "**".into(),
-        MarkKind::Emph => "_".into(),
+        // `*`, not `_`: `_` cannot do intraword emphasis (CommonMark flanking),
+        // so `_a_你` re-imports as literal text; `*a*你` emphasizes correctly.
+        MarkKind::Emph => "*".into(),
         MarkKind::Underline => "<u>".into(),
         MarkKind::Strike => "~~".into(),
         MarkKind::Unknown { .. } => String::new(),
@@ -458,7 +491,7 @@ fn delim_open(kind: &MarkKind) -> String {
 fn delim_close(kind: &MarkKind) -> String {
     match kind {
         MarkKind::Strong => "**".into(),
-        MarkKind::Emph => "_".into(),
+        MarkKind::Emph => "*".into(),
         MarkKind::Underline => "</u>".into(),
         MarkKind::Strike => "~~".into(),
         _ => String::new(),
@@ -598,6 +631,46 @@ mod tests {
     #[test]
     fn literal_asterisks_escaped() {
         round_trips("2 * 3 = 6 and a_b_c");
+    }
+
+    #[test]
+    fn hard_break_round_trips() {
+        round_trips("line one\\\nline two");
+    }
+
+    #[test]
+    fn hard_break_in_list_item() {
+        round_trips("- one\\\ntwo\n- three");
+    }
+
+    #[test]
+    fn leading_ordered_marker_escaped() {
+        // Corpus prose that begins `N.` must not re-import as an ordered list.
+        let mut rt = from_markdown("x").unwrap();
+        rt.text = "1. not a list".into();
+        let md = to_markdown(&rt);
+        let back = from_markdown(&md).unwrap();
+        assert_eq!(back.lines[0].kind, LineKind::Para);
+        assert!(back.lines[0].containers.is_empty());
+        assert_eq!(back, rt);
+    }
+
+    #[test]
+    fn table_with_escaped_pipe_round_trips() {
+        round_trips("| a \\| b | c |\n| --- | --- |\n| 1 | 2 |");
+    }
+
+    #[test]
+    fn known_hard_break_limits() {
+        // Recorded, not hidden: a mark spanning a hard break splits per line.
+        let rt = from_markdown("**one\\\ntwo**").unwrap();
+        let rt2 = from_markdown(&to_markdown(&rt)).unwrap();
+        // The spanning strong becomes two per-line strongs on round-trip.
+        assert!(
+            rt != rt2,
+            "if this ever round-trips, promote it out of the known-limits list"
+        );
+        assert_eq!(rt2.marks.len(), 2, "mark split across the hard break");
     }
 
     #[test]

--- a/crates/richtext/src/import.rs
+++ b/crates/richtext/src/import.rs
@@ -1,0 +1,1012 @@
+//! Markdown import (cold): `normalize → pulldown → corpus`.
+//!
+//! The one place the `<u>` allowlist and `***` fixups run — once, at the
+//! boundary (issue #831 § Codecs). Input is normalized by
+//! [`quillmark_core::normalize::normalize_markdown`] (CRLF→LF, bidi strip, HTML
+//! comment-fence repair) so the corpus invariants hold by construction, then
+//! parsed with `pulldown_cmark` (CommonMark + strikethrough + pipe tables) and
+//! walked into a [`RichText`].
+//!
+//! ## Phase-1 canonicalizations (documented, not bugs)
+//!
+//! - **Soft breaks → space, hard breaks → line boundary.** A markdown hard break
+//!   (two trailing spaces or `\`) canonicalizes to a corpus line boundary,
+//!   indistinguishable from a paragraph break — the model has no
+//!   within-paragraph break and needs none for phase 1.
+//! - **Island ids are minted sequentially** (`isl-0`, `isl-1`, …) so import is a
+//!   pure, deterministic function. Real minting (the hash-nondeterminism source)
+//!   is phase 4; sequential ids round-trip (export drops them, re-import
+//!   re-mints the same sequence).
+//! - **Tables and images are islands.** Tables are block islands (their own
+//!   `Island` line); images are inline island slots. Both `Lossless` — pipe
+//!   tables and `![alt](url)` carry them faithfully.
+
+use crate::model::{
+    Container, Island, Line, LineKind, Loss, Mark, MarkKind, RichText, ISLAND_SLOT,
+};
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use quillmark_core::error::MAX_NESTING_DEPTH;
+use quillmark_core::normalize::normalize_markdown;
+use serde_json::json;
+use std::ops::Range;
+
+/// Import errors. Phase-1 surface is just the nesting guard (mirrors the typst
+/// backend's `ConversionError::NestingTooDeep`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportError {
+    /// Container nesting exceeded [`MAX_NESTING_DEPTH`].
+    NestingTooDeep { depth: usize, max: usize },
+}
+
+impl std::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImportError::NestingTooDeep { depth, max } => {
+                write!(f, "nesting too deep: {depth} (max {max})")
+            }
+        }
+    }
+}
+impl std::error::Error for ImportError {}
+
+/// Import markdown into a normalized, validated [`RichText`] corpus.
+pub fn from_markdown(markdown: &str) -> Result<RichText, ImportError> {
+    let normalized = normalize_markdown(markdown);
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TABLES);
+    let parser = Parser::new_ext(&normalized, options);
+    let fixer = MarkdownFixer::new(parser.into_offset_iter(), &normalized);
+
+    let mut b = Builder::new(&normalized);
+    b.run(fixer)?;
+    let mut rt = b.finish();
+    rt.normalize();
+    Ok(rt)
+}
+
+// ---------------------------------------------------------------------------
+// Corpus builder
+// ---------------------------------------------------------------------------
+
+struct Builder<'a> {
+    source: &'a str,
+    text: String,
+    pos: usize, // USV position = char count of `text`
+    lines: Vec<Line>,
+    cur: Option<Line>, // the line currently open (kind + containers fixed at open)
+    /// A block start records the kind the next inline content should open a
+    /// fresh line with. Set at Paragraph/Heading/Item (tight lists emit no
+    /// Paragraph wrapper, so Item must force a line); cleared when a block that
+    /// owns its own lines (List/Quote/CodeBlock/Table) takes over.
+    pending_kind: Option<LineKind>,
+    marks: Vec<Mark>,
+    open_marks: Vec<(MarkKind, usize)>, // (kind, start)
+    islands: Vec<Island>,
+    island_seq: usize,
+    containers: Vec<Container>,
+    list_stack: Vec<ListInfo>,
+    // code block
+    code_lang: Option<String>,
+    in_code: bool,
+    code_opened: bool, // whether the current code block has opened its first line
+    // image collection
+    image_depth: usize,
+    image_url: String,
+    image_alt: String,
+    // table collection
+    table: Option<TableAcc>,
+}
+
+#[derive(Clone)]
+struct ListInfo {
+    ordered: bool,
+    start: u64,
+    /// 0-based index of the next item — becomes the item's `ordinal`.
+    count: u64,
+}
+
+struct TableAcc {
+    aligns: Vec<&'static str>,
+    header: Vec<String>,
+    rows: Vec<Vec<String>>,
+    cur_row: Vec<String>,
+    in_head: bool,
+}
+
+fn align_str(a: &pulldown_cmark::Alignment) -> &'static str {
+    match a {
+        pulldown_cmark::Alignment::None => "none",
+        pulldown_cmark::Alignment::Left => "left",
+        pulldown_cmark::Alignment::Center => "center",
+        pulldown_cmark::Alignment::Right => "right",
+    }
+}
+
+impl<'a> Builder<'a> {
+    fn new(source: &'a str) -> Self {
+        Builder {
+            source,
+            text: String::new(),
+            pos: 0,
+            lines: Vec::new(),
+            cur: None,
+            pending_kind: None,
+            marks: Vec::new(),
+            open_marks: Vec::new(),
+            islands: Vec::new(),
+            island_seq: 0,
+            containers: Vec::new(),
+            list_stack: Vec::new(),
+            code_lang: None,
+            in_code: false,
+            code_opened: false,
+            image_depth: 0,
+            image_url: String::new(),
+            image_alt: String::new(),
+            table: None,
+        }
+    }
+
+    /// Open a fresh line with `kind` and the current container path. The first
+    /// open sets the line directly; each later one first closes the previous
+    /// line with a single `\n` boundary — so `lines.len()` always equals the
+    /// `\n`-segment count.
+    fn open_line(&mut self, kind: LineKind) {
+        if let Some(prev) = self.cur.take() {
+            self.text.push('\n');
+            self.pos += 1;
+            self.lines.push(prev);
+        }
+        self.cur = Some(Line {
+            kind,
+            containers: self.containers.clone(),
+        });
+    }
+
+    /// Open a fresh line for a `pending_kind` set at the last block start, or
+    /// (defensively) a `default` line if inline content arrives with none
+    /// pending and no line open. A no-op when a line is already open and no new
+    /// one is pending — inline content flows onto the current line.
+    fn ensure_open(&mut self, default: LineKind) {
+        if let Some(k) = self.pending_kind.take() {
+            self.open_line(k);
+        } else if self.cur.is_none() {
+            self.open_line(default);
+        }
+    }
+
+    /// Append inline text to the current line, stripping any characters the
+    /// corpus invariants forbid (stray `\r`, stray island slots; stray `\n`
+    /// becomes a space — inline text should carry none).
+    fn push_inline(&mut self, s: &str) {
+        self.ensure_open(LineKind::Para);
+        for c in s.chars() {
+            let c = match c {
+                '\r' => continue,
+                ISLAND_SLOT => continue,
+                '\n' => ' ',
+                other => other,
+            };
+            self.text.push(c);
+            self.pos += 1;
+        }
+    }
+
+    fn open_mark(&mut self, kind: MarkKind) {
+        self.open_marks.push((kind, self.pos));
+    }
+
+    fn close_mark(&mut self) {
+        // Well-nested by pulldown: close the innermost open mark.
+        if let Some((kind, start)) = self.open_marks.pop() {
+            self.marks.push(Mark {
+                start,
+                end: self.pos,
+                kind,
+            });
+        }
+    }
+
+    fn mint_island(&mut self, island_type: &str, props: serde_json::Value, loss: Loss) {
+        let id = format!("isl-{}", self.island_seq);
+        self.island_seq += 1;
+        self.islands.push(Island {
+            id,
+            island_type: island_type.to_string(),
+            props,
+            loss,
+        });
+    }
+
+    fn check_depth(&self) -> Result<(), ImportError> {
+        // Container path plus open marks approximates the structural depth the
+        // typst backend caps; bound it identically for parity.
+        let depth = self.containers.len() + self.open_marks.len();
+        if depth > MAX_NESTING_DEPTH {
+            return Err(ImportError::NestingTooDeep {
+                depth,
+                max: MAX_NESTING_DEPTH,
+            });
+        }
+        Ok(())
+    }
+
+    fn run<I>(&mut self, iter: I) -> Result<(), ImportError>
+    where
+        I: Iterator<Item = (Event<'a>, Range<usize>)>,
+    {
+        for (event, range) in iter {
+            // Image alt collection intercepts everything until the image closes.
+            if self.image_depth > 0 {
+                match &event {
+                    Event::Start(Tag::Image { .. }) => self.image_depth += 1,
+                    Event::End(TagEnd::Image) => {
+                        self.image_depth -= 1;
+                        if self.image_depth == 0 {
+                            self.emit_image();
+                        }
+                    }
+                    Event::Text(t) | Event::Code(t) => self.image_alt.push_str(t),
+                    Event::SoftBreak | Event::HardBreak => self.image_alt.push(' '),
+                    _ => {}
+                }
+                continue;
+            }
+
+            // Table collection routes structural events to the accumulator and
+            // ignores inline content (captured by cell source-slicing).
+            if self.table.is_some() {
+                self.table_event(&event, &range);
+                if matches!(event, Event::End(TagEnd::Table)) {
+                    self.emit_table();
+                }
+                continue;
+            }
+
+            match event {
+                Event::Start(tag) => self.start_tag(tag, range)?,
+                Event::End(tag) => self.end_tag(tag),
+                Event::Text(t) => {
+                    if self.in_code {
+                        self.push_code_content(&t);
+                    } else {
+                        self.push_inline(&t);
+                    }
+                }
+                Event::Code(t) => {
+                    self.ensure_open(LineKind::Para);
+                    let start = self.pos;
+                    self.push_inline(&t);
+                    self.marks.push(Mark {
+                        start,
+                        end: self.pos,
+                        kind: MarkKind::Code,
+                    });
+                }
+                Event::SoftBreak => self.push_inline(" "),
+                Event::HardBreak => {
+                    // Canonicalized to a line boundary of the same kind: arm a
+                    // pending line so the next content opens it.
+                    let kind = self
+                        .cur
+                        .as_ref()
+                        .map(|l| l.kind.clone())
+                        .unwrap_or(LineKind::Para);
+                    self.pending_kind = Some(kind);
+                }
+                // Html/InlineHtml already stripped or rewritten by the fixer;
+                // math/footnotes/etc. produce no corpus content.
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn start_tag(&mut self, tag: Tag<'a>, range: Range<usize>) -> Result<(), ImportError> {
+        match tag {
+            // Block starts arm a pending line; the next inline content opens it.
+            Tag::Paragraph => self.pending_kind = Some(LineKind::Para),
+            Tag::Heading { level, .. } => {
+                self.pending_kind = Some(LineKind::Heading {
+                    level: heading_level(level),
+                })
+            }
+            Tag::CodeBlock(kind) => {
+                self.pending_kind = None; // code opens its own lines
+                self.in_code = true;
+                self.code_lang = match kind {
+                    pulldown_cmark::CodeBlockKind::Fenced(lang) => {
+                        let l = sanitize_lang(&lang);
+                        if l.is_empty() {
+                            None
+                        } else {
+                            Some(l)
+                        }
+                    }
+                    pulldown_cmark::CodeBlockKind::Indented => None,
+                };
+                // First code line opens on the first content chunk; nothing to
+                // open yet (a code block with no content still yields one line,
+                // handled in push_code_content / end).
+                self.code_opened = false;
+            }
+            Tag::List(start) => {
+                self.pending_kind = None; // nested list content sets its own
+                self.list_stack.push(ListInfo {
+                    ordered: start.is_some(),
+                    start: start.unwrap_or(1),
+                    count: 0,
+                });
+            }
+            Tag::Item => {
+                // Tight-list items carry no Paragraph wrapper, so the item start
+                // is what forces a new line for the item's first inline content.
+                self.pending_kind = Some(LineKind::Para);
+                let container = match self.list_stack.last_mut() {
+                    Some(info) => {
+                        let ordinal = info.count;
+                        info.count += 1;
+                        Container::ListItem {
+                            ordered: info.ordered,
+                            start: info.start,
+                            ordinal,
+                        }
+                    }
+                    None => Container::ListItem {
+                        ordered: false,
+                        start: 1,
+                        ordinal: 0,
+                    },
+                };
+                self.containers.push(container);
+                self.check_depth()?;
+            }
+            Tag::BlockQuote(_) => {
+                self.pending_kind = None; // quote content sets its own
+                self.containers.push(Container::Quote);
+                self.check_depth()?;
+            }
+            Tag::Table(aligns) => {
+                self.pending_kind = None;
+                self.open_line(LineKind::Island);
+                self.text.push(ISLAND_SLOT);
+                self.pos += 1;
+                self.table = Some(TableAcc {
+                    aligns: aligns.iter().map(align_str).collect(),
+                    header: Vec::new(),
+                    rows: Vec::new(),
+                    cur_row: Vec::new(),
+                    in_head: false,
+                });
+            }
+            Tag::Emphasis => {
+                self.open_mark(MarkKind::Emph);
+                self.check_depth()?;
+            }
+            Tag::Strong => {
+                // The fixer rewrites `<u>` to Start(Strong); distinguish it by
+                // peeking the source (parity with the typst backend).
+                let kind = if self
+                    .source
+                    .get(range.start..range.start + 2)
+                    .is_some_and(|s| s.eq_ignore_ascii_case("<u"))
+                {
+                    MarkKind::Underline
+                } else {
+                    MarkKind::Strong
+                };
+                self.open_mark(kind);
+                self.check_depth()?;
+            }
+            Tag::Strikethrough => {
+                self.open_mark(MarkKind::Strike);
+                self.check_depth()?;
+            }
+            Tag::Link { dest_url, .. } => {
+                self.open_mark(MarkKind::Link {
+                    url: dest_url.to_string(),
+                });
+                self.check_depth()?;
+            }
+            Tag::Image { dest_url, .. } => {
+                self.image_url = dest_url.to_string();
+                self.image_alt.clear();
+                self.image_depth = 1;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::CodeBlock => {
+                if !self.code_opened {
+                    // Empty code block: one empty Code line.
+                    let lang = self.code_lang.take();
+                    self.open_line(LineKind::Code { lang });
+                }
+                self.in_code = false;
+                self.code_lang = None;
+            }
+            TagEnd::List(_) => {
+                self.list_stack.pop();
+            }
+            TagEnd::Item => {
+                self.containers.pop();
+            }
+            TagEnd::BlockQuote(_) => {
+                self.containers.pop();
+            }
+            TagEnd::Emphasis
+            | TagEnd::Strong
+            | TagEnd::Strikethrough
+            | TagEnd::Link => self.close_mark(),
+            _ => {}
+        }
+    }
+
+    fn push_code_content(&mut self, content: &str) {
+        // pulldown appends a trailing newline as the last line's terminator, not
+        // content; drop exactly one so an N-line block yields N lines.
+        let content = content.strip_suffix('\n').unwrap_or(content);
+        for seg in content.split('\n') {
+            self.open_line(LineKind::Code {
+                lang: self.code_lang.clone(),
+            });
+            self.code_opened = true;
+            // Code text is literal; still enforce corpus invariants.
+            self.push_code_line(seg);
+        }
+    }
+
+    fn push_code_line(&mut self, seg: &str) {
+        for c in seg.chars() {
+            let c = match c {
+                '\r' | '\n' => continue,
+                ISLAND_SLOT => continue,
+                other => other,
+            };
+            self.text.push(c);
+            self.pos += 1;
+        }
+    }
+
+    // ---- table ----
+
+    fn table_event(&mut self, event: &Event, range: &Range<usize>) {
+        let Some(acc) = self.table.as_mut() else {
+            return;
+        };
+        match event {
+            Event::Start(Tag::TableHead) => acc.in_head = true,
+            Event::End(TagEnd::TableHead) => {
+                acc.header = std::mem::take(&mut acc.cur_row);
+                acc.in_head = false;
+            }
+            Event::Start(Tag::TableRow) => acc.cur_row.clear(),
+            Event::End(TagEnd::TableRow) => {
+                if !acc.in_head {
+                    let row = std::mem::take(&mut acc.cur_row);
+                    acc.rows.push(row);
+                }
+            }
+            Event::Start(Tag::TableCell) => {
+                // Capture the cell's markdown source verbatim (preserves inline
+                // formatting), so a pipe table round-trips losslessly.
+                let cell = self.source.get(range.clone()).unwrap_or("").trim();
+                acc.cur_row.push(cell.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    fn emit_table(&mut self) {
+        if let Some(acc) = self.table.take() {
+            let props = json!({
+                "aligns": acc.aligns,
+                "header": acc.header,
+                "rows": acc.rows,
+            });
+            self.mint_island("table", props, Loss::Lossless);
+        }
+    }
+
+    fn emit_image(&mut self) {
+        self.ensure_open(LineKind::Para);
+        self.text.push(ISLAND_SLOT);
+        self.pos += 1;
+        let props = json!({
+            "url": self.image_url,
+            "alt": self.image_alt.trim(),
+        });
+        self.mint_island("image", props, Loss::Lossless);
+    }
+
+    fn finish(mut self) -> RichText {
+        if let Some(last) = self.cur.take() {
+            self.lines.push(last);
+        }
+        if self.lines.is_empty() {
+            // Empty document: one empty Para line.
+            self.lines.push(Line {
+                kind: LineKind::Para,
+                containers: Vec::new(),
+            });
+        }
+        // Close any marks left open (unterminated `<u>`, malformed input).
+        while !self.open_marks.is_empty() {
+            self.close_mark();
+        }
+        RichText {
+            text: self.text,
+            lines: self.lines,
+            marks: self.marks,
+            islands: self.islands,
+        }
+    }
+}
+
+fn heading_level(level: pulldown_cmark::HeadingLevel) -> u8 {
+    use pulldown_cmark::HeadingLevel::*;
+    match level {
+        H1 => 1,
+        H2 => 2,
+        H3 => 3,
+        H4 => 4,
+        H5 => 5,
+        H6 => 6,
+    }
+}
+
+/// Sanitize a code-block info string to a language identifier (parity with the
+/// typst backend's `sanitize_lang_tag`).
+fn sanitize_lang(lang: &str) -> String {
+    lang.chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+'))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// MarkdownFixer — ported from crates/backends/typst/src/convert.rs.
+//
+// Two jobs before events reach the builder: allowlist `<u>…</u>` as underline
+// (rewrite to Strong start/end, detected by source peek) and strip all other
+// raw HTML; and fix `***`-adjacency runs pulldown splits awkwardly. Phase 2
+// unifies this with the backend's copy; phase 1 duplicates it to stay
+// engine-off.
+// ---------------------------------------------------------------------------
+
+fn is_u_open_tag(html: &str) -> bool {
+    let s = html.trim();
+    if s.starts_with('<') && s.ends_with('>') {
+        s[1..s.len() - 1].trim().eq_ignore_ascii_case("u")
+    } else {
+        false
+    }
+}
+
+fn is_u_close_tag(html: &str) -> bool {
+    let s = html.trim();
+    if s.starts_with("</") && s.ends_with('>') {
+        s[2..s.len() - 1].trim().eq_ignore_ascii_case("u")
+    } else {
+        false
+    }
+}
+
+struct MarkdownFixer<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>> {
+    inner: std::iter::Peekable<I>,
+    source: &'a str,
+    buffer: Vec<(Event<'a>, Range<usize>)>,
+    emph_depth: usize,
+    strong_depth: usize,
+}
+
+impl<'a, I> MarkdownFixer<'a, I>
+where
+    I: Iterator<Item = (Event<'a>, Range<usize>)>,
+{
+    fn new(inner: I, source: &'a str) -> Self {
+        Self {
+            inner: inner.peekable(),
+            source,
+            buffer: Vec::new(),
+            emph_depth: 0,
+            strong_depth: 0,
+        }
+    }
+
+    fn events_for_stars(
+        star_count: usize,
+        is_start: bool,
+        start_idx: usize,
+    ) -> Vec<(Event<'a>, Range<usize>)> {
+        let mut events = Vec::new();
+        let mut offset = 0;
+        let mut remaining = star_count;
+
+        if remaining >= 2 {
+            let len = 2;
+            let range = start_idx + offset..start_idx + offset + len;
+            let event = if is_start {
+                Event::Start(Tag::Strong)
+            } else {
+                Event::End(TagEnd::Strong)
+            };
+            events.push((event, range));
+            remaining -= 2;
+            offset += 2;
+        }
+        if remaining >= 1 {
+            let len = 1;
+            let range = start_idx + offset..start_idx + offset + len;
+            let event = if is_start {
+                Event::Start(Tag::Emphasis)
+            } else {
+                Event::End(TagEnd::Emphasis)
+            };
+            events.push((event, range));
+        }
+        if !is_start {
+            events.reverse();
+        }
+        events
+    }
+
+    fn coalesce_text_range(&mut self, initial_range: Range<usize>) -> Range<usize> {
+        let mut merged_range = initial_range;
+        while let Some((next_event, next_range)) = self.inner.peek() {
+            if matches!(next_event, Event::Text(_)) && next_range.start == merged_range.end {
+                merged_range.end = next_range.end;
+                self.inner.next();
+            } else {
+                break;
+            }
+        }
+        merged_range
+    }
+
+    fn closable_star_count(&self, star_count: usize) -> usize {
+        let mut remaining = star_count;
+        let mut consumed = 0;
+        if remaining >= 2 && self.strong_depth > 0 {
+            remaining -= 2;
+            consumed += 2;
+        }
+        if remaining >= 1 && self.emph_depth > 0 {
+            consumed += 1;
+        }
+        consumed
+    }
+
+    fn handle_candidate(
+        &mut self,
+        candidate: (Event<'a>, Range<usize>),
+    ) -> Option<(Event<'a>, Range<usize>)> {
+        let (event, range) = candidate;
+
+        match &event {
+            Event::Start(Tag::Emphasis) => self.emph_depth += 1,
+            Event::Start(Tag::Strong) => self.strong_depth += 1,
+            Event::End(TagEnd::Emphasis) => self.emph_depth = self.emph_depth.saturating_sub(1),
+            Event::End(TagEnd::Strong) => self.strong_depth = self.strong_depth.saturating_sub(1),
+            _ => {}
+        }
+
+        match &event {
+            Event::Text(cow_str) => {
+                let s = cow_str.as_ref();
+                if s.ends_with('*') {
+                    let is_strong_start = if let Some(next) = self.buffer.last() {
+                        matches!(next.0, Event::Start(Tag::Strong))
+                    } else {
+                        matches!(self.inner.peek(), Some((Event::Start(Tag::Strong), _)))
+                    };
+                    if is_strong_start {
+                        let star_count = s.chars().rev().take_while(|c| *c == '*').count();
+                        if star_count > 0 && star_count <= 3 {
+                            let text_len = s.len() - star_count;
+                            let text_content = &s[..text_len];
+                            let star_events =
+                                Self::events_for_stars(star_count, true, range.start + text_len);
+                            let next_event = if !self.buffer.is_empty() {
+                                self.buffer.pop().unwrap()
+                            } else {
+                                self.inner.next().unwrap()
+                            };
+                            self.buffer.push(next_event);
+                            for ev in star_events.into_iter().rev() {
+                                self.buffer.push(ev);
+                            }
+                            if !text_content.is_empty() {
+                                return Some((
+                                    Event::Text(text_content.to_string().into()),
+                                    range.start..range.start + text_len,
+                                ));
+                            } else {
+                                return None;
+                            }
+                        }
+                    }
+                }
+            }
+            Event::End(TagEnd::Strong) | Event::End(TagEnd::Emphasis) => {
+                let has_open_tags = self.emph_depth > 0 || self.strong_depth > 0;
+                if !has_open_tags {
+                    return Some((event, range));
+                }
+                let next_is_star_text =
+                    if let Some((Event::Text(cow_str), _)) = self.buffer.last() {
+                        cow_str.starts_with('*')
+                    } else if let Some((Event::Text(cow_str), _)) = self.inner.peek() {
+                        cow_str.starts_with('*')
+                    } else {
+                        false
+                    };
+                if next_is_star_text {
+                    let (text_event, text_range) = if !self.buffer.is_empty() {
+                        self.buffer.pop().unwrap()
+                    } else {
+                        let (_ev, rng) = self.inner.next().unwrap();
+                        let merged_range = self.coalesce_text_range(rng);
+                        let text = self.source[merged_range.clone()].into();
+                        (Event::Text(text), merged_range)
+                    };
+                    if let Event::Text(cow_str) = text_event {
+                        let s = cow_str.as_ref();
+                        let star_count = s.chars().take_while(|c| *c == '*').count();
+                        let consumable = self.closable_star_count(star_count);
+                        if consumable > 0 {
+                            let star_events =
+                                Self::events_for_stars(consumable, false, text_range.start);
+                            let text_after = &s[consumable..];
+                            if !text_after.is_empty() {
+                                self.buffer.push((
+                                    Event::Text(text_after.to_string().into()),
+                                    text_range.start + consumable..text_range.end,
+                                ));
+                            }
+                            for ev in star_events.into_iter().rev() {
+                                self.buffer.push(ev);
+                            }
+                            return Some((event, range));
+                        } else {
+                            self.buffer.push((Event::Text(cow_str), text_range));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        Some((event, range))
+    }
+}
+
+impl<'a, I> Iterator for MarkdownFixer<'a, I>
+where
+    I: Iterator<Item = (Event<'a>, Range<usize>)>,
+{
+    type Item = (Event<'a>, Range<usize>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(event) = self.buffer.pop() {
+                if let Some(result) = self.handle_candidate(event) {
+                    return Some(result);
+                } else {
+                    continue;
+                }
+            }
+            let (event, range) = self.inner.next()?;
+            let (event, range) = match event {
+                Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_open_tag(html) => {
+                    (Event::Start(Tag::Strong), range)
+                }
+                Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_close_tag(html) => {
+                    (Event::End(TagEnd::Strong), range)
+                }
+                Event::Html(_) | Event::InlineHtml(_) => continue,
+                other => (other, range),
+            };
+            if let Some(result) = self.handle_candidate((event, range)) {
+                return Some(result);
+            } else {
+                continue;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::LineKind;
+
+    fn imp(md: &str) -> RichText {
+        let rt = from_markdown(md).unwrap();
+        assert_eq!(rt.validate(), Ok(()), "invariants for {md:?}");
+        rt
+    }
+
+    #[test]
+    fn plain_paragraph() {
+        let rt = imp("Hello world");
+        assert_eq!(rt.text, "Hello world");
+        assert_eq!(rt.lines.len(), 1);
+        assert_eq!(rt.lines[0].kind, LineKind::Para);
+        assert!(rt.marks.is_empty());
+    }
+
+    #[test]
+    fn bold_and_italic_marks() {
+        let rt = imp("a **b** _c_");
+        assert_eq!(rt.text, "a b c");
+        // "b" at 2..3 strong, "c" at 4..5 emph
+        assert!(rt.marks.contains(&Mark {
+            start: 2,
+            end: 3,
+            kind: MarkKind::Strong
+        }));
+        assert!(rt.marks.contains(&Mark {
+            start: 4,
+            end: 5,
+            kind: MarkKind::Emph
+        }));
+    }
+
+    #[test]
+    fn underline_from_u_tag() {
+        let rt = imp("x <u>y</u> z");
+        assert_eq!(rt.text, "x y z");
+        assert!(rt.marks.iter().any(|m| m.kind == MarkKind::Underline
+            && m.start == 2
+            && m.end == 3));
+    }
+
+    #[test]
+    fn other_html_stripped() {
+        let rt = imp("a <span>b</span> c");
+        assert_eq!(rt.text, "a b c");
+    }
+
+    #[test]
+    fn two_paragraphs_two_lines() {
+        let rt = imp("one\n\ntwo");
+        assert_eq!(rt.text, "one\ntwo");
+        assert_eq!(rt.lines.len(), 2);
+        assert!(rt.lines.iter().all(|l| l.kind == LineKind::Para));
+    }
+
+    #[test]
+    fn heading_line_kind() {
+        let rt = imp("## Title");
+        assert_eq!(rt.text, "Title");
+        assert_eq!(rt.lines[0].kind, LineKind::Heading { level: 2 });
+    }
+
+    #[test]
+    fn inline_code_mark() {
+        let rt = imp("run `cargo test` now");
+        assert_eq!(rt.text, "run cargo test now");
+        assert!(rt
+            .marks
+            .iter()
+            .any(|m| m.kind == MarkKind::Code && m.start == 4 && m.end == 14));
+    }
+
+    #[test]
+    fn code_block_lines() {
+        let rt = imp("```rust\nfn a() {}\nfn b() {}\n```");
+        assert_eq!(rt.text, "fn a() {}\nfn b() {}");
+        assert_eq!(rt.lines.len(), 2);
+        assert!(rt
+            .lines
+            .iter()
+            .all(|l| l.kind == LineKind::Code { lang: Some("rust".into()) }));
+    }
+
+    #[test]
+    fn bullet_list_containers() {
+        let rt = imp("- a\n- b");
+        assert_eq!(rt.text, "a\nb");
+        assert_eq!(rt.lines.len(), 2);
+        // Two items: same list (ordered=false, start=1), distinct ordinals.
+        assert_eq!(
+            rt.lines[0].containers,
+            vec![Container::ListItem {
+                ordered: false,
+                start: 1,
+                ordinal: 0
+            }]
+        );
+        assert_eq!(
+            rt.lines[1].containers,
+            vec![Container::ListItem {
+                ordered: false,
+                start: 1,
+                ordinal: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn ordered_list_custom_start() {
+        let rt = imp("3. a\n4. b");
+        assert_eq!(
+            rt.lines[0].containers,
+            vec![Container::ListItem {
+                ordered: true,
+                start: 3,
+                ordinal: 0
+            }]
+        );
+        assert_eq!(
+            rt.lines[1].containers,
+            vec![Container::ListItem {
+                ordered: true,
+                start: 3,
+                ordinal: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn multi_paragraph_list_item_shares_container() {
+        // One item with two paragraphs -> two Para lines sharing one ListItem.
+        let rt = imp("- first\n\n  second");
+        assert_eq!(rt.lines.len(), 2);
+        assert_eq!(rt.lines[0].containers, rt.lines[1].containers);
+        assert_eq!(
+            rt.lines[0].containers,
+            vec![Container::ListItem {
+                ordered: false,
+                start: 1,
+                ordinal: 0
+            }]
+        );
+    }
+
+    #[test]
+    fn blockquote_container() {
+        let rt = imp("> quoted");
+        assert_eq!(rt.text, "quoted");
+        assert_eq!(rt.lines[0].containers, vec![Container::Quote]);
+    }
+
+    #[test]
+    fn table_is_block_island() {
+        let rt = imp("| a | b |\n|---|---|\n| 1 | 2 |");
+        assert_eq!(rt.text, "\u{FFFC}");
+        assert_eq!(rt.lines[0].kind, LineKind::Island);
+        assert_eq!(rt.islands.len(), 1);
+        assert_eq!(rt.islands[0].island_type, "table");
+        assert_eq!(rt.islands[0].loss, Loss::Lossless);
+    }
+
+    #[test]
+    fn image_is_inline_island() {
+        let rt = imp("see ![a cat](cat.png) here");
+        assert_eq!(rt.text, "see \u{FFFC} here");
+        assert_eq!(rt.islands.len(), 1);
+        assert_eq!(rt.islands[0].island_type, "image");
+        assert_eq!(rt.islands[0].props["url"], "cat.png");
+        assert_eq!(rt.islands[0].props["alt"], "a cat");
+    }
+
+    #[test]
+    fn empty_input_one_empty_line() {
+        let rt = imp("");
+        assert_eq!(rt.text, "");
+        assert_eq!(rt.lines.len(), 1);
+    }
+
+    #[test]
+    fn astral_positions_are_usv() {
+        let rt = imp("a😀**b**");
+        // 'a'(0) '😀'(1) 'b'(2) — strong over "b" is 2..3 in USV.
+        assert_eq!(rt.text, "a😀b");
+        assert!(rt.marks.iter().any(|m| m.start == 2 && m.end == 3 && m.kind == MarkKind::Strong));
+    }
+}

--- a/crates/richtext/src/import.rs
+++ b/crates/richtext/src/import.rs
@@ -9,10 +9,22 @@
 //!
 //! ## Phase-1 canonicalizations (documented, not bugs)
 //!
-//! - **Soft breaks → space, hard breaks → line boundary.** A markdown hard break
-//!   (two trailing spaces or `\`) canonicalizes to a corpus line boundary,
-//!   indistinguishable from a paragraph break — the model has no
-//!   within-paragraph break and needs none for phase 1.
+//! Import maps some distinct markdown to one canonical corpus. All of them, in
+//! one place:
+//!
+//! - **Soft breaks → space; hard breaks → a `continues` line.** A soft break is
+//!   a space (CommonMark rendering); a hard break (two trailing spaces or `\`)
+//!   is a within-block continuation line ([`crate::model::Line::continues`]),
+//!   kept distinct from a paragraph boundary. A hard break inside a heading is a
+//!   space (ATX headings can't carry one).
+//! - **Adjacent sibling lists of the same shape merge.** Two consecutive lists
+//!   of the same kind whose items share an `ordinal` (`* a` then `+ b`, or two
+//!   ordered lists both starting at 1) are indistinguishable from one list /
+//!   one multi-paragraph item — item identity is positional `ordinal`, not a
+//!   minted list instance. Adjacent block quotes likewise merge into one.
+//! - **Empty blocks and containers keep their line.** An empty heading (`#`),
+//!   empty paragraph, empty `- ` item, or empty `>` quote each yields one empty
+//!   line so the structure survives, rather than vanishing.
 //! - **Island ids are minted sequentially** (`isl-0`, `isl-1`, …) so import is a
 //!   pure, deterministic function. Real minting (the hash-nondeterminism source)
 //!   is phase 4; sequential ids round-trip (export drops them, re-import
@@ -75,16 +87,21 @@ struct Builder<'a> {
     pos: usize, // USV position = char count of `text`
     lines: Vec<Line>,
     cur: Option<Line>, // the line currently open (kind + containers fixed at open)
-    /// A block start records the kind the next inline content should open a
-    /// fresh line with. Set at Paragraph/Heading/Item (tight lists emit no
-    /// Paragraph wrapper, so Item must force a line); cleared when a block that
-    /// owns its own lines (List/Quote/CodeBlock/Table) takes over.
-    pending_kind: Option<LineKind>,
+    /// A block start records `(kind, continues)` the next inline content should
+    /// open a fresh line with. Set at Paragraph/Heading/Item (tight lists emit no
+    /// Paragraph wrapper, so Item must force a line) with `continues = false`; a
+    /// hard break sets `continues = true`. Cleared when a block that owns its own
+    /// lines (List/Quote/CodeBlock/Table) takes over.
+    pending: Option<(LineKind, bool)>,
     marks: Vec<Mark>,
     open_marks: Vec<(MarkKind, usize)>, // (kind, start)
     islands: Vec<Island>,
     island_seq: usize,
     containers: Vec<Container>,
+    /// Parallel to `containers`: the [`Self::emitted`] count when each container
+    /// opened, so a container that closes having emitted no line (an empty `>`
+    /// quote, an empty `- ` item) can still get one.
+    container_marks: Vec<usize>,
     list_stack: Vec<ListInfo>,
     // code block
     code_lang: Option<String>,
@@ -131,12 +148,13 @@ impl<'a> Builder<'a> {
             pos: 0,
             lines: Vec::new(),
             cur: None,
-            pending_kind: None,
+            pending: None,
             marks: Vec::new(),
             open_marks: Vec::new(),
             islands: Vec::new(),
             island_seq: 0,
             containers: Vec::new(),
+            container_marks: Vec::new(),
             list_stack: Vec::new(),
             code_lang: None,
             in_code: false,
@@ -152,7 +170,9 @@ impl<'a> Builder<'a> {
     /// open sets the line directly; each later one first closes the previous
     /// line with a single `\n` boundary — so `lines.len()` always equals the
     /// `\n`-segment count.
-    fn open_line(&mut self, kind: LineKind) {
+    fn open_line(&mut self, kind: LineKind, continues: bool) {
+        // The first line (no line yet open) can never continue anything.
+        let continues = continues && self.cur.is_some();
         if let Some(prev) = self.cur.take() {
             self.text.push('\n');
             self.pos += 1;
@@ -161,6 +181,7 @@ impl<'a> Builder<'a> {
         self.cur = Some(Line {
             kind,
             containers: self.containers.clone(),
+            continues,
         });
     }
 
@@ -169,10 +190,10 @@ impl<'a> Builder<'a> {
     /// pending and no line open. A no-op when a line is already open and no new
     /// one is pending — inline content flows onto the current line.
     fn ensure_open(&mut self, default: LineKind) {
-        if let Some(k) = self.pending_kind.take() {
-            self.open_line(k);
+        if let Some((k, cont)) = self.pending.take() {
+            self.open_line(k, cont);
         } else if self.cur.is_none() {
-            self.open_line(default);
+            self.open_line(default, false);
         }
     }
 
@@ -193,7 +214,38 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Lines emitted so far, counting the line currently open. A container that
+    /// closes with this unchanged from when it opened produced nothing.
+    fn emitted(&self) -> usize {
+        self.lines.len() + usize::from(self.cur.is_some())
+    }
+
+    /// Open a line for a block that ended with no inline content (an empty
+    /// heading `#`, an empty paragraph) — otherwise the block, and any content
+    /// model it carries, is silently lost.
+    fn flush_empty_block(&mut self) {
+        if let Some((k, cont)) = self.pending.take() {
+            self.open_line(k, cont);
+        }
+    }
+
+    /// Close a container: if it emitted no line, give it one empty `Para` line
+    /// (an empty `- ` item, an empty `>` quote) so the structure survives; then
+    /// pop it. `mark` is the [`Self::emitted`] snapshot from when it opened.
+    fn close_container(&mut self, mark: usize) {
+        if self.emitted() == mark {
+            self.pending = None;
+            self.open_line(LineKind::Para, false);
+        }
+        self.containers.pop();
+    }
+
     fn open_mark(&mut self, kind: MarkKind) {
+        // Resolve any armed line first, so a mark that begins a block records
+        // the position *after* the block's line boundary — not the `\n` before
+        // it. Without this the mark swallows the separator and equal content
+        // from an editor vs from import serializes to different canonical bytes.
+        self.ensure_open(LineKind::Para);
         self.open_marks.push((kind, self.pos));
     }
 
@@ -286,14 +338,24 @@ impl<'a> Builder<'a> {
                 }
                 Event::SoftBreak => self.push_inline(" "),
                 Event::HardBreak => {
-                    // Canonicalized to a line boundary of the same kind: arm a
-                    // pending line so the next content opens it.
-                    let kind = self
-                        .cur
-                        .as_ref()
-                        .map(|l| l.kind.clone())
-                        .unwrap_or(LineKind::Para);
-                    self.pending_kind = Some(kind);
+                    match self.cur.as_ref().map(|l| &l.kind) {
+                        // ATX headings can't carry a hard break in markdown, so
+                        // one inside a heading canonicalizes to a space (a
+                        // documented, representable choice).
+                        Some(LineKind::Heading { .. }) => self.push_inline(" "),
+                        // Elsewhere: a within-block line break — arm a pending
+                        // continuation line (same kind, continues = true) so it
+                        // stays one block and export re-emits a hard break, not a
+                        // paragraph split.
+                        _ => {
+                            let kind = self
+                                .cur
+                                .as_ref()
+                                .map(|l| l.kind.clone())
+                                .unwrap_or(LineKind::Para);
+                            self.pending = Some((kind, true));
+                        }
+                    }
                 }
                 // Html/InlineHtml already stripped or rewritten by the fixer;
                 // math/footnotes/etc. produce no corpus content.
@@ -305,15 +367,19 @@ impl<'a> Builder<'a> {
 
     fn start_tag(&mut self, tag: Tag<'a>, range: Range<usize>) -> Result<(), ImportError> {
         match tag {
-            // Block starts arm a pending line; the next inline content opens it.
-            Tag::Paragraph => self.pending_kind = Some(LineKind::Para),
+            // Block starts arm a pending line (new block, continues = false);
+            // the next inline content opens it.
+            Tag::Paragraph => self.pending = Some((LineKind::Para, false)),
             Tag::Heading { level, .. } => {
-                self.pending_kind = Some(LineKind::Heading {
-                    level: heading_level(level),
-                })
+                self.pending = Some((
+                    LineKind::Heading {
+                        level: heading_level(level),
+                    },
+                    false,
+                ))
             }
             Tag::CodeBlock(kind) => {
-                self.pending_kind = None; // code opens its own lines
+                self.pending = None; // code opens its own lines
                 self.in_code = true;
                 self.code_lang = match kind {
                     pulldown_cmark::CodeBlockKind::Fenced(lang) => {
@@ -332,7 +398,7 @@ impl<'a> Builder<'a> {
                 self.code_opened = false;
             }
             Tag::List(start) => {
-                self.pending_kind = None; // nested list content sets its own
+                self.pending = None; // nested list content sets its own
                 self.list_stack.push(ListInfo {
                     ordered: start.is_some(),
                     start: start.unwrap_or(1),
@@ -342,7 +408,8 @@ impl<'a> Builder<'a> {
             Tag::Item => {
                 // Tight-list items carry no Paragraph wrapper, so the item start
                 // is what forces a new line for the item's first inline content.
-                self.pending_kind = Some(LineKind::Para);
+                self.pending = Some((LineKind::Para, false));
+                self.container_marks.push(self.emitted());
                 let container = match self.list_stack.last_mut() {
                     Some(info) => {
                         let ordinal = info.count;
@@ -363,13 +430,14 @@ impl<'a> Builder<'a> {
                 self.check_depth()?;
             }
             Tag::BlockQuote(_) => {
-                self.pending_kind = None; // quote content sets its own
+                self.pending = None; // quote content sets its own
+                self.container_marks.push(self.emitted());
                 self.containers.push(Container::Quote);
                 self.check_depth()?;
             }
             Tag::Table(aligns) => {
-                self.pending_kind = None;
-                self.open_line(LineKind::Island);
+                self.pending = None;
+                self.open_line(LineKind::Island, false);
                 self.text.push(ISLAND_SLOT);
                 self.pos += 1;
                 self.table = Some(TableAcc {
@@ -425,7 +493,7 @@ impl<'a> Builder<'a> {
                 if !self.code_opened {
                     // Empty code block: one empty Code line.
                     let lang = self.code_lang.take();
-                    self.open_line(LineKind::Code { lang });
+                    self.open_line(LineKind::Code { lang }, false);
                 }
                 self.in_code = false;
                 self.code_lang = None;
@@ -434,15 +502,19 @@ impl<'a> Builder<'a> {
                 self.list_stack.pop();
             }
             TagEnd::Item => {
-                self.containers.pop();
+                let mark = self.container_marks.pop().unwrap_or(0);
+                self.close_container(mark);
             }
             TagEnd::BlockQuote(_) => {
-                self.containers.pop();
+                let mark = self.container_marks.pop().unwrap_or(0);
+                self.close_container(mark);
             }
             TagEnd::Emphasis
             | TagEnd::Strong
             | TagEnd::Strikethrough
             | TagEnd::Link => self.close_mark(),
+            // A block that produced no inline content still gets its line.
+            TagEnd::Heading(_) | TagEnd::Paragraph => self.flush_empty_block(),
             _ => {}
         }
     }
@@ -452,9 +524,15 @@ impl<'a> Builder<'a> {
         // content; drop exactly one so an N-line block yields N lines.
         let content = content.strip_suffix('\n').unwrap_or(content);
         for seg in content.split('\n') {
-            self.open_line(LineKind::Code {
-                lang: self.code_lang.clone(),
-            });
+            // First line of the block starts it (continues = false); every later
+            // line is a within-block continuation, so the fence stays one block.
+            let continues = self.code_opened;
+            self.open_line(
+                LineKind::Code {
+                    lang: self.code_lang.clone(),
+                },
+                continues,
+            );
             self.code_opened = true;
             // Code text is literal; still enforce corpus invariants.
             self.push_code_line(seg);
@@ -533,6 +611,7 @@ impl<'a> Builder<'a> {
             self.lines.push(Line {
                 kind: LineKind::Para,
                 containers: Vec::new(),
+                continues: false,
             });
         }
         // Close any marks left open (unterminated `<u>`, malformed input).
@@ -996,10 +1075,98 @@ mod tests {
     }
 
     #[test]
+    fn empty_list_item_keeps_its_line() {
+        // An empty `- ` item (here an empty bullet nested in an ordered item)
+        // must not vanish (regression for the container-flush fix).
+        let rt = imp("- a\n-\n- b");
+        assert_eq!(rt.lines.len(), 3, "empty middle item preserved");
+    }
+
+    #[test]
+    fn empty_blockquote_keeps_its_line() {
+        let rt = imp("> ");
+        assert_eq!(rt.lines.len(), 1);
+        assert_eq!(rt.lines[0].containers, vec![Container::Quote]);
+    }
+
+    #[test]
+    fn adjacent_sibling_lists_merge_is_stable() {
+        // Documented canonicalization: two sibling bullet lists collapse to one.
+        // Distinct markdown, one corpus — but the corpus is a fixed point.
+        let rt = imp("* a\n\n+ b");
+        let rt2 = from_markdown(&crate::export::to_markdown(&rt)).unwrap();
+        assert_eq!(rt, rt2, "merged sibling lists still round-trip");
+    }
+
+    #[test]
     fn empty_input_one_empty_line() {
         let rt = imp("");
         assert_eq!(rt.text, "");
         assert_eq!(rt.lines.len(), 1);
+    }
+
+    #[test]
+    fn mark_does_not_swallow_leading_newline() {
+        // Regression (review finding 1): a mark starting a block must begin at
+        // the content, not on the preceding line boundary.
+        let rt = imp("a\n\n**b**");
+        assert_eq!(rt.text, "a\nb");
+        let m = &rt.marks[0];
+        assert_eq!((m.start, m.end), (2, 3));
+        assert_eq!(rt.text.chars().nth(m.start), Some('b'));
+    }
+
+    #[test]
+    fn import_and_editor_corpus_same_canonical_bytes() {
+        // The freeze's central promise: equal content → equal bytes, whatever
+        // the producer. Import of "a\n\n**b**" must byte-match a hand-built
+        // editor corpus of the same content.
+        let imported = imp("a\n\n**b**");
+        let editor = RichText {
+            text: "a\nb".into(),
+            lines: vec![
+                Line {
+                    kind: LineKind::Para,
+                    containers: vec![],
+                    continues: false,
+                },
+                Line {
+                    kind: LineKind::Para,
+                    containers: vec![],
+                    continues: false,
+                },
+            ],
+            marks: vec![Mark {
+                start: 2,
+                end: 3,
+                kind: MarkKind::Strong,
+            }],
+            islands: vec![],
+        };
+        assert_eq!(imported.to_canonical_json(), editor.to_canonical_json());
+    }
+
+    #[test]
+    fn hard_break_is_a_continuation_line() {
+        let rt = imp("line one\\\nline two");
+        assert_eq!(rt.text, "line one\nline two");
+        assert_eq!(rt.lines.len(), 2);
+        assert!(!rt.lines[0].continues);
+        assert!(rt.lines[1].continues, "hard break -> continuation line");
+    }
+
+    #[test]
+    fn heading_cannot_carry_hard_break() {
+        // ATX headings are single-line: `## a  \nb` is a heading plus a separate
+        // paragraph, never a heading with a continuation. (The heading→space
+        // canonicalization in HardBreak handling is defensive for editor-built
+        // corpora, unreachable via markdown import.)
+        let rt = imp("## a  \nb");
+        assert_eq!(rt.text, "a\nb");
+        assert_eq!(rt.lines.len(), 2);
+        assert_eq!(rt.lines[0].kind, LineKind::Heading { level: 2 });
+        assert_eq!(rt.lines[1].kind, LineKind::Para);
+        assert!(!rt.lines[1].continues, "separate block, not a continuation");
     }
 
     #[test]

--- a/crates/richtext/src/lib.rs
+++ b/crates/richtext/src/lib.rs
@@ -1,0 +1,34 @@
+//! `RichText` — the canonical corpus content model for Quillmark (issue #831).
+//!
+//! One [`RichText`] per content field: a single text sequence carrying line
+//! attributes, anchored marks, and embedded islands, over one coordinate space
+//! of Unicode scalar values. Markdown is demoted to a *projection* — import
+//! ([`import::from_markdown`]) and export ([`export::to_markdown`]) codecs — so
+//! every edit is a splice and all structure moves with it.
+//!
+//! This crate is **phase 1**: the model, the canonical serialization freeze,
+//! the markdown codecs, and the delta/rebase surface, exercised in isolation.
+//! No engine crate consumes it yet (phase 2 wires the seam and storage). See
+//! `prose/plans/richtext/` for the phase map.
+//!
+//! ## Layout
+//!
+//! - [`model`] — the [`RichText`] type, the mark set, normalization (the three
+//!   Spike-A rules), and invariants. The freeze.
+//! - [`serial`] — canonical, byte-deterministic JSON. One encoding for the seam
+//!   and for storage.
+//! - [`import`] — markdown → corpus (normalize → pulldown → corpus).
+//! - [`export`] — corpus → markdown, per island loss class.
+//! - [`delta`] — a per-field delta (Quill-Delta semantics), cold-parse + corpus
+//!   diff, and mark/island rebase with a block-move detector.
+//! - [`usv`] — coordinate conversions across the UTF-8 / UTF-16 / USV boundary.
+
+pub mod delta;
+pub mod export;
+pub mod import;
+pub mod model;
+pub mod serial;
+pub mod usv;
+
+pub use model::{Container, Invariant, Island, Line, LineKind, Loss, Mark, MarkKind, RichText, Usv};
+pub use serial::ParseError;

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -1,0 +1,546 @@
+//! The `RichText` corpus model — one text sequence per field carrying line
+//! attributes, anchored marks, and embedded islands, over a single coordinate
+//! space of Unicode scalar values (Rust `char`).
+//!
+//! This is the phase-1 freeze (issue #831): the mark set, the three
+//! normalization rules, and the invariants are what canonical serialization
+//! commits to. Everything an editor disagrees on (edge-expand,
+//! adjacent-merge-at-insertion) is *not* encoded — the model only ever stores
+//! the resulting range, so the stored form is identical whatever the editor
+//! did. See `prose/plans/richtext/phase-0.md` § Spike A.
+
+use serde_json::Value as JsonValue;
+
+/// A position in a [`RichText`], counted in Unicode scalar values (USV) — never
+/// bytes, never UTF-16 units. One astral char is 1 USV / 4 UTF-8 bytes / 2
+/// UTF-16 units. Conversions to/from the JS (UTF-16) and Rust (UTF-8)
+/// boundaries live in [`crate::usv`].
+pub type Usv = usize;
+
+/// U+FFFC OBJECT REPLACEMENT CHARACTER — the single-USV slot an island occupies
+/// in the corpus. One slot per island; every slot has a backing island. A stray
+/// slot (or a slot with no island) is an invariant violation.
+pub const ISLAND_SLOT: char = '\u{FFFC}';
+
+/// One content field as a corpus: the text plus the structure that rides on it.
+///
+/// Invariants (established once by import normalization, checked by
+/// [`RichText::validate`]): the text holds no `\r` and no bidi controls; the
+/// count of [`ISLAND_SLOT`] equals `islands.len()`; `lines.len()` equals the
+/// number of `\n`-separated segments; marks are normalized (sorted, unioned).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RichText {
+    /// The corpus. `\n` is a line boundary; [`ISLAND_SLOT`] is an island slot.
+    pub text: String,
+    /// One entry per `\n`-separated segment of `text`, in order. The line tree
+    /// is *derived* from this flat list plus each line's `containers` path — it
+    /// is never stored, so a split/join is a single-char edit with no identity
+    /// crisis (there are no paragraph IDs).
+    pub lines: Vec<Line>,
+    /// Marks over char ranges, kept normalized: sorted by
+    /// `(start, end, kind-ord, attrs)`, same-kind formatting marks unioned.
+    pub marks: Vec<Mark>,
+    /// One entry per [`ISLAND_SLOT`], in slot order (ascending char position).
+    pub islands: Vec<Island>,
+}
+
+/// A line's attributes: its block role plus the container path it sits in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Line {
+    pub kind: LineKind,
+    /// Ancestor containers, outermost first. A multi-paragraph list item is two
+    /// `Para` lines sharing one `[ListItem]` path; a paragraph in a quote in a
+    /// list item is `[ListItem, Quote]`.
+    pub containers: Vec<Container>,
+}
+
+/// The block role of a line. The tree between lines is inferred: two adjacent
+/// lines with equal `kind`+`containers` are two blocks of that role (e.g. two
+/// paragraphs), never one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LineKind {
+    Para,
+    /// ATX/Setext heading, level 1..=6.
+    Heading { level: u8 },
+    /// A line of a code block. `lang` is the (sanitized) info string, shared by
+    /// every line of the same block.
+    Code { lang: Option<String> },
+    /// A block-level island: the line's sole content is one [`ISLAND_SLOT`].
+    Island,
+}
+
+/// A container a line nests inside. The ancestor path is a `Vec<Container>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Container {
+    /// A list item. `ordered` distinguishes `1.` from `-`; `start` is the list's
+    /// first number (1 by default); `ordinal` is this item's 0-based index in
+    /// its list. Item identity is the full triple: two lines belong to the same
+    /// item iff their whole container path (ordinals included) is equal — so a
+    /// multi-paragraph item is two lines sharing one `ListItem`, while the next
+    /// item differs by `ordinal`. Positional and deterministic — no minted ids.
+    ListItem {
+        ordered: bool,
+        start: u64,
+        ordinal: u64,
+    },
+    /// A block quote. Adjacent lines sharing `[Quote]` are one multi-paragraph
+    /// quote; phase 1 does not distinguish two adjacent separate quotes (they
+    /// merge on round-trip — a documented canonicalization).
+    Quote,
+}
+
+/// A mark over a char range `[start, end)`. `start == end` (zero-width) is legal
+/// only for [`MarkKind::Anchor`]; normalization drops zero-width formatting.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Mark {
+    pub start: Usv,
+    pub end: Usv,
+    pub kind: MarkKind,
+}
+
+/// The mark set — **open**: an unknown kind round-trips as [`MarkKind::Unknown`],
+/// absorbed as a new *type*, never a changed semantics of a known one. Two
+/// algebra classes: formatting is a property of a range (two coincident are
+/// redundant); identity is a handle (two over the same range are two things).
+#[derive(Debug, Clone, PartialEq)]
+pub enum MarkKind {
+    // Formatting — round-trippable projection marks. `is_formatting()`.
+    Strong,
+    Emph,
+    Underline,
+    Strike,
+    Code,
+    Link {
+        url: String,
+    },
+    // Identity — a handle, not a property. Never merged, may be zero-width.
+    /// A comment thread or stable anchor, carried by id and rebased across
+    /// edits like any position. No markdown projection (omitted on export;
+    /// survives via diff-rebase).
+    Anchor {
+        id: String,
+    },
+    // Open-set escape hatch — an unknown mark type, round-tripped opaque.
+    Unknown {
+        tag: String,
+        attrs: JsonValue,
+    },
+}
+
+/// A structured object with no honest text encoding — a table, figure, or future
+/// embed — occupying one [`ISLAND_SLOT`] in the corpus.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Island {
+    /// Minted, `$id`-style stable id. The single source of hash
+    /// nondeterminism once islands mint (phase 4); text stays deterministic.
+    pub id: String,
+    /// Island type discriminator (`"table"`, `"image"`, …). Unknown types
+    /// round-trip opaque.
+    pub island_type: String,
+    /// Typed payload. Recursively key-sorted by normalization so it hashes
+    /// deterministically despite `serde_json`'s `preserve_order`.
+    pub props: JsonValue,
+    /// How faithfully the markdown projection can carry this island.
+    pub loss: Loss,
+}
+
+/// The markdown-projection loss class of an island.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Loss {
+    /// Markdown carries it faithfully (round-trips identically).
+    Lossless,
+    /// Markdown carries an approximation (round-trips visibly, not identically).
+    Degraded,
+    /// No markdown encoding; export emits a placeholder only.
+    Unrepresentable,
+}
+
+impl MarkKind {
+    /// Formatting marks are a property of a range and union when coincident;
+    /// identity/unknown marks are handles and never merge (Spike-A rules).
+    pub fn is_formatting(&self) -> bool {
+        matches!(
+            self,
+            MarkKind::Strong
+                | MarkKind::Emph
+                | MarkKind::Underline
+                | MarkKind::Strike
+                | MarkKind::Code
+                | MarkKind::Link { .. }
+        )
+    }
+
+    /// Total order over kinds for the canonical sort tie-break, after
+    /// `(start, end)`. Stable across releases — part of the freeze.
+    pub fn ord(&self) -> u8 {
+        match self {
+            MarkKind::Strong => 0,
+            MarkKind::Emph => 1,
+            MarkKind::Underline => 2,
+            MarkKind::Strike => 3,
+            MarkKind::Code => 4,
+            MarkKind::Link { .. } => 5,
+            MarkKind::Anchor { .. } => 6,
+            MarkKind::Unknown { .. } => 7,
+        }
+    }
+
+    /// Attribute tie-break string, appended after `ord` in the canonical sort so
+    /// two marks that differ only in attrs order deterministically. Also the
+    /// grouping key for same-kind union (two formatting marks union only when
+    /// this matches — e.g. two `link`s union only at the same url).
+    pub fn attrs_key(&self) -> String {
+        match self {
+            MarkKind::Link { url } => url.clone(),
+            MarkKind::Anchor { id } => id.clone(),
+            MarkKind::Unknown { tag, attrs } => {
+                // Attrs sorted so the key is order-insensitive.
+                format!("{}\u{0}{}", tag, canonical_json_string(attrs))
+            }
+            _ => String::new(),
+        }
+    }
+}
+
+/// A `serde_json::Value` rendered to a string with object keys recursively
+/// sorted — order-insensitive, so it is a stable comparison/grouping key.
+pub(crate) fn canonical_json_string(v: &JsonValue) -> String {
+    serde_json::to_string(&sorted_value(v)).unwrap_or_default()
+}
+
+/// Rebuild `v` with every object's keys sorted, recursively. Pins island
+/// `props` (and unknown-mark attrs) against `preserve_order` leaking insertion
+/// order into the canonical bytes / content hash (Spike C carry-forward).
+pub(crate) fn sorted_value(v: &JsonValue) -> JsonValue {
+    match v {
+        JsonValue::Array(items) => JsonValue::Array(items.iter().map(sorted_value).collect()),
+        JsonValue::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for k in keys {
+                out.insert(k.clone(), sorted_value(&map[k]));
+            }
+            JsonValue::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+/// The bidi formatting chars import normalization strips; their presence in a
+/// corpus is an invariant violation. Mirrors `quillmark_core::normalize`'s set.
+fn is_bidi_char(c: char) -> bool {
+    matches!(
+        c,
+        '\u{061C}'
+            | '\u{200E}'
+            | '\u{200F}'
+            | '\u{202A}'
+            | '\u{202B}'
+            | '\u{202C}'
+            | '\u{202D}'
+            | '\u{202E}'
+            | '\u{2066}'
+            | '\u{2067}'
+            | '\u{2068}'
+            | '\u{2069}'
+    )
+}
+
+/// Ways a [`RichText`] can violate its invariants. Returned by
+/// [`RichText::validate`]; import normalization guarantees none of these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Invariant {
+    /// `\r` in the text (line endings must be normalized to `\n`).
+    CarriageReturn,
+    /// A bidi formatting control in the text.
+    BidiControl(char),
+    /// `island_slot_count != islands.len()`.
+    IslandSlotMismatch { slots: usize, islands: usize },
+    /// `lines.len() != newline_segment_count`.
+    LineCountMismatch { lines: usize, segments: usize },
+    /// A mark range runs past the corpus or is inverted (`start > end`).
+    MarkOutOfRange { start: Usv, end: Usv, len: Usv },
+    /// A zero-width formatting mark survived normalization.
+    ZeroWidthFormatting { at: Usv },
+    /// A heading level outside 1..=6.
+    BadHeadingLevel(u8),
+}
+
+impl RichText {
+    /// An empty corpus: one empty `Para` line, no marks, no islands.
+    pub fn empty() -> Self {
+        RichText {
+            text: String::new(),
+            lines: vec![Line {
+                kind: LineKind::Para,
+                containers: Vec::new(),
+            }],
+            marks: Vec::new(),
+            islands: Vec::new(),
+        }
+    }
+
+    /// Total length in USV.
+    pub fn len_usv(&self) -> Usv {
+        self.text.chars().count()
+    }
+
+    /// Number of `\n`-separated segments — the required `lines.len()`.
+    pub fn segment_count(&self) -> usize {
+        self.text.chars().filter(|c| *c == '\n').count() + 1
+    }
+
+    /// Normalize marks in place: drop zero-width formatting, union same-kind
+    /// formatting that is adjacent or overlapping, recursively key-sort island
+    /// props and unknown-mark attrs, then sort marks canonically. Idempotent —
+    /// the fixed point the canonical serialization commits to.
+    pub fn normalize(&mut self) {
+        // Islands: canonicalize props key order.
+        for island in &mut self.islands {
+            island.props = sorted_value(&island.props);
+        }
+        for mark in &mut self.marks {
+            if let MarkKind::Unknown { attrs, .. } = &mut mark.kind {
+                *attrs = sorted_value(attrs);
+            }
+        }
+        self.marks = normalize_marks(std::mem::take(&mut self.marks));
+    }
+
+    /// Check every invariant. `Ok(())` on a well-formed corpus. Import
+    /// guarantees this; a hand-built corpus should be run through it in tests.
+    pub fn validate(&self) -> Result<(), Invariant> {
+        let mut slots = 0usize;
+        for c in self.text.chars() {
+            if c == '\r' {
+                return Err(Invariant::CarriageReturn);
+            }
+            if is_bidi_char(c) {
+                return Err(Invariant::BidiControl(c));
+            }
+            if c == ISLAND_SLOT {
+                slots += 1;
+            }
+        }
+        if slots != self.islands.len() {
+            return Err(Invariant::IslandSlotMismatch {
+                slots,
+                islands: self.islands.len(),
+            });
+        }
+        let segments = self.segment_count();
+        if self.lines.len() != segments {
+            return Err(Invariant::LineCountMismatch {
+                lines: self.lines.len(),
+                segments,
+            });
+        }
+        let len = self.len_usv();
+        for m in &self.marks {
+            if m.start > m.end || m.end > len {
+                return Err(Invariant::MarkOutOfRange {
+                    start: m.start,
+                    end: m.end,
+                    len,
+                });
+            }
+            if m.start == m.end && m.kind.is_formatting() {
+                return Err(Invariant::ZeroWidthFormatting { at: m.start });
+            }
+        }
+        for line in &self.lines {
+            if let LineKind::Heading { level } = line.kind {
+                if !(1..=6).contains(&level) {
+                    return Err(Invariant::BadHeadingLevel(level));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Apply the three Spike-A rules and the canonical sort to a flat mark list.
+///
+/// 1. Same-kind formatting marks union when adjacent *or* overlapping.
+/// 2. Different-kind marks overlap freely (never split into runs).
+/// 3. Identity (and unknown) marks never merge.
+///
+/// Zero-width formatting marks are dropped (no-ops); zero-width anchors survive.
+pub(crate) fn normalize_marks(marks: Vec<Mark>) -> Vec<Mark> {
+    use std::collections::BTreeMap;
+
+    // Partition: formatting marks group by (ord, attrs_key) for union; identity
+    // and unknown pass through untouched (but zero-width formatting is dropped).
+    let mut groups: BTreeMap<(u8, String), Vec<(Usv, Usv)>> = BTreeMap::new();
+    let mut kind_of: BTreeMap<(u8, String), MarkKind> = BTreeMap::new();
+    let mut passthrough: Vec<Mark> = Vec::new();
+
+    for m in marks {
+        if m.kind.is_formatting() {
+            if m.start >= m.end {
+                continue; // drop zero-width / inverted formatting
+            }
+            let key = (m.kind.ord(), m.kind.attrs_key());
+            kind_of.entry(key.clone()).or_insert_with(|| m.kind.clone());
+            groups.entry(key).or_default().push((m.start, m.end));
+        } else {
+            passthrough.push(m);
+        }
+    }
+
+    let mut out: Vec<Mark> = Vec::new();
+    for (key, mut ranges) in groups {
+        ranges.sort_unstable();
+        let kind = kind_of.remove(&key).expect("kind recorded with group");
+        let mut cur = ranges[0];
+        for &(s, e) in &ranges[1..] {
+            if s <= cur.1 {
+                // adjacent (s == cur.1) or overlapping — union
+                cur.1 = cur.1.max(e);
+            } else {
+                out.push(Mark {
+                    start: cur.0,
+                    end: cur.1,
+                    kind: kind.clone(),
+                });
+                cur = (s, e);
+            }
+        }
+        out.push(Mark {
+            start: cur.0,
+            end: cur.1,
+            kind,
+        });
+    }
+    out.extend(passthrough);
+
+    // Canonical sort: (start, end, kind-ord, attrs).
+    out.sort_by(|a, b| {
+        a.start
+            .cmp(&b.start)
+            .then(a.end.cmp(&b.end))
+            .then(a.kind.ord().cmp(&b.kind.ord()))
+            .then(a.kind.attrs_key().cmp(&b.kind.attrs_key()))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn f(start: Usv, end: Usv, kind: MarkKind) -> Mark {
+        Mark { start, end, kind }
+    }
+
+    #[test]
+    fn same_kind_adjacent_unions() {
+        // [0,3) strong + [3,6) strong -> [0,6) strong (rule 1, adjacency).
+        let got = normalize_marks(vec![
+            f(3, 6, MarkKind::Strong),
+            f(0, 3, MarkKind::Strong),
+        ]);
+        assert_eq!(got, vec![f(0, 6, MarkKind::Strong)]);
+    }
+
+    #[test]
+    fn same_kind_overlapping_unions() {
+        let got = normalize_marks(vec![f(0, 4, MarkKind::Emph), f(2, 7, MarkKind::Emph)]);
+        assert_eq!(got, vec![f(0, 7, MarkKind::Emph)]);
+    }
+
+    #[test]
+    fn different_kinds_overlap_freely() {
+        // Strong and emph over overlapping ranges stay two marks (rule 2).
+        let got = normalize_marks(vec![f(0, 5, MarkKind::Strong), f(2, 7, MarkKind::Emph)]);
+        assert_eq!(
+            got,
+            vec![f(0, 5, MarkKind::Strong), f(2, 7, MarkKind::Emph)]
+        );
+    }
+
+    #[test]
+    fn links_union_only_at_same_url() {
+        let a = MarkKind::Link { url: "a".into() };
+        let b = MarkKind::Link { url: "b".into() };
+        // Same url adjacent -> union; different url -> distinct.
+        let got = normalize_marks(vec![
+            f(0, 2, a.clone()),
+            f(2, 4, a.clone()),
+            f(4, 6, b.clone()),
+        ]);
+        assert_eq!(got, vec![f(0, 4, a), f(4, 6, b)]);
+    }
+
+    #[test]
+    fn identity_never_merges() {
+        // Two anchors over the same range are two distinct things (rule 3).
+        let a = MarkKind::Anchor { id: "c1".into() };
+        let b = MarkKind::Anchor { id: "c2".into() };
+        let got = normalize_marks(vec![f(3, 3, a.clone()), f(3, 3, b.clone())]);
+        assert_eq!(got.len(), 2);
+        assert!(got.contains(&f(3, 3, a)));
+        assert!(got.contains(&f(3, 3, b)));
+    }
+
+    #[test]
+    fn zero_width_formatting_dropped_zero_width_anchor_kept() {
+        let got = normalize_marks(vec![
+            f(2, 2, MarkKind::Strong),
+            f(2, 2, MarkKind::Anchor { id: "x".into() }),
+        ]);
+        assert_eq!(got, vec![f(2, 2, MarkKind::Anchor { id: "x".into() })]);
+    }
+
+    #[test]
+    fn empty_is_valid() {
+        assert_eq!(RichText::empty().validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_catches_slot_mismatch() {
+        let mut rt = RichText::empty();
+        rt.text = "\u{FFFC}".into();
+        rt.lines = vec![Line {
+            kind: LineKind::Island,
+            containers: vec![],
+        }];
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::IslandSlotMismatch {
+                slots: 1,
+                islands: 0
+            })
+        );
+    }
+
+    #[test]
+    fn validate_catches_line_count() {
+        let mut rt = RichText::empty();
+        rt.text = "a\nb".into(); // 2 segments, but 1 line
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::LineCountMismatch {
+                lines: 1,
+                segments: 2
+            })
+        );
+    }
+
+    #[test]
+    fn normalize_is_idempotent() {
+        let mut rt = RichText::empty();
+        rt.text = "hello world".into();
+        rt.marks = vec![
+            f(6, 11, MarkKind::Strong),
+            f(0, 5, MarkKind::Strong),
+            f(0, 5, MarkKind::Emph),
+        ];
+        rt.normalize();
+        let once = rt.marks.clone();
+        rt.normalize();
+        assert_eq!(rt.marks, once);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+}

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -52,6 +52,15 @@ pub struct Line {
     /// `Para` lines sharing one `[ListItem]` path; a paragraph in a quote in a
     /// list item is `[ListItem, Quote]`.
     pub containers: Vec<Container>,
+    /// Whether this line continues the previous line's *block* across a hard
+    /// line break (no paragraph break between), rather than starting a new
+    /// block. `false` = a new block (paragraph spacing on either side); `true` =
+    /// a within-block line break (markdown hard break; consecutive lines of one
+    /// code fence). The first line is always `false`. This is what keeps a hard
+    /// break (backend `#linebreak()`) distinct from a paragraph boundary through
+    /// the freeze, and what groups a code fence's lines without an
+    /// adjacency heuristic.
+    pub continues: bool,
 }
 
 /// The block role of a line. The tree between lines is inferred: two adjacent
@@ -74,10 +83,13 @@ pub enum LineKind {
 pub enum Container {
     /// A list item. `ordered` distinguishes `1.` from `-`; `start` is the list's
     /// first number (1 by default); `ordinal` is this item's 0-based index in
-    /// its list. Item identity is the full triple: two lines belong to the same
-    /// item iff their whole container path (ordinals included) is equal — so a
-    /// multi-paragraph item is two lines sharing one `ListItem`, while the next
-    /// item differs by `ordinal`. Positional and deterministic — no minted ids.
+    /// its list. Two *adjacent* lines belong to the same item iff their whole
+    /// container path (ordinals included) is equal — so a multi-paragraph item
+    /// is two lines sharing one `ListItem`, while the next item differs by
+    /// `ordinal`. (Identity is path **plus contiguity**: two sibling inner lists
+    /// under one outer item can produce equal first-item paths, distinguished
+    /// only by the non-adjacency of their runs.) Positional and deterministic —
+    /// no minted ids.
     ListItem {
         ordered: bool,
         start: u64,
@@ -265,6 +277,13 @@ pub enum Invariant {
     ZeroWidthFormatting { at: Usv },
     /// A heading level outside 1..=6.
     BadHeadingLevel(u8),
+    /// The first line has `continues: true` (nothing precedes it to continue).
+    FirstLineContinues,
+    /// An [`MarkKind::Unknown`] reused a reserved built-in `type` name.
+    ReservedUnknownTag(String),
+    /// A formatting mark edge sits on a `\n` (normalization should have trimmed
+    /// it) — a hand-built corpus that skipped `normalize`.
+    MarkEdgeOnNewline { at: Usv },
 }
 
 impl RichText {
@@ -275,6 +294,7 @@ impl RichText {
             lines: vec![Line {
                 kind: LineKind::Para,
                 containers: Vec::new(),
+                continues: false,
             }],
             marks: Vec::new(),
             islands: Vec::new(),
@@ -305,8 +325,30 @@ impl RichText {
                 *attrs = sorted_value(attrs);
             }
         }
+        // A formatting mark's edges never sit on a line boundary: markdown can't
+        // bold a `\n`, so two producers that disagree only about whether the
+        // boundary is "inside" the mark must canonicalize to the same bounds.
+        // Trim leading/trailing `\n` (interior boundaries are kept — a mark may
+        // legitimately span lines). Zero-width results are dropped below.
+        let chars: Vec<char> = self.text.chars().collect();
+        for m in &mut self.marks {
+            if m.kind.is_formatting() {
+                while m.start < m.end && chars.get(m.start) == Some(&'\n') {
+                    m.start += 1;
+                }
+                while m.end > m.start && chars.get(m.end - 1) == Some(&'\n') {
+                    m.end -= 1;
+                }
+            }
+        }
         self.marks = normalize_marks(std::mem::take(&mut self.marks));
     }
+
+    /// Mark `type` names the projection reserves; an [`MarkKind::Unknown`] may
+    /// not reuse one (its serialization would parse back as the built-in,
+    /// silently dropping its attrs — non-injective). Checked by [`validate`].
+    pub const RESERVED_MARK_TYPES: [&'static str; 7] =
+        ["strong", "emph", "underline", "strike", "code", "link", "anchor"];
 
     /// Check every invariant. `Ok(())` on a well-formed corpus. Import
     /// guarantees this; a hand-built corpus should be run through it in tests.
@@ -336,7 +378,11 @@ impl RichText {
                 segments,
             });
         }
+        if self.lines.first().is_some_and(|l| l.continues) {
+            return Err(Invariant::FirstLineContinues);
+        }
         let len = self.len_usv();
+        let chars: Vec<char> = self.text.chars().collect();
         for m in &self.marks {
             if m.start > m.end || m.end > len {
                 return Err(Invariant::MarkOutOfRange {
@@ -347,6 +393,19 @@ impl RichText {
             }
             if m.start == m.end && m.kind.is_formatting() {
                 return Err(Invariant::ZeroWidthFormatting { at: m.start });
+            }
+            if m.kind.is_formatting() {
+                if chars.get(m.start) == Some(&'\n') {
+                    return Err(Invariant::MarkEdgeOnNewline { at: m.start });
+                }
+                if m.end > m.start && chars.get(m.end - 1) == Some(&'\n') {
+                    return Err(Invariant::MarkEdgeOnNewline { at: m.end - 1 });
+                }
+            }
+            if let MarkKind::Unknown { tag, .. } = &m.kind {
+                if Self::RESERVED_MARK_TYPES.contains(&tag.as_str()) {
+                    return Err(Invariant::ReservedUnknownTag(tag.clone()));
+                }
             }
         }
         for line in &self.lines {
@@ -505,6 +564,7 @@ mod tests {
         rt.lines = vec![Line {
             kind: LineKind::Island,
             containers: vec![],
+            continues: false,
         }];
         assert_eq!(
             rt.validate(),

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -1,0 +1,413 @@
+//! Canonical JSON serialization — the phase-1 freeze.
+//!
+//! Byte-deterministic within this schema: equal [`RichText`] values (by
+//! `PartialEq` after [`RichText::normalize`]) serialize to byte-equal JSON,
+//! insensitive to the order marks/islands were discovered in. Three order
+//! sources are closed here and in `normalize`: mark order (canonical sort),
+//! island order (slot position), and object-key order inside island `props` /
+//! unknown-mark `attrs` (recursively sorted). `deserialize ∘ serialize` is a
+//! fixed point on canonical bytes.
+//!
+//! The seam encoding (Option A) and the storage encoding are the *same*
+//! canonical form — one serializer, not two to keep aligned.
+
+use crate::model::{
+    sorted_value, Container, Island, Line, LineKind, Loss, Mark, MarkKind, RichText,
+};
+use serde_json::{Map, Value};
+
+/// Why canonical-JSON parsing failed. Structural only — a well-formed producer
+/// (this crate's serializer, the seam, storage) never trips these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// Top-level JSON was not an object, or a required key was missing/mistyped.
+    Shape(&'static str),
+    /// The JSON itself did not parse.
+    Json(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::Shape(s) => write!(f, "richtext json shape: {s}"),
+            ParseError::Json(s) => write!(f, "richtext json parse: {s}"),
+        }
+    }
+}
+impl std::error::Error for ParseError {}
+
+impl RichText {
+    /// Serialize to canonical JSON bytes. Normalizes a copy first, so the output
+    /// is canonical regardless of the caller's mark/island order.
+    pub fn to_canonical_json(&self) -> String {
+        let mut rt = self.clone();
+        rt.normalize();
+        rt.to_value().to_string()
+    }
+
+    /// Parse canonical JSON. Normalizes defensively (idempotent), so
+    /// `from_canonical_json(to_canonical_json(x))` round-trips to a canonical
+    /// value and re-serializes to identical bytes.
+    pub fn from_canonical_json(s: &str) -> Result<RichText, ParseError> {
+        let v: Value = serde_json::from_str(s).map_err(|e| ParseError::Json(e.to_string()))?;
+        let mut rt = RichText::from_value(&v)?;
+        rt.normalize();
+        Ok(rt)
+    }
+
+    fn to_value(&self) -> Value {
+        let mut root = Map::new();
+        root.insert("text".into(), Value::String(self.text.clone()));
+        root.insert(
+            "lines".into(),
+            Value::Array(self.lines.iter().map(line_to_value).collect()),
+        );
+        root.insert(
+            "marks".into(),
+            Value::Array(self.marks.iter().map(mark_to_value).collect()),
+        );
+        root.insert(
+            "islands".into(),
+            Value::Array(self.islands.iter().map(island_to_value).collect()),
+        );
+        Value::Object(root)
+    }
+
+    fn from_value(v: &Value) -> Result<RichText, ParseError> {
+        let obj = v.as_object().ok_or(ParseError::Shape("root not object"))?;
+        let text = obj
+            .get("text")
+            .and_then(Value::as_str)
+            .ok_or(ParseError::Shape("text"))?
+            .to_string();
+        let lines = arr(obj, "lines")?
+            .iter()
+            .map(line_from_value)
+            .collect::<Result<_, _>>()?;
+        let marks = arr(obj, "marks")?
+            .iter()
+            .map(mark_from_value)
+            .collect::<Result<_, _>>()?;
+        let islands = arr(obj, "islands")?
+            .iter()
+            .map(island_from_value)
+            .collect::<Result<_, _>>()?;
+        Ok(RichText {
+            text,
+            lines,
+            marks,
+            islands,
+        })
+    }
+}
+
+fn arr<'a>(obj: &'a Map<String, Value>, key: &'static str) -> Result<&'a Vec<Value>, ParseError> {
+    obj.get(key)
+        .and_then(Value::as_array)
+        .ok_or(ParseError::Shape(key))
+}
+
+// ---- Line ----
+
+fn line_to_value(line: &Line) -> Value {
+    let mut m = Map::new();
+    match &line.kind {
+        LineKind::Para => {
+            m.insert("kind".into(), "para".into());
+        }
+        LineKind::Heading { level } => {
+            m.insert("kind".into(), "heading".into());
+            m.insert("level".into(), Value::from(*level));
+        }
+        LineKind::Code { lang } => {
+            m.insert("kind".into(), "code".into());
+            if let Some(l) = lang {
+                m.insert("lang".into(), Value::String(l.clone()));
+            }
+        }
+        LineKind::Island => {
+            m.insert("kind".into(), "island".into());
+        }
+    }
+    m.insert(
+        "containers".into(),
+        Value::Array(line.containers.iter().map(container_to_value).collect()),
+    );
+    Value::Object(m)
+}
+
+fn line_from_value(v: &Value) -> Result<Line, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("line"))?;
+    let kind = match o.get("kind").and_then(Value::as_str) {
+        Some("para") => LineKind::Para,
+        Some("heading") => LineKind::Heading {
+            level: o
+                .get("level")
+                .and_then(Value::as_u64)
+                .ok_or(ParseError::Shape("heading level"))? as u8,
+        },
+        Some("code") => LineKind::Code {
+            lang: o.get("lang").and_then(Value::as_str).map(str::to_string),
+        },
+        Some("island") => LineKind::Island,
+        _ => return Err(ParseError::Shape("line kind")),
+    };
+    let containers = o
+        .get("containers")
+        .and_then(Value::as_array)
+        .ok_or(ParseError::Shape("containers"))?
+        .iter()
+        .map(container_from_value)
+        .collect::<Result<_, _>>()?;
+    Ok(Line { kind, containers })
+}
+
+fn container_to_value(c: &Container) -> Value {
+    let mut m = Map::new();
+    match c {
+        Container::ListItem {
+            ordered,
+            start,
+            ordinal,
+        } => {
+            m.insert("container".into(), "list_item".into());
+            m.insert("ordered".into(), Value::Bool(*ordered));
+            m.insert("start".into(), Value::from(*start));
+            m.insert("ordinal".into(), Value::from(*ordinal));
+        }
+        Container::Quote => {
+            m.insert("container".into(), "quote".into());
+        }
+    }
+    Value::Object(m)
+}
+
+fn container_from_value(v: &Value) -> Result<Container, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("container"))?;
+    match o.get("container").and_then(Value::as_str) {
+        Some("list_item") => Ok(Container::ListItem {
+            ordered: o.get("ordered").and_then(Value::as_bool).unwrap_or(false),
+            start: o.get("start").and_then(Value::as_u64).unwrap_or(1),
+            ordinal: o.get("ordinal").and_then(Value::as_u64).unwrap_or(0),
+        }),
+        Some("quote") => Ok(Container::Quote),
+        _ => Err(ParseError::Shape("container kind")),
+    }
+}
+
+// ---- Mark ----
+
+fn mark_to_value(mark: &Mark) -> Value {
+    let mut m = Map::new();
+    m.insert("start".into(), Value::from(mark.start));
+    m.insert("end".into(), Value::from(mark.end));
+    match &mark.kind {
+        MarkKind::Strong => {
+            m.insert("type".into(), "strong".into());
+        }
+        MarkKind::Emph => {
+            m.insert("type".into(), "emph".into());
+        }
+        MarkKind::Underline => {
+            m.insert("type".into(), "underline".into());
+        }
+        MarkKind::Strike => {
+            m.insert("type".into(), "strike".into());
+        }
+        MarkKind::Code => {
+            m.insert("type".into(), "code".into());
+        }
+        MarkKind::Link { url } => {
+            m.insert("type".into(), "link".into());
+            m.insert("url".into(), Value::String(url.clone()));
+        }
+        MarkKind::Anchor { id } => {
+            m.insert("type".into(), "anchor".into());
+            m.insert("id".into(), Value::String(id.clone()));
+        }
+        MarkKind::Unknown { tag, attrs } => {
+            m.insert("type".into(), Value::String(tag.clone()));
+            m.insert("attrs".into(), sorted_value(attrs));
+        }
+    }
+    Value::Object(m)
+}
+
+fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("mark"))?;
+    let start = o
+        .get("start")
+        .and_then(Value::as_u64)
+        .ok_or(ParseError::Shape("mark start"))? as usize;
+    let end = o
+        .get("end")
+        .and_then(Value::as_u64)
+        .ok_or(ParseError::Shape("mark end"))? as usize;
+    let ty = o
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(ParseError::Shape("mark type"))?;
+    let kind = match ty {
+        "strong" => MarkKind::Strong,
+        "emph" => MarkKind::Emph,
+        "underline" => MarkKind::Underline,
+        "strike" => MarkKind::Strike,
+        "code" => MarkKind::Code,
+        "link" => MarkKind::Link {
+            url: o
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        },
+        "anchor" => MarkKind::Anchor {
+            id: o
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        },
+        // Open set: any other type name is an unknown mark, round-tripped opaque
+        // with whatever `attrs` it carried.
+        other => MarkKind::Unknown {
+            tag: other.to_string(),
+            attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
+        },
+    };
+    Ok(Mark { start, end, kind })
+}
+
+// ---- Island ----
+
+fn island_to_value(island: &Island) -> Value {
+    let mut m = Map::new();
+    m.insert("id".into(), Value::String(island.id.clone()));
+    m.insert("type".into(), Value::String(island.island_type.clone()));
+    m.insert("props".into(), sorted_value(&island.props));
+    m.insert("loss".into(), loss_to_str(island.loss).into());
+    Value::Object(m)
+}
+
+fn island_from_value(v: &Value) -> Result<Island, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("island"))?;
+    Ok(Island {
+        id: o
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or(ParseError::Shape("island id"))?
+            .to_string(),
+        island_type: o
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or(ParseError::Shape("island type"))?
+            .to_string(),
+        props: o.get("props").cloned().unwrap_or(Value::Null),
+        loss: loss_from_str(o.get("loss").and_then(Value::as_str).unwrap_or("lossless")),
+    })
+}
+
+fn loss_to_str(loss: Loss) -> &'static str {
+    match loss {
+        Loss::Lossless => "lossless",
+        Loss::Degraded => "degraded",
+        Loss::Unrepresentable => "unrepresentable",
+    }
+}
+
+fn loss_from_str(s: &str) -> Loss {
+    match s {
+        "degraded" => Loss::Degraded,
+        "unrepresentable" => Loss::Unrepresentable,
+        _ => Loss::Lossless,
+    }
+}
+
+/// Content-hash key: the canonical JSON, byte-for-byte. Exposed so a phase-2
+/// storage layer hashes the same bytes it serializes. `_` prefix-free name kept
+/// stable — part of the determinism contract.
+pub fn content_key(rt: &RichText) -> String {
+    rt.to_canonical_json()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Line, LineKind};
+
+    fn sample() -> RichText {
+        RichText {
+            text: "hello world".into(),
+            lines: vec![Line {
+                kind: LineKind::Para,
+                containers: vec![],
+            }],
+            marks: vec![
+                Mark {
+                    start: 6,
+                    end: 11,
+                    kind: MarkKind::Strong,
+                },
+                Mark {
+                    start: 0,
+                    end: 5,
+                    kind: MarkKind::Emph,
+                },
+            ],
+            islands: vec![],
+        }
+    }
+
+    #[test]
+    fn round_trips_and_is_fixed_point() {
+        let rt = sample();
+        let json = rt.to_canonical_json();
+        let back = RichText::from_canonical_json(&json).unwrap();
+        // Re-serializing the parsed value yields identical bytes (fixed point).
+        assert_eq!(back.to_canonical_json(), json);
+        assert_eq!(back.validate(), Ok(()));
+    }
+
+    #[test]
+    fn byte_deterministic_regardless_of_input_order() {
+        let a = sample();
+        let mut b = sample();
+        b.marks.reverse(); // different discovery order
+        assert_eq!(a.to_canonical_json(), b.to_canonical_json());
+    }
+
+    #[test]
+    fn island_props_key_order_does_not_leak() {
+        let mut one = RichText::empty();
+        one.text = "\u{FFFC}".into();
+        one.lines = vec![Line {
+            kind: LineKind::Island,
+            containers: vec![],
+        }];
+        one.islands = vec![Island {
+            id: "i1".into(),
+            island_type: "table".into(),
+            props: serde_json::json!({"b": 1, "a": 2}),
+            loss: Loss::Lossless,
+        }];
+        let mut two = one.clone();
+        two.islands[0].props = serde_json::json!({"a": 2, "b": 1}); // keys reversed
+        assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+    }
+
+    #[test]
+    fn unknown_mark_round_trips_opaque() {
+        let mut rt = RichText::empty();
+        rt.text = "abcd".into();
+        rt.marks = vec![Mark {
+            start: 0,
+            end: 4,
+            kind: MarkKind::Unknown {
+                tag: "highlight".into(),
+                attrs: serde_json::json!({"color": "yellow"}),
+            },
+        }];
+        let json = rt.to_canonical_json();
+        let back = RichText::from_canonical_json(&json).unwrap();
+        assert_eq!(back.marks[0].kind, rt.marks[0].kind);
+    }
+}

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -24,6 +24,8 @@ pub enum ParseError {
     Shape(&'static str),
     /// The JSON itself did not parse.
     Json(String),
+    /// The value parsed but violates a corpus invariant.
+    Invalid(crate::model::Invariant),
 }
 
 impl std::fmt::Display for ParseError {
@@ -31,6 +33,7 @@ impl std::fmt::Display for ParseError {
         match self {
             ParseError::Shape(s) => write!(f, "richtext json shape: {s}"),
             ParseError::Json(s) => write!(f, "richtext json parse: {s}"),
+            ParseError::Invalid(inv) => write!(f, "richtext invariant: {inv:?}"),
         }
     }
 }
@@ -38,20 +41,26 @@ impl std::error::Error for ParseError {}
 
 impl RichText {
     /// Serialize to canonical JSON bytes. Normalizes a copy first, so the output
-    /// is canonical regardless of the caller's mark/island order.
+    /// is canonical regardless of the caller's mark/island order. Every object
+    /// key is sorted recursively so the bytes do **not** depend on
+    /// `serde_json`'s `preserve_order` feature being enabled in the consumer's
+    /// crate graph — the canonical form is feature-independent.
     pub fn to_canonical_json(&self) -> String {
         let mut rt = self.clone();
         rt.normalize();
-        rt.to_value().to_string()
+        sorted_value(&rt.to_value()).to_string()
     }
 
-    /// Parse canonical JSON. Normalizes defensively (idempotent), so
+    /// Parse canonical JSON, normalize (idempotent), and validate. Returns
+    /// [`ParseError::Invalid`] for a corpus that violates its invariants, so
+    /// storage cannot silently round-trip a malformed value.
     /// `from_canonical_json(to_canonical_json(x))` round-trips to a canonical
     /// value and re-serializes to identical bytes.
     pub fn from_canonical_json(s: &str) -> Result<RichText, ParseError> {
         let v: Value = serde_json::from_str(s).map_err(|e| ParseError::Json(e.to_string()))?;
         let mut rt = RichText::from_value(&v)?;
         rt.normalize();
+        rt.validate().map_err(ParseError::Invalid)?;
         Ok(rt)
     }
 
@@ -133,6 +142,11 @@ fn line_to_value(line: &Line) -> Value {
         "containers".into(),
         Value::Array(line.containers.iter().map(container_to_value).collect()),
     );
+    // Omitted when false (the common case) — deterministic since presence is a
+    // pure function of the value.
+    if line.continues {
+        m.insert("continues".into(), Value::Bool(true));
+    }
     Value::Object(m)
 }
 
@@ -159,7 +173,12 @@ fn line_from_value(v: &Value) -> Result<Line, ParseError> {
         .iter()
         .map(container_from_value)
         .collect::<Result<_, _>>()?;
-    Ok(Line { kind, containers })
+    let continues = o.get("continues").and_then(Value::as_bool).unwrap_or(false);
+    Ok(Line {
+        kind,
+        containers,
+        continues,
+    })
 }
 
 fn container_to_value(c: &Container) -> Value {
@@ -316,9 +335,11 @@ fn loss_to_str(loss: Loss) -> &'static str {
 
 fn loss_from_str(s: &str) -> Loss {
     match s {
+        "lossless" => Loss::Lossless,
         "degraded" => Loss::Degraded,
-        "unrepresentable" => Loss::Unrepresentable,
-        _ => Loss::Lossless,
+        // Unknown/future loss class defaults to the *safe* end: never claim a
+        // value the reader can't interpret "carries faithfully".
+        _ => Loss::Unrepresentable,
     }
 }
 
@@ -340,6 +361,7 @@ mod tests {
             lines: vec![Line {
                 kind: LineKind::Para,
                 containers: vec![],
+                continues: false,
             }],
             marks: vec![
                 Mark {
@@ -382,6 +404,7 @@ mod tests {
         one.lines = vec![Line {
             kind: LineKind::Island,
             containers: vec![],
+            continues: false,
         }];
         one.islands = vec![Island {
             id: "i1".into(),
@@ -392,6 +415,55 @@ mod tests {
         let mut two = one.clone();
         two.islands[0].props = serde_json::json!({"a": 2, "b": 1}); // keys reversed
         assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+    }
+
+    #[test]
+    fn golden_bytes_are_feature_independent() {
+        // Pins the exact canonical form. Every object key is sorted, so the
+        // bytes do not depend on serde_json's preserve_order feature. If this
+        // string changes, the freeze changed — bump the schema version.
+        let rt = sample();
+        assert_eq!(
+            rt.to_canonical_json(),
+            r#"{"islands":[],"lines":[{"containers":[],"kind":"para"}],"marks":[{"end":5,"start":0,"type":"emph"},{"end":11,"start":6,"type":"strong"}],"text":"hello world"}"#
+        );
+    }
+
+    #[test]
+    fn from_canonical_json_rejects_invalid() {
+        // lines.len() != segment count — must not silently round-trip.
+        let bad = r#"{"text":"a\nb","lines":[{"kind":"para","containers":[]}],"marks":[],"islands":[]}"#;
+        assert!(matches!(
+            RichText::from_canonical_json(bad),
+            Err(ParseError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn reserved_unknown_tag_rejected() {
+        // An Unknown mark may not reuse a built-in type name (would parse back
+        // as the built-in, dropping attrs — non-injective).
+        let mut rt = RichText::empty();
+        rt.text = "abcd".into();
+        rt.marks = vec![Mark {
+            start: 0,
+            end: 4,
+            kind: MarkKind::Unknown {
+                tag: "strong".into(),
+                attrs: serde_json::json!({}),
+            },
+        }];
+        assert!(matches!(
+            rt.validate(),
+            Err(crate::model::Invariant::ReservedUnknownTag(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_loss_class_defaults_unrepresentable() {
+        let json = r#"{"text":"￼","lines":[{"kind":"island","containers":[]}],"marks":[],"islands":[{"id":"i1","type":"widget","props":{},"loss":"future_class"}]}"#;
+        let rt = RichText::from_canonical_json(json).unwrap();
+        assert_eq!(rt.islands[0].loss, Loss::Unrepresentable);
     }
 
     #[test]

--- a/crates/richtext/src/usv.rs
+++ b/crates/richtext/src/usv.rs
@@ -1,0 +1,94 @@
+//! Coordinate conversions across the binding boundary.
+//!
+//! [`RichText`](crate::RichText) positions count Unicode scalar values (USV,
+//! Rust `char`). The three boundaries that disagree:
+//!
+//! - **Rust / storage** — UTF-8 bytes. Slicing the corpus needs a byte offset.
+//! - **JS editors** — UTF-16 code units. Every delta crossing WASM converts.
+//! - **USV** — the model's coordinate. One astral char is 1 USV / 4 UTF-8 bytes
+//!   / 2 UTF-16 units.
+//!
+//! A UTF-16 index landing on a low surrogate (the tail half of an astral pair)
+//! rounds **down** to the char that owns it — the standing cross-binding rule
+//! the property suite pins.
+
+/// USV index → UTF-8 byte offset into `text`. Saturates to `text.len()` for an
+/// index at or past the end, so it is safe to use as a slice bound.
+pub fn char_to_byte(text: &str, char_idx: usize) -> usize {
+    text.char_indices()
+        .nth(char_idx)
+        .map(|(b, _)| b)
+        .unwrap_or(text.len())
+}
+
+/// USV index → UTF-16 code-unit index. Saturates to the UTF-16 length past the
+/// end.
+pub fn char_to_utf16(text: &str, char_idx: usize) -> usize {
+    text.chars()
+        .take(char_idx)
+        .map(|c| c.len_utf16())
+        .sum()
+}
+
+/// UTF-16 code-unit index → USV index. An index that lands mid-pair (on a low
+/// surrogate) rounds down to the owning char. Saturates to the USV length past
+/// the end.
+pub fn utf16_to_char(text: &str, utf16_idx: usize) -> usize {
+    let mut units = 0usize;
+    for (char_idx, c) in text.chars().enumerate() {
+        if units >= utf16_idx {
+            return char_idx;
+        }
+        units += c.len_utf16();
+        // If the target index fell strictly inside this char's pair, we passed
+        // it — this char owns it, so round down to it.
+        if units > utf16_idx {
+            return char_idx;
+        }
+    }
+    text.chars().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ASTRAL: &str = "a😀b"; // 'a'(1u16) '😀'(2u16) 'b'(1u16) => 3 USV, 4 UTF-16
+
+    #[test]
+    fn char_to_byte_astral() {
+        assert_eq!(char_to_byte(ASTRAL, 0), 0);
+        assert_eq!(char_to_byte(ASTRAL, 1), 1); // start of 😀
+        assert_eq!(char_to_byte(ASTRAL, 2), 5); // start of b (😀 is 4 bytes)
+        assert_eq!(char_to_byte(ASTRAL, 3), 6); // end
+        assert_eq!(char_to_byte(ASTRAL, 99), 6); // saturates
+    }
+
+    #[test]
+    fn char_to_utf16_astral() {
+        assert_eq!(char_to_utf16(ASTRAL, 0), 0);
+        assert_eq!(char_to_utf16(ASTRAL, 1), 1); // before 😀
+        assert_eq!(char_to_utf16(ASTRAL, 2), 3); // after 😀 (2 units)
+        assert_eq!(char_to_utf16(ASTRAL, 3), 4); // end
+    }
+
+    #[test]
+    fn utf16_to_char_astral() {
+        assert_eq!(utf16_to_char(ASTRAL, 0), 0);
+        assert_eq!(utf16_to_char(ASTRAL, 1), 1); // before 😀
+        assert_eq!(utf16_to_char(ASTRAL, 2), 1); // mid-surrogate -> rounds down to 😀
+        assert_eq!(utf16_to_char(ASTRAL, 3), 2); // after 😀
+        assert_eq!(utf16_to_char(ASTRAL, 4), 3); // end
+        assert_eq!(utf16_to_char(ASTRAL, 99), 3); // saturates
+    }
+
+    #[test]
+    fn round_trip_char_utf16() {
+        // Every char boundary round-trips (mid-surrogate indices don't exist as
+        // char positions, so we only check char starts).
+        for i in 0..=ASTRAL.chars().count() {
+            let u16i = char_to_utf16(ASTRAL, i);
+            assert_eq!(utf16_to_char(ASTRAL, u16i), i, "char {i}");
+        }
+    }
+}

--- a/crates/richtext/tests/properties.proptest-regressions
+++ b/crates/richtext/tests/properties.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9c1e8dbc283caf2e70531e5677b75f1b7e9b54f42f79c4abd450bba829dd88fd # shrinks to md = "| a | a |\n| --- | --- |\n| 1 | 2 |\n\n| a | a |\n| --- | --- |\n| 1 | 2 |"

--- a/crates/richtext/tests/properties.proptest-regressions
+++ b/crates/richtext/tests/properties.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 9c1e8dbc283caf2e70531e5677b75f1b7e9b54f42f79c4abd450bba829dd88fd # shrinks to md = "| a | a |\n| --- | --- |\n| 1 | 2 |\n\n| a | a |\n| --- | --- |\n| 1 | 2 |"

--- a/crates/richtext/tests/properties.rs
+++ b/crates/richtext/tests/properties.rs
@@ -1,0 +1,189 @@
+//! Phase-1 property suite (issue #831 step 1).
+//!
+//! The four properties the freeze rests on:
+//!
+//! 1. **Round-trip modulo loss class** — for a corpus from import,
+//!    `import(export(rt)) == rt`. Markdown source is not canonical; the corpus
+//!    is, so round-trip is defined at the corpus. Our generator emits only
+//!    lossless islands, so equality is exact.
+//! 2. **Canonical serialization** — byte-deterministic and a fixed point;
+//!    insensitive to mark/island discovery order.
+//! 3. **Diff-import preserves identity marks** — an anchor over text that
+//!    survives a rewrite is carried forward.
+//! 4. **USV boundary** — char↔UTF-16 round-trips at char boundaries; a
+//!    mid-surrogate index rounds down.
+
+use proptest::prelude::*;
+use quillmark_richtext::delta::diff_import;
+use quillmark_richtext::export::to_markdown;
+use quillmark_richtext::import::from_markdown;
+use quillmark_richtext::model::{Mark, MarkKind};
+use quillmark_richtext::usv::{char_to_utf16, utf16_to_char};
+use quillmark_richtext::RichText;
+
+// ---------------------------------------------------------------------------
+// A constrained markdown generator: combinations of the phase-1 constructs,
+// with inline tokens space-separated so the property exercises structure and
+// marks without depending on CommonMark's delimiter-adjacency corners (those
+// are pinned by explicit unit tests, not fuzzed here).
+// ---------------------------------------------------------------------------
+
+fn word() -> impl Strategy<Value = String> {
+    "[a-z]{1,6}"
+}
+
+fn inline_token() -> impl Strategy<Value = String> {
+    prop_oneof![
+        word(),
+        word().prop_map(|w| format!("**{w}**")),
+        word().prop_map(|w| format!("_{w}_")),
+        word().prop_map(|w| format!("~~{w}~~")),
+        word().prop_map(|w| format!("`{w}`")),
+        word().prop_map(|w| format!("<u>{w}</u>")),
+        (word(), word()).prop_map(|(t, u)| format!("[{t}](https://ex.com/{u})")),
+    ]
+}
+
+fn prose() -> impl Strategy<Value = String> {
+    prop::collection::vec(inline_token(), 1..5).prop_map(|toks| toks.join(" "))
+}
+
+fn block() -> impl Strategy<Value = String> {
+    prop_oneof![
+        prose(),
+        (1u8..=6, prose()).prop_map(|(lvl, p)| format!("{} {p}", "#".repeat(lvl as usize))),
+        prop::collection::vec(prose(), 1..4).prop_map(|items| items
+            .iter()
+            .map(|p| format!("- {p}"))
+            .collect::<Vec<_>>()
+            .join("\n")),
+        prop::collection::vec(prose(), 1..4).prop_map(|items| items
+            .iter()
+            .enumerate()
+            .map(|(i, p)| format!("{}. {p}", i + 1))
+            .collect::<Vec<_>>()
+            .join("\n")),
+        prose().prop_map(|p| format!("> {p}")),
+        prop::collection::vec(word(), 1..4)
+            .prop_map(|ls| format!("```\n{}\n```", ls.join("\n"))),
+        (word(), word()).prop_map(|(a, b)| format!("| {a} | {b} |\n| --- | --- |\n| 1 | 2 |")),
+    ]
+}
+
+fn document() -> impl Strategy<Value = String> {
+    prop::collection::vec(block(), 1..6).prop_map(|blocks| blocks.join("\n\n"))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(400))]
+
+    /// Property 1: the corpus is a fixed point of export∘import, and every
+    /// imported corpus satisfies its invariants.
+    #[test]
+    fn corpus_round_trip_and_invariants(md in document()) {
+        let rt = from_markdown(&md).unwrap();
+        prop_assert_eq!(rt.validate(), Ok(()), "invariants for {:?}", md);
+
+        let md2 = to_markdown(&rt);
+        let rt2 = from_markdown(&md2).unwrap();
+        prop_assert_eq!(&rt, &rt2, "not a fixed point.\n in:  {:?}\n out: {:?}", md, md2);
+    }
+
+    /// Property 2a: canonical JSON is a fixed point.
+    #[test]
+    fn canonical_json_fixed_point(md in document()) {
+        let rt = from_markdown(&md).unwrap();
+        let json = rt.to_canonical_json();
+        let back = RichText::from_canonical_json(&json).unwrap();
+        prop_assert_eq!(back.to_canonical_json(), json);
+    }
+
+    /// Property 2b: canonical bytes are insensitive to mark *discovery* order
+    /// (normalization sorts them). Islands are inherently ordered by slot
+    /// position, so only mark order is a free variable.
+    #[test]
+    fn canonical_json_order_insensitive(md in document()) {
+        let rt = from_markdown(&md).unwrap();
+        let mut shuffled = rt.clone();
+        shuffled.marks.reverse();
+        prop_assert_eq!(rt.to_canonical_json(), shuffled.to_canonical_json());
+    }
+
+    /// Property 3: an anchor over text that survives a rewrite is carried
+    /// forward by diff-import. We prepend context (edit elsewhere), so the
+    /// anchored span is untouched and must survive.
+    #[test]
+    fn diff_import_preserves_surviving_anchor(a in "[a-z]{3,8}", b in "[a-z]{3,8}") {
+        let base_md = format!("keep {a} here");
+        let mut base = from_markdown(&base_md).unwrap();
+        // Anchor exactly over the `a` word.
+        let start = 5;
+        let end = 5 + a.chars().count();
+        prop_assert_eq!(&base.text[start..end], a.as_str());
+        base.marks.push(Mark { start, end, kind: MarkKind::Anchor { id: "c1".into() } });
+        base.normalize();
+
+        // Rewrite prepends `b` (edit before the anchor); anchored text unchanged.
+        let new_md = format!("{b} keep {a} here");
+        let (new_rt, _delta) = diff_import(&base, &new_md).unwrap();
+        let anchor = new_rt.marks.iter()
+            .find(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1"));
+        prop_assert!(anchor.is_some(), "anchor lost across surviving edit");
+        let anchor = anchor.unwrap();
+        prop_assert_eq!(&new_rt.text[anchor.start..anchor.end], a.as_str());
+    }
+
+    /// Property 4a: char↔UTF-16 round-trips at every char boundary.
+    #[test]
+    fn usv_round_trip(s in ".{0,64}") {
+        let n = s.chars().count();
+        for i in 0..=n {
+            let u = char_to_utf16(&s, i);
+            prop_assert_eq!(utf16_to_char(&s, u), i, "char {} of {:?}", i, s);
+        }
+    }
+
+    /// Property 4b: a mid-surrogate UTF-16 index rounds down to its owning char.
+    #[test]
+    fn usv_mid_surrogate_rounds_down(prefix in "[a-z]{0,8}") {
+        // 😀 is a surrogate pair; the index just after its first unit must round
+        // down to the emoji's char index.
+        let s = format!("{prefix}😀x");
+        let emoji_char = prefix.chars().count();
+        let u_before = char_to_utf16(&s, emoji_char);
+        // u_before + 1 lands mid-pair.
+        prop_assert_eq!(utf16_to_char(&s, u_before + 1), emoji_char);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture corpus: the phase-1 codecs run against real fixture markdown bodies.
+// ---------------------------------------------------------------------------
+
+fn fixture_body(name: &str) -> String {
+    let path = quillmark_fixtures::resource_path(name);
+    std::fs::read_to_string(path).unwrap()
+}
+
+#[test]
+fn fixture_sample_round_trips() {
+    // sample.md is a prose-heavy body exercising headings, lists (nested),
+    // marks, links, and inline code — the codec's core surface.
+    let md = fixture_body("sample.md");
+    let rt = from_markdown(&md).expect("import sample.md");
+    assert_eq!(rt.validate(), Ok(()), "sample.md invariants");
+    let rt2 = from_markdown(&to_markdown(&rt)).unwrap();
+    assert_eq!(rt, rt2, "sample.md corpus not a fixed point");
+}
+
+#[test]
+fn fixture_bodies_import_and_are_valid() {
+    // Every prose resource imports to a valid corpus and is a fixed point.
+    for name in ["sample.md", "card_yaml_demo.md", "extended_metadata_demo.md"] {
+        let md = fixture_body(name);
+        let rt = from_markdown(&md).unwrap_or_else(|e| panic!("import {name}: {e}"));
+        assert_eq!(rt.validate(), Ok(()), "{name} invariants");
+        let rt2 = from_markdown(&to_markdown(&rt)).unwrap();
+        assert_eq!(rt, rt2, "{name} corpus not a fixed point");
+    }
+}

--- a/crates/richtext/tests/properties.rs
+++ b/crates/richtext/tests/properties.rs
@@ -28,30 +28,58 @@ use quillmark_richtext::RichText;
 // are pinned by explicit unit tests, not fuzzed here).
 // ---------------------------------------------------------------------------
 
-fn word() -> impl Strategy<Value = String> {
-    "[a-z]{1,6}"
+// `clean_word` is safe content for inside a formatted span / url / code / cell.
+fn clean_word() -> impl Strategy<Value = String> {
+    "[a-z0-9]{1,6}"
+}
+
+// `plain_word` carries inline-special and astral chars as *literal text*, so
+// escaping and USV bounds are exercised by the round-trip. The first char is
+// alphanumeric and the set excludes block-marker chars (`> # - .`): a
+// block marker *leading* an item's content (`- >`, `- #`) makes pulldown build
+// an empty nested block, not literal text — a degenerate corpus no editor emits
+// (leading-marker escaping is covered by `export::tests::*` unit tests instead).
+fn plain_word() -> impl Strategy<Value = String> {
+    r"[a-z0-9][a-z0-9*_~\\😀你]{0,5}"
 }
 
 fn inline_token() -> impl Strategy<Value = String> {
     prop_oneof![
-        word(),
-        word().prop_map(|w| format!("**{w}**")),
-        word().prop_map(|w| format!("_{w}_")),
-        word().prop_map(|w| format!("~~{w}~~")),
-        word().prop_map(|w| format!("`{w}`")),
-        word().prop_map(|w| format!("<u>{w}</u>")),
-        (word(), word()).prop_map(|(t, u)| format!("[{t}](https://ex.com/{u})")),
+        plain_word(),
+        clean_word().prop_map(|w| format!("**{w}**")),
+        clean_word().prop_map(|w| format!("_{w}_")),
+        clean_word().prop_map(|w| format!("~~{w}~~")),
+        clean_word().prop_map(|w| format!("`{w}`")),
+        clean_word().prop_map(|w| format!("<u>{w}</u>")),
+        (clean_word(), clean_word()).prop_map(|(t, u)| format!("[{t}](https://ex.com/{u})")),
     ]
 }
 
 fn prose() -> impl Strategy<Value = String> {
+    // Mix single-space and hard-break (`\`+newline) separators, and let some
+    // tokens abut, so delimiter-adjacency and hard breaks are covered.
     prop::collection::vec(inline_token(), 1..5).prop_map(|toks| toks.join(" "))
+}
+
+// Hard breaks join clean, non-empty *text* lines (the realistic case — an
+// address block, a signature). A mark that *spans* a hard break, or an empty
+// line adjacent to one, is a degenerate corpus markdown cannot represent (no
+// blank-then-forced-break syntax); those are recorded as documented codec
+// limits (see `export::tests::known_hard_break_limits`), not fuzzed here.
+fn hard_break_line() -> impl Strategy<Value = String> {
+    prop::collection::vec(clean_word(), 1..4).prop_map(|w| w.join(" "))
+}
+
+fn hard_break_prose() -> impl Strategy<Value = String> {
+    prop::collection::vec(hard_break_line(), 2..4).prop_map(|lines| lines.join("\\\n"))
 }
 
 fn block() -> impl Strategy<Value = String> {
     prop_oneof![
         prose(),
+        hard_break_prose(),
         (1u8..=6, prose()).prop_map(|(lvl, p)| format!("{} {p}", "#".repeat(lvl as usize))),
+        // Bullet list, some items multi-paragraph (nested blank line).
         prop::collection::vec(prose(), 1..4).prop_map(|items| items
             .iter()
             .map(|p| format!("- {p}"))
@@ -63,10 +91,13 @@ fn block() -> impl Strategy<Value = String> {
             .map(|(i, p)| format!("{}. {p}", i + 1))
             .collect::<Vec<_>>()
             .join("\n")),
+        // Nested bullet list (two container levels).
+        (prose(), prose(), prose())
+            .prop_map(|(a, b, c)| format!("- {a}\n  - {b}\n  - {c}")),
         prose().prop_map(|p| format!("> {p}")),
-        prop::collection::vec(word(), 1..4)
+        prop::collection::vec(clean_word(), 1..4)
             .prop_map(|ls| format!("```\n{}\n```", ls.join("\n"))),
-        (word(), word()).prop_map(|(a, b)| format!("| {a} | {b} |\n| --- | --- |\n| 1 | 2 |")),
+        (clean_word(), clean_word()).prop_map(|(a, b)| format!("| {a} | {b} |\n| --- | --- |\n| 1 | 2 |")),
     ]
 }
 

--- a/prose/plans/richtext/INDEX.md
+++ b/prose/plans/richtext/INDEX.md
@@ -99,8 +99,10 @@ not this list.
   set absorbs new mark *types*, not changed semantics of known ones.
   → **Resolved (phase 0·A):** editor-independent by construction — the model
   encodes only the mark set + three normalization rules and delegates
-  edge-expand / adjacent-merge to the editor. Phase 1 may freeze now; a live
-  binding is the residual gate ([phase-0.md](phase-0.md#residual-gate)).
+  edge-expand / adjacent-merge to the editor. **Frozen in phase 1** and verified
+  byte-deterministic across producers (import vs a hand-built editor corpus emit
+  identical bytes) and feature configs (whole-tree key sort); a live binding is
+  the residual gate ([phase-1.md](phase-1.md), [phase-0.md](phase-0.md#residual-gate)).
 - **Seam encoding, not map production.** `locate` / `position_at` / regions key
   on `(field, corpus range, revision)` however `typst` builds the map — but the
   map is a codegen artifact, so content must cross the seam *faithfully* (not as
@@ -117,15 +119,17 @@ not this list.
 - **Determinism has an honest boundary.** Migration is mint-free (legacy bodies
   hold no islands); island IDs mint at creation, so phase-4 hashing of
   island-bearing documents inherits mint-nondeterminism. Text stays
-  deterministic. → **Resolved (phase 0·C):** mint is the *sole* source; **new
-  carry-forward** — `serde_json` `preserve_order` leaks island `props` key order
-  into the hash unless keys are recursively sorted before hashing (phase 2).
+  deterministic. → **Resolved (phase 0·C):** mint is the *sole* source; the
+  `preserve_order` `props`-key-order leak is **closed in phase 1**
+  (`model::sorted_value` recursively sorts before serialization). Mint
+  nondeterminism does not appear until phase 4 (islands).
 - **The move-annotation weak spot lands on the flagship writer.** The stale-text
   writer (MCP `update_document`, saved `.qmd`) rebases via cold-parse + corpus
   diff; a reorder is delete+insert, so annotations on moved text drop unless a
-  move detector confines it. → **Resolved (phase 0·A):** move detector re-homes
-  a single near-verbatim block move; residual drop (moved *and* rewritten)
-  accepted and stated. See [phase-0.md](phase-0.md).
+  move detector confines it. → **Implemented in phase 1** (`delta::diff_import`):
+  a verbatim block move re-homes the anchor, restricted to *inserted* text
+  (overlap + length floor) so it cannot capture unrelated surviving text; residual
+  drop (moved *and* rewritten) accepted and stated. See [phase-1.md](phase-1.md).
 - **USV coordinates are a standing cross-binding tax.** JS editors are UTF-16,
   Rust UTF-8; every delta crossing WASM/Python converts at its boundary, and the
   property suite owns surrogate-pair / astral-plane correctness. → Validated in
@@ -139,25 +143,29 @@ Detail per phase in its own doc as it opens. Rough shape:
   schema lands. Editor binding (gates mark semantics), source-map/navigation
   inversion (gates the phase-2 emit design), seam + determinism prototype (gates
   Option A). Nothing here ships to `main`. **Reported — no red flag** (see
-  [phase-0.md](phase-0.md); runnable probe `crates/richtext-spikes/`). Phase 1
-  may open on the Spike-A contract, with a live-editor binding tracked as its
-  residual gate.
-- **Phase 1 — type + codecs, engine-off.** `RichText` + canonical serialization
-  (frozen on the [Spike-A contract](phase-0.md): mark set + three normalization
-  rules) + markdown⇄corpus import/export codecs +
-  property suite (round-trip modulo loss class; diff-import preserves
-  marks/islands). Exercised against the fixture corpus; engine untouched. Carry
-  from phase 0: the move detector and USV conversions have working shapes in
-  `crates/richtext-spikes/` to port and harden.
+  [phase-0.md](phase-0.md); runnable probe `crates/richtext-spikes/` on branch
+  `claude/issue-831-phase-0-tbjjm1`, not on `main`/`integration`). Phase 1 opened
+  on the Spike-A contract, with a live-editor binding tracked as its residual
+  gate.
+- **[Phase 1 — type + codecs, engine-off](phase-1.md)** — **landed.** `RichText`
+  + canonical serialization (frozen on the [Spike-A contract](phase-0.md): mark
+  set + three normalization rules) + markdown⇄corpus import/export codecs +
+  property suite. New crate `crates/richtext`, engine untouched. Built from the
+  written contract, then hardened against an independent review cross-checked
+  with the Phase-0 spike code — the freeze is byte-deterministic across producers
+  and feature configs. Decisions, review outcome, and the Phase-2 handover in
+  [phase-1.md](phase-1.md).
 - **Phase 2 — engine consumes RichText (delivers #829).** Seam carries
   RichText-JSON (Option A, [confirmed](phase-0.md)); `typst` emit
   with per-line windows + source map; `pdfform` `.text` lowering; `locate` /
   `position_at` + region re-key on `(field, corpus range, revision)`; storage
   cutover (new `StoredDocument` version, deterministic cold-import migration).
-  Two carry-forward items from phase 0: **(a)** character-precision nav = add
-  `glyph.span.1` to the resolved node range then invert the run map (Spike B);
-  **(b)** recursively canonicalize island `props` keys before hashing, or
-  `preserve_order` leaks insertion order into the content hash (Spike C).
+  Re-home the `RichText` type into `core` (codecs stay parser-side) and unify the
+  `MarkdownFixer` duplicated in Phase 1. Carry-forward: **(a)** character-precision
+  nav = add `glyph.span.1` to the resolved node range then invert the run map
+  (Spike B); **(b)** island `props` recursive key-sort before hashing —
+  **already done in Phase 1** (`model::sorted_value`), so Phase 2 inherits it.
+  Full list in [phase-1.md](phase-1.md#handover-to-phase-2).
 - **Phase 3 — edit surface.** Per-field delta (Quill-Delta semantics) + monotonic
   revision + bounded change log with position mapping; form-editor binding built
   on the phase-0 spike's frozen semantics. Opens the **residual Spike-A gate**:

--- a/prose/plans/richtext/phase-1.md
+++ b/prose/plans/richtext/phase-1.md
@@ -1,0 +1,161 @@
+# Phase 1 — type + codecs, engine-off
+
+`RichText` and its markdown projection, exercised in isolation. The freeze — the
+canonical serialization and mark semantics storage commits to — lands here,
+gated on the [Spike-A contract](phase-0.md). No engine crate consumes it yet;
+Phase 2 wires the seam and storage.
+
+**Status: landed.** Crate `crates/richtext` (`quillmark-richtext`), a workspace
+member held outside `default-members` (so `cargo test --workspace` runs it while
+the release/publish set skips it), `publish = false`. 74 unit + 8 property /
+fixture tests; the property suite runs thousands of randomized cases per
+property across seeds. Clippy clean.
+
+---
+
+## What shipped
+
+One crate, six modules, layered on `model.rs` with no cycles:
+
+- **`model.rs`** — `RichText { text, lines, marks, islands }` over a USV
+  coordinate space, plus `Line` / `LineKind` / `Container` / `Mark` / `MarkKind`
+  / `Island` / `Loss`. Owns `normalize()` (the freeze's semantics) and
+  `validate()` (the invariants).
+- **`serial.rs`** — canonical, byte-deterministic JSON. One encoding for the
+  seam and for storage.
+- **`import.rs`** — `from_markdown`: `normalize → pulldown → corpus`, with the
+  `<u>` allowlist and `***` fixups ported from the typst backend.
+- **`export.rs`** — `to_markdown`: corpus → markdown per island loss class.
+- **`delta.rs`** — `Delta` (Quill-Delta ops), `diff`, `map_pos`, and
+  `diff_import` (the stale-text writer: cold-parse + anchor rebase with a
+  block-move detector).
+- **`usv.rs`** — char / UTF-8 / UTF-16 conversions.
+
+Depends **down** on `quillmark-core` (reuses `normalize::normalize_markdown`) and
+on `pulldown-cmark`. The markdown engine stays **out of `core`** (canon: core has
+no markdown-engine dependency in production) — that is why the codecs live in
+this crate, not in `core`.
+
+## Locked decisions
+
+### Placement — a new crate, not a `core` module
+
+The parser-dependent codecs cannot live in `core` without breaking its
+markdown-engine-free invariant. Phase 1 is maximally additive: a new crate that
+touches no existing code. Phase 2 re-homes the *type* (`RichText` + canonical
+serialization) into `core` for storage while leaving the codecs parser-side. The
+freeze is the **bytes**, not the module path, so re-homing is mechanical.
+
+### The freeze — what storage commits to
+
+- **Shape.** Canonical JSON with **every object key recursively sorted**, so the
+  bytes are independent of `serde_json`'s `preserve_order` feature. Pinned by a
+  golden-bytes test; changing it bumps the schema version.
+- **Mark set** (open): `strong · emph · underline · strike · code · link{url}`
+  (formatting) + `anchor{id}` (zero-width identity) + `unknown{tag, attrs}`
+  (round-trips opaque). Unknown may not reuse a reserved built-in `type` name
+  (validated — else serialization is non-injective).
+- **Normalization** (idempotent, the fixed point): same-kind formatting union on
+  adjacent/overlap; different kinds overlap freely; identity never merges; sort
+  by `(start, end, kind-ord, attrs)`; **formatting-mark edges never sit on a
+  `\n`** (trimmed); island `props` / unknown `attrs` recursively key-sorted.
+- **Coordinates** count Unicode scalar values throughout.
+- **`Line.continues`** — a within-block hard line break (markdown hard break;
+  code-fence continuation) distinct from a paragraph boundary. This is a **model
+  shape** decision and therefore a one-way door: it exists now so Phase-2 emit
+  keeps a `#linebreak()` distinct from paragraph spacing.
+- **`ListItem { ordered, start, ordinal }`** — positional item identity, no
+  minted ids. A multi-paragraph item is two lines sharing one `ListItem`.
+- **Islands** — tables are block islands (own `Island` line), images inline
+  slots, both `Lossless`. Ids minted **sequentially** (`isl-N`) so import is a
+  pure function; real minting (the hash-nondeterminism source) is Phase 4.
+
+## Independent review outcome
+
+Phase 1 was built **from the written contract**, without the Phase-0 spike code
+(the `crates/richtext-spikes/` crate lives on `claude/issue-831-phase-0-tbjjm1`,
+not on `main`/`integration` — the `phase-0.md` references to it are to that
+branch). An independent review (Fable) then cross-checked the build against that
+spike code. It found the freeze not yet correct; every finding is fixed and
+pinned:
+
+- **Marks swallowed a block's leading `\n`** — import vs an editor-built corpus
+  of the same content serialized to *different* bytes. Fixed (mark starts
+  resolve the pending line; edges trim off `\n`); a test asserts import and a
+  hand-built corpus now emit identical bytes.
+- **Bytes depended on the `preserve_order` feature** — now whole-tree sorted.
+- **Hard-break collapse** — now modelled by `Line.continues`.
+- **Anchor relocation re-homed onto unrelated surviving text** — now restricted
+  to *inserted* regions with a length floor.
+- Leading ordered-marker escaping; `map_pos` `Assoc::After`; `is_deleted` left
+  edge; table pipe double-escaping; validate-on-parse; loss-class default.
+
+The broadened property suite (the review's other must-fix) then caught four more
+real bugs: emphasis exported as `_` (can't do intraword emphasis; now `*`), and
+empty heading / empty item / empty quote silently dropped on import (now each
+keeps its line). **The two independent derivations of the contract converged** —
+the crate is better than the spike on model shape (positional `ordinal`, real
+islands, open mark set); the spike was better on whole-tree sort and
+deleted-vs-inserted move detection, both now adopted.
+
+## Documented limits (recorded, not hidden)
+
+- **Degenerate, non-authorable corpora** don't round-trip: a mark *spanning* a
+  hard break (splits per line), an empty first line in a hard-break block
+  (markdown has no blank-then-forced-break). Pinned by a `known_hard_break_limits`
+  test.
+- **Coarse diff** (prefix/suffix trim): anchor *survival* holds, but the `Delta`
+  is not a minimal edit script. Phase 3 brings a Myers/LCS diff.
+- **Canonicalizations** (distinct markdown → one corpus): hard break → `continues`
+  line (heading hard break → space); adjacent sibling same-shape lists merge;
+  adjacent blockquotes merge; empty blocks/containers keep one empty line;
+  sequential island ids. All listed in `import.rs`'s module doc.
+
+## Handover to Phase 2
+
+Phase 2 makes the engine consume `RichText` and delivers #829. Carry-forward, in
+priority order:
+
+1. **Re-home the type, keep the codecs parser-side.** Move `RichText` +
+   `serial` into `core` for the new `StoredDocument` version; keep `import`/
+   `export` in a parser-bearing crate so `core` stays markdown-engine-free.
+   Canonical bytes are unchanged by the move.
+2. **Seam (Option A).** Carry structured `RichText`-JSON across
+   `Backend::open(source, json_data)` — never a markdown string. The canonical
+   serializer is ready; `pdfform` lowers via `RichText.text` minus island slots
+   (zero fixture churn — `sample_form` binds no content field).
+3. **Typst emit + source map.** Walk lines → markup (escaping as today),
+   recording per-line generated windows plus one `(corpus range ↔ generated
+   range)` pair per run. Spike-B carry: character precision = add `glyph.span.1`
+   (unused today at `span_scan.rs:197`) to the resolved node range, then invert
+   the run map (cluster-exact, invertible by recomputation).
+4. **Unify the `MarkdownFixer`.** It is **duplicated** in phase 1 (typst backend
+   copy + `richtext::import` copy) to stay additive. Phase 2 collapses the two.
+5. **`locate` / `position_at` + region re-key** on `(field, corpus range,
+   revision)`; the `regions()` run-machine rework for highlight boxes
+   (grounding §3.2) is Phase-2 work, out of scope for navigation.
+6. **Storage cutover** — new `StoredDocument` version; migration is a
+   deterministic cold import (legacy bodies hold no islands → mint-free).
+
+Already done here, so Phase 2 inherits it: **island `props` keys are recursively
+sorted before serialization** (Spike-C carry — otherwise `preserve_order` leaks
+insertion order into the content hash). The only remaining determinism boundary
+is island-id mint, which does not appear until Phase 4.
+
+**Residual Spike-A gate still stands** (Phase 3, not Phase 2): bind one live rich
+editor and confirm none forces an edge-expand / adjacent-merge semantic back into
+the model. Phase 1 froze only what the contract commits to — the mark set, the
+three rules, USV, `continues` — and delegates every disputed typing-time semantic
+to the editor, so the freeze is editor-independent by construction; the live
+binding is confirmation, not a reopening.
+
+## Verification
+
+- Unit tests per module (model normalization/invariants, serial fixed-point +
+  golden bytes, import/export round-trips, delta rebase/move).
+- Property suite (`tests/properties.rs`): corpus fixed point + invariants;
+  canonical determinism + order-insensitivity; anchor survival; USV boundary /
+  surrogate correctness. Generator spans special chars, hard breaks, nested
+  containers, astral chars.
+- Fixture corpus: `sample.md` and other resource bodies import to valid corpora
+  and are fixed points.

--- a/prose/plans/richtext/phase-1.md
+++ b/prose/plans/richtext/phase-1.md
@@ -136,6 +136,13 @@ priority order:
    (grounding §3.2) is Phase-2 work, out of scope for navigation.
 6. **Storage cutover** — new `StoredDocument` version; migration is a
    deterministic cold import (legacy bodies hold no islands → mint-free).
+7. **Block-quote emit decision.** RichText captures block quotes as
+   `Container::Quote`, but the current `mark_to_typst` has no `BlockQuote` arm —
+   it **flattens** quotes to plain paragraphs. So the superset is real: Phase-2
+   emit must *choose* to render quotes (a deliberate behavior change) or keep
+   flattening for bug-for-bug parity. Recommend rendering them, since the
+   structure is now first-class; land it as an explicit, tested decision, not a
+   silent consequence of consuming the corpus.
 
 Already done here, so Phase 2 inherits it: **island `props` keys are recursively
 sorted before serialization** (Spike-C carry — otherwise `preserve_order` leaks


### PR DESCRIPTION
Establish prose/plans/richtext as the integration point for the #831
richtext/corpus rework. Records the locked decisions (corpus model over
block tree; Option A — structured RichText-JSON across the data seam), the
technical takeaways from the seam analysis, and a rough phase map gated by a
Phase 0 spike round (editor binding, source-map inversion, seam+determinism).

Add a `plans/` tier to prose/README.md for multi-phase reworks in flight.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016Ggnw9tSV2qTKgYH7Gy8z1