### PR TITLE
test(core,quillmark): remove redundant and low-value tests

### DIFF
--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -1105,22 +1105,4 @@ mod tests {
         );
         assert_eq!(out, "dept: !must_fill placeholder # note\n");
     }
-
-    #[test]
-    fn fill_integer_emits_tag_with_value() {
-        let value = QuillValue::from_json(serde_json::json!(42));
-        let mut out = String::new();
-        emit_field(
-            &mut out,
-            "count",
-            value.as_json(),
-            0,
-            true,
-            &p("count"),
-            &[],
-            &[],
-            None,
-        );
-        assert_eq!(out, "count: !must_fill 42\n");
-    }
 }

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -1091,13 +1091,6 @@ mod tests {
     }
 
     #[test]
-    fn comment_after_plain_scalar_with_double_quote() {
-        let (v, c) = split_trailing_comment(" don\"t # note");
-        assert_eq!(v, " don\"t");
-        assert_eq!(c.as_deref(), Some("# note"));
-    }
-
-    #[test]
     fn hash_inside_quoted_scalar_is_not_a_comment() {
         let (v, c) = split_trailing_comment(" 'a # b'");
         assert_eq!(v, " 'a # b'");

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -1665,22 +1665,6 @@ Some text with --- dashes in it.";
     assert!(doc.cards()[0].body_markdown().contains("--- dashes"));
 }
 
-// `$quill` reference edge cases
-
-#[test]
-fn test_quill_with_underscore_prefix() {
-    let markdown = "~~~card-yaml\n$quill: _internal\n$kind: main\n~~~\n\nBody.";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.quill_reference().name, "_internal");
-}
-
-#[test]
-fn test_quill_with_numbers() {
-    let markdown = "~~~card-yaml\n$quill: form_8_v2\n$kind: main\n~~~\n\nBody.";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.quill_reference().name, "form_8_v2");
-}
-
 // Error handling
 
 #[test]

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -550,14 +550,6 @@ fn test_replace_body_reports_import_error() {
         Err(EditError::BodyImport(_)) => {}
         other => panic!("expected BodyImport, got {other:?}"),
     }
-    assert_eq!(
-        EditError::BodyImport(quillmark_richtext::import::ImportError::NestingTooDeep {
-            depth: 1,
-            max: 1
-        })
-        .variant_name(),
-        "BodyImport"
-    );
 }
 
 /// `install_body` installs a pre-built corpus verbatim — value semantics, no

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -560,18 +560,7 @@ main:
 
 #[test]
 fn test_field_schema_struct() {
-    // Test creating FieldSchema with minimal fields
-    let schema1 = FieldSchema::new(
-        "test_name".to_string(),
-        FieldType::String,
-        Some("Test description".to_string()),
-    );
-    assert_eq!(schema1.description, Some("Test description".to_string()));
-    assert_eq!(schema1.r#type, FieldType::String);
-    assert_eq!(schema1.example, None);
-    assert_eq!(schema1.default, None);
-
-    // Test parsing FieldSchema from YAML with all fields
+    // Parse a FieldSchema from YAML with every field set.
     let yaml_str = r#"
 description: "Full field schema"
 type: "string"
@@ -1267,46 +1256,6 @@ card_kinds:
     assert!(config.card_kind("conflict").is_some());
 }
 
-#[test]
-fn test_quill_config_ordering_with_cards() {
-    // Test that fields have proper UI ordering (ordering is field-level, not card-level)
-    let yaml_content = r#"
-quill:
-  name: ordering_test
-  version: "1.0"
-  backend: typst
-  description: Test ordering
-
-main:
-  fields:
-    first:
-      type: string
-      description: First
-    zero:
-      type: string
-      description: Zero
-
-card_kinds:
-  second:
-    description: Second
-    fields:
-      card_field:
-        type: string
-        description: A card field
-"#;
-
-    let config = QuillConfig::from_yaml(yaml_content).unwrap();
-
-    let second = config.card_kind("second").unwrap();
-
-    // Within main.fields, "first" is declared before "zero"; the field map
-    // carries that order.
-    assert_eq!(config.main.fields.get_index_of("first"), Some(0));
-    assert_eq!(config.main.fields.get_index_of("zero"), Some(1));
-
-    // Card fields carry declaration order too.
-    assert_eq!(second.fields.get_index_of("card_field"), Some(0));
-}
 #[test]
 fn test_card_field_order_preservation() {
     // Test that card fields preserve definition order (not alphabetical)
@@ -3392,17 +3341,6 @@ fn plaintext_wire_corpus_with_marks_is_rejected_not_stripped() {
     assert!(
         err.to_string().contains("plaintext"),
         "a mark-bearing corpus should fail a plaintext field, got: {err}"
-    );
-}
-
-#[test]
-fn plaintext_zero_value_is_empty_corpus() {
-    let field = FieldSchema::new("x".to_string(), FieldType::PlainText { inline: false }, None);
-    let zero = zero_value(&field);
-    assert!(
-        zero.as_json().is_object(),
-        "plaintext zero-fill is the empty corpus, not a string: {:?}",
-        zero.as_json()
     );
 }
 

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -283,18 +283,6 @@ card_kinds:
     }
 
     #[test]
-    fn set_reports_strict_conform_failure() {
-        let config = config();
-        let mut doc = blank_doc();
-        let mut ed = TypedWriter::new(&config, &mut doc);
-        let err = ed.set("qty", "not-a-number").unwrap_err();
-        assert_eq!(err.variant_name(), "FieldConform");
-        // A richtext(inline) violation surfaces through the richtext variant.
-        let err = ed.set("subject", "line one\n\nline two").unwrap_err();
-        assert_eq!(err.variant_name(), "FieldRichtextNotInline");
-    }
-
-    #[test]
     fn set_all_is_all_or_nothing() {
         let config = config();
         let mut doc = blank_doc();

--- a/crates/core/tests/markdown_field_test.rs
+++ b/crates/core/tests/markdown_field_test.rs
@@ -1,4 +1,4 @@
-use quillmark_core::{normalize::normalize_document, quill::QuillConfig, Document};
+use quillmark_core::quill::QuillConfig;
 
 #[test]
 fn test_markdown_type_is_a_load_error() {
@@ -57,26 +57,5 @@ main:
             .and_then(|v| v.get("type"))
             .and_then(|v| v.as_str()),
         Some("richtext")
-    );
-}
-
-#[test]
-fn test_markdown_field_normalization() {
-    // Create a document via from_markdown
-    let md = "~~~card-yaml\n$quill: test\n$kind: main\nmarkdown_field: This has <<guillemets>>\nstring_field: This has <<stripped>>\n~~~\n";
-    let doc = Document::from_markdown(md).unwrap();
-
-    // Normalize
-    let normalized = normalize_document(doc).expect("Failed to normalize document");
-    let fm = normalized.main().payload();
-
-    // Both fields pass through unchanged (no stripping on YAML fields)
-    assert_eq!(
-        fm.get("markdown_field").unwrap().as_str().unwrap(),
-        "This has <<guillemets>>"
-    );
-    assert_eq!(
-        fm.get("string_field").unwrap().as_str().unwrap(),
-        "This has <<stripped>>"
     );
 }

--- a/crates/quillmark/tests/security_tests.rs
+++ b/crates/quillmark/tests/security_tests.rs
@@ -5,31 +5,6 @@
 
 use quillmark_core::{Card, Document};
 
-/// Test deeply nested YAML structures hit the depth limit
-#[test]
-fn test_yaml_depth_limit_attack() {
-    // Create deeply nested YAML structure (exceeds MAX_YAML_DEPTH)
-    let mut deep_yaml = String::new();
-    for i in 0..150 {
-        deep_yaml.push_str(&"  ".repeat(i));
-        deep_yaml.push_str("a:\n");
-    }
-    let markdown = format!(
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\n{}~~~\n\nBody",
-        deep_yaml
-    );
-    let result = Document::from_markdown(&markdown);
-
-    // Should fail with YAML depth limit error
-    assert!(result.is_err(), "Should reject deeply nested YAML");
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("depth") || err_msg.contains("YAML") || err_msg.contains("limit"),
-        "Error should mention depth/limit: {}",
-        err_msg
-    );
-}
-
 /// Test card count limit prevents DoS
 #[test]
 fn test_card_count_limit_attack() {
@@ -50,70 +25,6 @@ fn test_card_count_limit_attack() {
     assert!(
         err_msg.contains("too large") || err_msg.contains("max"),
         "Error should mention limit: {}",
-        err_msg
-    );
-}
-
-/// Test that Typst special characters are properly escaped (injection prevention)
-#[test]
-fn test_typst_injection_via_special_chars() {
-    let malicious_inputs = vec![
-        r#"**"; eval("malicious")""#,
-        r#"$x$ math injection"#,
-        r#"#eval("danger")"#,
-        r#"@dangerous"#,
-        r#"~strike~`code`"#,
-    ];
-
-    for input in malicious_inputs {
-        let markdown = format!(
-            "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\n{}",
-            input
-        );
-        let result = Document::from_markdown(&markdown);
-        // Should parse without error (escaping happens during conversion)
-        assert!(
-            result.is_ok(),
-            "Should handle special chars in input: {}",
-            input
-        );
-    }
-}
-
-/// Test large input size limit
-#[test]
-fn test_input_size_limit() {
-    let large_content = "a".repeat(11 * 1024 * 1024); // 11 MB
-    let markdown = format!(
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Large\n~~~\n\n{}",
-        large_content
-    );
-    let result = Document::from_markdown(&markdown);
-
-    assert!(result.is_err(), "Should reject oversized input");
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("too large") || err_msg.contains("bytes"),
-        "Error should mention size limit: {}",
-        err_msg
-    );
-}
-
-/// Test YAML size limit
-#[test]
-fn test_yaml_size_limit() {
-    let large_value = "x".repeat(1024 * 1024 + 100);
-    let markdown = format!(
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\ndata: {}\n~~~\n\nBody",
-        large_value
-    );
-    let result = Document::from_markdown(&markdown);
-
-    assert!(result.is_err(), "Should reject oversized YAML");
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("too large") || err_msg.contains("YAML"),
-        "Error should mention YAML size: {}",
         err_msg
     );
 }
@@ -175,21 +86,5 @@ fn test_yaml_error_location() {
         err_msg.contains("line") || err_msg.contains("YAML"),
         "Error should include location context: {}",
         err_msg
-    );
-}
-
-/// Test that `~~~card-yaml` fences inside backtick code blocks are not parsed as metadata
-#[test]
-fn test_strict_fence_detection() {
-    let markdown =
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\n````\n~~~card-yaml\n$kind: test\nvalue: 1\n~~~\n````";
-    let result = Document::from_markdown(markdown);
-
-    assert!(result.is_ok(), "Should parse successfully: {:?}", result);
-    let doc = result.unwrap();
-    assert_eq!(
-        doc.cards().len(),
-        0,
-        "card-yaml fence inside ```` code block should not be parsed as metadata"
     );
 }


### PR DESCRIPTION
Prune 13 tests (net -249 lines) that duplicate coverage or assert nothing
meaningful. Each removal was verified against the code path it exercises:

- quillmark/security_tests: drop the yaml-depth, input-size, yaml-size, and
  fence-detection tests — the identical limits are already pinned in core
  (assemble_tests + card_fence_tests) and quillmark::Document is a verbatim
  re-export with no added logic. Drop test_typst_injection_via_special_chars,
  which only asserts is_ok() and never checks escaping (real coverage lives in
  typst emit.rs escape_tripwire_*).
- core: drop plaintext_zero_value_is_empty_corpus — it shares the single
  RichText|PlainText arm in fill.rs with the richtext variant that stays.
- core: drop test_quill_config_ordering_with_cards — its fields are already in
  alphabetical order, so it can't distinguish declaration order from a sort;
  test_field_order_preservation and the card variant cover it with non-
  alphabetical fields.
- core: drop the $quill underscore/number decompose tests — the name charset
  is unit-tested in version.rs and decompose-wiring by every other name test.
- core: drop fill_integer_emits_tag_with_value — same Bool|Number|String emit
  arm as fill_string (scalar rendering covered by saphyr_scalar_round_trips).
- core: drop the double-quote plain-scalar comment test — same
  find_comment_from catch-all as the apostrophe variant.
- core: drop test_markdown_field_normalization — dead scaffolding from the
  retired `type: markdown` feature; guillemet + YAML pass-through are covered
  by test_chevrons_preserved_in_all_contexts and normalize.rs.
- core: trim three vacuous assertions — the FieldSchema constructor field-echo,
  a hand-fabricated BodyImport variant_name check, and TypedWriter::set error
  forwarding (commit_field's own tests already pin the variants).

Deliberately kept: the normalize.rs main-vs-card pairs and the
Document/Card replace-body pair — same code path today, but they guard a real
structural seam where a future main-only or card-only branch is exactly what
they would catch.

All 630 core unit tests plus integration and doc tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0125uzSroVJy9S9tfgqnG4R9