### PR TITLE
bindings: KISS fixes for #856 API-surface findings

### DIFF
--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -269,6 +269,19 @@ def test_remove_card_then_push_card_round_trips_fields():
     assert doc.cards[0]["body_markdown"] == "Body\n"
 
 
+def test_push_card_accepts_corpus_dict_body():
+    """`body` on a pushed card may be the canonical corpus dict (the shape
+    `cards()`/`remove_card` emit), not just a markdown string — exercises
+    `py_dict_to_card`'s corpus-dict input path."""
+    doc = Document.from_markdown(SIMPLE_MD)
+    doc.push_card({"kind": "note", "body": "**Bold** body."})
+    corpus_body = doc.cards[0]["body"]
+    assert isinstance(corpus_body, dict)
+
+    doc.push_card({"kind": "note", "body": corpus_body})
+    assert doc.cards[1]["body_markdown"] == doc.cards[0]["body_markdown"]
+
+
 def test_make_card_accepts_any_kind_push_card_is_the_gate():
     """make_card is permissive data-shaping; the kind invariant is enforced at
     push_card, not construction."""

--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -20,7 +20,8 @@ import type {
 	PaintOptions as CanonicalPaintOptions,
 	PaintResult as CanonicalPaintResult,
 	FieldRegion as CanonicalFieldRegion,
-	ChangeSet as CanonicalChangeSet
+	ChangeSet as CanonicalChangeSet,
+	CorpusHit as CanonicalCorpusHit
   // The BUILT copy (synced from `runtime/runtime.d.ts` by build-wasm.sh / the
   // cp step), because only there does the d.ts's own `../core/wasm.js` import
   // resolve to the generated `pkg/core` build. The two copies are byte-identical.
@@ -35,7 +36,8 @@ import type {
 	PaintOptions as TypstPaintOptions,
 	PaintResult as TypstPaintResult,
 	FieldRegion as TypstFieldRegion,
-	ChangeSet as TypstChangeSet
+	ChangeSet as TypstChangeSet,
+	CorpusHit as TypstCorpusHit
 } from '../../../pkg/backends/typst/wasm';
 
 // One mutual-assignability pair per hoisted type: typst → canonical and
@@ -100,6 +102,11 @@ const changeSetB: TypstChangeSet = {} as CanonicalChangeSet;
 void changeSetA;
 void changeSetB;
 
+const corpusHitA: CanonicalCorpusHit = {} as TypstCorpusHit;
+const corpusHitB: TypstCorpusHit = {} as CanonicalCorpusHit;
+void corpusHitA;
+void corpusHitB;
+
 const renderResultKeys: KeysEqual<CanonicalRenderResult, TypstRenderResult> = true;
 const renderOptionsKeys: KeysEqual<CanonicalRenderOptions, TypstRenderOptions> = true;
 const artifactKeys: KeysEqual<CanonicalArtifact, TypstArtifact> = true;
@@ -108,6 +115,7 @@ const paintOptionsKeys: KeysEqual<CanonicalPaintOptions, TypstPaintOptions> = tr
 const paintResultKeys: KeysEqual<CanonicalPaintResult, TypstPaintResult> = true;
 const fieldRegionKeys: KeysEqual<CanonicalFieldRegion, TypstFieldRegion> = true;
 const changeSetKeys: KeysEqual<CanonicalChangeSet, TypstChangeSet> = true;
+const corpusHitKeys: KeysEqual<CanonicalCorpusHit, TypstCorpusHit> = true;
 void renderResultKeys;
 void renderOptionsKeys;
 void artifactKeys;
@@ -116,3 +124,4 @@ void paintOptionsKeys;
 void paintResultKeys;
 void fieldRegionKeys;
 void changeSetKeys;
+void corpusHitKeys;

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -145,7 +145,7 @@ export interface Card {
      * model. An editor writes this shape back; a markdown string is also accepted
      * on input (imported). Read `bodyMarkdown` for the markdown projection.
      */
-    body: RichText;
+    body: RichText | string;
     /** The body's markdown projection (`export ∘ body`). Read-only; `""` for an empty body. */
     bodyMarkdown: string;
 }
@@ -155,12 +155,47 @@ export interface Card {
  * fields). One text sequence over a single coordinate space (Unicode scalar
  * values): `text` plus line attributes, anchored `marks`, and embedded
  * `islands`. Every edit is a splice; markdown is a projection, not the model.
+ * Mirrors `quillmark_richtext::serial`'s canonical JSON encoding.
  */
 export interface RichText {
     text: string;
-    lines: unknown[];
-    marks: unknown[];
-    islands: unknown[];
+    lines: RichTextLine[];
+    marks: RichTextMark[];
+    islands: RichTextIsland[];
+}
+
+/** One `\n`-separated segment of `RichText.text`, in order. */
+export type RichTextLine = {
+    containers: RichTextContainer[];
+    /** A within-block hard line break rather than a new block. Omitted (false) in the common case. */
+    continues?: boolean;
+} & (
+    | { kind: "para" }
+    | { kind: "heading"; level: number }
+    | { kind: "code"; lang?: string }
+    | { kind: "island" }
+);
+
+/** An ancestor block a line nests inside, outermost first. */
+export type RichTextContainer =
+    | { container: "list_item"; ordered: boolean; start: number; ordinal: number }
+    | { container: "quote" };
+
+/** A mark over char range `[start, end)` into `RichText.text`. */
+export type RichTextMark = { start: number; end: number } & (
+    | { type: "strong" | "emph" | "underline" | "strike" | "code" }
+    | { type: "link"; url: string }
+    | { type: "anchor"; id: string }
+    | { type: string; attrs: unknown }
+);
+
+/** A structured object (table, figure, …) occupying one island slot in `RichText.text`. */
+export interface RichTextIsland {
+    id: string;
+    type: string;
+    props: unknown;
+    /** How faithfully the markdown projection can carry this island. */
+    loss: "lossless" | "degraded" | "unrepresentable";
 }
 "#;
 
@@ -1456,7 +1491,7 @@ impl LiveSession {
     /// path re-reads geometry rather than mapping positions forward).
     #[wasm_bindgen(getter, js_name = revision)]
     pub fn revision(&self) -> u32 {
-        self.inner.revision() as u32
+        self.inner.revision().try_into().unwrap_or(u32::MAX)
     }
 
     /// Commit a native form-editor edit to a content field: splice `delta` into

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -273,8 +273,10 @@ impl From<quillmark_core::RenderedRegion> for FieldRegion {
             rect: r.rect,
             span: r.span,
             // A session revision is a small monotonic counter; narrowing to the
-            // JS-number-friendly u32 at the boundary avoids a BigInt.
-            revision: r.revision.map(|v| v as u32),
+            // JS-number-friendly u32 at the boundary avoids a BigInt. Saturate
+            // rather than wrap so an implausible overflow reads as "very large,"
+            // not as a small stale-looking value.
+            revision: r.revision.map(|v| v.try_into().unwrap_or(u32::MAX)),
         }
     }
 }
@@ -305,7 +307,7 @@ impl From<quillmark_core::CorpusHit> for CorpusHit {
         CorpusHit {
             field: h.field,
             pos: h.pos,
-            revision: h.revision.map(|v| v as u32),
+            revision: h.revision.map(|v| v.try_into().unwrap_or(u32::MAX)),
         }
     }
 }

--- a/crates/quillmark/src/lib.rs
+++ b/crates/quillmark/src/lib.rs
@@ -20,8 +20,9 @@
 // (portable, declarative data); construct it from an in-memory tree with
 // `Quill::from_tree`, or from disk with the `quill_from_path` helper below.
 pub use quillmark_core::{
-    Artifact, Backend, Card, ChangeSet, Diagnostic, Document, LiveSession, Location, OutputFormat,
-    ParseError, ParseOutput, Quill, RenderError, RenderOptions, RenderResult, Severity,
+    Artifact, Backend, Card, ChangeSet, Delta, Diagnostic, Document, LiveSession, Location,
+    OutputFormat, ParseError, ParseOutput, Quill, RenderError, RenderOptions, RenderResult,
+    RichText, Severity,
 };
 
 mod load;


### PR DESCRIPTION
## Summary

Addresses 5 of the 7 low-priority API-surface findings from #856 with minimal, mechanical fixes:

- **Typed `RichText` in the wasm `.d.ts`** (`crates/bindings/wasm/src/engine.rs`) — `lines`/`marks`/`islands` were `unknown[]`; now real discriminated unions (`RichTextLine`, `RichTextMark`, `RichTextContainer`, `RichTextIsland`) mirroring `quillmark_richtext::serial`'s canonical JSON encoding. `Card.body` is now typed `RichText | string`, matching what `CardWire` actually accepts on input.
- **`CorpusHit` drift guard** (`runtime.types.test-d.ts`) — added the same canonical↔generated mutual-assignability + `KeysEqual` pair the other hoisted types (`FieldRegion`, `ChangeSet`, …) already get, so a shape drift between `quillmark_core::CorpusHit` and the wasm-generated type fails typecheck instead of silently drifting.
- **`u64 → u32` narrowing saturates instead of wraps** (`types.rs`, `engine.rs`) — `LiveSession.revision`, `FieldRegion.revision`, `CorpusHit.revision` now use `try_into().unwrap_or(u32::MAX)` instead of a hard `as u32` cast.
- **Facade re-exports `RichText`/`Delta`** (`crates/quillmark/src/lib.rs`) — a facade-only consumer of `Card::body()` can now name the type it gets back without depending on `quillmark-core`/`quillmark-richtext` directly.
- **Python corpus-input round trip test** — added `test_push_card_accepts_corpus_dict_body`, pushing a card whose `body` is the corpus dict shape `cards()`/`remove_card` emit through `py_dict_to_card`.

## Not included (need a design decision, not a mechanical fix)

- `applyFieldDelta` doesn't verify the `doc` handle matches the session (#856 item 4) — needs a decision on how `Document` gets a session-checkable identity.
- Collapsing the four `record_field_*` methods on `LiveSession` (#856 item 6) — an intentional public-API surface change with call-site fallout.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all pass)
- [ ] WASM typecheck (`npm run typecheck` in `crates/bindings/wasm`) — runs on CI in this environment
- [ ] Python bindings (`uv run pytest`) — runs on CI in this environment

Closes part of #856.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RgtJGRDvxniav5ozPwnUib)_