### PR TITLE
feat: keyed card reads getCardField/getCardMarkdown (#953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(wasm,python): keyed card reads `getCardField(index, name)` / `getCardMarkdown(index, name?)` (py `get_card_field` / `get_card_markdown`) — the card-indexed twins of `get` / `getMarkdown`, mirroring the `commitCardField` / `setCardField` write verbs so card reads no longer require a `payloadItems` walk (#953)
+
 ## v0.94.0 - 2026-07-15
 
 - Delete prose/plans directory

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -541,12 +541,11 @@ impl PyDocument {
         }
     }
 
-    /// Read a composable card's field value — the card-indexed twin of `get`.
-    /// Returns a dict for a richtext corpus, a scalar/list/dict otherwise, or
-    /// `None` when the field is absent. Raises `IndexOutOfRange` when `index` is
-    /// out of range: a bad card index is a boundary error, not an absent field, so
-    /// it surfaces the way the card write verbs do rather than reading back as
-    /// `None`. Mirrors WASM `Document.getCardField`.
+    /// Read a composable card's field value — the card-indexed twin of `get`: a
+    /// dict for a richtext corpus, a scalar/list/dict otherwise, or `None` when
+    /// the field is absent. An out-of-range `index` raises `IndexOutOfRange`, as
+    /// the card write verbs do — a bad index is a boundary error, not an absent
+    /// field. Mirrors WASM `Document.getCardField`.
     fn get_card_field<'py>(
         &self,
         py: Python<'py>,
@@ -560,9 +559,9 @@ impl PyDocument {
     }
 
     /// The markdown projection of a composable card's field (`name` given) or its
-    /// body (`name` omitted) — the card-indexed twin of `get_markdown`, returning
-    /// `""` for an absent field. Raises `IndexOutOfRange` when `index` is out of
-    /// range. Mirrors WASM `Document.getCardMarkdown`.
+    /// body (`name` omitted) — the card-indexed twin of `get_markdown`, `""` for
+    /// an absent field. An out-of-range `index` raises `IndexOutOfRange`. Mirrors
+    /// WASM `Document.getCardMarkdown`.
     #[pyo3(signature = (index, name=None))]
     fn get_card_markdown(&self, index: usize, name: Option<&str>) -> PyResult<String> {
         let card = self.card_or_raise(index)?;

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -541,6 +541,37 @@ impl PyDocument {
         }
     }
 
+    /// Read a composable card's field value — the card-indexed twin of `get`.
+    /// Returns a dict for a richtext corpus, a scalar/list/dict otherwise, or
+    /// `None` when the field is absent. Raises `IndexOutOfRange` when `index` is
+    /// out of range: a bad card index is a boundary error, not an absent field, so
+    /// it surfaces the way the card write verbs do rather than reading back as
+    /// `None`. Mirrors WASM `Document.getCardField`.
+    fn get_card_field<'py>(
+        &self,
+        py: Python<'py>,
+        index: usize,
+        name: &str,
+    ) -> PyResult<Option<Bound<'py, PyAny>>> {
+        match self.card_or_raise(index)?.payload().get(name) {
+            Some(v) => Ok(Some(quillvalue_to_py(py, v)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// The markdown projection of a composable card's field (`name` given) or its
+    /// body (`name` omitted) — the card-indexed twin of `get_markdown`, returning
+    /// `""` for an absent field. Raises `IndexOutOfRange` when `index` is out of
+    /// range. Mirrors WASM `Document.getCardMarkdown`.
+    #[pyo3(signature = (index, name=None))]
+    fn get_card_markdown(&self, index: usize, name: Option<&str>) -> PyResult<String> {
+        let card = self.card_or_raise(index)?;
+        Ok(match name {
+            Some(n) => card.field_markdown(n).unwrap_or_default(),
+            None => card.body_markdown(),
+        })
+    }
+
     /// Store an opaque value on a main-card field, clearing any `!must_fill`
     /// marker. The quill-free primitive: it holds only the `$quill` *reference*,
     /// stores the value verbatim, and defers coercion/validation to render.
@@ -879,6 +910,16 @@ impl PyDocument {
     fn card_mut_or_raise(&mut self, index: usize) -> PyResult<&mut quillmark_core::Card> {
         let len = self.inner.cards().len();
         self.inner.card_mut(index).ok_or_else(|| {
+            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
+        })
+    }
+
+    /// Resolve a composable card by index for a read, raising the same
+    /// `IndexOutOfRange` error the card mutators raise. The immutable twin of
+    /// `card_mut_or_raise`, shared by the card-indexed reads.
+    fn card_or_raise(&self, index: usize) -> PyResult<&quillmark_core::Card> {
+        let len = self.inner.cards().len();
+        self.inner.cards().get(index).ok_or_else(|| {
             convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
         })
     }

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -380,6 +380,43 @@ def test_set_card_field_out_of_range():
         doc.set_card_field(0, "title", "x")
 
 
+def test_get_card_field():
+    """get_card_field reads a card field by name — the card-indexed twin of get,
+    agreeing with the payload_items projection it replaces."""
+    doc = Document.from_markdown(MD_WITH_CARDS)
+    assert doc.get_card_field(0, "foo") == "bar"
+    assert doc.get_card_field(0, "foo") == field(doc.cards[0], "foo")
+    # A valid card with no such field reads back as None (not an error).
+    assert doc.get_card_field(0, "missing") is None
+
+
+def test_get_card_field_out_of_range():
+    """get_card_field raises IndexOutOfRange for a bad card index — a boundary
+    error, the way the card write verbs surface it, not an absent field."""
+    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.get_card_field(0, "foo")
+
+
+def test_get_card_markdown():
+    """get_card_markdown projects a card field (name given) or the card body
+    (name omitted) — the card-indexed twin of get_markdown."""
+    doc = Document.from_markdown(MD_WITH_CARDS)
+    # A bare string field imports as markdown.
+    assert "bar" in doc.get_card_markdown(0, "foo")
+    # Body when name omitted.
+    assert "Card one." in doc.get_card_markdown(0)
+    # Absent field → "".
+    assert doc.get_card_markdown(0, "missing") == ""
+
+
+def test_get_card_markdown_out_of_range():
+    """get_card_markdown raises IndexOutOfRange for a bad card index."""
+    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        doc.get_card_markdown(0)
+
+
 def test_revise_card_body():
     """revise(md, card=i) revises a card body and returns the text delta."""
     doc = Document.from_markdown(MD_WITH_CARDS)

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -156,7 +156,10 @@ title: Draft
     expect(doc.cards[0].kind).toBe('note')
 
     doc.setCardField(0, 'author', 'Bob')
-    expect(field(doc.cards[0], 'author')).toBe('Bob')
+    // Keyed card read (#953) — mirrors the write, no payloadItems walk. Agrees
+    // with the hand-rolled projection it replaces.
+    expect(doc.getCardField(0, 'author')).toBe('Bob')
+    expect(doc.getCardField(0, 'author')).toBe(field(doc.cards[0], 'author'))
 
     // Storage DTO round-trips losslessly — the editor's persistence path.
     const restored = Document.fromJson(doc.toJson())
@@ -165,5 +168,31 @@ title: Draft
     // Removal works back down to empty.
     doc.removeCard(0)
     expect(doc.cardCount).toBe(0)
+  })
+
+  it('keyed card reads mirror the card write verbs (#953)', () => {
+    const doc = Document.fromMarkdown(`~~~
+$quill: core_test
+$kind: main
+title: Draft
+~~~
+
+# Body`)
+    doc.pushCard(Document.makeCard('note', { author: 'Alice' }, 'A note body.'))
+
+    // getCardField — value keyed by name; undefined when the field is absent.
+    expect(doc.getCardField(0, 'author')).toBe('Alice')
+    expect(doc.getCardField(0, 'missing')).toBeUndefined()
+
+    // getCardMarkdown — the card body when name omitted, the field projection
+    // when named (a bare string field imports as markdown).
+    expect(doc.getCardMarkdown(0)).toContain('A note body.')
+    expect(doc.getCardMarkdown(0, 'author')).toContain('Alice')
+    expect(doc.getCardMarkdown(0, 'missing')).toBe('')
+
+    // An out-of-range index is a boundary error — it throws, the way the card
+    // write verbs do, rather than reading back as undefined/"".
+    expect(() => doc.getCardField(1, 'author')).toThrow()
+    expect(() => doc.getCardMarkdown(1)).toThrow()
   })
 })

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -859,12 +859,11 @@ impl Document {
     }
 
     /// Read a composable card's field value — the card-indexed twin of
-    /// [`get`](Self::get). Returns the raw payload value (a corpus object for a
-    /// richtext field, a scalar/array/object otherwise), or `undefined` when the
-    /// field is absent. Throws `[EditError::IndexOutOfRange]` when `index` is out
-    /// of range: a bad card index is a boundary error, not an absent field, so it
-    /// surfaces the way the card *write* verbs (`commitCardField` / `setCardField`
-    /// / `removeCardField`) do rather than reading back as `undefined`.
+    /// [`get`](Self::get): the raw payload value (a corpus object for a richtext
+    /// field, a scalar/array/object otherwise), or `undefined` when the field is
+    /// absent. An out-of-range `index` throws `[EditError::IndexOutOfRange]`, as
+    /// the card write verbs do — a bad index is a boundary error, not an absent
+    /// field.
     #[wasm_bindgen(js_name = getCardField)]
     pub fn get_card_field(&self, index: usize, name: &str) -> Result<JsValue, JsValue> {
         match self.card_or_throw(index)?.payload().get(name) {
@@ -875,12 +874,10 @@ impl Document {
 
     /// The markdown projection of a composable card's field (`name` given) or its
     /// body (`name` omitted) — the card-indexed twin of
-    /// [`getMarkdown`](Self::get_markdown), returning `""` for an absent field.
-    /// Re-coins the card-scoped projection the eager `cardFieldMarkdown` getter
-    /// dropped in #925 (the field case); the body case twins `getMarkdown()`.
-    /// Throws `[EditError::IndexOutOfRange]` when `index` is out of range — the
-    /// one idiom difference from the infallible main `getMarkdown`, forced by the
-    /// index.
+    /// [`getMarkdown`](Self::get_markdown), `""` for an absent field. An
+    /// out-of-range `index` throws `[EditError::IndexOutOfRange]`; that
+    /// fallibility is the one difference from the infallible main `getMarkdown`,
+    /// forced by the index.
     #[wasm_bindgen(js_name = getCardMarkdown)]
     pub fn get_card_markdown(
         &self,

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -858,6 +858,42 @@ impl Document {
         }
     }
 
+    /// Read a composable card's field value — the card-indexed twin of
+    /// [`get`](Self::get). Returns the raw payload value (a corpus object for a
+    /// richtext field, a scalar/array/object otherwise), or `undefined` when the
+    /// field is absent. Throws `[EditError::IndexOutOfRange]` when `index` is out
+    /// of range: a bad card index is a boundary error, not an absent field, so it
+    /// surfaces the way the card *write* verbs (`commitCardField` / `setCardField`
+    /// / `removeCardField`) do rather than reading back as `undefined`.
+    #[wasm_bindgen(js_name = getCardField)]
+    pub fn get_card_field(&self, index: usize, name: &str) -> Result<JsValue, JsValue> {
+        match self.card_or_throw(index)?.payload().get(name) {
+            Some(v) => serialize_or_throw(v.as_json(), "getCardField"),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// The markdown projection of a composable card's field (`name` given) or its
+    /// body (`name` omitted) — the card-indexed twin of
+    /// [`getMarkdown`](Self::get_markdown), returning `""` for an absent field.
+    /// Re-coins the card-scoped projection the eager `cardFieldMarkdown` getter
+    /// dropped in #925 (the field case); the body case twins `getMarkdown()`.
+    /// Throws `[EditError::IndexOutOfRange]` when `index` is out of range — the
+    /// one idiom difference from the infallible main `getMarkdown`, forced by the
+    /// index.
+    #[wasm_bindgen(js_name = getCardMarkdown)]
+    pub fn get_card_markdown(
+        &self,
+        index: usize,
+        #[wasm_bindgen(unchecked_optional_param_type = "string")] name: Option<String>,
+    ) -> Result<String, JsValue> {
+        let card = self.card_or_throw(index)?;
+        Ok(match name {
+            Some(n) => card.field_markdown(&n).unwrap_or_default(),
+            None => card.body_markdown(),
+        })
+    }
+
     /// Number of composable cards (excludes the main card). O(1).
     #[wasm_bindgen(getter, js_name = cardCount)]
     pub fn card_count(&self) -> usize {
@@ -1477,6 +1513,17 @@ impl Document {
     fn card_mut_or_throw(&mut self, index: usize) -> Result<&mut quillmark_core::Card, JsValue> {
         let len = self.inner.cards().len();
         self.inner.card_mut(index).ok_or_else(|| {
+            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+        })
+    }
+
+    /// Resolve a composable card by index for a read, mapping out-of-range to the
+    /// same `IndexOutOfRange` JS error the card mutators throw. The immutable twin
+    /// of [`card_mut_or_throw`](Self::card_mut_or_throw), shared by the
+    /// card-indexed reads.
+    fn card_or_throw(&self, index: usize) -> Result<&quillmark_core::Card, JsValue> {
+        let len = self.inner.cards().len();
+        self.inner.cards().get(index).ok_or_else(|| {
             edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
         })
     }

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -82,7 +82,8 @@ ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
 | Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
 | Card creation | `add_card(kind, fields, body?)` | `addCard` / `add_card` | identical — fused make + typed-commit + push, transactional |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
-| Reads | `card.field_markdown(..)` / `payload().get(..)` | `doc.getMarkdown(name?)` / `doc.get(name)` | **idiom** — the bindings fuse the read into one named verb on `Document` |
+| Reads (main) | `card.field_markdown(..)` / `payload().get(..)` | `doc.getMarkdown(name?)` / `doc.get(name)` | **idiom** — the bindings fuse the read into one named verb on `Document` |
+| Reads (card) | `cards()[i].field_markdown(..)` / `payload().get(..)` | `doc.getCardMarkdown(i, name?)` / `doc.getCardField(i, name)` | **idiom** — the card-indexed twins of the main reads, mirroring the card write verbs; `getCardMarkdown` is a fallible `Result` (the index bounds-check) where main `getMarkdown` is infallible |
 | Richtext ops | `card.revise_field(name, md)?` (borrow chain) | `doc.revise({card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation |
 | Opaque primitive | `set_field` / `set_fields` | `setField` / `setCardField` (JS), `set_field` / `set_fields` (py) | identical |
 


### PR DESCRIPTION
Add card-indexed read methods to complement the existing card write verbs, eliminating the need for `payloadItems` walks when reading composable card fields.

## Summary

Introduces `getCardField(index, name)` and `getCardMarkdown(index, name?)` to WASM and Python bindings as the read-side twins of `commitCardField` / `setCardField` / `removeCardField`. These methods provide direct, keyed access to composable card field values and markdown projections by card index, mirroring the ergonomics and error handling of the write verbs.

## Changes

- **WASM bindings** (`crates/bindings/wasm/src/engine.rs`):
  - `getCardField(index, name)`: Returns raw payload value (corpus object for richtext, scalar/array/object otherwise), or `undefined` for absent fields. Throws `IndexOutOfRange` for invalid card indices.
  - `getCardMarkdown(index, name?)`: Returns markdown projection of a field (when `name` given) or card body (when omitted). Returns `""` for absent fields. Throws `IndexOutOfRange` for invalid indices.
  - `card_or_throw()`: Helper method to resolve card by index with consistent error handling, mirroring `card_mut_or_throw`.

- **Python bindings** (`crates/bindings/python/src/types.rs`):
  - `get_card_field(index, name)`: Returns dict for richtext corpus, scalar/list/dict otherwise, or `None` for absent fields. Raises `IndexOutOfRange` for invalid indices.
  - `get_card_markdown(index, name=None)`: Returns markdown projection with same semantics as WASM variant.
  - `card_or_raise()`: Helper method for consistent card resolution and error handling.

- **Tests**:
  - WASM: Added comprehensive test suite covering field reads, markdown projections, absent fields, and out-of-range error handling.
  - Python: Added parallel test coverage for both new methods with boundary condition validation.

- **Documentation**: Updated `CHANGELOG.md` and `BINDINGS.md` to reflect the new keyed card read idiom.

## Implementation Details

- Both methods treat out-of-range card indices as boundary errors (throwing/raising), consistent with card write verbs, rather than returning undefined/None like main card reads.
- Absent fields return `undefined`/`None` for `getCardField`/`get_card_field` and `""`/`""` for markdown projections.
- The implementation reuses existing `field_markdown()` and `body_markdown()` methods from the core `Card` type.

https://claude.ai/code/session_01W7qdhBSKRFzwnrmaB6jfhR