### PR TITLE
wasm/canvas: report clamp on PaintResult; document paint compositing constraints

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -317,10 +317,19 @@ canvas.style.height = `${result.layoutHeight}px`;
   crisp output on high-DPI displays.
 - The effective rasterization scale is `layoutScale * densityScale`. If
   that would exceed the safe maximum (16384 px per side), `densityScale`
-  is clamped proportionally; compare `result.pixelWidth` against
-  `Math.round(result.layoutWidth * densityScale)` to detect.
+  is clamped proportionally; `result.clamped` reports it and
+  `result.effectiveDensityScale` is the density actually applied. A
+  clamped page renders soft at the same `canvas.style` size.
+- `paint` writes the whole backing store with `putImageData`, which
+  ignores the 2D context transform, `globalAlpha`, and clip. Give each
+  visible page its own `` element — you cannot composite two pages,
+  a sub-rect, or a context transform through `paint`.
 - `paint` is always a full repaint — setting the backing-store width /
-  height clears it. No `clearRect` required.
+  height clears it. No `clearRect` required. Each call re-rasterizes from
+  scratch (no per-page raster cache), so keep a page's canvas alive while
+  it stays near the viewport rather than pooling one canvas across pages:
+  an idle canvas retains its pixels for free, whereas reusing a canvas on
+  scroll re-runs a full render.
 - `pageCount` and `pageSize(page)` are stable for the session's
   lifetime (immutable snapshot) — cache them.
 - Worker support: pass an `OffscreenCanvasRenderingContext2D` and the

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -175,6 +175,10 @@ describe('LiveSession canvas preview', () => {
     expect(result.pixelWidth).toBe(Math.round(widthPt * layoutScale * densityScale))
     expect(result.pixelHeight).toBe(Math.round(heightPt * layoutScale * densityScale))
 
+    // No clamp on this modest density: reported honestly on the result.
+    expect(result.clamped).toBe(false)
+    expect(result.effectiveDensityScale).toBeCloseTo(densityScale, 6)
+
     // Painter owns canvas.width/height — they must equal the reported
     // pixel dimensions.
     expect(ctx.canvas.width).toBe(result.pixelWidth)
@@ -245,6 +249,14 @@ describe('LiveSession canvas preview', () => {
     expect(result.layoutHeight).toBeCloseTo(heightPt, 4)
     // Detect-clamp contract: pixelWidth < round(layoutWidth * densityScale).
     expect(result.pixelWidth).toBeLessThan(Math.round(result.layoutWidth * densityScale))
+    // The clamp is reported on the result, not just derivable from the dims.
+    expect(result.clamped).toBe(true)
+    // effectiveDensityScale is the reduced density; layoutScale defaults to 1,
+    // so pixelWidth == round(layoutWidth * effectiveDensityScale).
+    expect(result.effectiveDensityScale).toBeLessThan(densityScale)
+    expect(result.pixelWidth).toBe(
+      Math.round(result.layoutWidth * result.effectiveDensityScale),
+    )
   })
 
   it('paint throws on non-finite or non-positive layoutScale / densityScale', () => {

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -226,10 +226,23 @@ export interface PaintOptions {
  * @experimental Part of the iterative-session/canvas surface — see {@link LiveSession}.
  */
 export interface PaintResult {
-	layoutWidth: number;
+	layoutWidth: number;      // canvas.style.width target; independent of densityScale
 	layoutHeight: number;
-	pixelWidth: number;
+	pixelWidth: number;       // canvas.width the painter wrote (clamped at 16384)
 	pixelHeight: number;
+	/**
+	 * True when `MAX_BACKING_DIMENSION` forced `densityScale` down: the page is
+	 * painted at fewer device pixels than requested and renders soft at the same
+	 * `canvas.style` size. Reads the clamp off the return value instead of the
+	 * `pixelWidth < round(layoutWidth × densityScale)` derivation.
+	 */
+	clamped: boolean;
+	/**
+	 * The `densityScale` actually applied — equal to the requested value unless
+	 * `clamped`, then reduced proportionally. `layoutScale × effectiveDensityScale`
+	 * is the scale the backing store was rasterized at.
+	 */
+	effectiveDensityScale: number;
 }
 
 /**
@@ -436,7 +449,18 @@ export declare class LiveSession {
 	 * compositing (Typst rasterizes natively; pdfform rasterizes its
 	 * pre-flattened page). Effective rasterization scale is
 	 * `layoutScale × densityScale`, clamped so neither backing dimension exceeds
-	 * 16384 px — detect a clamp via {@link PaintResult.pixelWidth}.
+	 * 16384 px — {@link PaintResult.clamped} reports the clamp and
+	 * {@link PaintResult.effectiveDensityScale} the density actually applied.
+	 *
+	 * The write is a whole-backing-store `putImageData`, which bypasses the 2D
+	 * context transform, `globalAlpha`, and clip: the painter owns the entire
+	 * canvas, so give each visible page its own `` element. You cannot
+	 * paint two pages into one canvas, paint into a sub-rect, or apply a context
+	 * transform through this call — the raster is complete precisely so you never
+	 * need to. Keep the per-page canvases alive while their pages stay near the
+	 * viewport: each `paint` re-rasterizes from scratch, so reusing (pooling) a
+	 * canvas across pages on scroll re-runs a full render, whereas an idle canvas
+	 * retains its pixels for free.
 	 */
 	paint(
 		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -207,9 +207,9 @@ export interface RichTextIsland {
 /// 16k on Safari, lower on memory-constrained devices); 16384 is the
 /// floor that works everywhere we ship to. When a requested
 /// `layoutScale * densityScale` would exceed this, the painter clamps
-/// `densityScale` proportionally and surfaces the actual backing
-/// dimensions in the returned `PaintResult` so consumers can detect the
-/// clamp.
+/// `densityScale` proportionally and reports it on the returned
+/// `PaintResult` (`clamped` / `effectiveDensityScale`, plus the actual
+/// backing dimensions).
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 const MAX_BACKING_DIMENSION: u32 = 16384;
 
@@ -1449,12 +1449,22 @@ export interface PaintOptions {
  *   Equal to `round(layoutWidth * densityScale)` ×
  *   `round(layoutHeight * densityScale)` *unless* the requested backing
  *   exceeded the painter's safe maximum (16384 px per side), in which
- *   case `densityScale` was clamped to fit. Detect clamping via
- *   `pixelWidth < round(layoutWidth * densityScale)`.
+ *   case `densityScale` was clamped to fit.
+ * - `clamped` — `true` when that 16384-px clamp fired, so the page is
+ *   painted at fewer device pixels than requested and renders soft at the
+ *   same `canvas.style` size. Reads the clamp off the return value instead
+ *   of the `pixelWidth < round(layoutWidth * densityScale)` derivation.
+ * - `effectiveDensityScale` — the `densityScale` actually applied: the
+ *   requested value unless `clamped`, then reduced proportionally.
+ *   `layoutScale * effectiveDensityScale` is the scale the backing store
+ *   was rasterized at.
  *
  * The painter owns `canvas.width` / `canvas.height`; consumers must not
  * write to them. The painter does **not** touch `canvas.style.*`;
- * consumers own layout.
+ * consumers own layout. The write is a whole-backing-store `putImageData`,
+ * which bypasses the 2D context transform, `globalAlpha`, and clip: give
+ * each visible page its own `` — you cannot composite two pages, a
+ * sub-rect, or a context transform through `paint`.
  *
  * For `OffscreenCanvasRenderingContext2D` (Worker rasterization, no
  * DOM), `layoutWidth` / `layoutHeight` are informational — there's no
@@ -1465,6 +1475,8 @@ export interface PaintResult {
     layoutHeight: number;
     pixelWidth: number;
     pixelHeight: number;
+    clamped: boolean;
+    effectiveDensityScale: number;
 }
 "#;
 
@@ -1780,7 +1792,13 @@ impl LiveSession {
     /// `OffscreenCanvasRenderingContext2D`. The painter owns
     /// `canvas.width`/`height` (no `clearRect` needed); consumers own
     /// `canvas.style.*`. If `layoutScale * densityScale` exceeds 16384 px
-    /// per side, `densityScale` is clamped — detect via `PaintResult.pixelWidth`.
+    /// per side, `densityScale` is clamped — `PaintResult.clamped` reports it and
+    /// `PaintResult.effectiveDensityScale` carries the density actually applied.
+    ///
+    /// `put_image_data` writes the whole backing store, bypassing the 2D
+    /// context's transform, `globalAlpha`, and clip: the painter owns the entire
+    /// canvas, so each visible page needs its own `` — you cannot composite
+    /// two pages, a sub-rect, or a context transform through this call.
     ///
     /// Throws if the backend has no canvas painter, `page` is out of range,
     /// `ctx` is the wrong type, or either scale is non-finite or `<= 0`.
@@ -1833,7 +1851,8 @@ impl LiveSession {
         let desired_h = (layout_height * requested_density as f64).round();
         let max_dim = desired_w.max(desired_h);
 
-        let effective_density = if max_dim > MAX_BACKING_DIMENSION as f64 {
+        let clamped = max_dim > MAX_BACKING_DIMENSION as f64;
+        let effective_density = if clamped {
             (requested_density as f64) * (MAX_BACKING_DIMENSION as f64 / max_dim)
         } else {
             requested_density as f64
@@ -1885,6 +1904,8 @@ impl LiveSession {
             layout_height,
             pixel_width: pixel_w,
             pixel_height: pixel_h,
+            clamped,
+            effective_density_scale: effective_density,
         };
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         result
@@ -2008,4 +2029,13 @@ struct PaintResult {
     layout_height: f64,
     pixel_width: u32,
     pixel_height: u32,
+    /// True when `MAX_BACKING_DIMENSION` forced `densityScale` down: the page is
+    /// painted at fewer device pixels than requested, so it renders soft at the
+    /// same `canvas.style` size. The honest form of the pixel-dim derivation
+    /// consumers would otherwise reinvent.
+    clamped: bool,
+    /// The `densityScale` actually applied — equal to the requested value unless
+    /// `clamped`, then reduced proportionally. `layoutScale × effectiveDensityScale`
+    /// is the scale the backing store was rasterized at.
+    effective_density_scale: f64,
 }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -111,8 +111,9 @@
     - Fold `devicePixelRatio` and in-app zoom into `densityScale`;
       `layoutScale` controls display size.
     - If `layoutScale * densityScale` would push either dimension past 16384
-      px, `densityScale` is clamped to fit; compare `result.pixelWidth` to
-      `round(result.layoutWidth * densityScale)` to detect the clamp.
+      px, `densityScale` is clamped to fit; `result.clamped` reports it and
+      `result.effectiveDensityScale` is the density actually applied (a clamped
+      page renders soft at the same `canvas.style` size).
     - `pageCount` and `pageSize(page)` reflect the session's current compile:
       stable between edits, but re-read them after a committed `apply(doc)`,
       which recompiles in place and can change the page count

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -136,6 +136,23 @@ compositing of its own. Backends satisfy it differently:
   flat PDF via hayro — so field values appear in the raster on their own, with
   no regions-compositing by the caller.
 
+### Painter owns the canvas
+
+`paint` writes the whole backing store with `put_image_data`, which bypasses
+the 2D context transform, `globalAlpha`, and clip. The painter therefore owns
+the entire canvas: **give each visible page its own `` element.** You
+cannot paint two pages into one canvas, paint into a sub-rect, or push a page
+through a context transform — the raster is complete precisely so you never
+need to composite, and the write ignores context state so you could not if you
+tried.
+
+Because every `paint` re-rasterizes from scratch (no per-page raster cache on
+the session — a deliberate omission, § Decisions), keep a page's canvas alive
+while it stays near the viewport rather than pooling one canvas across pages: an
+idle canvas retains its pixels for free, whereas reusing a canvas on scroll
+re-runs a full render. This keeps memory bounded to *visible + margin* without
+paying re-rasterization on every scroll reversal.
+
 Field geometry is primarily a **session-level query**, `LiveSession::regions()`
 (see the region type in `crates/core/src/region.rs`): the interactive-preview
 path holds a session and reads geometry off the current compile with no render
@@ -284,6 +301,8 @@ interface PaintResult {
   layoutHeight: number;
   pixelWidth: number;     // canvas.width the painter wrote (clamped at 16384)
   pixelHeight: number;
+  clamped: boolean;       // MAX_BACKING_DIMENSION forced densityScale down
+  effectiveDensityScale: number;  // densityScale actually applied (== requested unless clamped)
 }
 
 interface FieldRegion {
@@ -314,11 +333,12 @@ Fold `window.devicePixelRatio`, in-app zoom, and `visualViewport.scale` into
 **`MAX_BACKING_DIMENSION` (16384 px per side)** — the floor that works across
 browsers (Chrome/Firefox ~32k, Safari 16k, lower on memory-constrained mobile)
 — the painter clamps `densityScale` proportionally and reports the actual
-backing dimensions. Detect a clamp via:
-
-```
-pixelWidth < round(layoutWidth × densityScale)
-```
+backing dimensions. `clamped` and `effectiveDensityScale` carry the fact and
+the applied density on the result, so the consumer reads the clamp off the
+return value rather than reconstructing it from
+`pixelWidth < round(layoutWidth × densityScale)`. A clamped page renders soft
+at the same `canvas.style` size; compare `effectiveDensityScale` to the
+requested `densityScale` to know by how much.
 
 Each `paint` resets the backing store (writing `canvas.width` clears it), so
 paint is always a full repaint — consumers never call `clearRect`.
@@ -407,6 +427,16 @@ by `runtime.test.js`.
   finished page (Typst natively, pdfform by pre-flattening values into content
   streams before rasterizing). Regions are an overlay sidecar, not a
   compositing input — the painter stays a dumb blit.
+- **No session raster cache — re-rasterize per `paint`.** Caching the last
+  raster per `(page, renderScale)` and blitting on scroll-back would skip
+  re-rasterizing unchanged pages (`ChangeSet` already names dirty pages to
+  invalidate), but it stays unbuilt: the surface ships ahead of its first
+  consumer, the megabyte-scale per-page buffers reintroduce the unbounded
+  memory the viewport-bounded design set out to avoid, and any `renderScale`
+  change (DPR / zoom) rotates the key and voids the cache. Consumer-side canvas
+  liveness (keep the visible page's canvas alive rather than pooling) covers the
+  common scroll case without that trade-off; a real consumer's profile is what
+  should justify the cache and its eviction policy, not speculation.
 - **Method on `LiveSession`, not a sub-handle.** Even with click resolution
   shipped (`fieldAt`), it shares no state with `paint` beyond the compile the
   whole session already owns — a `Preview` sub-handle grouping them is


### PR DESCRIPTION
Closes #885 (items 2 and 3; item 1 deferred with recorded rationale).

## Summary

A critical review of #885 confirmed its line references and core observations, corrected one technical detail (the unpremultiply is fused into the raster→Vec build, not a separate pass; the one-canvas-per-page constraint stems from the painter owning `canvas.width/height`, of which `put_image_data` is a consequence), and found item 1's prescription in tension with the design's own memory-bounded goal. This PR ships the two cheap, unambiguous items and records item 1 as a deliberate non-decision.

## Item 2 — clamp honesty on the return value

`paint` already computes the 16384-px clamp-adjusted density and discarded it. `PaintResult` now carries:

- `clamped: boolean` — whether `MAX_BACKING_DIMENSION` forced `densityScale` down
- `effectiveDensityScale: number` — the density actually applied

Consumers no longer reconstruct the clamp from `pixelWidth < round(layoutWidth × densityScale)` — a derivation that is also fragile across the f32/f64 boundary. A clamped page renders soft at the same `canvas.style` size, and `effectiveDensityScale` says by how much.

## Item 3 — compositing constraint documented

Documented that `put_image_data` writes the whole backing store and bypasses the 2D context transform, `globalAlpha`, and clip, so each visible page needs its own `` element — no compositing two pages, a sub-rect, or a context transform through `paint`. Stated in `runtime.d.ts`, `PREVIEW.md`, `README.md`, and the `paint` rustdoc.

## Item 1 — per-repaint re-rasterization (deferred, not built)

A session raster cache reintroduces the unbounded memory the viewport-bounded design set out to avoid, and any `renderScale` change (DPR/zoom) rotates the key and voids it — premature for an experimental, consumer-less surface. Recorded as a *Decisions and rationale* entry in `PREVIEW.md`, with consumer-side canvas-liveness guidance (keep the visible page's canvas alive rather than pooling one across pages) as the near-term answer.

## Files

- `crates/bindings/wasm/src/engine.rs` — new `PaintResult` fields + populate; `typescript_custom_section`, rustdoc, and `MAX_BACKING_DIMENSION` doc updated
- `crates/bindings/wasm/runtime/runtime.d.ts` — canonical `PaintResult` + `paint` doc (drift-guard twin of the generated types)
- `crates/bindings/wasm/canvas.test.js` — asserts `clamped` / `effectiveDensityScale` in both the clamped and unclamped cases
- `prose/canon/PREVIEW.md`, `crates/bindings/wasm/README.md`, `docs/getting-started/quickstart.md` — consumer docs

## Verification

`cargo check -p quillmark-wasm` passes. The `runtime.d.ts` ↔ generated-binding drift-guard types were updated on both sides so the `KeysEqual` type test stays green. JS/WASM tests run on CI per the repo's cloud workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167cSWsnDNT5cL8Q4HNqevn)_