### PR TITLE
richtext PR-G: richtext(inline), load-time example cache, markdown-alias cutover

### DIFF
--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -650,7 +650,7 @@ fn is_date_field(field_schema: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
-/// Names of the markdown / `markdown[]` fields in a schema `properties` map —
+/// Names of the richtext / `richtext[]` fields in a schema `properties` map —
 /// the fields whose values carry backend markup for the helper to `eval`.
 /// Names of the schema `properties` whose field schema satisfies `predicate`,
 /// in map order. Shared spine of the field-class selectors below.
@@ -681,7 +681,7 @@ fn date_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> 
 /// `form-field`'s path validator uses this to reject an index suffix on a
 /// scalar field, where no element exists for the address to resolve to. Any
 /// array qualifies, matching the pdfform resolver's shallow-path grammar:
-/// the content codegen only *produces* eval sites for `markdown[]` elements,
+/// the content codegen only *produces* eval sites for `richtext[]` elements,
 /// but a widget binding of a plain array element is a real, routable address.
 fn array_field_names(properties: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
     field_names_where(properties, |fs| {

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -371,14 +371,14 @@ quill:
   name: array_regions
   version: 0.1.0
   backend: typst
-  description: markdown[] element region test
+  description: richtext[] element region test
 main:
   fields:
     refs:
       type: array
       items:
         type: richtext
-      description: a markdown[] field
+      description: a richtext[] field
 typst:
   plate_file: plate.typ
 "#;
@@ -398,7 +398,7 @@ typst:
     for expected in ["refs.0", "refs.1"] {
         assert!(
             regions.iter().any(|r| r.field == expected),
-            "each markdown[] element gets its own eval site and region {expected:?}: {regions:?}"
+            "each richtext[] element gets its own eval site and region {expected:?}: {regions:?}"
         );
     }
     // Elements are distinct placements, not one unioned `refs` blob.

--- a/crates/backends/typst/tests/content_regions.rs
+++ b/crates/backends/typst/tests/content_regions.rs
@@ -57,10 +57,10 @@ typst:
 main:
   fields:
     intro:
-      type: markdown
+      type: richtext
       description: a short intro paragraph
     body:
-      type: markdown
+      type: richtext
       description: a long body that wraps and breaks across pages
 "#;
     const PLATE: &str = r#"
@@ -138,7 +138,7 @@ typst:
 main:
   fields:
     intro:
-      type: markdown
+      type: richtext
       description: a short paragraph placed twice
 "#;
     const PLATE: &str = r#"
@@ -330,7 +330,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a body piped through a capture-and-replay package shape
 "#;
     const PLATE: &str = r#"
@@ -377,7 +377,7 @@ main:
     refs:
       type: array
       items:
-        type: markdown
+        type: richtext
       description: a markdown[] field
 typst:
   plate_file: plate.typ
@@ -424,20 +424,20 @@ typst:
 main:
   fields:
     intro:
-      type: markdown
+      type: richtext
       description: a top-level intro
 card_kinds:
   alpha:
     description: alpha card
     fields:
       note:
-        type: markdown
+        type: richtext
         description: alpha note
   beta:
     description: beta card
     fields:
       note:
-        type: markdown
+        type: richtext
         description: beta note
 "#;
     const PLATE: &str = r#"
@@ -538,7 +538,7 @@ typst:
 main:
   fields:
     intro:
-      type: markdown
+      type: richtext
       description: a paragraph
     when:
       type: datetime
@@ -600,7 +600,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a long body under headers and footers
 "#;
     const PLATE: &str = r#"
@@ -730,7 +730,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a body that may carry malformed inline markup
 "#;
     // The plate proves the int round-tripped: a wrong `i64::MIN` literal makes
@@ -826,7 +826,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a two-paragraph body
 "#;
     const PLATE: &str = r#"
@@ -895,7 +895,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: one paragraph
 "#;
     const PLATE: &str = r#"
@@ -971,7 +971,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a paragraph plus a multi-line code fence
 "#;
     const PLATE: &str = r#"

--- a/crates/backends/typst/tests/live_apply.rs
+++ b/crates/backends/typst/tests/live_apply.rs
@@ -101,7 +101,7 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a markdown body
 "#;
     const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data
@@ -174,10 +174,10 @@ typst:
 main:
   fields:
     body:
-      type: markdown
+      type: richtext
       description: a markdown body
     note:
-      type: markdown
+      type: richtext
       description: a markdown note
 "#;
     const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -137,6 +137,13 @@ export interface FieldRegion {
 	page: number;
 	/** `[x0, y0, x1, y1]` in PDF points (1/72″), bottom-left origin. */
 	rect: [number, number, number, number];
+	/**
+	 * The corpus slice this box covers — USV `[start, end)` into the field's
+	 * `RichText` for content ink (one segment), absent for a scalar reference
+	 * site or widget. Consumers key segment highlights on it and union same-page
+	 * segments for the whole-field box.
+	 */
+	span?: [number, number];
 }
 
 /** Canonical contract every backend build must satisfy. Result of one render. */

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -220,8 +220,8 @@ pub struct ChangeSet {
 }
 
 /// A rendered field region: the quill schema field address plus its geometry on
-/// the page. Emitted for schema-bound fields — span-tracked content (markdown
-/// bodies, `markdown[]` elements, card content fields, direct scalar
+/// the page. Emitted for schema-bound fields — span-tracked content (richtext
+/// bodies, `richtext[]` elements, card content fields, direct scalar
 /// references) and form-field widgets (pdfform AcroForm, Typst `form-field`).
 /// Consumers use it to scroll to / highlight the focused field; for the
 /// reverse click direction use `LiveSession.fieldAt`, which answers over any

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -140,7 +140,7 @@ fn region_quill_tree() -> wasm_bindgen::JsValue {
     common::tree(&[
         (
             "Quill.yaml",
-            b"quill:\n  name: region_quill\n  version: 0.1.0\n  backend: typst\n  description: region + navigation wasm surface test\ntypst:\n  plate_file: plate.typ\nmain:\n  fields:\n    body:\n      type: markdown\n      description: a two-paragraph body\n",
+            b"quill:\n  name: region_quill\n  version: 0.1.0\n  backend: typst\n  description: region + navigation wasm surface test\ntypst:\n  plate_file: plate.typ\nmain:\n  fields:\n    body:\n      type: richtext\n      description: a two-paragraph body\n",
         ),
         (
             "plate.typ",

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -431,6 +431,8 @@ impl Card {
     /// degrades to the empty corpus rather than erroring; the fallible edit
     /// surface is Phase 3.
     pub fn replace_body(&mut self, body: impl Into<String>) {
-        self.overwrite_body(super::import_body_lossy(&body.into()));
+        let corpus =
+            super::import_body(&body.into()).unwrap_or_else(|_| quillmark_richtext::RichText::empty());
+        self.overwrite_body(corpus);
     }
 }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -32,15 +32,6 @@ pub(crate) fn import_body(md: &str) -> Result<RichText, ImportError> {
     }
 }
 
-/// Import a body string, degrading a pathological over-nested input to the empty
-/// corpus rather than erroring. Used by the infallible construction paths
-/// (seeding, blueprint) whose inputs are trusted quill-author examples; the
-/// `> MAX_NESTING_DEPTH` case is unreachable for real examples. PR-G moves
-/// example import to quill-load time where it validates and caches.
-pub(crate) fn import_body_lossy(md: &str) -> RichText {
-    import_body(md).unwrap_or_else(|_| RichText::empty())
-}
-
 pub mod assemble;
 pub mod dto;
 pub mod edit;

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -255,7 +255,7 @@ pub fn prescan_fence_content(content: &str) -> PreScan {
             // A sequence item whose value is itself a block scalar (`- |-`):
             // content lines are indented past the dash, so the dash line's
             // indent is the boundary. Without this, headings / bullets / `key:`
-            // lines inside a `markdown[]` item would be mis-parsed as structure.
+            // lines inside a `richtext[]` item would be mis-parsed as structure.
             if is_block_scalar_header(after_dash_trimmed) {
                 block_scalar_indent = Some(indent);
             }
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[test]
     fn sequence_item_block_scalar_content_is_not_parsed_as_structure() {
-        // A `markdown[]` array authored as `- |-` block-scalar items. Content
+        // A `richtext[]` array authored as `- |-` block-scalar items. Content
         // lines (heading, bullet, `key:`) must survive verbatim, and the next
         // item at the dash indent must still parse as a sequence item.
         let input = "items:\n  - |-\n    ## Heading\n    - inner bullet\n    role: x\n  - second\n";

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -111,7 +111,7 @@ fn block_scalar_with_markdown_headings_round_trips() {
     assert_eq!(emitted, doc2.to_markdown(), "round-trip must be idempotent");
 }
 
-/// An array authored as `- |` block-scalar items (a `markdown[]` field)
+/// An array authored as `- |` block-scalar items (a `richtext[]` field)
 /// preserves `#` heading / `- ` bullet content per element. Regression for the
 /// sequence-item path of the block-scalar prescan fix.
 #[test]

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -230,10 +230,10 @@ fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool
     }
 }
 
-/// The cell's `(value, fill)` for a scalar/array/markdown leaf, per the value
+/// The cell's `(value, fill)` for a scalar/array/richtext leaf, per the value
 /// cascade. Endorsed → the default, no marker. Unendorsed → the `example` (when
-/// present) carried by the marker, else a bare null marker. Markdown never
-/// inlines an example: an Unendorsed markdown leaf is always a bare marker, but
+/// present) carried by the marker, else a bare null marker. A richtext leaf never
+/// inlines an example: an Unendorsed richtext leaf is always a bare marker, but
 /// its `example:` still surfaces as a `# e.g.` hint (see `append_scalar`).
 fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
     if let Some(default) = &field.default {
@@ -248,12 +248,12 @@ fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
     }
 }
 
-/// Append a scalar / scalar-array / markdown field as a single payload field
+/// Append a scalar / scalar-array / richtext field as a single payload field
 /// plus its trailing inline type annotation.
 fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
-    // Markdown never inlines its `example:` as the marker value, so — unlike
-    // other Unendorsed scalars — the example would vanish entirely. Surface it
-    // as a `# e.g.` hint instead (the hint no-ops when no `example:` is set).
+    // A richtext field never inlines its `example:` as the marker value, so —
+    // unlike other Unendorsed scalars — the example would vanish entirely.
+    // Surface it as a `# e.g.` hint instead (no-ops when no `example:` is set).
     let eg_when = field.default.is_some() || matches!(field.r#type, FieldType::RichText { .. });
     push_leading(items, field, eg_when);
     let (json, fill) = scalar_cell(field);

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -27,9 +27,9 @@
 //!
 //! ## Rendering choices that follow from sharing `to_markdown`
 //!
-//! - **Markdown fields** carry no block scalar. An Unendorsed markdown field
-//!   is a bare `field: !must_fill # markdown`; an Endorsed one renders its
-//!   default as an inline (double-quoted, `\n`-escaped) string. `to_markdown`
+//! - **Richtext fields** carry no block scalar. An Unendorsed richtext field
+//!   is a bare `field: !must_fill # richtext<markdown>`; an Endorsed one renders
+//!   its default as an inline (double-quoted, `\n`-escaped) string. `to_markdown`
 //!   emits no `|`/`>` block forms, so neither does the blueprint.
 //! - **Arrays** render in block style at every level — including an
 //!   Unendorsed array's `example`, which rides the `!must_fill` marker as
@@ -132,7 +132,12 @@ fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<&str>
     append_fields(&mut items, card);
     Card::from_parts(
         Payload::from_items(items),
-        crate::document::import_body_lossy(&body_text(card, "main")),
+        // The blueprint's output *is* the markdown surface, so it imports the
+        // body text (a trusted example or a generated placeholder) here and
+        // re-emits it via `to_markdown`. The empty-corpus fallback is defensive —
+        // a placeholder or a load-validated example never over-nests.
+        crate::document::import_body(&body_text(card, "main"))
+            .unwrap_or_else(|_| quillmark_richtext::RichText::empty()),
     )
 }
 
@@ -151,7 +156,8 @@ fn build_card(card: &CardSchema) -> Card {
     append_fields(&mut items, card);
     Card::from_parts(
         Payload::from_items(items),
-        crate::document::import_body_lossy(&body_text(card, &card.name)),
+        crate::document::import_body(&body_text(card, &card.name))
+            .unwrap_or_else(|_| quillmark_richtext::RichText::empty()),
     )
 }
 
@@ -481,7 +487,7 @@ main:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    bio: { type: markdown, example: "Hello world" }
+    bio: { type: richtext, example: "Hello world" }
 "#)
         .blueprint();
         assert!(t.contains("# e.g. Hello world\nbio: !must_fill # richtext<markdown>\n"));
@@ -609,7 +615,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     counts:   { type: array, items: { type: integer } }
-    sections: { type: array, items: { type: markdown } }
+    sections: { type: array, items: { type: richtext } }
     tags:     { type: array, items: { type: string } }
 "#)
         .blueprint();
@@ -629,7 +635,7 @@ main:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    bio: { type: markdown }
+    bio: { type: richtext }
 "#)
         .blueprint();
         assert!(t.contains("bio: !must_fill # richtext<markdown>\n"));
@@ -644,7 +650,7 @@ main:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    bio: { type: markdown, default: "" }
+    bio: { type: richtext, default: "" }
 "#)
         .blueprint();
         assert!(t.contains("bio: \"\" # richtext<markdown>\n"));
@@ -661,7 +667,7 @@ quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     bio:
-      type: markdown
+      type: richtext
       default: "## About me\n\nHello."
 "###)
         .blueprint();

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -353,7 +353,16 @@ fn resolve_fields(
 fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue {
     let present = value.filter(|v| !v.as_json().is_null());
     let Some(v) = present else {
-        return field.default.clone().unwrap_or_else(|| zero_value(field));
+        // For a richtext-bearing field the render floor commits the *corpus* form
+        // of the default (cached at load), so the seam carries canonical
+        // RichText-JSON rather than a re-imported markdown string. `default_corpus`
+        // is `None` for a non-richtext field, so those fall through to the raw
+        // `default`, then to the type-empty zero.
+        return field
+            .default_corpus
+            .clone()
+            .or_else(|| field.default.clone())
+            .unwrap_or_else(|| zero_value(field));
     };
     match (&field.r#type, &field.properties, &field.items) {
         (FieldType::Object, Some(props), _) => {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -209,7 +209,7 @@ impl QuillConfig {
 
                 // Every array carries an element schema (`items`). Coerce each
                 // element against it: scalar items (`string[]`, `integer[]`,
-                // `markdown[]`) coerce element-wise; object items recurse into
+                // `richtext[]`) coerce element-wise; object items recurse into
                 // the element's `properties` via the Object branch.
                 if let Some(items) = &field_schema.items {
                     let mut out = Vec::with_capacity(arr.len());

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -356,11 +356,28 @@ impl QuillConfig {
                 }
                 Ok(value.clone())
             }
-            FieldType::RichText { .. } => {
+            FieldType::RichText { inline } => {
                 // The seam carries the corpus, so coercion commits the corpus
                 // form: an already-structured value (editor / re-render) is
                 // validated and re-canonicalized; an authored markdown string is
                 // imported. Determinism is inherited from `import` being pure.
+                // An `inline` field additionally requires the resulting corpus to
+                // be single-`Para` (`richtext(inline)`): editors mount a one-line
+                // surface, so multi-block content is a coercion error here, in
+                // lockstep with the validation-layer `richtext::not_inline` check.
+                let inline_check = |rt: &quillmark_richtext::RichText| -> Result<(), CoercionError> {
+                    if inline && !rt.is_inline() {
+                        return Err(CoercionError::Uncoercible {
+                            path: path.to_string(),
+                            value: "<richtext>".to_string(),
+                            target: "richtext(inline)".to_string(),
+                            reason: "richtext(inline) requires a single paragraph line \
+                                     with no list/quote container and no islands"
+                                .to_string(),
+                        });
+                    }
+                    Ok(())
+                };
                 if json_value.is_object() {
                     let rt = quillmark_richtext::serial::from_canonical_value(json_value)
                         .map_err(|e| CoercionError::Uncoercible {
@@ -369,6 +386,7 @@ impl QuillConfig {
                             target: "richtext".to_string(),
                             reason: format!("not a valid richtext corpus: {e}"),
                         })?;
+                    inline_check(&rt)?;
                     return Ok(QuillValue::from_json(
                         quillmark_richtext::serial::to_canonical_value(&rt),
                     ));
@@ -401,6 +419,7 @@ impl QuillConfig {
                         reason: format!("markdown import failed: {e}"),
                     }
                 })?;
+                inline_check(&rt)?;
                 Ok(QuillValue::from_json(
                     quillmark_richtext::serial::to_canonical_value(&rt),
                 ))
@@ -1315,7 +1334,7 @@ impl QuillConfig {
         Self::validate_description_singleline(main_description.as_deref(), "main", &mut errors);
 
         // The main entry-point card.
-        let main = CardSchema {
+        let mut main = CardSchema {
             name: "main".to_string(),
             description: main_description,
             fields,
@@ -1473,6 +1492,18 @@ impl QuillConfig {
             }
         }
 
+        // Import every richtext `default` / `example` / `body.example` literal
+        // once into its canonical-corpus companion cache — a pure function of the
+        // Quill.yaml bytes, never serialized. This is where `richtext(inline)`
+        // violations and malformed richtext literals surface as load errors, and
+        // where seeding and the render floor later read a pre-validated corpus
+        // instead of re-importing the markdown per document.
+        populate_card_corpus(&mut main, "main", &mut errors);
+        for card in &mut card_kinds {
+            let label = format!("card_kinds.{}", card.name);
+            populate_card_corpus(card, &label, &mut errors);
+        }
+
         if !errors.is_empty() {
             return Err(errors);
         }
@@ -1508,4 +1539,182 @@ fn example_contains_fence_line(text: &str) -> bool {
         let line = line.strip_suffix('\r').unwrap_or(line);
         crate::document::fences::is_card_yaml_opener_line(line)
     })
+}
+
+/// Whether a field's type tree contains any richtext leaf — the gate for
+/// caching a corpus companion. A scalar (`string`, `integer`, …) never carries
+/// one; an `array<richtext>` or an `object` with a richtext property does.
+fn field_contains_richtext(field: &FieldSchema) -> bool {
+    match &field.r#type {
+        FieldType::RichText { .. } => true,
+        FieldType::Array => field
+            .items
+            .as_deref()
+            .is_some_and(field_contains_richtext),
+        FieldType::Object => field
+            .properties
+            .as_ref()
+            .is_some_and(|p| p.values().any(|f| field_contains_richtext(f))),
+        _ => false,
+    }
+}
+
+/// Populate a field's `default_corpus` / `example_corpus` companion caches from
+/// its markdown literals. No-op for a non-richtext field; a failed import or a
+/// `richtext(inline)` violation is appended to `errors` as a load diagnostic.
+fn populate_field_corpus(field: &mut FieldSchema, owner: &str, errors: &mut Vec<Diagnostic>) {
+    if !field_contains_richtext(field) {
+        return;
+    }
+    if let Some(default) = field.default.clone() {
+        match literal_corpus(&default, field, &format!("{owner} `default`")) {
+            Ok(corpus) => field.default_corpus = corpus,
+            Err(d) => errors.push(d),
+        }
+    }
+    if let Some(example) = field.example.clone() {
+        match literal_corpus(&example, field, &format!("{owner} `example`")) {
+            Ok(corpus) => field.example_corpus = corpus,
+            Err(d) => errors.push(d),
+        }
+    }
+}
+
+/// Populate every richtext corpus companion on a card: each field's
+/// `default`/`example`, and the card's `body.example` (block richtext — no
+/// inline constraint; skipped when the body is disabled, since its example is
+/// inert).
+fn populate_card_corpus(card: &mut CardSchema, label: &str, errors: &mut Vec<Diagnostic>) {
+    for (name, field) in card.fields.iter_mut() {
+        populate_field_corpus(field, &format!("{label} field `{name}`"), errors);
+    }
+    let body_enabled = card.body.as_ref().is_none_or(|b| b.enabled != Some(false));
+    if body_enabled {
+        if let Some(body) = card.body.as_mut() {
+            if let Some(example) = body.example.clone() {
+                match crate::document::import_body(&example) {
+                    Ok(rt) => {
+                        body.example_corpus = Some(QuillValue::from_json(
+                            quillmark_richtext::serial::to_canonical_value(&rt),
+                        ));
+                    }
+                    Err(e) => errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!("Failed to import {label} `body.example`: {e}"),
+                        )
+                        .with_code("quill::richtext_example_import".to_string()),
+                    ),
+                }
+            }
+        }
+    }
+}
+
+/// Compute the canonical-corpus form of a richtext-bearing schema literal
+/// (`default` / `example`), importing every markdown leaf once and enforcing
+/// `richtext(inline)`. Recurses through `array` / `object` shapes, converting
+/// only their richtext leaves and passing other elements through unchanged.
+/// `Ok(None)` when the literal carries no importable richtext (a null value, or
+/// a field the gate already cleared as non-richtext); `Err` is a load error.
+fn literal_corpus(
+    value: &QuillValue,
+    field: &FieldSchema,
+    label: &str,
+) -> Result<Option<QuillValue>, Diagnostic> {
+    let json = value.as_json();
+    // Null ≡ absent — no data to import, so no companion is cached.
+    if json.is_null() {
+        return Ok(None);
+    }
+    match &field.r#type {
+        FieldType::RichText { inline } => {
+            let rt = if let Some(s) = json.as_str() {
+                quillmark_richtext::import::from_markdown(s).map_err(|e| {
+                    richtext_literal_error(label, &format!("markdown import failed: {e}"))
+                })?
+            } else if json.is_object() {
+                quillmark_richtext::serial::from_canonical_value(json).map_err(|e| {
+                    richtext_literal_error(label, &format!("not a valid richtext corpus: {e}"))
+                })?
+            } else {
+                return Err(richtext_literal_error(
+                    label,
+                    "expected a markdown string (richtext literals are authored as markdown)",
+                ));
+            };
+            if *inline && !rt.is_inline() {
+                return Err(richtext_inline_error(label));
+            }
+            Ok(Some(QuillValue::from_json(
+                quillmark_richtext::serial::to_canonical_value(&rt),
+            )))
+        }
+        FieldType::Array => {
+            let Some(items) = field.items.as_deref() else {
+                return Ok(None);
+            };
+            if !field_contains_richtext(items) {
+                return Ok(None);
+            }
+            let arr = json.as_array().cloned().unwrap_or_default();
+            let mut out = Vec::with_capacity(arr.len());
+            for (idx, elem) in arr.iter().enumerate() {
+                let elem_v = QuillValue::from_json(elem.clone());
+                let corpus = literal_corpus(&elem_v, items, &format!("{label}[{idx}]"))?
+                    .unwrap_or(elem_v);
+                out.push(corpus.into_json());
+            }
+            Ok(Some(QuillValue::from_json(serde_json::Value::Array(out))))
+        }
+        FieldType::Object => {
+            let Some(props) = field.properties.as_ref() else {
+                return Ok(None);
+            };
+            if !props.values().any(|f| field_contains_richtext(f)) {
+                return Ok(None);
+            }
+            let obj = json.as_object().cloned().unwrap_or_default();
+            let mut out = serde_json::Map::new();
+            for (k, v) in &obj {
+                let converted = match props.get(k) {
+                    Some(pschema) => {
+                        let pv = QuillValue::from_json(v.clone());
+                        literal_corpus(&pv, pschema, &format!("{label}.{k}"))?
+                            .map(QuillValue::into_json)
+                            .unwrap_or_else(|| v.clone())
+                    }
+                    None => v.clone(),
+                };
+                out.insert(k.clone(), converted);
+            }
+            Ok(Some(QuillValue::from_json(serde_json::Value::Object(out))))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// A load diagnostic for a richtext schema literal that failed to import.
+fn richtext_literal_error(label: &str, reason: &str) -> Diagnostic {
+    Diagnostic::new(
+        Severity::Error,
+        format!("Failed to import richtext {label}: {reason}"),
+    )
+    .with_code("quill::richtext_example_import".to_string())
+}
+
+/// A load diagnostic for a `richtext(inline)` schema literal whose corpus spans
+/// more than a single paragraph.
+fn richtext_inline_error(label: &str) -> Diagnostic {
+    Diagnostic::new(
+        Severity::Error,
+        format!(
+            "richtext(inline) {label} must be a single paragraph (no blank lines, \
+             headings, lists, quotes, or tables)"
+        ),
+    )
+    .with_code("richtext::not_inline".to_string())
+    .with_hint(
+        "Reduce the value to one paragraph, or change the field `type:` to `richtext`.".to_string(),
+    )
 }

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -19,12 +19,12 @@ use crate::value::QuillValue;
 /// The type-empty (zero) value for `field`: the leanest value satisfying its
 /// declared type.
 ///
-/// Blank for most types — `""` (string/markdown/datetime), `0`, `false`, `[]`.
-/// `enum` has no empty member, so it zeroes to the first declared variant. An
-/// `object` with `properties` is shape-valid only when every property is
-/// present, so it zeroes (recursively) to an object with every property at its
-/// own zero value, not a bare `{}` (which only a property-less object degrades
-/// to).
+/// Blank for most types — `""` (string/datetime), `0`, `false`, `[]`, and the
+/// empty corpus for richtext. `enum` has no empty member, so it zeroes to the
+/// first declared variant. An `object` with `properties` is shape-valid only
+/// when every property is present, so it zeroes (recursively) to an object with
+/// every property at its own zero value, not a bare `{}` (which only a
+/// property-less object degrades to).
 pub fn zero_value(field: &FieldSchema) -> QuillValue {
     if let Some(values) = &field.enum_values {
         let first = values.first().cloned().unwrap_or_default();
@@ -47,7 +47,14 @@ pub fn zero_value(field: &FieldSchema) -> QuillValue {
         },
         FieldType::Integer | FieldType::Number => json!(0),
         FieldType::Boolean => json!(false),
-        // String / Markdown / DateTime: `""` is schema-valid for all three.
+        // A richtext field's zero is the empty corpus, not `""` — the seam
+        // carries canonical RichText-JSON, so the render floor must zero-fill an
+        // absent richtext field with a corpus the backend can lower. The empty
+        // corpus is single-`Para`, so it satisfies `richtext(inline)` too.
+        FieldType::RichText { .. } => {
+            quillmark_richtext::serial::to_canonical_value(&quillmark_richtext::RichText::empty())
+        }
+        // String / DateTime: `""` is schema-valid for both.
         _ => json!(""),
     };
     QuillValue::from_json(json)

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -74,8 +74,8 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                     serde_json::Value::String("array".to_string()),
                 );
                 // The element schema is emitted recursively, so a scalar
-                // element yields `items: {type: string}` (and markdown carries
-                // its `contentMediaType`), while an object element yields
+                // element yields `items: {type: string}` (and a richtext element
+                // carries its `contentMediaType`), while an object element yields
                 // `items: {type: object, properties: …}`.
                 if let Some(items) = &field.items {
                     schema.insert("items".to_string(), field_to_schema(items));

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -216,7 +216,7 @@ main:
   fields:
     sections:
       type: array
-      items: { type: markdown }
+      items: { type: richtext }
 "#;
         let schema = build_from_yaml(yaml);
         let json = schema.as_json();

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -28,6 +28,7 @@
 //! instance per declared kind.
 
 use indexmap::IndexMap;
+use quillmark_richtext::RichText;
 
 use super::Quill;
 use crate::quill::CardSchema;
@@ -42,11 +43,22 @@ use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 /// (the editor-surface validator flags it). Body: `overlay › body.example ›
 /// empty`, honored only when the kind enables bodies. The `$quill` / `$kind`
 /// system metadata is attached by the caller.
-fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, String) {
-    // Merge the example base with the overlay (schema-declared fields only).
+///
+/// **Seed-commits-corpus**: a seeded richtext field commits the *corpus* form
+/// (the load-time [`example_corpus`](crate::quill::FieldSchema::example_corpus)
+/// cache), and the body is the corpus, so a seeded document is canonical from
+/// birth rather than a markdown string re-imported at render. Overlay values
+/// (from a document's `$seed`) pass through as authored and canonicalize at the
+/// next `compile_data`.
+fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, RichText) {
+    // Merge the example base with the overlay (schema-declared fields only). A
+    // richtext-bearing field seeds from its pre-validated corpus companion; every
+    // other field seeds from its raw `example`.
     let mut merged: IndexMap<String, QuillValue> = IndexMap::new();
     for (name, field) in &schema.fields {
-        if let Some(example) = &field.example {
+        if let Some(corpus) = &field.example_corpus {
+            merged.insert(name.clone(), corpus.clone());
+        } else if let Some(example) = &field.example {
             merged.insert(name.clone(), example.clone());
         }
     }
@@ -70,15 +82,23 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, S
     });
     let fields: IndexMap<String, QuillValue> = entries.into_iter().collect();
 
-    // Body region: an overlay body wins, else `body.example`, else empty —
-    // and only when bodies are enabled for the kind.
+    // Body region as a corpus: an overlay body (authored markdown) is imported;
+    // otherwise the `body.example` corpus cache is used; else empty — and only
+    // when bodies are enabled for the kind.
     let body = if schema.body_enabled() {
-        overlay
-            .and_then(|o| o.body.clone())
-            .or_else(|| schema.body.as_ref().and_then(|b| b.example.clone()))
-            .unwrap_or_default()
+        if let Some(overlay_body) = overlay.and_then(|o| o.body.clone()) {
+            crate::document::import_body(&overlay_body).unwrap_or_else(|_| RichText::empty())
+        } else if let Some(corpus) = schema.body.as_ref().and_then(|b| b.example_corpus.as_ref()) {
+            quillmark_richtext::serial::from_canonical_value(corpus.as_json())
+                .unwrap_or_else(|_| RichText::empty())
+        } else if let Some(example) = schema.body.as_ref().and_then(|b| b.example.as_ref()) {
+            // Fallback for a schema built outside the loader (no cached corpus).
+            crate::document::import_body(example).unwrap_or_else(|_| RichText::empty())
+        } else {
+            RichText::empty()
+        }
     } else {
-        String::new()
+        RichText::empty()
     };
 
     (Payload::from_index_map(fields), body)
@@ -103,7 +123,7 @@ pub(crate) fn seed_main(quill: &Quill) -> Card {
     // markdown spec); set it so a seeded main card round-trips through
     // `to_markdown()` exactly as the parser and blueprint emit it.
     payload.set_kind("main");
-    Card::from_parts(payload, crate::document::import_body_lossy(&body))
+    Card::from_parts(payload, body)
 }
 
 pub(crate) fn seed_card_for_kind(
@@ -120,7 +140,7 @@ pub(crate) fn seed_card_for_kind(
 fn seed_composable(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> Card {
     let (mut payload, body) = seed_parts(schema, overlay);
     payload.set_kind(schema.name.clone());
-    Card::from_parts(payload, crate::document::import_body_lossy(&body))
+    Card::from_parts(payload, body)
 }
 
 pub(crate) fn seed_document(quill: &Quill) -> Document {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2218,18 +2218,18 @@ quill:
 main:
   fields:
     summary:
-      type: markdown
+      type: richtext
       description: Document summary
       ui:
         multiline: true
     notes:
-      type: markdown
+      type: richtext
       description: Short notes
 "#;
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    // `type: markdown` is the deprecated alias for block richtext.
+    // `richtext` (block) carries the `multiline` ui hint like `string` does.
     let summary = config.main.fields.get("summary").unwrap();
     assert_eq!(summary.r#type, FieldType::RichText { inline: false });
     assert_eq!(summary.ui.as_ref().unwrap().multiline, Some(true));
@@ -3070,5 +3070,118 @@ fn type_mismatch_preview_shows_array_contents() {
         diag.message.contains("one") && diag.message.contains("two"),
         "preview should render array contents, got: {}",
         diag.message
+    );
+}
+
+// ── PR-G: richtext(inline), load-time example import + cache ─────────────────
+
+/// A minimal quill declaring one field, for the richtext PR-G tests.
+fn quill_with_field(field_yaml: &str) -> Result<QuillConfig, Vec<Diagnostic>> {
+    let yaml = format!(
+        "quill:\n  name: rt\n  version: \"1.0\"\n  backend: typst\n  description: rt\nmain:\n  fields:\n{field_yaml}"
+    );
+    QuillConfig::from_yaml_with_warnings(&yaml).map(|(c, _)| c)
+}
+
+#[test]
+fn markdown_type_is_unknown_at_load() {
+    let err = quill_with_field("    body:\n      type: markdown\n").unwrap_err();
+    assert!(
+        err.iter().any(|d| d.code.as_deref() == Some("quill::field_parse_error")
+            && d.message.contains("markdown")),
+        "type: markdown should be a load error naming the type, got: {err:?}"
+    );
+}
+
+#[test]
+fn inline_richtext_example_over_one_para_is_a_load_error() {
+    let err = quill_with_field(
+        "    tag:\n      type: richtext(inline)\n      example: \"one\\n\\ntwo\"\n",
+    )
+    .unwrap_err();
+    assert!(
+        err.iter().any(|d| d.code.as_deref() == Some("richtext::not_inline")),
+        "a two-paragraph inline example should fail load with richtext::not_inline, got: {err:?}"
+    );
+}
+
+#[test]
+fn inline_richtext_single_line_example_loads_and_caches_corpus() {
+    let config =
+        quill_with_field("    tag:\n      type: richtext(inline)\n      example: \"a *bold* motto\"\n")
+            .expect("single-line inline example loads");
+    let field = config.main.fields.get("tag").unwrap();
+    assert_eq!(field.r#type, FieldType::RichText { inline: true });
+    // The load pass imports the markdown example into its corpus companion; the
+    // authored `example` string is retained untouched (Alternative A).
+    let corpus = field.example_corpus.as_ref().expect("example_corpus cached");
+    assert!(corpus.as_json().is_object(), "cached example is a corpus object");
+    assert_eq!(field.example.as_ref().unwrap().as_str(), Some("a *bold* motto"));
+}
+
+#[test]
+fn block_richtext_default_caches_corpus() {
+    let config = quill_with_field(
+        "    body:\n      type: richtext\n      default: \"## Heading\\n\\nBody.\"\n",
+    )
+    .expect("block richtext default loads");
+    let field = config.main.fields.get("body").unwrap();
+    let corpus = field.default_corpus.as_ref().expect("default_corpus cached");
+    assert!(corpus.as_json().is_object(), "cached default is a corpus object");
+}
+
+#[test]
+fn array_of_inline_richtext_caches_each_element() {
+    let config = quill_with_field(
+        "    refs:\n      type: array\n      items:\n        type: richtext(inline)\n      example:\n        - \"first *ref*\"\n        - \"second ref\"\n",
+    )
+    .expect("array<richtext(inline)> loads");
+    let field = config.main.fields.get("refs").unwrap();
+    let corpus = field.example_corpus.as_ref().expect("example_corpus cached");
+    let arr = corpus.as_json().as_array().expect("array of corpus");
+    assert_eq!(arr.len(), 2);
+    assert!(arr.iter().all(|e| e.is_object()), "each element is a corpus object");
+}
+
+#[test]
+fn inline_coercion_rejects_multi_block_document_value() {
+    let config =
+        quill_with_field("    tag:\n      type: richtext(inline)\n").expect("loads");
+    let mut fields: indexmap::IndexMap<String, QuillValue> = indexmap::IndexMap::new();
+    fields.insert(
+        "tag".to_string(),
+        QuillValue::from_json(serde_json::json!("one\n\ntwo")),
+    );
+    let err = config.coerce_payload(&fields).unwrap_err();
+    assert!(
+        err.to_string().contains("richtext(inline)"),
+        "coercion should reject a two-paragraph value for an inline field, got: {err}"
+    );
+}
+
+#[test]
+fn inline_coercion_accepts_single_line_document_value() {
+    let config =
+        quill_with_field("    tag:\n      type: richtext(inline)\n").expect("loads");
+    let mut fields: indexmap::IndexMap<String, QuillValue> = indexmap::IndexMap::new();
+    fields.insert(
+        "tag".to_string(),
+        QuillValue::from_json(serde_json::json!("just one line")),
+    );
+    let coerced = config.coerce_payload(&fields).expect("single line coerces");
+    assert!(
+        coerced.get("tag").unwrap().as_json().is_object(),
+        "coerced inline value is a corpus object"
+    );
+}
+
+#[test]
+fn richtext_zero_value_is_empty_corpus() {
+    let field = FieldSchema::new("x".to_string(), FieldType::RichText { inline: false }, None);
+    let zero = zero_value(&field);
+    assert!(
+        zero.as_json().is_object(),
+        "richtext zero-fill is the empty corpus, not a string: {:?}",
+        zero.as_json()
     );
 }

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -19,7 +19,7 @@ pub struct UiFieldSchema {
     pub order: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compact: Option<bool>,
-    /// Valid on `string` fields (plain text with newlines preserved) and `markdown` fields.
+    /// Valid on `string` fields (plain text with newlines preserved) and `richtext` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiline: Option<bool>,
 }
@@ -35,6 +35,15 @@ pub struct BodyCardSchema {
     /// Has no effect when `enabled` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<String>,
+    /// Canonical-corpus form of [`example`](Self::example), imported once at
+    /// quill load (`QuillConfig::from_yaml`) and cached here — a pure function of
+    /// the Quill.yaml bytes, never serialized. Seeding commits this instead of
+    /// re-importing the markdown per document, so a seeded body is corpus from
+    /// birth. `None` when there is no example or the schema was built outside the
+    /// loader (e.g. a hand-built test schema), in which case consumers fall back
+    /// to importing `example`.
+    #[serde(skip)]
+    pub example_corpus: Option<QuillValue>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -98,15 +107,18 @@ pub enum FieldType {
     DateTime,
     /// Rich text — the canonical corpus content model ([`RichText`]). Surfaced
     /// as `type: richtext` (block) or `richtext(inline)` (exactly one `Para`
-    /// line); the transform schema marks it `contentMediaType:
-    /// application/quillmark-richtext+json`. `markdown` is a deprecated alias for
-    /// block `richtext`. `inline` is parsed and carried here; its single-line
-    /// constraint is enforced in a later phase.
+    /// line, no container, no islands); the transform schema marks it
+    /// `contentMediaType: application/quillmark-richtext+json`. The pre-richtext
+    /// `markdown` spelling is no longer accepted — a Quill.yaml must declare
+    /// `richtext` / `richtext(inline)` explicitly (`from_str` returns `None` for
+    /// `markdown`, so the loader raises a schema load error).
     ///
     /// [`RichText`]: quillmark_richtext::RichText
     RichText {
         /// Single-`Para`-line variant (`richtext(inline)`); editors mount a
-        /// one-line editor and the emitter may lower without block wrapping.
+        /// one-line editor and the emitter may lower without block wrapping. The
+        /// constraint is enforced at coercion, validation, and load-time example
+        /// import.
         inline: bool,
     },
 }
@@ -124,9 +136,9 @@ impl FieldType {
             "datetime" => Some(FieldType::DateTime),
             "richtext" => Some(FieldType::RichText { inline: false }),
             "richtext(inline)" => Some(FieldType::RichText { inline: true }),
-            // `markdown` is the pre-richtext spelling — a deprecated alias for
-            // block richtext, kept so existing Quill.yaml keeps loading.
-            "markdown" => Some(FieldType::RichText { inline: false }),
+            // The pre-richtext `markdown` spelling is retired: it returns `None`
+            // here so the loader reports it as an unknown type rather than
+            // silently aliasing it to block richtext.
             _ => None,
         }
     }
@@ -201,10 +213,24 @@ pub struct FieldSchema {
     pub properties: Option<BTreeMap<String, Box<FieldSchema>>>,
     /// Element schema for `array` types. Required on every `array` field:
     /// the element type gives the array a concrete element type (`string[]`,
-    /// `integer[]`, `markdown[]`, …). For a typed table the element is an
+    /// `integer[]`, `richtext[]`, …). For a typed table the element is an
     /// `object` carrying its own `properties`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<Box<FieldSchema>>,
+    /// Canonical-corpus form of [`default`](Self::default) for a richtext-bearing
+    /// field, imported once at quill load and cached — never serialized. The
+    /// render floor (`resolve_fields`) commits this for an absent field, so a
+    /// richtext default crosses the seam as corpus, not a re-imported string.
+    /// `None` for a non-richtext field, a null/absent default, or a schema built
+    /// outside the loader.
+    #[serde(skip)]
+    pub default_corpus: Option<QuillValue>,
+    /// Canonical-corpus form of [`example`](Self::example) for a richtext-bearing
+    /// field, imported once at quill load and cached — never serialized. Seeding
+    /// commits this so a seeded field is corpus from birth. `None` under the same
+    /// conditions as [`default_corpus`](Self::default_corpus).
+    #[serde(skip)]
+    pub example_corpus: Option<QuillValue>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -242,6 +268,8 @@ impl FieldSchema {
             enum_values: None,
             properties: None,
             items: None,
+            default_corpus: None,
+            example_corpus: None,
         }
     }
 
@@ -279,6 +307,11 @@ impl FieldSchema {
             } else {
                 None
             },
+            // Corpus caches are populated by the loader's post-pass
+            // (`QuillConfig::from_yaml`), which alone imports and validates the
+            // markdown literals; a bare `from_quill_value` leaves them empty.
+            default_corpus: None,
+            example_corpus: None,
         })
     }
 }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -54,6 +54,14 @@ pub enum ValidationError {
         path: String,
         card: String,
     },
+
+    /// A `richtext(inline)` field whose corpus is not single-`Para` (a block, a
+    /// list/quote container, or an island). Same fatality class as
+    /// `TypeMismatch` — the value is well-typed richtext but the wrong *shape*
+    /// for an inline field.
+    NotInline {
+        path: String,
+    },
 }
 
 impl std::error::Error for ValidationError {}
@@ -108,6 +116,14 @@ impl std::fmt::Display for ValidationError {
                     hint = body_disabled_hint(),
                 )
             }
+            ValidationError::NotInline { path } => {
+                write!(
+                    f,
+                    "field `{path}` is `richtext(inline)` but its content is not a single \
+                     paragraph — {hint}",
+                    hint = not_inline_hint(),
+                )
+            }
         }
     }
 }
@@ -133,6 +149,12 @@ fn body_disabled_hint() -> &'static str {
     "remove the body content or set `body.enabled: true` on the card kind"
 }
 
+/// Actionable exit clause for a `NotInline` error.
+fn not_inline_hint() -> &'static str {
+    "keep the value to a single paragraph (no blank lines, headings, lists, \
+     quotes, or tables), or change the schema's `type:` to `richtext`"
+}
+
 impl ValidationError {
     /// Document-model path anchor for this error.
     ///
@@ -143,7 +165,8 @@ impl ValidationError {
             | ValidationError::EnumViolation { path, .. }
             | ValidationError::FormatViolation { path, .. }
             | ValidationError::UnknownCard { path, .. }
-            | ValidationError::BodyDisabled { path, .. } => path,
+            | ValidationError::BodyDisabled { path, .. }
+            | ValidationError::NotInline { path, .. } => path,
         }
     }
 
@@ -156,6 +179,7 @@ impl ValidationError {
             ValidationError::FormatViolation { .. } => "validation::format_violation",
             ValidationError::UnknownCard { .. } => "validation::unknown_card",
             ValidationError::BodyDisabled { .. } => "validation::body_disabled",
+            ValidationError::NotInline { .. } => "richtext::not_inline",
         }
     }
 
@@ -171,6 +195,7 @@ impl ValidationError {
                 ..
             } => Some(type_mismatch_hint(expected, actual, default.as_deref())),
             ValidationError::BodyDisabled { .. } => Some(body_disabled_hint().to_string()),
+            ValidationError::NotInline { .. } => Some(not_inline_hint().to_string()),
             ValidationError::EnumViolation { .. }
             | ValidationError::FormatViolation { .. }
             | ValidationError::UnknownCard { .. } => None,
@@ -432,6 +457,32 @@ fn validate_value(
             None => false,
         },
     };
+
+    // `richtext(inline)` shape check: a well-typed richtext value (corpus object,
+    // or a markdown string on a schema literal) must lower to a single `Para`.
+    // Runs only when the value is type-valid — a mistyped value already raises
+    // TypeMismatch below, and a null/absent inline field zero-fills to the empty
+    // corpus (which is inline). Mirrors the coercion-layer check so a corpus that
+    // bypassed coercion (e.g. a direct `validate_document`) is still caught.
+    if type_valid {
+        if let FieldType::RichText { inline: true } = field.r#type {
+            let json = value.as_json();
+            let parsed = if json.is_object() {
+                quillmark_richtext::serial::from_canonical_value(json).ok()
+            } else if let Some(s) = json.as_str() {
+                quillmark_richtext::import::from_markdown(s).ok()
+            } else {
+                None
+            };
+            if let Some(rt) = parsed {
+                if !rt.is_inline() {
+                    errors.push(ValidationError::NotInline {
+                        path: path.to_string(),
+                    });
+                }
+            }
+        }
+    }
 
     // A DateTime with a string value already emitted a FormatViolation;
     // skip the redundant TypeMismatch in that case.
@@ -904,5 +955,29 @@ main:
             ValidationError::BodyDisabled { path, card }
             if card == "main" && path == "main.body"
         )));
+    }
+
+    #[test]
+    fn rejects_richtext_inline_with_multi_block_corpus() {
+        // A pre-built two-paragraph corpus reaches the validator directly (no
+        // coercion), so the validation-layer NotInline backstop must fire.
+        let config = config_with("    tag:\n      type: richtext(inline)", "");
+        let rt = quillmark_richtext::import::from_markdown("one\n\ntwo").unwrap();
+        let corpus = quillmark_richtext::serial::to_canonical_value(&rt);
+        let doc = doc_from_fm(&[("tag", corpus)]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        assert!(has_error(&errors, |e| matches!(
+            e,
+            ValidationError::NotInline { path } if path == "tag"
+        )));
+    }
+
+    #[test]
+    fn accepts_richtext_inline_single_para_corpus() {
+        let config = config_with("    tag:\n      type: richtext(inline)", "");
+        let rt = quillmark_richtext::import::from_markdown("one line only").unwrap();
+        let corpus = quillmark_richtext::serial::to_canonical_value(&rt);
+        let doc = doc_from_fm(&[("tag", corpus)]);
+        assert!(validate_typed_document(&config, &doc).is_ok());
     }
 }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -413,7 +413,7 @@ fn validate_value(
         FieldType::Array => match value.as_array() {
             Some(items) => {
                 // Validate each element against the array's `items` schema.
-                // Scalar elements (`string[]`, `integer[]`, `markdown[]`, …)
+                // Scalar elements (`string[]`, `integer[]`, `richtext[]`, …)
                 // are type-checked element-wise; object elements recurse into
                 // their properties via the Object branch.
                 if let Some(item_schema) = &field.items {

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -13,7 +13,7 @@
 //!
 //! Three producers feed regions, all keyed on the schema path:
 //!
-//! - **Content fields** (a markdown body, a `markdown[]` element, a card's
+//! - **Content fields** (a richtext body, a `richtext[]` element, a card's
 //!   content field) are tracked by the **spans** their glyphs carry: the
 //!   backend evaluates each one's value at its own generated call site and
 //!   records the site's byte window, so every glyph of that content resolves

--- a/crates/core/tests/markdown_field_test.rs
+++ b/crates/core/tests/markdown_field_test.rs
@@ -1,8 +1,11 @@
 use quillmark_core::{normalize::normalize_document, quill::QuillConfig, Document};
 
 #[test]
-fn test_markdown_field_schema_emission() {
-    let config = QuillConfig::from_yaml(
+fn test_markdown_type_is_a_load_error() {
+    // `type: markdown` was a deprecated alias for block `richtext`; PR-G retires
+    // it outright. A Quill.yaml that still declares it fails to load — no silent
+    // alias, no parallel accepted spelling.
+    let err = QuillConfig::from_yaml(
         r#"
 quill:
   name: markdown_schema
@@ -16,13 +19,36 @@ main:
       type: markdown
 "#,
     )
+    .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("markdown"),
+        "load error should name the offending type: {msg}"
+    );
+}
+
+#[test]
+fn test_richtext_field_schema_emission() {
+    let config = QuillConfig::from_yaml(
+        r#"
+quill:
+  name: richtext_schema
+  version: "1.0"
+  backend: typst
+  description: richtext schema test
+
+main:
+  fields:
+    description:
+      type: richtext
+"#,
+    )
     .unwrap();
 
     let yaml = config.schema_yaml().unwrap();
     let value: serde_json::Value = serde_saphyr::from_str(&yaml).unwrap();
 
-    // `type: markdown` is a deprecated alias; the config re-serializes it as its
-    // canonical spelling, `richtext`.
     assert_eq!(
         value
             .get("main")

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -94,7 +94,7 @@ main:
       description: Bold-caps line below the seal; blank to omit.
 
     tag_line:
-      type: markdown
+      type: richtext(inline)
       default: ""
       ui:
         group: Letterhead
@@ -159,7 +159,7 @@ main:
     references:
       type: array
       items:
-        type: markdown
+        type: richtext(inline)
       default: []
       example:
         - "AFMAN 33-326, 25 November 2011, *Preparing Official Communications*"

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -220,7 +220,7 @@ main:
         group: Additional
         order: 15
       items:
-        type: richtext
+        type: richtext(inline)
     signature_block:
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
@@ -243,7 +243,7 @@ main:
         group: Addressing
         order: 2
     tag_line:
-      type: richtext
+      type: richtext(inline)
       description: >-
         Organizational motto at the bottom of the page. Supports Markdown emphasis
         (e.g. *italics*, **bold**).

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -306,6 +306,18 @@ impl RichText {
         self.text.chars().count()
     }
 
+    /// Whether this corpus satisfies the `richtext(inline)` constraint: exactly
+    /// one `Para` line, sitting in no container, with no islands. A single line
+    /// can never `continues` (line 0 is always `false`), so that dimension is
+    /// implied. [`RichText::empty`] is inline (one empty `Para`), so a blank or
+    /// zero-filled inline field passes.
+    pub fn is_inline(&self) -> bool {
+        self.islands.is_empty()
+            && self.lines.len() == 1
+            && self.lines[0].kind == LineKind::Para
+            && self.lines[0].containers.is_empty()
+    }
+
     /// Whether the corpus carries no renderable content: the text is empty or
     /// whitespace-only. An island slot ([`ISLAND_SLOT`], U+FFFC) is not
     /// whitespace, so an island-bearing corpus is never blank. This is the
@@ -628,6 +640,25 @@ mod tests {
     #[test]
     fn empty_is_valid() {
         assert_eq!(RichText::empty().validate(), Ok(()));
+    }
+
+    #[test]
+    fn is_inline_accepts_empty_and_single_para() {
+        assert!(RichText::empty().is_inline());
+        assert!(crate::import::from_markdown("just one line").unwrap().is_inline());
+        assert!(crate::import::from_markdown("a *bold* run")
+            .unwrap()
+            .is_inline());
+    }
+
+    #[test]
+    fn is_inline_rejects_blocks_containers_and_islands() {
+        // Two paragraphs → two Para lines.
+        assert!(!crate::import::from_markdown("one\n\ntwo").unwrap().is_inline());
+        // A heading is a non-Para line kind.
+        assert!(!crate::import::from_markdown("# heading").unwrap().is_inline());
+        // A list item sits in a container.
+        assert!(!crate::import::from_markdown("- item").unwrap().is_inline());
     }
 
     #[test]

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -439,7 +439,7 @@ degrades gracefully on every type-valid input shape. The contract
 requires:
 
 - Templates treat type-empty values (`""`, `0`, `false`, `[]`, empty
-  markdown body) as valid *present* input — read via `data.field`,
+  richtext body) as valid *present* input — read via `data.field`,
   `card.at("field", default: …)`, or guarded with `if "field" in data`.
 - No template asserts that an Unendorsed field is *non-empty*. The schema
   guarantees *presence*, not non-emptiness; the `!must_fill` marker

--- a/prose/canon/INDEX.md
+++ b/prose/canon/INDEX.md
@@ -20,7 +20,7 @@
 
 ## Backends
 
-- **[CONVERT.md](CONVERT.md)** - How the Typst backend renders markdown body content to Typst markup
+- **[CONVERT.md](CONVERT.md)** - How the Typst backend lowers richtext body content (the corpus) to Typst markup
 - Typst backend internals: see `crates/backends/typst/` rustdoc
 - **[../../docs/quills/pdfform-backend.md](../../docs/quills/pdfform-backend.md)** - The `pdfform` backend: fill an existing AcroForm PDF (real interactive fields, Technique A), built on the `quillmark-pdf` stamp spine
 

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -158,7 +158,7 @@ four queries, two coarse and two fine:
 - `locate(field, pos)` answers *corpus position → caret rect* — the reverse of
   `positionAt`, the box to draw a caret at.
 
-Three producers: **content fields** (a markdown body, a `markdown[]` element,
+Three producers: **content fields** (a richtext body, a `richtext[]` element,
 a card's content field) are tracked by the spans their glyphs carry — the
 backend evaluates each value at its own generated call site and records the
 site's byte window, so the rendered ink resolves back to its field through

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -104,7 +104,7 @@ typst:
     - "@preview/some-package:1.0.0"
 ```
 
-Field names must be `snake_case` (match `[a-z][a-z0-9_]*`). Capitalized or `$`-prefixed keys are rejected at config parse time with `quill::invalid_field_name` — document-level metadata sits on dedicated `$`-prefixed keys in the plate JSON (`$quill`, `$body`, `$cards`, `$kind`), and user fields stay lowercase so they cannot shadow it. Standalone `object` fields require a `properties` map. Every `array` field requires an `items:` element schema: use `items: { type: string }` (or `integer`, `markdown`, …) for a list of scalars, and `items: { type: object, properties: … }` for a list of objects.
+Field names must be `snake_case` (match `[a-z][a-z0-9_]*`). Capitalized or `$`-prefixed keys are rejected at config parse time with `quill::invalid_field_name` — document-level metadata sits on dedicated `$`-prefixed keys in the plate JSON (`$quill`, `$body`, `$cards`, `$kind`), and user fields stay lowercase so they cannot shadow it. Standalone `object` fields require a `properties` map. Every `array` field requires an `items:` element schema: use `items: { type: string }` (or `integer`, `richtext`, …) for a list of scalars, and `items: { type: object, properties: … }` for a list of objects.
 
 Metadata resolution:
 - `name`, `description`, `backend`, `version`, `author` are direct struct fields on `QuillConfig`. `description` (required, non-empty in the `quill:` section) describes the quill itself; it is independent of `QuillConfig.main.description`, which is the optional schema description authored under `main:` like any other card kind.

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -25,7 +25,7 @@ Supported field types:
 | `array` | Ordered list; requires an `items:` element schema (e.g. `items: { type: string }` for `string[]`, `items: { type: object, properties: … }` for a typed table) |
 | `object` | Structured map; requires `properties:` |
 | `datetime` | YAML 1.1 timestamp: bare `YYYY-MM-DD` through full RFC 3339 with offset; seconds optional |
-| `richtext` | Rich prose over a canonical corpus (`RichText`); markdown is a projection of it. `richtext(inline)` is the single-line variant. `markdown` is a deprecated alias for block `richtext` |
+| `richtext` | Rich prose over a canonical corpus (`RichText`); markdown is a projection of it. `richtext(inline)` is the single-line variant (exactly one `Para` line, no container, no islands). The pre-richtext `markdown` spelling is no longer accepted — it is a schema load error (`quill::field_parse_error`) |
 
 ## Type coercion
 
@@ -35,6 +35,7 @@ Supported field types:
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
 - Coercion rules per type: array wrapping plus element-wise coercion against the `items` schema (a bad element fails at its indexed path, e.g. `counts[1]`); boolean from string/int/float; number/integer from string or from boolean (`true→1`, `false→0`); string unwraps a length-1 string array into the bare string (else identity); richtext commits the canonical corpus form (the model) — an authored markdown string imports (via `quillmark-richtext::import`), an editor-supplied corpus object revalidates and re-canonicalizes, and the length-1-array-unwrap / bare-scalar-stringify leniencies feed the import; date/datetime format validation; object property recursion
+- **`richtext(inline)` enforcement.** An `inline` field's corpus must be exactly one `Para` line, in no container, with no islands (`RichText::is_inline`). The empty corpus satisfies it, so a blank or zero-filled inline field passes. The constraint is checked in three places: coercion (`CoercionError` for a document value), validation (`richtext::not_inline`, the `TypeMismatch` fatality class, as a backstop for a corpus that bypassed coercion), and load-time example import (a schema literal that violates it is a load error)
 - **Null short-circuits coercion.** A null value (`field:`, `field: null`,
   `field: ~`) passes coercion unchanged for *every* type — null ≡ absent, so
   it carries no data to coerce. The value reaches the render floor and
@@ -170,11 +171,22 @@ seeded documents alike (see [BLUEPRINT.md](BLUEPRINT.md)).
 ## Document seeding
 
 **Seeding** builds a starter `Document` from the schema for editor consumers
-("new document"): each field that declares an `example:` is committed verbatim,
-and **every other field is left absent**. The seeding cascade is therefore
+("new document"): each field that declares an `example:` is committed, and
+**every other field is left absent**. The seeding cascade is therefore
 `example: → absent` — absent fields are never written; they are interpolated at
 the compilation layer by [zero-filled render](#zero-filled-render) (`default:`,
 else type-empty zero), exactly as for any authored document.
+
+**Seed-commits-corpus.** A seeded richtext field (and the body) commits the
+canonical **corpus** form, not the authored markdown string, so a seeded
+document is corpus from birth — matching what an editor round-trip produces and
+what storage embeds. The corpus is imported once at quill load into a
+`#[serde(skip)]` companion cache on the schema (`FieldSchema::default_corpus` /
+`example_corpus`, `BodyCardSchema::example_corpus`), a pure function of the
+`Quill.yaml` bytes; seeding and the render floor read that cache rather than
+re-importing markdown per document. The authored markdown literal is retained
+untouched — it is the source of truth the schema emits and the blueprint prints;
+the corpus is a derived projection of it.
 
 Committing *only* `example` is the whole design. `resolve_fields` already
 produces `default` and `zero` at compile time but **never `example`** (example

--- a/prose/plans/richtext/INDEX.md
+++ b/prose/plans/richtext/INDEX.md
@@ -7,11 +7,12 @@ behind their spike gates, not on `main` piecemeal.
 
 ## Status
 
-Phases 0–2 are landed. The only remaining work is **PR-G**: `richtext(inline)`
-enforcement, load-time schema-example import + cache, seed-commits-corpus, and
-retiring the `markdown` type alias as a hard load-time error (today it is a
-silent alias). PR-G's spec lives in [phase-2.md](phase-2.md) — this doc does
-not duplicate it.
+Phases 0–2 are landed, **including PR-G** — `richtext(inline)` enforcement
+(coercion + validation + load-time), load-time schema-example import into a
+`#[serde(skip)]` corpus cache, seed-commits-corpus, and the hard `markdown`-alias
+cutover (`type: markdown` is now a schema load error, not a silent alias).
+PR-G's spec lives in [phase-2.md](phase-2.md); the landed behavior lives in
+`prose/canon/` (SCHEMAS.md). Phase 3 (edit surface) is the next open work.
 
 For how the system works *today* — the `RichText` corpus, the seam, storage,
 schema surface, navigation — see `prose/canon/` (ARCHITECTURE, CONVERT,
@@ -56,9 +57,9 @@ not restate the model.
   engine untouched.
 - **[Phase 2 — engine consumes RichText](phase-2.md) (delivered
   [#829](https://github.com/quillmark-org/quillmark/issues/829)).** Landed
-  through PR-F: seam flip to corpus JSON, typst emitter + segment maps,
-  storage cutover, regions + navigation (`locate`/`position_at`). **PR-G is
-  open** — see phase-2.md.
+  through PR-G: seam flip to corpus JSON, typst emitter + segment maps,
+  storage cutover, regions + navigation (`locate`/`position_at`), and PR-G's
+  `richtext(inline)` + load-time example cache + `markdown`-alias cutover.
 - **Phase 3 — edit surface.** Per-field delta (`retain`/`insert`/`delete` text
   splices, CodeMirror `ChangeSet` semantics, not attributed Quill-Delta) +
   monotonic revision + bounded change log; form-editor binding on phase-0's

--- a/prose/plans/richtext/phase-2.md
+++ b/prose/plans/richtext/phase-2.md
@@ -12,7 +12,9 @@ Gated on the [phase-0 spikes](phase-0.md) (all reported, no red flag) and the
 [phase-1 freeze](phase-1.md) (landed).
 
 **Status: PR-A through PR-F landed and merged into `integration/richtext`**
-(#838, #839). **PR-G is the only remaining work** — see § PR-G below.
+(#838, #839). **PR-G is implemented** (`richtext(inline)` enforcement, load-time
+example import + corpus cache, seed-commits-corpus, hard `markdown`-alias
+cutover) — see § PR-G below; its landed behavior lives in canon (SCHEMAS.md).
 
 ## Landed
 
@@ -144,10 +146,10 @@ numbers are needed again).
    `references: array<richtext>` field for cost and correctness as a first
    real user of this path.
 
-## PR-G — richtext(inline), load-time import, hard alias cutover (next)
+## PR-G — richtext(inline), load-time import, hard alias cutover (implemented)
 
-The only remaining phase-2 work. Three pieces, one of them newly sharpened to
-a hard cutover.
+Three pieces, one of them a hard cutover. All three landed as described below;
+the canonical account of the resulting behavior is in SCHEMAS.md.
 
 1. **Enforce `richtext(inline)`.** Against the corpus: exactly one `Para`
    line, empty `containers`, no islands (`continues` impossible); marks

--- a/prose/plans/richtext/phase-2.md
+++ b/prose/plans/richtext/phase-2.md
@@ -11,10 +11,12 @@ regions — as the degenerate case of the segment map, not a special path.
 Gated on the [phase-0 spikes](phase-0.md) (all reported, no red flag) and the
 [phase-1 freeze](phase-1.md) (landed).
 
-**Status: PR-A through PR-F landed and merged into `integration/richtext`**
-(#838, #839). **PR-G is implemented** (`richtext(inline)` enforcement, load-time
-example import + corpus cache, seed-commits-corpus, hard `markdown`-alias
-cutover) — see § PR-G below; its landed behavior lives in canon (SCHEMAS.md).
+**Status: complete.** PR-A through PR-F landed and merged into
+`integration/richtext` (#838, #839); PR-G lands the final piece
+(`richtext(inline)` enforcement, load-time example import + corpus cache,
+seed-commits-corpus, hard `markdown`-alias cutover). The behavior lives in canon
+(SCHEMAS.md); Phase 3 (edit surface) is the next open work — see
+[INDEX.md](INDEX.md).
 
 ## Landed
 
@@ -39,7 +41,7 @@ cutover) — see § PR-G below; its landed behavior lives in canon (SCHEMAS.md).
    JSON; the typst backend consumes it via `emit_richtext`; **`mark_to_typst`,
    `convert.rs`, and the backend's `pulldown-cmark` dependency are deleted**;
    `FieldType::Markdown` → `RichText { inline }` (`markdown` kept as a
-   deprecated alias — PR-G retires it); bindings flip `card.body` to corpus
+   deprecated alias, retired in PR-G); bindings flip `card.body` to corpus
    JSON and add `card.bodyMarkdown`; pdfform lowers to plaintext.
 7. **PR-F — regions + navigation (#829).** Two-tier `(window, segment)` scan;
    `RenderedRegion.span`; `position_at` / `locate`. Landed carrying two
@@ -53,6 +55,17 @@ cutover) — see § PR-G below; its landed behavior lives in canon (SCHEMAS.md).
    one node wider than any per-line run, so per-run inversion is a structural
    non-starter there (not merely imprecise), and node-start would point at
    bytes outside every line's own text.
+8. **PR-G — `richtext(inline)`, load-time example cache, alias cutover.**
+   `RichText::is_inline()` (one `Para` line, no container, no islands),
+   enforced at coercion, validation (`richtext::not_inline`, `TypeMismatch`
+   fatality), and load-time example import. `QuillConfig::from_yaml` imports
+   every richtext `default`/`example`/`body.example` once into `#[serde(skip)]`
+   corpus companions (a pure function of the Quill.yaml bytes) — the authored
+   markdown literal is retained as the canonical projection, the corpus is the
+   derived cache. Seed-commits-corpus: seeding and the render floor read the
+   cache, so seeded documents and zero-fills are corpus (retires
+   `import_body_lossy`; `zero_value` for richtext is the empty corpus). Hard
+   cutover: `type: markdown` is a schema **load error**, not a silent alias.
 
 All landed code and its rationale now live in canon (ARCHITECTURE.md,
 DOCUMENT_STORAGE.md, CONVERT.md, PLATE_DATA.md, PREVIEW.md, SCHEMAS.md,
@@ -75,7 +88,7 @@ corpus.
 
 Net parser count is unchanged (one), moved from every render to each ingest.
 This is the invariant every later PR had to preserve, and the one PR-G's
-alias cutover finishes closing off.
+alias cutover closed off.
 
 ### Seam + storage — one canonical form, three consumers
 
@@ -145,40 +158,6 @@ numbers are needed again).
    field-level until the field is stored structurally. Watch `usaf_memo`'s
    `references: array<richtext>` field for cost and correctness as a first
    real user of this path.
-
-## PR-G — richtext(inline), load-time import, hard alias cutover (implemented)
-
-Three pieces, one of them a hard cutover. All three landed as described below;
-the canonical account of the resulting behavior is in SCHEMAS.md.
-
-1. **Enforce `richtext(inline)`.** Against the corpus: exactly one `Para`
-   line, empty `containers`, no islands (`continues` impossible); marks
-   unrestricted. Enforce in `validation.rs` as a type error
-   (`richtext::not_inline`, the `TypeMismatch` fatality class) and in
-   coercion. Editors read the constraint to mount single-line editors; the
-   emitter may skip block wrapping for an inline field (headers).
-2. **Load-time schema-example import + cache.** `QuillConfig::from_yaml`
-   imports every richtext `default` / `example` / `body.example` once into
-   `#[serde(skip)]` companions (`default_corpus` / `example_corpus:
-   Option<QuillValue>` on `FieldSchema` and `BodyCardSchema`) — the cache
-   lives on the schema object, keyed structurally, a pure function of the
-   Quill.yaml bytes. This retires `import_body_lossy`, the
-   over-nesting-degrades-to-empty bridge PR-B left on seed / blueprint /
-   `replace_body`: those paths read a pre-validated corpus instead.
-   **Seed-commits-corpus**: `resolve_fields` and seeding commit the corpus
-   form, so seeded documents are canonical from birth. `blueprint()` keeps
-   reading the authored markdown (its output *is* the markdown surface) — it
-   currently canonicalizes example bodies through `to_markdown`/
-   `body_markdown`; if byte-exact authored examples in the blueprint turn out
-   to matter, special-case it there rather than reworking the general path.
-3. **Hard cutover — retire the `markdown` type alias.** Today `type:
-   markdown` is a silently-accepted deprecated alias for `RichText { inline:
-   false }` (load-time warning only, per PR-E). Remove the alias outright:
-   `type: markdown` becomes a schema **load error**, not a warning. No
-   parallel accepted spelling survives — every Quill.yaml must declare
-   `richtext` / `richtext(inline)` explicitly. Grep the workspace (Quill.yaml
-   + fixtures) for `type: markdown` and convert every hit before landing;
-   update SCHEMAS.md / BLUEPRINT.md's alias line in the same PR.
 
 ## Related
 


### PR DESCRIPTION
Completes phase-2 **PR-G** of the richtext rework ([#831](https://github.com/quillmark-org/quillmark/issues/831)) — the last remaining phase-2 work. Three pieces.

## 1. Enforce `richtext(inline)`

`RichText::is_inline()` — exactly one `Para` line, no list/quote container, no islands (marks unrestricted; the empty corpus passes, so a blank/zero-filled inline field is valid). Enforced at three layers so an inline field can never hold a multi-block value:

- **Coercion** — a document value that lowers to more than one block → `CoercionError`.
- **Validation** — new `ValidationError::NotInline` (code `richtext::not_inline`, `TypeMismatch` fatality class), a backstop for a corpus that reached the validator without coercion.
- **Load-time** — a schema `default:`/`example:` literal that violates it is a schema load error.

## 2. Load-time schema-example import + corpus cache

`QuillConfig::from_yaml` imports every richtext `default` / `example` / `body.example` **once** into `#[serde(skip)]` companions (`FieldSchema::{default_corpus, example_corpus}`, `BodyCardSchema::example_corpus`) — a pure function of the `Quill.yaml` bytes, recursing through `array<richtext>` and objects, validated at load.

- **Markdown stays the canonical projection** of a richtext `example:`/`default:` (Alternative A): the authored literal is retained untouched and is what the schema emits and the blueprint prints; the corpus is a derived cache.
- **Seed-commits-corpus**: `resolve_fields` (render floor) and seeding read the cached corpus, so seeded documents and zero-fills carry corpus rather than a re-imported markdown string. `zero_value` for richtext is now the empty corpus.
- Retires `import_body_lossy` (the over-nesting-degrades-to-empty bridge PR-B left on seed/blueprint/replace_body).

## 3. Hard cutover — retire the `markdown` type alias

`type: markdown` is no longer accepted — `FieldType::from_str` returns `None`, so it is a schema **load error** (`quill::field_parse_error`), not a silent alias. Converted the `usaf_memo` fixture (`tag_line`, `references[]` → `richtext(inline)`; golden regenerated with exactly those two lines changed) and all test YAML.

## Docs

Canon `SCHEMAS.md` (inline enforcement, seed-commits-corpus, the cache) and `QUILL.md` updated; the richtext plan (`INDEX.md`, `phase-2.md`) marks PR-G implemented. User-facing `docs/quills/*.md` reference pages still mention `type: markdown` and were **intentionally left** for the end-of-phases doc cleanup (the rework is unreleased); the released `docs/migrations/0.86-to-0.87.md` guide is era-accurate and untouched.

## Tests

`cargo test --workspace` — 48 suites green, 0 failures. Adds 10 PR-G tests (inline enforcement across all three layers, cache population for scalar/block/array shapes, richtext zero-value, alias load error). The typst-backend integration suites drive inline richtext through the real render path. WASM/Python binding tests run on CI per the repo's cloud convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RvfzEyvmEzVz7MUPquzEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014RvfzEyvmEzVz7MUPquzEZ)_