### PR TITLE
richtext: fix issue #854 cleanup findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,14 +2376,11 @@ dependencies = [
 name = "quillmark-richtext"
 version = "0.92.1"
 dependencies = [
- "indexmap",
  "proptest",
  "pulldown-cmark",
  "quillmark-fixtures",
- "serde",
  "serde_json",
  "similar",
- "unicode-normalization",
 ]
 
 [[package]]

--- a/crates/richtext/Cargo.toml
+++ b/crates/richtext/Cargo.toml
@@ -14,10 +14,7 @@ description = "RichText corpus content model, canonical serialization, edit delt
 publish = true
 
 [dependencies]
-serde = { workspace = true }
 serde_json = { workspace = true }
-indexmap = { workspace = true }
-unicode-normalization = { workspace = true }
 # The markdown projection's parser. This crate is the workspace's single home
 # for a CommonMark parser; render paths consume the corpus, never markdown.
 pulldown-cmark = { workspace = true }

--- a/crates/richtext/src/delta.rs
+++ b/crates/richtext/src/delta.rs
@@ -65,10 +65,31 @@ pub enum Assoc {
     After,
 }
 
+/// A delta's expected base length disagreed with the text it was applied to —
+/// the delta was built against a different revision of the base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BaseLengthMismatch {
+    pub expected: usize,
+    pub actual: usize,
+}
+
 impl Delta {
+    /// Chars of base the `Retain`/`Delete` ops together consume — the base
+    /// length this delta was built against.
+    pub fn expected_base_len(&self) -> usize {
+        self.ops
+            .iter()
+            .map(|op| match op {
+                Op::Retain(n) | Op::Delete(n) => *n,
+                Op::Insert(_) => 0,
+            })
+            .sum()
+    }
+
     /// Apply to `base`, producing the new text. Ignores over-long
     /// `Retain`/`Delete` gracefully (clamps), so a mismatched delta cannot
-    /// panic.
+    /// panic. Silently produces garbage on a length mismatch — use
+    /// [`Self::try_apply`] where the base's provenance isn't already trusted.
     pub fn apply(&self, base: &str) -> String {
         let chars: Vec<char> = base.chars().collect();
         let mut out = String::new();
@@ -88,6 +109,17 @@ impl Delta {
         }
         out.extend(&chars[i.min(chars.len())..]);
         out
+    }
+
+    /// [`Self::apply`], but rejects a delta whose expected base length
+    /// disagrees with `base`'s actual length instead of clamping silently.
+    pub fn try_apply(&self, base: &str) -> Result<String, BaseLengthMismatch> {
+        let expected = self.expected_base_len();
+        let actual = base.chars().count();
+        if expected != actual {
+            return Err(BaseLengthMismatch { expected, actual });
+        }
+        Ok(self.apply(base))
     }
 
     /// Map a base char position to its new position. `assoc` decides the side of
@@ -401,7 +433,9 @@ fn relocate_point(
 /// can split a moved block across an inserted region and the retained
 /// suffix; demanding containment would miss real moves, while demanding overlap
 /// still rejects an unrelated occurrence sitting entirely in retained text.
-/// Enforces [`MIN_MOVE`].
+/// Enforces [`MIN_MOVE`]. O(hay × needle) naive scan — fine at memo/document
+/// scale; a large-document target would want a substring-search algorithm
+/// (e.g. KMP) here.
 fn find_in_spans(hay: &[char], needle: &[char], spans: &[(usize, usize)]) -> Option<usize> {
     if needle.len() < MIN_MOVE || needle.len() > hay.len() {
         return None;

--- a/crates/richtext/src/import.rs
+++ b/crates/richtext/src/import.rs
@@ -787,13 +787,11 @@ fn sanitize_lang(lang: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// MarkdownFixer — ported from crates/backends/typst/src/convert.rs.
+// MarkdownFixer — the crate's single copy of the pulldown-cmark event fixups.
 //
 // Two jobs before events reach the builder: allowlist `<u>…</u>` as underline
 // (rewrite to Strong start/end, detected by source peek) and strip all other
-// raw HTML; and fix `***`-adjacency runs pulldown splits awkwardly. Phase 2
-// unifies this with the backend's copy; phase 1 duplicates it to stay
-// engine-off.
+// raw HTML; and fix `***`-adjacency runs pulldown splits awkwardly.
 // ---------------------------------------------------------------------------
 
 fn is_u_open_tag(html: &str) -> bool {

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -9,6 +9,7 @@
 //! the resulting range, so the stored form is identical whatever the editor
 //! did. See `prose/plans/richtext/phase-0.md` § Spike A.
 
+use crate::normalize::is_bidi_char;
 use serde_json::Value as JsonValue;
 
 /// A position in a [`RichText`], counted in Unicode scalar values (USV) — never
@@ -247,26 +248,6 @@ pub(crate) fn sorted_value(v: &JsonValue) -> JsonValue {
     }
 }
 
-/// The bidi formatting chars import normalization strips; their presence in a
-/// corpus is an invariant violation. Mirrors [`crate::normalize`]'s set.
-fn is_bidi_char(c: char) -> bool {
-    matches!(
-        c,
-        '\u{061C}'
-            | '\u{200E}'
-            | '\u{200F}'
-            | '\u{202A}'
-            | '\u{202B}'
-            | '\u{202C}'
-            | '\u{202D}'
-            | '\u{202E}'
-            | '\u{2066}'
-            | '\u{2067}'
-            | '\u{2068}'
-            | '\u{2069}'
-    )
-}
-
 /// Ways a [`RichText`] can violate its invariants. Returned by
 /// [`RichText::validate`]; import normalization guarantees none of these.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -365,14 +346,17 @@ impl RichText {
         // boundary is "inside" the mark must canonicalize to the same bounds.
         // Trim leading/trailing `\n` (interior boundaries are kept — a mark may
         // legitimately span lines). Zero-width results are dropped below.
-        let chars: Vec<char> = self.text.chars().collect();
-        for m in &mut self.marks {
-            if m.kind.is_formatting() {
-                while m.start < m.end && chars.get(m.start) == Some(&'\n') {
-                    m.start += 1;
-                }
-                while m.end > m.start && chars.get(m.end - 1) == Some(&'\n') {
-                    m.end -= 1;
+        // Skip the full-text char collection when nothing needs trimming.
+        if self.marks.iter().any(|m| m.kind.is_formatting()) {
+            let chars: Vec<char> = self.text.chars().collect();
+            for m in &mut self.marks {
+                if m.kind.is_formatting() {
+                    while m.start < m.end && chars.get(m.start) == Some(&'\n') {
+                        m.start += 1;
+                    }
+                    while m.end > m.start && chars.get(m.end - 1) == Some(&'\n') {
+                        m.end -= 1;
+                    }
                 }
             }
         }

--- a/crates/richtext/src/normalize.rs
+++ b/crates/richtext/src/normalize.rs
@@ -9,7 +9,7 @@
 //! this crate is a leaf `quillmark-core` depends on.
 
 #[inline]
-fn is_bidi_char(c: char) -> bool {
+pub(crate) fn is_bidi_char(c: char) -> bool {
     matches!(
         c,
         '\u{061C}' // ARABIC LETTER MARK (ALM)

--- a/crates/richtext/src/ops.rs
+++ b/crates/richtext/src/ops.rs
@@ -59,12 +59,22 @@ pub enum ApplyError {
         line: usize,
         lines: usize,
     },
+    SplitPositionOutOfRange {
+        at: Usv,
+        len: Usv,
+    },
     SplitAtNewline {
         at: Usv,
     },
     LineCountMismatch {
         lines: usize,
         segments: usize,
+    },
+    /// The text delta's expected base length disagreed with the corpus —
+    /// it was built against a different revision.
+    DeltaBaseMismatch {
+        expected: usize,
+        actual: usize,
     },
     /// An `Op::Insert` carried a raw [`ISLAND_SLOT`]. Islands are structurally
     /// uneditable through the text channel — a slot inserted here would have no
@@ -96,7 +106,12 @@ impl RichText {
 
         let old_chars: Vec<char> = self.text.chars().collect();
         let old_lines = self.lines.clone();
-        let new_text = delta.apply(&self.text);
+        let new_text = delta
+            .try_apply(&self.text)
+            .map_err(|e| ApplyError::DeltaBaseMismatch {
+                expected: e.expected,
+                actual: e.actual,
+            })?;
 
         for m in &mut self.marks {
             if m.start == m.end {
@@ -217,25 +232,26 @@ impl RichText {
     }
 
     fn split_line(&mut self, at: Usv) -> Result<(), ApplyError> {
-        let len = self.len_usv();
+        let char_indices: Vec<(usize, char)> = self.text.char_indices().collect();
+        let len = char_indices.len();
         if at > len {
-            return Err(ApplyError::MarkOutOfRange {
-                start: at,
-                end: at,
-                len,
-            });
+            return Err(ApplyError::SplitPositionOutOfRange { at, len });
         }
-        if at > 0 && self.text.chars().nth(at - 1) == Some('\n') {
+        if at > 0 && char_indices[at - 1].1 == '\n' {
             return Err(ApplyError::SplitAtNewline { at });
         }
-        if at < len && self.text.chars().nth(at) == Some('\n') {
+        if at < len && char_indices[at].1 == '\n' {
             return Err(ApplyError::SplitAtNewline { at });
         }
 
-        let byte = char_to_byte(&self.text, at);
+        // `at`'s newline-adjacency neighbors, `at`'s byte offset, and the
+        // newline count before `at` (== the post-insert line index, since the
+        // insertion lands at index `at`, not before it) all come from this
+        // one pass over `char_indices`, instead of four separate text scans.
+        let byte = char_indices.get(at).map_or(self.text.len(), |&(b, _)| b);
+        let line_idx = char_indices[..at].iter().filter(|&(_, c)| *c == '\n').count();
         self.text.insert(byte, '\n');
 
-        let line_idx = line_index_at(self.text.chars().collect::<Vec<_>>().as_slice(), at);
         let template = self
             .lines
             .get(line_idx)
@@ -414,10 +430,6 @@ fn sync_islands_for_delta(
         .zip(keep)
         .filter_map(|(island, keep)| keep.then_some(island))
         .collect()
-}
-
-fn line_index_at(chars: &[char], at: Usv) -> usize {
-    chars.iter().take(at).filter(|&&c| c == '\n').count()
 }
 
 fn newline_at_line_boundary(text: &str, line: usize) -> Result<Usv, ApplyError> {

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -177,12 +177,16 @@ fn line_from_value(v: &Value) -> Result<Line, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("line"))?;
     let kind = match o.get("kind").and_then(Value::as_str) {
         Some("para") => LineKind::Para,
-        Some("heading") => LineKind::Heading {
-            level: o
+        Some("heading") => {
+            let level = o
                 .get("level")
                 .and_then(Value::as_u64)
-                .ok_or(ParseError::Shape("heading level"))? as u8,
-        },
+                .ok_or(ParseError::Shape("heading level"))?;
+            if !(1..=6).contains(&level) {
+                return Err(ParseError::Shape("heading level"));
+            }
+            LineKind::Heading { level: level as u8 }
+        }
         Some("code") => LineKind::Code {
             lang: o.get("lang").and_then(Value::as_str).map(str::to_string),
         },

--- a/crates/richtext/src/usv.rs
+++ b/crates/richtext/src/usv.rs
@@ -1,10 +1,14 @@
-//! Coordinate conversions across the binding boundary.
+//! Coordinate conversions between USV and the two other coordinate spaces a
+//! consumer may hold a position in.
 //!
 //! [`RichText`](crate::RichText) positions count Unicode scalar values (USV,
-//! Rust `char`). The three boundaries that disagree:
+//! Rust `char`) throughout, including at the WASM boundary — the `wasm`
+//! binding's delta and hit-test APIs pass raw USV positions through and leave
+//! any UTF-16 conversion to the JS caller, so the helpers here are unused at
+//! that boundary today. Three coordinate spaces disagree:
 //!
 //! - **Rust / storage** — UTF-8 bytes. Slicing the corpus needs a byte offset.
-//! - **JS editors** — UTF-16 code units. Every delta crossing WASM converts.
+//! - **JS editors** — UTF-16 code units, if a caller chooses to convert.
 //! - **USV** — the model's coordinate. One astral char is 1 USV / 4 UTF-8 bytes
 //!   / 2 UTF-16 units.
 //!


### PR DESCRIPTION
## Summary

Fixes all 8 low-priority cleanup findings from #854:

1. **Unused deps** — dropped `serde`, `indexmap`, `unicode-normalization` from `crates/richtext/Cargo.toml` (nothing under `src/` referenced them directly; only `serde_json` is used).
2. **Stale comment** — `import.rs`'s `MarkdownFixer` banner no longer narrates the removed `convert.rs`/phase-2 migration story; states the current fact instead.
3. **Error-variant reuse** — `split_line`'s bounds check now returns a new `ApplyError::SplitPositionOutOfRange` instead of misusing `MarkOutOfRange`.
4. **Silent truncation** — `serial.rs` validates the raw heading-level `u64` is in `1..=6` before casting to `u8`, so `{"level": 262}` now errors instead of wrapping to `6`.
5. **`Delta::apply` silently clamps** — added `Delta::try_apply`/`expected_base_len`, wired into `apply_text_delta` (the real caller from `apply_field_change` / the WASM `applyFieldDelta` path) via a new `ApplyError::DeltaBaseMismatch`, so a delta built against a stale revision now errors instead of silently clamping into garbage.
6. **`is_bidi_char` duplication** — kept the single (better-commented) copy in `normalize.rs` as `pub(crate)`; `model.rs` now imports it instead of duplicating.
7. **`usv.rs` doc mismatch** — corrected the module doc to state that USV positions pass straight through the WASM boundary unconverted (matches `engine.rs`'s actual behavior — the UTF-16 helpers are exercised only by this crate's own tests today).
8. **Perf nits** — `split_line` fuses four separate text scans into one pass over `char_indices`; `normalize()` skips its full-text char collection when no formatting marks need boundary trimming; `find_in_spans` gets a one-line complexity note flagging it as a documented follow-up (left as-is per the issue — fine at current document scale).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green except one **pre-existing, unrelated** failure (`change_log::tests::invalidate_fails_closed_for_pre_apply_bases`), confirmed present before these changes via `git stash`
- [x] `cargo clippy -p quillmark-richtext --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WuNpKVheJdWRQmj81qsHFB)_