### PR TITLE
Reject nested ui.group; auto-order nested object properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,6 +2297,7 @@ name = "quillmark-cli"
 version = "0.92.1"
 dependencies = [
  "clap",
+ "indexmap",
  "quillmark",
  "quillmark-core",
  "serde_json",

--- a/crates/bindings/cli/Cargo.toml
+++ b/crates/bindings/cli/Cargo.toml
@@ -23,6 +23,7 @@ doc = false
 
 [dependencies]
 clap = { version = "~4.5", features = ["derive"] }
+indexmap = { workspace = true }
 quillmark = { workspace = true }
 quillmark-core = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -1,7 +1,7 @@
 use crate::errors::{CliError, Result};
 use clap::Parser;
 use quillmark_core::quill::{CardSchema, FieldSchema, QuillConfig};
-use std::collections::BTreeMap;
+use indexmap::IndexMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -223,7 +223,7 @@ fn validate_file_references(
 /// diagnostics. This pass only adds the advisory checks the parser does not:
 /// empty enum constraints and missing field descriptions.
 fn validate_field_schemas(
-    fields: &BTreeMap<String, FieldSchema>,
+    fields: &IndexMap<String, FieldSchema>,
     result: &mut ValidationResult,
     context: &str,
 ) {

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -186,7 +186,7 @@ impl PyQuill {
     /// `validation::must_fill` warning for each `!must_fill` marker left in
     /// the document. Field values, defaults, and order are not part of this
     /// surface: read them from the `Document` payload and `Quill.schema`
-    /// (fields carry `ui.order`).
+    /// (schema key order is display order).
     fn validate<'py>(
         &self,
         py: Python<'py>,

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -213,9 +213,9 @@ const diagnostics = quill.validate(Document.fromMarkdown(markdown));
 const errors = diagnostics.filter(d => d.severity === "error");
 ```
 
-To render a form editor, read field definitions from `quill.schema` (sort
-fields by each field's `ui.order`) and the authored values from the
-`Document` payload — there is no separate form-view projection.
+To render a form editor, read field definitions from `quill.schema` (walk
+`fields` in key order — declaration order is display order) and the authored
+values from the `Document` payload — there is no separate form-view projection.
 
 ### `quill.seedDocument()`
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -15,10 +15,12 @@ use wasm_bindgen::prelude::*;
 /// Emitted via `typescript_custom_section` as the single source of truth.
 #[wasm_bindgen(typescript_custom_section)]
 const METADATA_TS: &'static str = r#"
-/** UI layout hints for a single field. */
+/** UI layout hints for a single field. Field display order is not a hint:
+ * key order in the schema's `fields`/`properties` objects is declaration
+ * order, the ordering contract. */
 export interface QuillFieldUi {
+    title?: string;
     group?: string;
-    order?: number;
     compact?: boolean;
     multiline?: boolean;
 }
@@ -498,9 +500,10 @@ impl Quill {
     }
 
     /// Document schema for the quill: the user-fillable fields plus their
-    /// `ui` hints (title / group / order / compact / multiline). The single
+    /// `ui` hints (title / group / compact / multiline). The single
     /// field-metadata surface — drives form editors and LLM/MCP consumers
-    /// alike. Returns the `QuillSchema` shape.
+    /// alike. Key order in `fields`/`properties` is declaration order — the
+    /// ordering contract. Returns the `QuillSchema` shape.
     #[wasm_bindgen(getter, js_name = schema, unchecked_return_type = "QuillSchema")]
     pub fn schema(&self) -> Result<JsValue, JsValue> {
         let value = self.inner.config().schema();
@@ -562,7 +565,7 @@ impl Quill {
     /// `validation::must_fill` warning for each `!must_fill` marker left in
     /// the document. Field values, defaults, and order are not part of this
     /// surface: read them from the `Document` payload and `Quill.schema`
-    /// (fields carry `ui.order`).
+    /// (schema key order is display order).
     #[wasm_bindgen(js_name = validate, unchecked_return_type = "Diagnostic[]")]
     pub fn validate(&self, doc: &Document) -> Result<JsValue, JsValue> {
         let diags = self.inner.validate(&doc.inner);

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -22,7 +22,10 @@ pub use formats::parse_date_ymd;
 pub use ignore::QuillIgnore;
 pub use schema::{build_transform_schema, QUILLMARK_INLINE_KEY, RICHTEXT_MEDIA_TYPE};
 pub use tree::FileTreeNode;
-pub use types::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
+pub use types::{
+    BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, GroupSchema, UiCardSchema,
+    UiFieldSchema,
+};
 
 use std::collections::HashMap;
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -196,16 +196,15 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
         }
     }
     // Ungrouped is the implicit leading pseudo-group (rank 0). Grouped clusters
-    // (rank 1) sort by registry position; with no registry every group ties at
-    // `usize::MAX` and the stable sort preserves first appearance.
+    // sort by registry position shifted past it (`pos + 1`); with no registry
+    // every group ties at `usize::MAX` and the stable sort preserves first
+    // appearance.
     groups.sort_by_key(|(g, _)| match g {
-        None => (0, 0),
-        Some(id) => (
-            1,
-            registry
-                .and_then(|order| order.iter().position(|o| o == id))
-                .unwrap_or(usize::MAX),
-        ),
+        None => 0,
+        Some(id) => registry
+            .and_then(|order| order.iter().position(|o| o == id))
+            .map(|pos| pos + 1)
+            .unwrap_or(usize::MAX),
     });
     groups.into_iter().flat_map(|(_, fields)| fields).collect()
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -40,10 +40,10 @@
 //!   A *non-empty* partial default is rendered verbatim (a deliberate
 //!   "already handled" signal); only `{}` expands.
 //!
-//! `ui.order` controls field ordering. `ui.group` clusters fields together
-//! within the document but emits no banner.
+//! Declaration order controls field ordering. `ui.group` clusters fields
+//! together within the document but emits no banner.
 
-use std::collections::BTreeMap;
+use indexmap::IndexMap;
 
 use super::{zero_value, CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
@@ -162,8 +162,8 @@ fn build_card(card: &CardSchema) -> Card {
 }
 
 /// Append every field of a card as payload items, clustered by `ui.group` and
-/// ordered by `ui.order`. Group order follows the card's `ui.groups` registry
-/// when present.
+/// ordered by declaration order. Group order follows the card's `ui.groups`
+/// registry when present.
 fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
     let registry: Option<Vec<&str>> = card
         .ui
@@ -175,9 +175,10 @@ fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
     }
 }
 
-/// Order fields by `ui.group` (ungrouped lead, then grouped clusters) with
-/// `ui.order` sorting within each cluster. Grouped clusters follow the
-/// `registry` declaration order when a registry is present, else first-
+/// Order fields by `ui.group` (ungrouped lead, then grouped clusters),
+/// preserving declaration order within each cluster (`fields` arrives in
+/// declaration order and the clustering is stable). Grouped clusters follow
+/// the `registry` declaration order when a registry is present, else first-
 /// appearance order (the deprecated implicit-group fallback); for a migrated
 /// quill the two are identical. Grouping is purely positional (no banner); the
 /// clusters are flattened into a single field stream.
@@ -185,10 +186,8 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
     fields: I,
     registry: Option<&[&str]>,
 ) -> Vec<&'a FieldSchema> {
-    let mut sorted: Vec<&FieldSchema> = fields.into_iter().collect();
-    sorted.sort_by_key(|f| f.ui_order());
     let mut groups: Vec<(Option<&str>, Vec<&FieldSchema>)> = Vec::new();
-    for field in sorted {
+    for field in fields {
         let group = field.ui.as_ref().and_then(|u| u.group.as_deref());
         match groups.iter_mut().find(|(g, _)| *g == group) {
             Some(slot) => slot.1.push(field),
@@ -287,20 +286,14 @@ fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     items.push(PayloadItem::comment_inline(type_expression(field)));
 }
 
-fn sort_props(props: &BTreeMap<String, Box<FieldSchema>>) -> Vec<&FieldSchema> {
-    let mut v: Vec<&FieldSchema> = props.values().map(|b| b.as_ref()).collect();
-    v.sort_by_key(|f| f.ui_order());
-    v
-}
-
 /// Build the per-property body of an Unendorsed typed container: the value
-/// mapping (each property at its own cell), the nested comments (description +
-/// `# e.g.` + inline type annotation, addressed by `container_path`/slot), and
-/// the nested fill paths. `prefix` is the container path of the mapping
-/// relative to the field value (`[]` for a typed dict, `[Index(0)]` for a typed
-/// table's synthetic row).
+/// mapping (each property at its own cell, in declaration order), the nested
+/// comments (description + `# e.g.` + inline type annotation, addressed by
+/// `container_path`/slot), and the nested fill paths. `prefix` is the container
+/// path of the mapping relative to the field value (`[]` for a typed dict,
+/// `[Index(0)]` for a typed table's synthetic row).
 fn build_property_mapping(
-    props: &BTreeMap<String, Box<FieldSchema>>,
+    props: &IndexMap<String, Box<FieldSchema>>,
     prefix: &[PathSegment],
 ) -> (
     JsonMap<String, JsonValue>,
@@ -310,7 +303,7 @@ fn build_property_mapping(
     let mut map = JsonMap::new();
     let mut nested = Vec::new();
     let mut fills = Vec::new();
-    for (slot, prop) in sort_props(props).into_iter().enumerate() {
+    for (slot, prop) in props.values().map(|b| b.as_ref()).enumerate() {
         if let Some(desc) = collapse_opt(&prop.description) {
             nested.push(NestedComment {
                 container_path: prefix.to_vec(),
@@ -355,7 +348,7 @@ fn build_property_mapping(
 fn append_typed_dict(
     items: &mut Vec<PayloadItem>,
     field: &FieldSchema,
-    props: &BTreeMap<String, Box<FieldSchema>>,
+    props: &IndexMap<String, Box<FieldSchema>>,
 ) {
     push_leading(items, field, true);
 
@@ -385,7 +378,7 @@ fn append_typed_dict(
 fn append_typed_table(
     items: &mut Vec<PayloadItem>,
     field: &FieldSchema,
-    item_props: &BTreeMap<String, Box<FieldSchema>>,
+    item_props: &IndexMap<String, Box<FieldSchema>>,
 ) {
     push_leading(items, field, true);
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -162,18 +162,29 @@ fn build_card(card: &CardSchema) -> Card {
 }
 
 /// Append every field of a card as payload items, clustered by `ui.group` and
-/// ordered by `ui.order`.
+/// ordered by `ui.order`. Group order follows the card's `ui.groups` registry
+/// when present.
 fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
-    for field in group_fields(card.fields.values()) {
+    let registry: Option<Vec<&str>> = card
+        .ui
+        .as_ref()
+        .and_then(|u| u.groups.as_ref())
+        .map(|r| r.0.iter().map(|g| g.id.as_str()).collect());
+    for field in group_fields(card.fields.values(), registry.as_deref()) {
         append_field(items, field);
     }
 }
 
-/// Order fields by `ui.group` (ungrouped lead, then groups in first-appearance
-/// order) with `ui.order` sorting within each cluster. Grouping is purely
-/// positional (no banner); the clusters are flattened into a single field
-/// stream.
-fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(fields: I) -> Vec<&'a FieldSchema> {
+/// Order fields by `ui.group` (ungrouped lead, then grouped clusters) with
+/// `ui.order` sorting within each cluster. Grouped clusters follow the
+/// `registry` declaration order when a registry is present, else first-
+/// appearance order (the deprecated implicit-group fallback); for a migrated
+/// quill the two are identical. Grouping is purely positional (no banner); the
+/// clusters are flattened into a single field stream.
+fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
+    fields: I,
+    registry: Option<&[&str]>,
+) -> Vec<&'a FieldSchema> {
     let mut sorted: Vec<&FieldSchema> = fields.into_iter().collect();
     sorted.sort_by_key(|f| f.ui_order());
     let mut groups: Vec<(Option<&str>, Vec<&FieldSchema>)> = Vec::new();
@@ -184,7 +195,18 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(fields: I) -> Vec<&
             None => groups.push((group, vec![field])),
         }
     }
-    groups.sort_by_key(|(g, _)| g.is_some());
+    // Ungrouped is the implicit leading pseudo-group (rank 0). Grouped clusters
+    // (rank 1) sort by registry position; with no registry every group ties at
+    // `usize::MAX` and the stable sort preserves first appearance.
+    groups.sort_by_key(|(g, _)| match g {
+        None => (0, 0),
+        Some(id) => (
+            1,
+            registry
+                .and_then(|order| order.iter().position(|o| o == id))
+                .unwrap_or(usize::MAX),
+        ),
+    });
     groups.into_iter().flat_map(|(_, fields)| fields).collect()
 }
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -168,7 +168,7 @@ impl Quill {
     ///
     /// Field values, defaults, and presentation order are not part of this
     /// surface — read them from the [`Document`] payload and the quill schema
-    /// (`quill.config().schema()`, carrying each field's `ui.order`).
+    /// (`quill.config().schema()`, whose key order is display order).
     pub fn validate(&self, doc: &Document) -> Vec<Diagnostic> {
         let mut diags = match self.config().validate_document(doc) {
             Ok(()) => Vec::new(),

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -10,7 +10,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::types::RICHTEXT_INLINE_TOKEN_MSG;
-use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema, UiFieldSchema};
+use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
 /// string — a boolean (`true`/`false`) or number (`47`, `1.0`). `None` for
@@ -746,6 +746,23 @@ impl QuillConfig {
         // `from_quill_value` folds the wire key into the `FieldType` enum
         // (`resolve_richtext_inline`); no second check belongs here.
 
+        // `ui.group` clusters card-level fields only — the blueprint's grouping
+        // pass never descends into object properties or array items, so a nested
+        // `group` is an inert knob. Reject it rather than let it silently do
+        // nothing, the same dead-knob class this walk exists to catch.
+        if position != ShapePosition::Top
+            && schema.ui.as_ref().and_then(|u| u.group.as_ref()).is_some()
+        {
+            return err(
+                "quill::nested_group_not_supported",
+                format!(
+                    "Field '{owner}' sets ui.group in a nested position. Grouping applies \
+                     only to card-level fields; an object property or array item cannot \
+                     join a group."
+                ),
+            );
+        }
+
         match schema.r#type {
             FieldType::Object => {
                 // An object nested inside another object (a Leaf position) is
@@ -1094,20 +1111,9 @@ impl QuillConfig {
                         continue;
                     }
 
-                    // Always set ui.order based on position
-                    if schema.ui.is_none() {
-                        schema.ui = Some(UiFieldSchema {
-                            title: None,
-                            group: None,
-                            order: Some(order),
-                            compact: None,
-                            multiline: None,
-                        });
-                    } else if let Some(ui) = &mut schema.ui {
-                        if ui.order.is_none() {
-                            ui.order = Some(order);
-                        }
-                    }
+                    // Assign this card-level field its positional `ui.order`
+                    // (nested properties are stamped in `from_quill_value`).
+                    schema.set_ui_order_if_unset(order);
 
                     let owner = format!("{} '{}'", context, field_name);
                     Self::validate_field_blueprint_constraints(&schema, &owner, errors);

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1,5 +1,5 @@
 //! Quill configuration parsing and normalization.
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::error::Error as StdError;
 
 use indexmap::IndexMap;
@@ -10,7 +10,7 @@ use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
 use super::types::RICHTEXT_INLINE_TOKEN_MSG;
-use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, UiCardSchema};
+use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
 /// string — a boolean (`true`/`false`) or number (`47`, `1.0`). `None` for
@@ -929,6 +929,99 @@ impl QuillConfig {
         }
     }
 
+    /// Validate a card's group registry and every card-level field's `ui.group`
+    /// reference against it. Nested `ui.group` is already rejected upstream by
+    /// [`validate_field_schema_shape`](Self::validate_field_schema_shape), so
+    /// only card-level fields are considered here.
+    ///
+    /// With a registry present, `ui.group` is a *reference*: registry ids carry
+    /// the same snake_case discipline as field keys and must be unique, and a
+    /// reference to an id the registry does not declare is `quill::unknown_group`
+    /// (the "no mixing implicit and declared" rule falls out of this — with a
+    /// registry there is no implicit fallback). With no registry, each `ui.group`
+    /// is a deprecated implicit group (label-as-identity, today's semantics
+    /// untouched) and the card earns one `quill::implicit_group` warning.
+    fn validate_card_groups(
+        label: &str,
+        card: &CardSchema,
+        errors: &mut Vec<Diagnostic>,
+        warnings: &mut Vec<Diagnostic>,
+    ) {
+        let referenced: Vec<&str> = card
+            .fields
+            .values()
+            .filter_map(|f| f.ui.as_ref().and_then(|u| u.group.as_deref()))
+            .collect();
+
+        match card.ui.as_ref().and_then(|u| u.groups.as_ref()) {
+            Some(GroupRegistry(groups)) => {
+                let mut ids: HashSet<&str> = HashSet::new();
+                for g in groups {
+                    if !Self::is_snake_case_identifier(&g.id) {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!(
+                                    "{label} group id '{}' must be snake_case (lowercase letters, \
+                                     digits, and underscores only); the display label goes in \
+                                     'title:'.",
+                                    g.id
+                                ),
+                            )
+                            .with_code("quill::invalid_group_id".to_string()),
+                        );
+                    }
+                    // Insert regardless of snake_case validity so a reference to
+                    // an ill-named id resolves — one diagnostic, not a cascade.
+                    if !ids.insert(g.id.as_str()) {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!("{label} declares group '{}' more than once.", g.id),
+                            )
+                            .with_code("quill::duplicate_group".to_string()),
+                        );
+                    }
+                }
+                // One diagnostic per distinct unresolved reference.
+                let unresolved: BTreeSet<&str> =
+                    referenced.iter().copied().filter(|g| !ids.contains(g)).collect();
+                for group in unresolved {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "{label} field references group '{group}', which is not declared \
+                                 in ui.groups. Add it to the registry, or fix the reference."
+                            ),
+                        )
+                        .with_code("quill::unknown_group".to_string()),
+                    );
+                }
+            }
+            None => {
+                if !referenced.is_empty() {
+                    warnings.push(
+                        Diagnostic::new(
+                            Severity::Warning,
+                            format!(
+                                "{label} uses ui.group without a ui.groups registry (implicit \
+                                 groups). Declare the groups under the card's ui.groups; implicit \
+                                 groups are deprecated and become an error in a future release."
+                            ),
+                        )
+                        .with_code("quill::implicit_group".to_string())
+                        .with_hint(
+                            "Add a ui.groups registry listing each group id, and reference the id \
+                             from each field's ui.group."
+                                .to_string(),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
     /// Validate a single `example:` or `default:` literal against the declared
     /// schema, pushing `quill::*`-namespaced [`Diagnostic`]s for any violations.
     ///
@@ -1407,7 +1500,7 @@ impl QuillConfig {
                             format!("Invalid 'quill.ui' block: {}", e),
                         )
                         .with_code("quill::invalid_ui".to_string())
-                        .with_hint("Valid key under 'ui' is: title.".to_string()),
+                        .with_hint("Valid keys under 'ui' are: title, groups.".to_string()),
                     );
                     None
                 }
@@ -1502,7 +1595,7 @@ impl QuillConfig {
                     errors.push(
                         Diagnostic::new(Severity::Error, format!("Invalid 'main.ui' block: {}", e))
                             .with_code("quill::invalid_ui".to_string())
-                            .with_hint("Valid key under 'ui' is: title.".to_string()),
+                            .with_hint("Valid keys under 'ui' are: title, groups.".to_string()),
                     );
                     None
                 }
@@ -1661,6 +1754,17 @@ impl QuillConfig {
             if let Some(d) = warn_example_unused(&format!("card_kinds.{}", card.name), &card.body) {
                 warnings.push(d);
             }
+        }
+
+        // Validate each card's group registry and its fields' group references.
+        Self::validate_card_groups("main", &main, &mut errors, &mut warnings);
+        for card in &card_kinds {
+            Self::validate_card_groups(
+                &format!("card_kinds.{}", card.name),
+                card,
+                &mut errors,
+                &mut warnings,
+            );
         }
 
         // Error when `body.example` contains a line that the document parser

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1,5 +1,5 @@
 //! Quill configuration parsing and normalization.
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::error::Error as StdError;
 
 use indexmap::IndexMap;
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Diagnostic, Severity};
 use crate::value::QuillValue;
 
-use super::types::RICHTEXT_INLINE_TOKEN_MSG;
+use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG};
 use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
@@ -81,7 +81,7 @@ pub struct QuillConfig {
 struct CardSchemaDef {
     pub description: Option<String>,
     // Declared so `deny_unknown_fields` accepts a `fields:` block on a card.
-    // Fields are re-parsed via `parse_fields_with_order` for ordering.
+    // Fields are parsed separately via `parse_fields` (per-field diagnostics).
     #[allow(dead_code)]
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub ui: Option<UiCardSchema>,
@@ -154,6 +154,10 @@ impl QuillConfig {
     /// card kind. The quill reference (constructed as `name@version` from
     /// quill metadata) and card-kind discriminators are document-level
     /// metadata, not fields, so they do not appear here.
+    ///
+    /// Key order is the ordering contract: fields, nested properties, and card
+    /// kinds all emit in declaration order (`preserve_order` end-to-end), so a
+    /// consumer walking the maps in key order renders the authored layout.
     pub fn schema(&self) -> serde_json::Value {
         let mut obj = serde_json::Map::new();
 
@@ -162,18 +166,15 @@ impl QuillConfig {
         obj.insert("main".to_string(), main_value);
 
         if !self.card_kinds.is_empty() {
-            let card_kinds: BTreeMap<String, serde_json::Value> = self
-                .card_kinds
-                .iter()
-                .map(|card| {
-                    let card_value =
-                        serde_json::to_value(card).expect("CardSchema is always serializable");
-                    (card.name.clone(), card_value)
-                })
-                .collect();
+            let mut card_kinds = serde_json::Map::new();
+            for card in &self.card_kinds {
+                let card_value =
+                    serde_json::to_value(card).expect("CardSchema is always serializable");
+                card_kinds.insert(card.name.clone(), card_value);
+            }
             obj.insert(
                 "card_kinds".to_string(),
-                serde_json::to_value(&card_kinds).expect("card_kinds map is always serializable"),
+                serde_json::Value::Object(card_kinds),
             );
         }
 
@@ -681,7 +682,7 @@ impl QuillConfig {
     /// child's path is `"{parent_path}.{k}"`.
     fn coerce_object_props(
         obj: &serde_json::Map<String, serde_json::Value>,
-        props: &std::collections::BTreeMap<String, Box<super::FieldSchema>>,
+        props: &IndexMap<String, Box<super::FieldSchema>>,
         parent_path: &str,
         mode: Leniency,
     ) -> Result<serde_json::Map<String, serde_json::Value>, CoercionError> {
@@ -1152,17 +1153,17 @@ impl QuillConfig {
     }
 
     /// Parse fields from a JSON map into `FieldSchema`s (both `main.fields` and
-    /// a card kind's `fields`), assigning each field's `ui.order` from its
-    /// position in `key_order` (definition order). `context` labels error
-    /// messages (e.g. `"field schema"`, `"card_kind 'note' field"`).
-    fn parse_fields_with_order(
+    /// a card kind's `fields`). Declaration order rides the map itself: the
+    /// source map preserves key order (serde_json's `preserve_order`) and the
+    /// returned `IndexMap` keeps insertion order, so no ordering pass runs.
+    /// `context` labels error messages (e.g. `"field schema"`,
+    /// `"card_kind 'note' field"`).
+    fn parse_fields(
         fields_map: &serde_json::Map<String, serde_json::Value>,
-        key_order: &[String],
         context: &str,
         errors: &mut Vec<Diagnostic>,
-    ) -> BTreeMap<String, FieldSchema> {
-        let mut fields = BTreeMap::new();
-        let mut fallback_counter = 0;
+    ) -> IndexMap<String, FieldSchema> {
+        let mut fields = IndexMap::new();
 
         for (field_name, field_value) in fields_map {
             if !Self::is_snake_case_identifier(field_name) {
@@ -1181,18 +1182,9 @@ impl QuillConfig {
                 continue;
             }
 
-            // Determine order from key_order, or use fallback counter
-            let order = if let Some(idx) = key_order.iter().position(|k| k == field_name) {
-                idx as i32
-            } else {
-                let o = key_order.len() as i32 + fallback_counter;
-                fallback_counter += 1;
-                o
-            };
-
             let quill_value = QuillValue::from_json(field_value.clone());
             match FieldSchema::from_quill_value(field_name.clone(), &quill_value) {
-                Ok(mut schema) => {
+                Ok(schema) => {
                     // One recursive pass enforces the whole shape contract:
                     // containers carry the right child schema (`object` →
                     // `properties`, `array` → `items`), and nesting stops after
@@ -1203,10 +1195,6 @@ impl QuillConfig {
                         errors.push(diag);
                         continue;
                     }
-
-                    // Assign this card-level field its positional `ui.order`
-                    // (nested properties are stamped in `from_quill_value`).
-                    schema.set_ui_order_if_unset(order);
 
                     let owner = format!("{} '{}'", context, field_name);
                     Self::validate_field_blueprint_constraints(&schema, &owner, errors);
@@ -1238,6 +1226,13 @@ impl QuillConfig {
                 return Some(
                     "'title' is not a valid field key; use 'description' instead.".to_string(),
                 );
+            }
+            if obj
+                .get("ui")
+                .and_then(|u| u.as_object())
+                .is_some_and(|u| u.contains_key("order"))
+            {
+                return Some(format!("{UI_ORDER_REMOVED_MSG}."));
             }
             if obj.get("type").and_then(|v| v.as_str()) == Some("richtext(inline)") {
                 return Some(format!("{RICHTEXT_INLINE_TOKEN_MSG}."));
@@ -1561,25 +1556,13 @@ impl QuillConfig {
         let main_obj_opt = quill_yaml_val.get("main").and_then(|v| v.as_object());
 
         // Extract main.fields (optional)
-        let fields = if let Some(main_obj) = main_obj_opt {
-            if let Some(fields_val) = main_obj.get("fields") {
-                if let Some(fields_map) = fields_val.as_object() {
-                    // With preserve_order feature, keys iterator respects insertion order
-                    let field_order: Vec<String> = fields_map.keys().cloned().collect();
-                    Self::parse_fields_with_order(
-                        fields_map,
-                        &field_order,
-                        "field schema",
-                        &mut errors,
-                    )
-                } else {
-                    BTreeMap::new()
-                }
-            } else {
-                BTreeMap::new()
-            }
+        let fields = if let Some(fields_map) = main_obj_opt
+            .and_then(|main_obj| main_obj.get("fields"))
+            .and_then(|v| v.as_object())
+        {
+            Self::parse_fields(fields_map, "field schema", &mut errors)
         } else {
-            BTreeMap::new()
+            IndexMap::new()
         };
 
         // Extract main.ui (optional). Fail loudly on malformed UI metadata rather
@@ -1694,16 +1677,13 @@ impl QuillConfig {
                         let card_fields = if let Some(card_fields_table) =
                             card_value.get("fields").and_then(|v| v.as_object())
                         {
-                            let card_field_order: Vec<String> =
-                                card_fields_table.keys().cloned().collect();
-                            Self::parse_fields_with_order(
+                            Self::parse_fields(
                                 card_fields_table,
-                                &card_field_order,
                                 &format!("card_kind '{}' field", card_name),
                                 &mut errors,
                             )
                         } else {
-                            BTreeMap::new()
+                            IndexMap::new()
                         };
 
                         Self::validate_description_singleline(

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -51,31 +51,23 @@ use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 /// (from a document's `$seed`) pass through as authored and canonicalize at the
 /// next `compile_data`.
 fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, RichText) {
-    // Merge the example base with the overlay (schema-declared fields only). A
-    // richtext-bearing field seeds from its pre-validated corpus companion; every
-    // other field seeds from its raw `example`.
-    let mut merged: IndexMap<String, QuillValue> = IndexMap::new();
+    // Drive by `schema.fields` (declaration order), so the result is in
+    // declaration order natively — no merge-then-sort. Per field the precedence
+    // is `overlay › example_corpus › example › absent`: a richtext-bearing field
+    // seeds from its pre-validated corpus companion, every other from its raw
+    // `example`, and the overlay overrides either (and can supply a value for a
+    // `default`-only field the base omits). An overlay key naming no schema
+    // field is skipped — it is never iterated here.
+    let mut fields: IndexMap<String, QuillValue> = IndexMap::new();
     for (name, field) in &schema.fields {
-        if let Some(corpus) = &field.example_corpus {
-            merged.insert(name.clone(), corpus.clone());
-        } else if let Some(example) = &field.example {
-            merged.insert(name.clone(), example.clone());
+        let value = overlay
+            .and_then(|o| o.fields.get(name))
+            .or(field.example_corpus.as_ref())
+            .or(field.example.as_ref());
+        if let Some(value) = value {
+            fields.insert(name.clone(), value.clone());
         }
     }
-    if let Some(overlay) = overlay {
-        for (name, value) in &overlay.fields {
-            if schema.fields.contains_key(name) {
-                merged.insert(name.clone(), value.clone());
-            }
-        }
-    }
-
-    // Order by schema declaration order (the schema's field-map index). Every
-    // key is a declared field here, so the lookup always resolves; the
-    // `usize::MAX` fallback is defensive.
-    let mut entries: Vec<(String, QuillValue)> = merged.into_iter().collect();
-    entries.sort_by_key(|(name, _)| schema.fields.get_index_of(name).unwrap_or(usize::MAX));
-    let fields: IndexMap<String, QuillValue> = entries.into_iter().collect();
 
     // Body region as a corpus: an overlay body (authored markdown) is imported;
     // otherwise the `body.example` corpus cache is used; else empty — and only

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -38,7 +38,7 @@ use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 /// [`SeedOverlay`] over the schema-example base. Per field the precedence is
 /// `overlay › example › absent`; the overlay may also add a field the base
 /// omits (a `default`-only field with no `example`). The final fields are
-/// ordered by `ui.order` (matching the blueprint). Only fields declared on the
+/// ordered by schema declaration order (matching the blueprint). Only fields declared on the
 /// schema are included — an overlay key naming no schema field is ignored here
 /// (the editor-surface validator flags it). Body: `overlay › body.example ›
 /// empty`, honored only when the kind enables bodies. The `$quill` / `$kind`
@@ -70,16 +70,11 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, R
         }
     }
 
-    // Order by `ui.order`. Every key is a declared field here, so the lookup
-    // always resolves; the `i32::MAX` fallback is defensive.
+    // Order by schema declaration order (the schema's field-map index). Every
+    // key is a declared field here, so the lookup always resolves; the
+    // `usize::MAX` fallback is defensive.
     let mut entries: Vec<(String, QuillValue)> = merged.into_iter().collect();
-    entries.sort_by_key(|(name, _)| {
-        schema
-            .fields
-            .get(name)
-            .map(|f| f.ui_order())
-            .unwrap_or(i32::MAX)
-    });
+    entries.sort_by_key(|(name, _)| schema.fields.get_index_of(name).unwrap_or(usize::MAX));
     let fields: IndexMap<String, QuillValue> = entries.into_iter().collect();
 
     // Body region as a corpus: an overlay body (authored markdown) is imported;

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -235,14 +235,44 @@ fn overlay_adds_a_field_the_base_omits() {
 }
 
 #[test]
-fn overlay_fields_are_ordered_by_ui_order() {
+fn overlay_fields_are_ordered_by_declaration() {
     let quill = quill_from_yaml(QUILL);
     // Overlay touches `tag` (declared 2nd) and `author` (declared 1st); the
-    // result must still be ordered by ui.order, not overlay insertion order.
+    // result must still be in declaration order, not overlay insertion order.
     let ov = overlay(json!({ "tag": "pinned", "author": "Custom" }));
     let card = quill.seed_card("note", Some(&ov)).expect("known kind");
     let keys: Vec<&str> = card.payload().keys().map(String::as_str).collect();
     assert_eq!(keys, vec!["author", "tag"]);
+}
+
+#[test]
+fn overlay_added_field_lands_in_declaration_position() {
+    // The seed is driven by schema declaration order, so an overlay that adds a
+    // base-omitted field lands at its *declared* position, not appended last.
+    // Here `alpha` (no example, declared first) is base-omitted while `beta`
+    // (declared second) flows from its example; overlaying `alpha` must place
+    // it ahead of `beta`.
+    let quill = quill_from_yaml(
+        r#"
+quill:
+  name: order_seed
+  version: "1.0"
+  backend: typst
+  description: Seed order test
+card_kinds:
+  note:
+    fields:
+      alpha:
+        type: string
+      beta:
+        type: string
+        example: B
+"#,
+    );
+    let ov = overlay(json!({ "alpha": "A" }));
+    let card = quill.seed_card("note", Some(&ov)).expect("known kind");
+    let keys: Vec<&str> = card.payload().keys().map(String::as_str).collect();
+    assert_eq!(keys, vec!["alpha", "beta"]);
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1542,6 +1542,128 @@ main:
 }
 
 #[test]
+fn nested_object_properties_receive_positional_ui_order() {
+    // Properties render in declaration order, not the alphabetical order their
+    // `BTreeMap` storage would otherwise impose: `zulu` is declared first, so
+    // it sorts ahead of `alpha` despite the reversed alphabet.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        zulu: { type: string }
+        alpha: { type: string }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let props = config.main.fields["address"].properties.as_ref().unwrap();
+    assert_eq!(props["zulu"].ui_order(), 0);
+    assert_eq!(props["alpha"].ui_order(), 1);
+}
+
+#[test]
+fn typed_table_row_properties_receive_positional_ui_order() {
+    // The synthetic row of a typed table is an object built by the same
+    // `from_quill_value` recursion, so its properties get positional order too.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          org: { type: string }
+          year: { type: integer }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let props = config.main.fields["rows"].items.as_ref().unwrap();
+    let props = props.properties.as_ref().unwrap();
+    assert_eq!(props["org"].ui_order(), 0);
+    assert_eq!(props["year"].ui_order(), 1);
+}
+
+#[test]
+fn nested_property_explicit_ui_order_is_preserved() {
+    // An author-supplied `order` on a nested property is never overwritten; the
+    // sibling without one still receives its positional index.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street: { type: string, ui: { order: 5 } }
+        city: { type: string }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let props = config.main.fields["address"].properties.as_ref().unwrap();
+    assert_eq!(props["street"].ui_order(), 5);
+    assert_eq!(props["city"].ui_order(), 1);
+}
+
+#[test]
+fn ui_group_on_object_property_is_rejected() {
+    // `ui.group` clusters card-level fields only; on a typed-dictionary
+    // property it was silently inert, and now loads as a hard error.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street: { type: string, ui: { group: Location } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_group_not_supported")));
+}
+
+#[test]
+fn ui_group_on_typed_table_property_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          score: { type: number, ui: { group: Metrics } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::nested_group_not_supported")));
+}
+
+#[test]
+fn ui_group_on_card_level_field_is_still_accepted() {
+    // Regression guard: the nested-position rejection must not touch card-level
+    // fields, where grouping is the whole point.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    subject: { type: string, ui: { group: Addressing } }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    assert_eq!(
+        config.main.fields["subject"]
+            .ui
+            .as_ref()
+            .and_then(|u| u.group.as_deref()),
+        Some("Addressing")
+    );
+}
+
+#[test]
 fn test_array_items_recursive_coercion() {
     let yaml_content = r#"
 quill:

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1032,24 +1032,17 @@ main:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    // Check that fields have correct order based on TOML position
-    // Order is automatically generated based on field position
-
-    let first = config.main.fields.get("first").unwrap();
-    assert_eq!(first.ui.as_ref().unwrap().order, Some(0));
-
-    let second = config.main.fields.get("second").unwrap();
-    assert_eq!(second.ui.as_ref().unwrap().order, Some(1));
+    // Declaration order is display order, carried structurally by the field
+    // map — no stamped `ui.order` integer. Iterating the map yields the
+    // authored order.
+    let names: Vec<&str> = config.main.fields.keys().map(|k| k.as_str()).collect();
+    assert_eq!(names, ["first", "second", "third", "fourth"]);
 
     let third = config.main.fields.get("third").unwrap();
-    assert_eq!(third.ui.as_ref().unwrap().order, Some(2));
     assert_eq!(
         third.ui.as_ref().unwrap().group,
         Some("Test Group".to_string())
     );
-
-    let fourth = config.main.fields.get("fourth").unwrap();
-    assert_eq!(fourth.ui.as_ref().unwrap().order, Some(3));
 }
 
 #[test]
@@ -1075,7 +1068,9 @@ main:
     let author_field = &config.main.fields["author"];
     let ui = author_field.ui.as_ref().unwrap();
     assert_eq!(ui.group, Some("Author Info".to_string()));
-    assert_eq!(ui.order, Some(0)); // First field should have order 0
+    // Order is not a field-level knob; `author` leads because it is declared
+    // first in the field map.
+    assert_eq!(config.main.fields.get_index_of("author"), Some(0));
 }
 #[test]
 fn test_field_schema_with_description() {
@@ -1302,23 +1297,15 @@ card_kinds:
 
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
 
-    let first = config.main.fields.get("first").unwrap();
-    let zero = config.main.fields.get("zero").unwrap();
     let second = config.card_kind("second").unwrap();
 
-    // Check field ordering
-    let ord_first = first.ui.as_ref().unwrap().order.unwrap();
-    let ord_zero = zero.ui.as_ref().unwrap().order.unwrap();
+    // Within main.fields, "first" is declared before "zero"; the field map
+    // carries that order.
+    assert_eq!(config.main.fields.get_index_of("first"), Some(0));
+    assert_eq!(config.main.fields.get_index_of("zero"), Some(1));
 
-    // Within fields, "first" is before "zero"
-    assert!(ord_first < ord_zero);
-    assert_eq!(ord_first, 0);
-    assert_eq!(ord_zero, 1);
-
-    // Card fields should also have ordering
-    let card_field = second.fields.get("card_field").unwrap();
-    let ord_card_field = card_field.ui.as_ref().unwrap().order.unwrap();
-    assert_eq!(ord_card_field, 0); // First (and only) field in this card
+    // Card fields carry declaration order too.
+    assert_eq!(second.fields.get_index_of("card_field"), Some(0));
 }
 #[test]
 fn test_card_field_order_preservation() {
@@ -1347,17 +1334,9 @@ card_kinds:
     let config = QuillConfig::from_yaml(yaml_content).unwrap();
     let card = config.card_kind("mycard").unwrap();
 
-    let z_first = card.fields.get("z_first").unwrap();
-    let a_second = card.fields.get("a_second").unwrap();
-
-    // Check orders
-    let z_order = z_first.ui.as_ref().unwrap().order.unwrap();
-    let a_order = a_second.ui.as_ref().unwrap().order.unwrap();
-
-    // If strict file order is preserved:
-    // z_first should be 0, a_second should be 1
-    assert_eq!(z_order, 0, "z_first should be 0 (defined first)");
-    assert_eq!(a_order, 1, "a_second should be 1 (defined second)");
+    // Declaration order (z_first, then a_second) is preserved, not alphabetized.
+    let names: Vec<&str> = card.fields.keys().map(|k| k.as_str()).collect();
+    assert_eq!(names, ["z_first", "a_second"]);
 }
 #[test]
 fn test_nested_schema_parsing() {
@@ -1542,10 +1521,10 @@ main:
 }
 
 #[test]
-fn nested_object_properties_receive_positional_ui_order() {
-    // Properties render in declaration order, not the alphabetical order their
-    // `BTreeMap` storage would otherwise impose: `zulu` is declared first, so
-    // it sorts ahead of `alpha` despite the reversed alphabet.
+fn nested_object_properties_preserve_declaration_order() {
+    // Properties render in declaration order, not the alphabetical order a
+    // `BTreeMap` would impose: `zulu` is declared first, so it leads `alpha`
+    // despite the reversed alphabet. The `IndexMap` carries the order.
     let yaml = r#"
 quill: { name: x, version: "1.0", backend: typst, description: x }
 main:
@@ -1558,14 +1537,14 @@ main:
 "#;
     let config = QuillConfig::from_yaml(yaml).unwrap();
     let props = config.main.fields["address"].properties.as_ref().unwrap();
-    assert_eq!(props["zulu"].ui_order(), 0);
-    assert_eq!(props["alpha"].ui_order(), 1);
+    let names: Vec<&str> = props.keys().map(|k| k.as_str()).collect();
+    assert_eq!(names, ["zulu", "alpha"]);
 }
 
 #[test]
-fn typed_table_row_properties_receive_positional_ui_order() {
+fn typed_table_row_properties_preserve_declaration_order() {
     // The synthetic row of a typed table is an object built by the same
-    // `from_quill_value` recursion, so its properties get positional order too.
+    // `from_quill_value` recursion, so its properties keep declaration order too.
     let yaml = r#"
 quill: { name: x, version: "1.0", backend: typst, description: x }
 main:
@@ -1581,14 +1560,15 @@ main:
     let config = QuillConfig::from_yaml(yaml).unwrap();
     let props = config.main.fields["rows"].items.as_ref().unwrap();
     let props = props.properties.as_ref().unwrap();
-    assert_eq!(props["org"].ui_order(), 0);
-    assert_eq!(props["year"].ui_order(), 1);
+    let names: Vec<&str> = props.keys().map(|k| k.as_str()).collect();
+    assert_eq!(names, ["org", "year"]);
 }
 
 #[test]
-fn nested_property_explicit_ui_order_is_preserved() {
-    // An author-supplied `order` on a nested property is never overwritten; the
-    // sibling without one still receives its positional index.
+fn authored_ui_order_on_nested_property_is_rejected() {
+    // `ui.order` is retired: display order is declaration order. An authored
+    // `order` on any field — nested or top-level — is a hard load error with
+    // the migration message.
     let yaml = r#"
 quill: { name: x, version: "1.0", backend: typst, description: x }
 main:
@@ -1599,10 +1579,35 @@ main:
         street: { type: string, ui: { order: 5 } }
         city: { type: string }
 "#;
-    let config = QuillConfig::from_yaml(yaml).unwrap();
-    let props = config.main.fields["address"].properties.as_ref().unwrap();
-    assert_eq!(props["street"].ui_order(), 5);
-    assert_eq!(props["city"].ui_order(), 1);
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("ui.order is no longer accepted")),
+        "expected ui.order rejection, got: {err:?}"
+    );
+}
+
+#[test]
+fn authored_ui_order_on_card_field_is_rejected() {
+    // Same rejection at card level, with an actionable hint.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    title: { type: string, ui: { order: 3 } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    let hit = err
+        .iter()
+        .find(|d| d.message.contains("ui.order is no longer accepted"))
+        .expect("expected ui.order rejection");
+    assert!(
+        hit.hint
+            .as_deref()
+            .is_some_and(|h| h.contains("reorder the fields")),
+        "expected migration hint, got: {:?}",
+        hit.hint
+    );
 }
 
 #[test]
@@ -2338,9 +2343,11 @@ main:
     assert_eq!(summary.r#type, FieldType::RichText { inline: false });
     assert_eq!(summary.ui.as_ref().unwrap().multiline, Some(true));
 
+    // A field with no authored `ui:` block now carries `ui: None` — order is
+    // no longer stamped, so nothing fabricates a `ui` block.
     let notes = config.main.fields.get("notes").unwrap();
     assert_eq!(notes.r#type, FieldType::RichText { inline: false });
-    assert_eq!(notes.ui.as_ref().unwrap().multiline, None);
+    assert!(notes.ui.is_none());
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1671,8 +1671,8 @@ main:
 #[test]
 fn group_registry_list_form_orders_blueprint_by_declaration() {
     // The registry declares `beta` before `alpha`, but a field references
-    // `alpha` first (lower ui.order). Clustering must follow registry order
-    // (beta, then alpha), not first-appearance order.
+    // `alpha` first (earlier in declaration order). Clustering must follow
+    // registry order (beta, then alpha), not first-appearance order.
     let yaml = r#"
 quill: { name: x, version: "1.0", backend: typst, description: x }
 main:

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1664,6 +1664,163 @@ main:
 }
 
 #[test]
+fn group_registry_list_form_orders_blueprint_by_declaration() {
+    // The registry declares `beta` before `alpha`, but a field references
+    // `alpha` first (lower ui.order). Clustering must follow registry order
+    // (beta, then alpha), not first-appearance order.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [beta, alpha]
+  fields:
+    a1: { type: string, ui: { group: alpha } }
+    b1: { type: string, ui: { group: beta } }
+"#;
+    let bp = QuillConfig::from_yaml(yaml).unwrap().blueprint();
+    let a = bp.find("a1:").unwrap();
+    let b = bp.find("b1:").unwrap();
+    assert!(b < a, "registry order (beta<alpha) must drive clustering:\n{bp}");
+}
+
+#[test]
+fn group_registry_map_form_carries_title_override() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups:
+      addressing: {}
+      letterhead: { title: "Letterhead & Seal" }
+  fields:
+    a: { type: string, ui: { group: addressing } }
+    l: { type: string, ui: { group: letterhead } }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let reg = &config.main.ui.as_ref().unwrap().groups.as_ref().unwrap().0;
+    assert_eq!(reg.len(), 2);
+    assert_eq!(reg[0].id, "addressing");
+    assert_eq!(reg[0].title, None);
+    assert_eq!(reg[1].id, "letterhead");
+    assert_eq!(reg[1].title.as_deref(), Some("Letterhead & Seal"));
+}
+
+#[test]
+fn unknown_group_reference_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [addressing]
+  fields:
+    subject: { type: string, ui: { group: letterhead } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::unknown_group")));
+}
+
+#[test]
+fn implicit_group_without_registry_warns() {
+    // No registry + a field group is the deprecated implicit-group form.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  fields:
+    subject: { type: string, ui: { group: Addressing } }
+"#;
+    let (_config, warnings) = QuillConfig::from_yaml_with_warnings(yaml).unwrap();
+    assert!(warnings
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::implicit_group")));
+}
+
+#[test]
+fn duplicate_group_id_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [addressing, addressing]
+  fields:
+    subject: { type: string, ui: { group: addressing } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::duplicate_group")));
+}
+
+#[test]
+fn non_snake_case_group_id_is_rejected() {
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [Addressing]
+  fields:
+    subject: { type: string, ui: { group: Addressing } }
+"#;
+    let err = QuillConfig::from_yaml_with_warnings(yaml).unwrap_err();
+    assert!(err
+        .iter()
+        .any(|d| d.code.as_deref() == Some("quill::invalid_group_id")));
+}
+
+#[test]
+fn group_registry_round_trips_through_serde_and_schema() {
+    // List-form input normalizes to the canonical map form on emit, preserving
+    // declaration order, and re-parses to the identical registry.
+    let yaml = r#"
+quill: { name: x, version: "1.0", backend: typst, description: x }
+main:
+  ui:
+    groups: [addressing, letterhead]
+  fields:
+    a: { type: string, ui: { group: addressing } }
+    l: { type: string, ui: { group: letterhead } }
+"#;
+    let config = QuillConfig::from_yaml(yaml).unwrap();
+    let ui = config.main.ui.clone().unwrap();
+    let json = serde_json::to_value(&ui).unwrap();
+    let back: UiCardSchema = serde_json::from_value(json).unwrap();
+    assert_eq!(ui, back, "registry must survive emit → parse");
+
+    // Emission carries order (preserve_order) and titles are omitted when derived.
+    let schema = config.schema();
+    let groups = schema["main"]["ui"]["groups"].as_object().unwrap();
+    let keys: Vec<&str> = groups.keys().map(String::as_str).collect();
+    assert_eq!(keys, ["addressing", "letterhead"]);
+    assert!(groups["addressing"].as_object().unwrap().is_empty());
+}
+
+#[test]
+fn migrated_group_fixtures_declare_registries_and_do_not_warn() {
+    for name in ["usaf_memo/0.2.0", "cmu_letter/0.1.0", "classic_resume/0.1.0"] {
+        let path = quillmark_fixtures::resource_path(&format!("quills/{name}/Quill.yaml"));
+        let yaml = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {name}: {e}"));
+        let (config, warnings) = QuillConfig::from_yaml_with_warnings(&yaml)
+            .unwrap_or_else(|e| panic!("{name} must load: {e:?}"));
+        assert!(
+            !warnings
+                .iter()
+                .any(|d| d.code.as_deref() == Some("quill::implicit_group")),
+            "{name} still emits implicit_group: {warnings:?}"
+        );
+        assert!(
+            config
+                .main
+                .ui
+                .as_ref()
+                .and_then(|u| u.groups.as_ref())
+                .is_some(),
+            "{name} main should declare a group registry"
+        );
+    }
+}
+
+#[test]
 fn test_array_items_recursive_coercion() {
     let yaml_content = r#"
 quill:

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -425,22 +425,14 @@ impl FieldSchema {
     /// they are built (`from_quill_value`), so `ui_order()` is meaningful at
     /// every depth. Never overrides an author-supplied `order`.
     pub(crate) fn set_ui_order_if_unset(&mut self, order: i32) {
-        match &mut self.ui {
-            Some(ui) => {
-                if ui.order.is_none() {
-                    ui.order = Some(order);
-                }
-            }
-            None => {
-                self.ui = Some(UiFieldSchema {
-                    title: None,
-                    group: None,
-                    order: Some(order),
-                    compact: None,
-                    multiline: None,
-                });
-            }
-        }
+        let ui = self.ui.get_or_insert(UiFieldSchema {
+            title: None,
+            group: None,
+            order: None,
+            compact: None,
+            multiline: None,
+        });
+        ui.order.get_or_insert(order);
     }
 
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -309,6 +309,30 @@ impl FieldSchema {
         self.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX)
     }
 
+    /// Stamp `order` onto `ui.order` when the author left it unset, creating the
+    /// `ui` block if absent. Positional ordering derived from declaration order
+    /// — applied at card level by the loader and to nested object properties as
+    /// they are built (`from_quill_value`), so `ui_order()` is meaningful at
+    /// every depth. Never overrides an author-supplied `order`.
+    pub(crate) fn set_ui_order_if_unset(&mut self, order: i32) {
+        match &mut self.ui {
+            Some(ui) => {
+                if ui.order.is_none() {
+                    ui.order = Some(order);
+                }
+            }
+            None => {
+                self.ui = Some(UiFieldSchema {
+                    title: None,
+                    group: None,
+                    order: Some(order),
+                    compact: None,
+                    multiline: None,
+                });
+            }
+        }
+    }
+
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {
         Self {
             name,
@@ -347,14 +371,16 @@ impl FieldSchema {
             enum_values,
             properties: if let Some(props) = def.properties {
                 let mut p = BTreeMap::new();
-                for (key, value) in props {
-                    p.insert(
-                        key.clone(),
-                        Box::new(FieldSchema::from_quill_value(
-                            key,
-                            &QuillValue::from_json(value),
-                        )?),
-                    );
+                // Declaration order (preserved by serde_json's `preserve_order`)
+                // assigns each property a positional `ui.order`, mirroring the
+                // card-level pass in `parse_fields_with_order`. Without this,
+                // properties live in a `BTreeMap` and would render alphabetically,
+                // discarding authored order one nesting level down.
+                for (index, (key, value)) in props.into_iter().enumerate() {
+                    let mut prop =
+                        FieldSchema::from_quill_value(key.clone(), &QuillValue::from_json(value))?;
+                    prop.set_ui_order_if_unset(index as i32);
+                    p.insert(key, Box::new(prop));
                 }
                 Some(p)
             } else {

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -53,6 +53,116 @@ pub struct UiCardSchema {
     /// template. See `docs/quills/quill-yaml-reference.md`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// The card's group registry: the visible table of contents that names
+    /// every group a field may reference and fixes their display order. A
+    /// field's `ui.group` is a *reference* into this registry, validated at
+    /// load. Absent when the card declares no groups (or uses the deprecated
+    /// implicit-group form).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<GroupRegistry>,
+}
+
+/// One entry in a card's [`GroupRegistry`]: a snake_case identity plus an
+/// optional display-label override. The `id` decouples identity from label the
+/// same way a field's snake_case key decouples from its `ui.title` — a rename
+/// of the label touches one line and never breaks a `ui.group` reference or
+/// persisted per-group editor state. When `title` is `None`, consumers derive
+/// the label from `id` (`memo_for` → "Memo For"), exactly as they derive a
+/// field label from its key.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupSchema {
+    /// snake_case identity; rides the registry map key (or list item) on the wire.
+    pub id: String,
+    /// Display-label override; `None` means derive the label from `id`.
+    pub title: Option<String>,
+}
+
+/// A card's ordered group registry (`main.ui.groups` or a card kind's
+/// `ui.groups`). Declaration order **is** display order — the same contract
+/// field declaration order gives `ui.order` — so it is held as a `Vec` that
+/// survives regardless of surface form. Authored as either a sequence of ids
+/// (`[addressing, letterhead]`, titles derived) or a mapping of id to
+/// attributes (`{ letterhead: { title: … } }`, for label overrides); both fold
+/// into the same ordered list. Serializes back to the canonical mapping form,
+/// declaration order preserved.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupRegistry(pub Vec<GroupSchema>);
+
+/// The attribute block of a registry entry in the mapping authoring/emission
+/// form (`id: { title: … }`). A bare `id:` (null) or `id: {}` carries no
+/// override.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GroupEntryDef {
+    title: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for GroupRegistry {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct RegistryVisitor;
+        impl<'de> serde::de::Visitor<'de> for RegistryVisitor {
+            type Value = GroupRegistry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a sequence of group ids or a mapping of group id to attributes")
+            }
+
+            // Sequence form: `[addressing, letterhead]` — bare ids, titles derived.
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<GroupRegistry, A::Error> {
+                let mut groups = Vec::new();
+                while let Some(id) = seq.next_element::<String>()? {
+                    groups.push(GroupSchema { id, title: None });
+                }
+                Ok(GroupRegistry(groups))
+            }
+
+            // Mapping form: `{ addressing: {}, letterhead: { title: … } }`.
+            // A null or `{}` value carries no override; declaration order is
+            // preserved by serde_json's `preserve_order`.
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<GroupRegistry, A::Error> {
+                let mut groups = Vec::new();
+                while let Some((id, def)) = map.next_entry::<String, Option<GroupEntryDef>>()? {
+                    groups.push(GroupSchema {
+                        id,
+                        title: def.and_then(|d| d.title),
+                    });
+                }
+                Ok(GroupRegistry(groups))
+            }
+        }
+        deserializer.deserialize_any(RegistryVisitor)
+    }
+}
+
+impl Serialize for GroupRegistry {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        // Canonical form: the mapping, so a title override has a home and the
+        // registry key (identity) is explicit. A title-less entry emits an
+        // empty object; the map's declaration order carries the display-order
+        // contract on the wire.
+        #[derive(Serialize)]
+        struct GroupEntryOut<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            title: Option<&'a str>,
+        }
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for group in &self.0 {
+            map.serialize_entry(
+                &group.id,
+                &GroupEntryOut {
+                    title: group.title.as_deref(),
+                },
+            )?;
+        }
+        map.end()
+    }
 }
 
 /// Schema definition for a card kind (composable content blocks)

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -1,27 +1,63 @@
 //! Quill schema and core type definitions.
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::value::QuillValue;
 
-/// UI-specific metadata for field rendering
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+/// UI-specific metadata for field rendering.
+///
+/// Field display order is not a `ui` knob: declaration order in Quill.yaml
+/// **is** display order, carried structurally by the schema's ordered field
+/// maps ([`CardSchema::fields`], [`FieldSchema::properties`]) and by key order
+/// on the emitted-schema wire. The retired `ui.order` key is rejected with a
+/// pointed message (see [`UI_ORDER_REMOVED_MSG`]).
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UiFieldSchema {
     /// Display label for the field — decoupled from the snake_case wire key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
-    /// Automatically generated based on field position in Quill.yaml.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compact: Option<bool>,
     /// Valid on `string` fields (plain text with newlines preserved) and `richtext` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiline: Option<bool>,
+}
+
+/// Migration message for the retired `ui.order` key — shared by the
+/// [`UiFieldSchema`] deserializer's error and `QuillConfig::field_parse_hint`'s
+/// hint text, so the two can't drift.
+pub(crate) const UI_ORDER_REMOVED_MSG: &str = "ui.order is no longer accepted; \
+     field display order is declaration order — reorder the fields in Quill.yaml instead";
+
+/// Wire shape of a `ui:` block. `order` is declared so its rejection carries
+/// the migration message rather than serde's generic unknown-key error.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UiFieldSchemaDef {
+    title: Option<String>,
+    group: Option<String>,
+    order: Option<serde_json::Value>,
+    compact: Option<bool>,
+    multiline: Option<bool>,
+}
+
+impl<'de> Deserialize<'de> for UiFieldSchema {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let def = UiFieldSchemaDef::deserialize(deserializer)?;
+        if def.order.is_some() {
+            return Err(serde::de::Error::custom(UI_ORDER_REMOVED_MSG));
+        }
+        Ok(UiFieldSchema {
+            title: def.title,
+            group: def.group,
+            compact: def.compact,
+            multiline: def.multiline,
+        })
+    }
 }
 
 /// Body namespace configuration for a card kind
@@ -79,7 +115,7 @@ pub struct GroupSchema {
 
 /// A card's ordered group registry (`main.ui.groups` or a card kind's
 /// `ui.groups`). Declaration order **is** display order — the same contract
-/// field declaration order gives `ui.order` — so it is held as a `Vec` that
+/// fields carry through their ordered map — so it is held as a `Vec` that
 /// survives regardless of surface form. Authored as either a sequence of ids
 /// (`[addressing, letterhead]`, titles derived) or a mapping of id to
 /// attributes (`{ letterhead: { title: … } }`, for label overrides); both fold
@@ -173,7 +209,10 @@ pub struct CardSchema {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub fields: BTreeMap<String, FieldSchema>,
+    /// Declaration order is display order: the map preserves Quill.yaml key
+    /// order end-to-end (parse, iteration, `schema()` emission), so ordering
+    /// needs no side-channel knob.
+    pub fields: IndexMap<String, FieldSchema>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiCardSchema>,
     /// Controls whether a body editor is shown and provides optional guide text.
@@ -367,8 +406,9 @@ pub struct FieldSchema {
     /// Restricts valid values on string fields. Serializes as `enum`.
     pub enum_values: Option<Vec<String>>,
     /// Nested field schemas for `object` types (the typed dictionary's
-    /// properties).
-    pub properties: Option<BTreeMap<String, Box<FieldSchema>>>,
+    /// properties). Ordered: declaration order is display order at every
+    /// nesting level, carried by the map itself.
+    pub properties: Option<IndexMap<String, Box<FieldSchema>>>,
     /// Element schema for `array` types. Required on every `array` field:
     /// the element type gives the array a concrete element type (`string[]`,
     /// `integer[]`, `richtext[]`, …). For a typed table the element is an
@@ -412,29 +452,6 @@ struct FieldSchemaDef {
 }
 
 impl FieldSchema {
-    /// Sort key for blueprint/form/seed field ordering: `ui.order` when set,
-    /// else `i32::MAX` (declaration order is assigned to `ui.order` at parse
-    /// time, so the fallback is defensive). The one shared ordering producer.
-    pub fn ui_order(&self) -> i32 {
-        self.ui.as_ref().and_then(|u| u.order).unwrap_or(i32::MAX)
-    }
-
-    /// Stamp `order` onto `ui.order` when the author left it unset, creating the
-    /// `ui` block if absent. Positional ordering derived from declaration order
-    /// — applied at card level by the loader and to nested object properties as
-    /// they are built (`from_quill_value`), so `ui_order()` is meaningful at
-    /// every depth. Never overrides an author-supplied `order`.
-    pub(crate) fn set_ui_order_if_unset(&mut self, order: i32) {
-        let ui = self.ui.get_or_insert(UiFieldSchema {
-            title: None,
-            group: None,
-            order: None,
-            compact: None,
-            multiline: None,
-        });
-        ui.order.get_or_insert(order);
-    }
-
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {
         Self {
             name,
@@ -472,16 +489,13 @@ impl FieldSchema {
             ui: def.ui,
             enum_values,
             properties: if let Some(props) = def.properties {
-                let mut p = BTreeMap::new();
                 // Declaration order (preserved by serde_json's `preserve_order`)
-                // assigns each property a positional `ui.order`, mirroring the
-                // card-level pass in `parse_fields_with_order`. Without this,
-                // properties live in a `BTreeMap` and would render alphabetically,
-                // discarding authored order one nesting level down.
-                for (index, (key, value)) in props.into_iter().enumerate() {
-                    let mut prop =
+                // carries straight into the `IndexMap`, so nested properties
+                // render in authored order at every depth.
+                let mut p = IndexMap::new();
+                for (key, value) in props {
+                    let prop =
                         FieldSchema::from_quill_value(key.clone(), &QuillValue::from_json(value))?;
-                    prop.set_ui_order_if_unset(index as i32);
                     p.insert(key, Box::new(prop));
                 }
                 Some(p)

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -12,7 +12,7 @@ use crate::value::QuillValue;
 /// **is** display order, carried structurally by the schema's ordered field
 /// maps ([`CardSchema::fields`], [`FieldSchema::properties`]) and by key order
 /// on the emitted-schema wire. The retired `ui.order` key is rejected with a
-/// pointed message (see [`UI_ORDER_REMOVED_MSG`]).
+/// pointed message (`UI_ORDER_REMOVED_MSG`).
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UiFieldSchema {
     /// Display label for the field — decoupled from the snake_case wire key.

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -23,7 +23,7 @@
 //! cannot cross a binding boundary that carries no lifetimes (wasm-bindgen /
 //! pyo3 objects); those surfaces construct one per call from the quill handle.
 
-use std::collections::BTreeMap;
+use indexmap::IndexMap;
 
 use crate::document::edit::resolve_field_write;
 use crate::document::{Card, Document, EditError};
@@ -186,7 +186,7 @@ impl CardWriter<'_> {
 /// `set`'s reject-the-typo decision.
 fn set_all_impl<K, V, I>(
     card: &mut Card,
-    fields_schema: Option<&BTreeMap<String, FieldSchema>>,
+    fields_schema: Option<&IndexMap<String, FieldSchema>>,
     fields: I,
 ) -> Result<(), Vec<(String, EditError)>>
 where

--- a/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/classic_resume/0.1.0/Quill.yaml
@@ -8,12 +8,14 @@ typst:
   plate_file: plate.typ
 
 main:
+  ui:
+    groups: [personal_info]
   fields:
     name:
       type: string
       example: John Doe
       ui:
-        group: Personal Info
+        group: personal_info
 
     contacts:
       type: array
@@ -24,7 +26,7 @@ main:
         - 123-456-7890
         - linkedin.com/in/johndoe
       ui:
-        group: Personal Info
+        group: personal_info
       description: List of contact details (email, phone, links, etc.)
 
 card_kinds:

--- a/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/cmu_letter/0.1.0/Quill.yaml
@@ -8,6 +8,8 @@ typst:
   plate_file: plate.typ
 
 main:
+  ui:
+    groups: [essentials, letterhead, advanced]
   fields:
     recipient:
       type: array
@@ -18,7 +20,7 @@ main:
         - 123 Main St
         - Anytown, USA
       ui:
-        group: Essentials
+        group: essentials
       description: The recipient's name and full mailing address.
 
     signature_block:
@@ -29,7 +31,7 @@ main:
         - First M. Last
         - Title
       ui:
-        group: Essentials
+        group: essentials
       description: "The signer's information. Line 1: Name. Line 2: Title."
 
     department:
@@ -37,7 +39,7 @@ main:
       default: ""
       example: Department of Electrical and Computer Engineering
       ui:
-        group: Letterhead
+        group: letterhead
       description: The department or organizational unit name for the letterhead.
 
     address:
@@ -48,7 +50,7 @@ main:
         - 5000 Forbes Avenue
         - Pittsburgh, PA 15213-3890
       ui:
-        group: Letterhead
+        group: letterhead
       description: The sender's institutional mailing address.
 
     url:
@@ -56,11 +58,11 @@ main:
       default: ""
       example: www.ece.cmu.edu
       ui:
-        group: Letterhead
+        group: letterhead
       description: The department or university website URL.
 
     date:
       type: datetime
       ui:
-        group: Advanced
+        group: advanced
       description: The date to appear on the letter.

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -8,6 +8,8 @@ typst:
   plate_file: plate.typ
 
 main:
+  ui:
+    groups: [addressing, letterhead, classification, additional]
   body:
     example: |
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.
@@ -22,7 +24,7 @@ main:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
       ui:
-        group: Addressing
+        group: addressing
       description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For many recipients, enter 'SEE DISTRIBUTION' and list them in the Distribution field."
 
     memo_from:
@@ -36,7 +38,7 @@ main:
         - 123 Street Ave
         - City ST 12345-6789
       ui:
-        group: Addressing
+        group: addressing
       description: "If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence. Omit entirely to produce a Memorandum for Record (no MEMO FROM line)."
 
     subject:
@@ -44,7 +46,7 @@ main:
       inline: true
       example: Subject of the Memorandum
       ui:
-        group: Addressing
+        group: addressing
       description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
 
     signature_block:
@@ -55,14 +57,14 @@ main:
         - "FIRST M. LAST, Rank, USAF"
         - Duty Title
       ui:
-        group: Addressing
+        group: addressing
       description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
 
     letterhead_title:
       type: string
       default: DEPARTMENT OF THE AIR FORCE
       ui:
-        group: Letterhead
+        group: letterhead
       description: Change only for Joint Commands or DoW agencies.
 
     letterhead_caption:
@@ -72,7 +74,7 @@ main:
       example:
         - HEADQUARTERS [UNIT NAME]
       ui:
-        group: Letterhead
+        group: letterhead
       description: The full organization name of your unit.
 
     letterhead_seal:
@@ -82,7 +84,7 @@ main:
         - dod
       default: dow
       ui:
-        group: Letterhead
+        group: letterhead
         compact: true
       description: Department of War (DoW) or Department of Defense (DoD) seal shown in the letterhead.
 
@@ -90,7 +92,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         compact: true
       description: Bold-caps line below the seal; blank to omit.
 
@@ -99,7 +101,7 @@ main:
       inline: true
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         compact: true
       description: "Organizational motto at the bottom of the page. Supports Markdown emphasis (e.g. *italics*, **bold**)."
 
@@ -114,7 +116,7 @@ main:
         - TOP SECRET
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Select the classification marking shown in the header and footer banner. Unclassified documents typically omit this banner entirely — leave blank unless the document is CUI or classified. Mark per DAFI 16-1404 (DoDM 5200.48 for CUI) and applicable DoD guidance."
 
@@ -122,7 +124,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Banner dissemination suffix appended after double slash (e.g. 'NF' renders as CUI//NF in the header/footer). Leave blank for no suffix."
 
@@ -130,7 +132,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Office or organization that designated this information as CUI (e.g., 'SAF/AA'). Required by DoDM 5200.48 when classification is CUI."
 
@@ -138,7 +140,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY'). Leave blank to omit."
 
@@ -146,7 +148,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Limited dissemination control shown in the indicator block (e.g., 'FEDONLY', 'NOFORN'). Independent from the banner suffix above."
 
@@ -154,7 +156,7 @@ main:
       type: string
       default: ""
       ui:
-        group: Classification
+        group: classification
         compact: true
       description: "Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234, john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI."
 
@@ -168,7 +170,7 @@ main:
         - "AFMAN 33-326, 25 November 2011, *Preparing Official Communications*"
         - "AFI 33-360, *Publications and Forms Management*"
       ui:
-        group: Additional
+        group: additional
       description: "References, auto-lettered (a), (b), (c) per AFH 33-337. Cite each by organization, type, date, and title; italicize publication titles with *asterisks* (standard Markdown emphasis)."
 
     cc:
@@ -179,7 +181,7 @@ main:
       example:
         - Rank and Name, ORG/SYMBOL
       ui:
-        group: Additional
+        group: additional
       description: List office symbols of recipients to receive copies.
 
     distribution:
@@ -191,7 +193,7 @@ main:
         - ORG1/SYMBOL
         - ORG2/SYMBOL
       ui:
-        group: Additional
+        group: additional
       description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
 
     attachments:
@@ -202,7 +204,7 @@ main:
       example:
         - Attachment description, YYYY MMM DD
       ui:
-        group: Additional
+        group: additional
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
     memo_style:
@@ -212,7 +214,7 @@ main:
         - daf
       default: usaf
       ui:
-        group: Additional
+        group: additional
         compact: true
       description: "USAF memorandum or DAF headquarters memorandum; DAF changes date format and body paragraph layout per AFH 33-337."
 
@@ -220,7 +222,7 @@ main:
       type: number
       default: 12
       ui:
-        group: Additional
+        group: additional
         compact: true
       description: Body text size in points; decimals allowed (e.g. 11.5).
 
@@ -228,7 +230,7 @@ main:
       type: datetime
       default: ""
       ui:
-        group: Additional
+        group: additional
         compact: true
       description: YYYY-MM-DD. Leave blank to use today's date.
 
@@ -237,18 +239,19 @@ card_kinds:
     description: Chain of routing endorsements. Each endorsement block adds an official response or forwarding action to the original memo.
     ui:
       title: Routing indorsement
+      groups: [addressing, additional]
     fields:
       from:
         type: string
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
         description: Office symbol or Rank Name of the endorsing official.
       for:
         type: string
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
         description: Office symbol or organization receiving the endorsed memo.
       signature_block:
         type: array
@@ -258,7 +261,7 @@ card_kinds:
           - "FIRST M. LAST, Rank, USAF"
           - Duty Title
         ui:
-          group: Addressing
+          group: addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
       format:
         type: string
@@ -268,7 +271,7 @@ card_kinds:
           - separate_page
         default: standard
         ui:
-          group: Additional
+          group: additional
           compact: true
         description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
       action:
@@ -280,13 +283,13 @@ card_kinds:
           - disapprove
         default: ""
         ui:
-          group: Additional
+          group: additional
           compact: true
         description: "Action taken by the endorser. Leave blank to hide the Approve/Disapprove line entirely, 'undecided' to display the line with neither option circled, 'approve' or 'disapprove' to circle the selected option."
       date:
         type: datetime
         default: ""
         ui:
-          group: Additional
+          group: additional
           compact: true
         description: "YYYY-MM-DD. Date the endorser signs/forwards the memo (per AFH 33-337 Ch. 14, this is distinct from the originating memo's date). Leave blank to render a fill-in line for the endorser to date by hand when signing."

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -9,7 +9,7 @@ main:
       example:
       - Attachment description, YYYY MMM DD
       ui:
-        group: Additional
+        group: additional
         order: 18
       items:
         type: string
@@ -20,7 +20,7 @@ main:
       example:
       - Rank and Name, ORG/SYMBOL
       ui:
-        group: Additional
+        group: additional
         order: 16
       items:
         type: string
@@ -33,7 +33,7 @@ main:
         applicable DoD guidance.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 9
         compact: true
       enum:
@@ -50,7 +50,7 @@ main:
         Leave blank to omit.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 12
         compact: true
     cui_controlled_by:
@@ -60,7 +60,7 @@ main:
         'SAF/AA'). Required by DoDM 5200.48 when classification is CUI.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 11
         compact: true
     cui_limited_dissemination:
@@ -70,7 +70,7 @@ main:
         'NOFORN'). Independent from the banner suffix above.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 13
         compact: true
     cui_poc:
@@ -80,7 +80,7 @@ main:
         john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 14
         compact: true
     date:
@@ -88,7 +88,7 @@ main:
       description: YYYY-MM-DD. Leave blank to use today's date.
       default: ""
       ui:
-        group: Additional
+        group: additional
         order: 21
         compact: true
     dissemination:
@@ -98,7 +98,7 @@ main:
         CUI//NF in the header/footer). Leave blank for no suffix.
       default: ""
       ui:
-        group: Classification
+        group: classification
         order: 10
         compact: true
     distribution:
@@ -111,7 +111,7 @@ main:
       - ORG1/SYMBOL
       - ORG2/SYMBOL
       ui:
-        group: Additional
+        group: additional
         order: 17
       items:
         type: string
@@ -120,7 +120,7 @@ main:
       description: Body text size in points; decimals allowed (e.g. 11.5).
       default: 12
       ui:
-        group: Additional
+        group: additional
         order: 20
         compact: true
     letterhead_caption:
@@ -129,7 +129,7 @@ main:
       example:
       - HEADQUARTERS [UNIT NAME]
       ui:
-        group: Letterhead
+        group: letterhead
         order: 5
       items:
         type: string
@@ -140,7 +140,7 @@ main:
         letterhead.
       default: dow
       ui:
-        group: Letterhead
+        group: letterhead
         order: 6
         compact: true
       enum:
@@ -151,7 +151,7 @@ main:
       description: Bold-caps line below the seal; blank to omit.
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         order: 7
         compact: true
     letterhead_title:
@@ -159,7 +159,7 @@ main:
       description: Change only for Joint Commands or DoW agencies.
       default: DEPARTMENT OF THE AIR FORCE
       ui:
-        group: Letterhead
+        group: letterhead
         order: 4
     memo_for:
       type: array
@@ -171,7 +171,7 @@ main:
       - ORG1/SYMBOL
       - ORG2/SYMBOL
       ui:
-        group: Addressing
+        group: addressing
         order: 0
       items:
         type: string
@@ -189,7 +189,7 @@ main:
       - 123 Street Ave
       - City ST 12345-6789
       ui:
-        group: Addressing
+        group: addressing
         order: 1
       items:
         type: string
@@ -200,7 +200,7 @@ main:
         body paragraph layout per AFH 33-337.
       default: usaf
       ui:
-        group: Additional
+        group: additional
         order: 19
         compact: true
       enum:
@@ -217,7 +217,7 @@ main:
       - AFMAN 33-326, 25 November 2011, *Preparing Official Communications*
       - AFI 33-360, *Publications and Forms Management*
       ui:
-        group: Additional
+        group: additional
         order: 15
       items:
         type: richtext
@@ -229,7 +229,7 @@ main:
       - FIRST M. LAST, Rank, USAF
       - Duty Title
       ui:
-        group: Addressing
+        group: addressing
         order: 3
       items:
         type: string
@@ -241,7 +241,7 @@ main:
         applicable.
       example: Subject of the Memorandum
       ui:
-        group: Addressing
+        group: addressing
         order: 2
       inline: true
     tag_line:
@@ -251,10 +251,16 @@ main:
         (e.g. *italics*, **bold**).
       default: ""
       ui:
-        group: Letterhead
+        group: letterhead
         order: 8
         compact: true
       inline: true
+  ui:
+    groups:
+      addressing: {}
+      letterhead: {}
+      classification: {}
+      additional: {}
   body:
     example: |
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.
@@ -274,7 +280,7 @@ card_kinds:
           or 'disapprove' to circle the selected option.
         default: ""
         ui:
-          group: Additional
+          group: additional
           order: 4
           compact: true
         enum:
@@ -290,7 +296,7 @@ card_kinds:
           fill-in line for the endorser to date by hand when signing.
         default: ""
         ui:
-          group: Additional
+          group: additional
           order: 5
           compact: true
       for:
@@ -298,14 +304,14 @@ card_kinds:
         description: Office symbol or organization receiving the endorsed memo.
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
           order: 1
       format:
         type: string
         description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
         default: standard
         ui:
-          group: Additional
+          group: additional
           order: 3
           compact: true
         enum:
@@ -317,7 +323,7 @@ card_kinds:
         description: Office symbol or Rank Name of the endorsing official.
         example: ORG/SYMBOL
         ui:
-          group: Addressing
+          group: addressing
           order: 0
       signature_block:
         type: array
@@ -326,9 +332,12 @@ card_kinds:
         - FIRST M. LAST, Rank, USAF
         - Duty Title
         ui:
-          group: Addressing
+          group: addressing
           order: 2
         items:
           type: string
     ui:
       title: Routing indorsement
+      groups:
+        addressing: {}
+        additional: {}

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -1,166 +1,5 @@
 main:
   fields:
-    attachments:
-      type: array
-      description: >-
-        List attachments in the order they are mentioned in the memo. Briefly describe
-        each; do not use 'as stated' or abbreviations.
-      default: []
-      example:
-      - Attachment description, YYYY MMM DD
-      ui:
-        group: additional
-        order: 18
-      items:
-        type: string
-    cc:
-      type: array
-      description: List office symbols of recipients to receive copies.
-      default: []
-      example:
-      - Rank and Name, ORG/SYMBOL
-      ui:
-        group: additional
-        order: 16
-      items:
-        type: string
-    classification:
-      type: string
-      description: >-
-        Select the classification marking shown in the header and footer banner.
-        Unclassified documents typically omit this banner entirely — leave blank unless the
-        document is CUI or classified. Mark per DAFI 16-1404 (DoDM 5200.48 for CUI) and
-        applicable DoD guidance.
-      default: ""
-      ui:
-        group: classification
-        order: 9
-        compact: true
-      enum:
-      - ""
-      - UNCLASSIFIED
-      - CUI
-      - CONFIDENTIAL
-      - SECRET
-      - TOP SECRET
-    cui_category:
-      type: string
-      description: >-
-        CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY').
-        Leave blank to omit.
-      default: ""
-      ui:
-        group: classification
-        order: 12
-        compact: true
-    cui_controlled_by:
-      type: string
-      description: >-
-        Office or organization that designated this information as CUI (e.g.,
-        'SAF/AA'). Required by DoDM 5200.48 when classification is CUI.
-      default: ""
-      ui:
-        group: classification
-        order: 11
-        compact: true
-    cui_limited_dissemination:
-      type: string
-      description: >-
-        Limited dissemination control shown in the indicator block (e.g., 'FEDONLY',
-        'NOFORN'). Independent from the banner suffix above.
-      default: ""
-      ui:
-        group: classification
-        order: 13
-        compact: true
-    cui_poc:
-      type: string
-      description: >-
-        Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234,
-        john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI.
-      default: ""
-      ui:
-        group: classification
-        order: 14
-        compact: true
-    date:
-      type: datetime
-      description: YYYY-MM-DD. Leave blank to use today's date.
-      default: ""
-      ui:
-        group: additional
-        order: 21
-        compact: true
-    dissemination:
-      type: string
-      description: >-
-        Banner dissemination suffix appended after double slash (e.g. 'NF' renders as
-        CUI//NF in the header/footer). Leave blank for no suffix.
-      default: ""
-      ui:
-        group: classification
-        order: 10
-        compact: true
-    distribution:
-      type: array
-      description: >-
-        Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For'
-        field.
-      default: []
-      example:
-      - ORG1/SYMBOL
-      - ORG2/SYMBOL
-      ui:
-        group: additional
-        order: 17
-      items:
-        type: string
-    font_size:
-      type: number
-      description: Body text size in points; decimals allowed (e.g. 11.5).
-      default: 12
-      ui:
-        group: additional
-        order: 20
-        compact: true
-    letterhead_caption:
-      type: array
-      description: The full organization name of your unit.
-      example:
-      - HEADQUARTERS [UNIT NAME]
-      ui:
-        group: letterhead
-        order: 5
-      items:
-        type: string
-    letterhead_seal:
-      type: string
-      description: >-
-        Department of War (DoW) or Department of Defense (DoD) seal shown in the
-        letterhead.
-      default: dow
-      ui:
-        group: letterhead
-        order: 6
-        compact: true
-      enum:
-      - dow
-      - dod
-    letterhead_seal_subtitle:
-      type: string
-      description: Bold-caps line below the seal; blank to omit.
-      default: ""
-      ui:
-        group: letterhead
-        order: 7
-        compact: true
-    letterhead_title:
-      type: string
-      description: Change only for Joint Commands or DoW agencies.
-      default: DEPARTMENT OF THE AIR FORCE
-      ui:
-        group: letterhead
-        order: 4
     memo_for:
       type: array
       description: >-
@@ -172,7 +11,6 @@ main:
       - ORG2/SYMBOL
       ui:
         group: addressing
-        order: 0
       items:
         type: string
     memo_from:
@@ -190,22 +28,135 @@ main:
       - City ST 12345-6789
       ui:
         group: addressing
-        order: 1
       items:
         type: string
-    memo_style:
+    subject:
+      type: richtext
+      description: >-
+        Be brief and clear. Capitalize the first letter of each word except articles,
+        prepositions, and conjunctions. Include suspense dates in parentheses if
+        applicable.
+      example: Subject of the Memorandum
+      ui:
+        group: addressing
+      inline: true
+    signature_block:
+      type: array
+      description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
+      example:
+      - FIRST M. LAST, Rank, USAF
+      - Duty Title
+      ui:
+        group: addressing
+      items:
+        type: string
+    letterhead_title:
+      type: string
+      description: Change only for Joint Commands or DoW agencies.
+      default: DEPARTMENT OF THE AIR FORCE
+      ui:
+        group: letterhead
+    letterhead_caption:
+      type: array
+      description: The full organization name of your unit.
+      example:
+      - HEADQUARTERS [UNIT NAME]
+      ui:
+        group: letterhead
+      items:
+        type: string
+    letterhead_seal:
       type: string
       description: >-
-        USAF memorandum or DAF headquarters memorandum; DAF changes date format and
-        body paragraph layout per AFH 33-337.
-      default: usaf
+        Department of War (DoW) or Department of Defense (DoD) seal shown in the
+        letterhead.
+      default: dow
       ui:
-        group: additional
-        order: 19
+        group: letterhead
         compact: true
       enum:
-      - usaf
-      - daf
+      - dow
+      - dod
+    letterhead_seal_subtitle:
+      type: string
+      description: Bold-caps line below the seal; blank to omit.
+      default: ""
+      ui:
+        group: letterhead
+        compact: true
+    tag_line:
+      type: richtext
+      description: >-
+        Organizational motto at the bottom of the page. Supports Markdown emphasis
+        (e.g. *italics*, **bold**).
+      default: ""
+      ui:
+        group: letterhead
+        compact: true
+      inline: true
+    classification:
+      type: string
+      description: >-
+        Select the classification marking shown in the header and footer banner.
+        Unclassified documents typically omit this banner entirely — leave blank unless the
+        document is CUI or classified. Mark per DAFI 16-1404 (DoDM 5200.48 for CUI) and
+        applicable DoD guidance.
+      default: ""
+      ui:
+        group: classification
+        compact: true
+      enum:
+      - ""
+      - UNCLASSIFIED
+      - CUI
+      - CONFIDENTIAL
+      - SECRET
+      - TOP SECRET
+    dissemination:
+      type: string
+      description: >-
+        Banner dissemination suffix appended after double slash (e.g. 'NF' renders as
+        CUI//NF in the header/footer). Leave blank for no suffix.
+      default: ""
+      ui:
+        group: classification
+        compact: true
+    cui_controlled_by:
+      type: string
+      description: >-
+        Office or organization that designated this information as CUI (e.g.,
+        'SAF/AA'). Required by DoDM 5200.48 when classification is CUI.
+      default: ""
+      ui:
+        group: classification
+        compact: true
+    cui_category:
+      type: string
+      description: >-
+        CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY').
+        Leave blank to omit.
+      default: ""
+      ui:
+        group: classification
+        compact: true
+    cui_limited_dissemination:
+      type: string
+      description: >-
+        Limited dissemination control shown in the indicator block (e.g., 'FEDONLY',
+        'NOFORN'). Independent from the banner suffix above.
+      default: ""
+      ui:
+        group: classification
+        compact: true
+    cui_poc:
+      type: string
+      description: >-
+        Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234,
+        john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI.
+      default: ""
+      ui:
+        group: classification
+        compact: true
     references:
       type: array
       description: >-
@@ -218,43 +169,70 @@ main:
       - AFI 33-360, *Publications and Forms Management*
       ui:
         group: additional
-        order: 15
       items:
         type: richtext
         inline: true
-    signature_block:
+    cc:
       type: array
-      description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
+      description: List office symbols of recipients to receive copies.
+      default: []
       example:
-      - FIRST M. LAST, Rank, USAF
-      - Duty Title
+      - Rank and Name, ORG/SYMBOL
       ui:
-        group: addressing
-        order: 3
+        group: additional
       items:
         type: string
-    subject:
-      type: richtext
+    distribution:
+      type: array
       description: >-
-        Be brief and clear. Capitalize the first letter of each word except articles,
-        prepositions, and conjunctions. Include suspense dates in parentheses if
-        applicable.
-      example: Subject of the Memorandum
+        Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For'
+        field.
+      default: []
+      example:
+      - ORG1/SYMBOL
+      - ORG2/SYMBOL
       ui:
-        group: addressing
-        order: 2
-      inline: true
-    tag_line:
-      type: richtext
+        group: additional
+      items:
+        type: string
+    attachments:
+      type: array
       description: >-
-        Organizational motto at the bottom of the page. Supports Markdown emphasis
-        (e.g. *italics*, **bold**).
+        List attachments in the order they are mentioned in the memo. Briefly describe
+        each; do not use 'as stated' or abbreviations.
+      default: []
+      example:
+      - Attachment description, YYYY MMM DD
+      ui:
+        group: additional
+      items:
+        type: string
+    memo_style:
+      type: string
+      description: >-
+        USAF memorandum or DAF headquarters memorandum; DAF changes date format and
+        body paragraph layout per AFH 33-337.
+      default: usaf
+      ui:
+        group: additional
+        compact: true
+      enum:
+      - usaf
+      - daf
+    font_size:
+      type: number
+      description: Body text size in points; decimals allowed (e.g. 11.5).
+      default: 12
+      ui:
+        group: additional
+        compact: true
+    date:
+      type: datetime
+      description: YYYY-MM-DD. Leave blank to use today's date.
       default: ""
       ui:
-        group: letterhead
-        order: 8
+        group: additional
         compact: true
-      inline: true
   ui:
     groups:
       addressing: {}
@@ -272,6 +250,39 @@ card_kinds:
       Chain of routing endorsements. Each endorsement block adds an official response
       or forwarding action to the original memo.
     fields:
+      from:
+        type: string
+        description: Office symbol or Rank Name of the endorsing official.
+        example: ORG/SYMBOL
+        ui:
+          group: addressing
+      for:
+        type: string
+        description: Office symbol or organization receiving the endorsed memo.
+        example: ORG/SYMBOL
+        ui:
+          group: addressing
+      signature_block:
+        type: array
+        description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
+        example:
+        - FIRST M. LAST, Rank, USAF
+        - Duty Title
+        ui:
+          group: addressing
+        items:
+          type: string
+      format:
+        type: string
+        description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
+        default: standard
+        ui:
+          group: additional
+          compact: true
+        enum:
+        - standard
+        - informal
+        - separate_page
       action:
         type: string
         description: >-
@@ -281,7 +292,6 @@ card_kinds:
         default: ""
         ui:
           group: additional
-          order: 4
           compact: true
         enum:
         - ""
@@ -297,45 +307,7 @@ card_kinds:
         default: ""
         ui:
           group: additional
-          order: 5
           compact: true
-      for:
-        type: string
-        description: Office symbol or organization receiving the endorsed memo.
-        example: ORG/SYMBOL
-        ui:
-          group: addressing
-          order: 1
-      format:
-        type: string
-        description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
-        default: standard
-        ui:
-          group: additional
-          order: 3
-          compact: true
-        enum:
-        - standard
-        - informal
-        - separate_page
-      from:
-        type: string
-        description: Office symbol or Rank Name of the endorsing official.
-        example: ORG/SYMBOL
-        ui:
-          group: addressing
-          order: 0
-      signature_block:
-        type: array
-        description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
-        example:
-        - FIRST M. LAST, Rank, USAF
-        - Duty Title
-        ui:
-          group: addressing
-          order: 2
-        items:
-          type: string
     ui:
       title: Routing indorsement
       groups:

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -60,7 +60,7 @@ fn arb_field_schema(max_depth: u32) -> impl Strategy<Value = FieldSchema> {
     let leaf = arb_leaf_field_type().prop_map(|ty| FieldSchema::new(String::new(), ty, None));
     leaf.prop_recursive(max_depth, 24, 3, |inner| {
         let props_map = prop::collection::btree_map(PROP_NAME_RE, inner, 1..=3).prop_map(|m| {
-            let mut props: BTreeMap<String, Box<FieldSchema>> = BTreeMap::new();
+            let mut props: IndexMap<String, Box<FieldSchema>> = IndexMap::new();
             for (k, mut v) in m {
                 v.name = k.clone();
                 props.insert(k, Box::new(v));
@@ -124,7 +124,7 @@ fn arb_json_value(max_depth: u32) -> impl Strategy<Value = serde_json::Value> {
 fn config_with_one_field(schema: FieldSchema) -> QuillConfig {
     let mut schema = schema;
     schema.name = ROOT_FIELD.to_string();
-    let mut fields = BTreeMap::new();
+    let mut fields = IndexMap::new();
     fields.insert(ROOT_FIELD.to_string(), schema);
     let main = CardSchema {
         name: "main".to_string(),
@@ -297,7 +297,7 @@ proptest! {
 #[test]
 fn regression_t2_array_of_object_path() {
     // Schema: { f: array, items: { x: integer } }
-    let mut inner = BTreeMap::new();
+    let mut inner = IndexMap::new();
     inner.insert(
         "x".to_string(),
         Box::new(FieldSchema::new("x".to_string(), FieldType::Integer, None)),

--- a/crates/fuzz/src/coerce_fuzz.rs
+++ b/crates/fuzz/src/coerce_fuzz.rs
@@ -28,7 +28,7 @@
 //! - **W3 (commit ∘ commit = commit):** a committed value is a fixed point —
 //!   re-committing it yields the same stored value.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use indexmap::IndexMap;
 use proptest::prelude::*;

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -148,6 +148,38 @@ identifiers, keys — values a template computes with (`#link` / `#image`,
 comparison, keying), not prose it lays out. Use `plaintext` for prose the author
 navigates, `enum` for a closed set.
 
+## `ui.group` is card-level only; nested properties keep authored order (#941)
+
+Two independent schema-authoring fixes to the `ui.*` block. Both touch only
+Quill.yaml; documents, wire shapes, and the blueprint grammar are unchanged.
+
+- **`ui.group` in a nested position is now a load error.** Grouping clusters a
+  card's top-level fields; the blueprint's grouping pass never descended into an
+  object's properties or an array's items, so a `group` there was silently
+  inert. It now fails with `quill::nested_group_not_supported`. A `group` on a
+  card-level field (under `main.fields` or a card kind's `fields`) is unaffected
+  — that is where grouping has always applied.
+
+  ```
+  0.93 (silently ignored)           0.94 (load error)
+  address:                          address:
+    type: object                      type: object
+    properties:                       properties:
+      street:                           street:
+        type: string                      type: string
+        ui: { group: Location }         # move the group up to the card-level
+                                        # field, or drop it
+  ```
+
+- **Typed-dictionary and typed-table-row properties now render in declaration
+  order.** Positional `ui.order` auto-assignment previously ran only on
+  card-level fields; nested properties live in a `BTreeMap` and defaulted to
+  `i32::MAX`, so they rendered alphabetically, discarding authored order one
+  level down. They now receive positional `ui.order` from declaration order, the
+  same rule top-level fields already followed. Blueprints and forms for a quill
+  whose nested properties were authored out of alphabetical order will reorder to
+  match the Quill.yaml; an explicit `ui.order` on a property still wins.
+
 ## The addressed richtext write surface + corpus codec (#925)
 
 The richtext write surface was a grid: every verb stamped out once per address

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -169,7 +169,7 @@ main:                             main:
 ```
 
 - **Registry keys are snake_case ids; declaration order is display order** — the
-  same contract field declaration order gives `ui.order`. Consumers derive the
+  same contract fields follow (declaration order is field display order). Consumers derive the
   label from the id (`addressing` → "Addressing"), exactly as a field label is
   derived from its key; override it with the mapping form, `letterhead: { title:
   "Letterhead & Seal" }`. Renaming a label touches one line and never breaks a
@@ -223,13 +223,44 @@ blueprint grammar are unchanged.
   ```
 
 - **Typed-dictionary and typed-table-row properties now render in declaration
-  order.** Positional `ui.order` auto-assignment previously ran only on
-  card-level fields; nested properties live in a `BTreeMap` and defaulted to
-  `i32::MAX`, so they rendered alphabetically, discarding authored order one
-  level down. They now receive positional `ui.order` from declaration order, the
-  same rule top-level fields already followed. Blueprints and forms for a quill
-  whose nested properties were authored out of alphabetical order will reorder to
-  match the Quill.yaml; an explicit `ui.order` on a property still wins.
+  order.** Nested properties previously lived in a `BTreeMap` and rendered
+  alphabetically, discarding authored order one level down. Properties now
+  preserve declaration order, the same rule top-level fields follow (see the
+  `ui.order` removal below — declaration order is the one ordering contract at
+  every depth). Blueprints and forms for a quill whose nested properties were
+  authored out of alphabetical order will reorder to match the Quill.yaml.
+
+## `ui.order` retires; declaration order is the ordering contract (#941)
+
+Field display order stops being a `ui` knob and becomes purely **structural**:
+the order fields (and nested properties) are declared in `Quill.yaml` *is* their
+display order, carried by the schema's ordered field maps through parsing,
+`schema()` emission, the blueprint, and seeding. There is no derived integer to
+read or author.
+
+```
+0.93 (stamped + overridable)      0.94 (declaration order)
+main:                             main:
+  fields:                           fields:
+    title:                            # to move a field, move its block
+      type: string                    special_field:
+      ui: { order: 5 }                  type: string
+```
+
+- **`ui.order` is removed.** An authored `ui: { order: N }` on any field —
+  card-level or nested — is a load error (`quill::field_parse_error`) with a hint
+  to reorder the fields in `Quill.yaml`. Reorder by moving the field's block.
+- **The emitted schema no longer carries `order:`.** `QuillConfig::schema()` (the
+  surface editors and MCP/LLM consumers read) previously stamped an
+  auto-generated `ui.order` integer onto every field; that key is gone. Read
+  **key order** of the `fields` / `properties` objects instead — it is declaration
+  order, preserved on the wire. A consumer that sorted by `ui.order` should walk
+  the map in key order and drop the sort.
+- **Card kinds emit in declaration order too** — `schema().card_kinds` was
+  alphabetized (a `BTreeMap`) and now preserves the `Quill.yaml` order.
+- **A field with no authored `ui:` now has no `ui` block.** Order stamping used to
+  fabricate one (`ui: { order: N }`) even when the author wrote none; a field with
+  only structural metadata now serializes without a `ui` key.
 
 ## The addressed richtext write surface + corpus codec (#925)
 

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -148,10 +148,61 @@ identifiers, keys — values a template computes with (`#link` / `#image`,
 comparison, keying), not prose it lays out. Use `plaintext` for prose the author
 navigates, `enum` for a closed set.
 
+## Group registry: `ui.groups`, validated `ui.group` references (#941)
+
+Groups gain a **card-level registry**. A group is no longer just the set of
+fields sharing a byte-identical `ui.group` string (where the display label
+doubled as identity and a typo silently split a section). Each card declares
+`ui.groups` — an ordered list of snake_case ids — and a field's `ui.group`
+becomes a *reference* into it.
+
+```
+0.93 (label is identity)          0.94 (id is identity, label derived)
+main:                             main:
+  fields:                           ui:
+    memo_for:                         groups: [addressing, letterhead]
+      ui: { group: Addressing }     fields:
+    subject:                          memo_for:
+      ui: { group: Addressing }         ui: { group: addressing }
+                                      subject:
+                                        ui: { group: addressing }
+```
+
+- **Registry keys are snake_case ids; declaration order is display order** — the
+  same contract field declaration order gives `ui.order`. Consumers derive the
+  label from the id (`addressing` → "Addressing"), exactly as a field label is
+  derived from its key; override it with the mapping form, `letterhead: { title:
+  "Letterhead & Seal" }`. Renaming a label touches one line and never breaks a
+  reference or persisted per-group editor state.
+- **The registry has two interchangeable forms:** a bare sequence of ids
+  (`[addressing, letterhead]`) when no label needs overriding, or a mapping of
+  id → attributes when one does. Both fold to the same ordered registry and
+  re-emit as the mapping form in `QuillConfig::schema()`.
+- **`ui.group` is validated:** a value with no matching registry key is
+  `quill::unknown_group`; a registry id that is not snake_case is
+  `quill::invalid_group_id`; a repeated id is `quill::duplicate_group`. Because a
+  registry is authoritative when present, there is no implicit fallback to mix
+  with — an undeclared reference simply fails.
+- **Implicit groups are deprecated, not yet removed.** A `ui.group` with no
+  `ui.groups` registry keeps today's exact semantics — the value *is* the label
+  and identity, groups order by first appearance — and now emits a
+  `quill::implicit_group` warning. It becomes an error in a future release.
+  Migrate by adding a `ui.groups` registry and lowercasing each `ui.group` to
+  its id. (No slug is invented during the deprecation window: implicit identity
+  stays the literal label, so nothing a consumer might persist changes shape
+  before you choose explicit ids.)
+- **The blueprint is unchanged in shape** — it still clusters by group and emits
+  no banner; only its group-*ordering* input switches from first-appearance to
+  registry order, which for a migrated quill is identical.
+
+The bundled quills (`usaf_memo`, `cmu_letter`, `classic_resume`) are migrated to
+the registry form as worked examples.
+
 ## `ui.group` is card-level only; nested properties keep authored order (#941)
 
-Two independent schema-authoring fixes to the `ui.*` block. Both touch only
-Quill.yaml; documents, wire shapes, and the blueprint grammar are unchanged.
+Two independent schema-authoring fixes to the `ui.*` block, landed ahead of the
+registry above. Both touch only Quill.yaml; documents, wire shapes, and the
+blueprint grammar are unchanged.
 
 - **`ui.group` in a nested position is now a load error.** Grouping clusters a
   card's top-level fields; the blueprint's grouping pass never descended into an

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -42,7 +42,10 @@ guides in order.
   types join the schema: `plaintext` (navigable unformatted prose over the
   richtext corpus, via a literal codec) and a promoted first-class `enum`
   (`type: enum` + `values:`, the `enum:` modifier on `string` deprecated for one
-  release); `string` narrows to open scalar data (#938).
+  release); `string` narrows to open scalar data (#938). Two `ui.*` fixes:
+  `ui.group` in a nested position is now a load error
+  (`quill::nested_group_not_supported`), and typed-dictionary / typed-table-row
+  properties render in declaration order instead of alphabetically (#941).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -42,8 +42,12 @@ guides in order.
   types join the schema: `plaintext` (navigable unformatted prose over the
   richtext corpus, via a literal codec) and a promoted first-class `enum`
   (`type: enum` + `values:`, the `enum:` modifier on `string` deprecated for one
-  release); `string` narrows to open scalar data (#938). Two `ui.*` fixes:
-  `ui.group` in a nested position is now a load error
+  release); `string` narrows to open scalar data (#938). Groups gain a
+  card-level `ui.groups` registry: `ui.group` becomes a validated reference to a
+  snake_case id (`quill::unknown_group`), registry declaration order fixes
+  display order, labels derive from ids with a `title:` override, and bare
+  label-as-identity groups are deprecated (`quill::implicit_group`); plus two
+  `ui.*` fixes — `ui.group` in a nested position is now a load error
   (`quill::nested_group_not_supported`), and typed-dictionary / typed-table-row
   properties render in declaration order instead of alphabetically (#941).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -56,7 +56,11 @@ guides in order.
   (`quill::implicit_group`); plus two `ui.*` fixes — `ui.group` in a nested
   position is now a load error (`quill::nested_group_not_supported`), and
   typed-dictionary / typed-table-row properties render in declaration order
-  instead of alphabetically (#941).
+  instead of alphabetically (#941). Field ordering then goes fully structural:
+  `ui.order` is removed (an authored `order:` is a load error), field and
+  card-kind display order becomes the key order of the emitted schema
+  (declaration order), and the auto-stamped `order:` integer disappears from
+  `QuillConfig::schema()` — consumers walk the maps in key order (#941).
 - [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
   orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
   instead of the `<must-fill>` string sentinel, and bare-null / `field:` now

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -237,9 +237,11 @@ main:
 
 Fields with the same `group` value are rendered together. The group name becomes the section heading.
 
+`group` applies only to card-level fields (those directly under a card's `fields:`). Grouping never descends into an object's properties or an array's items, so a `group` on a nested property is a hard error (`quill::nested_group_not_supported`) rather than a silently inert knob.
+
 ### `order`
 
-Auto-assigned from field position. To override:
+Auto-assigned from field position. This positional assignment applies at every level — card-level fields *and* the properties of a typed dictionary or typed-table row — so nested properties render in declaration order rather than alphabetically. To override:
 
 ```yaml
 main:

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -66,7 +66,7 @@ typst:
 
 The main document card holds **root-block field schemas** under `main.fields`. Optional `main.description` describes the schema itself (independent of `quill.description`, which describes the quill package). Optional `main.ui` sets container-level UI for that card. `quill.ui` is a fallback for `main.ui`, not a merge: any `main.ui` — even an empty `ui: {}` — wins wholesale, and `quill.ui` applies only when `main.ui` is absent.
 
-Field order under `main.fields` determines display order in UIs — the first field gets `order: 0`, the second gets `order: 1`, and so on.
+Field order under `main.fields` **is** display order in UIs: the declaration order of the keys is carried structurally through parsing and schema emission, so consumers walk the fields in key order. There is no `ui.order` knob — to reorder fields, reorder them in `Quill.yaml`.
 
 Field keys must be `snake_case` (`^[a-z][a-z0-9_]*$`). Capitalized field keys are reserved.
 
@@ -255,19 +255,11 @@ The two registry forms are interchangeable: a bare sequence of ids (`[addressing
 
 **Implicit groups (deprecated).** A `ui.group` with no `ui.groups` registry on the card still works: each distinct value is an implicit group whose label *is* the value, ordered by first appearance — today's behavior. It now emits a `quill::implicit_group` deprecation warning and will become an error in a future release. Declare a registry to silence it.
 
-### `order`
+### field order
 
-Auto-assigned from field position. This positional assignment applies at every level — card-level fields *and* the properties of a typed dictionary or typed-table row — so nested properties render in declaration order rather than alphabetically. To override:
+Field display order is **declaration order** — the order the keys appear in `Quill.yaml`. This holds at every level: card-level fields, and the properties of a typed dictionary or typed-table row. The order is carried structurally (the schema's field maps preserve key order, and `schema()` re-emits that order), so no per-field knob is involved.
 
-```yaml
-main:
-  fields:
-    # Will get order: 0 from position, but we force it to 5
-    special_field:
-      type: string
-      ui:
-        order: 5
-```
+There is no `ui.order` key. It was removed: an authored `ui: { order: N }` is now a load error (`quill::field_parse_error`) directing you to reorder the fields instead. To move a field, move its block in `Quill.yaml`.
 
 ### `compact`
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -208,36 +208,52 @@ main:
         title: To       # "Memo For" would confuse users unfamiliar with memo conventions
 ```
 
-### `group`
+### `group` and the group registry
 
-Organizes fields into visual sections:
+Groups organize fields into visual sections. A group has two parts: a **registry** declared once on the card (`ui.groups`), and a per-field **reference** (`ui.group`) into that registry.
 
 ```yaml
 main:
+  ui:
+    groups: [addressing, letterhead]   # declaration order = display order
   fields:
     memo_for:
       type: array
       items:
         type: string
       ui:
-        group: Addressing
+        group: addressing              # a reference, validated against the registry
 
     memo_from:
       type: array
       items:
         type: string
       ui:
-        group: Addressing
+        group: addressing
 
     letterhead_title:
       type: string
       ui:
-        group: Letterhead
+        group: letterhead
 ```
 
-Fields with the same `group` value are rendered together. The group name becomes the section heading.
+The registry is the card's table of contents. Its keys are **snake_case ids** (same discipline as field keys), and their declaration order fixes the group display order — the contract every consumer follows, exactly as field declaration order fixes `ui.order`. A field's `ui.group` names one of those ids; a value with no matching registry key is a load error (`quill::unknown_group`), so a one-character typo can no longer silently split a section.
+
+**Identity is the id, not the label.** Consumers derive a group's display label from its id (`addressing` → "Addressing"), just as a field label is derived from its key. Override the derived label with `title:` — which requires the mapping form of the registry:
+
+```yaml
+main:
+  ui:
+    groups:
+      addressing: {}                       # label derived: "Addressing"
+      letterhead: { title: "Letterhead & Seal" }   # label overridden
+```
+
+The two registry forms are interchangeable: a bare sequence of ids (`[addressing, letterhead]`) when no labels need overriding, or a mapping of id → attributes when they do. Renaming a label touches one line and never breaks a `ui.group` reference or persisted per-group editor state.
 
 `group` applies only to card-level fields (those directly under a card's `fields:`). Grouping never descends into an object's properties or an array's items, so a `group` on a nested property is a hard error (`quill::nested_group_not_supported`) rather than a silently inert knob.
+
+**Implicit groups (deprecated).** A `ui.group` with no `ui.groups` registry on the card still works: each distinct value is an implicit group whose label *is* the value, ordered by first appearance — today's behavior. It now emits a `quill::implicit_group` deprecation warning and will become an error in a future release. Declare a registry to silence it.
 
 ### `order`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
-      - 0.93 → 0.94 (richtext(inline) token retires; declare inline flag): migrations/0.93-to-0.94.md
+      - 0.93 → 0.94 (richtext(inline) token retires; ui.order removed, declaration order is the ordering contract): migrations/0.93-to-0.94.md
       - 0.92 → 0.93 (!must_fill marker; null ≡ absent; delete-ok removed): migrations/0.92-to-0.93.md
       - 0.91 → 0.92 ($seed overlays; !fill → !must_fill): migrations/0.91-to-0.92.md
       - 0.90 → 0.91 (column-zero ~~~ fence; name/depth enforcement): migrations/0.90-to-0.91.md

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -358,11 +358,12 @@ rejected at `Quill.yaml` parse time (`quill::object_missing_properties`).
 
 ## UI metadata honored
 
-`ui.order` controls field ordering within the document. Most other `ui:`
-keys (`ui.group`, `ui.compact`, `ui.multiline`, `ui.title`) are
-presentation-only and do not affect blueprint output. In particular,
-`ui.group` emits no banner lines; fields within the same `ui.group`
-cluster together via `ui.order`.
+Field declaration order controls field ordering within the document —
+carried structurally by the schema's ordered field maps, not a `ui`
+key. The `ui:` keys (`ui.group`, `ui.compact`, `ui.multiline`,
+`ui.title`) are presentation-only and do not affect blueprint output. In
+particular, `ui.group` emits no banner lines; fields within the same
+`ui.group` cluster together while preserving declaration order.
 
 ## Body markers
 

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -148,7 +148,7 @@ $seed:
 
 `Quill::seed_card(kind, overlay)` layers the overlay over the quill's
 schema-`example:` seed, per field `overlay › example › absent`, ordered by
-`ui.order` (see [SCHEMAS.md](SCHEMAS.md) "Document seeding"). The overlay is
+field declaration order (see [SCHEMAS.md](SCHEMAS.md) "Document seeding"). The overlay is
 *sparse*: fields it omits keep flowing from the live quill seed, so it tracks
 the quill rather than freezing a snapshot. The overlay is read off the main
 card's `$seed` map (`Card::seed`, exposed as `card.seed` in the bindings) and

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -258,7 +258,7 @@ document carries no `$seed`).
 `QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:
 
 - Field types, constraints, and `enum`/`default`/`example` annotations
-- `ui` hints on fields and card kinds (`group`, `order`, `compact`, `multiline`, `title`)
+- `ui` hints on fields (`group`, `order`, `compact`, `multiline`, `title`) and on cards (`title`, plus the `groups` registry that `group` references)
 - `body` blocks on cards (`enabled`, `example`)
 
 The schema describes only the user-fillable fields. The quill reference

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -121,7 +121,8 @@ it, not the engine.
 
 No surface owns a precedence *policy*; each **projection cuts the same ladder**
 at a different rung, and the per-rung producers are shared (`zero_value` for the
-floor, `FieldSchema::ui_order` for ordering):
+floor; field ordering is declaration order, carried by the schema's ordered
+field maps rather than a sort key):
 
 | Projection | Per-field precedence | Floor | Output |
 |---|---|---|---|
@@ -242,7 +243,7 @@ projection — there is no annotated `example` string. Implemented by
 Seeding a *new card into an existing document* — `Quill::seed_card(kind,
 overlay)` — adds one more rung above `example:`: a curated, per-document
 **overlay** read from the main card's `$seed` map. Per field the precedence is
-**`$seed` overlay › `example:` › absent** (ordered by `ui.order`), and `default`
+**`$seed` overlay › `example:` › absent** (ordered by field declaration order), and `default`
 / `zero` stay deferred to the render floor exactly as everywhere else, so the
 "never persist a `default`" invariant holds. The overlay is *sparse* — fields it
 omits keep flowing from the schema seed, so it tracks an evolving quill rather
@@ -258,7 +259,7 @@ document carries no `$seed`).
 `QuillConfig::schema()` returns the structural schema as `serde_json::Value`. It includes:
 
 - Field types, constraints, and `enum`/`default`/`example` annotations
-- `ui` hints on fields (`group`, `order`, `compact`, `multiline`, `title`) and on cards (`title`, plus the `groups` registry that `group` references)
+- `ui` hints on fields (`group`, `compact`, `multiline`, `title`) and on cards (`title`, plus the `groups` registry that `group` references). Field display order is not a hint: it is the key order of the emitted `fields`/`properties` maps (declaration order)
 - `body` blocks on cards (`enabled`, `example`)
 
 The schema describes only the user-fillable fields. The quill reference


### PR DESCRIPTION
Two orthogonal ui.* schema-authoring fixes from issue #941, independent of
the proposed group registry.

- ui.group in a nested position (an object property or array item) was
  parsed and round-tripped but never consumed: the blueprint's grouping
  pass runs only on card-level fields, so a nested group silently did
  nothing. validate_field_schema_shape now rejects it with
  quill::nested_group_not_supported, joining the strict-parse regime.

- Typed-dictionary and typed-table-row properties never received the
  positional ui.order the card-level parse assigns, so they lived in a
  BTreeMap and rendered alphabetically, discarding authored order one
  nesting level down. from_quill_value now stamps positional order onto
  nested properties in declaration order (preserved by serde_json's
  preserve_order), via a shared set_ui_order_if_unset helper that also
  replaces the inline card-level assignment.

Docs: quill-yaml-reference notes group is card-level only and order
applies at every level; migration guide 0.93-to-0.94 and its index entry
document both behavior changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VH4bRvRFiEbRR7kkmhPbNN