### PR TITLE
Prune over-engineered simplification findings; fix drifted docs

### DIFF
--- a/prose/simplifications/richtext.md
+++ b/prose/simplifications/richtext.md
@@ -10,20 +10,6 @@ single-pass cursor rewrite is possible but the interleaving of retain/insert
 with the template-clone rule has edge cases on malformed corpora; semantics
 need pinning by tests before restructuring.
 
-### ops.rs:330, ops.rs:391 — `sync_lines_for_delta` / `sync_islands_for_delta` are twins
-
-The same Retain/Delete char-walk over `old_chars`, differing only in sentinel
-(`\n` vs `ISLAND_SLOT`) and action. A fix to the walk must land twice. Fix: one
-shared walk parameterized by sentinel handler — mechanical but restructures the
-delta-apply path.
-
-_Assessed and deferred (2026-07):_ the genuinely shared skeleton is only the
-bounded per-char advance (`for op … if old >= len break`), ~10 lines; the
-per-op actions diverge hard (lines rebuild structure on `Insert`; islands
-ignore it), and the two closures both mutate captured state, so sharing needs a
-`trait DeltaWalk` + generic walker whose cost exceeds the dedup. Revisit only if
-a third consumer of the same walk appears.
-
 ### ops.rs:221 — `apply_field_change` normalizes three times
 
 `apply_text_delta`, `apply_line_ops`, and `apply_mark_ops` each end with
@@ -64,13 +50,17 @@ implicit trailing retain the documented contract of `try_apply` itself.
 
 ### import.rs:512 — the `MarkdownFixer` erases the `<u>`/`Strong` distinction it owns
 
-The fixer rewrites `<u>`/`</u>` into `Strong` events; both downstream
-consumers then sniff raw source bytes to recover the distinction, and the two
-peeks already disagree with the fixer's `is_u_open_tag` whitespace handling
-(`< u >` classifies as Strong at the peek, Underline at the fixer). Fix: the
-fixer emits the distinction explicitly (wrapper event or `MarkKind`), deleting
-both peeks. The low-risk helper extraction above narrows the drift but not the
-altitude.
+The fixer rewrites `<u>`/`</u>` into `Strong` events; both downstream consumers
+(`Tag::Strong` at import.rs:526 and the table-cell path at import.rs:689) then
+re-sniff raw source bytes via `strong_or_underline` to recover the distinction.
+That peek's 2-byte `<u`-prefix test and the fixer's `is_u_open_tag` (trim +
+inner `== "u"`) are two hand-synced encodings of one rule that classify a tag
+like `<ul>` oppositely; only the fixer's gate — which never converts `<ul>` to
+`Strong` — keeps that divergence from reaching the peek today. Fix: the fixer
+emits the distinction explicitly (wrapper event or `MarkKind`), deleting both
+peeks. The shared `strong_or_underline` helper already narrows the drift but not
+the altitude — the distinction is still recovered from source bytes rather than
+carried.
 
 ### change_log.rs:77, change_log.rs:169 — unused `ChangeLog` surface
 

--- a/prose/simplifications/seams.md
+++ b/prose/simplifications/seams.md
@@ -4,11 +4,11 @@ All entries need judgment — each spans crates or changes a contract.
 
 ### Every apply round-trips each richtext value through the canonical codec three times
 
-Per `apply`/`applyFieldDelta`: `to_data_json` serializes the
+Per `apply`/`applyFieldDelta`: `to_plate_json` serializes the
 already-normalized body via `to_canonical_value` (clone + normalize + build
-tree + `sorted_value` rebuild — `core/src/document/mod.rs:346`), coercion
+tree + `sorted_value` rebuild — `core/src/document/mod.rs:382`), coercion
 re-parses with `from_canonical_value` and re-serializes
-(`core/src/quill/config.rs:382`), and backend codegen parses a third time
+(`core/src/quill/config.rs:405`), and backend codegen parses a third time
 before `emit_richtext` (`backends/typst/src/helper.rs:180`). ~3 full
 parse/serialize + normalize passes over every corpus per keystroke preview
 recompile. Fix: treat a corpus emitted by `to_canonical_value` as already

--- a/prose/simplifications/typst.md
+++ b/prose/simplifications/typst.md
@@ -13,16 +13,6 @@ delimiter change must land twice. Fix: give `wraps_and_codes` the clip bounds
 mark ranges to the segment window — parameterize carefully and pin with the
 round-trip tests.
 
-### emit.rs:139 — `gen_cluster` re-derives escape structure from generated text
-
-The scan re-parses the backend's own output (`\/\/` coupling, `\X`, `\u{..}`),
-duplicating knowledge encoded in `escape_markup`/`escape_string`; agreement is
-maintained only by the `escape_tripwire` tests, and
-`invert_gen_offset`/`forward_corpus_offset` correctness rides on the pairing.
-Deeper form: the emitter records the cluster table (corpus-chars, byte-len
-pairs) at generation time so the scan reads structure. The no-stored-table
-design is a documented deliberate tradeoff — weigh the memory cost first.
-
 ### span_scan.rs:557 vs span_scan.rs:272 — `walk_glyphs` duplicates `collect_page_hits`
 
 ~60 lines of identical frame-walk geometry (`Group` transform recursion,


### PR DESCRIPTION
Review of `prose/simplifications/` against current code. No finding was *invalid* (all premises still hold), but two proposed fixes cost more than the problem they solve, and a few citations had drifted.

## Cut (fix disproportionate to the problem)

- **richtext `ops.rs:330/391`** (`sync_lines_for_delta` / `sync_islands_for_delta` twins) — the genuinely shared code is ~10 lines of Retain-advance skeleton; the Delete and Insert arms diverge hard and both closures mutate captured state, so the proposed `trait DeltaWalk` + generic walker costs more than it removes. Already self-assessed as "deferred," so the entry was dead weight.
- **typst `emit.rs:139`** (`gen_cluster` re-derives escape structure) — the deeper fix stores a per-char cluster table whose memory grows with document text, just to delete a scan already pinned by the `escape_tripwire` tests. The no-stored-table design is a documented deliberate tradeoff.

## Corrected

- **richtext `import.rs:512`** (`<u>`/`Strong` distinction) — the old text claimed the two peeks "already disagree" (`< u >` example). Verified against source: both peeks call the same `strong_or_underline`, invoked only on `Start(Strong)` ranges, and every input passing the fixer's `is_u_open_tag` gate also passes the 2-byte `<u` test — so they never disagree on reachable input, and the `< u >` case is unreachable (pulldown-cmark emits `InlineHtml` only for a well-formed tag). Rewrote to describe the real *latent* divergence (`<ul>` classifies oppositely), guarded by the fixer gate. The altitude point stands.

## Refreshed citations

- **seams.md** — `to_data_json` → `to_plate_json`; `core/src/document/mod.rs:346` → `:382`; `core/src/quill/config.rs:382` → `:405` (`helper.rs:180` was still accurate).

Borderline findings (island dispatch-table, dirty-flag variant, hand-sorted-keys, generic glyph walker, corpus-companion caches, pdfform schema classification, delta-commit helper) were left intact — each already pairs a proportionate alternative with the heavier one.

Docs-only; no code or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhqHADtYPVsBL8zhezaPYT)_