### PR TITLE
richtext+core: pure Delta codec + install/revise body & field verbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "js-sys",
  "quillmark",
  "quillmark-core",
+ "quillmark-richtext",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,6 +2379,7 @@ dependencies = [
  "proptest",
  "pulldown-cmark",
  "quillmark-fixtures",
+ "serde",
  "serde_json",
  "similar",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "pyo3",
  "quillmark",
  "quillmark-core",
+ "quillmark-richtext",
  "serde_json",
 ]
 

--- a/crates/bindings/python/Cargo.toml
+++ b/crates/bindings/python/Cargo.toml
@@ -14,4 +14,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "~0.26", features = ["extension-module", "abi3-py310"] }
 quillmark = { workspace = true, default-features = true }
 quillmark-core = { workspace = true }
+# The corpus codec (import_markdown / export_markdown / rebase / map_pos) and
+# the change-bundle op wire; the addressed write surface lowers to it.
+quillmark-richtext = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bindings/python/python/quillmark/__init__.py
+++ b/crates/bindings/python/python/quillmark/__init__.py
@@ -11,6 +11,10 @@ from ._quillmark import (
     QuillmarkError,
     RenderResult,
     Severity,
+    import_markdown,
+    export_markdown,
+    rebase,
+    map_pos,
 )
 
 __all__ = [
@@ -24,6 +28,10 @@ __all__ = [
     "QuillmarkError",
     "RenderResult",
     "Severity",
+    "import_markdown",
+    "export_markdown",
+    "rebase",
+    "map_pos",
 ]
 
 __version__ = "0.1.0"

--- a/crates/bindings/python/src/lib.rs
+++ b/crates/bindings/python/src/lib.rs
@@ -23,6 +23,13 @@ fn _quillmark(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOutputFormat>()?;
     m.add_class::<PySeverity>()?;
 
+    // The document-free corpus codec — the on-demand markdown projection
+    // (`export_markdown`) plus `import_markdown` / `rebase` / `map_pos`.
+    m.add_function(wrap_pyfunction!(types::import_markdown, m)?)?;
+    m.add_function(wrap_pyfunction!(types::export_markdown, m)?)?;
+    m.add_function(wrap_pyfunction!(types::rebase, m)?)?;
+    m.add_function(wrap_pyfunction!(types::map_pos, m)?)?;
+
     m.add("QuillmarkError", m.py().get_type::<QuillmarkError>())?;
 
     Ok(())

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1480,9 +1480,9 @@ fn delta_to_json(delta: &quillmark_core::Delta) -> serde_json::Value {
     serde_json::to_value(delta).unwrap_or(serde_json::Value::Null)
 }
 
-/// Lower an `apply_change` bundle (`{delta?, line_ops?, mark_ops?}`) to core ops.
-/// A missing `delta` is the identity; missing op lists are empty. Accepts both
-/// snake_case (`line_ops`) and camelCase (`lineOps`) keys.
+/// Lower an `apply_change` bundle (`{delta?, line_ops?, mark_ops?}`) to core ops
+/// via the shared richtext reader (which accepts both snake_case and camelCase
+/// keys), mapping its message to a `ValueError`.
 fn parse_change_bundle(
     value: &Bound<'_, PyAny>,
 ) -> PyResult<(
@@ -1491,47 +1491,7 @@ fn parse_change_bundle(
     Vec<quillmark_core::MarkOp>,
 )> {
     let json = py_to_json(value)?;
-    let obj = json.as_object().ok_or_else(|| {
-        PyValueError::new_err("bundle must be a dict { delta?, line_ops?, mark_ops? }")
-    })?;
-    let get = |snake: &str, camel: &str| obj.get(snake).or_else(|| obj.get(camel));
-    let delta = match get("delta", "delta") {
-        Some(serde_json::Value::Null) | None => quillmark_core::Delta { ops: Vec::new() },
-        Some(d) => serde_json::from_value(d.clone())
-            .map_err(|e| PyValueError::new_err(format!("invalid delta: {e}")))?,
-    };
-    let line_ops = parse_op_list(
-        get("line_ops", "lineOps"),
-        quillmark_richtext::line_op_from_value,
-        "line_ops",
-    )?;
-    let mark_ops = parse_op_list(
-        get("mark_ops", "markOps"),
-        quillmark_richtext::mark_op_from_value,
-        "mark_ops",
-    )?;
-    Ok((delta, line_ops, mark_ops))
-}
-
-/// Lower an optional JSON array of op objects through `convert`, mapping a shape
-/// error to a `ValueError` naming `what`.
-fn parse_op_list<T>(
-    value: Option<&serde_json::Value>,
-    convert: impl Fn(&serde_json::Value) -> Result<T, quillmark_richtext::ParseError>,
-    what: &str,
-) -> PyResult<Vec<T>> {
-    let Some(value) = value else {
-        return Ok(Vec::new());
-    };
-    if value.is_null() {
-        return Ok(Vec::new());
-    }
-    let arr = value
-        .as_array()
-        .ok_or_else(|| PyValueError::new_err(format!("{what} must be a list")))?;
-    arr.iter()
-        .map(|v| convert(v).map_err(|e| PyValueError::new_err(format!("invalid {what}: {e}"))))
-        .collect()
+    quillmark_richtext::change_bundle_from_value(&json).map_err(PyValueError::new_err)
 }
 
 /// Import a markdown string to a canonical `RichText` corpus dict — the pure,

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -406,42 +406,114 @@ impl PyDocument {
     }
 
     /// Main card's global body as canonical RichText-JSON — the source-of-truth
-    /// content model (a corpus dict, `{text, lines, marks, islands}`). Use
-    /// [`body_markdown`](Self::body_markdown) for the markdown projection.
+    /// content model (a corpus dict, `{text, lines, marks, islands}`). For the
+    /// markdown projection call the codec `export_markdown(doc.body)`.
     #[getter]
     fn body<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let wire = quillmark_core::CardWire::from(self.inner.main());
         json_to_py(py, &wire.body)
     }
 
-    /// Main card's global body rendered back to its markdown projection
-    /// (`export ∘ body`).
-    #[getter]
-    fn body_markdown(&self) -> String {
-        self.inner.main().body_markdown()
+    /// **Install** a richtext value at the address `(card, field)` — value
+    /// semantics, corpus only. `rt` is a canonical corpus dict; the identity
+    /// anchors of any previous value are gone. An absent `field` targets the
+    /// body, an absent `card` the main card. For "here's new markdown," use
+    /// [`revise`](Self::revise); the cold path is `install(import_markdown(md))`,
+    /// which spells anchor loss at the call site. The kwargs idiom of WASM
+    /// `doc.install(addr, rt)`. Raises on an out-of-range card, a malformed field
+    /// name, or an `rt` that is not a canonical corpus dict.
+    #[pyo3(signature = (rt, card=None, field=None))]
+    fn install(
+        &mut self,
+        rt: Bound<'_, PyAny>,
+        card: Option<usize>,
+        field: Option<&str>,
+    ) -> PyResult<()> {
+        let corpus = py_to_corpus(&rt)?;
+        let target = self.addr_card_mut(card)?;
+        match field {
+            None => {
+                target.install_body(corpus);
+                Ok(())
+            }
+            Some(name) => target.install_field(name, corpus).map_err(convert_edit_error),
+        }
     }
 
-    /// Corpus-native body writer on the main card — the write twin of the
-    /// [`body`](Self::body) getter, so a body read as a corpus dict writes back
-    /// losslessly (identity marks, island ids, corpus-only formatting intact).
-    /// `body` is a corpus dict (`{text, lines, marks, islands}`), an importable
-    /// markdown string, or `None`; unlike [`replace_body`](Self::replace_body)
-    /// (markdown only) this does not drop corpus-only formatting. Raises
-    /// `QuillmarkError` if `body` is none of those. Mirrors WASM `setBody`.
-    fn set_body(&mut self, body: Bound<'_, PyAny>) -> PyResult<()> {
-        let json = py_to_json(&body)?;
-        self.inner
-            .main_mut()
-            .set_body_value(&json)
-            .map_err(convert_edit_error)
+    /// **Revise** the richtext value at `(card, field)` from a markdown string —
+    /// edit semantics, the default write path, returning the text `Delta` dict.
+    /// Imports the markdown, diffs it against the current value, rebases surviving
+    /// anchors, and returns the change to map positions through (`map_pos`). An
+    /// absent `field` targets the body, an absent `card` the main card; an absent
+    /// field cold-imports from empty. The kwargs idiom of WASM
+    /// `doc.revise(addr, md)`. Raises on an out-of-range card, a malformed field
+    /// name, a present non-corpus field value, or an over-nested markdown input.
+    #[pyo3(signature = (markdown, card=None, field=None))]
+    fn revise<'py>(
+        &mut self,
+        py: Python<'py>,
+        markdown: &str,
+        card: Option<usize>,
+        field: Option<&str>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let target = self.addr_card_mut(card)?;
+        let delta = match field {
+            None => target.revise_body(markdown),
+            Some(name) => target.revise_field(name, markdown),
+        }
+        .map_err(convert_edit_error)?;
+        json_to_py(py, &delta_to_json(&delta))
     }
 
-    /// The markdown projection of a richtext-valued field on the main card
-    /// (`export ∘ decode`) — the field-level twin of `body_markdown`. Returns
-    /// `None` when the field is absent or does not decode as richtext (e.g. a
-    /// plain scalar written via `set_field`). Mirrors WASM `fieldMarkdown`.
-    fn field_markdown(&self, name: &str) -> Option<String> {
-        self.inner.main().field_markdown(name)
+    /// **Apply** a committed corpus edit `bundle` (`{delta?, line_ops?, mark_ops?}`)
+    /// at `(card, field)` — the editor splice: text delta, then line ops, then
+    /// mark ops (mark ranges in post-delta coordinates), each all-or-nothing. An
+    /// absent `field` targets the body, an absent `card` the main card. The kwargs
+    /// idiom of WASM `doc.applyChange(addr, bundle)`. Raises on an out-of-range
+    /// card, a field that is not richtext, a malformed bundle, or an out-of-bounds
+    /// op (the value is unchanged on a failed apply).
+    #[pyo3(signature = (bundle, card=None, field=None))]
+    fn apply_change(
+        &mut self,
+        bundle: Bound<'_, PyAny>,
+        card: Option<usize>,
+        field: Option<&str>,
+    ) -> PyResult<()> {
+        let (delta, line_ops, mark_ops) = parse_change_bundle(&bundle)?;
+        let target = self.addr_card_mut(card)?;
+        match field {
+            None => target.apply_body_change(&delta, &line_ops, &mark_ops),
+            Some(name) => {
+                target.apply_field_richtext_change(name, &delta, &line_ops, &mark_ops)
+            }
+        }
+        .map_err(convert_edit_error)
+    }
+
+    /// **Commit** a typed value at `(card, field)`, resolving the field's schema
+    /// `type` from `quill` — the one typed write verb for every field type, the
+    /// kwargs idiom of WASM `doc.commit(addr, value, quill)`. Requires `field`
+    /// (the body carries no schema type). A field the schema does not declare
+    /// raises `[EditError::UnknownField]`; a typed mismatch raises now, not at
+    /// render.
+    #[pyo3(signature = (value, quill, *, card=None, field))]
+    fn commit(
+        &mut self,
+        value: Bound<'_, PyAny>,
+        quill: PyRef<'_, PyQuill>,
+        card: Option<usize>,
+        field: &str,
+    ) -> PyResult<()> {
+        let qv = py_to_quillvalue(&value)?;
+        let mut editor = quill.inner.editor(&mut self.inner);
+        match card {
+            None => editor.set(field, qv).map_err(convert_edit_error),
+            Some(index) => editor
+                .card(index)
+                .map_err(convert_edit_error)?
+                .set(field, qv)
+                .map_err(convert_edit_error),
+        }
     }
 
     /// Main (entry) card as a dict with `kind`, `quill`, `id`, `payload_items`,
@@ -734,10 +806,24 @@ impl PyDocument {
         Ok(())
     }
 
+    /// **Deprecated** — alias for `revise(markdown)`, kept one release cycle.
+    /// Revise the main card's body from a markdown string (edit semantics, a
+    /// `diff_import` that rebases surviving anchors). Discards the text delta;
+    /// call [`revise`](Self::revise) to receive it.
     fn replace_body(&mut self, body: &str) -> PyResult<()> {
         self.inner
             .main_mut()
-            .replace_body(body)
+            .revise_body(body)
+            .map(|_| ())
+            .map_err(convert_edit_error)
+    }
+
+    /// **Deprecated** — alias for `revise(markdown, card=index)`, kept one
+    /// release cycle. Revise the composable card body from a markdown string.
+    fn update_card_body(&mut self, index: usize, body: &str) -> PyResult<()> {
+        self.card_mut_or_raise(index)?
+            .revise_body(body)
+            .map(|_| ())
             .map_err(convert_edit_error)
     }
 
@@ -774,9 +860,8 @@ impl PyDocument {
             seed: None,
             payload_items,
             // The `body` argument is markdown; `Card::try_from` imports it to the
-            // corpus, and `card_to_pydict` re-emits the corpus + its projection.
+            // corpus, and `card_to_pydict` re-emits the corpus body.
             body: serde_json::Value::String(body.unwrap_or_default()),
-            body_markdown: String::new(),
         };
         let card = quillmark_core::Card::try_from(wire)
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
@@ -862,35 +947,6 @@ impl PyDocument {
         }
     }
 
-    fn replace_card_body(&mut self, index: usize, body: &str) -> PyResult<()> {
-        self.card_mut_or_raise(index)?
-            .replace_body(body)
-            .map_err(convert_edit_error)
-    }
-
-    /// Corpus-native body writer on the composable card at `index` — the
-    /// card-indexed twin of [`set_body`](Self::set_body), and the corpus
-    /// counterpart to [`replace_card_body`](Self::replace_card_body) (markdown
-    /// only). `body` is a corpus dict, an importable markdown string, or `None`.
-    /// Raises `QuillmarkError` on an out-of-range index or a body that is none of
-    /// those. Mirrors WASM `setCardBody`.
-    fn set_card_body(&mut self, index: usize, body: Bound<'_, PyAny>) -> PyResult<()> {
-        let json = py_to_json(&body)?;
-        self.card_mut_or_raise(index)?
-            .set_body_value(&json)
-            .map_err(convert_edit_error)
-    }
-
-    /// The markdown projection of a richtext-valued field on the composable card
-    /// at `index` — the card-indexed twin of [`field_markdown`](Self::field_markdown).
-    /// Returns `None` when `index` is out of range, the field is absent, or it
-    /// does not decode as richtext. Mirrors WASM `cardFieldMarkdown`.
-    fn card_field_markdown(&self, index: usize, name: &str) -> Option<String> {
-        self.inner
-            .cards()
-            .get(index)
-            .and_then(|c| c.field_markdown(name))
-    }
 }
 
 impl PyDocument {
@@ -902,6 +958,16 @@ impl PyDocument {
         self.inner.card_mut(index).ok_or_else(|| {
             convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
         })
+    }
+
+    /// Resolve the card an address targets: the main card when `card` is `None`,
+    /// else the composable card at that index (out-of-range raises). The static
+    /// address axis the four addressed content verbs share.
+    fn addr_card_mut(&mut self, card: Option<usize>) -> PyResult<&mut quillmark_core::Card> {
+        match card {
+            None => Ok(self.inner.main_mut()),
+            Some(index) => self.card_mut_or_raise(index),
+        }
     }
 }
 
@@ -1170,10 +1236,10 @@ fn card_to_pydict<'py>(
         None => d.set_item("seed", py.None())?,
     }
 
-    // `body` is the canonical corpus (source of truth); `body_markdown` its
-    // read-only projection. The reverse path (`py_dict_to_card`) reads `body`.
+    // `body` is the canonical corpus (source of truth); the markdown projection
+    // is the on-demand `export_markdown(body)` codec. The reverse path
+    // (`py_dict_to_card`) reads `body`.
     d.set_item("body", json_to_py(py, &wire.body)?)?;
-    d.set_item("body_markdown", &wire.body_markdown)?;
     Ok(d)
 }
 
@@ -1391,4 +1457,140 @@ fn py_dict_to_card(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::Card> {
         ))
     })?;
     quillmark_core::Card::try_from(wire).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+// ── Addressed-write helpers + corpus codec ──────────────────────────────────────
+
+/// Decode a Python value as a canonical `RichText` corpus dict — the `install`
+/// input (value semantics, corpus only). Rejects a markdown string: the cold
+/// path is `install(import_markdown(md))`.
+fn py_to_corpus(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::RichText> {
+    let json = py_to_json(value)?;
+    if !json.is_object() {
+        return Err(PyValueError::new_err(
+            "expected a RichText corpus dict; for markdown use import_markdown(md) first",
+        ));
+    }
+    quillmark_richtext::serial::from_canonical_value(&json)
+        .map_err(|e| PyValueError::new_err(format!("not a canonical RichText corpus: {e}")))
+}
+
+/// Serialize a [`Delta`](quillmark_core::Delta) to its JSON wire (`{ops: [...]}`).
+fn delta_to_json(delta: &quillmark_core::Delta) -> serde_json::Value {
+    serde_json::to_value(delta).unwrap_or(serde_json::Value::Null)
+}
+
+/// Lower an `apply_change` bundle (`{delta?, line_ops?, mark_ops?}`) to core ops.
+/// A missing `delta` is the identity; missing op lists are empty. Accepts both
+/// snake_case (`line_ops`) and camelCase (`lineOps`) keys.
+fn parse_change_bundle(
+    value: &Bound<'_, PyAny>,
+) -> PyResult<(
+    quillmark_core::Delta,
+    Vec<quillmark_core::LineOp>,
+    Vec<quillmark_core::MarkOp>,
+)> {
+    let json = py_to_json(value)?;
+    let obj = json.as_object().ok_or_else(|| {
+        PyValueError::new_err("bundle must be a dict { delta?, line_ops?, mark_ops? }")
+    })?;
+    let get = |snake: &str, camel: &str| obj.get(snake).or_else(|| obj.get(camel));
+    let delta = match get("delta", "delta") {
+        Some(serde_json::Value::Null) | None => quillmark_core::Delta { ops: Vec::new() },
+        Some(d) => serde_json::from_value(d.clone())
+            .map_err(|e| PyValueError::new_err(format!("invalid delta: {e}")))?,
+    };
+    let line_ops = parse_op_list(
+        get("line_ops", "lineOps"),
+        quillmark_richtext::line_op_from_value,
+        "line_ops",
+    )?;
+    let mark_ops = parse_op_list(
+        get("mark_ops", "markOps"),
+        quillmark_richtext::mark_op_from_value,
+        "mark_ops",
+    )?;
+    Ok((delta, line_ops, mark_ops))
+}
+
+/// Lower an optional JSON array of op objects through `convert`, mapping a shape
+/// error to a `ValueError` naming `what`.
+fn parse_op_list<T>(
+    value: Option<&serde_json::Value>,
+    convert: impl Fn(&serde_json::Value) -> Result<T, quillmark_richtext::ParseError>,
+    what: &str,
+) -> PyResult<Vec<T>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    if value.is_null() {
+        return Ok(Vec::new());
+    }
+    let arr = value
+        .as_array()
+        .ok_or_else(|| PyValueError::new_err(format!("{what} must be a list")))?;
+    arr.iter()
+        .map(|v| convert(v).map_err(|e| PyValueError::new_err(format!("invalid {what}: {e}"))))
+        .collect()
+}
+
+/// Import a markdown string to a canonical `RichText` corpus dict — the pure,
+/// document-free codec. Pair with `install(import_markdown(md))` to spell the
+/// cold (anchor-losing) write; prefer `revise` for edit semantics. Raises on an
+/// over-nested input.
+#[pyfunction]
+pub fn import_markdown<'py>(py: Python<'py>, markdown: &str) -> PyResult<Bound<'py, PyAny>> {
+    let corpus = quillmark_richtext::from_markdown(markdown)
+        .map_err(|e| PyValueError::new_err(format!("import_markdown: {e}")))?;
+    json_to_py(py, &quillmark_richtext::serial::to_canonical_value(&corpus))
+}
+
+/// Export a canonical `RichText` corpus dict to its markdown projection — the
+/// pure codec that replaces the eager `body_markdown` / `field_markdown`
+/// precomputes (`export_markdown(doc.body)`). Raises if `rt` is not a corpus.
+#[pyfunction]
+pub fn export_markdown(rt: Bound<'_, PyAny>) -> PyResult<String> {
+    let corpus = py_to_corpus(&rt)?;
+    Ok(quillmark_richtext::to_markdown(&corpus))
+}
+
+/// Rebase `markdown` onto a `base` corpus dict — the pure, document-free twin of
+/// `revise`: cold-import + `diff_import`, returning `{corpus, delta}` (surviving
+/// anchors rebased). Raises on an over-nested input or a non-corpus `base`.
+#[pyfunction]
+pub fn rebase<'py>(
+    py: Python<'py>,
+    base: Bound<'_, PyAny>,
+    markdown: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    let base = py_to_corpus(&base)?;
+    let (corpus, delta) = quillmark_richtext::diff_import(&base, markdown)
+        .map_err(|e| PyValueError::new_err(format!("rebase: {e}")))?;
+    let out = serde_json::json!({
+        "corpus": quillmark_richtext::serial::to_canonical_value(&corpus),
+        "delta": delta_to_json(&delta),
+    });
+    json_to_py(py, &out)
+}
+
+/// Map a base corpus position through a `delta` (a `{ops: [...]}` dict) to its
+/// new position — the pure position-mapping codec for holding a caret stable
+/// across a `revise`. `assoc` is `"before"` or `"after"` (`"after"` moves past a
+/// same-position insertion). Raises on a malformed `delta`.
+#[pyfunction]
+#[pyo3(signature = (delta, pos, assoc="before"))]
+pub fn map_pos(delta: Bound<'_, PyAny>, pos: usize, assoc: &str) -> PyResult<usize> {
+    let json = py_to_json(&delta)?;
+    let delta: quillmark_core::Delta = serde_json::from_value(json)
+        .map_err(|e| PyValueError::new_err(format!("map_pos: invalid delta: {e}")))?;
+    let assoc = match assoc {
+        "before" => quillmark_core::Assoc::Before,
+        "after" => quillmark_core::Assoc::After,
+        _ => {
+            return Err(PyValueError::new_err(
+                "map_pos: assoc must be \"before\" or \"after\"",
+            ))
+        }
+    };
+    Ok(delta.map_pos(pos, assoc))
 }

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -3,7 +3,17 @@
 import re
 
 import pytest
-from quillmark import Quillmark, Quill, Document, OutputFormat, QuillmarkError
+from quillmark import (
+    Quillmark,
+    Quill,
+    Document,
+    OutputFormat,
+    QuillmarkError,
+    import_markdown,
+    export_markdown,
+    rebase,
+    map_pos,
+)
 from conftest import QUILLS_PATH, _latest_version
 
 
@@ -86,7 +96,7 @@ def test_blank_document_constructor():
     doc = Document("test_quill")
     assert doc.quill_ref == "test_quill"
     assert doc.card_count == 0
-    assert doc.body_markdown == ""
+    assert export_markdown(doc.body) == ""
     assert field_keys(doc.main) == []
     doc.set_fields({"title": "Hello"})
     assert field(doc.main, "title") == "Hello"
@@ -231,7 +241,7 @@ def test_replace_body():
     """replace_body replaces the global Markdown body."""
     doc = Document.from_markdown(SIMPLE_MD)
     doc.replace_body("New body content.")
-    assert doc.body_markdown == "New body content.\n"
+    assert export_markdown(doc.body) == "New body content.\n"
 
 
 def test_push_card():
@@ -240,7 +250,7 @@ def test_push_card():
     doc.push_card({"kind": "note", "body": "Card body."})
     assert len(doc.cards) == 1
     assert doc.cards[0]["kind"] == "note"
-    assert doc.cards[0]["body_markdown"] == "Card body.\n"
+    assert export_markdown(doc.cards[0]["body"]) == "Card body.\n"
 
 
 def test_push_card_invalid_kind():
@@ -266,7 +276,7 @@ def test_remove_card_then_push_card_round_trips_fields():
     assert len(doc.cards) == 1
     assert doc.cards[0]["kind"] == "note"
     assert field(doc.cards[0], "author") == "Alice"  # field survived the round-trip
-    assert doc.cards[0]["body_markdown"] == "Body\n"
+    assert export_markdown(doc.cards[0]["body"]) == "Body\n"
 
 
 def test_push_card_accepts_corpus_dict_body():
@@ -279,7 +289,7 @@ def test_push_card_accepts_corpus_dict_body():
     assert isinstance(corpus_body, dict)
 
     doc.push_card({"kind": "note", "body": corpus_body})
-    assert doc.cards[1]["body_markdown"] == doc.cards[0]["body_markdown"]
+    assert export_markdown(doc.cards[1]["body"]) == export_markdown(doc.cards[0]["body"])
 
 
 def test_make_card_accepts_any_kind_push_card_is_the_gate():
@@ -370,18 +380,26 @@ def test_set_card_field_out_of_range():
         doc.set_card_field(0, "title", "x")
 
 
-def test_replace_card_body():
-    """replace_card_body replaces the card body."""
+def test_revise_card_body():
+    """revise(md, card=i) revises a card body and returns the text delta."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.replace_card_body(0, "New card body.")
-    assert doc.cards[0]["body_markdown"] == "New card body.\n"
+    delta = doc.revise("New card body.", card=0)
+    assert export_markdown(doc.cards[0]["body"]) == "New card body.\n"
+    assert isinstance(delta["ops"], list)
 
 
-def test_replace_card_body_out_of_range():
-    """replace_card_body raises EditError when card index is out of range."""
+def test_revise_card_body_out_of_range():
+    """revise(md, card=i) raises EditError when card index is out of range."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.replace_card_body(0, "x")
+        doc.revise("x", card=0)
+
+
+def test_update_card_body_deprecated_alias():
+    """update_card_body (deprecated alias for revise(md, card=i)) still works."""
+    doc = Document.from_markdown(MD_WITH_CARDS)
+    doc.update_card_body(0, "New card body.")
+    assert export_markdown(doc.cards[0]["body"]) == "New card body.\n"
 
 
 def test_set_ext_adds_map():
@@ -538,11 +556,11 @@ def test_to_markdown_general_round_trip():
     # Re-parse and assert structure survives
     doc2 = Document.from_markdown(emitted)
     assert field(doc2.main, "title") == "New Title"
-    assert doc2.body_markdown.rstrip("\n") == "Updated body"
+    assert export_markdown(doc2.body).rstrip("\n") == "Updated body"
     assert len(doc2.cards) == original_card_count + 1
     assert doc2.cards[0]["kind"] == "note"
     assert field(doc2.cards[0], "author") == "Alice"
-    assert doc2.cards[0]["body_markdown"] == "Hello\n"
+    assert export_markdown(doc2.cards[0]["body"]) == "Hello\n"
 
 
 def test_to_markdown_ambiguous_string_survival():
@@ -623,6 +641,45 @@ def test_commit_card_field_index_out_of_range():
     doc = Document("richtext_form@0.1.0")
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         doc.commit_card_field(quill, 0, "body", "x")
+
+
+# ── Addressed content verbs — commit / revise / apply_change ──────────────────
+
+
+def test_commit_addressed_typed_door():
+    """commit(value, quill, field=...) is the addressed typed door; the body has
+    no schema type so a field is required, and a typo raises UnknownField."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    doc.commit("A **bold** intro.", quill, field="bio")
+    assert isinstance(field(doc.main, "bio"), dict)
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        doc.commit("x", quill, field="stray")
+    with pytest.raises(TypeError):
+        doc.commit("x", quill)  # field is a required keyword
+
+
+def test_revise_field_and_apply_change_splice():
+    """revise({field}) diff-imports a richtext field; apply_change splices marks."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    doc.revise("make it bold here", field="bio")
+    doc.apply_change(
+        {"mark_ops": [{"op": "add", "start": 8, "end": 12, "type": "strong"}]},
+        field="bio",
+    )
+    assert export_markdown(field(doc.main, "bio")) == "make it **bold** here\n"
+
+
+def test_corpus_codec_rebase_and_map_pos():
+    """The document-free codec round-trips and maps a position through a rebase."""
+    rt = import_markdown("hello world")
+    assert rt["text"] == "hello world"
+    assert export_markdown(rt) == "hello world\n"
+    out = rebase(rt, "hello brave world")
+    assert out["corpus"]["text"] == "hello brave world"
+    assert map_pos(out["delta"], 6, "before") == 6
+    assert map_pos(out["delta"], 11, "after") == 17
 
 
 # ── Typed batched writes — commit_fields / commit_card_fields ─────────────────

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from quillmark import Document, QuillmarkError
+from quillmark import (
+    Document,
+    QuillmarkError,
+    import_markdown,
+    export_markdown,
+    rebase,
+    map_pos,
+)
 
 import os
 from pathlib import Path
@@ -40,17 +47,18 @@ def test_payload_access(taro_md):
 def test_body_is_str(taro_md):
     """Test that body is a str (not None)."""
     doc = Document.from_markdown(taro_md)
-    # `body` is the canonical corpus (a dict); `body_markdown` its projection.
+    # `body` is the canonical corpus (a dict); its markdown projection is the
+    # on-demand `export_markdown(body)` codec.
     assert isinstance(doc.body, dict)
-    assert isinstance(doc.body_markdown, str)
-    assert "nutty" in doc.body_markdown
+    assert isinstance(export_markdown(doc.body), str)
+    assert "nutty" in export_markdown(doc.body)
 
 
 def test_body_empty_when_absent():
     """Test that body is empty string when no body content."""
     md = "~~~card-yaml\n$quill: taro\n$kind: main\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n~~~\n"
     doc = Document.from_markdown(md)
-    assert doc.body_markdown == ""
+    assert export_markdown(doc.body) == ""
 
 
 def test_cards_access():
@@ -64,7 +72,7 @@ def test_cards_access():
     card = doc.cards[0]
     assert card["kind"] == "note"
     assert field(card, "foo") == "bar"
-    assert "Card body." in card["body_markdown"]
+    assert "Card body." in export_markdown(card["body"])
 
 
 def test_cards_empty_when_none():
@@ -309,38 +317,44 @@ def test_document_authoring_text_helpers():
     assert isinstance(instr, str) and "taro" in instr
 
 
-def test_set_body_corpus_round_trip():
-    """`set_body` accepts the corpus dict `body` reads back — the corpus-native
-    writer closing the read/write asymmetry (WASM `setBody` parity). Issue #902."""
+def test_install_body_corpus_round_trip():
+    """`install(rt)` installs the corpus dict `body` reads back — value semantics,
+    lossless (not markdown-forced). The kwargs idiom of WASM `install`."""
     doc = Document.from_markdown(
         "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: T\n~~~\n\n**bold** body\n"
     )
     corpus = doc.body
     assert isinstance(corpus, dict)
-    # Write the read-back corpus to a fresh doc: lossless (not markdown-forced).
+    # Install the read-back corpus into a fresh doc: lossless.
     doc2 = Document.from_markdown("~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: T\n~~~\n")
-    doc2.set_body(corpus)
+    doc2.install(corpus)
     assert doc2.body == corpus
-    # A markdown string and None are also accepted.
-    doc2.set_body("plain text")
-    assert "plain text" in doc2.body_markdown
-    doc2.set_body(None)
-    assert doc2.body_markdown == ""
+    # The cold markdown path is spelled with the codec; clearing installs empty.
+    doc2.install(import_markdown("plain text"))
+    assert "plain text" in export_markdown(doc2.body)
+    doc2.install(import_markdown(""))
+    assert export_markdown(doc2.body) == ""
+    # A markdown string cannot be installed directly (value semantics, corpus only).
+    with pytest.raises((QuillmarkError, ValueError)):
+        doc2.install("plain markdown")
 
 
-def test_set_card_body_and_field_markdown_parity():
-    """`set_card_body` writes a composable card's corpus body; `field_markdown`
-    / `card_field_markdown` project a richtext field to markdown (WASM parity)."""
+def test_addressed_card_body_and_field_projection():
+    """`install(rt, card=i)` writes a composable card's corpus body; a committed
+    richtext field projects through `export_markdown` (the codec that replaces
+    the retired `field_markdown` / `card_field_markdown`)."""
     md = (
         "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: Main\n~~~\n\nMain body.\n\n"
         "~~~card-yaml\n$kind: note\nfoo: bar\n~~~\n\nCard body.\n"
     )
     doc = Document.from_markdown(md)
-    doc.set_card_body(0, "**new** card body")
-    assert "**new** card body" in doc.cards[0]["body_markdown"]
-    # field_markdown returns None for a non-richtext / absent field.
-    assert doc.field_markdown("missing") is None
-    assert doc.card_field_markdown(0, "missing") is None
+    doc.install(import_markdown("**new** card body"), card=0)
+    assert "**new** card body" in export_markdown(doc.cards[0]["body"])
+    # A revise on a card body returns a Delta receipt.
+    delta = doc.revise("plain card body", card=0)
+    assert isinstance(delta["ops"], list)
+    # An absent field has no value to project.
+    assert field(doc.main, "missing") is None
 
 
 def test_nested_fill_exposed_as_nested_fills():

--- a/crates/bindings/wasm/Cargo.toml
+++ b/crates/bindings/wasm/Cargo.toml
@@ -18,6 +18,9 @@ crate-type = ["cdylib", "rlib"]
 # version pin is needed. `typst` re-enables Typst via `quillmark/typst`.
 quillmark = { path = "../../quillmark", default-features = false }
 quillmark-core = { workspace = true }
+# The corpus codec (importMarkdown / exportMarkdown / rebase / mapPos) and the
+# change-bundle op wire live here; the addressed write surface lowers to it.
+quillmark-richtext = { workspace = true }
 wasm-bindgen = "0.2"
 serde = { workspace = true }
 serde_bytes = "0.11"

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -8,7 +8,15 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { Quillmark, Quill, Document } from '@quillmark-wasm'
+import {
+  Quillmark,
+  Quill,
+  Document,
+  importMarkdown,
+  exportMarkdown,
+  rebase,
+  mapPos,
+} from '@quillmark-wasm'
 import { makeQuill } from './test-helpers.js'
 
 /** Read a field value from a card's payloadItems list by key. */
@@ -61,13 +69,13 @@ describe('Document.fromMarkdown', () => {
   it('should expose body as a corpus with a markdown projection', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
 
-    // `body` is the canonical corpus (source-of-truth model); `bodyMarkdown` is
-    // the markdown projection.
+    // `body` is the canonical corpus (source-of-truth model); the markdown
+    // projection is the on-demand `exportMarkdown(body)` codec.
     expect(typeof doc.main.body).toBe('object')
     expect(typeof doc.main.body.text).toBe('string')
     expect(doc.main.body.text).toContain('Hello World')
-    expect(typeof doc.main.bodyMarkdown).toBe('string')
-    expect(doc.main.bodyMarkdown).toContain('Hello World')
+    expect(typeof exportMarkdown(doc.main.body)).toBe('string')
+    expect(exportMarkdown(doc.main.body)).toContain('Hello World')
   })
 
   it('should expose cards as an array', () => {
@@ -97,7 +105,7 @@ Card body.
     expect(doc.cards.length).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
     expect(field(doc.cards[0], 'foo')).toBe('bar')
-    expect(doc.cards[0].bodyMarkdown).toContain('Card body.')
+    expect(exportMarkdown(doc.cards[0].body)).toContain('Card body.')
   })
 
   it('should expose warnings array', () => {
@@ -177,15 +185,15 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
     // Note on trailing newlines: the global body is followed by a card fence,
     // so the wire format inserts a line terminator + F2 blank line between
     // them (`Updated body\n\n~~~card-yaml`). On re-parse the F2 blank is
-    // stripped but the terminator stays, so `doc2.main.bodyMarkdown === 'Updated body\n'`. The card
+    // stripped but the terminator stays, so `exportMarkdown(doc2.main.body) === 'Updated body\n'`. The card
     // body is at EOF and has no F2 separator, so it survives byte-for-byte.
     const doc2 = Document.fromMarkdown(emitted)
     expect(field(doc2.main, 'title')).toBe('New Title')
-    expect(doc2.main.bodyMarkdown).toBe('Updated body\n')
+    expect(exportMarkdown(doc2.main.body)).toBe('Updated body\n')
     expect(doc2.cards.length).toBe(originalCardCount + 1)
     expect(doc2.cards[0].kind).toBe('note')
     expect(field(doc2.cards[0], 'author')).toBe('Alice')
-    expect(doc2.cards[0].bodyMarkdown).toBe('Hello\n')
+    expect(exportMarkdown(doc2.cards[0].body)).toBe('Hello\n')
   })
 
   it('ambiguous-string survival: YAML-keyword values are preserved as strings', () => {
@@ -248,7 +256,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     expect(field(restored.main, 'title')).toBe('New Title')
     expect(restored.cards[0].kind).toBe('note')
     expect(field(restored.cards[0], 'author')).toBe('Alice')
-    expect(restored.cards[0].bodyMarkdown).toBe('Hello\n')
+    expect(exportMarkdown(restored.cards[0].body)).toBe('Hello\n')
   })
 
   it('toJson output is standard JSON parseable by the JSON global', () => {
@@ -522,7 +530,7 @@ describe('Document blank-canvas constructor', () => {
     const doc = new Document('test_quill')
     expect(doc.quillRef).toBe('test_quill')
     expect(doc.cards.length).toBe(0)
-    expect(doc.main.bodyMarkdown).toBe('')
+    expect(exportMarkdown(doc.main.body)).toBe('')
     doc.setFields({ title: 'Hello' })
     expect(field(doc.main, 'title')).toBe('Hello')
   })
@@ -567,7 +575,7 @@ describe('Document editor surface — setFields / setCardFields', () => {
   })
 })
 
-describe('Document editor surface — setQuillRef / replaceBody', () => {
+describe('Document editor surface — setQuillRef / replaceBody(deprecated) / install / revise', () => {
   it('setQuillRef changes the quillRef', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.setQuillRef('new_quill')
@@ -579,39 +587,60 @@ describe('Document editor surface — setQuillRef / replaceBody', () => {
     expect(() => doc.setQuillRef('INVALID QUILL REF WITH SPACES')).toThrow()
   })
 
-  it('replaceBody changes the body', () => {
+  it('replaceBody (deprecated alias for revise) changes the body', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.replaceBody('Brand new body.')
-    expect(doc.main.bodyMarkdown).toBe('Brand new body.\n')
+    expect(exportMarkdown(doc.main.body)).toBe('Brand new body.\n')
   })
 
-  it('setBody accepts a markdown string', () => {
+  it('revise({}, md) revises the main body and returns the text delta', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setBody('Body from **markdown**.')
-    expect(doc.main.bodyMarkdown).toBe('Body from **markdown**.\n')
+    const delta = doc.revise({}, 'Body from **markdown**.')
+    expect(exportMarkdown(doc.main.body)).toBe('Body from **markdown**.\n')
+    // The receipt is a structured-clone-able change set.
+    expect(Array.isArray(delta.ops)).toBe(true)
   })
 
-  it('setBody accepts a corpus object round-tripped from doc.main.body', () => {
-    // The corpus is the source-of-truth shape doc.main.body reads back; writing
-    // it straight through is the read/write symmetry #874 closes.
+  it('install({}, rt) installs a corpus object with value semantics', () => {
+    // The corpus is the source-of-truth shape doc.main.body reads back; the
+    // cold path spells importMarkdown at the call site.
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    const src = Document.fromMarkdown('~~~card-yaml\n$quill: q@1.0.0\n~~~\n\nCorpus **body** here.')
-    const corpus = src.main.body
+    const corpus = importMarkdown('Corpus **body** here.')
     expect(typeof corpus).toBe('object')
-    doc.setBody(corpus)
+    doc.install({}, corpus)
     expect(doc.main.body.text).toBe('Corpus body here.')
-    expect(doc.main.bodyMarkdown).toBe('Corpus **body** here.\n')
+    expect(exportMarkdown(doc.main.body)).toBe('Corpus **body** here.\n')
   })
 
-  it('setBody(null) clears the body', () => {
+  it('install({}, importMarkdown("")) clears the body', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setBody(null)
-    expect(doc.main.bodyMarkdown).toBe('')
+    doc.install({}, importMarkdown(''))
+    expect(exportMarkdown(doc.main.body)).toBe('')
   })
 
-  it('setBody throws BodyDecode on a non-corpus object', () => {
+  it('install rejects a non-corpus value (markdown must go through importMarkdown)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setBody({ not: 'a corpus' })).toThrow(/BodyDecode/)
+    expect(() => doc.install({}, 'plain markdown')).toThrow()
+    expect(() => doc.install({}, { not: 'a corpus' })).toThrow()
+  })
+})
+
+describe('Corpus codec — importMarkdown / exportMarkdown / rebase / mapPos', () => {
+  it('importMarkdown ∘ exportMarkdown round-trips a body', () => {
+    const rt = importMarkdown('A **bold** line.')
+    expect(typeof rt).toBe('object')
+    expect(rt.text).toBe('A bold line.')
+    expect(exportMarkdown(rt)).toBe('A **bold** line.\n')
+  })
+
+  it('rebase computes a corpus + delta and mapPos maps a position through it', () => {
+    const base = importMarkdown('hello world')
+    const { corpus, delta } = rebase(base, 'hello brave world')
+    expect(corpus.text).toBe('hello brave world')
+    expect(Array.isArray(delta.ops)).toBe(true)
+    // A caret at the end of "hello " stays; one after "world" shifts past "brave ".
+    expect(mapPos(delta, 6, 'before')).toBe(6)
+    expect(mapPos(delta, 11, 'after')).toBe(17)
   })
 })
 
@@ -647,7 +676,8 @@ card_kinds:
     const doc = blankDoc()
     doc.commitField(quill, 'intro', 'A **bold** intro.')
     expect(typeof field(doc.main, 'intro')).toBe('object')
-    expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
+    // The markdown projection of a richtext field is exportMarkdown ∘ its corpus.
+    expect(exportMarkdown(field(doc.main, 'intro'))).toBe('A **bold** intro.\n')
 
     doc.commitField(quill, 'qty', '3')
     expect(field(doc.main, 'qty')).toBe(3)
@@ -663,11 +693,17 @@ card_kinds:
     expect(field(doc.main, 'stray')).toBe('x')
   })
 
-  it('fieldMarkdown returns undefined for an absent or non-richtext field', () => {
+  it('exportMarkdown composes on a committed richtext field; a scalar field is not a corpus', () => {
+    const quill = buildQuill()
     const doc = blankDoc()
-    expect(doc.fieldMarkdown('nonexistent')).toBeUndefined()
+    // Absent field: the value is undefined, nothing to project.
+    expect(field(doc.main, 'nonexistent')).toBeUndefined()
+    // A non-richtext scalar is stored verbatim, not a corpus object.
     doc.setField('count', 3)
-    expect(doc.fieldMarkdown('count')).toBeUndefined()
+    expect(field(doc.main, 'count')).toBe(3)
+    // A committed richtext field projects through the codec.
+    doc.commitField(quill, 'intro', 'plain intro')
+    expect(exportMarkdown(field(doc.main, 'intro'))).toBe('plain intro\n')
   })
 
   it('commitField fails a strict mismatch and a richtext(inline) violation', () => {
@@ -678,13 +714,46 @@ card_kinds:
       .toThrow(/FieldRichtextNotInline/)
   })
 
+  it('commit(addr, value, quill) is the addressed typed door for main and card fields', () => {
+    const quill = buildQuill()
+    const doc = Document.fromMarkdown(
+      '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
+    )
+    // Main field, resolving the schema type from the quill.
+    doc.commit({ field: 'qty' }, '3', quill)
+    expect(field(doc.main, 'qty')).toBe(3)
+    // Card field, addressed by index.
+    doc.commit({ card: 0, field: 'body' }, 'Card **body**.', quill)
+    expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.\n')
+    // A typo is rejected on the typed path; the body has no schema type.
+    expect(() => doc.commit({ field: 'stray' }, 'x', quill)).toThrow(/UnknownField/)
+    expect(() => doc.commit({}, 'x', quill)).toThrow(/addr\.field/)
+  })
+
+  it('revise({field}) rebases a richtext field anchor and applyChange splices it', () => {
+    const quill = buildQuill()
+    const doc = blankDoc()
+    // revise the field from markdown (edit semantics), then splice a formatting
+    // mark over "bold" via applyChange.
+    doc.revise({ field: 'intro' }, 'make it bold here')
+    doc.applyChange(
+      { field: 'intro' },
+      { markOps: [{ op: 'add', start: 8, end: 12, type: 'strong' }] },
+    )
+    expect(exportMarkdown(field(doc.main, 'intro'))).toBe('make it **bold** here\n')
+    // An out-of-bounds op leaves the value unchanged (all-or-nothing).
+    expect(() =>
+      doc.applyChange({ field: 'intro' }, { markOps: [{ op: 'add', start: 999, end: 1000, type: 'emph' }] }),
+    ).toThrow()
+  })
+
   it('commitCardField resolves the card-kind schema and errors on a bad index', () => {
     const quill = buildQuill()
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
     doc.commitCardField(quill, 0, 'body', 'Card **body**.')
-    expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+    expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.\n')
     expect(() => doc.commitCardField(quill, 9, 'body', 'x')).toThrow(/IndexOutOfRange/)
   })
 
@@ -693,7 +762,7 @@ card_kinds:
     const doc = blankDoc()
     doc.commitFields(quill, { intro: 'A **bold** intro.', qty: '3' })
     // The values were coerced, not stored verbatim.
-    expect(doc.fieldMarkdown('intro')).toBe('A **bold** intro.\n')
+    expect(exportMarkdown(field(doc.main, 'intro'))).toBe('A **bold** intro.\n')
     expect(field(doc.main, 'qty')).toBe(3)
   })
 
@@ -723,7 +792,7 @@ card_kinds:
       '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
     doc.commitCardFields(quill, 0, { body: 'Card **body**.' })
-    expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+    expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.\n')
     // An undeclared field on the card aborts the batch.
     expect(() => doc.commitCardFields(quill, 0, { stray: 'x' })).toThrow(/UnknownField/)
     expect(() => doc.commitCardFields(quill, 9, { body: 'x' })).toThrow(/IndexOutOfRange/)
@@ -757,7 +826,7 @@ Card two.
     doc.pushCard(Document.makeCard('note', {}, 'My card.'))
     expect(doc.cards.length).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
-    expect(doc.cards[0].bodyMarkdown).toBe('My card.\n')
+    expect(exportMarkdown(doc.cards[0].body)).toBe('My card.\n')
   })
 
   it('pushCard throws on invalid kind', () => {
@@ -797,7 +866,7 @@ Card two.
     const bare = Document.makeCard('note')
     expect(bare.kind).toBe('note')
     expect(bare.payloadItems).toEqual([])
-    expect(bare.bodyMarkdown).toBe('')
+    expect(exportMarkdown(bare.body)).toBe('')
   })
 
   it('a stale { kind, fields } object is a loud error, not a silent empty card', () => {
@@ -923,7 +992,7 @@ describe('Document.equals', () => {
   })
 })
 
-describe('Document editor surface — setCardField / replaceCardBody', () => {
+describe('Document editor surface — setCardField / install / revise (card)', () => {
   const MD_WITH_CARD = `~~~card-yaml
 $quill: test_quill
 $kind: main
@@ -973,47 +1042,37 @@ Card body.
     expect(() => doc.removeCardField(0, 'foo')).toThrow(/IndexOutOfRange/)
   })
 
-  it('replaceCardBody replaces card body', () => {
+  it('revise({card:0}, md) revises a card body and returns the delta', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    doc.replaceCardBody(0, 'New card body.')
-    expect(doc.cards[0].bodyMarkdown).toBe('New card body.\n')
+    const delta = doc.revise({ card: 0 }, 'New card body.')
+    expect(exportMarkdown(doc.cards[0].body)).toBe('New card body.\n')
+    expect(Array.isArray(delta.ops)).toBe(true)
   })
 
-  it('replaceCardBody throws IndexOutOfRange when card absent', () => {
+  it('revise({card:0}, md) throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.replaceCardBody(0, 'x')).toThrow(/IndexOutOfRange/)
+    expect(() => doc.revise({ card: 0 }, 'x')).toThrow(/IndexOutOfRange/)
   })
 
-  it('setCardBody accepts a markdown string', () => {
+  it('install({card:0}, rt) installs a corpus into a card body', () => {
+    // The corpus is the shape doc.cards[i].body reads back; the card-indexed
+    // twin of the main-body install path.
+    const corpus = importMarkdown('Card body from **markdown**.')
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    doc.setCardBody(0, 'Card body from **markdown**.')
-    expect(doc.cards[0].bodyMarkdown).toBe('Card body from **markdown**.\n')
-  })
-
-  it('setCardBody accepts a corpus object round-tripped from a card body', () => {
-    // The corpus is the shape doc.cards[i].body reads back; writing it straight
-    // through must round-trip, the card-indexed twin of the setBody corpus path.
-    const src = Document.fromMarkdown(MD_WITH_CARD)
-    const corpus = src.cards[0].body
-    const doc = Document.fromMarkdown(MD_WITH_CARD)
-    doc.setCardBody(0, corpus)
+    doc.install({ card: 0 }, corpus)
     expect(doc.cards[0].body.text).toBe(corpus.text)
+    expect(exportMarkdown(doc.cards[0].body)).toBe('Card body from **markdown**.\n')
   })
 
-  it('setCardBody(null) clears the card body', () => {
+  it('install({card:0}, importMarkdown("")) clears the card body', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    doc.setCardBody(0, null)
+    doc.install({ card: 0 }, importMarkdown(''))
     expect(doc.cards[0].body.text).toBe('')
   })
 
-  it('setCardBody throws BodyDecode on a non-corpus object', () => {
-    const doc = Document.fromMarkdown(MD_WITH_CARD)
-    expect(() => doc.setCardBody(0, { not: 'a corpus' })).toThrow(/BodyDecode/)
-  })
-
-  it('setCardBody throws IndexOutOfRange when card absent', () => {
+  it('install({card:0}, ...) throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.setCardBody(0, 'x')).toThrow(/IndexOutOfRange/)
+    expect(() => doc.install({ card: 0 }, importMarkdown('x'))).toThrow(/IndexOutOfRange/)
   })
 })
 
@@ -1029,10 +1088,10 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
 
     // Assert state
     expect(field(doc.main, 'author')).toBe('Bob')
-    expect(doc.main.bodyMarkdown).toBe('New body text.\n')
+    expect(exportMarkdown(doc.main.body)).toBe('New body text.\n')
     expect(doc.cards.length).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
-    expect(doc.cards[0].bodyMarkdown).toBe('Card content.\n')
+    expect(exportMarkdown(doc.cards[0].body)).toBe('Card content.\n')
     expect(doc.quillRef).toBe('updated_quill')
 
     // Original title still present

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -18,6 +18,7 @@ import {
   DocumentEditor,
   CardEditor,
   isQuillmarkError,
+  exportMarkdown,
 } from '@quillmark-wasm/runtime'
 // Pin that the runtime's Quill IS the internal core build's class (re-export,
 // not a parallel wrapper). This imports the internal core artifact directly —
@@ -165,7 +166,7 @@ card_kinds:
     )
     const ed = new DocumentEditor(buildQuill(), doc)
     ed.card(0).set('body', 'Card **body**.')
-    expect(doc.cardFieldMarkdown(0, 'body')).toBe('Card **body**.\n')
+    expect(exportMarkdown(fieldOf(doc.cards[0], 'body'))).toBe('Card **body**.\n')
   })
 
   it('a bad card index throws at write time, not at card()', () => {

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -14,6 +14,8 @@
 // public entry point, so this is a structural fact. Replacing the re-export
 // with a wrapper is a breaking design change, not a refactor. See runtime.js.
 export { Quill, Document, init } from '../core/wasm.js';
+// The document-free corpus codec, re-exported from the core build.
+export { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js';
 
 // Core-build types consumers read off `Quill`/`Document`.
 export type {

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -53,6 +53,11 @@
 // "re-exports the internal core build classes verbatim" case
 // (`Quill === CoreQuill`) is the executable guard for this invariant.
 export { Quill, Document, init } from '../core/wasm.js';
+// The document-free corpus codec — re-exported verbatim from the core build so
+// the runtime subpath exposes `exportMarkdown(body)` (the on-demand markdown
+// projection that replaces the eager `bodyMarkdown`), `importMarkdown`, and the
+// position-mapping pair (`rebase`, `mapPos`).
+export { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js';
 
 /**
  * Narrow an unknown caught value to a `QuillmarkError` — the error every

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1494,9 +1494,8 @@ fn js_to_corpus(value: JsValue, ctx: &str) -> Result<quillmark_core::RichText, J
         .map_err(|e| WasmError::from(format!("{ctx}: not a canonical RichText corpus: {e}")).to_js_value())
 }
 
-/// Lower a `ChangeBundle` (`{ delta?, lineOps?, markOps? }`) to core ops. A
-/// missing `delta` is the identity (no text change); missing op arrays are
-/// empty.
+/// Lower a `ChangeBundle` (`{ delta?, lineOps?, markOps? }`) to core ops via the
+/// shared richtext reader, mapping its message to a `WasmError`.
 fn parse_change_bundle(
     value: &JsValue,
 ) -> Result<
@@ -1508,42 +1507,8 @@ fn parse_change_bundle(
     JsValue,
 > {
     let json = js_value_to_json(value.clone(), "applyChange")?;
-    let obj = json.as_object().ok_or_else(|| {
-        WasmError::from("applyChange: bundle must be an object { delta?, lineOps?, markOps? }")
-            .to_js_value()
-    })?;
-    let delta = match obj.get("delta") {
-        Some(serde_json::Value::Null) | None => quillmark_core::Delta { ops: Vec::new() },
-        Some(d) => serde_json::from_value(d.clone())
-            .map_err(|e| WasmError::from(format!("applyChange: invalid delta: {e}")).to_js_value())?,
-    };
-    let line_ops = parse_op_array(obj.get("lineOps"), quillmark_richtext::line_op_from_value, "lineOps")?;
-    let mark_ops = parse_op_array(obj.get("markOps"), quillmark_richtext::mark_op_from_value, "markOps")?;
-    Ok((delta, line_ops, mark_ops))
-}
-
-/// Lower an optional JSON array of op objects through `convert`, mapping a shape
-/// error to a `WasmError` naming `what`.
-fn parse_op_array<T>(
-    value: Option<&serde_json::Value>,
-    convert: impl Fn(&serde_json::Value) -> Result<T, quillmark_richtext::ParseError>,
-    what: &str,
-) -> Result<Vec<T>, JsValue> {
-    let Some(value) = value else {
-        return Ok(Vec::new());
-    };
-    if value.is_null() {
-        return Ok(Vec::new());
-    }
-    let arr = value.as_array().ok_or_else(|| {
-        WasmError::from(format!("applyChange: {what} must be an array")).to_js_value()
-    })?;
-    arr.iter()
-        .map(|v| {
-            convert(v)
-                .map_err(|e| WasmError::from(format!("applyChange: invalid {what}: {e}")).to_js_value())
-        })
-        .collect()
+    quillmark_richtext::change_bundle_from_value(&json)
+        .map_err(|e| WasmError::from(format!("applyChange: {e}")).to_js_value())
 }
 
 // ── Corpus codec (document-free) ────────────────────────────────────────────────

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1085,7 +1085,7 @@ impl Document {
     /// semantics**, the default write path, returning the text [`Delta`]. Imports
     /// the markdown, diffs it against the current value, rebases surviving
     /// identity anchors, and returns the change an editor bridge maps its own
-    /// positions through ([`mapPos`]). An absent `addr.field` targets the body, an
+    /// positions through (`mapPos`). An absent `addr.field` targets the body, an
     /// absent `addr.card` the main card; an absent field cold-imports from empty.
     ///
     /// Throws on an out-of-range card, a malformed field name, a present

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -149,13 +149,11 @@ export interface Card {
     payloadItems: PayloadItem[];
     /**
      * The card body as canonical `RichText` — the source-of-truth content model.
-     * Always this corpus shape on read, never a markdown string; read
-     * `bodyMarkdown` for the markdown projection. Write a body back with
-     * `setBody` / `setCardBody`, or via `CardInput.body`.
+     * Always this corpus shape on read, never a markdown string. For the markdown
+     * projection call the codec `exportMarkdown(card.body)`. Write a body back
+     * with `doc.install(addr, rt)` / `doc.revise(addr, md)`, or via `CardInput.body`.
      */
     body: RichText;
-    /** The body's markdown projection (`export ∘ body`). Read-only; `""` for an empty body. */
-    bodyMarkdown: string;
 }
 
 /**
@@ -163,9 +161,8 @@ export interface Card {
  * `Document.pushCard` / `Document.insertCard`. Like `Card` but `body` also
  * takes a markdown `string` (imported to the corpus, so a markdown / LLM writer
  * needn't build the `RichText` shape), and every field but `kind` is optional —
- * an absent field defaults (no payload items, an empty body). `bodyMarkdown` is
- * ignored (`body` is authoritative). Write one inline (`{ kind, body }`) or
- * build it with `Document.makeCard`.
+ * an absent field defaults (no payload items, an empty body). Write one inline
+ * (`{ kind, body }`) or build it with `Document.makeCard`.
  */
 export interface CardInput {
     kind: string;
@@ -175,7 +172,6 @@ export interface CardInput {
     seed?: Record<string, unknown>;
     payloadItems?: PayloadItem[];
     body?: RichText | string;
-    bodyMarkdown?: string;
 }
 
 /**
@@ -225,6 +221,65 @@ export interface RichTextIsland {
     props: unknown;
     /** How faithfully the markdown projection can carry this island. */
     loss: "lossless" | "degraded" | "unrepresentable";
+}
+
+/**
+ * A richtext write address. An absent `field` targets the card body; an absent
+ * `card` targets the main card. `{}` is the main-card body; `{ card: 2 }` the
+ * body of the composable card at index 2; `{ field: "intro" }` the main card's
+ * `intro` richtext field; `{ card: 2, field: "intro" }` a card field.
+ */
+export interface Addr {
+    card?: number;
+    field?: string;
+}
+
+/**
+ * A text-splice change set over the USV corpus (CodeMirror `ChangeSet`
+ * semantics) — plain, structured-clone-able data. Returned by `revise` and by
+ * the `rebase` codec; map a stored position through it with `mapPos`.
+ */
+export interface Delta {
+    ops: ({ retain: number } | { insert: string } | { delete: number })[];
+}
+
+/** Which side of a same-position insertion `mapPos` lands a point on. */
+export type Assoc = "before" | "after";
+
+/**
+ * A mark edit in post-text-delta coordinates. `add` / `remove` carry the
+ * `RichTextMark` vocabulary (`{ type, … }`); `removeAnchor` drops one identity
+ * anchor by id.
+ */
+export type MarkOp =
+    | ({ op: "add" | "remove"; start: number; end: number } & (
+          | { type: "strong" | "emph" | "underline" | "strike" | "code" }
+          | { type: "link"; url: string }
+          | { type: "anchor"; id: string }
+          | { type: string; attrs: unknown }
+      ))
+    | { op: "removeAnchor"; id: string };
+
+/** A line/block edit. `split`/`join` splice `\n`; `setKind`/`setContainers` touch metadata. */
+export type LineOp =
+    | { op: "split"; at: number }
+    | { op: "join"; line: number }
+    | ({ op: "setKind"; line: number } & (
+          | { kind: "para" | "island" | "rule" }
+          | { kind: "heading"; level: number }
+          | { kind: "code"; lang?: string }
+      ))
+    | { op: "setContainers"; line: number; containers: RichTextContainer[] };
+
+/**
+ * A committed corpus edit bundle for `applyChange`: a text `delta` (default no
+ * text change), then `lineOps`, then `markOps` (mark ranges are in post-delta
+ * coordinates). Every field is optional.
+ */
+export interface ChangeBundle {
+    delta?: Delta;
+    lineOps?: LineOp[];
+    markOps?: MarkOp[];
 }
 "#;
 
@@ -985,35 +1040,134 @@ impl Document {
         Ok(())
     }
 
+    /// **Deprecated** — alias for `revise({}, markdown)`, kept one release cycle.
+    /// Revise the main card's body from a markdown string (edit semantics: a
+    /// `diff_import` that rebases surviving anchors). Discards the text delta;
+    /// call [`revise`](Document::revise) to receive it.
     #[wasm_bindgen(js_name = replaceBody)]
     pub fn replace_body(&mut self, body: &str) -> Result<(), JsValue> {
         self.inner
             .main_mut()
-            .replace_body(body)
+            .revise_body(body)
+            .map(|_| ())
             .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Set the main card's body from a **corpus object** (canonical
-    /// RichText-JSON) or a markdown string — the corpus-native counterpart to
-    /// [`replaceBody`](Document::replace_body), which accepts markdown only.
-    /// `body` is the same `RichText | string` shape `Document.main.body` reads
-    /// back, so a corpus-native editor writes the body straight through with no
-    /// lossy markdown round-trip (a corpus-only mark such as `underline`
-    /// survives). `null` clears the body to empty. Closes the read/write
-    /// asymmetry `doc.main.body` (corpus in, corpus out) otherwise had.
+    /// **Install** a richtext value at `addr` — **value semantics**, corpus only.
+    /// Stores exactly `rt` (a canonical `RichText` corpus object); the identity
+    /// anchors of any previous value are gone. An absent `addr.field` targets the
+    /// body, an absent `addr.card` the main card. For "here's new markdown," use
+    /// [`revise`](Document::revise); the cold-import path is spelled at the call
+    /// site as `install(addr, importMarkdown(md))`, so anchor loss is visible in
+    /// source.
     ///
-    /// Throws `[EditError::BodyDecode]` if `body` is neither a valid corpus
-    /// object, an importable markdown string, nor `null`.
-    #[wasm_bindgen(js_name = setBody)]
-    pub fn set_body(
+    /// Throws on an out-of-range card, a malformed field name, or an `rt` that is
+    /// not a canonical corpus object.
+    #[wasm_bindgen(js_name = install)]
+    pub fn install(
         &mut self,
-        #[wasm_bindgen(unchecked_param_type = "RichText | string")] body: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "RichText")] rt: JsValue,
     ) -> Result<(), JsValue> {
-        let json = js_value_to_json(body, "setBody")?;
-        self.inner
-            .main_mut()
-            .set_body_value(&json)
-            .map_err(|e| edit_error_to_js(&e))
+        let addr = Addr::from_js(&addr)?;
+        let corpus = js_to_corpus(rt, "install")?;
+        let card = self.addr_card_mut(&addr)?;
+        match &addr.field {
+            None => {
+                card.install_body(corpus);
+                Ok(())
+            }
+            Some(field) => card.install_field(field, corpus).map_err(|e| edit_error_to_js(&e)),
+        }
+    }
+
+    /// **Revise** the richtext value at `addr` from a markdown string — **edit
+    /// semantics**, the default write path, returning the text [`Delta`]. Imports
+    /// the markdown, diffs it against the current value, rebases surviving
+    /// identity anchors, and returns the change an editor bridge maps its own
+    /// positions through ([`mapPos`]). An absent `addr.field` targets the body, an
+    /// absent `addr.card` the main card; an absent field cold-imports from empty.
+    ///
+    /// Throws on an out-of-range card, a malformed field name, a present
+    /// non-corpus field value, or an over-nested markdown input.
+    #[wasm_bindgen(js_name = revise, unchecked_return_type = "Delta")]
+    pub fn revise(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        markdown: &str,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        let card = self.addr_card_mut(&addr)?;
+        let delta = match &addr.field {
+            None => card.revise_body(markdown),
+            Some(field) => card.revise_field(field, markdown),
+        }
+        .map_err(|e| edit_error_to_js(&e))?;
+        serialize_or_throw(&delta, "revise")
+    }
+
+    /// **Apply** a committed corpus edit `bundle` (`{ delta?, lineOps?, markOps? }`)
+    /// at `addr` — the editor splice: text delta first, then line ops, then mark
+    /// ops (mark ranges in post-delta coordinates), each all-or-nothing. An absent
+    /// `addr.field` targets the body, an absent `addr.card` the main card.
+    ///
+    /// Throws on an out-of-range card, a field that is not richtext, a malformed
+    /// bundle, or an op that applies out of bounds (the value is unchanged on a
+    /// failed apply).
+    #[wasm_bindgen(js_name = applyChange)]
+    pub fn apply_change(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "ChangeBundle")] bundle: JsValue,
+    ) -> Result<(), JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        let (delta, line_ops, mark_ops) = parse_change_bundle(&bundle)?;
+        let card = self.addr_card_mut(&addr)?;
+        match &addr.field {
+            None => card.apply_body_change(&delta, &line_ops, &mark_ops),
+            Some(field) => {
+                card.apply_field_richtext_change(field, &delta, &line_ops, &mark_ops)
+            }
+        }
+        .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// **Commit** a typed value at `addr.field`, resolving the field's schema
+    /// `type` from `quill` — the one typed write verb for every field type
+    /// (richtext, scalar, array, object). The schema carries any `inline`
+    /// constraint. A richtext-typed field stores the canonical corpus (identity
+    /// and corpus-only marks intact). Requires `addr.field`; the body carries no
+    /// schema type, so a bodyless `addr` throws.
+    ///
+    /// A field the schema does not declare throws `[EditError::UnknownField]`
+    /// (a typo on the typed path — use [`setField`](Document::set_field) for
+    /// opaque storage); a typed mismatch throws now, not at render.
+    #[wasm_bindgen(js_name = commit)]
+    pub fn commit(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        value: JsValue,
+        quill: &Quill,
+    ) -> Result<(), JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        let field = addr.field.as_deref().ok_or_else(|| {
+            WasmError::from(
+                "commit requires addr.field — the body carries no schema type; \
+                 use install/revise for the body",
+            )
+            .to_js_value()
+        })?;
+        let json = js_value_to_json(value, "commit")?;
+        let qv = quillmark_core::QuillValue::from_json(json);
+        let mut editor = quill.inner.editor(&mut self.inner);
+        match addr.card {
+            None => editor.set(field, qv).map_err(|e| edit_error_to_js(&e)),
+            Some(index) => editor
+                .card(index)
+                .map_err(|e| edit_error_to_js(&e))?
+                .set(field, qv)
+                .map_err(|e| edit_error_to_js(&e)),
+        }
     }
 
     /// Typed field write on the main card, resolving the field's schema `type`
@@ -1073,18 +1227,6 @@ impl Document {
             .map_err(edit_errors_to_js)
     }
 
-    /// The markdown projection of a richtext field on the main card
-    /// (`export ∘ decode`) — the field-level twin of `main.bodyMarkdown`.
-    /// Returns `undefined` when the field is absent or does not decode as
-    /// richtext (e.g. a plain scalar written via [`setField`](Document::set_field)).
-    #[wasm_bindgen(js_name = fieldMarkdown, unchecked_return_type = "string | undefined")]
-    pub fn field_markdown(&self, name: &str) -> JsValue {
-        match self.inner.main().field_markdown(name) {
-            Some(md) => JsValue::from_str(&md),
-            None => JsValue::UNDEFINED,
-        }
-    }
-
     /// Build a fresh `Card` from a kind and a flat field map — the ergonomic
     /// constructor for `pushCard` / `insertCard`. `fields` is an optional
     /// `Record<string, unknown>` (each entry becomes a card field, in
@@ -1126,11 +1268,10 @@ impl Document {
             // The `body` argument is markdown; `Card::try_from` imports it to the
             // corpus (and validates the fields).
             body: serde_json::Value::String(body.unwrap_or_default()),
-            body_markdown: String::new(),
         };
         // Round-trip through `Card` so the emitted card carries the corpus body
-        // (the source-of-truth shape `cards()` returns) plus its markdown
-        // projection, not the raw authored string.
+        // (the source-of-truth shape `cards()` returns), not the raw authored
+        // string.
         let card = quillmark_core::Card::try_from(string_wire)
             .map_err(|e| WasmError::from(format!("makeCard: {e}")).to_js_value())?;
         let wire = quillmark_core::CardWire::from(&card);
@@ -1259,23 +1400,6 @@ impl Document {
             .map_err(edit_errors_to_js)
     }
 
-    /// The markdown projection of a richtext field on the card at `index` — the
-    /// card-indexed twin of [`fieldMarkdown`](Document::field_markdown). Returns
-    /// `undefined` when `index` is out of range, the field is absent, or it does
-    /// not decode as richtext.
-    #[wasm_bindgen(js_name = cardFieldMarkdown, unchecked_return_type = "string | undefined")]
-    pub fn card_field_markdown(&self, index: usize, name: &str) -> JsValue {
-        match self
-            .inner
-            .cards()
-            .get(index)
-            .and_then(|c| c.field_markdown(name))
-        {
-            Some(md) => JsValue::from_str(&md),
-            None => JsValue::UNDEFINED,
-        }
-    }
-
     /// Batched twin of [`setCardField`](Document::set_card_field): set
     /// several fields on the card at `index` atomically. Same all-or-nothing,
     /// one-diagnostic-per-field contract as [`setFields`](Document::set_fields).
@@ -1306,45 +1430,6 @@ impl Document {
         })
     }
 
-    /// Replace the body of the card at `index` from a markdown string — the
-    /// card-indexed twin of [`replaceBody`](Document::replace_body). Throws if
-    /// out of range.
-    #[wasm_bindgen(js_name = replaceCardBody)]
-    pub fn replace_card_body(&mut self, index: usize, body: &str) -> Result<(), JsValue> {
-        self.card_mut_or_throw(index)?
-            .replace_body(body)
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
-    /// Set the body of the card at `index` from a **corpus object** (canonical
-    /// RichText-JSON) or a markdown string — the card-indexed twin of
-    /// [`setBody`](Document::set_body), and the corpus-native counterpart to
-    /// [`replaceCardBody`](Document::replace_card_body), which accepts markdown
-    /// only. `body` is the same `RichText | string` shape `Document.cards[i].body`
-    /// reads back, so a corpus-native editor writes a card body straight through
-    /// with no lossy markdown round-trip — a corpus-only mark such as `underline`,
-    /// and anchor/island identity ids, survive. `null` clears the body to empty.
-    ///
-    /// A card body is reachable only here: `$body` is rejected by
-    /// [`commitCardField`](Document::commit_card_field) (the reserved `$`-prefix
-    /// fails the field-name check), so the field channel cannot address it. This
-    /// closes the last markdown-forced write in the corpus surface — a non-main
-    /// card body (issue #892).
-    ///
-    /// Throws `[EditError::BodyDecode]` if `body` is neither a valid corpus
-    /// object, an importable markdown string, nor `null`, and
-    /// `[EditError::IndexOutOfRange]` when the card is absent.
-    #[wasm_bindgen(js_name = setCardBody)]
-    pub fn set_card_body(
-        &mut self,
-        index: usize,
-        #[wasm_bindgen(unchecked_param_type = "RichText | string")] body: JsValue,
-    ) -> Result<(), JsValue> {
-        let json = js_value_to_json(body, "setCardBody")?;
-        self.card_mut_or_throw(index)?
-            .set_body_value(&json)
-            .map_err(|e| edit_error_to_js(&e))
-    }
 }
 
 impl Document {
@@ -1358,6 +1443,178 @@ impl Document {
             edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
         })
     }
+
+    /// Resolve the card an [`Addr`] targets: the main card when `addr.card` is
+    /// absent, else the composable card at that index (out-of-range throws). The
+    /// static address axis the four addressed content verbs share.
+    fn addr_card_mut(&mut self, addr: &Addr) -> Result<&mut quillmark_core::Card, JsValue> {
+        match addr.card {
+            None => Ok(self.inner.main_mut()),
+            Some(index) => self.card_mut_or_throw(index),
+        }
+    }
+}
+
+// ── Addressed write surface ────────────────────────────────────────────────────
+
+/// A richtext write address (`{ card?, field? }`). Absent `field` = body, absent
+/// `card` = main. Mirrors the `Addr` TS interface.
+#[derive(serde::Deserialize, Default)]
+struct Addr {
+    #[serde(default)]
+    card: Option<usize>,
+    #[serde(default)]
+    field: Option<String>,
+}
+
+impl Addr {
+    /// Deserialize an `Addr` from its JS object (`undefined`/`null`/`{}` all mean
+    /// the main-card body).
+    fn from_js(value: &JsValue) -> Result<Addr, JsValue> {
+        if value.is_undefined() || value.is_null() {
+            return Ok(Addr::default());
+        }
+        serde_wasm_bindgen::from_value(value.clone())
+            .map_err(|e| WasmError::from(format!("addr must be an Addr object: {e}")).to_js_value())
+    }
+}
+
+/// Decode a JS value as a canonical `RichText` corpus object — the `install`
+/// input (value semantics, corpus only). Rejects a markdown string: the cold
+/// path is spelled `install(addr, importMarkdown(md))`.
+fn js_to_corpus(value: JsValue, ctx: &str) -> Result<quillmark_core::RichText, JsValue> {
+    let json = js_value_to_json(value, ctx)?;
+    if !json.is_object() {
+        return Err(WasmError::from(format!(
+            "{ctx}: expected a RichText corpus object; for markdown use importMarkdown(md) first"
+        ))
+        .to_js_value());
+    }
+    quillmark_richtext::serial::from_canonical_value(&json)
+        .map_err(|e| WasmError::from(format!("{ctx}: not a canonical RichText corpus: {e}")).to_js_value())
+}
+
+/// Lower a `ChangeBundle` (`{ delta?, lineOps?, markOps? }`) to core ops. A
+/// missing `delta` is the identity (no text change); missing op arrays are
+/// empty.
+fn parse_change_bundle(
+    value: &JsValue,
+) -> Result<
+    (
+        quillmark_core::Delta,
+        Vec<quillmark_core::LineOp>,
+        Vec<quillmark_core::MarkOp>,
+    ),
+    JsValue,
+> {
+    let json = js_value_to_json(value.clone(), "applyChange")?;
+    let obj = json.as_object().ok_or_else(|| {
+        WasmError::from("applyChange: bundle must be an object { delta?, lineOps?, markOps? }")
+            .to_js_value()
+    })?;
+    let delta = match obj.get("delta") {
+        Some(serde_json::Value::Null) | None => quillmark_core::Delta { ops: Vec::new() },
+        Some(d) => serde_json::from_value(d.clone())
+            .map_err(|e| WasmError::from(format!("applyChange: invalid delta: {e}")).to_js_value())?,
+    };
+    let line_ops = parse_op_array(obj.get("lineOps"), quillmark_richtext::line_op_from_value, "lineOps")?;
+    let mark_ops = parse_op_array(obj.get("markOps"), quillmark_richtext::mark_op_from_value, "markOps")?;
+    Ok((delta, line_ops, mark_ops))
+}
+
+/// Lower an optional JSON array of op objects through `convert`, mapping a shape
+/// error to a `WasmError` naming `what`.
+fn parse_op_array<T>(
+    value: Option<&serde_json::Value>,
+    convert: impl Fn(&serde_json::Value) -> Result<T, quillmark_richtext::ParseError>,
+    what: &str,
+) -> Result<Vec<T>, JsValue> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    if value.is_null() {
+        return Ok(Vec::new());
+    }
+    let arr = value.as_array().ok_or_else(|| {
+        WasmError::from(format!("applyChange: {what} must be an array")).to_js_value()
+    })?;
+    arr.iter()
+        .map(|v| {
+            convert(v)
+                .map_err(|e| WasmError::from(format!("applyChange: invalid {what}: {e}")).to_js_value())
+        })
+        .collect()
+}
+
+// ── Corpus codec (document-free) ────────────────────────────────────────────────
+
+/// Import a markdown string to a canonical `RichText` corpus — the pure,
+/// document-free codec. Pair with `install(addr, importMarkdown(md))` to spell
+/// the cold (anchor-losing) write at the call site; prefer `revise` for edit
+/// semantics. Throws on an over-nested input.
+#[wasm_bindgen(js_name = importMarkdown, unchecked_return_type = "RichText")]
+pub fn import_markdown(markdown: &str) -> Result<JsValue, JsValue> {
+    let corpus = quillmark_richtext::from_markdown(markdown)
+        .map_err(|e| WasmError::from(format!("importMarkdown: {e}")).to_js_value())?;
+    serialize_or_throw(
+        &quillmark_richtext::serial::to_canonical_value(&corpus),
+        "importMarkdown",
+    )
+}
+
+/// Export a canonical `RichText` corpus to its markdown projection — the pure
+/// codec that replaces the eager `bodyMarkdown` / `fieldMarkdown` precomputes
+/// (`exportMarkdown(card.body)`). Throws if `rt` is not a canonical corpus.
+#[wasm_bindgen(js_name = exportMarkdown)]
+pub fn export_markdown(
+    #[wasm_bindgen(unchecked_param_type = "RichText")] rt: JsValue,
+) -> Result<String, JsValue> {
+    let corpus = js_to_corpus(rt, "exportMarkdown")?;
+    Ok(quillmark_richtext::to_markdown(&corpus))
+}
+
+/// Rebase `markdown` onto a `base` corpus — the pure, document-free twin of
+/// `revise`: cold-import + `diff_import`, returning the new `corpus` and the
+/// text `delta` (surviving anchors rebased). Use it to compute a revise without
+/// a document in hand; `revise(addr, md)` fuses this with the store for
+/// atomicity. Throws on an over-nested markdown input or a non-corpus `base`.
+#[wasm_bindgen(js_name = rebase, unchecked_return_type = "{ corpus: RichText; delta: Delta }")]
+pub fn rebase(
+    #[wasm_bindgen(unchecked_param_type = "RichText")] base: JsValue,
+    markdown: &str,
+) -> Result<JsValue, JsValue> {
+    let base = js_to_corpus(base, "rebase")?;
+    let (corpus, delta) = quillmark_richtext::diff_import(&base, markdown)
+        .map_err(|e| WasmError::from(format!("rebase: {e}")).to_js_value())?;
+    let out = serde_json::json!({
+        "corpus": quillmark_richtext::serial::to_canonical_value(&corpus),
+        "delta": serde_json::to_value(&delta).unwrap_or(serde_json::Value::Null),
+    });
+    serialize_or_throw(&out, "rebase")
+}
+
+/// Map a base corpus position through a `delta` to its new position — the pure
+/// position-mapping codec an editor bridge composes to hold a caret stable
+/// across a `revise`. `assoc` decides the side of a same-position insertion
+/// (`"after"` moves past it). Throws on a malformed `delta`.
+#[wasm_bindgen(js_name = mapPos)]
+pub fn map_pos(
+    #[wasm_bindgen(unchecked_param_type = "Delta")] delta: JsValue,
+    pos: usize,
+    #[wasm_bindgen(unchecked_param_type = "Assoc")] assoc: JsValue,
+) -> Result<usize, JsValue> {
+    let delta: quillmark_core::Delta = serde_wasm_bindgen::from_value(delta)
+        .map_err(|e| WasmError::from(format!("mapPos: invalid delta: {e}")).to_js_value())?;
+    let assoc = match assoc.as_string().as_deref() {
+        Some("before") => quillmark_core::Assoc::Before,
+        Some("after") => quillmark_core::Assoc::After,
+        _ => {
+            return Err(
+                WasmError::from("mapPos: assoc must be \"before\" or \"after\"").to_js_value(),
+            )
+        }
+    };
+    Ok(delta.map_pos(pos, assoc))
 }
 
 // ── Edit helpers ──────────────────────────────────────────────────────────────
@@ -1478,9 +1735,6 @@ fn js_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
             "seed",
             "payloadItems",
             "body",
-            // The read-only markdown projection; accepted (and ignored) so a card
-            // returned by `cards()` round-trips back through `pushCard`.
-            "bodyMarkdown",
         ];
         for key in js_sys::Object::keys(obj).iter() {
             if let Some(k) = key.as_string() {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -85,21 +85,12 @@ pub enum EditError {
     #[error("body import failed: {0}")]
     BodyImport(ImportError),
 
-    /// A body value in the corpus-or-markdown encoding could not be decoded: a
-    /// JSON object that is not a canonical richtext corpus, a markdown string
-    /// that failed to import, or a shape that is neither object, string, nor
-    /// null. Retained for callers that decode a JSON-valued body at a boundary;
-    /// the corpus writers ([`Card::install_body`](Card::install_body) /
-    /// [`Card::revise_body`](Card::revise_body)) take a typed [`RichText`] or a
-    /// markdown string and never produce it.
-    #[error("body decode failed: {0}")]
-    BodyDecode(String),
-
     /// A richtext field value in the corpus-or-markdown encoding could not be
     /// decoded: a JSON object that is not a canonical richtext corpus, a
     /// markdown string that failed to import, or a shape that is neither
-    /// object, string, nor null. The field-level twin of [`BodyDecode`](Self::BodyDecode);
-    /// returned by [`Card::commit_field`](Card::commit_field) on a richtext field
+    /// object, string, nor null. Returned by
+    /// [`Card::commit_field`](Card::commit_field) on a richtext field, by
+    /// [`Card::revise_field`](Card::revise_field) on a present non-corpus field,
     /// and by [`Card::apply_field_richtext_change`](Card::apply_field_richtext_change).
     #[error("richtext field '{field}' decode failed: {message}")]
     FieldRichtextDecode { field: String, message: String },
@@ -142,7 +133,6 @@ impl EditError {
             EditError::IndexOutOfRange { .. } => "IndexOutOfRange",
             EditError::ValueTooDeep { .. } => "ValueTooDeep",
             EditError::BodyImport(_) => "BodyImport",
-            EditError::BodyDecode(_) => "BodyDecode",
             EditError::FieldRichtextDecode { .. } => "FieldRichtextDecode",
             EditError::FieldRichtextNotInline(_) => "FieldRichtextNotInline",
             EditError::FieldConform { .. } => "FieldConform",
@@ -573,10 +563,20 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
+        self.store_field_corpus(name, &corpus);
+        Ok(())
+    }
+
+    /// Store `corpus` as the canonical corpus-JSON value of field `name` — the
+    /// one place a richtext field's corpus is committed to the payload, shared by
+    /// [`install_field`](Self::install_field), [`revise_field`](Self::revise_field),
+    /// and [`apply_field_richtext_change`](Self::apply_field_richtext_change).
+    /// Assumes `name` is already validated (all three callers check it or resolve
+    /// an existing field first).
+    fn store_field_corpus(&mut self, name: &str, corpus: &RichText) {
+        let canonical = quillmark_richtext::serial::to_canonical_value(corpus);
         self.payload_mut()
             .insert(name.to_string(), QuillValue::from_json(canonical));
-        Ok(())
     }
 
     /// Write-time commit: validate and normalize `value` per the field's schema
@@ -679,9 +679,7 @@ impl Card {
             None => RichText::empty(),
         };
         let (corpus, delta) = diff_import(&base, &body.into()).map_err(EditError::BodyImport)?;
-        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
-        self.payload_mut()
-            .insert(name.to_string(), QuillValue::from_json(canonical));
+        self.store_field_corpus(name, &corpus);
         Ok(delta)
     }
 
@@ -740,9 +738,7 @@ impl Card {
         corpus
             .apply_field_change(text_delta, line_ops, mark_ops)
             .map_err(EditError::CorpusApply)?;
-        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
-        self.payload_mut()
-            .insert(name.to_string(), QuillValue::from_json(canonical));
+        self.store_field_corpus(name, &corpus);
         Ok(())
     }
 }

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -88,7 +88,10 @@ pub enum EditError {
     /// A body value in the corpus-or-markdown encoding could not be decoded: a
     /// JSON object that is not a canonical richtext corpus, a markdown string
     /// that failed to import, or a shape that is neither object, string, nor
-    /// null. Returned by [`Card::set_body_value`](Card::set_body_value).
+    /// null. Retained for callers that decode a JSON-valued body at a boundary;
+    /// the corpus writers ([`Card::install_body`](Card::install_body) /
+    /// [`Card::revise_body`](Card::revise_body)) take a typed [`RichText`] or a
+    /// markdown string and never produce it.
     #[error("body decode failed: {0}")]
     BodyDecode(String),
 
@@ -545,51 +548,35 @@ impl Card {
         removed
     }
 
-    /// Set the body corpus directly from a pre-built [`RichText`]. The native
-    /// richtext writer: a corpus is valid by construction, so this is
-    /// infallible — no markdown import, no schema check. Use it when the caller
-    /// already holds a corpus (a decoded canonical-JSON body, another field's
-    /// value, an editor's serialized state); use [`replace_body`](Self::replace_body)
-    /// to import from an authored markdown string instead.
-    pub fn set_body_corpus(&mut self, corpus: RichText) {
+    /// Install the body corpus directly from a pre-built [`RichText`] — **value
+    /// semantics**, the native richtext writer. A corpus is valid by
+    /// construction, so this is infallible: no markdown import, no diff, no
+    /// schema check; the identity anchors of the previous body are *gone*
+    /// (install-this-exact-value, so a `to_markdown → install` round-trip cannot
+    /// resurrect them). Use it when the caller already holds a corpus (a decoded
+    /// canonical-JSON body, another field's value, an editor's serialized state).
+    /// For "here's new authored markdown," use [`revise_body`](Self::revise_body),
+    /// which rebases surviving anchors; the cold-import path is spelled at the
+    /// call site as `install_body(import_body(md)?)`.
+    pub fn install_body(&mut self, corpus: RichText) {
         self.overwrite_body(corpus);
     }
 
-    /// Set the body from either accepted richtext encoding — a canonical corpus
-    /// **object** (decoded and validated) or an authored markdown **string**
-    /// (imported) — the write twin of the `Card.body` read shape
-    /// (`RichText | string`). `null` installs the empty corpus. Routes through
-    /// the one object-vs-string dispatch (`decode_richtext_value`), so it
-    /// stays lossless for corpus-only marks a markdown projection cannot carry
-    /// (e.g. `underline`), unlike serializing to markdown and calling
-    /// [`replace_body`](Self::replace_body). Prefer the typed
-    /// [`set_body_corpus`](Self::set_body_corpus) when the caller already holds a
-    /// [`RichText`]; this is for a JSON-valued body crossing a binding boundary.
-    pub fn set_body_value(&mut self, value: &serde_json::Value) -> Result<(), EditError> {
-        match crate::document::decode_richtext_value(value) {
-            Some(result) => {
-                let corpus = result.map_err(|e| EditError::BodyDecode(e.into_message()))?;
-                self.overwrite_body(corpus);
-                Ok(())
-            }
-            // Neither object nor string: `null` is the empty corpus; anything
-            // else is an invalid body value.
-            None => match value {
-                serde_json::Value::Null => {
-                    self.overwrite_body(RichText::empty());
-                    Ok(())
-                }
-                other => Err(EditError::BodyDecode(format!(
-                    "expected a richtext corpus object or a markdown string, got {}",
-                    match other {
-                        serde_json::Value::Bool(_) => "a boolean",
-                        serde_json::Value::Number(_) => "a number",
-                        serde_json::Value::Array(_) => "an array",
-                        _ => "an unsupported value",
-                    }
-                ))),
-            },
+    /// Install a richtext field's corpus directly from a pre-built [`RichText`]
+    /// — the field-level twin of [`install_body`](Self::install_body). Value
+    /// semantics: stores the canonical corpus JSON verbatim (identity marks and
+    /// corpus-only marks such as `underline` intact), no diff, no schema check
+    /// (schema-blind, like [`apply_field_richtext_change`](Self::apply_field_richtext_change)
+    /// — [`commit_field`](Self::commit_field) is the typed door). Returns
+    /// [`EditError::InvalidFieldName`] for a malformed name.
+    pub fn install_field(&mut self, name: &str, corpus: RichText) -> Result<(), EditError> {
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
         }
+        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
+        self.payload_mut()
+            .insert(name.to_string(), QuillValue::from_json(canonical));
+        Ok(())
     }
 
     /// Write-time commit: validate and normalize `value` per the field's schema
@@ -639,29 +626,62 @@ impl Card {
         Ok(())
     }
 
-    /// Replace the body from an authored markdown string — the whole-document
-    /// (stale-text / LLM / MCP) writer. Imports the markdown, diffs it against
-    /// the current body, and rebases surviving identity anchors onto the new
-    /// text (cold import + [`diff_import`]). A pathologically over-nested input
-    /// (`> MAX_NESTING_DEPTH`) returns [`EditError::BodyImport`] rather than
-    /// silently degrading to the empty corpus. To also obtain the text
-    /// [`Delta`] for recording into a session change log, call
-    /// [`import_body_delta`](Self::import_body_delta).
-    pub fn replace_body(&mut self, body: impl Into<String>) -> Result<(), EditError> {
-        self.import_body_delta(body).map(|_| ())
-    }
-
-    /// Import an authored markdown string into the body and return the text
-    /// [`Delta`] from the old body to the new one — the observable form of
-    /// [`replace_body`](Self::replace_body). The returned delta is the text
-    /// change an editor bridge maps its own positions through across a
-    /// whole-document replace. Surviving identity anchors rebase onto the new
-    /// text; formatting marks are re-derived by the fresh import. Returns
-    /// [`EditError::BodyImport`] on an over-nested input.
-    pub fn import_body_delta(&mut self, body: impl Into<String>) -> Result<Delta, EditError> {
+    /// Revise the body from an authored markdown string — **edit semantics**,
+    /// the whole-document (stale-text / LLM / MCP) writer, and the receipt-
+    /// returning default write path. Imports the markdown, diffs it against the
+    /// current body, and rebases surviving identity anchors onto the new text
+    /// (cold import + [`diff_import`]), then returns the text [`Delta`] from the
+    /// old body to the new one — the change an editor bridge maps its own
+    /// positions through across a whole-document replace ([`Delta::map_pos`]).
+    /// Surviving identity anchors rebase; formatting marks are re-derived by the
+    /// fresh import. A pathologically over-nested input (`> MAX_NESTING_DEPTH`)
+    /// returns [`EditError::BodyImport`] rather than silently degrading to the
+    /// empty corpus. Discard the receipt with `let _ = card.revise_body(md)?;`
+    /// when caret stability is not needed.
+    pub fn revise_body(&mut self, body: impl Into<String>) -> Result<Delta, EditError> {
         let (corpus, delta) =
             diff_import(self.body(), &body.into()).map_err(EditError::BodyImport)?;
         self.overwrite_body(corpus);
+        Ok(delta)
+    }
+
+    /// Revise a richtext field from an authored markdown string — the
+    /// field-level twin of [`revise_body`](Self::revise_body), and the
+    /// field-level `diff_import` the write surface previously lacked (the only
+    /// field-corpus writers were the cold [`commit_field`](Self::commit_field)
+    /// and the splice [`apply_field_richtext_change`](Self::apply_field_richtext_change),
+    /// so an LLM rewriting a richtext field's markdown had no anchor-preserving
+    /// path). Decodes the field's current corpus as the diff base (an **absent**
+    /// field cold-imports from empty), rebases surviving anchors onto the new
+    /// text, re-stores the canonical corpus, and returns the text [`Delta`].
+    ///
+    /// Schema-blind by design — the corpus-writer stratum splices without the
+    /// quill (like [`apply_field_richtext_change`](Self::apply_field_richtext_change));
+    /// [`commit_field`](Self::commit_field) is the typed door that enforces
+    /// `richtext(inline)`, and a violation otherwise surfaces at validate/render.
+    ///
+    /// Returns [`EditError::InvalidFieldName`] for a malformed name,
+    /// [`EditError::FieldRichtextDecode`] when the field is present but is not a
+    /// richtext corpus (a scalar a `set_field` wrote), and
+    /// [`EditError::BodyImport`] on an over-nested markdown input.
+    pub fn revise_field(&mut self, name: &str, body: impl Into<String>) -> Result<Delta, EditError> {
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
+        }
+        let base = match self.field_richtext(name) {
+            Some(Ok(rt)) => rt,
+            Some(Err(e)) => {
+                return Err(EditError::FieldRichtextDecode {
+                    field: name.to_string(),
+                    message: e.into_message(),
+                })
+            }
+            None => RichText::empty(),
+        };
+        let (corpus, delta) = diff_import(&base, &body.into()).map_err(EditError::BodyImport)?;
+        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
+        self.payload_mut()
+            .insert(name.to_string(), QuillValue::from_json(canonical));
         Ok(delta)
     }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -186,7 +186,7 @@ fn test_document_set_quill_ref() {
 #[test]
 fn test_document_replace_body() {
     let mut doc = make_doc();
-    doc.main_mut().replace_body("New body content.").unwrap();
+    doc.main_mut().revise_body("New body content.").unwrap();
     assert_eq!(doc.main().body_markdown(), "New body content.\n");
 }
 
@@ -256,7 +256,7 @@ fn test_document_card_mut() {
     let mut doc = make_doc_with_cards();
     {
         let card = doc.card_mut(0).unwrap();
-        card.replace_body("Updated card body.").unwrap();
+        card.revise_body("Updated card body.").unwrap();
     }
     assert_eq!(doc.cards()[0].body_markdown(), "Updated card body.\n");
 }
@@ -534,7 +534,7 @@ fn test_card_remove_field_invalid_name_throws() {
 #[test]
 fn test_card_set_body() {
     let mut card = Card::new("note").unwrap();
-    card.replace_body("Card body text.").unwrap();
+    card.revise_body("Card body text.").unwrap();
     assert_eq!(card.body_markdown(), "Card body text.\n");
 }
 
@@ -546,7 +546,7 @@ fn test_card_set_body() {
 fn test_replace_body_reports_import_error() {
     let mut card = Card::new("note").unwrap();
     let deep = ">".repeat(crate::error::MAX_NESTING_DEPTH + 5);
-    match card.replace_body(&deep) {
+    match card.revise_body(&deep) {
         Err(EditError::BodyImport(_)) => {}
         other => panic!("expected BodyImport, got {other:?}"),
     }
@@ -560,20 +560,10 @@ fn test_replace_body_reports_import_error() {
     );
 }
 
-/// `set_body_corpus` installs a pre-built corpus verbatim — no markdown import.
+/// `install_body` installs a pre-built corpus verbatim — value semantics, no
+/// markdown import, lossless for corpus-only marks a markdown projection drops.
 #[test]
-fn test_set_body_corpus_sets_directly() {
-    let mut card = Card::new("note").unwrap();
-    let corpus = quillmark_richtext::import::from_markdown("**bold** body").unwrap();
-    card.set_body_corpus(corpus.clone());
-    assert_eq!(card.body(), &corpus);
-    assert_eq!(card.body_markdown(), "**bold** body\n");
-}
-
-/// `set_body_value` accepts a **canonical corpus object** and installs it
-/// verbatim — the corpus-native write path, lossless for corpus-only marks.
-#[test]
-fn test_set_body_value_accepts_corpus_object() {
+fn test_install_body_sets_directly() {
     use quillmark_richtext::model::{Mark, MarkKind};
 
     let mut corpus = quillmark_richtext::import::from_markdown("underlined body").unwrap();
@@ -584,10 +574,9 @@ fn test_set_body_value_accepts_corpus_object() {
         kind: MarkKind::Underline,
     });
     corpus.normalize();
-    let json = quillmark_richtext::serial::to_canonical_value(&corpus);
 
     let mut card = Card::new("note").unwrap();
-    card.set_body_value(&json).unwrap();
+    card.install_body(corpus.clone());
     assert_eq!(card.body(), &corpus);
     assert!(card
         .body()
@@ -596,38 +585,76 @@ fn test_set_body_value_accepts_corpus_object() {
         .any(|m| matches!(m.kind, MarkKind::Underline)));
 }
 
-/// `set_body_value` also accepts a **markdown string** (imported) and clears
-/// the body on `null` — the whole `Card.body` read shape (`RichText | string`)
-/// as a write. A non-corpus object / other shape is `EditError::BodyDecode`.
+/// `install_field` installs a pre-built corpus into a richtext field verbatim —
+/// the field-level twin of `install_body`, lossless for corpus-only marks, and
+/// reads back through `field_richtext`. A malformed name is rejected.
 #[test]
-fn test_set_body_value_accepts_markdown_and_null_and_rejects_bad() {
+fn test_install_field_sets_directly() {
+    use quillmark_richtext::model::{Mark, MarkKind};
+
+    let mut corpus = quillmark_richtext::import::from_markdown("underlined intro").unwrap();
+    corpus.marks.push(Mark {
+        start: 0,
+        end: 10,
+        kind: MarkKind::Underline,
+    });
+    corpus.normalize();
+
     let mut card = Card::new("note").unwrap();
+    card.install_field("intro", corpus.clone()).unwrap();
+    let read = card.field_richtext("intro").unwrap().unwrap();
+    assert_eq!(read, corpus);
+    assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 
-    card.set_body_value(&serde_json::json!("**bold** body")).unwrap();
-    assert_eq!(card.body_markdown(), "**bold** body\n");
-
-    card.set_body_value(&serde_json::Value::Null).unwrap();
-    assert!(card.body().is_blank());
-
-    // An object that is not a canonical corpus, and a bare number, both fail.
     assert_eq!(
-        card.set_body_value(&serde_json::json!({ "not": "a corpus" }))
+        card.install_field("$bad", quillmark_richtext::RichText::empty())
             .unwrap_err()
             .variant_name(),
-        "BodyDecode"
+        "InvalidFieldName"
     );
+}
+
+/// `revise_field` imports markdown into a richtext field with edit semantics,
+/// rebasing surviving anchors and returning the text delta. An absent field
+/// cold-imports from empty; a present non-corpus value is a decode error.
+#[test]
+fn test_revise_field_diff_imports_and_returns_delta() {
+    use quillmark_richtext::model::{Mark, MarkKind};
+
+    let mut card = Card::new("note").unwrap();
+    // Cold start against an absent field.
+    let delta = card.revise_field("intro", "hello target world").unwrap();
+    assert!(!delta.ops.is_empty());
+
+    // Anchor the field, then revise — the anchor rebases onto surviving text.
+    let mut base = card.field_richtext("intro").unwrap().unwrap();
+    base.marks.push(Mark {
+        start: 6,
+        end: 12, // "target"
+        kind: MarkKind::Anchor { id: "c1".into() },
+    });
+    base.normalize();
+    card.install_field("intro", base).unwrap();
+    card.revise_field("intro", "why keep the target here").unwrap();
+    let read = card.field_richtext("intro").unwrap().unwrap();
+    assert!(read
+        .marks
+        .iter()
+        .any(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1")));
+
+    // A present non-corpus scalar is a decode error.
+    card.set_field("count", crate::QuillValue::from_json(serde_json::json!(3)))
+        .unwrap();
     assert_eq!(
-        card.set_body_value(&serde_json::json!(42))
-            .unwrap_err()
-            .variant_name(),
-        "BodyDecode"
+        card.revise_field("count", "x").unwrap_err().variant_name(),
+        "FieldRichtextDecode"
     );
 }
 
 /// `commit_field` on a richtext field accepts a **canonical corpus object**,
 /// stores it as the field's canonical value (lossless for corpus-only marks),
-/// and reads back through `field_richtext` — the field-level twin of
-/// `set_body_value` / `body`.
+/// and reads back through `field_richtext` — the typed door beside the
+/// value-semantics `install_field` / `body`.
 #[test]
 fn test_commit_field_richtext_corpus_object_reads_back() {
     use quillmark_richtext::model::{Mark, MarkKind};
@@ -909,15 +936,15 @@ fn test_noncanonical_order_corpus_field_stays_structural() {
     );
 }
 
-/// `import_body_delta` updates the body and returns the text delta from the
-/// old body to the new — the recordable whole-document (stale-text) writer.
+/// `revise_body` updates the body and returns the text delta from the old body
+/// to the new — the recordable whole-document (stale-text) writer.
 #[test]
-fn test_import_body_delta_returns_delta_and_updates_body() {
+fn test_revise_body_returns_delta_and_updates_body() {
     use crate::{Assoc, Delta};
 
     let mut card = Card::new("note").unwrap();
-    card.replace_body("hello world").unwrap();
-    let delta: Delta = card.import_body_delta("hello brave world").unwrap();
+    card.revise_body("hello world").unwrap();
+    let delta: Delta = card.revise_body("hello brave world").unwrap();
     assert_eq!(card.body().text, "hello brave world");
     // The delta maps a stale position at the end of "hello " forward across
     // the inserted "brave ".
@@ -925,10 +952,10 @@ fn test_import_body_delta_returns_delta_and_updates_body() {
     assert_eq!(delta.map_pos(11, Assoc::After), 17);
 }
 
-/// A whole-document markdown replace rebases a surviving identity anchor onto
+/// A whole-document markdown revise rebases a surviving identity anchor onto
 /// the new text via `diff_import`, where the old fresh-import path dropped it.
 #[test]
-fn test_import_body_delta_rebases_anchor() {
+fn test_revise_body_rebases_anchor() {
     use quillmark_richtext::model::{Mark, MarkKind};
 
     let mut base = quillmark_richtext::import::from_markdown("keep the target word").unwrap();
@@ -940,9 +967,9 @@ fn test_import_body_delta_rebases_anchor() {
     });
     base.normalize();
     let mut card = Card::new("note").unwrap();
-    card.set_body_corpus(base);
+    card.install_body(base);
 
-    card.import_body_delta("why keep the target word").unwrap();
+    card.revise_body("why keep the target word").unwrap();
     let anchor = card
         .body()
         .marks
@@ -964,7 +991,7 @@ fn test_apply_body_change_applies_bundle() {
     use quillmark_richtext::model::MarkKind;
 
     let mut card = Card::new("note").unwrap();
-    card.replace_body("abc").unwrap();
+    card.revise_body("abc").unwrap();
     let d = diff("abc", "abXc");
     card.apply_body_change(
         &d,
@@ -995,7 +1022,7 @@ fn test_apply_body_change_reports_out_of_range() {
     use quillmark_richtext::model::MarkKind;
 
     let mut card = Card::new("note").unwrap();
-    card.replace_body("abc").unwrap();
+    card.revise_body("abc").unwrap();
     let identity = diff("abc", "abc");
     let result = card.apply_body_change(
         &identity,
@@ -1104,7 +1131,7 @@ fn test_invariants_after_mutation_sequence() {
     doc.remove_card(1); // summary, appendix
 
     // 6. Replace body
-    doc.main_mut().replace_body("Updated body.").unwrap();
+    doc.main_mut().revise_body("Updated body.").unwrap();
 
     // 7. Remove a payload field
     doc.main_mut().remove_field("version").unwrap();

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -128,16 +128,13 @@ pub struct CardWire {
     /// model (a corpus object, `{text, lines, marks, islands}`). The empty corpus
     /// when absent. A markdown string is also accepted on input (imported), so an
     /// LLM/markdown writer can still hand a string here.
+    ///
+    /// No `body_markdown` projection rides this wire: the eager `export ∘ body`
+    /// precompute was dropped (the delimiter-safety fix makes `to_markdown`
+    /// re-parse every rendered line, so it is no longer cheap) in favor of the
+    /// on-demand `exportMarkdown(body)` codec at the binding boundary.
     #[serde(default)]
     pub body: JsonValue,
-    /// The body's markdown projection (`export ∘ body`) — a read convenience, not
-    /// stored state. Always emitted (empty string for an empty body, so consumers
-    /// need not guard for absence); ignored on input (`body` is authoritative, so
-    /// a round-trip through this shape is lossless regardless of `bodyMarkdown`).
-    /// The snake_case `body_markdown` is also accepted on input (the Python dict
-    /// shape), like `payload_items`.
-    #[serde(default, alias = "body_markdown")]
-    pub body_markdown: String,
 }
 
 /// Failure converting a [`CardWire`] back into a [`Card`].
@@ -176,7 +173,6 @@ impl From<&Card> for CardWire {
             seed: None,
             payload_items: Vec::new(),
             body: quillmark_richtext::serial::to_canonical_value(card.body()),
-            body_markdown: card.body_markdown(),
         };
         for item in card.payload().items() {
             match item {
@@ -310,7 +306,7 @@ impl TryFrom<CardWire> for Card {
 /// of truth in two accepted encodings: a **corpus object** (an editor / a
 /// re-serialized card) is deserialized and validated; a **markdown string** (an
 /// LLM / markdown writer) is imported. `null`/absent is the empty corpus; any
-/// other shape is an invalid `$body`. `body_markdown` is never read.
+/// other shape is an invalid `$body`.
 fn body_from_wire(body: &JsonValue) -> Result<RichText, WireError> {
     let invalid = |reason: String| WireError::InvalidField {
         key: "$body".to_string(),
@@ -481,7 +477,6 @@ mod tests {
                 nested_fills: Vec::new(),
             }],
             body: JsonValue::Null,
-            body_markdown: String::new(),
         })
         .unwrap();
         let json = serde_json::to_value(CardWire::from(&card)).unwrap();
@@ -502,7 +497,6 @@ mod tests {
             seed: None,
             payload_items: Vec::new(),
             body: JsonValue::Null,
-            body_markdown: String::new(),
         })
         .unwrap_err();
         assert!(matches!(err, WireError::InvalidQuillReference { .. }));

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -49,7 +49,7 @@ pub mod session;
 pub use session::{ApplyError, Assoc, ChangeSet, Delta, LineOp, LiveSession, MarkOp, Op};
 
 /// The canonical corpus content model — re-exported so consumers of the
-/// document mutators ([`Card::set_body_corpus`], [`Card::apply_body_change`])
+/// document mutators ([`Card::install_body`], [`Card::apply_body_change`])
 /// can name the type without depending on `quillmark-richtext` directly.
 pub use quillmark_richtext::RichText;
 

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -792,7 +792,7 @@ main:
         );
         // Prose triggers the error; whitespace-only does not.
         let mut prose_card = typed_card("skills", &[("items", json!(["Rust"]))]);
-        prose_card.replace_body("Should not be here.").unwrap();
+        prose_card.revise_body("Should not be here.").unwrap();
         let doc = doc_with_typed_cards(&[], vec![prose_card]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
@@ -802,7 +802,7 @@ main:
         )));
 
         let mut ws_card = typed_card("skills", &[("items", json!(["Rust"]))]);
-        ws_card.replace_body("\n   \n").unwrap();
+        ws_card.revise_body("\n   \n").unwrap();
         let ok_doc = doc_with_typed_cards(&[], vec![ws_card]);
         assert!(validate_typed_document(&config, &ok_doc).is_ok());
     }

--- a/crates/richtext/Cargo.toml
+++ b/crates/richtext/Cargo.toml
@@ -14,6 +14,7 @@ description = "RichText corpus content model, canonical serialization, edit delt
 publish = true
 
 [dependencies]
+serde = { workspace = true }
 serde_json = { workspace = true }
 # The markdown projection's parser. This crate is the workspace's single home
 # for a CommonMark parser; render paths consume the corpus, never markdown.

--- a/crates/richtext/src/delta.rs
+++ b/crates/richtext/src/delta.rs
@@ -36,19 +36,28 @@
 //! follow-up.
 
 use crate::model::{Mark, MarkKind, RichText};
+use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
 use std::borrow::Cow;
 
 /// A per-field edit against a base corpus. Ops apply left-to-right, consuming
 /// base positions; `Retain`/`Delete` advance the base cursor, `Insert` adds new
 /// text. USV throughout.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializes as `{ "ops": [ {"retain": n} | {"insert": s} | {"delete": n} ] }`
+/// — plain, structured-clone-able data an editor bridge stores in a change
+/// record and maps its own positions through ([`map_pos`](Self::map_pos)). The
+/// serde shape is the wire the `rebase` codec and `applyChange` bundle carry
+/// across the language bindings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Delta {
     pub ops: Vec<Op>,
 }
 
-/// One delta operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// One delta operation. Serializes externally-tagged with a lowercase key
+/// (`{"retain": 5}`, `{"insert": "x"}`, `{"delete": 2}`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Op {
     /// Keep `n` chars of the base unchanged.
     Retain(usize),
@@ -58,8 +67,10 @@ pub enum Op {
     Delete(usize),
 }
 
-/// Which side of a same-position insertion a mapped point lands on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Which side of a same-position insertion a mapped point lands on. Serializes
+/// as `"before"` / `"after"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Assoc {
     /// Stay before inserted text.
     Before,

--- a/crates/richtext/src/lib.rs
+++ b/crates/richtext/src/lib.rs
@@ -49,8 +49,8 @@ pub use model::{
 };
 pub use normalize::normalize_markdown;
 pub use ops::{
-    line_op_from_value, line_op_to_value, mark_op_from_value, mark_op_to_value, ApplyError, LineOp,
-    MarkOp,
+    change_bundle_from_value, line_op_from_value, line_op_to_value, mark_op_from_value,
+    mark_op_to_value, ApplyError, LineOp, MarkOp,
 };
 pub use serial::ParseError;
 

--- a/crates/richtext/src/lib.rs
+++ b/crates/richtext/src/lib.rs
@@ -41,12 +41,17 @@ pub mod ops;
 pub mod serial;
 pub mod usv;
 
-pub use delta::{Assoc, Delta, Op};
+pub use delta::{diff_import, Assoc, Delta, Op};
+pub use export::to_markdown;
+pub use import::from_markdown;
 pub use model::{
     Container, Invariant, Island, Line, LineKind, Loss, Mark, MarkKind, RichText, Usv,
 };
 pub use normalize::normalize_markdown;
-pub use ops::{ApplyError, LineOp, MarkOp};
+pub use ops::{
+    line_op_from_value, line_op_to_value, mark_op_from_value, mark_op_to_value, ApplyError, LineOp,
+    MarkOp,
+};
 pub use serial::ParseError;
 
 /// Maximum container nesting depth the markdown codecs accept before erroring.

--- a/crates/richtext/src/ops.rs
+++ b/crates/richtext/src/ops.rs
@@ -203,6 +203,53 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
     }
 }
 
+/// Lower a committed change **bundle** object (`{delta?, lineOps?, markOps?}`) to
+/// core ops — the whole-bundle reader the `applyChange` verb needs, so each
+/// binding lowers a JS/Python bundle in one call instead of re-deriving the
+/// delta/op extraction. A missing `delta` is the identity (no text change); a
+/// missing/`null` op array is empty. Both camelCase (`lineOps`) and snake_case
+/// (`line_ops`) keys are accepted, so the one reader serves the wasm (camelCase)
+/// and Python (either) surfaces. The error is a message string the binding wraps
+/// in its own error type.
+#[allow(clippy::type_complexity)]
+pub fn change_bundle_from_value(
+    v: &Value,
+) -> Result<(Delta, Vec<LineOp>, Vec<MarkOp>), String> {
+    let obj = v
+        .as_object()
+        .ok_or("bundle must be an object { delta?, lineOps?, markOps? }")?;
+    let get = |snake: &str, camel: &str| obj.get(snake).or_else(|| obj.get(camel));
+    let delta = match get("delta", "delta") {
+        Some(Value::Null) | None => Delta { ops: Vec::new() },
+        Some(d) => serde_json::from_value(d.clone()).map_err(|e| format!("invalid delta: {e}"))?,
+    };
+    let line_ops = op_array(get("line_ops", "lineOps"), line_op_from_value, "lineOps")?;
+    let mark_ops = op_array(get("mark_ops", "markOps"), mark_op_from_value, "markOps")?;
+    Ok((delta, line_ops, mark_ops))
+}
+
+/// Lower an optional JSON array of op objects through `convert` (missing/`null`
+/// → empty), naming `what` in any shape-error message. The list twin shared by
+/// [`change_bundle_from_value`]'s line- and mark-op channels.
+fn op_array<T>(
+    value: Option<&Value>,
+    convert: impl Fn(&Value) -> Result<T, ParseError>,
+    what: &str,
+) -> Result<Vec<T>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    if value.is_null() {
+        return Ok(Vec::new());
+    }
+    let arr = value
+        .as_array()
+        .ok_or_else(|| format!("{what} must be an array"))?;
+    arr.iter()
+        .map(|v| convert(v).map_err(|e| format!("invalid {what}: {e}")))
+        .collect()
+}
+
 /// Why an apply failed — range or line index out of bounds, or invariants
 /// broken before normalization could repair them.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/richtext/src/ops.rs
+++ b/crates/richtext/src/ops.rs
@@ -53,6 +53,156 @@ pub enum LineOp {
     },
 }
 
+// ── Change-bundle wire (mark / line op ⇄ JSON) ──────────────────────────────
+//
+// [`Delta`] serializes through serde derive; [`MarkOp`] and [`LineOp`] carry
+// [`MarkKind`] / [`LineKind`] / [`Container`], whose canonical JSON is the
+// hand-written `serial` encoding (the `{type, …}` / `{kind, …}` discriminants a
+// `RichTextMark` / `RichTextLine` already uses). These converters reuse that
+// exact vocabulary so the `applyChange` bundle speaks the same shapes the
+// corpus read surface does, rather than a second serde-derived dialect. The
+// language bindings call them to lower a JS/Python bundle to core ops.
+
+use crate::serial::{
+    container_from_value, container_to_value, line_kind_from_value, line_kind_to_value,
+    mark_from_value, mark_to_value, ParseError,
+};
+use serde_json::{Map, Value};
+
+/// Encode a [`MarkOp`] to its wire object. `Add`/`Remove` carry the mark
+/// vocabulary (`{op, start, end, type, …}`); `RemoveAnchor` is `{op, id}`.
+pub fn mark_op_to_value(op: &MarkOp) -> Value {
+    let mut m = Map::new();
+    match op {
+        MarkOp::Add { start, end, kind } => {
+            m.insert("op".into(), "add".into());
+            merge_mark(&mut m, *start, *end, kind);
+        }
+        MarkOp::Remove { start, end, kind } => {
+            m.insert("op".into(), "remove".into());
+            merge_mark(&mut m, *start, *end, kind);
+        }
+        MarkOp::RemoveAnchor { id } => {
+            m.insert("op".into(), "removeAnchor".into());
+            m.insert("id".into(), Value::String(id.clone()));
+        }
+    }
+    Value::Object(m)
+}
+
+/// Merge a mark's `{start, end, type, …}` fields into an op object, reusing the
+/// canonical `serial` mark encoding.
+fn merge_mark(m: &mut Map<String, Value>, start: Usv, end: Usv, kind: &MarkKind) {
+    let mark = Mark {
+        start,
+        end,
+        kind: kind.clone(),
+    };
+    if let Value::Object(fields) = mark_to_value(&mark) {
+        m.extend(fields);
+    }
+}
+
+/// Decode a [`MarkOp`] from its wire object. Dispatches on `op`; `add`/`remove`
+/// read the mark vocabulary through [`mark_from_value`].
+pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("mark op"))?;
+    match o.get("op").and_then(Value::as_str) {
+        Some("add") => {
+            let mark = mark_from_value(v)?;
+            Ok(MarkOp::Add {
+                start: mark.start,
+                end: mark.end,
+                kind: mark.kind,
+            })
+        }
+        Some("remove") => {
+            let mark = mark_from_value(v)?;
+            Ok(MarkOp::Remove {
+                start: mark.start,
+                end: mark.end,
+                kind: mark.kind,
+            })
+        }
+        Some("removeAnchor") => Ok(MarkOp::RemoveAnchor {
+            id: o
+                .get("id")
+                .and_then(Value::as_str)
+                .ok_or(ParseError::Shape("removeAnchor id"))?
+                .to_string(),
+        }),
+        _ => Err(ParseError::Shape("mark op kind")),
+    }
+}
+
+/// Encode a [`LineOp`] to its wire object. `SetKind` flattens the line-kind
+/// discriminant (`kind`/`level`/`lang`) alongside `op`/`line`.
+pub fn line_op_to_value(op: &LineOp) -> Value {
+    let mut m = Map::new();
+    match op {
+        LineOp::Split { at } => {
+            m.insert("op".into(), "split".into());
+            m.insert("at".into(), Value::from(*at));
+        }
+        LineOp::Join { line } => {
+            m.insert("op".into(), "join".into());
+            m.insert("line".into(), Value::from(*line));
+        }
+        LineOp::SetKind { line, kind } => {
+            m.insert("op".into(), "setKind".into());
+            m.insert("line".into(), Value::from(*line));
+            if let Value::Object(fields) = line_kind_to_value(kind) {
+                m.extend(fields);
+            }
+        }
+        LineOp::SetContainers { line, containers } => {
+            m.insert("op".into(), "setContainers".into());
+            m.insert("line".into(), Value::from(*line));
+            m.insert(
+                "containers".into(),
+                Value::Array(containers.iter().map(container_to_value).collect()),
+            );
+        }
+    }
+    Value::Object(m)
+}
+
+/// Decode a [`LineOp`] from its wire object. Dispatches on `op`.
+pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("line op"))?;
+    let line = || {
+        o.get("line")
+            .and_then(Value::as_u64)
+            .map(|n| n as usize)
+            .ok_or(ParseError::Shape("line op line"))
+    };
+    match o.get("op").and_then(Value::as_str) {
+        Some("split") => Ok(LineOp::Split {
+            at: o
+                .get("at")
+                .and_then(Value::as_u64)
+                .map(|n| n as usize)
+                .ok_or(ParseError::Shape("split at"))?,
+        }),
+        Some("join") => Ok(LineOp::Join { line: line()? }),
+        Some("setKind") => Ok(LineOp::SetKind {
+            line: line()?,
+            kind: line_kind_from_value(v)?,
+        }),
+        Some("setContainers") => Ok(LineOp::SetContainers {
+            line: line()?,
+            containers: o
+                .get("containers")
+                .and_then(Value::as_array)
+                .ok_or(ParseError::Shape("setContainers containers"))?
+                .iter()
+                .map(container_from_value)
+                .collect::<Result<_, _>>()?,
+        }),
+        _ => Err(ParseError::Shape("line op kind")),
+    }
+}
+
 /// Why an apply failed — range or line index out of bounds, or invariants
 /// broken before normalization could repair them.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -537,6 +687,67 @@ mod tests {
     use super::*;
     use crate::delta::diff;
     use crate::import::from_markdown;
+
+    #[test]
+    fn mark_op_wire_round_trips_each_variant() {
+        let ops = vec![
+            MarkOp::Add {
+                start: 0,
+                end: 3,
+                kind: MarkKind::Strong,
+            },
+            MarkOp::Add {
+                start: 1,
+                end: 2,
+                kind: MarkKind::Link {
+                    url: "https://x".into(),
+                },
+            },
+            MarkOp::Remove {
+                start: 4,
+                end: 6,
+                kind: MarkKind::Anchor { id: "c1".into() },
+            },
+            MarkOp::RemoveAnchor { id: "c2".into() },
+        ];
+        for op in ops {
+            let v = mark_op_to_value(&op);
+            assert_eq!(mark_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        }
+    }
+
+    #[test]
+    fn line_op_wire_round_trips_each_variant() {
+        let ops = vec![
+            LineOp::Split { at: 5 },
+            LineOp::Join { line: 1 },
+            LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Heading { level: 2 },
+            },
+            LineOp::SetContainers {
+                line: 2,
+                containers: vec![Container::Quote],
+            },
+        ];
+        for op in ops {
+            let v = line_op_to_value(&op);
+            assert_eq!(line_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        }
+    }
+
+    #[test]
+    fn delta_serde_shape() {
+        let d = Delta {
+            ops: vec![Op::Retain(2), Op::Insert("hi".into()), Op::Delete(1)],
+        };
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({"ops": [{"retain": 2}, {"insert": "hi"}, {"delete": 1}]})
+        );
+        assert_eq!(serde_json::from_value::<Delta>(v).unwrap(), d);
+    }
 
     #[test]
     fn apply_text_delta_rebases_marks() {

--- a/crates/richtext/src/serial.rs
+++ b/crates/richtext/src/serial.rs
@@ -139,9 +139,13 @@ fn arr<'a>(obj: &'a Map<String, Value>, key: &'static str) -> Result<&'a Vec<Val
 
 // ---- Line ----
 
-fn line_to_value(line: &Line) -> Value {
+/// Encode a [`LineKind`] into its canonical `kind` fields (`"para"`,
+/// `{"kind":"heading","level":n}`, …). Public so the mark/line **op** wire
+/// ([`crate::ops`]) reuses the exact discriminant a `RichTextLine` carries,
+/// rather than forking the encoding.
+pub fn line_kind_to_value(kind: &LineKind) -> Value {
     let mut m = Map::new();
-    match &line.kind {
+    match kind {
         LineKind::Para => {
             m.insert("kind".into(), "para".into());
         }
@@ -162,6 +166,39 @@ fn line_to_value(line: &Line) -> Value {
             m.insert("kind".into(), "rule".into());
         }
     }
+    Value::Object(m)
+}
+
+/// Decode a [`LineKind`] from an object carrying the canonical `kind` fields.
+/// The inverse of [`line_kind_to_value`]; the shared line-kind reader for
+/// [`line_from_value`] and the line-op wire.
+pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
+    let o = v.as_object().ok_or(ParseError::Shape("line"))?;
+    match o.get("kind").and_then(Value::as_str) {
+        Some("para") => Ok(LineKind::Para),
+        Some("heading") => {
+            let level = o
+                .get("level")
+                .and_then(Value::as_u64)
+                .ok_or(ParseError::Shape("heading level"))?;
+            if !(1..=6).contains(&level) {
+                return Err(ParseError::Shape("heading level"));
+            }
+            Ok(LineKind::Heading { level: level as u8 })
+        }
+        Some("code") => Ok(LineKind::Code {
+            lang: o.get("lang").and_then(Value::as_str).map(str::to_string),
+        }),
+        Some("island") => Ok(LineKind::Island),
+        Some("rule") => Ok(LineKind::Rule),
+        _ => Err(ParseError::Shape("line kind")),
+    }
+}
+
+fn line_to_value(line: &Line) -> Value {
+    let Value::Object(mut m) = line_kind_to_value(&line.kind) else {
+        unreachable!("line_kind_to_value always returns an object")
+    };
     m.insert(
         "containers".into(),
         Value::Array(line.containers.iter().map(container_to_value).collect()),
@@ -176,25 +213,7 @@ fn line_to_value(line: &Line) -> Value {
 
 fn line_from_value(v: &Value) -> Result<Line, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("line"))?;
-    let kind = match o.get("kind").and_then(Value::as_str) {
-        Some("para") => LineKind::Para,
-        Some("heading") => {
-            let level = o
-                .get("level")
-                .and_then(Value::as_u64)
-                .ok_or(ParseError::Shape("heading level"))?;
-            if !(1..=6).contains(&level) {
-                return Err(ParseError::Shape("heading level"));
-            }
-            LineKind::Heading { level: level as u8 }
-        }
-        Some("code") => LineKind::Code {
-            lang: o.get("lang").and_then(Value::as_str).map(str::to_string),
-        },
-        Some("island") => LineKind::Island,
-        Some("rule") => LineKind::Rule,
-        _ => return Err(ParseError::Shape("line kind")),
-    };
+    let kind = line_kind_from_value(v)?;
     let containers = o
         .get("containers")
         .and_then(Value::as_array)
@@ -210,7 +229,10 @@ fn line_from_value(v: &Value) -> Result<Line, ParseError> {
     })
 }
 
-fn container_to_value(c: &Container) -> Value {
+/// Encode a [`Container`] into its canonical wire object. Public so the line-op
+/// wire ([`crate::ops`]) reuses the same container shape a `RichTextLine`
+/// carries.
+pub fn container_to_value(c: &Container) -> Value {
     let mut m = Map::new();
     match c {
         Container::ListItem {
@@ -230,7 +252,9 @@ fn container_to_value(c: &Container) -> Value {
     Value::Object(m)
 }
 
-fn container_from_value(v: &Value) -> Result<Container, ParseError> {
+/// Decode a [`Container`] from its canonical wire object. The inverse of
+/// [`container_to_value`].
+pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("container"))?;
     match o.get("container").and_then(Value::as_str) {
         Some("list_item") => Ok(Container::ListItem {
@@ -245,7 +269,10 @@ fn container_from_value(v: &Value) -> Result<Container, ParseError> {
 
 // ---- Mark ----
 
-fn mark_to_value(mark: &Mark) -> Value {
+/// Encode a [`Mark`] (`{start, end, type, …}`) into its canonical wire object.
+/// Public so the mark-op wire ([`crate::ops`]) reuses the exact `type`
+/// discriminant a `RichTextMark` carries.
+pub fn mark_to_value(mark: &Mark) -> Value {
     let mut m = Map::new();
     m.insert("start".into(), Value::from(mark.start));
     m.insert("end".into(), Value::from(mark.end));
@@ -281,7 +308,10 @@ fn mark_to_value(mark: &Mark) -> Value {
     Value::Object(m)
 }
 
-fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
+/// Decode a [`Mark`] from its canonical wire object. The inverse of
+/// [`mark_to_value`]; the shared mark reader for the corpus decoder and the
+/// mark-op wire.
+pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("mark"))?;
     let start = o
         .get("start")

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -82,6 +82,87 @@ line, a grid cell, `measure(..)` — no longer triggers Typst's non-fatal
 "parbreak may not occur inside of a paragraph" warning. No plate change is
 needed; block (`inline` omitted) richtext is unaffected.
 
+## The addressed richtext write surface + corpus codec (#925)
+
+The richtext write surface was a grid: every verb stamped out once per address
+(main / card-at-index), and the fix window for it was still open (nearly the
+whole write surface is unreleased). #925 collapses the grid into **one codec
+layer plus four addressed verbs**, and — the field gap that motivated it —
+gives richtext *fields* the anchor-preserving `diff_import` writer they lacked.
+All of this is **pre-release reshaping**: only three released names churn (the
+deprecations below); everything else is added or retired outright.
+
+### Layer 1 — the document-free corpus codec
+
+Four pure functions (no document, no handle) — wasm free functions / Python
+module functions:
+
+| Codec | wasm | Python |
+|---|---|---|
+| markdown → corpus | `importMarkdown(md): RichText` | `import_markdown(md) -> dict` |
+| corpus → markdown | `exportMarkdown(rt): string` | `export_markdown(rt) -> str` |
+| cold-import + diff | `rebase(base, md): { corpus, delta }` | `rebase(base, md) -> dict` |
+| map a position | `mapPos(delta, pos, assoc): number` | `map_pos(delta, pos, assoc) -> int` |
+
+`exportMarkdown(body)` **replaces the eager `bodyMarkdown` / `fieldMarkdown` /
+`cardFieldMarkdown` projections** — dropped from the `Card` DTO and the always-
+emitted `CardWire.body_markdown` before either shipped. The precompute is no
+longer cheap (the delimiter-safety fix makes `to_markdown` re-parse every
+rendered line), so it is on-demand now. `Delta` is plain, structured-clone-able
+data (`{ops: [{retain}|{insert}|{delete}]}`) that stores in a change record and
+maps positions through with `mapPos`.
+
+### Layer 2 — four addressed content verbs
+
+An **address** locates a richtext value: `{ card?, field? }` in wasm (absent
+`field` = body, absent `card` = main); the same axis as kwargs in Python
+(`card=`, `field=`).
+
+| Verb | wasm | Python | Semantics |
+|---|---|---|---|
+| install | `doc.install(addr, rt)` | `doc.install(rt, card=, field=)` | value: store exactly this corpus (anchors of the old value gone) |
+| revise | `doc.revise(addr, md) → Delta` | `doc.revise(md, card=, field=) -> dict` | edit: `diff_import`, anchors rebase, returns the delta receipt |
+| applyChange | `doc.applyChange(addr, bundle)` | `doc.apply_change(bundle, card=, field=)` | editor splice: `{ delta?, lineOps?, markOps? }` |
+| commit | `doc.commit(addr, value, quill)` | `doc.commit(value, quill, field=, card=)` | typed, schema-carried (field required) |
+
+The cold (anchor-losing) path is spelled at the call site —
+`install(addr, importMarkdown(md))` — so anchor loss is visible in source;
+`revise` is the default for "here's new markdown." `revise` stays a fused verb
+(not `rebase` + `install`) for atomicity against interleaved mutation.
+
+**Retired pre-release** (the grid the four verbs replace — no deprecation):
+
+| Retired | Use instead |
+|---|---|
+| wasm `setBody` / `setCardBody` (corpus writes) | `install(addr, rt)` |
+| wasm `replaceCardBody` (markdown card body) | `revise({ card: i }, md)` |
+| wasm `fieldMarkdown` / `cardFieldMarkdown` | `exportMarkdown(fieldCorpus)` |
+| wasm `Card.bodyMarkdown` / `CardWire.body_markdown` | `exportMarkdown(card.body)` |
+| Python `set_body` / `set_card_body` | `install(rt, card=, field=)` |
+| Python `replace_card_body` | `revise(md, card=i)` |
+| Python `field_markdown` / `card_field_markdown` / `body_markdown` | `export_markdown(corpus)` |
+
+Core mirrors the vocabulary, not the addressing (wasm-bindgen cannot export
+`&mut Card`, pyo3 classes carry no lifetimes, so only the bindings need the
+runtime `Addr`): `Card::install_body(rt)` / `revise_body(md) -> Delta` replace
+the `set_body_corpus` / `replace_body` / `import_body_delta` trio, and the field
+twins `Card::install_field(name, rt)` / **`revise_field(name, md) -> Delta`**
+(new — the field-level `diff_import`) close the gap where a richtext field had
+no anchor-preserving markdown writer. `install`/`revise` on a field are
+schema-blind (the corpus-writer stratum splices without the quill, like
+`apply_field_richtext_change`); `commit` is the typed door that enforces
+`richtext(inline)`, and a violation otherwise surfaces at validate/render.
+
+### The three released-API deprecations
+
+Only these three shipped at v0.92.1, so only these get a one-cycle alias:
+
+| Deprecated (aliased for one cycle) | Alias for |
+|---|---|
+| wasm `replaceBody(md)` | `revise({}, md)` (delta discarded) |
+| Python `replace_body(md)` | `revise(md)` (delta discarded) |
+| Python `update_card_body(index, md)` | `revise(md, card=index)` |
+
 ## Typed field writes: `commit_field` and the schema-bound editor (#893)
 
 The type a write commits belongs in the **schema**, not the method name — so
@@ -98,9 +179,11 @@ pre-release** and folded into the one typed writer below.
 | wasm `updateCardRichtextField(index, name, value, inline?)` | wasm `commitCardField(quill, index, name, value)` |
 | — (Python had no richtext field writer) | Python `Document.commit_field(quill, name, value)` / `commit_card_field(quill, index, name, value)` |
 
-Read twins are unchanged: `Card::field_richtext(name)` / `field_markdown(name)`
-(wasm `fieldMarkdown` / `cardFieldMarkdown`), and the incremental splice
-`Card::apply_field_richtext_change(name, ..)`.
+The corpus read twin is `Card::field_richtext(name)`; the markdown projection
+is the on-demand `exportMarkdown(fieldCorpus)` codec (the eager `field_markdown`
+/ wasm `fieldMarkdown` / `cardFieldMarkdown` projections retired in #925, above).
+The incremental splice is `Card::apply_field_richtext_change(name, ..)`, exposed
+at the boundary as `applyChange({ field }, bundle)`.
 
 - **`commit_field` is not richtext-specific.** It commits *any* field type: a
   richtext value imports/adopts the corpus (storing the canonical corpus object,
@@ -135,18 +218,18 @@ The wire and the storage DTO are unaffected.
 
 [`TypedEditor`]: the `editor` module in `quillmark-core`.
 
-### Card bodies: `setCardBody` completes the corpus write surface (#892)
+### Card bodies close the corpus write surface (#892, reshaped by #925)
 
-wasm `setCardBody(index, RichText | string)` is the card-indexed twin of
-`setBody` — the corpus-native counterpart to `replaceCardBody`, which stays
-markdown-only. It closes the one remaining markdown-forced write: a **non-main
-card body**. `commitCardField(quill, index, "$body", …)` is never a path —
-`$body`'s reserved `$`-prefix fails the field-name check — so a card body needs
-its own writer, backed by the existing `Card::set_body_value` (the same core
-primitive `setBody` uses). A corpus-native editor can now write every address —
-main body, main/card richtext fields, and card bodies — with no markdown
-intermediary. Card bodies already read back as corpus via `cards[i].body`
-(markdown via `cards[i].bodyMarkdown`), so this closes the read/write asymmetry.
+The non-main card body — the one address `commitCardField(quill, index, "$body",
+…)` can never reach, since `$body`'s reserved `$`-prefix fails the field-name
+check — is written through the addressed verbs like any other: `install({ card:
+i }, rt)` (corpus, value semantics) or `revise({ card: i }, md)` (markdown, edit
+semantics). A corpus-native editor writes every address — main body, main/card
+richtext fields, and card bodies — with no per-address method to forget. Card
+bodies read back as corpus via `cards[i].body` (markdown via
+`exportMarkdown(cards[i].body)`). (The intermediate `setCardBody` /
+`replaceCardBody` writers from an earlier draft of this cycle were retired
+pre-release into `install` / `revise`.)
 
 ### On-disk identity is markdown-lossy by design
 
@@ -171,16 +254,18 @@ surface is pre-release):
 |---|---|---|
 | wasm `updateCardField` / py `update_card_field` | `setCardField` / `set_card_field` | `setField` / `set_field` |
 | wasm `updateCardFields` / py `update_card_fields` | `setCardFields` / `set_card_fields` | `setFields` / `set_fields` |
-| wasm `updateCardBody` / py `update_card_body` | `replaceCardBody` / `replace_card_body` | `replaceBody` / `replace_body` |
 
 Behavior is unchanged — only the names move. `setCardField` stores opaquely
-(the card twin of `setField`); `replaceCardBody` imports a markdown body (the
-card twin of `replaceBody`), distinct from the corpus-native `setCardBody`.
+(the card twin of `setField`). The card *body* writer this section originally
+renamed (`updateCardBody` → `replaceCardBody`) was superseded by #925's
+addressed `revise({ card: i }, md)`; Python keeps `update_card_body` as a
+one-cycle deprecated alias for it (it was a released name), while the unreleased
+`replaceCardBody` / `replace_card_body` were retired outright.
 
-The write-verb set is now small and each verb names one discipline: **`set`**
-(store opaque), **`commit`** (typed, per #893), **`replace`** (markdown body
-import), **`remove`**. The already-mechanical twins (`setCardExt`,
-`removeCardField`, `commitCardField`, `setCardBody`, `cardFieldMarkdown`) are
+The opaque/typed field write-verb set stays small — **`set`** (store opaque),
+**`commit`** (typed, per #893), **`remove`** — with body/richtext writes handled
+by the addressed `install` / `revise` / `applyChange` verbs (#925). The already-
+mechanical twins (`setCardExt`, `removeCardField`, `commitCardField`) are
 unaffected.
 
 ## wasm `Card` read/write split: `body: RichText` on read, `CardInput` on write (#917)
@@ -198,8 +283,9 @@ no signal at all. The read and write shapes are now two types:
 | returned by | `main` / `cards` / `removeCard` / `seedMain` / `seedCard` / `makeCard` | — |
 | accepted by | — | `pushCard` / `insertCard` |
 
-- **Read `card.body` is now `RichText`.** No narrowing, no provenance guess. Read
-  `card.bodyMarkdown` for the markdown projection (unchanged).
+- **Read `card.body` is now `RichText`.** No narrowing, no provenance guess. For
+  the markdown projection call `exportMarkdown(card.body)` (the eager
+  `bodyMarkdown` projection was dropped in #925).
 - **`pushCard` / `insertCard` accept `CardInput`.** `body` still takes a markdown
   string, and — new — every field but `kind` is optional, so a bare
   `doc.pushCard({ kind: "note", body: "…" })` type-checks (it always ran; the old
@@ -208,10 +294,10 @@ no signal at all. The read and write shapes are now two types:
   `pushCard(seedCard("note"))`, and `pushCard(makeCard(…))` all still type-check —
   a card read from one document pushes straight into another.
 - **Breaking for TS only.** A variable annotated `Card` that held a
-  freshly-built `{ kind, body: "md", payloadItems: [], bodyMarkdown: "" }` for
-  `pushCard` should be re-annotated `CardInput` (or left inferred). Runtime
-  behavior, the storage DTO, and the Python binding (dynamically typed;
-  `card.body` already returns the corpus dict) are unchanged.
+  freshly-built `{ kind, body: "md", payloadItems: [] }` for `pushCard` should be
+  re-annotated `CardInput` (or left inferred). Runtime behavior, the storage DTO,
+  and the Python binding (dynamically typed; `card.body` already returns the
+  corpus dict) are unchanged. (`bodyMarkdown` is no longer a `Card` field — #925.)
 
 `CardInput` is not the pre-0.88 flat input DTO (a divergent shape, removed in
 0.87 → 0.88): it is structurally `Card` with `body` widened and the read-only
@@ -228,8 +314,8 @@ a parallel core-side position map: `positionAt` (point → corpus position) and
 `locate` (corpus position → caret rect) are exact inverses over the current
 compile and are the whole bidirectional cursor bridge, needing no forward map.
 
-A live editor writes a field with `commitField(quill, name, value)` (or
-`setBody`) and recompiles with `apply(doc)`. Typst recompiles incrementally either way
+A live editor writes a field with `commit({ field }, value, quill)` (or the body
+with `install` / `revise`) and recompiles with `apply(doc)`. Typst recompiles incrementally either way
 (`Source::replace` + `comemo`), so a whole-field write costs the same on the
 compile as a splice would have — the delta path bought no incrementality it did
 not already have. `CorpusHit` / `FieldRegion` carry no `revision`.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -21,13 +21,19 @@ guides in order.
   mismatch at the write, not at render (#893). Live field edits go through the
   writer + `apply(doc)` (the experimental `applyFieldDelta` / change-log surface
   was removed, #886). Card-write verbs become mechanical twins of their
-  main-card names — `updateCardField`/`updateCardFields`/`updateCardBody` rename
-  to `setCardField`/`setCardFields`/`replaceCardBody` (#895). The wasm `Card`
+  main-card names — `updateCardField`/`updateCardFields` rename to
+  `setCardField`/`setCardFields` (#895). The wasm `Card`
   shape splits by direction: a read `Card` always has `body: RichText`, while
   `pushCard` / `insertCard` take a `CardInput` whose `body` still accepts a
-  markdown string and whose non-`kind` fields are optional (#917). On-disk
-  (`.qmd`) identity stays markdown-lossy — the storage DTO is the lossless
-  carrier.
+  markdown string and whose non-`kind` fields are optional (#917). The richtext
+  write grid then collapses into a document-free corpus codec (`importMarkdown`
+  / `exportMarkdown` / `rebase` / `mapPos`) plus four addressed content verbs
+  (`install` / `revise` / `applyChange` / `commit`); the eager
+  `bodyMarkdown`/`fieldMarkdown` projections and the per-address body writers
+  retire pre-release, `replaceBody` / `replace_body` / `update_card_body` alias
+  for one cycle, and richtext fields gain the anchor-preserving `revise_field`
+  (#925). On-disk (`.qmd`) identity stays markdown-lossy — the storage DTO is
+  the lossless carrier.
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now


### PR DESCRIPTION
Add serde derives to Delta/Op/Assoc and public mark/line-op JSON wire
converters (reusing the serial mark/line vocabulary) for the addressed
applyChange bundle. Re-export the pure codec (from_markdown/to_markdown/
diff_import) from the richtext root.

Core: rename set_body_corpus -> install_body; collapse replace_body/
import_body_delta into revise_body(md) -> Delta; add install_field(name, rt)
and the field-level diff_import revise_field(name, md) -> Delta (schema-blind,
splice precedent). Remove set_body_value. Drop the eager body_markdown
projection from CardWire (exportMarkdown composition replaces it).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QvyMAMQiqWJn8zwKkYhyXH