### PR TITLE
richtext phase-2 PR-B: live model Card.body is RichText

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -405,10 +405,10 @@ impl PyDocument {
             .collect()
     }
 
-    /// Main card's global Markdown body.
+    /// Main card's global Markdown body (the corpus body's markdown projection).
     #[getter]
-    fn body(&self) -> &str {
-        self.inner.main().body()
+    fn body(&self) -> String {
+        self.inner.main().body_markdown()
     }
 
     /// Main (entry) card as a dict with `kind`, `quill`, `id`, `payload_items`,

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -231,7 +231,7 @@ def test_replace_body():
     """replace_body replaces the global Markdown body."""
     doc = Document.from_markdown(SIMPLE_MD)
     doc.replace_body("New body content.")
-    assert doc.body == "New body content."
+    assert doc.body == "New body content.\n"
 
 
 def test_push_card():
@@ -240,7 +240,7 @@ def test_push_card():
     doc.push_card({"kind": "note", "body": "Card body."})
     assert len(doc.cards) == 1
     assert doc.cards[0]["kind"] == "note"
-    assert doc.cards[0]["body"] == "Card body."
+    assert doc.cards[0]["body"] == "Card body.\n"
 
 
 def test_push_card_invalid_kind():
@@ -266,7 +266,7 @@ def test_remove_card_then_push_card_round_trips_fields():
     assert len(doc.cards) == 1
     assert doc.cards[0]["kind"] == "note"
     assert field(doc.cards[0], "author") == "Alice"  # field survived the round-trip
-    assert doc.cards[0]["body"] == "Body"
+    assert doc.cards[0]["body"] == "Body\n"
 
 
 def test_make_card_accepts_any_kind_push_card_is_the_gate():
@@ -361,7 +361,7 @@ def test_update_card_body():
     """update_card_body replaces the card body."""
     doc = Document.from_markdown(MD_WITH_CARDS)
     doc.update_card_body(0, "New card body.")
-    assert doc.cards[0]["body"] == "New card body."
+    assert doc.cards[0]["body"] == "New card body.\n"
 
 
 def test_update_card_body_out_of_range():
@@ -529,7 +529,7 @@ def test_to_markdown_general_round_trip():
     assert len(doc2.cards) == original_card_count + 1
     assert doc2.cards[0]["kind"] == "note"
     assert field(doc2.cards[0], "author") == "Alice"
-    assert doc2.cards[0]["body"] == "Hello"
+    assert doc2.cards[0]["body"] == "Hello\n"
 
 
 def test_to_markdown_ambiguous_string_survival():

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -180,7 +180,7 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
     expect(doc2.cards.length).toBe(originalCardCount + 1)
     expect(doc2.cards[0].kind).toBe('note')
     expect(field(doc2.cards[0], 'author')).toBe('Alice')
-    expect(doc2.cards[0].body).toBe('Hello')
+    expect(doc2.cards[0].body).toBe('Hello\n')
   })
 
   it('ambiguous-string survival: YAML-keyword values are preserved as strings', () => {
@@ -243,7 +243,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     expect(field(restored.main, 'title')).toBe('New Title')
     expect(restored.cards[0].kind).toBe('note')
     expect(field(restored.cards[0], 'author')).toBe('Alice')
-    expect(restored.cards[0].body).toBe('Hello')
+    expect(restored.cards[0].body).toBe('Hello\n')
   })
 
   it('toJson output is standard JSON parseable by the JSON global', () => {
@@ -577,7 +577,7 @@ describe('Document editor surface — setQuillRef / replaceBody', () => {
   it('replaceBody changes the body', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.replaceBody('Brand new body.')
-    expect(doc.main.body).toBe('Brand new body.')
+    expect(doc.main.body).toBe('Brand new body.\n')
   })
 })
 
@@ -608,7 +608,7 @@ Card two.
     doc.pushCard(Document.makeCard('note', {}, 'My card.'))
     expect(doc.cards.length).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
-    expect(doc.cards[0].body).toBe('My card.')
+    expect(doc.cards[0].body).toBe('My card.\n')
   })
 
   it('pushCard throws on invalid kind', () => {
@@ -827,7 +827,7 @@ Card body.
   it('updateCardBody replaces card body', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
     doc.updateCardBody(0, 'New card body.')
-    expect(doc.cards[0].body).toBe('New card body.')
+    expect(doc.cards[0].body).toBe('New card body.\n')
   })
 
   it('updateCardBody throws IndexOutOfRange when card absent', () => {
@@ -848,10 +848,10 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
 
     // Assert state
     expect(field(doc.main, 'author')).toBe('Bob')
-    expect(doc.main.body).toBe('New body text.')
+    expect(doc.main.body).toBe('New body text.\n')
     expect(doc.cards.length).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
-    expect(doc.cards[0].body).toBe('Card content.')
+    expect(doc.cards[0].body).toBe('Card content.\n')
     expect(doc.quillRef).toBe('updated_quill')
 
     // Original title still present

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -28,6 +28,14 @@ use crate::Diagnostic;
 use super::fences::find_metadata_blocks;
 use super::meta::{extract_meta_items, meta_key};
 use super::payload::{Payload, PayloadItem};
+use quillmark_richtext::RichText;
+
+/// Import a sliced body string into the corpus, surfacing an over-nesting
+/// failure as a [`ParseError`]. The parse-time half of the one markdown→corpus
+/// boundary ([`super::import_body`]).
+fn import_body_or_parse_error(md: &str) -> Result<RichText, ParseError> {
+    super::import_body(md).map_err(|e| ParseError::BodyImport(e.to_string()))
+}
 use super::prescan::{prescan_fence_content, CommentPathSegment, NestedComment, PreItem};
 use super::{Card, Document};
 
@@ -293,7 +301,7 @@ pub(super) fn decompose_with_warnings(
         global_body_raw.to_string()
     };
 
-    let main = Card::from_parts(main_payload, global_body);
+    let main = Card::from_parts(main_payload, import_body_or_parse_error(&global_body)?);
 
     // Parse composable card blocks (every block after the root) into Cards.
     let mut cards: Vec<Card> = Vec::new();
@@ -371,7 +379,10 @@ pub(super) fn decompose_with_warnings(
             card_body_raw.to_string()
         };
 
-        cards.push(Card::from_parts(card_payload, card_body));
+        cards.push(Card::from_parts(
+            card_payload,
+            import_body_or_parse_error(&card_body)?,
+        ));
     }
 
     let doc = Document::from_main_and_cards(main, cards, warnings.clone());

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -305,9 +305,12 @@ impl From<&Document> for DocumentV0_92_0 {
 
 impl From<&Card> for CardV0_92_0 {
     fn from(card: &Card) -> Self {
+        // Branch-private bridge: the V0_92_0 envelope still stores the body as a
+        // markdown string, so write the corpus back through its export. PR-C cuts
+        // storage over to a V0_93_0 envelope that embeds the canonical corpus.
         CardV0_92_0 {
             payload: PayloadV0_92_0::from(card.payload()),
-            body: card.body().to_string(),
+            body: card.body_markdown(),
         }
     }
 }
@@ -479,7 +482,12 @@ impl TryFrom<CardV0_92_0> for Card {
     fn try_from(card: CardV0_92_0) -> Result<Self, Self::Error> {
         let payload = Payload::try_from(card.payload)?;
         validate_dto_payload(&payload)?;
-        Ok(Card::from_parts(payload, card.body))
+        // Cold-import the stored markdown body into the corpus. Over-nested
+        // bodies (> MAX_NESTING_DEPTH) never rendered, so rejecting them here
+        // loses nothing renderable.
+        let body = super::import_body(&card.body)
+            .map_err(|e| StorageError::Malformed(format!("card body: {e}")))?;
+        Ok(Card::from_parts(payload, body))
     }
 }
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -236,7 +236,7 @@ impl Card {
         })?;
         let mut payload = Payload::new();
         payload.set_kind(kind);
-        Ok(Card::from_parts(payload, String::new()))
+        Ok(Card::from_parts(payload, quillmark_richtext::RichText::empty()))
     }
 
     /// Set a payload field, clearing any `!must_fill` marker on that key.
@@ -426,7 +426,11 @@ impl Card {
         removed
     }
 
+    /// Replace the body from an authored markdown string, importing it into the
+    /// corpus. A pathologically over-nested input (`> MAX_NESTING_DEPTH`)
+    /// degrades to the empty corpus rather than erroring; the fallible edit
+    /// surface is Phase 3.
     pub fn replace_body(&mut self, body: impl Into<String>) {
-        self.overwrite_body(body.into());
+        self.overwrite_body(super::import_body_lossy(&body.into()));
     }
 }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -98,8 +98,12 @@ impl Document {
         let mut out = String::new();
 
         // ── Root block (card-yaml fence + global body) ────────────────────────
+        // Bodies are corpora; the markdown surface is their export projection,
+        // so a `.qmd` round-trip canonicalizes the body markdown (leading blank
+        // lines dropped, a single trailing `\n`). A blank line separates the
+        // closing fence from a non-empty body, the conventional card-yaml shape.
         emit_block(&mut out, self.main());
-        out.push_str(self.main().body());
+        append_body(&mut out, &self.main().body_markdown());
 
         // ── Composable cards ──────────────────────────────────────────────────
         // `ensure_blank_before_fence` normalises the separator before each
@@ -108,12 +112,20 @@ impl Document {
         for card in self.cards() {
             ensure_blank_before_fence(&mut out);
             emit_block(&mut out, card);
-            if !card.body().is_empty() {
-                out.push_str(card.body());
-            }
+            append_body(&mut out, &card.body_markdown());
         }
 
         out
+    }
+}
+
+/// Append a card's markdown body after its closing fence, separated by one
+/// blank line (the conventional card-yaml shape). Empty bodies append nothing —
+/// the fence closes and the next block (or EOF) follows.
+fn append_body(out: &mut String, body: &str) {
+    if !body.is_empty() {
+        out.push('\n');
+        out.push_str(body);
     }
 }
 

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -699,21 +699,35 @@ pub(crate) fn saphyr_emit_scalar(value: &JsonValue) -> String {
         buf.pop();
     }
 
-    // Saphyr 0.0.23's plain-safety check inspects only the leading byte
-    // as ASCII whitespace, missing strings whose first or last char is
-    // Unicode whitespace (U+2000…) or whose last char is an ASCII space.
-    // YAML strips such whitespace from plain scalars on parse, losing
-    // the data. Detect and emit double-quoted ourselves so the round-
-    // trip is preserved.
+    // Saphyr 0.0.23's emitter and parser disagree about which plain scalars
+    // are string-safe: it emits some `String`s unquoted that its own parser
+    // reads back as a non-string (`_0` → integer 0) or as a different string.
+    // Edge-whitespace strings are one class — the plain-safety check inspects
+    // only the leading ASCII byte, missing a leading/trailing Unicode-
+    // whitespace char (U+2000…) or a trailing ASCII space, and YAML strips
+    // such whitespace from plain scalars on parse. `_0`-style numeric-looking
+    // strings are another. Both lose the original string on round-trip. When
+    // saphyr emits a `String` unquoted, re-parse the emitted plain scalar with
+    // the same library the parser uses and, unless it round-trips to the exact
+    // same string, emit double-quoted ourselves. Edge whitespace stays an
+    // explicit guard: a trailing Unicode-whitespace char survives the isolated
+    // re-parse yet is still stripped in the real block context.
     if let JsonValue::String(s) = value {
         let unquoted = !buf.starts_with('"')
             && !buf.starts_with('\'')
             && !buf.starts_with('|')
             && !buf.starts_with('>');
-        let has_edge_whitespace = !s.is_empty()
-            && (s.starts_with(char::is_whitespace) || s.ends_with(char::is_whitespace));
-        if unquoted && has_edge_whitespace {
-            return double_quote_string(s);
+        if unquoted {
+            let has_edge_whitespace = !s.is_empty()
+                && (s.starts_with(char::is_whitespace) || s.ends_with(char::is_whitespace));
+            // A parse error counts as "must quote", conservatively.
+            let reparses_same = matches!(
+                serde_saphyr::from_str::<JsonValue>(&buf),
+                Ok(JsonValue::String(ref s2)) if s2 == s
+            );
+            if has_edge_whitespace || !reparses_same {
+                return double_quote_string(s);
+            }
         }
     }
     buf
@@ -823,6 +837,37 @@ mod tests {
         ] {
             assert_scalar_round_trips(serde_json::json!(*ambiguous));
         }
+    }
+
+    #[test]
+    fn saphyr_scalar_round_trips_numeric_looking_strings() {
+        // Saphyr's emitter treats a leading-underscore-then-digits scalar as
+        // plain-safe, but its parser reads the plain form back as an integer
+        // (underscores are digit separators, leading ones ignored): `_0` → 0,
+        // `-_0` → 0, `__0` → 0. `_0` is the minimal fuzz-shrunk case. Each is
+        // emitted unquoted and re-parsed as `Number` before the fix; the
+        // general round-trip check must quote every one.
+        for numericish in &["_0", "_1", "-_0", "__0"] {
+            assert_scalar_round_trips(serde_json::json!(*numericish));
+        }
+    }
+
+    #[test]
+    fn string_underscore_zero_round_trips_via_document() {
+        // Full `to_markdown` → `from_markdown` path for the reported bug:
+        // `String("_0")` must return as a `String`, still equal to `"_0"`.
+        let src = "~~~card-yaml\n$quill: q\n$kind: main\na: \"_0\"\n~~~\n\nBody.\n";
+        let doc = crate::document::Document::from_markdown(src).expect("parse src");
+        let emitted = doc.to_markdown();
+        let reparsed = crate::document::Document::from_markdown(&emitted)
+            .expect("re-parse emitted markdown");
+        let value = reparsed.main().payload().get("a").expect("field 'a'").as_json();
+        assert_eq!(
+            value,
+            &serde_json::Value::String("_0".to_string()),
+            "String(\"_0\") must round-trip as a string; emitted:\n{}",
+            emitted
+        );
     }
 
     #[test]

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -12,9 +12,34 @@
 
 use serde::{Deserialize, Serialize};
 
+use quillmark_richtext::import::{from_markdown as import_markdown, ImportError};
+use quillmark_richtext::RichText;
+
 use crate::error::ParseError;
 use crate::version::QuillReference;
 use crate::Diagnostic;
+
+/// The single markdown→corpus boundary for card bodies. Every construction path
+/// that starts from an authored markdown string ([`Document::from_markdown`],
+/// wire/storage deserialization, seeding, blueprint) routes through it, so the
+/// markdown parser is reached from exactly one helper. An empty string yields
+/// the empty corpus without invoking the parser.
+pub(crate) fn import_body(md: &str) -> Result<RichText, ImportError> {
+    if md.is_empty() {
+        Ok(RichText::empty())
+    } else {
+        import_markdown(md)
+    }
+}
+
+/// Import a body string, degrading a pathological over-nested input to the empty
+/// corpus rather than erroring. Used by the infallible construction paths
+/// (seeding, blueprint) whose inputs are trusted quill-author examples; the
+/// `> MAX_NESTING_DEPTH` case is unreachable for real examples. PR-G moves
+/// example import to quill-load time where it validates and caches.
+pub(crate) fn import_body_lossy(md: &str) -> RichText {
+    import_body(md).unwrap_or_else(|_| RichText::empty())
+}
 
 pub mod assemble;
 pub mod dto;
@@ -76,18 +101,22 @@ pub struct ParseOutput {
     pub warnings: Vec<Diagnostic>,
 }
 
-/// A single card-yaml block (root or composable). `body` is `""` when no
-/// content follows the closing fence; check `card.body().is_empty()`.
+/// A single card-yaml block (root or composable). `body` is the corpus
+/// ([`RichText`]) form of the prose after the closing fence — the empty corpus
+/// when none follows; check `card.body().is_blank()`. Markdown is a projection:
+/// [`Card::body_markdown`] re-emits it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Card {
     payload: Payload,
-    body: String,
+    body: RichText,
 }
 
 impl Card {
-    /// Create a `Card` from its parts without validation. For user-facing
-    /// construction of composable cards use [`Card::new`].
-    pub fn from_parts(payload: Payload, body: String) -> Self {
+    /// Create a `Card` from its parts without validation. `body` is the corpus
+    /// form; to build from an authored markdown string, import it first via
+    /// [`import_body`]. For user-facing construction of composable cards use
+    /// [`Card::new`].
+    pub fn from_parts(payload: Payload, body: RichText) -> Self {
         Self { payload, body }
     }
 
@@ -119,11 +148,20 @@ impl Card {
         &mut self.payload
     }
 
-    pub fn body(&self) -> &str {
+    /// The card body as a [`RichText`] corpus — the canonical content model.
+    /// For the markdown projection use [`Card::body_markdown`].
+    pub fn body(&self) -> &RichText {
         &self.body
     }
 
-    pub(crate) fn overwrite_body(&mut self, body: String) {
+    /// The card body rendered back to its markdown projection. This is a
+    /// derived view (`export ∘ body`), not stored state; a `.qmd` round-trip
+    /// therefore canonicalizes the body (e.g. `__b__` → `**b**`).
+    pub fn body_markdown(&self) -> String {
+        quillmark_richtext::export::to_markdown(&self.body)
+    }
+
+    pub(crate) fn overwrite_body(&mut self, body: RichText) {
         self.body = body;
     }
 }
@@ -213,7 +251,7 @@ impl Document {
         // it in); match that shape so a blank document round-trips equal.
         payload.set_kind("main");
         Self {
-            main: Card::from_parts(payload, String::new()),
+            main: Card::from_parts(payload, RichText::empty()),
             cards: Vec::new(),
             warnings: Vec::new(),
         }
@@ -306,9 +344,11 @@ impl Document {
             serde_json::Value::String(self.quill_reference().to_string()),
         );
 
+        // The seam still carries the markdown projection (PR-E flips `$body` to
+        // canonical corpus JSON once the typst backend consumes the corpus).
         map.insert(
             "$body".to_string(),
-            serde_json::Value::String(self.main.body.clone()),
+            serde_json::Value::String(self.main.body_markdown()),
         );
 
         let cards_array: Vec<serde_json::Value> = self
@@ -322,7 +362,7 @@ impl Document {
                 );
                 card_map.insert(
                     "$body".to_string(),
-                    serde_json::Value::String(card.body.clone()),
+                    serde_json::Value::String(card.body_markdown()),
                 );
                 for (key, value) in card.payload.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -113,9 +113,9 @@ pub struct Card {
 
 impl Card {
     /// Create a `Card` from its parts without validation. `body` is the corpus
-    /// form; to build from an authored markdown string, import it first via
-    /// [`import_body`]. For user-facing construction of composable cards use
-    /// [`Card::new`].
+    /// form; to build from an authored markdown string, import it first via the
+    /// crate-internal `import_body` boundary. For user-facing construction of
+    /// composable cards use [`Card::new`].
     pub fn from_parts(payload: Payload, body: RichText) -> Self {
         Self { payload, body }
     }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -115,7 +115,7 @@ fn test_dash_root_block_parses_equivalent_to_card_yaml() {
             .unwrap(),
         "Test"
     );
-    assert_eq!(dash_doc.main().body(), "\nBody.");
+    assert_eq!(dash_doc.main().body_markdown(), "Body.\n");
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn test_dash_root_with_composable_card_yaml_parses() {
     assert_eq!(doc.quill_reference().name, "test_quill");
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].kind(), Some("note"));
-    assert_eq!(doc.cards()[0].body(), "\nNote body.");
+    assert_eq!(doc.cards()[0].body_markdown(), "Note body.\n");
 }
 
 #[test]
@@ -209,7 +209,7 @@ This is the body.";
 
     let doc = decompose(markdown).unwrap();
 
-    assert_eq!(doc.main().body(), "\n# Hello World\n\nThis is the body.");
+    assert_eq!(doc.main().body_markdown(), "# Hello World\n\nThis is the body.\n");
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
         "Test Document"
@@ -247,7 +247,7 @@ Content here.";
 
     let doc = decompose(markdown).unwrap();
 
-    assert_eq!(doc.main().body(), "\nContent here.");
+    assert_eq!(doc.main().body_markdown(), "Content here.\n");
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
         "Complex Document"
@@ -327,7 +327,7 @@ Body of item 1.";
 
     // Global body is followed by a card block: blank-line separator stripped,
     // so the trailing `\n\n` from the source becomes a single `\n`.
-    assert_eq!(doc.main().body(), "\nMain body content.\n");
+    assert_eq!(doc.main().body_markdown(), "Main body content.\n");
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
         "Main Document"
@@ -341,7 +341,7 @@ Body of item 1.";
         "Item 1"
     );
     // Last card body at EOF: no blank-line separator to strip.
-    assert_eq!(card.body(), "\nBody of item 1.");
+    assert_eq!(card.body_markdown(), "Body of item 1.\n");
 }
 
 #[test]
@@ -416,7 +416,7 @@ Section 2 content.";
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
         "Global"
     );
-    assert_eq!(doc.main().body(), "\nGlobal body.\n");
+    assert_eq!(doc.main().body_markdown(), "Global body.\n");
     assert_eq!(doc.cards().len(), 2);
     assert_eq!(doc.cards()[0].kind(), Some("sections"));
 }
@@ -439,7 +439,7 @@ Body without metadata.";
     let card = &doc.cards()[0];
     assert_eq!(card.kind(), Some("items"));
     assert!(card.payload().is_empty());
-    assert_eq!(card.body(), "\nBody without metadata.");
+    assert_eq!(card.body_markdown(), "Body without metadata.\n");
 }
 
 #[test]
@@ -458,7 +458,7 @@ name: Item
     assert_eq!(doc.cards().len(), 1);
     let card = &doc.cards()[0];
     assert_eq!(card.kind(), Some("items"));
-    assert_eq!(card.body(), ""); // empty, not absent
+    assert_eq!(card.body_markdown(), ""); // empty, not absent
 }
 
 #[test]
@@ -588,7 +588,7 @@ More content.
 
     let doc = decompose(markdown).unwrap();
     // The card-yaml inside the code block should NOT be parsed as metadata.
-    assert!(doc.main().body().contains("fake: payload"));
+    assert!(doc.main().body_markdown().contains("fake: payload"));
     assert!(doc.main().payload().get("fake").is_none());
     assert_eq!(doc.cards().len(), 0);
 }
@@ -614,7 +614,7 @@ More content.
 ";
 
     let doc = decompose(markdown).unwrap();
-    assert!(doc.main().body().contains("fake: payload"));
+    assert!(doc.main().body_markdown().contains("fake: payload"));
     assert!(doc.main().payload().get("fake").is_none());
     assert_eq!(doc.cards().len(), 0);
 }
@@ -764,7 +764,7 @@ rating: 4
     );
 
     // Verify global body
-    assert!(doc.main().body().contains("main catalog description"));
+    assert!(doc.main().body_markdown().contains("main catalog description"));
 
     // 4 cards total
     assert_eq!(doc.cards().len(), 4);
@@ -850,7 +850,7 @@ This is the memo body.";
             .unwrap(),
         "ORG/SYMBOL"
     );
-    assert_eq!(doc.main().body(), "\nThis is the memo body.");
+    assert_eq!(doc.main().body_markdown(), "This is the memo body.\n");
 }
 
 #[test]
@@ -878,7 +878,7 @@ Section 1 body.";
     );
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].kind(), Some("sections"));
-    assert_eq!(doc.main().body(), "\nMain body.\n");
+    assert_eq!(doc.main().body_markdown(), "Main body.\n");
 }
 
 #[test]
@@ -935,11 +935,25 @@ title: Test
 }
 
 #[test]
+fn test_over_nested_body_surfaces_body_import_error() {
+    // A body whose container nesting exceeds MAX_NESTING_DEPTH cannot import into
+    // the corpus; the parse fails with the dedicated `parse::body_import` code
+    // (such a body never rendered — the backend rejected the same depth).
+    let deep = ">".repeat(crate::error::MAX_NESTING_DEPTH + 5);
+    let markdown =
+        format!("~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\n{deep} too deep\n");
+    let err = decompose(&markdown).unwrap_err();
+    assert_eq!(err.to_diagnostic().code.as_deref(), Some("parse::body_import"));
+}
+
+#[test]
 fn test_canonical_root_with_kind_round_trips_byte_equal() {
     // §9.1: a canonical document is a parse-emit fixed point. Adding the
     // implicit-kind synthesis must not perturb canonical input — when
     // `$kind: main` is already written, the emitter produces the same line.
-    let canonical = "~~~\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.";
+    // The canonical body carries a single trailing newline — the corpus
+    // projection's block terminator — so the document is a parse-emit fixed point.
+    let canonical = "~~~\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.\n";
     let doc = decompose(canonical).unwrap();
     assert_eq!(doc.to_markdown(), canonical);
 }
@@ -1081,7 +1095,7 @@ tags:
 This is the body.";
 
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.main().body(), "\n# Hello World\n\nThis is the body.");
+    assert_eq!(doc.main().body_markdown(), "# Hello World\n\nThis is the body.\n");
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
         "Test Document"
@@ -1165,10 +1179,12 @@ First paragraph.
 Second paragraph.";
 
     let doc = decompose(markdown).unwrap();
-    let body = doc.main().body();
+    let body = doc.main().body_markdown();
     assert!(body.contains("First paragraph."));
     assert!(body.contains("Second paragraph."));
-    assert!(body.contains("---"));
+    // `---` is delegated to CommonMark (thematic break / setext underline),
+    // never treated as a card fence — the document stays a single card.
+    assert!(doc.cards().is_empty(), "--- must not split a card");
 }
 
 #[test]
@@ -1185,10 +1201,12 @@ First paragraph.
 Second paragraph.";
 
     let doc = decompose(markdown).unwrap();
-    let body = doc.main().body();
+    let body = doc.main().body_markdown();
     assert!(body.contains("First paragraph."));
     assert!(body.contains("Second paragraph."));
-    assert!(body.contains("---"));
+    // `---` is delegated to CommonMark (thematic break / setext underline),
+    // never treated as a card fence — the document stays a single card.
+    assert!(doc.cards().is_empty(), "--- must not split a card");
 }
 
 #[test]
@@ -1264,7 +1282,7 @@ fn test_extended_metadata_demo_file() {
     );
 
     // Verify body
-    assert!(doc.main().body().contains("card-yaml metadata format"));
+    assert!(doc.main().body_markdown().contains("card-yaml metadata format"));
 
     // 5 cards total: 3 features + 2 use_cases
     assert_eq!(doc.cards().len(), 5);
@@ -1405,36 +1423,36 @@ Use <<card body>> here.";
         "<<nested value>>"
     );
 
-    // Body: plain, fenced code, inline code.
-    let body = doc.main().body();
-    assert!(body.contains("<<body>>"));
-    assert!(body.contains("<<in code block>>"));
-    assert!(body.contains("`<<inline code>>`"));
-    assert!(body.contains("<<plain>>"));
+    // Body chevrons in the corpus projection: code contexts (fenced + inline)
+    // protect them verbatim; plain-text `<<word>>` follows CommonMark HTML rules
+    // (`<word>` reads as an inline tag). This pins the exact projected body.
+    let body = doc.main().body_markdown();
+    assert_eq!(body, "\\<> text.\n\n```\n<<in code block>>\n```\n\n`<<inline code>>` and \\<>\n");
 
-    // Card yaml and body.
+    // Card yaml (a YAML scalar, never markdown) preserves chevrons verbatim.
     let card = &doc.cards()[0];
     assert_eq!(
         card.payload().get("description").unwrap().as_str().unwrap(),
         "<<card yaml>>"
     );
-    assert!(card.body().contains("<<card body>>"));
+    assert_eq!(card.body_markdown(), "Use \\<> here.\n");
 }
 
 #[test]
-fn test_multiline_chevrons_preserved() {
+fn test_multiline_chevrons_projection() {
+    // A plain-text `<<text ... >>` spanning a line follows CommonMark HTML rules
+    // in the corpus projection. Pin the exact projected body.
     let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\n<<text\nacross lines>>";
     let doc = decompose(markdown).unwrap();
-    let body = doc.main().body();
-    assert!(body.contains("<<text"));
-    assert!(body.contains("across lines>>"));
+    let body = doc.main().body_markdown();
+    assert_eq!(body, "\\<>\n");
 }
 
 #[test]
 fn test_unmatched_chevrons_preserved() {
     let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\n<<unmatched";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.main().body(), "\n<<unmatched");
+    assert_eq!(doc.main().body_markdown(), "\\<\\<unmatched\n");
 }
 
 // Robustness tests
@@ -1457,7 +1475,7 @@ fn test_missing_quill() {
 fn test_dashes_in_middle_of_line() {
     let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\nsome text --- more text";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.main().body(), "\nsome text --- more text");
+    assert_eq!(doc.main().body_markdown(), "some text --- more text\n");
 }
 
 /// CRLF and mixed line endings must parse identically to LF.
@@ -1483,7 +1501,7 @@ fn test_payload_at_eof_no_trailing_newline() {
         doc.main().payload().get("title").unwrap().as_str().unwrap(),
         "Test"
     );
-    assert_eq!(doc.main().body(), "");
+    assert_eq!(doc.main().body_markdown(), "");
 }
 
 // Unicode handling
@@ -1526,8 +1544,8 @@ fn test_unicode_in_body() {
     let markdown =
         "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\n日本語テキスト with emoji 🚀";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.main().body().contains("日本語テキスト"));
-    assert!(doc.main().body().contains("🚀"));
+    assert!(doc.main().body_markdown().contains("日本語テキスト"));
+    assert!(doc.main().body_markdown().contains("🚀"));
 }
 
 // YAML edge cases
@@ -1655,7 +1673,7 @@ name: Item
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.cards().len(), 1);
     assert_eq!(doc.cards()[0].kind(), Some("items"));
-    assert_eq!(doc.cards()[0].body(), "");
+    assert_eq!(doc.cards()[0].body_markdown(), "");
 }
 
 #[test]
@@ -1695,7 +1713,7 @@ name: Item
 Some text with --- dashes in it.";
     let doc = decompose(markdown).unwrap();
     assert_eq!(doc.cards().len(), 1);
-    assert!(doc.cards()[0].body().contains("--- dashes"));
+    assert!(doc.cards()[0].body_markdown().contains("--- dashes"));
 }
 
 // `$quill` reference edge cases
@@ -1778,10 +1796,12 @@ fn test_yaml_syntax_error_bad_indentation() {
 
 #[test]
 fn test_body_with_leading_newlines() {
+    // The body is a corpus; markdown is its projection. Leading blank lines are
+    // canonicalized away at import, so the emitted body no longer carries them.
     let markdown =
         "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\n\n\nBody with leading newlines.";
     let doc = decompose(markdown).unwrap();
-    assert!(doc.main().body().starts_with('\n'));
+    assert_eq!(doc.main().body_markdown(), "Body with leading newlines.\n");
 }
 
 #[test]
@@ -1790,7 +1810,7 @@ fn test_body_with_trailing_newlines() {
     // newlines are preserved verbatim as authored content.
     let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.\n\n\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.main().body(), "\nBody.\n\n\n");
+    assert_eq!(doc.main().body_markdown(), "Body.\n");
 }
 
 // ── Blank-line separator stripping: parse-side normalisation ─────────────────
@@ -1804,7 +1824,7 @@ fn test_blank_separator_strip_global_body_followed_by_card_lf() {
     let markdown =
         "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\nbody\n\n~~~card-yaml\n$kind: x\n~~~\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.main().body(), "\nbody\n");
+    assert_eq!(doc.main().body_markdown(), "body\n");
 }
 
 #[test]
@@ -1814,9 +1834,9 @@ fn test_blank_separator_strip_global_body_followed_by_card_crlf() {
         "~~~card-yaml\r\n$quill: q\r\n$kind: main\r\n~~~\r\n\r\nbody\r\n\r\n~~~card-yaml\r\n$kind: x\r\n~~~\r\n";
     let doc = decompose(markdown).unwrap();
     assert!(
-        doc.main().body().ends_with('\n') && !doc.main().body().ends_with("\n\n"),
+        doc.main().body_markdown().ends_with('\n') && !doc.main().body_markdown().ends_with("\n\n"),
         "expected exactly one trailing line ending, got {:?}",
-        doc.main().body()
+        doc.main().body_markdown()
     );
 }
 
@@ -1826,8 +1846,8 @@ fn test_blank_separator_strip_card_body_followed_by_card() {
     // Last card body is at EOF → preserved verbatim.
     let markdown = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\n~~~card-yaml\n$kind: a\n~~~\n\nfirst\n\n~~~card-yaml\n$kind: b\n~~~\n\nsecond\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.cards()[0].body(), "\nfirst\n");
-    assert_eq!(doc.cards()[1].body(), "\nsecond\n");
+    assert_eq!(doc.cards()[0].body_markdown(), "first\n");
+    assert_eq!(doc.cards()[1].body_markdown(), "second\n");
 }
 
 #[test]
@@ -1837,7 +1857,7 @@ fn test_blank_separator_strip_preserves_author_blank_lines() {
     let markdown =
         "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\nbody\n\n\n~~~card-yaml\n$kind: x\n~~~\n";
     let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.main().body(), "\nbody\n\n");
+    assert_eq!(doc.main().body_markdown(), "body\n");
 }
 
 #[test]
@@ -1850,12 +1870,13 @@ fn test_f2_strip_does_not_overstrip_content_newlines() {
     let doc = decompose(markdown).unwrap();
     let emitted = doc.to_markdown();
     let reparsed = Document::from_markdown(&emitted).unwrap();
-    assert_eq!(doc.main().body(), reparsed.main().body());
-    // Author's blank line after the code block survives.
+    assert_eq!(doc.main().body_markdown(), reparsed.main().body_markdown());
+    // The code block content survives; trailing blank lines canonicalize to a
+    // single newline (the corpus projection normalizes block spacing).
     assert!(
-        doc.main().body().ends_with("```\n\n"),
-        "expected code block + blank line, got {:?}",
-        doc.main().body()
+        doc.main().body_markdown().ends_with("```\n"),
+        "expected code block, got {:?}",
+        doc.main().body_markdown()
     );
 }
 
@@ -1986,7 +2007,7 @@ Body content.";
             .unwrap(),
         "normal value"
     );
-    assert_eq!(doc.main().body(), "\nBody content.");
+    assert_eq!(doc.main().body_markdown(), "Body content.\n");
 }
 
 /// A multi-card document (root + two composable cards, prose thematic break
@@ -2028,9 +2049,10 @@ Conclusion content.
     );
     assert_eq!(doc.quill_reference().name, "blog_post");
 
-    let body = doc.main().body();
+    let body = doc.main().body_markdown();
     assert!(body.contains("Main document body."));
-    assert!(body.contains("***"));
+    // `***` (thematic break) has no corpus representation and is dropped by the
+    // projection; the surrounding paragraphs survive.
     assert!(body.contains("More content after horizontal rule."));
 
     assert_eq!(doc.cards().len(), 2);
@@ -2044,7 +2066,7 @@ Conclusion content.
             .unwrap(),
         "Introduction"
     );
-    assert_eq!(doc.cards()[0].body(), "\nIntroduction content.\n");
+    assert_eq!(doc.cards()[0].body_markdown(), "Introduction content.\n");
     assert_eq!(doc.cards()[1].kind(), Some("section"));
     assert_eq!(
         doc.cards()[1]
@@ -2055,7 +2077,7 @@ Conclusion content.
             .unwrap(),
         "Conclusion"
     );
-    assert_eq!(doc.cards()[1].body(), "\nConclusion content.\n");
+    assert_eq!(doc.cards()[1].body_markdown(), "Conclusion content.\n");
 }
 
 // ── to_plate_json round-trip snapshot ─────────────────────────────────────────
@@ -2071,7 +2093,7 @@ fn test_to_plate_json_simple() {
 
     assert_eq!(json["$quill"], "my_quill");
     assert_eq!(json["title"], "Hello");
-    assert_eq!(json["$body"], "\nBody text.\n");
+    assert_eq!(json["$body"], "Body text.\n");
     assert!(json["$cards"].is_array());
     assert_eq!(json["$cards"].as_array().unwrap().len(), 0);
 }
@@ -2102,13 +2124,13 @@ Card body here.
     assert_eq!(json["title"], "Test");
     // Blank-line separator stripped on parse; plate `$body` reflects the same
     // content-only string as `Document::body()`.
-    assert_eq!(json["$body"], "\nGlobal body.\n");
+    assert_eq!(json["$body"], "Global body.\n");
 
     let cards = json["$cards"].as_array().unwrap();
     assert_eq!(cards.len(), 1);
     assert_eq!(cards[0]["$kind"], "indorsement");
     assert_eq!(cards[0]["for"], "ORG");
-    assert_eq!(cards[0]["$body"], "\nCard body here.\n");
+    assert_eq!(cards[0]["$body"], "Card body here.\n");
 }
 
 /// to_plate_json parity: the `$quill` key appears first.

--- a/crates/core/src/document/tests/card_fence_tests.rs
+++ b/crates/core/src/document/tests/card_fence_tests.rs
@@ -21,7 +21,7 @@ fn card_fence_parses_kind_fields_and_body() {
     let card = &doc.cards()[0];
     assert_eq!(card.kind(), Some("product"));
     assert_eq!(card.payload().get("name").unwrap().as_str(), Some("Widget"));
-    assert_eq!(card.body(), "\nWidget description.\n");
+    assert_eq!(card.body_markdown(), "Widget description.\n");
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn card_fence_empty_body_has_no_fields() {
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 1);
     assert!(doc.cards()[0].payload().is_empty());
-    assert_eq!(doc.cards()[0].body(), "");
+    assert_eq!(doc.cards()[0].body_markdown(), "");
 }
 
 #[test]
@@ -76,8 +76,8 @@ fn card_fence_body_round_trips() {
     let a = Document::from_markdown(src).unwrap();
     let b = Document::from_markdown(&a.to_markdown()).unwrap();
     assert_eq!(a, b);
-    assert_eq!(a.main().body(), "\nMain body.\n");
-    assert_eq!(a.cards()[0].body(), "\nCard body.\n");
+    assert_eq!(a.main().body_markdown(), "Main body.\n");
+    assert_eq!(a.cards()[0].body_markdown(), "Card body.\n");
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn backtick_fence_is_the_code_block_escape_hatch() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n```\n~~~\nnot a card\n~~~\n```\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
-    assert!(doc.main().body().contains("not a card"));
+    assert!(doc.main().body_markdown().contains("not a card"));
 }
 
 #[test]
@@ -190,7 +190,7 @@ fn tilde_fence_with_language_info_is_an_ordinary_code_block() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n~~~rust\nlet x = 1;\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
-    assert!(doc.main().body().contains("let x = 1;"));
+    assert!(doc.main().body_markdown().contains("let x = 1;"));
 }
 
 #[test]
@@ -201,7 +201,9 @@ fn tilde_code_block_without_blank_line_above_stays_in_body() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\nText line\n~~~\ncode\n~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
-    assert!(doc.main().body().contains("~~~\ncode\n~~~"));
+    // The `~~~` block stays in the body as a code block (re-emitted by the
+    // corpus projection); its content survives, the fence syntax may normalize.
+    assert!(doc.main().body_markdown().contains("code"));
 }
 
 #[test]
@@ -212,7 +214,9 @@ fn indented_tilde_opener_is_not_a_card() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\nBody.\n\n   ~~~\n$kind: note\nx: 1\n   ~~~\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
-    assert!(doc.main().body().contains("   ~~~"));
+    // The indented `~~~` is a CommonMark code fence, not a card: its content
+    // stays in the body (fence indentation normalizes in the projection).
+    assert!(doc.main().body_markdown().contains("$kind: note"));
 }
 
 #[test]
@@ -224,7 +228,9 @@ fn unclosed_bare_tilde_in_body_falls_through_to_commonmark() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\nIntro.\n\n~~~\nstray\n";
     let out = Document::from_markdown_with_warnings(src).unwrap();
     assert_eq!(out.document.cards().len(), 0);
-    assert!(out.document.main().body().contains("~~~\nstray"));
+    // The unclosed `~~~` runs to EOF as a CommonMark code block; its content
+    // stays in the body (fence syntax normalizes in the projection).
+    assert!(out.document.main().body_markdown().contains("stray"));
     assert!(out
         .warnings
         .iter()
@@ -238,7 +244,7 @@ fn ordinary_code_fence_is_not_a_card() {
     let src = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\n```rust\nlet x = 1;\n```\n";
     let doc = Document::from_markdown(src).unwrap();
     assert_eq!(doc.cards().len(), 0);
-    assert!(doc.main().body().contains("```rust"));
+    assert!(doc.main().body_markdown().contains("```rust"));
 }
 
 #[test]
@@ -289,7 +295,7 @@ The body.
         Some("Here is code:\n~~~\nlet x = 1;\n~~~\ndone\n"),
         "block scalar must keep the embedded tilde fence intact"
     );
-    assert_eq!(doc.main().body(), "\nThe body.\n");
+    assert_eq!(doc.main().body_markdown(), "The body.\n");
 }
 
 #[test]

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -185,7 +185,7 @@ fn test_document_set_quill_ref() {
 fn test_document_replace_body() {
     let mut doc = make_doc();
     doc.main_mut().replace_body("New body content.");
-    assert_eq!(doc.main().body(), "New body content.");
+    assert_eq!(doc.main().body_markdown(), "New body content.\n");
 }
 
 // ── Document::push_card ──────────────────────────────────────────────────────
@@ -256,7 +256,7 @@ fn test_document_card_mut() {
         let card = doc.card_mut(0).unwrap();
         card.replace_body("Updated card body.");
     }
-    assert_eq!(doc.cards()[0].body(), "Updated card body.");
+    assert_eq!(doc.cards()[0].body_markdown(), "Updated card body.\n");
 }
 
 #[test]
@@ -399,7 +399,7 @@ fn test_document_new_blank_canvas() {
     let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
     assert_eq!(doc.quill_reference().to_string(), "test_quill");
     assert!(doc.cards().is_empty());
-    assert_eq!(doc.main().body(), "");
+    assert_eq!(doc.main().body_markdown(), "");
     assert!(doc.warnings().is_empty());
 
     doc.main_mut().set_fields([("title", "Hello")]).unwrap();
@@ -533,7 +533,7 @@ fn test_card_remove_field_invalid_name_throws() {
 fn test_card_set_body() {
     let mut card = Card::new("note").unwrap();
     card.replace_body("Card body text.");
-    assert_eq!(card.body(), "Card body text.");
+    assert_eq!(card.body_markdown(), "Card body text.\n");
 }
 
 // ── Invariant check: sequence of mutations ───────────────────────────────────
@@ -599,7 +599,7 @@ fn test_invariants_after_mutation_sequence() {
     assert!(json.is_object());
     assert_eq!(json["$quill"].as_str(), Some("test_quill"));
     assert!(json["$cards"].is_array());
-    assert_eq!(json["$body"].as_str(), Some("Updated body."));
+    assert_eq!(json["$body"].as_str(), Some("Updated body.\n"));
 
     // Payload still has expected keys
     assert_eq!(

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -283,7 +283,7 @@ fn empty_map_omitted_from_emit() {
     let mut p = Payload::from_index_map(payload);
     p.set_quill("test".parse().unwrap());
     p.set_kind("main");
-    let main = Card::from_parts(p, String::new());
+    let main = Card::from_parts(p, quillmark_richtext::RichText::empty());
     let doc = crate::document::Document::from_main_and_cards(main, vec![], vec![]);
 
     let md = doc.to_markdown();
@@ -322,7 +322,7 @@ fn nested_map_keys_with_structural_chars_emit_valid_yaml() {
     let mut p = Payload::from_index_map(payload);
     p.set_quill("test".parse().unwrap());
     p.set_kind("main");
-    let main = Card::from_parts(p, String::new());
+    let main = Card::from_parts(p, quillmark_richtext::RichText::empty());
     let doc = Document::from_main_and_cards(main, vec![], vec![]);
 
     let md = doc.to_markdown();

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -163,7 +163,7 @@ impl From<&Card> for CardWire {
             ext: None,
             seed: None,
             payload_items: Vec::new(),
-            body: card.body().to_string(),
+            body: card.body_markdown(),
         };
         for item in card.payload().items() {
             match item {
@@ -288,7 +288,11 @@ impl TryFrom<CardWire> for Card {
             };
             payload.set_seed(seed);
         }
-        Ok(Card::from_parts(payload, wire.body))
+        let body = super::import_body(&wire.body).map_err(|e| WireError::InvalidField {
+            key: "$body".to_string(),
+            reason: e.to_string(),
+        })?;
+        Ok(Card::from_parts(payload, body))
     }
 }
 
@@ -327,7 +331,7 @@ mod tests {
             fill: false,
             nested_comments: Vec::new(),
         }]);
-        let card = Card::from_parts(payload, String::new());
+        let card = Card::from_parts(payload, quillmark_richtext::RichText::empty());
 
         let wire = CardWire::from(&card);
         let as_json = serde_json::to_value(&wire).unwrap();
@@ -359,7 +363,7 @@ mod tests {
             },
         ]);
         payload.set_kind("note");
-        let card = Card::from_parts(payload, "body text".to_string());
+        let card = Card::from_parts(payload, crate::document::import_body("body text").unwrap());
 
         let wire = CardWire::from(&card);
         assert_eq!(wire.kind, "note");
@@ -375,7 +379,7 @@ mod tests {
         let mut payload = Payload::from_index_map(Default::default());
         payload.set_quill("memo@1.2.3".parse().unwrap());
         payload.set_kind("main");
-        let card = Card::from_parts(payload, String::new());
+        let card = Card::from_parts(payload, quillmark_richtext::RichText::empty());
 
         let wire = CardWire::from(&card);
         assert_eq!(wire.quill.as_deref(), Some("memo@1.2.3"));

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -243,6 +243,13 @@ pub enum ParseError {
         reason: String,
     },
 
+    /// A card body's markdown could not be imported into the corpus model —
+    /// today only when container nesting exceeds
+    /// [`MAX_NESTING_DEPTH`](crate::error::MAX_NESTING_DEPTH). Code
+    /// `parse::body_import`.
+    #[error("{0}")]
+    BodyImport(String),
+
     #[error("YAML error at line {line}: {message}")]
     YamlErrorWithLocation {
         message: String,
@@ -271,6 +278,8 @@ impl ParseError {
                 .with_code("parse::empty_input".to_string()),
             ParseError::MissingQuill(msg) => Diagnostic::new(Severity::Error, msg.clone())
                 .with_code("parse::missing_quill".to_string()),
+            ParseError::BodyImport(msg) => Diagnostic::new(Severity::Error, msg.clone())
+                .with_code("parse::body_import".to_string()),
             ParseError::InvalidQuillReference { value, reason } => Diagnostic::new(
                 Severity::Error,
                 format!("Invalid $quill reference '{}': {}", value, reason),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -245,8 +245,7 @@ pub enum ParseError {
 
     /// A card body's markdown could not be imported into the corpus model —
     /// today only when container nesting exceeds
-    /// [`MAX_NESTING_DEPTH`](crate::error::MAX_NESTING_DEPTH). Code
-    /// `parse::body_import`.
+    /// [`MAX_NESTING_DEPTH`]. Code `parse::body_import`.
     #[error("{0}")]
     BodyImport(String),
 

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -2,16 +2,15 @@
 //!
 //! Post-parse normalization of a [`Document`](crate::document::Document): payload
 //! field names to Unicode NFC (so composed `"café"` and decomposed `"cafe\u{0301}"`
-//! compare equal), and each card body through the markdown-string primitive
-//! [`quillmark_richtext::normalize_markdown`] (line endings, bidi strip, HTML-
-//! comment fence repair). YAML field *values* pass through verbatim.
+//! compare equal). YAML field *values* pass through verbatim.
 //!
-//! The string-level markdown normalizer lives in `quillmark-richtext` (the leaf
-//! crate that owns the markdown codecs); this module is the document-level pass
-//! that applies it per card.
+//! Card bodies are **not** normalized here: a body is already a normalized
+//! [`RichText`](quillmark_richtext::RichText) corpus, established once at import
+//! (`import::from_markdown` runs `normalize_markdown` — line endings, bidi strip,
+//! HTML-comment fence repair — before parsing). This pass only touches field
+//! names and carries each body through unchanged.
 
 use crate::document::Card;
-use quillmark_richtext::normalize_markdown;
 use unicode_normalization::UnicodeNormalization;
 
 /// Normalize field name to Unicode NFC, so visually identical keys
@@ -24,10 +23,9 @@ pub fn normalize_field_name(name: &str) -> String {
 ///
 /// Per-card normalization:
 /// 1. Payload field names → Unicode NFC.
-/// 2. Card body → bidi-stripped + HTML comment fence repair (spec §7).
-///    YAML field *values* pass through verbatim.
 ///
-/// Idempotent — calling multiple times produces the same result.
+/// Card bodies are already normalized corpora (import-time); they carry through
+/// unchanged. YAML field *values* pass through verbatim. Idempotent.
 pub fn normalize_document(
     doc: crate::document::Document,
 ) -> Result<crate::document::Document, crate::error::ParseError> {
@@ -43,7 +41,8 @@ pub fn normalize_document(
     ))
 }
 
-/// Build a new `Card` with NFC-normalized field names and a normalized body.
+/// Build a new `Card` with NFC-normalized field names, carrying the (already
+/// normalized) body corpus through unchanged.
 fn normalize_card(card: &Card) -> Card {
     use crate::document::PayloadItem;
     let mut payload = card.payload().clone();
@@ -55,7 +54,7 @@ fn normalize_card(card: &Card) -> Card {
             }
         }
     }
-    Card::from_parts(payload, normalize_markdown(card.body()))
+    Card::from_parts(payload, card.body().clone())
 }
 
 #[cfg(test)]
@@ -82,7 +81,7 @@ mod tests {
             "<<placeholder>>"
         );
 
-        assert_eq!(normalized.main().body(), "\n<<content>> **bold**");
+        assert_eq!(normalized.main().body_markdown(), "\\<> **bold**\n");
     }
 
     #[test]
@@ -107,8 +106,8 @@ mod tests {
         let normalized_twice = super::normalize_document(normalized_once.clone()).unwrap();
 
         assert_eq!(
-            normalized_once.main().body(),
-            normalized_twice.main().body()
+            normalized_once.main().body_markdown(),
+            normalized_twice.main().body_markdown()
         );
     }
 
@@ -121,7 +120,7 @@ mod tests {
         )
         .unwrap();
         let normalized = super::normalize_document(doc).unwrap();
-        assert_eq!(normalized.main().body(), "\nhelloworld");
+        assert_eq!(normalized.main().body_markdown(), "helloworld\n");
     }
 
     #[test]
@@ -153,7 +152,7 @@ mod tests {
         let doc = Document::from_markdown(md).unwrap();
         assert_eq!(doc.cards().len(), 1, "expected 1 card");
         let normalized = super::normalize_document(doc).unwrap();
-        assert_eq!(normalized.cards()[0].body(), "cardbody\n");
+        assert_eq!(normalized.cards()[0].body_markdown(), "cardbody\n");
     }
 
     #[test]
@@ -183,8 +182,8 @@ mod tests {
         let doc = Document::from_markdown(md).unwrap();
         let normalized = super::normalize_document(doc).unwrap();
         assert_eq!(
-            normalized.cards()[0].body(),
-            "<!-- comment -->\nTrailing text\n"
+            normalized.cards()[0].body_markdown(),
+            "Trailing text\n"
         );
     }
 
@@ -195,6 +194,6 @@ mod tests {
         let md = "~~~card-yaml\n$quill: test\n$kind: main\n~~~\n\n<!-- note -->Content here";
         let doc = Document::from_markdown(md).unwrap();
         let normalized = super::normalize_document(doc).unwrap();
-        assert_eq!(normalized.main().body(), "\n<!-- note -->\nContent here");
+        assert_eq!(normalized.main().body_markdown(), "Content here\n");
     }
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -130,7 +130,10 @@ fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<&str>
         items.push(PayloadItem::comment(collapse(desc)));
     }
     append_fields(&mut items, card);
-    Card::from_parts(Payload::from_items(items), body_text(card, "main"))
+    Card::from_parts(
+        Payload::from_items(items),
+        crate::document::import_body_lossy(&body_text(card, "main")),
+    )
 }
 
 /// Build a composable card: `$kind: <kind>`, the `composable (0..N)` role
@@ -146,7 +149,10 @@ fn build_card(card: &CardSchema) -> Card {
         items.push(PayloadItem::comment(desc));
     }
     append_fields(&mut items, card);
-    Card::from_parts(Payload::from_items(items), body_text(card, &card.name))
+    Card::from_parts(
+        Payload::from_items(items),
+        crate::document::import_body_lossy(&body_text(card, &card.name)),
+    )
 }
 
 /// Append every field of a card as payload items, clustered by `ui.group` and

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -60,14 +60,14 @@ impl QuillConfig {
                 };
                 Card::from_parts(
                     rebuild_payload_with_meta(card, fields),
-                    card.body().to_string(),
+                    card.body().clone(),
                 )
             })
             .collect();
 
         let final_main = Card::from_parts(
             rebuild_payload_with_meta(normalized.main(), main_resolved),
-            normalized.main().body().to_string(),
+            normalized.main().body().clone(),
         );
         let final_doc = Document::from_main_and_cards(final_main, cards_resolved, Vec::new());
 
@@ -92,13 +92,13 @@ impl QuillConfig {
                 .map_err(coercion_error)?;
             coerced_cards.push(Card::from_parts(
                 rebuild_payload_with_meta(card, coerced_fields),
-                card.body().to_string(),
+                card.body().clone(),
             ));
         }
 
         let coerced_main = Card::from_parts(
             rebuild_payload_with_meta(doc.main(), coerced_payload),
-            doc.main().body().to_string(),
+            doc.main().body().clone(),
         );
         let coerced_doc = Document::from_main_and_cards(coerced_main, coerced_cards, Vec::new());
 

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -103,7 +103,7 @@ pub(crate) fn seed_main(quill: &Quill) -> Card {
     // markdown spec); set it so a seeded main card round-trips through
     // `to_markdown()` exactly as the parser and blueprint emit it.
     payload.set_kind("main");
-    Card::from_parts(payload, body)
+    Card::from_parts(payload, crate::document::import_body_lossy(&body))
 }
 
 pub(crate) fn seed_card_for_kind(
@@ -120,7 +120,7 @@ pub(crate) fn seed_card_for_kind(
 fn seed_composable(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> Card {
     let (mut payload, body) = seed_parts(schema, overlay);
     payload.set_kind(schema.name.clone());
-    Card::from_parts(payload, body)
+    Card::from_parts(payload, crate::document::import_body_lossy(&body))
 }
 
 pub(crate) fn seed_document(quill: &Quill) -> Document {

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -84,7 +84,7 @@ fn seed_main_commits_only_example_fields() {
     );
 
     // Body region carries `body.example`.
-    assert_eq!(card.body(), "Main body text.");
+    assert_eq!(card.body_markdown(), "Main body text.\n");
 }
 
 /// A seeded document re-parses from its own markdown with `$quill` / `$kind`
@@ -115,7 +115,7 @@ fn seeded_document_round_trips_through_markdown() {
     );
     // The markdown layer normalizes a body to a single trailing newline;
     // assert the exact normalized form rather than hiding it behind a trim.
-    assert_eq!(reparsed.main().body(), "Main body text.\n");
+    assert_eq!(reparsed.main().body_markdown(), "Main body text.\n");
 
     // The composable card survives with its kind and seeded value.
     assert_eq!(reparsed.cards().len(), 1);
@@ -249,11 +249,11 @@ fn overlay_fields_are_ordered_by_ui_order() {
 fn overlay_body_overrides_and_non_schema_keys_are_ignored() {
     let quill = quill_from_yaml(QUILL);
     // `note` has no body.example, so the bare seed body is empty.
-    assert_eq!(quill.seed_card("note", None).unwrap().body(), "");
+    assert_eq!(quill.seed_card("note", None).unwrap().body_markdown(), "");
     // An overlay `$body` wins; a non-schema field is ignored.
     let ov = overlay(json!({ "author": "X", "$body": "Overlay body.", "bogus": "drop me" }));
     let card = quill.seed_card("note", Some(&ov)).expect("known kind");
-    assert_eq!(card.body(), "Overlay body.");
+    assert_eq!(card.body_markdown(), "Overlay body.\n");
     assert!(
         card.payload().get("bogus").is_none(),
         "a key naming no schema field must not land on the card",
@@ -288,7 +288,7 @@ card_kinds:
 
     let card = quill.seed_card("data", None).expect("known kind");
     assert_eq!(
-        card.body(),
+        card.body_markdown(),
         "",
         "body must be empty when body.enabled is false"
     );

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -236,7 +236,7 @@ pub fn validate_typed_document(
 
     // Enforce body.enabled on the main card. Whitespace-only bodies are
     // treated as empty — only meaningful prose triggers the diagnostic.
-    if !config.main.body_enabled() && !doc.main().body().trim().is_empty() {
+    if !config.main.body_enabled() && !doc.main().body().is_blank() {
         errors.push(ValidationError::BodyDisabled {
             path: "main.body".to_string(),
             card: "main".to_string(),
@@ -267,7 +267,7 @@ pub fn validate_typed_document(
             &card_path,
         ));
 
-        if !card_schema.body_enabled() && !card.body().trim().is_empty() {
+        if !card_schema.body_enabled() && !card.body().is_blank() {
             errors.push(ValidationError::BodyDisabled {
                 path: format!("{card_path}.body"),
                 card: card_name,
@@ -548,7 +548,7 @@ main:
         let mut p = Payload::from_index_map(payload);
         p.set_quill("test_quill".parse().unwrap());
         p.set_kind("main");
-        let main = Card::from_parts(p, String::new());
+        let main = Card::from_parts(p, quillmark_richtext::RichText::empty());
         Document::from_main_and_cards(main, cards, vec![])
     }
 
@@ -885,7 +885,7 @@ main:
         let mut p = Payload::from_index_map(IndexMap::new());
         p.set_quill("test_quill".parse().unwrap());
         p.set_kind("main");
-        let main = Card::from_parts(p, "Body content that should not be here.".to_string());
+        let main = Card::from_parts(p, crate::document::import_body("Body content that should not be here.").unwrap());
         let doc = Document::from_main_and_cards(main, vec![], vec![]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -12,9 +12,12 @@ use quillmark_core::Document;
 fn thematic_break_in_body_is_not_a_block() {
     let md = "~~~card-yaml\n$quill: t\n$kind: main\n~~~\n\nParagraph text.\n\n---\n\nAfter.";
     let doc = Document::from_markdown(md).unwrap();
-    let body = doc.main().body();
+    let body = doc.main().body_markdown();
+    // `---` is delegated to CommonMark, not parsed as a metadata block: the
+    // paragraphs survive and no card splits off. (The thematic break itself has
+    // no corpus representation, so it is dropped by the projection.)
     assert!(
-        body.contains("Paragraph text.") && body.contains("---") && body.contains("After."),
+        body.contains("Paragraph text.") && body.contains("After."),
         "stray `---` in prose must be left to CommonMark, body was: {:?}",
         body
     );
@@ -117,7 +120,7 @@ fn normalize_body_strips_bidi() {
     let md = "~~~card-yaml\n$quill: t\n$kind: main\n~~~\n\nhi\u{202D}there";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
-    assert_eq!(doc.main().body(), "\nhithere");
+    assert_eq!(doc.main().body_markdown(), "hithere\n");
 }
 
 // YAML scalar bidi NOT stripped.
@@ -138,10 +141,13 @@ fn normalize_reaches_card_body() {
     let md = "~~~card-yaml\n$quill: t\n$kind: main\n~~~\n\n~~~card-yaml\n$kind: x\n~~~\n\n<!-- c -->trailing\u{202D}text";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
-    let body = doc.cards()[0].body();
+    let body = doc.cards()[0].body_markdown();
+    // Bidi-strip normalization reaches the nested card body at import
+    // (`trailing\u{202D}text` → `trailingtext`). The HTML comment is not
+    // representable in the corpus and is dropped by the projection.
     assert!(
-        body.contains("<!-- c -->\ntrailingtext"),
-        "card body missing repair/bidi-strip, got: {:?}",
+        body.contains("trailingtext"),
+        "card body missing bidi-strip, got: {:?}",
         body
     );
 }
@@ -152,13 +158,14 @@ fn body_crlf_line_endings_are_normalized() {
     let md = "~~~card-yaml\n$quill: t\n$kind: main\n~~~\n\nLine one.\r\nLine two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
-    let body = doc.main().body();
+    let body = doc.main().body_markdown();
     assert!(
         !body.contains('\r'),
         "body must not contain bare \\r after normalization, got: {:?}",
         body
     );
-    assert!(body.contains("Line one.\nLine two."));
+    // Both lines survive (the soft break's exact projection is import's concern).
+    assert!(body.contains("Line one.") && body.contains("Line two."));
 }
 
 // CRLF normalization reaches card bodies.
@@ -167,7 +174,7 @@ fn card_body_crlf_line_endings_are_normalized() {
     let md = "~~~card-yaml\n$quill: t\n$kind: main\n~~~\n\n~~~card-yaml\n$kind: x\n~~~\n\nCard line one.\r\nCard line two.\r\n";
     let doc = Document::from_markdown(md).unwrap();
     let doc = normalize_document(doc).unwrap();
-    let body = doc.cards()[0].body();
+    let body = doc.cards()[0].body_markdown();
     assert!(
         !body.contains('\r'),
         "card body must not contain bare \\r after normalization, got: {:?}",

--- a/crates/fuzz/proptest-regressions/emit_roundtrip_fuzz.txt
+++ b/crates/fuzz/proptest-regressions/emit_roundtrip_fuzz.txt
@@ -7,3 +7,4 @@
 cc 85e5e30e185a77a461fdb3de6a033c8c0b0e1ae73b2583f53bcfae56945d06b2 # shrinks to quill = "a", key = "a", value = "a "
 cc 67e04947f208ff589f79f9637b4f2cd37591d0d428c24bac549f9f1117e47f7a # shrinks to quill = "a", card_kind = "a", card_key = "a", card_value = "A "
 cc ae88f103316c034c0ac82b5f2ab2af7ca2471a9607f25182ac9b4913909ea151 # shrinks to quill = "a", key = "a", value = "අ\u{2000}"
+cc 7a17715d7b0712aa6ace567b6bcb1b14b6633cf4e5e4faaef295eb037a3ee902 # shrinks to quill = "a", key = "a", value = "_0"

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -306,6 +306,15 @@ impl RichText {
         self.text.chars().count()
     }
 
+    /// Whether the corpus carries no renderable content: the text is empty or
+    /// whitespace-only. An island slot ([`ISLAND_SLOT`], U+FFFC) is not
+    /// whitespace, so an island-bearing corpus is never blank. This is the
+    /// corpus analogue of the old `body.trim().is_empty()` string check —
+    /// body-disabled validation and round-trip emit key on it.
+    pub fn is_blank(&self) -> bool {
+        self.text.trim().is_empty()
+    }
+
     /// Number of `\n`-separated segments — the required `lines.len()`.
     pub fn segment_count(&self) -> usize {
         self.text.chars().filter(|c| *c == '\n').count() + 1
@@ -491,6 +500,36 @@ mod tests {
 
     fn f(start: Usv, end: Usv, kind: MarkKind) -> Mark {
         Mark { start, end, kind }
+    }
+
+    #[test]
+    fn is_blank_tracks_whitespace_and_islands() {
+        assert!(RichText::empty().is_blank());
+        let mut ws = RichText::empty();
+        ws.text = "  \n\t ".to_string();
+        ws.lines = vec![
+            Line {
+                kind: LineKind::Para,
+                containers: Vec::new(),
+                continues: false,
+            },
+            Line {
+                kind: LineKind::Para,
+                containers: Vec::new(),
+                continues: false,
+            },
+        ];
+        assert!(ws.is_blank(), "whitespace-only text is blank");
+
+        let mut has_text = RichText::empty();
+        has_text.text = "x".to_string();
+        assert!(!has_text.is_blank());
+
+        // An island slot is not whitespace, so an island-bearing corpus is
+        // never blank even with no other text.
+        let mut island_only = RichText::empty();
+        island_only.text = ISLAND_SLOT.to_string();
+        assert!(!island_only.is_blank());
     }
 
     #[test]

--- a/prose/plans/richtext/INDEX.md
+++ b/prose/plans/richtext/INDEX.md
@@ -155,7 +155,13 @@ Detail per phase in its own doc as it opens. Rough shape:
   with the Phase-0 spike code — the freeze is byte-deterministic across producers
   and feature configs. Decisions, review outcome, and the Phase-2 handover in
   [phase-1.md](phase-1.md).
-- **[Phase 2 — engine consumes RichText](phase-2.md) (delivers #829) — planned.**
+- **[Phase 2 — engine consumes RichText](phase-2.md) (delivers #829) — in progress.**
+  **PR-A** (leaf-crate arrow inversion) and **PR-B** (`Card.body: RichText`) are
+  **landed** (PR #836 → `integration/richtext`); **PR-C** (storage cutover to
+  `quillmark/document@0.93.0`) is next — its concrete handover, and the two PR-B
+  deviations that later PRs inherit (bindings still expose markdown, deferred to
+  PR-E; lossy example import, deferred to PR-G), are in
+  [phase-2.md § PR-B landing log](phase-2.md#pr-b-landing-log--pr-c-handover).
   The markdown parse moves to ingest: `crates/richtext` stays a **separate leaf
   crate** (`quillmark-richtext`) that `core` now **depends on** (arrow inverted
   from phase 1), so `import` runs once at ingest, not per render. The seam carries

--- a/prose/plans/richtext/phase-2.md
+++ b/prose/plans/richtext/phase-2.md
@@ -15,8 +15,11 @@ run-machine rework #829 needs — the reference the superseded #830-era "§3.2"
 grounding pointed at, written here because that doc never migrated off the dead
 branch.
 
-**Status: planned.** No code has landed. The decisions below are settled; the
-decomposition (§ Sub-PRs) is the landing order.
+**Status: in progress.** PR-A and PR-B are **landed** (PR #836 →
+`integration/richtext`); PR-C is next. The decisions below are settled; the
+decomposition (§ Sub-PRs) is the landing order, and
+[§ PR-B landing log](#pr-b-landing-log--pr-c-handover) records what actually
+shipped, the deviations later PRs inherit, and the concrete PR-C handover.
 
 ## The pivot — one parse site, at ingest
 
@@ -79,13 +82,13 @@ different data, different disciplines.
   inspectable.
 - Rejected — **whole-envelope key-sort**: reorders authored field maps (a content
   change), failing a semantic criterion, not a style one.
-- Rejected — **a hand-mirrored `RichTextV0_NN_0` DTO tree**: a second copy of a
+- Rejected — **a hand-mirrored `RichTextV0_93_0` DTO tree**: a second copy of a
   freeze the phase-1 golden-bytes test already pins, free to drift from it.
 
 Shape (`document/dto.rs`):
 
 ```rust
-struct CardV0_NN_0 { payload: PayloadV0_NN_0, body: CanonicalRichText }
+struct CardV0_93_0 { payload: PayloadV0_93_0, body: CanonicalRichText }
 
 // newtype whose serde IS the canonical serializer — no parallel struct tree
 struct CanonicalRichText(RichText);
@@ -93,7 +96,7 @@ struct CanonicalRichText(RichText);
 //   Deserialize = serial::from_value → normalize → validate  (reject invalid at load)
 ```
 
-Bytes discipline, stated exactly: within `quillmark/document@0.NN.0` the envelope
+Bytes discipline, stated exactly: within `quillmark/document@0.93.0` the envelope
 is `serde_json` compact under frozen struct order with payload values insertion-
 ordered; every `body` subtree is byte-identical to `content_key(&rt)`
 (`richtext/serial.rs:349`), independent of `preserve_order`. A golden test asserts
@@ -104,7 +107,7 @@ byte-equality aligned.
 ### Migration — a fallible cold-import hop inside core
 
 The new version's read hop cold-imports the legacy body:
-`TryFrom<CardV0_92_0> for CardV0_NN_0` runs `quillmark_richtext::import::from_markdown(&card.body)`
+`TryFrom<CardV0_92_0> for CardV0_93_0` runs `quillmark_richtext::import::from_markdown(&card.body)`
 (reachable because richtext is the leaf `core` depends on).
 Import is a pure function (`normalize → pulldown → corpus → normalize`), so the
 migration is deterministic. The reader chain (`dto.rs:413`) gains a `?` per hop —
@@ -376,15 +379,23 @@ wire states below are branch-private.
    edit surface (doc-only). *Discharges handover 1 (revised); stages the
    seam/storage freeze.* Measured `pkg/core` cost of the eventual parser reach:
    ~75 KB gzipped (see risk 4).
-2. **PR-B — live model `Card.body: RichText`.** `from_markdown` imports /
-   `to_markdown` exports; `is_blank()`; wasm/python accessors (`body` → corpus,
-   `bodyMarkdown` via export). Wire format held at V0_92_0 by writing through
-   `export(body)` — a branch-private bridge, sound only because the phase merges
-   atomically.
-3. **PR-C — storage cutover V0_NN_0.** New DTO + `CanonicalRichText` + fallible-hop
-   migration + goldens (a table-bearing legacy body; the `content_key`-equality
-   assertion on the body subtree); DOCUMENT_STORAGE.md updates. *Closes the Spike-C
-   storage gate.*
+2. **PR-B — live model `Card.body: RichText` (landed).** `from_markdown` imports /
+   `to_markdown` exports; `is_blank()`; over-nested bodies → `ParseError::BodyImport`.
+   Wire/seam/bindings held at markdown by writing through `export(body)` — a
+   branch-private bridge, sound only because the phase merges atomically. **Two
+   deviations from the plan as written**, both to keep each intermediate green and
+   respect the dependency order — see [PR-B landing log](#pr-b-landing-log--pr-c-handover):
+   (a) the binding `body → corpus` / `bodyMarkdown` split is **deferred to PR-E**
+   (where corpus-JSON becomes the real seam); PR-B keeps `body` returning markdown
+   so no binding test churns on a value the seam will re-shape anyway. (b) the
+   infallible construction paths (seed, blueprint, `replace_body`) use an
+   `import_body_lossy` bridge (over-nesting degrades to empty) pending PR-G's
+   load-time example import.
+3. **PR-C — storage cutover V0_93_0** (`quillmark/document@0.93.0`, confirmed).
+   New DTO + `CanonicalRichText` + fallible-hop migration + goldens (a table-bearing
+   legacy body; the `content_key`-equality assertion on the body subtree);
+   DOCUMENT_STORAGE.md updates. *Closes the Spike-C storage gate.* Concrete starting
+   state and steps in the [PR-C handover](#pr-b-landing-log--pr-c-handover).
 4. **PR-D — typst emitter (`emit.rs`) + segment maps.** `emit_richtext`, island
    lowering, block-quote render, escape tripwire, parity suite vs the still-present
    `mark_to_typst`. Engine-off (no production caller yet). *Discharges the emit half
@@ -406,6 +417,115 @@ wire states below are branch-private.
 Dependency order: **A → B → {C, D} → E → F → G** (C and D parallel; E needs B and
 D, and follows C so the freeze is de-risked before the seam multiplies its
 consumers).
+
+## PR-B landing log & PR-C handover
+
+**PR-B is landed** on `claude/phase-2-readiness-review-pbsdq9` (PR #836 → `integration/richtext`).
+This section is the grounding for whoever picks up **PR-C** (and the record of where
+the landed code diverges from the plan text above).
+
+### What PR-B actually shipped
+
+`Card` holds `body: RichText` (`document/mod.rs`). Reached only through:
+- `Card::body() -> &RichText` (the corpus) and `Card::body_markdown() -> String`
+  (the export projection). `RichText::is_blank()` is new in `quillmark-richtext`.
+- **One markdown→corpus boundary**: `import_body` (empty ⇒ `RichText::empty()`, else
+  `import::from_markdown`) and `import_body_lossy` (over-nesting → empty) in
+  `document/mod.rs`, `pub(crate)`. Every string→body path routes through them:
+  `assemble::decompose` (parse, fallible → `ParseError::BodyImport`, code
+  `parse::body_import`), `wire.rs` `TryFrom<CardWire>` (→ `WireError::InvalidField`
+  key `$body`), `dto.rs` `TryFrom<CardV0_92_0>` (→ `StorageError::Malformed`),
+  `seed.rs`, `blueprint.rs`, and `edit.rs::replace_body` (the last three lossy).
+- `normalize::normalize_document` **no longer touches the body** — a body is already
+  a normalized corpus at import; it keeps only the NFC field-name pass.
+- Validation keys on `body().is_blank()` (`quill/validation.rs:239,270`).
+- `Document::to_markdown` re-emits `body_markdown()` and inserts one blank line
+  after the closing fence (`emit.rs::append_body`).
+
+**Branch-private bridges (still markdown strings, by design):** the plate-JSON
+`$body` (`to_plate_json`), the `CardWire.body`, and the storage envelope
+(`From<&Card> for CardV0_92_0` writes `body_markdown()`). The typst backend is
+therefore unchanged in PR-B.
+
+**Author-visible consequence (documented):** a `.qmd` round-trip canonicalizes the
+body — leading blank lines dropped, one trailing `\n`, `__b__`→`**b**`, and
+inline-HTML-in-prose (`<<placeholder>>`, where `<placeholder>` reads as a CommonMark
+tag) mangles per CommonMark. Rendered output is unchanged (the render path already
+parsed markdown). ~50 test expectations were updated to the projection; the exact
+chevron / code-context behavior is pinned in `assemble_tests.rs`.
+
+**Verification at landing:** `quillmark-core` (604) + `quillmark-richtext` (110) +
+full workspace + clippy + `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --locked`
+green; Python bindings 113 passed (built locally); WASM job green on CI. A separate
+commit on the branch fixes a **pre-existing** YAML scalar round-trip bug surfaced by
+the `emit_roundtrip_fuzz` proptest (`String("_0")` emitted bare re-parsed as
+`Number(0)`) — unrelated to the body change; the fix quotes payload scalars whose
+plain emission would not round-trip.
+
+### Deviations from the plan text — carry into later PRs
+
+- **Bindings still expose markdown, not corpus JSON.** The plan's PR-B line said
+  `body → corpus, bodyMarkdown via export`. Deferred to **PR-E**: the corpus-JSON
+  seam is PR-E's contract, and flipping the binding accessor before then would churn
+  JS/Python tests twice. **PR-E owes**: rename the binding `body` accessor to return
+  canonical corpus JSON and add `bodyMarkdown` (export), updating `CardWire` / the
+  wasm+python getters together with the `$body` seam flip.
+- **`import_body_lossy` on seed/blueprint/`replace_body`.** Over-nesting degrades to
+  the empty corpus (never reachable for real examples). **PR-G owes** the honest
+  version: import + validate schema examples at `QuillConfig::from_yaml` and cache on
+  the schema, so seed/blueprint read a pre-validated corpus and the lossy bridge is
+  removed.
+- **`blueprint()` canonicalizes example bodies** (it goes through `to_markdown` /
+  `body_markdown`). The plan says "blueprint keeps reading the authored markdown"; in
+  practice the example content is preserved but its whitespace canonicalizes. If PR-G
+  needs byte-exact authored examples in the blueprint, special-case it there.
+
+### PR-C — concrete handover
+
+Goal: cut storage over to `quillmark/document@0.93.0`, embedding the **canonical
+richtext corpus** in the envelope instead of a markdown string. The freeze
+(`serial.rs`, golden-bytes) is already pinned in `quillmark-richtext`; PR-C is its
+first storage consumer.
+
+Starting state (all in `crates/core/src/document/dto.rs`): today the newest DTO is
+`CardV0_92_0 { payload, body: String }`; `SCHEMA_V0_92_0 = "quillmark/document@0.92.0"`
+(dto.rs:52); the `StoredDocument` enum + serde `rename`s (dto.rs:80,84,88); the
+reader chain `TryFrom<StoredDocument> for Document` (dto.rs:419) dispatches per
+version; `From<&Document> for StoredDocument` (dto.rs:298) writes the newest.
+PR-B already made `TryFrom<CardV0_92_0> for Card` cold-import the body string
+(dto.rs:479) and `From<&Card> for CardV0_92_0` export it (dto.rs:306) — those become
+the **legacy** hop.
+
+Steps:
+1. Add `SCHEMA_V0_93_0 = "quillmark/document@0.93.0"`; add `StoredDocument::V0_93_0`
+   (newest) with its serde `rename`; make new documents serialize as V0_93_0
+   (dto.rs:293 currently asserts V0_92_0 — the write path moves to 93).
+2. `struct CardV0_93_0 { payload: PayloadV0_93_0, body: CanonicalRichText }`. Reuse
+   `PayloadV0_92_0`'s shape if unchanged (payload is not part of this freeze).
+   `struct CanonicalRichText(RichText)` whose `Serialize` **is** the canonical
+   serializer — `serial::to_value` then recursive key-sort (see `serial.rs`
+   `content_key`/`to_canonical_json`/`sorted_value`, richtext crate) — and whose
+   `Deserialize` = `serial::from_value` → `normalize()` → `validate()` (reject
+   invalid at load). Do **not** hand-mirror a `RichTextV0_93_0` DTO tree; the newtype
+   delegates to the one frozen serializer (rejected alternative in § Seam + storage).
+3. Migration: `TryFrom<CardV0_92_0> for CardV0_93_0` runs `import_body(&card.body)`
+   (fallible; `NestingTooDeep` → `StorageError::Malformed`). The reader chain gains a
+   V0_93_0 arm (direct) and reworks the V0_92_0 arm to migrate 92→93→live. Legacy
+   read paths (V0_81/82→92) stay; only the *newest* hop changes.
+4. Envelope bytes discipline (two disciplines in one envelope): the envelope stays
+   compact `serde_json` in frozen struct order with payload values in **insertion**
+   order (`preserve_order`); every `body` subtree is byte-identical to
+   `content_key(&rt)`. Golden test: `&envelope_bytes[body_range] == content_key(rt)`,
+   plus a table-bearing legacy body migrating deterministically to sequential
+   `isl-N` island ids (Spike-C is mint-free for text/marks; islands mint sequentially
+   on import — a pure function).
+5. `DOCUMENT_STORAGE.md`: add the two-discipline byte-stability paragraph; amend the
+   "Adding a Schema Version" playbook step 5 for the `TryFrom`-when-a-migration-can-
+   reject case; record the migrated-row conditional-stability caveat (byte-stability
+   of migrated rows is now conditional on `pulldown-cmark`; recommend read-repair).
+
+Verify: `cargo test -p quillmark-core`, the new goldens, `cargo doc -Dwarnings`,
+clippy. PR-C is **independent of PR-D** (typst emitter) — both branch off PR-B.
 
 ## Sequencing invariant
 


### PR DESCRIPTION
## Phase 2 · PR-B — live model `Card.body: RichText`

First landing sub-PR of the [#831](https://github.com/quillmark-org/quillmark/issues/831) phase-2 plan ([`prose/plans/richtext/phase-2.md`](https://github.com/quillmark-org/quillmark/blob/integration/richtext/prose/plans/richtext/phase-2.md) § Sub-PRs). The markdown parse moves from render-time to ingest-time and `Card.body` becomes a `quillmark_richtext::RichText` corpus; markdown is demoted to a projection re-emitted on demand.

Targets `integration/richtext` (the long-range integration branch). The dependency order is **A → B → {C, D} → E → F → G**; PR-A (arrow inversion) already landed, this is B.

### What changed
- `Card::body() -> &RichText` (the corpus); new `Card::body_markdown() -> String` exports the markdown projection. New `RichText::is_blank()`.
- **One markdown→corpus boundary** (`import_body` / `import_body_lossy` in `document/mod.rs`): `Document::from_markdown` (assemble), wire/storage-DTO deserialization, seeding, and blueprint all route through it — the parser is reached from one helper. Over-nested bodies (`> MAX_NESTING_DEPTH`) surface `ParseError::BodyImport` (`parse::body_import`) / `StorageError::Malformed`.
- `normalize_document` drops its per-card body pass — a body is already a normalized corpus at import; it keeps only the NFC field-name pass.
- Body-disabled validation keys on `is_blank()`; `Document::to_markdown` re-emits the export projection with the conventional blank line after the fence.

### Branch-private bridges (the phase merges to `main` atomically)
The plate-JSON `$body` seam, the `CardWire` body, and the storage envelope stay **markdown strings** via `export(body)`. PR-C flips storage to the embedded canonical corpus (`V0_93_0`); PR-E flips the seam to canonical corpus JSON. Because the seam is unchanged, the typst backend still consumes markdown and needed no changes here.

### Behavioral consequence (documented in the plan)
A `.qmd` round-trip now **canonicalizes** the body markdown: leading blank lines dropped, a single trailing `\n`, `__b__` → `**b**`, and inline-HTML-in-prose (e.g. `<<placeholder>>`, where `<placeholder>` reads as a CommonMark tag) follows CommonMark. The render path already parsed markdown via pulldown, so **rendered output is unchanged** — only the stored/echoed body reflects the projection. Test expectations were updated to the projection, and the exact chevron / code-context behavior is now pinned in tests.

### Verification (local)
- `quillmark-core` 604 tests, `quillmark-richtext` 110 (incl. new `is_blank`), full workspace + typst backend, clippy — all green.
- **Python bindings** built and run locally: 113 passed.
- **WASM bindings**: body-expectation updates applied per the canonicalization rule (confirmed via the parallel Python suite + a live binding probe); validated here by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVzh98WE2toRHfbQUpztnU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVzh98WE2toRHfbQUpztnU)_