### PR TITLE
wasm: split Card read type from CardInput write type (#917)

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -232,18 +232,24 @@ const markdown = doc.toMarkdown();
 
 For per-card seeding, `quill.seedMain()` returns just the `$kind: main` card
 and `quill.seedCard(kind)` returns a starter composable card (or `undefined`
-if the kind is not declared). Both return the same `Card` shape as
+if the kind is not declared). Both return the read `Card` shape of
 `doc.main` / `doc.cards`, which `doc.pushCard` / `doc.insertCard` accept
 directly:
 
 ```ts
 doc.pushCard(quill.seedCard("note"));                 // seed → push
 doc.pushCard(Document.makeCard("note", { x: 1 }));    // build from a flat map
+doc.pushCard({ kind: "note", body: "Plain **markdown**." });  // bare inline
 ```
 
-There is one `Card` shape in both directions — `pushCard` / `insertCard` take
-exactly what `cards` / `removeCard` / `seedCard` return. Build a fresh card
-from a flat field map with `Document.makeCard(kind, fields?, body?)`.
+Reads and writes are two aligned shapes. A read `Card` always has `body:
+RichText` (canonical corpus, never a raw string) — no narrowing, no guessing
+whether the body was normalized. The write shape `CardInput` widens `body` to
+`RichText | string` (a markdown string imports to the corpus) and makes every
+field but `kind` optional. Every `Card` is a valid `CardInput`, so `pushCard` /
+`insertCard` still take exactly what `cards` / `removeCard` / `seedCard` return.
+Build a fresh card from a flat field map with
+`Document.makeCard(kind, fields?, body?)`.
 
 Batch mutation: `doc.setFields({...})` / `doc.setCardFields(index, {...})`
 apply a whole object atomically — on any invalid field nothing is applied and

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -97,10 +97,12 @@ export interface QuillMetadata {
 "#;
 
 /// TypeScript for the canonical `Card` wire shape (mirrors
-/// `quillmark_core::CardWire`), referenced by name via `unchecked_param_type`
-/// on `pushCard` / `insertCard`. The single shape both *returned* by
-/// `Document.main` / `cards` / `removeCard` / `quill.seedCard` and *accepted*
-/// by `pushCard` / `insertCard` / `Document.makeCard`.
+/// `quillmark_core::CardWire`) and its write-input twin `CardInput`. `Card` is
+/// the read shape *returned* by `Document.main` / `cards` / `removeCard` /
+/// `quill.seedCard` / `Document.makeCard`; `CardInput` is the shape *accepted*
+/// by `pushCard` / `insertCard` (referenced by name via `unchecked_param_type`).
+/// They differ only in `body`: a read is always canonical `RichText`, a write
+/// also takes a markdown `string`.
 #[wasm_bindgen(typescript_custom_section)]
 const CARD_TS: &'static str = r#"
 /**
@@ -126,10 +128,11 @@ export type PayloadItem =
     | { type: "comment"; text: string; inline?: boolean };
 
 /**
- * A single card block. The one shape exchanged in both directions: returned by
- * `Document.main` / `Document.cards` / `Document.removeCard` / `Quill.seedCard`,
- * and accepted by `Document.pushCard` / `Document.insertCard`. Build a fresh
- * one with `Document.makeCard`.
+ * A single card block, as read back from a document: returned by
+ * `Document.main` / `Document.cards` / `Document.removeCard` / `Quill.seedCard`
+ * / `Document.makeCard`. To feed a card *into* a document use `CardInput`
+ * (which `pushCard` / `insertCard` accept); every `Card` is a valid `CardInput`,
+ * so a card read from one document pushes straight into another.
  *
  * `$` system entries are hoisted to named fields: `kind` (the `$kind`, empty
  * string when none), optional `quill` (the `$quill` `name@version`, main card
@@ -145,13 +148,34 @@ export interface Card {
     seed?: Record<string, unknown>;
     payloadItems: PayloadItem[];
     /**
-     * The card body as canonical RichText-JSON — the source-of-truth content
-     * model. An editor writes this shape back; a markdown string is also accepted
-     * on input (imported). Read `bodyMarkdown` for the markdown projection.
+     * The card body as canonical `RichText` — the source-of-truth content model.
+     * Always this corpus shape on read, never a markdown string; read
+     * `bodyMarkdown` for the markdown projection. Write a body back with
+     * `setBody` / `setCardBody`, or via `CardInput.body`.
      */
-    body: RichText | string;
+    body: RichText;
     /** The body's markdown projection (`export ∘ body`). Read-only; `""` for an empty body. */
     bodyMarkdown: string;
+}
+
+/**
+ * A card written *into* a document — the input twin of `Card`, accepted by
+ * `Document.pushCard` / `Document.insertCard`. Like `Card` but `body` also
+ * takes a markdown `string` (imported to the corpus, so a markdown / LLM writer
+ * needn't build the `RichText` shape), and every field but `kind` is optional —
+ * an absent field defaults (no payload items, an empty body). `bodyMarkdown` is
+ * ignored (`body` is authoritative). Write one inline (`{ kind, body }`) or
+ * build it with `Document.makeCard`.
+ */
+export interface CardInput {
+    kind: string;
+    quill?: string;
+    id?: string;
+    ext?: Record<string, unknown>;
+    seed?: Record<string, unknown>;
+    payloadItems?: PayloadItem[];
+    body?: RichText | string;
+    bodyMarkdown?: string;
 }
 
 /**
@@ -1121,14 +1145,15 @@ impl Document {
         })
     }
 
-    /// Append a card to the end of the card list. Accepts a `Card` (the shape
-    /// returned by `cards` / `removeCard` / `quill.seedCard`); build a fresh
-    /// one with [`Document.makeCard`](Document::make_card). Throws if
-    /// `card.kind` is not a valid kind name.
+    /// Append a card to the end of the card list. Accepts a `CardInput` — a card
+    /// read back (`cards` / `removeCard` / `quill.seedCard`), a
+    /// [`makeCard`](Document::make_card) result, or a bare `{ kind, body }`
+    /// (every returned `Card` is a valid `CardInput`). Throws if `card.kind` is
+    /// not a valid kind name.
     #[wasm_bindgen(js_name = pushCard)]
     pub fn push_card(
         &mut self,
-        #[wasm_bindgen(unchecked_param_type = "Card")] card: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
     ) -> Result<(), JsValue> {
         let core_card = js_to_card(&card)?;
         self.inner
@@ -1137,12 +1162,12 @@ impl Document {
     }
 
     /// Insert a card at `index` (must be in `0..=cards.length`). Accepts a
-    /// `Card` (see [`pushCard`](Self::push_card)).
+    /// `CardInput` (see [`pushCard`](Self::push_card)).
     #[wasm_bindgen(js_name = insertCard)]
     pub fn insert_card(
         &mut self,
         index: usize,
-        #[wasm_bindgen(unchecked_param_type = "Card")] card: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
     ) -> Result<(), JsValue> {
         let core_card = js_to_card(&card)?;
         self.inner
@@ -1457,7 +1482,7 @@ fn card_to_js(card: &quillmark_core::Card) -> Result<JsValue, JsValue> {
     serialize_or_throw(&quillmark_core::CardWire::from(card), "card")
 }
 
-/// Deserialize a `Card`-shaped JS value into a core
+/// Deserialize a `CardInput`-shaped JS value into a core
 /// [`Card`](quillmark_core::Card) via [`CardWire`](quillmark_core::CardWire).
 /// The single place WASM turns JS into a core card — used by `pushCard` /
 /// `insertCard`.
@@ -1484,7 +1509,7 @@ fn js_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
             if let Some(k) = key.as_string() {
                 if !ALLOWED.contains(&k.as_str()) {
                     return Err(WasmError::from(format!(
-                        "card has unknown field `{k}`; expected a Card \
+                        "card has unknown field `{k}`; expected a CardInput \
                          {{ kind, payloadItems, body, … }} — build one with \
                          Document.makeCard(kind, fields, body)"
                     ))

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -180,6 +180,40 @@ import), **`remove`**. The already-mechanical twins (`setCardExt`,
 `removeCardField`, `commitCardField`, `setCardBody`, `cardFieldMarkdown`) are
 unaffected.
 
+## wasm `Card` read/write split: `body: RichText` on read, `CardInput` on write (#917)
+
+The wasm `.d.ts` `Card` shape typed `body: RichText | string` for **both**
+directions. A read is always canonical `RichText` (the runtime normalizes on
+the way out — never a lazy string), so the union only ever widened the read
+type: TS callers had to narrow `card.body` on every access, and JS callers got
+no signal at all. The read and write shapes are now two types:
+
+| | Read (`Card`) | Write (`CardInput`) |
+|---|---|---|
+| `body` | `RichText` (always corpus) | `RichText \| string` (markdown imports) |
+| non-`kind` fields | present | optional (absent → default) |
+| returned by | `main` / `cards` / `removeCard` / `seedMain` / `seedCard` / `makeCard` | — |
+| accepted by | — | `pushCard` / `insertCard` |
+
+- **Read `card.body` is now `RichText`.** No narrowing, no provenance guess. Read
+  `card.bodyMarkdown` for the markdown projection (unchanged).
+- **`pushCard` / `insertCard` accept `CardInput`.** `body` still takes a markdown
+  string, and — new — every field but `kind` is optional, so a bare
+  `doc.pushCard({ kind: "note", body: "…" })` type-checks (it always ran; the old
+  required-everything `Card` param just mistyped it).
+- **Every `Card` is a valid `CardInput`.** `pushCard(removeCard(0))`,
+  `pushCard(seedCard("note"))`, and `pushCard(makeCard(…))` all still type-check —
+  a card read from one document pushes straight into another.
+- **Breaking for TS only.** A variable annotated `Card` that held a
+  freshly-built `{ kind, body: "md", payloadItems: [], bodyMarkdown: "" }` for
+  `pushCard` should be re-annotated `CardInput` (or left inferred). Runtime
+  behavior, the storage DTO, and the Python binding (dynamically typed;
+  `card.body` already returns the corpus dict) are unchanged.
+
+`CardInput` is not the pre-0.88 flat input DTO (a divergent shape, removed in
+0.87 → 0.88): it is structurally `Card` with `body` widened and the read-only
+projections made optional, so the two shapes stay aligned.
+
 ## Live field edits go through `commitField` + `apply(doc)` (#886)
 
 There is no incremental field-delta verb. An earlier unreleased iteration added

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -22,8 +22,12 @@ guides in order.
   writer + `apply(doc)` (the experimental `applyFieldDelta` / change-log surface
   was removed, #886). Card-write verbs become mechanical twins of their
   main-card names — `updateCardField`/`updateCardFields`/`updateCardBody` rename
-  to `setCardField`/`setCardFields`/`replaceCardBody` (#895). On-disk (`.qmd`)
-  identity stays markdown-lossy — the storage DTO is the lossless carrier.
+  to `setCardField`/`setCardFields`/`replaceCardBody` (#895). The wasm `Card`
+  shape splits by direction: a read `Card` always has `body: RichText`, while
+  `pushCard` / `insertCard` take a `CardInput` whose `body` still accepts a
+  markdown string and whose non-`kind` fields are optional (#917). On-disk
+  (`.qmd`) identity stays markdown-lossy — the storage DTO is the lossless
+  carrier.
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now


### PR DESCRIPTION
`Card.body` was typed `RichText | string` for both directions, but a read
is always canonical `RichText` (core normalizes on the way out) — the union
only ever widened the read path, forcing TS callers to narrow on every
`card.body` access and giving JS callers no signal.

Split the shape by direction:
- `Card` (read): `body: RichText`, returned by main/cards/removeCard/seed*/
  makeCard. No narrowing, no provenance guess.
- `CardInput` (write): `body: RichText | string` and every field but `kind`
  optional, accepted by pushCard/insertCard. A bare `{ kind, body }` now
  type-checks (it always ran; the old required-everything param mistyped it).

Every `Card` is a valid `CardInput`, so read-then-push still type-checks.
Runtime behavior, the storage DTO, and the Python binding are unchanged;
this is a wasm `.d.ts` correction. Breaking for TS callers that annotated a
push argument as `Card` — re-annotate `CardInput`. Docs and the 0.93→0.94
migration guide updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTwZ1sP9f4iTQjF21qqn9s