### PR TITLE
richtext: unify field and body write surfaces — corpus writer for richtext fields (#881)

### DIFF
--- a/crates/backends/pdfform/tests/richtext_form.rs
+++ b/crates/backends/pdfform/tests/richtext_form.rs
@@ -85,3 +85,63 @@ fn richtext_fields_lower_to_plaintext_field_values() {
         "A bold claim and emphasis."
     );
 }
+
+/// Same render, but the richtext fields are written via `set_field_richtext`, so
+/// each is **stored as a canonical corpus object** rather than an authored
+/// markdown string. This exercises coercion's object branch (re-validate +
+/// re-canonicalize) end-to-end and proves it lowers identically to the
+/// string-authored path — the corpus-from-write form renders the same PDF.
+#[test]
+fn richtext_fields_written_as_corpus_render_identically() {
+    let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("richtext_form"))
+        .expect("load richtext_form quill");
+    let engine = Quillmark::new();
+
+    // Start from the string-authored doc, then re-write each field through the
+    // corpus writer: passing markdown still stores the *canonical corpus object*
+    // (decode → canonicalize), so the payload now carries corpus objects.
+    let mut doc = Document::from_markdown(FILLED).expect("parse markdown");
+    let main = doc.main_mut();
+    main.set_field_richtext("headline", &serde_json::json!("The **headline**"), true)
+        .expect("inline richtext write");
+    main.set_field_richtext(
+        "bio",
+        &serde_json::json!("A **bold** claim and _emphasis_."),
+        false,
+    )
+    .expect("block richtext write");
+    // Precondition: the fields are stored structurally as corpus objects now.
+    assert!(main.payload().get("headline").unwrap().as_json().is_object());
+    assert!(main.payload().get("bio").unwrap().as_json().is_object());
+
+    let result = engine
+        .render(
+            &quill,
+            &doc,
+            &RenderOptions {
+                output_format: Some(OutputFormat::Pdf),
+                ..Default::default()
+            },
+        )
+        .expect("render ok");
+
+    let pdf = &result.artifacts[0].bytes;
+    let doc = PdfDoc::load_mem(pdf).expect("lopdf reparse — structurally valid");
+    let cat = doc.catalog().expect("catalog");
+    let af = doc
+        .get_object(cat.get(b"AcroForm").unwrap().as_reference().unwrap())
+        .unwrap()
+        .as_dict()
+        .unwrap();
+
+    let headline = widget(&doc, af, "FullName");
+    assert_eq!(
+        decode_pdf_text(headline.get(b"V").unwrap().as_str().unwrap()),
+        "The headline"
+    );
+    let bio = widget(&doc, af, "Comments");
+    assert_eq!(
+        decode_pdf_text(bio.get(b"V").unwrap().as_str().unwrap()),
+        "A bold claim and emphasis."
+    );
+}

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -615,6 +615,61 @@ describe('Document editor surface — setQuillRef / replaceBody', () => {
   })
 })
 
+describe('Document editor surface — setRichtextField / fieldMarkdown', () => {
+  it('setRichtextField accepts a markdown string and stores a corpus object', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setRichtextField('intro', 'A **bold** intro.')
+    // Stored structurally as the corpus, not the authored string.
+    expect(typeof field(doc.main, 'intro')).toBe('object')
+    expect(field(doc.main, 'intro').text).toBe('A bold intro.')
+    // fieldMarkdown is the projection twin of bodyMarkdown.
+    expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
+  })
+
+  it('setRichtextField accepts a corpus object round-tripped from a body', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    const src = Document.fromMarkdown('~~~card-yaml\n$quill: q@1.0.0\n~~~\n\nCorpus **field** here.')
+    const corpus = src.main.body
+    expect(typeof corpus).toBe('object')
+    doc.setRichtextField('intro', corpus)
+    expect(field(doc.main, 'intro').text).toBe('Corpus field here.')
+    expect(doc.fieldMarkdown('intro')).toBe('Corpus **field** here.\n')
+  })
+
+  it('setRichtextField(name, null) stores the empty corpus', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setRichtextField('intro', null)
+    expect(doc.fieldMarkdown('intro')).toBe('')
+  })
+
+  it('setRichtextField(inline=true) throws FieldRichtextNotInline on multi-block', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    doc.setRichtextField('title', 'one line', true) // ok
+    expect(() => doc.setRichtextField('title', 'line one\n\nline two', true))
+      .toThrow(/FieldRichtextNotInline/)
+  })
+
+  it('setRichtextField throws FieldRichtextDecode on a non-corpus object', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(() => doc.setRichtextField('intro', { not: 'a corpus' })).toThrow(/FieldRichtextDecode/)
+  })
+
+  it('fieldMarkdown returns undefined for an absent or non-richtext field', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    expect(doc.fieldMarkdown('nonexistent')).toBeUndefined()
+    doc.setField('count', 3)
+    expect(doc.fieldMarkdown('count')).toBeUndefined()
+  })
+
+  it('updateCardRichtextField / cardFieldMarkdown target a card by index', () => {
+    const doc = Document.fromMarkdown(
+      '~~~card-yaml\n$quill: q@1.0.0\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
+    )
+    doc.updateCardRichtextField(0, 'note', 'Card **note**.')
+    expect(doc.cardFieldMarkdown(0, 'note')).toBe('Card **note**.\n')
+  })
+})
+
 describe('Document editor surface — card mutations', () => {
   const MD_WITH_CARDS = `~~~card-yaml
 $quill: test_quill

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -415,6 +415,16 @@ A single line of body ink.`
       expect(typeof session.mapFieldPos).toBe('function')
       expect(session.mapFieldPos('$body', 0, 0, 'after')).toBe(4)
 
+      // applyFieldDelta un-gate (#881): a non-`$body` address now dispatches to
+      // the richtext-field path instead of the old hard "only $body in this
+      // phase" rejection. `title` is a plain string field, so the field path
+      // rejects it with FieldRichtextDecode (not the removed gate error), and
+      // the session is untouched — the revision does not advance on failure.
+      expect(() =>
+        session.applyFieldDelta(doc, 'title', session.revision, { ops: [{ insert: 'X' }] }),
+      ).toThrow(/FieldRichtextDecode/)
+      expect(session.revision).toBe(1)
+
       // apply — recompile in place.
       expect(typeof session.apply).toBe('function')
       const cs = session.apply(Document.fromMarkdown(SMOKE_MARKDOWN))

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -995,6 +995,51 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
+    /// Set a **richtext** field on the main card from a corpus object (canonical
+    /// RichText-JSON) or a markdown string — the field-level twin of
+    /// [`setBody`](Document::set_body), and the corpus-native counterpart to
+    /// [`setField`](Document::set_field) (which stores an opaque value). The
+    /// field is stored as the canonical corpus, so identity marks (anchors,
+    /// island ids) live on it and survive compiles and the storage DTO; a
+    /// corpus-only mark such as `underline` round-trips losslessly, unlike the
+    /// card-yaml markdown projection. `null` stores the empty corpus.
+    ///
+    /// `inline` (default `false`) mirrors the schema's `richtext(inline)`
+    /// constraint: when `true`, a multi-block value throws
+    /// `[EditError::FieldRichtextNotInline]` here at write rather than at a later
+    /// render. The caller supplies it because a `Document` carries only a
+    /// `$quill` reference, not the resolved field type — an editor holds the
+    /// schema and knows whether the target is `richtext(inline)`.
+    ///
+    /// Throws `[EditError::FieldRichtextDecode]` if `value` is neither a valid
+    /// corpus object, an importable markdown string, nor `null`, and
+    /// `[EditError::InvalidFieldName]` on a malformed name.
+    #[wasm_bindgen(js_name = setRichtextField)]
+    pub fn set_richtext_field(
+        &mut self,
+        name: &str,
+        #[wasm_bindgen(unchecked_param_type = "RichText | string")] value: JsValue,
+        #[wasm_bindgen(unchecked_optional_param_type = "boolean")] inline: Option<bool>,
+    ) -> Result<(), JsValue> {
+        let json = js_value_to_json(value, "setRichtextField")?;
+        self.inner
+            .main_mut()
+            .set_field_richtext(name, &json, inline.unwrap_or(false))
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// The markdown projection of a richtext field on the main card
+    /// (`export ∘ decode`) — the field-level twin of `main.bodyMarkdown`.
+    /// Returns `undefined` when the field is absent or does not decode as
+    /// richtext (e.g. a plain scalar written via [`setField`](Document::set_field)).
+    #[wasm_bindgen(js_name = fieldMarkdown, unchecked_return_type = "string | undefined")]
+    pub fn field_markdown(&self, name: &str) -> JsValue {
+        match self.inner.main().field_markdown(name) {
+            Some(md) => JsValue::from_str(&md),
+            None => JsValue::UNDEFINED,
+        }
+    }
+
     /// Build a fresh `Card` from a kind and a flat field map — the ergonomic
     /// constructor for `pushCard` / `insertCard`. `fields` is an optional
     /// `Record<string, unknown>` (each entry becomes a card field, in
@@ -1119,6 +1164,42 @@ impl Document {
         self.card_mut_or_throw(index)?
             .set_field(name, qv)
             .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// Set a **richtext** field on the card at `index` — the card-indexed twin of
+    /// [`setRichtextField`](Document::set_richtext_field). Stores the canonical
+    /// corpus; `inline` (default `false`) enforces `richtext(inline)` at write.
+    /// Throws if `index` is out of range, on a malformed name, or on a value that
+    /// is neither a corpus object, an importable markdown string, nor `null`.
+    #[wasm_bindgen(js_name = updateCardRichtextField)]
+    pub fn update_card_richtext_field(
+        &mut self,
+        index: usize,
+        name: &str,
+        #[wasm_bindgen(unchecked_param_type = "RichText | string")] value: JsValue,
+        #[wasm_bindgen(unchecked_optional_param_type = "boolean")] inline: Option<bool>,
+    ) -> Result<(), JsValue> {
+        let json = js_value_to_json(value, "updateCardRichtextField")?;
+        self.card_mut_or_throw(index)?
+            .set_field_richtext(name, &json, inline.unwrap_or(false))
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// The markdown projection of a richtext field on the card at `index` — the
+    /// card-indexed twin of [`fieldMarkdown`](Document::field_markdown). Returns
+    /// `undefined` when `index` is out of range, the field is absent, or it does
+    /// not decode as richtext.
+    #[wasm_bindgen(js_name = cardFieldMarkdown, unchecked_return_type = "string | undefined")]
+    pub fn card_field_markdown(&self, index: usize, name: &str) -> JsValue {
+        match self
+            .inner
+            .cards()
+            .get(index)
+            .and_then(|c| c.field_markdown(name))
+        {
+            Some(md) => JsValue::from_str(&md),
+            None => JsValue::UNDEFINED,
+        }
     }
 
     /// Batched twin of [`updateCardField`](Document::update_card_field): set

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1633,14 +1633,24 @@ impl LiveSession {
     /// and changes nothing, so a stale delta is never spliced onto the wrong
     /// base — re-read and recompute instead.
     ///
-    /// This phase targets the **main body** corpus only (`field === "$body"`);
-    /// any other address throws (use `apply(doc)` for those). Transactional on
-    /// the compile *and* on `doc`: a failed splice or recompile leaves both the
-    /// preview and `doc` byte-identical to before the call (the splice is
-    /// rolled back), so a caller's natural retry with the same arguments is
-    /// safe rather than double-applying the delta. `revision` does not advance
-    /// on failure either. On success `doc`'s body carries the edit, the
-    /// preview reflects it, and `revision` is `baseRevision + 1`.
+    /// The address is either the **main body** (`field === "$body"`) or a
+    /// **richtext field** on the main card by name (its stored value must be a
+    /// corpus — i.e. written via [`setRichtextField`](Document::set_richtext_field));
+    /// any other address throws (use `apply(doc)` for those). Field deltas
+    /// record and map under the field path, so a position captured on a field
+    /// stays anchored across edits ([`mapFieldPos`](Session::map_field_pos)).
+    /// Transactional on the compile *and* on `doc`: a failed splice or recompile
+    /// leaves both the preview and `doc` byte-identical to before the call (the
+    /// splice is rolled back), so a caller's natural retry with the same
+    /// arguments is safe rather than double-applying the delta. `revision` does
+    /// not advance on failure either. On success the addressed corpus carries
+    /// the edit, the preview reflects it, and `revision` is `baseRevision + 1`.
+    ///
+    /// Only the text `Delta` rides this path; mark/line op channels
+    /// (`apply_mark_ops` / `apply_line_ops`) are not yet exposed over the seam,
+    /// so a formatting toggle or block split still falls back to whole-document
+    /// `setBody` + `apply(doc)`. Exposing those channels is the follow-up that
+    /// makes formatting and block edits ride the non-invalidating path too.
     #[wasm_bindgen(js_name = applyFieldDelta)]
     pub fn apply_field_delta(
         &mut self,
@@ -1649,13 +1659,6 @@ impl LiveSession {
         base_revision: u32,
         delta: Delta,
     ) -> Result<ChangeSet, JsValue> {
-        if field != "$body" {
-            return Err(WasmError::from(format!(
-                "applyFieldDelta: '{field}' is not a delta-path target; only the main body \
-                 '$body' is supported in this phase — use apply(doc) for whole-document edits"
-            ))
-            .to_js_value());
-        }
         let core_delta: quillmark_core::Delta = delta.into();
 
         // Guard the base revision before touching anything: a stale delta is
@@ -1669,28 +1672,37 @@ impl LiveSession {
                 .to_js_value()
             })?;
 
-        // Snapshot the pre-edit body: `apply_body_change` is itself atomic, but
-        // the compile and record steps that follow it can fail *after* the body
-        // has changed, so restoring the snapshot on any failure leaves `doc`
-        // exactly as it was — a caller's retry then never double-applies the
-        // delta onto an already-mutated document. This snapshot is the
-        // compile/record transaction boundary, not a guard against a
-        // half-applied body.
-        let pre_edit_body = doc.inner.main().body().clone();
+        // Snapshot the pre-edit corpus for the addressed target: the splice is
+        // itself atomic, but the compile and record steps that follow can fail
+        // *after* the corpus has changed, so restoring the snapshot on any
+        // failure leaves `doc` exactly as it was — a caller's retry then never
+        // double-applies the delta onto an already-mutated document. `$body`
+        // snapshots the body corpus; a field snapshots its stored value.
+        let is_body = field == "$body";
+        let pre_edit_body = is_body.then(|| doc.inner.main().body().clone());
+        let pre_edit_field =
+            (!is_body).then(|| doc.inner.main().payload().get(field).cloned());
 
-        // Splice the main body corpus (text delta only), then recompile from the
+        // Splice the addressed corpus (text delta only), then recompile from the
         // mutated document and record the delta atomically — transactional on the
         // compile and, via the snapshot above, on `doc` itself. The seam
         // recompiles *without* invalidating the change log (unlike whole-document
         // `apply`) and records the delta against the guarded base in one step:
         // the revision advances to `base_revision + 1` in lockstep with the
         // preview, or nothing changes and `doc` rolls back. On any failure the
-        // single site below restores the body and returns the step's error.
+        // single site below restores the corpus and returns the step's error.
         let spliced = (|| -> Result<quillmark_core::ChangeSet, JsValue> {
-            doc.inner
-                .main_mut()
-                .apply_body_change(&core_delta, &[], &[])
-                .map_err(|e| edit_error_to_js(&e))?;
+            if is_body {
+                doc.inner
+                    .main_mut()
+                    .apply_body_change(&core_delta, &[], &[])
+                    .map_err(|e| edit_error_to_js(&e))?;
+            } else {
+                doc.inner
+                    .main_mut()
+                    .apply_field_richtext_change(field, &core_delta, &[], &[])
+                    .map_err(|e| edit_error_to_js(&e))?;
+            }
             let json_data = self.compile_checked(&doc.inner)?;
             self.inner
                 .apply_for_field_delta(
@@ -1704,7 +1716,20 @@ impl LiveSession {
         let cs = match spliced {
             Ok(cs) => cs,
             Err(e) => {
-                doc.inner.main_mut().set_body_corpus(pre_edit_body);
+                if let Some(body) = pre_edit_body {
+                    doc.inner.main_mut().set_body_corpus(body);
+                } else if let Some(field_value) = pre_edit_field {
+                    // Restore the field's prior value (or remove it if it was
+                    // absent), undoing any splice that landed before the failure.
+                    match field_value {
+                        Some(v) => {
+                            doc.inner.main_mut().payload_mut().insert(field, v);
+                        }
+                        None => {
+                            let _ = doc.inner.main_mut().remove_field(field);
+                        }
+                    }
+                }
                 return Err(e);
             }
         };

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1045,6 +1045,35 @@ This body and the metadata above are an indorsement card.
     }
 
     #[test]
+    fn corpus_field_survives_storage_round_trip_losslessly() {
+        // A richtext field stored as a canonical corpus object is the case the
+        // card-yaml markdown projection is lossy for; the storage DTO is the
+        // lossless carrier, so identity marks (an `underline` with no markdown
+        // form) survive a serde-JSON round-trip that a `.qmd` save would drop.
+        use quillmark_richtext::model::{Mark, MarkKind};
+
+        let mut doc = sample();
+        let mut corpus = quillmark_richtext::import::from_markdown("underlined intro").unwrap();
+        corpus.marks.push(Mark {
+            start: 0,
+            end: 10,
+            kind: MarkKind::Underline,
+        });
+        corpus.normalize();
+        let json = quillmark_richtext::serial::to_canonical_value(&corpus);
+        doc.main_mut().set_field_richtext("intro", &json, false).unwrap();
+
+        let stored = serde_json::to_string(&doc).unwrap();
+        let restored: Document = serde_json::from_str(&stored).unwrap();
+        assert_eq!(doc, restored, "corpus field must survive storage round-trip");
+        let read = restored.main().field_richtext("intro").unwrap().unwrap();
+        assert!(
+            read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)),
+            "underline (corpus-only) must survive the DTO carrier"
+        );
+    }
+
+    #[test]
     fn nested_fill_survives_storage_round_trip() {
         // A `!must_fill` marker on a nested object leaf rides the `nested_fills`
         // path list (the JSON `value` projection is fill-free).

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -81,6 +81,22 @@ pub enum EditError {
     #[error("body decode failed: {0}")]
     BodyDecode(String),
 
+    /// A richtext field value in the corpus-or-markdown encoding could not be
+    /// decoded: a JSON object that is not a canonical richtext corpus, a
+    /// markdown string that failed to import, or a shape that is neither
+    /// object, string, nor null. The field-level twin of [`BodyDecode`](Self::BodyDecode);
+    /// returned by [`Card::set_field_richtext`](Card::set_field_richtext).
+    #[error("richtext field '{field}' decode failed: {message}")]
+    FieldRichtextDecode { field: String, message: String },
+
+    /// A richtext field written under the `richtext(inline)` constraint decoded
+    /// to a multi-block corpus (more than one line, a container, or an island).
+    /// The write-time counterpart of the coercion/validation `richtext(inline)`
+    /// check; returned by [`Card::set_field_richtext`](Card::set_field_richtext)
+    /// when its `inline` argument is set.
+    #[error("richtext field '{0}' is not inline: richtext(inline) requires a single paragraph line with no list/quote container and no islands")]
+    FieldRichtextNotInline(String),
+
     /// A corpus field-change bundle (text delta, line ops, mark ops) applied
     /// out of bounds or broke an invariant normalization could not repair.
     #[error("corpus apply failed: {0:?}")]
@@ -101,6 +117,8 @@ impl EditError {
             EditError::ValueTooDeep { .. } => "ValueTooDeep",
             EditError::BodyImport(_) => "BodyImport",
             EditError::BodyDecode(_) => "BodyDecode",
+            EditError::FieldRichtextDecode { .. } => "FieldRichtextDecode",
+            EditError::FieldRichtextNotInline(_) => "FieldRichtextNotInline",
             EditError::CorpusApply(_) => "CorpusApply",
         }
     }
@@ -499,6 +517,82 @@ impl Card {
                 ))),
             },
         }
+    }
+
+    /// Set a payload field to a **richtext corpus**, committing the corpus form
+    /// at write — the field-level twin of [`set_body_value`](Self::set_body_value),
+    /// and the writer that makes a schema-richtext field corpus-from-write-onward
+    /// (`$body` is corpus by construction; a field is corpus *iff* the caller
+    /// picks this method over the string-storing [`set_field`](Self::set_field)).
+    ///
+    /// Accepts either encoding the seam carries — a canonical corpus **object**
+    /// (decoded and validated) or an authored markdown **string** (imported) —
+    /// and stores the canonical corpus JSON, so identity marks (anchors, island
+    /// ids) live on the stored value and persist across compiles and DTO
+    /// round-trips. `null` stores the empty corpus. Routes through the one
+    /// object-vs-string dispatch ([`decode_richtext_value`](crate::document::decode_richtext_value)),
+    /// so it stays lossless for corpus-only marks a markdown projection cannot
+    /// carry (e.g. `underline`); a Markdown (`.qmd`) save projects the field back
+    /// to a string ([`Card::field_markdown`]) and re-imports a fresh corpus on
+    /// reload, so on-disk persistence is markdown-lossy by design — identity
+    /// survives the live/DTO carriers, not a card-yaml round-trip.
+    ///
+    /// `inline` mirrors the schema's `richtext(inline)` constraint: when set, a
+    /// decoded multi-block corpus is rejected here with
+    /// [`EditError::FieldRichtextNotInline`], in lockstep with the coercion- and
+    /// validation-layer `richtext(inline)` checks — so the write is the strict
+    /// commit (fail at write, not at a later render). The caller supplies it
+    /// because a [`Document`] holds only a `$quill` *reference*, not the resolved
+    /// [`FieldType`](crate::quill::FieldType); an editor holds the schema and
+    /// knows whether the target field is `richtext(inline)`.
+    ///
+    /// Returns [`EditError::InvalidFieldName`] for a malformed name and
+    /// [`EditError::FieldRichtextDecode`] for a value that is neither a corpus
+    /// object, an importable markdown string, nor `null`.
+    pub fn set_field_richtext(
+        &mut self,
+        name: &str,
+        value: &serde_json::Value,
+        inline: bool,
+    ) -> Result<(), EditError> {
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
+        }
+        let corpus = match crate::document::decode_richtext_value(value) {
+            Some(result) => result.map_err(|e| EditError::FieldRichtextDecode {
+                field: name.to_string(),
+                message: e.into_message(),
+            })?,
+            // Neither object nor string: `null` is the empty corpus; anything
+            // else is an invalid richtext value.
+            None => match value {
+                serde_json::Value::Null => RichText::empty(),
+                other => {
+                    return Err(EditError::FieldRichtextDecode {
+                        field: name.to_string(),
+                        message: format!(
+                            "expected a richtext corpus object or a markdown string, got {}",
+                            match other {
+                                serde_json::Value::Bool(_) => "a boolean",
+                                serde_json::Value::Number(_) => "a number",
+                                serde_json::Value::Array(_) => "an array",
+                                _ => "an unsupported value",
+                            }
+                        ),
+                    })
+                }
+            },
+        };
+        if inline && !corpus.is_inline() {
+            return Err(EditError::FieldRichtextNotInline(name.to_string()));
+        }
+        // Store the canonical corpus object. Depth-checking is unnecessary: a
+        // corpus nests a fixed handful of levels (well under `MAX_YAML_DEPTH`),
+        // and `decode_richtext_value` already validated it.
+        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
+        self.payload_mut()
+            .insert(name.to_string(), QuillValue::from_json(canonical));
+        Ok(())
     }
 
     /// Replace the body from an authored markdown string — the whole-document

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -645,4 +645,46 @@ impl Card {
             .apply_field_change(text_delta, line_ops, mark_ops)
             .map_err(EditError::CorpusApply)
     }
+
+    /// Splice a corpus field-change bundle into a **richtext-valued field**'s
+    /// stored corpus — the field-path twin of [`apply_body_change`](Self::apply_body_change),
+    /// and what lets identity marks (anchors, island ids) persist on field
+    /// content across incremental edits. Decodes the field's canonical corpus,
+    /// applies the text delta plus any line/mark ops in the same all-or-nothing
+    /// bundle, and re-stores the canonical result.
+    ///
+    /// Returns [`EditError::FieldRichtextDecode`] when the field is absent or its
+    /// stored value is not a richtext corpus (the caller addresses a field it
+    /// knows is richtext, exactly as when writing it), and
+    /// [`EditError::CorpusApply`] when the bundle applies out of bounds.
+    pub fn apply_field_richtext_change(
+        &mut self,
+        name: &str,
+        text_delta: &Delta,
+        line_ops: &[LineOp],
+        mark_ops: &[MarkOp],
+    ) -> Result<(), EditError> {
+        let mut corpus = match self.field_richtext(name) {
+            Some(Ok(rt)) => rt,
+            Some(Err(e)) => {
+                return Err(EditError::FieldRichtextDecode {
+                    field: name.to_string(),
+                    message: e.into_message(),
+                })
+            }
+            None => {
+                return Err(EditError::FieldRichtextDecode {
+                    field: name.to_string(),
+                    message: "field is absent".to_string(),
+                })
+            }
+        };
+        corpus
+            .apply_field_change(text_delta, line_ops, mark_ops)
+            .map_err(EditError::CorpusApply)?;
+        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
+        self.payload_mut()
+            .insert(name.to_string(), QuillValue::from_json(canonical));
+        Ok(())
+    }
 }

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -221,6 +221,31 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                 fill,
                 nested_comments,
             } => {
+                // A richtext field stores its value as a canonical corpus
+                // object (via `set_field_richtext`); card-yaml is the
+                // human-authored surface, so it projects back to a markdown
+                // string here — the field-level twin of the `$body` projection,
+                // lossy per the corpus's island loss class (the DTO stays the
+                // lossless carrier). A corpus field is never `!must_fill` and
+                // its content carries no user nested-comments/fills, so the
+                // projected scalar routes through the plain string path.
+                if !*fill {
+                    if let Some(markdown) = project_corpus_field(value.as_json()) {
+                        emit_field(
+                            out,
+                            key,
+                            &JsonValue::String(markdown),
+                            0,
+                            false,
+                            &[],
+                            &[],
+                            &[],
+                            trailer,
+                        );
+                        i += if consumed_trailer { 2 } else { 1 };
+                        continue;
+                    }
+                }
                 // Paths in `nested_comments` are relative to this field's
                 // value, so the container path starts empty.
                 let path: Vec<CommentPathSegment> = Vec::new();
@@ -248,6 +273,34 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
         }
         i += if consumed_trailer { 2 } else { 1 };
     }
+}
+
+/// The markdown projection of a richtext-valued field, or `None` when `value` is
+/// not a canonical corpus object.
+///
+/// A richtext field written via [`Card::set_field_richtext`](super::Card::set_field_richtext)
+/// stores the canonical corpus object; emit projects it to a markdown string so
+/// card-yaml — the human-authored surface — stays markdown-clean rather than
+/// carrying a nested `{text, lines, marks, islands}` tree. Projection is lossy
+/// per the corpus's island loss class (the same tradeoff `$body` makes): island
+/// ids and corpus-only marks do not survive a `.qmd` round-trip, so on-disk
+/// identity is markdown-lossy by design; the storage DTO is the lossless carrier.
+///
+/// The guard requires the object to round-trip *byte-for-byte* as a canonical
+/// corpus, so a user object field that merely resembles one (extra keys,
+/// non-canonical shape) stays structural. A corpus object only ever arises from
+/// the programmatic corpus writer — `from_markdown` is schema-less and stores a
+/// richtext field authored as markdown as a plain string — so this never fires
+/// on a parse-originated document, leaving the emit round-trip property intact.
+fn project_corpus_field(value: &JsonValue) -> Option<String> {
+    if !value.is_object() {
+        return None;
+    }
+    let rt = quillmark_richtext::serial::from_canonical_value(value).ok()?;
+    if quillmark_richtext::serial::to_canonical_value(&rt) != *value {
+        return None;
+    }
+    Some(quillmark_richtext::export::to_markdown(&rt))
 }
 
 /// Ensure `out` ends with `\n\n` so the next fence has a blank line above it.

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -34,7 +34,9 @@ pub(crate) fn import_body(md: &str) -> Result<RichText, ImportError> {
 
 /// Which encoding a [`decode_richtext_value`] failure came from, so a call site
 /// can prefix its diagnostic per encoding without re-deriving the dispatch.
-pub(crate) enum RichtextDecodeError {
+/// Surfaced publicly as the error of [`Card::field_richtext`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RichtextDecodeError {
     /// A JSON object that is not a valid canonical corpus.
     NotCorpus(String),
     /// A markdown string that failed to import.
@@ -43,7 +45,7 @@ pub(crate) enum RichtextDecodeError {
 
 impl RichtextDecodeError {
     /// The inner failure message, without an encoding-specific prefix.
-    pub(crate) fn into_message(self) -> String {
+    pub fn into_message(self) -> String {
         match self {
             RichtextDecodeError::NotCorpus(m) | RichtextDecodeError::BadMarkdown(m) => m,
         }
@@ -202,6 +204,45 @@ impl Card {
 
     pub(crate) fn body_mut(&mut self) -> &mut RichText {
         &mut self.body
+    }
+
+    /// Read a richtext-valued user field back as a [`RichText`] corpus — the
+    /// field-level twin of [`Card::body`]. Decodes the stored value through the
+    /// same object-or-markdown dispatch the writer
+    /// ([`set_field_richtext`](Card::set_field_richtext)) commits, so a field
+    /// stored as a canonical corpus reads back losslessly (identity marks
+    /// intact) and a still-authored markdown string imports.
+    ///
+    /// - `None` — the field is absent.
+    /// - `Some(Ok(rt))` — decoded corpus.
+    /// - `Some(Err(_))` — the field is present but neither a corpus object nor
+    ///   an importable markdown string (e.g. a bare number a `set_field` wrote).
+    ///
+    /// A `Document` carries no schema, so this cannot itself tell a richtext
+    /// field from a plain string field; the caller names a field it knows is
+    /// richtext, exactly as it does when writing.
+    pub fn field_richtext(&self, name: &str) -> Option<Result<RichText, RichtextDecodeError>> {
+        let value = self.payload.get(name)?.as_json();
+        Some(match crate::document::decode_richtext_value(value) {
+            Some(result) => result,
+            None => match value {
+                serde_json::Value::Null => Ok(RichText::empty()),
+                _ => Err(RichtextDecodeError::NotCorpus(
+                    "expected a richtext corpus object or a markdown string".to_string(),
+                )),
+            },
+        })
+    }
+
+    /// The markdown projection of a richtext-valued field (`export ∘ decode`) —
+    /// the field-level twin of [`Card::body_markdown`], and the projection an
+    /// emit or a `.qmd` save writes for a corpus-valued field. `None` when the
+    /// field is absent or does not decode as richtext.
+    pub fn field_markdown(&self, name: &str) -> Option<String> {
+        match self.field_richtext(name)? {
+            Ok(rt) => Some(quillmark_richtext::export::to_markdown(&rt)),
+            Err(_) => None,
+        }
     }
 }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -703,6 +703,51 @@ fn test_field_richtext_absent_and_non_richtext() {
     assert!(card.field_markdown("count").is_none());
 }
 
+/// A corpus-valued field emits to card-yaml as its **markdown projection**, not
+/// a nested `{text, lines, marks, islands}` object — card-yaml stays
+/// markdown-clean. Re-parsing yields a string field (schema-less parse), the
+/// documented on-disk identity boundary; the corpus survives only via the DTO.
+#[test]
+fn test_corpus_field_emits_as_markdown_projection() {
+    let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
+    doc.main_mut()
+        .set_field_richtext("intro", &serde_json::json!("**bold** intro"), false)
+        .unwrap();
+
+    let md = doc.to_markdown();
+    // Projected to a quoted markdown scalar (the `body_markdown` projection,
+    // trailing newline and all), not a block mapping.
+    assert!(
+        md.contains("intro: \"**bold** intro\\n\""),
+        "expected markdown projection, got:\n{md}"
+    );
+    assert!(!md.contains("lines:"), "corpus object leaked into card-yaml:\n{md}");
+
+    // Re-parse: schema-less, so the field is now a plain string (identity lost
+    // on disk — the intended boundary), but the markdown content survives.
+    let reparsed = Document::from_markdown(&md).unwrap();
+    assert_eq!(
+        reparsed.main().payload().get("intro").unwrap().as_str(),
+        Some("**bold** intro\n")
+    );
+}
+
+/// A plain object field that is *not* a canonical corpus emits structurally
+/// (unchanged) — projection fires only on genuine corpus objects.
+#[test]
+fn test_non_corpus_object_field_emits_structurally() {
+    let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
+    doc.main_mut()
+        .set_field(
+            "addr",
+            QuillValue::from_json(serde_json::json!({ "city": "Paris" })),
+        )
+        .unwrap();
+    let md = doc.to_markdown();
+    assert!(md.contains("addr:"), "{md}");
+    assert!(md.contains("city: Paris"), "{md}");
+}
+
 /// `import_body_delta` updates the body and returns the text delta from the
 /// old body to the new — the recordable whole-document (stale-text) writer.
 #[test]

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -611,6 +611,98 @@ fn test_set_body_value_accepts_markdown_and_null_and_rejects_bad() {
     );
 }
 
+/// `set_field_richtext` accepts a **canonical corpus object**, stores it as the
+/// field's canonical value (lossless for corpus-only marks), and reads back
+/// through `field_richtext` — the field-level twin of `set_body_value` / `body`.
+#[test]
+fn test_set_field_richtext_accepts_corpus_object_and_reads_back() {
+    use quillmark_richtext::model::{Mark, MarkKind};
+
+    let mut corpus = quillmark_richtext::import::from_markdown("underlined intro").unwrap();
+    // `underline` has no markdown projection — the corpus store must keep it.
+    corpus.marks.push(Mark {
+        start: 0,
+        end: 10,
+        kind: MarkKind::Underline,
+    });
+    corpus.normalize();
+    let json = quillmark_richtext::serial::to_canonical_value(&corpus);
+
+    let mut card = Card::new("note").unwrap();
+    card.set_field_richtext("intro", &json, false).unwrap();
+
+    // Stored structurally as the corpus object, not the authored string.
+    assert!(card.payload().get("intro").unwrap().as_json().is_object());
+    // Reads back losslessly, underline intact.
+    let read = card.field_richtext("intro").unwrap().unwrap();
+    assert_eq!(read, corpus);
+    assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
+}
+
+/// `set_field_richtext` also accepts a **markdown string** (imported) and `null`
+/// (empty corpus); `field_markdown` is the projection twin of `body_markdown`.
+/// A non-corpus object / other shape is `EditError::FieldRichtextDecode`.
+#[test]
+fn test_set_field_richtext_accepts_markdown_and_null_and_rejects_bad() {
+    let mut card = Card::new("note").unwrap();
+
+    card.set_field_richtext("intro", &serde_json::json!("**bold** intro"), false)
+        .unwrap();
+    assert_eq!(card.field_markdown("intro").unwrap(), "**bold** intro\n");
+
+    card.set_field_richtext("intro", &serde_json::Value::Null, false)
+        .unwrap();
+    assert!(card.field_richtext("intro").unwrap().unwrap().is_blank());
+
+    assert_eq!(
+        card.set_field_richtext("intro", &serde_json::json!({ "not": "a corpus" }), false)
+            .unwrap_err()
+            .variant_name(),
+        "FieldRichtextDecode"
+    );
+    assert_eq!(
+        card.set_field_richtext("intro", &serde_json::json!(42), false)
+            .unwrap_err()
+            .variant_name(),
+        "FieldRichtextDecode"
+    );
+}
+
+/// `set_field_richtext(inline = true)` commits the `richtext(inline)` check at
+/// write: a single-`Para` corpus stores, a multi-block corpus is
+/// `EditError::FieldRichtextNotInline` — the write is the strict commit, not a
+/// deferred render failure.
+#[test]
+fn test_set_field_richtext_inline_enforced_at_write() {
+    let mut card = Card::new("note").unwrap();
+
+    // One paragraph line: inline, accepted.
+    card.set_field_richtext("title", &serde_json::json!("A single line"), true)
+        .unwrap();
+    assert_eq!(card.field_markdown("title").unwrap(), "A single line\n");
+
+    // Two blocks: rejected at write, and nothing is stored over the good value.
+    let err = card
+        .set_field_richtext("title", &serde_json::json!("line one\n\nline two"), true)
+        .unwrap_err();
+    assert_eq!(err.variant_name(), "FieldRichtextNotInline");
+    assert_eq!(card.field_markdown("title").unwrap(), "A single line\n");
+}
+
+/// `field_richtext` on an absent field is `None`; on a plain non-richtext field
+/// value it is `Some(Err(_))` — the read mirrors the write in needing the caller
+/// to name a field it knows is richtext.
+#[test]
+fn test_field_richtext_absent_and_non_richtext() {
+    let mut card = Card::new("note").unwrap();
+    assert!(card.field_richtext("missing").is_none());
+    assert!(card.field_markdown("missing").is_none());
+
+    card.set_field("count", 3).unwrap();
+    assert!(card.field_richtext("count").unwrap().is_err());
+    assert!(card.field_markdown("count").is_none());
+}
+
 /// `import_body_delta` updates the body and returns the text delta from the
 /// old body to the new — the recordable whole-document (stale-text) writer.
 #[test]

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -851,6 +851,64 @@ fn test_apply_body_change_reports_out_of_range() {
     }
 }
 
+/// `apply_field_richtext_change` splices a bundle into a richtext field's stored
+/// corpus and re-stores it — the field-path twin of `apply_body_change`.
+/// Identity marks (a strong span applied post-delta) survive on the re-stored
+/// corpus, which is what makes anchors persist on field content across edits.
+#[test]
+fn test_apply_field_richtext_change_splices_and_persists() {
+    use crate::MarkOp;
+    use quillmark_richtext::delta::diff;
+    use quillmark_richtext::model::MarkKind;
+
+    let mut card = Card::new("note").unwrap();
+    card.set_field_richtext("intro", &serde_json::json!("abc"), false)
+        .unwrap();
+    let d = diff("abc", "abXc");
+    card.apply_field_richtext_change(
+        "intro",
+        &d,
+        &[],
+        &[MarkOp::Add {
+            start: 3,
+            end: 4,
+            kind: MarkKind::Strong,
+        }],
+    )
+    .unwrap();
+
+    // The stored value is still a canonical corpus object carrying the edit.
+    assert!(card.payload().get("intro").unwrap().as_json().is_object());
+    let rt = card.field_richtext("intro").unwrap().unwrap();
+    assert_eq!(rt.text, "abXc");
+    assert!(rt.marks.iter().any(|m| matches!(m.kind, MarkKind::Strong)));
+}
+
+/// `apply_field_richtext_change` on an absent or non-richtext field is a
+/// `FieldRichtextDecode` error, not a panic — the caller must address a field it
+/// knows is richtext.
+#[test]
+fn test_apply_field_richtext_change_rejects_non_richtext() {
+    use quillmark_richtext::delta::diff;
+
+    let mut card = Card::new("note").unwrap();
+    let identity = diff("", "");
+    assert_eq!(
+        card.apply_field_richtext_change("missing", &identity, &[], &[])
+            .unwrap_err()
+            .variant_name(),
+        "FieldRichtextDecode"
+    );
+
+    card.set_field("count", 3).unwrap();
+    assert_eq!(
+        card.apply_field_richtext_change("count", &identity, &[], &[])
+            .unwrap_err()
+            .variant_name(),
+        "FieldRichtextDecode"
+    );
+}
+
 // ── Invariant check: sequence of mutations ───────────────────────────────────
 
 /// After a deterministic sequence of mutations, the document must satisfy:

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -388,6 +388,38 @@ mod tests {
         assert_eq!(back, card, "nested fill must survive Card → wire → Card");
     }
 
+    /// A richtext field stored as a canonical corpus object rides the wire
+    /// **structurally and losslessly** — the same opaque-JSON `Field` carrier as
+    /// any object value, so identity marks (an `underline` with no markdown
+    /// projection) survive Card → wire → Card. This is the lossless carrier the
+    /// card-yaml markdown projection (emit) deliberately is not.
+    #[test]
+    fn card_wire_round_trips_corpus_field_losslessly() {
+        use quillmark_richtext::model::{Mark, MarkKind};
+
+        let mut card = Card::new("note").unwrap();
+        let mut corpus = quillmark_richtext::import::from_markdown("underlined intro").unwrap();
+        corpus.marks.push(Mark {
+            start: 0,
+            end: 10,
+            kind: MarkKind::Underline,
+        });
+        corpus.normalize();
+        let json = quillmark_richtext::serial::to_canonical_value(&corpus);
+        card.set_field_richtext("intro", &json, false).unwrap();
+
+        let wire = CardWire::from(&card);
+        // Carried as the corpus object, verbatim — not a markdown projection.
+        let as_json = serde_json::to_value(&wire).unwrap();
+        assert!(as_json["payloadItems"][0]["value"].is_object());
+
+        let back = Card::try_from(wire).expect("wire → card");
+        assert_eq!(back, card, "corpus field must survive Card → wire → Card");
+        // Underline (corpus-only, no markdown form) is intact after the round-trip.
+        let read = back.field_richtext("intro").unwrap().unwrap();
+        assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
+    }
+
     /// A field-and-comment card with `$kind` round-trips Card → wire → Card.
     #[test]
     fn card_wire_round_trips_fields_and_comment() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,7 +27,7 @@
 pub mod document;
 pub use document::{
     Card, CardWire, Document, EditError, ParseOutput, Payload, PayloadItem, PayloadItemWire,
-    SeedOverlay, WireError,
+    RichtextDecodeError, SeedOverlay, WireError,
 };
 
 pub mod backend;

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -81,3 +81,63 @@ paragraph break), so nesting it in an inline slot — `par(..)`, a signature
 line, a grid cell, `measure(..)` — no longer triggers Typst's non-fatal
 "parbreak may not occur inside of a paragraph" warning. No plate change is
 needed; block (`inline` omitted) richtext is unaffected.
+
+## Richtext fields: a corpus writer, `set_field_richtext` (#881)
+
+A richtext value now has one write contract everywhere. `$body` was already
+corpus-from-construction; a richtext **field** gains a writer that commits the
+corpus at write instead of only re-coercing per render. This is a **writer**
+guarantee, not a type guarantee — the field is corpus *iff* the caller picks
+the richtext writer over the plain one, because a `Document` holds a `$quill`
+*reference*, not the resolved schema, and cannot tell a markdown-for-richtext
+string from an ordinary string value.
+
+| Body (existing) | Richtext field (new) |
+|---|---|
+| `Card::set_body_value(&json)` | `Card::set_field_richtext(name, &json, inline)` |
+| `Card::body()` / `body_markdown()` | `Card::field_richtext(name)` / `field_markdown(name)` |
+| `Card::apply_body_change(..)` | `Card::apply_field_richtext_change(name, ..)` |
+| wasm `setBody(RichText \| string)` | wasm `setRichtextField(name, RichText \| string, inline?)` |
+| — | wasm `updateCardRichtextField(index, name, value, inline?)` |
+| wasm `main.bodyMarkdown` | wasm `fieldMarkdown(name)` / `cardFieldMarkdown(index, name)` |
+
+- Accepts either encoding the seam carries — a canonical corpus **object** or an
+  authored markdown **string** — and stores the canonical corpus, so a
+  corpus-only mark (`underline`) and identity ids survive where a markdown
+  projection would drop them.
+- `inline` mirrors the schema's `richtext(inline)` constraint and is enforced
+  **at write** (`EditError::FieldRichtextNotInline` / wasm
+  `[EditError::FieldRichtextNotInline]`), in lockstep with the coercion and
+  validation checks. The caller supplies it because the editor holds the schema;
+  the write is the strict commit, not a deferred render failure.
+- `set_field` (plain) and hand-authored YAML are unchanged: a richtext field
+  authored as a markdown string stays a string until render coercion imports it.
+  No `.qmd` file needs editing.
+
+### On-disk identity is markdown-lossy by design
+
+A corpus-valued field **projects to a markdown string** in emitted card-yaml
+(`Document::to_markdown` / `.qmd`), keeping the human-authored surface
+markdown-clean rather than embedding a `{text, lines, marks, islands}` tree. So
+identity marks (anchors, island ids) and corpus-only formatting persist across
+compiles and the **storage DTO** (`to_json`/`from_json` — the lossless carrier),
+but **not** across a `.qmd` save-and-reload, which re-imports a fresh corpus.
+Persistent field anchors (`applyFieldDelta` on a field, below) are a live-session
+/ DTO guarantee, not a card-yaml one.
+
+## `applyFieldDelta` accepts richtext field addresses (#881)
+
+The wasm delta path was `$body`-only "in this phase"; it now also targets a
+richtext field on the main card by name (its stored value must be a corpus —
+i.e. written via `setRichtextField`). Field deltas record and map under the
+field path, so a caret or highlight captured on a field stays anchored across
+edits via `mapFieldPos`. The transaction contract is unchanged (compile-and-doc
+rollback on failure, `revision` advances only on success). A non-`$body`,
+non-richtext address now fails with `[EditError::FieldRichtextDecode]` instead
+of the removed "only `$body` is supported" gate error.
+
+Still text-`Delta`-only: the mark/line op channels are not yet exposed over the
+seam, so a formatting toggle or block split (Enter) still falls back to
+`setBody`/`setRichtextField` + `apply(doc)`, which invalidates the change log.
+Exposing those channels is the follow-up that puts formatting and block edits on
+the same non-invalidating path.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -15,7 +15,10 @@ guides in order.
 - [0.93 → 0.94](0.93-to-0.94.md) — `type: richtext(inline)` retires; declare
   `type: richtext` with `inline: true` instead. Blueprint still emits
   `richtext(inline)<markdown>`; `build_transform_schema` gains
-  `quillmark:inline: true`.
+  `quillmark:inline: true`. Richtext fields gain a corpus writer
+  (`set_field_richtext` / wasm `setRichtextField`) that commits the corpus at
+  write; `applyFieldDelta` accepts richtext field addresses. On-disk (`.qmd`)
+  identity stays markdown-lossy — the storage DTO is the lossless carrier.
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now


### PR DESCRIPTION
Closes the body/field write-surface asymmetry from #881: a richtext value is written as `RichText | markdown-string` and is corpus from that write onward, everywhere — not only for `$body`.

Resolves the one open design decision as **(a) explicit writer** (no schema binding), with the refinements from the issue's own critical review: this is a **writer** guarantee (a field is corpus *iff* the caller picks the richtext writer), and `inline` is enforced **at write** via an explicit param (the editor holds the schema; a `Document` holds only a `$quill` reference).

## What changed, by step

1. **Core writer + read-back** — `Card::set_field_richtext(name, value, inline)` mirrors `set_body_value`: decodes a corpus object or a markdown string (or `null`), enforces `richtext(inline)` at write (`EditError::FieldRichtextNotInline`), and stores the canonical corpus. `Card::field_richtext` / `field_markdown` mirror `body` / `body_markdown`. `RichtextDecodeError` is now public.
2. **Wire/DTO** — no structural change needed: field values are already opaque JSON, so a corpus object rides both carriers verbatim. Added round-trip tests proving the DTO/wire are the **lossless carrier** (an `underline`, which has no markdown projection, survives) that emit deliberately is not.
3. **Emit projection** — a corpus-valued field projects to a markdown string in card-yaml so the human-authored surface stays markdown-clean. Guarded by a canonical round-trip so only genuine corpus objects project; since a corpus object only ever arises from the programmatic writer (`from_markdown` is schema-less), parse-originated round-trips — and the emit fuzz property — are unaffected.
4. **Coercion** — unchanged. Added an end-to-end pdfform test proving a field written as a corpus object renders identically to the string-authored path (coercion's object branch re-validates + re-canonicalizes).
5. **WASM** — `setRichtextField` / `updateCardRichtextField` (optional `inline`) mirror `setBody`; `fieldMarkdown` / `cardFieldMarkdown` are the per-field projection twins of `main.bodyMarkdown`. The canonical runtime re-exports `Document` verbatim, so no forwarding change.
6. **`applyFieldDelta` un-gate** — `Card::apply_field_richtext_change` is the field-path twin of `apply_body_change`; the wasm wrapper now dispatches `$body` → body splice, a richtext field name → the field splice, with the same transactional compile+doc rollback. The session's `apply_for_field_delta` / `map_field_pos` were already path-generic. Field anchors now persist across incremental edits.

## Known boundaries (documented, by design)

- **On-disk identity is markdown-lossy.** A `.qmd` save projects a corpus field to markdown and re-imports a fresh corpus on reload; identity (anchors, island ids) survives compiles and the **storage DTO** (the lossless carrier), not a card-yaml round-trip. This is the concrete face of the #873 hazard, stated explicitly in the migration guide.
- **`applyFieldDelta` is text-`Delta`-only.** The mark/line op channels are not yet exposed over the seam (the addendum's 6b), so a formatting toggle or block split still falls back to `setBody`/`setRichtextField` + `apply(doc)`. Exposing those channels is the follow-up that puts formatting/block edits on the non-invalidating path.

## Tests

Full `cargo test --workspace` green (50 binaries, 0 failures). New coverage: core writer/read-back, inline-at-write enforcement, emit projection + non-corpus-object structural emit, wire + DTO lossless round-trip, `apply_field_richtext_change` splice/persist + reject-non-richtext, pdfform end-to-end corpus-field render parity, and WASM `basic.test.js` / `runtime.test.js` (built and run on CI).

Docs: new sections in the working migration guide (`docs/migrations/0.93-to-0.94.md`) and an updated index entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjbyrH9M5SaLoTgECWvxLN)_