### PR TITLE
core: make ParseOutput the single owner of parse warnings (#959)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **breaking** core: `Payload::insert` / `insert_fill` now validate the field-name and value-depth invariant at the boundary and return `Result<_, FieldViolation>`, closing the `payload_mut().insert(...)` hole that let a direct caller build an invalid document; pre-validated internal callers use the new `pub(crate)` `insert_unchecked` / `insert_fill_unchecked` (#958)
 - **breaking** core: parse warnings live only on `ParseOutput` — the redundant `Document::warnings` field + `warnings()` getter are dropped and `Document::from_main_and_cards` no longer takes a `warnings` param (`Document` `PartialEq` is now a plain derive). `from_markdown` / `from_markdown_with_warnings` are unchanged (#959)
 - feat(wasm,python): keyed card reads `getCardField(index, name)` / `getCardMarkdown(index, name?)` (py `get_card_field` / `get_card_markdown`) — the card-indexed twins of `get` / `getMarkdown`, mirroring the `commitCardField` / `setCardField` write verbs so card reads no longer require a `payloadItems` walk (#953)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **breaking** core: `Payload::insert` / `insert_fill` now validate the field-name and value-depth invariant at the boundary and return `Result<_, FieldViolation>`, closing the `payload_mut().insert(...)` hole that let a direct caller build an invalid document; pre-validated internal callers use the new `pub(crate)` `insert_unchecked` / `insert_fill_unchecked` (#958)
+- feat(wasm,core): single-card reads — `doc.card(i)` (throws out of range), `doc.cardIndexById(id)` (first match; `$id` is non-unique), and `doc.seedOverlay(kind)`, backed by core `Document::card(i)` / `find_card(id)`. Reading one card, resolving a `$id`, or fetching a `$seed` overlay no longer serializes the whole `cards` array or main card (#956)
 - **breaking** core: parse warnings live only on `ParseOutput` — the redundant `Document::warnings` field + `warnings()` getter are dropped and `Document::from_main_and_cards` no longer takes a `warnings` param (`Document` `PartialEq` is now a plain derive). `from_markdown` / `from_markdown_with_warnings` are unchanged (#959)
 - feat(wasm,python): keyed card reads `getCardField(index, name)` / `getCardMarkdown(index, name?)` (py `get_card_field` / `get_card_markdown`) — the card-indexed twins of `get` / `getMarkdown`, mirroring the `commitCardField` / `setCardField` write verbs so card reads no longer require a `payloadItems` walk (#953)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **breaking** core: parse warnings live only on `ParseOutput` — the redundant `Document::warnings` field + `warnings()` getter are dropped and `Document::from_main_and_cards` no longer takes a `warnings` param (`Document` `PartialEq` is now a plain derive). `from_markdown` / `from_markdown_with_warnings` are unchanged (#959)
 - feat(wasm,python): keyed card reads `getCardField(index, name)` / `getCardMarkdown(index, name?)` (py `get_card_field` / `get_card_markdown`) — the card-indexed twins of `get` / `getMarkdown`, mirroring the `commitCardField` / `setCardField` write verbs so card reads no longer require a `payloadItems` walk (#953)
 
 ## v0.94.0 - 2026-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **breaking** wasm: fold `pushCard` into `insertCard(card, at?)` — one insertion verb per lane, absent `at` appends; `insertCard`'s parameters reorder to `(card, at?)`. Delete the deprecated `replaceBody` alias (use `revise({}, md)` or `writer.setBody`) (#961)
+- feat(core,wasm): positioned card insert — `TypedWriter::add_card` / `writer.addCard` and the `addCard` ABI take an `at` position, so a positioned typed insert is one atomic call instead of `addCard` + `moveCard`; add `TypedWriter::remove_card` (mirrors JS `writer.removeCard`) and a JS `CardWriter.kind` getter (mirrors core `CardWriter::kind()`) (#961)
 - **breaking** core: `Payload::insert` / `insert_fill` now validate the field-name and value-depth invariant at the boundary and return `Result<_, FieldViolation>`, closing the `payload_mut().insert(...)` hole that let a direct caller build an invalid document; pre-validated internal callers use the new `pub(crate)` `insert_unchecked` / `insert_fill_unchecked` (#958)
 - feat(wasm,core): single-card reads — `doc.card(i)` (throws out of range), `doc.cardIndexById(id)` (first match; `$id` is non-unique), and `doc.seedOverlay(kind)`, backed by core `Document::card(i)` / `find_card(id)`. Reading one card, resolving a `$id`, or fetching a `$seed` overlay no longer serializes the whole `cards` array or main card (#956)
 - **breaking** core: parse warnings live only on `ParseOutput` — the redundant `Document::warnings` field + `warnings()` getter are dropped and `Document::from_main_and_cards` no longer takes a `warnings` param (`Document` `PartialEq` is now a plain derive). `from_markdown` / `from_markdown_with_warnings` are unchanged (#959)

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1015,7 +1015,7 @@ impl PyWriter {
         quill
             .inner
             .writer(&mut doc.inner)
-            .add_card(kind, batch, body.as_deref())
+            .add_card(kind, batch, body.as_deref(), None)
             .map_err(convert_edit_errors)
     }
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -89,7 +89,7 @@ is resolved at render time, not here. Loads no backend binary.
 A blank document: a main card carrying only `$quill`, an empty body, and no
 composable cards — the programmatic blank canvas. Absent fields resolve at
 render time (schema `default`, else type-empty zero), so nothing the caller
-did not set reaches the output. Build it up with `setFields` / `pushCard`.
+did not set reaches the output. Build it up with `setFields` / `insertCard`.
 For an example-filled starter use `quill.seedDocument()`. Throws on an
 invalid quill reference.
 
@@ -233,21 +233,21 @@ const markdown = doc.toMarkdown();
 For per-card seeding, `quill.seedMain()` returns just the `$kind: main` card
 and `quill.seedCard(kind)` returns a starter composable card (or `undefined`
 if the kind is not declared). Both return the read `Card` shape of
-`doc.main` / `doc.cards`, which `doc.pushCard` / `doc.insertCard` accept
-directly:
+`doc.main` / `doc.cards`, which `doc.insertCard` accepts directly:
 
 ```ts
-doc.pushCard(quill.seedCard("note"));                 // seed → push
-doc.pushCard(Document.makeCard("note", { x: 1 }));    // build from a flat map
-doc.pushCard({ kind: "note", body: "Plain **markdown**." });  // bare inline
+doc.insertCard(quill.seedCard("note"));                 // seed → append
+doc.insertCard(Document.makeCard("note", { x: 1 }));    // build from a flat map
+doc.insertCard({ kind: "note", body: "Plain **markdown**." });  // bare inline
+doc.insertCard({ kind: "note" }, 0);                    // insert at index 0
 ```
 
 Reads and writes are two aligned shapes. A read `Card` always has `body:
 RichText` (canonical corpus, never a raw string) — no narrowing, no guessing
 whether the body was normalized. The write shape `CardInput` widens `body` to
 `RichText | string` (a markdown string imports to the corpus) and makes every
-field but `kind` optional. Every `Card` is a valid `CardInput`, so `pushCard` /
-`insertCard` still take exactly what `cards` / `removeCard` / `seedCard` return.
+field but `kind` optional. Every `Card` is a valid `CardInput`, so `insertCard`
+still takes exactly what `cards` / `removeCard` / `seedCard` return.
 Build a fresh card from a flat field map with
 `Document.makeCard(kind, fields?, body?)`.
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -172,8 +172,8 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
 
     // Mutate
     doc.setField('title', 'New Title')
-    doc.pushCard(Document.makeCard('note', { author: 'Alice' }, 'Hello'))
-    doc.replaceBody('Updated body')
+    doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'Hello'))
+    doc.revise({}, 'Updated body')
 
     // Emit
     const emitted = doc.toMarkdown()
@@ -248,7 +248,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
   it('round-trips a mutated document with cards', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.setField('title', 'New Title')
-    doc.pushCard(Document.makeCard('note', { author: 'Alice' }, 'Hello'))
+    doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'Hello'))
 
     const restored = Document.fromJson(doc.toJson())
 
@@ -567,7 +567,7 @@ describe('Document editor surface — setFields / setCardFields', () => {
 
   it('setCardFields is the card-indexed twin of setFields', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.pushCard(Document.makeCard('note', { foo: 'bar' }))
+    doc.insertCard(Document.makeCard('note', { foo: 'bar' }))
     doc.setCardFields(0, { foo: 'baz', extra: 1 })
     expect(field(doc.cards[0], 'foo')).toBe('baz')
     expect(field(doc.cards[0], 'extra')).toBe(1)
@@ -575,7 +575,7 @@ describe('Document editor surface — setFields / setCardFields', () => {
   })
 })
 
-describe('Document editor surface — setQuillRef / replaceBody(deprecated) / install / revise', () => {
+describe('Document editor surface — setQuillRef / install / revise', () => {
   it('setQuillRef changes the quillRef', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.setQuillRef('new_quill')
@@ -585,12 +585,6 @@ describe('Document editor surface — setQuillRef / replaceBody(deprecated) / in
   it('setQuillRef throws on invalid reference', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     expect(() => doc.setQuillRef('INVALID QUILL REF WITH SPACES')).toThrow()
-  })
-
-  it('replaceBody (deprecated alias for revise) changes the body', () => {
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.replaceBody('Brand new body.')
-    expect(exportMarkdown(doc.main.body)).toBe('Brand new body.\n')
   })
 
   it('revise({}, md) revises the main body and returns the text delta', () => {
@@ -826,42 +820,42 @@ $kind: summary
 Card two.
 `
 
-  it('pushCard appends a card', () => {
+  it('insertCard appends a card when at is omitted', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.pushCard(Document.makeCard('note', {}, 'My card.'))
+    doc.insertCard(Document.makeCard('note', {}, 'My card.'))
     expect(doc.cards.length).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
     expect(exportMarkdown(doc.cards[0].body)).toBe('My card.\n')
   })
 
-  it('pushCard throws on invalid kind', () => {
+  it('insertCard throws on invalid kind', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.pushCard({ kind: 'BadKind' })).toThrow(/InvalidKindName/)
+    expect(() => doc.insertCard({ kind: 'BadKind' })).toThrow(/InvalidKindName/)
   })
 
-  it('removeCard → pushCard round-trips a card with fields (read shape == write shape)', () => {
+  it('removeCard → insertCard round-trips a card with fields (read shape == write shape)', () => {
     // The whole point of the one-Card-shape change: a card returned by
-    // removeCard feeds straight back into pushCard with its fields intact.
+    // removeCard feeds straight back into insertCard with its fields intact.
     const doc = Document.fromMarkdown(MD_WITH_CARDS) // `note` (foo: bar) + `summary`
     const initialCount = doc.cards.length
     const removed = doc.removeCard(0) // the `note` card
     expect(doc.cards.length).toBe(initialCount - 1)
     expect(field(removed, 'foo')).toBe('bar')
 
-    doc.pushCard(removed) // re-push the returned card; fields must not drop
+    doc.insertCard(removed) // re-push the returned card; fields must not drop
     expect(doc.cards.length).toBe(initialCount)
     const repushed = doc.cards[doc.cards.length - 1]
     expect(repushed.kind).toBe('note')
     expect(field(repushed, 'foo')).toBe('bar')
   })
 
-  it('makeCard accepts any kind; pushCard is the kind gate', () => {
+  it('makeCard accepts any kind; insertCard is the kind gate', () => {
     // makeCard is pure data-shaping (permissive); the cards-list invariant is
     // enforced at insertion, not construction.
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const bad = Document.makeCard('BadKind', { x: 1 })
     expect(bad.kind).toBe('BadKind') // construction succeeds
-    expect(() => doc.pushCard(bad)).toThrow(/InvalidKindName/) // insertion rejects
+    expect(() => doc.insertCard(bad)).toThrow(/InvalidKindName/) // insertion rejects
   })
 
   it('makeCard treats fields and body as optional', () => {
@@ -876,19 +870,19 @@ Card two.
 
   it('a stale { kind, fields } object is a loud error, not a silent empty card', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.pushCard({ kind: 'note', fields: { x: 1 } })).toThrow()
+    expect(() => doc.insertCard({ kind: 'note', fields: { x: 1 } })).toThrow()
   })
 
   it('insertCard inserts at specified index', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARDS)
-    doc.insertCard(0, { kind: 'intro' })
+    doc.insertCard({ kind: 'intro' }, 0)
     expect(doc.cards[0].kind).toBe('intro')
     expect(doc.cards[1].kind).toBe('note')
   })
 
-  it('insertCard throws IndexOutOfRange when index > len', () => {
+  it('insertCard throws IndexOutOfRange when at > len', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.insertCard(5, { kind: 'note' })).toThrow(/IndexOutOfRange/)
+    expect(() => doc.insertCard({ kind: 'note' }, 5)).toThrow(/IndexOutOfRange/)
   })
 
   it('removeCard removes and returns the card', () => {
@@ -949,7 +943,7 @@ Card two.
 
     const two = Document.fromMarkdown(MD_WITH_CARDS)
     expect(two.cardCount).toBe(2)
-    two.pushCard({ kind: 'extra' })
+    two.insertCard({ kind: 'extra' })
     expect(two.cardCount).toBe(3)
     two.removeCard(0)
     expect(two.cardCount).toBe(2)
@@ -979,14 +973,14 @@ describe('Document.equals', () => {
   it('returns false after a body mutation', () => {
     const a = Document.fromMarkdown(TEST_MARKDOWN)
     const b = Document.fromMarkdown(TEST_MARKDOWN)
-    b.replaceBody('Different body')
+    b.revise({}, 'Different body')
     expect(a.equals(b)).toBe(false)
   })
 
   it('returns false after pushing a card', () => {
     const a = Document.fromMarkdown(TEST_MARKDOWN)
     const b = Document.fromMarkdown(TEST_MARKDOWN)
-    b.pushCard({ kind: 'note' })
+    b.insertCard({ kind: 'note' })
     expect(a.equals(b)).toBe(false)
   })
 
@@ -1087,8 +1081,8 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
 
     // Mutate
     doc.setField('author', 'Bob')
-    doc.replaceBody('New body text.')
-    doc.pushCard({ kind: 'note', body: 'Card content.' })
+    doc.revise({}, 'New body text.')
+    doc.insertCard({ kind: 'note', body: 'Card content.' })
     doc.setQuillRef('updated_quill')
 
     // Assert state
@@ -1161,7 +1155,7 @@ describe('Document editor surface — $ext mutators', () => {
 
   it('card-level ext mutators target the card at index', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.pushCard({ kind: 'note', body: 'x' })
+    doc.insertCard({ kind: 'note', body: 'x' })
     doc.setCardExt(0, { agent: { note: 'y' } })
     expect(doc.cards[0].ext.agent.note).toBe('y')
     expect(doc.removeCardExt(0).agent.note).toBe('y')
@@ -1170,7 +1164,7 @@ describe('Document editor surface — $ext mutators', () => {
 
   it('card-level namespace mutators preserve siblings and clear when empty', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.pushCard({ kind: 'note', body: 'x' })
+    doc.insertCard({ kind: 'note', body: 'x' })
     doc.setCardExtNamespace(0, 'editor', { title: 'A' })
     doc.setCardExtNamespace(0, 'tutorial', ['step-1'])
     expect(doc.removeCardExtNamespace(0, 'tutorial')).toEqual(['step-1'])
@@ -1628,7 +1622,7 @@ title: !must_fill
 })
 
 describe('nested !must_fill', () => {
-  it('exposes nestedFills on a field item, surviving storage and pushCard', () => {
+  it('exposes nestedFills on a field item, surviving storage and insertCard', () => {
     const md = `~~~card-yaml
 $quill: q@0.1
 $kind: main
@@ -1645,11 +1639,11 @@ addr:
     const restored = Document.fromJson(doc.toJson())
     expect(restored.toMarkdown()).toContain('street: !must_fill')
 
-    // A card built with nestedFills survives pushCard → emit.
+    // A card built with nestedFills survives insertCard → emit.
     const doc2 = Document.fromMarkdown(
       '~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: x\n~~~\n',
     )
-    doc2.pushCard({
+    doc2.insertCard({
       kind: 'note',
       payloadItems: [
         {

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -151,7 +151,7 @@ title: Draft
 
     // Edit the main card and append a composable card.
     doc.setField('title', 'Final')
-    doc.pushCard(Document.makeCard('note', { author: 'Alice' }, 'A note.'))
+    doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'A note.'))
     expect(doc.cardCount).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
 
@@ -178,7 +178,7 @@ title: Draft
 ~~~
 
 # Body`)
-    doc.pushCard(Document.makeCard('note', { author: 'Alice' }, 'A note body.'))
+    doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'A note body.'))
 
     // getCardField — value keyed by name; undefined when the field is absent.
     expect(doc.getCardField(0, 'author')).toBe('Alice')
@@ -204,9 +204,9 @@ title: Draft
 ~~~
 
 # Body`)
-    doc.pushCard({ kind: 'note', id: 'dup', body: 'A' })
-    doc.pushCard({ kind: 'note', id: 'other', body: 'B' })
-    doc.pushCard({ kind: 'note', id: 'dup', body: 'C' })
+    doc.insertCard({ kind: 'note', id: 'dup', body: 'A' })
+    doc.insertCard({ kind: 'note', id: 'other', body: 'B' })
+    doc.insertCard({ kind: 'note', id: 'dup', body: 'C' })
 
     // card(i) reads one whole card without materializing the cards array.
     expect(doc.card(1).kind).toBe('note')

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -195,4 +195,33 @@ title: Draft
     expect(() => doc.getCardField(1, 'author')).toThrow()
     expect(() => doc.getCardMarkdown(1)).toThrow()
   })
+
+  it('single-card, $id, and seed-overlay reads (#956)', () => {
+    const doc = Document.fromMarkdown(`~~~
+$quill: core_test
+$kind: main
+title: Draft
+~~~
+
+# Body`)
+    doc.pushCard({ kind: 'note', id: 'dup', body: 'A' })
+    doc.pushCard({ kind: 'note', id: 'other', body: 'B' })
+    doc.pushCard({ kind: 'note', id: 'dup', body: 'C' })
+
+    // card(i) reads one whole card without materializing the cards array.
+    expect(doc.card(1).kind).toBe('note')
+    expect(doc.card(1).id).toBe('other')
+    expect(() => doc.card(3)).toThrow() // out of range is a boundary error
+
+    // cardIndexById resolves the durable $id address; non-unique → first match.
+    expect(doc.cardIndexById('dup')).toBe(0)
+    expect(doc.cardIndexById('other')).toBe(1)
+    expect(doc.cardIndexById('missing')).toBeUndefined()
+
+    // seedOverlay reads one $seed[kind] entry off the main card cheaply, the
+    // overlay you feed straight into quill.seedCard(kind, overlay).
+    doc.setSeedNamespace('note', { author: 'Seeded' })
+    expect(doc.seedOverlay('note')).toEqual({ author: 'Seeded' })
+    expect(doc.seedOverlay('absent')).toBeUndefined()
+  })
 })

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -509,11 +509,14 @@ export declare class DocumentWriter {
 	setBody(markdown: string): void;
 	/**
 	 * Build a composable card of `kind`, typed-commit `fields` onto it, set its
-	 * body from optional markdown, and append it — the fused `makeCard` + typed
-	 * commit + `pushCard`. Transactional: a rejected field (throws a per-field
-	 * diagnostic bundle) or an invalid kind/body leaves the document untouched.
+	 * body from optional markdown, and place it — the fused `makeCard` + typed
+	 * commit + insertion. `at` picks the position: omitted appends, a number
+	 * inserts at that index, so a positioned typed insert is one atomic call
+	 * rather than `addCard` + `moveCard`. Transactional: a rejected field (throws
+	 * a per-field diagnostic bundle) or an invalid kind/body/position leaves the
+	 * document untouched.
 	 */
-	addCard(kind: string, fields?: Record<string, unknown>, body?: string): void;
+	addCard(kind: string, fields?: Record<string, unknown>, body?: string, at?: number): void;
 	/** Remove the composable card at `index`, returning it (or `undefined`). */
 	removeCard(index: number): Card | undefined;
 	/**
@@ -535,6 +538,12 @@ export declare class CardWriter {
 	constructor(quill: Quill, doc: Document, index: number);
 	/** The bound card index. */
 	readonly index: number;
+	/**
+	 * The bound card's `$kind` (empty string when it carries none), read through
+	 * the document — mirrors core `CardWriter::kind()`. Throws `IndexOutOfRange`
+	 * if the bound index is out of range.
+	 */
+	readonly kind: string;
 	set(name: string, value: unknown): void;
 	setAll(fields: Record<string, unknown>): void;
 	/** Set this card's body from markdown (edit semantics), discarding the delta. */

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -588,18 +588,22 @@ export class DocumentWriter {
 	}
 	/**
 	 * Build a composable card of `kind`, typed-commit `fields` onto it, set its
-	 * body from optional markdown, and append it — the fused `makeCard` + typed
-	 * commit + `pushCard`. Transactional: the card is committed in full before it
-	 * joins the document, so a rejected field (throws a per-field diagnostic
-	 * bundle, `UnknownField` per undeclared name) or an invalid kind/body leaves
-	 * the document untouched. See `Document.addCard`.
+	 * body from optional markdown, and place it — the fused `makeCard` + typed
+	 * commit + insertion. `at` picks the position: omitted appends, a number
+	 * inserts at that index (`0..=cardCount`), so a positioned typed insert is one
+	 * atomic call rather than `addCard` + `moveCard`. Transactional: the card is
+	 * committed in full before it joins the document, so a rejected field (throws
+	 * a per-field diagnostic bundle, `UnknownField` per undeclared name) or an
+	 * invalid kind/body/position leaves the document untouched. See
+	 * `Document.addCard`.
 	 * @param {string} kind
 	 * @param {Record<string, unknown>} [fields]
 	 * @param {string} [body]
+	 * @param {number} [at] insertion index; appends when omitted
 	 * @returns {void}
 	 */
-	addCard(kind, fields, body) {
-		return this.#doc.addCard(this.#quill, kind, fields, body);
+	addCard(kind, fields, body, at) {
+		return this.#doc.addCard(this.#quill, kind, fields, body, at);
 	}
 	/**
 	 * Remove the composable card at `index`, returning it (or `undefined` if the
@@ -649,6 +653,15 @@ export class CardWriter {
 	/** The bound card index. */
 	get index() {
 		return this.#index;
+	}
+	/**
+	 * The bound card's `$kind` (empty string when it carries none), read through
+	 * the document — mirrors core `CardWriter::kind()`. Ephemeral like the cursor
+	 * itself: throws `IndexOutOfRange` if the bound index is out of range.
+	 * @returns {string}
+	 */
+	get kind() {
+		return this.#doc.card(this.#index).kind;
 	}
 	/**
 	 * Typed-commit one field on this card, per `Document.commitCardField`.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -898,10 +898,10 @@ impl Document {
     }
 
     /// A single composable card by index — the whole `Card`, the card-indexed
-    /// twin of the [`main`](Self::main) getter, so reading one card no longer
-    /// means materializing every card via [`cards`](Self::cards). An
-    /// out-of-range `index` throws `[EditError::IndexOutOfRange]`, matching the
-    /// card write verbs.
+    /// twin of the [`main`](Self::main) getter, so reading one card need not
+    /// materialize every card via [`cards`](Self::cards). An out-of-range
+    /// `index` throws `[EditError::IndexOutOfRange]`, matching the card write
+    /// verbs.
     #[wasm_bindgen(js_name = card, unchecked_return_type = "Card")]
     pub fn card(&self, index: usize) -> Result<JsValue, JsValue> {
         card_to_js(self.card_or_throw(index)?)

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -107,7 +107,7 @@ export interface QuillMetadata {
 /// `quillmark_core::CardWire`) and its write-input twin `CardInput`. `Card` is
 /// the read shape *returned* by `Document.main` / `cards` / `removeCard` /
 /// `quill.seedCard` / `Document.makeCard`; `CardInput` is the shape *accepted*
-/// by `pushCard` / `insertCard` (referenced by name via `unchecked_param_type`).
+/// by `insertCard` (referenced by name via `unchecked_param_type`).
 /// They differ only in `body`: a read is always canonical `RichText`, a write
 /// also takes a markdown `string`.
 #[wasm_bindgen(typescript_custom_section)]
@@ -128,7 +128,7 @@ export type PayloadItem =
           /**
            * Paths to `!must_fill` markers nested *inside* `value` (the `value`
            * projection itself is fill-free). Absent when the field has no nested
-           * placeholders. Preserved across `pushCard` / `makeCard`.
+           * placeholders. Preserved across `insertCard` / `makeCard`.
            */
           nestedFills?: PathStep[][];
       }
@@ -138,7 +138,7 @@ export type PayloadItem =
  * A single card block, as read back from a document: returned by
  * `Document.main` / `Document.cards` / `Document.removeCard` / `Quill.seedCard`
  * / `Document.makeCard`. To feed a card *into* a document use `CardInput`
- * (which `pushCard` / `insertCard` accept); every `Card` is a valid `CardInput`,
+ * (which `insertCard` accepts); every `Card` is a valid `CardInput`,
  * so a card read from one document pushes straight into another.
  *
  * `$` system entries are hoisted to named fields: `kind` (the `$kind`, empty
@@ -165,7 +165,7 @@ export interface Card {
 
 /**
  * A card written *into* a document — the input twin of `Card`, accepted by
- * `Document.pushCard` / `Document.insertCard`. Like `Card` but `body` also
+ * `Document.insertCard`. Like `Card` but `body` also
  * takes a markdown `string` (imported to the corpus, so a markdown / LLM writer
  * needn't build the `RichText` shape), and every field but `kind` is optional —
  * an absent field defaults (no payload items, an empty body). Write one inline
@@ -611,7 +611,7 @@ impl Quill {
     /// layering an optional per-kind seed `overlay` over the schema-example
     /// base (`overlay › example › absent`). Returns `undefined` if `cardKind`
     /// is not declared in this quill's schema, else a `Card` that feeds
-    /// straight into `Document.pushCard` / `insertCard`.
+    /// straight into `Document.insertCard`.
     ///
     /// Pass `document.seedOverlay(cardKind)` as `overlay` so a card added to a
     /// template-derived document inherits its curated starting values; omit it
@@ -1153,19 +1153,6 @@ impl Document {
         Ok(())
     }
 
-    /// **Deprecated** — alias for `revise({}, markdown)`, kept one release cycle.
-    /// Revise the main card's body from a markdown string (edit semantics: a
-    /// `diff_import` that rebases surviving anchors). Discards the text delta;
-    /// call [`revise`](Document::revise) to receive it.
-    #[wasm_bindgen(js_name = replaceBody)]
-    pub fn replace_body(&mut self, body: &str) -> Result<(), JsValue> {
-        self.inner
-            .main_mut()
-            .revise_body(body)
-            .map(|_| ())
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
     /// **Install** a richtext value at `addr` — **value semantics**, corpus only.
     /// Stores exactly `rt` (a canonical `RichText` corpus object); the identity
     /// anchors of any previous value are gone. An absent `addr.field` targets the
@@ -1303,14 +1290,17 @@ impl Document {
     }
 
     /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
-    /// body from optional markdown, and append it — the ABI under
-    /// `writer.addCard`. Fuses `makeCard` + typed commit + `pushCard`
-    /// transactionally: the card is committed in full before it joins the
-    /// document, so a rejected field (or an invalid kind or body) leaves the
-    /// document untouched. Field errors throw the same per-field diagnostic
-    /// bundle as [`commitFields`](Self::commit_fields), including an
-    /// `[EditError::UnknownField]` per undeclared name; an invalid kind or body
-    /// throws a single-entry bundle keyed `$kind` / `$body`.
+    /// body from optional markdown, and place it — the ABI under `writer.addCard`.
+    /// `at` picks the position: absent appends, a number inserts at that index
+    /// (`0..=cards.length`), so a positioned typed insert is one atomic call
+    /// rather than `addCard` + `moveCard`. Fuses `makeCard` + typed commit +
+    /// insertion transactionally: the card is committed in full before it joins
+    /// the document, so a rejected field (or an invalid kind, body, or
+    /// out-of-range `at`) leaves the document untouched. Field errors throw the
+    /// same per-field diagnostic bundle as [`commitFields`](Self::commit_fields),
+    /// including an `[EditError::UnknownField]` per undeclared name; an invalid
+    /// kind or body, or an out-of-range position, throws a single-entry bundle
+    /// keyed `$kind` / `$body`.
     #[wasm_bindgen(js_name = addCard)]
     pub fn add_card(
         &mut self,
@@ -1320,6 +1310,7 @@ impl Document {
             JsValue,
         >,
         #[wasm_bindgen(unchecked_optional_param_type = "string")] body: Option<String>,
+        #[wasm_bindgen(unchecked_optional_param_type = "number")] at: Option<usize>,
     ) -> Result<(), JsValue> {
         let batch = match fields {
             Some(f) => js_value_to_field_batch(&f, "addCard")?,
@@ -1328,15 +1319,15 @@ impl Document {
         quill
             .inner
             .writer(&mut self.inner)
-            .add_card(kind, batch, body.as_deref())
+            .add_card(kind, batch, body.as_deref(), at)
             .map_err(edit_errors_to_js)
     }
 
     /// Build a fresh `Card` from a kind and a flat field map — the ergonomic
-    /// constructor for `pushCard` / `insertCard`. `fields` is an optional
+    /// constructor for `insertCard`. `fields` is an optional
     /// `Record<string, unknown>` (each entry becomes a card field, in
     /// insertion order); `body` defaults to `""`. Kind validity is checked by
-    /// `pushCard` / `insertCard`, not here.
+    /// `insertCard`, not here.
     #[wasm_bindgen(js_name = makeCard, unchecked_return_type = "Card")]
     pub fn make_card(
         kind: String,
@@ -1386,34 +1377,24 @@ impl Document {
         })
     }
 
-    /// Append a card to the end of the card list. Accepts a `CardInput` — a card
-    /// read back (`cards` / `removeCard` / `quill.seedCard`), a
-    /// [`makeCard`](Document::make_card) result, or a bare `{ kind, body }`
+    /// Insert a card — the single insertion verb: `at` absent appends, a number
+    /// inserts at that index (must be in `0..=cards.length`). Accepts a
+    /// `CardInput` — a card read back (`cards` / `removeCard` / `quill.seedCard`),
+    /// a [`makeCard`](Document::make_card) result, or a bare `{ kind, body }`
     /// (every returned `Card` is a valid `CardInput`). Throws if `card.kind` is
-    /// not a valid kind name.
-    #[wasm_bindgen(js_name = pushCard)]
-    pub fn push_card(
-        &mut self,
-        #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
-    ) -> Result<(), JsValue> {
-        let core_card = js_to_card(&card)?;
-        self.inner
-            .push_card(core_card)
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
-    /// Insert a card at `index` (must be in `0..=cards.length`). Accepts a
-    /// `CardInput` (see [`pushCard`](Self::push_card)).
+    /// not a valid kind name, or if `at` is out of range.
     #[wasm_bindgen(js_name = insertCard)]
     pub fn insert_card(
         &mut self,
-        index: usize,
         #[wasm_bindgen(unchecked_param_type = "CardInput")] card: JsValue,
+        #[wasm_bindgen(unchecked_optional_param_type = "number")] at: Option<usize>,
     ) -> Result<(), JsValue> {
         let core_card = js_to_card(&card)?;
-        self.inner
-            .insert_card(index, core_card)
-            .map_err(|e| edit_error_to_js(&e))
+        match at {
+            Some(index) => self.inner.insert_card(index, core_card),
+            None => self.inner.push_card(core_card),
+        }
+        .map_err(|e| edit_error_to_js(&e))
     }
 
     #[wasm_bindgen(js_name = removeCard, unchecked_return_type = "Card | undefined")]
@@ -1799,8 +1780,7 @@ fn card_to_js(card: &quillmark_core::Card) -> Result<JsValue, JsValue> {
 
 /// Deserialize a `CardInput`-shaped JS value into a core
 /// [`Card`](quillmark_core::Card) via [`CardWire`](quillmark_core::CardWire).
-/// The single place WASM turns JS into a core card — used by `pushCard` /
-/// `insertCard`.
+/// The single place WASM turns JS into a core card — used by `insertCard`.
 fn js_to_card(value: &JsValue) -> Result<quillmark_core::Card, JsValue> {
     // `serde_wasm_bindgen` does not honor the core type's
     // `#[serde(deny_unknown_fields)]` (it looks up known fields rather than

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -613,7 +613,7 @@ impl Quill {
     /// is not declared in this quill's schema, else a `Card` that feeds
     /// straight into `Document.pushCard` / `insertCard`.
     ///
-    /// Pass `document.main.seed?.[cardKind]` as `overlay` so a card added to a
+    /// Pass `document.seedOverlay(cardKind)` as `overlay` so a card added to a
     /// template-derived document inherits its curated starting values; omit it
     /// (or pass `undefined` / `null`) for the bare schema seed. `overlay` is a
     /// plain object — this reads the document, it does not mutate it.
@@ -895,6 +895,41 @@ impl Document {
     #[wasm_bindgen(getter, js_name = cardCount)]
     pub fn card_count(&self) -> usize {
         self.inner.cards().len()
+    }
+
+    /// A single composable card by index — the whole `Card`, the card-indexed
+    /// twin of the [`main`](Self::main) getter, so reading one card no longer
+    /// means materializing every card via [`cards`](Self::cards). An
+    /// out-of-range `index` throws `[EditError::IndexOutOfRange]`, matching the
+    /// card write verbs.
+    #[wasm_bindgen(js_name = card, unchecked_return_type = "Card")]
+    pub fn card(&self, index: usize) -> Result<JsValue, JsValue> {
+        card_to_js(self.card_or_throw(index)?)
+    }
+
+    /// The index of the first composable card whose `$id` equals `id`, or
+    /// `undefined` when none carries it. Resolves the canonical durable address
+    /// without a hand-rolled scan over [`cards`](Self::cards); `$id` is
+    /// non-unique by design, so the first match wins.
+    #[wasm_bindgen(js_name = cardIndexById, unchecked_return_type = "number | undefined")]
+    pub fn card_index_by_id(&self, id: &str) -> JsValue {
+        match self.inner.find_card(id) {
+            Some((index, _)) => JsValue::from_f64(index as f64),
+            None => JsValue::UNDEFINED,
+        }
+    }
+
+    /// The main card's `$seed` overlay object for `kind` (the `$seed[kind]`
+    /// entry), or `undefined` when absent. The cheap read that feeds
+    /// `quill.seedCard(kind, overlay)` without serializing the whole main card
+    /// via [`main`](Self::main) to fish out one key — and it keeps `seedCard`
+    /// pure: the quill still never reads the document.
+    #[wasm_bindgen(js_name = seedOverlay, unchecked_return_type = "Record<string, unknown> | undefined")]
+    pub fn seed_overlay(&self, kind: &str) -> Result<JsValue, JsValue> {
+        match self.inner.main().seed().and_then(|seed| seed.get(kind)) {
+            Some(overlay) => serialize_or_throw(overlay, "seedOverlay"),
+            None => Ok(JsValue::UNDEFINED),
+        }
     }
 
     /// Structural equality (parse-time `warnings` excluded). Use to debounce

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -385,7 +385,7 @@ pub(super) fn decompose_with_warnings(
         ));
     }
 
-    let doc = Document::from_main_and_cards(main, cards, warnings.clone());
+    let doc = Document::from_main_and_cards(main, cards);
 
     Ok((doc, warnings))
 }

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -562,7 +562,7 @@ impl TryFrom<DocumentV0_93_0> for Document {
                 }
             }
         }
-        Ok(Document::from_main_and_cards(main, cards, Vec::new()))
+        Ok(Document::from_main_and_cards(main, cards))
     }
 }
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -157,14 +157,22 @@ pub enum FieldViolation {
     TooDeep,
 }
 
-/// Map a [`FieldViolation`] to the mutator error surface.
-fn check_field(name: &str, value: &serde_json::Value) -> Result<(), EditError> {
-    validate_field(name, value).map_err(|v| match v {
+/// Map a [`FieldViolation`] to the mutator error surface — the single
+/// translation the `Card` mutators and the validating
+/// [`Payload::insert`](crate::document::Payload::insert) both route through.
+pub(crate) fn edit_error_from_violation(name: &str, v: FieldViolation) -> EditError {
+    match v {
         FieldViolation::InvalidName => EditError::InvalidFieldName(name.to_string()),
         FieldViolation::TooDeep => EditError::ValueTooDeep {
             max: crate::document::limits::MAX_YAML_DEPTH,
         },
-    })
+    }
+}
+
+/// Validate a user field at the mutator boundary, mapping a violation to the
+/// mutator error surface.
+fn check_field(name: &str, value: &serde_json::Value) -> Result<(), EditError> {
+    validate_field(name, value).map_err(|v| edit_error_from_violation(name, v))
 }
 
 /// Depth-bound an out-of-band meta map (`$ext` / `$seed`). Both ride the same
@@ -358,9 +366,9 @@ impl Card {
     /// Returns [`EditError::InvalidFieldName`] when `name` does not match
     /// `[A-Za-z_][A-Za-z0-9_]*`.
     pub fn set_field(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
-        let value = value.into();
-        check_field(name, value.as_json())?;
-        self.payload_mut().insert(name.to_string(), value);
+        self.payload_mut()
+            .insert(name.to_string(), value.into())
+            .map_err(|v| edit_error_from_violation(name, v))?;
         Ok(())
     }
 
@@ -368,9 +376,9 @@ impl Card {
     /// `Null` emits as `key: !must_fill`; scalars/sequences as `key: !must_fill <value>`.
     /// Same validation as [`Card::set_field`].
     pub fn set_fill(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
-        let value = value.into();
-        check_field(name, value.as_json())?;
-        self.payload_mut().insert_fill(name.to_string(), value);
+        self.payload_mut()
+            .insert_fill(name.to_string(), value.into())
+            .map_err(|v| edit_error_from_violation(name, v))?;
         Ok(())
     }
 
@@ -404,8 +412,10 @@ impl Card {
         if !errors.is_empty() {
             return Err(errors);
         }
+        // Batch validated above; apply through the unchecked insert so the
+        // whole-batch check is not re-run per field.
         for (name, value) in fields {
-            self.payload_mut().insert(name, value);
+            self.payload_mut().insert_unchecked(name, value);
         }
         Ok(())
     }
@@ -576,7 +586,7 @@ impl Card {
     fn store_field_corpus(&mut self, name: &str, corpus: &RichText) {
         let canonical = quillmark_richtext::serial::to_canonical_value(corpus);
         self.payload_mut()
-            .insert(name.to_string(), QuillValue::from_json(canonical));
+            .insert_unchecked(name.to_string(), QuillValue::from_json(canonical));
     }
 
     /// Write-time commit: validate and normalize `value` per the field's schema
@@ -622,7 +632,8 @@ impl Card {
         schema: &FieldSchema,
     ) -> Result<(), EditError> {
         let stored = resolve_field_write(name, value.into(), schema)?;
-        self.payload_mut().insert(name.to_string(), stored);
+        // `resolve_field_write` already validated name + stored-value depth.
+        self.payload_mut().insert_unchecked(name.to_string(), stored);
         Ok(())
     }
 

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -405,6 +405,27 @@ impl Document {
         &mut self.cards
     }
 
+    /// A single composable card by index — the immutable twin of
+    /// [`card_mut`](Document::card_mut), so reading one card's payload does not
+    /// require materializing every card via [`cards`](Document::cards). `None`
+    /// when out of range.
+    pub fn card(&self, index: usize) -> Option<&Card> {
+        self.cards.get(index)
+    }
+
+    /// The first composable card whose `$id` equals `id`, with its index —
+    /// resolving the canonical durable address ([PROGRAMMATIC.md]) without a
+    /// hand-rolled scan over [`cards`](Document::cards). `$id` is non-unique by
+    /// design, so this returns the first match; `None` when no card carries it.
+    ///
+    /// [PROGRAMMATIC.md]: https://github.com/borb-sh/quillmark/blob/main/prose/canon/PROGRAMMATIC.md
+    pub fn find_card(&self, id: &str) -> Option<(usize, &Card)> {
+        self.cards
+            .iter()
+            .enumerate()
+            .find(|(_, card)| card.id() == Some(id))
+    }
+
     pub(crate) fn cards_vec_mut(&mut self) -> &mut Vec<Card> {
         &mut self.cards
     }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -326,20 +326,16 @@ impl SeedOverlay {
 
 /// A fully-parsed Quillmark document. Serde routes through [`StoredDocument`];
 /// for the plate wire shape see [`Document::to_plate_json`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Parse-time warnings are *not* document state — they ride out-of-band on
+/// [`ParseOutput`] from [`Document::from_markdown_with_warnings`], the single
+/// owner. Equality and the storage DTO therefore cover only structural content
+/// (`main` and `cards`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(into = "StoredDocument", try_from = "StoredDocument")]
 pub struct Document {
     main: Card,
     cards: Vec<Card>,
-    warnings: Vec<Diagnostic>,
-}
-
-// `warnings` are parse-time observations and vary on round-trips; equality
-// covers only structural content (`main` and `cards`).
-impl PartialEq for Document {
-    fn eq(&self, other: &Self) -> bool {
-        self.main == other.main && self.cards == other.cards
-    }
 }
 
 impl Document {
@@ -358,13 +354,12 @@ impl Document {
         Self {
             main: Card::from_parts(payload, RichText::empty()),
             cards: Vec::new(),
-            warnings: Vec::new(),
         }
     }
 
     /// Create a `Document` from a pre-built main card and composable cards.
     /// `main` must carry `$quill`; composable cards must not.
-    pub fn from_main_and_cards(main: Card, cards: Vec<Card>, warnings: Vec<Diagnostic>) -> Self {
+    pub fn from_main_and_cards(main: Card, cards: Vec<Card>) -> Self {
         debug_assert!(main.quill().is_some(), "main card must carry `$quill`");
         debug_assert!(
             cards.iter().all(|c| c.quill().is_none()),
@@ -374,11 +369,7 @@ impl Document {
             cards.iter().all(|c| c.seed().is_none()),
             "composable cards must not carry `$seed`"
         );
-        Self {
-            main,
-            cards,
-            warnings,
-        }
+        Self { main, cards }
     }
 
     pub fn from_markdown(markdown: &str) -> Result<Self, ParseError> {
@@ -412,13 +403,6 @@ impl Document {
 
     pub fn cards_mut(&mut self) -> &mut [Card] {
         &mut self.cards
-    }
-
-    /// Non-fatal warnings from the parse; empty for a [`Document::new`] blank
-    /// canvas. [`Document::from_main_and_cards`] carries whatever `warnings`
-    /// the caller passes.
-    pub fn warnings(&self) -> &[Diagnostic] {
-        &self.warnings
     }
 
     pub(crate) fn cards_vec_mut(&mut self) -> &mut Vec<Card> {

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -561,8 +561,8 @@ impl Payload {
     /// the "a constructed document cannot be invalid" invariant holds even for
     /// the direct `Payload` path reachable through
     /// [`Card::payload_mut`](super::Card::payload_mut). Pre-validated callers
-    /// (typed commit, all-or-nothing batches) use
-    /// [`insert_unchecked`](Self::insert_unchecked) to skip the redundant check.
+    /// (typed commit, all-or-nothing batches) use `insert_unchecked` to skip the
+    /// redundant check.
     pub fn insert(
         &mut self,
         key: impl Into<String>,
@@ -575,8 +575,8 @@ impl Payload {
 
     /// [`insert`](Self::insert) without the field-invariant check. `pub(crate)`
     /// for callers that have already validated the exact stored `(name, value)`
-    /// — [`resolve_field_write`](super::edit::resolve_field_write) and the
-    /// batch setters that validate the whole batch before applying any of it.
+    /// — `resolve_field_write` and the batch setters that validate the whole
+    /// batch before applying any of it.
     pub(crate) fn insert_unchecked(
         &mut self,
         key: impl Into<String>,
@@ -623,7 +623,7 @@ impl Payload {
     }
 
     /// [`insert_fill`](Self::insert_fill) without the field-invariant check;
-    /// the fill twin of [`insert_unchecked`](Self::insert_unchecked).
+    /// the fill twin of `insert_unchecked`.
     pub(crate) fn insert_fill_unchecked(
         &mut self,
         key: impl Into<String>,

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -555,7 +555,33 @@ impl Payload {
     /// untouched. Replacing an existing field discards its
     /// `nested_comments` because the new value tree may not contain
     /// matching positions.
-    pub fn insert(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
+    ///
+    /// Validates the field name and value depth
+    /// ([`validate_field`](super::edit::validate_field)) at this boundary, so
+    /// the "a constructed document cannot be invalid" invariant holds even for
+    /// the direct `Payload` path reachable through
+    /// [`Card::payload_mut`](super::Card::payload_mut). Pre-validated callers
+    /// (typed commit, all-or-nothing batches) use
+    /// [`insert_unchecked`](Self::insert_unchecked) to skip the redundant check.
+    pub fn insert(
+        &mut self,
+        key: impl Into<String>,
+        value: QuillValue,
+    ) -> Result<Option<QuillValue>, super::edit::FieldViolation> {
+        let key = key.into();
+        super::edit::validate_field(&key, value.as_json())?;
+        Ok(self.insert_unchecked(key, value))
+    }
+
+    /// [`insert`](Self::insert) without the field-invariant check. `pub(crate)`
+    /// for callers that have already validated the exact stored `(name, value)`
+    /// — [`resolve_field_write`](super::edit::resolve_field_write) and the
+    /// batch setters that validate the whole batch before applying any of it.
+    pub(crate) fn insert_unchecked(
+        &mut self,
+        key: impl Into<String>,
+        value: QuillValue,
+    ) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
             if let PayloadItem::Field {
@@ -584,8 +610,25 @@ impl Payload {
 
     /// Insert or update a user field and mark it as a `!must_fill` placeholder.
     /// Preserves position for existing keys; appends new keys at the end.
-    /// Replacing an existing field discards its `nested_comments`.
-    pub fn insert_fill(&mut self, key: impl Into<String>, value: QuillValue) -> Option<QuillValue> {
+    /// Replacing an existing field discards its `nested_comments`. Validates
+    /// at the boundary like [`insert`](Self::insert).
+    pub fn insert_fill(
+        &mut self,
+        key: impl Into<String>,
+        value: QuillValue,
+    ) -> Result<Option<QuillValue>, super::edit::FieldViolation> {
+        let key = key.into();
+        super::edit::validate_field(&key, value.as_json())?;
+        Ok(self.insert_fill_unchecked(key, value))
+    }
+
+    /// [`insert_fill`](Self::insert_fill) without the field-invariant check;
+    /// the fill twin of [`insert_unchecked`](Self::insert_unchecked).
+    pub(crate) fn insert_fill_unchecked(
+        &mut self,
+        key: impl Into<String>,
+        value: QuillValue,
+    ) -> Option<QuillValue> {
         let key = key.into();
         for item in self.items.iter_mut() {
             if let PayloadItem::Field {
@@ -669,7 +712,7 @@ mod tests {
         let mut fm = Payload::new();
         fm.set_quill("foo@0.1".parse().unwrap());
         fm.set_kind("main");
-        fm.insert("title", qv("Hello"));
+        fm.insert("title", qv("Hello")).unwrap();
         let last = fm.items().last().unwrap();
         assert!(matches!(last, PayloadItem::Field { key, .. } if key == "title"));
     }
@@ -677,9 +720,9 @@ mod tests {
     #[test]
     fn insert_existing_preserves_position() {
         let mut fm = Payload::new();
-        fm.insert("a", qv("1"));
-        fm.insert("b", qv("2"));
-        fm.insert("a", qv("updated"));
+        fm.insert("a", qv("1")).unwrap();
+        fm.insert("b", qv("2")).unwrap();
+        fm.insert("a", qv("updated")).unwrap();
         let keys: Vec<&String> = fm.keys().collect();
         assert_eq!(keys, vec!["a", "b"]);
         assert_eq!(fm.get("a").unwrap().as_str(), Some("updated"));
@@ -688,10 +731,42 @@ mod tests {
     #[test]
     fn insert_clears_fill() {
         let mut fm = Payload::new();
-        fm.insert_fill("k", qv("placeholder"));
+        fm.insert_fill("k", qv("placeholder")).unwrap();
         assert!(fm.is_fill("k"));
-        fm.insert("k", qv("user value"));
+        fm.insert("k", qv("user value")).unwrap();
         assert!(!fm.is_fill("k"));
+    }
+
+    #[test]
+    fn insert_enforces_the_field_invariant() {
+        use super::super::edit::FieldViolation;
+
+        // Malformed name — the `payload_mut().insert(...)` hole that used to
+        // let an invalid field into a "constructed" document.
+        let mut fm = Payload::new();
+        assert_eq!(fm.insert("bad name", qv("v")), Err(FieldViolation::InvalidName));
+        assert_eq!(fm.insert("$id", qv("v")), Err(FieldViolation::InvalidName));
+        assert_eq!(
+            fm.insert_fill("bad name", qv("v")),
+            Err(FieldViolation::InvalidName)
+        );
+
+        // Over-deep value.
+        let mut deep = serde_json::json!(0);
+        for _ in 0..(crate::document::limits::MAX_YAML_DEPTH + 5) {
+            deep = serde_json::json!([deep]);
+        }
+        assert_eq!(
+            fm.insert("field", QuillValue::from_json(deep)),
+            Err(FieldViolation::TooDeep)
+        );
+
+        // Nothing was applied on any rejection.
+        assert!(fm.items().is_empty());
+
+        // The unchecked path is the deliberate escape hatch — no validation.
+        fm.insert_unchecked("bad name", qv("v"));
+        assert_eq!(fm.items().len(), 1);
     }
 
     #[test]

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -549,12 +549,10 @@ impl Payload {
         })
     }
 
-    /// Insert or update a user field. Always clears the `fill` marker
-    /// (field is no longer a placeholder). Preserves position for existing
-    /// keys; appends new keys at the end. `$` entries and comments are
-    /// untouched. Replacing an existing field discards its
-    /// `nested_comments` because the new value tree may not contain
-    /// matching positions.
+    /// Insert or update a user field, clearing any `!must_fill` marker.
+    /// Preserves position for an existing key; appends a new one. `$` entries
+    /// and comments are untouched; replacing a field discards its
+    /// `nested_comments` (the new value tree may not carry matching positions).
     ///
     /// Validates the field name and value depth
     /// ([`validate_field`](super::edit::validate_field)) at this boundary, so
@@ -570,7 +568,19 @@ impl Payload {
     ) -> Result<Option<QuillValue>, super::edit::FieldViolation> {
         let key = key.into();
         super::edit::validate_field(&key, value.as_json())?;
-        Ok(self.insert_unchecked(key, value))
+        Ok(self.insert_item(key, value, false))
+    }
+
+    /// Insert or update a user field and mark it a `!must_fill` placeholder;
+    /// same rules and boundary validation as [`insert`](Self::insert).
+    pub fn insert_fill(
+        &mut self,
+        key: impl Into<String>,
+        value: QuillValue,
+    ) -> Result<Option<QuillValue>, super::edit::FieldViolation> {
+        let key = key.into();
+        super::edit::validate_field(&key, value.as_json())?;
+        Ok(self.insert_item(key, value, true))
     }
 
     /// [`insert`](Self::insert) without the field-invariant check. `pub(crate)`
@@ -582,18 +592,23 @@ impl Payload {
         key: impl Into<String>,
         value: QuillValue,
     ) -> Option<QuillValue> {
-        let key = key.into();
+        self.insert_item(key.into(), value, false)
+    }
+
+    /// Insert or replace field `key` with `value`, setting its fill marker.
+    /// Position-preserving for an existing key, append otherwise.
+    fn insert_item(&mut self, key: String, value: QuillValue, fill: bool) -> Option<QuillValue> {
         for item in self.items.iter_mut() {
             if let PayloadItem::Field {
                 key: k,
                 value: v,
-                fill,
+                fill: item_fill,
                 nested_comments,
             } = item
             {
                 if k == &key {
                     let old = std::mem::replace(v, value);
-                    *fill = false;
+                    *item_fill = fill;
                     nested_comments.clear();
                     return Some(old);
                 }
@@ -602,54 +617,7 @@ impl Payload {
         self.items.push(PayloadItem::Field {
             key,
             value,
-            fill: false,
-            nested_comments: Vec::new(),
-        });
-        None
-    }
-
-    /// Insert or update a user field and mark it as a `!must_fill` placeholder.
-    /// Preserves position for existing keys; appends new keys at the end.
-    /// Replacing an existing field discards its `nested_comments`. Validates
-    /// at the boundary like [`insert`](Self::insert).
-    pub fn insert_fill(
-        &mut self,
-        key: impl Into<String>,
-        value: QuillValue,
-    ) -> Result<Option<QuillValue>, super::edit::FieldViolation> {
-        let key = key.into();
-        super::edit::validate_field(&key, value.as_json())?;
-        Ok(self.insert_fill_unchecked(key, value))
-    }
-
-    /// [`insert_fill`](Self::insert_fill) without the field-invariant check;
-    /// the fill twin of `insert_unchecked`.
-    pub(crate) fn insert_fill_unchecked(
-        &mut self,
-        key: impl Into<String>,
-        value: QuillValue,
-    ) -> Option<QuillValue> {
-        let key = key.into();
-        for item in self.items.iter_mut() {
-            if let PayloadItem::Field {
-                key: k,
-                value: v,
-                fill,
-                nested_comments,
-            } = item
-            {
-                if k == &key {
-                    let old = std::mem::replace(v, value);
-                    *fill = true;
-                    nested_comments.clear();
-                    return Some(old);
-                }
-            }
-        }
-        self.items.push(PayloadItem::Field {
-            key,
-            value,
-            fill: true,
+            fill,
             nested_comments: Vec::new(),
         });
         None
@@ -741,8 +709,8 @@ mod tests {
     fn insert_enforces_the_field_invariant() {
         use super::super::edit::FieldViolation;
 
-        // Malformed name — the `payload_mut().insert(...)` hole that used to
-        // let an invalid field into a "constructed" document.
+        // A malformed name is refused: `payload_mut().insert(...)` cannot seat
+        // an invalid field in a "constructed" document.
         let mut fm = Payload::new();
         assert_eq!(fm.insert("bad name", qv("v")), Err(FieldViolation::InvalidName));
         assert_eq!(fm.insert("$id", qv("v")), Err(FieldViolation::InvalidName));

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -402,7 +402,6 @@ fn test_document_new_blank_canvas() {
     assert_eq!(doc.quill_reference().to_string(), "test_quill");
     assert!(doc.cards().is_empty());
     assert_eq!(doc.main().body_markdown(), "");
-    assert!(doc.warnings().is_empty());
 
     doc.main_mut().set_fields([("title", "Hello")]).unwrap();
     let mut card = Card::new("note").unwrap();

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1432,3 +1432,31 @@ fn wire_card_rejects_value_past_depth_limit_and_bad_names() {
         "expected name error, got {err}"
     );
 }
+
+// ── Single-card / $id reads (#956) ───────────────────────────────────────────
+
+#[test]
+fn find_card_returns_first_match_and_card_indexes() {
+    let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
+
+    let mut c0 = Card::new("item").unwrap();
+    c0.payload_mut().set_id("dup");
+    let mut c1 = Card::new("item").unwrap();
+    c1.payload_mut().set_id("other");
+    let mut c2 = Card::new("item").unwrap();
+    c2.payload_mut().set_id("dup");
+    doc.push_card(c0).unwrap();
+    doc.push_card(c1).unwrap();
+    doc.push_card(c2).unwrap();
+
+    // `$id` is non-unique by design — find_card returns the first match.
+    let (idx, card) = doc.find_card("dup").unwrap();
+    assert_eq!(idx, 0);
+    assert_eq!(card.id(), Some("dup"));
+    assert_eq!(doc.find_card("other").map(|(i, _)| i), Some(1));
+    assert!(doc.find_card("missing").is_none());
+
+    // card(i) is the immutable single-card read; None out of range.
+    assert_eq!(doc.card(1).unwrap().id(), Some("other"));
+    assert!(doc.card(3).is_none());
+}

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -242,7 +242,7 @@ fn empty_map_omitted_from_emit() {
     p.set_quill("test".parse().unwrap());
     p.set_kind("main");
     let main = Card::from_parts(p, quillmark_richtext::RichText::empty());
-    let doc = crate::document::Document::from_main_and_cards(main, vec![], vec![]);
+    let doc = crate::document::Document::from_main_and_cards(main, vec![]);
 
     let md = doc.to_markdown();
     assert!(
@@ -281,7 +281,7 @@ fn nested_map_keys_with_structural_chars_emit_valid_yaml() {
     p.set_quill("test".parse().unwrap());
     p.set_kind("main");
     let main = Card::from_parts(p, quillmark_richtext::RichText::empty());
-    let doc = Document::from_main_and_cards(main, vec![], vec![]);
+    let doc = Document::from_main_and_cards(main, vec![]);
 
     let md = doc.to_markdown();
     let reparsed = Document::from_markdown(&md)

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -34,11 +34,7 @@ pub fn normalize_document(
     let main = normalize_card(doc.main());
     let normalized_cards: Vec<Card> = doc.cards().iter().map(normalize_card).collect();
 
-    Ok(Document::from_main_and_cards(
-        main,
-        normalized_cards,
-        doc.warnings().to_vec(),
-    ))
+    Ok(Document::from_main_and_cards(main, normalized_cards))
 }
 
 /// Build a new `Card` with NFC-normalized field names, carrying the (already

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -84,7 +84,7 @@ impl QuillConfig {
         );
         let cards = self.card_kinds.iter().map(build_card).collect();
 
-        Document::from_main_and_cards(main, cards, Vec::new()).to_markdown()
+        Document::from_main_and_cards(main, cards).to_markdown()
     }
 }
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -66,7 +66,7 @@ impl QuillConfig {
             rebuild_payload_with_meta(normalized.main(), main_resolved),
             normalized.main().body().clone(),
         );
-        let final_doc = Document::from_main_and_cards(final_main, cards_resolved, Vec::new());
+        let final_doc = Document::from_main_and_cards(final_main, cards_resolved);
 
         Ok(final_doc.to_plate_json())
     }
@@ -97,7 +97,7 @@ impl QuillConfig {
             rebuild_payload_with_meta(doc.main(), coerced_payload),
             doc.main().body().clone(),
         );
-        let coerced_doc = Document::from_main_and_cards(coerced_main, coerced_cards, Vec::new());
+        let coerced_doc = Document::from_main_and_cards(coerced_main, coerced_cards);
 
         // Only *malformed* input is fatal (a value that won't coerce/validate).
         // An incomplete document — absent fields or `!must_fill` placeholders —

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -140,7 +140,7 @@ pub(crate) fn seed_document(quill: &Quill) -> Document {
         .iter()
         .map(|schema| seed_composable(schema, None))
         .collect();
-    Document::from_main_and_cards(main, cards, Vec::new())
+    Document::from_main_and_cards(main, cards)
 }
 
 #[cfg(test)]

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -660,7 +660,7 @@ main:
         p.set_quill("test_quill".parse().unwrap());
         p.set_kind("main");
         let main = Card::from_parts(p, quillmark_richtext::RichText::empty());
-        Document::from_main_and_cards(main, cards, vec![])
+        Document::from_main_and_cards(main, cards)
     }
 
     fn typed_card(tag: &str, fields: &[(&str, serde_json::Value)]) -> Card {
@@ -972,7 +972,7 @@ main:
             p,
             crate::document::import_body("Body content that should not be here.").unwrap(),
         );
-        let doc = Document::from_main_and_cards(main, vec![], vec![]);
+        let doc = Document::from_main_and_cards(main, vec![]);
         let errors = validate_typed_document(&config, &doc).unwrap_err();
         assert!(has_error(&errors, |e| matches!(
             e,

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -365,7 +365,7 @@ card_kinds:
             let mut ed = TypedWriter::new(&config, &mut doc);
             ed.add_card("note", [("body", "a")], None, None).unwrap();
             ed.add_card("note", [("body", "c")], None, None).unwrap();
-            // Positioned typed insert in one atomic call (was add_card + move_card).
+            // Positioned typed insert in one atomic call.
             ed.add_card("note", [("body", "b")], None, Some(1)).unwrap();
         }
         let bodies: Vec<String> = doc

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -213,8 +213,9 @@ where
     if !errors.is_empty() {
         return Err(errors);
     }
+    // Every entry validated by `resolve_field_write` above; apply unchecked.
     for (name, stored) in resolved {
-        card.payload_mut().insert(name, stored);
+        card.payload_mut().insert_unchecked(name, stored);
     }
     Ok(())
 }

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -84,20 +84,26 @@ impl<'a> TypedWriter<'a> {
     }
 
     /// Build a composable card of `kind`, typed-commit `fields` onto it,
-    /// optionally set its body from markdown, and append it — the fused
-    /// [`Card::new`](crate::Card::new) + typed writes + [`push_card`]. The card is
-    /// committed in full *before* it joins the document, so it is transactional by
-    /// construction: a rejected field (or an invalid kind or body) leaves the
-    /// document untouched. Field errors use the all-or-nothing bundle of
-    /// [`set_all`](Self::set_all); an invalid kind or body surfaces as a
-    /// single-entry bundle keyed `$kind` / `$body`.
+    /// optionally set its body from markdown, and place it — the fused
+    /// [`Card::new`](crate::Card::new) + typed writes + insertion. `at` picks the
+    /// position: `None` appends ([`push_card`]), `Some(i)` inserts at index `i`
+    /// ([`insert_card`]), so a positioned typed insert is one atomic call rather
+    /// than `add_card` + [`move_card`](Document::move_card). The card is committed
+    /// in full *before* it joins the document, so it is transactional by
+    /// construction: a rejected field (or an invalid kind, body, or out-of-range
+    /// `at`) leaves the document untouched. Field errors use the all-or-nothing
+    /// bundle of [`set_all`](Self::set_all); an invalid kind or body, or an
+    /// out-of-range position, surfaces as a single-entry bundle keyed `$kind` /
+    /// `$body`.
     ///
     /// [`push_card`]: Document::push_card
+    /// [`insert_card`]: Document::insert_card
     pub fn add_card<K, V, I>(
         &mut self,
         kind: &str,
         fields: I,
         body: Option<&str>,
+        at: Option<usize>,
     ) -> Result<(), Vec<(String, EditError)>>
     where
         K: Into<String>,
@@ -111,10 +117,19 @@ impl<'a> TypedWriter<'a> {
             card.revise_body(md)
                 .map_err(|e| vec![("$body".to_string(), e)])?;
         }
-        self.doc
-            .push_card(card)
-            .map_err(|e| vec![("$kind".to_string(), e)])?;
+        match at {
+            Some(index) => self.doc.insert_card(index, card),
+            None => self.doc.push_card(card),
+        }
+        .map_err(|e| vec![("$kind".to_string(), e)])?;
         Ok(())
+    }
+
+    /// Remove the composable card at `index`, returning it — the tier-1 writer
+    /// spelling of [`Document::remove_card`], mirroring the JS `writer.removeCard`
+    /// sugar. `None` when `index` is out of range.
+    pub fn remove_card(&mut self, index: usize) -> Option<Card> {
+        self.doc.remove_card(index)
     }
 
     /// A schema-bound writer for the composable card at `index`. The card's
@@ -334,12 +349,50 @@ card_kinds:
         let config = config();
         let mut doc = blank_doc();
         let mut ed = TypedWriter::new(&config, &mut doc);
-        ed.add_card("note", [("body", "**hi**")], Some("card body"))
+        ed.add_card("note", [("body", "**hi**")], Some("card body"), None)
             .unwrap();
         assert_eq!(doc.cards().len(), 1);
         assert_eq!(doc.cards()[0].kind(), Some("note"));
         assert_eq!(doc.cards()[0].field_markdown("body").unwrap(), "**hi**\n");
         assert_eq!(doc.cards()[0].body_markdown(), "card body\n");
+    }
+
+    #[test]
+    fn add_card_at_inserts_and_remove_card_returns() {
+        let config = config();
+        let mut doc = blank_doc();
+        {
+            let mut ed = TypedWriter::new(&config, &mut doc);
+            ed.add_card("note", [("body", "a")], None, None).unwrap();
+            ed.add_card("note", [("body", "c")], None, None).unwrap();
+            // Positioned typed insert in one atomic call (was add_card + move_card).
+            ed.add_card("note", [("body", "b")], None, Some(1)).unwrap();
+        }
+        let bodies: Vec<String> = doc
+            .cards()
+            .iter()
+            .map(|c| c.field_markdown("body").unwrap())
+            .collect();
+        assert_eq!(bodies, ["a\n", "b\n", "c\n"]);
+
+        // An out-of-range position is transactional — nothing is inserted.
+        {
+            let mut ed = TypedWriter::new(&config, &mut doc);
+            let errs = ed
+                .add_card("note", [("body", "x")], None, Some(9))
+                .unwrap_err();
+            assert_eq!(errs[0].0, "$kind");
+        }
+        assert_eq!(doc.cards().len(), 3);
+
+        // remove_card returns the removed card; None out of range.
+        {
+            let mut ed = TypedWriter::new(&config, &mut doc);
+            let removed = ed.remove_card(1).unwrap();
+            assert_eq!(removed.field_markdown("body").unwrap(), "b\n");
+            assert!(ed.remove_card(5).is_none());
+        }
+        assert_eq!(doc.cards().len(), 2);
     }
 
     #[test]
@@ -349,7 +402,7 @@ card_kinds:
         let mut ed = TypedWriter::new(&config, &mut doc);
         // An undeclared field aborts the commit; the card never joins the document.
         let errs = ed
-            .add_card("note", [("stray", "x")], None)
+            .add_card("note", [("stray", "x")], None, None)
             .unwrap_err();
         assert_eq!(errs[0].0, "stray");
         assert_eq!(errs[0].1.variant_name(), "UnknownField");
@@ -362,7 +415,9 @@ card_kinds:
         let mut doc = blank_doc();
         let mut ed = TypedWriter::new(&config, &mut doc);
         // A reserved kind is refused before any card is built.
-        let errs = ed.add_card("$reserved", [] as [(&str, &str); 0], None).unwrap_err();
+        let errs = ed
+            .add_card("$reserved", [] as [(&str, &str); 0], None, None)
+            .unwrap_err();
         assert_eq!(errs[0].0, "$kind");
         assert_eq!(doc.cards().len(), 0);
     }

--- a/docs/migrations/0.94-to-0.95.md
+++ b/docs/migrations/0.94-to-0.95.md
@@ -1,0 +1,101 @@
+# 0.94 → 0.95 — one insertion verb, a validating payload floor, and warnings off `Document`
+
+Three breaking changes, all pre-1.0 cleanups. The WASM card surface loses a
+redundant verb, the core `Payload` map API grows a validation floor, and
+parse warnings stop living on `Document`. Everything else in the release is
+additive (new reads and a positioned insert) and needs no action.
+
+## WASM: `pushCard` folds into `insertCard(card, at?)`; `replaceBody` is deleted (#961)
+
+One insertion verb per lane. `pushCard` is gone and `insertCard` now takes the
+card **first** and an optional position **second** — absent `at` appends, a
+number inserts at that index (`0..=cardCount`, out of range throws
+`IndexOutOfRange`).
+
+```
+0.94                                   0.95
+doc.pushCard(card)                     doc.insertCard(card)
+doc.insertCard(2, card)                doc.insertCard(card, 2)
+```
+
+The deprecated `replaceBody` alias is removed. Use the corpus-lane `revise` or
+the writer:
+
+```
+0.94                                   0.95
+doc.replaceBody(md)                    doc.revise({}, md)
+                                       // or  quill.writer(doc).setBody(md)
+```
+
+`removeCard` / `moveCard` / `makeCard` are unchanged. Every `Card` a document
+returns is still a valid `CardInput` for `insertCard`.
+
+## Positioned insert, `removeCard`, and a cursor `kind` — additive (#961)
+
+No action; these only add reach.
+
+- `writer.addCard(kind, fields?, body?, at?)` (WASM) and
+  `TypedWriter::add_card(kind, fields, body, at)` (core) take a position, so a
+  positioned typed insert is one atomic call instead of `addCard` + `moveCard`.
+- `TypedWriter::remove_card(i)` now exists in core, mirroring the JS
+  `writer.removeCard(i)` sugar.
+- The JS `CardWriter` gains a `kind` getter (reads through `doc.card(i)`),
+  mirroring core `CardWriter::kind()`.
+
+## core: `Payload::insert` / `insert_fill` validate and return `Result` (#958)
+
+The direct `Payload` map API — reachable through the public
+`Card::payload_mut()` — validated nothing, so `payload_mut().insert(bad, v)`
+could seat an invalid field in a document that "cannot be invalid." Both now
+enforce the field-name / value-depth invariant at the boundary and return
+`Result<Option<QuillValue>, FieldViolation>`.
+
+```rust
+// 0.94
+card.payload_mut().insert("qty".to_string(), v);          // -> Option<QuillValue>
+
+// 0.95
+card.payload_mut().insert("qty".to_string(), v)?;         // -> Result<_, FieldViolation>
+```
+
+Only direct `Payload` callers are affected — the `Card` / writer mutators
+(`set_field`, `set_fields`, `commit_field`, `set` / `set_all`) are unchanged in
+signature and behavior; they already validated. A caller that has *already*
+validated the exact stored value (and wants to skip the re-check) uses the new
+`pub(crate)` `insert_unchecked` / `insert_fill_unchecked`.
+
+## core: parse warnings live only on `ParseOutput` (#959)
+
+Warnings were bookkept in three places. They are now owned solely by
+`ParseOutput`; `Document` no longer carries them.
+
+- `Document::warnings()` — **removed.** Read `ParseOutput::warnings` from
+  `Document::from_markdown_with_warnings`; the binding wrappers
+  (`doc.warnings` in WASM / Python) are unchanged, as they always kept their own
+  copy.
+- `Document::from_main_and_cards(main, cards, warnings)` →
+  `from_main_and_cards(main, cards)` — the `warnings` parameter is dropped.
+- `Document`'s `PartialEq` is now a plain derive (it only ever excluded
+  `warnings`); equality is unchanged (structural: `main` + `cards`).
+
+`from_markdown` and `from_markdown_with_warnings` keep their signatures.
+
+## Additive reads — no action (#956)
+
+New reads that avoid whole-document serialization; nothing to migrate.
+
+- `doc.card(i)` (WASM) / `Document::card(i)` (core) — one whole card by index
+  without materializing the `cards` array (throws / `None` out of range).
+- `doc.cardIndexById(id)` (WASM) / `Document::find_card(id)` (core) — resolve a
+  `$id` to its index without a hand-rolled scan (`$id` is non-unique; first
+  match wins).
+- `doc.seedOverlay(kind)` (WASM) — the main card's `$seed[kind]` overlay,
+  fed straight into `quill.seedCard(kind, overlay)`, without serializing the
+  whole main card.
+
+## Python
+
+The Python surface trails on this release (per its second-class status): the
+positioned `add_card(at)`, the single-card reads, and a cursor `kind` getter are
+not yet mirrored. Python's `Payload` is not exposed, so #958 does not affect it;
+its `doc.warnings` getter is unchanged by #959.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,6 +18,21 @@ guides in order.
 
 ## Available guides
 
+- [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
+  `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to
+  `(card, at?)`) and the deprecated `replaceBody` alias is deleted (use
+  `revise({}, md)` / `writer.setBody`); the typed `addCard` / `add_card` gains a
+  position, `TypedWriter::remove_card` and a JS `CardWriter.kind` getter close
+  writer/cursor asymmetries (#961). Core `Payload::insert` / `insert_fill`
+  validate the field-name/depth invariant at the boundary and return
+  `Result<_, FieldViolation>`, closing the `payload_mut().insert(...)` hole (a
+  `pub(crate)` `insert_unchecked` serves pre-validated callers; the `Card`/writer
+  mutators are unchanged) (#958). Parse warnings move fully onto `ParseOutput`:
+  `Document::warnings()` and the `from_main_and_cards` `warnings` param are
+  removed and `Document` `PartialEq` becomes a plain derive; `from_markdown` /
+  `from_markdown_with_warnings` are unchanged (#959). Additive, no action:
+  single-card reads `card(i)` / `cardIndexById(id)` / `seedOverlay(kind)` backed
+  by core `Document::card(i)` / `find_card(id)` (#956).
 - [0.93 → 0.94](0.93-to-0.94.md) — `type: richtext(inline)` retires; declare
   `type: richtext` with `inline: true` instead. Blueprint still emits
   `richtext(inline)<markdown>`; `build_transform_schema` gains

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -80,10 +80,14 @@ ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
 | Typed writer front door | `quill.writer(&mut doc)` | `quill.writer(doc)` | **idiom** — core holds `&mut Document` under the checker; the bindings re-borrow per call (pyo3/wasm objects carry no lifetime), so the guarantee becomes the ephemerality convention |
 | Scalar / batch write | `set` / `set_all` | `set` / `setAll` (JS), `set` / `set_all` (py) | identical |
 | Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
-| Card creation | `add_card(kind, fields, body?)` | `addCard` / `add_card` | identical — fused make + typed-commit + push, transactional |
+| Card creation | `add_card(kind, fields, body?, at?)` | `addCard(kind, fields?, body?, at?)` | identical — fused make + typed-commit + insert, transactional (`at` appends when absent, else inserts at the index — one atomic positioned insert, not `addCard` + `moveCard`) |
+| Card insertion | `push_card(card)` / `insert_card(i, card)` | `insertCard(card, at?)` | **idiom** — the binding folds core's append + positional-insert verbs into one; absent `at` appends |
+| Card removal (writer) | `writer.remove_card(i)` | `writer.removeCard(i)` | identical |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
+| Cursor kind | `writer.card(i)?.kind()` | `writer.card(i).kind` | identical — the JS getter reads through `doc.card(i)` |
 | Reads (main) | `card.field_markdown(..)` / `payload().get(..)` | `doc.getMarkdown(name?)` / `doc.get(name)` | **idiom** — the bindings fuse the read into one named verb on `Document` |
 | Reads (card) | `cards()[i].field_markdown(..)` / `payload().get(..)` | `doc.getCardMarkdown(i, name?)` / `doc.getCardField(i, name)` | **idiom** — the card-indexed twins of the main reads, mirroring the card write verbs; `getCardMarkdown` is a fallible `Result` (the index bounds-check) where main `getMarkdown` is infallible |
+| Reads (whole card / `$id` / seed) | `card(i)` / `find_card(id)` / `main().seed()` | `doc.card(i)` / `doc.cardIndexById(id)` / `doc.seedOverlay(kind)` | **idiom** — the bindings fuse each into one named verb on `Document`; `card(i)` throws out of range, `find_card`/`cardIndexById` return the first `$id` match (non-unique by design) |
 | Richtext ops | `card.revise_field(name, md)?` (borrow chain) | `doc.revise({card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation |
 | Opaque primitive | `set_field` / `set_fields` | `setField` / `setCardField` (JS), `set_field` / `set_fields` (py) | identical |
 


### PR DESCRIPTION
Parse warnings were bookkept three times: stored on Document (and
returned by clone from decompose_with_warnings), duplicated on
ParseOutput, and copied again into the binding wrappers. The Document
field was already the odd member — excluded from the storage DTO,
immutable by convention, and the sole reason PartialEq was hand-written.

Drop the Document.warnings field, its warnings() getter, and the
from_main_and_cards warnings param; PartialEq is now a plain derive.
ParseOutput remains the single post-parse owner and the binding wrappers
keep their own copy, so nothing changes at that boundary. from_markdown
and from_markdown_with_warnings keep their signatures.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013dtq1cSnz5jtZVgxuq7wi1