### PR TITLE
richtext/core/bindings: address issues #902–#906

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -958,6 +958,13 @@ fn table_markup(props: &serde_json::Value) -> String {
             }
         }
     }
+    // A zero-column (empty) table has no renderable content and `columns: 0`
+    // would fail to compile; emit nothing, matching the markdown export path
+    // (`export::emit_table` early-returns on `cols == 0`). An empty table island
+    // is well-formed (`RichText::validate` accepts it), so this is reachable.
+    if cols == 0 {
+        return String::new();
+    }
 
     let cell = |v: &serde_json::Value| {
         let (text, marks) = quillmark_richtext::serial::parse_cell(v);
@@ -1661,6 +1668,14 @@ mod tests {
         });
         let out = table_markup(&props);
         assert!(out.contains("columns: 2,"), "got {out:?}");
+    }
+
+    /// A zero-column (empty) table emits nothing rather than `#table(columns: 0)`
+    /// (which fails to compile), matching the markdown export path. Issue #904.
+    #[test]
+    fn empty_table_emits_nothing() {
+        let props = serde_json::json!({ "header": [], "aligns": [], "rows": [] });
+        assert_eq!(table_markup(&props), "");
     }
 
     /// A paragraph is one segment even across a hard break; a heading and a code

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -421,6 +421,29 @@ impl PyDocument {
         self.inner.main().body_markdown()
     }
 
+    /// Corpus-native body writer on the main card — the write twin of the
+    /// [`body`](Self::body) getter, so a body read as a corpus dict writes back
+    /// losslessly (identity marks, island ids, corpus-only formatting intact).
+    /// `body` is a corpus dict (`{text, lines, marks, islands}`), an importable
+    /// markdown string, or `None`; unlike [`replace_body`](Self::replace_body)
+    /// (markdown only) this does not drop corpus-only formatting. Raises
+    /// `QuillmarkError` if `body` is none of those. Mirrors WASM `setBody`.
+    fn set_body(&mut self, body: Bound<'_, PyAny>) -> PyResult<()> {
+        let json = py_to_json(&body)?;
+        self.inner
+            .main_mut()
+            .set_body_value(&json)
+            .map_err(convert_edit_error)
+    }
+
+    /// The markdown projection of a richtext-valued field on the main card
+    /// (`export ∘ decode`) — the field-level twin of `body_markdown`. Returns
+    /// `None` when the field is absent or does not decode as richtext (e.g. a
+    /// plain scalar written via `set_field`). Mirrors WASM `fieldMarkdown`.
+    fn field_markdown(&self, name: &str) -> Option<String> {
+        self.inner.main().field_markdown(name)
+    }
+
     /// Main (entry) card as a dict with `kind`, `quill`, `id`, `payload_items`,
     /// `ext`, `seed`, and `body`.
     #[getter]
@@ -780,6 +803,30 @@ impl PyDocument {
         self.card_mut_or_raise(index)?
             .replace_body(body)
             .map_err(convert_edit_error)
+    }
+
+    /// Corpus-native body writer on the composable card at `index` — the
+    /// card-indexed twin of [`set_body`](Self::set_body), and the corpus
+    /// counterpart to [`replace_card_body`](Self::replace_card_body) (markdown
+    /// only). `body` is a corpus dict, an importable markdown string, or `None`.
+    /// Raises `QuillmarkError` on an out-of-range index or a body that is none of
+    /// those. Mirrors WASM `setCardBody`.
+    fn set_card_body(&mut self, index: usize, body: Bound<'_, PyAny>) -> PyResult<()> {
+        let json = py_to_json(&body)?;
+        self.card_mut_or_raise(index)?
+            .set_body_value(&json)
+            .map_err(convert_edit_error)
+    }
+
+    /// The markdown projection of a richtext-valued field on the composable card
+    /// at `index` — the card-indexed twin of [`field_markdown`](Self::field_markdown).
+    /// Returns `None` when `index` is out of range, the field is absent, or it
+    /// does not decode as richtext. Mirrors WASM `cardFieldMarkdown`.
+    fn card_field_markdown(&self, index: usize, name: &str) -> Option<String> {
+        self.inner
+            .cards()
+            .get(index)
+            .and_then(|c| c.field_markdown(name))
     }
 }
 

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -309,6 +309,40 @@ def test_document_authoring_text_helpers():
     assert isinstance(instr, str) and "taro" in instr
 
 
+def test_set_body_corpus_round_trip():
+    """`set_body` accepts the corpus dict `body` reads back — the corpus-native
+    writer closing the read/write asymmetry (WASM `setBody` parity). Issue #902."""
+    doc = Document.from_markdown(
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: T\n~~~\n\n**bold** body\n"
+    )
+    corpus = doc.body
+    assert isinstance(corpus, dict)
+    # Write the read-back corpus to a fresh doc: lossless (not markdown-forced).
+    doc2 = Document.from_markdown("~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: T\n~~~\n")
+    doc2.set_body(corpus)
+    assert doc2.body == corpus
+    # A markdown string and None are also accepted.
+    doc2.set_body("plain text")
+    assert "plain text" in doc2.body_markdown
+    doc2.set_body(None)
+    assert doc2.body_markdown == ""
+
+
+def test_set_card_body_and_field_markdown_parity():
+    """`set_card_body` writes a composable card's corpus body; `field_markdown`
+    / `card_field_markdown` project a richtext field to markdown (WASM parity)."""
+    md = (
+        "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: Main\n~~~\n\nMain body.\n\n"
+        "~~~card-yaml\n$kind: note\nfoo: bar\n~~~\n\nCard body.\n"
+    )
+    doc = Document.from_markdown(md)
+    doc.set_card_body(0, "**new** card body")
+    assert "**new** card body" in doc.cards[0]["body_markdown"]
+    # field_markdown returns None for a non-richtext / absent field.
+    assert doc.field_markdown("missing") is None
+    assert doc.card_field_markdown(0, "missing") is None
+
+
 def test_nested_fill_exposed_as_nested_fills():
     """A nested !must_fill marker is exposed as `nestedFills` on the field item
     and survives the storage round-trip (binding parity for nested fills)."""

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -54,6 +54,10 @@ export interface QuillFieldSchema {
     ui?: QuillFieldUi;
     properties?: Record<string, QuillFieldSchema>;
     items?: QuillFieldSchema;
+    /** Present (and `true`) only on a `richtext` field declared `richtext(inline)`
+     *  — the single-paragraph, container-free, island-free constraint. Core
+     *  serializes `inline: true` into the schema JSON; absent otherwise. */
+    inline?: boolean;
 }
 
 /** Schema entry for the main card or a named card kind. */

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -23,7 +23,7 @@ use quillmark_richtext::{ApplyError, Delta, LineOp, MarkOp, RichText};
 
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::document::{Card, Document, Payload};
-use crate::quill::{CoercionError, FieldSchema, FieldType, Leniency, QuillConfig};
+use crate::quill::{CoercionError, FieldSchema, Leniency, QuillConfig};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 
@@ -189,27 +189,27 @@ pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldV
 
 /// Map a strict-write [`CoercionError`] to the field-write [`EditError`] surface.
 ///
-/// A richtext field routes to the dedicated `FieldRichtext*` variants — the
-/// same surface [`Card::apply_field_richtext_change`] produces, and the one the
-/// wasm/Python error mappers (and their tests) key on; the inline violation is
-/// distinguished by the coercion `target`. Every other type uses the general
+/// A failed richtext coercion routes to the dedicated `FieldRichtext*` variants
+/// — the same surface [`Card::apply_field_richtext_change`] produces, and the
+/// one the wasm/Python error mappers (and their tests) key on. This keys on the
+/// coercion `target`, not the top-level field type, because the richtext
+/// constraint can be **nested**: an `array` of `richtext(inline)` items fails
+/// with `target == "richtext(inline)"` while the field's own type is `Array`.
+/// The richtext coercion emits exactly `"richtext"` / `"richtext(inline)"`
+/// (see `QuillConfig::conform_value`); every other target uses the general
 /// [`EditError::FieldConform`].
-fn conform_error_to_edit(name: &str, schema: &FieldSchema, err: CoercionError) -> EditError {
+fn conform_error_to_edit(name: &str, err: CoercionError) -> EditError {
     let CoercionError::Uncoercible { target, reason, .. } = err;
-    if matches!(schema.r#type, FieldType::RichText { .. }) {
-        if target == "richtext(inline)" {
-            EditError::FieldRichtextNotInline(name.to_string())
-        } else {
-            EditError::FieldRichtextDecode {
-                field: name.to_string(),
-                message: reason,
-            }
-        }
-    } else {
-        EditError::FieldConform {
+    match target.as_str() {
+        "richtext(inline)" => EditError::FieldRichtextNotInline(name.to_string()),
+        "richtext" => EditError::FieldRichtextDecode {
             field: name.to_string(),
             message: reason,
-        }
+        },
+        _ => EditError::FieldConform {
+            field: name.to_string(),
+            message: reason,
+        },
     }
 }
 
@@ -231,7 +231,7 @@ pub(crate) fn resolve_field_write(
     }
     let stored = match schema {
         Some(schema) => QuillConfig::conform_value(&value, schema, name, Leniency::Write)
-            .map_err(|e| conform_error_to_edit(name, schema, e))?,
+            .map_err(|e| conform_error_to_edit(name, e))?,
         None => value,
     };
     // Depth-bound the stored form (name already validated above).

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -41,6 +41,15 @@ impl Document {
     ///    `QuillValue::String("01234")` round-trips as a string, never as an
     ///    integer.  This guarantee is the whole point of owning emission.
     ///
+    ///    **Corpus-field carve-out.** A richtext field committed as a canonical
+    ///    corpus object (and the card `$body`) is *intentionally* markdown-lossy
+    ///    on `.qmd` emit: it projects to its markdown form (`project_corpus_field`),
+    ///    so identity marks (anchors, island ids) and corpus-only marks
+    ///    (`underline`) do not survive a `to_markdown`→`from_markdown` round-trip.
+    ///    On-disk identity is markdown-lossy by design; the storage DTO is the
+    ///    lossless carrier. The value-equality guarantee above holds for every
+    ///    field the writer did not commit as canonical corpus.
+    ///
     /// 2. **Emit-idempotent.** `to_markdown` is a pure function of `doc`; two
     ///    calls on the same `doc` return byte-equal strings.
     ///
@@ -286,18 +295,29 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
 /// ids and corpus-only marks do not survive a `.qmd` round-trip, so on-disk
 /// identity is markdown-lossy by design; the storage DTO is the lossless carrier.
 ///
-/// The guard requires the object to round-trip *byte-for-byte* as a canonical
-/// corpus, so a user object field that merely resembles one (extra keys,
-/// non-canonical shape) stays structural. A corpus object only ever arises from
-/// the programmatic corpus writer — `from_markdown` is schema-less and stores a
-/// richtext field authored as markdown as a plain string — so this never fires
-/// on a parse-originated document, leaving the emit round-trip property intact.
+/// The guard requires the object to serialize back to a **byte-identical**
+/// canonical corpus, so a user object field that merely resembles one (extra
+/// keys, non-canonical shape, or non-canonical key order) stays structural. The
+/// comparison is on the serialized *strings*, not the `serde_json::Value`s: with
+/// `serde_json/preserve_order` on (it is in this workspace), `Value`'s `PartialEq`
+/// is an order-independent `IndexMap` compare, so a `Value != Value` guard would
+/// also accept a content-canonical object whose keys are in non-canonical order —
+/// projecting (and thus markdown-flattening) it. String equality pins key order.
+///
+/// A corpus object normally only arises from the programmatic corpus writer
+/// (`from_markdown` is schema-less and stores a markdown-authored richtext field
+/// as a plain string), so on a parse-originated document this projects only the
+/// fields the writer deliberately committed as corpus.
 fn project_corpus_field(value: &JsonValue) -> Option<String> {
     if !value.is_object() {
         return None;
     }
     let rt = quillmark_richtext::serial::from_canonical_value(value).ok()?;
-    if quillmark_richtext::serial::to_canonical_value(&rt) != *value {
+    // Byte-exact: canonical-string equality, not `Value` equality (which is
+    // order-independent under `preserve_order`). Only a corpus in canonical key
+    // order projects; anything else stays a structural field.
+    let canonical = quillmark_richtext::serial::to_canonical_value(&rt);
+    if serde_json::to_string(&canonical).ok()? != serde_json::to_string(value).ok()? {
         return None;
     }
     Some(quillmark_richtext::export::to_markdown(&rt))

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -707,6 +707,42 @@ fn test_commit_field_richtext_inline_enforced_at_write() {
     assert_eq!(card.field_markdown("title").unwrap(), "A single line\n");
 }
 
+/// A multi-block element committed to an `array` of `richtext(inline)` items
+/// classifies as `FieldRichtextNotInline`, not the generic `FieldConform`: the
+/// mapper keys on the coercion target (`richtext(inline)`), so the richtext
+/// constraint is honored even when it is nested under an array. Issue #906.
+#[test]
+fn test_commit_field_array_of_inline_richtext_reports_not_inline() {
+    use crate::quill::{FieldSchema, FieldType};
+
+    let mut card = Card::new("note").unwrap();
+    let mut schema = FieldSchema::new("refs".to_string(), FieldType::Array, None);
+    schema.items = Some(Box::new(FieldSchema::new(
+        "refs".to_string(),
+        FieldType::RichText { inline: true },
+        None,
+    )));
+
+    // A single-line element coerces to a corpus and the array commits.
+    card.commit_field(
+        "refs",
+        QuillValue::from_json(serde_json::json!(["one line"])),
+        &schema,
+    )
+    .unwrap();
+
+    // A two-block element fails the inline check, surfaced as the richtext
+    // variant (not FieldConform) despite the field's own type being Array.
+    let err = card
+        .commit_field(
+            "refs",
+            QuillValue::from_json(serde_json::json!(["line one\n\nline two"])),
+            &schema,
+        )
+        .unwrap_err();
+    assert_eq!(err.variant_name(), "FieldRichtextNotInline");
+}
+
 // ── commit_field (typed write) ───────────────────────────────────────────────
 
 /// `commit_field` on a scalar schema stores the coerced canonical (`"3"` → `3`);
@@ -839,6 +875,38 @@ fn test_non_corpus_object_field_emits_structurally() {
     let md = doc.to_markdown();
     assert!(md.contains("addr:"), "{md}");
     assert!(md.contains("city: Paris"), "{md}");
+}
+
+/// A content-canonical corpus whose top-level keys are in NON-canonical order
+/// stays structural — the projection guard is byte-exact (canonical-string
+/// equality), not the order-independent `Value` compare it used to be. Under
+/// the old guard this projected to a flattened markdown scalar, breaking the
+/// field's round-trip. Issue #905.
+#[test]
+fn test_noncanonical_order_corpus_field_stays_structural() {
+    // A real corpus, then its top-level keys rebuilt in reverse (same content,
+    // non-canonical bytes).
+    let rt = quillmark_richtext::import::from_markdown("**bold**").unwrap();
+    let canonical = quillmark_richtext::serial::to_canonical_value(&rt);
+    let obj = canonical.as_object().unwrap();
+    let mut scrambled = serde_json::Map::new();
+    for k in obj.keys().rev() {
+        scrambled.insert(k.clone(), obj[k].clone());
+    }
+
+    let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
+    doc.main_mut()
+        .set_field(
+            "intro",
+            QuillValue::from_json(serde_json::Value::Object(scrambled)),
+        )
+        .unwrap();
+    let md = doc.to_markdown();
+    // Structural: the corpus keys survive; it did not collapse to `intro: "..."`.
+    assert!(
+        md.contains("marks:") && md.contains("lines:"),
+        "non-canonical-order corpus should stay structural, got:\n{md}"
+    );
 }
 
 /// `import_body_delta` updates the body and returns the text delta from the

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -350,16 +350,23 @@ fn resolve_fields(
 fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue {
     let present = value.filter(|v| !v.as_json().is_null());
     let Some(v) = present else {
-        // For a richtext-bearing field the render floor commits the *corpus* form
-        // of the default (cached at load), so the seam carries canonical
-        // RichText-JSON rather than a re-imported markdown string. `default_corpus`
-        // is `None` for a non-richtext field, so those fall through to the raw
-        // `default`, then to the type-empty zero.
-        return field
-            .default_corpus
-            .clone()
-            .or_else(|| field.default.clone())
-            .unwrap_or_else(|| zero_value(field));
+        // A richtext-bearing field commits the *corpus* form of its default
+        // (`default_corpus`, cached at load by `from_yaml`), so the seam carries
+        // canonical RichText-JSON the backend can classify. It must NOT fall
+        // through to the raw markdown `default`: `resolve_fields` runs after
+        // `coerce_and_validate`, so a bare markdown string injected here would
+        // reach the plate uncoerced and be misread. A richtext field with no
+        // cached `default_corpus` (only reachable via a serde-built
+        // `QuillConfig`, never `from_yaml`) zero-fills to the empty corpus.
+        if matches!(field.r#type, FieldType::RichText { .. }) {
+            return field
+                .default_corpus
+                .clone()
+                .unwrap_or_else(|| zero_value(field));
+        }
+        // Non-richtext: `default_corpus` is always `None`, so use the raw
+        // `default`, then the type-empty zero.
+        return field.default.clone().unwrap_or_else(|| zero_value(field));
     };
     match (&field.r#type, &field.properties, &field.items) {
         (FieldType::Object, Some(props), _) => {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -131,6 +131,14 @@ pub(crate) enum Leniency {
     /// cross-type `Boolean`↔`Number` coercions are dropped and every
     /// defer-to-validation fall-through becomes a `CoercionError` — so a
     /// mismatched value fails at the write, not silently at a later render.
+    ///
+    /// "Strict" is asymmetric by target, not absolute: `string` and `array` are
+    /// universal sinks, so a scalar→`string` (`true` → `"true"`) and a
+    /// scalar→singleton-`array` wrap stay lenient even here (both are lossless,
+    /// unambiguous, and author-intended); only the lossy/ambiguous crossings —
+    /// scalar→`object`, `String`→`number`/`bool`, `Boolean`↔`Number` — are
+    /// rejected. A strict write thus still reshapes toward `string`/`array`
+    /// while refusing to invent structure or reinterpret a scalar's type.
     Write,
 }
 

--- a/crates/richtext/src/import.rs
+++ b/crates/richtext/src/import.rs
@@ -120,6 +120,12 @@ impl Inline {
     /// Append inline text, stripping characters the corpus forbids: `\r` and a
     /// stray [`ISLAND_SLOT`] are dropped; a stray `\n` becomes a space (inline
     /// text carries no line boundary — real ones go through [`Self::push_raw`]).
+    ///
+    /// A literal [`ISLAND_SLOT`] (U+FFFC) in source markdown is dropped
+    /// *silently and by design*: the slot char is the reserved island sentinel,
+    /// so admitting a bare one would break the slot-count invariant. Such a char
+    /// in prose is a paste/render artifact, never authored content, so its loss
+    /// carries no signal — this is a fixed point, not lossy round-tripping.
     fn push_text(&mut self, s: &str) {
         for c in s.chars() {
             let c = match c {

--- a/crates/richtext/src/model.rs
+++ b/crates/richtext/src/model.rs
@@ -327,6 +327,15 @@ pub enum Invariant {
     /// would break the exported table). `cell` is the flat header-then-rows
     /// index; `normalize` rewrites the newline to a space.
     TableCellNewline { cell: usize },
+    /// Two islands share an `id`. Ids are a minted, stable identity (the sole
+    /// source of hash nondeterminism); import mints them by index so they never
+    /// collide, but a hand-built or round-tripped corpus can. Downstream code
+    /// that keys islands by id would otherwise silently pick the wrong one.
+    IslandIdCollision { id: String },
+    /// A table island's `header` prop is present but not a JSON array — it
+    /// cannot carry column cells. `normalize` rewrites a non-array header to an
+    /// empty array (a zero-column, content-free table).
+    TableHeaderNotArray,
 }
 
 impl RichText {
@@ -505,7 +514,15 @@ impl RichText {
         // Table-cell marks: the prose range/zero-width/reserved-tag rules again,
         // but each mark is bounded by its own cell's text length (in USV). Cells
         // hold no `\n`, so the edge-on-newline rule does not apply.
+        let mut seen_ids = std::collections::HashSet::with_capacity(self.islands.len());
         for island in &self.islands {
+            // Ids are a minted, stable identity — the sole source of hash
+            // nondeterminism — so two islands may not share one.
+            if !seen_ids.insert(island.id.as_str()) {
+                return Err(Invariant::IslandIdCollision {
+                    id: island.id.clone(),
+                });
+            }
             // Structural shape (table column/row/aligns consistency, `\n`-free
             // cells) before the per-cell mark ranges — a ragged island is
             // ill-formed regardless of its marks.
@@ -595,6 +612,12 @@ pub(crate) fn normalize_marks(marks: Vec<Mark>) -> Vec<Mark> {
     // Canonical sort: (start, end, kind-ord, attrs). Key cached per mark so
     // `attrs_key`'s allocation runs once each, not once per comparison.
     out.sort_by_cached_key(|m| (m.start, m.end, m.kind.ord(), m.kind.attrs_key()));
+    // Drop byte-identical duplicates. Identity/unknown handles never *merge*
+    // (Spike-A rule 3), but two marks equal in range, kind, and attrs are the
+    // same handle recorded twice — redundant bytes, not two handles. The sort
+    // above makes any such pair adjacent, so `dedup` (structural `PartialEq`,
+    // order-independent for `Unknown` attrs under `preserve_order`) removes it.
+    out.dedup();
     out
 }
 
@@ -962,5 +985,77 @@ mod tests {
         assert_eq!(rt.validate(), Ok(()));
         rt.normalize();
         assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// A non-array `header` carries no cells: `validate` rejects it and
+    /// `normalize` repairs it to an empty array (a zero-column table that then
+    /// validates). Issue #904.
+    #[test]
+    fn non_array_table_header_is_rejected_then_repaired() {
+        let mut rt = table_rt(serde_json::json!({
+            "header": "oops",
+            "aligns": [],
+            "rows": [],
+        }));
+        assert_eq!(rt.validate(), Err(Invariant::TableHeaderNotArray));
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        assert_eq!(rt.islands[0].props["header"], serde_json::json!([]));
+    }
+
+    /// Two islands sharing an `id` violate the minted-identity invariant.
+    /// Import mints ids by index so never collides; a hand-built corpus can.
+    /// Issue #903.
+    #[test]
+    fn duplicate_island_id_is_rejected() {
+        let mut rt = RichText::empty();
+        rt.text = format!("{ISLAND_SLOT}\n{ISLAND_SLOT}");
+        rt.lines = vec![
+            Line {
+                kind: LineKind::Island,
+                containers: vec![],
+                continues: false,
+            },
+            Line {
+                kind: LineKind::Island,
+                containers: vec![],
+                continues: false,
+            },
+        ];
+        let table = |id: &str| Island {
+            id: id.into(),
+            island_type: "table".into(),
+            props: serde_json::json!({ "header": [cell("h")], "aligns": ["none"], "rows": [] }),
+            loss: Loss::Lossless,
+        };
+        rt.islands = vec![table("dup"), table("dup")];
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::IslandIdCollision { id: "dup".into() })
+        );
+        // Distinct ids validate.
+        rt.islands = vec![table("a"), table("b")];
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// `normalize` drops a byte-identical duplicate identity mark (same range,
+    /// same id) — the same handle recorded twice is redundant, not two handles.
+    /// Distinct-id anchors over the same range are kept. Issue #906.
+    #[test]
+    fn normalize_dedupes_identical_identity_marks() {
+        let mut rt = RichText::empty();
+        rt.text = "abcd".into();
+        let anchor = |id: &str| Mark {
+            start: 0,
+            end: 4,
+            kind: MarkKind::Anchor { id: id.into() },
+        };
+        rt.marks = vec![anchor("x"), anchor("x")];
+        rt.normalize();
+        assert_eq!(rt.marks, vec![anchor("x")]);
+        // Different ids over the same range are distinct handles — both survive.
+        rt.marks = vec![anchor("x"), anchor("y")];
+        rt.normalize();
+        assert_eq!(rt.marks.len(), 2);
     }
 }

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -441,6 +441,12 @@ fn normalize_table_props(props: &mut Value) {
         return;
     };
     let header = obj.entry("header").or_insert_with(|| Value::Array(vec![]));
+    // A non-array header (a bare string, say) carries no cells; rewrite it to an
+    // empty array so it canonicalizes to a zero-column, content-free table
+    // rather than retaining opaque garbage that `validate` would then reject.
+    if !header.is_array() {
+        *header = Value::Array(vec![]);
+    }
     pad_row(header, cols);
     if let Some(h) = header.as_array_mut() {
         h.iter_mut().for_each(canon_cell);
@@ -506,6 +512,13 @@ fn canon_cell(cell: &mut Value) {
 /// and each body row must share (the header width), plus the `\n`-free-cell rule.
 /// The validate-side twin of [`normalize_table_props`].
 fn table_shape_error(props: &Value) -> Option<Invariant> {
+    // A present-but-non-array header can't carry column cells — `normalize`
+    // rewrites it to an empty array, so an un-normalized one is a hand-built
+    // degenerate island. (An absent header is a zero-column table, which is
+    // well-formed: `empty_table_is_valid`.)
+    if props.get("header").is_some_and(|h| !h.is_array()) {
+        return Some(Invariant::TableHeaderNotArray);
+    }
     let cols = props
         .get("header")
         .and_then(Value::as_array)


### PR DESCRIPTION
Addresses six diff-review findings on the richtext content model. Issue **#901 deferred** per request.

## Changes

**#903 — island id uniqueness** — Added `Invariant::IslandIdCollision`; `validate()` rejects two islands sharing an `id` (a minted, stable identity — the sole source of hash nondeterminism). Import mints by index and never collides; a hand-built/round-tripped corpus can.

**#904 — degenerate/empty table** — Kept the existing "empty table is valid" policy (there's an `empty_table_is_valid` test) and made the projection paths agree: the Typst emitter now emits nothing on `cols == 0` instead of `#table(columns: 0)` (a compile hazard), matching markdown export. Added `Invariant::TableHeaderNotArray`; `normalize` rewrites a non-array `header` to `[]`.

**#905 — corpus-projection guard + docs** — `project_corpus_field` now compares canonical *strings* (byte-exact) rather than `serde_json::Value`s, whose `PartialEq` is order-independent under `preserve_order` — the exact hole the issue found. A content-canonical corpus in non-canonical key order now stays structural instead of being markdown-flattened. Corrected the `project_corpus_field` and `to_markdown` contract docstrings (byte-for-byte claim; corpus-field round-trip carve-out).

**#902 — Python parity** — Added `set_body` / `set_card_body` (backed by the same `Card::set_body_value` wasm uses) and `field_markdown` / `card_field_markdown`, closing the read/write asymmetry #892 fixed for wasm. Added `inline?: boolean` to the wasm `QuillFieldSchema` TS interface (core already serializes `inline: true`).

**#906 — low-severity basket**
1. Array-of-inline richtext element error now classifies as `FieldRichtextNotInline` (was `FieldConform`) — `conform_error_to_edit` keys on the coercion target, not the top-level field type.
2. Richtext `default` fallback no longer injects an uncoerced markdown string; a richtext field with no cached `default_corpus` zero-fills to the empty corpus.
3. `normalize` drops byte-identical duplicate identity/unknown handles (the same handle recorded twice), while still never merging distinct handles.
4. Documented the deliberate silent drop of a literal U+FFFC (reserved island slot) in `push_text`.
5. Documented the strict-write leniency asymmetry (`string`/`array` are universal sinks; scalar→object/number/bool are rejected).

## Not actioned
**#906.6 (deleted pre-commit fmt hook)** — The removal was deliberate and there is currently **no** fmt enforcement anywhere (nor a clippy gate — intentionally removed per a note in `ci.yml`); the tree carries 59 files of pre-existing fmt drift. Restoring enforcement needs an out-of-scope tree-wide reformat and is a maintainer policy call, so it's flagged rather than forced. All changes in this PR are fmt-clean.

## Tests
Added coverage for #903, #904, #905, #906.1, #906.3, and #902 (python). `cargo test` on richtext / core / typst / quillmark / pdfform is green (612 core, 143 richtext, …). Python & wasm binding suites run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYTPLMyC7b5dU1MoQ6o4qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYTPLMyC7b5dU1MoQ6o4qG)_