### PR TITLE
Re-export corpus edit vocabulary from @quillmark/wasm root (#948)

### DIFF
--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -125,3 +125,43 @@ void paintResultKeys;
 void fieldRegionKeys;
 void changeSetKeys;
 void corpusHitKeys;
+
+// ── Re-export presence guard (#948) ─────────────────────────────────────────
+// The corpus edit vocabulary is DECLARED in the core build but consumed through
+// the single runtime entry point. Importing every name from the runtime root
+// here asserts the re-export in `runtime/runtime.d.ts` stays present: drop any
+// one and this import stops resolving, failing `npm run typecheck`. Type-only —
+// no runtime code, no assignability claim, pure existence.
+import type {
+	RichText,
+	RichTextLine,
+	RichTextContainer,
+	RichTextMark,
+	RichTextIsland,
+	CardInput,
+	PathStep,
+	Addr,
+	Delta,
+	Assoc,
+	LineOp,
+	MarkOp,
+	ChangeBundle
+} from '../../../pkg/runtime/runtime.d.ts';
+
+// Referencing each name in an exported tuple keeps the import "used" without a
+// runtime statement; an exported alias is never an unused-local error.
+export type CorpusExportsPresent = [
+	RichText,
+	RichTextLine,
+	RichTextContainer,
+	RichTextMark,
+	RichTextIsland,
+	CardInput,
+	PathStep,
+	Addr,
+	Delta,
+	Assoc,
+	LineOp,
+	MarkOp,
+	ChangeBundle
+];

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -33,6 +33,30 @@ export type {
 	QuillMetadata
 } from '../core/wasm.js';
 
+// Corpus edit vocabulary — the op-grained content model `Document`'s methods
+// speak (`applyChange(addr, bundle)`, `install(addr, rt)`, `revise(…) => Delta`).
+// Declared in the core build; re-exported here so the single public entry point
+// names every type its own re-exported surface already references — `Card.body`
+// is a `RichText`, `PayloadItem.nestedFills` a `PathStep[][]`, `CardInput.body` a
+// `RichText | string` — rather than forcing consumers to derive them structurally
+// off the `Document` handle. The corpus write path (a ProseMirror↔corpus codec)
+// must name all of them; they are its correctness core, not edge types.
+export type {
+	RichText,
+	RichTextLine,
+	RichTextContainer,
+	RichTextMark,
+	RichTextIsland,
+	CardInput,
+	PathStep,
+	Addr,
+	Delta,
+	Assoc,
+	LineOp,
+	MarkOp,
+	ChangeBundle
+} from '../core/wasm.js';
+
 // ── Error contract ──────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Fixes #948.

## What

`crates/bindings/wasm/runtime/runtime.d.ts` re-exported the `Quill`/`Document` handles, the render-side types, and the schema/diagnostic types — but not the **op-grained corpus vocabulary** those handles' own method signatures speak. This adds a type-only re-export block for:

- `RichText`, `RichTextLine`, `RichTextContainer`, `RichTextMark`, `RichTextIsland`
- `Addr`, `Delta`, `Assoc`, `LineOp`, `MarkOp`, `ChangeBundle`
- `CardInput`, `PathStep`

All 13 are declared in the core build (the `typescript_custom_section` blocks in `crates/bindings/wasm/src/engine.rs`), but `@quillmark/wasm/core` is not an exported subpath, so a consumer could reach them from neither entry point.

## Why

The gap left the public surface incoherent: the root already re-exports `Card` (`body: RichText`), `PayloadItem` (`nestedFills: PathStep[][]`), and `CardInput` (`body: RichText | string`) — types whose members reference types the consumer cannot name. A ProseMirror↔corpus codec (`doc.applyChange(addr, bundle)`, `doc.install(addr, rt)`, `doc.revise(...) => Delta`) must name all of them; they are its correctness core, not edge types. The downstream workaround was structural derivation off the re-exported handles (`Parameters<...>[0]`, `ReturnType<...>`) — drift-proof but indirect, and forced on every consumer.

## Approach

Chose the re-export (not a new `/core` subpath) to preserve the single-public-entry-point invariant the file's own header declares canonical. Type-only, so `runtime.js` is untouched and no runtime code changes.

## Guard

Added a re-export presence check to `runtime.types.test-d.ts`: it imports every name from the built runtime root, so dropping any re-export makes the import stop resolving and fails `npm run typecheck`. (`.test-d.ts` is a regular TS file, so `TS2305` surfaces at the import site even under `skipLibCheck`.)

## Testing

Type-only change verified end-to-end by CI's `npm run typecheck` (requires the WASM build; not run locally per repo convention). Each re-exported name confirmed declared in `engine.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfT52qmTHxFaD26BUgSfxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfT52qmTHxFaD26BUgSfxF)_