### PR TITLE
Move richtext inline to `inline: true` schema field

### DIFF
--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -19,7 +19,7 @@ pub use config::{CoercionError, QuillConfig};
 pub use fill::zero_value;
 pub use formats::parse_date_ymd;
 pub use ignore::QuillIgnore;
-pub use schema::{build_transform_schema, RICHTEXT_MEDIA_TYPE};
+pub use schema::{build_transform_schema, QUILLMARK_INLINE_KEY, RICHTEXT_MEDIA_TYPE};
 pub use tree::FileTreeNode;
 pub use types::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -557,6 +557,15 @@ impl QuillConfig {
                 ),
             );
         }
+        if schema.inline.is_some() && !matches!(schema.r#type, FieldType::RichText { .. }) {
+            return err(
+                "quill::inline_not_supported",
+                format!(
+                    "Field '{owner}' declares 'inline' but is not type: richtext. \
+                     'inline' is only valid on richtext fields."
+                ),
+            );
+        }
 
         match schema.r#type {
             FieldType::Object => {
@@ -950,6 +959,13 @@ impl QuillConfig {
             if obj.contains_key("title") {
                 return Some(
                     "'title' is not a valid field key; use 'description' instead.".to_string(),
+                );
+            }
+            if obj.get("type").and_then(|v| v.as_str()) == Some("richtext(inline)") {
+                return Some(
+                    "richtext(inline) is no longer accepted as a type token; \
+                     use type: richtext with inline: true."
+                        .to_string(),
                 );
             }
         }

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -15,6 +15,11 @@ use crate::value::QuillValue;
 /// corpus rather than a scalar.
 pub const RICHTEXT_MEDIA_TYPE: &str = "application/quillmark-richtext+json";
 
+/// Transform-schema keyword marking a single-`Para` richtext field (`inline: true`
+/// in Quill.yaml). Blueprint still emits `richtext(inline)<markdown>`; this key
+/// is the JSON Schema–shaped wire for editor and backend consumers.
+pub const QUILLMARK_INLINE_KEY: &str = "quillmark:inline";
+
 /// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
 ///
 /// The descriptor marks richtext fields with `contentMediaType:
@@ -37,7 +42,7 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                     serde_json::Value::String("string".to_string()),
                 );
             }
-            FieldType::RichText { .. } => {
+            FieldType::RichText { inline } => {
                 // The corpus crosses the seam as a JSON object (canonical
                 // RichText-JSON), not a string; `type: object` + the richtext
                 // media type is how a backend classifies it to lower the corpus.
@@ -49,6 +54,12 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                     "contentMediaType".to_string(),
                     serde_json::Value::String(RICHTEXT_MEDIA_TYPE.to_string()),
                 );
+                if inline {
+                    schema.insert(
+                        QUILLMARK_INLINE_KEY.to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+                }
             }
             FieldType::Number => {
                 schema.insert(
@@ -293,6 +304,50 @@ card_kinds:
                 "{def_name} $body should be richtext"
             );
         }
+    }
+
+    #[test]
+    fn inline_richtext_emits_quillmark_inline() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    subject:
+      type: richtext
+      inline: true
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let subject = &json["properties"]["subject"];
+        assert_eq!(subject["type"], "object");
+        assert_eq!(subject["contentMediaType"], RICHTEXT_MEDIA_TYPE);
+        assert_eq!(subject[QUILLMARK_INLINE_KEY], true);
+    }
+
+    #[test]
+    fn inline_richtext_array_items_emit_quillmark_inline() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    refs:
+      type: array
+      items:
+        type: richtext
+        inline: true
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let items = &json["properties"]["refs"]["items"];
+        assert_eq!(items[QUILLMARK_INLINE_KEY], true);
     }
 
     #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -3073,7 +3073,7 @@ fn type_mismatch_preview_shows_array_contents() {
     );
 }
 
-// ── PR-G: richtext(inline), load-time example import + cache ─────────────────
+// ── PR-G: richtext inline field, load-time example import + cache ─────────────
 
 /// A minimal quill declaring one field, for the richtext PR-G tests.
 fn quill_with_field(field_yaml: &str) -> Result<QuillConfig, Vec<Diagnostic>> {
@@ -3095,9 +3095,40 @@ fn markdown_type_is_unknown_at_load() {
 }
 
 #[test]
+fn richtext_inline_type_token_is_rejected_at_load() {
+    let err = quill_with_field("    tag:\n      type: richtext(inline)\n").unwrap_err();
+    assert!(
+        err.iter().any(|d| {
+            d.code.as_deref() == Some("quill::field_parse_error")
+                && d.message.contains("richtext(inline)")
+        }),
+        "type: richtext(inline) should be a load error, got: {err:?}"
+    );
+    assert!(
+        err.iter().any(|d| {
+            d.hint
+                .as_deref()
+                .is_some_and(|h| h.contains("inline: true"))
+        }),
+        "load error should hint at inline: true, got: {err:?}"
+    );
+}
+
+#[test]
+fn inline_on_non_richtext_field_is_rejected_at_load() {
+    let err = quill_with_field("    name:\n      type: string\n      inline: true\n").unwrap_err();
+    assert!(
+        err.iter().any(|d| {
+            d.code.as_deref() == Some("quill::field_parse_error") && d.message.contains("inline")
+        }),
+        "inline on string should fail parse, got: {err:?}"
+    );
+}
+
+#[test]
 fn inline_richtext_example_over_one_para_is_a_load_error() {
     let err = quill_with_field(
-        "    tag:\n      type: richtext(inline)\n      example: \"one\\n\\ntwo\"\n",
+        "    tag:\n      type: richtext\n      inline: true\n      example: \"one\\n\\ntwo\"\n",
     )
     .unwrap_err();
     assert!(
@@ -3110,11 +3141,12 @@ fn inline_richtext_example_over_one_para_is_a_load_error() {
 #[test]
 fn inline_richtext_single_line_example_loads_and_caches_corpus() {
     let config = quill_with_field(
-        "    tag:\n      type: richtext(inline)\n      example: \"a *bold* motto\"\n",
+        "    tag:\n      type: richtext\n      inline: true\n      example: \"a *bold* motto\"\n",
     )
     .expect("single-line inline example loads");
     let field = config.main.fields.get("tag").unwrap();
     assert_eq!(field.r#type, FieldType::RichText { inline: true });
+    assert_eq!(field.inline, Some(true));
     // The load pass imports the markdown example into its corpus companion; the
     // authored `example` string is retained untouched (Alternative A).
     let corpus = field
@@ -3151,9 +3183,9 @@ fn block_richtext_default_caches_corpus() {
 #[test]
 fn array_of_inline_richtext_caches_each_element() {
     let config = quill_with_field(
-        "    refs:\n      type: array\n      items:\n        type: richtext(inline)\n      example:\n        - \"first *ref*\"\n        - \"second ref\"\n",
+        "    refs:\n      type: array\n      items:\n        type: richtext\n        inline: true\n      example:\n        - \"first *ref*\"\n        - \"second ref\"\n",
     )
-    .expect("array<richtext(inline)> loads");
+    .expect("array<inline richtext> loads");
     let field = config.main.fields.get("refs").unwrap();
     let corpus = field
         .example_corpus
@@ -3169,7 +3201,8 @@ fn array_of_inline_richtext_caches_each_element() {
 
 #[test]
 fn inline_coercion_rejects_multi_block_document_value() {
-    let config = quill_with_field("    tag:\n      type: richtext(inline)\n").expect("loads");
+    let config =
+        quill_with_field("    tag:\n      type: richtext\n      inline: true\n").expect("loads");
     let mut fields: indexmap::IndexMap<String, QuillValue> = indexmap::IndexMap::new();
     fields.insert(
         "tag".to_string(),
@@ -3184,7 +3217,8 @@ fn inline_coercion_rejects_multi_block_document_value() {
 
 #[test]
 fn inline_coercion_accepts_single_line_document_value() {
-    let config = quill_with_field("    tag:\n      type: richtext(inline)\n").expect("loads");
+    let config =
+        quill_with_field("    tag:\n      type: richtext\n      inline: true\n").expect("loads");
     let mut fields: indexmap::IndexMap<String, QuillValue> = indexmap::IndexMap::new();
     fields.insert(
         "tag".to_string(),

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -91,8 +91,8 @@ impl CardSchema {
 ///
 /// Serializes as its type expression (`FieldType::as_str`) and deserializes by
 /// parsing that string (`FieldType::from_str`), so a YAML `type:` value round-
-/// trips as the one token that names it — including the parenthesized refinement
-/// `richtext(inline)`, which a plain serde enum could not carry.
+/// trips as the one token that names it. Richtext inline shape is declared on
+/// [`FieldSchema::inline`], not in the `type:` token.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldType {
     String,
@@ -106,19 +106,19 @@ pub enum FieldType {
     /// (bare `YYYY-MM-DD` through full RFC 3339 with offset).
     DateTime,
     /// Rich text — the canonical corpus content model ([`RichText`]). Surfaced
-    /// as `type: richtext` (block) or `richtext(inline)` (exactly one `Para`
-    /// line, no container, no islands); the transform schema marks it
-    /// `contentMediaType: application/quillmark-richtext+json`. The pre-richtext
-    /// `markdown` spelling is no longer accepted — a Quill.yaml must declare
-    /// `richtext` / `richtext(inline)` explicitly (`from_str` returns `None` for
-    /// `markdown`, so the loader raises a schema load error).
+    /// as `type: richtext`; single-line shape is declared with [`FieldSchema::inline`].
+    /// The transform schema marks it `contentMediaType:
+    /// application/quillmark-richtext+json` and, when inline, `quillmark:inline:
+    /// true`. The pre-richtext `markdown` spelling is no longer accepted — a
+    /// Quill.yaml must declare `richtext` explicitly (`from_str` returns `None`
+    /// for `markdown`, so the loader raises a schema load error).
     ///
     /// [`RichText`]: quillmark_richtext::RichText
     RichText {
-        /// Single-`Para`-line variant (`richtext(inline)`); editors mount a
-        /// one-line editor and the emitter may lower without block wrapping. The
-        /// constraint is enforced at coercion, validation, and load-time example
-        /// import.
+        /// When `true`, the field is `richtext(inline)` — exactly one `Para`
+        /// line, no container, no islands. Populated from [`FieldSchema::inline`]
+        /// at load; editors mount a one-line surface. Enforced at coercion,
+        /// validation, and load-time example import.
         inline: bool,
     },
 }
@@ -135,7 +135,6 @@ impl FieldType {
             "object" => Some(FieldType::Object),
             "datetime" => Some(FieldType::DateTime),
             "richtext" => Some(FieldType::RichText { inline: false }),
-            "richtext(inline)" => Some(FieldType::RichText { inline: true }),
             // The pre-richtext `markdown` spelling is retired: it returns `None`
             // here so the loader reports it as an unknown type rather than
             // silently aliasing it to block richtext.
@@ -152,8 +151,7 @@ impl FieldType {
             FieldType::Array => "array",
             FieldType::Object => "object",
             FieldType::DateTime => "datetime",
-            FieldType::RichText { inline: false } => "richtext",
-            FieldType::RichText { inline: true } => "richtext(inline)",
+            FieldType::RichText { .. } => "richtext",
         }
     }
 }
@@ -167,6 +165,12 @@ impl Serialize for FieldType {
 impl<'de> Deserialize<'de> for FieldType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
+        if s.trim() == "richtext(inline)" {
+            return Err(serde::de::Error::custom(
+                "richtext(inline) is no longer accepted as a type token; \
+                 use type: richtext with inline: true",
+            ));
+        }
         FieldType::from_str(&s)
             .ok_or_else(|| serde::de::Error::custom(format!("unknown field type: {s:?}")))
     }
@@ -217,6 +221,11 @@ pub struct FieldSchema {
     /// `object` carrying its own `properties`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<Box<FieldSchema>>,
+    /// When `true` on a `richtext` field, the corpus must be exactly one `Para`
+    /// line (no container, no islands). Omitted on block richtext and on every
+    /// other type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline: Option<bool>,
     /// Canonical-corpus form of [`default`](Self::default) for a richtext-bearing
     /// field, imported once at quill load and cached — never serialized. The
     /// render floor (`resolve_fields`) commits this for an absent field, so a
@@ -247,6 +256,7 @@ struct FieldSchemaDef {
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
     // Element schema for arrays.
     pub items: Option<serde_json::Value>,
+    pub inline: Option<bool>,
 }
 
 impl FieldSchema {
@@ -268,6 +278,7 @@ impl FieldSchema {
             enum_values: None,
             properties: None,
             items: None,
+            inline: None,
             default_corpus: None,
             example_corpus: None,
         }
@@ -276,14 +287,20 @@ impl FieldSchema {
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
         let def: FieldSchemaDef = serde_json::from_value(value.clone().into_json())
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
+        let r#type = Self::resolve_richtext_inline(def.r#type, def.inline)?;
+        let inline = match &r#type {
+            FieldType::RichText { inline: true } => Some(true),
+            _ => None,
+        };
         Ok(Self {
             name: key.clone(),
-            r#type: def.r#type,
+            r#type,
             description: def.description,
             default: def.default,
             example: def.example,
             ui: def.ui,
             enum_values: def.enum_values,
+            inline,
             properties: if let Some(props) = def.properties {
                 let mut p = BTreeMap::new();
                 for (key, value) in props {
@@ -313,5 +330,25 @@ impl FieldSchema {
             default_corpus: None,
             example_corpus: None,
         })
+    }
+
+    fn resolve_richtext_inline(
+        r#type: FieldType,
+        inline: Option<bool>,
+    ) -> Result<FieldType, String> {
+        match (r#type, inline) {
+            (FieldType::RichText { .. }, Some(true)) => Ok(FieldType::RichText { inline: true }),
+            (FieldType::RichText { .. }, Some(false) | None) => {
+                Ok(FieldType::RichText { inline: false })
+            }
+            (other, Some(_)) => {
+                let _ = other;
+                Err(
+                "inline is only valid on type: richtext fields; omit inline or declare type: richtext"
+                    .to_string(),
+            )
+            }
+            (other, None) => Ok(other),
+        }
     }
 }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -964,7 +964,7 @@ main:
     fn rejects_richtext_inline_with_multi_block_corpus() {
         // A pre-built two-paragraph corpus reaches the validator directly (no
         // coercion), so the validation-layer NotInline backstop must fire.
-        let config = config_with("    tag:\n      type: richtext(inline)", "");
+        let config = config_with("    tag:\n      type: richtext\n      inline: true", "");
         let rt = quillmark_richtext::import::from_markdown("one\n\ntwo").unwrap();
         let corpus = quillmark_richtext::serial::to_canonical_value(&rt);
         let doc = doc_from_fm(&[("tag", corpus)]);
@@ -977,7 +977,7 @@ main:
 
     #[test]
     fn accepts_richtext_inline_single_para_corpus() {
-        let config = config_with("    tag:\n      type: richtext(inline)", "");
+        let config = config_with("    tag:\n      type: richtext\n      inline: true", "");
         let rt = quillmark_richtext::import::from_markdown("one line only").unwrap();
         let corpus = quillmark_richtext::serial::to_canonical_value(&rt);
         let doc = doc_from_fm(&[("tag", corpus)]);

--- a/crates/fixtures/resources/quills/richtext_form/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/richtext_form/0.1.0/Quill.yaml
@@ -9,7 +9,8 @@ main:
     enabled: false
   fields:
     headline:
-      type: richtext(inline)
+      type: richtext
+      inline: true
       default: ""
       example: "The **headline**"
       description: "Inline richtext bound to the single-line FullName widget; lowered to plaintext."

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -40,7 +40,8 @@ main:
       description: "If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence. Omit entirely to produce a Memorandum for Record (no MEMO FROM line)."
 
     subject:
-      type: richtext(inline)
+      type: richtext
+      inline: true
       example: Subject of the Memorandum
       ui:
         group: Addressing
@@ -94,7 +95,8 @@ main:
       description: Bold-caps line below the seal; blank to omit.
 
     tag_line:
-      type: richtext(inline)
+      type: richtext
+      inline: true
       default: ""
       ui:
         group: Letterhead
@@ -159,7 +161,8 @@ main:
     references:
       type: array
       items:
-        type: richtext(inline)
+        type: richtext
+        inline: true
       default: []
       example:
         - "AFMAN 33-326, 25 November 2011, *Preparing Official Communications*"

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -220,7 +220,8 @@ main:
         group: Additional
         order: 15
       items:
-        type: richtext(inline)
+        type: richtext
+        inline: true
     signature_block:
       type: array
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
@@ -233,7 +234,7 @@ main:
       items:
         type: string
     subject:
-      type: richtext(inline)
+      type: richtext
       description: >-
         Be brief and clear. Capitalize the first letter of each word except articles,
         prepositions, and conjunctions. Include suspense dates in parentheses if
@@ -242,8 +243,9 @@ main:
       ui:
         group: Addressing
         order: 2
+      inline: true
     tag_line:
-      type: richtext(inline)
+      type: richtext
       description: >-
         Organizational motto at the bottom of the page. Supports Markdown emphasis
         (e.g. *italics*, **bold**).
@@ -252,6 +254,7 @@ main:
         group: Letterhead
         order: 8
         compact: true
+      inline: true
   body:
     example: |
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -1,0 +1,41 @@
+# 0.93 → 0.94 — `richtext(inline)` type token retires; use `inline: true`
+
+Single-line richtext shape is still a **schema validation** concern, not a UI
+hint. Only the Quill.yaml spelling changes: `type: richtext(inline)` is a hard
+load error; declare `inline: true` on a `richtext` field instead.
+
+## Quill.yaml
+
+```
+0.93 (retired)                    0.94
+subject:                          subject:
+  type: richtext(inline)            type: richtext
+  example: Memo subject             inline: true
+                                   example: Memo subject
+
+refs:                             refs:
+  type: array                       type: array
+  items:                            items:
+    type: richtext(inline)            type: richtext
+                                     inline: true
+```
+
+- `type: richtext(inline)` → `quill::field_parse_error` with a hint to use
+  `inline: true`.
+- `inline: true` on a non-`richtext` field → `quill::field_parse_error`.
+- `inline: false` may be omitted (block richtext is the default).
+
+Shape enforcement is unchanged: coercion, validation (`richtext::not_inline`),
+and load-time `example:` / `default:` import still require exactly one `Para`
+line with no container and no islands.
+
+## Projections (unchanged spelling)
+
+| Surface | Inline field annotation |
+|---|---|
+| Blueprint | `# richtext(inline)<markdown>` (derived from `inline: true`) |
+| `QuillConfig::schema()` | `type: richtext` + `inline: true` |
+| `build_transform_schema()` | `contentMediaType: application/quillmark-richtext+json` + `quillmark:inline: true` |
+
+Documents and corpus wire shapes are unaffected — only quill schema authoring
+changes.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -12,6 +12,10 @@ guides in order.
 
 ## Available guides
 
+- [0.93 → 0.94](0.93-to-0.94.md) — `type: richtext(inline)` retires; declare
+  `type: richtext` with `inline: true` instead. Blueprint still emits
+  `richtext(inline)<markdown>`; `build_transform_schema` gains
+  `quillmark:inline: true`.
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -25,7 +25,7 @@ Supported field types:
 | `array` | Ordered list; requires an `items:` element schema (e.g. `items: { type: string }` for `string[]`, `items: { type: object, properties: … }` for a typed table) |
 | `object` | Structured map; requires `properties:` |
 | `datetime` | YAML 1.1 timestamp: bare `YYYY-MM-DD` through full RFC 3339 with offset; seconds optional |
-| `richtext` | Rich prose over a canonical corpus (`RichText`); markdown is a projection of it. `richtext(inline)` is the single-line variant (exactly one `Para` line, no container, no islands). The pre-richtext `markdown` spelling is no longer accepted — it is a schema load error (`quill::field_parse_error`) |
+| `richtext` | Rich prose over a canonical corpus (`RichText`); markdown is a projection of it. Declare `inline: true` for the single-line variant (exactly one `Para` line, no container, no islands). The pre-richtext `markdown` spelling and the retired `type: richtext(inline)` token are schema load errors (`quill::field_parse_error`) |
 
 ## Type coercion
 
@@ -35,7 +35,7 @@ Supported field types:
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
 - Coercion rules per type: array wrapping plus element-wise coercion against the `items` schema (a bad element fails at its indexed path, e.g. `counts[1]`); boolean from string/int/float; number/integer from string or from boolean (`true→1`, `false→0`); string unwraps a length-1 string array into the bare string (else identity); richtext commits the canonical corpus form (the model) — an authored markdown string imports (via `quillmark-richtext::import`), an editor-supplied corpus object revalidates and re-canonicalizes, and the length-1-array-unwrap / bare-scalar-stringify leniencies feed the import; date/datetime format validation; object property recursion
-- **`richtext(inline)` enforcement.** An `inline` field's corpus must be exactly one `Para` line, in no container, with no islands (`RichText::is_inline`). The empty corpus satisfies it, so a blank or zero-filled inline field passes. The constraint is checked in three places: coercion (`CoercionError` for a document value), validation (`richtext::not_inline`, the `TypeMismatch` fatality class, as a backstop for a corpus that bypassed coercion), and load-time example import (a schema literal that violates it is a load error)
+- **`inline` richtext enforcement.** A `richtext` field with `inline: true` requires its corpus to be exactly one `Para` line, in no container, with no islands (`RichText::is_inline`). The empty corpus satisfies it, so a blank or zero-filled inline field passes. The constraint is checked in three places: coercion (`CoercionError` for a document value), validation (`richtext::not_inline`, the `TypeMismatch` fatality class, as a backstop for a corpus that bypassed coercion), and load-time example import (a schema literal that violates it is a load error). Blueprint still annotates inline fields as `richtext(inline)<markdown>`; `build_transform_schema` emits `quillmark:inline: true`
 - **Null short-circuits coercion.** A null value (`field:`, `field: null`,
   `field: ~`) passes coercion unchanged for *every* type — null ≡ absent, so
   it carries no data to coerce. The value reaches the render floor and
@@ -258,7 +258,7 @@ metadata, not schema fields, and do not appear in `fields`.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`properties`/`items`/`ui`. `items` (the element schema, itself a `FieldSchema`) is required on `array` fields and rejected elsewhere; `properties` is used by `object` fields (and by an array's `object`-typed `items`).
+Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`inline`/`properties`/`items`/`ui`. `inline` is valid only on `richtext` fields. `items` (the element schema, itself a `FieldSchema`) is required on `array` fields and rejected elsewhere; `properties` is used by `object` fields (and by an array's `object`-typed `items`).
 
 ### `default` and `example`
 


### PR DESCRIPTION
## Summary

- Retires `type: richtext(inline)` as a hard load error; single-line richtext shape is declared with `type: richtext` + `inline: true` on `FieldSchema`.
- Blueprint still derives `richtext(inline)<markdown>` for LLM-facing annotations; `build_transform_schema` now emits `quillmark:inline: true` for editor/backend consumers.
- Updates `usaf_memo` and `richtext_form` fixtures, schema golden, canon (`SCHEMAS.md`), and migration guide `0.93 → 0.94`.

## Test plan

- [x] `cargo test --workspace`
- [x] `UPDATE_GOLDEN=1 cargo test -p quillmark-core schema_snapshot_usaf_memo_0_2_0`
- [x] Inline load/coercion/validation tests (`richtext_inline_*`, `inline_richtext_*`)
- [x] Transform schema tests for `quillmark:inline`