### PR TITLE
Rename TypedEditor to TypedWriter across all surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   dispatches on the schema — the write surface stays O(1) in field types. Adds
   `EditError::FieldConform` for non-richtext mismatches (richtext keeps
   `FieldRichtextDecode` / `FieldRichtextNotInline`). A schema-bound
-  `TypedEditor` (`Quill::editor(&mut doc)`) is the front door: `set` / `set_all`
+  `TypedWriter` (`Quill::writer(&mut doc)`) is the front door: `set` / `set_all`
   resolve field types and strict-commit; a name the schema does not declare is a
   typo on the typed path, so it fails with `EditError::UnknownField` instead of
   falling to the opaque store (#918) — opaque storage stays available through the

--- a/crates/backends/pdfform/tests/richtext_form.rs
+++ b/crates/backends/pdfform/tests/richtext_form.rs
@@ -86,7 +86,7 @@ fn richtext_fields_lower_to_plaintext_field_values() {
     );
 }
 
-/// Same render, but the richtext fields are written via the typed editor, so
+/// Same render, but the richtext fields are written via the typed writer, so
 /// each is **stored as a canonical corpus object** rather than an authored
 /// markdown string. This exercises coercion's object branch (re-validate +
 /// re-canonicalize) end-to-end and proves it lowers identically to the
@@ -98,7 +98,7 @@ fn richtext_fields_written_as_corpus_render_identically() {
     let engine = Quillmark::new();
 
     // Start from the string-authored doc, then re-write each field through the
-    // schema-bound typed editor: `commit_field` stores the *canonical corpus
+    // schema-bound typed writer: `commit_field` stores the *canonical corpus
     // object* (decode → canonicalize) for a richtext-typed field, so the payload
     // now carries corpus objects.
     let mut doc = Document::from_markdown(FILLED).expect("parse markdown");

--- a/crates/backends/pdfform/tests/richtext_form.rs
+++ b/crates/backends/pdfform/tests/richtext_form.rs
@@ -103,7 +103,7 @@ fn richtext_fields_written_as_corpus_render_identically() {
     // now carries corpus objects.
     let mut doc = Document::from_markdown(FILLED).expect("parse markdown");
     {
-        let mut ed = quill.editor(&mut doc);
+        let mut ed = quill.writer(&mut doc);
         ed.set("headline", "The **headline**")
             .expect("inline richtext write");
         ed.set("bio", "A **bold** claim and _emphasis_.")

--- a/crates/bindings/python/src/lib.rs
+++ b/crates/bindings/python/src/lib.rs
@@ -7,7 +7,7 @@ mod types;
 pub use enums::{PyOutputFormat, PySeverity};
 pub use errors::{convert_edit_error, convert_render_error, QuillmarkError};
 pub use types::{
-    PyArtifact, PyCardEditor, PyDiagnostic, PyDocument, PyEditor, PyLocation, PyQuill, PyQuillmark,
+    PyArtifact, PyCardWriter, PyDiagnostic, PyDocument, PyWriter, PyLocation, PyQuill, PyQuillmark,
     PyRenderResult,
 };
 
@@ -16,8 +16,8 @@ fn _quillmark(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyQuillmark>()?;
     m.add_class::<PyQuill>()?;
     m.add_class::<PyDocument>()?;
-    m.add_class::<PyEditor>()?;
-    m.add_class::<PyCardEditor>()?;
+    m.add_class::<PyWriter>()?;
+    m.add_class::<PyCardWriter>()?;
     m.add_class::<PyRenderResult>()?;
     m.add_class::<PyArtifact>()?;
     m.add_class::<PyDiagnostic>()?;

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -115,6 +115,16 @@ impl PyQuill {
         self.inner.backend_id().to_string()
     }
 
+    /// Bind this quill's schema to `doc` for typed writes — the documented front
+    /// door, mirroring core `quill.writer(&mut doc)` and WASM `quill.writer(doc)`.
+    /// The quill owns the schema, so it is the factory. Returns a `Writer` holding
+    /// both objects by reference and re-borrowing per call (pyo3 objects carry no
+    /// lifetime, so the writer cannot hold the borrow the way core's `TypedWriter`
+    /// does). Ephemeral by convention — bind, write, discard.
+    fn writer(slf: Py<Self>, doc: Py<PyDocument>) -> PyWriter {
+        PyWriter { quill: slf, doc }
+    }
+
     #[getter]
     fn quill_ref(&self) -> String {
         let source = &self.inner;
@@ -507,20 +517,11 @@ impl PyDocument {
         Ok(result)
     }
 
-    /// Bind `quill`'s schema to this document for typed writes — the documented
-    /// front door, mirroring core `quill.editor(&mut doc)` and WASM
-    /// `quill.editor(doc)`. Returns an `Editor` holding both objects by reference
-    /// and re-borrowing per call (pyo3 objects carry no lifetime, so the editor
-    /// cannot hold the borrow the way core's `TypedEditor` does). Ephemeral by
-    /// convention — bind, write, discard.
-    fn editor(slf: Py<Self>, quill: Py<PyQuill>) -> PyEditor {
-        PyEditor { quill, doc: slf }
-    }
 
     /// Read a main-card field's stored value — a dict for a richtext corpus, a
     /// scalar/list/dict otherwise, or `None` when the field is absent. The
     /// quill-free read: reads need no schema, so they live on `Document`, not the
-    /// typed editor. For the markdown projection of a richtext value use
+    /// typed writer. For the markdown projection of a richtext value use
     /// `get_markdown`. Mirrors WASM `Document.get`.
     fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
         match self.inner.main().payload().get(name) {
@@ -548,7 +549,7 @@ impl PyDocument {
     /// Reach for it deliberately — standalone data with no quill in hand,
     /// quill-agnostic storage/migration, or a store-now-validate-later editor
     /// holding not-yet-conforming input. When a quill *is* in hand, prefer the
-    /// typed editor (`doc.editor(quill).set(name, value)`) so a mismatch surfaces
+    /// typed writer (`doc.writer(quill).set(name, value)`) so a mismatch surfaces
     /// at the write. Raises `QuillmarkError` on a malformed name. Mirrors WASM
     /// `setField`.
     fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
@@ -574,8 +575,8 @@ impl PyDocument {
     /// (database columns, form keys) surface every violation in one pass.
     ///
     /// The batched quill-free primitive (see `set_field`) — stores every value
-    /// opaquely, deferring coercion to render. Prefer the typed editor
-    /// (`doc.editor(quill).set_all(fields)`) whenever a quill is in hand: it
+    /// opaquely, deferring coercion to render. Prefer the typed writer
+    /// (`doc.writer(quill).set_all(fields)`) whenever a quill is in hand: it
     /// typed-commits the batch and reports per-field routing, so a form
     /// submitting a card is not silently stripped of schema typing. Mirrors WASM
     /// `setFields`.
@@ -828,7 +829,7 @@ impl PyDocument {
 
     /// Store an opaque value on the composable card at `index` — the
     /// card-indexed twin of `set_field`, and the same quill-free primitive.
-    /// Prefer the typed editor (`doc.editor(quill).card(index).set(...)`) when a
+    /// Prefer the typed writer (`doc.writer(quill).card(index).set(...)`) when a
     /// quill is in hand. Raises on an out-of-range index or a malformed name.
     /// Mirrors WASM `setCardField`.
     fn set_card_field(
@@ -846,7 +847,7 @@ impl PyDocument {
     /// Batched twin of `set_card_field`: set several fields on the composable
     /// card at `index` atomically. Same all-or-nothing, one-diagnostic-per-field
     /// contract as `set_fields`, and the same quill-free-primitive framing —
-    /// prefer the typed editor (`doc.editor(quill).card(index).set_all(...)`)
+    /// prefer the typed writer (`doc.writer(quill).card(index).set_all(...)`)
     /// when a quill is in hand. Mirrors WASM `setCardFields`.
     fn set_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
@@ -896,19 +897,19 @@ impl PyDocument {
 }
 
 /// A `Document` bound to its `Quill` for typed writes — the tier-1 default,
-/// from `Document.editor(quill)`. Speaks names, values, and markdown; a consumer
+/// from `Quill.writer(doc)`. Speaks names, values, and markdown; a consumer
 /// here never meets an address, a corpus dict, or a delta. It holds both objects
 /// by reference and re-borrows them per call (pyo3 objects carry no lifetime, so
-/// unlike core's `TypedEditor` it cannot keep the borrow) — so it is ephemeral by
-/// convention: bind, write, discard. Mirrors WASM `quill.editor(doc)`.
-#[pyclass(name = "Editor")]
-pub struct PyEditor {
+/// unlike core's `TypedWriter` it cannot keep the borrow) — so it is ephemeral by
+/// convention: bind, write, discard. Mirrors WASM `quill.writer(doc)`.
+#[pyclass(name = "Writer")]
+pub struct PyWriter {
     quill: Py<PyQuill>,
     doc: Py<PyDocument>,
 }
 
 #[pymethods]
-impl PyEditor {
+impl PyWriter {
     /// The bound document — the same object passed in, mutated in place.
     #[getter]
     fn document(&self, py: Python<'_>) -> Py<PyDocument> {
@@ -923,7 +924,7 @@ impl PyEditor {
         let mut doc = self.doc.borrow_mut(py);
         quill
             .inner
-            .editor(&mut doc.inner)
+            .writer(&mut doc.inner)
             .set(name, qv)
             .map_err(convert_edit_error)
     }
@@ -937,7 +938,7 @@ impl PyEditor {
         let mut doc = self.doc.borrow_mut(py);
         quill
             .inner
-            .editor(&mut doc.inner)
+            .writer(&mut doc.inner)
             .set_all(batch)
             .map_err(convert_edit_errors)
     }
@@ -950,7 +951,7 @@ impl PyEditor {
         let mut doc = self.doc.borrow_mut(py);
         quill
             .inner
-            .editor(&mut doc.inner)
+            .writer(&mut doc.inner)
             .set_body(markdown)
             .map_err(convert_edit_error)
     }
@@ -975,7 +976,7 @@ impl PyEditor {
         let mut doc = self.doc.borrow_mut(py);
         quill
             .inner
-            .editor(&mut doc.inner)
+            .writer(&mut doc.inner)
             .add_card(kind, batch, body.as_deref())
             .map_err(convert_edit_errors)
     }
@@ -995,12 +996,12 @@ impl PyEditor {
         }
     }
 
-    /// A `CardEditor` for the composable card at `index`. The index is checked
+    /// A `CardWriter` for the composable card at `index`. The index is checked
     /// lazily at the write, so this never raises. The cursor is ephemeral — a
     /// `remove_card`/`add_card` between binding and writing silently retargets
     /// it; for durable addressing stamp `$id` and re-resolve at write time.
-    fn card(&self, py: Python<'_>, index: usize) -> PyCardEditor {
-        PyCardEditor {
+    fn card(&self, py: Python<'_>, index: usize) -> PyCardWriter {
+        PyCardWriter {
             quill: self.quill.clone_ref(py),
             doc: self.doc.clone_ref(py),
             index,
@@ -1008,18 +1009,18 @@ impl PyEditor {
     }
 }
 
-/// A composable card bound to its `Quill` for typed writes, from `Editor.card`.
-/// Same verbs as `Editor`, targeting the card at its bound index; each write
+/// A composable card bound to its `Quill` for typed writes, from `Writer.card`.
+/// Same verbs as `Writer`, targeting the card at its bound index; each write
 /// raises `[EditError::IndexOutOfRange]` if that index is out of range.
-#[pyclass(name = "CardEditor")]
-pub struct PyCardEditor {
+#[pyclass(name = "CardWriter")]
+pub struct PyCardWriter {
     quill: Py<PyQuill>,
     doc: Py<PyDocument>,
     index: usize,
 }
 
 #[pymethods]
-impl PyCardEditor {
+impl PyCardWriter {
     /// The bound card index.
     #[getter]
     fn index(&self) -> usize {
@@ -1035,7 +1036,7 @@ impl PyCardEditor {
         let mut doc = self.doc.borrow_mut(py);
         quill
             .inner
-            .editor(&mut doc.inner)
+            .writer(&mut doc.inner)
             .card(self.index)
             .map_err(convert_edit_error)?
             .set(name, qv)
@@ -1043,13 +1044,13 @@ impl PyCardEditor {
     }
 
     /// Typed-commit several fields on this card atomically — same per-field
-    /// diagnostic bundle as `Editor.set_all`.
+    /// diagnostic bundle as `Writer.set_all`.
     fn set_all(&self, py: Python<'_>, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
-        let mut editor = quill.inner.editor(&mut doc.inner);
-        editor
+        let mut writer = quill.inner.writer(&mut doc.inner);
+        writer
             .card(self.index)
             .map_err(convert_edit_error)?
             .set_all(batch)
@@ -1062,7 +1063,7 @@ impl PyCardEditor {
         let mut doc = self.doc.borrow_mut(py);
         quill
             .inner
-            .editor(&mut doc.inner)
+            .writer(&mut doc.inner)
             .card(self.index)
             .map_err(convert_edit_error)?
             .set_body(markdown)

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -117,10 +117,8 @@ impl PyQuill {
 
     /// Bind this quill's schema to `doc` for typed writes — the documented front
     /// door, mirroring core `quill.writer(&mut doc)` and WASM `quill.writer(doc)`.
-    /// The quill owns the schema, so it is the factory. Returns a `Writer` holding
-    /// both objects by reference and re-borrowing per call (pyo3 objects carry no
-    /// lifetime, so the writer cannot hold the borrow the way core's `TypedWriter`
-    /// does). Ephemeral by convention — bind, write, discard.
+    /// The quill owns the schema, so it is the factory. See [`PyWriter`] for the
+    /// re-borrow/ephemerality contract.
     fn writer(slf: Py<Self>, doc: Py<PyDocument>) -> PyWriter {
         PyWriter { quill: slf, doc }
     }
@@ -549,7 +547,7 @@ impl PyDocument {
     /// Reach for it deliberately — standalone data with no quill in hand,
     /// quill-agnostic storage/migration, or a store-now-validate-later editor
     /// holding not-yet-conforming input. When a quill *is* in hand, prefer the
-    /// typed writer (`doc.writer(quill).set(name, value)`) so a mismatch surfaces
+    /// typed writer (`quill.writer(doc).set(name, value)`) so a mismatch surfaces
     /// at the write. Raises `QuillmarkError` on a malformed name. Mirrors WASM
     /// `setField`.
     fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
@@ -576,7 +574,7 @@ impl PyDocument {
     ///
     /// The batched quill-free primitive (see `set_field`) — stores every value
     /// opaquely, deferring coercion to render. Prefer the typed writer
-    /// (`doc.writer(quill).set_all(fields)`) whenever a quill is in hand: it
+    /// (`quill.writer(doc).set_all(fields)`) whenever a quill is in hand: it
     /// typed-commits the batch and reports per-field routing, so a form
     /// submitting a card is not silently stripped of schema typing. Mirrors WASM
     /// `setFields`.
@@ -829,7 +827,7 @@ impl PyDocument {
 
     /// Store an opaque value on the composable card at `index` — the
     /// card-indexed twin of `set_field`, and the same quill-free primitive.
-    /// Prefer the typed writer (`doc.writer(quill).card(index).set(...)`) when a
+    /// Prefer the typed writer (`quill.writer(doc).card(index).set(...)`) when a
     /// quill is in hand. Raises on an out-of-range index or a malformed name.
     /// Mirrors WASM `setCardField`.
     fn set_card_field(
@@ -847,7 +845,7 @@ impl PyDocument {
     /// Batched twin of `set_card_field`: set several fields on the composable
     /// card at `index` atomically. Same all-or-nothing, one-diagnostic-per-field
     /// contract as `set_fields`, and the same quill-free-primitive framing —
-    /// prefer the typed writer (`doc.writer(quill).card(index).set_all(...)`)
+    /// prefer the typed writer (`quill.writer(doc).card(index).set_all(...)`)
     /// when a quill is in hand. Mirrors WASM `setCardFields`.
     fn set_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -596,7 +596,7 @@ def test_to_markdown_ambiguous_string_survival():
     assert field(doc2.main, "date_str") == "2024-01-15"
 
 
-# ── Tier-1 typed editor — doc.editor(quill) front door ────────────────────────
+# ── Tier-1 typed writer — quill.writer(doc) front door ────────────────────────
 
 
 def _richtext_form_quill():
@@ -609,11 +609,11 @@ def _taro_quill():
     return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
 
 
-def test_editor_front_door_set_and_reads():
-    """doc.editor(quill).set writes; the reads live quill-free on the Document."""
+def test_writer_front_door_set_and_reads():
+    """quill.writer(doc).set writes; the reads live quill-free on the Document."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
-    ed = doc.editor(quill)
+    ed = quill.writer(doc)
     ed.set("author", "Ada")
     ed.set_all({"title": "On Taro"})
     assert ed.document is doc  # holds the same object, mutated in place
@@ -623,20 +623,20 @@ def test_editor_front_door_set_and_reads():
     assert doc.get_markdown() == "A **taro** essay.\n"
 
 
-def test_editor_set_rejects_unknown_field():
+def test_writer_set_rejects_unknown_field():
     """An undeclared name is a typo on the typed path — it raises, nothing lands."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     with pytest.raises(QuillmarkError, match="UnknownField"):
-        doc.editor(quill).set("stray", "x")
+        quill.writer(doc).set("stray", "x")
     assert not has_field(doc.main, "stray")
 
 
-def test_editor_add_card_transactional():
+def test_writer_add_card_transactional():
     """add_card fuses make + typed commit + push; a typo leaves the doc untouched."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
-    ed = doc.editor(quill)
+    ed = quill.writer(doc)
     ed.add_card("quotes", {"author": "Basho"}, "A quote body.")
     assert len(doc.cards) == 1
     assert field(doc.cards[0], "author") == "Basho"
@@ -645,11 +645,11 @@ def test_editor_add_card_transactional():
     assert len(doc.cards) == 1  # nothing joined the document
 
 
-def test_editor_card_cursor_set_and_body():
-    """editor.card(i) targets the composable card; a bad index raises at the write."""
+def test_writer_card_cursor_set_and_body():
+    """writer.card(i) targets the composable card; a bad index raises at the write."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
-    ed = doc.editor(quill)
+    ed = quill.writer(doc)
     ed.add_card("quotes", {"author": "Basho"})
     ed.card(0).set("author", "Issa")
     assert field(doc.cards[0], "author") == "Issa"
@@ -657,30 +657,30 @@ def test_editor_card_cursor_set_and_body():
         ed.card(9).set("author", "x")
 
 
-def test_editor_set_coerces_richtext_to_corpus():
+def test_writer_set_coerces_richtext_to_corpus():
     """A richtext field commits the canonical corpus, not the authored markdown."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    doc.editor(quill).set("bio", "A **bold** intro.")
+    quill.writer(doc).set("bio", "A **bold** intro.")
     value = field(doc.main, "bio")
     assert isinstance(value, dict)  # stored as the corpus dict, not a string
     assert value["text"] == "A bold intro."
 
 
-def test_editor_set_rejects_inline_violation():
+def test_writer_set_rejects_inline_violation():
     """A richtext(inline) field rejects multi-block content at the write."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
     with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
-        doc.editor(quill).set("headline", "line one\n\nline two")
+        quill.writer(doc).set("headline", "line one\n\nline two")
 
 
-def test_editor_set_all_is_all_or_nothing():
+def test_writer_set_all_is_all_or_nothing():
     """A mid-batch inline violation aborts set_all — nothing lingers."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
     with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
-        doc.editor(quill).set_all({"bio": "ok", "headline": "line one\n\nline two"})
+        quill.writer(doc).set_all({"bio": "ok", "headline": "line one\n\nline two"})
     assert not has_field(doc.main, "bio")
 
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -286,23 +286,23 @@ Per-keystroke cost is the same either way (both mutate the in-memory `Document`
 in place; no seam is crossed), so steering to `commit*` buys the type check for
 free.
 
-#### `DocumentEditor` / `CardEditor` — bind the quill once
+#### `DocumentWriter` / `CardWriter` — bind the quill once
 
 The `commit*` verbs take the `quill` handle per call (the document carries no
 schema). When you hold both a quill and a document — a form editor, an MCP
-writer — bind them once with the editor sugar and issue bare verbs:
+writer — bind them once with the writer sugar and issue bare verbs:
 
 ```ts
-import { DocumentEditor } from "@quillmark/wasm";
+import { DocumentWriter } from "@quillmark/wasm";
 
-const ed = new DocumentEditor(quill, doc);          // JS twin of Rust `quill.editor(doc)`
+const ed = new DocumentWriter(quill, doc);          // JS twin of Rust `quill.writer(doc)`
 ed.set("subject", "Q3 results");                    // strict-committed to the schema type
 ed.setAll({ qty: "3", subject: "Q3" });             // all-or-nothing batch
 ed.set("titel", "x");                               // throws UnknownField — a typo, not a fallback
 ed.card(2).set("body", "**note**");                 // composable card, resolved by its $kind
 ```
 
-`DocumentEditor` / `CardEditor` are pure JS holding references to your existing
+`DocumentWriter` / `CardWriter` are pure JS holding references to your existing
 `quill` and `doc` — no WASM handle of their own, nothing to `free()`. `card(i)`
 is lazy: it never throws; an out-of-range index throws `IndexOutOfRange` at the
 write.

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -15,8 +15,8 @@ import {
   Quill,
   Document,
   Engine,
-  DocumentEditor,
-  CardEditor,
+  DocumentWriter,
+  CardWriter,
   isQuillmarkError,
   exportMarkdown,
 } from '@quillmark-wasm/runtime'
@@ -111,15 +111,15 @@ describe('@quillmark/wasm/runtime — surface', () => {
   })
 })
 
-// The typed-editor sugar binds a quill to a document once, so writes are bare
-// `set` / `setAll` / `card(i).set` — the JS twin of Rust's `quill.editor(doc)`,
+// The typed-writer sugar binds a quill to a document once, so writes are bare
+// `set` / `setAll` / `card(i).set` — the JS twin of Rust's `quill.writer(doc)`,
 // forwarding to the `commit*` verbs (typed for a schema field, opaque otherwise).
-describe('@quillmark/wasm/runtime — DocumentEditor / CardEditor (bind the quill once)', () => {
+describe('@quillmark/wasm/runtime — DocumentWriter / CardWriter (bind the quill once)', () => {
   const EDITOR_QUILL_YAML = `quill:
   name: editor_test
   version: "1.0"
   backend: typst
-  description: Typed editor sugar test
+  description: Typed writer sugar test
 
 main:
   fields:
@@ -141,41 +141,41 @@ card_kinds:
   const fieldOf = (card, key) =>
     card.payloadItems.find((i) => i.type === 'field' && i.key === key)?.value
 
-  it('quill.editor(doc) is the front door and returns a DocumentEditor', () => {
+  it('quill.writer(doc) is the front door and returns a DocumentWriter', () => {
     const quill = buildQuill()
-    const ed = quill.editor(blankDoc())
-    expect(ed).toBeInstanceOf(DocumentEditor)
+    const ed = quill.writer(blankDoc())
+    expect(ed).toBeInstanceOf(DocumentWriter)
     // The factory is sugar over the constructor — same class, no wrapping.
-    expect(new DocumentEditor(quill, blankDoc())).toBeInstanceOf(DocumentEditor)
+    expect(new DocumentWriter(quill, blankDoc())).toBeInstanceOf(DocumentWriter)
   })
 
   it('set binds the quill once and strict-commits a schema field', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     ed.set('qty', '3') // schema field → strict coerce
     expect(fieldOf(ed.document.main, 'qty')).toBe(3)
   })
 
   it('set rejects an undeclared name as a typo, not a fallback', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     expect(() => ed.set('stray', 'x')).toThrow(/UnknownField/)
     expect(fieldOf(ed.document.main, 'stray')).toBeUndefined()
   })
 
   it('setAll aborts the whole batch on a typo, applying nothing', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     expect(() => ed.setAll({ qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
     expect(fieldOf(ed.document.main, 'qty')).toBeUndefined()
     expect(fieldOf(ed.document.main, 'titel')).toBeUndefined()
   })
 
   it('setBody writes the main body from markdown, receipt-free', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     ed.setBody('New **body**.')
     expect(ed.document.getMarkdown()).toBe('New **body**.\n')
   })
 
   it('addCard fuses make + typed commit + push, transactionally', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     // `body` here is the card's richtext FIELD; the third arg is the card body.
     ed.addCard('note', { body: 'Field **body**.' }, 'Card body text.')
     expect(ed.document.cards).toHaveLength(1)
@@ -188,7 +188,7 @@ card_kinds:
   })
 
   it('removeCard drops the card and returns it', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     ed.addCard('note', { body: 'x' })
     const removed = ed.removeCard(0)
     expect(removed.kind).toBe('note')
@@ -199,7 +199,7 @@ card_kinds:
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: editor_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
-    const ed = buildQuill().editor(doc)
+    const ed = buildQuill().writer(doc)
     ed.card(0).set('body', 'Card **body**.')
     expect(exportMarkdown(fieldOf(doc.cards[0], 'body'))).toBe('Card **body**.\n')
     ed.card(0).setBody('Card body md.')
@@ -207,14 +207,14 @@ card_kinds:
   })
 
   it('a bad card index throws at write time, not at card()', () => {
-    const ed = buildQuill().editor(blankDoc())
-    const cardEd = ed.card(9) // lazy: constructing the CardEditor never throws
-    expect(cardEd).toBeInstanceOf(CardEditor)
+    const ed = buildQuill().writer(blankDoc())
+    const cardEd = ed.card(9) // lazy: constructing the CardWriter never throws
+    expect(cardEd).toBeInstanceOf(CardWriter)
     expect(() => cardEd.set('body', 'x')).toThrow(/IndexOutOfRange/)
   })
 
   it('get / getMarkdown read main fields quill-free, off the Document', () => {
-    const ed = buildQuill().editor(blankDoc())
+    const ed = buildQuill().writer(blankDoc())
     ed.set('qty', '3')
     ed.set('subject', 'Q3 **results**')
     expect(ed.document.get('qty')).toBe(3)

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -442,27 +442,27 @@ export declare class LiveSession {
 	free(): void;
 }
 
-// ── Typed editor — the tier-1 front door ────────────────────────────────────
+// ── Typed writer — the tier-1 front door ────────────────────────────────────
 
-// `quill.editor(doc)` is patched onto the re-exported `Quill` prototype (the
+// `quill.writer(doc)` is patched onto the re-exported `Quill` prototype (the
 // class is re-exported verbatim, so the method is declared by merging into the
 // core module's `Quill` rather than redeclaring the class).
 declare module '../core/wasm.js' {
 	interface Quill {
 		/**
 		 * Bind this quill's schema to `doc` for typed writes — the documented
-		 * front door, mirroring core's `quill.editor(&mut doc)`. The schema grants
-		 * the typing, so the quill is the factory. The returned editor holds both
+		 * front door, mirroring core's `quill.writer(&mut doc)`. The schema grants
+		 * the typing, so the quill is the factory. The returned writer holds both
 		 * handles by reference and owns neither (nothing to `free()`); it is
 		 * ephemeral by convention — bind, write, discard.
 		 */
-		editor(doc: Document): DocumentEditor;
+		writer(doc: Document): DocumentWriter;
 	}
 }
 
 /**
  * A `Document` bound to its `Quill` for typed writes — the tier-1 default,
- * constructed via {@link Quill.editor}. Speaks names, values, and markdown; a
+ * constructed via {@link Quill.writer}. Speaks names, values, and markdown; a
  * consumer here never meets an `Addr`, a corpus object, or a `Delta`. Bare
  * `set` / `setAll` / `setBody` / `addCard` / `card(i).set` instead of threading
  * the `quill` handle through every `commit*` call. Holds both handles by
@@ -475,7 +475,7 @@ declare module '../core/wasm.js' {
  * deliberate quill-free primitive (standalone data, storage/migration infra, or
  * holding not-yet-conforming in-progress input).
  */
-export declare class DocumentEditor {
+export declare class DocumentWriter {
 	constructor(quill: Quill, doc: Document);
 	/** The bound document — the instance passed in, mutated in place. */
 	readonly document: Document;
@@ -506,21 +506,21 @@ export declare class DocumentEditor {
 	/** Remove the composable card at `index`, returning it (or `undefined`). */
 	removeCard(index: number): Card | undefined;
 	/**
-	 * A {@link CardEditor} for the composable card at `index`. Index validity is
+	 * A {@link CardWriter} for the composable card at `index`. Index validity is
 	 * checked lazily at commit time, so this never throws. The cursor is
 	 * ephemeral — a `removeCard`/`addCard` between binding and writing silently
 	 * retargets it; for durable addressing stamp `$id` and re-resolve at write.
 	 */
-	card(index: number): CardEditor;
+	card(index: number): CardWriter;
 }
 
 /**
  * A composable card bound to its `Quill` for typed writes, from
- * {@link DocumentEditor.card}. Same verbs as {@link DocumentEditor}, targeting
+ * {@link DocumentWriter.card}. Same verbs as {@link DocumentWriter}, targeting
  * the card at its bound index; each write throws `IndexOutOfRange` if that index
  * is out of range.
  */
-export declare class CardEditor {
+export declare class CardWriter {
 	constructor(quill: Quill, doc: Document, index: number);
 	/** The bound card index. */
 	readonly index: number;

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -54,7 +54,7 @@
 // (`Quill === CoreQuill`) is the executable guard for this invariant.
 //
 // Imported (not bare re-exported) so `Quill` is a local binding this module can
-// augment — `quill.editor(doc)` is patched onto its prototype below. The
+// augment — `quill.writer(doc)` is patched onto its prototype below. The
 // re-export keeps the identity: the exported `Quill` IS the core class.
 import { Quill, Document, init } from '../core/wasm.js';
 export { Quill, Document, init };
@@ -520,8 +520,8 @@ export class LiveSession {
 	}
 }
 
-// ── Typed-editor sugar: bind the quill once ─────────────────────────────────
-// Rust exposes `quill.editor(&mut doc)` so a caller issues bare `set` / `set_all`
+// ── Typed-writer sugar: bind the quill once ─────────────────────────────────
+// Rust exposes `quill.writer(&mut doc)` so a caller issues bare `set` / `set_all`
 // without threading the schema per write. The WASM `commit*` verbs can't borrow
 // like that — a `Document` carries only a `$quill` REFERENCE, not the resolved
 // schema, so each `commit*` method takes the `quill` handle as its first
@@ -538,11 +538,11 @@ export class LiveSession {
 
 /**
  * A {@link Document} bound to its {@link Quill} for typed writes — the JS twin
- * of Rust's `quill.editor(&mut doc)`. Writes target the main card; use
+ * of Rust's `quill.writer(&mut doc)`. Writes target the main card; use
  * {@link card} for a composable card. Holds both handles by reference and owns
  * neither, so there is nothing to `free()`.
  */
-export class DocumentEditor {
+export class DocumentWriter {
 	#quill;
 	#doc;
 	/**
@@ -614,7 +614,7 @@ export class DocumentEditor {
 		return this.#doc.removeCard(index);
 	}
 	/**
-	 * A {@link CardEditor} bound to the composable card at `index`. Index
+	 * A {@link CardWriter} bound to the composable card at `index`. Index
 	 * validity is checked lazily by the underlying write (it throws
 	 * `IndexOutOfRange` at commit time), so constructing one never throws.
 	 *
@@ -623,19 +623,19 @@ export class DocumentEditor {
 	 * retargets it. For durable addressing stamp `$id` and re-resolve the index
 	 * at write time.
 	 * @param {number} index
-	 * @returns {CardEditor}
+	 * @returns {CardWriter}
 	 */
 	card(index) {
-		return new CardEditor(this.#quill, this.#doc, index);
+		return new CardWriter(this.#quill, this.#doc, index);
 	}
 }
 
 /**
  * A single composable card bound to its {@link Quill} for typed writes, from
- * {@link DocumentEditor.card}. Same `set` / `setAll` verbs as
- * {@link DocumentEditor}, targeting the card at its bound index.
+ * {@link DocumentWriter.card}. Same `set` / `setAll` verbs as
+ * {@link DocumentWriter}, targeting the card at its bound index.
  */
-export class CardEditor {
+export class CardWriter {
 	#quill;
 	#doc;
 	#index;
@@ -676,7 +676,7 @@ export class CardEditor {
 	}
 	/**
 	 * Set this card's body from markdown (edit semantics), discarding the delta —
-	 * the card twin of {@link DocumentEditor.setBody}.
+	 * the card twin of {@link DocumentWriter.setBody}.
 	 * @param {string} markdown
 	 * @returns {void}
 	 */
@@ -685,22 +685,22 @@ export class CardEditor {
 	}
 }
 
-// ── `quill.editor(doc)` — the typed front door ──────────────────────────────
+// ── `quill.writer(doc)` — the typed front door ──────────────────────────────
 // The tier-1 default: bind the quill's schema to a document and issue bare
-// typed writes. Mirrors core's `quill.editor(&mut doc)` — the schema grants the
+// typed writes. Mirrors core's `quill.writer(&mut doc)` — the schema grants the
 // typing, so the quill (not the document) is the factory. Patched onto the
 // re-exported `Quill` prototype rather than wrapped: `Quill === CoreQuill`
 // stays true (the identity invariant above); this only adds a method that
-// constructs the pure-JS editor, which owns no WASM handle.
+// constructs the pure-JS writer, which owns no WASM handle.
 /**
- * A {@link DocumentEditor} binding this quill's schema to `doc` for typed
- * writes — the documented front door. The returned editor holds both handles by
+ * A {@link DocumentWriter} binding this quill's schema to `doc` for typed
+ * writes — the documented front door. The returned writer holds both handles by
  * reference and owns neither, so there is nothing to `free()`. Ephemeral by
  * convention: bind, write, discard.
  * @this {Quill}
  * @param {Document} doc the document to mutate, held by reference (not owned)
- * @returns {DocumentEditor}
+ * @returns {DocumentWriter}
  */
-Quill.prototype.editor = function editor(doc) {
-	return new DocumentEditor(this, doc);
+Quill.prototype.writer = function writer(doc) {
+	return new DocumentWriter(this, doc);
 };

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -816,7 +816,7 @@ impl Document {
     /// Read a main-card field's stored value — the raw payload value (a corpus
     /// object for a richtext field, a scalar/array/object otherwise), or
     /// `undefined` when the field is absent. The quill-free read: reads need no
-    /// schema, so they live on `Document`, not the typed editor. For the markdown
+    /// schema, so they live on `Document`, not the typed writer. For the markdown
     /// projection of a richtext value use [`getMarkdown`](Self::get_markdown).
     #[wasm_bindgen(js_name = get)]
     pub fn get(&self, name: &str) -> Result<JsValue, JsValue> {
@@ -1193,7 +1193,7 @@ impl Document {
         let qv = quillmark_core::QuillValue::from_json(json);
         quill
             .inner
-            .editor(&mut self.inner)
+            .writer(&mut self.inner)
             .set(name, qv)
             .map_err(|e| edit_error_to_js(&e))
     }
@@ -1214,14 +1214,14 @@ impl Document {
         let batch = js_value_to_field_batch(&fields, "commitFields")?;
         quill
             .inner
-            .editor(&mut self.inner)
+            .writer(&mut self.inner)
             .set_all(batch)
             .map_err(edit_errors_to_js)
     }
 
     /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
     /// body from optional markdown, and append it — the ABI under
-    /// `editor.addCard`. Fuses `makeCard` + typed commit + `pushCard`
+    /// `writer.addCard`. Fuses `makeCard` + typed commit + `pushCard`
     /// transactionally: the card is committed in full before it joins the
     /// document, so a rejected field (or an invalid kind or body) leaves the
     /// document untouched. Field errors throw the same per-field diagnostic
@@ -1244,7 +1244,7 @@ impl Document {
         };
         quill
             .inner
-            .editor(&mut self.inner)
+            .writer(&mut self.inner)
             .add_card(kind, batch, body.as_deref())
             .map_err(edit_errors_to_js)
     }
@@ -1394,8 +1394,8 @@ impl Document {
     ) -> Result<(), JsValue> {
         let json = js_value_to_json(value, "commitCardField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
-        let mut editor = quill.inner.editor(&mut self.inner);
-        let mut card = editor.card(index).map_err(|e| edit_error_to_js(&e))?;
+        let mut writer = quill.inner.writer(&mut self.inner);
+        let mut card = writer.card(index).map_err(|e| edit_error_to_js(&e))?;
         card.set(name, qv).map_err(|e| edit_error_to_js(&e))
     }
 
@@ -1414,8 +1414,8 @@ impl Document {
         #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
     ) -> Result<(), JsValue> {
         let batch = js_value_to_field_batch(&fields, "commitCardFields")?;
-        let mut editor = quill.inner.editor(&mut self.inner);
-        editor
+        let mut writer = quill.inner.writer(&mut self.inner);
+        writer
             .card(index)
             .map_err(|e| edit_error_to_js(&e))?
             .set_all(batch)

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -57,8 +57,8 @@ pub enum EditError {
     #[error("invalid field name '{0}': must match [A-Za-z_][A-Za-z0-9_]*")]
     InvalidFieldName(String),
 
-    /// A typed write ([`TypedEditor::set`](crate::TypedEditor::set) /
-    /// [`CardEditor::set`](crate::CardEditor::set)) addressed a well-formed name
+    /// A typed write ([`TypedWriter::set`](crate::TypedWriter::set) /
+    /// [`CardWriter::set`](crate::CardWriter::set)) addressed a well-formed name
     /// that the bound schema does not declare (or a card whose `$kind` carries
     /// no schema). The typed path resolves every name to a schema type, so an
     /// undeclared name is a typo, not a fallback — it fails here instead of
@@ -219,7 +219,7 @@ fn conform_error_to_edit(name: &str, err: CoercionError) -> EditError {
 
 /// Compute the canonical stored form of a typed field write **without applying
 /// it** — the dry-run shared by [`Card::commit_field`] and the batched,
-/// all-or-nothing [`TypedEditor::set_all`](crate::TypedEditor::set_all).
+/// all-or-nothing [`TypedWriter::set_all`](crate::TypedWriter::set_all).
 ///
 /// Strict `Leniency::Write` conform against `schema`; the name and stored-value
 /// depth are validated too, so a batch can collect every violation before any
@@ -607,7 +607,7 @@ impl Card {
     ///
     /// The caller supplies the `schema` because a [`Document`] holds only a
     /// `$quill` *reference*, not the resolved schema; an editor holds it (see
-    /// [`crate::TypedEditor`], which resolves the schema per field and calls
+    /// [`crate::TypedWriter`], which resolves the schema per field and calls
     /// this).
     ///
     /// Returns [`EditError::InvalidFieldName`] for a malformed name,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,8 +30,8 @@ pub use document::{
     RichtextDecodeError, SeedOverlay, WireError,
 };
 
-pub mod editor;
-pub use editor::{CardEditor, TypedEditor};
+pub mod writer;
+pub use writer::{CardWriter, TypedWriter};
 
 pub mod backend;
 pub use backend::{formats_support_canvas, Backend};

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -71,12 +71,12 @@ impl Quill {
         &self.config
     }
 
-    /// A schema-bound [`TypedEditor`](crate::TypedEditor) over `doc`. The front
+    /// A schema-bound [`TypedWriter`](crate::TypedWriter) over `doc`. The front
     /// door for typed field writes: it resolves each field's type from this
     /// quill's schema, so callers issue one verb (`set`) with no type token or
-    /// `inline` flag. See the [`editor`](crate::editor) module.
-    pub fn editor<'a>(&'a self, doc: &'a mut crate::document::Document) -> crate::TypedEditor<'a> {
-        crate::TypedEditor::new(&self.config, doc)
+    /// `inline` flag. See the [`writer`](crate::writer) module.
+    pub fn writer<'a>(&'a self, doc: &'a mut crate::document::Document) -> crate::TypedWriter<'a> {
+        crate::TypedWriter::new(&self.config, doc)
     }
 
     /// The in-memory file tree for this quill.

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -379,7 +379,7 @@ card_kinds:
     }
 
     #[test]
-    fn card_editor_resolves_card_kind_schema() {
+    fn card_writer_resolves_card_kind_schema() {
         let config = config();
         let mut doc = blank_doc();
         doc.push_card(Card::new("note").unwrap()).unwrap();

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -1,25 +1,25 @@
-//! Schema-bound typed editor — the front door for typed field writes.
+//! Schema-bound typed writer — the front door for typed field writes.
 //!
 //! [`Card::commit_field`](crate::Card::commit_field) still asks the caller to
 //! fetch a [`FieldSchema`] per write. Every consumer that wants typed writes (a
 //! form editor, an MCP server) already holds the resolved [`QuillConfig`] — it
-//! renders with it. [`Quill::editor`](crate::Quill::editor) binds the schema
+//! renders with it. [`Quill::writer`](crate::Quill::writer) binds the schema
 //! once, so callers issue one verb (`set`) and never pass a type token or an
-//! `inline` flag: the editor resolves each field's type itself, strict-commits
+//! `inline` flag: the writer resolves each field's type itself, strict-commits
 //! a schema field, and rejects a name the schema does not declare with
 //! [`EditError::UnknownField`] — on the typed path an undeclared name is a typo,
 //! not a fallback. Opaque storage stays available on purpose through the raw
 //! [`Card::set_field`](crate::Card::set_field) verb.
 //!
 //! ```ignore
-//! let mut ed = quill.editor(&mut doc);
-//! ed.set("subject", "Q3 results")?;       // richtext(inline) → strict corpus commit
-//! ed.set("qty", "3")?;                    // integer → strict coerce, stores 3
-//! ed.card(2)?.set("desc", corpus_json)?;  // card kind → CardSchema → field type
-//! ed.set_all([("a", "1"), ("b", "2")])?;  // batched, all-or-nothing
+//! let mut w = quill.writer(&mut doc);
+//! w.set("subject", "Q3 results")?;       // richtext(inline) → strict corpus commit
+//! w.set("qty", "3")?;                    // integer → strict coerce, stores 3
+//! w.card(2)?.set("desc", corpus_json)?;  // card kind → CardSchema → field type
+//! w.set_all([("a", "1"), ("b", "2")])?;  // batched, all-or-nothing
 //! ```
 //!
-//! The editor holds `&mut Document` and `&QuillConfig`, so a bound `TypedEditor`
+//! The writer holds `&mut Document` and `&QuillConfig`, so a bound `TypedWriter`
 //! cannot cross a binding boundary that carries no lifetimes (wasm-bindgen /
 //! pyo3 objects); those surfaces construct one per call from the quill handle.
 
@@ -31,15 +31,15 @@ use crate::quill::{CardSchema, FieldSchema, QuillConfig};
 use crate::value::QuillValue;
 
 /// A [`Document`] bound to its [`QuillConfig`] for typed writes. Construct with
-/// [`Quill::editor`](crate::Quill::editor). Writes target the main card; use
+/// [`Quill::writer`](crate::Quill::writer). Writes target the main card; use
 /// [`card`](Self::card) for a composable card.
-pub struct TypedEditor<'a> {
+pub struct TypedWriter<'a> {
     config: &'a QuillConfig,
     doc: &'a mut Document,
 }
 
-impl<'a> TypedEditor<'a> {
-    /// Bind `doc` to `config`. Prefer [`Quill::editor`](crate::Quill::editor).
+impl<'a> TypedWriter<'a> {
+    /// Bind `doc` to `config`. Prefer [`Quill::writer`](crate::Quill::writer).
     pub fn new(config: &'a QuillConfig, doc: &'a mut Document) -> Self {
         Self { config, doc }
     }
@@ -117,13 +117,13 @@ impl<'a> TypedEditor<'a> {
         Ok(())
     }
 
-    /// A schema-bound editor for the composable card at `index`. The card's
+    /// A schema-bound writer for the composable card at `index`. The card's
     /// `$kind` resolves its [`CardSchema`]; an unknown kind carries no schema, so
     /// every field on it is undeclared and its typed writes fail with
     /// [`EditError::UnknownField`] (write such a card opaquely through
     /// [`Card::set_field`](crate::Card::set_field)). Returns
     /// [`EditError::IndexOutOfRange`] when `index` is out of range.
-    pub fn card(&mut self, index: usize) -> Result<CardEditor<'_>, EditError> {
+    pub fn card(&mut self, index: usize) -> Result<CardWriter<'_>, EditError> {
         let config = self.config;
         let len = self.doc.cards().len();
         let card = self
@@ -131,18 +131,18 @@ impl<'a> TypedEditor<'a> {
             .card_mut(index)
             .ok_or(EditError::IndexOutOfRange { index, len })?;
         let schema = card.kind().and_then(|k| config.card_kind(k));
-        Ok(CardEditor { schema, card })
+        Ok(CardWriter { schema, card })
     }
 }
 
 /// A single composable card bound to its [`CardSchema`], from
-/// [`TypedEditor::card`]. Same `set` / `set_all` verbs as [`TypedEditor`].
-pub struct CardEditor<'a> {
+/// [`TypedWriter::card`]. Same `set` / `set_all` verbs as [`TypedWriter`].
+pub struct CardWriter<'a> {
     schema: Option<&'a CardSchema>,
     card: &'a mut Card,
 }
 
-impl CardEditor<'_> {
+impl CardWriter<'_> {
     /// The card's `$kind`, if any.
     pub fn kind(&self) -> Option<&str> {
         self.card.kind()
@@ -160,13 +160,13 @@ impl CardEditor<'_> {
     }
 
     /// Revise this card's body from markdown (edit semantics), discarding the
-    /// delta — the card twin of [`TypedEditor::set_body`].
+    /// delta — the card twin of [`TypedWriter::set_body`].
     pub fn set_body(&mut self, markdown: &str) -> Result<(), EditError> {
         self.card.revise_body(markdown).map(|_| ())
     }
 
     /// Write several fields on this card atomically — see
-    /// [`TypedEditor::set_all`]; an undeclared name aborts the whole batch with
+    /// [`TypedWriter::set_all`]; an undeclared name aborts the whole batch with
     /// [`EditError::UnknownField`].
     pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
     where
@@ -178,8 +178,8 @@ impl CardEditor<'_> {
     }
 }
 
-/// All-or-nothing batched write shared by [`TypedEditor::set_all`] and
-/// [`CardEditor::set_all`]: resolve every field first (collecting every error),
+/// All-or-nothing batched write shared by [`TypedWriter::set_all`] and
+/// [`CardWriter::set_all`]: resolve every field first (collecting every error),
 /// apply none on failure, apply all on success. A name absent from
 /// `fields_schema` (or every name, when the whole schema is `None` — an unknown
 /// card kind) is an [`EditError::UnknownField`], the batch form of the scalar
@@ -258,7 +258,7 @@ card_kinds:
     fn set_resolves_schema_field_as_typed_commit() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
 
         // A schema field commits typed: "3" → 3, richtext string → corpus.
         ed.set("qty", "3").unwrap();
@@ -274,7 +274,7 @@ card_kinds:
     fn set_rejects_unknown_field() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         // Unknown field on the typed path is a typo, not a fallback: it fails
         // here and nothing is written. Opaque storage is the raw `set_field`.
         let err = ed.set("notafield", "x").unwrap_err();
@@ -286,7 +286,7 @@ card_kinds:
     fn set_reports_strict_conform_failure() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         let err = ed.set("qty", "not-a-number").unwrap_err();
         assert_eq!(err.variant_name(), "FieldConform");
         // A richtext(inline) violation surfaces through the richtext variant.
@@ -298,7 +298,7 @@ card_kinds:
     fn set_all_is_all_or_nothing() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         // One bad field aborts the whole batch; nothing is applied.
         let errs = ed
             .set_all([("qty", "5"), ("subject", "bad\n\nblock")])
@@ -308,7 +308,7 @@ card_kinds:
         assert!(doc.main().payload().get("qty").is_none());
 
         // A clean batch applies every field.
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         ed.set_all([("qty", "5"), ("subject", "ok")]).unwrap();
         assert_eq!(
             doc.main().payload().get("qty").unwrap().as_json(),
@@ -320,7 +320,7 @@ card_kinds:
     fn set_all_rejects_unknown_field() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         // A whole-form submit with a typo'd name: `qty` is a schema field, `titel`
         // is not. The undeclared name aborts the all-or-nothing batch — nothing is
         // written and the typo is reported.
@@ -335,7 +335,7 @@ card_kinds:
     fn set_body_revises_main_body() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         ed.set_body("**hi**").unwrap();
         assert_eq!(doc.main().body_markdown(), "**hi**\n");
     }
@@ -344,7 +344,7 @@ card_kinds:
     fn add_card_fuses_new_commit_push() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         ed.add_card("note", [("body", "**hi**")], Some("card body"))
             .unwrap();
         assert_eq!(doc.cards().len(), 1);
@@ -357,7 +357,7 @@ card_kinds:
     fn add_card_is_transactional_on_bad_field() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         // An undeclared field aborts the commit; the card never joins the document.
         let errs = ed
             .add_card("note", [("stray", "x")], None)
@@ -371,7 +371,7 @@ card_kinds:
     fn add_card_reports_invalid_kind() {
         let config = config();
         let mut doc = blank_doc();
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         // A reserved kind is refused before any card is built.
         let errs = ed.add_card("$reserved", [] as [(&str, &str); 0], None).unwrap_err();
         assert_eq!(errs[0].0, "$kind");
@@ -384,7 +384,7 @@ card_kinds:
         let mut doc = blank_doc();
         doc.push_card(Card::new("note").unwrap()).unwrap();
 
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         let mut card_ed = ed.card(0).unwrap();
         card_ed.set("body", "**hi**").unwrap();
         // Unknown field on a known card → rejected as a typo.
@@ -394,7 +394,7 @@ card_kinds:
         assert_eq!(doc.cards()[0].field_markdown("body").unwrap(), "**hi**\n");
 
         // Out-of-range card index errors.
-        let mut ed = TypedEditor::new(&config, &mut doc);
+        let mut ed = TypedWriter::new(&config, &mut doc);
         assert!(matches!(
             ed.card(9),
             Err(EditError::IndexOutOfRange { .. })

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -376,7 +376,7 @@ interaction. The decision tree:
 | `commit*` demoted to ABI | `commitField` / `commitFields` / `commitCardField(s)` stay as the stable ABI under the writer's `set` / `set_all`, dropped from the documented surface. |
 
 The hand-written WASM runtime becomes the real API and the wasm class its ABI —
-committed to, not just tolerated. See [BINDINGS.md](../../prose/canon/BINDINGS.md)
+committed to, not just tolerated. See [BINDINGS.md](https://github.com/quillmark-org/quillmark/blob/main/prose/canon/BINDINGS.md)
 for the parity table that now governs core-vs-bindings drift.
 
 ### One idiom difference to know

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -171,7 +171,7 @@ Only these three shipped at v0.92.1, so only these get a one-cycle alias:
 | Python `replace_body(md)` | `revise(md)` (delta discarded) |
 | Python `update_card_body(index, md)` | `revise(md, card=index)` |
 
-## Typed field writes: `commit_field` and the schema-bound editor (#893)
+## Typed field writes: `commit_field` and the schema-bound writer (#893)
 
 The type a write commits belongs in the **schema**, not the method name — so
 there is one typed writer per address that dispatches on the field's

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -126,7 +126,7 @@ An **address** locates a richtext value: `{ card?, field? }` in wasm (absent
 
 (An earlier draft added a fourth addressed verb, `commit(addr, value, quill)`,
 for typed field writes. #932 deleted it pre-release: typed writes are the
-[typed editor](#the-two-tier-binding-surface-932)'s job, not the corpus lane's,
+[typed writer](#the-two-tier-binding-surface-932)'s job, not the corpus lane's,
 and the addressed `commit` only duplicated `commitField` / `commitCardField`
 behind an `Addr`. The corpus lane is content-only — `install` / `revise` /
 `applyChange`, no schema in sight.)
@@ -157,7 +157,7 @@ twins `Card::install_field(name, rt)` / **`revise_field(name, md) -> Delta`**
 no anchor-preserving markdown writer. `install`/`revise` on a field are
 schema-blind (the corpus-writer stratum splices without the quill, like
 `apply_field_richtext_change`); the typed door that enforces `richtext(inline)`
-is the editor's `commit_field` (reached as `editor.set` in the bindings — WASM's
+is the writer's `commit_field` (reached as `writer.set` in the bindings — WASM's
 `commitField` ABI, Python's direct core call), and a violation on the
 schema-blind path otherwise surfaces at validate/render.
 
@@ -185,7 +185,7 @@ pre-release** and folded into the one typed writer below.
 | `Card::set_field_richtext(name, &json, inline)` | `Card::commit_field(name, value, &field_schema)` |
 | wasm `setRichtextField(name, value, inline?)` | wasm `commitField(quill, name, value)` |
 | wasm `updateCardRichtextField(index, name, value, inline?)` | wasm `commitCardField(quill, index, name, value)` |
-| — (Python had no richtext field writer) | Python `doc.editor(quill).set(name, value)` / `.card(index).set(name, value)` (the standalone `Document.commit_field` / `commit_card_field` this section first added were deleted by #932 — see below) |
+| — (Python had no richtext field writer) | Python `quill.writer(doc).set(name, value)` / `.card(index).set(name, value)` (the standalone `Document.commit_field` / `commit_card_field` this section first added were deleted by #932 — see below) |
 
 The corpus read twin is `Card::field_richtext(name)`; the markdown projection
 is the on-demand `exportMarkdown(fieldCorpus)` codec (the eager `field_markdown`
@@ -205,21 +205,21 @@ at the boundary as `applyChange({ field }, bundle)`.
   corpus.
 - **The schema carries `inline`.** A richtext `FieldSchema` with `inline: true`
   enforces `richtext(inline)` at the commit — no write-side flag.
-- **The schema-bound editor is the front door.** `quill.editor(&mut doc)`
-  ([`TypedEditor`]) resolves each field's type itself, so callers issue one verb
-  with no type token: `ed.set("qty", "3")?`, `ed.card(2)?.set("desc", v)?`,
-  `ed.set_all([..])?` (all-or-nothing). `set` strict-commits a schema field and
+- **The schema-bound writer is the front door.** `quill.writer(&mut doc)`
+  ([`TypedWriter`]) resolves each field's type itself, so callers issue one verb
+  with no type token: `w.set("qty", "3")?`, `w.card(2)?.set("desc", v)?`,
+  `w.set_all([..])?` (all-or-nothing). `set` strict-commits a schema field and
   rejects a name the schema does not declare with `EditError::UnknownField` — on
   the typed path an undeclared name is a typo, not a fallback, so it fails at the
   write rather than landing silently in the opaque store (#918). Opaque storage
   stays available on purpose through the raw `set_field` / `setField` /
-  `setCardField` verbs. In the bindings the editor is a real object —
-  `quill.editor(doc)` (WASM) / `doc.editor(quill)` (Python) — that re-borrows the
-  quill + document per call, since wasm-bindgen / pyo3 objects carry no lifetime
-  (#932). WASM keeps the per-call `commitField` verbs as the ABI its editor
-  delegates to; Python's editor calls core directly, so its standalone
-  `commit_field` was deleted (#932). Both return nothing on success and throw on
-  an undeclared name.
+  `setCardField` verbs. In the bindings the writer is a real object —
+  `quill.writer(doc)` in WASM and Python alike — that re-borrows the quill +
+  document per call, since wasm-bindgen / pyo3 objects carry no lifetime (#932).
+  The quill owns the schema, so it is the factory on every surface. WASM keeps
+  the per-call `commitField` verbs as the ABI its writer delegates to; Python's
+  writer calls core directly, so its standalone `commit_field` was deleted
+  (#932). Both return nothing on success and throw on an undeclared name.
 - **`set_field` is unchanged.** The opaque path (store verbatim, coerce at
   render) stays for keystroke-level state and DB-row batch generators; the split
   is `set_field` = *coerce at render* vs `commit_field` = *canonicalize now, fail
@@ -228,7 +228,7 @@ at the boundary as `applyChange({ field }, bundle)`.
 
 The wire and the storage DTO are unaffected.
 
-[`TypedEditor`]: the `editor` module in `quillmark-core`.
+[`TypedWriter`]: the `writer` module in `quillmark-core`.
 
 ### Card bodies close the corpus write surface (#892, reshaped by #925)
 
@@ -326,8 +326,8 @@ a parallel core-side position map: `positionAt` (point → corpus position) and
 `locate` (corpus position → caret rect) are exact inverses over the current
 compile and are the whole bidirectional cursor bridge, needing no forward map.
 
-A live editor writes a field through the typed editor
-(`quill.editor(doc).set(field, value)`, or the ABI `commitField`) — or the body
+A live editor writes a field through the typed writer
+(`quill.writer(doc).set(field, value)`, or the ABI `commitField`) — or the body
 with `install` / `revise` — and recompiles with `apply(doc)`. Typst recompiles incrementally either way
 (`Source::replace` + `comemo`), so a whole-field write costs the same on the
 compile as a splice would have — the delta path bought no incrementality it did
@@ -349,14 +349,14 @@ object, or a `Delta`. A consumer who does crosses one marked door.
 ### Tiers are strata, not a partition
 
 Tier 1 is **sugar over** tier 2 and the typed-commit path, not a walled-off
-region: `editor.setBody(md)` *is* `revise({}, md)` with the receipt discarded,
-and `editor.set` *is* `commitField` with the quill bound once. Anything tier 1
+region: `writer.setBody(md)` *is* `revise({}, md)` with the receipt discarded,
+and `writer.set` *is* `commitField` with the quill bound once. Anything tier 1
 writes, tier 2 can write with more control. So the decision tree picks a
 *default*, not a *cage* — a live editor legitimately writes fields through the
-typed editor and bodies/splices through the addressed verbs in the same
+typed writer and bodies/splices through the addressed verbs in the same
 interaction. The decision tree:
 
-- **Have a quill? Use `quill.editor(doc)`** (Python: `doc.editor(quill)`) — the
+- **Have a quill? Use `quill.writer(doc)`** — the
   documented default. Typed `set` / `set_all`, `setBody`, `addCard`,
   `removeCard`, `card(i)`. Names in, markdown in, diagnostics out.
 - **Corpus surgery with anchors?** The addressed `install` / `revise` /
@@ -369,11 +369,11 @@ interaction. The decision tree:
 
 | Change | Detail |
 |---|---|
-| `quill.editor(doc)` is the front door | WASM patches `editor(doc)` onto the re-exported `Quill` prototype (the `Quill === CoreQuill` identity holds; the editor owns no wasm handle); Python adds `Document.editor(quill) -> Editor`; core already had `Quill::editor(&mut doc)`. |
-| Editor gaps closed | `setBody` / `set_body`, `addCard` / `add_card` (fused make + typed-commit + push, transactional), `removeCard`, `card(i).setBody` — mirrored into core's `TypedEditor` so the parity rows read *identical*. |
-| Reads live on `Document`, quill-free | `get(name)` / `getMarkdown(name?)` — reads need no schema, so they sit on `Document`, not the editor. `getMarkdown` re-coins, **lazily and by name**, the projection the eager `fieldMarkdown` / `bodyMarkdown` getters dropped in #925 (the drop was of the *eager precompute*, not the capability). |
-| `commit(addr, value, quill)` deleted | Unreleased; it only duplicated `commitField` / `commitCardField` behind an `Addr`, dragging a schema into the content-only corpus lane. The typed door is the editor. |
-| `commit*` demoted to ABI | `commitField` / `commitFields` / `commitCardField(s)` stay as the stable ABI under the editor's `set` / `set_all`, dropped from the documented surface. |
+| `quill.writer(doc)` is the front door | WASM patches `writer(doc)` onto the re-exported `Quill` prototype (the `Quill === CoreQuill` identity holds; the writer owns no wasm handle); Python adds `Quill.writer(doc) -> Writer`; core already had `Quill::writer(&mut doc)`. |
+| Writer gaps closed | `setBody` / `set_body`, `addCard` / `add_card` (fused make + typed-commit + push, transactional), `removeCard`, `card(i).setBody` — mirrored into core's `TypedWriter` so the parity rows read *identical*. |
+| Reads live on `Document`, quill-free | `get(name)` / `getMarkdown(name?)` — reads need no schema, so they sit on `Document`, not the writer. `getMarkdown` re-coins, **lazily and by name**, the projection the eager `fieldMarkdown` / `bodyMarkdown` getters dropped in #925 (the drop was of the *eager precompute*, not the capability). |
+| `commit(addr, value, quill)` deleted | Unreleased; it only duplicated `commitField` / `commitCardField` behind an `Addr`, dragging a schema into the content-only corpus lane. The typed door is the writer. |
+| `commit*` demoted to ABI | `commitField` / `commitFields` / `commitCardField(s)` stay as the stable ABI under the writer's `set` / `set_all`, dropped from the documented surface. |
 
 The hand-written WASM runtime becomes the real API and the wasm class its ABI —
 committed to, not just tolerated. See [BINDINGS.md](../../prose/canon/BINDINGS.md)
@@ -381,10 +381,10 @@ for the parity table that now governs core-vs-bindings drift.
 
 ### One idiom difference to know
 
-The typed editor is the one shape pyo3 carries worst. Core's `TypedEditor` holds
-`&mut Document` under the borrow checker; WASM's `DocumentEditor` and Python's
-`Editor` cannot — they **re-borrow per call** (a captured quill + document, each
-write reconstructing the core editor). The guarantee does not cross the boundary:
-a held borrow becomes a convention (*editors and card cursors are ephemeral —
+The typed writer is the one shape pyo3 carries worst. Core's `TypedWriter` holds
+`&mut Document` under the borrow checker; WASM's `DocumentWriter` and Python's
+`Writer` cannot — they **re-borrow per call** (a captured quill + document, each
+write reconstructing the core writer). The guarantee does not cross the boundary:
+a held borrow becomes a convention (*writers and card cursors are ephemeral —
 bind, write, discard*). The parity table classes this row **idiom**, not
 identical.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -17,7 +17,7 @@ guides in order.
   `richtext(inline)<markdown>`; `build_transform_schema` gains
   `quillmark:inline: true`. Typed field writes land: one schema-dispatched
   writer (`Card::commit_field` / wasm `commitField` / Python `commit_field`) for
-  every field type, plus the schema-bound `TypedEditor`; strict writes fail a
+  every field type, plus the schema-bound `TypedWriter`; strict writes fail a
   mismatch at the write, not at render (#893). Live field edits go through the
   writer + `apply(doc)` (the experimental `applyFieldDelta` / change-log surface
   was removed, #886). Card-write verbs become mechanical twins of their
@@ -34,11 +34,11 @@ guides in order.
   for one cycle, and richtext fields gain the anchor-preserving `revise_field`
   (#925). On-disk (`.qmd`) identity stays markdown-lossy — the storage DTO is
   the lossless carrier. The binding write surface then settles into two tiers:
-  `quill.editor(doc)` (Python `doc.editor(quill)`) is the documented default —
+  `quill.writer(doc)` (WASM and Python alike) is the documented default —
   typed `set` / `set_all` / `setBody` / `addCard` / `card(i)` and quill-free
   `get` / `getMarkdown` reads — over the corpus lane and the opaque `setField`
   primitive; the addressed `commit(addr, …)` is deleted (subsumed by the
-  editor) and a core-vs-bindings parity table governs drift (#932).
+  writer) and a core-vs-bindings parity table governs drift (#932).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -39,8 +39,8 @@ The mutation surface has a stated default, decided by one sentence:
 > **Tier 1 speaks names, values, and markdown. Tier 2 speaks addresses,
 > corpora, and receipts.**
 
-Tier 1 is the typed editor — `quill.editor(doc)` (Python `doc.editor(quill)`),
-mirroring core's `quill.editor(&mut doc)`. It is the documented default: bare
+Tier 1 is the typed writer — `quill.writer(doc)`, mirroring core's
+`quill.writer(&mut doc)`. It is the documented default: bare
 `set` / `set_all` / `setBody` / `addCard` / `card(i)`, names and markdown in,
 diagnostics out — a consumer here never meets an `Addr`, a corpus object, or a
 `Delta`. Tier 2 is the corpus lane — the addressed `install` / `revise` /
@@ -48,16 +48,16 @@ diagnostics out — a consumer here never meets an `Addr`, a corpus object, or a
 `mapPos` codec — for the audience that has anchor identity to preserve.
 
 **The tiers are strata, not a partition.** Tier 1 is *sugar over* tier 2 and the
-typed-commit path — `editor.setBody(md)` is `revise({}, md)` with the receipt
-discarded; `editor.set` is `commitField` with the quill bound once. Anything
+typed-commit path — `writer.setBody(md)` is `revise({}, md)` with the receipt
+discarded; `writer.set` is `commitField` with the quill bound once. Anything
 tier 1 writes, tier 2 can write with more control, so the decision tree picks a
 *default*, not a *cage*: a live editor legitimately writes fields through the
-editor and bodies/splices through the addressed verbs in one interaction. Reads
+writer and bodies/splices through the addressed verbs in one interaction. Reads
 (`get` / `getMarkdown`) need no schema, so they sit on `Document`, not the
-editor. The quill-free `setField` / `setCardField` primitive stays the third
+writer. The quill-free `setField` / `setCardField` primitive stays the third
 lane — verbatim storage, coercion deferred to render.
 
-**Editors and card cursors are ephemeral — bind, write, discard.** They hold an
+**Writers and card cursors are ephemeral — bind, write, discard.** They hold an
 address (the quill + document, or an index), never a cache; every call reads
 through the document, so a `removeCard` / `addCard` between binding a cursor and
 writing through it silently retargets it. Durable addressing is `$id` stamped at
@@ -65,7 +65,7 @@ build and re-resolved at patch time ([PROGRAMMATIC.md](PROGRAMMATIC.md)), not a
 held handle.
 
 **The hand-written runtime is the real API; the wasm class is its ABI.** The
-`commit*` verbs are the stable ABI under the editor's `set` / `set_all` — dropped
+`commit*` verbs are the stable ABI under the writer's `set` / `set_all` — dropped
 from the documented surface, not from the binary. This design commits to that
 split rather than merely tolerating it.
 
@@ -77,16 +77,16 @@ ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
 
 | Concept | Core | Bindings | Class |
 |---|---|---|---|
-| Typed editor front door | `quill.editor(&mut doc)` | `quill.editor(doc)` / `doc.editor(quill)` | **idiom** — core holds `&mut Document` under the checker; the bindings re-borrow per call (pyo3/wasm objects carry no lifetime), so the guarantee becomes the ephemerality convention |
+| Typed writer front door | `quill.writer(&mut doc)` | `quill.writer(doc)` | **idiom** — core holds `&mut Document` under the checker; the bindings re-borrow per call (pyo3/wasm objects carry no lifetime), so the guarantee becomes the ephemerality convention |
 | Scalar / batch write | `set` / `set_all` | `set` / `setAll` (JS), `set` / `set_all` (py) | identical |
 | Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
 | Card creation | `add_card(kind, fields, body?)` | `addCard` / `add_card` | identical — fused make + typed-commit + push, transactional |
-| Card cursor | `editor.card(i)?` (eager check) | `editor.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
+| Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
 | Reads | `card.field_markdown(..)` / `payload().get(..)` | `doc.getMarkdown(name?)` / `doc.get(name)` | **idiom** — the bindings fuse the read into one named verb on `Document` |
 | Richtext ops | `card.revise_field(name, md)?` (borrow chain) | `doc.revise({card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation |
 | Opaque primitive | `set_field` / `set_fields` | `setField` / `setCardField` (JS), `set_field` / `set_fields` (py) | identical |
 
-The single **idiom** row on the front door is the honest cost: the typed editor
+The single **idiom** row on the front door is the honest cost: the typed writer
 is the one shape pyo3 carries worst, so its "identical" is qualified, not
 claimed. See the as-built [0.93 → 0.94 migration](../../docs/migrations/0.93-to-0.94.md#the-two-tier-binding-surface-932).
 

--- a/prose/canon/PROGRAMMATIC.md
+++ b/prose/canon/PROGRAMMATIC.md
@@ -71,7 +71,7 @@ to the write by typed commit (below).
 Document mutation is a data primitive that never requires a Quill. `set_field` /
 `set_fields` hold only a `$quill` *reference*, enforce the structural invariants
 above, and store the value verbatim — coercion is deferred to render. Typed
-commit is a schema-bound layer over that primitive: `Quill::editor(&mut doc)`
+commit is a schema-bound layer over that primitive: `Quill::writer(&mut doc)`
 binds the resolved schema, and its `set` / `set_all` resolve each field's `type`,
 coerce to the canonical form (`"3"` → `3`, a markdown string → a richtext
 corpus), and fail at the write on a mismatch — the default whenever a Quill is
@@ -86,11 +86,11 @@ The primitive stays load-bearing — it is what lets a `Document` be constructed
 and `from_json`'d with no bundle (standalone data), what quill-agnostic
 storage/migration infra writes through, what a store-now-validate-later editor
 uses to hold not-yet-conforming input, and the way to store a value opaquely on
-purpose. Reach for the opaque `set_*` for those; reach for the editor by
-default. `Quill::editor(&mut doc)` is the documented front door in every
-surface: `quill.editor(doc)` in WASM, `doc.editor(quill)` in Python (the
-schema-bound `DocumentEditor` / `Editor` with `set` / `set_all` / `set_body` /
-`add_card` / `card(i)`). The `commitField` / `commitFields` (+ `commitCard*`)
+purpose. Reach for the opaque `set_*` for those; reach for the writer by
+default. `Quill::writer(&mut doc)` is the documented front door in every
+surface — `quill.writer(doc)` in WASM and Python alike (the schema-bound
+`DocumentWriter` / `Writer` with `set` / `set_all` / `set_body` /
+`add_card` / `card(i)`); the quill owns the schema, so it is the factory. The `commitField` / `commitFields` (+ `commitCard*`)
 verbs are the stable ABI underneath it, and `setField` / `setCardField` remain
 the quill-free opaque store. See [BINDINGS.md](BINDINGS.md) for the two-tier
 write surface and the core-vs-bindings parity table.


### PR DESCRIPTION
Renames the schema-bound typed mutation API from `TypedEditor` / `Editor` / `DocumentEditor` / `CardEditor` to `TypedWriter` / `Writer` / `DocumentWriter` / `CardWriter` across core, Python bindings, WASM bindings, and documentation.

## Summary

This change aligns terminology across the codebase to use "writer" instead of "editor" for the schema-bound typed mutation surface. The quill owns the schema and is the factory, so the method is `quill.writer(doc)` on all surfaces (core, WASM, Python), not `doc.editor(quill)`. The rename clarifies the semantic intent: these objects write typed fields to documents, and the quill (not the document) is the entry point.

## Key Changes

- **Core (`crates/core/src/`)**: Renamed `editor.rs` module to `writer.rs`; `TypedEditor` → `TypedWriter`, `CardEditor` → `CardWriter`; `Quill::editor()` → `Quill::writer()`
- **Python bindings (`crates/bindings/python/`)**: `PyEditor` → `PyWriter`, `PyCardEditor` → `PyCardWriter`; moved `writer()` method from `PyDocument` to `PyQuill` (schema is the factory)
- **WASM bindings (`crates/bindings/wasm/`)**: `DocumentEditor` → `DocumentWriter`, `CardEditor` → `CardWriter`; `quill.editor(doc)` → `quill.writer(doc)` in runtime and type definitions
- **Documentation & tests**: Updated all references in migration guides, README, docstrings, and test files to use "writer" terminology
- **Error messages**: Updated `EditError` doc comments to reference `TypedWriter` / `CardWriter`

## Implementation Details

- The factory pattern is now explicit: `quill.writer(doc)` on all surfaces (core, WASM, Python), making it clear the quill owns the schema
- Python's `writer()` method is now on `PyQuill` (not `PyDocument`), matching the core and WASM APIs
- All docstrings and comments updated to reflect the new terminology consistently
- Test names and descriptions updated (e.g., `test_editor_front_door_set_and_reads` → `test_writer_front_door_set_and_reads`)

https://claude.ai/code/session_0187FrkvTxUXeKxaAErgxbfu