### PR TITLE
ui.group: card-level group registry + nested-group/order fixes (#941)

### DIFF
--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -22,7 +22,10 @@ pub use formats::parse_date_ymd;
 pub use ignore::QuillIgnore;
 pub use schema::{build_transform_schema, QUILLMARK_INLINE_KEY, RICHTEXT_MEDIA_TYPE};
 pub use tree::FileTreeNode;
-pub use types::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
+pub use types::{
+    BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, GroupSchema, UiCardSchema,
+    UiFieldSchema,
+};
 
 use std::collections::HashMap;
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -196,16 +196,15 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
         }
     }
     // Ungrouped is the implicit leading pseudo-group (rank 0). Grouped clusters
-    // (rank 1) sort by registry position; with no registry every group ties at
-    // `usize::MAX` and the stable sort preserves first appearance.
+    // sort by registry position shifted past it (`pos + 1`); with no registry
+    // every group ties at `usize::MAX` and the stable sort preserves first
+    // appearance.
     groups.sort_by_key(|(g, _)| match g {
-        None => (0, 0),
-        Some(id) => (
-            1,
-            registry
-                .and_then(|order| order.iter().position(|o| o == id))
-                .unwrap_or(usize::MAX),
-        ),
+        None => 0,
+        Some(id) => registry
+            .and_then(|order| order.iter().position(|o| o == id))
+            .map(|pos| pos + 1)
+            .unwrap_or(usize::MAX),
     });
     groups.into_iter().flat_map(|(_, fields)| fields).collect()
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -162,18 +162,29 @@ fn build_card(card: &CardSchema) -> Card {
 }
 
 /// Append every field of a card as payload items, clustered by `ui.group` and
-/// ordered by `ui.order`.
+/// ordered by `ui.order`. Group order follows the card's `ui.groups` registry
+/// when present.
 fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
-    for field in group_fields(card.fields.values()) {
+    let registry: Option<Vec<&str>> = card
+        .ui
+        .as_ref()
+        .and_then(|u| u.groups.as_ref())
+        .map(|r| r.0.iter().map(|g| g.id.as_str()).collect());
+    for field in group_fields(card.fields.values(), registry.as_deref()) {
         append_field(items, field);
     }
 }
 
-/// Order fields by `ui.group` (ungrouped lead, then groups in first-appearance
-/// order) with `ui.order` sorting within each cluster. Grouping is purely
-/// positional (no banner); the clusters are flattened into a single field
-/// stream.
-fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(fields: I) -> Vec<&'a FieldSchema> {
+/// Order fields by `ui.group` (ungrouped lead, then grouped clusters) with
+/// `ui.order` sorting within each cluster. Grouped clusters follow the
+/// `registry` declaration order when a registry is present, else first-
+/// appearance order (the deprecated implicit-group fallback); for a migrated
+/// quill the two are identical. Grouping is purely positional (no banner); the
+/// clusters are flattened into a single field stream.
+fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
+    fields: I,
+    registry: Option<&[&str]>,
+) -> Vec<&'a FieldSchema> {
     let mut sorted: Vec<&FieldSchema> = fields.into_iter().collect();
     sorted.sort_by_key(|f| f.ui_order());
     let mut groups: Vec<(Option<&str>, Vec<&FieldSchema>)> = Vec::new();
@@ -184,7 +195,18 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(fields: I) -> Vec<&
             None => groups.push((group, vec![field])),
         }
     }
-    groups.sort_by_key(|(g, _)| g.is_some());
+    // Ungrouped is the implicit leading pseudo-group (rank 0). Grouped clusters
+    // (rank 1) sort by registry position; with no registry every group ties at
+    // `usize::MAX` and the stable sort preserves first appearance.
+    groups.sort_by_key(|(g, _)| match g {
+        None => (0, 0),
+        Some(id) => (
+            1,
+            registry
+                .and_then(|order| order.iter().position(|o| o == id))
+                .unwrap_or(usize::MAX),
+        ),
+    });
     groups.into_iter().flat_map(|(_, fields)| fields).collect()
 }
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -10,7 +10,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::types::RICHTEXT_INLINE_TOKEN_MSG;
-use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
+use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
 /// string — a boolean (`true`/`false`) or number (`47`, `1.0`). `None` for
@@ -746,6 +746,23 @@ impl QuillConfig {
         // `from_quill_value` folds the wire key into the `FieldType` enum
         // (`resolve_richtext_inline`); no second check belongs here.
 
+        // `ui.group` clusters card-level fields only — the blueprint's grouping
+        // pass never descends into object properties or array items, so a nested
+        // `group` is an inert knob. Reject it rather than let it silently do
+        // nothing, the same dead-knob class this walk exists to catch.
+        if position != ShapePosition::Top
+            && schema.ui.as_ref().and_then(|u| u.group.as_ref()).is_some()
+        {
+            return err(
+                "quill::nested_group_not_supported",
+                format!(
+                    "Field '{owner}' sets ui.group in a nested position. Grouping applies \
+                     only to card-level fields; an object property or array item cannot \
+                     join a group."
+                ),
+            );
+        }
+
         match schema.r#type {
             FieldType::Object => {
                 // An object nested inside another object (a Leaf position) is
@@ -1094,20 +1111,9 @@ impl QuillConfig {
                         continue;
                     }
 
-                    // Always set ui.order based on position
-                    if schema.ui.is_none() {
-                        schema.ui = Some(UiFieldSchema {
-                            title: None,
-                            group: None,
-                            order: Some(order),
-                            compact: None,
-                            multiline: None,
-                        });
-                    } else if let Some(ui) = &mut schema.ui {
-                        if ui.order.is_none() {
-                            ui.order = Some(order);
-                        }
-                    }
+                    // Assign this card-level field its positional `ui.order`
+                    // (nested properties are stamped in `from_quill_value`).
+                    schema.set_ui_order_if_unset(order);
 
                     let owner = format!("{} '{}'", context, field_name);
                     Self::validate_field_blueprint_constraints(&schema, &owner, errors);

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1,5 +1,5 @@
 //! Quill configuration parsing and normalization.
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::error::Error as StdError;
 
 use indexmap::IndexMap;
@@ -10,7 +10,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::types::RICHTEXT_INLINE_TOKEN_MSG;
-use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema};
+use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
 /// string — a boolean (`true`/`false`) or number (`47`, `1.0`). `None` for
@@ -929,6 +929,99 @@ impl QuillConfig {
         }
     }
 
+    /// Validate a card's group registry and every card-level field's `ui.group`
+    /// reference against it. Nested `ui.group` is already rejected upstream by
+    /// [`validate_field_schema_shape`](Self::validate_field_schema_shape), so
+    /// only card-level fields are considered here.
+    ///
+    /// With a registry present, `ui.group` is a *reference*: registry ids carry
+    /// the same snake_case discipline as field keys and must be unique, and a
+    /// reference to an id the registry does not declare is `quill::unknown_group`
+    /// (the "no mixing implicit and declared" rule falls out of this — with a
+    /// registry there is no implicit fallback). With no registry, each `ui.group`
+    /// is a deprecated implicit group (label-as-identity, today's semantics
+    /// untouched) and the card earns one `quill::implicit_group` warning.
+    fn validate_card_groups(
+        label: &str,
+        card: &CardSchema,
+        errors: &mut Vec<Diagnostic>,
+        warnings: &mut Vec<Diagnostic>,
+    ) {
+        let referenced: Vec<&str> = card
+            .fields
+            .values()
+            .filter_map(|f| f.ui.as_ref().and_then(|u| u.group.as_deref()))
+            .collect();
+
+        match card.ui.as_ref().and_then(|u| u.groups.as_ref()) {
+            Some(GroupRegistry(groups)) => {
+                let mut ids: HashSet<&str> = HashSet::new();
+                for g in groups {
+                    if !Self::is_snake_case_identifier(&g.id) {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!(
+                                    "{label} group id '{}' must be snake_case (lowercase letters, \
+                                     digits, and underscores only); the display label goes in \
+                                     'title:'.",
+                                    g.id
+                                ),
+                            )
+                            .with_code("quill::invalid_group_id".to_string()),
+                        );
+                    }
+                    // Insert regardless of snake_case validity so a reference to
+                    // an ill-named id resolves — one diagnostic, not a cascade.
+                    if !ids.insert(g.id.as_str()) {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!("{label} declares group '{}' more than once.", g.id),
+                            )
+                            .with_code("quill::duplicate_group".to_string()),
+                        );
+                    }
+                }
+                // One diagnostic per distinct unresolved reference.
+                let unresolved: BTreeSet<&str> =
+                    referenced.iter().copied().filter(|g| !ids.contains(g)).collect();
+                for group in unresolved {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "{label} field references group '{group}', which is not declared \
+                                 in ui.groups. Add it to the registry, or fix the reference."
+                            ),
+                        )
+                        .with_code("quill::unknown_group".to_string()),
+                    );
+                }
+            }
+            None => {
+                if !referenced.is_empty() {
+                    warnings.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            format!(
+                                "{label} uses ui.group without a ui.groups registry (implicit \
+                                 groups). Declare the groups under the card's ui.groups; implicit \
+                                 groups are deprecated and become an error in a future release."
+                            ),
+                        )
+                        .with_code("quill::implicit_group".to_string())
+                        .with_hint(
+                            "Add a ui.groups registry listing each group id, and reference the id \
+                             from each field's ui.group."
+                                .to_string(),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
     /// Validate a single `example:` or `default:` literal against the declared
     /// schema, pushing `quill::*`-namespaced [`Diagnostic`]s for any violations.
     ///
@@ -1407,7 +1500,7 @@ impl QuillConfig {
                             format!("Invalid 'quill.ui' block: {}", e),
                         )
                         .with_code("quill::invalid_ui".to_string())
-                        .with_hint("Valid key under 'ui' is: title.".to_string()),
+                        .with_hint("Valid keys under 'ui' are: title, groups.".to_string()),
                     );
                     None
                 }
@@ -1502,7 +1595,7 @@ impl QuillConfig {
                     errors.push(
                         Diagnostic::new(Severity::Error, format!("Invalid 'main.ui' block: {}", e))
                             .with_code("quill::invalid_ui".to_string())
-                            .with_hint("Valid key under 'ui' is: title.".to_string()),
+                            .with_hint("Valid keys under 'ui' are: title, groups.".to_string()),
                     );
                     None
                 }
@@ -1661,6 +1754,17 @@ impl QuillConfig {
             if let Some(d) = warn_example_unused(&format!("card_kinds.{}", card.name), &card.body) {
                 warnings.push(d);
             }
+        }
+
+        // Validate each card's group registry and its fields' group references.
+        Self::validate_card_groups("main", &main, &mut errors, &mut warnings);
+        for card in &card_kinds {
+            Self::validate_card_groups(
+                &format!("card_kinds.{}", card.name),
+                card,
+                &mut errors,
+                &mut warnings,
+            );
         }
 
         // Error when `body.example` contains a line that the document parser

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1542,6 +1542,128 @@ main:
 }
 
 #[test]
+fn nested_object_properties_receive_positional_ui_order() {
+    // Properties render in declaration order, not the alphabetical order their
+    // `BTreeMap` storage would otherwise impose: `zulu` is declared first, so
+    // it sorts ahead of `alpha` despite the reversed alphabet.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        zulu: { type: string }
+        alpha: { type: string }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let props = config.main.fields["address"].properties.as_ref().unwrap();
+    assert_eq!(props["zulu"].ui_order(), 0);
+    assert_eq!(props["alpha"].ui_order(), 1);
+}
+
+#[test]
+fn typed_table_row_properties_receive_positional_ui_order() {
+    // The synthetic row of a typed table is an object built by the same
+    // `from_quill_value` recursion, so its properties get positional order too.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          org: { type: string }
+          year: { type: integer }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let props = config.main.fields["rows"].items.as_ref().unwrap();
+    let props = props.properties.as_ref().unwrap();
+    assert_eq!(props["org"].ui_order(), 0);
+    assert_eq!(props["year"].ui_order(), 1);
+}
+
+#[test]
+fn nested_property_explicit_ui_order_is_preserved() {
+    // An author-supplied `order` on a nested property is never overwritten; the
+    // sibling without one still receives its positional index.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street: { type: string, ui: { order: 5 } }
+        city: { type: string }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let props = config.main.fields["address"].properties.as_ref().unwrap();
+    assert_eq!(props["street"].ui_order(), 5);
+    assert_eq!(props["city"].ui_order(), 1);
+}
+
+#[test]
+fn ui_group_on_object_property_is_rejected() {
+    // `ui.group` clusters card-level fields only; on a typed-dictionary
+    // property it was silently inert, and now loads as a hard error.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street: { type: string, ui: { group: Location } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_group_not_supported")));
+}
+
+#[test]
+fn ui_group_on_typed_table_property_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          score: { type: number, ui: { group: Metrics } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_group_not_supported")));
+}
+
+#[test]
+fn ui_group_on_card_level_field_is_still_accepted() {
+    // Regression guard: the nested-position rejection must not touch card-level
+    // fields, where grouping is the whole point.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    subject: { type: string, ui: { group: Addressing } }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    assert_eq!(
+        config.main.fields["subject"]
+            .ui
+            .as_ref()
+            .and_then(|u| u.group.as_deref()),
+        Some("Addressing")
+    );
+}
+
+#[test]
 fn test_array_items_recursive_coercion() {
     let yaml_content = r#"
 quill:

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1664,6 +1664,163 @@ main:
 }
 
 #[test]
+fn group_registry_list_form_orders_blueprint_by_declaration() {
+    // The registry declares `beta` before `alpha`, but a field references
+    // `alpha` first (lower ui.order). Clustering must follow registry order
+    // (beta, then alpha), not first-appearance order.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [beta, alpha]
+  fields:
+    a1: { type: string, ui: { group: alpha } }
+    b1: { type: string, ui: { group: beta } }
+"#;
+    let bp = QuillConfig::from_yaml(yaml).unwrap().blueprint();
+    let a = bp.find("a1:").unwrap();
+    let b = bp.find("b1:").unwrap();
+    assert!(b < a, "registry order (beta<alpha) must drive clustering:\n{bp}");
+}
+
+#[test]
+fn group_registry_map_form_carries_title_override() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups:
+      addressing: {}
+      letterhead: { title: "Letterhead & Seal" }
+  fields:
+    a: { type: string, ui: { group: addressing } }
+    l: { type: string, ui: { group: letterhead } }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let reg = &config.main.ui.as_ref().unwrap().groups.as_ref().unwrap().0;
+    assert_eq!(reg.len(), 2);
+    assert_eq!(reg[0].id, "addressing");
+    assert_eq!(reg[0].title, None);
+    assert_eq!(reg[1].id, "letterhead");
+    assert_eq!(reg[1].title.as_deref(), Some("Letterhead & Seal"));
+}
+
+#[test]
+fn unknown_group_reference_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [addressing]
+  fields:
+    subject: { type: string, ui: { group: letterhead } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::unknown_group")));
+}
+
+#[test]
+fn implicit_group_without_registry_warns() {
+    // No registry + a field group is the deprecated implicit-group form.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    subject: { type: string, ui: { group: Addressing } }
+"#;
+    let (_config, warnings) = QuillConfig::from_yaml_with_warnings(yaml).unwrap();
+    assert!(warnings
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::implicit_group")));
+}
+
+#[test]
+fn duplicate_group_id_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [addressing, addressing]
+  fields:
+    subject: { type: string, ui: { group: addressing } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::duplicate_group")));
+}
+
+#[test]
+fn non_snake_case_group_id_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [Addressing]
+  fields:
+    subject: { type: string, ui: { group: Addressing } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::invalid_group_id")));
+}
+
+#[test]
+fn group_registry_round_trips_through_serde_and_schema() {
+    // List-form input normalizes to the canonical map form on emit, preserving
+    // declaration order, and re-parses to the identical registry.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [addressing, letterhead]
+  fields:
+    a: { type: string, ui: { group: addressing } }
+    l: { type: string, ui: { group: letterhead } }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let ui = config.main.ui.clone().unwrap();
+    let json = serde_json::to_value(&ui).unwrap();
+    let back: UiCardSchema = serde_json::from_value(json).unwrap();
+    assert_eq!(ui, back, "registry must survive emit → parse");
+
+    // Emission carries order (preserve_order) and titles are omitted when derived.
+    let schema = config.schema();
+    let groups = schema["main"]["ui"]["groups"].as_object().unwrap();
+    let keys: Vec<&str> = groups.keys().map(String::as_str).collect();
+    assert_eq!(keys, ["addressing", "letterhead"]);
+    assert!(groups["addressing"].as_object().unwrap().is_empty());
+}
+
+#[test]
+fn migrated_group_fixtures_declare_registries_and_do_not_warn() {
+    for name in ["usaf_memo/0.2.0", "cmu_letter/0.1.0", "classic_resume/0.1.0"] {
+        let path = quillmark_fixtures::resource_path(&format!("quills/{name}/Quill.yaml"));
+        let yaml = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {name}: {e}"));
+        let (config, warnings) = QuillConfig::from_yaml_with_warnings(&yaml)
+            .unwrap_or_else(|e| panic!("{name} must load: {e:?}"));
+        assert!(
+            !warnings
+                .iter()
+                .any(|d| d.code.as_deref() == Some("quill::implicit_group")),
+            "{name} still emits implicit_group: {warnings:?}"
+        );
+        assert!(
+            config
+                .main
+                .ui
+                .as_ref()
+                .and_then(|u| u.groups.as_ref())
+                .is_some(),
+            "{name} main should declare a group registry"
+        );
+    }
+}
+
+#[test]
 fn test_array_items_recursive_coercion() {
     let yaml_content = r#"
 quill:

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -425,22 +425,14 @@ impl FieldSchema {
     /// they are built (`from_quill_value`), so `ui_order()` is meaningful at
     /// every depth. Never overrides an author-supplied `order`.
     pub(crate) fn set_ui_order_if_unset(&mut self, order: i32) {
-        match &mut self.ui {
-            Some(ui) => {
-                if ui.order.is_none() {
-                    ui.order = Some(order);
-                }
-            }
-            None => {
-                self.ui = Some(UiFieldSchema {
-                    title: None,
-                    group: None,
-                    order: Some(order),
-                    compact: None,
-                    multiline: None,
-                });
-            }
-        }
+        let ui = self.ui.get_or_insert(UiFieldSchema {
+            title: None,
+            group: None,
+            order: None,
+            compact: None,
+            multiline: None,
+        });
+        ui.order.get_or_insert(order);
     }
 
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -309,6 +309,30 @@ impl FieldSchema {
         self.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX)
     }
 
+    /// Stamp `order` onto `ui.order` when the author left it unset, creating the
+    /// `ui` block if absent. Positional ordering derived from declaration order
+    /// — applied at card level by the loader and to nested object properties as
+    /// they are built (`from_quill_value`), so `ui_order()` is meaningful at
+    /// every depth. Never overrides an author-supplied `order`.
+    pub(crate) fn set_ui_order_if_unset(&mut self, order: i32) {
+        match &mut self.ui {
+            Some(ui) => {
+                if ui.order.is_none() {
+                    ui.order = Some(order);
+                }
+            }
+            None => {
+                self.ui = Some(UiFieldSchema {
+                    title: None,
+                    group: None,
+                    order: Some(order),
+                    compact: None,
+                    multiline: None,
+                });
+            }
+        }
+    }
+
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {
         Self {
             name,
@@ -347,14 +371,16 @@ impl FieldSchema {
             enum_values,
             properties: if let Some(props) = def.properties {
                 let mut p = BTreeMap::new();
-                for (key, value) in props {
-                    p.insert(
-                        key.clone(),
-                        Box::new(FieldSchema::from_quill_value(
-                            key,
-                            &QuillValue::from_json(value),
-                        )?),
-                    );
+                // Declaration order (preserved by serde_json's `preserve_order`)
+                // assigns each property a positional `ui.order`, mirroring the
+                // card-level pass in `parse_fields_with_order`. Without this,
+                // properties live in a `BTreeMap` and would render alphabetically,
+                // discarding authored order one nesting level down.
+                for (index, (key, value)) in props.into_iter().enumerate() {
+                    let mut prop =
+                        FieldSchema::from_quill_value(key.clone(), &QuillValue::from_json(value))?;
+                    prop.set_ui_order_if_unset(index as i32);
+                    p.insert(key, Box::new(prop));
                 }
                 Some(p)
             } else {

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -53,6 +53,116 @@ pub struct UiCardSchema {
     /// template. See `docs/quills/quill-yaml-reference.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// The card's group registry: the visible table of contents that names
+    /// every group a field may reference and fixes their display order. A
+    /// field's `ui.group` is a *reference* into this registry, validated at
+    /// load. Absent when the card declares no groups (or uses the deprecated
+    /// implicit-group form).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<GroupRegistry>,
+}
+
+/// One entry in a card's [`GroupRegistry`]: a snake_case identity plus an
+/// optional display-label override. The `id` decouples identity from label the
+/// same way a field's snake_case key decouples from its `ui.title` — a rename
+/// of the label touches one line and never breaks a `ui.group` reference or
+/// persisted per-group editor state. When `title` is `None`, consumers derive
+/// the label from `id` (`memo_for` → "Memo For"), exactly as they derive a
+/// field label from its key.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupSchema {
+    /// snake_case identity; rides the registry map key (or list item) on the wire.
+    pub id: String,
+    /// Display-label override; `None` means derive the label from `id`.
+    pub title: Option<String>,
+}
+
+/// A card's ordered group registry (`main.ui.groups` or a card kind's
+/// `ui.groups`). Declaration order **is** display order — the same contract
+/// field declaration order gives `ui.order` — so it is held as a `Vec` that
+/// survives regardless of surface form. Authored as either a sequence of ids
+/// (`[addressing, letterhead]`, titles derived) or a mapping of id to
+/// attributes (`{ letterhead: { title: … } }`, for label overrides); both fold
+/// into the same ordered list. Serializes back to the canonical mapping form,
+/// declaration order preserved.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupRegistry(pub Vec<GroupSchema>);
+
+/// The attribute block of a registry entry in the mapping authoring/emission
+/// form (`id: { title: … }`). A bare `id:` (null) or `id: {}` carries no
+/// override.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GroupEntryDef {
+    title: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for GroupRegistry {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct RegistryVisitor;
+        impl<'de> serde::de::Visitor<'de> for RegistryVisitor {
+            type Value = GroupRegistry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a sequence of group ids or a mapping of group id to attributes")
+            }
+
+            // Sequence form: `[addressing, letterhead]` — bare ids, titles derived.
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<GroupRegistry, A::Error> {
+                let mut groups = Vec::new();
+                while let Some(id) = seq.next_element::<String>()? {
+                    groups.push(GroupSchema { id, title: None });
+                }
+                Ok(GroupRegistry(groups))
+            }
+
+            // Mapping form: `{ addressing: {}, letterhead: { title: … } }`.
+            // A null or `{}` value carries no override; declaration order is
+            // preserved by serde_json's `preserve_order`.
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<GroupRegistry, A::Error> {
+                let mut groups = Vec::new();
+                while let Some((id, def)) = map.next_entry::<String, Option<GroupEntryDef>>()? {
+                    groups.push(GroupSchema {
+                        id,
+                        title: def.and_then(|d| d.title),
+                    });
+                }
+                Ok(GroupRegistry(groups))
+            }
+        }
+        deserializer.deserialize_any(RegistryVisitor)
+    }
+}
+
+impl Serialize for GroupRegistry {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        // Canonical form: the mapping, so a title override has a home and the
+        // registry key (identity) is explicit. A title-less entry emits an
+        // empty object; the map's declaration order carries the display-order
+        // contract on the wire.
+        #[derive(Serialize)]
+        struct GroupEntryOut<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            title: Option<&'a str>,
+        }
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for group in &self.0 {
+            map.serialize_entry(
+                &group.id,
+                &GroupEntryOut {
+                    title: group.title.as_deref(),
+                },
+            )?;
+        }
+        map.end()
+    }
 }
 
 /// Schema definition for a card kind (composable content blocks)

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -8,12 +8,14 @@ typst:
   plate_file: plate.typ
 
 main:
+  ui:
+    groups: [personal_info]
   fields:
     name:
       type: string
       example: John Doe
       ui:
-        group: Personal Info
+        group: personal_info
 
     contacts:
       type: array
@@ -24,7 +26,7 @@ main:
         - 123-456-7890
         - linkedin.com/in/johndoe
       ui:
-        group: Personal Info
+        group: personal_info
       description: List of contact details (email, phone, links, etc.)
 
 card_kinds:

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -8,6 +8,8 @@ typst:
   plate_file: plate.typ
 
 main:
+  ui:
+    groups: [essentials, letterhead, advanced]
   fields:
     recipient:
       type: array
@@ -18,7 +20,7 @@ main:
         - 123 Main St
         - Anytown, USA
       ui:
-        group: Essentials
+        group: essentials
       description: The recipient's name and full mailing address.
 
     signature_block:
@@ -29,7 +31,7 @@ main:
         - First M. Last
         - Title
       ui:
-        group: Essentials
+        group: essentials
       description: "The signer's information. Line 1: Name. Line 2: Title."
 
     department:
@@ -37,7 +39,7 @@ main:
       default: ""
       example: Department of Electrical and Computer Engineering
       ui:
-        group: Letterhead
+        group: letterhead
       description: The department or organizational unit name for the letterhead.
 
     address:
@@ -48,7 +50,7 @@ main:
         - 5000 Forbes Avenue
         - Pittsburgh, PA 15213-3890
       ui:
-        group: Letterhead
+        group: letterhead
       description: The sender's institutional mailing address.
 
     url:
@@ -56,11 +58,11 @@ main:
       default: ""
       example: www.ece.cmu.edu
       ui:
-        group: Letterhead
+        group: letterhead
       description: The department or university website URL.
 
     date:
       type: datetime
       ui:
-        group: Advanced
+        group: advanced
       description: The date to appear on the letter.

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -8,6 +8,8 @@ typst:
   plate_file: plate.typ
 
 main:
+  ui:
+    groups: [addressing, letterhead, classification, additional]
   body:
     example: |
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.
@@ -22,7 +24,7 @@ main:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
       ui:
-        group: Addressing
+        group: addressing
       description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For many recipients, enter 'SEE DISTRIBUTION' and list them in the Distribution field."
 
     memo_from:
@@ -36,7 +38,7 @@ main:
         - 123 Street Ave
         - City ST 12345-6789
       ui:
-        group: Addressing
+        group: addressing
       description: "If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence. Omit entirely to produce a Memorandum for Record (no MEMO FROM line)."
 
     subject:
@@ -44,7 +46,7 @@ main:
       inline: true
       example: Subject of the Memorandum
       ui:
-        group: Addressing
+        group: addressing
       description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
 
     signature_block:
@@ -55,14 +57,14 @@ main:
         - "FIRST M. LAST, Rank, USAF"
         - Duty Title
       ui:
-        group: Addressing
+        group: addressing
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
 
     letterhead_title:
       type: string
       default: DEPARTMENT OF THE AIR FORCE
       ui:
-        group: Letterhead
+        group: letterhead
       description: Change only for Joint Commands or DoW agencies.
 
     letterhead_caption:
@@ -72,7 +74,7 @@ main:
       example:
         - HEADQUARTERS [UNIT NAME]
       ui:
-        group: Letterhead
+        group: letterhead
       description: The full organization name of your unit.
 
     letterhead_seal:
@@ -82,7 +84,7 @@ main:
         - dod
       default: dow
       ui:
-        group: Letterhead
+        group: letterhead
         compact: true
       description: Department of War (DoW) or Department of Defense (DoD) seal shown in the letterhead.
 
@@ -90,7 +92,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         compact: true
       description: Bold-caps line below the seal; blank to omit.
 
@@ -99,7 +101,7 @@ main:
       inline: true
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         compact: true
       description: "Organizational motto at the bottom of the page. Supports Markdown emphasis (e.g. *italics*, **bold**)."
 
@@ -114,7 +116,7 @@ main:
         - TOP SECRET
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Select the classification marking shown in the header and footer banner. Unclassified documents typically omit this banner entirely — leave blank unless the document is CUI or classified. Mark per DAFI 16-1404 (DoDM 5200.48 for CUI) and applicable DoD guidance."
 
@@ -122,7 +124,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Banner dissemination suffix appended after double slash (e.g. 'NF' renders as CUI//NF in the header/footer). Leave blank for no suffix."
 
@@ -130,7 +132,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Office or organization that designated this information as CUI (e.g., 'SAF/AA'). Required by DoDM 5200.48 when classification is CUI."
 
@@ -138,7 +140,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY'). Leave blank to omit."
 
@@ -146,7 +148,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Limited dissemination control shown in the indicator block (e.g., 'FEDONLY', 'NOFORN'). Independent from the banner suffix above."
 
@@ -154,7 +156,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234, john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI."
 
@@ -168,7 +170,7 @@ main:
         - "AFMAN 33-326, 25 November 2011, *Preparing Official Communications*"
         - "AFI 33-360, *Publications and Forms Management*"
       ui:
-        group: Additional
+        group: additional
       description: "References, auto-lettered (a), (b), (c) per AFH 33-337. Cite each by organization, type, date, and title; italicize publication titles with *asterisks* (standard Markdown emphasis)."
 
     cc:
@@ -179,7 +181,7 @@ main:
       example:
         - Rank and Name, ORG/SYMBOL
       ui:
-        group: Additional
+        group: additional
       description: List office symbols of recipients to receive copies.
 
     distribution:
@@ -191,7 +193,7 @@ main:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
       ui:
-        group: Additional
+        group: additional
       description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
 
     attachments:
@@ -202,7 +204,7 @@ main:
       example:
         - Attachment description, YYYY MMM DD
       ui:
-        group: Additional
+        group: additional
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
     memo_style:
@@ -212,7 +214,7 @@ main:
         - daf
       default: usaf
       ui:
-        group: Additional
+        group: additional
         compact: true
       description: "USAF memorandum or DAF headquarters memorandum; DAF changes date format and body paragraph layout per AFH 33-337."
 
@@ -220,7 +222,7 @@ main:
       type: number
       default: 12
       ui:
-        group: Additional
+        group: additional
         compact: true
       description: Body text size in points; decimals allowed (e.g. 11.5).
 
@@ -228,7 +230,7 @@ main:
       type: datetime
       default: ""
       ui:
-        group: Additional
+        group: additional
         compact: true
       description: YYYY-MM-DD. Leave blank to use today's date.
 
@@ -237,18 +239,19 @@ card_kinds:
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     ui:
       title: Routing indorsement
+      groups: [addressing, additional]
     fields:
       from:
         type: string
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
         description: Office symbol or Rank Name of the endorsing official.
       for:
         type: string
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
         description: Office symbol or organization receiving the endorsed memo.
       signature_block:
         type: array
@@ -258,7 +261,7 @@ card_kinds:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title
         ui:
-          group: Addressing
+          group: addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
       format:
         type: string
@@ -268,7 +271,7 @@ card_kinds:
           - separate_page
         default: standard
         ui:
-          group: Additional
+          group: additional
           compact: true
         description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
       action:
@@ -280,13 +283,13 @@ card_kinds:
           - disapprove
         default: ""
         ui:
-          group: Additional
+          group: additional
           compact: true
         description: "Action taken by the endorser. Leave blank to hide the Approve/Disapprove line entirely, 'undecided' to display the line with neither option circled, 'approve' or 'disapprove' to circle the selected option."
       date:
         type: datetime
         default: ""
         ui:
-          group: Additional
+          group: additional
           compact: true
         description: "YYYY-MM-DD. Date the endorser signs/forwards the memo (per AFH 33-337 Ch. 14, this is distinct from the originating memo's date). Leave blank to render a fill-in line for the endorser to date by hand when signing."

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -9,7 +9,7 @@ main:
       example:
       - Attachment description, YYYY MMM DD
       ui:
-        group: Additional
+        group: additional
         order: 18
       items:
         type: string
@@ -20,7 +20,7 @@ main:
       example:
       - Rank and Name, ORG/SYMBOL
       ui:
-        group: Additional
+        group: additional
         order: 16
       items:
         type: string
@@ -33,7 +33,7 @@ main:
         applicable DoD guidance.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 9
         compact: true
       enum:
@@ -50,7 +50,7 @@ main:
         Leave blank to omit.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 12
         compact: true
     cui_controlled_by:
@@ -60,7 +60,7 @@ main:
         'SAF/AA'). Required by DoDM 5200.48 when classification is CUI.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 11
         compact: true
     cui_limited_dissemination:
@@ -70,7 +70,7 @@ main:
         'NOFORN'). Independent from the banner suffix above.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 13
         compact: true
     cui_poc:
@@ -80,7 +80,7 @@ main:
         john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 14
         compact: true
     date:
@@ -88,7 +88,7 @@ main:
       description: YYYY-MM-DD. Leave blank to use today's date.
       default: ""
       ui:
-        group: Additional
+        group: additional
         order: 21
         compact: true
     dissemination:
@@ -98,7 +98,7 @@ main:
         CUI//NF in the header/footer). Leave blank for no suffix.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 10
         compact: true
     distribution:
@@ -111,7 +111,7 @@ main:
       - ORG1/SYMBOL
       - ORG2/SYMBOL
       ui:
-        group: Additional
+        group: additional
         order: 17
       items:
         type: string
@@ -120,7 +120,7 @@ main:
       description: Body text size in points; decimals allowed (e.g. 11.5).
       default: 12
       ui:
-        group: Additional
+        group: additional
         order: 20
         compact: true
     letterhead_caption:
@@ -129,7 +129,7 @@ main:
       example:
       - HEADQUARTERS [UNIT NAME]
       ui:
-        group: Letterhead
+        group: letterhead
         order: 5
       items:
         type: string
@@ -140,7 +140,7 @@ main:
         letterhead.
       default: dow
       ui:
-        group: Letterhead
+        group: letterhead
         order: 6
         compact: true
       enum:
@@ -151,7 +151,7 @@ main:
       description: Bold-caps line below the seal; blank to omit.
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         order: 7
         compact: true
     letterhead_title:
@@ -159,7 +159,7 @@ main:
       description: Change only for Joint Commands or DoW agencies.
       default: DEPARTMENT OF THE AIR FORCE
       ui:
-        group: Letterhead
+        group: letterhead
         order: 4
     memo_for:
       type: array
@@ -171,7 +171,7 @@ main:
       - ORG1/SYMBOL
       - ORG2/SYMBOL
       ui:
-        group: Addressing
+        group: addressing
         order: 0
       items:
         type: string
@@ -189,7 +189,7 @@ main:
       - 123 Street Ave
       - City ST 12345-6789
       ui:
-        group: Addressing
+        group: addressing
         order: 1
       items:
         type: string
@@ -200,7 +200,7 @@ main:
         body paragraph layout per AFH 33-337.
       default: usaf
       ui:
-        group: Additional
+        group: additional
         order: 19
         compact: true
       enum:
@@ -217,7 +217,7 @@ main:
       - AFMAN 33-326, 25 November 2011, *Preparing Official Communications*
       - AFI 33-360, *Publications and Forms Management*
       ui:
-        group: Additional
+        group: additional
         order: 15
       items:
         type: richtext
@@ -229,7 +229,7 @@ main:
       - FIRST M. LAST, Rank, USAF
       - Duty Title
       ui:
-        group: Addressing
+        group: addressing
         order: 3
       items:
         type: string
@@ -241,7 +241,7 @@ main:
         applicable.
       example: Subject of the Memorandum
       ui:
-        group: Addressing
+        group: addressing
         order: 2
       inline: true
     tag_line:
@@ -251,10 +251,16 @@ main:
         (e.g. *italics*, **bold**).
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         order: 8
         compact: true
       inline: true
+  ui:
+    groups:
+      addressing: {}
+      letterhead: {}
+      classification: {}
+      additional: {}
   body:
     example: |
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.
@@ -274,7 +280,7 @@ card_kinds:
           or 'disapprove' to circle the selected option.
         default: ""
         ui:
-          group: Additional
+          group: additional
           order: 4
           compact: true
         enum:
@@ -290,7 +296,7 @@ card_kinds:
           fill-in line for the endorser to date by hand when signing.
         default: ""
         ui:
-          group: Additional
+          group: additional
           order: 5
           compact: true
       for:
@@ -298,14 +304,14 @@ card_kinds:
         description: Office symbol or organization receiving the endorsed memo.
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
           order: 1
       format:
         type: string
         description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
         default: standard
         ui:
-          group: Additional
+          group: additional
           order: 3
           compact: true
         enum:
@@ -317,7 +323,7 @@ card_kinds:
         description: Office symbol or Rank Name of the endorsing official.
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
           order: 0
       signature_block:
         type: array
@@ -326,9 +332,12 @@ card_kinds:
         - FIRST M. LAST, Rank, USAF
         - Duty Title
         ui:
-          group: Addressing
+          group: addressing
           order: 2
         items:
           type: string
     ui:
       title: Routing indorsement
+      groups:
+        addressing: {}
+        additional: {}

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -148,6 +148,38 @@ identifiers, keys — values a template computes with (`#link` / `#image`,
 comparison, keying), not prose it lays out. Use `plaintext` for prose the author
 navigates, `enum` for a closed set.
 
+## `ui.group` is card-level only; nested properties keep authored order (#941)
+
+Two independent schema-authoring fixes to the `ui.*` block. Both touch only
+Quill.yaml; documents, wire shapes, and the blueprint grammar are unchanged.
+
+- **`ui.group` in a nested position is now a load error.** Grouping clusters a
+  card's top-level fields; the blueprint's grouping pass never descended into an
+  object's properties or an array's items, so a `group` there was silently
+  inert. It now fails with `quill::nested_group_not_supported`. A `group` on a
+  card-level field (under `main.fields` or a card kind's `fields`) is unaffected
+  — that is where grouping has always applied.
+
+  ```
+  0.93 (silently ignored)           0.94 (load error)
+  address:                          address:
+    type: object                      type: object
+    properties:                       properties:
+      street:                           street:
+        type: string                      type: string
+        ui: { group: Location }         # move the group up to the card-level
+                                        # field, or drop it
+  ```
+
+- **Typed-dictionary and typed-table-row properties now render in declaration
+  order.** Positional `ui.order` auto-assignment previously ran only on
+  card-level fields; nested properties live in a `BTreeMap` and defaulted to
+  `i32::MAX`, so they rendered alphabetically, discarding authored order one
+  level down. They now receive positional `ui.order` from declaration order, the
+  same rule top-level fields already followed. Blueprints and forms for a quill
+  whose nested properties were authored out of alphabetical order will reorder to
+  match the Quill.yaml; an explicit `ui.order` on a property still wins.
+
 ## The addressed richtext write surface + corpus codec (#925)
 
 The richtext write surface was a grid: every verb stamped out once per address

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -148,10 +148,61 @@ identifiers, keys — values a template computes with (`#link` / `#image`,
 comparison, keying), not prose it lays out. Use `plaintext` for prose the author
 navigates, `enum` for a closed set.
 
+## Group registry: `ui.groups`, validated `ui.group` references (#941)
+
+Groups gain a **card-level registry**. A group is no longer just the set of
+fields sharing a byte-identical `ui.group` string (where the display label
+doubled as identity and a typo silently split a section). Each card declares
+`ui.groups` — an ordered list of snake_case ids — and a field's `ui.group`
+becomes a *reference* into it.
+
+```
+0.93 (label is identity)          0.94 (id is identity, label derived)
+main:                             main:
+  fields:                           ui:
+    memo_for:                         groups: [addressing, letterhead]
+      ui: { group: Addressing }     fields:
+    subject:                          memo_for:
+      ui: { group: Addressing }         ui: { group: addressing }
+                                      subject:
+                                        ui: { group: addressing }
+```
+
+- **Registry keys are snake_case ids; declaration order is display order** — the
+  same contract field declaration order gives `ui.order`. Consumers derive the
+  label from the id (`addressing` → "Addressing"), exactly as a field label is
+  derived from its key; override it with the mapping form, `letterhead: { title:
+  "Letterhead & Seal" }`. Renaming a label touches one line and never breaks a
+  reference or persisted per-group editor state.
+- **The registry has two interchangeable forms:** a bare sequence of ids
+  (`[addressing, letterhead]`) when no label needs overriding, or a mapping of
+  id → attributes when one does. Both fold to the same ordered registry and
+  re-emit as the mapping form in `QuillConfig::schema()`.
+- **`ui.group` is validated:** a value with no matching registry key is
+  `quill::unknown_group`; a registry id that is not snake_case is
+  `quill::invalid_group_id`; a repeated id is `quill::duplicate_group`. Because a
+  registry is authoritative when present, there is no implicit fallback to mix
+  with — an undeclared reference simply fails.
+- **Implicit groups are deprecated, not yet removed.** A `ui.group` with no
+  `ui.groups` registry keeps today's exact semantics — the value *is* the label
+  and identity, groups order by first appearance — and now emits a
+  `quill::implicit_group` warning. It becomes an error in a future release.
+  Migrate by adding a `ui.groups` registry and lowercasing each `ui.group` to
+  its id. (No slug is invented during the deprecation window: implicit identity
+  stays the literal label, so nothing a consumer might persist changes shape
+  before you choose explicit ids.)
+- **The blueprint is unchanged in shape** — it still clusters by group and emits
+  no banner; only its group-*ordering* input switches from first-appearance to
+  registry order, which for a migrated quill is identical.
+
+The bundled quills (`usaf_memo`, `cmu_letter`, `classic_resume`) are migrated to
+the registry form as worked examples.
+
 ## `ui.group` is card-level only; nested properties keep authored order (#941)
 
-Two independent schema-authoring fixes to the `ui.*` block. Both touch only
-Quill.yaml; documents, wire shapes, and the blueprint grammar are unchanged.
+Two independent schema-authoring fixes to the `ui.*` block, landed ahead of the
+registry above. Both touch only Quill.yaml; documents, wire shapes, and the
+blueprint grammar are unchanged.
 
 - **`ui.group` in a nested position is now a load error.** Grouping clusters a
   card's top-level fields; the blueprint's grouping pass never descended into an

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -42,7 +42,10 @@ guides in order.
   types join the schema: `plaintext` (navigable unformatted prose over the
   richtext corpus, via a literal codec) and a promoted first-class `enum`
   (`type: enum` + `values:`, the `enum:` modifier on `string` deprecated for one
-  release); `string` narrows to open scalar data (#938).
+  release); `string` narrows to open scalar data (#938). Two `ui.*` fixes:
+  `ui.group` in a nested position is now a load error
+  (`quill::nested_group_not_supported`), and typed-dictionary / typed-table-row
+  properties render in declaration order instead of alphabetically (#941).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -42,8 +42,12 @@ guides in order.
   types join the schema: `plaintext` (navigable unformatted prose over the
   richtext corpus, via a literal codec) and a promoted first-class `enum`
   (`type: enum` + `values:`, the `enum:` modifier on `string` deprecated for one
-  release); `string` narrows to open scalar data (#938). Two `ui.*` fixes:
-  `ui.group` in a nested position is now a load error
+  release); `string` narrows to open scalar data (#938). Groups gain a
+  card-level `ui.groups` registry: `ui.group` becomes a validated reference to a
+  snake_case id (`quill::unknown_group`), registry declaration order fixes
+  display order, labels derive from ids with a `title:` override, and bare
+  label-as-identity groups are deprecated (`quill::implicit_group`); plus two
+  `ui.*` fixes — `ui.group` in a nested position is now a load error
   (`quill::nested_group_not_supported`), and typed-dictionary / typed-table-row
   properties render in declaration order instead of alphabetically (#941).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -237,9 +237,11 @@ main:
 
 Fields with the same `group` value are rendered together. The group name becomes the section heading.
 
+`group` applies only to card-level fields (those directly under a card's `fields:`). Grouping never descends into an object's properties or an array's items, so a `group` on a nested property is a hard error (`quill::nested_group_not_supported`) rather than a silently inert knob.
+
 ### `order`
 
-Auto-assigned from field position. To override:
+Auto-assigned from field position. This positional assignment applies at every level — card-level fields *and* the properties of a typed dictionary or typed-table row — so nested properties render in declaration order rather than alphabetically. To override:
 
 ```yaml
 main:

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -208,36 +208,52 @@ main:
         title: To       # "Memo For" would confuse users unfamiliar with memo conventions
 ```
 
-### `group`
+### `group` and the group registry
 
-Organizes fields into visual sections:
+Groups organize fields into visual sections. A group has two parts: a **registry** declared once on the card (`ui.groups`), and a per-field **reference** (`ui.group`) into that registry.
 
 ```yaml
 main:
+  ui:
+    groups: [addressing, letterhead]   # declaration order = display order
   fields:
     memo_for:
       type: array
       items:
         type: string
       ui:
-        group: Addressing
+        group: addressing              # a reference, validated against the registry
 
     memo_from:
       type: array
       items:
         type: string
       ui:
-        group: Addressing
+        group: addressing
 
     letterhead_title:
       type: string
       ui:
-        group: Letterhead
+        group: letterhead
 ```
 
-Fields with the same `group` value are rendered together. The group name becomes the section heading.
+The registry is the card's table of contents. Its keys are **snake_case ids** (same discipline as field keys), and their declaration order fixes the group display order — the contract every consumer follows, exactly as field declaration order fixes `ui.order`. A field's `ui.group` names one of those ids; a value with no matching registry key is a load error (`quill::unknown_group`), so a one-character typo can no longer silently split a section.
+
+**Identity is the id, not the label.** Consumers derive a group's display label from its id (`addressing` → "Addressing"), just as a field label is derived from its key. Override the derived label with `title:` — which requires the mapping form of the registry:
+
+```yaml
+main:
+  ui:
+    groups:
+      addressing: {}                       # label derived: "Addressing"
+      letterhead: { title: "Letterhead & Seal" }   # label overridden
+```
+
+The two registry forms are interchangeable: a bare sequence of ids (`[addressing, letterhead]`) when no labels need overriding, or a mapping of id → attributes when they do. Renaming a label touches one line and never breaks a `ui.group` reference or persisted per-group editor state.
 
 `group` applies only to card-level fields (those directly under a card's `fields:`). Grouping never descends into an object's properties or an array's items, so a `group` on a nested property is a hard error (`quill::nested_group_not_supported`) rather than a silently inert knob.
+
+**Implicit groups (deprecated).** A `ui.group` with no `ui.groups` registry on the card still works: each distinct value is an implicit group whose label *is* the value, ordered by first appearance — today's behavior. It now emits a `quill::implicit_group` deprecation warning and will become an error in a future release. Declare a registry to silence it.
 
 ### `order`
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -258,7 +258,7 @@ document carries no `$seed`).
 `QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:
 
 - Field types, constraints, and `enum`/`default`/`example` annotations
-- `ui` hints on fields and card kinds (`group`, `order`, `compact`, `multiline`, `title`)
+- `ui` hints on fields (`group`, `order`, `compact`, `multiline`, `title`) and on cards (`title`, plus the `groups` registry that `group` references)
 - `body` blocks on cards (`enabled`, `example`)
 
 The schema describes only the user-fillable fields. The quill reference


### PR DESCRIPTION
Implements issue #941: the card-level group registry (in the shape refined by the follow-up review), plus the two orthogonal `ui.*` fixes that land first. Touches only Quill.yaml schema authoring; documents, wire shapes, and the blueprint grammar are unchanged.

## 1. Group registry (`ui.groups`)

`ui.group` stops being label-as-identity and becomes a validated reference into a per-card registry.

```yaml
main:
  ui:
    groups: [addressing, letterhead]   # declaration order = display order
  fields:
    memo_for: { type: array, items: { type: string }, ui: { group: addressing } }
    subject:  { type: string, ui: { group: addressing } }
```

- **Identity is the id, not the label.** Registry keys are snake_case ids; consumers derive the display label from the id (`addressing` → "Addressing") exactly as a field label derives from its key. `title:` is override-only and requires the mapping form (`letterhead: { title: "Letterhead & Seal" }`). Renaming a label touches one line and never breaks a reference or persisted per-group editor state.
- **Two interchangeable authoring forms:** a bare sequence of ids (common case, titles derived) or a mapping of id → `{ title? }` (overrides). Both fold to one ordered `Vec` internally, so declaration order survives regardless of surface form; `schema()` re-emits the canonical mapping form with order preserved and derived titles omitted, so it round-trips.
- **Declaration order is display order** — the same contract field declaration order gives `ui.order`. The blueprint's `group_fields` switches its group-ordering input from first-appearance to registry order (ungrouped still leads, no banner change); for a migrated quill the two are identical.
- **Validation:** an unresolved `ui.group` is `quill::unknown_group`; a non-snake_case registry id is `quill::invalid_group_id`; a repeated id is `quill::duplicate_group`. A registry is authoritative when present, so there is no implicit fallback to mix with.
- **Implicit groups deprecated, not removed.** A `ui.group` with no registry keeps today's exact semantics (value is label and identity, first-appearance order — no slug invented) and emits a `quill::implicit_group` warning; it becomes an error in a future release.

## 2. Orthogonal fixes (landed first, independent of the registry)

- **`ui.group` in a nested position → load error** (`quill::nested_group_not_supported`). It was parsed and round-tripped but never consumed — the grouping pass runs only on card-level fields.
- **Nested object/table-row properties get positional `ui.order`** in declaration order (a shared `set_ui_order_if_unset` stamps card level and nested props through one path), so they stop alphabetizing out of `BTreeMap`. Bug-fix-shaped: plates consume by key, not order.

## Fixtures & tests

- `usaf_memo`, `cmu_letter`, `classic_resume` migrated to the registry form as worked examples; `usaf_memo` schema golden regenerated.
- 14 new tests: nested-group rejection, nested/table-row ordering, explicit-order preservation, list-form + map-form parsing, registry-driven blueprint ordering, `unknown_group` / `invalid_group_id` / `duplicate_group` / `implicit_group`, schema round-trip, and a fixtures-load-warning-free guard. Full workspace suite green (635 core tests); clippy clean.

## Docs

`quill-yaml-reference.md` (rewritten `group` section), `prose/canon/SCHEMAS.md`, and migration guide `0.93-to-0.94.md` + its index entry document the registry, both authoring forms, and the implicit-group deprecation.

## Open design questions deferred

Per-card vs. global registry scope is resolved here as **per-card** (each card, main or kind, declares its own `ui.groups`; references resolve within the card). The `schema()` emission path is implemented (canonical mapping form under each card's `ui.groups`). No further design decisions outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH4bRvRFiEbRR7kkmhPbNN