### PR TITLE
feat(wasm): setCardBody — corpus writer for a non-main card body (#892)

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -923,6 +923,38 @@ Card body.
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
     expect(() => doc.updateCardBody(0, 'x')).toThrow(/IndexOutOfRange/)
   })
+
+  it('setCardBody accepts a markdown string', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARD)
+    doc.setCardBody(0, 'Card body from **markdown**.')
+    expect(doc.cards[0].bodyMarkdown).toBe('Card body from **markdown**.\n')
+  })
+
+  it('setCardBody accepts a corpus object round-tripped from a card body', () => {
+    // The corpus is the shape doc.cards[i].body reads back; writing it straight
+    // through must round-trip, the card-indexed twin of the setBody corpus path.
+    const src = Document.fromMarkdown(MD_WITH_CARD)
+    const corpus = src.cards[0].body
+    const doc = Document.fromMarkdown(MD_WITH_CARD)
+    doc.setCardBody(0, corpus)
+    expect(doc.cards[0].body.text).toBe(corpus.text)
+  })
+
+  it('setCardBody(null) clears the card body', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARD)
+    doc.setCardBody(0, null)
+    expect(doc.cards[0].body.text).toBe('')
+  })
+
+  it('setCardBody throws BodyDecode on a non-corpus object', () => {
+    const doc = Document.fromMarkdown(MD_WITH_CARD)
+    expect(() => doc.setCardBody(0, { not: 'a corpus' })).toThrow(/BodyDecode/)
+  })
+
+  it('setCardBody throws IndexOutOfRange when card absent', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
+    expect(() => doc.setCardBody(0, 'x')).toThrow(/IndexOutOfRange/)
+  })
 })
 
 describe('Document editor surface — parse→mutate→read round-trip', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1232,6 +1232,36 @@ impl Document {
             .replace_body(body)
             .map_err(|e| edit_error_to_js(&e))
     }
+
+    /// Set the body of the card at `index` from a **corpus object** (canonical
+    /// RichText-JSON) or a markdown string — the card-indexed twin of
+    /// [`setBody`](Document::set_body), and the corpus-native counterpart to
+    /// [`updateCardBody`](Document::update_card_body), which accepts markdown
+    /// only. `body` is the same `RichText | string` shape `Document.cards[i].body`
+    /// reads back, so a corpus-native editor writes a card body straight through
+    /// with no lossy markdown round-trip — a corpus-only mark such as `underline`,
+    /// and anchor/island identity ids, survive. `null` clears the body to empty.
+    ///
+    /// A card body is reachable only here: `$body` is rejected by
+    /// [`updateCardRichtextField`](Document::update_card_richtext_field) (the
+    /// reserved `$`-prefix fails the field-name check), so the field channel
+    /// cannot address it. This closes the last markdown-forced write in the
+    /// corpus surface — a non-main card body (issue #892).
+    ///
+    /// Throws `[EditError::BodyDecode]` if `body` is neither a valid corpus
+    /// object, an importable markdown string, nor `null`, and
+    /// `[EditError::IndexOutOfRange]` when the card is absent.
+    #[wasm_bindgen(js_name = setCardBody)]
+    pub fn set_card_body(
+        &mut self,
+        index: usize,
+        #[wasm_bindgen(unchecked_param_type = "RichText | string")] body: JsValue,
+    ) -> Result<(), JsValue> {
+        let json = js_value_to_json(body, "setCardBody")?;
+        self.card_mut_or_throw(index)?
+            .set_body_value(&json)
+            .map_err(|e| edit_error_to_js(&e))
+    }
 }
 
 impl Document {

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -114,6 +114,19 @@ string from an ordinary string value.
   authored as a markdown string stays a string until render coercion imports it.
   No `.qmd` file needs editing.
 
+### Card bodies: `setCardBody` completes the corpus write surface (#892)
+
+wasm `setCardBody(index, RichText | string)` is the card-indexed twin of
+`setBody` — the corpus-native counterpart to `updateCardBody`, which stays
+markdown-only. It closes the one remaining markdown-forced write: a **non-main
+card body**. `updateCardRichtextField(index, "$body", …)` was never a path —
+`$body`'s reserved `$`-prefix fails the field-name check — so a card body needs
+its own writer, backed by the existing `Card::set_body_value` (the same core
+primitive `setBody` uses). A corpus-native editor can now write every address —
+main body, main/card richtext fields, and card bodies — with no markdown
+intermediary. Card bodies already read back as corpus via `cards[i].body`
+(markdown via `cards[i].bodyMarkdown`), so this closes the read/write asymmetry.
+
 ### On-disk identity is markdown-lossy by design
 
 A corpus-valued field **projects to a markdown string** in emitted card-yaml


### PR DESCRIPTION
Closes #892.

## Problem

`updateCardBody(index, body)` accepted a **markdown string only**, so a corpus-native editor had no path to set an indexed card's `$body` without a lossy markdown round-trip — dropping corpus-only marks (`underline`) and identity ids (anchors, island ids). `updateCardRichtextField(index, "$body", …)` is **not** a workaround: `$body`'s reserved `$`-prefix fails `is_valid_field_name`, so the field channel cannot address a body.

This was the one remaining markdown-forced write in an otherwise corpus-native surface (`setBody` #874, `setRichtextField`/`updateCardRichtextField` #881).

## Change

Add `setCardBody(index, RichText | string)` — the card-indexed twin of `setBody`, a thin binding over the existing core writer `Card::set_body_value` (`crates/core/src/document/edit.rs:495`), symmetric with how `updateCardRichtextField` wraps `set_field_richtext`. Object-or-markdown decode, canonical corpus stored, `null` clears, `IndexOutOfRange` when the card is absent. No `inline` param — a body is always block-level.

Every address is now corpus-native: main body, main/card richtext fields, and card bodies. Card bodies already read back as corpus via `cards[i].body` (markdown via `cards[i].bodyMarkdown`), so this restores write symmetry — no new read-back method needed.

## Files

- `crates/bindings/wasm/src/engine.rs` — the `setCardBody` binding.
- `crates/bindings/wasm/basic.test.js` — 5 tests mirroring the `setBody` suite (markdown string, corpus round-trip, `null` clear, `BodyDecode` on non-corpus, `IndexOutOfRange`).
- `docs/migrations/0.93-to-0.94.md` — subsection under the write-surface entry (working/unreleased guide).

## Verification

`cargo check -p quillmark-wasm --target wasm32-unknown-unknown` compiles clean. The wasm JS tests (`basic.test.js`) run on CI.

## Notes

- Implemented as a **new method** rather than widening `updateCardBody`, keeping existing markdown callers unchanged and the naming parallel to `setBody`/`replaceBody`.
- The broader, open-ended half — how the typed *field* write surface scales as corpus-backed types grow — is filed separately as #893 (this PR does not address it; a body has no type axis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNjCSuArx9b1DgngmTgDgS)_