### PR TITLE
feat(core,wasm,python)!: typed field writes reject unknown names (#918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@
   `EditError::FieldConform` for non-richtext mismatches (richtext keeps
   `FieldRichtextDecode` / `FieldRichtextNotInline`). A schema-bound
   `TypedEditor` (`Quill::editor(&mut doc)`) is the front door: `set` / `set_all`
-  resolve field types and report `Committed::{Typed,Opaque}`. Bindings gain
+  resolve field types and strict-commit; a name the schema does not declare is a
+  typo on the typed path, so it fails with `EditError::UnknownField` instead of
+  falling to the opaque store (#918) — opaque storage stays available through the
+  raw `set_field` / `setField` / `setCardField` verbs. Bindings gain
   `commitField` / `commitCardField` (wasm) and `commit_field` /
   `commit_card_field` (Python, net-new — Python had no richtext field writer).
   The pre-release richtext-specific writers are removed in the same cycle:

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -510,94 +510,86 @@ impl PyDocument {
     /// markdown string) commits to the canonical corpus here; scalars coerce to
     /// their declared type (`"3"` → `3`).
     ///
-    /// Returns `"typed"` when the field is declared in the schema (strict
-    /// commit — a mismatch raises now) or `"opaque"` when it is not (stored
-    /// verbatim, like `set_field`). Raises `QuillmarkError` on a typed mismatch
-    /// or a malformed name. Mirrors WASM `commitField`.
+    /// A field declared in the schema is strict-committed — a mismatch raises
+    /// now. A name the schema does not declare raises
+    /// `[EditError::UnknownField]` rather than falling to the opaque store: on
+    /// the typed path it is a typo. Use `set_field` when opaque storage is the
+    /// intent. Also raises `QuillmarkError` on a typed mismatch or a malformed
+    /// name. Mirrors WASM `commitField`.
     fn commit_field(
         &mut self,
         quill: PyRef<'_, PyQuill>,
         name: &str,
         value: Bound<'_, PyAny>,
-    ) -> PyResult<String> {
+    ) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         quill
             .inner
             .editor(&mut self.inner)
             .set(name, qv)
-            .map(|c| c.as_str().to_string())
             .map_err(convert_edit_error)
     }
 
     /// Batched twin of `commit_field`: typed-commit several main-card fields
     /// atomically, resolving each field's schema `type` from `quill`. This is
     /// the whole-card typed verb — prefer it over `set_fields` whenever a quill
-    /// is in hand, so a form submitting a card gets schema typing instead of the
-    /// opaque store. All-or-nothing with the same per-field-diagnostic error
-    /// contract as `set_fields`: nothing is applied on error and the raised
-    /// `QuillmarkError` carries one diagnostic per offending field (`path` =
-    /// field name).
-    ///
-    /// On success returns a `dict[str, str]` keyed by the input field names, in
-    /// input order — the batch form of `commit_field`'s scalar `"typed"` /
-    /// `"opaque"` return, so a whole-form submit still sees which names fell to
-    /// the opaque store (a likely typo) instead of losing that signal to the
-    /// batch the way `set_fields` does. Mirrors WASM `commitFields`.
-    fn commit_fields<'py>(
+    /// is in hand, so a form submitting a card gets schema typing. All-or-nothing
+    /// with the same per-field-diagnostic error contract as `set_fields`: nothing
+    /// is applied on error and the raised `QuillmarkError` carries one diagnostic
+    /// per offending field (`path` = field name), including an
+    /// `[EditError::UnknownField]` for any name the schema does not declare, so a
+    /// whole-form submit sees every typo in one pass. Mirrors WASM `commitFields`.
+    fn commit_fields(
         &mut self,
-        py: Python<'py>,
         quill: PyRef<'_, PyQuill>,
         fields: Bound<'_, PyDict>,
-    ) -> PyResult<Bound<'py, PyDict>> {
+    ) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
-        let routing = quill
+        quill
             .inner
             .editor(&mut self.inner)
             .set_all(batch)
-            .map_err(convert_edit_errors)?;
-        committed_routing_to_pydict(py, routing)
+            .map_err(convert_edit_errors)
     }
 
     /// Typed field write on the composable card at `index` — the card-indexed
     /// twin of `commit_field`, resolving the field's type from the card's
-    /// `$kind` schema in `quill`. Returns `"typed"` / `"opaque"`; raises on an
-    /// out-of-range index or a typed mismatch. Mirrors WASM `commitCardField`.
+    /// `$kind` schema in `quill`. Raises `[EditError::UnknownField]` for a field
+    /// the card-kind schema does not declare (an unknown `$kind` has no schema,
+    /// so every field is undeclared), on an out-of-range index, or a typed
+    /// mismatch. Mirrors WASM `commitCardField`.
     fn commit_card_field(
         &mut self,
         quill: PyRef<'_, PyQuill>,
         index: usize,
         name: &str,
         value: Bound<'_, PyAny>,
-    ) -> PyResult<String> {
+    ) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         let mut editor = quill.inner.editor(&mut self.inner);
         let mut card = editor.card(index).map_err(convert_edit_error)?;
-        card.set(name, qv)
-            .map(|c| c.as_str().to_string())
-            .map_err(convert_edit_error)
+        card.set(name, qv).map_err(convert_edit_error)
     }
 
     /// Batched twin of `commit_card_field`: typed-commit several fields on the
     /// composable card at `index` atomically, resolving each field's type from
     /// the card's `$kind` schema in `quill`. All-or-nothing with the same
-    /// per-field-diagnostic contract as `commit_fields`, whose `dict[str, str]`
-    /// routing shape it mirrors. Raises on an out-of-range index. Mirrors WASM
-    /// `commitCardFields`.
-    fn commit_card_fields<'py>(
+    /// per-field-diagnostic contract as `commit_fields` (an
+    /// `[EditError::UnknownField]` per undeclared name). Raises on an
+    /// out-of-range index. Mirrors WASM `commitCardFields`.
+    fn commit_card_fields(
         &mut self,
-        py: Python<'py>,
         quill: PyRef<'_, PyQuill>,
         index: usize,
         fields: Bound<'_, PyDict>,
-    ) -> PyResult<Bound<'py, PyDict>> {
+    ) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         let mut editor = quill.inner.editor(&mut self.inner);
-        let routing = editor
+        editor
             .card(index)
             .map_err(convert_edit_error)?
             .set_all(batch)
-            .map_err(convert_edit_errors)?;
-        committed_routing_to_pydict(py, routing)
+            .map_err(convert_edit_errors)
     }
 
     fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -1255,21 +1247,6 @@ fn pydict_to_field_batch(
         return Err(raise_with_diagnostics(diags, message));
     }
     Ok(batch)
-}
-
-/// Project the `(name, `[`Committed`](quillmark_core::Committed)`)` routing a
-/// typed `set_all` returns to the Python `dict[str, str]` (`"typed"` /
-/// `"opaque"`) that `commit_fields` / `commit_card_fields` hand back. Insertion
-/// order follows the input batch (the routing vec preserves it).
-fn committed_routing_to_pydict(
-    py: Python<'_>,
-    routing: Vec<(String, quillmark_core::Committed)>,
-) -> PyResult<Bound<'_, PyDict>> {
-    let dict = PyDict::new(py);
-    for (name, committed) in routing {
-        dict.set_item(name, committed.as_str())?;
-    }
-    Ok(dict)
 }
 
 fn py_to_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -590,18 +590,22 @@ def test_commit_field_richtext_typed():
     """commit_field resolves a richtext field's type and stores canonical corpus."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    assert doc.commit_field(quill, "bio", "A **bold** intro.") == "typed"
+    doc.commit_field(quill, "bio", "A **bold** intro.")
     value = field(doc.main, "bio")
     # Stored structurally as the corpus dict, not the authored markdown string.
     assert isinstance(value, dict)
     assert value["text"] == "A bold intro."
 
 
-def test_commit_field_unknown_field_is_opaque():
-    """A field absent from the schema stores opaquely, and the caller is told."""
+def test_commit_field_unknown_field_raises():
+    """A field absent from the schema is a typo on the typed path — it raises."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    assert doc.commit_field(quill, "stray", "x") == "opaque"
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        doc.commit_field(quill, "stray", "x")
+    assert not has_field(doc.main, "stray")
+    # Opaque storage stays available on purpose through the raw verb.
+    doc.set_field("stray", "x")
     assert field(doc.main, "stray") == "x"
 
 
@@ -629,26 +633,24 @@ def _taro_quill():
     return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
 
 
-def test_commit_fields_typed_batch_reports_routing():
-    """commit_fields typed-commits a batch and returns per-field routing."""
+def test_commit_fields_typed_batch():
+    """commit_fields typed-commits a batch, coercing each value to its type."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    routing = doc.commit_fields(quill, {"bio": "A **bold** intro.", "headline": "Hi"})
-    # Both are schema fields → typed, keyed by field name.
-    assert routing == {"bio": "typed", "headline": "typed"}
-    # And the richtext value was coerced to the corpus, not stored verbatim.
+    doc.commit_fields(quill, {"bio": "A **bold** intro.", "headline": "Hi"})
+    # The richtext value was coerced to the corpus, not stored verbatim.
     assert isinstance(field(doc.main, "bio"), dict)
 
 
-def test_commit_fields_reports_opaque_field_on_success():
-    """A typo the schema does not own stores opaquely and shows in the routing."""
+def test_commit_fields_rejects_unknown_field():
+    """A typo the schema does not own aborts the all-or-nothing batch."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    routing = doc.commit_fields(quill, {"bio": "hi", "titel": "oops"})
-    assert routing == {"bio": "typed", "titel": "opaque"}
-    # The signal set_fields drops: which names fell to the opaque store.
-    opaque = [n for n, r in routing.items() if r == "opaque"]
-    assert opaque == ["titel"]
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        doc.commit_fields(quill, {"bio": "hi", "titel": "oops"})
+    # Nothing applied — the good field must not linger either.
+    assert not has_field(doc.main, "bio")
+    assert not has_field(doc.main, "titel")
 
 
 def test_commit_fields_is_all_or_nothing():
@@ -660,15 +662,16 @@ def test_commit_fields_is_all_or_nothing():
     assert not has_field(doc.main, "bio")
 
 
-def test_commit_card_fields_typed_batch_reports_routing():
-    """commit_card_fields resolves the card's $kind schema and routes per field."""
+def test_commit_card_fields_typed_batch():
+    """commit_card_fields resolves the card's $kind schema and commits each field."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     doc.push_card(Document.make_card("quotes"))
-    routing = doc.commit_card_fields(quill, 0, {"author": "Ada", "stray": "x"})
-    # `author` is declared on the `quotes` kind; `stray` is not.
-    assert routing == {"author": "typed", "stray": "opaque"}
+    doc.commit_card_fields(quill, 0, {"author": "Ada"})
     assert field(doc.cards[0], "author") == "Ada"
+    # A field the `quotes` kind does not declare aborts the batch as a typo.
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        doc.commit_card_fields(quill, 0, {"stray": "x"})
 
 
 def test_commit_card_fields_index_out_of_range():

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -259,12 +259,12 @@ mutates through two layers:
   `doc.commitField(quill, name, value)` / `doc.commitFields(quill, {...})` (and
   the `commitCard*` twins) resolve each field's schema `type`, coerce the value
   to its canonical form (`"3"` → `3`, a markdown string → a richtext corpus),
-  and **fail now** on a mismatch instead of at render. The return value reports
-  where the value landed: `"typed"` for a schema field, `"opaque"` for one the
-  schema does not own. The batch form returns that per field —
-  `Record<string, "typed" | "opaque">`, in input order — so a whole-form submit
-  still sees which names fell through to the opaque store (a likely typo), the
-  signal `setFields` discards.
+  and **fail now** on a mismatch instead of at render. A name the schema does
+  not declare throws `UnknownField` rather than falling to the opaque store — on
+  the typed path an undeclared name is a typo, not a fallback. The batch form is
+  all-or-nothing: an undeclared name aborts the whole write and its per-field
+  diagnostics name every offending field, so a whole-form submit surfaces every
+  typo `setFields` would silently absorb.
 
 - **`set*` — the deliberate quill-free primitive.** `doc.setField(name, value)`
   / `doc.setFields({...})` (and the `setCard*` twins) validate only the field
@@ -290,10 +290,9 @@ writer — bind them once with the editor sugar and issue bare verbs:
 import { DocumentEditor } from "@quillmark/wasm";
 
 const ed = new DocumentEditor(quill, doc);          // JS twin of Rust `quill.editor(doc)`
-ed.set("subject", "Q3 results");                    // → "typed"
-const routing = ed.setAll({ qty: "3", titel: "x" }); // → { qty: "typed", titel: "opaque" }
-const typos = Object.entries(routing)
-  .filter(([, r]) => r === "opaque").map(([k]) => k); // ["titel"] — flag in the UI
+ed.set("subject", "Q3 results");                    // strict-committed to the schema type
+ed.setAll({ qty: "3", subject: "Q3" });             // all-or-nothing batch
+ed.set("titel", "x");                               // throws UnknownField — a typo, not a fallback
 ed.card(2).set("body", "**note**");                 // composable card, resolved by its $kind
 ```
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -645,18 +645,21 @@ card_kinds:
   it('commitField resolves the schema type: richtext string → corpus, integer "3" → 3', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    expect(doc.commitField(quill, 'intro', 'A **bold** intro.')).toBe('typed')
+    doc.commitField(quill, 'intro', 'A **bold** intro.')
     expect(typeof field(doc.main, 'intro')).toBe('object')
     expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
 
-    expect(doc.commitField(quill, 'qty', '3')).toBe('typed')
+    doc.commitField(quill, 'qty', '3')
     expect(field(doc.main, 'qty')).toBe(3)
   })
 
-  it('commitField stores an unknown field opaquely and says so', () => {
+  it('commitField rejects an unknown field as a typo and writes nothing', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    expect(doc.commitField(quill, 'stray', 'x')).toBe('opaque')
+    expect(() => doc.commitField(quill, 'stray', 'x')).toThrow(/UnknownField/)
+    expect(hasField(doc.main, 'stray')).toBe(false)
+    // Opaque storage stays available on purpose through the raw verb.
+    doc.setField('stray', 'x')
     expect(field(doc.main, 'stray')).toBe('x')
   })
 
@@ -680,33 +683,28 @@ card_kinds:
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
-    expect(doc.commitCardField(quill, 0, 'body', 'Card **body**.')).toBe('typed')
+    doc.commitCardField(quill, 0, 'body', 'Card **body**.')
     expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
     expect(() => doc.commitCardField(quill, 9, 'body', 'x')).toThrow(/IndexOutOfRange/)
   })
 
-  it('commitFields typed-commits a batch and reports per-field routing', () => {
+  it('commitFields typed-commits a batch', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    const routing = doc.commitFields(quill, { intro: 'A **bold** intro.', qty: '3' })
-    // Both are schema fields → typed, keyed by field name.
-    expect(routing).toEqual({ intro: 'typed', qty: 'typed' })
-    // And the values were coerced, not stored verbatim.
+    doc.commitFields(quill, { intro: 'A **bold** intro.', qty: '3' })
+    // The values were coerced, not stored verbatim.
     expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
     expect(field(doc.main, 'qty')).toBe(3)
   })
 
-  it('commitFields reports an opaque field on success, so a typo is visible', () => {
+  it('commitFields aborts the whole batch on a typo, reporting the unknown field', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    // `qty` is a schema field; `titel` is a typo the schema does not own — it
-    // still stores (opaque), and the routing record surfaces which one, instead
-    // of losing the signal to the batch the way setFields does.
-    const routing = doc.commitFields(quill, { qty: '5', titel: 'oops' })
-    expect(routing).toEqual({ qty: 'typed', titel: 'opaque' })
-    expect(field(doc.main, 'qty')).toBe(5)
-    const opaque = Object.entries(routing).filter(([, r]) => r === 'opaque').map(([n]) => n)
-    expect(opaque).toEqual(['titel'])
+    // `qty` is a schema field; `titel` is a typo the schema does not own — the
+    // undeclared name aborts the all-or-nothing batch and nothing is applied.
+    expect(() => doc.commitFields(quill, { qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
+    expect(hasField(doc.main, 'qty')).toBe(false)
+    expect(hasField(doc.main, 'titel')).toBe(false)
   })
 
   it('commitFields is all-or-nothing: a bad field aborts the whole batch', () => {
@@ -724,9 +722,10 @@ card_kinds:
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
-    const routing = doc.commitCardFields(quill, 0, { body: 'Card **body**.', stray: 'x' })
-    expect(routing).toEqual({ body: 'typed', stray: 'opaque' })
+    doc.commitCardFields(quill, 0, { body: 'Card **body**.' })
     expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+    // An undeclared field on the card aborts the batch.
+    expect(() => doc.commitCardFields(quill, 0, { stray: 'x' })).toThrow(/UnknownField/)
     expect(() => doc.commitCardFields(quill, 9, { body: 'x' })).toThrow(/IndexOutOfRange/)
   })
 })

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -140,19 +140,23 @@ card_kinds:
   const fieldOf = (card, key) =>
     card.payloadItems.find((i) => i.type === 'field' && i.key === key)?.value
 
-  it('set binds the quill once and routes typed vs opaque', () => {
+  it('set binds the quill once and strict-commits a schema field', () => {
     const ed = new DocumentEditor(buildQuill(), blankDoc())
-    expect(ed.set('qty', '3')).toBe('typed') // schema field → strict coerce
-    expect(ed.set('stray', 'x')).toBe('opaque') // unknown → verbatim store
+    ed.set('qty', '3') // schema field → strict coerce
     expect(fieldOf(ed.document.main, 'qty')).toBe(3)
-    expect(fieldOf(ed.document.main, 'stray')).toBe('x')
   })
 
-  it('setAll returns the per-field routing record, flagging a typo as opaque', () => {
+  it('set rejects an undeclared name as a typo, not a fallback', () => {
     const ed = new DocumentEditor(buildQuill(), blankDoc())
-    const routing = ed.setAll({ qty: '5', titel: 'oops' })
-    expect(routing).toEqual({ qty: 'typed', titel: 'opaque' })
-    expect(fieldOf(ed.document.main, 'qty')).toBe(5)
+    expect(() => ed.set('stray', 'x')).toThrow(/UnknownField/)
+    expect(fieldOf(ed.document.main, 'stray')).toBeUndefined()
+  })
+
+  it('setAll aborts the whole batch on a typo, applying nothing', () => {
+    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    expect(() => ed.setAll({ qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
+    expect(fieldOf(ed.document.main, 'qty')).toBeUndefined()
+    expect(fieldOf(ed.document.main, 'titel')).toBeUndefined()
   })
 
   it('card(i).set targets the composable card via its kind schema', () => {
@@ -160,7 +164,7 @@ card_kinds:
       '~~~card-yaml\n$quill: editor_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
     const ed = new DocumentEditor(buildQuill(), doc)
-    expect(ed.card(0).set('body', 'Card **body**.')).toBe('typed')
+    ed.card(0).set('body', 'Card **body**.')
     expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
   })
 

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -443,17 +443,6 @@ export declare class LiveSession {
 // ── Typed-editor sugar ──────────────────────────────────────────────────────
 
 /**
- * Which store a typed write used: `"typed"` when the field is declared in the
- * quill schema (strict commit — coerced to canonical form, a mismatch throws at
- * the write) or `"opaque"` when it is not (stored verbatim, like
- * `Document.setField`). A scalar write ({@link DocumentEditor.set}) returns one;
- * a batch ({@link DocumentEditor.setAll}) returns a `Record` of them keyed by
- * field name. The signal exists so a typo'd name silently landing in the opaque
- * store is visible at the write, not buried until validation.
- */
-export type Committed = 'typed' | 'opaque';
-
-/**
  * A `Document` bound to its `Quill` for typed writes — the JS twin of Rust's
  * `quill.editor(&mut doc)`. Binds the schema source once so writes are bare
  * `set` / `setAll` / `card(i).set` instead of threading the `quill` handle
@@ -461,29 +450,28 @@ export type Committed = 'typed' | 'opaque';
  * neither — nothing to `free()`.
  *
  * `commit*` is the default write path whenever a quill is in hand: it resolves
- * each field's schema type and typed-commits it, reporting {@link Committed}.
- * The raw `Document.setField` / `setFields` verbs remain the deliberate
- * quill-free primitive (standalone data, storage/migration infra, or holding
- * not-yet-conforming in-progress input) — reach for them only when you
- * intend the opaque store.
+ * each field's schema type and strict-commits it, throwing `UnknownField` for a
+ * name the schema does not declare — on the typed path an undeclared name is a
+ * typo, not a fallback. The raw `Document.setField` / `setFields` verbs remain
+ * the deliberate quill-free primitive (standalone data, storage/migration infra,
+ * or holding not-yet-conforming in-progress input) — and the way to store a
+ * value opaquely on purpose.
  */
 export declare class DocumentEditor {
 	constructor(quill: Quill, doc: Document);
 	/** The bound document — the instance passed in, mutated in place. */
 	readonly document: Document;
 	/**
-	 * Typed-commit one main-card field. `"typed"` for a schema field (strict
-	 * coerce, mismatch throws now), `"opaque"` for an unknown one.
+	 * Typed-commit one main-card field (strict coerce, mismatch throws now).
+	 * Throws `UnknownField` for a name the schema does not declare.
 	 */
-	set(name: string, value: unknown): Committed;
+	set(name: string, value: unknown): void;
 	/**
 	 * Typed-commit several main-card fields atomically — nothing is applied on
 	 * error (throws a {@link QuillmarkError} carrying one diagnostic per
-	 * offending field). On success returns the per-field routing keyed by field
-	 * name, so a whole-form submit still sees which names fell to the opaque
-	 * store.
+	 * offending field, including an `UnknownField` for each undeclared name).
 	 */
-	setAll(fields: Record<string, unknown>): Record<string, Committed>;
+	setAll(fields: Record<string, unknown>): void;
 	/**
 	 * A {@link CardEditor} for the composable card at `index`. Index validity is
 	 * checked lazily at commit time, so this never throws.
@@ -501,6 +489,6 @@ export declare class CardEditor {
 	constructor(quill: Quill, doc: Document, index: number);
 	/** The bound card index. */
 	readonly index: number;
-	set(name: string, value: unknown): Committed;
-	setAll(fields: Record<string, unknown>): Record<string, Committed>;
+	set(name: string, value: unknown): void;
+	setAll(fields: Record<string, unknown>): void;
 }

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -521,10 +521,10 @@ export class LiveSession {
 // They hold JS references to the caller's EXISTING handles — no WASM object of
 // their own, no `free()` burden, no second owner of either handle — and every
 // write delegates straight to the underlying `commit*` verb: a schema field is
-// typed-committed (coerced to canonical form, mismatch throws now), an unknown
-// field falls to the opaque store, and the return value says which (`"typed"` /
-// `"opaque"`, or the per-field record for the batch) so a typo'd name is visible
-// at the write, not buried until validation.
+// typed-committed (coerced to canonical form, mismatch throws now), and a name
+// the schema does not declare throws `UnknownField` rather than falling to the
+// opaque store — on the typed path an undeclared name is a typo. Opaque storage
+// stays available through the raw `Document.setField` / `setCardField` verbs.
 
 /**
  * A {@link Document} bound to its {@link Quill} for typed writes — the JS twin
@@ -548,24 +548,22 @@ export class DocumentEditor {
 		return this.#doc;
 	}
 	/**
-	 * Typed-commit one main-card field. Returns `"typed"` when the field is in
-	 * the schema (strict coerce, mismatch throws now) or `"opaque"` when it is
-	 * not (stored verbatim). See `Document.commitField`.
+	 * Typed-commit one main-card field (strict coerce, mismatch throws now).
+	 * Throws `UnknownField` for a name the schema does not declare. See
+	 * `Document.commitField`.
 	 * @param {string} name
 	 * @param {unknown} value
-	 * @returns {import('./runtime.d.ts').Committed}
+	 * @returns {void}
 	 */
 	set(name, value) {
 		return this.#doc.commitField(this.#quill, name, value);
 	}
 	/**
 	 * Typed-commit several main-card fields atomically — nothing is applied on
-	 * error. On success returns the per-field routing
-	 * `Record<string, "typed" | "opaque">`, so a whole-form submit still sees
-	 * which names fell to the opaque store (a likely typo). See
-	 * `Document.commitFields`.
+	 * error (throws a per-field diagnostic bundle, including an `UnknownField`
+	 * for each undeclared name). See `Document.commitFields`.
 	 * @param {Record<string, unknown>} fields
-	 * @returns {Record<string, import('./runtime.d.ts').Committed>}
+	 * @returns {void}
 	 */
 	setAll(fields) {
 		return this.#doc.commitFields(this.#quill, fields);
@@ -606,22 +604,22 @@ export class CardEditor {
 		return this.#index;
 	}
 	/**
-	 * Typed-commit one field on this card. `"typed"` / `"opaque"` per
-	 * `Document.commitCardField`. Throws `IndexOutOfRange` if the bound index
-	 * is out of range.
+	 * Typed-commit one field on this card, per `Document.commitCardField`.
+	 * Throws `UnknownField` for an undeclared name and `IndexOutOfRange` if the
+	 * bound index is out of range.
 	 * @param {string} name
 	 * @param {unknown} value
-	 * @returns {import('./runtime.d.ts').Committed}
+	 * @returns {void}
 	 */
 	set(name, value) {
 		return this.#doc.commitCardField(this.#quill, this.#index, name, value);
 	}
 	/**
-	 * Typed-commit several fields on this card atomically. Per-field routing
-	 * record on success, per `Document.commitCardFields`. Throws
-	 * `IndexOutOfRange` if the bound index is out of range.
+	 * Typed-commit several fields on this card atomically, per
+	 * `Document.commitCardFields`. Throws a per-field diagnostic bundle on error
+	 * and `IndexOutOfRange` if the bound index is out of range.
 	 * @param {Record<string, unknown>} fields
-	 * @returns {Record<string, import('./runtime.d.ts').Committed>}
+	 * @returns {void}
 	 */
 	setAll(fields) {
 		return this.#doc.commitCardFields(this.#quill, this.#index, fields);

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1001,29 +1001,30 @@ impl Document {
     /// Values use the encoding the seam already speaks: a corpus object
     /// or markdown string for richtext, a scalar/array/object otherwise.
     ///
-    /// Returns `"typed"` when the field is declared in the schema (strict
-    /// commit — a mismatch throws now, not at render) or `"opaque"` when it is
-    /// not (stored verbatim, like [`setField`](Document::set_field)). Throws
-    /// `[EditError::FieldConform]` / `[EditError::FieldRichtextDecode]` /
-    /// `[EditError::FieldRichtextNotInline]` on a typed mismatch and
-    /// `[EditError::InvalidFieldName]` on a malformed name.
+    /// A field declared in the schema is strict-committed — a mismatch throws
+    /// now, not at render. A name the schema does not declare throws
+    /// `[EditError::UnknownField]` rather than falling to the opaque store: on
+    /// the typed path it is a typo. Use [`setField`](Document::set_field) when
+    /// opaque storage is the intent. Also throws `[EditError::FieldConform]` /
+    /// `[EditError::FieldRichtextDecode]` / `[EditError::FieldRichtextNotInline]`
+    /// on a typed mismatch and `[EditError::InvalidFieldName]` on a malformed
+    /// name.
     ///
     /// The `quill` handle is passed per call because a `Document` carries only a
     /// `$quill` reference, not the resolved schema.
-    #[wasm_bindgen(js_name = commitField, unchecked_return_type = "\"typed\" | \"opaque\"")]
+    #[wasm_bindgen(js_name = commitField)]
     pub fn commit_field(
         &mut self,
         quill: &Quill,
         name: &str,
         value: JsValue,
-    ) -> Result<String, JsValue> {
+    ) -> Result<(), JsValue> {
         let json = js_value_to_json(value, "commitField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
         quill
             .inner
             .editor(&mut self.inner)
             .set(name, qv)
-            .map(|c| c.as_str().to_string())
             .map_err(|e| edit_error_to_js(&e))
     }
 
@@ -1032,26 +1033,20 @@ impl Document {
     /// from `quill`. All-or-nothing with the same per-field-diagnostic error
     /// contract as [`setFields`](Document::set_fields) — nothing is applied on
     /// error and the thrown error's `diagnostics` carry one entry per offending
-    /// field.
-    ///
-    /// On success returns a `Record<string, "typed" | "opaque">` keyed by the
-    /// input field names, in input order — the batch form of `commitField`'s
-    /// scalar return, so a whole-form submit still sees which names fell to the
-    /// opaque store (a likely typo) instead of losing that signal to the batch,
-    /// the way [`setFields`](Document::set_fields) does.
-    #[wasm_bindgen(js_name = commitFields, unchecked_return_type = "Record<string, \"typed\" | \"opaque\">")]
+    /// field, including an `[EditError::UnknownField]` for any name the schema
+    /// does not declare, so a whole-form submit sees every typo in one pass.
+    #[wasm_bindgen(js_name = commitFields)]
     pub fn commit_fields(
         &mut self,
         quill: &Quill,
         #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
-    ) -> Result<JsValue, JsValue> {
+    ) -> Result<(), JsValue> {
         let batch = js_value_to_field_batch(&fields, "commitFields")?;
-        let routing = quill
+        quill
             .inner
             .editor(&mut self.inner)
             .set_all(batch)
-            .map_err(edit_errors_to_js)?;
-        committed_batch_to_js(routing, "commitFields")
+            .map_err(edit_errors_to_js)
     }
 
     /// The markdown projection of a richtext field on the main card
@@ -1197,48 +1192,46 @@ impl Document {
     /// twin of [`commitField`](Document::commit_field). Resolves the field's
     /// type from the card's `$kind` schema in `quill` and strict-commits it.
     ///
-    /// Returns `"typed"` / `"opaque"` (see `commitField`). Throws
-    /// `[EditError::IndexOutOfRange]` when `index` is out of range, and the same
-    /// typed-mismatch / name errors as `commitField`.
-    #[wasm_bindgen(js_name = commitCardField, unchecked_return_type = "\"typed\" | \"opaque\"")]
+    /// Throws `[EditError::IndexOutOfRange]` when `index` is out of range, and
+    /// the same typed-mismatch / name errors as `commitField` — including
+    /// `[EditError::UnknownField]` for a field the card-kind schema does not
+    /// declare (an unknown `$kind` has no schema, so every field is undeclared).
+    #[wasm_bindgen(js_name = commitCardField)]
     pub fn commit_card_field(
         &mut self,
         quill: &Quill,
         index: usize,
         name: &str,
         value: JsValue,
-    ) -> Result<String, JsValue> {
+    ) -> Result<(), JsValue> {
         let json = js_value_to_json(value, "commitCardField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
         let mut editor = quill.inner.editor(&mut self.inner);
         let mut card = editor.card(index).map_err(|e| edit_error_to_js(&e))?;
-        card.set(name, qv)
-            .map(|c| c.as_str().to_string())
-            .map_err(|e| edit_error_to_js(&e))
+        card.set(name, qv).map_err(|e| edit_error_to_js(&e))
     }
 
     /// Batched twin of [`commitCardField`](Document::commit_card_field):
     /// typed-commit several fields on the card at `index` atomically, resolving
     /// each field's type from the card's `$kind` schema in `quill`. All-or-nothing
     /// with the same per-field-diagnostic contract as
-    /// [`commitFields`](Document::commit_fields), whose `Record<string, "typed" |
-    /// "opaque">` success shape it mirrors. Throws `[EditError::IndexOutOfRange]`
-    /// when `index` is out of range.
-    #[wasm_bindgen(js_name = commitCardFields, unchecked_return_type = "Record<string, \"typed\" | \"opaque\">")]
+    /// [`commitFields`](Document::commit_fields), including an
+    /// `[EditError::UnknownField]` diagnostic per undeclared name. Throws
+    /// `[EditError::IndexOutOfRange]` when `index` is out of range.
+    #[wasm_bindgen(js_name = commitCardFields)]
     pub fn commit_card_fields(
         &mut self,
         quill: &Quill,
         index: usize,
         #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
-    ) -> Result<JsValue, JsValue> {
+    ) -> Result<(), JsValue> {
         let batch = js_value_to_field_batch(&fields, "commitCardFields")?;
         let mut editor = quill.inner.editor(&mut self.inner);
-        let routing = editor
+        editor
             .card(index)
             .map_err(|e| edit_error_to_js(&e))?
             .set_all(batch)
-            .map_err(edit_errors_to_js)?;
-        committed_batch_to_js(routing, "commitCardFields")
+            .map_err(edit_errors_to_js)
     }
 
     /// The markdown projection of a richtext field on the card at `index` — the
@@ -1363,22 +1356,6 @@ fn edit_errors_to_js(errors: Vec<(String, quillmark_core::EditError)>) -> JsValu
         })
         .collect();
     WasmError { diagnostics }.to_js_value()
-}
-
-/// Serialize a batched typed-write routing — one `(name, `[`Committed`]`)` per
-/// field, in input order — to a JS `Record<string, "typed" | "opaque">`. The
-/// batch form of `commitField`'s scalar return: object key order follows the
-/// input (`preserve_order` is on workspace-wide), so a caller reads which names
-/// fell to the opaque store straight off the object.
-fn committed_batch_to_js(
-    routing: Vec<(String, quillmark_core::Committed)>,
-    ctx: &str,
-) -> Result<JsValue, JsValue> {
-    let map: serde_json::Map<String, serde_json::Value> = routing
-        .into_iter()
-        .map(|(name, c)| (name, serde_json::Value::String(c.as_str().to_string())))
-        .collect();
-    serialize_or_throw(&map, ctx)
 }
 
 /// Deserialize a plain JS object into the `(name, value)` batch

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -57,6 +57,16 @@ pub enum EditError {
     #[error("invalid field name '{0}': must match [A-Za-z_][A-Za-z0-9_]*")]
     InvalidFieldName(String),
 
+    /// A typed write ([`TypedEditor::set`](crate::TypedEditor::set) /
+    /// [`CardEditor::set`](crate::CardEditor::set)) addressed a well-formed name
+    /// that the bound schema does not declare (or a card whose `$kind` carries
+    /// no schema). The typed path resolves every name to a schema type, so an
+    /// undeclared name is a typo, not a fallback — it fails here instead of
+    /// landing silently in the opaque store. Reach for the raw
+    /// [`Card::set_field`](Card::set_field) when opaque storage is the intent.
+    #[error("field '{0}' is not declared in the schema")]
+    UnknownField(String),
+
     #[error("invalid card kind '{0}': must match [a-z_][a-z0-9_]*")]
     InvalidKindName(String),
 
@@ -123,6 +133,7 @@ impl EditError {
     pub fn variant_name(&self) -> &'static str {
         match self {
             EditError::InvalidFieldName(_) => "InvalidFieldName",
+            EditError::UnknownField(_) => "UnknownField",
             EditError::InvalidKindName(_) => "InvalidKindName",
             EditError::ReservedKind => "ReservedKind",
             EditError::IndexOutOfRange { .. } => "IndexOutOfRange",
@@ -213,27 +224,24 @@ fn conform_error_to_edit(name: &str, err: CoercionError) -> EditError {
     }
 }
 
-/// Compute the canonical stored form of a field write **without applying it** —
-/// the dry-run shared by [`Card::commit_field`] and the batched, all-or-nothing
-/// [`TypedEditor::set_all`](crate::TypedEditor::set_all).
+/// Compute the canonical stored form of a typed field write **without applying
+/// it** — the dry-run shared by [`Card::commit_field`] and the batched,
+/// all-or-nothing [`TypedEditor::set_all`](crate::TypedEditor::set_all).
 ///
-/// `schema = Some(_)` is a typed write (strict `Leniency::Write` conform);
-/// `schema = None` is an opaque write (mirrors [`Card::set_field`], storing the
-/// value verbatim). Either way the name and stored-value depth are validated,
-/// so a batch can collect every violation before any mutation.
+/// Strict `Leniency::Write` conform against `schema`; the name and stored-value
+/// depth are validated too, so a batch can collect every violation before any
+/// mutation. The unknown-name case never reaches here — the editor rejects it
+/// with [`EditError::UnknownField`] before there is a schema to conform against.
 pub(crate) fn resolve_field_write(
     name: &str,
     value: QuillValue,
-    schema: Option<&FieldSchema>,
+    schema: &FieldSchema,
 ) -> Result<QuillValue, EditError> {
     if !is_valid_field_name(name) {
         return Err(EditError::InvalidFieldName(name.to_string()));
     }
-    let stored = match schema {
-        Some(schema) => QuillConfig::conform_value(&value, schema, name, Leniency::Write)
-            .map_err(|e| conform_error_to_edit(name, e))?,
-        None => value,
-    };
+    let stored = QuillConfig::conform_value(&value, schema, name, Leniency::Write)
+        .map_err(|e| conform_error_to_edit(name, e))?;
     // Depth-bound the stored form (name already validated above).
     check_field(name, stored.as_json())?;
     Ok(stored)
@@ -626,7 +634,7 @@ impl Card {
         value: impl Into<QuillValue>,
         schema: &FieldSchema,
     ) -> Result<(), EditError> {
-        let stored = resolve_field_write(name, value.into(), Some(schema))?;
+        let stored = resolve_field_write(name, value.into(), schema)?;
         self.payload_mut().insert(name.to_string(), stored);
         Ok(())
     }

--- a/crates/core/src/editor.rs
+++ b/crates/core/src/editor.rs
@@ -5,9 +5,11 @@
 //! form editor, an MCP server) already holds the resolved [`QuillConfig`] — it
 //! renders with it. [`Quill::editor`](crate::Quill::editor) binds the schema
 //! once, so callers issue one verb (`set`) and never pass a type token or an
-//! `inline` flag: the editor resolves each field's type itself and routes a
-//! schema field through the strict commit and an unknown field through the
-//! opaque store.
+//! `inline` flag: the editor resolves each field's type itself, strict-commits
+//! a schema field, and rejects a name the schema does not declare with
+//! [`EditError::UnknownField`] — on the typed path an undeclared name is a typo,
+//! not a fallback. Opaque storage stays available on purpose through the raw
+//! [`Card::set_field`](crate::Card::set_field) verb.
 //!
 //! ```ignore
 //! let mut ed = quill.editor(&mut doc);
@@ -28,39 +30,6 @@ use crate::document::{Card, Document, EditError};
 use crate::quill::{CardSchema, FieldSchema, QuillConfig};
 use crate::value::QuillValue;
 
-/// Which store a [`TypedEditor::set`] / [`CardEditor::set`] used: `Typed` when
-/// the field is declared in the schema (strict commit), `Opaque` when it is not
-/// (verbatim store, mirroring [`Card::set_field`](crate::Card::set_field)).
-///
-/// An editor's caller usually meant a schema field, so a typo'd name silently
-/// storing opaque is otherwise invisible until validation — the return value
-/// surfaces which path ran.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Committed {
-    /// The field is declared in the schema; the value was strict-committed to
-    /// its canonical typed form.
-    Typed,
-    /// The field is not in the schema; the value was stored opaquely (the field
-    /// bag stays a bag).
-    Opaque,
-}
-
-impl Committed {
-    /// `true` for [`Committed::Typed`].
-    pub fn is_typed(self) -> bool {
-        matches!(self, Committed::Typed)
-    }
-
-    /// `"typed"` or `"opaque"` — the discriminant a binding surfaces to its
-    /// caller.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Committed::Typed => "typed",
-            Committed::Opaque => "opaque",
-        }
-    }
-}
-
 /// A [`Document`] bound to its [`QuillConfig`] for typed writes. Construct with
 /// [`Quill::editor`](crate::Quill::editor). Writes target the main card; use
 /// [`card`](Self::card) for a composable card.
@@ -76,43 +45,27 @@ impl<'a> TypedEditor<'a> {
     }
 
     /// Write a field on the main card. Resolves the field's schema type and
-    /// strict-commits it ([`Committed::Typed`]); an unknown field stores
-    /// opaquely ([`Committed::Opaque`]). Error surface is that of
-    /// [`Card::commit_field`](crate::Card::commit_field) /
-    /// [`Card::set_field`](crate::Card::set_field).
-    pub fn set(
-        &mut self,
-        name: &str,
-        value: impl Into<QuillValue>,
-    ) -> Result<Committed, EditError> {
+    /// strict-commits it; a name the schema does not declare fails with
+    /// [`EditError::UnknownField`] rather than falling to the opaque store — on
+    /// the typed path it is a typo. For deliberate opaque storage use the raw
+    /// [`Card::set_field`](crate::Card::set_field). Other errors are those of
+    /// [`Card::commit_field`](crate::Card::commit_field).
+    pub fn set(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
         let config = self.config;
         match config.main.fields.get(name) {
-            Some(schema) => {
-                self.doc.main_mut().commit_field(name, value, schema)?;
-                Ok(Committed::Typed)
-            }
-            None => {
-                self.doc.main_mut().set_field(name, value)?;
-                Ok(Committed::Opaque)
-            }
+            Some(schema) => self.doc.main_mut().commit_field(name, value, schema),
+            None => Err(EditError::UnknownField(name.to_string())),
         }
     }
 
     /// Write several main-card fields atomically — the typed twin of
     /// [`Card::set_fields`](crate::Card::set_fields). Every field is resolved
-    /// (typed conform or opaque store) before any is applied; on any violation
-    /// nothing is written and every offending field is returned as a
-    /// `(name, error)` pair.
-    ///
-    /// On success returns one `(name, `[`Committed`]`)` pair per field, in input
-    /// order — the batch form of [`set`](Self::set)'s scalar return, so a caller
-    /// submitting a whole form sees which names fell to the opaque store (a
-    /// likely typo) instead of losing that signal to the batch, the way
+    /// (strict conform, or [`EditError::UnknownField`] for a name the schema does
+    /// not declare) before any is applied; on any violation nothing is written
+    /// and every offending field is returned as a `(name, error)` pair, so a
+    /// caller submitting a whole form sees every typo in one pass the way
     /// [`Card::set_fields`](crate::Card::set_fields) does.
-    pub fn set_all<K, V, I>(
-        &mut self,
-        fields: I,
-    ) -> Result<Vec<(String, Committed)>, Vec<(String, EditError)>>
+    pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
     where
         K: Into<String>,
         V: Into<QuillValue>,
@@ -123,8 +76,10 @@ impl<'a> TypedEditor<'a> {
     }
 
     /// A schema-bound editor for the composable card at `index`. The card's
-    /// `$kind` resolves its [`CardSchema`]; an unknown kind degrades the whole
-    /// card to opaque writes (mirroring `coerce_card`). Returns
+    /// `$kind` resolves its [`CardSchema`]; an unknown kind carries no schema, so
+    /// every field on it is undeclared and its typed writes fail with
+    /// [`EditError::UnknownField`] (write such a card opaquely through
+    /// [`Card::set_field`](crate::Card::set_field)). Returns
     /// [`EditError::IndexOutOfRange`] when `index` is out of range.
     pub fn card(&mut self, index: usize) -> Result<CardEditor<'_>, EditError> {
         let config = self.config;
@@ -152,32 +107,20 @@ impl CardEditor<'_> {
     }
 
     /// Write a field on this card. Resolves the field against the card's
-    /// [`CardSchema`] (typed commit) or stores opaquely when the field — or the
-    /// whole card kind — is unknown.
-    pub fn set(
-        &mut self,
-        name: &str,
-        value: impl Into<QuillValue>,
-    ) -> Result<Committed, EditError> {
+    /// [`CardSchema`] and strict-commits it; a field the schema does not declare
+    /// — or any field when the card kind is unknown — fails with
+    /// [`EditError::UnknownField`] rather than storing opaquely.
+    pub fn set(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
         match self.schema.and_then(|s| s.fields.get(name)) {
-            Some(schema) => {
-                self.card.commit_field(name, value, schema)?;
-                Ok(Committed::Typed)
-            }
-            None => {
-                self.card.set_field(name, value)?;
-                Ok(Committed::Opaque)
-            }
+            Some(schema) => self.card.commit_field(name, value, schema),
+            None => Err(EditError::UnknownField(name.to_string())),
         }
     }
 
     /// Write several fields on this card atomically — see
-    /// [`TypedEditor::set_all`], including the per-field [`Committed`] routing
-    /// returned on success.
-    pub fn set_all<K, V, I>(
-        &mut self,
-        fields: I,
-    ) -> Result<Vec<(String, Committed)>, Vec<(String, EditError)>>
+    /// [`TypedEditor::set_all`]; an undeclared name aborts the whole batch with
+    /// [`EditError::UnknownField`].
+    pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
     where
         K: Into<String>,
         V: Into<QuillValue>,
@@ -189,15 +132,15 @@ impl CardEditor<'_> {
 
 /// All-or-nothing batched write shared by [`TypedEditor::set_all`] and
 /// [`CardEditor::set_all`]: resolve every field first (collecting every error),
-/// apply none on failure, apply all on success. Each field's routing — typed
-/// when it is in `fields_schema`, opaque when it is not — is the same decision
-/// the scalar `set` makes, recorded here so the batch can hand it back rather
-/// than swallow it.
+/// apply none on failure, apply all on success. A name absent from
+/// `fields_schema` (or every name, when the whole schema is `None` — an unknown
+/// card kind) is an [`EditError::UnknownField`], the batch form of the scalar
+/// `set`'s reject-the-typo decision.
 fn set_all_impl<K, V, I>(
     card: &mut Card,
     fields_schema: Option<&BTreeMap<String, FieldSchema>>,
     fields: I,
-) -> Result<Vec<(String, Committed)>, Vec<(String, EditError)>>
+) -> Result<(), Vec<(String, EditError)>>
 where
     K: Into<String>,
     V: Into<QuillValue>,
@@ -208,29 +151,24 @@ where
         .map(|(k, v)| (k.into(), v.into()))
         .collect();
 
-    let mut resolved: Vec<(String, QuillValue, Committed)> = Vec::with_capacity(fields.len());
+    let mut resolved: Vec<(String, QuillValue)> = Vec::with_capacity(fields.len());
     let mut errors: Vec<(String, EditError)> = Vec::new();
     for (name, value) in fields {
-        let schema = fields_schema.and_then(|m| m.get(&name));
-        let routed = if schema.is_some() {
-            Committed::Typed
-        } else {
-            Committed::Opaque
-        };
-        match resolve_field_write(&name, value, schema) {
-            Ok(stored) => resolved.push((name, stored, routed)),
-            Err(e) => errors.push((name, e)),
+        match fields_schema.and_then(|m| m.get(&name)) {
+            Some(schema) => match resolve_field_write(&name, value, schema) {
+                Ok(stored) => resolved.push((name, stored)),
+                Err(e) => errors.push((name, e)),
+            },
+            None => errors.push((name.clone(), EditError::UnknownField(name))),
         }
     }
     if !errors.is_empty() {
         return Err(errors);
     }
-    let mut routing = Vec::with_capacity(resolved.len());
-    for (name, stored, routed) in resolved {
-        card.payload_mut().insert(name.clone(), stored);
-        routing.push((name, routed));
+    for (name, stored) in resolved {
+        card.payload_mut().insert(name, stored);
     }
-    Ok(routing)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -275,8 +213,8 @@ card_kinds:
         let mut ed = TypedEditor::new(&config, &mut doc);
 
         // A schema field commits typed: "3" → 3, richtext string → corpus.
-        assert_eq!(ed.set("qty", "3").unwrap(), Committed::Typed);
-        assert_eq!(ed.set("subject", "Hello").unwrap(), Committed::Typed);
+        ed.set("qty", "3").unwrap();
+        ed.set("subject", "Hello").unwrap();
         assert_eq!(
             doc.main().payload().get("qty").unwrap().as_json(),
             &serde_json::json!(3)
@@ -285,16 +223,15 @@ card_kinds:
     }
 
     #[test]
-    fn set_stores_unknown_field_opaque() {
+    fn set_rejects_unknown_field() {
         let config = config();
         let mut doc = blank_doc();
         let mut ed = TypedEditor::new(&config, &mut doc);
-        // Unknown field → opaque store, and the caller can see it happened.
-        assert_eq!(ed.set("notafield", "x").unwrap(), Committed::Opaque);
-        assert_eq!(
-            doc.main().payload().get("notafield").unwrap().as_str(),
-            Some("x")
-        );
+        // Unknown field on the typed path is a typo, not a fallback: it fails
+        // here and nothing is written. Opaque storage is the raw `set_field`.
+        let err = ed.set("notafield", "x").unwrap_err();
+        assert_eq!(err.variant_name(), "UnknownField");
+        assert!(doc.main().payload().get("notafield").is_none());
     }
 
     #[test]
@@ -322,17 +259,9 @@ card_kinds:
         assert_eq!(errs[0].0, "subject");
         assert!(doc.main().payload().get("qty").is_none());
 
-        // A clean batch applies every field and reports each field's routing
-        // in input order.
+        // A clean batch applies every field.
         let mut ed = TypedEditor::new(&config, &mut doc);
-        let routing = ed.set_all([("qty", "5"), ("subject", "ok")]).unwrap();
-        assert_eq!(
-            routing,
-            vec![
-                ("qty".to_string(), Committed::Typed),
-                ("subject".to_string(), Committed::Typed),
-            ]
-        );
+        ed.set_all([("qty", "5"), ("subject", "ok")]).unwrap();
         assert_eq!(
             doc.main().payload().get("qty").unwrap().as_json(),
             &serde_json::json!(5)
@@ -340,27 +269,18 @@ card_kinds:
     }
 
     #[test]
-    fn set_all_reports_opaque_fields_on_success() {
+    fn set_all_rejects_unknown_field() {
         let config = config();
         let mut doc = blank_doc();
         let mut ed = TypedEditor::new(&config, &mut doc);
-        // A whole-form submit with a typo'd name: `qty` is a schema field (typed),
-        // `titel` is not (opaque). The batch succeeds — the opaque field is the
-        // signal a caller uses to flag the probable typo, not lost to the batch.
-        let routing = ed.set_all([("qty", "3"), ("titel", "oops")]).unwrap();
-        assert_eq!(
-            routing,
-            vec![
-                ("qty".to_string(), Committed::Typed),
-                ("titel".to_string(), Committed::Opaque),
-            ]
-        );
-        let opaque: Vec<&str> = routing
-            .iter()
-            .filter(|(_, c)| !c.is_typed())
-            .map(|(n, _)| n.as_str())
-            .collect();
-        assert_eq!(opaque, vec!["titel"]);
+        // A whole-form submit with a typo'd name: `qty` is a schema field, `titel`
+        // is not. The undeclared name aborts the all-or-nothing batch — nothing is
+        // written and the typo is reported.
+        let errs = ed.set_all([("qty", "3"), ("titel", "oops")]).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].0, "titel");
+        assert_eq!(errs[0].1.variant_name(), "UnknownField");
+        assert!(doc.main().payload().get("qty").is_none());
     }
 
     #[test]
@@ -371,9 +291,10 @@ card_kinds:
 
         let mut ed = TypedEditor::new(&config, &mut doc);
         let mut card_ed = ed.card(0).unwrap();
-        assert_eq!(card_ed.set("body", "**hi**").unwrap(), Committed::Typed);
-        // Unknown field on a known card → opaque.
-        assert_eq!(card_ed.set("stray", "v").unwrap(), Committed::Opaque);
+        card_ed.set("body", "**hi**").unwrap();
+        // Unknown field on a known card → rejected as a typo.
+        let err = card_ed.set("stray", "v").unwrap_err();
+        assert_eq!(err.variant_name(), "UnknownField");
 
         assert_eq!(doc.cards()[0].field_markdown("body").unwrap(), "**hi**\n");
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -31,7 +31,7 @@ pub use document::{
 };
 
 pub mod editor;
-pub use editor::{CardEditor, Committed, TypedEditor};
+pub use editor::{CardEditor, TypedEditor};
 
 pub mod backend;
 pub use backend::{formats_support_canvas, Backend};

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -117,11 +117,14 @@ Read twins are unchanged: `Card::field_richtext(name)` / `field_markdown(name)`
 - **The schema-bound editor is the front door.** `quill.editor(&mut doc)`
   ([`TypedEditor`]) resolves each field's type itself, so callers issue one verb
   with no type token: `ed.set("qty", "3")?`, `ed.card(2)?.set("desc", v)?`,
-  `ed.set_all([..])?` (all-or-nothing). `set` returns `Committed::Typed` for a
-  schema field or `Committed::Opaque` for an unknown one — a typo'd name storing
-  opaque is visible, not silent. The bindings pass the quill handle per call
-  instead of holding the editor (wasm-bindgen / pyo3 objects carry no lifetime),
-  and surface the discriminant as the `"typed"` / `"opaque"` return string.
+  `ed.set_all([..])?` (all-or-nothing). `set` strict-commits a schema field and
+  rejects a name the schema does not declare with `EditError::UnknownField` — on
+  the typed path an undeclared name is a typo, not a fallback, so it fails at the
+  write rather than landing silently in the opaque store (#918). Opaque storage
+  stays available on purpose through the raw `set_field` / `setField` /
+  `setCardField` verbs. The bindings pass the quill handle per call instead of
+  holding the editor (wasm-bindgen / pyo3 objects carry no lifetime); the commit
+  verbs return nothing on success and throw on an undeclared name.
 - **`set_field` is unchanged.** The opaque path (store verbatim, coerce at
   render) stays for keystroke-level state and DB-row batch generators; the split
   is `set_field` = *coerce at render* vs `commit_field` = *canonicalize now, fail

--- a/prose/canon/PROGRAMMATIC.md
+++ b/prose/canon/PROGRAMMATIC.md
@@ -75,19 +75,22 @@ commit is a schema-bound layer over that primitive: `Quill::editor(&mut doc)`
 binds the resolved schema, and its `set` / `set_all` resolve each field's `type`,
 coerce to the canonical form (`"3"` → `3`, a markdown string → a richtext
 corpus), and fail at the write on a mismatch — the default whenever a Quill is
-in hand. Each write reports where it landed (`Committed::{Typed, Opaque}`): a
-schema field commits typed, an unknown name falls to the opaque store, so a typo
-is visible at the write rather than at validation. `set_all` returns that
-decision per field, so a whole-form batch keeps the signal instead of swallowing
-it.
+in hand. A name the schema does not declare fails with `EditError::UnknownField`
+rather than falling to the opaque store: on the typed path an undeclared name is
+a typo, not a fallback, so it is refused at the write rather than surfacing later
+at validation. `set_all` is all-or-nothing and reports every undeclared name
+(and every conform failure) in one pass, so a whole-form batch surfaces every
+typo at once.
 
 The primitive stays load-bearing — it is what lets a `Document` be constructed
 and `from_json`'d with no bundle (standalone data), what quill-agnostic
-storage/migration infra writes through, and what a store-now-validate-later
-editor uses to hold not-yet-conforming input. Reach for the opaque `set_*` on
-purpose for those; reach for the editor / `commit` by default. The bindings
-mirror this: `commitField` / `commitFields` (+ `commitCard*`) and the JS
-`DocumentEditor` / `CardEditor` sugar over `set*`'s quill-free store.
+storage/migration infra writes through, what a store-now-validate-later editor
+uses to hold not-yet-conforming input, and the way to store a value opaquely on
+purpose. Reach for the opaque `set_*` for those; reach for the editor / `commit`
+by default. The bindings mirror this: `commitField` / `commitFields`
+(+ `commitCard*`) and the JS `DocumentEditor` / `CardEditor` sugar over the
+schema-bound editor, with `setField` / `setCardField` as the quill-free opaque
+store.
 
 ## Addressing cards for re-render
 


### PR DESCRIPTION
## Summary

Closes #918. The typed field-write path threw on a wrong **value shape** but silently accepted an **unknown field name**, routing it to the opaque store and surfacing it only via the advisory `Committed` (`"typed" | "opaque"`) return. For a schema-driven form editor — the primary consumer — a typo'd name is the likelier and more serious mistake, yet it was the case that didn't throw.

This makes the typed path strict and lets the now-vestigial `Committed` machinery fall away.

## What changed

**Strict typed writes.** `TypedEditor::set` / `CardEditor::set` / `set_all` (and the `commitField` / `commitFields` / `commitCard*` binding verbs) now fail with a new **`EditError::UnknownField`** for a name the bound schema does not declare, instead of falling to the opaque store. An unknown card `$kind` carries no schema, so every field on it is undeclared and rejected the same way. Opaque storage stays available on purpose through the raw `set_field` / `setField` / `setCardField` verbs — nothing is lost, only the *typed* path stops absorbing typos.

**Simplification cascade.** With unknown-name now an error, every successful typed write is typed, so the `Committed` signal built to surface the opaque fallback is dead:
- removed the `Committed` enum and its `"typed" | "opaque"` return — `set` / `commit*` return `()` (JS/Py: nothing) on success;
- removed the `committed_batch_to_js` (wasm) and `committed_routing_to_pydict` (Python) projections;
- narrowed `resolve_field_write` to a non-optional `&FieldSchema` (the opaque `None` arm is now unreachable — the editor rejects the name before there is a schema to conform against).

`set_all` stays all-or-nothing and now collects an `UnknownField` diagnostic per undeclared name alongside conform failures, so a whole-form submit still surfaces every typo in one pass.

## Design note

#918 is really an argument that the original advisory-signal design (#893) was the wrong call on the typed path. Rather than keep a return type that could only ever say `"typed"`, this commit commits fully to "on the typed path, an undeclared name is a bug" and removes the signal. Batch semantics flip accordingly: an unknown name in a batch aborts the write (previously it succeeded-with-signal) — a deliberate, tested behavior change. The whole typed-write surface is pre-release (unreleased `0.93→0.94` cycle), so this is folded into that cycle's migration notes rather than added as a new breaking bump.

## Touched surfaces

- **core**: `EditError::UnknownField`, `TypedEditor` / `CardEditor` strict routing, `resolve_field_write` signature, `Committed` removal + re-export.
- **wasm**: four `commit*` verbs, `runtime.d.ts` / `runtime.js` editor sugar, README.
- **python**: four `commit_*` methods, helper removal.
- **docs**: canon `PROGRAMMATIC.md`, `docs/migrations/0.93-to-0.94.md`, `CHANGELOG.md`.
- **tests**: core `editor.rs`, wasm `basic.test.js`, python `test_api_requirements.py` rewritten to the strict contract (reject-and-write-nothing, opaque-via-raw-verb).

## Testing

- `cargo build -p quillmark-core` passes locally. Binding builds/tests (wasm, Python) run on CI/CD per the repo's cloud workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvkU6Ukib9xrd1j2XsRAKw)_