### PR TITLE
Graduate live-session/canvas surface from @experimental to stable

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: Version bump type (ignored while iterating an existing RC)
+        description: Version bump type (ignored while iterating an existing RC, or when version_override is set)
         required: true
         type: choice
         options:
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      version_override:
+        description: Explicit next version (e.g. 0.94.0), used verbatim and overriding bump — set to skip a minor
+        required: false
+        type: string
+        default: ""
 
 jobs:
   prepare:
@@ -52,8 +57,16 @@ jobs:
             | jq -r '.packages[] | select(.name == "quillmark") | .version')
 
           RC="${{ inputs.release_candidate }}"
+          OVERRIDE="${{ inputs.version_override }}"
 
-          if [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+          if [[ -n "$OVERRIDE" ]]; then
+            # Explicit target (e.g. skip a minor): used verbatim; the checkbox
+            # still decides whether to cut it as a fresh -rc.1.
+            NEXT="$OVERRIDE"
+            if [[ "$RC" == "true" && "$NEXT" != *-rc.* ]]; then
+              NEXT="${NEXT}-rc.1"
+            fi
+          elif [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
             # Already an RC: the target base version is fixed, so `bump` is
             # ignored. The checkbox decides whether to iterate or promote.
             RC_BASE="${BASH_REMATCH[1]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ These notes cover everything since v0.92.1. No 0.93.x was separately
 published — the 0.93 milestone folds into this release, so the upgrade path
 from 0.92.1 is the `0.92-to-0.93` and `0.93-to-0.94` guides read in sequence.
 
+- feat(wasm): the live-session / canvas-paint surface graduates from
+  `@experimental` to stable — `Engine.open`, `LiveSession`, `apply` /
+  `ChangeSet`, `paint` / `PaintOptions` / `PaintResult`, `PageSize`, and the
+  `supportsCanvas` probe are now the committed preview API. The tag is dropped
+  from the runtime `.d.ts` / `.js`, the wasm README, and `PREVIEW.md`; further
+  shape changes follow the normal deprecation path rather than landing in any
+  0.x. `Engine.render` / `supportedFormats` remain the one-shot path
 - refactor(core)!: field ordering becomes fully structural — `ui.order` is
   removed and an authored `order:` is a load error. Field and card-kind display
   order is now the key order of the emitted schema (declaration order, backed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,68 @@
 
 ## Unreleased
 
+These notes cover everything since v0.92.1. No 0.93.x was separately
+published — the 0.93 milestone folds into this release, so the upgrade path
+from 0.92.1 is the `0.92-to-0.93` and `0.93-to-0.94` guides read in sequence.
+
+- refactor(core)!: field ordering becomes fully structural — `ui.order` is
+  removed and an authored `order:` is a load error. Field and card-kind display
+  order is now the key order of the emitted schema (declaration order, backed by
+  an `IndexMap`), and the auto-stamped `order:` integer disappears from
+  `QuillConfig::schema()`; consumers walk the maps in key order instead of
+  sorting on a stamped index. Typed-dictionary / typed-table-row properties
+  render in declaration order, not alphabetically (#941). See
+  `docs/migrations/0.93-to-0.94.md`
+- feat(core)!: a card-level `ui.groups` registry gives groups identity and
+  order. `ui.group` becomes a validated reference to a snake_case id
+  (`quill::unknown_group` for a dangling ref); the registry's declaration order
+  fixes group display order, labels derive from the id with a `title:` override,
+  and a bare label-as-identity group is deprecated (`quill::implicit_group`). A
+  nested `ui.group` is a load error (`quill::nested_group_not_supported`) (#941).
+  See `docs/migrations/0.93-to-0.94.md`
+- feat(core,typst,wasm,python)!: `plaintext` and a first-class `enum` join the
+  schema. `plaintext` is navigable unformatted prose carried over the richtext
+  corpus (a literal codec, with a `plaintext(field)` helper on the Typst side);
+  `enum` is promoted to `type: enum` + `values:`, and the `enum:` modifier on
+  `string` is deprecated for one release. `string` narrows to open scalar data
+  (#938). See `docs/migrations/0.93-to-0.94.md`
+- refactor(core)!: `type: richtext(inline)` retires — declare `type: richtext`
+  with `inline: true`. The old token is a hard `quill::field_parse_error`, and
+  `inline: true` on a non-richtext field is likewise rejected. Blueprint still
+  emits `richtext(inline)<markdown>` and `build_transform_schema` gains
+  `quillmark:inline: true`, both derived from the flag; documents and corpus
+  wire shapes are unaffected. See `docs/migrations/0.93-to-0.94.md`
+- refactor(pdfform)!: `form.json` slims to a binding layer (`form@0.2.0`). Bound
+  `fields` drop `type` / `options` / `multiline` (derived from the schema
+  field's kind, `enum` values, and `ui.multiline`); unbound widgets move to a
+  `widgets` section; binding runs at load, so a bad `schema_field` fails with
+  `pdfform::dangling_binding` / `pdfform::unbindable_field` instead of a silent
+  blank. `form@0.1.0` is rejected and `$cards` absolute-index addressing is
+  removed. Widget geometry is placed once at bind, not per render (#940). See
+  `docs/migrations/0.93-to-0.94.md`
+- refactor(core,richtext,wasm,python)!: the binding write surface settles into
+  two tiers over a document-free corpus codec. `quill.writer(doc)` (wasm and
+  Python alike) is the documented default — typed `set` / `set_all` / `setBody`
+  / `addCard` / `card(i)` and quill-free `get` / `getMarkdown` reads — layered
+  over the corpus lane (`importMarkdown` / `exportMarkdown` / `rebase` / `mapPos`
+  plus the addressed `install` / `revise` / `applyChange` verbs) and the opaque
+  `setField` primitive. The eager `bodyMarkdown` / `fieldMarkdown` projections
+  and the per-address body writers retire pre-release; `replaceBody` /
+  `replace_body` / `update_card_body` alias for one cycle; richtext fields gain
+  the anchor-preserving `revise_field`; the addressed `commit(addr, …)` is
+  deleted (subsumed by the writer). A core-vs-bindings parity table governs
+  drift (#925, #932). See `docs/migrations/0.93-to-0.94.md`
+- refactor(wasm)!: the `Card` shape splits by direction — a read `Card` always
+  carries `body: RichText`, while `pushCard` / `insertCard` take a `CardInput`
+  whose `body` still accepts a markdown string and whose non-`kind` fields are
+  optional (#917). The card-write verbs become mechanical twins of their
+  main-card names: `updateCardField` / `updateCardFields` rename to
+  `setCardField` / `setCardFields` (#895). See `docs/migrations/0.93-to-0.94.md`
+- fix(typst/overlay): underline / strike decoration ink no longer truncates
+  `$body` field regions — the region geometry is taken before decoration strokes
+  extend the glyph ink box, so a highlighted body field's box matches the text
+  instead of the overrun (#937)
+- chore: migrate org references `quillmark-org` → `borb-sh` across the tree
 - fix(richtext): the markdown-export codec never leaks a delimiter into the
   corpus. An editor `apply_mark_ops` mark can wrap a span markdown can't
   represent (a `strong`/`emph`/`strike` edge on punctuation/symbols/whitespace,

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -309,12 +309,6 @@ write.
 
 ### `engine.render(quill, parsed, opts?)` vs. `engine.open(quill, parsed)`
 
-> **Experimental:** the entire session surface — `engine.open`,
-> `LiveSession`, `apply`, `ChangeSet`, `paint`, `PaintOptions`, `PaintResult`,
-> `PageSize`, and the `supportsCanvas` probe — ships ahead of its first
-> production consumer and may change shape in any 0.x release. `engine.render`
-> is the stable path.
-
 Use **`engine.render`** for one-shot exports (PDF/SVG/PNG) — compiles, emits
 artifacts, done. Use **`LiveSession`** (returned by `engine.open`) for
 reactive previews: the session is a persistent compiler. `paint` / `render` /

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -195,7 +195,6 @@ export type OutputFormat = 'pdf' | 'svg' | 'txt' | 'png';
 
 /**
  * Canonical contract every backend build must satisfy. Page geometry in pt.
- * @experimental Part of the iterative-session/canvas surface — see {@link LiveSession}.
  */
 export interface PageSize {
 	widthPt: number;
@@ -204,7 +203,6 @@ export interface PageSize {
 
 /**
  * Canonical contract every backend build must satisfy. Inputs to `paint`.
- * @experimental Part of the iterative-session/canvas surface — see {@link LiveSession}.
  */
 export interface PaintOptions {
 	layoutScale?: number;
@@ -213,7 +211,6 @@ export interface PaintOptions {
 
 /**
  * Canonical contract every backend build must satisfy. Output of `paint`.
- * @experimental Part of the iterative-session/canvas surface — see {@link LiveSession}.
  */
 export interface PaintResult {
 	layoutWidth: number;      // canvas.style.width target; independent of densityScale
@@ -240,7 +237,6 @@ export interface PaintResult {
  * {@link LiveSession.apply}: `dirtyPages` lists the pages whose rendered
  * content differs from the previous compile, including added pages; removed
  * pages are implied by `pageCount`. Repaint `dirty ∩ visible`.
- * @experimental Part of the live-session/canvas surface — see {@link LiveSession}.
  */
 export interface ChangeSet {
 	pageCount: number;
@@ -294,9 +290,6 @@ export declare class Engine {
 	 * The `quill` and `doc` handles are read synchronously before the first
 	 * await, so the caller may `free()` them as soon as this call returns; the
 	 * caller owns the returned session and must `.free()` it.
-	 * @experimental Ships ahead of its first production consumer (the designed
-	 * canvas live-preview path — see `prose/canon/PREVIEW.md`). The session/paint
-	 * surface may change in any 0.x release; `render()` is the stable path.
 	 */
 	open(quill: Quill, doc: Document): Promise<LiveSession>;
 
@@ -318,7 +311,6 @@ export declare class Engine {
 	 * the resulting {@link LiveSession.supportsCanvas} answers `false`. Gate
 	 * mounting a canvas UI on this; gate the actual `paint` call on the session's
 	 * getter once `open()` has run.
-	 * @experimental Probes the experimental session/canvas surface — see {@link LiveSession}.
 	 */
 	supportsCanvas(quill: Quill): Promise<boolean>;
 }
@@ -335,11 +327,6 @@ export declare class Engine {
  * {@link LiveSession.regions} carries schema-field geometry for interactive
  * overlays / cross-navigation drawn on top of the raster; it is never needed to
  * complete the picture.
- *
- * @experimental The whole session/canvas-paint surface (`Engine.open`,
- * `LiveSession`, `PaintOptions`, `PaintResult`, `PageSize`) ships ahead of
- * its first production consumer and may change shape in any 0.x release.
- * The stable render path is `Engine.render`.
  */
 export declare class LiveSession {
 	private constructor();

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -318,9 +318,6 @@ export class Engine {
 	 * the caller owns the returned session and must `.free()` it. The `quill`
 	 * and `doc` handles are read synchronously before the first await, so the
 	 * caller may `free()` them as soon as this call returns.
-	 * @experimental Ships ahead of its first production consumer (the designed
-	 * canvas live-preview path); the session/paint surface may change in any
-	 * 0.x release. `render()` is the stable path.
 	 * @param {Quill} quill
 	 * @param {Document} doc
 	 * @returns {Promise<LiveSession>}

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -10,6 +10,12 @@ so a guide is the path forward, not an optional read. Each guide is scoped to a
 single version step; to cross several versions, work through the relevant
 guides in order.
 
+!!! note "0.93 was never separately published"
+
+    The 0.93 milestone folded into 0.94.0 — no 0.93.x release was tagged.
+    Upgrading from 0.92.1 means following the **0.92 → 0.93** and
+    **0.93 → 0.94** guides in sequence.
+
 ## Available guides
 
 - [0.93 → 0.94](0.93-to-0.94.md) — `type: richtext(inline)` retires; declare

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -106,8 +106,8 @@ otherwise too, so eviction is unconditional, not a session feature.
 
 **One session type.** Immutability is an invariant, not a type: reads between
 edits see a stable document because apply swaps the compile only on success,
-and the preview consumer (ours — the session surface is `@experimental` and
-preview is WASM-only by non-goal) executes serially. There is no separate
+and the preview consumer (ours — preview is WASM-only by non-goal) executes
+serially. There is no separate
 frozen snapshot type and no change-generation counter — with a single owned
 consumer there is no cross-edit reader to protect. If a long-lived read-only
 viewer ever needs to shed the retained world, a `freeze()` that drops it and


### PR DESCRIPTION
## Summary

Graduates the live-session/canvas-paint surface from `@experimental` to stable API, removes the experimental tag from all related types and methods, and updates documentation to reflect the commitment. Also adds support for explicit version override in the release workflow.

## Key Changes

- **API Stability**: Removed `@experimental` annotations from:
  - `Engine.open()`, `LiveSession`, `apply()` / `ChangeSet`, `paint()` / `PaintOptions` / `PaintResult`, `PageSize`, and `supportsCanvas` probe
  - Updated both TypeScript definitions (`runtime.d.ts`) and JSDoc comments (`runtime.js`)
  - Removed experimental notices from wasm README and `PREVIEW.md`

- **Release Workflow Enhancement**: Added `version_override` input to `release-prepare.yml` workflow to allow explicit version specification (e.g., to skip a minor version), overriding the bump type when set

- **Documentation Updates**:
  - Added comprehensive CHANGELOG entry documenting the graduation and all related breaking changes in 0.94.0
  - Updated migration guide index to note that 0.93 was never separately published
  - Clarified that `Engine.render()` / `supportedFormats` remain the one-shot stable path

## Implementation Details

The graduation is purely a documentation/annotation change — no runtime behavior modifications. Future shape changes to the now-stable API will follow the normal deprecation path rather than landing in any 0.x release. The CHANGELOG documents this alongside other major breaking changes in the 0.94.0 release (field ordering, ui.groups registry, plaintext/enum types, richtext(inline) retirement, pdfform binding layer, writer surface settlement, Card shape split, and typst/overlay underline fix).

https://claude.ai/code/session_01Qnf6pA76RXQYQKPYB5u5Bw