### PR TITLE
feat(richtext): preview revision stamp + WASM session delta API (PR-F/PR-G)

### DIFF
--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -400,6 +400,8 @@ pub(crate) fn scan(
                         (page_h - b.min_y) as f32,
                     ],
                     span,
+                    // The session wrapper stamps the revision; the backend has none.
+                    revision: None,
                 },
                 ki,
             ));
@@ -660,6 +662,8 @@ pub(crate) fn position_at(
     Some(CorpusHit {
         field: window.path.clone(),
         pos: invert_hit(helper, segmap, &hit.node, hit.offset),
+        // The session wrapper stamps the revision; the backend has none.
+        revision: None,
     })
 }
 
@@ -759,6 +763,8 @@ pub(crate) fn locate(
             (page_h - b.min_y) as f32,
         ],
         span: Some([pos, pos]),
+        // The session wrapper stamps the revision; the backend has none.
+        revision: None,
     })
 }
 

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -388,3 +388,96 @@ describe('LiveSession.apply', () => {
     session.free()
   })
 })
+
+describe('LiveSession revision stamp + applyFieldDelta (PR-F/PR-G)', () => {
+  // A pure-insert delta prepends `text` to the body corpus without needing to
+  // know its length (Delta.apply appends the untouched remainder after the ops).
+  const prepend = (text) => ({ ops: [{ insert: text }] })
+
+  it('stamps geometry reads with the current revision', () => {
+    const session = openSession()
+    expect(session.revision).toBe(0)
+
+    // Every region carries the session's revision; a fresh session is at 0.
+    const regions = session.regions()
+    expect(regions.length).toBeGreaterThan(0)
+    for (const r of regions) expect(r.revision).toBe(0)
+
+    // positionAt / locate stamp the same revision.
+    const bodyRegion = regions.find((r) => r.field === '$body' && r.span)
+    expect(bodyRegion).toBeTruthy()
+    const caret = session.locate('$body', bodyRegion.span[0])
+    expect(caret.revision).toBe(0)
+  })
+
+  it('applyFieldDelta splices the body, advances the revision, and dirties the page', () => {
+    const { engine, quill } = openQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const session = engine.open(quill, doc)
+    expect(session.revision).toBe(0)
+
+    const cs = session.applyFieldDelta(doc, '$body', 0, prepend('NEW '))
+    expect(cs.dirtyPages).toContain(0)
+
+    // The revision advanced and the mutation reached the document body.
+    expect(session.revision).toBe(1)
+    expect(doc.main.bodyMarkdown).toContain('NEW')
+
+    // The next read is stamped at the new revision.
+    const region = session.regions().find((r) => r.field === '$body')
+    expect(region.revision).toBe(1)
+    session.free()
+  })
+
+  it('maps a position captured at an older revision forward through the edit', () => {
+    const { engine, quill } = openQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const session = engine.open(quill, doc)
+
+    // At the base revision, mapping is the identity.
+    expect(session.mapFieldPos('$body', 0, 0, 'after')).toBe(0)
+
+    // Prepend a 4-USV run ("NEW ") at corpus position 0.
+    session.applyFieldDelta(doc, '$body', 0, prepend('NEW '))
+
+    // A position captured at revision 0 maps forward past the leading insert
+    // with Assoc::After, and stays put with Assoc::Before.
+    expect(session.mapFieldPos('$body', 0, 0, 'after')).toBe(4)
+    expect(session.mapFieldPos('$body', 0, 0, 'before')).toBe(0)
+    session.free()
+  })
+
+  it('rejects a stale base revision without mutating (session::revision_mismatch)', () => {
+    const { engine, quill } = openQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const session = engine.open(quill, doc)
+
+    session.applyFieldDelta(doc, '$body', 0, prepend('A '))
+    expect(session.revision).toBe(1)
+
+    // Re-submitting against the now-stale base 0 throws and changes nothing.
+    let thrown
+    try {
+      session.applyFieldDelta(doc, '$body', 0, prepend('B '))
+    } catch (e) {
+      thrown = e
+    }
+    expect(thrown).toBeTruthy()
+    expect(thrown.diagnostics?.[0]?.code).toBe('session::revision_mismatch')
+    expect(session.revision).toBe(1)
+    session.free()
+  })
+
+  it('rejects a non-body field as a delta-path target', () => {
+    const { engine, quill } = openQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const session = engine.open(quill, doc)
+    expect(() => session.applyFieldDelta(doc, 'subject', 0, prepend('x'))).toThrow(/\$body/)
+    session.free()
+  })
+
+  it('mapFieldPos accepts only "before" or "after"', () => {
+    const session = openSession()
+    expect(() => session.mapFieldPos('$body', 0, 0, 'sideways')).toThrow(/before.*after/)
+  })
+})

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -144,6 +144,13 @@ export interface FieldRegion {
 	 * segments for the whole-field box.
 	 */
 	span?: [number, number];
+	/**
+	 * The session {@link LiveSession.revision} this geometry was read at, so a
+	 * consumer can {@link LiveSession.mapFieldPos} a captured span forward across
+	 * later edits. Stamped only by a live-session read; absent on the
+	 * sessionless {@link RenderResult.regions} sidecar.
+	 */
+	revision?: number;
 }
 
 /** Canonical contract every backend build must satisfy. Result of one render. */

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -3,7 +3,7 @@
 use crate::error::WasmError;
 use crate::types::Diagnostic;
 #[cfg(any(feature = "typst", feature = "pdfform"))]
-use crate::types::{ChangeSet, CorpusHit, FieldRegion, RenderOptions, RenderResult};
+use crate::types::{ChangeSet, CorpusHit, Delta, FieldRegion, RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 use serde::Deserialize;
@@ -205,9 +205,14 @@ pub struct Quill {
     inner: quillmark::Quill,
 }
 
-/// Live render session: reads (`render`, `paint`, `pageSize`, `regions`, `fieldAt`)
-/// serve the current compile; `apply(doc)` recompiles in place. Apply is
-/// transactional — on throw, every read keeps serving the last-good compile.
+/// Live render session: reads (`render`, `paint`, `pageSize`, `regions`,
+/// `fieldAt`, `positionAt`, `locate`) serve the current compile. Two edit
+/// verbs, both transactional (on throw every read keeps serving the last-good
+/// compile): `apply(doc)` recompiles a whole document in place (the
+/// markdown/LLM path, revision-neutral), and `applyFieldDelta(doc, …)` splices
+/// one content field's corpus, advancing the monotonic `revision` so captured
+/// positions map forward via `mapFieldPos`. Geometry reads stamp that
+/// `revision` (`FieldRegion.revision` / `CorpusHit.revision`).
 ///
 /// **Empty documents.** A zero-page document yields a valid session
 /// (`pageCount === 0`); `paint(ctx, 0)` or `pageSize(0)` throws with
@@ -1441,6 +1446,128 @@ impl LiveSession {
             page_count: cs.page_count,
             dirty_pages: cs.dirty_pages,
         })
+    }
+
+    /// The session's monotonic edit revision — `0` before the first
+    /// `applyFieldDelta`, incremented by each committed native field edit. The
+    /// stamp on `regions()` / `positionAt` / `locate`; pass a captured value
+    /// back as `applyFieldDelta`'s `baseRevision` and to `mapFieldPos`. A
+    /// whole-document `apply(doc)` does **not** advance it (the markdown/LLM
+    /// path re-reads geometry rather than mapping positions forward).
+    #[wasm_bindgen(getter, js_name = revision)]
+    pub fn revision(&self) -> u32 {
+        self.inner.revision() as u32
+    }
+
+    /// Commit a native form-editor edit to a content field: splice `delta` into
+    /// the field's corpus on `doc`, recompile the preview, and record the delta
+    /// so later positions map forward — the delta-path twin of the
+    /// whole-document `apply(doc)` (markdown/LLM path).
+    ///
+    /// `baseRevision` is the revision the editor computed `delta` against
+    /// (captured from a read stamp or a prior `applyFieldDelta`). It must equal
+    /// the current `revision`; a mismatch throws `session::revision_mismatch`
+    /// and changes nothing, so a stale delta is never spliced onto the wrong
+    /// base — re-read and recompute instead.
+    ///
+    /// This phase targets the **main body** corpus only (`field === "$body"`);
+    /// any other address throws (use `apply(doc)` for those). Transactional on
+    /// the compile: a failed recompile keeps the last-good preview and does not
+    /// advance `revision`. On success `doc`'s body carries the edit, the
+    /// preview reflects it, and `revision` is `baseRevision + 1`.
+    #[wasm_bindgen(js_name = applyFieldDelta)]
+    pub fn apply_field_delta(
+        &mut self,
+        doc: &mut Document,
+        field: &str,
+        base_revision: u32,
+        delta: Delta,
+    ) -> Result<ChangeSet, JsValue> {
+        if field != "$body" {
+            return Err(WasmError::from(format!(
+                "applyFieldDelta: '{field}' is not a delta-path target; only the main body \
+                 '$body' is supported in this phase — use apply(doc) for whole-document edits"
+            ))
+            .to_js_value());
+        }
+        let core_delta: quillmark_core::Delta = delta.into();
+
+        // Guard the base revision before touching anything: a stale delta is
+        // rejected here, leaving `doc` and the session untouched.
+        self.inner
+            .ensure_base_revision(base_revision as u64)
+            .map_err(|d| WasmError { diagnostics: vec![d] }.to_js_value())?;
+
+        // Native writer: splice the main body corpus (text delta only).
+        doc.inner
+            .main_mut()
+            .apply_body_change(&core_delta, &[], &[])
+            .map_err(|e| edit_error_to_js(&e))?;
+
+        // Recompile from the mutated document, transactional on the compile.
+        self.config
+            .check_quill_reference(&doc.inner)
+            .map_err(|e| WasmError::from(e).to_js_value())?;
+        let json_data = self
+            .config
+            .compile_data(&doc.inner)
+            .map_err(|e| WasmError::from(e).to_js_value())?;
+        let cs = self
+            .inner
+            .apply(&json_data)
+            .map_err(|e| WasmError::from(e).to_js_value())?;
+
+        // Commit into the change log only after a successful recompile, so the
+        // revision advances in lockstep with the live preview.
+        self.inner.record_field_delta(field.to_string(), core_delta);
+
+        Ok(ChangeSet {
+            page_count: cs.page_count,
+            dirty_pages: cs.dirty_pages,
+        })
+    }
+
+    /// Map a USV `pos` in `field`, captured at `baseRevision`, forward through
+    /// the field's recorded deltas to its position in the current revision —
+    /// the mechanism that keeps a form caret or highlight anchored across
+    /// edits. `assoc` (`"before"` | `"after"`) picks the side of a
+    /// same-position insertion (`"after"` moves past inserted text). Throws
+    /// `session::stale_revision` when `baseRevision` predates the bounded change
+    /// log (the consumer must re-read at the current `revision`).
+    #[wasm_bindgen(js_name = mapFieldPos)]
+    pub fn map_field_pos(
+        &self,
+        field: &str,
+        base_revision: u32,
+        pos: usize,
+        #[wasm_bindgen(unchecked_param_type = "\"before\" | \"after\"")] assoc: &str,
+    ) -> Result<usize, JsValue> {
+        let assoc = match assoc {
+            "before" => quillmark_core::Assoc::Before,
+            "after" => quillmark_core::Assoc::After,
+            other => {
+                return Err(WasmError::from(format!(
+                    "mapFieldPos: assoc must be \"before\" or \"after\", got \"{other}\""
+                ))
+                .to_js_value())
+            }
+        };
+        self.inner
+            .map_field_pos(field, base_revision as u64, pos, assoc)
+            .map_err(|stale| {
+                WasmError {
+                    diagnostics: vec![quillmark_core::Diagnostic::new(
+                        quillmark_core::Severity::Error,
+                        format!(
+                            "position captured at revision {} predates the change log \
+                             (oldest retained {}); re-read at the current revision",
+                            stale.base_revision, stale.oldest_retained
+                        ),
+                    )
+                    .with_code("session::stale_revision".to_string())],
+                }
+                .to_js_value()
+            })
     }
 
     #[wasm_bindgen(js_name = render)]

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1496,7 +1496,12 @@ impl LiveSession {
         // rejected here, leaving `doc` and the session untouched.
         self.inner
             .ensure_base_revision(base_revision as u64)
-            .map_err(|d| WasmError { diagnostics: vec![d] }.to_js_value())?;
+            .map_err(|d| {
+                WasmError {
+                    diagnostics: vec![d],
+                }
+                .to_js_value()
+            })?;
 
         // Native writer: splice the main body corpus (text delta only).
         doc.inner

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -255,6 +255,13 @@ pub struct FieldRegion {
     /// union same-page segments for the whole-field box.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub span: Option<[usize; 2]>,
+    /// The `LiveSession.revision` this geometry was read at — `regions()` and
+    /// `locate()` stamp the current revision so a consumer can pair a highlight
+    /// box or caret with the edit state it reflects and map a position forward
+    /// through later edits (`mapFieldPos`). `undefined` on a one-shot
+    /// `RenderResult.regions` sidecar (no live session). Additive-optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u32>,
 }
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
@@ -265,6 +272,9 @@ impl From<quillmark_core::RenderedRegion> for FieldRegion {
             page: r.page,
             rect: r.rect,
             span: r.span,
+            // A session revision is a small monotonic counter; narrowing to the
+            // JS-number-friendly u32 at the boundary avoids a BigInt.
+            revision: r.revision.map(|v| v as u32),
         }
     }
 }
@@ -282,6 +292,11 @@ pub struct CorpusHit {
     pub field: String,
     /// USV offset into the field's `RichText`.
     pub pos: usize,
+    /// The `LiveSession.revision` this hit was resolved at — `positionAt`
+    /// stamps it so a caller can record the captured `pos` against this base
+    /// revision and map it forward (`mapFieldPos`). Additive-optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u32>,
 }
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
@@ -290,6 +305,49 @@ impl From<quillmark_core::CorpusHit> for CorpusHit {
         CorpusHit {
             field: h.field,
             pos: h.pos,
+            revision: h.revision.map(|v| v as u32),
+        }
+    }
+}
+
+/// A text-splice delta over a field's USV corpus — CodeMirror `ChangeSet`
+/// semantics: `retain` / `insert` / `delete` ops applied left-to-right,
+/// consuming base positions. The native form-editor edit unit `applyFieldDelta`
+/// consumes; carries no formatting (marks/lines are separate channels).
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct Delta {
+    pub ops: Vec<DeltaOp>,
+}
+
+/// One [`Delta`] op. On the wire: `{ retain: n }`, `{ insert: "text" }`, or
+/// `{ delete: n }` — exactly one key.
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+pub enum DeltaOp {
+    /// Keep `n` USV of the base unchanged.
+    Retain(usize),
+    /// Insert this text at the cursor.
+    Insert(String),
+    /// Drop `n` USV of the base.
+    Delete(usize),
+}
+
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+impl From<Delta> for quillmark_core::Delta {
+    fn from(d: Delta) -> Self {
+        quillmark_core::Delta {
+            ops: d
+                .ops
+                .into_iter()
+                .map(|op| match op {
+                    DeltaOp::Retain(n) => quillmark_core::Op::Retain(n),
+                    DeltaOp::Insert(s) => quillmark_core::Op::Insert(s),
+                    DeltaOp::Delete(n) => quillmark_core::Op::Delete(n),
+                })
+                .collect(),
         }
     }
 }
@@ -528,14 +586,16 @@ mod tests {
             page: 0,
             rect: [180.0, 672.0, 520.0, 692.0],
             span: None,
+            revision: None,
         };
         let json = serde_json::to_string(&region).unwrap();
         assert!(json.contains("\"field\":\"full_name\""));
         assert!(json.contains("\"page\":0"));
         assert!(json.contains("\"rect\":[180.0,672.0,520.0,692.0]"));
-        // A scalar/widget region omits `span`; no backend widget name or
-        // kind/value leaks into the wire shape.
+        // A scalar/widget region omits `span`; an unstamped region omits
+        // `revision`; no backend widget name or kind/value leaks either.
         assert!(!json.contains("\"span\""));
+        assert!(!json.contains("\"revision\""));
         assert!(!json.contains("\"name\""));
         assert!(!json.contains("\"kind\""));
     }
@@ -549,12 +609,15 @@ mod tests {
             page: 0,
             rect: [180.0, 422.0, 520.0, 462.0],
             span: Some([0, 25]),
+            revision: Some(4),
         };
         let json = serde_json::to_string(&region).unwrap();
+        assert!(json.contains("\"revision\":4"), "{json}");
         let back: FieldRegion = serde_json::from_str(&json).expect("round-trips");
         assert_eq!(back.field, "signature_block");
         assert_eq!(back.rect, [180.0, 422.0, 520.0, 462.0]);
         assert_eq!(back.span, Some([0, 25]));
+        assert_eq!(back.revision, Some(4));
     }
 
     #[test]
@@ -567,11 +630,33 @@ mod tests {
             page: 0,
             rect: [180.0, 538.0, 194.0, 552.0],
             span: None,
+            revision: Some(9),
         };
         let wasm_region: FieldRegion = core_region.into();
         assert_eq!(wasm_region.field, "agree");
         assert_eq!(wasm_region.page, 0);
         assert_eq!(wasm_region.rect, [180.0, 538.0, 194.0, 552.0]);
         assert_eq!(wasm_region.span, None);
+        // The core u64 revision narrows to u32 at the JS boundary.
+        assert_eq!(wasm_region.revision, Some(9));
+    }
+
+    #[test]
+    #[cfg(any(feature = "typst", feature = "pdfform"))]
+    fn delta_wire_converts_to_core() {
+        // `{ retain }`, `{ insert }`, `{ delete }` — one key each.
+        let json = r#"{"ops":[{"retain":3},{"insert":"XY"},{"delete":2}]}"#;
+        let wire: Delta = serde_json::from_str(json).expect("delta wire parses");
+        let core: quillmark_core::Delta = wire.into();
+        assert_eq!(
+            core.ops,
+            vec![
+                quillmark_core::Op::Retain(3),
+                quillmark_core::Op::Insert("XY".to_string()),
+                quillmark_core::Op::Delete(2),
+            ]
+        );
+        // The delta applies as CodeMirror text-splice semantics.
+        assert_eq!(core.apply("abcde"), "abcXY");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,7 +44,7 @@ pub use region::{CorpusHit, RenderedRegion};
 
 pub mod session;
 pub use session::{
-    ApplyError, Assoc, ChangeLog, ChangeSet, Delta, FieldChange, LineOp, LiveSession, MarkOp,
+    ApplyError, Assoc, ChangeLog, ChangeSet, Delta, FieldChange, LineOp, LiveSession, MarkOp, Op,
     StaleRevision,
 };
 

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -201,7 +201,10 @@ mod tests {
         };
         let json = serde_json::to_string(&region).unwrap();
         assert!(!json.contains("span"), "scalar region omits span: {json}");
-        assert!(!json.contains("revision"), "unstamped region omits revision: {json}");
+        assert!(
+            !json.contains("revision"),
+            "unstamped region omits revision: {json}"
+        );
         let back: RenderedRegion = serde_json::from_str(&json).unwrap();
         assert_eq!(back, region);
     }
@@ -238,7 +241,10 @@ mod tests {
             revision: None,
         };
         let json = serde_json::to_string(&hit).unwrap();
-        assert!(!json.contains("revision"), "unstamped hit omits revision: {json}");
+        assert!(
+            !json.contains("revision"),
+            "unstamped hit omits revision: {json}"
+        );
         let back: CorpusHit = serde_json::from_str(&json).unwrap();
         assert_eq!(back, hit);
     }

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -103,9 +103,21 @@ pub struct RenderedRegion {
     /// The corpus slice this box covers: USV `[start, end)` into the field's
     /// `RichText` for content ink (one segment's range), `None` for a scalar
     /// reference site or a widget — geometry with no corpus address. Additive
-    /// and optional so Phase 3 can append a `revision` without a break.
+    /// and optional, alongside `revision`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub span: Option<[usize; 2]>,
+    /// The [`LiveSession`](crate::LiveSession) revision this geometry was read
+    /// at. [`LiveSession::regions`](crate::LiveSession::regions) and
+    /// [`locate`](crate::LiveSession::locate) stamp the current revision so a
+    /// consumer can pair a captured box or caret with the edit state it
+    /// reflects and map a position forward through later edits
+    /// ([`map_field_pos`](crate::LiveSession::map_field_pos)). `None` for a
+    /// region produced outside a live session (a one-shot
+    /// [`RenderOptions::regions`](crate::RenderOptions) sidecar) or straight
+    /// from a backend. Additive-optional: omitted from the wire when `None`, so
+    /// this stamp does not break the phase-2 region shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
 }
 
 impl RenderedRegion {
@@ -142,6 +154,15 @@ pub struct CorpusHit {
     pub field: String,
     /// USV offset into the field's `RichText`.
     pub pos: usize,
+    /// The [`LiveSession`](crate::LiveSession) revision this hit was resolved
+    /// at — [`position_at`](crate::LiveSession::position_at) stamps the current
+    /// revision so a caller can record the captured `pos` against a base
+    /// revision and map it forward through later edits
+    /// ([`map_field_pos`](crate::LiveSession::map_field_pos)). `None` when the
+    /// hit came straight from a backend. Additive-optional: omitted from the
+    /// wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
 }
 
 #[cfg(test)]
@@ -155,29 +176,44 @@ mod tests {
             page: 0,
             rect: [180.0, 715.0, 520.0, 735.0],
             span: Some([12, 34]),
+            revision: Some(7),
         };
         let json = serde_json::to_string(&region).unwrap();
         assert!(json.contains("\"field\":\"full_name\""), "{json}");
         assert!(json.contains("\"span\":[12,34]"), "{json}");
+        assert!(json.contains("\"revision\":7"), "{json}");
         let back: RenderedRegion = serde_json::from_str(&json).unwrap();
         assert_eq!(back, region);
     }
 
-    /// `span` is omitted for a scalar/widget region and defaults back to `None`
-    /// on read — the additive-optional discipline that lets Phase 3 append a
-    /// `revision` without a wire break.
+    /// `span` and `revision` are both omitted when `None` and default back on
+    /// read — the additive-optional discipline that let Phase 3 append
+    /// `revision` without a wire break, and that keeps a backend-emitted region
+    /// (no session, no revision) parsing as a phase-2 region did.
     #[test]
-    fn scalar_region_omits_span() {
+    fn optional_fields_omitted_when_none() {
         let region = RenderedRegion {
             field: "subject".to_string(),
             page: 0,
             rect: [1.0, 2.0, 3.0, 4.0],
             span: None,
+            revision: None,
         };
         let json = serde_json::to_string(&region).unwrap();
         assert!(!json.contains("span"), "scalar region omits span: {json}");
+        assert!(!json.contains("revision"), "unstamped region omits revision: {json}");
         let back: RenderedRegion = serde_json::from_str(&json).unwrap();
         assert_eq!(back, region);
+    }
+
+    /// A phase-2 region on the wire (no `revision` key) still reads back — the
+    /// stamp is additive, not a required field.
+    #[test]
+    fn region_reads_legacy_wire_without_revision() {
+        let json = r#"{"field":"subject","page":0,"rect":[1.0,2.0,3.0,4.0]}"#;
+        let back: RenderedRegion = serde_json::from_str(json).unwrap();
+        assert_eq!(back.revision, None);
+        assert_eq!(back.span, None);
     }
 
     #[test]
@@ -185,9 +221,24 @@ mod tests {
         let hit = CorpusHit {
             field: "body".to_string(),
             pos: 42,
+            revision: Some(3),
         };
         let json = serde_json::to_string(&hit).unwrap();
         assert!(json.contains("\"field\":\"body\"") && json.contains("\"pos\":42"));
+        assert!(json.contains("\"revision\":3"), "{json}");
+        let back: CorpusHit = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, hit);
+    }
+
+    #[test]
+    fn corpus_hit_omits_revision_when_none() {
+        let hit = CorpusHit {
+            field: "body".to_string(),
+            pos: 42,
+            revision: None,
+        };
+        let json = serde_json::to_string(&hit).unwrap();
+        assert!(!json.contains("revision"), "unstamped hit omits revision: {json}");
         let back: CorpusHit = serde_json::from_str(&json).unwrap();
         assert_eq!(back, hit);
     }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -2,7 +2,7 @@ use crate::{
     CorpusHit, Diagnostic, RenderError, RenderOptions, RenderResult, RenderedRegion, Severity,
 };
 pub use quillmark_richtext::{
-    ApplyError, Assoc, ChangeLog, Delta, FieldChange, LineOp, MarkOp, StaleRevision,
+    ApplyError, Assoc, ChangeLog, Delta, FieldChange, LineOp, MarkOp, Op, StaleRevision,
 };
 
 /// What a committed [`LiveSession::apply`] changed.
@@ -214,6 +214,68 @@ impl LiveSession {
         self.change_log.record(path, text_delta)
     }
 
+    /// Record a text-only field splice **committed against `base_revision`**,
+    /// guarding revision monotonicity: a delta is only composable onto the
+    /// state it was computed from, so `base_revision` must equal the session's
+    /// current [`revision`](Self::revision). On a match records the delta,
+    /// bumps the revision, and returns the new one; on a mismatch records
+    /// nothing and returns a `session::revision_mismatch` [`Diagnostic`] — the
+    /// caller re-reads at the current revision and recomputes the delta rather
+    /// than splicing it onto the wrong base (a silent stale write). The write
+    /// twin of the read stamp on [`regions`](Self::regions) /
+    /// [`position_at`](Self::position_at): a consumer captures a base revision
+    /// from a read, then submits its delta against it here.
+    pub fn record_field_delta_at(
+        &mut self,
+        path: impl Into<String>,
+        base_revision: u64,
+        text_delta: Delta,
+    ) -> Result<u64, Diagnostic> {
+        self.ensure_base_revision(base_revision)?;
+        Ok(self.change_log.record(path, text_delta))
+    }
+
+    /// Bundle twin of [`record_field_delta_at`](Self::record_field_delta_at):
+    /// record a text delta plus mark/line ops against `base_revision`, with the
+    /// same monotonicity guard and `session::revision_mismatch` diagnostic.
+    pub fn record_field_change_at(
+        &mut self,
+        path: impl Into<String>,
+        base_revision: u64,
+        text_delta: Delta,
+        mark_ops: impl Into<Vec<MarkOp>>,
+        line_ops: impl Into<Vec<LineOp>>,
+    ) -> Result<u64, Diagnostic> {
+        self.ensure_base_revision(base_revision)?;
+        Ok(self
+            .change_log
+            .record_change(path, text_delta, mark_ops, line_ops))
+    }
+
+    /// Guard that `base_revision` matches the current revision — the raw check
+    /// behind [`record_field_delta_at`](Self::record_field_delta_at), exposed
+    /// for a caller that interleaves other work (a document mutation, a
+    /// recompile) between the guard and the record so the log advances only on
+    /// a fully-committed edit. Both a field delta submitted against a stale
+    /// read and an impossible future revision fail; the
+    /// `session::revision_mismatch` diagnostic reports the mismatch so the
+    /// caller re-reads at the current revision.
+    pub fn ensure_base_revision(&self, base_revision: u64) -> Result<(), Diagnostic> {
+        let current = self.revision();
+        if base_revision == current {
+            return Ok(());
+        }
+        Err(Diagnostic::new(
+            Severity::Error,
+            format!(
+                "field delta base revision {base_revision} does not match the session's \
+                 current revision {current}; re-read at the current revision and recompute \
+                 the delta"
+            ),
+        )
+        .with_code("session::revision_mismatch".to_string()))
+    }
+
     /// Map a USV position in `field` forward from `base_revision` through
     /// subsequent recorded text deltas for that field.
     pub fn map_field_pos(
@@ -277,8 +339,21 @@ impl LiveSession {
     /// placements of one content value are **not** enumerated — for
     /// point-driven lookup over any placement, use
     /// [`field_at`](Self::field_at).
+    ///
+    /// Each region is stamped with the current [`revision`](Self::revision)
+    /// ([`RenderedRegion::revision`]) so a consumer can pair a highlight box
+    /// with the edit state it reflects and map a position forward through
+    /// later edits.
     pub fn regions(&self) -> Vec<RenderedRegion> {
-        self.inner.regions()
+        let revision = self.revision();
+        self.inner
+            .regions()
+            .into_iter()
+            .map(|mut r| {
+                r.revision = Some(revision);
+                r
+            })
+            .collect()
     }
 
     /// The schema field whose content is under a point on `page` — the
@@ -302,17 +377,32 @@ impl LiveSession {
     /// degrades to the containing segment's start on origin-less ink (list
     /// markers, a code fence's interior). `None` off all content ink, on a
     /// scalar/widget, or for backends with no corpus map. See [`CorpusHit`].
+    ///
+    /// The hit is stamped with the current [`revision`](Self::revision)
+    /// ([`CorpusHit::revision`]) so a caller can record the captured `pos`
+    /// against that base revision and map it forward through later edits.
+    /// [`field_at`](Self::field_at) carries no such stamp — a field address is
+    /// revision-invariant, only a position drifts.
     pub fn position_at(&self, page: usize, x: f32, y: f32) -> Option<CorpusHit> {
-        self.inner.position_at(page, x, y)
+        let revision = self.revision();
+        self.inner.position_at(page, x, y).map(|mut h| {
+            h.revision = Some(revision);
+            h
+        })
     }
 
     /// A corpus position → **caret rect** — the reverse of
     /// [`position_at`](Self::position_at): given a field and a USV offset into
     /// its `RichText`, return the box (page-indexed) to draw a caret at. `None`
     /// when the field places no tracked content or the offset maps to no drawn
-    /// glyph.
+    /// glyph. The returned region is stamped with the current
+    /// [`revision`](Self::revision), like [`regions`](Self::regions).
     pub fn locate(&self, field: &str, pos: usize) -> Option<RenderedRegion> {
-        self.inner.locate(field, pos)
+        let revision = self.revision();
+        self.inner.locate(field, pos).map(|mut r| {
+            r.revision = Some(revision);
+            r
+        })
     }
 
     /// Non-fatal diagnostics of the session's **current compile** — set at
@@ -483,6 +573,90 @@ mod tests {
             session.map_field_pos("$body", 0, 11, Assoc::After).unwrap(),
             17
         );
+    }
+
+    /// A handle that surfaces one content region, one hit, and one caret rect,
+    /// all with `revision: None` — the backend never stamps; the wrapper does.
+    struct RegionHandle;
+    impl SessionHandle for RegionHandle {
+        fn render(&self, _: &RenderOptions) -> Result<RenderResult, RenderError> {
+            unimplemented!("render is not exercised by stamp tests")
+        }
+        fn page_count(&self) -> usize {
+            1
+        }
+        fn regions(&self) -> Vec<RenderedRegion> {
+            vec![RenderedRegion {
+                field: "subject".to_string(),
+                page: 0,
+                rect: [1.0, 2.0, 3.0, 4.0],
+                span: Some([0, 3]),
+                revision: None,
+            }]
+        }
+        fn position_at(&self, _: usize, _: f32, _: f32) -> Option<CorpusHit> {
+            Some(CorpusHit {
+                field: "subject".to_string(),
+                pos: 2,
+                revision: None,
+            })
+        }
+        fn locate(&self, field: &str, pos: usize) -> Option<RenderedRegion> {
+            Some(RenderedRegion {
+                field: field.to_string(),
+                page: 0,
+                rect: [1.0, 2.0, 1.0, 4.0],
+                span: Some([pos, pos]),
+                revision: None,
+            })
+        }
+    }
+
+    /// Every geometry read is stamped with the session's current revision, and
+    /// the stamp advances with each recorded edit.
+    #[test]
+    fn reads_are_stamped_with_current_revision() {
+        use quillmark_richtext::delta::diff;
+
+        let mut session = LiveSession::new(Box::new(RegionHandle));
+        assert_eq!(session.regions()[0].revision, Some(0));
+        assert_eq!(session.position_at(0, 2.0, 3.0).unwrap().revision, Some(0));
+        assert_eq!(session.locate("subject", 1).unwrap().revision, Some(0));
+
+        session.record_field_delta("subject", diff("abc", "abXc"));
+        assert_eq!(session.regions()[0].revision, Some(1));
+        assert_eq!(session.position_at(0, 2.0, 3.0).unwrap().revision, Some(1));
+        assert_eq!(session.locate("subject", 1).unwrap().revision, Some(1));
+    }
+
+    /// `record_field_delta_at` records only when its base revision matches the
+    /// current one; a stale base yields a `session::revision_mismatch`
+    /// diagnostic and records nothing.
+    #[test]
+    fn checked_record_guards_base_revision() {
+        use quillmark_richtext::delta::diff;
+
+        let mut session = LiveSession::new(Box::new(PlainHandle));
+        // Base 0 matches the fresh session → records, revision becomes 1.
+        let r = session
+            .record_field_delta_at("subject", 0, diff("abc", "abXc"))
+            .expect("base matches");
+        assert_eq!(r, 1);
+        assert_eq!(session.revision(), 1);
+
+        // Re-submitting against the now-stale base 0 is rejected, and the log
+        // does not advance.
+        let diag = session
+            .record_field_delta_at("subject", 0, diff("abXc", "abXYc"))
+            .expect_err("stale base rejected");
+        assert_eq!(diag.code.as_deref(), Some("session::revision_mismatch"));
+        assert_eq!(session.revision(), 1);
+
+        // Against the current base it records again.
+        let r = session
+            .record_field_change_at("subject", 1, diff("abXc", "abXYc"), [], [])
+            .expect("current base");
+        assert_eq!(r, 2);
     }
 
     #[test]

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -178,6 +178,8 @@ pub fn regions_of(fields: &[FieldSpec]) -> Vec<RenderedRegion> {
                 rect: f.rect,
                 // A widget is a fixed box with no corpus address.
                 span: None,
+                // The session wrapper stamps the revision; the backend has none.
+                revision: None,
             })
         })
         .collect()

--- a/prose/plans/richtext/phase-3.md
+++ b/prose/plans/richtext/phase-3.md
@@ -11,8 +11,8 @@ freeze](phase-1.md). Spike-A (phase-0 residual gate) closed in PR-A before PR-B
 freezes transport shape.
 
 **Status: open.** PR-A + PR-H **reported** on `spike/richtext-phase-3` (origin).
-**PR-B–E landed** on `integration/richtext` (`0c108163a`…). **PR-F** (preview
-wire + revision stamp) is next.
+**PR-B–G landed** on `integration/richtext` (`0c108163a`…). **PR-H**
+(form-editor POC promotion) is the remaining integration step.
 
 ## Spike branch
 
@@ -66,15 +66,24 @@ cd crates/richtext-spikes/form-poc && npm install && npm run dev  # PR-H manual
    retired for [`EditError::BodyImport`](../../crates/core/src/document/edit.rs)
    /`CorpusApply`. Existing field/kind invariant enforcement unchanged.
    Findings in § PR-E.
-6. **PR-F — preview wire + revision stamp.** Append optional `revision` to
-   [`RenderedRegion`](../../crates/core/src/region.rs) and tag read responses
-   (`regions`, `fieldAt`, `positionAt`, `locate`) — the additive-optional
-   discipline phase 2 froze for this. Session applies field deltas against a
-   base revision; mismatch surfaces as a diagnostic, not a silent stale read.
-7. **PR-G — WASM session API.** `LiveSession::applyFieldDelta` (or equivalent
-   batch) in [`bindings/wasm`](../../crates/bindings/wasm/); vitest coverage.
-   Whole-document `apply(doc)` remains for the markdown/LLM path; form fields
-   use the delta path.
+6. **PR-F — preview wire + revision stamp.** **Landed.** Optional `revision` on
+   [`RenderedRegion`](../../crates/core/src/region.rs) and
+   [`CorpusHit`](../../crates/core/src/region.rs), stamped by the
+   [`LiveSession`](../../crates/core/src/session.rs) wrapper on `regions` /
+   `locate` / `position_at` (backends emit `None`; `field_at` stays a bare,
+   revision-invariant address). `ensure_base_revision` /
+   `record_field_delta_at` / `record_field_change_at` guard a field delta
+   against its base revision — a mismatch is a `session::revision_mismatch`
+   diagnostic, not a silent stale write. Additive-optional throughout. Findings
+   in § PR-F.
+7. **PR-G — WASM session API.** **Landed.** `LiveSession.applyFieldDelta(doc,
+   field, baseRevision, delta)` in [`bindings/wasm`](../../crates/bindings/wasm/)
+   splices the main body corpus (`apply_body_change`), recompiles, and records
+   the delta; a `revision` getter and `mapFieldPos(field, base, pos, assoc)`
+   complete the surface, and `FieldRegion`/`CorpusHit` carry the optional
+   `revision`. Whole-document `apply(doc)` remains the markdown/LLM path; form
+   fields use the delta path. vitest coverage in `canvas.test.js`. Findings in
+   § PR-G.
 8. **PR-H — form-editor POC.** First end-to-end consumer:
    `crates/richtext-spikes/form-poc/` — Vite dev app with ProseMirror inline
    fields, `LiveSession.apply`, and canvas preview on `usaf_memo`. Reuses the
@@ -265,6 +274,67 @@ crate-internal `Card::body_mut`; `RichText` re-exported from
    `updateCardBody` and python `replace_body` / `update_card_body` wrappers now
    propagate instead of swallowing.
 
+## PR-F — preview wire + revision stamp findings
+
+**Implementation:** [`region.rs`](../../crates/core/src/region.rs),
+[`session.rs`](../../crates/core/src/session.rs).
+
+1. **Stamp at the wrapper, not the backend.** `revision` is an
+   additive-optional field on `RenderedRegion` and `CorpusHit`
+   (`skip_serializing_if = None`, so a phase-2 wire with no `revision` key still
+   reads back). Backends construct with `revision: None`; the
+   [`LiveSession`](../../crates/core/src/session.rs) wrapper overwrites it with
+   the current `revision()` on `regions` / `locate` / `position_at`. No backend
+   learns about revisions, and the one-shot `RenderOptions::regions` sidecar
+   stays `None` (no session).
+2. **`field_at` is not stamped.** It returns a bare field address, which is
+   revision-invariant — only a *position* drifts. Stamping it would have meant
+   changing its return shape (a break), against the freeze; the fine-grained
+   `position_at` carries the stamp instead.
+3. **Base-revision guard, three surfaces.** `ensure_base_revision` is the raw
+   check (`base == current`, else a `session::revision_mismatch` diagnostic);
+   `record_field_delta_at` / `record_field_change_at` fold guard-then-record for
+   callers where record *is* commit. A caller that interleaves a document
+   mutation and a recompile (PR-G) uses `ensure_base_revision` up front and the
+   plain `record_field_delta` last, so the log advances only on a fully
+   committed edit.
+
+## PR-G — WASM session API findings
+
+**Implementation:** [`engine.rs`](../../crates/bindings/wasm/src/engine.rs),
+[`types.rs`](../../crates/bindings/wasm/src/types.rs);
+[`canvas.test.js`](../../crates/bindings/wasm/canvas.test.js).
+
+1. **`applyFieldDelta` ties Document + session in one call.** It guards the base
+   revision (untouched on mismatch), splices the main body via
+   `apply_body_change` (text delta only), recompiles from the mutated document,
+   and records the delta into the log **last** — so `revision` advances in
+   lockstep with the live preview and a failed recompile leaves the log where it
+   was. The `field` argument is `$body` this phase (the only structurally-stored
+   corpus; scalar `richtext` fields still coerce from strings at `compile_data`);
+   any other address throws, pointing the caller at `apply(doc)`.
+2. **Delta wire shape.** `Delta = { ops: ({retain:n}|{insert:s}|{delete:n})[] }`
+   — CodeMirror-flavoured, externally-tagged with `camelCase` keys, converted to
+   `quillmark_core::Delta` at the boundary (`Op` newly re-exported from core). A
+   pure-insert delta (`{ops:[{insert:"…"}]}`) needs no length knowledge — apply
+   appends the untouched remainder — which the tests exploit.
+3. **`revision` narrows u64 → u32 at the boundary** to stay a JS `number`
+   (parity with `pageCount`), and `mapFieldPos(field, base, pos, "before"|"after")`
+   exposes the forward map, throwing `session::stale_revision` past the ring.
+   `FieldRegion.revision` / `CorpusHit.revision` are optional `u32`.
+4. **Whole-doc `apply(doc)` stays revision-neutral.** It recompiles from a
+   fully-formed document and records nothing (it holds no prior body to diff);
+   the markdown/LLM path re-reads geometry rather than mapping positions
+   forward. The stale-text writer that *wants* monotonic mapping records via
+   `Document::import_body_delta` + an explicit record at the caller (per PR-E),
+   not through `apply(doc)`.
+5. **Canonical `runtime.js` wrapper unchanged.** It already forwards only a
+   curated subset (no `positionAt` / `locate`), and its cross-wasm-memory
+   `apply` bridge (`mod.Document.fromJson(doc.toJson())`) does not compose with
+   an in-place *mutating* `applyFieldDelta`. The phase-3 nav/edit surface is
+   consumed off the backend-build `LiveSession` directly (as PR-H's spike does);
+   forwarding it through the canonical layer is a later pass.
+
 ## Sequencing invariant
 
 - Spike-A reports before PR-B freezes change-log entry shape (text delta only
@@ -272,6 +342,7 @@ crate-internal `Card::body_mut`; `RichText` re-exported from
 - PR-B (minimal diff) before PR-C (log stores deltas worth replaying). **Closed.**
 - PR-D (mark/line ops) before PR-E (mutators emit them). **Both landed.**
 - PR-F (revision stamp) before PR-G (WASM exposes revision-aware apply).
+  **Both landed.**
 - PR-A's bridge pattern is reused in PR-H; no second editor serialization.
 
 Phase 2 outputs (`RenderedRegion`, canonical bytes, segment maps) extend; none


### PR DESCRIPTION
## Summary

Phase-3 edit surface, PR-F and PR-G (both stack on PR-E, already merged into `integration/richtext`).

**PR-F — preview wire + revision stamp** (`crates/core`)
- Additive-optional `revision: Option<u64>` on `RenderedRegion` and `CorpusHit` (`skip_serializing_if`, so a phase-2 wire with no `revision` key still round-trips).
- Backends construct with `revision: None`; the `LiveSession` wrapper stamps the current `revision()` on `regions` / `position_at` / `locate`. `field_at` stays a bare, revision-invariant address (stamping it would break its shape against the phase-2 freeze).
- `ensure_base_revision` (raw `base == current` check → `session::revision_mismatch` diagnostic) plus `record_field_delta_at` / `record_field_change_at` that fold guard-then-record — a mismatch surfaces as a diagnostic, not a silent stale write.

**PR-G — WASM session API** (`crates/bindings/wasm`)
- `LiveSession.applyFieldDelta(doc, field, baseRevision, delta)`: guards the base revision, splices the `$body` corpus via `apply_body_change`, recompiles, and records the delta **last** — so `revision` advances only on a fully committed edit and a failed recompile leaves the log untouched. Non-`$body` fields throw, pointing callers at `apply(doc)`.
- `revision` getter (u64→u32 at the boundary) and `mapFieldPos(field, base, pos, "before"|"after")` (throws `session::stale_revision` past the ring buffer).
- CodeMirror-flavoured `Delta = { ops: ({retain}|{insert}|{delete})[] }` wire type, converted to `quillmark_core::Delta` at the boundary; optional `revision` on `FieldRegion`/`CorpusHit` (canonical `runtime.d.ts` + generated Typst `.d.ts`, kept in sync per the type-level drift guard).
- Whole-doc `apply(doc)` stays the revision-neutral markdown/LLM path.

Additive-optional throughout; no existing region/read-response shape changes. Findings recorded in `prose/plans/richtext/phase-3.md` (§ PR-F, § PR-G).

## Test plan

- [x] `cargo test -p quillmark-core -p quillmark-wasm --lib`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` (standing lint gate)
- [x] `./scripts/build-wasm.sh` (core size budget OK)
- [x] `vitest run canvas.test.js` — 18/18, including new PR-F/PR-G suite
- [x] `tsc --noEmit` type-level drift guard