### PR TITLE
typst/richtext: address #855 cleanup findings

### DIFF
--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -194,17 +194,11 @@ fn element_text(e: &Value) -> Option<String> {
     }
 }
 
-/// A richtext corpus's plaintext: `RichText.text` with island slots
-/// ([`ISLAND_SLOT`](quillmark_richtext::model::ISLAND_SLOT)) stripped — islands
-/// (tables, images) have no plaintext projection. `None` for a non-corpus object
-/// or an empty result.
+/// A richtext corpus's plaintext, via [`quillmark_richtext::export::to_plaintext`]
+/// (island slots stripped). `None` for a non-corpus object or an empty result.
 fn richtext_plaintext(v: &Value) -> Option<String> {
     let rt = quillmark_richtext::serial::from_canonical_value(v).ok()?;
-    let text: String = rt
-        .text
-        .chars()
-        .filter(|c| *c != quillmark_richtext::model::ISLAND_SLOT)
-        .collect();
+    let text = quillmark_richtext::export::to_plaintext(&rt);
     (!text.is_empty()).then_some(text)
 }
 

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -29,6 +29,13 @@
 //! - **Block quotes render** — the one intentional divergence from the prior
 //!   markdown lowering, which flattened them: `Container::Quote` →
 //!   `#quote(block: true)[…]` (a superset behavior, landed as a tested decision).
+//! - **Line-anchored text.** [`escape_markup`] neutralizes inline markup but is
+//!   position-blind; Typst's heading `= `, list `- `/`+ `/`N. `, and term `/ `
+//!   are line-anchored — only special as the first token of a source line. A
+//!   paragraph (or quote/list-item body) whose text opens with one lands at
+//!   column 0 and would render as that block, so [`emit_inline`] prefixes a
+//!   single `\` there ([`opens_line_anchor`]). Styling-only: `#`, `[`, `$` are
+//!   already escaped, so nothing here is a code-execution vector.
 //!
 //! ## The 2→4 escape coupling
 //!
@@ -85,6 +92,29 @@ pub fn escape_string(s: &str) -> String {
         }
     }
     out
+}
+
+/// Does `s` open a **line-anchored** Typst block — one only special as the first
+/// token of a source line? Heading `= ` (one or more `=` then space), bullet
+/// `- `, enum `+ ` or `N. ` (ASCII digits then `.` then space), term `/ `. A
+/// paragraph whose text starts with one of these, emitted at column 0, would
+/// render as that block instead of literal text ([`emit_inline`] escapes it).
+/// The trailing space is required — `=foo`, `-5`, `and/or`, `1.item` are inert,
+/// so this leaves ordinary prose untouched.
+fn opens_line_anchor(s: &str) -> bool {
+    let b = s.as_bytes();
+    match b.first().copied() {
+        Some(b'=') => {
+            let n = b.iter().take_while(|&&c| c == b'=').count();
+            b.get(n) == Some(&b' ')
+        }
+        Some(b'-') | Some(b'+') | Some(b'/') => b.get(1) == Some(&b' '),
+        Some(c) if c.is_ascii_digit() => {
+            let n = b.iter().take_while(|&&c| c.is_ascii_digit()).count();
+            b.get(n) == Some(&b'.') && b.get(n + 1) == Some(&b' ')
+        }
+        _ => false,
+    }
 }
 
 /// The escape discipline a text run was generated under — the recomputation key
@@ -148,6 +178,13 @@ fn gen_cluster(gen: &str, i: usize, ctx: EscapeCtx) -> (usize, usize) {
 /// start. A `target` inside a multi-byte cluster (an escape, the `//` coupling,
 /// a wide UTF-8 char) floors to that cluster's first corpus char, matching how
 /// `glyph.span.1` is computed once per shaped cluster.
+///
+/// "Cluster" here is the escape/USV cluster, not the Unicode grapheme cluster:
+/// the floor is per Unicode scalar value, so a caret can in principle resolve
+/// *between* a base character and a following combining mark. This is the
+/// model's granularity — the corpus indexes USV offsets throughout — so the
+/// navigation API is USV-exact, not grapheme-exact, by design; consumers place
+/// carets on scalar boundaries.
 pub(crate) fn invert_gen_offset(gen: &str, ctx: EscapeCtx, target: usize) -> usize {
     let (mut byte, mut corpus) = (0usize, 0usize);
     while byte < gen.len() {
@@ -639,6 +676,13 @@ impl<'a> Emit<'a> {
         // owns the segment-specific bits: `#linebreak()`, island slots, atomic
         // `#raw(...)` code, and escaped plain runs (recorded).
         let base = self.out.len();
+        // Whether this segment's markup opens at column 0 of a generated source
+        // line — the only place Typst's line-anchored syntax (heading `= `, list
+        // `- `/`+ `/`N. `, term `/ `) is active. True for a paragraph/island
+        // (preceded by `\n\n`, or the very first block) and a quote/list-item
+        // body's first line (preceded by `[\n`/`\n` + indent); false for heading
+        // content (preceded by its `= ` marker) and any run after inline markup.
+        let at_col0 = self.out.trim_end_matches([' ', '\t']).ends_with('\n') || self.out.is_empty();
         let mut buf = String::new();
         sweep_marks(lo, hi, &wraps, &mut buf, |buf, pos| {
             let c = self.chars[pos];
@@ -664,6 +708,16 @@ impl<'a> Emit<'a> {
             // Plain text run up to the next boundary.
             let re = next_boundary(pos, hi, &self.chars, &wraps, &codes);
             let content: String = self.chars[pos..re].iter().collect();
+            // A run landing at column 0 whose text opens a line-anchored token
+            // renders as that block, not literal text. Neutralize with one `\`
+            // — a valid escape for every trigger char, verified to render the
+            // exact literal — emitted *outside* the run's `gen` window, so
+            // `gen == escape_markup(corpus)` (and the escape-scan) stay exact.
+            // `buf.is_empty()` gates to the segment's first content: any wrap
+            // (`#strong[`) already opened here would put the token mid-line.
+            if at_col0 && buf.is_empty() && opens_line_anchor(&content) {
+                buf.push('\\');
+            }
             let rg0 = base + buf.len();
             buf.push_str(&escape_markup(&content));
             let rg1 = base + buf.len();
@@ -1619,5 +1673,68 @@ mod tests {
         assert_eq!(emit("```\nl1\nl2\nl3\n```").segments.len(), 1, "code fence");
         // A three-item list is three segments (one per item paragraph).
         assert_eq!(emit("- a\n- b\n- c").segments.len(), 3);
+    }
+
+    /// The line-anchor predicate: a trailing space is required, so the trigger
+    /// set is narrow and ordinary prose is untouched.
+    #[test]
+    fn line_anchor_predicate() {
+        for yes in ["= h", "== h", "- b", "+ n", "/ term: d", "1. i", "42. i"] {
+            assert!(opens_line_anchor(yes), "{yes:?} should trigger");
+        }
+        for no in [
+            "=foo", "==foo", "-5 degrees", "and/or", "1.item", "1) i", "hi", "", " = x",
+        ] {
+            assert!(!opens_line_anchor(no), "{no:?} should not trigger");
+        }
+    }
+
+    /// A paragraph whose text opens with a line-anchored token gets a single `\`
+    /// at column 0; the source map stays exact because the `\` sits *outside*
+    /// every run's `gen` window, so each run still slices to `escape_markup` of
+    /// its corpus. A wrap opening at the start (`#strong[…]`) puts the token
+    /// mid-line, so no `\` is added there.
+    #[test]
+    fn line_anchor_paragraph_prefixes_backslash() {
+        // Bare paragraph starts → escaped.
+        assert_eq!(emit_marked("= x", vec![]), "\\= x\n\n");
+        assert_eq!(emit_marked("- x", vec![]), "\\- x\n\n");
+        assert_eq!(emit_marked("+ x", vec![]), "\\+ x\n\n");
+        assert_eq!(emit_marked("/ t: d", vec![]), "\\/ t: d\n\n");
+        assert_eq!(emit_marked("1. x", vec![]), "\\1. x\n\n");
+        // Non-trigger prose is untouched.
+        assert_eq!(emit_marked("hello = x", vec![]), "hello = x\n\n");
+        assert_eq!(emit_marked("=x no space", vec![]), "=x no space\n\n");
+        // A wrap at the start neutralizes the line-anchor already → no `\`.
+        assert_eq!(
+            emit_marked(
+                "= x",
+                vec![Mark { start: 0, end: 3, kind: MarkKind::Strong }],
+            ),
+            "#strong[= x]\n\n",
+        );
+
+        // Source-map integrity: every run's generated slice equals the escape of
+        // its corpus, and the leading `\` is not inside any run.
+        use quillmark_richtext::model::Line;
+        let mut rt = RichText {
+            text: "= x".to_string(),
+            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
+            marks: vec![],
+            islands: vec![],
+        };
+        rt.normalize();
+        let ec = emit_richtext(&rt).unwrap();
+        let chars: Vec<char> = rt.text.chars().collect();
+        for seg in &ec.segments {
+            for (corpus, gen, ctx) in &seg.runs {
+                let src: String = chars[corpus.clone()].iter().collect();
+                let expect = match ctx {
+                    EscapeCtx::Markup => escape_markup(&src),
+                    EscapeCtx::StringLit => escape_string(&src),
+                };
+                assert_eq!(&ec.markup[gen.clone()], expect, "run slices to its escape");
+            }
+        }
     }
 }

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -29,13 +29,13 @@
 //! - **Block quotes render** — the one intentional divergence from the prior
 //!   markdown lowering, which flattened them: `Container::Quote` →
 //!   `#quote(block: true)[…]` (a superset behavior, landed as a tested decision).
-//! - **Line-anchored text.** [`escape_markup`] neutralizes inline markup but is
-//!   position-blind; Typst's heading `= `, list `- `/`+ `/`N. `, and term `/ `
-//!   are line-anchored — only special as the first token of a source line. A
-//!   paragraph (or quote/list-item body) whose text opens with one lands at
-//!   column 0 and would render as that block, so [`emit_inline`] prefixes a
-//!   single `\` there ([`opens_line_anchor`]). Styling-only: `#`, `[`, `$` are
-//!   already escaped, so nothing here is a code-execution vector.
+//! - **Line-anchored text.** [`escape_markup`](crate::emit::escape_markup)
+//!   neutralizes inline markup but is position-blind; Typst's heading `= `, list
+//!   `- `/`+ `/`N. `, and term `/ ` are line-anchored — only special as the
+//!   first token of a source line. A paragraph (or quote/list-item body) whose
+//!   text opens with one lands at column 0 and would render as that block, so
+//!   the emitter prefixes a single `\` there (`opens_line_anchor`). Styling-only:
+//!   `#`, `[`, `$` are already escaped, so nothing here is a code-execution vector.
 //!
 //! ## The 2→4 escape coupling
 //!

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -865,6 +865,72 @@ mod tests {
         );
     }
 
+    /// A paragraph whose text opens with a line-anchored Typst token (`= `, `- `,
+    /// `+ `, `N. `, `/ `) must render as literal text, not a heading/list/term.
+    /// The emitter prefixes a `\` at column 0; this compiles the corpus and asks
+    /// Typst's introspector how many of each block it actually produced — the
+    /// end-to-end teeth behind `emit::opens_line_anchor`, run against the real
+    /// Typst grammar so a future Typst version that changes line-anchoring fails
+    /// loud here.
+    #[test]
+    fn line_anchored_paragraph_text_stays_literal() {
+        use quillmark_core::FileTreeNode;
+        use typst::foundations::{NativeElement, Selector};
+        use typst::introspection::Introspector;
+        use typst::model::{EnumElem, HeadingElem, ListElem, TermsElem};
+
+        const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 300pt, height: 400pt, margin: 20pt)
+#set text(size: 11pt)
+#data.body
+"#;
+        let quill = || {
+            let yaml = "quill:\n  name: anchor\n  version: 0.1.0\n  backend: typst\n  description: line-anchor guard\ntypst:\n  plate_file: plate.typ\nmain:\n  fields:\n    body:\n      type: richtext\n      description: body\n";
+            let mut files = HashMap::new();
+            files.insert(
+                "Quill.yaml".to_string(),
+                FileTreeNode::File { contents: yaml.as_bytes().to_vec() },
+            );
+            files.insert(
+                "plate.typ".to_string(),
+                FileTreeNode::File { contents: PLATE.as_bytes().to_vec() },
+            );
+            Quill::from_tree(FileTreeNode::Directory { files }).expect("quill")
+        };
+        // Build the corpus as `Para` lines directly — an editor can place a
+        // paragraph whose literal text opens with any of these tokens (markdown
+        // import would instead parse `- `/`+ `/`N. ` as real lists, which is not
+        // the bug). Each line is its own paragraph, so each starts at column 0.
+        use quillmark_richtext::model::{Line, LineKind, RichText};
+        let para = |_: usize| Line { kind: LineKind::Para, containers: vec![], continues: false };
+        let mut rt = RichText {
+            text: "= Heading\n- bullet\n+ numbered\n1. dotted\n/ term: desc".to_string(),
+            lines: (0..5).map(para).collect(),
+            marks: vec![],
+            islands: vec![],
+        };
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()), "corpus invariants");
+        let q = quill();
+        let json =
+            serde_json::json!({ "body": quillmark_richtext::serial::to_canonical_value(&rt) });
+        let plate_content = read_plate(&q).expect("plate");
+        let transform_schema = build_transform_schema(q.config());
+        let schema_meta = SchemaMeta::from_schema_json(transform_schema.as_json());
+        let data = transformed_data(&schema_meta, &json).expect("data");
+        let (world, _w) =
+            world::QuillWorld::new_with_data(&q, &plate_content, &data, &schema_meta)
+                .expect("world");
+        let (document, _warn) = compile::compile_document(&world).expect("compile");
+
+        let intro = document.introspector();
+        let count = |e| intro.query(&Selector::Elem(e, None)).len();
+        assert_eq!(count(<HeadingElem as NativeElement>::ELEM), 0, "no heading");
+        assert_eq!(count(<ListElem as NativeElement>::ELEM), 0, "no bullet list");
+        assert_eq!(count(<EnumElem as NativeElement>::ELEM), 0, "no enum");
+        assert_eq!(count(<TermsElem as NativeElement>::ELEM), 0, "no term list");
+    }
+
     #[test]
     fn test_is_richtext_field() {
         let richtext_schema = json!({

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -542,6 +542,12 @@ struct GlyphHit {
     page: usize,
     rect: Aabb,
     node: Range<usize>,
+    /// Byte offset within the resolved node, straight from `glyph.span.1` —
+    /// Typst types the intra-node span offset as `u16`, so a single text node
+    /// wider than 64 KiB saturates it. Graceful degrade, not a panic: the offset
+    /// floors to the last representable byte, so a caret in an overlong node
+    /// resolves to the cluster/segment boundary rather than the exact glyph. No
+    /// emitted node approaches this bound (paragraphs split into per-line runs).
     offset: u16,
     window: usize,
     seg: Option<usize>,

--- a/crates/richtext/src/delta.rs
+++ b/crates/richtext/src/delta.rs
@@ -232,8 +232,8 @@ const CHAR_DIFF_LIMIT: usize = 5_000;
 /// Single-line text diffs at char granularity; multi-line text diffs at line
 /// granularity so a paragraph reorder surfaces as whole-line insert spans the
 /// move detector can match (char Myers fragments reordered blocks). Above
-/// [`CHAR_DIFF_LIMIT`] chars, the single-line path skips Myers entirely and
-/// uses [`coarse_replace`] instead.
+/// `CHAR_DIFF_LIMIT` chars, the single-line path skips Myers entirely and
+/// uses `coarse_replace` instead.
 pub fn diff(base: &str, new: &str) -> Delta {
     let multiline = base.contains('\n') || new.contains('\n');
     if !multiline

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -50,6 +50,15 @@ pub fn to_markdown(rt: &RichText) -> String {
     out
 }
 
+/// Render a corpus to plaintext: [`RichText::text`] with island slots
+/// ([`ISLAND_SLOT`]) removed. The lossy sibling of [`to_markdown`] — it drops
+/// every mark and island (tables, images have no plaintext projection), keeping
+/// only literal text. Callers that want a non-empty result should check for the
+/// empty string themselves.
+pub fn to_plaintext(rt: &RichText) -> String {
+    rt.text.chars().filter(|&c| c != ISLAND_SLOT).collect()
+}
+
 struct Ctx<'a> {
     rt: &'a RichText,
     segments: &'a [Segment],
@@ -725,6 +734,32 @@ mod tests {
             rt, rt2,
             "corpus not a fixed point.\n  in:  {md:?}\n  mid: {md2:?}"
         );
+    }
+
+    /// [`to_plaintext`] keeps literal text, drops marks, and strips island
+    /// slots — the lossy projection pdfform binds to non-content fields.
+    #[test]
+    fn plaintext_drops_marks_and_islands() {
+        // Marks contribute no delimiters to plaintext.
+        let rt = marked(
+            "bold text",
+            vec![Mark { start: 0, end: 4, kind: MarkKind::Strong }],
+        );
+        assert_eq!(to_plaintext(&rt), "bold text");
+        // An island slot in the text is removed.
+        let mut rt = RichText {
+            text: format!("see {ISLAND_SLOT} here"),
+            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
+            marks: vec![],
+            islands: vec![Island {
+                id: String::new(),
+                island_type: "image".into(),
+                props: serde_json::Value::Null,
+                loss: Loss::Unrepresentable,
+            }],
+        };
+        rt.normalize();
+        assert_eq!(to_plaintext(&rt), "see  here");
     }
 
     /// A single-paragraph corpus over `text` with hand-placed `marks` — the


### PR DESCRIPTION
Addresses the low-priority cleanup/hardening bucket in #855. All six findings were verified against the code first; four warranted a change, two were docs-only, and #3 (per-query rescans) was left as-is per the issue's own "defer unless a hot UI loop appears" guidance.

## Finding 1 — line-anchored markup escape (the only behavioral change)

`escape_markup` neutralizes inline markup but is position-blind. Typst's heading `= `, list `- `/`+ `/`N. `, and term `/ ` syntax is *line-anchored* — only special as the first token of a source line. A paragraph (or quote / list-item body) whose literal text opens with one lands at column 0 and rendered as that block instead of literal text (styling-level only; `#`, `[`, `$` are already escaped, so no code-execution vector).

`emit_inline` now prefixes a single `\` when a plain run lands at column 0 and opens such a token. The `\` is emitted **outside** the run's `gen` window, so `run.gen == escape_markup(corpus)` and the escape-scan inversion stay byte-exact — no change to `escape_markup`/`gen_cluster` or their tripwire tests.

Grounded empirically against the real Typst grammar (not assumed): the introspector confirms `= Heading`→heading / `- `→list / `+ `→enum / `1. `→enum / `/ `→term all drop to **zero** blocks once escaped, and the escaped forms render the exact literal text (`\= Heading` → "= Heading", no backslash artifact). The `N. ` dotted-enum case was found during that probing and is handled too, though the issue listed only `= - + /`. The predicate requires a trailing space, so ordinary prose (`=foo`, `-5`, `and/or`, `1.item`) is untouched.

## Findings 4 & 5 — docs

- `GlyphHit.offset` (`glyph.span.1`): documented the Typst-imposed `u16` bound — a single text node >64 KiB saturates the intra-node offset and degrades gracefully to the cluster/segment floor.
- `invert_gen_offset`: documented that navigation is USV-exact, not grapheme-exact — a caret can resolve between a base char and a combining mark, consistent with the corpus's USV-offset model.

## Finding 6 — dedup

Hoisted the richtext→plaintext projection into `quillmark_richtext::export::to_plaintext`, beside `to_markdown`. `pdfform/src/resolve.rs` now calls it instead of reimplementing the island-slot strip.

## Tests

- `emit::line_anchor_predicate` — trigger/non-trigger cases for the predicate.
- `emit::line_anchor_paragraph_prefixes_backslash` — `\`-prefix emission, the `#strong[…]` mid-line non-trigger, and source-map integrity (each run still slices to `escape_markup` of its corpus).
- `line_anchored_paragraph_text_stays_literal` (end-to-end) — compiles a corpus of all five forms and asserts the Typst introspector counts zero heading/list/enum/term blocks. Fails loud if a future Typst version changes line-anchoring.
- `export::plaintext_drops_marks_and_islands` — `to_plaintext` drops marks and strips island slots.

`cargo test` green across `quillmark-typst`, `quillmark-richtext`, `quillmark-pdfform`.

Related epic: #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmQicmThcKPrZdF6aRd4xd)_