### PR TITLE
Render thematic breaks (---/***/___) instead of dropping them

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -535,6 +535,16 @@ impl<'a> Emit<'a> {
                     runs,
                 });
             }
+            LineKind::Rule => {
+                let g0 = self.out.len();
+                self.out.push_str("#line(length: 100%)");
+                let g1 = self.out.len();
+                self.segments.push(SegmentMap {
+                    corpus: lo..hi,
+                    gen: g0..g1,
+                    runs: Vec::new(),
+                });
+            }
         }
         self.end_newline = false;
     }
@@ -1001,6 +1011,10 @@ mod tests {
             "Hello~World",
             "Use path/to/file for the file",
             "Path: C:\\\\Users\\\\file",
+            // thematic breaks
+            "one\n\n---\n\ntwo",
+            "one\n\n***\n\ntwo",
+            "one\n\n___\n\ntwo",
             // lists
             "- Item 1\n- Item 2\n- Item 3",
             "1. First\n2. Second\n3. Third",
@@ -1106,6 +1120,19 @@ mod tests {
         let out = emit("> one\n>\n> two").markup;
         assert!(out.contains("#quote(block: true)["));
         assert!(out.contains("one") && out.contains("two"));
+    }
+
+    // ---- thematic breaks ----
+
+    #[test]
+    fn thematic_break_renders_line() {
+        for src in ["---", "***", "___"] {
+            let out = emit(&format!("one\n\n{src}\n\ntwo")).markup;
+            assert_eq!(
+                out, "one\n\n#line(length: 100%)\n\ntwo\n\n",
+                "source: {src}, got {out:?}"
+            );
+        }
     }
 
     // ---- structured table cells (Option A) ----

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -254,6 +254,7 @@ fn emit_leaf_block(ctx: &Ctx, range: std::ops::Range<usize>, out: &mut String) {
             let parts: Vec<String> = range.map(|i| render_inline(ctx, i, true)).collect();
             out.push_str(&parts.join("\\\n"));
         }
+        LineKind::Rule => out.push_str("---"),
     }
 }
 
@@ -686,6 +687,22 @@ mod tests {
     #[test]
     fn table() {
         round_trips("| a | b |\n| --- | --- |\n| 1 | 2 |");
+    }
+
+    #[test]
+    fn thematic_break() {
+        round_trips("one\n\n***\n\ntwo");
+    }
+
+    #[test]
+    fn thematic_break_canonicalizes_to_dashes() {
+        // `***`/`___` and `---` all import to the same `Rule` line, so export
+        // re-emits the canonical `---` whatever the source delimiter was.
+        for src in ["***", "___", "- - -"] {
+            let rt = from_markdown(&format!("one\n\n{src}\n\ntwo")).unwrap();
+            let md = to_markdown(&rt);
+            assert!(md.contains("\n\n---\n\n"), "source: {src}, got: {md:?}");
+        }
     }
 
     #[test]

--- a/crates/richtext/src/import.rs
+++ b/crates/richtext/src/import.rs
@@ -32,6 +32,10 @@
 //! - **Tables and images are islands.** Tables are block islands (their own
 //!   `Island` line); images are inline island slots. Both `Lossless` — pipe
 //!   tables and `![alt](url)` carry them faithfully.
+//! - **Thematic breaks are `Rule` lines.** `---`/`***`/`___` in prose (never
+//!   the root-block frontmatter alias, resolved before this layer runs) map
+//!   to a `LineKind::Rule` line carrying no text — the break is the line
+//!   itself.
 
 use crate::model::{
     Container, Island, Line, LineKind, Loss, Mark, MarkKind, RichText, ISLAND_SLOT,
@@ -387,6 +391,7 @@ impl<'a> Builder<'a> {
                     self.ensure_open(LineKind::Para);
                     self.inline.push_code(&t);
                 }
+                Event::Rule => self.open_line(LineKind::Rule, false),
                 Event::SoftBreak => self.push_inline(" "),
                 Event::HardBreak => {
                     match self.cur.as_ref().map(|l| &l.kind) {
@@ -1187,6 +1192,20 @@ mod tests {
         let rt = imp("> quoted");
         assert_eq!(rt.text, "quoted");
         assert_eq!(rt.lines[0].containers, vec![Container::Quote]);
+    }
+
+    #[test]
+    fn thematic_break_is_rule_line() {
+        for src in ["---", "***", "___"] {
+            let md = format!("one\n\n{src}\n\ntwo");
+            let rt = imp(&md);
+            assert_eq!(rt.lines.len(), 3, "source: {src}");
+            assert_eq!(rt.lines[0].kind, LineKind::Para);
+            assert_eq!(rt.lines[1].kind, LineKind::Rule, "source: {src}");
+            assert_eq!(rt.lines[2].kind, LineKind::Para);
+            // The rule line carries no text of its own.
+            assert_eq!(rt.text, "one\n\ntwo");
+        }
     }
 
     #[test]

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -80,6 +80,10 @@ pub enum LineKind {
     },
     /// A block-level island: the line's sole content is one [`ISLAND_SLOT`].
     Island,
+    /// A thematic break (`---`/`***`/`___`). The line carries no text — the
+    /// break is the line itself, parallel to how an island's content is its
+    /// one slot char.
+    Rule,
 }
 
 /// A container a line nests inside. The ancestor path is a `Vec<Container>`.

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -157,6 +157,9 @@ fn line_to_value(line: &Line) -> Value {
         LineKind::Island => {
             m.insert("kind".into(), "island".into());
         }
+        LineKind::Rule => {
+            m.insert("kind".into(), "rule".into());
+        }
     }
     m.insert(
         "containers".into(),
@@ -184,6 +187,7 @@ fn line_from_value(v: &Value) -> Result<Line, ParseError> {
             lang: o.get("lang").and_then(Value::as_str).map(str::to_string),
         },
         Some("island") => LineKind::Island,
+        Some("rule") => LineKind::Rule,
         _ => return Err(ParseError::Shape("line kind")),
     };
     let containers = o

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -50,6 +50,7 @@ Two escapers guard the two Typst contexts; both live in `emit`:
 | `LineKind::Heading{level}` | `=` … `======` (`level` × `=`) |
 | `LineKind::Para` | inline content; a hard break (a `continues` line join) emits `#linebreak()`, a soft break is a space (both settled at import) |
 | `LineKind::Code{lang}` (code fence) | `#raw(block: true, lang: "…", "…")`; `lang:` emitted only when the language tag is non-empty |
+| `LineKind::Rule` (thematic break) | `#line(length: 100%)` |
 | `MarkKind::Strong` | `#strong[…]` |
 | `MarkKind::Emph` | `#emph[…]` |
 | `MarkKind::Underline` | `#underline[…]` |


### PR DESCRIPTION
## Summary

- Thematic breaks (`---`/`***`/`___`) were silently dropped by the `RichText` importer and never reached the Typst emitter — this PR renders them as a horizontal rule instead.
- Adds `LineKind::Rule` to the `RichText` corpus model: a block line carrying no text, parallel to how an island's content is its one slot char.
- Import maps `Event::Rule` to a `Rule` line (previously fell into a catch-all no-op).
- Export re-emits the canonical `---` for a `Rule` line.
- Canonical JSON round-trip (`serial.rs`) handles the new `"rule"` line kind.
- The Typst backend lowers `Rule` to `#line(length: 100%)`, using the same block spacing other block handlers use.
- `prose/canon/CONVERT.md` gets the new element-mapping row.

## Test plan

- [x] `cargo test -p quillmark-richtext -p quillmark-typst` — new unit tests for import (`thematic_break_is_rule_line`), export fixed-point round-trip (`thematic_break`, `thematic_break_canonicalizes_to_dashes`), and Typst emission (`thematic_break_renders_line`) all pass.
- [x] `cargo test --workspace` — full suite green, no regressions.

Fixes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015HiRtYnYfh2PPtKBi4DwmN)_