### PR TITLE
#913: mirror the WASM typed batch on Python (commit_fields + set/commit reframe)

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -461,6 +461,14 @@ impl PyDocument {
         Ok(result)
     }
 
+    /// Store an opaque value on a main-card field, clearing any `!must_fill`
+    /// marker. The quill-free primitive: it holds only the `$quill` *reference*,
+    /// stores the value verbatim, and defers coercion/validation to render.
+    /// Reach for it deliberately — standalone data with no quill in hand,
+    /// quill-agnostic storage/migration, or a store-now-validate-later editor
+    /// holding not-yet-conforming input. When a quill *is* in hand, prefer
+    /// `commit_field` (typed commit) so a mismatch surfaces at the write.
+    /// Raises `QuillmarkError` on a malformed name. Mirrors WASM `setField`.
     fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         self.inner
@@ -482,7 +490,12 @@ impl PyDocument {
     /// error; the raised `QuillmarkError` carries one diagnostic per
     /// offending field (`path` = field name), so externally-sourced names
     /// (database columns, form keys) surface every violation in one pass.
-    /// Mirrors WASM `setFields`.
+    ///
+    /// The batched quill-free primitive (see `set_field`) — stores every value
+    /// opaquely, deferring coercion to render. Prefer `commit_fields` whenever a
+    /// quill is in hand: it typed-commits the batch and reports per-field
+    /// routing, so a form submitting a card is not silently stripped of schema
+    /// typing. Mirrors WASM `setFields`.
     fn set_fields(&mut self, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         self.inner
@@ -516,6 +529,35 @@ impl PyDocument {
             .map_err(convert_edit_error)
     }
 
+    /// Batched twin of `commit_field`: typed-commit several main-card fields
+    /// atomically, resolving each field's schema `type` from `quill`. This is
+    /// the whole-card typed verb — prefer it over `set_fields` whenever a quill
+    /// is in hand, so a form submitting a card gets schema typing instead of the
+    /// opaque store. All-or-nothing with the same per-field-diagnostic error
+    /// contract as `set_fields`: nothing is applied on error and the raised
+    /// `QuillmarkError` carries one diagnostic per offending field (`path` =
+    /// field name).
+    ///
+    /// On success returns a `dict[str, str]` keyed by the input field names, in
+    /// input order — the batch form of `commit_field`'s scalar `"typed"` /
+    /// `"opaque"` return, so a whole-form submit still sees which names fell to
+    /// the opaque store (a likely typo) instead of losing that signal to the
+    /// batch the way `set_fields` does. Mirrors WASM `commitFields`.
+    fn commit_fields<'py>(
+        &mut self,
+        py: Python<'py>,
+        quill: PyRef<'_, PyQuill>,
+        fields: Bound<'_, PyDict>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let batch = pydict_to_field_batch(&fields)?;
+        let routing = quill
+            .inner
+            .editor(&mut self.inner)
+            .set_all(batch)
+            .map_err(convert_edit_errors)?;
+        committed_routing_to_pydict(py, routing)
+    }
+
     /// Typed field write on the composable card at `index` — the card-indexed
     /// twin of `commit_field`, resolving the field's type from the card's
     /// `$kind` schema in `quill`. Returns `"typed"` / `"opaque"`; raises on an
@@ -533,6 +575,29 @@ impl PyDocument {
         card.set(name, qv)
             .map(|c| c.as_str().to_string())
             .map_err(convert_edit_error)
+    }
+
+    /// Batched twin of `commit_card_field`: typed-commit several fields on the
+    /// composable card at `index` atomically, resolving each field's type from
+    /// the card's `$kind` schema in `quill`. All-or-nothing with the same
+    /// per-field-diagnostic contract as `commit_fields`, whose `dict[str, str]`
+    /// routing shape it mirrors. Raises on an out-of-range index. Mirrors WASM
+    /// `commitCardFields`.
+    fn commit_card_fields<'py>(
+        &mut self,
+        py: Python<'py>,
+        quill: PyRef<'_, PyQuill>,
+        index: usize,
+        fields: Bound<'_, PyDict>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let batch = pydict_to_field_batch(&fields)?;
+        let mut editor = quill.inner.editor(&mut self.inner);
+        let routing = editor
+            .card(index)
+            .map_err(convert_edit_error)?
+            .set_all(batch)
+            .map_err(convert_edit_errors)?;
+        committed_routing_to_pydict(py, routing)
     }
 
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -761,6 +826,10 @@ impl PyDocument {
             .map_err(convert_edit_error)
     }
 
+    /// Store an opaque value on the composable card at `index` — the
+    /// card-indexed twin of `set_field`, and the same quill-free primitive.
+    /// Prefer `commit_card_field` when a quill is in hand. Raises on an
+    /// out-of-range index or a malformed name. Mirrors WASM `setCardField`.
     fn set_card_field(
         &mut self,
         index: usize,
@@ -773,9 +842,11 @@ impl PyDocument {
             .map_err(convert_edit_error)
     }
 
-    /// Batched twin of `set_card_field`: set several fields on the
-    /// composable card at `index` atomically. Same all-or-nothing,
-    /// one-diagnostic-per-field contract as `set_fields`.
+    /// Batched twin of `set_card_field`: set several fields on the composable
+    /// card at `index` atomically. Same all-or-nothing, one-diagnostic-per-field
+    /// contract as `set_fields`, and the same quill-free-primitive framing —
+    /// prefer `commit_card_fields` when a quill is in hand. Mirrors WASM
+    /// `setCardFields`.
     fn set_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         self.card_mut_or_raise(index)?
@@ -1184,6 +1255,21 @@ fn pydict_to_field_batch(
         return Err(raise_with_diagnostics(diags, message));
     }
     Ok(batch)
+}
+
+/// Project the `(name, `[`Committed`](quillmark_core::Committed)`)` routing a
+/// typed `set_all` returns to the Python `dict[str, str]` (`"typed"` /
+/// `"opaque"`) that `commit_fields` / `commit_card_fields` hand back. Insertion
+/// order follows the input batch (the routing vec preserves it).
+fn committed_routing_to_pydict(
+    py: Python<'_>,
+    routing: Vec<(String, quillmark_core::Committed)>,
+) -> PyResult<Bound<'_, PyDict>> {
+    let dict = PyDict::new(py);
+    for (name, committed) in routing {
+        dict.set_item(name, committed.as_str())?;
+    }
+    Ok(dict)
 }
 
 fn py_to_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -619,3 +619,61 @@ def test_commit_card_field_index_out_of_range():
     doc = Document("richtext_form@0.1.0")
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         doc.commit_card_field(quill, 0, "body", "x")
+
+
+# ── Typed batched writes — commit_fields / commit_card_fields ─────────────────
+
+
+def _taro_quill():
+    """The taro fixture quill (main: string fields; card kind `quotes`)."""
+    return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
+
+
+def test_commit_fields_typed_batch_reports_routing():
+    """commit_fields typed-commits a batch and returns per-field routing."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    routing = doc.commit_fields(quill, {"bio": "A **bold** intro.", "headline": "Hi"})
+    # Both are schema fields → typed, keyed by field name.
+    assert routing == {"bio": "typed", "headline": "typed"}
+    # And the richtext value was coerced to the corpus, not stored verbatim.
+    assert isinstance(field(doc.main, "bio"), dict)
+
+
+def test_commit_fields_reports_opaque_field_on_success():
+    """A typo the schema does not own stores opaquely and shows in the routing."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    routing = doc.commit_fields(quill, {"bio": "hi", "titel": "oops"})
+    assert routing == {"bio": "typed", "titel": "opaque"}
+    # The signal set_fields drops: which names fell to the opaque store.
+    opaque = [n for n, r in routing.items() if r == "opaque"]
+    assert opaque == ["titel"]
+
+
+def test_commit_fields_is_all_or_nothing():
+    """A richtext(inline) violation aborts the whole batch — nothing lingers."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+        doc.commit_fields(quill, {"bio": "ok", "headline": "line one\n\nline two"})
+    assert not has_field(doc.main, "bio")
+
+
+def test_commit_card_fields_typed_batch_reports_routing():
+    """commit_card_fields resolves the card's $kind schema and routes per field."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    doc.push_card(Document.make_card("quotes"))
+    routing = doc.commit_card_fields(quill, 0, {"author": "Ada", "stray": "x"})
+    # `author` is declared on the `quotes` kind; `stray` is not.
+    assert routing == {"author": "typed", "stray": "opaque"}
+    assert field(doc.cards[0], "author") == "Ada"
+
+
+def test_commit_card_fields_index_out_of_range():
+    """commit_card_fields surfaces IndexOutOfRange for a missing card."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.commit_card_fields(quill, 0, {"author": "x"})


### PR DESCRIPTION
Closes #913.

Binding-local to `crates/bindings/python`. Mirrors the WASM typed-editor completion (#911/#912) onto the Python surface. No changes under `crates/core` / `crates/quillmark` — the shared `set_all` routing is already in place on `integration/richtext`.

## The gap

Python had the same asymmetry #911 fixed for WASM: single typed writes (`commit_field` / `commit_card_field`) existed, but the typed *batch* did not. The opaque `set_fields` / `set_card_fields` were the only whole-card verbs, so a form submitting a card silently dropped schema typing.

| Granularity | Typed (schema-bound) | Opaque (quill-free) |
|---|---|---|
| Single field | `commit_field` / `commit_card_field` ✅ | `set_field` / `set_card_field` ✅ |
| Batched | **`commit_fields` / `commit_card_fields`** (new) | `set_fields` / `set_card_fields` ✅ |

## Changes

1. **`commit_fields` / `commit_card_fields`** route through `TypedEditor::set_all` / `CardEditor::set_all`. All-or-nothing with the same per-field-diagnostic contract as `set_fields` (nothing applied on error; one diagnostic per offending field, `path` = field name). On success they return a `dict[str, str]` routing (`{"qty": "typed", "titel": "opaque"}`) — the plural of `commit_field`'s scalar `"typed"` / `"opaque"`, so a whole-form submit sees which names fell to the opaque store (a likely typo), the signal `set_fields` drops.
2. **Docstring reframe** to match #912: `commit*` is the default typed verb whenever a quill is in hand; `set*` is the deliberate quill-free primitive (standalone data, storage/migration infra, store-now-validate-later), mirroring canon `PROGRAMMATIC.md`.
3. **Editor sugar decision — not shipped.** `doc.commit_fields(quill, {...})` is already clean, and pyo3 objects carry no lifetimes, so a Python `DocumentEditor` / `CardEditor` would be a pure-Python wrapper holding refs to the caller's `Quill` + `Document` — a desync-prone parallel surface for marginal ergonomic gain over the per-call verbs.

## Tests

`crates/bindings/python/tests/test_api_requirements.py`: typed batch routing, opaque-field-on-success (typo visibility), all-or-nothing abort, and `IndexOutOfRange` for both verbs. Full Python suite passes (119 tests); `cargo check` / `clippy` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WJY8fABQYmTm6TneEV8wE

---
_Generated by [Claude Code](https://claude.ai/code/session_016WJY8fABQYmTm6TneEV8wE)_