### PR TITLE
pdfform: derive widget intrinsics from the quill schema (form@0.2.0, #940)

### DIFF
--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -1,7 +1,9 @@
 //! The **bind** step: at quill load, resolve every `form.json` field against the
-//! quill schema and derive its widget intrinsics — so `form.json` never restates
-//! what the schema already carries, and a widget bound to a nonexistent field is
-//! a load error, not a silent blank.
+//! two static inputs — the quill schema and the background geometry — into the
+//! session's value-free widget layer. Everything here is a pure function of the
+//! quill (not the document), so it runs once at open, never per render:
+//! `form.json` never restates what the schema carries, and a widget bound to a
+//! nonexistent field or an out-of-range page is a load error, not a silent blank.
 //!
 //! Two products, one per field population ([`crate::form`]):
 //! - A **bound** field names a `schema_field`. [`bind`] walks that path against
@@ -14,15 +16,17 @@
 //!   through (no schema to consult).
 //!
 //! Both collapse to a [`BoundWidget`] — the value-free intrinsic layer the
-//! session holds for its lifetime; per-document value resolution ([`crate::resolve`])
-//! runs against it.
+//! session holds for its lifetime, its `rect` already flipped to final PDF
+//! geometry. Per-document value resolution ([`crate::resolve`]) runs against it
+//! and touches nothing but the value.
 
 use quillmark_core::quill::{FieldSchema, FieldType as SchemaType, QuillConfig};
 use quillmark_pdf::FieldType as WidgetType;
 
 use crate::form::{BoundField, FormSpec, Rect, UnboundWidget, WidgetKind};
 
-/// A `form.json` field with its widget intrinsics resolved: geometry plus a
+/// A `form.json` field with everything static about it resolved: **final**
+/// geometry (bottom-left `[x0, y0, x1, y1]`, page-range validated) plus a
 /// value-free [`WidgetType`]. A bound field carries `Some(schema_field)` (its
 /// value is resolved per document); an unbound widget carries `None`.
 #[derive(Debug, Clone, PartialEq)]
@@ -30,14 +34,14 @@ pub struct BoundWidget {
     pub name: String,
     pub schema_field: Option<String>,
     pub page: usize,
-    pub rect: Rect,
+    pub rect: [f32; 4],
     pub field_type: WidgetType,
     pub tooltip: Option<String>,
 }
 
-/// Why binding a `form.json` field against the quill schema failed. Both
-/// variants are load errors — the point of binding at load is to turn what was a
-/// silently-blank widget into a diagnostic.
+/// Why binding a `form.json` field failed. Every variant is a load error — the
+/// point of binding at load is to turn what was a silently-blank (or misplaced)
+/// widget into a diagnostic.
 #[derive(Debug)]
 pub enum BindError {
     /// A `schema_field` path does not resolve: a missing root, or a `.segment`
@@ -55,6 +59,12 @@ pub enum BindError {
         path: String,
         ty: String,
     },
+    /// A widget targets a page the background PDF does not have.
+    PageOutOfRange {
+        name: String,
+        page: usize,
+        page_count: usize,
+    },
 }
 
 impl BindError {
@@ -63,6 +73,7 @@ impl BindError {
         match self {
             BindError::Dangling { .. } => "pdfform::dangling_binding",
             BindError::Unbindable { .. } => "pdfform::unbindable_field",
+            BindError::PageOutOfRange { .. } => "pdfform::field_page_out_of_range",
         }
     }
 }
@@ -85,31 +96,47 @@ impl std::fmt::Display for BindError {
                  type `{ty}` — no widget can render it; bind a scalar, enum, boolean, or an array \
                  of those instead"
             ),
+            BindError::PageOutOfRange {
+                name,
+                page,
+                page_count,
+            } => write!(
+                f,
+                "form.json field {name:?} targets page {page} but `form.pdf` has {page_count} page(s)"
+            ),
         }
     }
 }
 
-/// Resolve and project every field in `spec` against `config`, yielding the
-/// session's value-free widget layer. Bound fields inherit their kind, choice
-/// options, multiline, and tooltip from the schema; unbound widgets pass their
-/// declared kind through unchanged.
+/// Resolve and place every field in `spec` against the schema and the page
+/// geometry, yielding the session's value-free widget layer. Bound fields
+/// inherit their kind, choice options, multiline, and tooltip from the schema;
+/// unbound widgets pass their declared kind through unchanged; every widget's
+/// rect is flipped to final geometry and its page validated — all of it once,
+/// here, so nothing downstream repeats it per document.
 pub fn bind_widgets(
     spec: &FormSpec,
     config: &QuillConfig,
+    page_boxes: &[[f32; 4]],
 ) -> Result<Vec<BoundWidget>, BindError> {
     let mut bound = Vec::with_capacity(spec.fields.len() + spec.widgets.len());
     for field in &spec.fields {
-        bound.push(bind_field(field, config)?);
+        bound.push(bind_field(field, config, page_boxes)?);
     }
     for widget in &spec.widgets {
-        bound.push(bind_unbound(widget));
+        bound.push(bind_unbound(widget, page_boxes)?);
     }
     Ok(bound)
 }
 
-/// Bind one schema-bound field: resolve its path, project the widget kind, and
-/// inherit the tooltip (an explicit `tooltip` overrides the schema `description`).
-fn bind_field(field: &BoundField, config: &QuillConfig) -> Result<BoundWidget, BindError> {
+/// Bind one schema-bound field: resolve its path, project the widget kind, place
+/// its geometry, and inherit the tooltip (an explicit `tooltip` overrides the
+/// schema `description`).
+fn bind_field(
+    field: &BoundField,
+    config: &QuillConfig,
+    page_boxes: &[[f32; 4]],
+) -> Result<BoundWidget, BindError> {
     let schema = bind(config, &field.name, &field.schema_field)?;
     let field_type = project_kind(schema, &field.name, &field.schema_field)?;
     let tooltip = field
@@ -120,23 +147,55 @@ fn bind_field(field: &BoundField, config: &QuillConfig) -> Result<BoundWidget, B
         name: field.name.clone(),
         schema_field: Some(field.schema_field.clone()),
         page: field.page,
-        rect: field.rect,
+        rect: place(&field.name, field.page, field.rect, page_boxes)?,
         field_type,
         tooltip,
     })
 }
 
-/// Lift one unbound widget: its declared kind maps straight to a [`WidgetType`],
-/// no schema consulted.
-fn bind_unbound(widget: &UnboundWidget) -> BoundWidget {
-    BoundWidget {
+/// Lift one unbound widget: its declared kind maps straight to a [`WidgetType`]
+/// (no schema consulted) and its geometry is placed.
+fn bind_unbound(
+    widget: &UnboundWidget,
+    page_boxes: &[[f32; 4]],
+) -> Result<BoundWidget, BindError> {
+    Ok(BoundWidget {
         name: widget.name.clone(),
         schema_field: None,
         page: widget.page,
-        rect: widget.rect,
+        rect: place(&widget.name, widget.page, widget.rect, page_boxes)?,
         field_type: widget_type(&widget.kind),
         tooltip: widget.tooltip.clone(),
-    }
+    })
+}
+
+/// Flip a widget's top-left, page-relative rect to final bottom-left PDF
+/// geometry against its page's media box, validating the page exists. Runs once
+/// per widget at load — the geometry is fixed for the session's lifetime.
+fn place(
+    name: &str,
+    page: usize,
+    rect: Rect,
+    page_boxes: &[[f32; 4]],
+) -> Result<[f32; 4], BindError> {
+    let media_box = page_boxes.get(page).ok_or_else(|| BindError::PageOutOfRange {
+        name: name.to_string(),
+        page,
+        page_count: page_boxes.len(),
+    })?;
+    Ok(flip_rect(rect, *media_box))
+}
+
+/// Page-relative top-left `{x,y,w,h}` → spine bottom-left `[x0, y0, x1, y1]` in
+/// PDF user space. Honours a non-zero page origin: the left edge is the MediaBox
+/// `x0` and `y` is measured down from the top edge (MediaBox `y1`), so a
+/// translated MediaBox (e.g. `[10 20 622 812]`) places widgets correctly rather
+/// than shifting them by the origin. This is the single biggest hand-authoring
+/// footgun, defused structurally in one place.
+fn flip_rect(r: Rect, media_box: [f32; 4]) -> [f32; 4] {
+    let left = media_box[0];
+    let top = media_box[3];
+    [left + r.x, top - (r.y + r.h), left + r.x + r.w, top - r.y]
 }
 
 /// Resolve a `schema_field` path to the leaf [`FieldSchema`] it addresses.
@@ -513,8 +572,45 @@ main:
             }"#,
         )
         .unwrap();
-        let bound = bind_widgets(&spec, &cfg).unwrap();
+        let mb = [[0.0, 0.0, 612.0, 792.0]];
+        let bound = bind_widgets(&spec, &cfg, &mb).unwrap();
         assert_eq!(bound[0].tooltip.as_deref(), Some("From the schema."));
         assert_eq!(bound[1].tooltip.as_deref(), Some("Override."));
+    }
+
+    #[test]
+    fn place_flips_to_bottom_left_and_honours_origin() {
+        let r = Rect {
+            x: 180.0,
+            y: 90.0,
+            w: 14.0,
+            h: 14.0,
+        };
+        // Zero-origin page.
+        assert_eq!(
+            place("W", 0, r, &[[0.0, 0.0, 600.0, 800.0]]).unwrap(),
+            [180.0, 800.0 - 104.0, 194.0, 800.0 - 90.0]
+        );
+        // Translated MediaBox [10 20 622 812]: widgets land offset by the origin.
+        assert_eq!(
+            place("W", 0, r, &[[10.0, 20.0, 622.0, 812.0]]).unwrap(),
+            [10.0 + 180.0, 812.0 - 104.0, 10.0 + 194.0, 812.0 - 90.0]
+        );
+    }
+
+    #[test]
+    fn place_rejects_out_of_range_page() {
+        let r = Rect {
+            x: 0.0,
+            y: 0.0,
+            w: 1.0,
+            h: 1.0,
+        };
+        match place("W", 2, r, &[[0.0, 0.0, 612.0, 792.0]]) {
+            Err(e @ BindError::PageOutOfRange { .. }) => {
+                assert_eq!(e.code(), "pdfform::field_page_out_of_range");
+            }
+            other => panic!("expected PageOutOfRange, got {other:?}"),
+        }
     }
 }

--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -1,0 +1,520 @@
+//! The **bind** step: at quill load, resolve every `form.json` field against the
+//! quill schema and derive its widget intrinsics — so `form.json` never restates
+//! what the schema already carries, and a widget bound to a nonexistent field is
+//! a load error, not a silent blank.
+//!
+//! Two products, one per field population ([`crate::form`]):
+//! - A **bound** field names a `schema_field`. [`bind`] walks that path against
+//!   the [`QuillConfig`] to the leaf [`FieldSchema`], and [`project_kind`]
+//!   projects that resolved field to a widget kind (choice/checkbox/text). The
+//!   projection is **total or it is a load error**: a field that resolves to an
+//!   `object` or an array of objects/arrays has no widget shape
+//!   ([`BindError::Unbindable`]).
+//! - An **unbound** widget carries its own declared `type`, copied straight
+//!   through (no schema to consult).
+//!
+//! Both collapse to a [`BoundWidget`] — the value-free intrinsic layer the
+//! session holds for its lifetime; per-document value resolution ([`crate::resolve`])
+//! runs against it.
+
+use quillmark_core::quill::{FieldSchema, FieldType as SchemaType, QuillConfig};
+use quillmark_pdf::FieldType as WidgetType;
+
+use crate::form::{BoundField, FormSpec, Rect, UnboundWidget, WidgetKind};
+
+/// A `form.json` field with its widget intrinsics resolved: geometry plus a
+/// value-free [`WidgetType`]. A bound field carries `Some(schema_field)` (its
+/// value is resolved per document); an unbound widget carries `None`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoundWidget {
+    pub name: String,
+    pub schema_field: Option<String>,
+    pub page: usize,
+    pub rect: Rect,
+    pub field_type: WidgetType,
+    pub tooltip: Option<String>,
+}
+
+/// Why binding a `form.json` field against the quill schema failed. Both
+/// variants are load errors — the point of binding at load is to turn what was a
+/// silently-blank widget into a diagnostic.
+#[derive(Debug)]
+pub enum BindError {
+    /// A `schema_field` path does not resolve: a missing root, or a `.segment`
+    /// that descends into the wrong shape or a nonexistent key. Names the failing
+    /// segment.
+    Dangling {
+        name: String,
+        path: String,
+        segment: String,
+    },
+    /// A `schema_field` resolves, but to a schema type with no widget shape (an
+    /// `object`, or an array of objects/arrays).
+    Unbindable {
+        name: String,
+        path: String,
+        ty: String,
+    },
+}
+
+impl BindError {
+    /// The stable error code a caller stamps on the surfaced diagnostic.
+    pub fn code(&self) -> &'static str {
+        match self {
+            BindError::Dangling { .. } => "pdfform::dangling_binding",
+            BindError::Unbindable { .. } => "pdfform::unbindable_field",
+        }
+    }
+}
+
+impl std::fmt::Display for BindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BindError::Dangling {
+                name,
+                path,
+                segment,
+            } => write!(
+                f,
+                "form.json field {name:?} binds schema_field {path:?}, but segment {segment:?} \
+                 does not resolve against the quill schema"
+            ),
+            BindError::Unbindable { name, path, ty } => write!(
+                f,
+                "form.json field {name:?} binds schema_field {path:?}, which resolves to schema \
+                 type `{ty}` — no widget can render it; bind a scalar, enum, boolean, or an array \
+                 of those instead"
+            ),
+        }
+    }
+}
+
+/// Resolve and project every field in `spec` against `config`, yielding the
+/// session's value-free widget layer. Bound fields inherit their kind, choice
+/// options, multiline, and tooltip from the schema; unbound widgets pass their
+/// declared kind through unchanged.
+pub fn bind_widgets(
+    spec: &FormSpec,
+    config: &QuillConfig,
+) -> Result<Vec<BoundWidget>, BindError> {
+    let mut bound = Vec::with_capacity(spec.fields.len() + spec.widgets.len());
+    for field in &spec.fields {
+        bound.push(bind_field(field, config)?);
+    }
+    for widget in &spec.widgets {
+        bound.push(bind_unbound(widget));
+    }
+    Ok(bound)
+}
+
+/// Bind one schema-bound field: resolve its path, project the widget kind, and
+/// inherit the tooltip (an explicit `tooltip` overrides the schema `description`).
+fn bind_field(field: &BoundField, config: &QuillConfig) -> Result<BoundWidget, BindError> {
+    let schema = bind(config, &field.name, &field.schema_field)?;
+    let field_type = project_kind(schema, &field.name, &field.schema_field)?;
+    let tooltip = field
+        .tooltip
+        .clone()
+        .or_else(|| schema.description.clone());
+    Ok(BoundWidget {
+        name: field.name.clone(),
+        schema_field: Some(field.schema_field.clone()),
+        page: field.page,
+        rect: field.rect,
+        field_type,
+        tooltip,
+    })
+}
+
+/// Lift one unbound widget: its declared kind maps straight to a [`WidgetType`],
+/// no schema consulted.
+fn bind_unbound(widget: &UnboundWidget) -> BoundWidget {
+    BoundWidget {
+        name: widget.name.clone(),
+        schema_field: None,
+        page: widget.page,
+        rect: widget.rect,
+        field_type: widget_type(&widget.kind),
+        tooltip: widget.tooltip.clone(),
+    }
+}
+
+/// Resolve a `schema_field` path to the leaf [`FieldSchema`] it addresses.
+///
+/// The root segment resolves in `main.fields`, or is the reserved `$cards`
+/// (below). Thereafter a `.N` segment requires the current schema be `array`
+/// (descend into `items`) and a `.key` segment requires `object` (descend into
+/// `properties[key]`). Any miss — a bad root, a wrong-shape descent, a missing
+/// key, or segments left dangling past a leaf — is a [`BindError::Dangling`].
+///
+/// `$cards.<kind>.<i>.<field>…` addresses a card field: `<kind>` names a card
+/// kind, `<i>` is the (numeric) instance index selected at value time, and
+/// `<field>…` descends into that kind's schema. **Absolute-index addressing
+/// (`$cards.<i>.<field>`) is not accepted in `form@0.2.0`** — a widget kind must
+/// be statically derivable, and only kind+index tells the schema which field it is.
+pub fn bind<'a>(
+    config: &'a QuillConfig,
+    name: &str,
+    path: &str,
+) -> Result<&'a FieldSchema, BindError> {
+    let dangling = |segment: &str| BindError::Dangling {
+        name: name.to_string(),
+        path: path.to_string(),
+        segment: segment.to_string(),
+    };
+
+    let mut parts = path.split('.');
+    // `split` on a non-empty string always yields at least one segment.
+    let root = parts.next().unwrap_or("");
+
+    let mut cur: &FieldSchema = if root == "$cards" {
+        let kind = parts.next().ok_or_else(|| dangling(root))?;
+        let card = config.card_kind(kind).ok_or_else(|| dangling(kind))?;
+        let idx = parts.next().ok_or_else(|| dangling(kind))?;
+        // The instance index selects a card at value time; it must be numeric,
+        // but does not descend the schema (all instances of a kind share it).
+        idx.parse::<usize>().map_err(|_| dangling(idx))?;
+        let card_field = parts.next().ok_or_else(|| dangling(idx))?;
+        card.fields
+            .get(card_field)
+            .ok_or_else(|| dangling(card_field))?
+    } else {
+        config.main.fields.get(root).ok_or_else(|| dangling(root))?
+    };
+
+    for seg in parts {
+        cur = descend(cur, seg).ok_or_else(|| dangling(seg))?;
+    }
+    Ok(cur)
+}
+
+/// Descend one path segment into `cur`: a numeric segment indexes an `array`
+/// (into its `items` element schema); a key segment reads an `object` property.
+/// A shape mismatch or missing key returns `None`.
+fn descend<'a>(cur: &'a FieldSchema, seg: &str) -> Option<&'a FieldSchema> {
+    match seg.parse::<usize>() {
+        Ok(_) => match cur.r#type {
+            SchemaType::Array => cur.items.as_deref(),
+            _ => None,
+        },
+        Err(_) => match cur.r#type {
+            SchemaType::Object => cur.properties.as_ref()?.get(seg).map(Box::as_ref),
+            _ => None,
+        },
+    }
+}
+
+/// Project a resolved [`FieldSchema`] to its widget kind. Keyed on the field's
+/// *capability*, not its `type` token — crucially, choice keys on
+/// `enum_values.is_some()`, so both `type: enum` and the deprecated `string` +
+/// `enum:` modifier project to a dropdown (keying on the `Enum` variant would
+/// silently demote the latter to a text box). Total or a load error: an
+/// `object`, or an array of objects/arrays, has no widget shape.
+pub fn project_kind(
+    field: &FieldSchema,
+    name: &str,
+    path: &str,
+) -> Result<WidgetType, BindError> {
+    // A finite string domain, however spelled, is a dropdown.
+    if let Some(values) = &field.enum_values {
+        return Ok(WidgetType::Choice {
+            options: values.clone(),
+        });
+    }
+    let unbindable = || BindError::Unbindable {
+        name: name.to_string(),
+        path: path.to_string(),
+        ty: type_desc(field),
+    };
+    Ok(match &field.r#type {
+        SchemaType::Boolean => WidgetType::Checkbox,
+        SchemaType::String
+        | SchemaType::Number
+        | SchemaType::Integer
+        | SchemaType::DateTime
+        | SchemaType::RichText { .. }
+        | SchemaType::PlainText { .. } => WidgetType::Text {
+            multiline: is_multiline(field),
+        },
+        // `Enum` without `enum_values` is unreachable (the loader requires
+        // `values:`); handled above. This arm keeps the match total.
+        SchemaType::Enum => WidgetType::Choice {
+            options: field.enum_values.clone().unwrap_or_default(),
+        },
+        // An array binds as text (element texts joined with newlines, matching
+        // `resolve::coerce_text`) only when its element is a scalar or prose;
+        // an array of objects/arrays, or an itemless array, has no widget shape.
+        SchemaType::Array => match field.items.as_deref() {
+            Some(items) if is_scalar_or_prose(items) => WidgetType::Text {
+                multiline: is_multiline(field),
+            },
+            _ => return Err(unbindable()),
+        },
+        SchemaType::Object => return Err(unbindable()),
+    })
+}
+
+/// Whether `field`'s widget is multi-line — inherited from the schema's
+/// `ui.multiline` hint.
+fn is_multiline(field: &FieldSchema) -> bool {
+    field
+        .ui
+        .as_ref()
+        .and_then(|u| u.multiline)
+        .unwrap_or(false)
+}
+
+/// A scalar or prose type binds to text; only `array`/`object` do not.
+fn is_scalar_or_prose(field: &FieldSchema) -> bool {
+    !matches!(field.r#type, SchemaType::Array | SchemaType::Object)
+}
+
+/// A human-readable type name for the unbindable diagnostic, spelling an array's
+/// element type (`array<object>`).
+fn type_desc(field: &FieldSchema) -> String {
+    match &field.r#type {
+        SchemaType::Array => format!(
+            "array<{}>",
+            field.items.as_ref().map_or("?", |i| i.r#type.as_str())
+        ),
+        other => other.as_str().to_string(),
+    }
+}
+
+/// Map an unbound widget's declared kind to a [`WidgetType`].
+fn widget_type(kind: &WidgetKind) -> WidgetType {
+    match kind {
+        WidgetKind::Text { multiline } => WidgetType::Text {
+            multiline: *multiline,
+        },
+        WidgetKind::Checkbox => WidgetType::Checkbox,
+        WidgetKind::Choice { options } => WidgetType::Choice {
+            options: options.clone(),
+        },
+        WidgetKind::Signature => WidgetType::Signature,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A quill schema exercising every projection arm and both card kinds.
+    const YAML: &str = r#"
+quill:
+  name: binder
+  version: 0.1.0
+  backend: pdfform
+  description: bind-test schema
+main:
+  body:
+    enabled: false
+  fields:
+    full_name:
+      type: string
+    comments:
+      type: array
+      items:
+        type: string
+      ui:
+        multiline: true
+    agree:
+      type: boolean
+    favorite_color:
+      type: string
+      enum: [red, green, blue]
+    promoted_color:
+      type: enum
+      values: [cyan, magenta]
+    count:
+      type: integer
+    when:
+      type: datetime
+    bio:
+      type: richtext
+    address:
+      type: object
+      properties:
+        street: { type: string }
+        city: { type: string }
+    refs:
+      type: array
+      items:
+        type: object
+        properties:
+          org: { type: string }
+card_kinds:
+  indorsement:
+    fields:
+      from:
+        type: string
+      signed:
+        type: boolean
+"#;
+
+    fn config() -> QuillConfig {
+        QuillConfig::from_yaml(YAML).expect("schema parses")
+    }
+
+    fn kind(path: &str) -> Result<WidgetType, BindError> {
+        let c = config();
+        let schema = bind(&c, "W", path)?;
+        project_kind(schema, "W", path)
+    }
+
+    #[test]
+    fn scalar_and_prose_project_to_text() {
+        assert_eq!(kind("full_name").unwrap(), WidgetType::Text { multiline: false });
+        assert_eq!(kind("count").unwrap(), WidgetType::Text { multiline: false });
+        assert_eq!(kind("when").unwrap(), WidgetType::Text { multiline: false });
+        assert_eq!(kind("bio").unwrap(), WidgetType::Text { multiline: false });
+    }
+
+    #[test]
+    fn boolean_projects_to_checkbox() {
+        assert_eq!(kind("agree").unwrap(), WidgetType::Checkbox);
+    }
+
+    #[test]
+    fn both_enum_spellings_project_to_choice() {
+        // Deprecated `string` + `enum:` and promoted `type: enum` both key on
+        // `enum_values.is_some()`.
+        assert_eq!(
+            kind("favorite_color").unwrap(),
+            WidgetType::Choice {
+                options: vec!["red".into(), "green".into(), "blue".into()]
+            }
+        );
+        assert_eq!(
+            kind("promoted_color").unwrap(),
+            WidgetType::Choice {
+                options: vec!["cyan".into(), "magenta".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn scalar_array_projects_to_multiline_text_via_ui() {
+        assert_eq!(kind("comments").unwrap(), WidgetType::Text { multiline: true });
+    }
+
+    #[test]
+    fn array_element_binds_to_scalar_text() {
+        assert_eq!(kind("comments.0").unwrap(), WidgetType::Text { multiline: false });
+    }
+
+    #[test]
+    fn object_property_binds() {
+        assert_eq!(kind("address.street").unwrap(), WidgetType::Text { multiline: false });
+    }
+
+    #[test]
+    fn object_and_object_array_are_unbindable() {
+        // `array<array>` is rejected by the schema loader itself
+        // (`quill::nested_array_not_supported`), so it can never reach `bind`;
+        // the two shapes that can are a bare `object` and an `array<object>`.
+        for (path, ty) in [("address", "object"), ("refs", "array<object>")] {
+            match kind(path) {
+                Err(e @ BindError::Unbindable { .. }) => {
+                    assert_eq!(e.code(), "pdfform::unbindable_field");
+                    assert!(e.to_string().contains(ty), "{path}: {e}");
+                }
+                other => panic!("{path}: expected Unbindable, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn dangling_root_and_segment_error() {
+        for (path, seg) in [
+            ("nonesuch", "nonesuch"),
+            ("full_name.0", "0"),        // scalar has no array index
+            ("address.zip", "zip"),      // no such property
+            ("comments.oops", "oops"),   // array wants a numeric index
+        ] {
+            let c = config();
+            match bind(&c, "W", path) {
+                Err(e @ BindError::Dangling { .. }) => {
+                    assert_eq!(e.code(), "pdfform::dangling_binding");
+                    assert!(e.to_string().contains(seg), "{path}: {e}");
+                }
+                other => panic!("{path}: expected Dangling, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn card_paths_bind_by_kind_and_index() {
+        assert_eq!(
+            kind("$cards.indorsement.0.from").unwrap(),
+            WidgetType::Text { multiline: false }
+        );
+        assert_eq!(
+            kind("$cards.indorsement.1.signed").unwrap(),
+            WidgetType::Checkbox
+        );
+    }
+
+    #[test]
+    fn card_absolute_index_and_bad_kind_are_dangling() {
+        let c = config();
+        // `$cards.0.from` — absolute index: `0` is not a card kind, so it dangles
+        // at that segment (absolute addressing is gone in form@0.2.0).
+        assert!(matches!(
+            bind(&c, "W", "$cards.0.from"),
+            Err(BindError::Dangling { .. })
+        ));
+        // Unknown kind.
+        assert!(matches!(
+            bind(&c, "W", "$cards.memo.0.author"),
+            Err(BindError::Dangling { .. })
+        ));
+        // Missing field after the index.
+        assert!(matches!(
+            bind(&c, "W", "$cards.indorsement.0"),
+            Err(BindError::Dangling { .. })
+        ));
+        // Non-numeric index.
+        assert!(matches!(
+            bind(&c, "W", "$cards.indorsement.x.from"),
+            Err(BindError::Dangling { .. })
+        ));
+    }
+
+    #[test]
+    fn tooltip_inherits_description_unless_overridden() {
+        let yaml = r#"
+quill:
+  name: t
+  version: 0.1.0
+  backend: pdfform
+  description: t
+main:
+  body:
+    enabled: false
+  fields:
+    a:
+      type: string
+      description: From the schema.
+    b:
+      type: string
+      description: Also schema.
+"#;
+        let cfg = QuillConfig::from_yaml(yaml).unwrap();
+        let spec = FormSpec::parse(
+            br#"{
+              "schema": "quillmark/form@0.2.0",
+              "fields": [
+                { "name": "A", "schema_field": "a", "page": 0,
+                  "rect": { "x": 0, "y": 0, "w": 1, "h": 1 } },
+                { "name": "B", "schema_field": "b", "page": 0,
+                  "rect": { "x": 0, "y": 2, "w": 1, "h": 1 }, "tooltip": "Override." }
+              ]
+            }"#,
+        )
+        .unwrap();
+        let bound = bind_widgets(&spec, &cfg).unwrap();
+        assert_eq!(bound[0].tooltip.as_deref(), Some("From the schema."));
+        assert_eq!(bound[1].tooltip.as_deref(), Some("Override."));
+    }
+}

--- a/crates/backends/pdfform/src/form.rs
+++ b/crates/backends/pdfform/src/form.rs
@@ -165,29 +165,26 @@ impl FormParseError {
     }
 }
 
+/// Just the `schema` tag, deserialized ahead of the full spec so the version
+/// gate runs *before* field-shape validation. A retired `form@0.1.0` file
+/// carries `0.1.0`-shaped fields (an unbound `signature` in `fields`, no
+/// `schema_field`) that no longer deserialize into a [`BoundField`]; gating on
+/// the tag first guarantees such a file gets the migration error, not a generic
+/// "missing field" JSON error.
+#[derive(Debug, Deserialize)]
+struct SchemaTag {
+    schema: String,
+}
+
 impl FormSpec {
     /// Parse and validate a `form.json` byte slice.
     pub fn parse(bytes: &[u8]) -> Result<FormSpec, FormParseError> {
+        // Gate the version on the tag alone, before the field shapes are read.
+        let tag: SchemaTag = serde_json::from_slice(bytes).map_err(FormParseError::Json)?;
+        check_version(&tag.schema)?;
         let spec: FormSpec = serde_json::from_slice(bytes).map_err(FormParseError::Json)?;
-        spec.check_version()?;
         spec.check_unique_names()?;
         Ok(spec)
-    }
-
-    /// The `schema` tag must name the supported `form@0.2.x`. The retired
-    /// `0.1.x` gets a targeted migration error; anything else is a foreign tag.
-    fn check_version(&self) -> Result<(), FormParseError> {
-        let version = self
-            .schema
-            .strip_prefix(SCHEMA_PREFIX)
-            .ok_or_else(|| FormParseError::BadSchema(self.schema.clone()))?;
-        if version_matches(version, SUPPORTED_MAJOR_MINOR) {
-            Ok(())
-        } else if version_matches(version, RETIRED_VERSION_MAJOR_MINOR) {
-            Err(FormParseError::RetiredVersion(self.schema.clone()))
-        } else {
-            Err(FormParseError::BadSchema(self.schema.clone()))
-        }
     }
 
     /// AcroForm `/T` names must be unique across *both* populations.
@@ -207,6 +204,21 @@ impl FormSpec {
             .iter()
             .map(|f| f.name.as_str())
             .chain(self.widgets.iter().map(|w| w.name.as_str()))
+    }
+}
+
+/// The `schema` tag must name the supported `form@0.2.x`. The retired `0.1.x`
+/// gets a targeted migration error; anything else is a foreign tag.
+fn check_version(schema: &str) -> Result<(), FormParseError> {
+    let version = schema
+        .strip_prefix(SCHEMA_PREFIX)
+        .ok_or_else(|| FormParseError::BadSchema(schema.to_string()))?;
+    if version_matches(version, SUPPORTED_MAJOR_MINOR) {
+        Ok(())
+    } else if version_matches(version, RETIRED_VERSION_MAJOR_MINOR) {
+        Err(FormParseError::RetiredVersion(schema.to_string()))
+    } else {
+        Err(FormParseError::BadSchema(schema.to_string()))
     }
 }
 
@@ -293,6 +305,29 @@ mod tests {
             Err(e @ FormParseError::RetiredVersion(_)) => {
                 assert_eq!(e.code(), "pdfform::form_schema_version");
                 assert!(e.to_string().contains(MIGRATION_GUIDE));
+            }
+            other => panic!("expected RetiredVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retired_v1_with_v1_shaped_fields_still_gets_migration_error() {
+        // A real 0.1.0 file carries an unbound `signature` in `fields` with no
+        // `schema_field` — which no longer deserializes into a BoundField. The
+        // version gate must fire on the tag *before* that shape is read, so the
+        // author gets the migration pointer, not a generic "missing field" error.
+        let json = br#"{
+          "schema": "quillmark/form@0.1.0",
+          "fields": [
+            { "name": "FullName", "schema_field": "full_name", "page": 0,
+              "rect": { "x": 0, "y": 0, "w": 1, "h": 1 }, "type": "text" },
+            { "name": "Signature", "page": 0,
+              "rect": { "x": 0, "y": 2, "w": 1, "h": 1 }, "type": "signature" }
+          ]
+        }"#;
+        match FormSpec::parse(json) {
+            Err(e @ FormParseError::RetiredVersion(_)) => {
+                assert_eq!(e.code(), "pdfform::form_schema_version");
             }
             other => panic!("expected RetiredVersion, got {other:?}"),
         }

--- a/crates/backends/pdfform/src/form.rs
+++ b/crates/backends/pdfform/src/form.rs
@@ -41,10 +41,11 @@ const SUPPORTED_MAJOR_MINOR: &str = "0.2";
 /// author at.
 const MIGRATION_GUIDE: &str = "docs/migrations/0.93-to-0.94.md";
 
-/// A parsed `form.json`: the schema tag plus the two field populations.
+/// A parsed `form.json`: the two field populations. The `schema` tag is read and
+/// version-gated separately ([`SchemaTag`]) before this is deserialized, so it
+/// is not restated here — any `schema` key in the JSON is simply ignored.
 #[derive(Debug, Clone, Deserialize)]
 pub struct FormSpec {
-    pub schema: String,
     /// Schema-bound widgets — kind/options/multiline/tooltip inherited from the
     /// referenced [`FieldSchema`](quillmark_core::FieldSchema).
     #[serde(default)]

--- a/crates/backends/pdfform/src/form.rs
+++ b/crates/backends/pdfform/src/form.rs
@@ -1,42 +1,90 @@
-//! `form.json` wire types and parsing.
+//! `form.json` wire types and parsing (`form@0.2.0`).
 //!
-//! `form.json` is the durable, value-free field-definition layer of a `pdfform`
-//! quill — the *format* side of Quillmark's quill/document dichotomy. It is
-//! complete enough to rebuild every widget yet flat and diffable. Unknown keys
-//! are ignored (additive evolution needs no version bump); invalid type/payload
-//! combinations are unrepresentable thanks to the internally-tagged `type`.
+//! `form.json` is the durable, value-free **placement + binding + widget-identity**
+//! layer of a `pdfform` quill — the *format* side of Quillmark's quill/document
+//! dichotomy. As of `form@0.2.0` it no longer restates what the quill schema
+//! already carries: a bound field names a `schema_field` and inherits its widget
+//! kind, options, multiline, and tooltip from the resolved
+//! [`FieldSchema`](quillmark_core::FieldSchema) (see [`crate::bind`]). Only the
+//! two things the schema cannot know — where the widget sits (`page`/`rect`) and
+//! which logical field it binds — live here.
+//!
+//! Two field populations, at different altitudes:
+//! - **`fields`** — bound widgets. Each references a `schema_field`; its kind is
+//!   *derived*, never declared, so `form.json` and the schema cannot drift.
+//! - **`widgets`** — unbound widgets with no schema field (a signer-filled
+//!   signature, an interactively-filled box). Having no schema to inherit from,
+//!   each carries its own `type`.
+//!
+//! Unknown keys are ignored (additive evolution needs no version bump); invalid
+//! type/payload combinations on an unbound widget are unrepresentable thanks to
+//! the internally-tagged `type`.
 
 use serde::Deserialize;
 
 /// The `schema` tag prefix every `form.json` must carry, following the Document
-/// DTO convention (`quillmark/form@<version>`). V1 adopts only the field+value
-/// format; the chained-migration machinery lands when a breaking change first
-/// does.
+/// DTO convention (`quillmark/form@<version>`).
 pub const SCHEMA_PREFIX: &str = "quillmark/form@";
 
-/// A parsed `form.json`: the schema tag plus the field reconstruction list.
+/// The `form.json` format version this backend reads. `0.2.0` slimmed bound
+/// fields to a binding layer that derives widget intrinsics from the quill
+/// schema; `0.1.0` (which restated `type`/`options`/`multiline`) is rejected at
+/// load with a migration pointer.
+pub const SCHEMA_VERSION: &str = "0.2.0";
+
+/// The retired format version, rejected with migration guidance.
+const RETIRED_VERSION_MAJOR_MINOR: &str = "0.1";
+/// The accepted major.minor; a matching patch is tolerated.
+const SUPPORTED_MAJOR_MINOR: &str = "0.2";
+
+/// The working migration guide the version error points a stranded `0.1.0`
+/// author at.
+const MIGRATION_GUIDE: &str = "docs/migrations/0.93-to-0.94.md";
+
+/// A parsed `form.json`: the schema tag plus the two field populations.
 #[derive(Debug, Clone, Deserialize)]
 pub struct FormSpec {
     pub schema: String,
-    pub fields: Vec<FormField>,
+    /// Schema-bound widgets — kind/options/multiline/tooltip inherited from the
+    /// referenced [`FieldSchema`](quillmark_core::FieldSchema).
+    #[serde(default)]
+    pub fields: Vec<BoundField>,
+    /// Unbound widgets — no schema field, so each declares its own `type`.
+    #[serde(default)]
+    pub widgets: Vec<UnboundWidget>,
 }
 
-/// One field definition: identity + geometry + binding + kind.
+/// One **bound** field: identity + geometry + binding. Its widget kind, choice
+/// options, and multiline flag are *not* here — they are derived from the
+/// resolved [`FieldSchema`](quillmark_core::FieldSchema) at load
+/// ([`crate::bind`]). `tooltip` is an optional override; when absent the field
+/// inherits the schema field's `description`.
 ///
-/// `rect` is **top-left** `{x,y,w,h}` in PDF points, page-relative — the
-/// loader flips it to the spine's bottom-left origin. `schema_field` is the
-/// document field this binds to; `None` means unbound (a signer fills it).
+/// `rect` is **top-left** `{x,y,w,h}` in PDF points, page-relative — the loader
+/// flips it to the spine's bottom-left origin.
 #[derive(Debug, Clone, Deserialize)]
-pub struct FormField {
+pub struct BoundField {
     pub name: String,
+    /// The document field this widget binds to. Resolved against the quill
+    /// schema at load; a dangling path is a load error, not a silent blank.
+    pub schema_field: String,
+    pub page: usize,
+    pub rect: Rect,
     #[serde(default)]
-    pub schema_field: Option<String>,
+    pub tooltip: Option<String>,
+}
+
+/// One **unbound** widget: identity + geometry + an explicit kind. Bound to no
+/// schema field (a signer fills it), so its intrinsics are declared, not derived.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UnboundWidget {
+    pub name: String,
     pub page: usize,
     pub rect: Rect,
     #[serde(default)]
     pub tooltip: Option<String>,
     #[serde(flatten)]
-    pub kind: FieldKind,
+    pub kind: WidgetKind,
 }
 
 /// A top-left rectangle in PDF points (1/72").
@@ -48,12 +96,13 @@ pub struct Rect {
     pub h: f32,
 }
 
-/// The kind of a [`FormField`] and its kind-specific definition. Internally
-/// tagged by `type` and flattened into the field, so the JSON stays flat while
-/// invalid combinations (a `signature` with `options`) are unrepresentable.
+/// The declared kind of an [`UnboundWidget`]. Internally tagged by `type` and
+/// flattened into the widget, so the JSON stays flat while invalid combinations
+/// (a `signature` with `options`) are unrepresentable. Bound fields carry no
+/// such tag — their kind is derived from the schema.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
-pub enum FieldKind {
+pub enum WidgetKind {
     Text {
         #[serde(default)]
         multiline: bool,
@@ -72,10 +121,14 @@ pub enum FormParseError {
     Json(serde_json::Error),
     /// The `schema` tag is not a recognized `quillmark/form@…` string.
     BadSchema(String),
-    /// Two fields share the same `name`. AcroForm top-level field names must be
-    /// unique — duplicates would stamp two `/T`-colliding fields and render as a
-    /// single malformed field, so reject them at parse time (mirroring the
-    /// Typst producer, which rejects duplicate `form-field` names).
+    /// The `schema` tag names the retired `form@0.1.0` format. Surfaced with its
+    /// own error code and a migration pointer, distinct from a foreign tag.
+    RetiredVersion(String),
+    /// Two fields/widgets share the same `name`. AcroForm top-level field names
+    /// must be unique across the whole form — duplicates would stamp two
+    /// `/T`-colliding fields and render as a single malformed field, so reject
+    /// them at parse time (mirroring the Typst producer, which rejects duplicate
+    /// `form-field` names).
     DuplicateField(String),
 }
 
@@ -85,7 +138,14 @@ impl std::fmt::Display for FormParseError {
             FormParseError::Json(e) => write!(f, "form.json is not valid: {e}"),
             FormParseError::BadSchema(s) => write!(
                 f,
-                "form.json `schema` is {s:?}, expected a \"{SCHEMA_PREFIX}<version>\" tag"
+                "form.json `schema` is {s:?}, expected a \"{SCHEMA_PREFIX}{SCHEMA_VERSION}\" tag"
+            ),
+            FormParseError::RetiredVersion(s) => write!(
+                f,
+                "form.json `schema` is {s:?}; the `form@{RETIRED_VERSION_MAJOR_MINOR}.x` format is \
+                 retired — bound fields no longer restate `type`/`options`/`multiline` (they are \
+                 derived from the quill schema). Migrate to \"{SCHEMA_PREFIX}{SCHEMA_VERSION}\"; \
+                 see {MIGRATION_GUIDE}"
             ),
             FormParseError::DuplicateField(name) => write!(
                 f,
@@ -95,21 +155,69 @@ impl std::fmt::Display for FormParseError {
     }
 }
 
+impl FormParseError {
+    /// The stable error code a caller stamps on the surfaced diagnostic.
+    pub fn code(&self) -> &'static str {
+        match self {
+            FormParseError::RetiredVersion(_) => "pdfform::form_schema_version",
+            _ => "pdfform::invalid_form_json",
+        }
+    }
+}
+
 impl FormSpec {
     /// Parse and validate a `form.json` byte slice.
     pub fn parse(bytes: &[u8]) -> Result<FormSpec, FormParseError> {
         let spec: FormSpec = serde_json::from_slice(bytes).map_err(FormParseError::Json)?;
-        if !spec.schema.starts_with(SCHEMA_PREFIX) {
-            return Err(FormParseError::BadSchema(spec.schema));
-        }
-        let mut seen = std::collections::HashSet::new();
-        for field in &spec.fields {
-            if !seen.insert(field.name.as_str()) {
-                return Err(FormParseError::DuplicateField(field.name.clone()));
-            }
-        }
+        spec.check_version()?;
+        spec.check_unique_names()?;
         Ok(spec)
     }
+
+    /// The `schema` tag must name the supported `form@0.2.x`. The retired
+    /// `0.1.x` gets a targeted migration error; anything else is a foreign tag.
+    fn check_version(&self) -> Result<(), FormParseError> {
+        let version = self
+            .schema
+            .strip_prefix(SCHEMA_PREFIX)
+            .ok_or_else(|| FormParseError::BadSchema(self.schema.clone()))?;
+        if version_matches(version, SUPPORTED_MAJOR_MINOR) {
+            Ok(())
+        } else if version_matches(version, RETIRED_VERSION_MAJOR_MINOR) {
+            Err(FormParseError::RetiredVersion(self.schema.clone()))
+        } else {
+            Err(FormParseError::BadSchema(self.schema.clone()))
+        }
+    }
+
+    /// AcroForm `/T` names must be unique across *both* populations.
+    fn check_unique_names(&self) -> Result<(), FormParseError> {
+        let mut seen = std::collections::HashSet::new();
+        for name in self.field_names() {
+            if !seen.insert(name) {
+                return Err(FormParseError::DuplicateField(name.to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Every widget name, bound then unbound, in declaration order.
+    fn field_names(&self) -> impl Iterator<Item = &str> {
+        self.fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .chain(self.widgets.iter().map(|w| w.name.as_str()))
+    }
+}
+
+/// A version string matches `<major.minor>` when it is exactly that or carries a
+/// `.patch` suffix — so `0.2` and `0.2.7` both match `"0.2"`, while `0.20` does
+/// not.
+fn version_matches(version: &str, major_minor: &str) -> bool {
+    version == major_minor
+        || version
+            .strip_prefix(major_minor)
+            .is_some_and(|rest| rest.starts_with('.'))
 }
 
 #[cfg(test)]
@@ -117,39 +225,77 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_all_four_kinds_and_ignores_unknown_keys() {
+    fn parses_bound_fields_and_unbound_widgets_ignoring_unknown_keys() {
         let json = br#"{
-          "schema": "quillmark/form@0.1.0",
+          "schema": "quillmark/form@0.2.0",
           "fields": [
             { "name": "FullName", "schema_field": "full_name", "page": 0,
-              "rect": { "x": 180, "y": 57, "w": 340, "h": 20 }, "type": "text",
+              "rect": { "x": 180, "y": 57, "w": 340, "h": 20 },
               "tooltip": "Full legal name", "future_key": 42 },
             { "name": "Comments", "schema_field": "comments", "page": 0,
-              "rect": { "x": 180, "y": 120, "w": 340, "h": 80 }, "type": "text", "multiline": true },
-            { "name": "Agree", "schema_field": "agree", "page": 0,
-              "rect": { "x": 180, "y": 90, "w": 14, "h": 14 }, "type": "checkbox" },
-            { "name": "FavoriteColor", "schema_field": "favorite_color", "page": 0,
-              "rect": { "x": 180, "y": 150, "w": 340, "h": 20 }, "type": "choice",
-              "options": ["red", "green", "blue"] },
+              "rect": { "x": 180, "y": 120, "w": 340, "h": 80 } }
+          ],
+          "widgets": [
             { "name": "Signature", "page": 0,
               "rect": { "x": 180, "y": 190, "w": 340, "h": 40 }, "type": "signature" }
           ]
         }"#;
         let spec = FormSpec::parse(json).expect("parse ok");
-        assert_eq!(spec.fields.len(), 5);
-        assert_eq!(spec.fields[0].kind, FieldKind::Text { multiline: false });
-        assert_eq!(spec.fields[0].schema_field.as_deref(), Some("full_name"));
-        assert_eq!(spec.fields[1].kind, FieldKind::Text { multiline: true });
-        assert_eq!(spec.fields[2].kind, FieldKind::Checkbox);
+        assert_eq!(spec.fields.len(), 2);
+        assert_eq!(spec.fields[0].schema_field, "full_name");
+        assert_eq!(spec.fields[0].tooltip.as_deref(), Some("Full legal name"));
+        assert_eq!(spec.fields[1].tooltip, None);
+        assert_eq!(spec.widgets.len(), 1);
+        assert_eq!(spec.widgets[0].kind, WidgetKind::Signature);
+    }
+
+    #[test]
+    fn unbound_widgets_carry_every_kind() {
+        let json = br#"{
+          "schema": "quillmark/form@0.2.0",
+          "widgets": [
+            { "name": "T", "page": 0, "rect": { "x": 0, "y": 0, "w": 1, "h": 1 },
+              "type": "text", "multiline": true },
+            { "name": "C", "page": 0, "rect": { "x": 0, "y": 2, "w": 1, "h": 1 }, "type": "checkbox" },
+            { "name": "Ch", "page": 0, "rect": { "x": 0, "y": 4, "w": 1, "h": 1 },
+              "type": "choice", "options": ["a", "b"] },
+            { "name": "S", "page": 0, "rect": { "x": 0, "y": 6, "w": 1, "h": 1 }, "type": "signature" }
+          ]
+        }"#;
+        let spec = FormSpec::parse(json).expect("parse ok");
+        assert_eq!(spec.widgets[0].kind, WidgetKind::Text { multiline: true });
+        assert_eq!(spec.widgets[1].kind, WidgetKind::Checkbox);
         assert_eq!(
-            spec.fields[3].kind,
-            FieldKind::Choice {
-                options: vec!["red".into(), "green".into(), "blue".into()]
+            spec.widgets[2].kind,
+            WidgetKind::Choice {
+                options: vec!["a".into(), "b".into()]
             }
         );
-        assert_eq!(spec.fields[4].kind, FieldKind::Signature);
-        // Unbound signature.
-        assert_eq!(spec.fields[4].schema_field, None);
+        assert_eq!(spec.widgets[3].kind, WidgetKind::Signature);
+    }
+
+    #[test]
+    fn empty_populations_default_to_empty_vecs() {
+        let spec = FormSpec::parse(br#"{ "schema": "quillmark/form@0.2.0" }"#).expect("parse ok");
+        assert!(spec.fields.is_empty());
+        assert!(spec.widgets.is_empty());
+    }
+
+    #[test]
+    fn accepts_patch_within_supported_minor() {
+        assert!(FormSpec::parse(br#"{ "schema": "quillmark/form@0.2.7", "fields": [] }"#).is_ok());
+    }
+
+    #[test]
+    fn rejects_retired_v1_with_migration_code() {
+        let json = br#"{ "schema": "quillmark/form@0.1.0", "fields": [] }"#;
+        match FormSpec::parse(json) {
+            Err(e @ FormParseError::RetiredVersion(_)) => {
+                assert_eq!(e.code(), "pdfform::form_schema_version");
+                assert!(e.to_string().contains(MIGRATION_GUIDE));
+            }
+            other => panic!("expected RetiredVersion, got {other:?}"),
+        }
     }
 
     #[test]
@@ -162,17 +308,37 @@ mod tests {
     }
 
     #[test]
-    fn rejects_duplicate_field_names() {
+    fn rejects_unknown_form_version_as_bad_schema() {
+        let json = br#"{ "schema": "quillmark/form@9.9.9", "fields": [] }"#;
+        assert!(matches!(
+            FormSpec::parse(json),
+            Err(FormParseError::BadSchema(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_names_across_populations() {
         let json = br#"{
-          "schema": "quillmark/form@0.1.0",
+          "schema": "quillmark/form@0.2.0",
           "fields": [
-            { "name": "Dup", "page": 0, "rect": { "x": 0, "y": 0, "w": 1, "h": 1 }, "type": "text" },
-            { "name": "Dup", "page": 0, "rect": { "x": 0, "y": 2, "w": 1, "h": 1 }, "type": "text" }
+            { "name": "Dup", "schema_field": "a", "page": 0, "rect": { "x": 0, "y": 0, "w": 1, "h": 1 } }
+          ],
+          "widgets": [
+            { "name": "Dup", "page": 0, "rect": { "x": 0, "y": 2, "w": 1, "h": 1 }, "type": "signature" }
           ]
         }"#;
         match FormSpec::parse(json) {
             Err(FormParseError::DuplicateField(name)) => assert_eq!(name, "Dup"),
             other => panic!("expected DuplicateField, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn version_matches_guards_adjacent_minors() {
+        assert!(version_matches("0.2", "0.2"));
+        assert!(version_matches("0.2.0", "0.2"));
+        assert!(version_matches("0.2.15", "0.2"));
+        assert!(!version_matches("0.20", "0.2"));
+        assert!(!version_matches("0.21.0", "0.2"));
     }
 }

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -14,11 +14,13 @@
 //! backends collapse to the same `&[FieldSpec]` seam; they differ only in where
 //! geometry and values come from.
 
+mod bind;
 mod flatten;
 mod form;
 mod resolve;
 mod typography;
 
+use bind::BoundWidget;
 use flatten::flatten as flatten_to_pdf;
 use form::FormSpec;
 use quillmark_core::session::SessionHandle;
@@ -83,15 +85,22 @@ impl Backend for PdfformBackend {
             )
         })?;
 
-        let spec = FormSpec::parse(form_json)
-            .map_err(|e| engine_err("pdfform::invalid_form_json", e.to_string()))?;
+        let spec =
+            FormSpec::parse(form_json).map_err(|e| engine_err(e.code(), e.to_string()))?;
+
+        // Bind at load: resolve every field against the quill schema and derive
+        // its widget intrinsics (kind, options, multiline, tooltip). A dangling
+        // or unbindable `schema_field` is a load error here, not a silent blank
+        // at value time.
+        let bound = bind::bind_widgets(&spec, source.config())
+            .map_err(|e| engine_err(e.code(), e.to_string()))?;
 
         // Page boxes drive the top-left → bottom-left flip (honouring a
         // non-zero page origin); reading them from the background also surfaces
         // a malformed/out-of-contract base early.
         let page_boxes = quillmark_pdf::page_media_boxes(&base_pdf).map_err(map_pdf_err)?;
 
-        let field_specs = resolve_field_specs(&spec, &page_boxes, json_data)?;
+        let field_specs = resolve_field_specs(&bound, &page_boxes, json_data)?;
 
         // Pre-flatten once so render_rgba / SVG / PNG renders have a
         // ready-to-rasterize flat PDF without re-running flatten on every
@@ -100,7 +109,7 @@ impl Backend for PdfformBackend {
 
         Ok(LiveSession::new(Box::new(PdfformSession {
             base_pdf,
-            spec,
+            bound,
             field_specs,
             page_boxes,
             flat_pdf,
@@ -108,26 +117,27 @@ impl Backend for PdfformBackend {
     }
 }
 
-/// Resolve the form spec's fields against document data — the per-document
-/// half of `open`, re-run by each `apply`.
+/// Resolve the bound widgets' values against document data — the per-document
+/// half of `open`, re-run by each `apply`. Intrinsics were already derived at
+/// bind time; this pass only flips geometry and resolves values.
 fn resolve_field_specs(
-    spec: &FormSpec,
+    bound: &[BoundWidget],
     page_boxes: &[[f32; 4]],
     json_data: &serde_json::Value,
 ) -> Result<Vec<FieldSpec>, RenderError> {
     let page_count = page_boxes.len();
-    let mut field_specs: Vec<FieldSpec> = Vec::with_capacity(spec.fields.len());
-    for field in &spec.fields {
-        let media_box = page_boxes.get(field.page).copied().ok_or_else(|| {
+    let mut field_specs: Vec<FieldSpec> = Vec::with_capacity(bound.len());
+    for widget in bound {
+        let media_box = page_boxes.get(widget.page).copied().ok_or_else(|| {
             engine_err(
                 "pdfform::field_page_out_of_range",
                 format!(
                     "field {:?} targets page {} but `{FORM_PDF}` has {page_count} page(s)",
-                    field.name, field.page
+                    widget.name, widget.page
                 ),
             )
         })?;
-        field_specs.push(resolve::field_spec(field, media_box, json_data));
+        field_specs.push(resolve::field_spec(widget, media_box, json_data));
     }
     Ok(field_specs)
 }
@@ -137,9 +147,9 @@ fn resolve_field_specs(
 #[derive(Debug)]
 struct PdfformSession {
     base_pdf: Vec<u8>,
-    /// The parsed `form.json` field definitions; re-resolved against new
-    /// document data by each `apply`.
-    spec: FormSpec,
+    /// The value-free widget layer, bound against the quill schema at open;
+    /// re-resolved against new document data by each `apply`.
+    bound: Vec<BoundWidget>,
     field_specs: Vec<FieldSpec>,
     /// Page media-boxes from the background; used by `page_size_pt` without
     /// reparsing the PDF on every canvas-paint call. Its length is the page
@@ -243,7 +253,7 @@ impl SessionHandle for PdfformSession {
     /// changed; the background never changes, so field deltas are the only
     /// visible delta.
     fn apply(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
-        let field_specs = resolve_field_specs(&self.spec, &self.page_boxes, json_data)?;
+        let field_specs = resolve_field_specs(&self.bound, &self.page_boxes, json_data)?;
         let flat_pdf = flatten_to_pdf(self.base_pdf.clone(), &field_specs).map_err(map_pdf_err)?;
 
         let mut dirty_pages: Vec<usize> = self

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -88,19 +88,21 @@ impl Backend for PdfformBackend {
         let spec =
             FormSpec::parse(form_json).map_err(|e| engine_err(e.code(), e.to_string()))?;
 
-        // Bind at load: resolve every field against the quill schema and derive
-        // its widget intrinsics (kind, options, multiline, tooltip). A dangling
-        // or unbindable `schema_field` is a load error here, not a silent blank
-        // at value time.
-        let bound = bind::bind_widgets(&spec, source.config())
-            .map_err(|e| engine_err(e.code(), e.to_string()))?;
-
         // Page boxes drive the top-left → bottom-left flip (honouring a
         // non-zero page origin); reading them from the background also surfaces
-        // a malformed/out-of-contract base early.
+        // a malformed/out-of-contract base early. Read before binding so
+        // geometry is placed once, at load.
         let page_boxes = quillmark_pdf::page_media_boxes(&base_pdf).map_err(map_pdf_err)?;
 
-        let field_specs = resolve_field_specs(&bound, &page_boxes, json_data)?;
+        // Bind at load: resolve every field against the two static inputs — the
+        // quill schema (kind, options, multiline, tooltip) and the page geometry
+        // (final rect, page-range check). A dangling/unbindable `schema_field` or
+        // an out-of-range page is a load error here, not a silent blank or a
+        // per-render recomputation.
+        let bound = bind::bind_widgets(&spec, source.config(), &page_boxes)
+            .map_err(|e| engine_err(e.code(), e.to_string()))?;
+
+        let field_specs = resolve_field_specs(&bound, json_data);
 
         // Pre-flatten once so render_rgba / SVG / PNG renders have a
         // ready-to-rasterize flat PDF without re-running flatten on every
@@ -118,28 +120,14 @@ impl Backend for PdfformBackend {
 }
 
 /// Resolve the bound widgets' values against document data — the per-document
-/// half of `open`, re-run by each `apply`. Intrinsics were already derived at
-/// bind time; this pass only flips geometry and resolves values.
-fn resolve_field_specs(
-    bound: &[BoundWidget],
-    page_boxes: &[[f32; 4]],
-    json_data: &serde_json::Value,
-) -> Result<Vec<FieldSpec>, RenderError> {
-    let page_count = page_boxes.len();
-    let mut field_specs: Vec<FieldSpec> = Vec::with_capacity(bound.len());
-    for widget in bound {
-        let media_box = page_boxes.get(widget.page).copied().ok_or_else(|| {
-            engine_err(
-                "pdfform::field_page_out_of_range",
-                format!(
-                    "field {:?} targets page {} but `{FORM_PDF}` has {page_count} page(s)",
-                    widget.name, widget.page
-                ),
-            )
-        })?;
-        field_specs.push(resolve::field_spec(widget, media_box, json_data));
-    }
-    Ok(field_specs)
+/// half of `open`, re-run by each `apply`. Intrinsics and geometry were already
+/// resolved at bind time, so this pass only fills in values; nothing here can
+/// fail.
+fn resolve_field_specs(bound: &[BoundWidget], json_data: &serde_json::Value) -> Vec<FieldSpec> {
+    bound
+        .iter()
+        .map(|widget| resolve::field_spec(widget, json_data))
+        .collect()
 }
 
 /// A `pdfform` render session: the stripped background plus the resolved field
@@ -253,7 +241,7 @@ impl SessionHandle for PdfformSession {
     /// changed; the background never changes, so field deltas are the only
     /// visible delta.
     fn apply(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
-        let field_specs = resolve_field_specs(&self.bound, &self.page_boxes, json_data)?;
+        let field_specs = resolve_field_specs(&self.bound, json_data);
         let flat_pdf = flatten_to_pdf(self.base_pdf.clone(), &field_specs).map_err(map_pdf_err)?;
 
         let mut dirty_pages: Vec<usize> = self

--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -1,7 +1,8 @@
 //! The value step: turn a value-free [`BoundWidget`] plus the document's
 //! `compile_data` JSON into a stamp-spine [`FieldSpec`]. Intrinsics (kind,
-//! options, multiline, tooltip) were already derived from the quill schema at
-//! load ([`crate::bind`]); this module resolves only the per-document *value*.
+//! options, multiline, tooltip) and final geometry were already resolved from
+//! the static inputs at load ([`crate::bind`]); this module resolves only the
+//! per-document *value* and copies the rest through.
 //!
 //! Binding is against `compile_data` — the same validated, zero-filled object
 //! the Typst plate reads as `data.*` — so zero-fill, schema validation,
@@ -26,34 +27,19 @@ use quillmark_pdf::{FieldSpec, FieldType, CHECKBOX_ON_STATE};
 use serde_json::Value;
 
 use crate::bind::BoundWidget;
-use crate::form::Rect;
 
-/// Build a [`FieldSpec`] for `widget`, flipping its top-left rect to bottom-left
-/// against the page's `media_box` and resolving its bound value from `data`.
-///
-/// `media_box` is the normalized `[x0, y0, x1, y1]` of the target page.
-pub fn field_spec(widget: &BoundWidget, media_box: [f32; 4], data: &Value) -> FieldSpec {
+/// Build a [`FieldSpec`] for `widget`: copy its already-final identity, geometry,
+/// and kind through, and resolve its bound value from `data`.
+pub fn field_spec(widget: &BoundWidget, data: &Value) -> FieldSpec {
     FieldSpec {
         name: widget.name.clone(),
         schema_field: widget.schema_field.clone(),
         page: widget.page,
-        rect: flip_rect(widget.rect, media_box),
+        rect: widget.rect,
         field_type: widget.field_type.clone(),
         value: resolve_value(&widget.field_type, widget.schema_field.as_deref(), data),
         tooltip: widget.tooltip.clone(),
     }
-}
-
-/// Page-relative top-left `{x,y,w,h}` → spine bottom-left `[x0, y0, x1, y1]` in
-/// PDF user space. Honours a non-zero page origin: the left edge is the
-/// MediaBox `x0` and `y` is measured down from the top edge (MediaBox `y1`), so
-/// a translated MediaBox (e.g. `[10 20 622 812]`) places widgets correctly
-/// rather than shifting them by the origin. This is the single biggest
-/// hand-authoring footgun, defused structurally in one place.
-fn flip_rect(r: Rect, media_box: [f32; 4]) -> [f32; 4] {
-    let left = media_box[0];
-    let top = media_box[3];
-    [left + r.x, top - (r.y + r.h), left + r.x + r.w, top - r.y]
 }
 
 /// Resolve a widget's bound value. `None` (blank) for: an unbound widget
@@ -442,25 +428,21 @@ mod tests {
         });
 
         // Two card slots, one per page, each bound to a distinct instance index.
-        let mb = [0.0, 0.0, 612.0, 792.0];
+        // Geometry is already final (placed at bind time); this test pins the
+        // value/page binding, so the rect is an opaque placeholder.
         let slot = |name: &str, page: usize, schema_field: &str| BoundWidget {
             name: name.into(),
             schema_field: Some(schema_field.into()),
             page,
-            rect: Rect {
-                x: 100.0,
-                y: 100.0,
-                w: 200.0,
-                h: 20.0,
-            },
+            rect: [100.0, 100.0, 300.0, 120.0],
             field_type: FieldType::Text { multiline: false },
             tooltip: None,
         };
         let slot0 = slot("Indorsement0From", 0, "$cards.indorsement.0.from");
         let slot1 = slot("Indorsement1From", 1, "$cards.indorsement.1.from");
 
-        let spec0 = field_spec(&slot0, mb, &data);
-        let spec1 = field_spec(&slot1, mb, &data);
+        let spec0 = field_spec(&slot0, &data);
+        let spec1 = field_spec(&slot1, &data);
 
         // Instance 0's value on page 0; instance 1's value on page 1.
         assert_eq!(spec0.page, 0, "first slot is on page 0");
@@ -471,37 +453,5 @@ mod tests {
         // The names carry through unchanged (the spine writes them to /T).
         assert_eq!(spec0.name, "Indorsement0From");
         assert_eq!(spec1.name, "Indorsement1From");
-    }
-
-    #[test]
-    fn rect_flip_is_bottom_left() {
-        // A 14×14 box at top-left (180, 90) on an 800-tall, zero-origin page.
-        let r = Rect {
-            x: 180.0,
-            y: 90.0,
-            w: 14.0,
-            h: 14.0,
-        };
-        assert_eq!(
-            flip_rect(r, [0.0, 0.0, 600.0, 800.0]),
-            [180.0, 800.0 - 104.0, 194.0, 800.0 - 90.0]
-        );
-    }
-
-    #[test]
-    fn rect_flip_honours_nonzero_origin() {
-        // Same box on a page whose MediaBox is translated to [10 20 622 812].
-        // Widgets must land offset by the origin, not at a (0,0) origin.
-        let r = Rect {
-            x: 180.0,
-            y: 100.0,
-            w: 14.0,
-            h: 14.0,
-        };
-        let mb = [10.0, 20.0, 622.0, 812.0]; // top edge y1 = 812
-        assert_eq!(
-            flip_rect(r, mb),
-            [10.0 + 180.0, 812.0 - 114.0, 10.0 + 194.0, 812.0 - 100.0]
-        );
     }
 }

--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -1,5 +1,7 @@
-//! The resolver: the bind step that turns a value-free [`FormField`] plus the
-//! document's `compile_data` JSON into a stamp-spine [`FieldSpec`].
+//! The value step: turn a value-free [`BoundWidget`] plus the document's
+//! `compile_data` JSON into a stamp-spine [`FieldSpec`]. Intrinsics (kind,
+//! options, multiline, tooltip) were already derived from the quill schema at
+//! load ([`crate::bind`]); this module resolves only the per-document *value*.
 //!
 //! Binding is against `compile_data` — the same validated, zero-filled object
 //! the Typst plate reads as `data.*` — so zero-fill, schema validation,
@@ -12,37 +14,33 @@
 //!
 //! A `schema_field` rooted at the reserved `$cards` key binds to one card
 //! instance in the document's `$cards` array (the same array the Typst plate
-//! iterates). Two forms, so a fixed-capacity form can lay out repeated card
-//! slots:
-//!
-//! - **By absolute index:** `$cards.<i>.<field>` — the `i`-th card overall
-//!   (e.g. `$cards.0.from`).
-//! - **By kind + index:** `$cards.<kind>.<i>.<field>` — the `i`-th card whose
-//!   `$kind` is `<kind>` (e.g. `$cards.indorsement.1.from` is the second
-//!   indorsement). This survives reordering and intervening cards of other
-//!   kinds, which absolute indexing does not.
-//!
-//! Either form descends the remaining path into the chosen card object exactly
+//! iterates), by kind + index: `$cards.<kind>.<i>.<field>` — the `i`-th card
+//! whose `$kind` is `<kind>` (e.g. `$cards.indorsement.1.from` is the second
+//! indorsement). This survives reordering and intervening cards of other kinds.
+//! Absolute-index addressing (`$cards.<i>`) was retired in `form@0.2.0`: a
+//! widget kind must be statically derivable at load, and only the kind names the
+//! field. The path descends the remaining segments into the chosen card exactly
 //! as a top-level binding would.
 
 use quillmark_pdf::{FieldSpec, FieldType, CHECKBOX_ON_STATE};
 use serde_json::Value;
 
-use crate::form::{FieldKind, FormField, Rect};
+use crate::bind::BoundWidget;
+use crate::form::Rect;
 
-/// Build a [`FieldSpec`] for `field`, flipping its top-left rect to bottom-left
+/// Build a [`FieldSpec`] for `widget`, flipping its top-left rect to bottom-left
 /// against the page's `media_box` and resolving its bound value from `data`.
 ///
 /// `media_box` is the normalized `[x0, y0, x1, y1]` of the target page.
-pub fn field_spec(field: &FormField, media_box: [f32; 4], data: &Value) -> FieldSpec {
+pub fn field_spec(widget: &BoundWidget, media_box: [f32; 4], data: &Value) -> FieldSpec {
     FieldSpec {
-        name: field.name.clone(),
-        schema_field: field.schema_field.clone(),
-        page: field.page,
-        rect: flip_rect(field.rect, media_box),
-        field_type: field_type(&field.kind),
-        value: resolve_value(&field.kind, field.schema_field.as_deref(), data),
-        tooltip: field.tooltip.clone(),
+        name: widget.name.clone(),
+        schema_field: widget.schema_field.clone(),
+        page: widget.page,
+        rect: flip_rect(widget.rect, media_box),
+        field_type: widget.field_type.clone(),
+        value: resolve_value(&widget.field_type, widget.schema_field.as_deref(), data),
+        tooltip: widget.tooltip.clone(),
     }
 }
 
@@ -58,36 +56,22 @@ fn flip_rect(r: Rect, media_box: [f32; 4]) -> [f32; 4] {
     [left + r.x, top - (r.y + r.h), left + r.x + r.w, top - r.y]
 }
 
-fn field_type(kind: &FieldKind) -> FieldType {
-    match kind {
-        FieldKind::Text { multiline } => FieldType::Text {
-            multiline: *multiline,
-        },
-        FieldKind::Checkbox => FieldType::Checkbox,
-        FieldKind::Choice { options } => FieldType::Choice {
-            options: options.clone(),
-        },
-        FieldKind::Signature => FieldType::Signature,
-    }
-}
-
-/// Resolve a field's bound value. `None` (blank) for: an unbound field
+/// Resolve a widget's bound value. `None` (blank) for: an unbound widget
 /// (`schema_field: None`), an absent/null target, a signature, an empty text
 /// value, an unchecked checkbox, or a choice value matching no option.
-fn resolve_value(kind: &FieldKind, schema_field: Option<&str>, data: &Value) -> Option<String> {
+fn resolve_value(field_type: &FieldType, schema_field: Option<&str>, data: &Value) -> Option<String> {
     let raw = lookup(data, schema_field?)?;
-    match kind {
-        FieldKind::Text { .. } => coerce_text(raw),
-        FieldKind::Checkbox => is_truthy(raw).then(|| CHECKBOX_ON_STATE.to_string()),
-        FieldKind::Choice { options } => coerce_choice(raw, options),
-        FieldKind::Signature => None,
+    match field_type {
+        FieldType::Text { .. } => coerce_text(raw),
+        FieldType::Checkbox => is_truthy(raw).then(|| CHECKBOX_ON_STATE.to_string()),
+        FieldType::Choice { options } => coerce_choice(raw, options),
+        FieldType::Signature => None,
     }
 }
 
 /// Dereference a shallow `field[.<index-or-key>]*` path against `data`. A path
-/// rooted at the reserved `$cards` key resolves a card instance (by absolute
-/// index, or by `$kind` + index) before descending the rest. Returns `None` for
-/// any missing segment.
+/// rooted at the reserved `$cards` key resolves a card instance (by `$kind` +
+/// index) before descending the rest. Returns `None` for any missing segment.
 fn lookup<'a>(data: &'a Value, path: &str) -> Option<&'a Value> {
     let mut parts = path.split('.');
     let root = parts.next()?;
@@ -97,30 +81,21 @@ fn lookup<'a>(data: &'a Value, path: &str) -> Option<&'a Value> {
     descend(data.get(root)?, parts)
 }
 
-/// Resolve a `$cards`-rooted path: select one card from the `$cards` array
-/// either by absolute index (`$cards.<i>...`) or by kind + index
-/// (`$cards.<kind>.<i>...`), then descend the remaining segments into it.
-///
-/// The first segment is tried as an absolute index *before* being treated as a
-/// kind, so **card kinds are expected to be non-numeric**: a `$kind` that is a
-/// numeric string can only be reached by its absolute index, never by kind.
+/// Resolve a `$cards.<kind>.<i>...` path: select the `i`-th card whose `$kind`
+/// is `<kind>`, then descend the remaining segments into it. Absolute indexing
+/// was retired in `form@0.2.0` (the bind step rejects it), so the first segment
+/// is always a kind and the second its instance index.
 fn lookup_card<'a, 'p, I>(data: &'a Value, mut parts: I) -> Option<&'a Value>
 where
     I: Iterator<Item = &'p str>,
 {
     let cards = data.get("$cards")?.as_array()?;
-    let first = parts.next()?;
-    let card = if let Ok(i) = first.parse::<usize>() {
-        // `$cards.<i>...` — absolute index.
-        cards.get(i)?
-    } else {
-        // `$cards.<kind>.<i>...` — the i-th card of that `$kind`.
-        let i: usize = parts.next()?.parse().ok()?;
-        cards
-            .iter()
-            .filter(|c| c.get("$kind").and_then(Value::as_str) == Some(first))
-            .nth(i)?
-    };
+    let kind = parts.next()?;
+    let i: usize = parts.next()?.parse().ok()?;
+    let card = cards
+        .iter()
+        .filter(|c| c.get("$kind").and_then(Value::as_str) == Some(kind))
+        .nth(i)?;
     descend(card, parts)
 }
 
@@ -248,7 +223,7 @@ mod tests {
     }
 
     fn text(field: &str) -> Option<String> {
-        resolve_value(&FieldKind::Text { multiline: false }, Some(field), &data())
+        resolve_value(&FieldType::Text { multiline: false }, Some(field), &data())
     }
 
     #[test]
@@ -256,7 +231,7 @@ mod tests {
         assert_eq!(text("full_name"), Some("Ada Lovelace".into()));
         assert_eq!(
             resolve_value(
-                &FieldKind::Text { multiline: true },
+                &FieldType::Text { multiline: true },
                 Some("comments"),
                 &data()
             ),
@@ -331,14 +306,14 @@ mod tests {
     #[test]
     fn unbound_is_blank() {
         assert_eq!(
-            resolve_value(&FieldKind::Text { multiline: false }, None, &data()),
+            resolve_value(&FieldType::Text { multiline: false }, None, &data()),
             None
         );
     }
 
     #[test]
     fn checkbox_truthiness() {
-        let on = |f| resolve_value(&FieldKind::Checkbox, Some(f), &data());
+        let on = |f| resolve_value(&FieldType::Checkbox, Some(f), &data());
         assert_eq!(on("agree"), Some(CHECKBOX_ON_STATE.to_string()));
         assert_eq!(on("decline"), None);
         assert_eq!(on("missing"), None);
@@ -347,7 +322,7 @@ mod tests {
     #[test]
     fn choice_must_match_option() {
         let opts = vec!["red".to_string(), "green".to_string(), "blue".to_string()];
-        let kind = FieldKind::Choice { options: opts };
+        let kind = FieldType::Choice { options: opts };
         assert_eq!(
             resolve_value(&kind, Some("favorite_color"), &data()),
             Some("green".into())
@@ -359,13 +334,13 @@ mod tests {
     #[test]
     fn signature_never_binds() {
         assert_eq!(
-            resolve_value(&FieldKind::Signature, Some("full_name"), &data()),
+            resolve_value(&FieldType::Signature, Some("full_name"), &data()),
             None
         );
     }
 
     /// A mixed-kind `$cards` array: two indorsements with a note between them,
-    /// so by-kind indexing must skip the note that absolute indexing would not.
+    /// so by-kind indexing must skip the note.
     fn card_data() -> Value {
         json!({
             "$cards": [
@@ -378,19 +353,10 @@ mod tests {
 
     fn card_text(path: &str) -> Option<String> {
         resolve_value(
-            &FieldKind::Text { multiline: false },
+            &FieldType::Text { multiline: false },
             Some(path),
             &card_data(),
         )
-    }
-
-    #[test]
-    fn card_absolute_index() {
-        assert_eq!(card_text("$cards.0.from"), Some("Alice".into()));
-        assert_eq!(card_text("$cards.1.from"), Some("ignored".into()));
-        assert_eq!(card_text("$cards.2.from"), Some("Bob".into()));
-        // Past the end → blank.
-        assert_eq!(card_text("$cards.3.from"), None);
     }
 
     #[test]
@@ -406,9 +372,9 @@ mod tests {
     }
 
     #[test]
-    fn card_coercion_runs_per_field_kind() {
+    fn card_coercion_runs_per_widget_type() {
         // A checkbox bound to a card field coerces truthiness like any other.
-        let agree = |path| resolve_value(&FieldKind::Checkbox, Some(path), &card_data());
+        let agree = |path| resolve_value(&FieldType::Checkbox, Some(path), &card_data());
         assert_eq!(
             agree("$cards.indorsement.0.agree"),
             Some(CHECKBOX_ON_STATE.to_string())
@@ -421,7 +387,10 @@ mod tests {
         // Missing index after a kind, a bare `$cards`, and a missing field.
         assert_eq!(card_text("$cards.indorsement"), None);
         assert_eq!(card_text("$cards"), None);
-        assert_eq!(card_text("$cards.0.missing"), None);
+        assert_eq!(card_text("$cards.indorsement.0.missing"), None);
+        // Absolute-index addressing is gone: `$cards.0.from` reads `0` as a kind,
+        // which matches no card's `$kind`, so it resolves blank.
+        assert_eq!(card_text("$cards.0.from"), None);
     }
 
     #[test]
@@ -456,26 +425,6 @@ mod tests {
         assert_eq!(coerce_text(&json!([])), None);
     }
 
-    #[test]
-    fn numeric_card_kind_cannot_be_addressed_by_kind() {
-        // KNOWN LIMITATION: `lookup_card` tries `parse::<usize>()` on the first
-        // segment first, so a `$kind` that is a numeric string is unreachable by
-        // kind — `$cards.<n>...` is always read as an absolute index. Card kinds
-        // are therefore expected to be non-numeric.
-        let data = json!({
-            "$cards": [
-                { "$kind": "note", "from": "first" },
-                { "$kind": "2",    "from": "numeric-kind" }
-            ]
-        });
-        let by = |path| resolve_value(&FieldKind::Text { multiline: false }, Some(path), &data);
-        // `$cards.2.from` is read as absolute index 2 (out of range) — NOT as
-        // "kind \"2\", index <next>".
-        assert_eq!(by("$cards.2.from"), None);
-        // The numeric-kind card is only reachable by its absolute index.
-        assert_eq!(by("$cards.1.from"), Some("numeric-kind".into()));
-    }
-
     /// Card slots on a STATIC multi-page form, end-to-end through `field_spec`:
     /// a form with one card slot per page binds each card INSTANCE to its own
     /// page via card-instance addressing. Two cards of one kind, two slots on two
@@ -494,7 +443,7 @@ mod tests {
 
         // Two card slots, one per page, each bound to a distinct instance index.
         let mb = [0.0, 0.0, 612.0, 792.0];
-        let slot = |name: &str, page: usize, schema_field: &str| FormField {
+        let slot = |name: &str, page: usize, schema_field: &str| BoundWidget {
             name: name.into(),
             schema_field: Some(schema_field.into()),
             page,
@@ -504,8 +453,8 @@ mod tests {
                 w: 200.0,
                 h: 20.0,
             },
+            field_type: FieldType::Text { multiline: false },
             tooltip: None,
-            kind: FieldKind::Text { multiline: false },
         };
         let slot0 = slot("Indorsement0From", 0, "$cards.indorsement.0.from");
         let slot1 = slot("Indorsement1From", 1, "$cards.indorsement.1.from");

--- a/crates/backends/pdfform/tests/sample_form.rs
+++ b/crates/backends/pdfform/tests/sample_form.rs
@@ -97,12 +97,14 @@ fn fixture_renders_structurally_valid_filled_pdf() {
     // `/V`+`/AS`, and `/FT` names) are owned by the spine seam in
     // `quillmark-pdf/tests/stamp.rs`.
 
-    // Text: bound scalar value + tooltip.
+    // Text: bound scalar value + tooltip. The form.json field carries no
+    // `tooltip`, so `/TU` is inherited from the schema field's `description`
+    // (form@0.2.0 derives the tooltip when unset).
     let full = widget(&doc, af, "FullName");
     assert_eq!(full.get(b"V").unwrap().as_str().unwrap(), b"Ada Lovelace");
     assert_eq!(
         full.get(b"TU").unwrap().as_str().unwrap(),
-        b"Full legal name of the applicant"
+        b"Full legal name of the applicant. Binds the FullName text field."
     );
 
     // Multiline text: array joined with newlines.

--- a/crates/fixtures/resources/quills/richtext_form/0.1.0/form.json
+++ b/crates/fixtures/resources/quills/richtext_form/0.1.0/form.json
@@ -1,22 +1,17 @@
 {
-  "schema": "quillmark/form@0.1.0",
+  "schema": "quillmark/form@0.2.0",
   "fields": [
     {
       "name": "FullName",
       "schema_field": "headline",
       "page": 0,
-      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 },
-      "type": "text",
-      "tooltip": "Inline richtext headline, lowered to plaintext"
+      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 }
     },
     {
       "name": "Comments",
       "schema_field": "bio",
       "page": 0,
-      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 },
-      "type": "text",
-      "multiline": true,
-      "tooltip": "Block richtext bio, lowered to plaintext"
+      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 }
     }
   ]
 }

--- a/crates/fixtures/resources/quills/sample_form/0.1.0/form.json
+++ b/crates/fixtures/resources/quills/sample_form/0.1.0/form.json
@@ -1,43 +1,37 @@
 {
-  "schema": "quillmark/form@0.1.0",
+  "schema": "quillmark/form@0.2.0",
   "fields": [
     {
       "name": "FullName",
       "schema_field": "full_name",
       "page": 0,
-      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 },
-      "type": "text",
-      "tooltip": "Full legal name of the applicant"
+      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 }
     },
     {
       "name": "Comments",
       "schema_field": "comments",
       "page": 0,
-      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 },
-      "type": "text",
-      "multiline": true,
-      "tooltip": "Free-form comments"
+      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 }
     },
     {
       "name": "Agree",
       "schema_field": "agree",
       "page": 0,
-      "rect": { "x": 180, "y": 240, "w": 14, "h": 14 },
-      "type": "checkbox"
+      "rect": { "x": 180, "y": 240, "w": 14, "h": 14 }
     },
     {
       "name": "FavoriteColor",
       "schema_field": "favorite_color",
       "page": 0,
-      "rect": { "x": 180, "y": 280, "w": 340, "h": 20 },
-      "type": "choice",
-      "options": ["red", "green", "blue"]
-    },
+      "rect": { "x": 180, "y": 280, "w": 340, "h": 20 }
+    }
+  ],
+  "widgets": [
     {
       "name": "Signature",
+      "type": "signature",
       "page": 0,
-      "rect": { "x": 180, "y": 330, "w": 340, "h": 40 },
-      "type": "signature"
+      "rect": { "x": 180, "y": 330, "w": 340, "h": 40 }
     }
   ]
 }

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -454,3 +454,74 @@ write reconstructing the core writer). The guarantee does not cross the boundary
 a held borrow becomes a convention (*writers and card cursors are ephemeral —
 bind, write, discard*). The parity table classes this row **idiom**, not
 identical.
+
+## `pdfform`'s `form.json` slims to a binding layer — `form@0.2.0` (#940)
+
+`form.json` used to restate what the quill schema already carried: a bound
+field's `type`, choice `options`, and `multiline` flag duplicated the schema
+field's kind, `enum` values, and `ui.multiline`. Worst was the silent failure —
+a widget bound to a nonexistent `schema_field` rendered blank with no error.
+
+`form@0.2.0` removes the duplication. A **bound field** carries only where it
+sits and what it binds; its widget kind, options, multiline, and tooltip are
+**derived** from the resolved `FieldSchema` at load. **Unbound widgets** (a
+signer-filled signature) move to a separate `widgets` section and keep their own
+`type`, since they have no schema field to inherit from.
+
+```jsonc
+// form@0.1.0 (retired)              // form@0.2.0
+{ "schema": "quillmark/form@0.1.0",  { "schema": "quillmark/form@0.2.0",
+  "fields": [                          "fields": [
+    { "name": "FavoriteColor",           { "name": "FavoriteColor",
+      "schema_field": "favorite_color",    "schema_field": "favorite_color",
+      "page": 0, "rect": { … },            "page": 0, "rect": { … } }
+      "type": "choice",                  ],   // kind, options, multiline,
+      "options": ["red","green","blue"]  "widgets": [   // tooltip all derived
+    },                                     { "name": "Signature",
+    { "name": "Signature",                   "type": "signature",
+      "page": 0, "rect": { … },              "page": 0, "rect": { … } }
+      "type": "signature" }              ]
+  ] }                                  }
+```
+
+### What to change in a `form.json`
+
+- Bump `schema` to `quillmark/form@0.2.0`. **A `form@0.1.0` file is rejected at
+  load** with `pdfform::form_schema_version`.
+- On each **bound** field (one with a `schema_field`), delete `type`, `options`,
+  and `multiline` — they are derived. Keep `name`, `schema_field`, `page`,
+  `rect`. `tooltip` is now an optional override; drop it to inherit the schema
+  field's `description`.
+- Move every field **without** a `schema_field` (signatures, signer-filled
+  boxes) into a new top-level `widgets` array. These keep `type` (and
+  `multiline` / `options` where the type calls for it).
+
+### Widget kind is derived from the schema field's capability
+
+The projection keys on capability, not the `type` token — so both `type: enum`
+and the deprecated `string` + `enum:` modifier yield a dropdown:
+
+| Resolved schema field | Widget kind |
+|---|---|
+| has `enum` values (any spelling) | choice, options = the enum values |
+| `boolean` | checkbox |
+| `string`, `number`, `integer`, `datetime`, `richtext`, `plaintext` | text |
+| array of the above | text (elements newline-joined) |
+| `object`, or array of objects | **load error** `pdfform::unbindable_field` |
+
+### Two new load-time errors replace silent blanks
+
+Binding now runs at `Backend::open`, so a bad reference fails loudly instead of
+rendering an empty widget:
+
+- `pdfform::dangling_binding` — a `schema_field` path that does not resolve
+  against the schema (bad root, wrong-shape descent, missing key), naming the
+  failing segment.
+- `pdfform::unbindable_field` — a path that resolves to a shape no widget can
+  render (an `object`, or an array of objects).
+
+### `$cards` absolute-index addressing is removed
+
+A bound field addressing a card must use `$cards.<kind>.<i>.<field>`.
+`$cards.<i>.<field>` (absolute index) is gone: a widget's kind must be derivable
+at load, and only the kind names which schema field the slot binds.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -42,7 +42,14 @@ guides in order.
   types join the schema: `plaintext` (navigable unformatted prose over the
   richtext corpus, via a literal codec) and a promoted first-class `enum`
   (`type: enum` + `values:`, the `enum:` modifier on `string` deprecated for one
-  release); `string` narrows to open scalar data (#938).
+  release); `string` narrows to open scalar data (#938). The `pdfform` backend's
+  `form.json` slims to a binding layer — `form@0.2.0`: bound `fields` drop
+  `type`/`options`/`multiline` (derived from the schema field's kind, `enum`
+  values, and `ui.multiline`), unbound widgets move to a `widgets` section,
+  binding runs at load so a bad `schema_field` fails with
+  `pdfform::dangling_binding` / `pdfform::unbindable_field` instead of a silent
+  blank, `form@0.1.0` is rejected, and `$cards` absolute-index addressing is
+  removed (#940).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -16,7 +16,7 @@ my-form/
 ```
 
 - **`form.pdf`** — the *stripped background*: the normalized form with its `/AcroForm`, widget annotations, and page `/Annots` removed (pure pages, rules, boxes, and labels).
-- **`form.json`** — the complete, value-free description of every field: name, page, geometry, type.
+- **`form.json`** — the value-free **placement + binding** layer: where each widget sits (`page`, `rect`) and which schema field it binds (`schema_field`). Everything intrinsic — widget kind, choice options, multiline, tooltip — is *derived* from the quill schema, not restated here.
 
 At render time the backend writes the AcroForm **fresh** from `form.json` onto the background, then binds each field's value from your document data. It never reads or reconciles a form already in `form.pdf`.
 
@@ -72,65 +72,87 @@ See the [Quill.yaml Reference](quill-yaml-reference.md) for the full field-type 
 
 ## `form.json`
 
-`form.json` is a durable, version-controlled artifact — complete enough to rebuild every widget, yet readable and diffable. Each entry describes one field:
+`form.json` is a durable, version-controlled artifact — readable and diffable. It carries two populations: **bound `fields`** that reference a `schema_field` and inherit their widget kind from the schema, and **unbound `widgets`** with no schema field (a signer fills them), which declare their own `type`:
 
 ```json
 {
-  "schema": "quillmark/form@0.1.0",
+  "schema": "quillmark/form@0.2.0",
   "fields": [
     {
       "name": "FullName",
       "schema_field": "full_name",
       "page": 0,
-      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 },
-      "type": "text",
-      "tooltip": "Full legal name of the applicant"
+      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 }
     },
     {
       "name": "Comments",
       "schema_field": "comments",
       "page": 0,
-      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 },
-      "type": "text",
-      "multiline": true
+      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 }
     },
     {
       "name": "Agree",
       "schema_field": "agree",
       "page": 0,
-      "rect": { "x": 180, "y": 240, "w": 14, "h": 14 },
-      "type": "checkbox"
+      "rect": { "x": 180, "y": 240, "w": 14, "h": 14 }
     },
     {
       "name": "FavoriteColor",
       "schema_field": "favorite_color",
       "page": 0,
-      "rect": { "x": 180, "y": 280, "w": 340, "h": 20 },
-      "type": "choice",
-      "options": ["red", "green", "blue"]
-    },
+      "rect": { "x": 180, "y": 280, "w": 340, "h": 20 }
+    }
+  ],
+  "widgets": [
     {
       "name": "Signature",
+      "type": "signature",
       "page": 0,
-      "rect": { "x": 180, "y": 330, "w": 340, "h": 40 },
-      "type": "signature"
+      "rect": { "x": 180, "y": 330, "w": 340, "h": 40 }
     }
   ]
 }
 ```
 
-### Field keys
+Note what is **absent** from the bound fields: no `type`, `options`, or `multiline`. `FullName` is a text box because `full_name` is a `string`; `Agree` is a checkbox because `agree` is a `boolean`; `FavoriteColor` is a dropdown whose options are the schema field's `enum` values; `Comments` is a multi-line text box because `comments` is a scalar array with `ui.multiline`. The two files cannot drift, because there is only one source of truth.
+
+### Bound-field keys (`fields`)
 
 | Key | Required | Notes |
 |---|---|---|
-| `name` | yes | The widget's `/T` entry — unique within the document. |
+| `name` | yes | The widget's `/T` entry — unique across **both** `fields` and `widgets`. |
+| `schema_field` | yes | The document field this widget binds to. Resolved against the quill schema at load; a dangling path is a load error (`pdfform::dangling_binding`), not a silent blank. |
 | `page` | yes | 0-based page index into `form.pdf`. |
 | `rect` | yes | `{x, y, w, h}` in **PDF points** (1/72"), **top-left origin**, page-relative (see below). |
+| `tooltip` | no | Overrides the widget's `/TU`. When omitted, the field inherits the schema field's `description`. |
+
+### Unbound-widget keys (`widgets`)
+
+An unbound widget has no `schema_field`, so it cannot inherit a kind — it declares one.
+
+| Key | Required | Notes |
+|---|---|---|
+| `name` | yes | The widget's `/T` entry — unique across both populations. |
 | `type` | yes | One of `text`, `checkbox`, `choice`, `signature`. |
-| `schema_field` | no | The document field this widget binds to. Omit for unbound fields (e.g. a signer-filled signature). |
-| `tooltip` | no | The widget's `/TU` tooltip. |
+| `page` | yes | 0-based page index into `form.pdf`. |
+| `rect` | yes | Same top-left geometry as a bound field. |
+| `tooltip` | no | The widget's `/TU`. |
 | `multiline` | text only | `true` for a multi-line text box. |
 | `options` | choice only | The dropdown options, as bare strings. |
+
+### Widget-kind projection
+
+A bound field's kind is derived from the **capability of the resolved schema field**, not its `type` token — so both `type: enum` and the deprecated `string` + `enum:` modifier project to a dropdown. The projection is total, or the quill fails to load:
+
+| Resolved schema field | Widget kind |
+|---|---|
+| has `enum` values (any spelling) | **choice**, options = the enum values |
+| `boolean` | **checkbox** |
+| `string`, `number`, `integer`, `datetime`, `richtext`, `plaintext` | **text** |
+| array of the above (scalar or prose) | **text** — elements joined with newlines |
+| `object`, or array of objects | **load error** `pdfform::unbindable_field` |
+
+`multiline` on a text widget comes from the schema field's `ui.multiline`.
 
 ### Top-left coordinates
 
@@ -138,7 +160,7 @@ See the [Quill.yaml Reference](quill-yaml-reference.md) for the full field-type 
 
 ### Schema versioning and unknown keys
 
-`schema` follows the convention `quillmark/form@<version>`, hand-set at the last format change (never auto-derived from a crate version). Unknown keys are **ignored, not rejected**, so the format can grow additively — old engines skip new keys and new engines default missing ones.
+`schema` follows the convention `quillmark/form@<version>`, hand-set at the last format change (never auto-derived from a crate version). The current format is **`quillmark/form@0.2.0`**. Unknown *keys* are **ignored, not rejected**, so the format can grow additively — but a retired *version* is rejected: a `form@0.1.0` file (which restated `type`/`options`/`multiline` on each field) fails to load with `pdfform::form_schema_version` and a pointer to the migration guide.
 
 ### Opinionated styling
 
@@ -146,10 +168,10 @@ The background owns all visual chrome; each widget is a transparent input over i
 
 ## Binding values
 
-Each field's value comes from the **resolver**: for every `form.json` field with a `schema_field`, the backend dereferences that path against your document data and coerces it to the field's type.
+Each field's value comes from the **resolver**: for every bound field, the backend dereferences its `schema_field` against your document data and coerces it to the field's derived widget kind.
 
 - **Bound against the same validated data the Typst plate sees.** Schema validation, defaults, zero-fill, and scalar coercion are all inherited — there is no second data pipeline.
-- **Addressing** is a shallow path rooted at a schema field name, optionally with an array index or nested key: `full_name`, `comments.0`.
+- **Addressing** is a shallow path rooted at a schema field name, optionally with an array index or nested key: `full_name`, `comments.0`, `address.street`. The path is validated against the schema at load: a `.N` segment requires an array, a `.key` segment requires an object, and any miss is a `pdfform::dangling_binding` load error naming the failing segment.
 - **Coercion is type-directed:**
 
 | Type | Binding |
@@ -163,19 +185,20 @@ Each field's value comes from the **resolver**: for every `form.json` field with
 
 ### Card-instance addressing
 
-A `schema_field` rooted at the reserved `$cards` key binds one card instance from the document's `$cards` array (the same array the Typst plate iterates):
+A `schema_field` rooted at the reserved `$cards` key binds one card instance from the document's `$cards` array (the same array the Typst plate iterates), **by kind + index**:
 
-- **By absolute index:** `$cards.0.from` — the first card overall.
-- **By kind + index:** `$cards.indorsement.1.from` — the second card whose `$kind` is `indorsement`, skipping intervening cards of other kinds.
+- `$cards.indorsement.1.from` — the `from` field of the second card whose `$kind` is `indorsement`, skipping intervening cards of other kinds.
 
-This lets a **static, fixed-capacity** form lay out a bounded number of card slots across its existing pages — each slot a `form.json` field with its own `page`, bound to a distinct instance.
+Absolute-index addressing (`$cards.0.from`) is **not accepted** in `form@0.2.0`: a widget's kind must be statically derivable at load, and only the *kind* names which schema field the slot binds (an absolute index does not, since the card at that position varies per document).
+
+This lets a **static, fixed-capacity** form lay out a bounded number of card slots across its existing pages — each slot a bound field with its own `page`, bound to a distinct instance.
 
 !!! warning "Static forms only"
     `pdfform` stamps over a fixed, pre-existing page set. It never composes content, appends continuation pages, or merges PDFs. A document carrying more card instances than the form has slots is the author's concern, not the engine's.
 
 ## Signature fields
 
-A `type: signature` field (with no `schema_field`) produces a clickable, **unsigned** AcroForm signature widget. Open the result in Acrobat — or any reader that supports form signing — and the widget presents a "Sign Here" affordance.
+A `type: signature` entry in the `widgets` section produces a clickable, **unsigned** AcroForm signature widget. Open the result in Acrobat — or any reader that supports form signing — and the widget presents a "Sign Here" affordance.
 
 The widget is unsigned: Quillmark performs no cryptography. To produce a signed PDF, run the output through pyHanko, Acrobat, endesive, or another signing tool.
 


### PR DESCRIPTION
form.json restated facts the quill schema already carried — a bound field's
type, choice options, and multiline duplicated the schema field's kind, enum
values, and ui.multiline, and could drift silently. Worse, a widget bound to a
nonexistent schema_field rendered blank with no error.

Slim form.json to a placement + binding layer:

- Bound `fields` carry only name/schema_field/page/rect and an optional tooltip
  (inherited from the schema field's `description` when unset). Widget kind,
  options, and multiline are derived from the resolved FieldSchema.
- Unbound `widgets` (signatures, signer-filled boxes) move to a separate
  section and keep their own `type`.
- New `bind.rs` resolves each schema_field against the QuillConfig at
  Backend::open and projects the widget kind from the field's capability — choice
  keys on enum_values.is_some() (covers both `type: enum` and the deprecated
  string+enum: modifier), boolean → checkbox, scalar/prose/scalar-array → text,
  object/array-of-object → the `pdfform::unbindable_field` load error.
- Binding is total or a load error: a dangling path fails with
  `pdfform::dangling_binding` naming the segment, replacing the silent blank.
- `form@0.1.0` is rejected with `pdfform::form_schema_version` and a migration
  pointer; the format is now `form@0.2.0`.
- `$cards` absolute-index addressing is removed — only `$cards.<kind>.<i>.<field>`,
  so a widget kind is statically derivable.
- The session holds Vec<BoundWidget> (value-free intrinsics bound once); apply
  re-resolves only values.

Migrate the sample_form and richtext_form fixtures; rewrite the pdfform backend
doc; add the migration entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013mQ3ZcsV2m5TjBH4NB9Pf6