### PR TITLE
refactor: batch-resolve prose/simplifications findings (deletions, seams, dedup)

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -332,24 +332,34 @@ impl<'a> Emit<'a> {
     fn emit_block_level(&mut self, range: Range<usize>, depth: usize) {
         let mut i = range.start;
         while i < range.end {
-            let cont = self.rt.lines[i].containers.get(depth).cloned();
-            match cont {
-                Some(Container::ListItem { ordered, start, .. }) => {
-                    let j = self.list_run_end(range.clone(), depth, ordered, start, i);
-                    self.emit_list(i..j, depth, ordered, start);
-                    i = j;
-                }
-                Some(Container::Quote) => {
-                    let j = self.quote_run_end(range.clone(), depth, i);
-                    self.emit_quote(i..j, depth);
-                    i = j;
-                }
-                None => {
-                    let j = self.segment_end(range.clone(), depth, i);
-                    self.emit_leaf_terminated(i..j);
-                    i = j;
-                }
+            if let Some(j) = self.try_emit_container(range.clone(), depth, i) {
+                i = j;
+                continue;
             }
+            let j = self.segment_end(range.clone(), depth, i);
+            self.emit_leaf_terminated(i..j);
+            i = j;
+        }
+    }
+
+    /// If the block at `i` opens a list or quote container at `depth`, emit the
+    /// whole run and return its end index; return `None` for a leaf, leaving the
+    /// caller to emit it under its own discipline (top-level terminated vs list
+    /// item body). The container dispatch shared by [`Self::emit_block_level`]
+    /// and [`Self::emit_item_body`].
+    fn try_emit_container(&mut self, range: Range<usize>, depth: usize, i: usize) -> Option<usize> {
+        match self.rt.lines[i].containers.get(depth).cloned() {
+            Some(Container::ListItem { ordered, start, .. }) => {
+                let j = self.list_run_end(range.clone(), depth, ordered, start, i);
+                self.emit_list(i..j, depth, ordered, start);
+                Some(j)
+            }
+            Some(Container::Quote) => {
+                let j = self.quote_run_end(range.clone(), depth, i);
+                self.emit_quote(i..j, depth);
+                Some(j)
+            }
+            _ => None,
         }
     }
 
@@ -492,35 +502,25 @@ impl<'a> Emit<'a> {
         let mut first_block = true;
         let mut i = range.start;
         while i < range.end {
-            let cont = self.rt.lines[i].containers.get(content_depth).cloned();
-            match cont {
-                Some(Container::ListItem { ordered, start, .. }) => {
-                    let j = self.list_run_end(range.clone(), content_depth, ordered, start, i);
-                    self.emit_list(i..j, content_depth, ordered, start);
-                    i = j;
-                }
-                Some(Container::Quote) => {
-                    let j = self.quote_run_end(range.clone(), content_depth, i);
-                    self.emit_quote(i..j, content_depth);
-                    i = j;
-                }
-                None => {
-                    let j = self.segment_end(range.clone(), content_depth, i);
-                    if !first_block {
-                        // Continuation block: the previous block left one `\n`;
-                        // this adds a second plus the indent → blank line + indent.
-                        self.out.push('\n');
-                        self.out.push_str(&cont_indent);
-                        self.end_newline = false;
-                    }
-                    self.emit_segment(i..j);
-                    if !self.end_newline {
-                        self.out.push('\n');
-                        self.end_newline = true;
-                    }
-                    i = j;
-                }
+            if let Some(j) = self.try_emit_container(range.clone(), content_depth, i) {
+                i = j;
+                first_block = false;
+                continue;
             }
+            let j = self.segment_end(range.clone(), content_depth, i);
+            if !first_block {
+                // Continuation block: the previous block left one `\n`; this adds
+                // a second plus the indent → blank line + indent.
+                self.out.push('\n');
+                self.out.push_str(&cont_indent);
+                self.end_newline = false;
+            }
+            self.emit_segment(i..j);
+            if !self.end_newline {
+                self.out.push('\n');
+                self.end_newline = true;
+            }
+            i = j;
             first_block = false;
         }
     }
@@ -760,26 +760,15 @@ fn wrap_open(kind: &MarkKind) -> String {
     }
 }
 
-/// Clip wrapping marks so none crosses the interior of an atomic code span. A
-/// wrap edge landing strictly inside a `[cs, ce)` code span is pulled to that
-/// span's boundary (`start`→`ce`, `end`→`cs`); a wrap swallowed whole by a code
-/// span collapses and drops. `#raw(...)` is atomic and cannot carry partial
-/// styling, so a partial wrap/code overlap becomes the wrap over the text
-/// *outside* the code — and, crucially, no wrap `end` is left hiding inside a
-/// code span the sweep's cursor jumps over (start→end atomically), which is what
-/// produced unbalanced markup for `strong[0,4)` + `code[2,6)`. A wrap whose
-/// range strictly contains a code span keeps both edges (neither is interior),
-/// so the code nests inside it as before.
+/// Clip wrapping marks so none crosses the interior of an atomic `#raw(...)`
+/// code span (`start`→`ce`, `end`→`cs`), then drop any wrap a span swallowed
+/// whole. Enforces the #846 balance via the shared
+/// [`clip_range_to_atomic`](quillmark_richtext::export::clip_range_to_atomic) —
+/// the same rule this crate's inline emitter and richtext's export both apply,
+/// here against code spans only (export also clips against link text).
 fn clip_wraps_to_codes(wraps: &mut Vec<Wrap>, codes: &[(usize, usize)]) {
-    for &(cs, ce) in codes {
-        for w in wraps.iter_mut() {
-            if cs < w.start && w.start < ce {
-                w.start = ce;
-            }
-            if cs < w.end && w.end < ce {
-                w.end = cs;
-            }
-        }
+    for w in wraps.iter_mut() {
+        quillmark_richtext::export::clip_range_to_atomic(&mut w.start, &mut w.end, codes);
     }
     wraps.retain(|w| w.start < w.end);
 }

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1544,10 +1544,13 @@ impl LiveSession {
                 .to_js_value()
             })?;
 
-        // Snapshot the pre-edit body: the fallible steps below mutate only the
-        // main body corpus (`apply_body_change`), so restoring it leaves `doc`
+        // Snapshot the pre-edit body: `apply_body_change` is itself atomic, but
+        // the compile and record steps that follow it can fail *after* the body
+        // has changed, so restoring the snapshot on any failure leaves `doc`
         // exactly as it was — a caller's retry then never double-applies the
-        // delta onto an already-mutated document.
+        // delta onto an already-mutated document. This snapshot is the
+        // compile/record transaction boundary, not a guard against a
+        // half-applied body.
         let pre_edit_body = doc.inner.main().body().clone();
 
         // Splice the main body corpus (text delta only), then recompile from the

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -14,7 +14,7 @@
 //!
 //! - **`quillmark/document@0.93.0`** — current. The V0_92_0 payload model with
 //!   the card `body` stored as the **canonical richtext corpus** embedded
-//!   structurally (a nested object byte-identical to `content_key`), not a
+//!   structurally (a nested object byte-identical to `to_canonical_json`), not a
 //!   markdown string. The envelope carries two byte disciplines: the outer
 //!   structure stays compact `serde_json` in frozen struct + payload-insertion
 //!   order (`preserve_order`), while every `body` subtree is the recursively
@@ -59,7 +59,7 @@ use crate::version::QuillReference;
 
 /// Schema version for the V0_93_0 wire format. Newly serialized documents carry
 /// this tag. Stores the card `body` as the canonical richtext corpus embedded
-/// structurally (byte-identical to `content_key`) rather than a markdown string;
+/// structurally (byte-identical to `to_canonical_json`) rather than a markdown string;
 /// the payload shape is unchanged from V0_92_0.
 pub const SCHEMA_V0_93_0: &str = "quillmark/document@0.93.0";
 
@@ -170,14 +170,14 @@ pub type PayloadV0_93_0 = PayloadV0_92_0;
 /// a hand-mirrored DTO tree that could drift from the frozen wire format:
 ///
 /// - `Serialize` emits the recursively key-sorted structure byte-identical to
-///   `content_key(&self.0)` as a **nested JSON object**, never an escaped string.
-///   Embedded in the compact envelope, the `body` subtree bytes equal
-///   `content_key`, independent of `preserve_order`.
+///   `self.0.to_canonical_json()` as a **nested JSON object**, never an escaped
+///   string. Embedded in the compact envelope, the `body` subtree bytes equal
+///   that canonical JSON, independent of `preserve_order`.
 /// - `Deserialize` parses that structure, normalizes, and validates, so an
 ///   invalid corpus is rejected at load (a serde error) rather than silently
 ///   round-tripped.
 ///
-/// Byte-equality with `content_key` holds because every `RichText` in a live
+/// Byte-equality with `to_canonical_json` holds because every `RichText` in a live
 /// [`Document`] is normalized at construction; the serializer normalizes a copy
 /// regardless, so a hand-built value cannot leak non-canonical bytes.
 #[derive(Debug, Clone, PartialEq)]
@@ -1344,7 +1344,7 @@ title: Hi
 
     /// Slice the value of the first top-level `"body":` object out of a compact
     /// `serde_json` envelope — the exact bytes embedded, balanced-brace and
-    /// string-aware. Used to prove the body subtree equals `content_key`.
+    /// string-aware. Used to prove the body subtree equals `to_canonical_json`.
     fn locate_body_subtree(envelope: &str) -> &str {
         const KEY: &str = "\"body\":";
         let start = envelope.find(KEY).expect("body key present") + KEY.len();
@@ -1380,10 +1380,10 @@ title: Hi
     }
 
     #[test]
-    fn body_subtree_is_byte_identical_to_content_key() {
+    fn body_subtree_is_byte_identical_to_canonical_json() {
         // Two disciplines in one envelope: the outer structure is compact
         // insertion-ordered serde_json, but the `body` subtree is the canonical
-        // richtext form, byte-identical to `content_key(&rt)`.
+        // richtext form, byte-identical to `rt.to_canonical_json()`.
         let doc = Document::from_markdown(
             "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: Hi\n~~~\n\n\
              A paragraph with **bold**, _emph_, and a [link](https://example.com).\n\n\
@@ -1395,12 +1395,12 @@ title: Hi
             !rt.marks.is_empty(),
             "test needs a non-trivial corpus (marks present)"
         );
-        let expected = quillmark_richtext::serial::content_key(&rt);
+        let expected = rt.to_canonical_json();
         let envelope = serde_json::to_string(&doc).unwrap();
         let body = locate_body_subtree(&envelope);
         assert_eq!(
             body, expected,
-            "the envelope body subtree must equal content_key byte-for-byte"
+            "the envelope body subtree must equal to_canonical_json byte-for-byte"
         );
         // A nested structure, not a double-encoded string.
         assert!(body.starts_with("{\"islands\":"));
@@ -1445,7 +1445,7 @@ title: Hi
         // The @0.93.0 table-body canonical bytes changed with this; the freeze is
         // branch-private/unreleased, so amending this golden pre-release is
         // expected. Regenerated golden below.
-        let key = quillmark_richtext::serial::content_key(body);
+        let key = body.to_canonical_json();
         assert_eq!(
             key,
             "{\"islands\":[{\"id\":\"isl-0\",\"loss\":\"lossless\",\"props\":{\

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -492,9 +492,10 @@ impl Card {
     /// session change log passes the same `text_delta`, `line_ops`, and
     /// `mark_ops` to
     /// [`record_field_change_at`](crate::LiveSession::record_field_change_at).
-    /// Returns [`EditError::CorpusApply`] when an op is out of bounds; the body
-    /// is unchanged on error only up to the failing op — apply the bundle
-    /// against a body at the delta's base revision.
+    /// Returns [`EditError::CorpusApply`] when an op is out of bounds; the apply
+    /// is all-or-nothing ([`RichText::apply_field_change`]), so the body is
+    /// unchanged on error — apply the bundle against a body at the delta's base
+    /// revision.
     pub fn apply_body_change(
         &mut self,
         text_delta: &Delta,

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -32,6 +32,50 @@ pub(crate) fn import_body(md: &str) -> Result<RichText, ImportError> {
     }
 }
 
+/// Which encoding a [`decode_richtext_value`] failure came from, so a call site
+/// can prefix its diagnostic per encoding without re-deriving the dispatch.
+pub(crate) enum RichtextDecodeError {
+    /// A JSON object that is not a valid canonical corpus.
+    NotCorpus(String),
+    /// A markdown string that failed to import.
+    BadMarkdown(String),
+}
+
+impl RichtextDecodeError {
+    /// The inner failure message, without an encoding-specific prefix.
+    pub(crate) fn into_message(self) -> String {
+        match self {
+            RichtextDecodeError::NotCorpus(m) | RichtextDecodeError::BadMarkdown(m) => m,
+        }
+    }
+}
+
+/// Decode a JSON value in either accepted richtext encoding: a canonical corpus
+/// **object** ([`from_canonical_value`](quillmark_richtext::serial::from_canonical_value))
+/// or an authored markdown **string** (via [`import_body`], the single markdown
+/// boundary). The one place the object-vs-string dispatch lives; a call site
+/// handles the shapes that are neither — `null`, array, scalar — and maps the
+/// error into its own type.
+///
+/// - `Some(Ok(rt))` — decoded.
+/// - `Some(Err(e))` — an object that is not a corpus, or a string that failed
+///   to import; `e` names the encoding so the caller can prefix its message.
+/// - `None` — the value is neither an object nor a string.
+pub(crate) fn decode_richtext_value(
+    value: &serde_json::Value,
+) -> Option<Result<RichText, RichtextDecodeError>> {
+    match value {
+        serde_json::Value::Object(_) => Some(
+            quillmark_richtext::serial::from_canonical_value(value)
+                .map_err(|e| RichtextDecodeError::NotCorpus(e.to_string())),
+        ),
+        serde_json::Value::String(md) => {
+            Some(import_body(md).map_err(|e| RichtextDecodeError::BadMarkdown(e.to_string())))
+        }
+        _ => None,
+    }
+}
+
 pub mod assemble;
 pub mod dto;
 pub mod edit;

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -344,7 +344,7 @@ impl Document {
         );
 
         // The seam carries the body as canonical RichText-JSON (Option A): a
-        // nested corpus object, byte-identical to `content_key`, never a lossy
+        // nested corpus object, byte-identical to `to_canonical_json`, never a lossy
         // markdown string. Backends lower the corpus (typst → markup + source
         // map; pdfform → `.text`); the markdown projection is `body_markdown`.
         map.insert(

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -316,20 +316,22 @@ fn body_from_wire(body: &JsonValue) -> Result<RichText, WireError> {
         key: "$body".to_string(),
         reason,
     };
-    match body {
-        JsonValue::String(md) => super::import_body(md).map_err(|e| invalid(e.to_string())),
-        JsonValue::Object(_) => quillmark_richtext::serial::from_canonical_value(body)
-            .map_err(|e| invalid(e.to_string())),
-        JsonValue::Null => Ok(RichText::empty()),
-        other => Err(invalid(format!(
-            "expected a richtext corpus object or a markdown string, got {}",
-            match other {
-                JsonValue::Bool(_) => "a boolean",
-                JsonValue::Number(_) => "a number",
-                JsonValue::Array(_) => "an array",
-                _ => "an unsupported value",
-            }
-        ))),
+    match super::decode_richtext_value(body) {
+        Some(result) => result.map_err(|e| invalid(e.into_message())),
+        // `null`/absent is the empty corpus; every other non-decodable shape is
+        // an invalid `$body`.
+        None => match body {
+            JsonValue::Null => Ok(RichText::empty()),
+            other => Err(invalid(format!(
+                "expected a richtext corpus object or a markdown string, got {}",
+                match other {
+                    JsonValue::Bool(_) => "a boolean",
+                    JsonValue::Number(_) => "a number",
+                    JsonValue::Array(_) => "an array",
+                    _ => "an unsupported value",
+                }
+            ))),
+        },
     }
 }
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -381,6 +381,12 @@ impl QuillConfig {
                 // be single-`Para` (`richtext(inline)`): editors mount a one-line
                 // surface, so multi-block content is a coercion error here, in
                 // lockstep with the validation-layer `richtext::not_inline` check.
+                //
+                // This is the deliberately-lenient sibling of
+                // `document::decode_richtext_value` (used by the strict wire /
+                // literal / validation sites): the string branch below reduces a
+                // bare scalar or length-1 array to text before importing, which
+                // the strict decoder must not do, so it stays open-coded here.
                 let inline_check =
                     |rt: &quillmark_richtext::RichText| -> Result<(), CoercionError> {
                         if inline && !rt.is_inline() {
@@ -1639,19 +1645,25 @@ fn literal_corpus(
     }
     match &field.r#type {
         FieldType::RichText { inline } => {
-            let rt = if let Some(s) = json.as_str() {
-                quillmark_richtext::import::from_markdown(s).map_err(|e| {
-                    richtext_literal_error(label, &format!("markdown import failed: {e}"))
-                })?
-            } else if json.is_object() {
-                quillmark_richtext::serial::from_canonical_value(json).map_err(|e| {
-                    richtext_literal_error(label, &format!("not a valid richtext corpus: {e}"))
-                })?
-            } else {
-                return Err(richtext_literal_error(
-                    label,
-                    "expected a markdown string (richtext literals are authored as markdown)",
-                ));
+            let rt = match crate::document::decode_richtext_value(json) {
+                Some(Ok(rt)) => rt,
+                Some(Err(e)) => {
+                    let reason = match e {
+                        crate::document::RichtextDecodeError::BadMarkdown(m) => {
+                            format!("markdown import failed: {m}")
+                        }
+                        crate::document::RichtextDecodeError::NotCorpus(m) => {
+                            format!("not a valid richtext corpus: {m}")
+                        }
+                    };
+                    return Err(richtext_literal_error(label, &reason));
+                }
+                None => {
+                    return Err(richtext_literal_error(
+                        label,
+                        "expected a markdown string (richtext literals are authored as markdown)",
+                    ));
+                }
             };
             if *inline && !rt.is_inline() {
                 return Err(richtext_inline_error(label));

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -562,15 +562,9 @@ impl QuillConfig {
                 ),
             );
         }
-        if schema.inline.is_some() && !matches!(schema.r#type, FieldType::RichText { .. }) {
-            return err(
-                "quill::inline_not_supported",
-                format!(
-                    "Field '{owner}' declares 'inline' but is not type: richtext. \
-                     'inline' is only valid on richtext fields."
-                ),
-            );
-        }
+        // `inline` on a non-richtext field is rejected earlier and once, when
+        // `from_quill_value` folds the wire key into the `FieldType` enum
+        // (`resolve_richtext_inline`); no second check belongs here.
 
         match schema.r#type {
             FieldType::Object => {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2939,7 +2939,6 @@ fn inline_richtext_single_line_example_loads_and_caches_corpus() {
     .expect("single-line inline example loads");
     let field = config.main.fields.get("tag").unwrap();
     assert_eq!(field.r#type, FieldType::RichText { inline: true });
-    assert_eq!(field.inline, Some(true));
     // The load pass imports the markdown example into its corpus companion; the
     // authored `example` string is retained untouched (Alternative A).
     let corpus = field

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -193,55 +193,51 @@ impl<'de> Deserialize<'de> for FieldType {
 /// not a requirement: a missing or null Unendorsed field zero-fills at
 /// render. A surviving `!must_fill` placeholder is surfaced as the non-fatal
 /// `validation::must_fill` warning. There is no separate `required:` axis.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// The richtext single-line constraint has **one** carrier — the
+/// `FieldType::RichText { inline }` enum. The wire's sibling `inline:` key folds
+/// into that enum at deserialize (via [`from_quill_value`](Self::from_quill_value),
+/// which the custom `Deserialize` below routes through), and the custom
+/// `Serialize` re-emits it from the enum, so the flag can never live in two
+/// places that disagree.
+///
+/// `Serialize`/`Deserialize` are hand-written (below) rather than derived: the
+/// wire folds a sibling `inline:` key into the `FieldType` enum, `name` rides
+/// the map key, and the `*_corpus` caches never serialize.
+#[derive(Debug, Clone, PartialEq)]
 pub struct FieldSchema {
-    /// The map key carries this on the wire; skipped during serialization to avoid duplication.
-    #[serde(skip_serializing, default)]
+    /// The map key carries this on the wire; not serialized, to avoid duplication.
     pub name: String,
     pub r#type: FieldType,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// The value most authors want; interpolated when the field is omitted.
     /// Its presence makes the field Endorsed.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<QuillValue>,
     /// A value matching the desired type and shape but not the value most
     /// authors want; documents shape only and never renders as the value.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<QuillValue>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiFieldSchema>,
-    /// Restricts valid values on string fields.
-    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    /// Restricts valid values on string fields. Serializes as `enum`.
     pub enum_values: Option<Vec<String>>,
     /// Nested field schemas for `object` types (the typed dictionary's
     /// properties).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, Box<FieldSchema>>>,
     /// Element schema for `array` types. Required on every `array` field:
     /// the element type gives the array a concrete element type (`string[]`,
     /// `integer[]`, `richtext[]`, …). For a typed table the element is an
     /// `object` carrying its own `properties`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Option<Box<FieldSchema>>,
-    /// When `true` on a `richtext` field, the corpus must be exactly one `Para`
-    /// line (no container, no islands). Omitted on block richtext and on every
-    /// other type.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub inline: Option<bool>,
     /// Canonical-corpus form of [`default`](Self::default) for a richtext-bearing
     /// field, imported once at quill load and cached — never serialized. The
     /// render floor (`resolve_fields`) commits this for an absent field, so a
     /// richtext default crosses the seam as corpus, not a re-imported string.
     /// `None` for a non-richtext field, a null/absent default, or a schema built
     /// outside the loader.
-    #[serde(skip)]
     pub default_corpus: Option<QuillValue>,
     /// Canonical-corpus form of [`example`](Self::example) for a richtext-bearing
     /// field, imported once at quill load and cached — never serialized. Seeding
     /// commits this so a seeded field is corpus from birth. `None` under the same
     /// conditions as [`default_corpus`](Self::default_corpus).
-    #[serde(skip)]
     pub example_corpus: Option<QuillValue>,
 }
 
@@ -281,7 +277,6 @@ impl FieldSchema {
             enum_values: None,
             properties: None,
             items: None,
-            inline: None,
             default_corpus: None,
             example_corpus: None,
         }
@@ -290,11 +285,9 @@ impl FieldSchema {
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
         let def: FieldSchemaDef = serde_json::from_value(value.clone().into_json())
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
+        // The sole inline sync point: the wire `inline:` key folds into the enum
+        // here, so `FieldType::RichText { inline }` is the one carrier thereafter.
         let r#type = Self::resolve_richtext_inline(def.r#type, def.inline)?;
-        let inline = match &r#type {
-            FieldType::RichText { inline: true } => Some(true),
-            _ => None,
-        };
         Ok(Self {
             name: key.clone(),
             r#type,
@@ -303,7 +296,6 @@ impl FieldSchema {
             example: def.example,
             ui: def.ui,
             enum_values: def.enum_values,
-            inline,
             properties: if let Some(props) = def.properties {
                 let mut p = BTreeMap::new();
                 for (key, value) in props {
@@ -350,5 +342,65 @@ impl FieldSchema {
             ),
             (other, None) => Ok(other),
         }
+    }
+}
+
+impl Serialize for FieldSchema {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        // `inline: true` is projected back out of the enum — the flag's single
+        // carrier — so the wire round-trips. `name` rides the map key; the
+        // `*_corpus` caches are load-time derivations, never serialized.
+        let inline = matches!(self.r#type, FieldType::RichText { inline: true }).then_some(true);
+        let len = 1
+            + inline.is_some() as usize
+            + self.description.is_some() as usize
+            + self.default.is_some() as usize
+            + self.example.is_some() as usize
+            + self.ui.is_some() as usize
+            + self.enum_values.is_some() as usize
+            + self.properties.is_some() as usize
+            + self.items.is_some() as usize;
+        // Field order matches the struct declaration (the prior derived output),
+        // so `inline` trails the block — golden schema snapshots don't drift.
+        let mut map = serializer.serialize_map(Some(len))?;
+        map.serialize_entry("type", &self.r#type)?;
+        if let Some(v) = &self.description {
+            map.serialize_entry("description", v)?;
+        }
+        if let Some(v) = &self.default {
+            map.serialize_entry("default", v)?;
+        }
+        if let Some(v) = &self.example {
+            map.serialize_entry("example", v)?;
+        }
+        if let Some(v) = &self.ui {
+            map.serialize_entry("ui", v)?;
+        }
+        if let Some(v) = &self.enum_values {
+            map.serialize_entry("enum", v)?;
+        }
+        if let Some(v) = &self.properties {
+            map.serialize_entry("properties", v)?;
+        }
+        if let Some(v) = &self.items {
+            map.serialize_entry("items", v)?;
+        }
+        if let Some(v) = inline {
+            map.serialize_entry("inline", &v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for FieldSchema {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // One deserialize path, shared with `from_quill_value`, so the sibling
+        // `inline:` key always folds into `FieldType::RichText { inline }` and
+        // two-carrier drift is impossible. `name` is filled from the map key by
+        // the container; a bare schema deserializes nameless.
+        let value = serde_json::Value::deserialize(deserializer)?;
+        FieldSchema::from_quill_value(String::new(), &QuillValue::from_json(value))
+            .map_err(serde::de::Error::custom)
     }
 }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -466,14 +466,11 @@ fn validate_value(
     // bypassed coercion (e.g. a direct `validate_document`) is still caught.
     if type_valid {
         if let FieldType::RichText { inline: true } = field.r#type {
-            let json = value.as_json();
-            let parsed = if json.is_object() {
-                quillmark_richtext::serial::from_canonical_value(json).ok()
-            } else if let Some(s) = json.as_str() {
-                quillmark_richtext::import::from_markdown(s).ok()
-            } else {
-                None
-            };
+            // A decode failure here is not this layer's error to report (a
+            // mistyped value already raised TypeMismatch); swallow it and only
+            // flag a well-formed corpus that is not single-`Para`.
+            let parsed = crate::document::decode_richtext_value(value.as_json())
+                .and_then(Result::ok);
             if let Some(rt) = parsed {
                 if !rt.is_inline() {
                     errors.push(ValidationError::NotInline {

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -573,17 +573,32 @@ fn render_marked_core(
 /// would be missed and left unbalanced (the #846 shape). A wrap that strictly
 /// *contains* a span keeps both edges, so the span still nests inside it.
 fn clip_fmt_to_atomic(fmt: &mut Vec<(usize, usize, &MarkKind)>, atomics: &[(usize, usize)]) {
-    for &(cs, ce) in atomics {
-        for m in fmt.iter_mut() {
-            if cs < m.0 && m.0 < ce {
-                m.0 = ce;
-            }
-            if cs < m.1 && m.1 < ce {
-                m.1 = cs;
-            }
-        }
+    for m in fmt.iter_mut() {
+        clip_range_to_atomic(&mut m.0, &mut m.1, atomics);
     }
     fmt.retain(|m| m.0 < m.1);
+}
+
+/// The #846 balance rule for a single `[*start, *end)` range against a set of
+/// atomic spans. A range edge landing strictly inside an atomic `[cs, ce)` span
+/// is pulled to that span's boundary (`start`→`ce`, `end`→`cs`); an edge outside
+/// every span is untouched. An atomic span can't carry partial styling, and a
+/// mark-sweep cursor jumps a span's interior start→end, so an edge left hiding
+/// inside would be missed and render unbalanced. A range that strictly *contains*
+/// a span keeps both edges, so the span still nests inside it. Applying the spans
+/// in sequence is order-independent across ranges, so a caller may loop ranges
+/// or spans on the outside — a range whose edges cross after clipping (swallowed
+/// whole) is left empty for the caller to drop. Shared by this crate's export
+/// and the Typst backend's inline emitter, the two sites that enforce #846.
+pub fn clip_range_to_atomic(start: &mut usize, end: &mut usize, atomics: &[(usize, usize)]) {
+    for &(cs, ce) in atomics {
+        if cs < *start && *start < ce {
+            *start = ce;
+        }
+        if cs < *end && *end < ce {
+            *end = cs;
+        }
+    }
 }
 
 /// Nest `strong`/`emph` marks that partially overlap, by truncating the

--- a/crates/richtext/src/lib.rs
+++ b/crates/richtext/src/lib.rs
@@ -32,7 +32,7 @@
 //!   [`apply_line_ops`](RichText::apply_line_ops).
 //! - [`normalize`] — the markdown-string input primitive (line endings, bidi
 //!   strip, HTML-comment fence repair), applied at the import boundary.
-//! - [`usv`] — coordinate conversions across the UTF-8 / UTF-16 / USV boundary.
+//! - [`usv`] — USV → UTF-8 byte-offset conversion for slicing the corpus.
 
 pub mod change_log;
 pub mod delta;

--- a/crates/richtext/src/ops.rs
+++ b/crates/richtext/src/ops.rs
@@ -218,15 +218,30 @@ impl RichText {
     }
 
     /// One committed field edit bundle: text delta, then line ops, then marks.
+    ///
+    /// All-or-nothing: on any op's error `self` is left exactly as it was, so a
+    /// caller need not snapshot-and-restore around a failed bundle. A bundle
+    /// carrying line or mark ops has several fallible stages that would
+    /// otherwise partially commit, so it is staged on a scratch copy and
+    /// swapped in only once every stage succeeds. The pure-text-delta path (the
+    /// per-keystroke hot path) skips the clone: `apply_text_delta` validates the
+    /// delta before mutating, so it is already atomic on the errors a caller can
+    /// provoke.
     pub fn apply_field_change(
         &mut self,
         text_delta: &Delta,
         line_ops: &[LineOp],
         mark_ops: &[MarkOp],
     ) -> Result<(), ApplyError> {
-        self.apply_text_delta(text_delta)?;
-        self.apply_line_ops(line_ops)?;
-        self.apply_mark_ops(mark_ops)
+        if line_ops.is_empty() && mark_ops.is_empty() {
+            return self.apply_text_delta(text_delta);
+        }
+        let mut scratch = self.clone();
+        scratch.apply_text_delta(text_delta)?;
+        scratch.apply_line_ops(line_ops)?;
+        scratch.apply_mark_ops(mark_ops)?;
+        *self = scratch;
+        Ok(())
     }
 
     fn line_mut(&mut self, line: usize) -> Result<&mut Line, ApplyError> {
@@ -640,5 +655,33 @@ mod tests {
             .unwrap();
         assert_eq!((strong.start, strong.end), (3, 4));
         assert_eq!(rt.text, "abXc");
+    }
+
+    #[test]
+    fn apply_field_change_is_all_or_nothing() {
+        // A bundle whose text delta and first mark op succeed but whose second
+        // mark op is out of range must leave the corpus exactly as it was — the
+        // successful earlier stages do not partially commit.
+        let mut rt = from_markdown("abc").unwrap();
+        let before = rt.clone();
+        let d = diff("abc", "abXc");
+        let err = rt.apply_field_change(
+            &d,
+            &[],
+            &[
+                MarkOp::Add {
+                    start: 0,
+                    end: 2,
+                    kind: MarkKind::Strong,
+                },
+                MarkOp::Add {
+                    start: 99,
+                    end: 100,
+                    kind: MarkKind::Emph,
+                },
+            ],
+        );
+        assert!(matches!(err, Err(ApplyError::MarkOutOfRange { .. })));
+        assert_eq!(rt, before, "failed bundle must not mutate the corpus");
     }
 }

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -106,12 +106,12 @@ impl RichText {
 }
 
 /// The canonical richtext form as a structural [`Value`] — the recursively
-/// key-sorted tree [`content_key`] renders to bytes. A storage layer embeds
-/// this as a nested object (never an escaped string): serializing the returned
-/// value with `serde_json` is byte-identical to [`content_key`]
-/// (`to_canonical_value(rt).to_string() == content_key(rt)`), independent of the
-/// consumer's `preserve_order` feature. Normalizes a copy first, so the value is
-/// canonical whatever the caller's mark/island order.
+/// key-sorted tree [`RichText::to_canonical_json`] renders to bytes. A storage
+/// layer embeds this as a nested object (never an escaped string): serializing
+/// the returned value with `serde_json` is byte-identical to that JSON
+/// (`to_canonical_value(rt).to_string() == rt.to_canonical_json()`), independent
+/// of the consumer's `preserve_order` feature. Normalizes a copy first, so the
+/// value is canonical whatever the caller's mark/island order.
 pub fn to_canonical_value(rt: &RichText) -> Value {
     let mut rt = rt.clone();
     rt.normalize();
@@ -447,13 +447,6 @@ fn loss_from_str(s: &str) -> Loss {
         // value the reader can't interpret "carries faithfully".
         _ => Loss::Unrepresentable,
     }
-}
-
-/// Content-hash key: the canonical JSON, byte-for-byte. Exposed so a storage
-/// layer hashes the same bytes it serializes. `_` prefix-free name kept
-/// stable — part of the determinism contract.
-pub fn content_key(rt: &RichText) -> String {
-    rt.to_canonical_json()
 }
 
 #[cfg(test)]

--- a/crates/richtext/src/usv.rs
+++ b/crates/richtext/src/usv.rs
@@ -1,20 +1,12 @@
-//! Coordinate conversions between USV and the two other coordinate spaces a
-//! consumer may hold a position in.
+//! USV → UTF-8 byte conversion, the one coordinate crossing storage needs.
 //!
 //! [`RichText`](crate::RichText) positions count Unicode scalar values (USV,
 //! Rust `char`) throughout, including at the WASM boundary — the `wasm`
 //! binding's delta and hit-test APIs pass raw USV positions through and leave
-//! any UTF-16 conversion to the JS caller, so the helpers here are unused at
-//! that boundary today. Three coordinate spaces disagree:
+//! any UTF-16 conversion to the JS caller. Two coordinate spaces disagree here:
 //!
 //! - **Rust / storage** — UTF-8 bytes. Slicing the corpus needs a byte offset.
-//! - **JS editors** — UTF-16 code units, if a caller chooses to convert.
-//! - **USV** — the model's coordinate. One astral char is 1 USV / 4 UTF-8 bytes
-//!   / 2 UTF-16 units.
-//!
-//! A UTF-16 index landing on a low surrogate (the tail half of an astral pair)
-//! rounds **down** to the char that owns it — the standing cross-binding rule
-//! the property suite pins.
+//! - **USV** — the model's coordinate. One astral char is 1 USV / 4 UTF-8 bytes.
 
 /// USV index → UTF-8 byte offset into `text`. Saturates to `text.len()` for an
 /// index at or past the end, so it is safe to use as a slice bound.
@@ -23,31 +15,6 @@ pub fn char_to_byte(text: &str, char_idx: usize) -> usize {
         .nth(char_idx)
         .map(|(b, _)| b)
         .unwrap_or(text.len())
-}
-
-/// USV index → UTF-16 code-unit index. Saturates to the UTF-16 length past the
-/// end.
-pub fn char_to_utf16(text: &str, char_idx: usize) -> usize {
-    text.chars().take(char_idx).map(|c| c.len_utf16()).sum()
-}
-
-/// UTF-16 code-unit index → USV index. An index that lands mid-pair (on a low
-/// surrogate) rounds down to the owning char. Saturates to the USV length past
-/// the end.
-pub fn utf16_to_char(text: &str, utf16_idx: usize) -> usize {
-    let mut units = 0usize;
-    for (char_idx, c) in text.chars().enumerate() {
-        if units >= utf16_idx {
-            return char_idx;
-        }
-        units += c.len_utf16();
-        // If the target index fell strictly inside this char's pair, we passed
-        // it — this char owns it, so round down to it.
-        if units > utf16_idx {
-            return char_idx;
-        }
-    }
-    text.chars().count()
 }
 
 #[cfg(test)]
@@ -63,33 +30,5 @@ mod tests {
         assert_eq!(char_to_byte(ASTRAL, 2), 5); // start of b (😀 is 4 bytes)
         assert_eq!(char_to_byte(ASTRAL, 3), 6); // end
         assert_eq!(char_to_byte(ASTRAL, 99), 6); // saturates
-    }
-
-    #[test]
-    fn char_to_utf16_astral() {
-        assert_eq!(char_to_utf16(ASTRAL, 0), 0);
-        assert_eq!(char_to_utf16(ASTRAL, 1), 1); // before 😀
-        assert_eq!(char_to_utf16(ASTRAL, 2), 3); // after 😀 (2 units)
-        assert_eq!(char_to_utf16(ASTRAL, 3), 4); // end
-    }
-
-    #[test]
-    fn utf16_to_char_astral() {
-        assert_eq!(utf16_to_char(ASTRAL, 0), 0);
-        assert_eq!(utf16_to_char(ASTRAL, 1), 1); // before 😀
-        assert_eq!(utf16_to_char(ASTRAL, 2), 1); // mid-surrogate -> rounds down to 😀
-        assert_eq!(utf16_to_char(ASTRAL, 3), 2); // after 😀
-        assert_eq!(utf16_to_char(ASTRAL, 4), 3); // end
-        assert_eq!(utf16_to_char(ASTRAL, 99), 3); // saturates
-    }
-
-    #[test]
-    fn round_trip_char_utf16() {
-        // Every char boundary round-trips (mid-surrogate indices don't exist as
-        // char positions, so we only check char starts).
-        for i in 0..=ASTRAL.chars().count() {
-            let u16i = char_to_utf16(ASTRAL, i);
-            assert_eq!(utf16_to_char(ASTRAL, u16i), i, "char {i}");
-        }
     }
 }

--- a/crates/richtext/tests/properties.rs
+++ b/crates/richtext/tests/properties.rs
@@ -10,15 +10,12 @@
 //!    insensitive to mark/island discovery order.
 //! 3. **Diff-import preserves identity marks** — an anchor over text that
 //!    survives a rewrite is carried forward.
-//! 4. **USV boundary** — char↔UTF-16 round-trips at char boundaries; a
-//!    mid-surrogate index rounds down.
 
 use proptest::prelude::*;
 use quillmark_richtext::delta::diff_import;
 use quillmark_richtext::export::to_markdown;
 use quillmark_richtext::import::from_markdown;
 use quillmark_richtext::model::{Line, Mark, MarkKind};
-use quillmark_richtext::usv::{char_to_utf16, utf16_to_char};
 use quillmark_richtext::{Delta, LineKind, LineOp, MarkOp, Op, RichText};
 
 // ---------------------------------------------------------------------------
@@ -260,27 +257,6 @@ proptest! {
         prop_assert_eq!(&new_rt.text[anchor.start..anchor.end], a.as_str());
     }
 
-    /// Property 4a: char↔UTF-16 round-trips at every char boundary.
-    #[test]
-    fn usv_round_trip(s in ".{0,64}") {
-        let n = s.chars().count();
-        for i in 0..=n {
-            let u = char_to_utf16(&s, i);
-            prop_assert_eq!(utf16_to_char(&s, u), i, "char {} of {:?}", i, s);
-        }
-    }
-
-    /// Property 4b: a mid-surrogate UTF-16 index rounds down to its owning char.
-    #[test]
-    fn usv_mid_surrogate_rounds_down(prefix in "[a-z]{0,8}") {
-        // 😀 is a surrogate pair; the index just after its first unit must round
-        // down to the emoji's char index.
-        let s = format!("{prefix}😀x");
-        let emoji_char = prefix.chars().count();
-        let u_before = char_to_utf16(&s, emoji_char);
-        // u_before + 1 lands mid-pair.
-        prop_assert_eq!(utf16_to_char(&s, u_before + 1), emoji_char);
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -103,7 +103,7 @@ values keeps YAML insertion order via the workspace's
 `serde_json/preserve_order` feature, and no whole-envelope key sort is
 applied. Every `body` subtree, by contrast, is the recursively key-sorted
 **canonical richtext form** (`CanonicalRichText` in `dto.rs`) — byte-identical
-to `content_key(&rt)` and independent of `preserve_order`, even in a
+to `rt.to_canonical_json()` and independent of `preserve_order`, even in a
 consumer crate graph that lacks the feature. Sortedness is semantic
 *inside* the corpus (mark/island/attribute order carries no meaning, so the
 serializer commits to one bit pattern); insertion order is semantic

--- a/prose/simplifications/core.md
+++ b/prose/simplifications/core.md
@@ -51,7 +51,10 @@ cut.
 
 ### document/edit.rs:448 — `Card::set_body_corpus` is a public alias of `overwrite_body`
 
-One line, no consumer outside core's own unit tests (wasm mutates bodies via
-`apply_body_change`; storage builds cards via `from_parts`); a second public
-write path to the body corpus. lib.rs docs reference it and it may be intended
-editor API — decide, then cut or document as the canonical setter.
+One line, a second public write path to the body corpus. No longer dead: the
+`ab082e8` rollback rewrite made the wasm binding call it as the body-restore
+step (`wasm/src/engine.rs`), so it now has exactly one production consumer —
+the original "no consumer outside unit tests" premise is void. Residual: the
+rollback could call `overwrite_body` directly; whether the alias earns its
+public surface is now a question about the rollback path, better framed by the
+"transactionality is the caller's job" seam entry than as dead code.

--- a/prose/simplifications/core.md
+++ b/prose/simplifications/core.md
@@ -2,30 +2,6 @@
 
 ## Needs judgment
 
-### quill/types.rs:117, quill/types.rs:228 — the richtext `inline` flag has two carriers
-
-Stored on `FieldType::RichText { inline }` and again as `FieldSchema.inline`,
-synced only inside `from_quill_value` (`resolve_richtext_inline`). The derived
-`Deserialize` on `FieldSchema` does not sync: `{type: "richtext", inline:
-true}` deserializes to `RichText { inline: false }` + `inline: Some(true)`,
-silently dropping the constraint for every `FieldType`-matching consumer
-(coercion, validation, blueprint, transform schema). The "inline only on
-richtext" rule is also enforced twice with different error surfaces
-(types.rs:344 parse error vs config.rs:560 `quill::inline_not_supported`).
-Fix: one representation — `inline` only on `FieldSchema` with `FieldType` a
-plain token, or a custom (de)serialize deriving the struct field from the
-enum. Public API shape.
-
-### quill/config.rs:560 — `inline_not_supported` is unreachable through the loader
-
-Every `FieldSchema` reaching `validate_field_schema_shape` comes from
-`from_quill_value`, which already rejects `inline` on non-richtext types; no
-test or code references the error code. A second, differently-worded
-enforcement of one rule. Reachable in principle via derived-`Deserialize`
-schemas, so deleting trades away defense-in-depth — pick one enforcement
-point deliberately. Collapses to nothing if the two-carrier finding above is
-fixed.
-
 ### quill/compose.rs:359 — corpus companion caches leak maybe-populated state to callers
 
 `default_corpus`/`example_corpus` are populated only by a loader post-pass

--- a/prose/simplifications/core.md
+++ b/prose/simplifications/core.md
@@ -24,13 +24,3 @@ re-export to keep semver-stable for a client that does not exist. Fix: keep
 only the used surface; add record/bundle variants when a consumer appears.
 Possibly deliberate forward surface — decide, then either wire a consumer or
 cut.
-
-### document/edit.rs:448 — `Card::set_body_corpus` is a public alias of `overwrite_body`
-
-One line, a second public write path to the body corpus. No longer dead: the
-`ab082e8` rollback rewrite made the wasm binding call it as the body-restore
-step (`wasm/src/engine.rs`), so it now has exactly one production consumer —
-the original "no consumer outside unit tests" premise is void. Residual: the
-rollback could call `overwrite_body` directly; whether the alias earns its
-public surface is now a question about the rollback path, better framed by the
-"transactionality is the caller's job" seam entry than as dead code.

--- a/prose/simplifications/richtext.md
+++ b/prose/simplifications/richtext.md
@@ -17,6 +17,13 @@ The same Retain/Delete char-walk over `old_chars`, differing only in sentinel
 shared walk parameterized by sentinel handler — mechanical but restructures the
 delta-apply path.
 
+_Assessed and deferred (2026-07):_ the genuinely shared skeleton is only the
+bounded per-char advance (`for op … if old >= len break`), ~10 lines; the
+per-op actions diverge hard (lines rebuild structure on `Insert`; islands
+ignore it), and the two closures both mutate captured state, so sharing needs a
+`trait DeltaWalk` + generic walker whose cost exceeds the dedup. Revisit only if
+a third consumer of the same walk appears.
+
 ### ops.rs:221 — `apply_field_change` normalizes three times
 
 `apply_text_delta`, `apply_line_ops`, and `apply_mark_ops` each end with

--- a/prose/simplifications/richtext.md
+++ b/prose/simplifications/richtext.md
@@ -65,14 +65,6 @@ fixer emits the distinction explicitly (wrapper event or `MarkKind`), deleting
 both peeks. The low-risk helper extraction above narrows the drift but not the
 altitude.
 
-### usv.rs:30 — `char_to_utf16` / `utf16_to_char` have no production consumers
-
-Only the crate's own property tests use them; the module doc states the WASM
-boundary passes raw USV and leaves UTF-16 to JS. Public surrogate-rounding
-semantics to document and keep stable for a caller that does not exist. Fix:
-delete until a UTF-16 consumer appears (`char_to_byte` stays). Public API of a
-published crate.
-
 ### change_log.rs:77, change_log.rs:169 — unused `ChangeLog` surface
 
 `len`, `is_empty`, `entries_after`, and the `CHANGE_LOG_DEFAULT_CAPACITY`
@@ -81,12 +73,6 @@ session.rs uses only `record`/`record_change`/`revision`/`map_pos`/
 `invalidate`. `entries_after` implies an incremental-reader protocol that is
 not wired anywhere. Fix: drop or demote to `#[cfg(test)]` until the
 delta-transport consumer lands. Published-crate API.
-
-### serial.rs:455 — `content_key` is a second public name for `to_canonical_json`
-
-A one-line alias whose only workspace use is one core dto test; both names are
-frozen by the determinism contract. Fix: drop the alias and reference
-`to_canonical_json` directly. Public API; core/dto.rs docs cite the name.
 
 ### serial.rs:115 — `to_canonical_value` builds the JSON tree twice
 

--- a/prose/simplifications/seams.md
+++ b/prose/simplifications/seams.md
@@ -2,24 +2,23 @@
 
 All entries need judgment — each spans crates or changes a contract.
 
-### Four sites re-implement the dual-shape richtext decode
+### ~~Four sites re-implement the dual-shape richtext decode~~ (three unified)
 
-`core/src/document/wire.rs:314` (`body_from_wire`), the coercion branch
-`core/src/quill/config.rs:359`, `literal_corpus` at
-`core/src/quill/config.rs:1646`, and the validation backstop
-`core/src/quill/validation.rs:470` each independently implement "JSON object →
-`serial::from_canonical_value`, string → `from_markdown`, then optional
-`is_inline` check / re-canonicalize". The accepted `$body`/richtext-value
-encodings are defined in four places that already drift: wire.rs accepts
-`null`, config.rs adds array-unwrap/scalar leniency, validation.rs
-`.ok()`-swallows decode errors. The inline-violation prose is separately
-restated three times (coercion's `inline_check`, `validation.rs`'s
-`not_inline_hint`, `config.rs`'s `richtext_inline_error`). Fix: one shared
-decoder (`RichText::from_json_or_markdown` beside `from_canonical_value`, or
-next to `document::import_body`) plus a single `check_inline`, with per-site
-error wrapping and *deliberate* per-site leniency kept local — the leniency
-differences are intentional in places and must be preserved, which is what
-makes this a judgment call.
+Done for the three strict sites. `document::decode_richtext_value` (next to
+`import_body`) is now the one place the "JSON object → `from_canonical_value`,
+string → `import_body`" dispatch lives; `body_from_wire`, `literal_corpus`, and
+the `validation.rs` backstop call it and keep only their deliberate local
+handling — wire's `null` → empty and shape error, literal's per-encoding
+message prefixes (via the `RichtextDecodeError` variant), validation's
+`.ok()`-swallow. All three now reach markdown through the single `import_body`
+boundary rather than three raw `from_markdown` calls.
+
+The coercion branch (`config.rs`) stays open-coded on purpose: its string path
+is deliberately lenient (reduce a scalar / length-1 array to text before
+import), which the strict decoder must not do — flagged in a comment beside it.
+The inline-violation surfaces (`CoercionError`, `ValidationError::NotInline`,
+`richtext_inline_error`) are intentionally per-layer error types over the one
+shared `rt.is_inline()` condition, so they are left distinct.
 
 ### Every apply round-trips each richtext value through the canonical codec three times
 

--- a/prose/simplifications/seams.md
+++ b/prose/simplifications/seams.md
@@ -2,24 +2,6 @@
 
 All entries need judgment — each spans crates or changes a contract.
 
-### ~~Four sites re-implement the dual-shape richtext decode~~ (three unified)
-
-Done for the three strict sites. `document::decode_richtext_value` (next to
-`import_body`) is now the one place the "JSON object → `from_canonical_value`,
-string → `import_body`" dispatch lives; `body_from_wire`, `literal_corpus`, and
-the `validation.rs` backstop call it and keep only their deliberate local
-handling — wire's `null` → empty and shape error, literal's per-encoding
-message prefixes (via the `RichtextDecodeError` variant), validation's
-`.ok()`-swallow. All three now reach markdown through the single `import_body`
-boundary rather than three raw `from_markdown` calls.
-
-The coercion branch (`config.rs`) stays open-coded on purpose: its string path
-is deliberately lenient (reduce a scalar / length-1 array to text before
-import), which the strict decoder must not do — flagged in a comment beside it.
-The inline-violation surfaces (`CoercionError`, `ValidationError::NotInline`,
-`richtext_inline_error`) are intentionally per-layer error types over the one
-shared `rt.is_inline()` condition, so they are left distinct.
-
 ### Every apply round-trips each richtext value through the canonical codec three times
 
 Per `apply`/`applyFieldDelta`: `to_data_json` serializes the
@@ -48,15 +30,8 @@ a core/quillmark-level
 `apply_field_delta(session, config, doc, field, base_revision, delta)` owning
 field-address routing and the transaction; bindings become thin wrappers.
 
-### ~~Transactionality is the caller's job~~ (done for the corpus apply)
-
-`RichText::apply_field_change` is now all-or-nothing: a multi-op bundle stages
-on a scratch copy and swaps on success (`richtext/src/ops.rs`), and
-`Card::apply_body_change` documents the same contract, so no consumer needs to
-snapshot-and-restore around a *half-applied body*. The WASM binding still holds
-one body snapshot (`wasm/src/engine.rs`), but only as the transaction boundary
-for the compile and record steps that run *after* the (now atomic) body
-mutation and can still fail — which is the separate "delta-commit orchestration
-lives in the WASM binding" seam above, not corpus transactionality. Close that
-seam (a core/quillmark-level `apply_field_delta` owning apply + compile + record
-+ rollback) and the caller-side snapshot goes with it.
+The corpus apply is now atomic (`RichText::apply_field_change` stages on a
+scratch copy and swaps on success), so the binding's remaining body snapshot
+guards only the compile and record steps that run *after* the body mutation —
+not a half-applied body. Closing this seam absorbs that snapshot into the
+core-owned transaction.

--- a/prose/simplifications/seams.md
+++ b/prose/simplifications/seams.md
@@ -49,14 +49,15 @@ a core/quillmark-level
 `apply_field_delta(session, config, doc, field, base_revision, delta)` owning
 field-address routing and the transaction; bindings become thin wrappers.
 
-### Transactionality is the caller's job
+### ~~Transactionality is the caller's job~~ (done for the corpus apply)
 
-`Card::apply_body_change` is documented non-transactional ("body is unchanged
-on error only up to the failing op" — `core/src/document/edit.rs:497`), so the
-WASM binding snapshots the main card and hand-rolls rollback at two exits
-(`wasm/src/engine.rs:1554`). Every consumer must replicate the
-clone-and-restore dance or corrupt the document on a failed op. Fix: make
-transactionality the callee's contract — apply to a scratch copy and swap on
-success in `RichText::apply_field_change` (or `Card::apply_body_change`),
-deleting the caller-side rollback. Subsumes the two low-risk rollback entries
-in bindings.md.
+`RichText::apply_field_change` is now all-or-nothing: a multi-op bundle stages
+on a scratch copy and swaps on success (`richtext/src/ops.rs`), and
+`Card::apply_body_change` documents the same contract, so no consumer needs to
+snapshot-and-restore around a *half-applied body*. The WASM binding still holds
+one body snapshot (`wasm/src/engine.rs`), but only as the transaction boundary
+for the compile and record steps that run *after* the (now atomic) body
+mutation and can still fail — which is the separate "delta-commit orchestration
+lives in the WASM binding" seam above, not corpus transactionality. Close that
+seam (a core/quillmark-level `apply_field_delta` owning apply + compile + record
++ rollback) and the caller-side snapshot goes with it.

--- a/prose/simplifications/typst.md
+++ b/prose/simplifications/typst.md
@@ -13,23 +13,6 @@ delimiter change must land twice. Fix: give `wraps_and_codes` the clip bounds
 mark ranges to the segment window — parameterize carefully and pin with the
 round-trip tests.
 
-### emit.rs:776 — `clip_wraps_to_codes` duplicates `clip_fmt_to_atomic`
-
-Same edge-pull rule and swallowed-mark drop as
-`richtext/src/export.rs:563` — the #846-class balance invariant enforced by
-two hand-kept copies in two crates. Fix: one range-based clip helper in
-`quillmark-richtext` taking the atomic span set as a parameter (export clips
-against codes+links, emit against codes only); pin behavior with the existing
-round-trip tests.
-
-### emit.rs:330 vs emit.rs:488 — container dispatch duplicated across the two walkers
-
-`emit_block_level` and `emit_item_body` carry byte-identical
-`Container::ListItem`/`Container::Quote` arms (run-end computation +
-recursion); only the leaf arm differs. A new `Container` variant must be
-mirrored in both. Fix: a shared `try_emit_container(range, depth, i)` helper
-both loops call before their own leaf arm — restructures a recursive emitter.
-
 ### emit.rs:139 — `gen_cluster` re-derives escape structure from generated text
 
 The scan re-parses the backend's own output (`\/\/` coupling, `\X`, `\u{..}`),


### PR DESCRIPTION
## Summary

Works through the `prose/simplifications/` review, resolving the tractable findings and recording judgment/rationale for the rest. Each change is a separate CI-validated commit; `cargo test --workspace` is green at HEAD.

## Changes (by commit)

**1. Delete verified-dead public surface** — `usv::char_to_utf16`/`utf16_to_char` (only property tests used them; module doc says JS owns UTF-16) and `serial::content_key` (a one-line alias of `to_canonical_json`). Callers/docs repointed to `to_canonical_json`. Pre-1.0 crates, so removal rides a minor bump.

**2. Single carrier for the richtext `inline` flag** — `FieldType::RichText { inline }` is now the sole carrier; the redundant `FieldSchema.inline` field is gone. Hand-written `Serialize`/`Deserialize` fold the wire's sibling `inline:` key into the enum at one sync point, so the derived-path two-carrier drift (`RichText { inline: false }` + `inline: Some(true)`) is unrepresentable. `Serialize` re-emits `inline` in the prior position, so golden schema snapshots are unchanged. Drops the unreachable `quill::inline_not_supported` check (enforcement already lives once in `resolve_richtext_inline`).

**3. `apply_field_change` is all-or-nothing** — a bundle with line/mark ops stages on a scratch copy and swaps on success, so a mid-bundle failure no longer half-mutates the body. The pure-text hot path stays clone-free (`apply_text_delta` validates before mutating). `Card::apply_body_change` documents the contract; the WASM body snapshot is re-scoped in comment to what it actually guards (the compile/record steps — the separate orchestration seam).

**4. One shared decoder for the dual-shape richtext seam** — `document::decode_richtext_value` (beside `import_body`) is now the single object-vs-string dispatch. The three strict sites (`body_from_wire`, `literal_corpus`, validation backstop) route through it and keep only their deliberate local handling; all three now reach markdown via the one `import_body` boundary. The coercion branch stays open-coded on purpose (its string path is deliberately lenient), annotated as such.

**5. Dedup container dispatch and the #846 clip** — extract typst's `try_emit_container` (the byte-identical `ListItem`/`Quote` arms shared by the two block walkers); extract `quillmark_richtext::export::clip_range_to_atomic`, the #846 balance rule that was hand-kept in both richtext export and the typst emitter.

**6. Docs** — removed each resolved entry from `prose/simplifications/`; corrected the stale `set_body_corpus` entry (it gained a production consumer in a prior commit); recorded the assessed-and-deferred rationale on the `sync_lines`/`sync_islands` twin-merge (shared skeleton too thin to justify a trait-based walker).

## Deliberately deferred (unchanged, still documented as findings)

Each carries a real perf/memory tradeoff or deep restructure the review flags: the `gen_cluster` escape re-derivation (memory tradeoff), `span_scan` `walk_glyphs`/`collect_page_hits` geometry (hot path), table-cell normalize dirty-flag, the island-type dispatch table, quadratic line removal, `normalize`-3× per bundle, short-delta leniency altitude, `emit_inline`/`wraps_and_codes`, and the full delta-commit orchestration seam. The change-log/session-delta surface is kept as intended forward API.

## Testing

`cargo test --workspace` — green. Added a regression test pinning the all-or-nothing apply contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7ZatLCUPLRzN34VzkRv6R