### PR TITLE
richtext: escape image alt/URL and link URL on markdown export (#900)

### DIFF
--- a/crates/richtext/src/export.rs
+++ b/crates/richtext/src/export.rs
@@ -383,7 +383,60 @@ fn emit_table(isl: &Island, out: &mut String) {
 fn emit_image(isl: &Island, out: &mut String) {
     let url = isl.props.get("url").and_then(|v| v.as_str()).unwrap_or("");
     let alt = isl.props.get("alt").and_then(|v| v.as_str()).unwrap_or("");
-    out.push_str(&format!("![{}]({})", alt, url));
+    // Alt is inline content of `![…]`: escape it like a link's display text so a
+    // `]`/`\`/`&`/delimiter can't terminate the markup or decode on re-import.
+    // Url goes through `emit_url` (bare when safe, else angle-wrapped + escaped).
+    out.push_str("![");
+    out.push_str(&escape_run(&alt.chars().collect::<Vec<_>>(), false));
+    out.push_str("](");
+    emit_url(url, out);
+    out.push(')');
+}
+
+/// Emit a link/image destination that re-imports to `url` verbatim. A bare
+/// (unbracketed) destination round-trips only for a URL with no whitespace,
+/// control char, `<`, `>`, `\`, or `&`, and balanced parentheses — CommonMark's
+/// unbracketed form. Anything else is angle-wrapped, with `<`, `>`, `\`, and `&`
+/// backslash-escaped so the sequence re-parses to the exact URL: unescaped `<`/`>`
+/// are illegal even inside the wrap, and `\`/`&` would otherwise be consumed as an
+/// escape or entity reference on re-import (the same `&`-always-escaped rule
+/// [`escape_char_into`] applies to prose). Spaces and parentheses need no escape
+/// inside the wrap, so a spaced or unbalanced-paren URL wraps without further work.
+fn emit_url(url: &str, out: &mut String) {
+    if url_is_bare_safe(url) {
+        out.push_str(url);
+        return;
+    }
+    out.push('<');
+    for c in url.chars() {
+        if matches!(c, '<' | '>' | '\\' | '&') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('>');
+}
+
+/// Whether `url` re-imports verbatim as a bare (unbracketed) link destination:
+/// no whitespace/control/`<`/`>`/`\`/`&`, and balanced parentheses. A `false`
+/// routes the URL through [`emit_url`]'s angle-wrapped, escaped form.
+fn url_is_bare_safe(url: &str) -> bool {
+    let mut depth: i32 = 0;
+    for c in url.chars() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            '<' | '>' | '\\' | '&' => return false,
+            c if c.is_whitespace() || c.is_control() => return false,
+            _ => {}
+        }
+    }
+    depth == 0
 }
 
 // ---------------------------------------------------------------------------
@@ -538,7 +591,7 @@ fn render_marked_core(
             out.push('[');
             out.push_str(&escape_run(&chars[ls..le], escape_pipe));
             out.push_str("](");
-            out.push_str(url);
+            emit_url(url, &mut out);
             out.push(')');
             pos = le;
             continue;
@@ -1135,5 +1188,77 @@ mod tests {
         // A multi-`#` trailing run and a no-space `#` both round-trip.
         round_trips("# heading \\#\\#");
         round_trips("## title\\#");
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #900: unescaped image alt/URL and link URL cause silent content
+    // loss on round-trip (a special char terminates the markup early).
+    // ---------------------------------------------------------------------
+
+    /// The exact #900 image repro: an alt with `\]` imports to alt text "a]b";
+    /// exporting it unescaped as `![a]b](x.png)` re-imports as prose with the
+    /// image gone. The alt must be escaped so the island survives.
+    #[test]
+    fn image_alt_specials_round_trip() {
+        // `]`, `\`, `&`, and emphasis delimiters in alt all survive.
+        round_trips("see ![a\\]b](x.png) here");
+        round_trips("see ![a\\\\b](x.png) here");
+        round_trips("see ![a&b](x.png) here");
+        round_trips("see ![a\\*b\\_c](x.png) here");
+        // The pinned repro: the image is not lost.
+        let rt = from_markdown("see ![a\\]b](x.png) here").unwrap();
+        assert_eq!(rt.islands.len(), 1, "one image island");
+        assert_eq!(rt.islands[0].props["alt"], "a]b");
+        let md = to_markdown(&rt);
+        let rt2 = from_markdown(&md).unwrap();
+        assert_eq!(rt2.islands.len(), 1, "image survived, got md {md:?}");
+        assert_eq!(rt2.islands[0].props["alt"], "a]b");
+    }
+
+    /// The exact #900 link repro: a URL with a space imports to link url
+    /// "foo bar"; exporting it unescaped as `[t](foo bar)` re-imports as prose
+    /// with the link gone. The URL must be angle-wrapped.
+    #[test]
+    fn link_url_with_space_round_trips() {
+        round_trips("a [t](<foo bar>) b");
+        let rt = from_markdown("a [t](<foo bar>) b").unwrap();
+        assert!(
+            rt.marks
+                .iter()
+                .any(|m| matches!(&m.kind, MarkKind::Link { url } if url == "foo bar")),
+            "link url with space imported"
+        );
+        let md = to_markdown(&rt);
+        assert!(md.contains("<foo bar>"), "url angle-wrapped, got {md:?}");
+        let rt2 = from_markdown(&md).unwrap();
+        assert_eq!(rt, rt2);
+    }
+
+    /// Image and link URLs carrying the destination-terminating specials —
+    /// unbalanced parens, `&`, `<`/`>`, backslash — all round-trip.
+    #[test]
+    fn url_specials_round_trip() {
+        // Balanced parens stay bare (CommonMark permits them); the others wrap.
+        round_trips("see [t](https://en.wikipedia.org/wiki/Rust_(programming_language)) x");
+        round_trips("see ![a](<x y.png>) here");
+        round_trips("see [t](<a )b>) x");
+        round_trips("see [t](<a&b>) x");
+        round_trips("see [t](<a\\<b\\>c>) x");
+        round_trips("see [t](<a\\\\b>) x");
+    }
+
+    /// `emit_url` chooses bare for a clean URL and angle-wraps only when a
+    /// special forces it — the aesthetic contract (common URLs stay unbracketed).
+    #[test]
+    fn emit_url_bare_when_safe() {
+        let mut bare = String::new();
+        emit_url("https://ex.com/a(b)c", &mut bare);
+        assert_eq!(bare, "https://ex.com/a(b)c", "balanced parens stay bare");
+        let mut wrapped = String::new();
+        emit_url("a b", &mut wrapped);
+        assert_eq!(wrapped, "<a b>", "space forces the wrap");
+        let mut esc = String::new();
+        emit_url("a&<\\b", &mut esc);
+        assert_eq!(esc, "<a\\&\\<\\\\b>", "specials escaped inside the wrap");
     }
 }

--- a/crates/richtext/tests/properties.rs
+++ b/crates/richtext/tests/properties.rs
@@ -43,6 +43,20 @@ fn plain_word() -> impl Strategy<Value = String> {
     r"[a-z0-9][a-z0-9*_~\\&#>.+😀你-]{0,5}"
 }
 
+// `special_alt`/`special_url` carry the destination- and markup-terminating
+// chars #900 exposed, in *markdown source* form: a raw `]`/`[`/`\` would break
+// the markup at the source level (those live only in the direct-corpus
+// `image_and_link_specials_round_trip` property), so alt carries `&` and inline
+// delimiters as literal text, and the url is angle-wrapped in source so a space,
+// paren, or `&` reaches the corpus intact — the escape paths `clean_word` missed.
+fn special_alt() -> impl Strategy<Value = String> {
+    (clean_word(), r"[a-z0-9&*_~#.+]{0,4}").prop_map(|(a, b)| format!("{a}{b}"))
+}
+
+fn special_url() -> impl Strategy<Value = String> {
+    (clean_word(), r"[a-z0-9 ()&]{1,5}").prop_map(|(a, b)| format!("ex.com/{a}{b}"))
+}
+
 fn inline_token() -> impl Strategy<Value = String> {
     prop_oneof![
         plain_word(),
@@ -52,6 +66,11 @@ fn inline_token() -> impl Strategy<Value = String> {
         clean_word().prop_map(|w| format!("`{w}`")),
         clean_word().prop_map(|w| format!("<u>{w}</u>")),
         (clean_word(), clean_word()).prop_map(|(t, u)| format!("[{t}](https://ex.com/{u})")),
+        // #900: a link/image whose url and alt carry specials the escaper must
+        // neutralize (space/paren/`&` in the angle-wrapped url; `&`/delimiters
+        // in the alt), exercised in prose context (marks, lists, hard breaks).
+        (clean_word(), special_url()).prop_map(|(t, u)| format!("[{t}](<{u}>)")),
+        (special_alt(), special_url()).prop_map(|(a, u)| format!("![{a}](<{u}>)")),
     ]
 }
 
@@ -212,6 +231,42 @@ proptest! {
         // point (it lives in the `from_markdown` domain the contract covers).
         prop_assert_eq!(&rt2, &from_markdown(&to_markdown(&rt2)).unwrap(),
             "re-imported overlap corpus not a fixed point: {:?}", md);
+    }
+
+    /// Issue #900: image alt and image/link URLs carry the markup- and
+    /// destination-terminating specials — `]`/`[`/`\` in alt, spaces, unbalanced
+    /// parens, `&`, `<`/`>`/`\` in a url — that the codec must escape so the
+    /// island/link survives export∘import. The `clean_word` alt/url generator
+    /// never emitted them (the gap the issue found); the corpus is built directly
+    /// in the shape import produces (alt trimmed, no newline) to hit the escaper
+    /// without fighting source-level markdown quirks.
+    #[test]
+    fn image_and_link_specials_round_trip(
+        alt in r"[a-z0-9\]\[\\&<>*_~#().+ -]{0,10}",
+        img_url in r"[a-z0-9 ()&<>\\]{0,10}",
+        link_url in r"[a-z0-9 ()&<>\\]{0,10}",
+    ) {
+        // Import trims alt and never yields a leading/trailing-space alt; match
+        // that so the hand-built corpus stays inside the fixed-point domain.
+        let alt = alt.trim().to_string();
+        let text = "lnk\u{FFFC}".to_string(); // link over "lnk", image slot after
+        let mut rt = RichText {
+            text,
+            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
+            marks: vec![Mark { start: 0, end: 3, kind: MarkKind::Link { url: link_url } }],
+            islands: vec![Island {
+                // The id import mints for the first island, so re-import compares equal.
+                id: "isl-0".into(),
+                island_type: "image".into(),
+                props: json!({ "alt": alt, "url": img_url }),
+                loss: Loss::Lossless,
+            }],
+        };
+        rt.normalize();
+        prop_assert_eq!(rt.validate(), Ok(()), "hand-built corpus invalid");
+        let md = to_markdown(&rt);
+        let rt2 = from_markdown(&md).unwrap();
+        prop_assert_eq!(&rt, &rt2, "alt/url specials not a fixed point.\n  md: {:?}", md);
     }
 
     /// Property 2a: canonical JSON is a fixed point.


### PR DESCRIPTION
Fixes #900.

## Problem

The markdown export codec wrote image alt text, image URLs, and link URLs **verbatim, with no escaping**, so a special character in any of them terminated the markup early and the construct was silently lost (or corrupted) on re-import — a fixed-point violation on a codec that advertises exact round-trip.

- `[a]b](x.png)` — the `]` in alt closes `[…]` early → image gone
- `[t](foo bar)` — the space ends the bare destination → link gone

The Typst emitter already escaped image alt/URL via `escape_string`; this was a markdown-codec-only gap. The property generator only emitted clean words in alt/URL positions, which is why it slipped through.

## Fix

**Image alt** (`emit_image`) now routes through the same `escape_run` the link *display text* and table cells already use, so `]`/`\`/`&`/inline delimiters are neutralized.

**Both image and link URLs** now go through a new `emit_url` helper:
- Emits **bare** when the URL re-imports verbatim unbracketed (no whitespace/control/`<`/`>`/`\`/`&`, balanced parens) — common URLs like `cat.png` and `https://en.wikipedia.org/wiki/Rust_(programming_language)` stay clean.
- Otherwise **angle-wraps** and backslash-escapes `<`/`>`/`\`/`&` so the destination re-parses to the exact URL. Spaces and unbalanced parens are legal inside `<…>`, so they wrap without further escaping. The always-escape-`&` choice mirrors `escape_char_into`'s prose rule (avoids the fragile "would this form an entity" detection the codebase already rejected).

pulldown-cmark's angle-form parsing (backslash escapes, entity decoding, balanced-paren preservation) was verified empirically before settling the escaper.

## Tests

- Extended the property generator's alt/URL positions to carry these specials — in prose via the source generator, and via a new direct-corpus property `image_and_link_specials_round_trip` covering `]`/`[`/`\`/`<`/`>` that can't appear raw in markdown source.
- Added unit tests for both confirmed repros plus edge cases (balanced paren stays bare; space, unbalanced paren, `&`, `<`/`>`, `\` each wrap and round-trip).

`cargo test --workspace` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014u4CKoe3LKoDANHvW9dR4e

---
_Generated by [Claude Code](https://claude.ai/code/session_014u4CKoe3LKoDANHvW9dR4e)_