### PR TITLE
feat(richtext): fallible document body mutators (PR-E)

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -610,8 +610,11 @@ impl PyDocument {
         Ok(())
     }
 
-    fn replace_body(&mut self, body: &str) {
-        self.inner.main_mut().replace_body(body);
+    fn replace_body(&mut self, body: &str) -> PyResult<()> {
+        self.inner
+            .main_mut()
+            .replace_body(body)
+            .map_err(convert_edit_error)
     }
 
     /// Build a fresh `Card` dict from a kind and a flat field mapping — the
@@ -730,8 +733,9 @@ impl PyDocument {
     }
 
     fn update_card_body(&mut self, index: usize, body: &str) -> PyResult<()> {
-        self.card_mut_or_raise(index)?.replace_body(body);
-        Ok(())
+        self.card_mut_or_raise(index)?
+            .replace_body(body)
+            .map_err(convert_edit_error)
     }
 }
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -900,8 +900,11 @@ impl Document {
     }
 
     #[wasm_bindgen(js_name = replaceBody)]
-    pub fn replace_body(&mut self, body: &str) {
-        self.inner.main_mut().replace_body(body);
+    pub fn replace_body(&mut self, body: &str) -> Result<(), JsValue> {
+        self.inner
+            .main_mut()
+            .replace_body(body)
+            .map_err(|e| edit_error_to_js(&e))
     }
 
     /// Build a fresh `Card` from a kind and a flat field map — the ergonomic
@@ -1063,8 +1066,9 @@ impl Document {
     /// Replace the body of the card at `index`. Throws if out of range.
     #[wasm_bindgen(js_name = updateCardBody)]
     pub fn update_card_body(&mut self, index: usize, body: &str) -> Result<(), JsValue> {
-        self.card_mut_or_throw(index)?.replace_body(body);
-        Ok(())
+        self.card_mut_or_throw(index)?
+            .replace_body(body)
+            .map_err(|e| edit_error_to_js(&e))
     }
 }
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -17,6 +17,10 @@
 
 use unicode_normalization::UnicodeNormalization;
 
+use quillmark_richtext::delta::diff_import;
+use quillmark_richtext::import::ImportError;
+use quillmark_richtext::{ApplyError, Delta, LineOp, MarkOp, RichText};
+
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::document::{Card, Document, Payload};
 use crate::value::QuillValue;
@@ -63,6 +67,17 @@ pub enum EditError {
 
     #[error("value nests deeper than the maximum of {max} levels")]
     ValueTooDeep { max: usize },
+
+    /// Markdown body import failed — the corpus codec rejected the input
+    /// (e.g. container nesting past [`MAX_NESTING_DEPTH`](quillmark_richtext::MAX_NESTING_DEPTH)).
+    /// The fallible replacement for the pre-phase-3 silent degrade-to-empty.
+    #[error("body import failed: {0}")]
+    BodyImport(ImportError),
+
+    /// A corpus field-change bundle (text delta, line ops, mark ops) applied
+    /// out of bounds or broke an invariant normalization could not repair.
+    #[error("corpus apply failed: {0:?}")]
+    CorpusApply(ApplyError),
 }
 
 impl EditError {
@@ -77,6 +92,8 @@ impl EditError {
             EditError::ReservedKind => "ReservedKind",
             EditError::IndexOutOfRange { .. } => "IndexOutOfRange",
             EditError::ValueTooDeep { .. } => "ValueTooDeep",
+            EditError::BodyImport(_) => "BodyImport",
+            EditError::CorpusApply(_) => "CorpusApply",
         }
     }
 }
@@ -429,13 +446,63 @@ impl Card {
         removed
     }
 
-    /// Replace the body from an authored markdown string, importing it into the
-    /// corpus. A pathologically over-nested input (`> MAX_NESTING_DEPTH`)
-    /// degrades to the empty corpus rather than erroring; the fallible edit
-    /// surface is Phase 3.
-    pub fn replace_body(&mut self, body: impl Into<String>) {
-        let corpus = super::import_body(&body.into())
-            .unwrap_or_else(|_| quillmark_richtext::RichText::empty());
+    /// Set the body corpus directly from a pre-built [`RichText`]. The native
+    /// richtext writer: a corpus is valid by construction, so this is
+    /// infallible — no markdown import, no schema check. Use it when the caller
+    /// already holds a corpus (a decoded canonical-JSON body, another field's
+    /// value, an editor's serialized state); use [`replace_body`](Self::replace_body)
+    /// to import from an authored markdown string instead.
+    pub fn set_body_corpus(&mut self, corpus: RichText) {
         self.overwrite_body(corpus);
+    }
+
+    /// Replace the body from an authored markdown string — the whole-document
+    /// (stale-text / LLM / MCP) writer. Imports the markdown, diffs it against
+    /// the current body, and rebases surviving identity anchors onto the new
+    /// text (cold import + [`diff_import`]). A pathologically over-nested input
+    /// (`> MAX_NESTING_DEPTH`) returns [`EditError::BodyImport`] rather than
+    /// silently degrading to the empty corpus (retired in phase 3). To also
+    /// obtain the text [`Delta`] for recording into a session change log, call
+    /// [`import_body_delta`](Self::import_body_delta).
+    pub fn replace_body(&mut self, body: impl Into<String>) -> Result<(), EditError> {
+        self.import_body_delta(body).map(|_| ())
+    }
+
+    /// Import an authored markdown string into the body and return the text
+    /// [`Delta`] from the old body to the new one — the recordable form of
+    /// [`replace_body`](Self::replace_body). The stale-text writer wired to the
+    /// change log: a caller holding a [`LiveSession`](crate::LiveSession) feeds
+    /// the returned delta to
+    /// [`record_field_delta`](crate::LiveSession::record_field_delta) so a
+    /// stale corpus position maps forward through the whole-document replace,
+    /// the same as a native field edit. Surviving identity anchors rebase onto
+    /// the new text; formatting marks are re-derived by the fresh import.
+    /// Returns [`EditError::BodyImport`] on an over-nested input.
+    pub fn import_body_delta(&mut self, body: impl Into<String>) -> Result<Delta, EditError> {
+        let (corpus, delta) =
+            diff_import(self.body(), &body.into()).map_err(EditError::BodyImport)?;
+        self.overwrite_body(corpus);
+        Ok(delta)
+    }
+
+    /// Apply a committed field-change bundle to the body corpus — the native
+    /// form-editor writer. Order is text delta → line ops → mark ops, each
+    /// followed by normalization ([`RichText::apply_field_change`]); mark
+    /// ranges are in post-text-delta coordinates. A caller recording into a
+    /// session change log passes the same `text_delta`, `line_ops`, and
+    /// `mark_ops` to
+    /// [`record_field_change`](crate::LiveSession::record_field_change).
+    /// Returns [`EditError::CorpusApply`] when an op is out of bounds; the body
+    /// is unchanged on error only up to the failing op — apply the bundle
+    /// against a body at the delta's base revision.
+    pub fn apply_body_change(
+        &mut self,
+        text_delta: &Delta,
+        line_ops: &[LineOp],
+        mark_ops: &[MarkOp],
+    ) -> Result<(), EditError> {
+        self.body_mut()
+            .apply_field_change(text_delta, line_ops, mark_ops)
+            .map_err(EditError::CorpusApply)
     }
 }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -155,6 +155,10 @@ impl Card {
     pub(crate) fn overwrite_body(&mut self, body: RichText) {
         self.body = body;
     }
+
+    pub(crate) fn body_mut(&mut self) -> &mut RichText {
+        &mut self.body
+    }
 }
 
 /// A parsed, per-kind **seed overlay**: the sparse fields (and optional body)

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -184,7 +184,7 @@ fn test_document_set_quill_ref() {
 #[test]
 fn test_document_replace_body() {
     let mut doc = make_doc();
-    doc.main_mut().replace_body("New body content.");
+    doc.main_mut().replace_body("New body content.").unwrap();
     assert_eq!(doc.main().body_markdown(), "New body content.\n");
 }
 
@@ -254,7 +254,7 @@ fn test_document_card_mut() {
     let mut doc = make_doc_with_cards();
     {
         let card = doc.card_mut(0).unwrap();
-        card.replace_body("Updated card body.");
+        card.replace_body("Updated card body.").unwrap();
     }
     assert_eq!(doc.cards()[0].body_markdown(), "Updated card body.\n");
 }
@@ -532,8 +532,143 @@ fn test_card_remove_field_invalid_name_throws() {
 #[test]
 fn test_card_set_body() {
     let mut card = Card::new("note").unwrap();
-    card.replace_body("Card body text.");
+    card.replace_body("Card body text.").unwrap();
     assert_eq!(card.body_markdown(), "Card body text.\n");
+}
+
+// ── Card richtext body writers (PR-E) ────────────────────────────────────────
+
+/// A body markdown import past the container-nesting limit now returns
+/// `EditError::BodyImport` instead of silently degrading to the empty corpus.
+#[test]
+fn test_replace_body_reports_import_error() {
+    let mut card = Card::new("note").unwrap();
+    let deep = ">".repeat(crate::error::MAX_NESTING_DEPTH + 5);
+    match card.replace_body(&deep) {
+        Err(EditError::BodyImport(_)) => {}
+        other => panic!("expected BodyImport, got {other:?}"),
+    }
+    assert_eq!(
+        EditError::BodyImport(quillmark_richtext::import::ImportError::NestingTooDeep {
+            depth: 1,
+            max: 1
+        })
+        .variant_name(),
+        "BodyImport"
+    );
+}
+
+/// `set_body_corpus` installs a pre-built corpus verbatim — no markdown import.
+#[test]
+fn test_set_body_corpus_sets_directly() {
+    let mut card = Card::new("note").unwrap();
+    let corpus = quillmark_richtext::import::from_markdown("**bold** body").unwrap();
+    card.set_body_corpus(corpus.clone());
+    assert_eq!(card.body(), &corpus);
+    assert_eq!(card.body_markdown(), "**bold** body\n");
+}
+
+/// `import_body_delta` updates the body and returns the text delta from the
+/// old body to the new — the recordable whole-document (stale-text) writer.
+#[test]
+fn test_import_body_delta_returns_delta_and_updates_body() {
+    use crate::{Assoc, Delta};
+
+    let mut card = Card::new("note").unwrap();
+    card.replace_body("hello world").unwrap();
+    let delta: Delta = card.import_body_delta("hello brave world").unwrap();
+    assert_eq!(card.body().text, "hello brave world");
+    // The delta maps a stale position at the end of "hello " forward across
+    // the inserted "brave ".
+    assert_eq!(delta.map_pos(6, Assoc::Before), 6);
+    assert_eq!(delta.map_pos(11, Assoc::After), 17);
+}
+
+/// A whole-document markdown replace rebases a surviving identity anchor onto
+/// the new text via `diff_import`, where the old fresh-import path dropped it.
+#[test]
+fn test_import_body_delta_rebases_anchor() {
+    use quillmark_richtext::model::{Mark, MarkKind};
+
+    let mut base = quillmark_richtext::import::from_markdown("keep the target word").unwrap();
+    // Anchor over "target" (chars 9..15).
+    base.marks.push(Mark {
+        start: 9,
+        end: 15,
+        kind: MarkKind::Anchor { id: "c1".into() },
+    });
+    base.normalize();
+    let mut card = Card::new("note").unwrap();
+    card.set_body_corpus(base);
+
+    card.import_body_delta("why keep the target word").unwrap();
+    let anchor = card
+        .body()
+        .marks
+        .iter()
+        .find(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1"))
+        .expect("identity anchor survives the whole-document replace");
+    let text = &card.body().text;
+    let s = quillmark_richtext::usv::char_to_byte(text, anchor.start);
+    let e = quillmark_richtext::usv::char_to_byte(text, anchor.end);
+    assert_eq!(&text[s..e], "target");
+}
+
+/// `apply_body_change` applies a native field-change bundle (text delta, then
+/// line ops, then mark ops) to the body corpus.
+#[test]
+fn test_apply_body_change_applies_bundle() {
+    use crate::MarkOp;
+    use quillmark_richtext::delta::diff;
+    use quillmark_richtext::model::MarkKind;
+
+    let mut card = Card::new("note").unwrap();
+    card.replace_body("abc").unwrap();
+    let d = diff("abc", "abXc");
+    card.apply_body_change(
+        &d,
+        &[],
+        &[MarkOp::Add {
+            start: 3,
+            end: 4,
+            kind: MarkKind::Strong,
+        }],
+    )
+    .unwrap();
+    assert_eq!(card.body().text, "abXc");
+    let strong = card
+        .body()
+        .marks
+        .iter()
+        .find(|m| matches!(m.kind, MarkKind::Strong))
+        .expect("strong mark applied post-delta");
+    assert_eq!((strong.start, strong.end), (3, 4));
+}
+
+/// An out-of-range mark op surfaces as `EditError::CorpusApply` rather than a
+/// panic or a silent no-op.
+#[test]
+fn test_apply_body_change_reports_out_of_range() {
+    use crate::MarkOp;
+    use quillmark_richtext::delta::diff;
+    use quillmark_richtext::model::MarkKind;
+
+    let mut card = Card::new("note").unwrap();
+    card.replace_body("abc").unwrap();
+    let identity = diff("abc", "abc");
+    let result = card.apply_body_change(
+        &identity,
+        &[],
+        &[MarkOp::Add {
+            start: 0,
+            end: 99,
+            kind: MarkKind::Strong,
+        }],
+    );
+    match result {
+        Err(EditError::CorpusApply(_)) => {}
+        other => panic!("expected CorpusApply, got {other:?}"),
+    }
 }
 
 // ── Invariant check: sequence of mutations ───────────────────────────────────
@@ -571,7 +706,7 @@ fn test_invariants_after_mutation_sequence() {
     doc.remove_card(1); // summary, appendix
 
     // 6. Replace body
-    doc.main_mut().replace_body("Updated body.");
+    doc.main_mut().replace_body("Updated body.").unwrap();
 
     // 7. Remove a payload field
     doc.main_mut().remove_field("version").unwrap();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -48,6 +48,11 @@ pub use session::{
     StaleRevision,
 };
 
+/// The canonical corpus content model — re-exported so consumers of the
+/// document mutators ([`Card::set_body_corpus`], [`Card::apply_body_change`])
+/// can name the type without depending on `quillmark-richtext` directly.
+pub use quillmark_richtext::RichText;
+
 pub mod quill;
 pub use quill::{zero_value, FileTreeNode, Quill, QuillIgnore, STANDARD_METADATA_KEYS};
 

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -823,7 +823,7 @@ main:
         );
         // Prose triggers the error; whitespace-only does not.
         let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);
-        prose_card.replace_body("Should not be here.");
+        prose_card.replace_body("Should not be here.").unwrap();
         let doc = doc_with_typed_cards(&[], vec![prose_card]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -833,7 +833,7 @@ main:
         )));
 
         let mut ws_card = typed_card("skills", &[("items", json!(["Rust"]))]);
-        ws_card.replace_body("\n   \n");
+        ws_card.replace_body("\n   \n").unwrap();
         let ok_doc = doc_with_typed_cards(&[], vec![ws_card]);
         assert!(validate_typed_document(&config, &ok_doc).is_ok());
     }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -458,6 +458,33 @@ mod tests {
         );
     }
 
+    /// The PR-E wiring seam: a document body edit produces a text delta
+    /// (`Card::import_body_delta`) that the session records, so a stale corpus
+    /// position maps forward through the whole-document replace.
+    #[test]
+    fn record_body_edit_into_change_log() {
+        let mut doc =
+            crate::Document::from_markdown("~~~\n$quill: q@1.0\n$kind: main\n~~~\n\nhello world\n")
+                .unwrap();
+        let mut session = LiveSession::new(Box::new(PlainHandle));
+        assert_eq!(session.revision(), 0);
+
+        let delta = doc
+            .main_mut()
+            .import_body_delta("hello brave world")
+            .unwrap();
+        let rev = session.record_field_delta("$body", delta);
+        assert_eq!(rev, 1);
+        assert_eq!(doc.main().body().text, "hello brave world");
+
+        // A caret captured at the end of "hello " (pos 6) before the edit maps
+        // past the inserted "brave " when read at the base revision.
+        assert_eq!(
+            session.map_field_pos("$body", 0, 11, Assoc::After).unwrap(),
+            17
+        );
+    }
+
     #[test]
     fn supports_canvas_derives_from_seam() {
         // A session that exposes page geometry is canvas-capable…

--- a/prose/plans/richtext/INDEX.md
+++ b/prose/plans/richtext/INDEX.md
@@ -13,8 +13,8 @@ Phases 0–2 are landed, **including PR-G** — `richtext(inline)` enforcement
 cutover (`type: markdown` is now a schema load error, not a silent alias).
 PR-G's spec lives in [phase-2.md](phase-2.md); the landed behavior lives in
 `prose/canon/` (SCHEMAS.md). **Phase 3 (edit surface) is open** — PR-A + PR-H
-reported on `spike/richtext-phase-3`; **PR-B–D landed** on
-`integration/richtext`; PR-E (document mutators) is next. See
+reported on `spike/richtext-phase-3`; **PR-B–E landed** on
+`integration/richtext`; PR-F (preview wire + revision stamp) is next. See
 [phase-3.md](phase-3.md).
 
 For how the system works *today* — the `RichText` corpus, the seam, storage,
@@ -69,8 +69,9 @@ not restate the model.
   form-editor binding on phase-0's frozen mark semantics. PR-A + PR-H probes on
   `spike/richtext-phase-3` — Spike-A closed the phase-0 residual gate (no model
   change); form POC confirms whole-doc `LiveSession.apply` + region
-  cross-navigation for inline fields. **PR-B–D landed** (Myers diff, change log,
-  mark/line ops). PR-E (document mutators) is next.
+  cross-navigation for inline fields. **PR-B–E landed** (Myers diff, change log,
+  mark/line ops, fallible document mutators). PR-F (preview wire + revision
+  stamp) is next.
 - **Phase 4 — islands + collab.** First real island type (tables, with
   per-creation id minting rather than import's sequential ids), then a
   text-CRDT sync binding if wanted; core stays CRDT-free.

--- a/prose/plans/richtext/phase-3.md
+++ b/prose/plans/richtext/phase-3.md
@@ -11,8 +11,8 @@ freeze](phase-1.md). Spike-A (phase-0 residual gate) closed in PR-A before PR-B
 freezes transport shape.
 
 **Status: open.** PR-A + PR-H **reported** on `spike/richtext-phase-3` (origin).
-**PR-B–D landed** on `integration/richtext` (`0c108163a`…`002607c6e`). **PR-E**
-(document mutators) is next.
+**PR-B–E landed** on `integration/richtext` (`0c108163a`…). **PR-F** (preview
+wire + revision stamp) is next.
 
 ## Spike branch
 
@@ -57,10 +57,15 @@ cd crates/richtext-spikes/form-poc && npm install && npm run dev  # PR-H manual
    `apply_field_change` (text → line → mark; normalize after each).
    `FieldChange` carries `mark_ops` + `line_ops`; change-log `map_pos` stays
    text-delta-only. Findings in § PR-D.
-5. **PR-E — fallible document mutators.** Typed richtext field writers on
-   [`Card`](../../crates/core/src/document/edit.rs): set corpus, apply delta
-   bundle, import-with-error (retire silent `replace_body` degradation).
-   Document-level batch apply with invariant enforcement unchanged.
+5. **PR-E — fallible document mutators.** **Landed.** Typed richtext body
+   writers on [`Card`](../../crates/core/src/document/edit.rs):
+   `set_body_corpus` (native corpus set), `apply_body_change` (text delta →
+   line ops → mark ops bundle), `import_body_delta` (whole-document markdown
+   replace via `diff_import`, returns the text delta for change-log
+   recording), and a now-fallible `replace_body` — the silent degrade-to-empty
+   retired for [`EditError::BodyImport`](../../crates/core/src/document/edit.rs)
+   /`CorpusApply`. Existing field/kind invariant enforcement unchanged.
+   Findings in § PR-E.
 6. **PR-F — preview wire + revision stamp.** Append optional `revision` to
    [`RenderedRegion`](../../crates/core/src/region.rs) and tag read responses
    (`regions`, `fieldAt`, `positionAt`, `locate`) — the additive-optional
@@ -233,12 +238,39 @@ extended in [`change_log.rs`](../../crates/richtext/src/change_log.rs).
 3. **Mark ranges in mark ops are post-text-delta coordinates** within the same
    revision.
 
+## PR-E — document mutator findings
+
+**Implementation:** [`edit.rs`](../../crates/core/src/document/edit.rs); one new
+crate-internal `Card::body_mut`; `RichText` re-exported from
+[`quillmark_core`](../../crates/core/src/lib.rs).
+
+1. **Two writers, one corpus, three entry points.** The form-editor path is
+   `apply_body_change` (a native delta + line/mark bundle the editor already
+   computed); the stale-text path is `import_body_delta` (cold import +
+   `diff_import`), with `replace_body` its delta-discarding wrapper.
+   `set_body_corpus` is the raw native set for a corpus decoded elsewhere.
+2. **`diff_import` now wired to `Document`.** `import_body_delta` is the seam:
+   it rebases surviving identity anchors onto the fresh import (the old
+   fresh-`import_body` `replace_body` dropped them) and returns the text delta,
+   so the whole-document replace records into the change log exactly like a
+   field edit. The session still owns the log — the mutator returns the delta;
+   the caller records it (`record_field_delta` / `record_field_change`). Card
+   holds no session reference.
+3. **Silent degradation retired.** `replace_body` was infallible, degrading an
+   over-nested body to the empty corpus; it now returns
+   `EditError::BodyImport`. `apply_body_change` surfaces an out-of-bounds op as
+   `EditError::CorpusApply` (wrapping `ApplyError`). Both new variants ride the
+   existing `variant_name` → `[EditError::<Variant>]` binding contract, so
+   wasm/python surface them without a mapper change; the wasm `replaceBody` /
+   `updateCardBody` and python `replace_body` / `update_card_body` wrappers now
+   propagate instead of swallowing.
+
 ## Sequencing invariant
 
 - Spike-A reports before PR-B freezes change-log entry shape (text delta only
   until PR-D, but the log slot must accommodate mark/line ops). **Closed.**
 - PR-B (minimal diff) before PR-C (log stores deltas worth replaying). **Closed.**
-- PR-D (mark/line ops) before PR-E (mutators emit them). **PR-D landed.**
+- PR-D (mark/line ops) before PR-E (mutators emit them). **Both landed.**
 - PR-F (revision stamp) before PR-G (WASM exposes revision-aware apply).
 - PR-A's bridge pattern is reused in PR-H; no second editor serialization.
 


### PR DESCRIPTION
## Summary

Phase 3 **PR-E** — fallible document mutators. Typed richtext body writers on `Card`, wiring `diff_import` to `Document` and retiring the silent `replace_body` degradation.

- **`set_body_corpus(RichText)`** — native corpus set, infallible.
- **`apply_body_change(&Delta, &[LineOp], &[MarkOp])`** — form-editor bundle writer (text → line → mark, normalize after each); out-of-bounds ops → `EditError::CorpusApply`.
- **`import_body_delta(body) -> Result<Delta, EditError>`** — stale-text writer wiring `diff_import` to `Document`; rebases surviving identity anchors and returns the text delta for change-log recording.
- **`replace_body(body) -> Result<(), EditError>`** — now fallible (delta-discarding wrapper over `import_body_delta`); over-nested input returns `EditError::BodyImport` instead of degrading to the empty corpus.
- New `EditError::BodyImport` / `CorpusApply` variants ride the existing `[EditError::<Variant>]` binding contract; `RichText` re-exported from `quillmark_core`; crate-internal `Card::body_mut` added.
- wasm (`replaceBody`, `updateCardBody`) and python (`replace_body`, `update_card_body`) wrappers now propagate the error instead of swallowing.

The session still owns the change log — the mutator returns/accepts the delta and the caller records it (`record_field_delta` / `record_field_change`); `Card` holds no session reference.

## Test plan

- [x] `cargo test -p quillmark-richtext -p quillmark-core` (green; 6 new core edit tests + 1 session wiring test)
- [x] `cargo check -p quillmark-python`
- [x] `cargo check -p quillmark-wasm --target wasm32-unknown-unknown`
- [ ] CI: wasm + python binding test suites

Docs: `phase-3.md` (PR-E landed + findings) and `INDEX.md` updated; next is PR-F (preview wire + revision stamp).