### PR TITLE
Tables: canonical shape, honest in-cell images, property + e2e coverage (#880)

### DIFF
--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -194,6 +194,10 @@ fn element_text(e: &Value) -> Option<String> {
 
 /// A richtext corpus's plaintext, via [`quillmark_richtext::export::to_plaintext`]
 /// (island slots stripped). `None` for a non-corpus object or an empty result.
+///
+/// Tables and images carry no plaintext, so a corpus whose content is only a
+/// table binds nothing here — the field renders blank, no diagnostic. This is
+/// the decided pdfform limitation (issue #880); see `to_plaintext`.
 fn richtext_plaintext(v: &Value) -> Option<String> {
     let rt = quillmark_richtext::serial::from_canonical_value(v).ok()?;
     let text = quillmark_richtext::export::to_plaintext(&rt);

--- a/crates/fixtures/resources/quills/table_demo/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/table_demo/0.1.0/Quill.yaml
@@ -1,0 +1,14 @@
+quill:
+  name: table_demo
+  version: 0.1.0
+  backend: typst
+  description: Exercises a GFM table through the full markdown -> RichText -> Typst pipeline
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+    title:
+      description: title of document
+      type: string

--- a/crates/fixtures/resources/quills/table_demo/0.1.0/plate.typ
+++ b/crates/fixtures/resources/quills/table_demo/0.1.0/plate.typ
@@ -1,0 +1,9 @@
+#import "@local/quillmark-helper:0.1.0": data
+
+// The whole point of this fixture: `$body` carries a GFM table, which the
+// markdown -> RichText -> Typst path lowers to `#table(...)`. Rendering the
+// body end-to-end is the coverage — alignment, formatted cells, and ragged
+// rows all reach the emitter here, not just the inline codec's unit tests.
+#underline(data.title)
+
+#data.at("$body")

--- a/crates/quillmark/tests/table_render_test.rs
+++ b/crates/quillmark/tests/table_render_test.rs
@@ -1,0 +1,90 @@
+//! End-to-end coverage for GFM tables (issue #880): a table in a document
+//! `$body` renders through the full markdown -> RichText -> Typst -> artifact
+//! pipeline. The inline codec's unit tests pin `import(export(t))`; this pins
+//! the *rendered* path — the Typst emitter's `#table(...)` lowering, exercised
+//! with column alignment, formatted cells, and a ragged row that the model
+//! layer normalizes before it reaches the backend.
+
+#![cfg(feature = "typst")]
+
+use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark_fixtures::quills_path;
+
+fn render(markdown: &str, format: OutputFormat) -> quillmark::RenderResult {
+    let engine = Quillmark::new();
+    let quill =
+        quillmark::quill_from_path(quills_path("table_demo")).expect("table_demo should load");
+    let parsed = Document::from_markdown(markdown)
+        .unwrap_or_else(|e| panic!("document failed to parse: {e:?}\n---\n{markdown}"));
+    engine
+        .render(
+            &quill,
+            &parsed,
+            &RenderOptions {
+                output_format: Some(format),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|e| panic!("render failed: {e:?}\n---\n{markdown}"))
+}
+
+const FRONTMATTER: &str = "\
+~~~card-yaml
+$quill: table_demo@0.1.0
+$kind: main
+title: Table Demo
+~~~
+";
+
+fn doc(body: &str) -> String {
+    format!("{FRONTMATTER}\n{body}\n")
+}
+
+/// A body-borne pipe table — aligned columns, a formatted header cell, and a
+/// short (ragged) row that normalization pads — renders through Typst without a
+/// compile error and draws visibly more than the same document with no table.
+///
+/// A successful render is itself the load-bearing signal: a malformed
+/// `#table(...)` lowering would fail Typst compilation and the helper would
+/// panic. SVG vectorizes text into glyph paths, so the cell strings are not
+/// literal substrings — the size comparison against an empty body is the
+/// non-fragile proxy for "the table drew a grid and rows onto the page".
+#[test]
+fn table_body_renders_through_typst() {
+    let table = render(
+        &doc(
+            "| Fruit | **Rank** | Note |\n\
+             | :--- | :---: | ---: |\n\
+             | Taro | 1 | best |\n\
+             | Vanilla | 2 |",
+        ),
+        OutputFormat::Svg,
+    );
+    assert!(!table.artifacts.is_empty(), "render produced no artifacts");
+    let table_svg = &table.artifacts[0].bytes;
+    assert!(!table_svg.is_empty(), "rendered artifact is empty");
+
+    // Control: the same document with a plain one-line body. The table version
+    // adds cell grid strokes and three rows of text, so it is clearly larger.
+    let plain = render(&doc("just a line"), OutputFormat::Svg);
+    let plain_svg = &plain.artifacts[0].bytes;
+    assert!(
+        table_svg.len() > plain_svg.len(),
+        "table body ({} bytes) did not draw more than an empty body ({} bytes)",
+        table_svg.len(),
+        plain_svg.len()
+    );
+}
+
+/// The table also renders to PDF (a distinct Typst export path) without error.
+#[test]
+fn table_body_renders_to_pdf() {
+    let result = render(
+        &doc("| a | b |\n| --- | --- |\n| 1 | 2 |"),
+        OutputFormat::Pdf,
+    );
+    assert!(
+        result.artifacts.first().is_some_and(|a| !a.bytes.is_empty()),
+        "table did not render to a non-empty PDF"
+    );
+}

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -360,8 +360,13 @@ fn emit_table(isl: &Island, out: &mut String) {
     if let Some(rs) = rows {
         for row in rs {
             if let Some(r) = row.as_array() {
+                // Pad/truncate to the header's column count so a ragged island
+                // (one that skipped normalization) still emits a rectangular
+                // table — the same count the Typst projection uses post-normalize.
+                let mut cells: Vec<String> = r.iter().map(render_cell_md).collect();
+                cells.resize(cols, String::new());
                 out.push_str("\n| ");
-                out.push_str(&r.iter().map(render_cell_md).collect::<Vec<_>>().join(" | "));
+                out.push_str(&cells.join(" | "));
                 out.push_str(" |");
             }
         }

--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -55,6 +55,13 @@ pub fn to_markdown(rt: &RichText) -> String {
 /// every mark and island (tables, images have no plaintext projection), keeping
 /// only literal text. Callers that want a non-empty result should check for the
 /// empty string themselves.
+///
+/// Tables (and images) having no plaintext form is a **decided limitation**, not
+/// an oversight (issue #880): the pdfform backend fills a form field from this
+/// projection, so a field bound to a table-bearing corpus renders the surrounding
+/// text and silently omits the table. A degraded row/tab dump was rejected — it
+/// would read as a faithful table and mislead — so the projection drops the
+/// island outright. Revisit only if a form field ever needs tabular fill.
 pub fn to_plaintext(rt: &RichText) -> String {
     rt.text.chars().filter(|&c| c != ISLAND_SLOT).collect()
 }

--- a/crates/richtext/src/import.rs
+++ b/crates/richtext/src/import.rs
@@ -225,6 +225,15 @@ struct TableAcc {
     /// The cell currently open (between `Tag::TableCell` start/end), building its
     /// inline text + marks with the same [`Inline`] machinery prose uses.
     cell: Option<Inline>,
+    /// Open-image nesting inside the current cell. GFM permits inline images in
+    /// cells, but a cell has no island slot to carry one; while `> 0` the image's
+    /// alt flows into the cell as plain text (the degraded projection) and its
+    /// url is dropped. Mirrors the top-level `image_depth` interception.
+    img_depth: usize,
+    /// Whether any cell dropped an image's url — the island is then minted
+    /// [`Loss::Degraded`], not `Lossless`: the markdown/Typst projection carries
+    /// the alt text but not the image.
+    degraded: bool,
 }
 
 fn align_str(a: &pulldown_cmark::Alignment) -> &'static str {
@@ -531,6 +540,8 @@ impl Builder {
                     cur_row: Vec::new(),
                     in_head: false,
                     cell: None,
+                    img_depth: 0,
+                    degraded: false,
                 });
             }
             Tag::Emphasis => {
@@ -635,7 +646,43 @@ impl Builder {
     /// the SAME [`Inline`] machinery prose uses — a cell is flat inline (no lines,
     /// no nested islands), so its marks are USV offsets into its own text.
     fn table_event(&mut self, event: &Event, range: &Range<usize>) {
+        // An image open inside the current cell intercepts everything until it
+        // closes: the alt text lands in the cell as plain text (marks flattened,
+        // like the top-level image path), the url is dropped, and the island is
+        // flagged degraded. A cell has no island slot to carry a real image.
+        if self.table.as_ref().is_some_and(|a| a.img_depth > 0) {
+            match event {
+                Event::Start(Tag::Image { .. }) => {
+                    if let Some(a) = self.table.as_mut() {
+                        a.img_depth += 1;
+                    }
+                }
+                Event::End(TagEnd::Image) => {
+                    if let Some(a) = self.table.as_mut() {
+                        a.img_depth -= 1;
+                    }
+                }
+                Event::Text(t) | Event::Code(t) => {
+                    if let Some(c) = self.cell_mut() {
+                        c.push_text(t);
+                    }
+                }
+                Event::SoftBreak | Event::HardBreak => {
+                    if let Some(c) = self.cell_mut() {
+                        c.push_text(" ");
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
         match event {
+            Event::Start(Tag::Image { .. }) => {
+                if let Some(a) = self.table.as_mut() {
+                    a.img_depth += 1;
+                    a.degraded = true;
+                }
+            }
             Event::Start(Tag::TableHead) => {
                 if let Some(a) = self.table.as_mut() {
                     a.in_head = true;
@@ -736,7 +783,14 @@ impl Builder {
                 "header": acc.header,
                 "rows": acc.rows,
             });
-            self.mint_island("table", props, Loss::Lossless);
+            // Degraded when a cell dropped an inline image's url — the projection
+            // then carries the alt text but not the image (not a fixed point).
+            let loss = if acc.degraded {
+                Loss::Degraded
+            } else {
+                Loss::Lossless
+            };
+            self.mint_island("table", props, loss);
         }
     }
 
@@ -1246,6 +1300,22 @@ mod tests {
         assert_eq!(rt.islands.len(), 1);
         assert_eq!(rt.islands[0].island_type, "table");
         assert_eq!(rt.islands[0].loss, Loss::Lossless);
+    }
+
+    #[test]
+    fn table_with_cell_image_degrades() {
+        // GFM permits an inline image in a cell; the cell has no island slot to
+        // carry it, so the alt text lands as plain cell text, the url is dropped,
+        // and the island is Degraded (not the silent-Lossless lie).
+        let rt = imp("| a | b |\n|---|---|\n| ![a cat](cat.png) | 2 |");
+        assert_eq!(rt.islands.len(), 1);
+        assert_eq!(rt.islands[0].island_type, "table");
+        assert_eq!(rt.islands[0].loss, Loss::Degraded);
+        // The dropped image left no nested island; alt survived as cell text.
+        assert_eq!(rt.islands[0].props["rows"][0][0]["text"], "a cat");
+        // A table with no cell image stays Lossless (regression guard).
+        let plain = imp("| a | b |\n|---|---|\n| 1 | 2 |");
+        assert_eq!(plain.islands[0].loss, Loss::Lossless);
     }
 
     #[test]

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -317,6 +317,16 @@ pub enum Invariant {
     /// A formatting mark edge sits on a `\n` (normalization should have trimmed
     /// it) — a hand-built corpus that skipped `normalize`.
     MarkEdgeOnNewline { at: Usv },
+    /// A table island's `aligns` length differs from its column count (the
+    /// header width). `normalize` syncs `aligns` to the column count.
+    TableAlignsMismatch { aligns: usize, cols: usize },
+    /// A table island body row's width differs from the column count (the header
+    /// width). `normalize` pads short rows (and the header) to the widest.
+    TableRaggedRow { row: usize, width: usize, cols: usize },
+    /// A table cell's text carries a `\n` — cells are single-line (a newline
+    /// would break the exported table). `cell` is the flat header-then-rows
+    /// index; `normalize` rewrites the newline to a space.
+    TableCellNewline { cell: usize },
 }
 
 impl RichText {
@@ -371,11 +381,13 @@ impl RichText {
     /// the fixed point the canonical serialization commits to.
     pub fn normalize(&mut self) {
         // Islands: canonicalize props key order. A table island's cells carry
-        // inline `{text, marks}`; canonicalize each cell's marks (sort, union,
-        // drop zero-width) first so equal cells serialize to equal bytes — the
-        // props are otherwise opaque here.
+        // inline `{text, marks}`; repair its shape (pad the header/rows/aligns to
+        // one column count, rewrite any cell `\n` to a space) and canonicalize
+        // each cell's marks (sort, union, drop zero-width) first so equal cells
+        // serialize to equal bytes and `validate` holds — the props are
+        // otherwise opaque here.
         for island in &mut self.islands {
-            crate::serial::normalize_island_cell_marks(island);
+            crate::serial::normalize_island_structure(island);
             // Rebuild props only when a key is actually out of order — an
             // untouched island (a pure text splice) stays sorted, so this skips
             // the deep clone on the common per-keystroke path.
@@ -494,6 +506,12 @@ impl RichText {
         // but each mark is bounded by its own cell's text length (in USV). Cells
         // hold no `\n`, so the edge-on-newline rule does not apply.
         for island in &self.islands {
+            // Structural shape (table column/row/aligns consistency, `\n`-free
+            // cells) before the per-cell mark ranges — a ragged island is
+            // ill-formed regardless of its marks.
+            if let Some(e) = crate::serial::island_shape_error(island) {
+                return Err(e);
+            }
             for (text, marks) in crate::serial::island_cell_marks(island) {
                 let clen = text.chars().count();
                 for m in &marks {
@@ -831,5 +849,118 @@ mod tests {
                 len: 2
             })
         );
+    }
+
+    /// A `RichText` holding a single table island with the given props — the
+    /// shared fixture for the table-shape invariant tests.
+    fn table_rt(props: serde_json::Value) -> RichText {
+        let mut rt = RichText::empty();
+        rt.text = ISLAND_SLOT.to_string();
+        rt.lines = vec![Line {
+            kind: LineKind::Island,
+            containers: vec![],
+            continues: false,
+        }];
+        rt.islands = vec![Island {
+            id: "i".into(),
+            island_type: "table".into(),
+            props,
+            loss: Loss::Lossless,
+        }];
+        rt
+    }
+
+    fn cell(t: &str) -> serde_json::Value {
+        serde_json::json!({ "text": t, "marks": [] })
+    }
+
+    /// `validate` rejects a ragged body row, an `aligns`/column mismatch, and a
+    /// cell carrying a `\n` — the three table-shape invariants.
+    #[test]
+    fn validate_catches_table_shape() {
+        // Ragged row: header has 2 columns, the row has 3.
+        let rt = table_rt(serde_json::json!({
+            "aligns": ["none", "none"],
+            "header": [cell("a"), cell("b")],
+            "rows": [[cell("1"), cell("2"), cell("3")]],
+        }));
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::TableRaggedRow {
+                row: 0,
+                width: 3,
+                cols: 2
+            })
+        );
+
+        // aligns length differs from the column count.
+        let rt = table_rt(serde_json::json!({
+            "aligns": ["none"],
+            "header": [cell("a"), cell("b")],
+            "rows": [],
+        }));
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::TableAlignsMismatch { aligns: 1, cols: 2 })
+        );
+
+        // A `\n` in a cell (flat header-then-rows index 1 = the second header cell).
+        let rt = table_rt(serde_json::json!({
+            "aligns": ["none", "none"],
+            "header": [cell("a"), cell("b\nc")],
+            "rows": [],
+        }));
+        assert_eq!(rt.validate(), Err(Invariant::TableCellNewline { cell: 1 }));
+    }
+
+    /// `normalize` repairs every table-shape violation — pads the header and
+    /// short rows to the widest column count, syncs `aligns`, and rewrites a
+    /// cell `\n` to a space — so the result validates and is idempotent. This is
+    /// also the one-column-count unification: the widest row (3) drives the
+    /// header width, so the markdown (header-derived) and Typst (widest-row)
+    /// projections agree.
+    #[test]
+    fn normalize_repairs_table_shape() {
+        let mut rt = table_rt(serde_json::json!({
+            "aligns": ["none"],
+            "header": [cell("h")],
+            "rows": [
+                [cell("a"), cell("b"), cell("c")],
+                [cell("d\ne")],
+            ],
+        }));
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+
+        let props = &rt.islands[0].props;
+        assert_eq!(props["header"].as_array().unwrap().len(), 3);
+        assert_eq!(props["aligns"].as_array().unwrap().len(), 3);
+        for row in props["rows"].as_array().unwrap() {
+            assert_eq!(row.as_array().unwrap().len(), 3);
+        }
+        // Padded aligns default to "none"; the padded cells are empty.
+        assert_eq!(props["aligns"][2], serde_json::json!("none"));
+        assert_eq!(props["header"][1]["text"], serde_json::json!(""));
+        // The `\n` in "d\ne" became a space, preserving char count.
+        assert_eq!(props["rows"][1][0]["text"], serde_json::json!("d e"));
+
+        // Idempotent on canonical bytes.
+        let once = rt.to_canonical_json();
+        rt.normalize();
+        assert_eq!(rt.to_canonical_json(), once);
+    }
+
+    /// An empty table (no header, no rows) is trivially well-formed: every width
+    /// is zero, so no shape invariant fires and `normalize` leaves it alone.
+    #[test]
+    fn empty_table_is_valid() {
+        let mut rt = table_rt(serde_json::json!({
+            "aligns": [],
+            "header": [],
+            "rows": [],
+        }));
+        assert_eq!(rt.validate(), Ok(()));
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
     }
 }

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -12,8 +12,8 @@
 //! canonical form — one serializer, not two to keep aligned.
 
 use crate::model::{
-    sort_keys_owned, sorted_value, Container, Island, Line, LineKind, Loss, Mark, MarkKind,
-    RichText,
+    sort_keys_owned, sorted_value, Container, Invariant, Island, Line, LineKind, Loss, Mark,
+    MarkKind, RichText,
 };
 use serde_json::{Map, Value};
 
@@ -392,18 +392,18 @@ fn island_is_mark_carrying(island_type: &str) -> bool {
     matches!(island_type, "table")
 }
 
-/// Canonicalize a mark-carrying island's cell marks in place (a no-op for a
+/// Repair a mark-carrying island's structure in place (a no-op for a
 /// non-mark-carrying type) — the normalize-side island-type dispatch, kept
 /// beside the table codec rather than as a bare `"table"` match in `model`.
-pub(crate) fn normalize_island_cell_marks(island: &mut Island) {
+pub(crate) fn normalize_island_structure(island: &mut Island) {
     if island_is_mark_carrying(&island.island_type) {
-        normalize_table_cell_marks(&mut island.props);
+        normalize_table_props(&mut island.props);
     }
 }
 
 /// A mark-carrying island's `(text, marks)` cells for validation (empty for a
 /// non-mark-carrying type) — the validate-side twin of
-/// [`normalize_island_cell_marks`].
+/// [`normalize_island_structure`].
 pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
     if island_is_mark_carrying(&island.island_type) {
         table_cells(&island.props)
@@ -412,25 +412,131 @@ pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
     }
 }
 
-/// Canonicalize a table island's cell marks in place: re-run mark normalization
-/// (sort, same-kind union, drop zero-width) on each cell so equal cells
-/// serialize to equal bytes. Cells hold no `\n`, so there is no line-boundary
-/// edge-trim. Reached via [`normalize_island_cell_marks`].
-fn normalize_table_cell_marks(props: &mut Value) {
-    fn canon(cell: &mut Value) {
-        let (text, marks) = parse_cell(cell);
-        *cell = cell_to_value(&text, &crate::model::normalize_marks(marks));
+/// A mark-carrying island's shape violation, if any (`None` for a well-formed
+/// or non-mark-carrying island) — the validate-side twin of the shape repair in
+/// [`normalize_island_structure`]. `normalize` guarantees this returns `None`.
+pub(crate) fn island_shape_error(island: &Island) -> Option<Invariant> {
+    if island_is_mark_carrying(&island.island_type) {
+        table_shape_error(&island.props)
+    } else {
+        None
     }
-    if let Some(h) = props.get_mut("header").and_then(Value::as_array_mut) {
-        h.iter_mut().for_each(canon);
+}
+
+/// Repair a table island's props in place to the canonical shape:
+///
+/// - **One column count.** `cols` is the widest of the header, any body row, and
+///   `aligns`; the header, each row, and `aligns` are padded up to it (padding
+///   only grows — no cell is ever truncated). Materializing the count into the
+///   header means the markdown projection (header-derived) and the Typst
+///   projection (widest-row) agree on one number.
+/// - **Single-line cells.** Any `\n`/`\r` in a cell's text becomes a space (the
+///   same rule import applies to soft/hard breaks). A 1:1 replacement keeps char
+///   offsets stable, so the cell's marks stay in range.
+/// - **Canonical cell marks.** Each cell's marks are re-normalized (sort,
+///   same-kind union, drop zero-width) so equal cells serialize to equal bytes.
+fn normalize_table_props(props: &mut Value) {
+    let cols = table_cols(props);
+    let Some(obj) = props.as_object_mut() else {
+        return;
+    };
+    let header = obj.entry("header").or_insert_with(|| Value::Array(vec![]));
+    pad_row(header, cols);
+    if let Some(h) = header.as_array_mut() {
+        h.iter_mut().for_each(canon_cell);
     }
-    if let Some(rows) = props.get_mut("rows").and_then(Value::as_array_mut) {
+    let aligns = obj.entry("aligns").or_insert_with(|| Value::Array(vec![]));
+    if let Some(a) = aligns.as_array_mut() {
+        while a.len() < cols {
+            a.push(Value::String("none".into()));
+        }
+    }
+    if let Some(rows) = obj.get_mut("rows").and_then(Value::as_array_mut) {
         for row in rows.iter_mut() {
+            pad_row(row, cols);
             if let Some(r) = row.as_array_mut() {
-                r.iter_mut().for_each(canon);
+                r.iter_mut().for_each(canon_cell);
             }
         }
     }
+}
+
+/// A table's canonical column count: the widest of its header, any body row, and
+/// its `aligns` array. Padding (never truncation) brings every part up to it.
+fn table_cols(props: &Value) -> usize {
+    let arr_len = |k: &str| props.get(k).and_then(Value::as_array).map(|a| a.len());
+    let header = arr_len("header").unwrap_or(0);
+    let aligns = arr_len("aligns").unwrap_or(0);
+    let widest_row = props
+        .get("rows")
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .map(|r| r.as_array().map(|a| a.len()).unwrap_or(0))
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    header.max(aligns).max(widest_row)
+}
+
+/// Pad a cell array (header or body row) up to `cols` with empty cells. Never
+/// shrinks — `cols` is the widest, so a shorter array only grows.
+fn pad_row(v: &mut Value, cols: usize) {
+    if let Some(arr) = v.as_array_mut() {
+        while arr.len() < cols {
+            arr.push(cell_to_value("", &[]));
+        }
+    }
+}
+
+/// De-newline a cell's text (each `\n`/`\r` → a space, 1:1 so mark offsets hold)
+/// and re-normalize its marks. Reached per-cell from [`normalize_table_props`].
+fn canon_cell(cell: &mut Value) {
+    let (text, marks) = parse_cell(cell);
+    let text = if text.contains(['\n', '\r']) {
+        text.replace(['\n', '\r'], " ")
+    } else {
+        text
+    };
+    *cell = cell_to_value(&text, &crate::model::normalize_marks(marks));
+}
+
+/// A table island's shape violation, if any — the widths the header, `aligns`,
+/// and each body row must share (the header width), plus the `\n`-free-cell rule.
+/// The validate-side twin of [`normalize_table_props`].
+fn table_shape_error(props: &Value) -> Option<Invariant> {
+    let cols = props
+        .get("header")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let aligns = props
+        .get("aligns")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    if aligns != cols {
+        return Some(Invariant::TableAlignsMismatch { aligns, cols });
+    }
+    if let Some(rows) = props.get("rows").and_then(Value::as_array) {
+        for (i, row) in rows.iter().enumerate() {
+            let width = row.as_array().map(|a| a.len()).unwrap_or(0);
+            if width != cols {
+                return Some(Invariant::TableRaggedRow {
+                    row: i,
+                    width,
+                    cols,
+                });
+            }
+        }
+    }
+    for (i, (text, _)) in table_cells(props).iter().enumerate() {
+        if text.contains('\n') || text.contains('\r') {
+            return Some(Invariant::TableCellNewline { cell: i });
+        }
+    }
+    None
 }
 
 // ---- Island ----

--- a/crates/richtext/tests/properties.rs
+++ b/crates/richtext/tests/properties.rs
@@ -16,7 +16,8 @@ use quillmark_richtext::delta::diff_import;
 use quillmark_richtext::export::to_markdown;
 use quillmark_richtext::import::from_markdown;
 use quillmark_richtext::model::{Line, Mark, MarkKind};
-use quillmark_richtext::{Delta, LineKind, LineOp, MarkOp, Op, RichText};
+use quillmark_richtext::{Delta, Island, LineKind, LineOp, Loss, MarkOp, Op, RichText};
+use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
 // A constrained markdown generator: combinations of the phase-1 constructs,
@@ -373,6 +374,120 @@ proptest! {
 fn fixture_body(name: &str) -> String {
     let path = quillmark_fixtures::resource_path(name);
     std::fs::read_to_string(path).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Structured-table property (issue #880): an editor-built table island — one
+// whose shape markdown import never produces (ragged rows, an empty/short
+// header, an `aligns` array out of sync with the columns) — is a fixed point of
+// export∘import *after normalization*, and normalization always yields a corpus
+// that `validate()` accepts. Cell content is drawn from import-produced cells
+// (so representability and canonical marks are guaranteed by construction);
+// the generator's entropy is the table *shape* plus in-cell literal specials
+// (`|`, backtick, backslash) and unicode, which the codec must escape.
+// ---------------------------------------------------------------------------
+
+/// A cell's markdown content: clean words, formatted spans, and words carrying
+/// literal specials that must escape to survive a pipe cell and round-trip.
+fn cell_token() -> impl Strategy<Value = String> {
+    prop_oneof![
+        clean_word(),
+        clean_word().prop_map(|w| format!("{w}\\|{w}")), // literal pipe
+        clean_word().prop_map(|w| format!("{w}\\`{w}")), // literal backtick
+        clean_word().prop_map(|w| format!("{w}\\\\{w}")), // literal backslash
+        clean_word().prop_map(|w| format!("{w}你{w}")),  // BMP unicode
+        clean_word().prop_map(|w| format!("{w}😀")),     // astral unicode
+        clean_word().prop_map(|w| format!("**{w}**")),
+        clean_word().prop_map(|w| format!("*{w}*")),
+        clean_word().prop_map(|w| format!("~~{w}~~")),
+        clean_word().prop_map(|w| format!("`{w}`")),
+        (clean_word(), clean_word()).prop_map(|(t, u)| format!("[{t}](https://ex.com/{u})")),
+    ]
+}
+
+fn cell_content() -> impl Strategy<Value = String> {
+    prop::collection::vec(cell_token(), 1..3).prop_map(|toks| toks.join(" "))
+}
+
+fn alignment() -> impl Strategy<Value = &'static str> {
+    prop_oneof![Just("none"), Just("left"), Just("center"), Just("right")]
+}
+
+/// The canonical `{text, marks}` cells for a row of markdown contents, obtained
+/// by importing a header-only table — so each cell is representable and its
+/// marks are canonical by construction. `contents` must be non-empty.
+fn import_row(contents: &[String]) -> Vec<Value> {
+    let cols = contents.len();
+    let header = contents.join(" | ");
+    let delim = vec!["---"; cols].join(" | ");
+    let body = vec!["x"; cols].join(" | ");
+    let md = format!("| {header} |\n| {delim} |\n| {body} |");
+    let rt = from_markdown(&md).unwrap();
+    rt.islands[0].props["header"].as_array().unwrap().clone()
+}
+
+/// A single-table corpus with the given (possibly ill-shaped) props. `id` is the
+/// first-island id import mints (`isl-0`), so a re-imported table compares equal.
+fn table_corpus(aligns: Vec<&str>, header: Vec<Value>, rows: Vec<Vec<Value>>) -> RichText {
+    RichText {
+        text: "\u{FFFC}".into(),
+        lines: vec![Line {
+            kind: LineKind::Island,
+            containers: vec![],
+            continues: false,
+        }],
+        marks: vec![],
+        islands: vec![Island {
+            id: "isl-0".into(),
+            island_type: "table".into(),
+            props: json!({ "aligns": aligns, "header": header, "rows": rows }),
+            loss: Loss::Lossless,
+        }],
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// A structurally ill-shaped table island normalizes to a valid corpus and
+    /// is a fixed point of export∘import.
+    #[test]
+    fn table_island_normalizes_and_round_trips(
+        header in prop::collection::vec(cell_content(), 0..4),
+        rows in prop::collection::vec(prop::collection::vec(cell_content(), 0..4), 0..4),
+        aligns in prop::collection::vec(alignment(), 0..5),
+    ) {
+        let header_cells = if header.is_empty() { vec![] } else { import_row(&header) };
+        let row_cells: Vec<Vec<Value>> = rows
+            .iter()
+            .map(|r| if r.is_empty() { vec![] } else { import_row(r) })
+            .collect();
+
+        // The widest column count drives normalization. A fully empty table (all
+        // widths zero) has no markdown projection — export drops it, so it cannot
+        // round-trip; skip it (a contentless table is out of the fixed-point
+        // contract, like the documented hard-break limits).
+        let cols = header_cells.len()
+            .max(aligns.len())
+            .max(row_cells.iter().map(Vec::len).max().unwrap_or(0));
+        prop_assume!(cols >= 1);
+
+        let mut rt = table_corpus(aligns.clone(), header_cells, row_cells);
+        rt.normalize();
+        prop_assert_eq!(rt.validate(), Ok(()), "normalized table invalid");
+
+        // Post-normalize shape: one column count across header, aligns, rows.
+        let props = &rt.islands[0].props;
+        prop_assert_eq!(props["header"].as_array().unwrap().len(), cols);
+        prop_assert_eq!(props["aligns"].as_array().unwrap().len(), cols);
+        for row in props["rows"].as_array().unwrap() {
+            prop_assert_eq!(row.as_array().unwrap().len(), cols);
+        }
+
+        let md = to_markdown(&rt);
+        let rt2 = from_markdown(&md).unwrap();
+        prop_assert_eq!(&rt, &rt2, "table not a fixed point.\n  md: {:?}", md);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes the production-parity gaps tracked in #880. Table support was already lossless for the common path; this establishes the missing shape contract and coverage, and settles the two open policy questions.

## Changes

**Canonical table shape (gaps B + C).** `validate()` gains three invariants — `aligns` length and every body-row width must equal the header's column count, and no cell text may hold a `\n`. `normalize()` repairs to satisfy them: the column count is the widest of header/rows/aligns, materialized by padding the header, each row, and `aligns` up to it (padding only grows — no cell is truncated); each cell `\n`/`\r` becomes a space (1:1, so mark offsets stay valid). Materializing the count into the header makes the markdown projection (header-derived) and the Typst projection (widest-row) agree, so the per-backend column-count divergence dissolves. Markdown export also pads/truncates rows defensively for un-normalized islands. The island-type dispatch stays centralized in `serial`, so adding a mark-carrying island type remains a single edit.

**In-cell images degrade honestly (gap A).** An inline image in a cell used to be swallowed by `table_event`'s catch-all: alt absorbed as plain text, url dropped, island still minted `Loss::Lossless` — a lie. It is now intercepted like the top-level image path: alt flows in as the degraded text projection, the url is dropped, and the island is minted `Loss::Degraded`. A plain table with no cell image stays `Lossless`.

**Property coverage (gap D).** A proptest generator for ill-shaped table islands — ragged rows, empty/short header, `aligns` out of sync — with cell content drawn from import-produced cells (representability + canonical marks guaranteed by construction) carrying literal pipes, backticks, backslashes, and BMP/astral unicode. Asserts `normalize()` yields a corpus `validate()` accepts with one column count across header/aligns/rows, and that the normalized island is a fixed point of export∘import. Holds at 4000 cases.

**End-to-end fixture (gap E).** A `table_demo` Typst Quill plus a test pushing a pipe table (aligned columns, a formatted header cell, a ragged row) through markdown → RichText → Typst → artifact, to both SVG and PDF. A successful compile is the load-bearing signal; the size comparison against an empty body is the non-fragile proxy that the grid drew (SVG vectorizes text into glyph paths). The fixture also joins the quiver contract tests.

**pdfform projection (gap F).** Documented as a decided limitation, not an oversight: a form field bound to a table-bearing corpus renders surrounding text and omits the table silently. A degraded row/tab dump was rejected (it would read as a faithful table and mislead); no diagnostic surfaced. Recorded at the projection definition (`to_plaintext`) and the binding site (`resolve`).

## Notes / deliberate choices

- The `validate`↔`normalize` relationship is decisive (reject vs. repair) and pinned by the property test — this is what keeps the two projections from silently diverging again.
- A genuinely empty table (all widths 0) has no markdown projection and is left as-is; the property test skips it.
- In-cell images degrade to **alt-as-text**, not a link mark — the link representation silently changes cell semantics (image→link), so it's left as a possible follow-up.
- The **self-minted island ids** note in #880 (`model.rs:155-157`) is left untouched as its own concern.

## Testing

`cargo test --workspace` green. Table property stressed to 4000 cases.

## Non-goals

Colspan/rowspan and block content in cells remain out of scope per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172tM1cpLGW9FVkWhz4LaSL

---
_Generated by [Claude Code](https://claude.ai/code/session_0172tM1cpLGW9FVkWhz4LaSL)_