### PR TITLE
test(wasm): close the last hole in the #813 LiveSession delegation guard (locate)

### DIFF
--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -493,6 +493,19 @@ A single line of body ink.`
       expect(chit.field).toBe('$body')
       expect(chit.granularity).toBe('cluster')
 
+      // locate — the corpus-position → caret-rect reverse of positionAt, and the
+      // one documented member this every-member smoke test had been skipping (so
+      // a dropped `locate` delegation would have sailed through it — the exact
+      // #801 bug class). Round-trip the offset positionAt just resolved: locating
+      // $body at that USV position returns a caret rect on the same field/page.
+      expect(typeof session.locate).toBe('function')
+      const caret = session.locate('$body', chit.pos)
+      expect(caret.field).toBe('$body')
+      expect(caret.page).toBe(body.page)
+      expect(caret.rect).toHaveLength(4)
+      // A field that places no tracked content resolves nowhere.
+      expect(session.locate('does_not_exist', 0)).toBeUndefined()
+
       // paint.
       expect(typeof session.paint).toBe('function')
       const ctx = new FakeCanvasRenderingContext2D()


### PR DESCRIPTION
## Context

Issue #813 ("Land `LiveSession.fieldAt` delegation; harden `page_hashes` against source spans") landed on `main` via PR #813. Its two substantive fixes and their tests are **already present and passing** on `integration/richtext` (this branch's base), re-landed through the #800/#900-series rework:

- **`fieldAt` delegation** — `crates/bindings/wasm/runtime/runtime.js:467`, plus the every-member smoke test in `runtime.test.js`.
- **`page_hashes` drops source spans** — `crates/backends/typst/src/lib.rs` (`hash_text` + `walk` omit every glyph/shape/image `Span`), the `sorted()` canonicalization in `helper.rs` that removes the field-order byte shift (the actual root cause of the web-app dirty-every-reapply symptom), and the acceptance tests `identical_reapply_of_markdown_content_is_clean`, `reapply_with_reordered_fields_same_content_is_clean`, `reordered_input_emits_byte_identical_source`, and the `page_hashes_ignore_span_shift_when_ink_is_identical` unit test — all green locally.

So #813 is effectively resolved on `integration/richtext`. This PR closes the one residual gap I found while verifying that.

## The gap

The canonical-`LiveSession` smoke test (`runtime.test.js`) exists precisely to call **every** documented member on a live session, so a dropped `runtime.js` delegation fails there rather than only in a consumer — the `fieldAt is not a function` bug class (#801) the type-level drift guard structurally can't catch.

It exercised every member **except `locate`** — the corpus-position → caret-rect reverse of `positionAt`, declared in `runtime.d.ts:412` and delegated in `runtime.js:486`, but never called on a canonical session. A dropped `locate` forward would have sailed through the very guard meant to stop it.

## The change

One added block in the smoke test: round-trip the offset `positionAt` resolves — locating `$body` at that USV position returns a caret rect on the same field/page — plus the undefined branch for a field placing no tracked content. Closes the last hole in the delegation guard.

## Verification

- Rust reapply/page_hashes acceptance + unit tests: pass locally (`cargo test -p quillmark-typst`).
- `runtime.test.js` builds WASM first; per project convention the bindings suite runs on CI. Syntax-checked locally (`node --check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018CdhYLHNWWek4FXCcHfCnK)_