### PR TITLE
Typed field writes: schema-carried types, one commit dispatch (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@
 
 ## Unreleased
 
+- feat(core,wasm,python): typed field writes via schema-carried types. One
+  per-type write dispatch (`conform_value(value, schema, mode)`) unifies the
+  render floor's coercion with a strict-write mode behind a `Leniency` flag; one
+  typed writer per address, `Card::commit_field(name, value, &FieldSchema)`,
+  dispatches on the schema and subsumes `set_field_richtext` (now a deprecated
+  wrapper) — the write surface stays O(1) in field types. Adds
+  `EditError::FieldConform` for non-richtext mismatches (richtext keeps
+  `FieldRichtextDecode` / `FieldRichtextNotInline`). A schema-bound
+  `TypedEditor` (`Quill::editor(&mut doc)`) is the front door: `set` / `set_all`
+  resolve field types and report `Committed::{Typed,Opaque}`. Bindings gain
+  `commitField` / `commitCardField` (wasm) and `commit_field` /
+  `commit_card_field` (Python, net-new — Python had no richtext field writer);
+  `setRichtextField` / `updateCardRichtextField` deprecate into them. Strict
+  writes drop the render floor's cross-type `Boolean`↔`Number` coercions and
+  fail a shape mismatch at the write, not at a later render (#893)
 - remove(core,richtext,wasm)!: delete the incremental-edit surface — the
   per-field change log and everything layered on it: `richtext::ChangeLog` /
   `FieldChange` / `StaleRevision`; `LiveSession::revision` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,22 @@
 
 ## Unreleased
 
-- feat(core,wasm,python): typed field writes via schema-carried types. One
+- feat(core,wasm,python)!: typed field writes via schema-carried types. One
   per-type write dispatch (`conform_value(value, schema, mode)`) unifies the
   render floor's coercion with a strict-write mode behind a `Leniency` flag; one
   typed writer per address, `Card::commit_field(name, value, &FieldSchema)`,
-  dispatches on the schema and subsumes `set_field_richtext` (now a deprecated
-  wrapper) — the write surface stays O(1) in field types. Adds
+  dispatches on the schema — the write surface stays O(1) in field types. Adds
   `EditError::FieldConform` for non-richtext mismatches (richtext keeps
   `FieldRichtextDecode` / `FieldRichtextNotInline`). A schema-bound
   `TypedEditor` (`Quill::editor(&mut doc)`) is the front door: `set` / `set_all`
   resolve field types and report `Committed::{Typed,Opaque}`. Bindings gain
   `commitField` / `commitCardField` (wasm) and `commit_field` /
-  `commit_card_field` (Python, net-new — Python had no richtext field writer);
-  `setRichtextField` / `updateCardRichtextField` deprecate into them. Strict
-  writes drop the render floor's cross-type `Boolean`↔`Number` coercions and
-  fail a shape mismatch at the write, not at a later render (#893)
+  `commit_card_field` (Python, net-new — Python had no richtext field writer).
+  The pre-release richtext-specific writers are removed in the same cycle:
+  `Card::set_field_richtext`, wasm `setRichtextField` / `updateCardRichtextField`
+  — use the typed writer, which carries the `inline` constraint in the schema.
+  Strict writes drop the render floor's cross-type `Boolean`↔`Number` coercions
+  and fail a shape mismatch at the write, not at a later render (#893)
 - remove(core,richtext,wasm)!: delete the incremental-edit surface — the
   per-field change log and everything layered on it: `richtext::ChangeLog` /
   `FieldChange` / `StaleRevision`; `LiveSession::revision` /

--- a/crates/backends/pdfform/tests/richtext_form.rs
+++ b/crates/backends/pdfform/tests/richtext_form.rs
@@ -92,6 +92,7 @@ fn richtext_fields_lower_to_plaintext_field_values() {
 /// re-canonicalize) end-to-end and proves it lowers identically to the
 /// string-authored path — the corpus-from-write form renders the same PDF.
 #[test]
+#[allow(deprecated)] // exercises the deprecated `set_field_richtext` wrapper
 fn richtext_fields_written_as_corpus_render_identically() {
     let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("richtext_form"))
         .expect("load richtext_form quill");

--- a/crates/backends/pdfform/tests/richtext_form.rs
+++ b/crates/backends/pdfform/tests/richtext_form.rs
@@ -86,32 +86,31 @@ fn richtext_fields_lower_to_plaintext_field_values() {
     );
 }
 
-/// Same render, but the richtext fields are written via `set_field_richtext`, so
+/// Same render, but the richtext fields are written via the typed editor, so
 /// each is **stored as a canonical corpus object** rather than an authored
 /// markdown string. This exercises coercion's object branch (re-validate +
 /// re-canonicalize) end-to-end and proves it lowers identically to the
 /// string-authored path — the corpus-from-write form renders the same PDF.
 #[test]
-#[allow(deprecated)] // exercises the deprecated `set_field_richtext` wrapper
 fn richtext_fields_written_as_corpus_render_identically() {
     let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("richtext_form"))
         .expect("load richtext_form quill");
     let engine = Quillmark::new();
 
     // Start from the string-authored doc, then re-write each field through the
-    // corpus writer: passing markdown still stores the *canonical corpus object*
-    // (decode → canonicalize), so the payload now carries corpus objects.
+    // schema-bound typed editor: `commit_field` stores the *canonical corpus
+    // object* (decode → canonicalize) for a richtext-typed field, so the payload
+    // now carries corpus objects.
     let mut doc = Document::from_markdown(FILLED).expect("parse markdown");
-    let main = doc.main_mut();
-    main.set_field_richtext("headline", &serde_json::json!("The **headline**"), true)
-        .expect("inline richtext write");
-    main.set_field_richtext(
-        "bio",
-        &serde_json::json!("A **bold** claim and _emphasis_."),
-        false,
-    )
-    .expect("block richtext write");
+    {
+        let mut ed = quill.editor(&mut doc);
+        ed.set("headline", "The **headline**")
+            .expect("inline richtext write");
+        ed.set("bio", "A **bold** claim and _emphasis_.")
+            .expect("block richtext write");
+    }
     // Precondition: the fields are stored structurally as corpus objects now.
+    let main = doc.main();
     assert!(main.payload().get("headline").unwrap().as_json().is_object());
     assert!(main.payload().get("bio").unwrap().as_json().is_object());
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -468,6 +468,50 @@ impl PyDocument {
             .map_err(convert_edit_errors)
     }
 
+    /// Typed field write on the main card, resolving the field's schema `type`
+    /// from `quill` — the one write verb for every field type. Python has no
+    /// richtext field writer otherwise, so a richtext value (a corpus dict or a
+    /// markdown string) commits to the canonical corpus here; scalars coerce to
+    /// their declared type (`"3"` → `3`).
+    ///
+    /// Returns `"typed"` when the field is declared in the schema (strict
+    /// commit — a mismatch raises now) or `"opaque"` when it is not (stored
+    /// verbatim, like `set_field`). Raises `QuillmarkError` on a typed mismatch
+    /// or a malformed name. Mirrors WASM `commitField`.
+    fn commit_field(
+        &mut self,
+        quill: PyRef<'_, PyQuill>,
+        name: &str,
+        value: Bound<'_, PyAny>,
+    ) -> PyResult<String> {
+        let qv = py_to_quillvalue(&value)?;
+        quill
+            .inner
+            .editor(&mut self.inner)
+            .set(name, qv)
+            .map(|c| c.as_str().to_string())
+            .map_err(convert_edit_error)
+    }
+
+    /// Typed field write on the composable card at `index` — the card-indexed
+    /// twin of `commit_field`, resolving the field's type from the card's
+    /// `$kind` schema in `quill`. Returns `"typed"` / `"opaque"`; raises on an
+    /// out-of-range index or a typed mismatch. Mirrors WASM `commitCardField`.
+    fn commit_card_field(
+        &mut self,
+        quill: PyRef<'_, PyQuill>,
+        index: usize,
+        name: &str,
+        value: Bound<'_, PyAny>,
+    ) -> PyResult<String> {
+        let qv = py_to_quillvalue(&value)?;
+        let mut editor = quill.inner.editor(&mut self.inner);
+        let mut card = editor.card(index).map_err(convert_edit_error)?;
+        card.set(name, qv)
+            .map(|c| c.as_str().to_string())
+            .map_err(convert_edit_error)
+    }
+
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match self
             .inner

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -576,3 +576,46 @@ def test_to_markdown_ambiguous_string_survival():
     assert field(doc2.main, "str_null") == "null"
     assert field(doc2.main, "octal_str") == "01234"
     assert field(doc2.main, "date_str") == "2024-01-15"
+
+
+# ── Typed field writes — commit_field / commit_card_field ─────────────────────
+
+
+def _richtext_form_quill():
+    """The richtext_form fixture quill (headline: richtext inline, bio: richtext)."""
+    return Quill.from_path(str(_latest_version(QUILLS_PATH / "richtext_form")))
+
+
+def test_commit_field_richtext_typed():
+    """commit_field resolves a richtext field's type and stores canonical corpus."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    assert doc.commit_field(quill, "bio", "A **bold** intro.") == "typed"
+    value = field(doc.main, "bio")
+    # Stored structurally as the corpus dict, not the authored markdown string.
+    assert isinstance(value, dict)
+    assert value["text"] == "A bold intro."
+
+
+def test_commit_field_unknown_field_is_opaque():
+    """A field absent from the schema stores opaquely, and the caller is told."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    assert doc.commit_field(quill, "stray", "x") == "opaque"
+    assert field(doc.main, "stray") == "x"
+
+
+def test_commit_field_inline_violation_raises():
+    """A richtext(inline) field rejects multi-block content at the write."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+        doc.commit_field(quill, "headline", "line one\n\nline two")
+
+
+def test_commit_card_field_index_out_of_range():
+    """commit_card_field surfaces IndexOutOfRange for a missing card."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.commit_card_field(quill, 0, "body", "x")

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -670,6 +670,70 @@ describe('Document editor surface — setRichtextField / fieldMarkdown', () => {
   })
 })
 
+describe('Document editor surface — commitField / commitCardField', () => {
+  const COMMIT_QUILL_YAML = `quill:
+  name: commit_test
+  version: "1.0"
+  backend: typst
+  description: Typed write smoke test
+
+main:
+  fields:
+    subject:
+      type: richtext
+      inline: true
+    intro:
+      type: richtext
+    qty:
+      type: integer
+
+card_kinds:
+  note:
+    fields:
+      body:
+        type: richtext
+`
+  const buildQuill = () =>
+    Quill.fromTree(makeQuill({ name: 'commit_test', plate: TEST_PLATE, quillYaml: COMMIT_QUILL_YAML }))
+  const blankDoc = () => Document.fromMarkdown('~~~card-yaml\n$quill: commit_test\n~~~\n\nBody.')
+
+  it('commitField resolves the schema type: richtext string → corpus, integer "3" → 3', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    expect(doc.commitField(quill, 'intro', 'A **bold** intro.')).toBe('typed')
+    expect(typeof field(doc.main, 'intro')).toBe('object')
+    expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
+
+    expect(doc.commitField(quill, 'qty', '3')).toBe('typed')
+    expect(field(doc.main, 'qty')).toBe(3)
+  })
+
+  it('commitField stores an unknown field opaquely and says so', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    expect(doc.commitField(quill, 'stray', 'x')).toBe('opaque')
+    expect(field(doc.main, 'stray')).toBe('x')
+  })
+
+  it('commitField fails a strict mismatch and a richtext(inline) violation', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    expect(() => doc.commitField(quill, 'qty', 'not-a-number')).toThrow(/FieldConform/)
+    expect(() => doc.commitField(quill, 'subject', 'line one\n\nline two'))
+      .toThrow(/FieldRichtextNotInline/)
+  })
+
+  it('commitCardField resolves the card-kind schema and errors on a bad index', () => {
+    const quill = buildQuill()
+    const doc = Document.fromMarkdown(
+      '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
+    )
+    expect(doc.commitCardField(quill, 0, 'body', 'Card **body**.')).toBe('typed')
+    expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+    expect(() => doc.commitCardField(quill, 9, 'body', 'x')).toThrow(/IndexOutOfRange/)
+  })
+})
+
 describe('Document editor surface — card mutations', () => {
   const MD_WITH_CARDS = `~~~card-yaml
 $quill: test_quill

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -615,61 +615,6 @@ describe('Document editor surface — setQuillRef / replaceBody', () => {
   })
 })
 
-describe('Document editor surface — setRichtextField / fieldMarkdown', () => {
-  it('setRichtextField accepts a markdown string and stores a corpus object', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setRichtextField('intro', 'A **bold** intro.')
-    // Stored structurally as the corpus, not the authored string.
-    expect(typeof field(doc.main, 'intro')).toBe('object')
-    expect(field(doc.main, 'intro').text).toBe('A bold intro.')
-    // fieldMarkdown is the projection twin of bodyMarkdown.
-    expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
-  })
-
-  it('setRichtextField accepts a corpus object round-tripped from a body', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    const src = Document.fromMarkdown('~~~card-yaml\n$quill: q@1.0.0\n~~~\n\nCorpus **field** here.')
-    const corpus = src.main.body
-    expect(typeof corpus).toBe('object')
-    doc.setRichtextField('intro', corpus)
-    expect(field(doc.main, 'intro').text).toBe('Corpus field here.')
-    expect(doc.fieldMarkdown('intro')).toBe('Corpus **field** here.\n')
-  })
-
-  it('setRichtextField(name, null) stores the empty corpus', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setRichtextField('intro', null)
-    expect(doc.fieldMarkdown('intro')).toBe('')
-  })
-
-  it('setRichtextField(inline=true) throws FieldRichtextNotInline on multi-block', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setRichtextField('title', 'one line', true) // ok
-    expect(() => doc.setRichtextField('title', 'line one\n\nline two', true))
-      .toThrow(/FieldRichtextNotInline/)
-  })
-
-  it('setRichtextField throws FieldRichtextDecode on a non-corpus object', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setRichtextField('intro', { not: 'a corpus' })).toThrow(/FieldRichtextDecode/)
-  })
-
-  it('fieldMarkdown returns undefined for an absent or non-richtext field', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(doc.fieldMarkdown('nonexistent')).toBeUndefined()
-    doc.setField('count', 3)
-    expect(doc.fieldMarkdown('count')).toBeUndefined()
-  })
-
-  it('updateCardRichtextField / cardFieldMarkdown target a card by index', () => {
-    const doc = Document.fromMarkdown(
-      '~~~card-yaml\n$quill: q@1.0.0\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
-    )
-    doc.updateCardRichtextField(0, 'note', 'Card **note**.')
-    expect(doc.cardFieldMarkdown(0, 'note')).toBe('Card **note**.\n')
-  })
-})
-
 describe('Document editor surface — commitField / commitCardField', () => {
   const COMMIT_QUILL_YAML = `quill:
   name: commit_test
@@ -713,6 +658,13 @@ card_kinds:
     const doc = blankDoc()
     expect(doc.commitField(quill, 'stray', 'x')).toBe('opaque')
     expect(field(doc.main, 'stray')).toBe('x')
+  })
+
+  it('fieldMarkdown returns undefined for an absent or non-richtext field', () => {
+    const doc = blankDoc()
+    expect(doc.fieldMarkdown('nonexistent')).toBeUndefined()
+    doc.setField('count', 3)
+    expect(doc.fieldMarkdown('count')).toBeUndefined()
   })
 
   it('commitField fails a strict mismatch and a richtext(inline) violation', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1007,6 +1007,11 @@ impl Document {
     /// Throws `[EditError::FieldRichtextDecode]` if `value` is neither a valid
     /// corpus object, an importable markdown string, nor `null`, and
     /// `[EditError::InvalidFieldName]` on a malformed name.
+    ///
+    /// **Deprecated**: use [`commitField`](Document::commit_field), which
+    /// resolves the field's type (including the `richtext(inline)` constraint)
+    /// from the quill schema — the one write verb for every field type.
+    #[allow(deprecated)]
     #[wasm_bindgen(js_name = setRichtextField)]
     pub fn set_richtext_field(
         &mut self,
@@ -1018,6 +1023,39 @@ impl Document {
         self.inner
             .main_mut()
             .set_field_richtext(name, &json, inline.unwrap_or(false))
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// Typed field write on the main card, resolving the field's schema `type`
+    /// from `quill` — the one write verb for **every** field type (richtext,
+    /// scalar, array, object), subsuming [`setRichtextField`](Document::set_richtext_field).
+    /// The schema carries the `inline` constraint, so no type token or flag is
+    /// passed. Values use the encoding the seam already speaks: a corpus object
+    /// or markdown string for richtext, a scalar/array/object otherwise.
+    ///
+    /// Returns `"typed"` when the field is declared in the schema (strict
+    /// commit — a mismatch throws now, not at render) or `"opaque"` when it is
+    /// not (stored verbatim, like [`setField`](Document::set_field)). Throws
+    /// `[EditError::FieldConform]` / `[EditError::FieldRichtextDecode]` /
+    /// `[EditError::FieldRichtextNotInline]` on a typed mismatch and
+    /// `[EditError::InvalidFieldName]` on a malformed name.
+    ///
+    /// The `quill` handle is passed per call because a `Document` carries only a
+    /// `$quill` reference, not the resolved schema.
+    #[wasm_bindgen(js_name = commitField, unchecked_return_type = "\"typed\" | \"opaque\"")]
+    pub fn commit_field(
+        &mut self,
+        quill: &Quill,
+        name: &str,
+        value: JsValue,
+    ) -> Result<String, JsValue> {
+        let json = js_value_to_json(value, "commitField")?;
+        let qv = quillmark_core::QuillValue::from_json(json);
+        quill
+            .inner
+            .editor(&mut self.inner)
+            .set(name, qv)
+            .map(|c| c.as_str().to_string())
             .map_err(|e| edit_error_to_js(&e))
     }
 
@@ -1164,6 +1202,10 @@ impl Document {
     /// corpus; `inline` (default `false`) enforces `richtext(inline)` at write.
     /// Throws if `index` is out of range, on a malformed name, or on a value that
     /// is neither a corpus object, an importable markdown string, nor `null`.
+    ///
+    /// **Deprecated**: use [`commitCardField`](Document::commit_card_field),
+    /// which resolves the field's type from the quill schema.
+    #[allow(deprecated)]
     #[wasm_bindgen(js_name = updateCardRichtextField)]
     pub fn update_card_richtext_field(
         &mut self,
@@ -1175,6 +1217,31 @@ impl Document {
         let json = js_value_to_json(value, "updateCardRichtextField")?;
         self.card_mut_or_throw(index)?
             .set_field_richtext(name, &json, inline.unwrap_or(false))
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// Typed field write on the composable card at `index` — the card-indexed
+    /// twin of [`commitField`](Document::commit_field). Resolves the field's
+    /// type from the card's `$kind` schema in `quill` and strict-commits it;
+    /// subsumes [`updateCardRichtextField`](Document::update_card_richtext_field).
+    ///
+    /// Returns `"typed"` / `"opaque"` (see `commitField`). Throws
+    /// `[EditError::IndexOutOfRange]` when `index` is out of range, and the same
+    /// typed-mismatch / name errors as `commitField`.
+    #[wasm_bindgen(js_name = commitCardField, unchecked_return_type = "\"typed\" | \"opaque\"")]
+    pub fn commit_card_field(
+        &mut self,
+        quill: &Quill,
+        index: usize,
+        name: &str,
+        value: JsValue,
+    ) -> Result<String, JsValue> {
+        let json = js_value_to_json(value, "commitCardField")?;
+        let qv = quillmark_core::QuillValue::from_json(json);
+        let mut editor = quill.inner.editor(&mut self.inner);
+        let mut card = editor.card(index).map_err(|e| edit_error_to_js(&e))?;
+        card.set(name, qv)
+            .map(|c| c.as_str().to_string())
             .map_err(|e| edit_error_to_js(&e))
     }
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -988,49 +988,13 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Set a **richtext** field on the main card from a corpus object (canonical
-    /// RichText-JSON) or a markdown string — the field-level twin of
-    /// [`setBody`](Document::set_body), and the corpus-native counterpart to
-    /// [`setField`](Document::set_field) (which stores an opaque value). The
-    /// field is stored as the canonical corpus, so identity marks (anchors,
-    /// island ids) live on it and survive compiles and the storage DTO; a
-    /// corpus-only mark such as `underline` round-trips losslessly, unlike the
-    /// card-yaml markdown projection. `null` stores the empty corpus.
-    ///
-    /// `inline` (default `false`) mirrors the schema's `richtext(inline)`
-    /// constraint: when `true`, a multi-block value throws
-    /// `[EditError::FieldRichtextNotInline]` here at write rather than at a later
-    /// render. The caller supplies it because a `Document` carries only a
-    /// `$quill` reference, not the resolved field type — an editor holds the
-    /// schema and knows whether the target is `richtext(inline)`.
-    ///
-    /// Throws `[EditError::FieldRichtextDecode]` if `value` is neither a valid
-    /// corpus object, an importable markdown string, nor `null`, and
-    /// `[EditError::InvalidFieldName]` on a malformed name.
-    ///
-    /// **Deprecated**: use [`commitField`](Document::commit_field), which
-    /// resolves the field's type (including the `richtext(inline)` constraint)
-    /// from the quill schema — the one write verb for every field type.
-    #[allow(deprecated)]
-    #[wasm_bindgen(js_name = setRichtextField)]
-    pub fn set_richtext_field(
-        &mut self,
-        name: &str,
-        #[wasm_bindgen(unchecked_param_type = "RichText | string")] value: JsValue,
-        #[wasm_bindgen(unchecked_optional_param_type = "boolean")] inline: Option<bool>,
-    ) -> Result<(), JsValue> {
-        let json = js_value_to_json(value, "setRichtextField")?;
-        self.inner
-            .main_mut()
-            .set_field_richtext(name, &json, inline.unwrap_or(false))
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
     /// Typed field write on the main card, resolving the field's schema `type`
     /// from `quill` — the one write verb for **every** field type (richtext,
-    /// scalar, array, object), subsuming [`setRichtextField`](Document::set_richtext_field).
-    /// The schema carries the `inline` constraint, so no type token or flag is
-    /// passed. Values use the encoding the seam already speaks: a corpus object
+    /// scalar, array, object). The schema carries the `inline` constraint, so no
+    /// type token or flag is passed. A richtext-typed field stores the canonical
+    /// corpus, so identity marks (anchors, island ids) and corpus-only marks
+    /// (e.g. `underline`) live on it and survive compiles and the storage DTO.
+    /// Values use the encoding the seam already speaks: a corpus object
     /// or markdown string for richtext, a scalar/array/object otherwise.
     ///
     /// Returns `"typed"` when the field is declared in the schema (strict
@@ -1197,33 +1161,9 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Set a **richtext** field on the card at `index` — the card-indexed twin of
-    /// [`setRichtextField`](Document::set_richtext_field). Stores the canonical
-    /// corpus; `inline` (default `false`) enforces `richtext(inline)` at write.
-    /// Throws if `index` is out of range, on a malformed name, or on a value that
-    /// is neither a corpus object, an importable markdown string, nor `null`.
-    ///
-    /// **Deprecated**: use [`commitCardField`](Document::commit_card_field),
-    /// which resolves the field's type from the quill schema.
-    #[allow(deprecated)]
-    #[wasm_bindgen(js_name = updateCardRichtextField)]
-    pub fn update_card_richtext_field(
-        &mut self,
-        index: usize,
-        name: &str,
-        #[wasm_bindgen(unchecked_param_type = "RichText | string")] value: JsValue,
-        #[wasm_bindgen(unchecked_optional_param_type = "boolean")] inline: Option<bool>,
-    ) -> Result<(), JsValue> {
-        let json = js_value_to_json(value, "updateCardRichtextField")?;
-        self.card_mut_or_throw(index)?
-            .set_field_richtext(name, &json, inline.unwrap_or(false))
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
     /// Typed field write on the composable card at `index` — the card-indexed
     /// twin of [`commitField`](Document::commit_field). Resolves the field's
-    /// type from the card's `$kind` schema in `quill` and strict-commits it;
-    /// subsumes [`updateCardRichtextField`](Document::update_card_richtext_field).
+    /// type from the card's `$kind` schema in `quill` and strict-commits it.
     ///
     /// Returns `"typed"` / `"opaque"` (see `commitField`). Throws
     /// `[EditError::IndexOutOfRange]` when `index` is out of range, and the same
@@ -1310,10 +1250,10 @@ impl Document {
     /// and anchor/island identity ids, survive. `null` clears the body to empty.
     ///
     /// A card body is reachable only here: `$body` is rejected by
-    /// [`updateCardRichtextField`](Document::update_card_richtext_field) (the
-    /// reserved `$`-prefix fails the field-name check), so the field channel
-    /// cannot address it. This closes the last markdown-forced write in the
-    /// corpus surface — a non-main card body (issue #892).
+    /// [`commitCardField`](Document::commit_card_field) (the reserved `$`-prefix
+    /// fails the field-name check), so the field channel cannot address it. This
+    /// closes the last markdown-forced write in the corpus surface — a non-main
+    /// card body (issue #892).
     ///
     /// Throws `[EditError::BodyDecode]` if `body` is neither a valid corpus
     /// object, an importable markdown string, nor `null`, and

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1045,7 +1045,6 @@ This body and the metadata above are an indorsement card.
     }
 
     #[test]
-    #[allow(deprecated)] // exercises the deprecated `set_field_richtext` wrapper
     fn corpus_field_survives_storage_round_trip_losslessly() {
         // A richtext field stored as a canonical corpus object is the case the
         // card-yaml markdown projection is lossy for; the storage DTO is the
@@ -1062,7 +1061,14 @@ This body and the metadata above are an indorsement card.
         });
         corpus.normalize();
         let json = quillmark_richtext::serial::to_canonical_value(&corpus);
-        doc.main_mut().set_field_richtext("intro", &json, false).unwrap();
+        let schema = crate::quill::FieldSchema::new(
+            "intro".to_string(),
+            crate::quill::FieldType::RichText { inline: false },
+            None,
+        );
+        doc.main_mut()
+            .commit_field("intro", crate::QuillValue::from_json(json), &schema)
+            .unwrap();
 
         let stored = serde_json::to_string(&doc).unwrap();
         let restored: Document = serde_json::from_str(&stored).unwrap();

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1045,6 +1045,7 @@ This body and the metadata above are an indorsement card.
     }
 
     #[test]
+    #[allow(deprecated)] // exercises the deprecated `set_field_richtext` wrapper
     fn corpus_field_survives_storage_round_trip_losslessly() {
         // A richtext field stored as a canonical corpus object is the case the
         // card-yaml markdown projection is lossy for; the storage DTO is the

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -23,6 +23,7 @@ use quillmark_richtext::{ApplyError, Delta, LineOp, MarkOp, RichText};
 
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::document::{Card, Document, Payload};
+use crate::quill::{CoercionError, FieldSchema, FieldType, Leniency, QuillConfig};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
@@ -97,6 +98,16 @@ pub enum EditError {
     #[error("richtext field '{0}' is not inline: richtext(inline) requires a single paragraph line with no list/quote container and no islands")]
     FieldRichtextNotInline(String),
 
+    /// A typed write ([`Card::commit_field`](Card::commit_field)) could not
+    /// conform the value to the field's schema type — the general write-commit
+    /// failure for scalar/array/object types (a `"x"` for an `integer`, a
+    /// non-object for an `object`, …). Richtext fields report through the
+    /// dedicated [`FieldRichtextDecode`](Self::FieldRichtextDecode) /
+    /// [`FieldRichtextNotInline`](Self::FieldRichtextNotInline) variants
+    /// instead, so the richtext write surface is unchanged.
+    #[error("field '{field}' does not conform to its schema type: {message}")]
+    FieldConform { field: String, message: String },
+
     /// A corpus field-change bundle (text delta, line ops, mark ops) applied
     /// out of bounds or broke an invariant normalization could not repair.
     #[error("corpus apply failed: {0:?}")]
@@ -119,6 +130,7 @@ impl EditError {
             EditError::BodyDecode(_) => "BodyDecode",
             EditError::FieldRichtextDecode { .. } => "FieldRichtextDecode",
             EditError::FieldRichtextNotInline(_) => "FieldRichtextNotInline",
+            EditError::FieldConform { .. } => "FieldConform",
             EditError::CorpusApply(_) => "CorpusApply",
         }
     }
@@ -172,6 +184,59 @@ pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldV
         return Err(FieldViolation::TooDeep);
     }
     Ok(())
+}
+
+/// Map a strict-write [`CoercionError`] to the field-write [`EditError`] surface.
+///
+/// A richtext field routes to the dedicated `FieldRichtext*` variants — the
+/// same surface [`Card::apply_field_richtext_change`] and the deprecated
+/// [`Card::set_field_richtext`] produce, and the one the wasm/Python error
+/// mappers (and their tests) key on; the inline violation is distinguished by
+/// the coercion `target`. Every other type uses the general
+/// [`EditError::FieldConform`].
+fn conform_error_to_edit(name: &str, schema: &FieldSchema, err: CoercionError) -> EditError {
+    let CoercionError::Uncoercible { target, reason, .. } = err;
+    if matches!(schema.r#type, FieldType::RichText { .. }) {
+        if target == "richtext(inline)" {
+            EditError::FieldRichtextNotInline(name.to_string())
+        } else {
+            EditError::FieldRichtextDecode {
+                field: name.to_string(),
+                message: reason,
+            }
+        }
+    } else {
+        EditError::FieldConform {
+            field: name.to_string(),
+            message: reason,
+        }
+    }
+}
+
+/// Compute the canonical stored form of a field write **without applying it** —
+/// the dry-run shared by [`Card::commit_field`] and the batched, all-or-nothing
+/// [`TypedEditor::set_all`](crate::TypedEditor::set_all).
+///
+/// `schema = Some(_)` is a typed write (strict `Leniency::Write` conform);
+/// `schema = None` is an opaque write (mirrors [`Card::set_field`], storing the
+/// value verbatim). Either way the name and stored-value depth are validated,
+/// so a batch can collect every violation before any mutation.
+pub(crate) fn resolve_field_write(
+    name: &str,
+    value: QuillValue,
+    schema: Option<&FieldSchema>,
+) -> Result<QuillValue, EditError> {
+    if !is_valid_field_name(name) {
+        return Err(EditError::InvalidFieldName(name.to_string()));
+    }
+    let stored = match schema {
+        Some(schema) => QuillConfig::conform_value(&value, schema, name, Leniency::Write)
+            .map_err(|e| conform_error_to_edit(name, schema, e))?,
+        None => value,
+    };
+    // Depth-bound the stored form (name already validated above).
+    check_field(name, stored.as_json())?;
+    Ok(stored)
 }
 
 impl Document {
@@ -519,36 +584,75 @@ impl Card {
         }
     }
 
+    /// Write-time commit: validate and normalize `value` per the field's schema
+    /// `type` and store the canonical form. The typed sibling of the opaque
+    /// [`set_field`](Self::set_field) — the one write verb for *every* field
+    /// type (richtext today, any future corpus model tomorrow), dispatching on
+    /// the [`FieldSchema`] rather than growing a per-type method.
+    ///
+    /// The two write disciplines: [`set_field`](Self::set_field) stores the
+    /// value opaquely and defers coercion to render (keystroke-level state,
+    /// data-in-flight); `commit_field` canonicalizes now and fails now (an
+    /// editor blur/save, an agent write). Neither is forced on the other.
+    ///
+    /// Behavior by `type`:
+    /// - **richtext** — imports a markdown string / adopts a corpus object and
+    ///   stores canonical corpus JSON, so identity marks (anchors, island ids)
+    ///   live on the stored value from the write; a `richtext(inline)` schema
+    ///   rejects a multi-block value with [`EditError::FieldRichtextNotInline`].
+    /// - **scalars** (`string`/`integer`/`number`/`boolean`/`datetime`) — stores
+    ///   the coerced canonical (`"3"` → `3`), applying only value-parsing
+    ///   normalizations; a cross-type value that the render floor would coerce
+    ///   (e.g. `1` → `true`) or a shape mismatch fails here instead.
+    /// - **array** / **object** — coerces each element/property against the
+    ///   element/property schema.
+    /// - **null** — passes through unchanged (the null ≡ absent rule); nothing
+    ///   is coerced. (The deprecated [`set_field_richtext`](Self::set_field_richtext)
+    ///   pins the older null → empty-corpus behavior instead.)
+    ///
+    /// The caller supplies the `schema` because a [`Document`] holds only a
+    /// `$quill` *reference*, not the resolved schema; an editor holds it (see
+    /// [`crate::TypedEditor`], which resolves the schema per field and calls
+    /// this).
+    ///
+    /// Returns [`EditError::InvalidFieldName`] for a malformed name,
+    /// [`EditError::FieldRichtextDecode`] / [`EditError::FieldRichtextNotInline`]
+    /// for a richtext field, [`EditError::FieldConform`] for any other type
+    /// mismatch, and [`EditError::ValueTooDeep`] when the stored value nests
+    /// past the §8 depth limit.
+    pub fn commit_field(
+        &mut self,
+        name: &str,
+        value: impl Into<QuillValue>,
+        schema: &FieldSchema,
+    ) -> Result<(), EditError> {
+        let stored = resolve_field_write(name, value.into(), Some(schema))?;
+        self.payload_mut().insert(name.to_string(), stored);
+        Ok(())
+    }
+
     /// Set a payload field to a **richtext corpus**, committing the corpus form
-    /// at write — the field-level twin of [`set_body_value`](Self::set_body_value),
-    /// and the writer that makes a schema-richtext field corpus-from-write-onward
-    /// (`$body` is corpus by construction; a field is corpus *iff* the caller
-    /// picks this method over the string-storing [`set_field`](Self::set_field)).
+    /// at write.
+    ///
+    /// **Deprecated**: use [`commit_field`](Self::commit_field) with a
+    /// `FieldSchema` of `type: richtext` — the schema carries the `inline`
+    /// constraint, so the `inline: bool` parameter is subsumed. This wrapper
+    /// delegates to `commit_field`, keeping one behavior pin: `null` stores the
+    /// empty corpus (where `commit_field` passes null through).
     ///
     /// Accepts either encoding the seam carries — a canonical corpus **object**
     /// (decoded and validated) or an authored markdown **string** (imported) —
     /// and stores the canonical corpus JSON, so identity marks (anchors, island
     /// ids) live on the stored value and persist across compiles and DTO
-    /// round-trips. `null` stores the empty corpus. Routes through the one
-    /// object-vs-string dispatch (`decode_richtext_value`), so it stays lossless
-    /// for corpus-only marks a markdown projection cannot carry (e.g.
-    /// `underline`); a Markdown (`.qmd`) save projects the field back
-    /// to a string ([`Card::field_markdown`]) and re-imports a fresh corpus on
-    /// reload, so on-disk persistence is markdown-lossy by design — identity
-    /// survives the live/DTO carriers, not a card-yaml round-trip.
-    ///
-    /// `inline` mirrors the schema's `richtext(inline)` constraint: when set, a
-    /// decoded multi-block corpus is rejected here with
-    /// [`EditError::FieldRichtextNotInline`], in lockstep with the coercion- and
-    /// validation-layer `richtext(inline)` checks — so the write is the strict
-    /// commit (fail at write, not at a later render). The caller supplies it
-    /// because a [`Document`] holds only a `$quill` *reference*, not the resolved
-    /// [`FieldType`](crate::quill::FieldType); an editor holds the schema and
-    /// knows whether the target field is `richtext(inline)`.
+    /// round-trips. `null` stores the empty corpus.
     ///
     /// Returns [`EditError::InvalidFieldName`] for a malformed name and
     /// [`EditError::FieldRichtextDecode`] for a value that is neither a corpus
     /// object, an importable markdown string, nor `null`.
+    #[deprecated(
+        since = "0.94.0",
+        note = "use `commit_field` with a richtext `FieldSchema`; the schema carries the inline constraint"
+    )]
     pub fn set_field_richtext(
         &mut self,
         name: &str,
@@ -558,41 +662,16 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        let corpus = match crate::document::decode_richtext_value(value) {
-            Some(result) => result.map_err(|e| EditError::FieldRichtextDecode {
-                field: name.to_string(),
-                message: e.into_message(),
-            })?,
-            // Neither object nor string: `null` is the empty corpus; anything
-            // else is an invalid richtext value.
-            None => match value {
-                serde_json::Value::Null => RichText::empty(),
-                other => {
-                    return Err(EditError::FieldRichtextDecode {
-                        field: name.to_string(),
-                        message: format!(
-                            "expected a richtext corpus object or a markdown string, got {}",
-                            match other {
-                                serde_json::Value::Bool(_) => "a boolean",
-                                serde_json::Value::Number(_) => "a number",
-                                serde_json::Value::Array(_) => "an array",
-                                _ => "an unsupported value",
-                            }
-                        ),
-                    })
-                }
-            },
-        };
-        if inline && !corpus.is_inline() {
-            return Err(EditError::FieldRichtextNotInline(name.to_string()));
+        // Behavior pin: `null` stores the empty corpus, where `commit_field`
+        // passes null through (the null ≡ absent rule).
+        if value.is_null() {
+            let canonical = quillmark_richtext::serial::to_canonical_value(&RichText::empty());
+            self.payload_mut()
+                .insert(name.to_string(), QuillValue::from_json(canonical));
+            return Ok(());
         }
-        // Store the canonical corpus object. Depth-checking is unnecessary: a
-        // corpus nests a fixed handful of levels (well under `MAX_YAML_DEPTH`),
-        // and `decode_richtext_value` already validated it.
-        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
-        self.payload_mut()
-            .insert(name.to_string(), QuillValue::from_json(canonical));
-        Ok(())
+        let schema = FieldSchema::new(name.to_string(), FieldType::RichText { inline }, None);
+        self.commit_field(name, QuillValue::from_json(value.clone()), &schema)
     }
 
     /// Replace the body from an authored markdown string — the whole-document

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -86,15 +86,16 @@ pub enum EditError {
     /// decoded: a JSON object that is not a canonical richtext corpus, a
     /// markdown string that failed to import, or a shape that is neither
     /// object, string, nor null. The field-level twin of [`BodyDecode`](Self::BodyDecode);
-    /// returned by [`Card::set_field_richtext`](Card::set_field_richtext).
+    /// returned by [`Card::commit_field`](Card::commit_field) on a richtext field
+    /// and by [`Card::apply_field_richtext_change`](Card::apply_field_richtext_change).
     #[error("richtext field '{field}' decode failed: {message}")]
     FieldRichtextDecode { field: String, message: String },
 
     /// A richtext field written under the `richtext(inline)` constraint decoded
     /// to a multi-block corpus (more than one line, a container, or an island).
     /// The write-time counterpart of the coercion/validation `richtext(inline)`
-    /// check; returned by [`Card::set_field_richtext`](Card::set_field_richtext)
-    /// when its `inline` argument is set.
+    /// check; returned by [`Card::commit_field`](Card::commit_field) when the
+    /// field's schema is `richtext` with `inline: true`.
     #[error("richtext field '{0}' is not inline: richtext(inline) requires a single paragraph line with no list/quote container and no islands")]
     FieldRichtextNotInline(String),
 
@@ -189,10 +190,9 @@ pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldV
 /// Map a strict-write [`CoercionError`] to the field-write [`EditError`] surface.
 ///
 /// A richtext field routes to the dedicated `FieldRichtext*` variants — the
-/// same surface [`Card::apply_field_richtext_change`] and the deprecated
-/// [`Card::set_field_richtext`] produce, and the one the wasm/Python error
-/// mappers (and their tests) key on; the inline violation is distinguished by
-/// the coercion `target`. Every other type uses the general
+/// same surface [`Card::apply_field_richtext_change`] produces, and the one the
+/// wasm/Python error mappers (and their tests) key on; the inline violation is
+/// distinguished by the coercion `target`. Every other type uses the general
 /// [`EditError::FieldConform`].
 fn conform_error_to_edit(name: &str, schema: &FieldSchema, err: CoercionError) -> EditError {
     let CoercionError::Uncoercible { target, reason, .. } = err;
@@ -607,8 +607,8 @@ impl Card {
     /// - **array** / **object** — coerces each element/property against the
     ///   element/property schema.
     /// - **null** — passes through unchanged (the null ≡ absent rule); nothing
-    ///   is coerced. (The deprecated [`set_field_richtext`](Self::set_field_richtext)
-    ///   pins the older null → empty-corpus behavior instead.)
+    ///   is coerced (a richtext `null` reads back as the empty corpus via
+    ///   [`field_richtext`](Self::field_richtext)).
     ///
     /// The caller supplies the `schema` because a [`Document`] holds only a
     /// `$quill` *reference*, not the resolved schema; an editor holds it (see
@@ -629,49 +629,6 @@ impl Card {
         let stored = resolve_field_write(name, value.into(), Some(schema))?;
         self.payload_mut().insert(name.to_string(), stored);
         Ok(())
-    }
-
-    /// Set a payload field to a **richtext corpus**, committing the corpus form
-    /// at write.
-    ///
-    /// **Deprecated**: use [`commit_field`](Self::commit_field) with a
-    /// `FieldSchema` of `type: richtext` — the schema carries the `inline`
-    /// constraint, so the `inline: bool` parameter is subsumed. This wrapper
-    /// delegates to `commit_field`, keeping one behavior pin: `null` stores the
-    /// empty corpus (where `commit_field` passes null through).
-    ///
-    /// Accepts either encoding the seam carries — a canonical corpus **object**
-    /// (decoded and validated) or an authored markdown **string** (imported) —
-    /// and stores the canonical corpus JSON, so identity marks (anchors, island
-    /// ids) live on the stored value and persist across compiles and DTO
-    /// round-trips. `null` stores the empty corpus.
-    ///
-    /// Returns [`EditError::InvalidFieldName`] for a malformed name and
-    /// [`EditError::FieldRichtextDecode`] for a value that is neither a corpus
-    /// object, an importable markdown string, nor `null`.
-    #[deprecated(
-        since = "0.94.0",
-        note = "use `commit_field` with a richtext `FieldSchema`; the schema carries the inline constraint"
-    )]
-    pub fn set_field_richtext(
-        &mut self,
-        name: &str,
-        value: &serde_json::Value,
-        inline: bool,
-    ) -> Result<(), EditError> {
-        if !is_valid_field_name(name) {
-            return Err(EditError::InvalidFieldName(name.to_string()));
-        }
-        // Behavior pin: `null` stores the empty corpus, where `commit_field`
-        // passes null through (the null ≡ absent rule).
-        if value.is_null() {
-            let canonical = quillmark_richtext::serial::to_canonical_value(&RichText::empty());
-            self.payload_mut()
-                .insert(name.to_string(), QuillValue::from_json(canonical));
-            return Ok(());
-        }
-        let schema = FieldSchema::new(name.to_string(), FieldType::RichText { inline }, None);
-        self.commit_field(name, QuillValue::from_json(value.clone()), &schema)
     }
 
     /// Replace the body from an authored markdown string — the whole-document

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -222,7 +222,7 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                 nested_comments,
             } => {
                 // A richtext field stores its value as a canonical corpus
-                // object (via `set_field_richtext`); card-yaml is the
+                // object (via `commit_field`); card-yaml is the
                 // human-authored surface, so it projects back to a markdown
                 // string here — the field-level twin of the `$body` projection,
                 // lossy per the corpus's island loss class (the DTO stays the
@@ -278,7 +278,7 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
 /// The markdown projection of a richtext-valued field, or `None` when `value` is
 /// not a canonical corpus object.
 ///
-/// A richtext field written via [`Card::set_field_richtext`](super::Card::set_field_richtext)
+/// A richtext field written via [`Card::commit_field`](super::Card::commit_field)
 /// stores the canonical corpus object; emit projects it to a markdown string so
 /// card-yaml — the human-authored surface — stays markdown-clean rather than
 /// carrying a nested `{text, lines, marks, islands}` tree. Projection is lossy

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -209,7 +209,7 @@ impl Card {
     /// Read a richtext-valued user field back as a [`RichText`] corpus — the
     /// field-level twin of [`Card::body`]. Decodes the stored value through the
     /// same object-or-markdown dispatch the writer
-    /// ([`set_field_richtext`](Card::set_field_richtext)) commits, so a field
+    /// ([`commit_field`](Card::commit_field)) commits, so a field
     /// stored as a canonical corpus reads back losslessly (identity marks
     /// intact) and a still-authored markdown string imports.
     ///

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1,7 +1,4 @@
 //! Unit tests for the document editor surface.
-// The `set_field_richtext` tests below are kept as regression guards for the
-// deprecated wrapper's preserved behavior; allow the deprecation here.
-#![allow(deprecated)]
 
 use crate::document::edit::{is_valid_field_name, EditError};
 use crate::document::meta::is_valid_kind_name;
@@ -28,6 +25,19 @@ fn make_doc_with_cards() -> Document {
 
 fn qv(s: &str) -> QuillValue {
     QuillValue::from_json(serde_json::json!(s))
+}
+
+/// Commit `value` to a richtext field named `name` via `commit_field` and a
+/// synthesized richtext `FieldSchema` — the typed richtext write.
+fn commit_richtext(
+    card: &mut Card,
+    name: &str,
+    value: &serde_json::Value,
+    inline: bool,
+) -> Result<(), EditError> {
+    use crate::quill::{FieldSchema, FieldType};
+    let schema = FieldSchema::new(name.to_string(), FieldType::RichText { inline }, None);
+    card.commit_field(name, QuillValue::from_json(value.clone()), &schema)
 }
 
 fn qv_int(n: i64) -> QuillValue {
@@ -614,11 +624,12 @@ fn test_set_body_value_accepts_markdown_and_null_and_rejects_bad() {
     );
 }
 
-/// `set_field_richtext` accepts a **canonical corpus object**, stores it as the
-/// field's canonical value (lossless for corpus-only marks), and reads back
-/// through `field_richtext` — the field-level twin of `set_body_value` / `body`.
+/// `commit_field` on a richtext field accepts a **canonical corpus object**,
+/// stores it as the field's canonical value (lossless for corpus-only marks),
+/// and reads back through `field_richtext` — the field-level twin of
+/// `set_body_value` / `body`.
 #[test]
-fn test_set_field_richtext_accepts_corpus_object_and_reads_back() {
+fn test_commit_field_richtext_corpus_object_reads_back() {
     use quillmark_richtext::model::{Mark, MarkKind};
 
     let mut corpus = quillmark_richtext::import::from_markdown("underlined intro").unwrap();
@@ -632,7 +643,7 @@ fn test_set_field_richtext_accepts_corpus_object_and_reads_back() {
     let json = quillmark_richtext::serial::to_canonical_value(&corpus);
 
     let mut card = Card::new("note").unwrap();
-    card.set_field_richtext("intro", &json, false).unwrap();
+    commit_richtext(&mut card, "intro", &json, false).unwrap();
 
     // Stored structurally as the corpus object, not the authored string.
     assert!(card.payload().get("intro").unwrap().as_json().is_object());
@@ -642,52 +653,56 @@ fn test_set_field_richtext_accepts_corpus_object_and_reads_back() {
     assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 }
 
-/// `set_field_richtext` also accepts a **markdown string** (imported) and `null`
-/// (empty corpus); `field_markdown` is the projection twin of `body_markdown`.
-/// A non-corpus object / other shape is `EditError::FieldRichtextDecode`.
+/// A richtext `commit_field` accepts a **markdown string** (imported) and passes
+/// `null` through (reading back as the empty corpus); `field_markdown` is the
+/// projection twin of `body_markdown`. A non-corpus object / other shape is
+/// `EditError::FieldRichtextDecode`.
 #[test]
-fn test_set_field_richtext_accepts_markdown_and_null_and_rejects_bad() {
+fn test_commit_field_richtext_markdown_null_and_rejects_bad() {
     let mut card = Card::new("note").unwrap();
 
-    card.set_field_richtext("intro", &serde_json::json!("**bold** intro"), false)
-        .unwrap();
+    commit_richtext(&mut card, "intro", &serde_json::json!("**bold** intro"), false).unwrap();
     assert_eq!(card.field_markdown("intro").unwrap(), "**bold** intro\n");
 
-    card.set_field_richtext("intro", &serde_json::Value::Null, false)
-        .unwrap();
+    // null passes through (stored as null) and reads back as the empty corpus.
+    commit_richtext(&mut card, "intro", &serde_json::Value::Null, false).unwrap();
+    assert!(card.payload().get("intro").unwrap().as_json().is_null());
     assert!(card.field_richtext("intro").unwrap().unwrap().is_blank());
 
     assert_eq!(
-        card.set_field_richtext("intro", &serde_json::json!({ "not": "a corpus" }), false)
+        commit_richtext(&mut card, "intro", &serde_json::json!({ "not": "a corpus" }), false)
             .unwrap_err()
             .variant_name(),
         "FieldRichtextDecode"
     );
     assert_eq!(
-        card.set_field_richtext("intro", &serde_json::json!(42), false)
+        commit_richtext(&mut card, "intro", &serde_json::json!(42), false)
             .unwrap_err()
             .variant_name(),
         "FieldRichtextDecode"
     );
 }
 
-/// `set_field_richtext(inline = true)` commits the `richtext(inline)` check at
+/// A richtext(inline) `commit_field` commits the `richtext(inline)` check at
 /// write: a single-`Para` corpus stores, a multi-block corpus is
 /// `EditError::FieldRichtextNotInline` — the write is the strict commit, not a
 /// deferred render failure.
 #[test]
-fn test_set_field_richtext_inline_enforced_at_write() {
+fn test_commit_field_richtext_inline_enforced_at_write() {
     let mut card = Card::new("note").unwrap();
 
     // One paragraph line: inline, accepted.
-    card.set_field_richtext("title", &serde_json::json!("A single line"), true)
-        .unwrap();
+    commit_richtext(&mut card, "title", &serde_json::json!("A single line"), true).unwrap();
     assert_eq!(card.field_markdown("title").unwrap(), "A single line\n");
 
     // Two blocks: rejected at write, and nothing is stored over the good value.
-    let err = card
-        .set_field_richtext("title", &serde_json::json!("line one\n\nline two"), true)
-        .unwrap_err();
+    let err = commit_richtext(
+        &mut card,
+        "title",
+        &serde_json::json!("line one\n\nline two"),
+        true,
+    )
+    .unwrap_err();
     assert_eq!(err.variant_name(), "FieldRichtextNotInline");
     assert_eq!(card.field_markdown("title").unwrap(), "A single line\n");
 }
@@ -748,59 +763,6 @@ fn test_commit_field_object_rejects_non_object() {
     );
 }
 
-/// `commit_field` on a richtext schema commits the corpus and reports through
-/// the richtext-specific error variants (decode / inline), matching the
-/// deprecated `set_field_richtext` surface the bindings key on.
-#[test]
-fn test_commit_field_richtext_variants() {
-    use crate::quill::{FieldSchema, FieldType};
-
-    let mut card = Card::new("note").unwrap();
-    let block = FieldSchema::new("intro".to_string(), FieldType::RichText { inline: false }, None);
-    let inline = FieldSchema::new("title".to_string(), FieldType::RichText { inline: true }, None);
-
-    // Markdown string imports to corpus.
-    card.commit_field(
-        "intro",
-        QuillValue::from_json(serde_json::json!("**bold** intro")),
-        &block,
-    )
-    .unwrap();
-    assert_eq!(card.field_markdown("intro").unwrap(), "**bold** intro\n");
-
-    // A bare scalar is not a richtext write (no scalar→markdown reduction).
-    assert_eq!(
-        card.commit_field("intro", QuillValue::from_json(serde_json::json!(42)), &block)
-            .unwrap_err()
-            .variant_name(),
-        "FieldRichtextDecode"
-    );
-
-    // Multi-block into a richtext(inline) field fails at write.
-    assert_eq!(
-        card.commit_field(
-            "title",
-            QuillValue::from_json(serde_json::json!("line one\n\nline two")),
-            &inline,
-        )
-        .unwrap_err()
-        .variant_name(),
-        "FieldRichtextNotInline"
-    );
-}
-
-/// `commit_field` passes `null` through (the null ≡ absent rule) — a divergence
-/// from the deprecated `set_field_richtext`, which stores the empty corpus.
-#[test]
-fn test_commit_field_null_passes_through() {
-    use crate::quill::{FieldSchema, FieldType};
-
-    let mut card = Card::new("note").unwrap();
-    let schema = FieldSchema::new("intro".to_string(), FieldType::RichText { inline: false }, None);
-    card.commit_field("intro", QuillValue::null(), &schema).unwrap();
-    assert!(card.payload().get("intro").unwrap().as_json().is_null());
-}
-
 /// A malformed field name fails with `InvalidFieldName` before any coercion.
 #[test]
 fn test_commit_field_rejects_bad_name() {
@@ -837,9 +799,13 @@ fn test_field_richtext_absent_and_non_richtext() {
 #[test]
 fn test_corpus_field_emits_as_markdown_projection() {
     let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
-    doc.main_mut()
-        .set_field_richtext("intro", &serde_json::json!("**bold** intro"), false)
-        .unwrap();
+    commit_richtext(
+        doc.main_mut(),
+        "intro",
+        &serde_json::json!("**bold** intro"),
+        false,
+    )
+    .unwrap();
 
     let md = doc.to_markdown();
     // Projected to a quoted markdown scalar (the `body_markdown` projection,
@@ -989,8 +955,7 @@ fn test_apply_field_richtext_change_splices_and_persists() {
     use quillmark_richtext::model::MarkKind;
 
     let mut card = Card::new("note").unwrap();
-    card.set_field_richtext("intro", &serde_json::json!("abc"), false)
-        .unwrap();
+    commit_richtext(&mut card, "intro", &serde_json::json!("abc"), false).unwrap();
     let d = diff("abc", "abXc");
     card.apply_field_richtext_change(
         "intro",

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1,4 +1,7 @@
 //! Unit tests for the document editor surface.
+// The `set_field_richtext` tests below are kept as regression guards for the
+// deprecated wrapper's preserved behavior; allow the deprecation here.
+#![allow(deprecated)]
 
 use crate::document::edit::{is_valid_field_name, EditError};
 use crate::document::meta::is_valid_kind_name;
@@ -687,6 +690,130 @@ fn test_set_field_richtext_inline_enforced_at_write() {
         .unwrap_err();
     assert_eq!(err.variant_name(), "FieldRichtextNotInline");
     assert_eq!(card.field_markdown("title").unwrap(), "A single line\n");
+}
+
+// ── commit_field (typed write) ───────────────────────────────────────────────
+
+/// `commit_field` on a scalar schema stores the coerced canonical (`"3"` → `3`);
+/// a strict write drops the render floor's cross-type coercions (a `bool` for an
+/// `integer` field) and fails a shape mismatch with `EditError::FieldConform`.
+#[test]
+fn test_commit_field_scalar_strict() {
+    use crate::quill::{FieldSchema, FieldType};
+
+    let mut card = Card::new("note").unwrap();
+    let int_schema = FieldSchema::new("qty".to_string(), FieldType::Integer, None);
+
+    // Value-parsing normalization survives: "3" → 3.
+    card.commit_field("qty", QuillValue::from_json(serde_json::json!("3")), &int_schema)
+        .unwrap();
+    assert_eq!(
+        card.payload().get("qty").unwrap().as_json(),
+        &serde_json::json!(3)
+    );
+
+    // Cross-type boolean→integer is a render-floor leniency, dropped on write.
+    let err = card
+        .commit_field("qty", QuillValue::from_json(serde_json::json!(true)), &int_schema)
+        .unwrap_err();
+    assert_eq!(err.variant_name(), "FieldConform");
+
+    // A non-numeric string is a mismatch and fails now, not at render.
+    assert_eq!(
+        card.commit_field("qty", QuillValue::from_json(serde_json::json!("x")), &int_schema)
+            .unwrap_err()
+            .variant_name(),
+        "FieldConform"
+    );
+    // The good value is untouched by the failed writes.
+    assert_eq!(
+        card.payload().get("qty").unwrap().as_json(),
+        &serde_json::json!(3)
+    );
+}
+
+/// `commit_field` on an `object` schema fails a non-object value with
+/// `FieldConform`, where the render floor would defer to validation.
+#[test]
+fn test_commit_field_object_rejects_non_object() {
+    use crate::quill::{FieldSchema, FieldType};
+
+    let mut card = Card::new("note").unwrap();
+    let schema = FieldSchema::new("meta".to_string(), FieldType::Object, None);
+    assert_eq!(
+        card.commit_field("meta", QuillValue::from_json(serde_json::json!(42)), &schema)
+            .unwrap_err()
+            .variant_name(),
+        "FieldConform"
+    );
+}
+
+/// `commit_field` on a richtext schema commits the corpus and reports through
+/// the richtext-specific error variants (decode / inline), matching the
+/// deprecated `set_field_richtext` surface the bindings key on.
+#[test]
+fn test_commit_field_richtext_variants() {
+    use crate::quill::{FieldSchema, FieldType};
+
+    let mut card = Card::new("note").unwrap();
+    let block = FieldSchema::new("intro".to_string(), FieldType::RichText { inline: false }, None);
+    let inline = FieldSchema::new("title".to_string(), FieldType::RichText { inline: true }, None);
+
+    // Markdown string imports to corpus.
+    card.commit_field(
+        "intro",
+        QuillValue::from_json(serde_json::json!("**bold** intro")),
+        &block,
+    )
+    .unwrap();
+    assert_eq!(card.field_markdown("intro").unwrap(), "**bold** intro\n");
+
+    // A bare scalar is not a richtext write (no scalar→markdown reduction).
+    assert_eq!(
+        card.commit_field("intro", QuillValue::from_json(serde_json::json!(42)), &block)
+            .unwrap_err()
+            .variant_name(),
+        "FieldRichtextDecode"
+    );
+
+    // Multi-block into a richtext(inline) field fails at write.
+    assert_eq!(
+        card.commit_field(
+            "title",
+            QuillValue::from_json(serde_json::json!("line one\n\nline two")),
+            &inline,
+        )
+        .unwrap_err()
+        .variant_name(),
+        "FieldRichtextNotInline"
+    );
+}
+
+/// `commit_field` passes `null` through (the null ≡ absent rule) — a divergence
+/// from the deprecated `set_field_richtext`, which stores the empty corpus.
+#[test]
+fn test_commit_field_null_passes_through() {
+    use crate::quill::{FieldSchema, FieldType};
+
+    let mut card = Card::new("note").unwrap();
+    let schema = FieldSchema::new("intro".to_string(), FieldType::RichText { inline: false }, None);
+    card.commit_field("intro", QuillValue::null(), &schema).unwrap();
+    assert!(card.payload().get("intro").unwrap().as_json().is_null());
+}
+
+/// A malformed field name fails with `InvalidFieldName` before any coercion.
+#[test]
+fn test_commit_field_rejects_bad_name() {
+    use crate::quill::{FieldSchema, FieldType};
+
+    let mut card = Card::new("note").unwrap();
+    let schema = FieldSchema::new("$bad".to_string(), FieldType::Integer, None);
+    assert_eq!(
+        card.commit_field("$bad", QuillValue::from_json(serde_json::json!(1)), &schema)
+            .unwrap_err()
+            .variant_name(),
+        "InvalidFieldName"
+    );
 }
 
 /// `field_richtext` on an absent field is `None`; on a plain non-richtext field

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -394,7 +394,6 @@ mod tests {
     /// projection) survive Card → wire → Card. This is the lossless carrier the
     /// card-yaml markdown projection (emit) deliberately is not.
     #[test]
-    #[allow(deprecated)] // exercises the deprecated `set_field_richtext` wrapper
     fn card_wire_round_trips_corpus_field_losslessly() {
         use quillmark_richtext::model::{Mark, MarkKind};
 
@@ -407,7 +406,13 @@ mod tests {
         });
         corpus.normalize();
         let json = quillmark_richtext::serial::to_canonical_value(&corpus);
-        card.set_field_richtext("intro", &json, false).unwrap();
+        let schema = crate::quill::FieldSchema::new(
+            "intro".to_string(),
+            crate::quill::FieldType::RichText { inline: false },
+            None,
+        );
+        card.commit_field("intro", crate::QuillValue::from_json(json), &schema)
+            .unwrap();
 
         let wire = CardWire::from(&card);
         // Carried as the corpus object, verbatim — not a markdown projection.

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -394,6 +394,7 @@ mod tests {
     /// projection) survive Card → wire → Card. This is the lossless carrier the
     /// card-yaml markdown projection (emit) deliberately is not.
     #[test]
+    #[allow(deprecated)] // exercises the deprecated `set_field_richtext` wrapper
     fn card_wire_round_trips_corpus_field_losslessly() {
         use quillmark_richtext::model::{Mark, MarkKind};
 

--- a/crates/core/src/editor.rs
+++ b/crates/core/src/editor.rs
@@ -1,0 +1,332 @@
+//! Schema-bound typed editor — the front door for typed field writes.
+//!
+//! [`Card::commit_field`](crate::Card::commit_field) still asks the caller to
+//! fetch a [`FieldSchema`] per write. Every consumer that wants typed writes (a
+//! form editor, an MCP server) already holds the resolved [`QuillConfig`] — it
+//! renders with it. [`Quill::editor`](crate::Quill::editor) binds the schema
+//! once, so callers issue one verb (`set`) and never pass a type token or an
+//! `inline` flag: the editor resolves each field's type itself and routes a
+//! schema field through the strict commit and an unknown field through the
+//! opaque store.
+//!
+//! ```ignore
+//! let mut ed = quill.editor(&mut doc);
+//! ed.set("subject", "Q3 results")?;       // richtext(inline) → strict corpus commit
+//! ed.set("qty", "3")?;                    // integer → strict coerce, stores 3
+//! ed.card(2)?.set("desc", corpus_json)?;  // card kind → CardSchema → field type
+//! ed.set_all([("a", "1"), ("b", "2")])?;  // batched, all-or-nothing
+//! ```
+//!
+//! The editor holds `&mut Document` and `&QuillConfig`, so a bound `TypedEditor`
+//! cannot cross a binding boundary that carries no lifetimes (wasm-bindgen /
+//! pyo3 objects); those surfaces construct one per call from the quill handle.
+
+use std::collections::BTreeMap;
+
+use crate::document::edit::resolve_field_write;
+use crate::document::{Card, Document, EditError};
+use crate::quill::{CardSchema, FieldSchema, QuillConfig};
+use crate::value::QuillValue;
+
+/// Which store a [`TypedEditor::set`] / [`CardEditor::set`] used: `Typed` when
+/// the field is declared in the schema (strict commit), `Opaque` when it is not
+/// (verbatim store, mirroring [`Card::set_field`](crate::Card::set_field)).
+///
+/// An editor's caller usually meant a schema field, so a typo'd name silently
+/// storing opaque is otherwise invisible until validation — the return value
+/// surfaces which path ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Committed {
+    /// The field is declared in the schema; the value was strict-committed to
+    /// its canonical typed form.
+    Typed,
+    /// The field is not in the schema; the value was stored opaquely (the field
+    /// bag stays a bag).
+    Opaque,
+}
+
+impl Committed {
+    /// `true` for [`Committed::Typed`].
+    pub fn is_typed(self) -> bool {
+        matches!(self, Committed::Typed)
+    }
+
+    /// `"typed"` or `"opaque"` — the discriminant a binding surfaces to its
+    /// caller.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Committed::Typed => "typed",
+            Committed::Opaque => "opaque",
+        }
+    }
+}
+
+/// A [`Document`] bound to its [`QuillConfig`] for typed writes. Construct with
+/// [`Quill::editor`](crate::Quill::editor). Writes target the main card; use
+/// [`card`](Self::card) for a composable card.
+pub struct TypedEditor<'a> {
+    config: &'a QuillConfig,
+    doc: &'a mut Document,
+}
+
+impl<'a> TypedEditor<'a> {
+    /// Bind `doc` to `config`. Prefer [`Quill::editor`](crate::Quill::editor).
+    pub fn new(config: &'a QuillConfig, doc: &'a mut Document) -> Self {
+        Self { config, doc }
+    }
+
+    /// Write a field on the main card. Resolves the field's schema type and
+    /// strict-commits it ([`Committed::Typed`]); an unknown field stores
+    /// opaquely ([`Committed::Opaque`]). Error surface is that of
+    /// [`Card::commit_field`](crate::Card::commit_field) /
+    /// [`Card::set_field`](crate::Card::set_field).
+    pub fn set(
+        &mut self,
+        name: &str,
+        value: impl Into<QuillValue>,
+    ) -> Result<Committed, EditError> {
+        let config = self.config;
+        match config.main.fields.get(name) {
+            Some(schema) => {
+                self.doc.main_mut().commit_field(name, value, schema)?;
+                Ok(Committed::Typed)
+            }
+            None => {
+                self.doc.main_mut().set_field(name, value)?;
+                Ok(Committed::Opaque)
+            }
+        }
+    }
+
+    /// Write several main-card fields atomically — the typed twin of
+    /// [`Card::set_fields`](crate::Card::set_fields). Every field is resolved
+    /// (typed conform or opaque store) before any is applied; on any violation
+    /// nothing is written and every offending field is returned as a
+    /// `(name, error)` pair.
+    pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
+    where
+        K: Into<String>,
+        V: Into<QuillValue>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let schema = Some(&self.config.main.fields);
+        set_all_impl(self.doc.main_mut(), schema, fields)
+    }
+
+    /// A schema-bound editor for the composable card at `index`. The card's
+    /// `$kind` resolves its [`CardSchema`]; an unknown kind degrades the whole
+    /// card to opaque writes (mirroring `coerce_card`). Returns
+    /// [`EditError::IndexOutOfRange`] when `index` is out of range.
+    pub fn card(&mut self, index: usize) -> Result<CardEditor<'_>, EditError> {
+        let config = self.config;
+        let len = self.doc.cards().len();
+        let card = self
+            .doc
+            .card_mut(index)
+            .ok_or(EditError::IndexOutOfRange { index, len })?;
+        let schema = card.kind().and_then(|k| config.card_kind(k));
+        Ok(CardEditor { schema, card })
+    }
+}
+
+/// A single composable card bound to its [`CardSchema`], from
+/// [`TypedEditor::card`]. Same `set` / `set_all` verbs as [`TypedEditor`].
+pub struct CardEditor<'a> {
+    schema: Option<&'a CardSchema>,
+    card: &'a mut Card,
+}
+
+impl CardEditor<'_> {
+    /// The card's `$kind`, if any.
+    pub fn kind(&self) -> Option<&str> {
+        self.card.kind()
+    }
+
+    /// Write a field on this card. Resolves the field against the card's
+    /// [`CardSchema`] (typed commit) or stores opaquely when the field — or the
+    /// whole card kind — is unknown.
+    pub fn set(
+        &mut self,
+        name: &str,
+        value: impl Into<QuillValue>,
+    ) -> Result<Committed, EditError> {
+        match self.schema.and_then(|s| s.fields.get(name)) {
+            Some(schema) => {
+                self.card.commit_field(name, value, schema)?;
+                Ok(Committed::Typed)
+            }
+            None => {
+                self.card.set_field(name, value)?;
+                Ok(Committed::Opaque)
+            }
+        }
+    }
+
+    /// Write several fields on this card atomically — see
+    /// [`TypedEditor::set_all`].
+    pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
+    where
+        K: Into<String>,
+        V: Into<QuillValue>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        set_all_impl(self.card, self.schema.map(|s| &s.fields), fields)
+    }
+}
+
+/// All-or-nothing batched write shared by [`TypedEditor::set_all`] and
+/// [`CardEditor::set_all`]: resolve every field first (collecting every error),
+/// apply none on failure, apply all on success.
+fn set_all_impl<K, V, I>(
+    card: &mut Card,
+    fields_schema: Option<&BTreeMap<String, FieldSchema>>,
+    fields: I,
+) -> Result<(), Vec<(String, EditError)>>
+where
+    K: Into<String>,
+    V: Into<QuillValue>,
+    I: IntoIterator<Item = (K, V)>,
+{
+    let fields: Vec<(String, QuillValue)> = fields
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect();
+
+    let mut resolved: Vec<(String, QuillValue)> = Vec::with_capacity(fields.len());
+    let mut errors: Vec<(String, EditError)> = Vec::new();
+    for (name, value) in fields {
+        let schema = fields_schema.and_then(|m| m.get(&name));
+        match resolve_field_write(&name, value, schema) {
+            Ok(stored) => resolved.push((name, stored)),
+            Err(e) => errors.push((name, e)),
+        }
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    for (name, stored) in resolved {
+        card.payload_mut().insert(name, stored);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::{Card, Document};
+    use crate::version::QuillReference;
+    use std::str::FromStr;
+
+    const QUILL_YAML: &str = "\
+quill:
+  name: memo
+  backend: typst
+  version: 1.0.0
+  description: Editor test quill
+main:
+  fields:
+    subject:
+      type: richtext
+      inline: true
+    qty:
+      type: integer
+card_kinds:
+  note:
+    fields:
+      body:
+        type: richtext
+";
+
+    fn config() -> QuillConfig {
+        QuillConfig::from_yaml(QUILL_YAML).expect("valid quill")
+    }
+
+    fn blank_doc() -> Document {
+        Document::new(QuillReference::from_str("memo@1.0.0").unwrap())
+    }
+
+    #[test]
+    fn set_resolves_schema_field_as_typed_commit() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+
+        // A schema field commits typed: "3" → 3, richtext string → corpus.
+        assert_eq!(ed.set("qty", "3").unwrap(), Committed::Typed);
+        assert_eq!(ed.set("subject", "Hello").unwrap(), Committed::Typed);
+        assert_eq!(
+            doc.main().payload().get("qty").unwrap().as_json(),
+            &serde_json::json!(3)
+        );
+        assert_eq!(doc.main().field_markdown("subject").unwrap(), "Hello\n");
+    }
+
+    #[test]
+    fn set_stores_unknown_field_opaque() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        // Unknown field → opaque store, and the caller can see it happened.
+        assert_eq!(ed.set("notafield", "x").unwrap(), Committed::Opaque);
+        assert_eq!(
+            doc.main().payload().get("notafield").unwrap().as_str(),
+            Some("x")
+        );
+    }
+
+    #[test]
+    fn set_reports_strict_conform_failure() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        let err = ed.set("qty", "not-a-number").unwrap_err();
+        assert_eq!(err.variant_name(), "FieldConform");
+        // A richtext(inline) violation surfaces through the richtext variant.
+        let err = ed.set("subject", "line one\n\nline two").unwrap_err();
+        assert_eq!(err.variant_name(), "FieldRichtextNotInline");
+    }
+
+    #[test]
+    fn set_all_is_all_or_nothing() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        // One bad field aborts the whole batch; nothing is applied.
+        let errs = ed
+            .set_all([("qty", "5"), ("subject", "bad\n\nblock")])
+            .unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].0, "subject");
+        assert!(doc.main().payload().get("qty").is_none());
+
+        // A clean batch applies every field.
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        ed.set_all([("qty", "5"), ("subject", "ok")]).unwrap();
+        assert_eq!(
+            doc.main().payload().get("qty").unwrap().as_json(),
+            &serde_json::json!(5)
+        );
+    }
+
+    #[test]
+    fn card_editor_resolves_card_kind_schema() {
+        let config = config();
+        let mut doc = blank_doc();
+        doc.push_card(Card::new("note").unwrap()).unwrap();
+
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut card_ed = ed.card(0).unwrap();
+        assert_eq!(card_ed.set("body", "**hi**").unwrap(), Committed::Typed);
+        // Unknown field on a known card → opaque.
+        assert_eq!(card_ed.set("stray", "v").unwrap(), Committed::Opaque);
+
+        assert_eq!(doc.cards()[0].field_markdown("body").unwrap(), "**hi**\n");
+
+        // Out-of-range card index errors.
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        assert!(matches!(
+            ed.card(9),
+            Err(EditError::IndexOutOfRange { .. })
+        ));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,6 +30,9 @@ pub use document::{
     RichtextDecodeError, SeedOverlay, WireError,
 };
 
+pub mod editor;
+pub use editor::{CardEditor, Committed, TypedEditor};
+
 pub mod backend;
 pub use backend::{formats_support_canvas, Backend};
 

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -16,6 +16,7 @@ mod types;
 pub(crate) mod validation;
 
 pub use config::{CoercionError, QuillConfig};
+pub(crate) use config::Leniency;
 pub use fill::zero_value;
 pub use formats::parse_date_ymd;
 pub use ignore::QuillIgnore;
@@ -68,6 +69,14 @@ impl Quill {
     /// The parsed schema configuration.
     pub fn config(&self) -> &QuillConfig {
         &self.config
+    }
+
+    /// A schema-bound [`TypedEditor`](crate::TypedEditor) over `doc`. The front
+    /// door for typed field writes: it resolves each field's type from this
+    /// quill's schema, so callers issue one verb (`set`) with no type token or
+    /// `inline` flag. See the [`editor`](crate::editor) module.
+    pub fn editor<'a>(&'a self, doc: &'a mut crate::document::Document) -> crate::TypedEditor<'a> {
+        crate::TypedEditor::new(&self.config, doc)
     }
 
     /// The in-memory file tree for this quill.

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -458,8 +458,8 @@ impl QuillConfig {
                 // canonical corpus object or a markdown string, nothing else. No
                 // scalar→string reduction (the render floor's lenient cascade
                 // below): a bare scalar for a richtext field fails the write. The
-                // messages mirror the deprecated `Card::set_field_richtext`, whose
-                // error variants the bindings still key on.
+                // messages mirror `Card::commit_field`'s richtext error variants,
+                // which the bindings key on.
                 if mode == Leniency::Write {
                     let corpus = match crate::document::decode_richtext_value(json_value) {
                         Some(result) => result.map_err(|e| CoercionError::Uncoercible {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -112,6 +112,28 @@ pub enum CoercionError {
     },
 }
 
+/// Write-side leniency mode for [`QuillConfig::conform_value`] — the one axis
+/// that separates the render floor's forgiving coercion from a strict typed
+/// write.
+///
+/// The dispatch is shared; only the arms that *defer to the validation layer*
+/// or *cross type boundaries* branch on this. See `conform_value`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Leniency {
+    /// The render floor's forgiving cascade (today's `coerce_value_strict`
+    /// behavior, unchanged): cross-type scalar coercions apply and a shape a
+    /// type cannot adopt falls through unchanged for the validation layer to
+    /// report.
+    Render,
+    /// A strict typed write ([`Card::commit_field`](crate::document::Card::commit_field)):
+    /// value-parsing normalizations still apply (`"3"` → `3`, a bare scalar
+    /// wraps into a singleton array, richtext markdown imports to corpus), but
+    /// cross-type `Boolean`↔`Number` coercions are dropped and every
+    /// defer-to-validation fall-through becomes a `CoercionError` — so a
+    /// mismatched value fails at the write, not silently at a later render.
+    Write,
+}
+
 impl QuillConfig {
     /// Returns a named card-kind schema by name.
     pub fn card_kind(&self, name: &str) -> Option<&CardSchema> {
@@ -161,7 +183,7 @@ impl QuillConfig {
                 let path = field_name.as_str();
                 coerced.insert(
                     field_name.clone(),
-                    Self::coerce_value_strict(field_value, field_schema, path)?,
+                    Self::conform_value(field_value, field_schema, path, Leniency::Render)?,
                 );
             } else {
                 coerced.insert(field_name.clone(), field_value.clone());
@@ -187,7 +209,7 @@ impl QuillConfig {
                 let path = format!("card_kinds.{card_kind}.{field_name}");
                 coerced.insert(
                     field_name.clone(),
-                    Self::coerce_value_strict(field_value, field_schema, &path)?,
+                    Self::conform_value(field_value, field_schema, &path, Leniency::Render)?,
                 );
             } else {
                 coerced.insert(field_name.clone(), field_value.clone());
@@ -204,10 +226,20 @@ impl QuillConfig {
         super::validation::validate_typed_document(self, doc)
     }
 
-    fn coerce_value_strict(
+    /// The one write-side per-type dispatch: given a value, a field's schema,
+    /// and a [`Leniency`] mode, validate/normalize the value to the canonical
+    /// form the type stores. `Render` is the render floor's forgiving coercion
+    /// (the former `coerce_value_strict`, behavior-preserving); `Write` is the
+    /// strict typed-write commit driving [`Card::commit_field`](crate::document::Card::commit_field).
+    ///
+    /// Validation keeps its own read-only dispatch (`validation::validate_value`),
+    /// synced with this via the shared helpers `scalar_as_string` /
+    /// `decode_richtext_value`.
+    pub(crate) fn conform_value(
         value: &QuillValue,
         field_schema: &super::FieldSchema,
         path: &str,
+        mode: Leniency,
     ) -> Result<QuillValue, CoercionError> {
         use super::FieldType;
 
@@ -238,10 +270,11 @@ impl QuillConfig {
                 if let Some(items) = &field_schema.items {
                     let mut out = Vec::with_capacity(arr.len());
                     for (idx, elem) in arr.iter().enumerate() {
-                        let coerced = Self::coerce_value_strict(
+                        let coerced = Self::conform_value(
                             &QuillValue::from_json(elem.clone()),
                             items,
                             &format!("{path}[{idx}]"),
+                            mode,
                         )?;
                         out.push(coerced.into_json());
                     }
@@ -265,16 +298,20 @@ impl QuillConfig {
                         return Ok(QuillValue::from_json(serde_json::Value::Bool(false)));
                     }
                 }
-                if let Some(n) = json_value.as_i64() {
-                    return Ok(QuillValue::from_json(serde_json::Value::Bool(n != 0)));
-                }
-                if let Some(n) = json_value.as_f64() {
-                    if n.is_nan() {
-                        return Ok(QuillValue::from_json(serde_json::Value::Bool(false)));
+                // Cross-type number→boolean is a render-floor leniency; a strict
+                // write requires an actual boolean or its `"true"`/`"false"` text.
+                if mode == Leniency::Render {
+                    if let Some(n) = json_value.as_i64() {
+                        return Ok(QuillValue::from_json(serde_json::Value::Bool(n != 0)));
                     }
-                    return Ok(QuillValue::from_json(serde_json::Value::Bool(
-                        n.abs() > f64::EPSILON,
-                    )));
+                    if let Some(n) = json_value.as_f64() {
+                        if n.is_nan() {
+                            return Ok(QuillValue::from_json(serde_json::Value::Bool(false)));
+                        }
+                        return Ok(QuillValue::from_json(serde_json::Value::Bool(
+                            n.abs() > f64::EPSILON,
+                        )));
+                    }
                 }
 
                 Err(CoercionError::Uncoercible {
@@ -304,11 +341,14 @@ impl QuillConfig {
                         reason: "string is not a valid number".to_string(),
                     });
                 }
-                if let Some(b) = json_value.as_bool() {
-                    let n = if b { 1 } else { 0 };
-                    return Ok(QuillValue::from_json(serde_json::Value::Number(
-                        serde_json::Number::from(n),
-                    )));
+                // Cross-type boolean→number is a render-floor leniency only.
+                if mode == Leniency::Render {
+                    if let Some(b) = json_value.as_bool() {
+                        let n = if b { 1 } else { 0 };
+                        return Ok(QuillValue::from_json(serde_json::Value::Number(
+                            serde_json::Number::from(n),
+                        )));
+                    }
                 }
 
                 Err(CoercionError::Uncoercible {
@@ -344,11 +384,14 @@ impl QuillConfig {
                         reason: "string is not a valid integer".to_string(),
                     });
                 }
-                if let Some(b) = json_value.as_bool() {
-                    let n = if b { 1 } else { 0 };
-                    return Ok(QuillValue::from_json(serde_json::Value::Number(
-                        serde_json::Number::from(n),
-                    )));
+                // Cross-type boolean→integer is a render-floor leniency only.
+                if mode == Leniency::Render {
+                    if let Some(b) = json_value.as_bool() {
+                        let n = if b { 1 } else { 0 };
+                        return Ok(QuillValue::from_json(serde_json::Value::Number(
+                            serde_json::Number::from(n),
+                        )));
+                    }
                 }
 
                 Err(CoercionError::Uncoercible {
@@ -370,7 +413,17 @@ impl QuillConfig {
                 if let Some(text) = lenient_string(json_value) {
                     return Ok(QuillValue::from_json(serde_json::Value::String(text)));
                 }
-                Ok(value.clone())
+                // A non-stringifiable shape (object, multi-element array): the
+                // render floor defers to validation, a strict write fails now.
+                match mode {
+                    Leniency::Render => Ok(value.clone()),
+                    Leniency::Write => Err(CoercionError::Uncoercible {
+                        path: path.to_string(),
+                        value: json_value.to_string(),
+                        target: "string".to_string(),
+                        reason: "value is not a string".to_string(),
+                    }),
+                }
             }
             FieldType::RichText { inline } => {
                 // The seam carries the corpus, so coercion commits the corpus
@@ -401,6 +454,42 @@ impl QuillConfig {
                         }
                         Ok(())
                     };
+                // A strict write uses `decode_richtext_value` semantics — a
+                // canonical corpus object or a markdown string, nothing else. No
+                // scalar→string reduction (the render floor's lenient cascade
+                // below): a bare scalar for a richtext field fails the write. The
+                // messages mirror the deprecated `Card::set_field_richtext`, whose
+                // error variants the bindings still key on.
+                if mode == Leniency::Write {
+                    let corpus = match crate::document::decode_richtext_value(json_value) {
+                        Some(result) => result.map_err(|e| CoercionError::Uncoercible {
+                            path: path.to_string(),
+                            value: "<richtext>".to_string(),
+                            target: "richtext".to_string(),
+                            reason: e.into_message(),
+                        })?,
+                        None => {
+                            return Err(CoercionError::Uncoercible {
+                                path: path.to_string(),
+                                value: json_value.to_string(),
+                                target: "richtext".to_string(),
+                                reason: format!(
+                                    "expected a richtext corpus object or a markdown string, got {}",
+                                    match json_value {
+                                        serde_json::Value::Bool(_) => "a boolean",
+                                        serde_json::Value::Number(_) => "a number",
+                                        serde_json::Value::Array(_) => "an array",
+                                        _ => "an unsupported value",
+                                    }
+                                ),
+                            })
+                        }
+                    };
+                    inline_check(&corpus)?;
+                    return Ok(QuillValue::from_json(
+                        quillmark_richtext::serial::to_canonical_value(&corpus),
+                    ));
+                }
                 if json_value.is_object() {
                     let rt = quillmark_richtext::serial::from_canonical_value(json_value).map_err(
                         |e| CoercionError::Uncoercible {
@@ -489,7 +578,7 @@ impl QuillConfig {
             FieldType::Object => {
                 if let Some(obj) = json_value.as_object() {
                     if let Some(props) = &field_schema.properties {
-                        let coerced_obj = Self::coerce_object_props(obj, props, path)?;
+                        let coerced_obj = Self::coerce_object_props(obj, props, path, mode)?;
                         Ok(QuillValue::from_json(serde_json::Value::Object(
                             coerced_obj,
                         )))
@@ -497,7 +586,17 @@ impl QuillConfig {
                         Ok(value.clone())
                     }
                 } else {
-                    Ok(value.clone())
+                    // A non-object value: the render floor defers to validation,
+                    // a strict write fails now.
+                    match mode {
+                        Leniency::Render => Ok(value.clone()),
+                        Leniency::Write => Err(CoercionError::Uncoercible {
+                            path: path.to_string(),
+                            value: json_value.to_string(),
+                            target: "object".to_string(),
+                            reason: "value is not an object".to_string(),
+                        }),
+                    }
                 }
             }
         }
@@ -511,6 +610,7 @@ impl QuillConfig {
         obj: &serde_json::Map<String, serde_json::Value>,
         props: &std::collections::BTreeMap<String, Box<super::FieldSchema>>,
         parent_path: &str,
+        mode: Leniency,
     ) -> Result<serde_json::Map<String, serde_json::Value>, CoercionError> {
         let mut out = serde_json::Map::new();
         for (k, v) in obj {
@@ -518,10 +618,11 @@ impl QuillConfig {
                 let child_path = format!("{parent_path}.{k}");
                 out.insert(
                     k.clone(),
-                    Self::coerce_value_strict(
+                    Self::conform_value(
                         &QuillValue::from_json(v.clone()),
                         prop_schema,
                         &child_path,
+                        mode,
                     )?
                     .into_json(),
                 );

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -16,13 +16,24 @@
 //!   `root_field` are drawn from the generator's character set.
 //! - **T3 (idempotence):** for any input where `coerce_payload` returns
 //!   `Ok(x)`, `coerce_payload(x) == Ok(x)`.
+//!
+//! The strict *write* side of the same dispatch (`conform_value` under
+//! `Leniency::Write`, reached through the public `Card::commit_field`) carries
+//! the parallel guarantees:
+//!
+//! - **W1 (no-panic):** `commit_field` returns `Ok | Err(_)` for any pair.
+//! - **W2 (typed error):** a failure is one of the typed-write `EditError`
+//!   variants (`FieldConform`, `FieldRichtext*`, `ValueTooDeep`,
+//!   `InvalidFieldName`), never a panic or an unrelated variant.
+//! - **W3 (commit ∘ commit = commit):** a committed value is a fixed point —
+//!   re-committing it yields the same stored value.
 
 use std::collections::{BTreeMap, HashMap};
 
 use indexmap::IndexMap;
 use proptest::prelude::*;
 use quillmark_core::quill::{CardSchema, CoercionError, FieldSchema, FieldType, QuillConfig};
-use quillmark_core::QuillValue;
+use quillmark_core::{Card, EditError, QuillValue};
 
 // -- Generators ---------------------------------------------------------------
 
@@ -219,6 +230,61 @@ proptest! {
                 .coerce_payload(&first)
                 .expect("second coerce must succeed when first did");
             prop_assert_eq!(first, second);
+        }
+    }
+}
+
+// -- Write-mode (strict commit) properties ------------------------------------
+
+/// Commit `value` to a single field `f` of the given `schema` via the public
+/// `Card::commit_field` (strict `Leniency::Write`) and return the stored form.
+fn commit_once(schema: &FieldSchema, value: serde_json::Value) -> Result<QuillValue, EditError> {
+    let mut card = Card::new("note").expect("valid card kind");
+    card.commit_field("f", QuillValue::from_json(value), schema)?;
+    Ok(card.payload().get("f").expect("field stored").clone())
+}
+
+proptest! {
+    // W1 — never panic, however adversarial the (schema, value) pair.
+    #[test]
+    fn commit_never_panics(
+        schema in arb_field_schema(4),
+        value in arb_json_value(4),
+    ) {
+        let _ = commit_once(&schema, value);
+    }
+
+    // W2 — a commit failure is one of the typed-write EditError variants.
+    #[test]
+    fn commit_error_is_typed(
+        schema in arb_field_schema(4),
+        value in arb_json_value(4),
+    ) {
+        if let Err(e) = commit_once(&schema, value) {
+            prop_assert!(
+                matches!(
+                    e,
+                    EditError::FieldConform { .. }
+                        | EditError::FieldRichtextDecode { .. }
+                        | EditError::FieldRichtextNotInline(_)
+                        | EditError::ValueTooDeep { .. }
+                        | EditError::InvalidFieldName(_)
+                ),
+                "unexpected commit error variant: {e:?}"
+            );
+        }
+    }
+
+    // W3 — commit ∘ commit = commit: re-committing a committed value is stable.
+    #[test]
+    fn commit_is_idempotent(
+        schema in arb_field_schema(4),
+        value in arb_json_value(4),
+    ) {
+        if let Ok(first) = commit_once(&schema, value) {
+            let second = commit_once(&schema, first.as_json().clone())
+                .expect("re-commit of a committed value must succeed");
+            prop_assert_eq!(first.as_json(), second.as_json());
         }
     }
 }

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -82,7 +82,53 @@ line, a grid cell, `measure(..)` — no longer triggers Typst's non-fatal
 "parbreak may not occur inside of a paragraph" warning. No plate change is
 needed; block (`inline` omitted) richtext is unaffected.
 
+## Typed field writes: `commit_field` and the schema-bound editor (#893)
+
+`set_field_richtext` / `setRichtextField` / `updateCardRichtextField` (below,
+#881) are **deprecated within this cycle**. The type a write commits belongs in
+the schema, not the method name — so there is one typed writer per address that
+dispatches on the field's `FieldSchema`, and it never grows a per-type sibling.
+
+| Deprecated | Use instead |
+|---|---|
+| `Card::set_field_richtext(name, &json, inline)` | `Card::commit_field(name, value, &field_schema)` |
+| wasm `setRichtextField(name, value, inline?)` | wasm `commitField(quill, name, value)` |
+| wasm `updateCardRichtextField(index, name, value, inline?)` | wasm `commitCardField(quill, index, name, value)` |
+| — (Python had no richtext field writer) | Python `Document.commit_field(quill, name, value)` / `commit_card_field(quill, index, name, value)` |
+
+- **`commit_field` is not richtext-specific.** It commits *any* field type: a
+  richtext value imports/adopts the corpus, a scalar coerces to its declared
+  type (`"3"` → `3`), an array/object coerces element-wise. The write is
+  **strict** — a mismatch the render floor would silently coerce (a `bool` into
+  an `integer`, a non-object into an `object`) fails now with
+  `EditError::FieldConform`; richtext fields keep the
+  `FieldRichtextDecode` / `FieldRichtextNotInline` variants. `null` passes
+  through (null ≡ absent), where the deprecated `set_field_richtext` stored the
+  empty corpus.
+- **`inline` is gone from the write API.** The schema carries it: a richtext
+  `FieldSchema` with `inline: true` enforces `richtext(inline)` at the commit.
+- **The schema-bound editor is the front door.** `quill.editor(&mut doc)`
+  ([`TypedEditor`]) resolves each field's type itself, so callers issue one verb
+  with no type token: `ed.set("qty", "3")?`, `ed.card(2)?.set("desc", v)?`,
+  `ed.set_all([..])?` (all-or-nothing). `set` returns `Committed::Typed` for a
+  schema field or `Committed::Opaque` for an unknown one — a typo'd name storing
+  opaque is visible, not silent. The bindings pass the quill handle per call
+  instead of holding the editor (wasm-bindgen / pyo3 objects carry no lifetime).
+- **`set_field` is unchanged.** The opaque path (store verbatim, coerce at
+  render) stays for keystroke-level state and DB-row batch generators; the split
+  is `set_field` = *coerce at render* vs `commit_field` = *canonicalize now, fail
+  now*.
+
+The wire, the storage DTO, and hand-authored `.qmd` are unaffected — a richtext
+field authored as a markdown string still imports at render.
+
+[`TypedEditor`]: the `editor` module in `quillmark-core`.
+
 ## Richtext fields: a corpus writer, `set_field_richtext` (#881)
+
+> Superseded by `commit_field` (above). The methods below still work as
+> deprecated aliases; the corpus-at-write and identity-persistence guarantees
+> they document carry over verbatim to `commit_field` on a richtext field.
 
 A richtext value now has one write contract everywhere. `$body` was already
 corpus-from-construction; a richtext **field** gains a writer that commits the

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -84,88 +84,60 @@ needed; block (`inline` omitted) richtext is unaffected.
 
 ## Typed field writes: `commit_field` and the schema-bound editor (#893)
 
-`set_field_richtext` / `setRichtextField` / `updateCardRichtextField` (below,
-#881) are **deprecated within this cycle**. The type a write commits belongs in
-the schema, not the method name — so there is one typed writer per address that
-dispatches on the field's `FieldSchema`, and it never grows a per-type sibling.
+The type a write commits belongs in the **schema**, not the method name — so
+there is one typed writer per address that dispatches on the field's
+`FieldSchema` and never grows a per-type sibling. An earlier iteration of this
+cycle shipped a richtext-specific writer (`set_field_richtext` / wasm
+`setRichtextField` / `updateCardRichtextField`); those were **removed
+pre-release** and folded into the one typed writer below.
 
-| Deprecated | Use instead |
+| Removed (pre-release) | Use instead |
 |---|---|
 | `Card::set_field_richtext(name, &json, inline)` | `Card::commit_field(name, value, &field_schema)` |
 | wasm `setRichtextField(name, value, inline?)` | wasm `commitField(quill, name, value)` |
 | wasm `updateCardRichtextField(index, name, value, inline?)` | wasm `commitCardField(quill, index, name, value)` |
 | — (Python had no richtext field writer) | Python `Document.commit_field(quill, name, value)` / `commit_card_field(quill, index, name, value)` |
 
+Read twins are unchanged: `Card::field_richtext(name)` / `field_markdown(name)`
+(wasm `fieldMarkdown` / `cardFieldMarkdown`), and the incremental splice
+`Card::apply_field_richtext_change(name, ..)`.
+
 - **`commit_field` is not richtext-specific.** It commits *any* field type: a
-  richtext value imports/adopts the corpus, a scalar coerces to its declared
-  type (`"3"` → `3`), an array/object coerces element-wise. The write is
-  **strict** — a mismatch the render floor would silently coerce (a `bool` into
-  an `integer`, a non-object into an `object`) fails now with
-  `EditError::FieldConform`; richtext fields keep the
-  `FieldRichtextDecode` / `FieldRichtextNotInline` variants. `null` passes
-  through (null ≡ absent), where the deprecated `set_field_richtext` stored the
-  empty corpus.
-- **`inline` is gone from the write API.** The schema carries it: a richtext
-  `FieldSchema` with `inline: true` enforces `richtext(inline)` at the commit.
+  richtext value imports/adopts the corpus (storing the canonical corpus object,
+  so a corpus-only mark like `underline` and identity ids survive where a
+  markdown projection would drop them), a scalar coerces to its declared type
+  (`"3"` → `3`), an array/object coerces element-wise. The write is **strict** —
+  a mismatch the render floor would silently coerce (a `bool` into an `integer`,
+  a non-object into an `object`) fails now with `EditError::FieldConform`;
+  richtext fields keep the `FieldRichtextDecode` / `FieldRichtextNotInline`
+  variants. `null` passes through (null ≡ absent) and reads back as the empty
+  corpus.
+- **The schema carries `inline`.** A richtext `FieldSchema` with `inline: true`
+  enforces `richtext(inline)` at the commit — no write-side flag.
 - **The schema-bound editor is the front door.** `quill.editor(&mut doc)`
   ([`TypedEditor`]) resolves each field's type itself, so callers issue one verb
   with no type token: `ed.set("qty", "3")?`, `ed.card(2)?.set("desc", v)?`,
   `ed.set_all([..])?` (all-or-nothing). `set` returns `Committed::Typed` for a
   schema field or `Committed::Opaque` for an unknown one — a typo'd name storing
   opaque is visible, not silent. The bindings pass the quill handle per call
-  instead of holding the editor (wasm-bindgen / pyo3 objects carry no lifetime).
+  instead of holding the editor (wasm-bindgen / pyo3 objects carry no lifetime),
+  and surface the discriminant as the `"typed"` / `"opaque"` return string.
 - **`set_field` is unchanged.** The opaque path (store verbatim, coerce at
   render) stays for keystroke-level state and DB-row batch generators; the split
   is `set_field` = *coerce at render* vs `commit_field` = *canonicalize now, fail
-  now*.
+  now*. A richtext field authored as a markdown string in hand-written `.qmd`
+  still imports at render — no file needs editing.
 
-The wire, the storage DTO, and hand-authored `.qmd` are unaffected — a richtext
-field authored as a markdown string still imports at render.
+The wire and the storage DTO are unaffected.
 
 [`TypedEditor`]: the `editor` module in `quillmark-core`.
-
-## Richtext fields: a corpus writer, `set_field_richtext` (#881)
-
-> Superseded by `commit_field` (above). The methods below still work as
-> deprecated aliases; the corpus-at-write and identity-persistence guarantees
-> they document carry over verbatim to `commit_field` on a richtext field.
-
-A richtext value now has one write contract everywhere. `$body` was already
-corpus-from-construction; a richtext **field** gains a writer that commits the
-corpus at write instead of only re-coercing per render. This is a **writer**
-guarantee, not a type guarantee — the field is corpus *iff* the caller picks
-the richtext writer over the plain one, because a `Document` holds a `$quill`
-*reference*, not the resolved schema, and cannot tell a markdown-for-richtext
-string from an ordinary string value.
-
-| Body (existing) | Richtext field (new) |
-|---|---|
-| `Card::set_body_value(&json)` | `Card::set_field_richtext(name, &json, inline)` |
-| `Card::body()` / `body_markdown()` | `Card::field_richtext(name)` / `field_markdown(name)` |
-| `Card::apply_body_change(..)` | `Card::apply_field_richtext_change(name, ..)` |
-| wasm `setBody(RichText \| string)` | wasm `setRichtextField(name, RichText \| string, inline?)` |
-| — | wasm `updateCardRichtextField(index, name, value, inline?)` |
-| wasm `main.bodyMarkdown` | wasm `fieldMarkdown(name)` / `cardFieldMarkdown(index, name)` |
-
-- Accepts either encoding the seam carries — a canonical corpus **object** or an
-  authored markdown **string** — and stores the canonical corpus, so a
-  corpus-only mark (`underline`) and identity ids survive where a markdown
-  projection would drop them.
-- `inline` mirrors the schema's `richtext(inline)` constraint and is enforced
-  **at write** (`EditError::FieldRichtextNotInline` / wasm
-  `[EditError::FieldRichtextNotInline]`), in lockstep with the coercion and
-  validation checks. The caller supplies it because the editor holds the schema;
-  the write is the strict commit, not a deferred render failure.
-- `set_field` (plain) and hand-authored YAML are unchanged: a richtext field
-  authored as a markdown string stays a string until render coercion imports it.
-  No `.qmd` file needs editing.
 
 ### Card bodies: `setCardBody` completes the corpus write surface (#892)
 
 wasm `setCardBody(index, RichText | string)` is the card-indexed twin of
 `setBody` — the corpus-native counterpart to `updateCardBody`, which stays
 markdown-only. It closes the one remaining markdown-forced write: a **non-main
-card body**. `updateCardRichtextField(index, "$body", …)` was never a path —
+card body**. `commitCardField(quill, index, "$body", …)` is never a path —
 `$body`'s reserved `$`-prefix fails the field-name check — so a card body needs
 its own writer, backed by the existing `Card::set_body_value` (the same core
 primitive `setBody` uses). A corpus-native editor can now write every address —
@@ -184,7 +156,7 @@ but **not** across a `.qmd` save-and-reload, which re-imports a fresh corpus.
 Persistent field anchors (identity marks on corpus field content) are a compile
 / DTO guarantee, not a card-yaml one.
 
-## Live field edits go through `setRichtextField` + `apply(doc)` (#886)
+## Live field edits go through `commitField` + `apply(doc)` (#886)
 
 There is no incremental field-delta verb. An earlier unreleased iteration added
 an experimental `applyFieldDelta` / `mapFieldPos` / `revision` surface — a
@@ -195,8 +167,8 @@ a parallel core-side position map: `positionAt` (point → corpus position) and
 `locate` (corpus position → caret rect) are exact inverses over the current
 compile and are the whole bidirectional cursor bridge, needing no forward map.
 
-A live editor writes a field with `setRichtextField(name, value)` (or `setBody`)
-and recompiles with `apply(doc)`. Typst recompiles incrementally either way
+A live editor writes a field with `commitField(quill, name, value)` (or
+`setBody`) and recompiles with `apply(doc)`. Typst recompiles incrementally either way
 (`Source::replace` + `comemo`), so a whole-field write costs the same on the
 compile as a splice would have — the delta path bought no incrementality it did
 not already have. `CorpusHit` / `FieldRegion` carry no `revision`.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -15,11 +15,13 @@ guides in order.
 - [0.93 → 0.94](0.93-to-0.94.md) — `type: richtext(inline)` retires; declare
   `type: richtext` with `inline: true` instead. Blueprint still emits
   `richtext(inline)<markdown>`; `build_transform_schema` gains
-  `quillmark:inline: true`. Richtext fields gain a corpus writer
-  (`set_field_richtext` / wasm `setRichtextField`) that commits the corpus at
-  write; live field edits go through it + `apply(doc)` (the experimental
-  `applyFieldDelta` / change-log surface was removed, #886). On-disk (`.qmd`)
-  identity stays markdown-lossy — the storage DTO is the lossless carrier.
+  `quillmark:inline: true`. Typed field writes land: one schema-dispatched
+  writer (`Card::commit_field` / wasm `commitField` / Python `commit_field`) for
+  every field type, plus the schema-bound `TypedEditor`; strict writes fail a
+  mismatch at the write, not at render (#893). Live field edits go through the
+  writer + `apply(doc)` (the experimental `applyFieldDelta` / change-log surface
+  was removed, #886). On-disk (`.qmd`) identity stays markdown-lossy — the
+  storage DTO is the lossless carrier.
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now


### PR DESCRIPTION
Implements the [#893](https://github.com/quillmark-org/quillmark/issues/893) proposal (`prose/proposals/893-typed-field-writes.md`): the **schema** carries a field's type at the write site, so the write surface stays O(1) in field types. Includes a **hard cutover** — the pre-release richtext-specific writers are removed, not deprecated.

## What changed

**Layer 1 — one write dispatch.** `coerce_value_strict` → `conform_value(value, schema, path, mode)` with a `Leniency` axis:
- `Render` — the render floor's forgiving cascade, **behavior-unchanged** (existing coercion tests + fuzz T1–T3 pin it).
- `Write` — strict typed write: value-parsing normalizations survive (`"3"`→`3`, scalar→`[scalar]`), cross-type `Boolean`↔`Number` coercions are dropped, and every defer-to-validation fall-through becomes a `CoercionError`. The richtext arm uses `decode_richtext_value` semantics (no scalar→markdown reduction).

**Layer 2 — one typed writer.** `Card::commit_field(name, value, &FieldSchema)` dispatches on the schema. Adds `EditError::FieldConform` for non-richtext mismatches; richtext keeps `FieldRichtextDecode` / `FieldRichtextNotInline`.

**Layer 3 — schema-bound editor.** `Quill::editor(&mut doc)` → `TypedEditor` / `CardEditor` with `set` / `set_all` / `card`, returning `Committed::{Typed,Opaque}` so a typo'd (opaque) field write is visible.

**Layer 4 — bindings.** wasm `commitField` / `commitCardField`, Python `commit_field` / `commit_card_field` (net-new — Python had no richtext field writer). Both return `"typed"` / `"opaque"`.

**Hard cutover.** Removed `Card::set_field_richtext`, wasm `setRichtextField` + `updateCardRichtextField`; migrated every call site and every doc/prose reference to `commit_field`. `null` on a richtext field now passes through (reads back as the empty corpus) rather than the old null→empty-corpus pin.

## Verification

- `cargo build --workspace` clean; `cargo test --workspace` — all suites pass (core incl. new `commit_field`/editor tests, fuzz **W1/W2/W3** including `commit ∘ commit = commit`, pdfform render-identity).
- `cargo doc` with `-D broken_intra_doc_links` clean on core and wasm.
- Added JS (`commitField`/`commitCardField`) and Python (`commit_field`/`commit_card_field`) binding tests — run on CI.

Closes #893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASYddaQ4AbzxNJpf8LQHHm)_