### PR TITLE
#911: finish exposing the typed editor in WASM (commitFields batch + JS editor sugar + reframe)

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -250,6 +250,58 @@ apply a whole object atomically — on any invalid field nothing is applied and
 the thrown error carries one diagnostic per offending field (`path` = field
 name).
 
+### Typed writes: `commit*` is the default, `set*` is the quill-free primitive
+
+A `Document` holds only a `$quill` *reference*, not the resolved schema, so it
+mutates through two layers:
+
+- **`commit*` — the schema-bound default whenever a quill is in hand.**
+  `doc.commitField(quill, name, value)` / `doc.commitFields(quill, {...})` (and
+  the `commitCard*` twins) resolve each field's schema `type`, coerce the value
+  to its canonical form (`"3"` → `3`, a markdown string → a richtext corpus),
+  and **fail now** on a mismatch instead of at render. The return value reports
+  where the value landed: `"typed"` for a schema field, `"opaque"` for one the
+  schema does not own. The batch form returns that per field —
+  `Record<string, "typed" | "opaque">`, in input order — so a whole-form submit
+  still sees which names fell through to the opaque store (a likely typo), the
+  signal `setFields` discards.
+
+- **`set*` — the deliberate quill-free primitive.** `doc.setField(name, value)`
+  / `doc.setFields({...})` (and the `setCard*` twins) validate only the field
+  name/depth/kind and store the value verbatim, no quill required. Reach for it
+  on purpose when you *want* the opaque store: quill-agnostic storage/migration
+  infra that has no bundle and must write regardless of a drifted schema;
+  store-now-validate-later editors holding in-progress input that `commit`
+  would reject; or verbatim passthrough of fields the schema doesn't own. It is
+  the lower layer, not a lighter `commit` — a typo'd field name stores silently
+  and only surfaces at `quill.validate` / render.
+
+Per-keystroke cost is the same either way (both mutate the in-memory `Document`
+in place; no seam is crossed), so steering to `commit*` buys the type check for
+free.
+
+#### `DocumentEditor` / `CardEditor` — bind the quill once
+
+The `commit*` verbs take the `quill` handle per call (the document carries no
+schema). When you hold both a quill and a document — a form editor, an MCP
+writer — bind them once with the editor sugar and issue bare verbs:
+
+```ts
+import { DocumentEditor } from "@quillmark/wasm";
+
+const ed = new DocumentEditor(quill, doc);          // JS twin of Rust `quill.editor(doc)`
+ed.set("subject", "Q3 results");                    // → "typed"
+const routing = ed.setAll({ qty: "3", titel: "x" }); // → { qty: "typed", titel: "opaque" }
+const typos = Object.entries(routing)
+  .filter(([, r]) => r === "opaque").map(([k]) => k); // ["titel"] — flag in the UI
+ed.card(2).set("body", "**note**");                 // composable card, resolved by its $kind
+```
+
+`DocumentEditor` / `CardEditor` are pure JS holding references to your existing
+`quill` and `doc` — no WASM handle of their own, nothing to `free()`. `card(i)`
+is lazy: it never throws; an out-of-range index throws `IndexOutOfRange` at the
+write.
+
 ### `engine.render(quill, parsed, opts?)` vs. `engine.open(quill, parsed)`
 
 > **Experimental:** the entire session surface — `engine.open`,

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -684,6 +684,51 @@ card_kinds:
     expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
     expect(() => doc.commitCardField(quill, 9, 'body', 'x')).toThrow(/IndexOutOfRange/)
   })
+
+  it('commitFields typed-commits a batch and reports per-field routing', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    const routing = doc.commitFields(quill, { intro: 'A **bold** intro.', qty: '3' })
+    // Both are schema fields → typed, keyed by field name.
+    expect(routing).toEqual({ intro: 'typed', qty: 'typed' })
+    // And the values were coerced, not stored verbatim.
+    expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
+    expect(field(doc.main, 'qty')).toBe(3)
+  })
+
+  it('commitFields reports an opaque field on success, so a typo is visible', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    // `qty` is a schema field; `titel` is a typo the schema does not own — it
+    // still stores (opaque), and the routing record surfaces which one, instead
+    // of losing the signal to the batch the way setFields does.
+    const routing = doc.commitFields(quill, { qty: '5', titel: 'oops' })
+    expect(routing).toEqual({ qty: 'typed', titel: 'opaque' })
+    expect(field(doc.main, 'qty')).toBe(5)
+    const opaque = Object.entries(routing).filter(([, r]) => r === 'opaque').map(([n]) => n)
+    expect(opaque).toEqual(['titel'])
+  })
+
+  it('commitFields is all-or-nothing: a bad field aborts the whole batch', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    // `subject` is richtext(inline); a multi-block value violates it, so nothing
+    // is applied — `qty` must not linger.
+    expect(() => doc.commitFields(quill, { qty: '5', subject: 'line one\n\nline two' }))
+      .toThrow(/FieldRichtextNotInline/)
+    expect(hasField(doc.main, 'qty')).toBe(false)
+  })
+
+  it('commitCardFields typed-commits card fields and errors on a bad index', () => {
+    const quill = buildQuill()
+    const doc = Document.fromMarkdown(
+      '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
+    )
+    const routing = doc.commitCardFields(quill, 0, { body: 'Card **body**.', stray: 'x' })
+    expect(routing).toEqual({ body: 'typed', stray: 'opaque' })
+    expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+    expect(() => doc.commitCardFields(quill, 9, { body: 'x' })).toThrow(/IndexOutOfRange/)
+  })
 })
 
 describe('Document editor surface — card mutations', () => {

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -11,7 +11,14 @@
  * Aliased to pkg/runtime/runtime.js in vitest.config.js.
  */
 import { describe, it, expect, beforeAll } from 'vitest'
-import { Quill, Document, Engine, isQuillmarkError } from '@quillmark-wasm/runtime'
+import {
+  Quill,
+  Document,
+  Engine,
+  DocumentEditor,
+  CardEditor,
+  isQuillmarkError,
+} from '@quillmark-wasm/runtime'
 // Pin that the runtime's Quill IS the internal core build's class (re-export,
 // not a parallel wrapper). This imports the internal core artifact directly —
 // `pkg/core` is NOT a public package subpath, it is the build the root
@@ -100,6 +107,68 @@ describe('@quillmark/wasm/runtime — surface', () => {
     // regardless of which build or WASM instance constructed it
     const foreign = Object.assign(new Error('x'), { diagnostics: [] })
     expect(isQuillmarkError(foreign)).toBe(true)
+  })
+})
+
+// The typed-editor sugar binds a quill to a document once, so writes are bare
+// `set` / `setAll` / `card(i).set` — the JS twin of Rust's `quill.editor(doc)`,
+// forwarding to the `commit*` verbs (typed for a schema field, opaque otherwise).
+describe('@quillmark/wasm/runtime — DocumentEditor / CardEditor (bind the quill once)', () => {
+  const EDITOR_QUILL_YAML = `quill:
+  name: editor_test
+  version: "1.0"
+  backend: typst
+  description: Typed editor sugar test
+
+main:
+  fields:
+    subject:
+      type: richtext
+      inline: true
+    qty:
+      type: integer
+
+card_kinds:
+  note:
+    fields:
+      body:
+        type: richtext
+`
+  const buildQuill = () =>
+    Quill.fromTree(makeQuill({ name: 'editor_test', plate: TEST_PLATE, quillYaml: EDITOR_QUILL_YAML }))
+  const blankDoc = () => Document.fromMarkdown('~~~card-yaml\n$quill: editor_test\n~~~\n\nBody.')
+  const fieldOf = (card, key) =>
+    card.payloadItems.find((i) => i.type === 'field' && i.key === key)?.value
+
+  it('set binds the quill once and routes typed vs opaque', () => {
+    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    expect(ed.set('qty', '3')).toBe('typed') // schema field → strict coerce
+    expect(ed.set('stray', 'x')).toBe('opaque') // unknown → verbatim store
+    expect(fieldOf(ed.document.main, 'qty')).toBe(3)
+    expect(fieldOf(ed.document.main, 'stray')).toBe('x')
+  })
+
+  it('setAll returns the per-field routing record, flagging a typo as opaque', () => {
+    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    const routing = ed.setAll({ qty: '5', titel: 'oops' })
+    expect(routing).toEqual({ qty: 'typed', titel: 'opaque' })
+    expect(fieldOf(ed.document.main, 'qty')).toBe(5)
+  })
+
+  it('card(i).set targets the composable card via its kind schema', () => {
+    const doc = Document.fromMarkdown(
+      '~~~card-yaml\n$quill: editor_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
+    )
+    const ed = new DocumentEditor(buildQuill(), doc)
+    expect(ed.card(0).set('body', 'Card **body**.')).toBe('typed')
+    expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+  })
+
+  it('a bad card index throws at write time, not at card()', () => {
+    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    const cardEd = ed.card(9) // lazy: constructing the CardEditor never throws
+    expect(cardEd).toBeInstanceOf(CardEditor)
+    expect(() => cardEd.set('body', 'x')).toThrow(/IndexOutOfRange/)
   })
 })
 

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -439,3 +439,68 @@ export declare class LiveSession {
 	): PaintResult;
 	free(): void;
 }
+
+// ── Typed-editor sugar ──────────────────────────────────────────────────────
+
+/**
+ * Which store a typed write used: `"typed"` when the field is declared in the
+ * quill schema (strict commit — coerced to canonical form, a mismatch throws at
+ * the write) or `"opaque"` when it is not (stored verbatim, like
+ * `Document.setField`). A scalar write ({@link DocumentEditor.set}) returns one;
+ * a batch ({@link DocumentEditor.setAll}) returns a `Record` of them keyed by
+ * field name. The signal exists so a typo'd name silently landing in the opaque
+ * store is visible at the write, not buried until validation.
+ */
+export type Committed = 'typed' | 'opaque';
+
+/**
+ * A `Document` bound to its `Quill` for typed writes — the JS twin of Rust's
+ * `quill.editor(&mut doc)`. Binds the schema source once so writes are bare
+ * `set` / `setAll` / `card(i).set` instead of threading the `quill` handle
+ * through every `commit*` call. Holds both handles by reference and owns
+ * neither — nothing to `free()`.
+ *
+ * `commit*` is the default write path whenever a quill is in hand: it resolves
+ * each field's schema type and typed-commits it, reporting {@link Committed}.
+ * The raw `Document.setField` / `setFields` verbs remain the deliberate
+ * quill-free primitive (standalone data, storage/migration infra, or holding
+ * not-yet-conforming in-progress input) — reach for them only when you
+ * intend the opaque store.
+ */
+export declare class DocumentEditor {
+	constructor(quill: Quill, doc: Document);
+	/** The bound document — the instance passed in, mutated in place. */
+	readonly document: Document;
+	/**
+	 * Typed-commit one main-card field. `"typed"` for a schema field (strict
+	 * coerce, mismatch throws now), `"opaque"` for an unknown one.
+	 */
+	set(name: string, value: unknown): Committed;
+	/**
+	 * Typed-commit several main-card fields atomically — nothing is applied on
+	 * error (throws a {@link QuillmarkError} carrying one diagnostic per
+	 * offending field). On success returns the per-field routing keyed by field
+	 * name, so a whole-form submit still sees which names fell to the opaque
+	 * store.
+	 */
+	setAll(fields: Record<string, unknown>): Record<string, Committed>;
+	/**
+	 * A {@link CardEditor} for the composable card at `index`. Index validity is
+	 * checked lazily at commit time, so this never throws.
+	 */
+	card(index: number): CardEditor;
+}
+
+/**
+ * A composable card bound to its `Quill` for typed writes, from
+ * {@link DocumentEditor.card}. Same verbs as {@link DocumentEditor}, targeting
+ * the card at its bound index; each write throws `IndexOutOfRange` if that index
+ * is out of range.
+ */
+export declare class CardEditor {
+	constructor(quill: Quill, doc: Document, index: number);
+	/** The bound card index. */
+	readonly index: number;
+	set(name: string, value: unknown): Committed;
+	setAll(fields: Record<string, unknown>): Record<string, Committed>;
+}

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -509,3 +509,121 @@ export class LiveSession {
 		this.#inner.free();
 	}
 }
+
+// ── Typed-editor sugar: bind the quill once ─────────────────────────────────
+// Rust exposes `quill.editor(&mut doc)` so a caller issues bare `set` / `set_all`
+// without threading the schema per write. The WASM `commit*` verbs can't borrow
+// like that — a `Document` carries only a `$quill` REFERENCE, not the resolved
+// schema, so each `commit*` method takes the `quill` handle as its first
+// argument. These pure-JS classes restore the Rust ergonomics: bind `quill` +
+// `doc` once, then issue `set` / `setAll` / `card(i).set`.
+//
+// They hold JS references to the caller's EXISTING handles — no WASM object of
+// their own, no `free()` burden, no second owner of either handle — and every
+// write delegates straight to the underlying `commit*` verb: a schema field is
+// typed-committed (coerced to canonical form, mismatch throws now), an unknown
+// field falls to the opaque store, and the return value says which (`"typed"` /
+// `"opaque"`, or the per-field record for the batch) so a typo'd name is visible
+// at the write, not buried until validation.
+
+/**
+ * A {@link Document} bound to its {@link Quill} for typed writes — the JS twin
+ * of Rust's `quill.editor(&mut doc)`. Writes target the main card; use
+ * {@link card} for a composable card. Holds both handles by reference and owns
+ * neither, so there is nothing to `free()`.
+ */
+export class DocumentEditor {
+	#quill;
+	#doc;
+	/**
+	 * @param {Quill} quill the schema source for typed commits
+	 * @param {Document} doc the document to mutate, held by reference (not owned)
+	 */
+	constructor(quill, doc) {
+		this.#quill = quill;
+		this.#doc = doc;
+	}
+	/** The bound document — the same instance passed in, mutated in place. */
+	get document() {
+		return this.#doc;
+	}
+	/**
+	 * Typed-commit one main-card field. Returns `"typed"` when the field is in
+	 * the schema (strict coerce, mismatch throws now) or `"opaque"` when it is
+	 * not (stored verbatim). See `Document.commitField`.
+	 * @param {string} name
+	 * @param {unknown} value
+	 * @returns {import('./runtime.d.ts').Committed}
+	 */
+	set(name, value) {
+		return this.#doc.commitField(this.#quill, name, value);
+	}
+	/**
+	 * Typed-commit several main-card fields atomically — nothing is applied on
+	 * error. On success returns the per-field routing
+	 * `Record<string, "typed" | "opaque">`, so a whole-form submit still sees
+	 * which names fell to the opaque store (a likely typo). See
+	 * `Document.commitFields`.
+	 * @param {Record<string, unknown>} fields
+	 * @returns {Record<string, import('./runtime.d.ts').Committed>}
+	 */
+	setAll(fields) {
+		return this.#doc.commitFields(this.#quill, fields);
+	}
+	/**
+	 * A {@link CardEditor} bound to the composable card at `index`. Index
+	 * validity is checked lazily by the underlying write (it throws
+	 * `IndexOutOfRange` at commit time), so constructing one never throws.
+	 * @param {number} index
+	 * @returns {CardEditor}
+	 */
+	card(index) {
+		return new CardEditor(this.#quill, this.#doc, index);
+	}
+}
+
+/**
+ * A single composable card bound to its {@link Quill} for typed writes, from
+ * {@link DocumentEditor.card}. Same `set` / `setAll` verbs as
+ * {@link DocumentEditor}, targeting the card at its bound index.
+ */
+export class CardEditor {
+	#quill;
+	#doc;
+	#index;
+	/**
+	 * @param {Quill} quill the schema source
+	 * @param {Document} doc the document to mutate, held by reference (not owned)
+	 * @param {number} index the composable card's index
+	 */
+	constructor(quill, doc, index) {
+		this.#quill = quill;
+		this.#doc = doc;
+		this.#index = index;
+	}
+	/** The bound card index. */
+	get index() {
+		return this.#index;
+	}
+	/**
+	 * Typed-commit one field on this card. `"typed"` / `"opaque"` per
+	 * `Document.commitCardField`. Throws `IndexOutOfRange` if the bound index
+	 * is out of range.
+	 * @param {string} name
+	 * @param {unknown} value
+	 * @returns {import('./runtime.d.ts').Committed}
+	 */
+	set(name, value) {
+		return this.#doc.commitCardField(this.#quill, this.#index, name, value);
+	}
+	/**
+	 * Typed-commit several fields on this card atomically. Per-field routing
+	 * record on success, per `Document.commitCardFields`. Throws
+	 * `IndexOutOfRange` if the bound index is out of range.
+	 * @param {Record<string, unknown>} fields
+	 * @returns {Record<string, import('./runtime.d.ts').Committed>}
+	 */
+	setAll(fields) {
+		return this.#doc.commitCardFields(this.#quill, this.#index, fields);
+	}
+}

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1027,6 +1027,33 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
+    /// Batched twin of [`commitField`](Document::commit_field): typed-commit
+    /// several main-card fields atomically, resolving each field's schema `type`
+    /// from `quill`. All-or-nothing with the same per-field-diagnostic error
+    /// contract as [`setFields`](Document::set_fields) — nothing is applied on
+    /// error and the thrown error's `diagnostics` carry one entry per offending
+    /// field.
+    ///
+    /// On success returns a `Record<string, "typed" | "opaque">` keyed by the
+    /// input field names, in input order — the batch form of `commitField`'s
+    /// scalar return, so a whole-form submit still sees which names fell to the
+    /// opaque store (a likely typo) instead of losing that signal to the batch,
+    /// the way [`setFields`](Document::set_fields) does.
+    #[wasm_bindgen(js_name = commitFields, unchecked_return_type = "Record<string, \"typed\" | \"opaque\">")]
+    pub fn commit_fields(
+        &mut self,
+        quill: &Quill,
+        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let batch = js_value_to_field_batch(&fields, "commitFields")?;
+        let routing = quill
+            .inner
+            .editor(&mut self.inner)
+            .set_all(batch)
+            .map_err(edit_errors_to_js)?;
+        committed_batch_to_js(routing, "commitFields")
+    }
+
     /// The markdown projection of a richtext field on the main card
     /// (`export ∘ decode`) — the field-level twin of `main.bodyMarkdown`.
     /// Returns `undefined` when the field is absent or does not decode as
@@ -1190,6 +1217,30 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
+    /// Batched twin of [`commitCardField`](Document::commit_card_field):
+    /// typed-commit several fields on the card at `index` atomically, resolving
+    /// each field's type from the card's `$kind` schema in `quill`. All-or-nothing
+    /// with the same per-field-diagnostic contract as
+    /// [`commitFields`](Document::commit_fields), whose `Record<string, "typed" |
+    /// "opaque">` success shape it mirrors. Throws `[EditError::IndexOutOfRange]`
+    /// when `index` is out of range.
+    #[wasm_bindgen(js_name = commitCardFields, unchecked_return_type = "Record<string, \"typed\" | \"opaque\">")]
+    pub fn commit_card_fields(
+        &mut self,
+        quill: &Quill,
+        index: usize,
+        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let batch = js_value_to_field_batch(&fields, "commitCardFields")?;
+        let mut editor = quill.inner.editor(&mut self.inner);
+        let routing = editor
+            .card(index)
+            .map_err(|e| edit_error_to_js(&e))?
+            .set_all(batch)
+            .map_err(edit_errors_to_js)?;
+        committed_batch_to_js(routing, "commitCardFields")
+    }
+
     /// The markdown projection of a richtext field on the card at `index` — the
     /// card-indexed twin of [`fieldMarkdown`](Document::field_markdown). Returns
     /// `undefined` when `index` is out of range, the field is absent, or it does
@@ -1312,6 +1363,22 @@ fn edit_errors_to_js(errors: Vec<(String, quillmark_core::EditError)>) -> JsValu
         })
         .collect();
     WasmError { diagnostics }.to_js_value()
+}
+
+/// Serialize a batched typed-write routing — one `(name, `[`Committed`]`)` per
+/// field, in input order — to a JS `Record<string, "typed" | "opaque">`. The
+/// batch form of `commitField`'s scalar return: object key order follows the
+/// input (`preserve_order` is on workspace-wide), so a caller reads which names
+/// fell to the opaque store straight off the object.
+fn committed_batch_to_js(
+    routing: Vec<(String, quillmark_core::Committed)>,
+    ctx: &str,
+) -> Result<JsValue, JsValue> {
+    let map: serde_json::Map<String, serde_json::Value> = routing
+        .into_iter()
+        .map(|(name, c)| (name, serde_json::Value::String(c.as_str().to_string())))
+        .collect();
+    serialize_or_throw(&map, ctx)
 }
 
 /// Deserialize a plain JS object into the `(name, value)` batch

--- a/crates/core/src/editor.rs
+++ b/crates/core/src/editor.rs
@@ -103,7 +103,16 @@ impl<'a> TypedEditor<'a> {
     /// (typed conform or opaque store) before any is applied; on any violation
     /// nothing is written and every offending field is returned as a
     /// `(name, error)` pair.
-    pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
+    ///
+    /// On success returns one `(name, `[`Committed`]`)` pair per field, in input
+    /// order — the batch form of [`set`](Self::set)'s scalar return, so a caller
+    /// submitting a whole form sees which names fell to the opaque store (a
+    /// likely typo) instead of losing that signal to the batch, the way
+    /// [`Card::set_fields`](crate::Card::set_fields) does.
+    pub fn set_all<K, V, I>(
+        &mut self,
+        fields: I,
+    ) -> Result<Vec<(String, Committed)>, Vec<(String, EditError)>>
     where
         K: Into<String>,
         V: Into<QuillValue>,
@@ -163,8 +172,12 @@ impl CardEditor<'_> {
     }
 
     /// Write several fields on this card atomically — see
-    /// [`TypedEditor::set_all`].
-    pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
+    /// [`TypedEditor::set_all`], including the per-field [`Committed`] routing
+    /// returned on success.
+    pub fn set_all<K, V, I>(
+        &mut self,
+        fields: I,
+    ) -> Result<Vec<(String, Committed)>, Vec<(String, EditError)>>
     where
         K: Into<String>,
         V: Into<QuillValue>,
@@ -176,12 +189,15 @@ impl CardEditor<'_> {
 
 /// All-or-nothing batched write shared by [`TypedEditor::set_all`] and
 /// [`CardEditor::set_all`]: resolve every field first (collecting every error),
-/// apply none on failure, apply all on success.
+/// apply none on failure, apply all on success. Each field's routing — typed
+/// when it is in `fields_schema`, opaque when it is not — is the same decision
+/// the scalar `set` makes, recorded here so the batch can hand it back rather
+/// than swallow it.
 fn set_all_impl<K, V, I>(
     card: &mut Card,
     fields_schema: Option<&BTreeMap<String, FieldSchema>>,
     fields: I,
-) -> Result<(), Vec<(String, EditError)>>
+) -> Result<Vec<(String, Committed)>, Vec<(String, EditError)>>
 where
     K: Into<String>,
     V: Into<QuillValue>,
@@ -192,22 +208,29 @@ where
         .map(|(k, v)| (k.into(), v.into()))
         .collect();
 
-    let mut resolved: Vec<(String, QuillValue)> = Vec::with_capacity(fields.len());
+    let mut resolved: Vec<(String, QuillValue, Committed)> = Vec::with_capacity(fields.len());
     let mut errors: Vec<(String, EditError)> = Vec::new();
     for (name, value) in fields {
         let schema = fields_schema.and_then(|m| m.get(&name));
+        let routed = if schema.is_some() {
+            Committed::Typed
+        } else {
+            Committed::Opaque
+        };
         match resolve_field_write(&name, value, schema) {
-            Ok(stored) => resolved.push((name, stored)),
+            Ok(stored) => resolved.push((name, stored, routed)),
             Err(e) => errors.push((name, e)),
         }
     }
     if !errors.is_empty() {
         return Err(errors);
     }
-    for (name, stored) in resolved {
-        card.payload_mut().insert(name, stored);
+    let mut routing = Vec::with_capacity(resolved.len());
+    for (name, stored, routed) in resolved {
+        card.payload_mut().insert(name.clone(), stored);
+        routing.push((name, routed));
     }
-    Ok(())
+    Ok(routing)
 }
 
 #[cfg(test)]
@@ -299,13 +322,45 @@ card_kinds:
         assert_eq!(errs[0].0, "subject");
         assert!(doc.main().payload().get("qty").is_none());
 
-        // A clean batch applies every field.
+        // A clean batch applies every field and reports each field's routing
+        // in input order.
         let mut ed = TypedEditor::new(&config, &mut doc);
-        ed.set_all([("qty", "5"), ("subject", "ok")]).unwrap();
+        let routing = ed.set_all([("qty", "5"), ("subject", "ok")]).unwrap();
+        assert_eq!(
+            routing,
+            vec![
+                ("qty".to_string(), Committed::Typed),
+                ("subject".to_string(), Committed::Typed),
+            ]
+        );
         assert_eq!(
             doc.main().payload().get("qty").unwrap().as_json(),
             &serde_json::json!(5)
         );
+    }
+
+    #[test]
+    fn set_all_reports_opaque_fields_on_success() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        // A whole-form submit with a typo'd name: `qty` is a schema field (typed),
+        // `titel` is not (opaque). The batch succeeds — the opaque field is the
+        // signal a caller uses to flag the probable typo, not lost to the batch.
+        let routing = ed.set_all([("qty", "3"), ("titel", "oops")]).unwrap();
+        assert_eq!(
+            routing,
+            vec![
+                ("qty".to_string(), Committed::Typed),
+                ("titel".to_string(), Committed::Opaque),
+            ]
+        );
+        let opaque: Vec<&str> = routing
+            .iter()
+            .filter(|(_, c)| !c.is_typed())
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(opaque, vec!["titel"]);
     }
 
     #[test]

--- a/prose/canon/PROGRAMMATIC.md
+++ b/prose/canon/PROGRAMMATIC.md
@@ -62,8 +62,32 @@ enforced per mutator call. `set_fields` validates its whole batch before
 applying any of it: on violation nothing is applied and the single error
 carries one diagnostic per offending field with `path` set to the field name —
 externally sourced names (database columns, form keys) surface every violation
-in one pass. Schema validation (types, enums, constraints) is a separate,
-also-batched pass at `Quill::validate` / render.
+in one pass. Schema validation (types, enums, constraints) is a separate pass:
+deferred to `Quill::validate` / render for the opaque store, or pulled forward
+to the write by typed commit (below).
+
+## Two write disciplines: opaque store vs typed commit
+
+Document mutation is a data primitive that never requires a Quill. `set_field` /
+`set_fields` hold only a `$quill` *reference*, enforce the structural invariants
+above, and store the value verbatim — coercion is deferred to render. Typed
+commit is a schema-bound layer over that primitive: `Quill::editor(&mut doc)`
+binds the resolved schema, and its `set` / `set_all` resolve each field's `type`,
+coerce to the canonical form (`"3"` → `3`, a markdown string → a richtext
+corpus), and fail at the write on a mismatch — the default whenever a Quill is
+in hand. Each write reports where it landed (`Committed::{Typed, Opaque}`): a
+schema field commits typed, an unknown name falls to the opaque store, so a typo
+is visible at the write rather than at validation. `set_all` returns that
+decision per field, so a whole-form batch keeps the signal instead of swallowing
+it.
+
+The primitive stays load-bearing — it is what lets a `Document` be constructed
+and `from_json`'d with no bundle (standalone data), what quill-agnostic
+storage/migration infra writes through, and what a store-now-validate-later
+editor uses to hold not-yet-conforming input. Reach for the opaque `set_*` on
+purpose for those; reach for the editor / `commit` by default. The bindings
+mirror this: `commitField` / `commitFields` (+ `commitCard*`) and the JS
+`DocumentEditor` / `CardEditor` sugar over `set*`'s quill-free store.
 
 ## Addressing cards for re-render
 


### PR DESCRIPTION
Closes #911. Base is `integration/richtext` — this completes the typed-write surface landed by #896, which does not exist on `main`.

## Problem

#896 shipped the schema-bound typed-write layer half-built: single-field typed writes (`commitField` / `commitCardField`) but no batched typed verb, and no ergonomic "bind the quill once" front door. Meanwhile the untyped `set*` verbs sit next to `commit*` as a co-equal default. The result is a silent-opacity footgun: a form building a whole card reaches for `setFields` (the only batch verb) and silently drops schema typing — a typo'd field name is stored verbatim and only surfaces at validate/render, far from the edit.

## Changes

- **Batch typed writes.** `commitFields` / `commitCardFields` (WASM), routing through the existing `TypedEditor::set_all` / `CardEditor::set_all`. All-or-nothing, one diagnostic per offending field on error, typed coercion for schema fields.
- **Close the batch silent-opacity gap.** `commitField`'s scalar return (`"typed" | "opaque"`) exists so a typo'd name that fell to the opaque store is visible at the write. The batch had no equivalent: `set_all` returned `()`, so a whole-form submit lost that signal. `set_all` now returns `Vec<(name, Committed)>` on success, surfaced by the batch verbs as `Record<string, "typed" | "opaque">`. `{ qty: "3", titel: "x" }` → `{ qty: "typed", titel: "opaque" }`.
- **JS `DocumentEditor` / `CardEditor` sugar** (`runtime.js` + `.d.ts`) — the JS twin of Rust's `quill.editor(&mut doc)`: bind the quill once, then `set` / `setAll` / `card(i).set`. Pure JS holding references to the caller's existing handles — no WASM object, no `free()`.
- **Reframe defaults/docs.** README gains a "`commit*` is the default, `set*` is the quill-free primitive" section documenting `set*`'s three legit use cases (standalone data, storage/migration infra, store-now-validate-later). Canon `PROGRAMMATIC.md` records the layering principle: document mutation is a data primitive that never requires a Quill; typed commit is a schema-bound layer over it, the default whenever a Quill is in hand.

## Scope deviation

The issue scoped this "no core changes." This makes exactly one additive change under `crates/core`: `TypedEditor::set_all` / `CardEditor::set_all` return `Vec<(name, Committed)>` instead of `()` on success. The typed/opaque routing decision is already made inside `set_all_impl`; returning it there is what lets the binding surface the record without re-deriving the rule at the seam. Two callers, both in `editor.rs`; the opaque `set*` path and every other core surface are untouched.

## Tests

- Core: `set_all` routing on success, including the mixed typed/opaque (typo-visible) case. `cargo test -p quillmark-core` green (606).
- `basic.test.js`: `commitFields` / `commitCardFields` typed batch, opaque-field-on-success, all-or-nothing abort, bad-index throw.
- `runtime.test.js`: `DocumentEditor` / `CardEditor` sugar — routing, per-field record, `card(i).set`, lazy index validation.

WASM/JS bundle tests run on CI (the `wasm32` target + Typst-to-wasm build is not available locally).

## Follow-up (not in this PR)

Python has the same gap — `commit_field` / `commit_card_field` but no batch and no editor sugar. The shared `set_all` routing is already in place, so a Python `commit_fields` / `commit_card_fields` (+ optional editor class) is a clean parity follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW7qTuSucyneQRDbHu1Zxg)_