### PR TITLE
fix(session): repair the #851 fix — transactional applyFieldDelta, fail-closed invalidation

### DIFF
--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -468,6 +468,49 @@ describe('LiveSession revision stamp + applyFieldDelta (PR-F/PR-G)', () => {
     session.free()
   })
 
+  it('leaves the body and revision untouched when the splice fails, and a retry is identical', () => {
+    const { engine, quill } = openQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const session = engine.open(quill, doc)
+
+    // U+FFFC is the island-slot sentinel: a text splice may not insert one
+    // (islands are minted through their own channel), so the corpus splice
+    // rejects before mutating. The delta-path recompile never runs, so `doc`
+    // and the revision stay exactly as they were — the transactional invariant.
+    const islandSlot = { ops: [{ insert: '￼' }] }
+    const bodyBefore = doc.main.bodyMarkdown
+    expect(session.revision).toBe(0)
+
+    let first
+    try {
+      session.applyFieldDelta(doc, '$body', 0, islandSlot)
+    } catch (e) {
+      first = e
+    }
+    expect(first).toBeTruthy()
+    expect(doc.main.bodyMarkdown).toBe(bodyBefore)
+    expect(session.revision).toBe(0)
+
+    // The failure left no partial state, so the natural retry with the same
+    // arguments behaves identically rather than double-applying or drifting.
+    let second
+    try {
+      session.applyFieldDelta(doc, '$body', 0, islandSlot)
+    } catch (e) {
+      second = e
+    }
+    expect(second).toBeTruthy()
+    expect(doc.main.bodyMarkdown).toBe(bodyBefore)
+    expect(session.revision).toBe(0)
+
+    // And the session still commits a valid edit afterward: the failed call
+    // did not wedge the change log.
+    session.applyFieldDelta(doc, '$body', 0, prepend('OK '))
+    expect(session.revision).toBe(1)
+    expect(doc.main.bodyMarkdown).toContain('OK')
+    session.free()
+  })
+
   it('rejects a non-body field as a delta-path target', () => {
     const { engine, quill } = openQuill()
     const doc = Document.fromMarkdown(TEST_MARKDOWN)

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1559,8 +1559,12 @@ impl LiveSession {
             return Err(edit_error_to_js(&e));
         }
 
-        // Recompile from the mutated document, transactional on the compile —
-        // and, via the snapshot above, on `doc` itself.
+        // Recompile from the mutated document and record the delta atomically,
+        // transactional on the compile — and, via the snapshot above, on `doc`
+        // itself. The seam recompiles *without* invalidating the change log
+        // (unlike whole-document `apply`) and records the delta against the
+        // guarded base in one step: the revision advances to `base_revision + 1`
+        // in lockstep with the preview, or nothing changes and `doc` rolls back.
         let recompiled = self
             .config
             .check_quill_reference(&doc.inner)
@@ -1572,7 +1576,12 @@ impl LiveSession {
             })
             .and_then(|json_data| {
                 self.inner
-                    .apply(&json_data)
+                    .apply_for_field_delta(
+                        field.to_string(),
+                        base_revision as u64,
+                        core_delta,
+                        &json_data,
+                    )
                     .map_err(|e| WasmError::from(e).to_js_value())
             });
         let cs = match recompiled {
@@ -1582,19 +1591,6 @@ impl LiveSession {
                 return Err(e);
             }
         };
-
-        // Commit into the change log only after a successful recompile, so the
-        // revision advances in lockstep with the live preview. Checked against
-        // `base_revision` like every other recording path — no unchecked
-        // bypass of the guard already enforced above.
-        self.inner
-            .record_field_delta_at(field.to_string(), base_revision as u64, core_delta)
-            .map_err(|d| {
-                WasmError {
-                    diagnostics: vec![d],
-                }
-                .to_js_value()
-            })?;
 
         Ok(ChangeSet {
             page_count: cs.page_count,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -433,6 +433,40 @@ impl LiveSession {
         self.change_log.invalidate();
         Ok(change_set)
     }
+
+    /// Recompile against `json_data` for a field-delta commit and record the
+    /// delta atomically — the delta path's counterpart to [`apply`](Self::apply).
+    /// Unlike `apply` it does **not** invalidate the change log: a whole-document
+    /// rewrite is not expressed as per-field deltas, so `apply` raises the
+    /// invalidation floor; a field delta *is* composable, so its `base_revision`
+    /// must fold forward rather than fail closed against a raised floor.
+    ///
+    /// Guards `base_revision` against the current [`revision`](Self::revision)
+    /// first: a mismatch returns `session::revision_mismatch`, records nothing,
+    /// and does not recompile. Then recompiles transactionally — on `Err` the
+    /// previous compile stays live and the revision does not advance. On success
+    /// records `text_delta` under `path` (advancing the revision to
+    /// `base_revision + 1`) and returns the [`ChangeSet`]. Because the
+    /// non-invalidating recompile leaves the revision unchanged, the guarded base
+    /// still matches when recording, so the whole call commits or leaves the
+    /// session untouched. The caller holding the source `Document` rolls its own
+    /// copy back on `Err`.
+    #[doc(hidden)]
+    pub fn apply_for_field_delta(
+        &mut self,
+        path: impl Into<String>,
+        base_revision: u64,
+        text_delta: Delta,
+        json_data: &serde_json::Value,
+    ) -> Result<ChangeSet, RenderError> {
+        self.ensure_base_revision(base_revision)
+            .map_err(RenderError::from_diag)?;
+        let change_set = self.inner.apply(json_data)?;
+        // The guard proved base == current and the recompile left the revision
+        // untouched, so this record cannot mismatch — commit it infallibly.
+        self.change_log.record(path, text_delta);
+        Ok(change_set)
+    }
 }
 
 #[cfg(test)]
@@ -649,6 +683,87 @@ mod tests {
             .record_field_change_at("subject", 1, diff("abXc", "abXYc"), [], [])
             .expect("current base");
         assert_eq!(r, 2);
+    }
+
+    /// Whole-document `apply` raises the change log's invalidation floor: a
+    /// position captured at a pre-apply base fails `map_field_pos` closed with
+    /// `StaleRevision` rather than folding through deltas the rewrite obsoleted.
+    #[test]
+    fn apply_invalidates_pre_apply_bases() {
+        use quillmark_richtext::delta::diff;
+
+        let mut session = LiveSession::new(Box::new(WarningHandle {
+            current: Vec::new(),
+            applies: 0,
+        }));
+        session
+            .record_field_delta_at("subject", 0, diff("abc", "abXc"))
+            .unwrap();
+        assert_eq!(session.revision(), 1);
+
+        session.apply(&serde_json::Value::Null).unwrap();
+        assert_eq!(session.revision(), 2);
+
+        let err = session
+            .map_field_pos("subject", 1, 0, Assoc::Before)
+            .unwrap_err();
+        assert_eq!(err.base_revision, 1);
+        assert_eq!(err.oldest_retained, 2);
+    }
+
+    /// The delta-path seam recompiles and records atomically without
+    /// invalidating: the delta lands in the log (a pre-recompile base maps
+    /// forward through it), and a subsequent field delta at the revision the
+    /// seam advanced to still records — no invalidation floor was raised.
+    #[test]
+    fn apply_for_field_delta_records_without_invalidating() {
+        use quillmark_richtext::delta::diff;
+
+        let mut session = LiveSession::new(Box::new(WarningHandle {
+            current: Vec::new(),
+            applies: 0,
+        }));
+        session
+            .apply_for_field_delta(
+                "$body",
+                0,
+                diff("abcdef", "abcXYdef"),
+                &serde_json::Value::Null,
+            )
+            .unwrap();
+        assert_eq!(session.revision(), 1);
+        // The recorded delta composes: a base-0 position folds through it.
+        assert_eq!(
+            session.map_field_pos("$body", 0, 3, Assoc::After).unwrap(),
+            5
+        );
+        // The seam advanced to revision 1 without a floor, so a delta at base 1
+        // still records instead of failing closed.
+        let r = session
+            .record_field_delta_at("$body", 1, diff("abcXYdef", "abcZdef"))
+            .unwrap();
+        assert_eq!(r, 2);
+    }
+
+    /// A stale base to the delta-path seam is rejected before recompiling: the
+    /// `session::revision_mismatch` guard fires, the revision does not advance,
+    /// and (per `WarningHandle`) no recompile ran.
+    #[test]
+    fn apply_for_field_delta_guards_base_revision() {
+        use quillmark_richtext::delta::diff;
+
+        let mut session = LiveSession::new(Box::new(WarningHandle {
+            current: Vec::new(),
+            applies: 0,
+        }));
+        let err = session
+            .apply_for_field_delta("$body", 5, diff("a", "b"), &serde_json::Value::Null)
+            .unwrap_err();
+        assert_eq!(
+            err.diagnostics()[0].code.as_deref(),
+            Some("session::revision_mismatch")
+        );
+        assert_eq!(session.revision(), 0);
     }
 
     #[test]

--- a/crates/richtext/src/change_log.rs
+++ b/crates/richtext/src/change_log.rs
@@ -42,6 +42,11 @@ pub struct ChangeLog {
     capacity: usize,
     revision: u64,
     entries: VecDeque<FieldChange>,
+    /// Invalidation floor: a `map_pos` against any `base_revision` strictly
+    /// below this fails closed. Raised to the post-bump revision by
+    /// [`invalidate`](Self::invalidate); `0` before any whole-document rewrite
+    /// bypasses the delta protocol.
+    invalidated_below: u64,
 }
 
 impl ChangeLog {
@@ -50,6 +55,7 @@ impl ChangeLog {
             capacity: capacity.max(1),
             revision: 0,
             entries: VecDeque::new(),
+            invalidated_below: 0,
         }
     }
 
@@ -126,6 +132,17 @@ impl ChangeLog {
                 oldest_retained: self.revision,
             });
         }
+        // A whole-document rewrite raised the invalidation floor: every base
+        // below it captured text this log's deltas no longer describe, so
+        // folding them would silently lie. The floor is the oldest base still
+        // mappable — a read taken at it composes identity forward through any
+        // deltas recorded since.
+        if base_revision < self.invalidated_below {
+            return Err(StaleRevision {
+                base_revision,
+                oldest_retained: self.invalidated_below,
+            });
+        }
         if let Some(oldest) = self.oldest_retained() {
             // The fold below needs every entry with revision > base_revision,
             // i.e. starting at `base_revision + 1`. That entry is retained iff
@@ -154,22 +171,17 @@ impl ChangeLog {
     }
 
     /// Invalidate the log for a whole-document rewrite that bypasses the
-    /// delta protocol (`LiveSession::apply`): bump the revision and drop
-    /// every entry, replacing them with one sentinel at the new revision. A
-    /// later `map_pos` call against any base revision recorded before this
-    /// point now fails closed with [`StaleRevision`] instead of silently
-    /// composing through per-field deltas that no longer describe the
-    /// current text. Returns the new revision.
+    /// delta protocol (`LiveSession::apply`): bump the revision, drop every
+    /// entry, and raise the invalidation floor to the new revision. A later
+    /// `map_pos` against any base below the floor fails closed with
+    /// [`StaleRevision`] instead of silently composing through per-field
+    /// deltas that no longer describe the current text; a base at or above the
+    /// floor still maps, folding forward through any deltas recorded after the
+    /// rewrite. Returns the new revision.
     pub fn invalidate(&mut self) -> u64 {
         self.revision = self.revision.saturating_add(1);
         self.entries.clear();
-        self.entries.push_back(FieldChange {
-            revision: self.revision,
-            path: String::new(),
-            text_delta: Delta { ops: Vec::new() },
-            mark_ops: Vec::new(),
-            line_ops: Vec::new(),
-        });
+        self.invalidated_below = self.revision;
         self.revision
     }
 }
@@ -349,6 +361,33 @@ mod tests {
         );
         // ...but a read taken exactly at the new revision still resolves.
         assert_eq!(log.map_pos("f", 3, 5, Assoc::Before).unwrap(), 5);
+    }
+
+    /// Deltas recorded *after* an invalidation fold forward normally from the
+    /// floor revision, while every pre-invalidation base stays stale: the
+    /// floor partitions mappable from unmappable bases, and records past it
+    /// re-arm the delta protocol.
+    #[test]
+    fn map_pos_after_invalidate_maps_from_floor() {
+        let mut log = ChangeLog::with_default_capacity();
+        log.record("f", diff("a", "b")); // rev 1
+        log.record("f", diff("b", "c")); // rev 2
+        assert_eq!(log.invalidate(), 3); // floor := 3
+        log.record("f", diff("abcdef", "abcXYdef")); // rev 4, base == floor
+
+        // A read at the floor (rev 3) folds through the rev-4 insert…
+        assert_eq!(log.map_pos("f", 3, 3, Assoc::After).unwrap(), 5);
+        // …and a read at rev 4 is current, so identity.
+        assert_eq!(log.map_pos("f", 4, 3, Assoc::Before).unwrap(), 3);
+        // But every pre-invalidation base is still stale against the floor,
+        // even though its needed entry was never in the ring.
+        assert_eq!(
+            log.map_pos("f", 2, 0, Assoc::Before).unwrap_err(),
+            StaleRevision {
+                base_revision: 2,
+                oldest_retained: 3,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #851 / #862, which merged with red CI (1 native failure, 3 WASM failures). Full analysis: https://github.com/quillmark-org/quillmark/issues/851#issuecomment-4929991948

## What broke

- **`applyFieldDelta` threw on every successful edit.** Its recompile routed through core `LiveSession::apply`, which (per the #862 gap-2 fix) invalidates the change log and bumps the revision — so the subsequent guarded `record_field_delta_at(base_revision)` always failed `session::revision_mismatch`, leaving `doc` and the compile mutated while the call reported failure. Cause of the 3 red WASM tests.
- **`ChangeLog::invalidate` didn't fail closed.** Its sentinel entry at revision N+1 couldn't express staleness under the corrected `base_revision + 1 < oldest` boundary (7e86f22, which #862's branch predated), so a position captured immediately before `apply()` mapped through as identity. Cause of the red `invalidate_fails_closed_for_pre_apply_bases`.

## Changes

- `crates/richtext/src/change_log.rs`: replace the sentinel with an explicit `invalidated_below` floor; `map_pos` returns `StaleRevision` for any base below it. New test covering post-invalidate records mapping from the floor while pre-invalidate bases stay stale.
- `crates/core/src/session.rs`: new `apply_for_field_delta` seam — guards the base revision, recompiles **without** invalidating, records the delta atomically (revision → base+1); a failed compile keeps the last-good compile and revision. Tests for the seam and for `apply()` invalidating pre-apply bases.
- `crates/bindings/wasm/src/engine.rs`: route `applyFieldDelta`'s recompile through the new seam, removing the always-failing separate record step; document rollback on any failure preserved.
- `crates/bindings/wasm/canvas.test.js`: failed-splice + retry test — the rejected edit leaves `doc` and `revision` unchanged and an identical retry behaves the same.

## Verification

- `cargo test --workspace`: green (previously failing `invalidate_fails_closed_for_pre_apply_bases` now passes).
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps`: clean.
- WASM vitest suite runs on this PR's CI (not runnable locally per repo policy); the 3 previously-red tests exercise exactly the repaired path.

Fixes #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131dn3dmgku1drjqjVnozsb

---
_Generated by [Claude Code](https://claude.ai/code/session_0131dn3dmgku1drjqjVnozsb)_