### PR TITLE
core: TypedEditor set_body + add_card (tier-1 mirror verbs)

### DIFF
--- a/crates/bindings/python/src/lib.rs
+++ b/crates/bindings/python/src/lib.rs
@@ -7,7 +7,8 @@ mod types;
 pub use enums::{PyOutputFormat, PySeverity};
 pub use errors::{convert_edit_error, convert_render_error, QuillmarkError};
 pub use types::{
-    PyArtifact, PyDiagnostic, PyDocument, PyLocation, PyQuill, PyQuillmark, PyRenderResult,
+    PyArtifact, PyCardEditor, PyDiagnostic, PyDocument, PyEditor, PyLocation, PyQuill, PyQuillmark,
+    PyRenderResult,
 };
 
 #[pymodule]
@@ -15,6 +16,8 @@ fn _quillmark(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyQuillmark>()?;
     m.add_class::<PyQuill>()?;
     m.add_class::<PyDocument>()?;
+    m.add_class::<PyEditor>()?;
+    m.add_class::<PyCardEditor>()?;
     m.add_class::<PyRenderResult>()?;
     m.add_class::<PyArtifact>()?;
     m.add_class::<PyDiagnostic>()?;

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -507,6 +507,41 @@ impl PyDocument {
         Ok(result)
     }
 
+    /// Bind `quill`'s schema to this document for typed writes — the documented
+    /// front door, mirroring core `quill.editor(&mut doc)` and WASM
+    /// `quill.editor(doc)`. Returns an `Editor` holding both objects by reference
+    /// and re-borrowing per call (pyo3 objects carry no lifetime, so the editor
+    /// cannot hold the borrow the way core's `TypedEditor` does). Ephemeral by
+    /// convention — bind, write, discard.
+    fn editor(slf: Py<Self>, quill: Py<PyQuill>) -> PyEditor {
+        PyEditor { quill, doc: slf }
+    }
+
+    /// Read a main-card field's stored value — a dict for a richtext corpus, a
+    /// scalar/list/dict otherwise, or `None` when the field is absent. The
+    /// quill-free read: reads need no schema, so they live on `Document`, not the
+    /// typed editor. For the markdown projection of a richtext value use
+    /// `get_markdown`. Mirrors WASM `Document.get`.
+    fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
+        match self.inner.main().payload().get(name) {
+            Some(v) => Ok(Some(quillvalue_to_py(py, v)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// The markdown projection of a main-card field (`name` given) or the main
+    /// body (`name` omitted) — the on-demand, lossy export (corpus-only marks do
+    /// not survive markdown), returning `""` for an absent field. Re-coins,
+    /// lazily and by name, the projection the eager `field_markdown` /
+    /// `body_markdown` getters dropped in #925. Mirrors WASM `Document.getMarkdown`.
+    #[pyo3(signature = (name=None))]
+    fn get_markdown(&self, name: Option<&str>) -> String {
+        match name {
+            Some(n) => self.inner.main().field_markdown(n).unwrap_or_default(),
+            None => self.inner.main().body_markdown(),
+        }
+    }
+
     /// Store an opaque value on a main-card field, clearing any `!must_fill`
     /// marker. The quill-free primitive: it holds only the `$quill` *reference*,
     /// stores the value verbatim, and defers coercion/validation to render.
@@ -936,12 +971,187 @@ impl PyDocument {
 
     /// Resolve the card an address targets: the main card when `card` is `None`,
     /// else the composable card at that index (out-of-range raises). The static
-    /// address axis the four addressed content verbs share.
+    /// address axis the addressed content verbs share.
     fn addr_card_mut(&mut self, card: Option<usize>) -> PyResult<&mut quillmark_core::Card> {
         match card {
             None => Ok(self.inner.main_mut()),
             Some(index) => self.card_mut_or_raise(index),
         }
+    }
+}
+
+/// A `Document` bound to its `Quill` for typed writes — the tier-1 default,
+/// from `Document.editor(quill)`. Speaks names, values, and markdown; a consumer
+/// here never meets an address, a corpus dict, or a delta. It holds both objects
+/// by reference and re-borrows them per call (pyo3 objects carry no lifetime, so
+/// unlike core's `TypedEditor` it cannot keep the borrow) — so it is ephemeral by
+/// convention: bind, write, discard. Mirrors WASM `quill.editor(doc)`.
+#[pyclass(name = "Editor")]
+pub struct PyEditor {
+    quill: Py<PyQuill>,
+    doc: Py<PyDocument>,
+}
+
+#[pymethods]
+impl PyEditor {
+    /// The bound document — the same object passed in, mutated in place.
+    #[getter]
+    fn document(&self, py: Python<'_>) -> Py<PyDocument> {
+        self.doc.clone_ref(py)
+    }
+
+    /// Typed-commit one main-card field (strict coerce, mismatch raises now).
+    /// Raises `[EditError::UnknownField]` for a name the schema does not declare.
+    fn set(&self, py: Python<'_>, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let qv = py_to_quillvalue(&value)?;
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .editor(&mut doc.inner)
+            .set(name, qv)
+            .map_err(convert_edit_error)
+    }
+
+    /// Typed-commit several main-card fields atomically — nothing is applied on
+    /// error, and the raised `QuillmarkError` carries one diagnostic per offending
+    /// field (an `[EditError::UnknownField]` per undeclared name).
+    fn set_all(&self, py: Python<'_>, fields: Bound<'_, PyDict>) -> PyResult<()> {
+        let batch = pydict_to_field_batch(&fields)?;
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .editor(&mut doc.inner)
+            .set_all(batch)
+            .map_err(convert_edit_errors)
+    }
+
+    /// Set the main body from markdown (edit semantics: anchors rebase),
+    /// discarding the delta — the receipt-free body write. Use `doc.revise(md)`
+    /// for the delta receipt.
+    fn set_body(&self, py: Python<'_>, markdown: &str) -> PyResult<()> {
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .editor(&mut doc.inner)
+            .set_body(markdown)
+            .map_err(convert_edit_error)
+    }
+
+    /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
+    /// body from optional markdown, and append it — the fused `make_card` + typed
+    /// commit + `push_card`. Transactional: a rejected field (raises a per-field
+    /// diagnostic bundle) or an invalid kind/body leaves the document untouched.
+    #[pyo3(signature = (kind, fields=None, body=None))]
+    fn add_card(
+        &self,
+        py: Python<'_>,
+        kind: &str,
+        fields: Option<Bound<'_, PyDict>>,
+        body: Option<String>,
+    ) -> PyResult<()> {
+        let batch = match fields {
+            Some(f) => pydict_to_field_batch(&f)?,
+            None => Vec::new(),
+        };
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .editor(&mut doc.inner)
+            .add_card(kind, batch, body.as_deref())
+            .map_err(convert_edit_errors)
+    }
+
+    /// Remove the composable card at `index`, returning it as a dict (or `None`
+    /// if the index is out of range) — the tier-1 spelling of
+    /// `Document.remove_card`.
+    fn remove_card<'py>(
+        &self,
+        py: Python<'py>,
+        index: usize,
+    ) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let mut doc = self.doc.borrow_mut(py);
+        match doc.inner.remove_card(index) {
+            Some(card) => Ok(Some(card_to_pydict(py, &card)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// A `CardEditor` for the composable card at `index`. The index is checked
+    /// lazily at the write, so this never raises. The cursor is ephemeral — a
+    /// `remove_card`/`add_card` between binding and writing silently retargets
+    /// it; for durable addressing stamp `$id` and re-resolve at write time.
+    fn card(&self, py: Python<'_>, index: usize) -> PyCardEditor {
+        PyCardEditor {
+            quill: self.quill.clone_ref(py),
+            doc: self.doc.clone_ref(py),
+            index,
+        }
+    }
+}
+
+/// A composable card bound to its `Quill` for typed writes, from `Editor.card`.
+/// Same verbs as `Editor`, targeting the card at its bound index; each write
+/// raises `[EditError::IndexOutOfRange]` if that index is out of range.
+#[pyclass(name = "CardEditor")]
+pub struct PyCardEditor {
+    quill: Py<PyQuill>,
+    doc: Py<PyDocument>,
+    index: usize,
+}
+
+#[pymethods]
+impl PyCardEditor {
+    /// The bound card index.
+    #[getter]
+    fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Typed-commit one field on this card, resolving its type from the card's
+    /// `$kind` schema. Raises `[EditError::UnknownField]` for an undeclared name
+    /// and `[EditError::IndexOutOfRange]` for a bad index.
+    fn set(&self, py: Python<'_>, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let qv = py_to_quillvalue(&value)?;
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .editor(&mut doc.inner)
+            .card(self.index)
+            .map_err(convert_edit_error)?
+            .set(name, qv)
+            .map_err(convert_edit_error)
+    }
+
+    /// Typed-commit several fields on this card atomically — same per-field
+    /// diagnostic bundle as `Editor.set_all`.
+    fn set_all(&self, py: Python<'_>, fields: Bound<'_, PyDict>) -> PyResult<()> {
+        let batch = pydict_to_field_batch(&fields)?;
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        let mut editor = quill.inner.editor(&mut doc.inner);
+        editor
+            .card(self.index)
+            .map_err(convert_edit_error)?
+            .set_all(batch)
+            .map_err(convert_edit_errors)
+    }
+
+    /// Set this card's body from markdown (edit semantics), discarding the delta.
+    fn set_body(&self, py: Python<'_>, markdown: &str) -> PyResult<()> {
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .editor(&mut doc.inner)
+            .card(self.index)
+            .map_err(convert_edit_error)?
+            .set_body(markdown)
+            .map_err(convert_edit_error)
     }
 }
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -490,32 +490,6 @@ impl PyDocument {
         .map_err(convert_edit_error)
     }
 
-    /// **Commit** a typed value at `(card, field)`, resolving the field's schema
-    /// `type` from `quill` — the one typed write verb for every field type, the
-    /// kwargs idiom of WASM `doc.commit(addr, value, quill)`. Requires `field`
-    /// (the body carries no schema type). A field the schema does not declare
-    /// raises `[EditError::UnknownField]`; a typed mismatch raises now, not at
-    /// render.
-    #[pyo3(signature = (value, quill, *, card=None, field))]
-    fn commit(
-        &mut self,
-        value: Bound<'_, PyAny>,
-        quill: PyRef<'_, PyQuill>,
-        card: Option<usize>,
-        field: &str,
-    ) -> PyResult<()> {
-        let qv = py_to_quillvalue(&value)?;
-        let mut editor = quill.inner.editor(&mut self.inner);
-        match card {
-            None => editor.set(field, qv).map_err(convert_edit_error),
-            Some(index) => editor
-                .card(index)
-                .map_err(convert_edit_error)?
-                .set(field, qv)
-                .map_err(convert_edit_error),
-        }
-    }
-
     /// Main (entry) card as a dict with `kind`, `quill`, `id`, `payload_items`,
     /// `ext`, `seed`, and `body`.
     #[getter]

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -547,9 +547,10 @@ impl PyDocument {
     /// stores the value verbatim, and defers coercion/validation to render.
     /// Reach for it deliberately — standalone data with no quill in hand,
     /// quill-agnostic storage/migration, or a store-now-validate-later editor
-    /// holding not-yet-conforming input. When a quill *is* in hand, prefer
-    /// `commit_field` (typed commit) so a mismatch surfaces at the write.
-    /// Raises `QuillmarkError` on a malformed name. Mirrors WASM `setField`.
+    /// holding not-yet-conforming input. When a quill *is* in hand, prefer the
+    /// typed editor (`doc.editor(quill).set(name, value)`) so a mismatch surfaces
+    /// at the write. Raises `QuillmarkError` on a malformed name. Mirrors WASM
+    /// `setField`.
     fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         self.inner
@@ -573,103 +574,16 @@ impl PyDocument {
     /// (database columns, form keys) surface every violation in one pass.
     ///
     /// The batched quill-free primitive (see `set_field`) — stores every value
-    /// opaquely, deferring coercion to render. Prefer `commit_fields` whenever a
-    /// quill is in hand: it typed-commits the batch and reports per-field
-    /// routing, so a form submitting a card is not silently stripped of schema
-    /// typing. Mirrors WASM `setFields`.
+    /// opaquely, deferring coercion to render. Prefer the typed editor
+    /// (`doc.editor(quill).set_all(fields)`) whenever a quill is in hand: it
+    /// typed-commits the batch and reports per-field routing, so a form
+    /// submitting a card is not silently stripped of schema typing. Mirrors WASM
+    /// `setFields`.
     fn set_fields(&mut self, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         self.inner
             .main_mut()
             .set_fields(batch)
-            .map_err(convert_edit_errors)
-    }
-
-    /// Typed field write on the main card, resolving the field's schema `type`
-    /// from `quill` — the one write verb for every field type. Python has no
-    /// richtext field writer otherwise, so a richtext value (a corpus dict or a
-    /// markdown string) commits to the canonical corpus here; scalars coerce to
-    /// their declared type (`"3"` → `3`).
-    ///
-    /// A field declared in the schema is strict-committed — a mismatch raises
-    /// now. A name the schema does not declare raises
-    /// `[EditError::UnknownField]` rather than falling to the opaque store: on
-    /// the typed path it is a typo. Use `set_field` when opaque storage is the
-    /// intent. Also raises `QuillmarkError` on a typed mismatch or a malformed
-    /// name. Mirrors WASM `commitField`.
-    fn commit_field(
-        &mut self,
-        quill: PyRef<'_, PyQuill>,
-        name: &str,
-        value: Bound<'_, PyAny>,
-    ) -> PyResult<()> {
-        let qv = py_to_quillvalue(&value)?;
-        quill
-            .inner
-            .editor(&mut self.inner)
-            .set(name, qv)
-            .map_err(convert_edit_error)
-    }
-
-    /// Batched twin of `commit_field`: typed-commit several main-card fields
-    /// atomically, resolving each field's schema `type` from `quill`. This is
-    /// the whole-card typed verb — prefer it over `set_fields` whenever a quill
-    /// is in hand, so a form submitting a card gets schema typing. All-or-nothing
-    /// with the same per-field-diagnostic error contract as `set_fields`: nothing
-    /// is applied on error and the raised `QuillmarkError` carries one diagnostic
-    /// per offending field (`path` = field name), including an
-    /// `[EditError::UnknownField]` for any name the schema does not declare, so a
-    /// whole-form submit sees every typo in one pass. Mirrors WASM `commitFields`.
-    fn commit_fields(
-        &mut self,
-        quill: PyRef<'_, PyQuill>,
-        fields: Bound<'_, PyDict>,
-    ) -> PyResult<()> {
-        let batch = pydict_to_field_batch(&fields)?;
-        quill
-            .inner
-            .editor(&mut self.inner)
-            .set_all(batch)
-            .map_err(convert_edit_errors)
-    }
-
-    /// Typed field write on the composable card at `index` — the card-indexed
-    /// twin of `commit_field`, resolving the field's type from the card's
-    /// `$kind` schema in `quill`. Raises `[EditError::UnknownField]` for a field
-    /// the card-kind schema does not declare (an unknown `$kind` has no schema,
-    /// so every field is undeclared), on an out-of-range index, or a typed
-    /// mismatch. Mirrors WASM `commitCardField`.
-    fn commit_card_field(
-        &mut self,
-        quill: PyRef<'_, PyQuill>,
-        index: usize,
-        name: &str,
-        value: Bound<'_, PyAny>,
-    ) -> PyResult<()> {
-        let qv = py_to_quillvalue(&value)?;
-        let mut editor = quill.inner.editor(&mut self.inner);
-        let mut card = editor.card(index).map_err(convert_edit_error)?;
-        card.set(name, qv).map_err(convert_edit_error)
-    }
-
-    /// Batched twin of `commit_card_field`: typed-commit several fields on the
-    /// composable card at `index` atomically, resolving each field's type from
-    /// the card's `$kind` schema in `quill`. All-or-nothing with the same
-    /// per-field-diagnostic contract as `commit_fields` (an
-    /// `[EditError::UnknownField]` per undeclared name). Raises on an
-    /// out-of-range index. Mirrors WASM `commitCardFields`.
-    fn commit_card_fields(
-        &mut self,
-        quill: PyRef<'_, PyQuill>,
-        index: usize,
-        fields: Bound<'_, PyDict>,
-    ) -> PyResult<()> {
-        let batch = pydict_to_field_batch(&fields)?;
-        let mut editor = quill.inner.editor(&mut self.inner);
-        editor
-            .card(index)
-            .map_err(convert_edit_error)?
-            .set_all(batch)
             .map_err(convert_edit_errors)
     }
 
@@ -914,8 +828,9 @@ impl PyDocument {
 
     /// Store an opaque value on the composable card at `index` — the
     /// card-indexed twin of `set_field`, and the same quill-free primitive.
-    /// Prefer `commit_card_field` when a quill is in hand. Raises on an
-    /// out-of-range index or a malformed name. Mirrors WASM `setCardField`.
+    /// Prefer the typed editor (`doc.editor(quill).card(index).set(...)`) when a
+    /// quill is in hand. Raises on an out-of-range index or a malformed name.
+    /// Mirrors WASM `setCardField`.
     fn set_card_field(
         &mut self,
         index: usize,
@@ -931,8 +846,8 @@ impl PyDocument {
     /// Batched twin of `set_card_field`: set several fields on the composable
     /// card at `index` atomically. Same all-or-nothing, one-diagnostic-per-field
     /// contract as `set_fields`, and the same quill-free-primitive framing —
-    /// prefer `commit_card_fields` when a quill is in hand. Mirrors WASM
-    /// `setCardFields`.
+    /// prefer the typed editor (`doc.editor(quill).card(index).set_all(...)`)
+    /// when a quill is in hand. Mirrors WASM `setCardFields`.
     fn set_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         self.card_mut_or_raise(index)?

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -643,6 +643,62 @@ def test_commit_card_field_index_out_of_range():
         doc.commit_card_field(quill, 0, "body", "x")
 
 
+# ── Tier-1 typed editor — doc.editor(quill) front door ────────────────────────
+
+
+def _taro_quill():
+    """The taro fixture quill (main string fields; a `quotes` card kind)."""
+    return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
+
+
+def test_editor_front_door_set_and_reads():
+    """doc.editor(quill).set writes; the reads live quill-free on the Document."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    ed = doc.editor(quill)
+    ed.set("author", "Ada")
+    ed.set_all({"title": "On Taro"})
+    assert ed.document is doc  # holds the same object, mutated in place
+    assert doc.get("author") == "Ada"
+    assert doc.get("missing") is None
+    ed.set_body("A **taro** essay.")
+    assert doc.get_markdown() == "A **taro** essay.\n"
+
+
+def test_editor_set_rejects_unknown_field():
+    """An undeclared name is a typo on the typed path — it raises, nothing lands."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        doc.editor(quill).set("stray", "x")
+    assert not has_field(doc.main, "stray")
+
+
+def test_editor_add_card_transactional():
+    """add_card fuses make + typed commit + push; a typo leaves the doc untouched."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    ed = doc.editor(quill)
+    ed.add_card("quotes", {"author": "Basho"}, "A quote body.")
+    assert len(doc.cards) == 1
+    assert field(doc.cards[0], "author") == "Basho"
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        ed.add_card("quotes", {"stray": "x"})
+    assert len(doc.cards) == 1  # nothing joined the document
+
+
+def test_editor_card_cursor_set_and_body():
+    """editor.card(i) targets the composable card; a bad index raises at the write."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    ed = doc.editor(quill)
+    ed.add_card("quotes", {"author": "Basho"})
+    ed.card(0).set("author", "Issa")
+    assert field(doc.cards[0], "author") == "Issa"
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        ed.card(9).set("author", "x")
+
+
 # ── Addressed content verbs — commit / revise / apply_change ──────────────────
 
 

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -646,19 +646,6 @@ def test_commit_card_field_index_out_of_range():
 # ── Addressed content verbs — commit / revise / apply_change ──────────────────
 
 
-def test_commit_addressed_typed_door():
-    """commit(value, quill, field=...) is the addressed typed door; the body has
-    no schema type so a field is required, and a typo raises UnknownField."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    doc.commit("A **bold** intro.", quill, field="bio")
-    assert isinstance(field(doc.main, "bio"), dict)
-    with pytest.raises(QuillmarkError, match="UnknownField"):
-        doc.commit("x", quill, field="stray")
-    with pytest.raises(TypeError):
-        doc.commit("x", quill)  # field is a required keyword
-
-
 def test_revise_field_and_apply_change_splice():
     """revise({field}) diff-imports a richtext field; apply_change splices marks."""
     quill = _richtext_form_quill()

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -596,54 +596,12 @@ def test_to_markdown_ambiguous_string_survival():
     assert field(doc2.main, "date_str") == "2024-01-15"
 
 
-# ── Typed field writes — commit_field / commit_card_field ─────────────────────
+# ── Tier-1 typed editor — doc.editor(quill) front door ────────────────────────
 
 
 def _richtext_form_quill():
     """The richtext_form fixture quill (headline: richtext inline, bio: richtext)."""
     return Quill.from_path(str(_latest_version(QUILLS_PATH / "richtext_form")))
-
-
-def test_commit_field_richtext_typed():
-    """commit_field resolves a richtext field's type and stores canonical corpus."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    doc.commit_field(quill, "bio", "A **bold** intro.")
-    value = field(doc.main, "bio")
-    # Stored structurally as the corpus dict, not the authored markdown string.
-    assert isinstance(value, dict)
-    assert value["text"] == "A bold intro."
-
-
-def test_commit_field_unknown_field_raises():
-    """A field absent from the schema is a typo on the typed path — it raises."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="UnknownField"):
-        doc.commit_field(quill, "stray", "x")
-    assert not has_field(doc.main, "stray")
-    # Opaque storage stays available on purpose through the raw verb.
-    doc.set_field("stray", "x")
-    assert field(doc.main, "stray") == "x"
-
-
-def test_commit_field_inline_violation_raises():
-    """A richtext(inline) field rejects multi-block content at the write."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
-        doc.commit_field(quill, "headline", "line one\n\nline two")
-
-
-def test_commit_card_field_index_out_of_range():
-    """commit_card_field surfaces IndexOutOfRange for a missing card."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.commit_card_field(quill, 0, "body", "x")
-
-
-# ── Tier-1 typed editor — doc.editor(quill) front door ────────────────────────
 
 
 def _taro_quill():
@@ -699,7 +657,34 @@ def test_editor_card_cursor_set_and_body():
         ed.card(9).set("author", "x")
 
 
-# ── Addressed content verbs — commit / revise / apply_change ──────────────────
+def test_editor_set_coerces_richtext_to_corpus():
+    """A richtext field commits the canonical corpus, not the authored markdown."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    doc.editor(quill).set("bio", "A **bold** intro.")
+    value = field(doc.main, "bio")
+    assert isinstance(value, dict)  # stored as the corpus dict, not a string
+    assert value["text"] == "A bold intro."
+
+
+def test_editor_set_rejects_inline_violation():
+    """A richtext(inline) field rejects multi-block content at the write."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+        doc.editor(quill).set("headline", "line one\n\nline two")
+
+
+def test_editor_set_all_is_all_or_nothing():
+    """A mid-batch inline violation aborts set_all — nothing lingers."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+        doc.editor(quill).set_all({"bio": "ok", "headline": "line one\n\nline two"})
+    assert not has_field(doc.main, "bio")
+
+
+# ── Addressed content verbs — revise / apply_change ───────────────────────────
 
 
 def test_revise_field_and_apply_change_splice():
@@ -725,58 +710,3 @@ def test_corpus_codec_rebase_and_map_pos():
     assert map_pos(out["delta"], 11, "after") == 17
 
 
-# ── Typed batched writes — commit_fields / commit_card_fields ─────────────────
-
-
-def _taro_quill():
-    """The taro fixture quill (main: string fields; card kind `quotes`)."""
-    return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
-
-
-def test_commit_fields_typed_batch():
-    """commit_fields typed-commits a batch, coercing each value to its type."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    doc.commit_fields(quill, {"bio": "A **bold** intro.", "headline": "Hi"})
-    # The richtext value was coerced to the corpus, not stored verbatim.
-    assert isinstance(field(doc.main, "bio"), dict)
-
-
-def test_commit_fields_rejects_unknown_field():
-    """A typo the schema does not own aborts the all-or-nothing batch."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="UnknownField"):
-        doc.commit_fields(quill, {"bio": "hi", "titel": "oops"})
-    # Nothing applied — the good field must not linger either.
-    assert not has_field(doc.main, "bio")
-    assert not has_field(doc.main, "titel")
-
-
-def test_commit_fields_is_all_or_nothing():
-    """A richtext(inline) violation aborts the whole batch — nothing lingers."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
-        doc.commit_fields(quill, {"bio": "ok", "headline": "line one\n\nline two"})
-    assert not has_field(doc.main, "bio")
-
-
-def test_commit_card_fields_typed_batch():
-    """commit_card_fields resolves the card's $kind schema and commits each field."""
-    quill = _taro_quill()
-    doc = Document("taro@0.1.0")
-    doc.push_card(Document.make_card("quotes"))
-    doc.commit_card_fields(quill, 0, {"author": "Ada"})
-    assert field(doc.cards[0], "author") == "Ada"
-    # A field the `quotes` kind does not declare aborts the batch as a typo.
-    with pytest.raises(QuillmarkError, match="UnknownField"):
-        doc.commit_card_fields(quill, 0, {"stray": "x"})
-
-
-def test_commit_card_fields_index_out_of_range():
-    """commit_card_fields surfaces IndexOutOfRange for a missing card."""
-    quill = _taro_quill()
-    doc = Document("taro@0.1.0")
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.commit_card_fields(quill, 0, {"author": "x"})

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -714,22 +714,6 @@ card_kinds:
       .toThrow(/FieldRichtextNotInline/)
   })
 
-  it('commit(addr, value, quill) is the addressed typed door for main and card fields', () => {
-    const quill = buildQuill()
-    const doc = Document.fromMarkdown(
-      '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
-    )
-    // Main field, resolving the schema type from the quill.
-    doc.commit({ field: 'qty' }, '3', quill)
-    expect(field(doc.main, 'qty')).toBe(3)
-    // Card field, addressed by index.
-    doc.commit({ card: 0, field: 'body' }, 'Card **body**.', quill)
-    expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.\n')
-    // A typo is rejected on the typed path; the body has no schema type.
-    expect(() => doc.commit({ field: 'stray' }, 'x', quill)).toThrow(/UnknownField/)
-    expect(() => doc.commit({}, 'x', quill)).toThrow(/addr\.field/)
-  })
-
   it('revise({field}) rebases a richtext field anchor and applyChange splices it', () => {
     const quill = buildQuill()
     const doc = blankDoc()

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -141,39 +141,86 @@ card_kinds:
   const fieldOf = (card, key) =>
     card.payloadItems.find((i) => i.type === 'field' && i.key === key)?.value
 
+  it('quill.editor(doc) is the front door and returns a DocumentEditor', () => {
+    const quill = buildQuill()
+    const ed = quill.editor(blankDoc())
+    expect(ed).toBeInstanceOf(DocumentEditor)
+    // The factory is sugar over the constructor — same class, no wrapping.
+    expect(new DocumentEditor(quill, blankDoc())).toBeInstanceOf(DocumentEditor)
+  })
+
   it('set binds the quill once and strict-commits a schema field', () => {
-    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    const ed = buildQuill().editor(blankDoc())
     ed.set('qty', '3') // schema field → strict coerce
     expect(fieldOf(ed.document.main, 'qty')).toBe(3)
   })
 
   it('set rejects an undeclared name as a typo, not a fallback', () => {
-    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    const ed = buildQuill().editor(blankDoc())
     expect(() => ed.set('stray', 'x')).toThrow(/UnknownField/)
     expect(fieldOf(ed.document.main, 'stray')).toBeUndefined()
   })
 
   it('setAll aborts the whole batch on a typo, applying nothing', () => {
-    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    const ed = buildQuill().editor(blankDoc())
     expect(() => ed.setAll({ qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
     expect(fieldOf(ed.document.main, 'qty')).toBeUndefined()
     expect(fieldOf(ed.document.main, 'titel')).toBeUndefined()
   })
 
-  it('card(i).set targets the composable card via its kind schema', () => {
+  it('setBody writes the main body from markdown, receipt-free', () => {
+    const ed = buildQuill().editor(blankDoc())
+    ed.setBody('New **body**.')
+    expect(ed.document.getMarkdown()).toBe('New **body**.\n')
+  })
+
+  it('addCard fuses make + typed commit + push, transactionally', () => {
+    const ed = buildQuill().editor(blankDoc())
+    // `body` here is the card's richtext FIELD; the third arg is the card body.
+    ed.addCard('note', { body: 'Field **body**.' }, 'Card body text.')
+    expect(ed.document.cards).toHaveLength(1)
+    expect(ed.document.cards[0].kind).toBe('note')
+    expect(exportMarkdown(fieldOf(ed.document.cards[0], 'body'))).toBe('Field **body**.\n')
+    expect(exportMarkdown(ed.document.cards[0].body)).toBe('Card body text.\n')
+    // A typo aborts the commit; the card never joins the document.
+    expect(() => ed.addCard('note', { stray: 'x' })).toThrow(/UnknownField/)
+    expect(ed.document.cards).toHaveLength(1)
+  })
+
+  it('removeCard drops the card and returns it', () => {
+    const ed = buildQuill().editor(blankDoc())
+    ed.addCard('note', { body: 'x' })
+    const removed = ed.removeCard(0)
+    expect(removed.kind).toBe('note')
+    expect(ed.document.cards).toHaveLength(0)
+  })
+
+  it('card(i).set / card(i).setBody target the composable card', () => {
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: editor_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
-    const ed = new DocumentEditor(buildQuill(), doc)
+    const ed = buildQuill().editor(doc)
     ed.card(0).set('body', 'Card **body**.')
     expect(exportMarkdown(fieldOf(doc.cards[0], 'body'))).toBe('Card **body**.\n')
+    ed.card(0).setBody('Card body md.')
+    expect(exportMarkdown(doc.cards[0].body)).toBe('Card body md.\n')
   })
 
   it('a bad card index throws at write time, not at card()', () => {
-    const ed = new DocumentEditor(buildQuill(), blankDoc())
+    const ed = buildQuill().editor(blankDoc())
     const cardEd = ed.card(9) // lazy: constructing the CardEditor never throws
     expect(cardEd).toBeInstanceOf(CardEditor)
     expect(() => cardEd.set('body', 'x')).toThrow(/IndexOutOfRange/)
+  })
+
+  it('get / getMarkdown read main fields quill-free, off the Document', () => {
+    const ed = buildQuill().editor(blankDoc())
+    ed.set('qty', '3')
+    ed.set('subject', 'Q3 **results**')
+    expect(ed.document.get('qty')).toBe(3)
+    expect(ed.document.getMarkdown('subject')).toBe('Q3 **results**\n')
+    expect(ed.document.get('missing')).toBeUndefined()
+    expect(ed.document.getMarkdown('missing')).toBe('')
   })
 })
 

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -70,7 +70,7 @@ export declare function isQuillmarkError(e: unknown): e is QuillmarkError;
 // (run via `npm run typecheck`), so these and the generated
 // `pkg/backends/typst/wasm.d.ts` cannot silently diverge.
 
-import type { Quill, Document } from '../core/wasm.js';
+import type { Quill, Document, Card } from '../core/wasm.js';
 import type { Diagnostic } from '../core/wasm.js';
 
 /** Canonical contract every backend build must satisfy. One emitted output. */
@@ -442,22 +442,38 @@ export declare class LiveSession {
 	free(): void;
 }
 
-// ── Typed-editor sugar ──────────────────────────────────────────────────────
+// ── Typed editor — the tier-1 front door ────────────────────────────────────
+
+// `quill.editor(doc)` is patched onto the re-exported `Quill` prototype (the
+// class is re-exported verbatim, so the method is declared by merging into the
+// core module's `Quill` rather than redeclaring the class).
+declare module '../core/wasm.js' {
+	interface Quill {
+		/**
+		 * Bind this quill's schema to `doc` for typed writes — the documented
+		 * front door, mirroring core's `quill.editor(&mut doc)`. The schema grants
+		 * the typing, so the quill is the factory. The returned editor holds both
+		 * handles by reference and owns neither (nothing to `free()`); it is
+		 * ephemeral by convention — bind, write, discard.
+		 */
+		editor(doc: Document): DocumentEditor;
+	}
+}
 
 /**
- * A `Document` bound to its `Quill` for typed writes — the JS twin of Rust's
- * `quill.editor(&mut doc)`. Binds the schema source once so writes are bare
- * `set` / `setAll` / `card(i).set` instead of threading the `quill` handle
- * through every `commit*` call. Holds both handles by reference and owns
- * neither — nothing to `free()`.
+ * A `Document` bound to its `Quill` for typed writes — the tier-1 default,
+ * constructed via {@link Quill.editor}. Speaks names, values, and markdown; a
+ * consumer here never meets an `Addr`, a corpus object, or a `Delta`. Bare
+ * `set` / `setAll` / `setBody` / `addCard` / `card(i).set` instead of threading
+ * the `quill` handle through every `commit*` call. Holds both handles by
+ * reference and owns neither — nothing to `free()`.
  *
- * `commit*` is the default write path whenever a quill is in hand: it resolves
- * each field's schema type and strict-commits it, throwing `UnknownField` for a
- * name the schema does not declare — on the typed path an undeclared name is a
- * typo, not a fallback. The raw `Document.setField` / `setFields` verbs remain
- * the deliberate quill-free primitive (standalone data, storage/migration infra,
- * or holding not-yet-conforming in-progress input) — and the way to store a
- * value opaquely on purpose.
+ * Typed commit is the default whenever a quill is in hand: it resolves each
+ * field's schema type and strict-commits it, throwing `UnknownField` for a name
+ * the schema does not declare — on the typed path an undeclared name is a typo,
+ * not a fallback. The raw `Document.setField` / `setFields` verbs remain the
+ * deliberate quill-free primitive (standalone data, storage/migration infra, or
+ * holding not-yet-conforming in-progress input).
  */
 export declare class DocumentEditor {
 	constructor(quill: Quill, doc: Document);
@@ -475,8 +491,25 @@ export declare class DocumentEditor {
 	 */
 	setAll(fields: Record<string, unknown>): void;
 	/**
+	 * Set the main body from markdown (edit semantics: anchors rebase), discarding
+	 * the delta — the receipt-free body write. Use `doc.revise({}, md)` for the
+	 * `Delta` receipt.
+	 */
+	setBody(markdown: string): void;
+	/**
+	 * Build a composable card of `kind`, typed-commit `fields` onto it, set its
+	 * body from optional markdown, and append it — the fused `makeCard` + typed
+	 * commit + `pushCard`. Transactional: a rejected field (throws a per-field
+	 * diagnostic bundle) or an invalid kind/body leaves the document untouched.
+	 */
+	addCard(kind: string, fields?: Record<string, unknown>, body?: string): void;
+	/** Remove the composable card at `index`, returning it (or `undefined`). */
+	removeCard(index: number): Card | undefined;
+	/**
 	 * A {@link CardEditor} for the composable card at `index`. Index validity is
-	 * checked lazily at commit time, so this never throws.
+	 * checked lazily at commit time, so this never throws. The cursor is
+	 * ephemeral — a `removeCard`/`addCard` between binding and writing silently
+	 * retargets it; for durable addressing stamp `$id` and re-resolve at write.
 	 */
 	card(index: number): CardEditor;
 }
@@ -493,4 +526,6 @@ export declare class CardEditor {
 	readonly index: number;
 	set(name: string, value: unknown): void;
 	setAll(fields: Record<string, unknown>): void;
+	/** Set this card's body from markdown (edit semantics), discarding the delta. */
+	setBody(markdown: string): void;
 }

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -52,7 +52,12 @@
 // (it is) so it tolerates handles from any core instance. The `runtime.test.js`
 // "re-exports the internal core build classes verbatim" case
 // (`Quill === CoreQuill`) is the executable guard for this invariant.
-export { Quill, Document, init } from '../core/wasm.js';
+//
+// Imported (not bare re-exported) so `Quill` is a local binding this module can
+// augment — `quill.editor(doc)` is patched onto its prototype below. The
+// re-export keeps the identity: the exported `Quill` IS the core class.
+import { Quill, Document, init } from '../core/wasm.js';
+export { Quill, Document, init };
 // The document-free corpus codec — re-exported verbatim from the core build so
 // the runtime subpath exposes `exportMarkdown(body)` (the on-demand markdown
 // projection that replaces the eager `bodyMarkdown`), `importMarkdown`, and the
@@ -574,9 +579,49 @@ export class DocumentEditor {
 		return this.#doc.commitFields(this.#quill, fields);
 	}
 	/**
+	 * Set the main body from markdown (edit semantics: surviving anchors rebase),
+	 * discarding the text delta — the receipt-free body write. Call
+	 * `doc.revise({}, md)` for the {@link Delta} receipt (the corpus-lane
+	 * spelling). Markdown in, no corpus or receipt in sight.
+	 * @param {string} markdown
+	 * @returns {void}
+	 */
+	setBody(markdown) {
+		this.#doc.revise({}, markdown);
+	}
+	/**
+	 * Build a composable card of `kind`, typed-commit `fields` onto it, set its
+	 * body from optional markdown, and append it — the fused `makeCard` + typed
+	 * commit + `pushCard`. Transactional: the card is committed in full before it
+	 * joins the document, so a rejected field (throws a per-field diagnostic
+	 * bundle, `UnknownField` per undeclared name) or an invalid kind/body leaves
+	 * the document untouched. See `Document.addCard`.
+	 * @param {string} kind
+	 * @param {Record<string, unknown>} [fields]
+	 * @param {string} [body]
+	 * @returns {void}
+	 */
+	addCard(kind, fields, body) {
+		return this.#doc.addCard(this.#quill, kind, fields, body);
+	}
+	/**
+	 * Remove the composable card at `index`, returning it (or `undefined` if the
+	 * index is out of range) — the tier-1 spelling of `Document.removeCard`.
+	 * @param {number} index
+	 * @returns {import('../core/wasm.js').Card | undefined}
+	 */
+	removeCard(index) {
+		return this.#doc.removeCard(index);
+	}
+	/**
 	 * A {@link CardEditor} bound to the composable card at `index`. Index
 	 * validity is checked lazily by the underlying write (it throws
 	 * `IndexOutOfRange` at commit time), so constructing one never throws.
+	 *
+	 * The cursor is ephemeral — bind, write, discard. It holds `index`, not the
+	 * card: a `removeCard`/`addCard` between binding and writing silently
+	 * retargets it. For durable addressing stamp `$id` and re-resolve the index
+	 * at write time.
 	 * @param {number} index
 	 * @returns {CardEditor}
 	 */
@@ -629,4 +674,33 @@ export class CardEditor {
 	setAll(fields) {
 		return this.#doc.commitCardFields(this.#quill, this.#index, fields);
 	}
+	/**
+	 * Set this card's body from markdown (edit semantics), discarding the delta —
+	 * the card twin of {@link DocumentEditor.setBody}.
+	 * @param {string} markdown
+	 * @returns {void}
+	 */
+	setBody(markdown) {
+		this.#doc.revise({ card: this.#index }, markdown);
+	}
 }
+
+// ── `quill.editor(doc)` — the typed front door ──────────────────────────────
+// The tier-1 default: bind the quill's schema to a document and issue bare
+// typed writes. Mirrors core's `quill.editor(&mut doc)` — the schema grants the
+// typing, so the quill (not the document) is the factory. Patched onto the
+// re-exported `Quill` prototype rather than wrapped: `Quill === CoreQuill`
+// stays true (the identity invariant above); this only adds a method that
+// constructs the pure-JS editor, which owns no WASM handle.
+/**
+ * A {@link DocumentEditor} binding this quill's schema to `doc` for typed
+ * writes — the documented front door. The returned editor holds both handles by
+ * reference and owns neither, so there is nothing to `free()`. Ephemeral by
+ * convention: bind, write, discard.
+ * @this {Quill}
+ * @param {Document} doc the document to mutate, held by reference (not owned)
+ * @returns {DocumentEditor}
+ */
+Quill.prototype.editor = function editor(doc) {
+	return new DocumentEditor(this, doc);
+};

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1132,44 +1132,6 @@ impl Document {
         .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// **Commit** a typed value at `addr.field`, resolving the field's schema
-    /// `type` from `quill` — the one typed write verb for every field type
-    /// (richtext, scalar, array, object). The schema carries any `inline`
-    /// constraint. A richtext-typed field stores the canonical corpus (identity
-    /// and corpus-only marks intact). Requires `addr.field`; the body carries no
-    /// schema type, so a bodyless `addr` throws.
-    ///
-    /// A field the schema does not declare throws `[EditError::UnknownField]`
-    /// (a typo on the typed path — use [`setField`](Document::set_field) for
-    /// opaque storage); a typed mismatch throws now, not at render.
-    #[wasm_bindgen(js_name = commit)]
-    pub fn commit(
-        &mut self,
-        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
-        value: JsValue,
-        quill: &Quill,
-    ) -> Result<(), JsValue> {
-        let addr = Addr::from_js(&addr)?;
-        let field = addr.field.as_deref().ok_or_else(|| {
-            WasmError::from(
-                "commit requires addr.field — the body carries no schema type; \
-                 use install/revise for the body",
-            )
-            .to_js_value()
-        })?;
-        let json = js_value_to_json(value, "commit")?;
-        let qv = quillmark_core::QuillValue::from_json(json);
-        let mut editor = quill.inner.editor(&mut self.inner);
-        match addr.card {
-            None => editor.set(field, qv).map_err(|e| edit_error_to_js(&e)),
-            Some(index) => editor
-                .card(index)
-                .map_err(|e| edit_error_to_js(&e))?
-                .set(field, qv)
-                .map_err(|e| edit_error_to_js(&e)),
-        }
-    }
-
     /// Typed field write on the main card, resolving the field's schema `type`
     /// from `quill` — the one write verb for **every** field type (richtext,
     /// scalar, array, object). The schema carries the `inline` constraint, so no

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1468,7 +1468,7 @@ impl Document {
 
     /// Resolve the card an [`Addr`] targets: the main card when `addr.card` is
     /// absent, else the composable card at that index (out-of-range throws). The
-    /// static address axis the four addressed content verbs share.
+    /// static address axis the addressed content verbs share.
     fn addr_card_mut(&mut self, addr: &Addr) -> Result<&mut quillmark_core::Card, JsValue> {
         match addr.card {
             None => Ok(self.inner.main_mut()),

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -813,6 +813,36 @@ impl Document {
         serialize_or_throw(&cards, "cards")
     }
 
+    /// Read a main-card field's stored value — the raw payload value (a corpus
+    /// object for a richtext field, a scalar/array/object otherwise), or
+    /// `undefined` when the field is absent. The quill-free read: reads need no
+    /// schema, so they live on `Document`, not the typed editor. For the markdown
+    /// projection of a richtext value use [`getMarkdown`](Self::get_markdown).
+    #[wasm_bindgen(js_name = get)]
+    pub fn get(&self, name: &str) -> Result<JsValue, JsValue> {
+        match self.inner.main().payload().get(name) {
+            Some(v) => serialize_or_throw(v.as_json(), "get"),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// The markdown projection of a main-card field (`name` given) or the main
+    /// body (`name` omitted) — the on-demand, lossy export (corpus-only marks do
+    /// not survive markdown), returning `""` for an absent field. Re-coins,
+    /// lazily and by name, the projection the eager `fieldMarkdown` /
+    /// `bodyMarkdown` getters dropped in #925; call it only when markdown is what
+    /// you need out.
+    #[wasm_bindgen(js_name = getMarkdown)]
+    pub fn get_markdown(
+        &self,
+        #[wasm_bindgen(unchecked_optional_param_type = "string")] name: Option<String>,
+    ) -> String {
+        match name {
+            Some(n) => self.inner.main().field_markdown(&n).unwrap_or_default(),
+            None => self.inner.main().body_markdown(),
+        }
+    }
+
     /// Number of composable cards (excludes the main card). O(1).
     #[wasm_bindgen(getter, js_name = cardCount)]
     pub fn card_count(&self) -> usize {
@@ -1186,6 +1216,36 @@ impl Document {
             .inner
             .editor(&mut self.inner)
             .set_all(batch)
+            .map_err(edit_errors_to_js)
+    }
+
+    /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
+    /// body from optional markdown, and append it — the ABI under
+    /// `editor.addCard`. Fuses `makeCard` + typed commit + `pushCard`
+    /// transactionally: the card is committed in full before it joins the
+    /// document, so a rejected field (or an invalid kind or body) leaves the
+    /// document untouched. Field errors throw the same per-field diagnostic
+    /// bundle as [`commitFields`](Self::commit_fields), including an
+    /// `[EditError::UnknownField]` per undeclared name; an invalid kind or body
+    /// throws a single-entry bundle keyed `$kind` / `$body`.
+    #[wasm_bindgen(js_name = addCard)]
+    pub fn add_card(
+        &mut self,
+        quill: &Quill,
+        kind: &str,
+        #[wasm_bindgen(unchecked_optional_param_type = "Record<string, unknown>")] fields: Option<
+            JsValue,
+        >,
+        #[wasm_bindgen(unchecked_optional_param_type = "string")] body: Option<String>,
+    ) -> Result<(), JsValue> {
+        let batch = match fields {
+            Some(f) => js_value_to_field_batch(&f, "addCard")?,
+            None => Vec::new(),
+        };
+        quill
+            .inner
+            .editor(&mut self.inner)
+            .add_card(kind, batch, body.as_deref())
             .map_err(edit_errors_to_js)
     }
 

--- a/crates/core/src/editor.rs
+++ b/crates/core/src/editor.rs
@@ -75,6 +75,48 @@ impl<'a> TypedEditor<'a> {
         set_all_impl(self.doc.main_mut(), schema, fields)
     }
 
+    /// Revise the main card's body from markdown (edit semantics: surviving
+    /// anchors rebase), discarding the text delta — the receipt-free body write.
+    /// Call [`Card::revise_body`](crate::Card::revise_body) on `doc.main_mut()`
+    /// for the [`Delta`](crate::Delta) receipt (the tier-2 spelling).
+    pub fn set_body(&mut self, markdown: &str) -> Result<(), EditError> {
+        self.doc.main_mut().revise_body(markdown).map(|_| ())
+    }
+
+    /// Build a composable card of `kind`, typed-commit `fields` onto it,
+    /// optionally set its body from markdown, and append it — the fused
+    /// [`Card::new`](crate::Card::new) + typed writes + [`push_card`]. The card is
+    /// committed in full *before* it joins the document, so it is transactional by
+    /// construction: a rejected field (or an invalid kind or body) leaves the
+    /// document untouched. Field errors use the all-or-nothing bundle of
+    /// [`set_all`](Self::set_all); an invalid kind or body surfaces as a
+    /// single-entry bundle keyed `$kind` / `$body`.
+    ///
+    /// [`push_card`]: Document::push_card
+    pub fn add_card<K, V, I>(
+        &mut self,
+        kind: &str,
+        fields: I,
+        body: Option<&str>,
+    ) -> Result<(), Vec<(String, EditError)>>
+    where
+        K: Into<String>,
+        V: Into<QuillValue>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let mut card = Card::new(kind).map_err(|e| vec![("$kind".to_string(), e)])?;
+        let schema = self.config.card_kind(kind).map(|s| &s.fields);
+        set_all_impl(&mut card, schema, fields)?;
+        if let Some(md) = body {
+            card.revise_body(md)
+                .map_err(|e| vec![("$body".to_string(), e)])?;
+        }
+        self.doc
+            .push_card(card)
+            .map_err(|e| vec![("$kind".to_string(), e)])?;
+        Ok(())
+    }
+
     /// A schema-bound editor for the composable card at `index`. The card's
     /// `$kind` resolves its [`CardSchema`]; an unknown kind carries no schema, so
     /// every field on it is undeclared and its typed writes fail with
@@ -115,6 +157,12 @@ impl CardEditor<'_> {
             Some(schema) => self.card.commit_field(name, value, schema),
             None => Err(EditError::UnknownField(name.to_string())),
         }
+    }
+
+    /// Revise this card's body from markdown (edit semantics), discarding the
+    /// delta — the card twin of [`TypedEditor::set_body`].
+    pub fn set_body(&mut self, markdown: &str) -> Result<(), EditError> {
+        self.card.revise_body(markdown).map(|_| ())
     }
 
     /// Write several fields on this card atomically — see
@@ -281,6 +329,53 @@ card_kinds:
         assert_eq!(errs[0].0, "titel");
         assert_eq!(errs[0].1.variant_name(), "UnknownField");
         assert!(doc.main().payload().get("qty").is_none());
+    }
+
+    #[test]
+    fn set_body_revises_main_body() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        ed.set_body("**hi**").unwrap();
+        assert_eq!(doc.main().body_markdown(), "**hi**\n");
+    }
+
+    #[test]
+    fn add_card_fuses_new_commit_push() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        ed.add_card("note", [("body", "**hi**")], Some("card body"))
+            .unwrap();
+        assert_eq!(doc.cards().len(), 1);
+        assert_eq!(doc.cards()[0].kind(), Some("note"));
+        assert_eq!(doc.cards()[0].field_markdown("body").unwrap(), "**hi**\n");
+        assert_eq!(doc.cards()[0].body_markdown(), "card body\n");
+    }
+
+    #[test]
+    fn add_card_is_transactional_on_bad_field() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        // An undeclared field aborts the commit; the card never joins the document.
+        let errs = ed
+            .add_card("note", [("stray", "x")], None)
+            .unwrap_err();
+        assert_eq!(errs[0].0, "stray");
+        assert_eq!(errs[0].1.variant_name(), "UnknownField");
+        assert_eq!(doc.cards().len(), 0);
+    }
+
+    #[test]
+    fn add_card_reports_invalid_kind() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedEditor::new(&config, &mut doc);
+        // A reserved kind is refused before any card is built.
+        let errs = ed.add_card("$reserved", [] as [(&str, &str); 0], None).unwrap_err();
+        assert_eq!(errs[0].0, "$kind");
+        assert_eq!(doc.cards().len(), 0);
     }
 
     #[test]

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -87,7 +87,7 @@ needed; block (`inline` omitted) richtext is unaffected.
 The richtext write surface was a grid: every verb stamped out once per address
 (main / card-at-index), and the fix window for it was still open (nearly the
 whole write surface is unreleased). #925 collapses the grid into **one codec
-layer plus four addressed verbs**, and — the field gap that motivated it —
+layer plus a handful of addressed verbs**, and — the field gap that motivated it —
 gives richtext *fields* the anchor-preserving `diff_import` writer they lacked.
 All of this is **pre-release reshaping**: only three released names churn (the
 deprecations below); everything else is added or retired outright.
@@ -112,7 +112,7 @@ rendered line), so it is on-demand now. `Delta` is plain, structured-clone-able
 data (`{ops: [{retain}|{insert}|{delete}]}`) that stores in a change record and
 maps positions through with `mapPos`.
 
-### Layer 2 — four addressed content verbs
+### Layer 2 — the addressed content verbs
 
 An **address** locates a richtext value: `{ card?, field? }` in wasm (absent
 `field` = body, absent `card` = main); the same axis as kwargs in Python
@@ -123,14 +123,20 @@ An **address** locates a richtext value: `{ card?, field? }` in wasm (absent
 | install | `doc.install(addr, rt)` | `doc.install(rt, card=, field=)` | value: store exactly this corpus (anchors of the old value gone) |
 | revise | `doc.revise(addr, md) → Delta` | `doc.revise(md, card=, field=) -> dict` | edit: `diff_import`, anchors rebase, returns the delta receipt |
 | applyChange | `doc.applyChange(addr, bundle)` | `doc.apply_change(bundle, card=, field=)` | editor splice: `{ delta?, lineOps?, markOps? }` |
-| commit | `doc.commit(addr, value, quill)` | `doc.commit(value, quill, field=, card=)` | typed, schema-carried (field required) |
+
+(An earlier draft added a fourth addressed verb, `commit(addr, value, quill)`,
+for typed field writes. #932 deleted it pre-release: typed writes are the
+[typed editor](#the-two-tier-binding-surface-932)'s job, not the corpus lane's,
+and the addressed `commit` only duplicated `commitField` / `commitCardField`
+behind an `Addr`. The corpus lane is content-only — `install` / `revise` /
+`applyChange`, no schema in sight.)
 
 The cold (anchor-losing) path is spelled at the call site —
 `install(addr, importMarkdown(md))` — so anchor loss is visible in source;
 `revise` is the default for "here's new markdown." `revise` stays a fused verb
 (not `rebase` + `install`) for atomicity against interleaved mutation.
 
-**Retired pre-release** (the grid the four verbs replace — no deprecation):
+**Retired pre-release** (the grid the addressed verbs replace — no deprecation):
 
 | Retired | Use instead |
 |---|---|
@@ -150,8 +156,9 @@ twins `Card::install_field(name, rt)` / **`revise_field(name, md) -> Delta`**
 (new — the field-level `diff_import`) close the gap where a richtext field had
 no anchor-preserving markdown writer. `install`/`revise` on a field are
 schema-blind (the corpus-writer stratum splices without the quill, like
-`apply_field_richtext_change`); `commit` is the typed door that enforces
-`richtext(inline)`, and a violation otherwise surfaces at validate/render.
+`apply_field_richtext_change`); the typed door that enforces `richtext(inline)`
+is the editor's `commit_field` (`commitField` / `commit_field` in the bindings),
+and a violation on the schema-blind path otherwise surfaces at validate/render.
 
 ### The three released-API deprecations
 

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -321,8 +321,65 @@ a parallel core-side position map: `positionAt` (point → corpus position) and
 `locate` (corpus position → caret rect) are exact inverses over the current
 compile and are the whole bidirectional cursor bridge, needing no forward map.
 
-A live editor writes a field with `commit({ field }, value, quill)` (or the body
-with `install` / `revise`) and recompiles with `apply(doc)`. Typst recompiles incrementally either way
+A live editor writes a field through the typed editor
+(`quill.editor(doc).set(field, value)`, or the ABI `commitField`) — or the body
+with `install` / `revise` — and recompiles with `apply(doc)`. Typst recompiles incrementally either way
 (`Source::replace` + `comemo`), so a whole-field write costs the same on the
 compile as a splice would have — the delta path bought no incrementality it did
 not already have. `CorpusHit` / `FieldRegion` carry no `revision`.
+
+## The two-tier binding surface (#932)
+
+The bindings grew three overlapping write families (the `commit*` verbs, the
+addressed content verbs, the opaque `set*` primitive) with no stated default.
+#932 does not add a family — it names a **default** and promotes the verb that
+already served it. One sentence decides where every verb lives:
+
+> **Tier 1 speaks names, values, and markdown. Tier 2 speaks addresses,
+> corpora, and receipts.**
+
+A consumer who never needs anchor identity never meets an `Addr`, a corpus
+object, or a `Delta`. A consumer who does crosses one marked door.
+
+### Tiers are strata, not a partition
+
+Tier 1 is **sugar over** tier 2 and the typed-commit path, not a walled-off
+region: `editor.setBody(md)` *is* `revise({}, md)` with the receipt discarded,
+and `editor.set` *is* `commitField` with the quill bound once. Anything tier 1
+writes, tier 2 can write with more control. So the decision tree picks a
+*default*, not a *cage* — a live editor legitimately writes fields through the
+typed editor and bodies/splices through the addressed verbs in the same
+interaction. The decision tree:
+
+- **Have a quill? Use `quill.editor(doc)`** (Python: `doc.editor(quill)`) — the
+  documented default. Typed `set` / `set_all`, `setBody`, `addCard`,
+  `removeCard`, `card(i)`. Names in, markdown in, diagnostics out.
+- **Corpus surgery with anchors?** The addressed `install` / `revise` /
+  `applyChange` verbs + the `importMarkdown` / `exportMarkdown` / `rebase` /
+  `mapPos` codec — the corpus lane, unchanged and content-only.
+- **No quill?** The opaque `setField` / `setCardField` primitive — verbatim
+  storage, coercion deferred to render.
+
+### What moved
+
+| Change | Detail |
+|---|---|
+| `quill.editor(doc)` is the front door | WASM patches `editor(doc)` onto the re-exported `Quill` prototype (the `Quill === CoreQuill` identity holds; the editor owns no wasm handle); Python adds `Document.editor(quill) -> Editor`; core already had `Quill::editor(&mut doc)`. |
+| Editor gaps closed | `setBody` / `set_body`, `addCard` / `add_card` (fused make + typed-commit + push, transactional), `removeCard`, `card(i).setBody` — mirrored into core's `TypedEditor` so the parity rows read *identical*. |
+| Reads live on `Document`, quill-free | `get(name)` / `getMarkdown(name?)` — reads need no schema, so they sit on `Document`, not the editor. `getMarkdown` re-coins, **lazily and by name**, the projection the eager `fieldMarkdown` / `bodyMarkdown` getters dropped in #925 (the drop was of the *eager precompute*, not the capability). |
+| `commit(addr, value, quill)` deleted | Unreleased; it only duplicated `commitField` / `commitCardField` behind an `Addr`, dragging a schema into the content-only corpus lane. The typed door is the editor. |
+| `commit*` demoted to ABI | `commitField` / `commitFields` / `commitCardField(s)` stay as the stable ABI under the editor's `set` / `set_all`, dropped from the documented surface. |
+
+The hand-written WASM runtime becomes the real API and the wasm class its ABI —
+committed to, not just tolerated. See [BINDINGS.md](../../prose/canon/BINDINGS.md)
+for the parity table that now governs core-vs-bindings drift.
+
+### One idiom difference to know
+
+The typed editor is the one shape pyo3 carries worst. Core's `TypedEditor` holds
+`&mut Document` under the borrow checker; WASM's `DocumentEditor` and Python's
+`Editor` cannot — they **re-borrow per call** (a captured quill + document, each
+write reconstructing the core editor). The guarantee does not cross the boundary:
+a held borrow becomes a convention (*editors and card cursors are ephemeral —
+bind, write, discard*). The parity table classes this row **idiom**, not
+identical.

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -157,8 +157,9 @@ twins `Card::install_field(name, rt)` / **`revise_field(name, md) -> Delta`**
 no anchor-preserving markdown writer. `install`/`revise` on a field are
 schema-blind (the corpus-writer stratum splices without the quill, like
 `apply_field_richtext_change`); the typed door that enforces `richtext(inline)`
-is the editor's `commit_field` (`commitField` / `commit_field` in the bindings),
-and a violation on the schema-blind path otherwise surfaces at validate/render.
+is the editor's `commit_field` (reached as `editor.set` in the bindings — WASM's
+`commitField` ABI, Python's direct core call), and a violation on the
+schema-blind path otherwise surfaces at validate/render.
 
 ### The three released-API deprecations
 
@@ -184,7 +185,7 @@ pre-release** and folded into the one typed writer below.
 | `Card::set_field_richtext(name, &json, inline)` | `Card::commit_field(name, value, &field_schema)` |
 | wasm `setRichtextField(name, value, inline?)` | wasm `commitField(quill, name, value)` |
 | wasm `updateCardRichtextField(index, name, value, inline?)` | wasm `commitCardField(quill, index, name, value)` |
-| — (Python had no richtext field writer) | Python `Document.commit_field(quill, name, value)` / `commit_card_field(quill, index, name, value)` |
+| — (Python had no richtext field writer) | Python `doc.editor(quill).set(name, value)` / `.card(index).set(name, value)` (the standalone `Document.commit_field` / `commit_card_field` this section first added were deleted by #932 — see below) |
 
 The corpus read twin is `Card::field_richtext(name)`; the markdown projection
 is the on-demand `exportMarkdown(fieldCorpus)` codec (the eager `field_markdown`
@@ -212,9 +213,13 @@ at the boundary as `applyChange({ field }, bundle)`.
   the typed path an undeclared name is a typo, not a fallback, so it fails at the
   write rather than landing silently in the opaque store (#918). Opaque storage
   stays available on purpose through the raw `set_field` / `setField` /
-  `setCardField` verbs. The bindings pass the quill handle per call instead of
-  holding the editor (wasm-bindgen / pyo3 objects carry no lifetime); the commit
-  verbs return nothing on success and throw on an undeclared name.
+  `setCardField` verbs. In the bindings the editor is a real object —
+  `quill.editor(doc)` (WASM) / `doc.editor(quill)` (Python) — that re-borrows the
+  quill + document per call, since wasm-bindgen / pyo3 objects carry no lifetime
+  (#932). WASM keeps the per-call `commitField` verbs as the ABI its editor
+  delegates to; Python's editor calls core directly, so its standalone
+  `commit_field` was deleted (#932). Both return nothing on success and throw on
+  an undeclared name.
 - **`set_field` is unchanged.** The opaque path (store verbatim, coerce at
   render) stays for keystroke-level state and DB-row batch generators; the split
   is `set_field` = *coerce at render* vs `commit_field` = *canonicalize now, fail

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -27,13 +27,18 @@ guides in order.
   `pushCard` / `insertCard` take a `CardInput` whose `body` still accepts a
   markdown string and whose non-`kind` fields are optional (#917). The richtext
   write grid then collapses into a document-free corpus codec (`importMarkdown`
-  / `exportMarkdown` / `rebase` / `mapPos`) plus four addressed content verbs
-  (`install` / `revise` / `applyChange` / `commit`); the eager
+  / `exportMarkdown` / `rebase` / `mapPos`) plus the addressed content verbs
+  (`install` / `revise` / `applyChange`); the eager
   `bodyMarkdown`/`fieldMarkdown` projections and the per-address body writers
   retire pre-release, `replaceBody` / `replace_body` / `update_card_body` alias
   for one cycle, and richtext fields gain the anchor-preserving `revise_field`
   (#925). On-disk (`.qmd`) identity stays markdown-lossy — the storage DTO is
-  the lossless carrier.
+  the lossless carrier. The binding write surface then settles into two tiers:
+  `quill.editor(doc)` (Python `doc.editor(quill)`) is the documented default —
+  typed `set` / `set_all` / `setBody` / `addCard` / `card(i)` and quill-free
+  `get` / `getMarkdown` reads — over the corpus lane and the opaque `setField`
+  primitive; the addressed `commit(addr, …)` is deleted (subsumed by the
+  editor) and a core-vs-bindings parity table governs drift (#932).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -32,6 +32,64 @@ The WASM binding is the reference surface; Python mirrors it and catches up
 on a best-effort basis (see its status notes below). New contract work lands
 in WASM first.
 
+## The write surface: two tiers over one primitive
+
+The mutation surface has a stated default, decided by one sentence:
+
+> **Tier 1 speaks names, values, and markdown. Tier 2 speaks addresses,
+> corpora, and receipts.**
+
+Tier 1 is the typed editor — `quill.editor(doc)` (Python `doc.editor(quill)`),
+mirroring core's `quill.editor(&mut doc)`. It is the documented default: bare
+`set` / `set_all` / `setBody` / `addCard` / `card(i)`, names and markdown in,
+diagnostics out — a consumer here never meets an `Addr`, a corpus object, or a
+`Delta`. Tier 2 is the corpus lane — the addressed `install` / `revise` /
+`applyChange` verbs plus the `importMarkdown` / `exportMarkdown` / `rebase` /
+`mapPos` codec — for the audience that has anchor identity to preserve.
+
+**The tiers are strata, not a partition.** Tier 1 is *sugar over* tier 2 and the
+typed-commit path — `editor.setBody(md)` is `revise({}, md)` with the receipt
+discarded; `editor.set` is `commitField` with the quill bound once. Anything
+tier 1 writes, tier 2 can write with more control, so the decision tree picks a
+*default*, not a *cage*: a live editor legitimately writes fields through the
+editor and bodies/splices through the addressed verbs in one interaction. Reads
+(`get` / `getMarkdown`) need no schema, so they sit on `Document`, not the
+editor. The quill-free `setField` / `setCardField` primitive stays the third
+lane — verbatim storage, coercion deferred to render.
+
+**Editors and card cursors are ephemeral — bind, write, discard.** They hold an
+address (the quill + document, or an index), never a cache; every call reads
+through the document, so a `removeCard` / `addCard` between binding a cursor and
+writing through it silently retargets it. Durable addressing is `$id` stamped at
+build and re-resolved at patch time ([PROGRAMMATIC.md](PROGRAMMATIC.md)), not a
+held handle.
+
+**The hand-written runtime is the real API; the wasm class is its ABI.** The
+`commit*` verbs are the stable ABI under the editor's `set` / `set_all` — dropped
+from the documented surface, not from the binary. This design commits to that
+split rather than merely tolerating it.
+
+### Parity table
+
+Every binding verb is *identical* to its core twin or names its one forced
+difference — **FFI** (a wasm-bindgen / pyo3 constraint) or **idiom** (a language
+ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
+
+| Concept | Core | Bindings | Class |
+|---|---|---|---|
+| Typed editor front door | `quill.editor(&mut doc)` | `quill.editor(doc)` / `doc.editor(quill)` | **idiom** — core holds `&mut Document` under the checker; the bindings re-borrow per call (pyo3/wasm objects carry no lifetime), so the guarantee becomes the ephemerality convention |
+| Scalar / batch write | `set` / `set_all` | `set` / `setAll` (JS), `set` / `set_all` (py) | identical |
+| Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
+| Card creation | `add_card(kind, fields, body?)` | `addCard` / `add_card` | identical — fused make + typed-commit + push, transactional |
+| Card cursor | `editor.card(i)?` (eager check) | `editor.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
+| Reads | `card.field_markdown(..)` / `payload().get(..)` | `doc.getMarkdown(name?)` / `doc.get(name)` | **idiom** — the bindings fuse the read into one named verb on `Document` |
+| Richtext ops | `card.revise_field(name, md)?` (borrow chain) | `doc.revise({card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation |
+| Opaque primitive | `set_field` / `set_fields` | `setField` / `setCardField` (JS), `set_field` / `set_fields` (py) | identical |
+
+The single **idiom** row on the front door is the honest cost: the typed editor
+is the one shape pyo3 carries worst, so its "identical" is qualified, not
+claimed. See the as-built [0.93 → 0.94 migration](../../docs/migrations/0.93-to-0.94.md#the-two-tier-binding-surface-932).
+
 ## Python — `bindings/quillmark-python`
 
 PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface mirroring

--- a/prose/canon/PROGRAMMATIC.md
+++ b/prose/canon/PROGRAMMATIC.md
@@ -86,11 +86,14 @@ The primitive stays load-bearing — it is what lets a `Document` be constructed
 and `from_json`'d with no bundle (standalone data), what quill-agnostic
 storage/migration infra writes through, what a store-now-validate-later editor
 uses to hold not-yet-conforming input, and the way to store a value opaquely on
-purpose. Reach for the opaque `set_*` for those; reach for the editor / `commit`
-by default. The bindings mirror this: `commitField` / `commitFields`
-(+ `commitCard*`) and the JS `DocumentEditor` / `CardEditor` sugar over the
-schema-bound editor, with `setField` / `setCardField` as the quill-free opaque
-store.
+purpose. Reach for the opaque `set_*` for those; reach for the editor by
+default. `Quill::editor(&mut doc)` is the documented front door in every
+surface: `quill.editor(doc)` in WASM, `doc.editor(quill)` in Python (the
+schema-bound `DocumentEditor` / `Editor` with `set` / `set_all` / `set_body` /
+`add_card` / `card(i)`). The `commitField` / `commitFields` (+ `commitCard*`)
+verbs are the stable ABI underneath it, and `setField` / `setCardField` remain
+the quill-free opaque store. See [BINDINGS.md](BINDINGS.md) for the two-tier
+write surface and the core-vs-bindings parity table.
 
 ## Addressing cards for re-render
 


### PR DESCRIPTION
Mirror the bindings' tier-1 editor gaps into core so the parity table's
rows read identical rather than accumulating unexplained gaps:

- TypedEditor::set_body / CardEditor::set_body — receipt-free body write
  (revise_body with the Delta discarded).
- TypedEditor::add_card — fused Card::new + typed commit + push_card,
  transactional by construction: the card is committed in full before it
  joins the document, so a rejected field / invalid kind / bad body leaves
  the document untouched. Field errors reuse set_all's all-or-nothing
  bundle; kind/body failures surface as a single-entry bundle keyed
  $kind / $body.

Refs #932.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LSTYDF6AKq84GfcW7f4VN2