### PR TITLE
Add setContinues line op so hard breaks lower op-wise (#949)

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -731,6 +731,27 @@ card_kinds:
     ).toThrow()
   })
 
+  it('applyChange setContinues lowers a hard break op-wise (#949)', () => {
+    const doc = blankDoc()
+    // Two paragraph lines (a delta-inserted `\n` mints `continues:false`), so
+    // export separates them with a blank line — two blocks.
+    doc.revise({}, 'one two')
+    doc.applyChange({}, { delta: { ops: [{ retain: 3 }, { insert: '\n' }, { retain: 4 }] } })
+    expect(exportMarkdown(doc.main.body)).toContain('\n\n')
+
+    // setContinues turns the boundary into a within-block hard break: one block,
+    // no blank-line separator — and identity anchors ride through (op, not install).
+    doc.applyChange({}, { lineOps: [{ op: 'setContinues', line: 1, continues: true }] })
+    expect(exportMarkdown(doc.main.body)).not.toContain('\n\n')
+    expect(doc.main.body.lines[1].continues).toBe(true)
+
+    // `continues:true` on line 0 has nothing to continue — rejected, value intact.
+    expect(() =>
+      doc.applyChange({}, { lineOps: [{ op: 'setContinues', line: 0, continues: true }] }),
+    ).toThrow()
+    expect(doc.main.body.lines[1].continues).toBe(true)
+  })
+
   it('commitCardField resolves the card-kind schema and errors on a bad index', () => {
     const quill = buildQuill()
     const doc = Document.fromMarkdown(

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -267,7 +267,13 @@ export type MarkOp =
       ))
     | { op: "removeAnchor"; id: string };
 
-/** A line/block edit. `split`/`join` splice `\n`; `setKind`/`setContainers` touch metadata. */
+/**
+ * A line/block edit. `split`/`join` splice `\n`; `setKind`/`setContainers`/
+ * `setContinues` touch metadata. `setContinues` sets/clears a line's within-block
+ * hard-break flag (`RichTextLine.continues`) — the op-grained way to lower a
+ * Shift+Enter hard break or a new code-fence interior line; `continues: true` on
+ * line 0 is rejected (nothing precedes it to continue).
+ */
 export type LineOp =
     | { op: "split"; at: number }
     | { op: "join"; line: number }
@@ -276,7 +282,8 @@ export type LineOp =
           | { kind: "heading"; level: number }
           | { kind: "code"; lang?: string }
       ))
-    | { op: "setContainers"; line: number; containers: RichTextContainer[] };
+    | { op: "setContainers"; line: number; containers: RichTextContainer[] }
+    | { op: "setContinues"; line: number; continues: boolean };
 
 /**
  * A committed corpus edit bundle for `applyChange`: a text `delta` (default no

--- a/crates/richtext/src/ops.rs
+++ b/crates/richtext/src/ops.rs
@@ -51,6 +51,16 @@ pub enum LineOp {
         line: usize,
         containers: Vec<Container>,
     },
+    /// Set (or clear) a line's `continues` flag — whether it continues the
+    /// previous line's block across a within-block hard break (a markdown hard
+    /// break, a code fence's interior line) rather than starting a new block.
+    /// The op-grained twin of the value that `install` already round-trips:
+    /// `split`/`join`/text-delta `\n` insertion all mint `continues: false`
+    /// lines, so without this a hard break or a new code-fence interior line is
+    /// unreachable op-wise and falls back to a whole-`install` (losing that
+    /// edit's identity anchors). Setting `continues: true` on line 0 is
+    /// [`ApplyError::FirstLineContinues`] (nothing precedes it to continue).
+    SetContinues { line: usize, continues: bool },
 }
 
 // ── Change-bundle wire (mark / line op ⇄ JSON) ──────────────────────────────
@@ -163,6 +173,11 @@ pub fn line_op_to_value(op: &LineOp) -> Value {
                 Value::Array(containers.iter().map(container_to_value).collect()),
             );
         }
+        LineOp::SetContinues { line, continues } => {
+            m.insert("op".into(), "setContinues".into());
+            m.insert("line".into(), Value::from(*line));
+            m.insert("continues".into(), Value::Bool(*continues));
+        }
     }
     Value::Object(m)
 }
@@ -198,6 +213,13 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
                 .iter()
                 .map(container_from_value)
                 .collect::<Result<_, _>>()?,
+        }),
+        Some("setContinues") => Ok(LineOp::SetContinues {
+            line: line()?,
+            continues: o
+                .get("continues")
+                .and_then(Value::as_bool)
+                .ok_or(ParseError::Shape("setContinues continues"))?,
         }),
         _ => Err(ParseError::Shape("line op kind")),
     }
@@ -274,6 +296,11 @@ pub enum ApplyError {
         lines: usize,
         segments: usize,
     },
+    /// A [`LineOp::SetContinues`] tried to set `continues: true` on line 0, which
+    /// has nothing before it to continue — the apply-time twin of the
+    /// [`Invariant::FirstLineContinues`](crate::model::Invariant::FirstLineContinues)
+    /// validation error, refused here because `normalize` does not repair it.
+    FirstLineContinues,
     /// The text delta's expected base length disagreed with the corpus —
     /// it was built against a different revision.
     DeltaBaseMismatch {
@@ -460,6 +487,18 @@ impl RichText {
                 LineOp::SetContainers { line, containers } => {
                     let line = self.line_mut(*line)?;
                     line.containers = containers.clone();
+                }
+                LineOp::SetContinues { line, continues } => {
+                    // Line 0 has nothing before it to continue: setting the flag
+                    // there would forge the `FirstLineContinues` invariant that
+                    // `normalize` does not repair. Reject before the write so the
+                    // corpus stays valid (`apply_field_change` stages line ops on
+                    // a scratch copy, so this leaves `self` untouched).
+                    if *line == 0 && *continues {
+                        return Err(ApplyError::FirstLineContinues);
+                    }
+                    let l = self.line_mut(*line)?;
+                    l.continues = *continues;
                 }
             }
         }
@@ -776,6 +815,14 @@ mod tests {
                 line: 2,
                 containers: vec![Container::Quote],
             },
+            LineOp::SetContinues {
+                line: 1,
+                continues: true,
+            },
+            LineOp::SetContinues {
+                line: 3,
+                continues: false,
+            },
         ];
         for op in ops {
             let v = line_op_to_value(&op);
@@ -996,6 +1043,62 @@ mod tests {
         }])
         .unwrap();
         assert!(matches!(rt.lines[0].kind, LineKind::Heading { level: 2 }));
+    }
+
+    #[test]
+    fn line_op_set_continues_sets_and_clears() {
+        // Two paragraph lines (delta-split → both `continues: false`, i.e. two
+        // blocks). `setContinues` on line 1 turns the boundary into a within-block
+        // hard break, and export then emits one block, not two paragraphs.
+        let mut rt = from_markdown("one two").unwrap();
+        rt.apply_text_delta(&diff("one two", "one\ntwo")).unwrap();
+        assert!(!rt.lines[1].continues, "delta-split newline is a new block");
+
+        rt.apply_line_ops(&[LineOp::SetContinues {
+            line: 1,
+            continues: true,
+        }])
+        .unwrap();
+        assert!(rt.lines[1].continues);
+        assert_eq!(rt.validate(), Ok(()));
+        assert_eq!(
+            crate::export::to_markdown(&rt).matches("\n\n").count(),
+            0,
+            "a within-block hard break is not a paragraph boundary"
+        );
+
+        // Clearing restores the block boundary.
+        rt.apply_line_ops(&[LineOp::SetContinues {
+            line: 1,
+            continues: false,
+        }])
+        .unwrap();
+        assert!(!rt.lines[1].continues);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    #[test]
+    fn line_op_set_continues_rejects_first_line() {
+        let mut rt = from_markdown("one two").unwrap();
+        rt.apply_text_delta(&diff("one two", "one\ntwo")).unwrap();
+        let before = rt.clone();
+        // `continues: true` on line 0 forges `FirstLineContinues`; refused, and
+        // the corpus is left untouched.
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContinues {
+                line: 0,
+                continues: true,
+            }]),
+            Err(ApplyError::FirstLineContinues)
+        );
+        assert_eq!(rt, before, "rejected op leaves the corpus untouched");
+        // Clearing line 0 (already `false`) is a no-op, not an error.
+        rt.apply_line_ops(&[LineOp::SetContinues {
+            line: 0,
+            continues: false,
+        }])
+        .unwrap();
+        assert_eq!(rt.validate(), Ok(()));
     }
 
     fn island(id: &str) -> Island {


### PR DESCRIPTION
Fixes #949.

## What

A `RichTextLine.continues` flag marks a *within-block* hard line break — a paragraph hard break, or a code fence's interior line. It's the difference between one code block of three lines and three separate code blocks. The `LineOp` vocabulary the `applyChange` bundle accepts (`split` / `join` / `setKind` / `setContainers`) had **no way to set or clear it**: `split`, `join`, and a text-delta `\n` all mint `continues: false` lines. So two common edits were unreachable op-wise:

- **Shift+Enter / hard break** inside a paragraph.
- **Enter inside a code block** (a new interior line).

Both fell back to `doc.install(addr, newRt)` — correct output, but at the cost of that edit's identity anchors, which is the very thing `applyChange` exists to preserve over `install`.

## Change

Adds `LineOp::SetContinues { line, continues }`, threaded through the wire codec (`line_op_to_value` / `line_op_from_value`) and therefore through every binding that lowers a bundle via the shared `change_bundle_from_value` — the wasm `applyChange` (TS `LineOp` union updated) and Python both pick it up with no per-binding code.

## Design decisions

- **Line-0 guard.** `apply_line_ops` only normalizes; it never validates, and `normalize` does not repair a first-line continuation. Setting `continues: true` on line 0 would forge the existing `Invariant::FirstLineContinues`, so it's rejected before the write with a new `ApplyError::FirstLineContinues` (the apply-time twin of that validation error). `apply_field_change` already stages line ops on a scratch copy, so a rejected op leaves the corpus untouched — verified by test. Clearing line 0 (already `false`) is a no-op, not an error.
- **Parity with `install`, not stricter.** The op sets the flag exactly as `install` already stores it; it adds no "continues must match predecessor kind/containers" constraint. Any such tightening would be a separate decision covering both write paths, so this op opens no new corpus shape that `install` couldn't already produce.
- **Additive.** New op variant + new error variant; no existing consumer needs to change. Nothing in-workspace matches these enums exhaustively (bindings lower via the shared reader and render `ApplyError` via `Debug`), so no downstream match breaks.

## Testing

- `quillmark-richtext` unit tests: wire round-trip for both boolean values; apply set→clear with an export assertion (a `continues` line emits **one** hard-break block, not two blank-line-separated paragraphs); the line-0 guard leaving the corpus byte-identical.
- `quillmark-richtext` + `quillmark-core` suites pass locally.
- `crates/bindings/wasm/basic.test.js` exercises the same path through `doc.applyChange` (runs on CI per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfT52qmTHxFaD26BUgSfxF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfT52qmTHxFaD26BUgSfxF)_