### PR TITLE
Write surface reshape: store_* verbs, one address, a schema-checked revise (#955, #957, #960)

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -110,11 +110,11 @@ doc.equals(other)
 doc.card_count
 doc.main; doc.cards; doc.body; doc.warnings
 
-doc.set_field("title", "New")
-doc.set_fields({"title": "New", "author": "A"})  # atomic batch; one diagnostic per bad field
+doc.store_field("title", "New")                  # opaque store (store = verbatim; the typed write is the writer)
+doc.store_fields({"title": "New", "author": "A"})  # atomic batch; one diagnostic per bad field
 doc.push_card(Document.make_card("note", {"x": 1}, "..."))  # or pass a Card from cards/remove_card/seed_card
 # insert_card, remove_card, move_card, set_card_kind,
-# set_card_field, set_card_fields, remove_card_field, replace_card_body, ...
+# store_card_field, store_card_fields, remove_card_field, replace_card_body, ...
 ```
 
 ## Schema model

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -579,20 +579,20 @@ impl PyDocument {
     /// holding not-yet-conforming input. When a quill *is* in hand, prefer the
     /// typed writer (`quill.writer(doc).set(name, value)`) so a mismatch surfaces
     /// at the write. Raises `QuillmarkError` on a malformed name. Mirrors WASM
-    /// `setField`.
-    fn set_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+    /// `storeField`.
+    fn store_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         self.inner
             .main_mut()
-            .set_field(name, qv)
+            .store_field(name, qv)
             .map_err(convert_edit_error)
     }
 
-    fn set_fill(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+    fn store_fill(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         self.inner
             .main_mut()
-            .set_fill(name, qv)
+            .store_fill(name, qv)
             .map_err(convert_edit_error)
     }
 
@@ -602,17 +602,17 @@ impl PyDocument {
     /// offending field (`path` = field name), so externally-sourced names
     /// (database columns, form keys) surface every violation in one pass.
     ///
-    /// The batched quill-free primitive (see `set_field`) — stores every value
+    /// The batched quill-free primitive (see `store_field`) — stores every value
     /// opaquely, deferring coercion to render. Prefer the typed writer
     /// (`quill.writer(doc).set_all(fields)`) whenever a quill is in hand: it
     /// typed-commits the batch and reports per-field routing, so a form
     /// submitting a card is not silently stripped of schema typing. Mirrors WASM
-    /// `setFields`.
-    fn set_fields(&mut self, fields: Bound<'_, PyDict>) -> PyResult<()> {
+    /// `storeFields`.
+    fn store_fields(&mut self, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         self.inner
             .main_mut()
-            .set_fields(batch)
+            .store_fields(batch)
             .map_err(convert_edit_errors)
     }
 
@@ -632,11 +632,11 @@ impl PyDocument {
     /// raises `ValueError` otherwise. `$ext` carries out-of-band consumer state
     /// and never reaches the rendered output. Pass `{}` for an explicit empty
     /// `$ext`.
-    fn set_ext(&mut self, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let map = py_to_object(&value, "set_ext")?;
+    fn store_ext(&mut self, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let map = py_to_object(&value, "store_ext")?;
         self.inner
             .main_mut()
-            .set_ext(map)
+            .store_ext(map)
             .map_err(convert_edit_error)?;
         Ok(())
     }
@@ -652,11 +652,11 @@ impl PyDocument {
     /// Merge `value` into the main card's `$ext` map under `namespace`, creating
     /// the map when absent and replacing any existing value at that key. Sibling
     /// namespaces are preserved so independent consumers don't clobber each other.
-    fn set_ext_namespace(&mut self, namespace: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+    fn store_ext_namespace(&mut self, namespace: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let json = py_to_json(&value)?;
         self.inner
             .main_mut()
-            .set_ext_namespace(namespace, json)
+            .store_ext_namespace(namespace, json)
             .map_err(convert_edit_error)?;
         Ok(())
     }
@@ -676,11 +676,11 @@ impl PyDocument {
     /// Merge a card-kind's seed `overlay` into the main card's `$seed` map
     /// under `card_kind`, preserving sibling kinds. Sets the starting values
     /// new cards of that kind spawn with.
-    fn set_seed_namespace(&mut self, card_kind: &str, overlay: Bound<'_, PyAny>) -> PyResult<()> {
+    fn store_seed_namespace(&mut self, card_kind: &str, overlay: Bound<'_, PyAny>) -> PyResult<()> {
         let json = py_to_json(&overlay)?;
         self.inner
             .main_mut()
-            .set_seed_namespace(card_kind, json)
+            .store_seed_namespace(card_kind, json)
             .map_err(convert_edit_error)?;
         Ok(())
     }
@@ -697,12 +697,12 @@ impl PyDocument {
     }
 
     /// Replace the `$ext` map on the composable card at `index`. Raises on
-    /// out-of-range index or non-dict value. Named to mirror `set_ext` on the
+    /// out-of-range index or non-dict value. Named to mirror `store_ext` on the
     /// main card; `set_card_ext_namespace` is the sibling-safe alternative.
-    fn set_card_ext(&mut self, index: usize, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let map = py_to_object(&value, "set_card_ext")?;
+    fn store_card_ext(&mut self, index: usize, value: Bound<'_, PyAny>) -> PyResult<()> {
+        let map = py_to_object(&value, "store_card_ext")?;
         self.card_mut_or_raise(index)?
-            .set_ext(map)
+            .store_ext(map)
             .map_err(convert_edit_error)?;
         Ok(())
     }
@@ -721,8 +721,8 @@ impl PyDocument {
 
     /// Merge `value` into the composable card's `$ext` map under `namespace`,
     /// preserving sibling namespaces. The card-indexed twin of
-    /// `set_ext_namespace`. Raises if `index` is out of range.
-    fn set_card_ext_namespace(
+    /// `store_ext_namespace`. Raises if `index` is out of range.
+    fn store_card_ext_namespace(
         &mut self,
         index: usize,
         namespace: &str,
@@ -730,7 +730,7 @@ impl PyDocument {
     ) -> PyResult<()> {
         let json = py_to_json(&value)?;
         self.card_mut_or_raise(index)?
-            .set_ext_namespace(namespace, json)
+            .store_ext_namespace(namespace, json)
             .map_err(convert_edit_error)?;
         Ok(())
     }
@@ -856,11 +856,11 @@ impl PyDocument {
     }
 
     /// Store an opaque value on the composable card at `index` — the
-    /// card-indexed twin of `set_field`, and the same quill-free primitive.
+    /// card-indexed twin of `store_field`, and the same quill-free primitive.
     /// Prefer the typed writer (`quill.writer(doc).card(index).set(...)`) when a
     /// quill is in hand. Raises on an out-of-range index or a malformed name.
-    /// Mirrors WASM `setCardField`.
-    fn set_card_field(
+    /// Mirrors WASM `storeField` with a card address.
+    fn store_card_field(
         &mut self,
         index: usize,
         name: &str,
@@ -868,19 +868,19 @@ impl PyDocument {
     ) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         self.card_mut_or_raise(index)?
-            .set_field(name, qv)
+            .store_field(name, qv)
             .map_err(convert_edit_error)
     }
 
-    /// Batched twin of `set_card_field`: set several fields on the composable
+    /// Batched twin of `store_card_field`: set several fields on the composable
     /// card at `index` atomically. Same all-or-nothing, one-diagnostic-per-field
-    /// contract as `set_fields`, and the same quill-free-primitive framing —
+    /// contract as `store_fields`, and the same quill-free-primitive framing —
     /// prefer the typed writer (`quill.writer(doc).card(index).set_all(...)`)
-    /// when a quill is in hand. Mirrors WASM `setCardFields`.
-    fn set_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
+    /// when a quill is in hand. Mirrors WASM `storeFields` with a card address.
+    fn store_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         self.card_mut_or_raise(index)?
-            .set_fields(batch)
+            .store_fields(batch)
             .map_err(convert_edit_errors)
     }
 
@@ -1421,7 +1421,7 @@ fn py_to_quillvalue(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::QuillV
     Ok(quillmark_core::QuillValue::from_json(json))
 }
 
-/// Convert a Python mapping to the `(name, value)` batch `Card::set_fields`
+/// Convert a Python mapping to the `(name, value)` batch `Card::store_fields`
 /// consumes. Value-conversion failures (depth bound, unsupported type) are
 /// collected — not fail-fast — into one `QuillmarkError` with a per-field
 /// `path`, matching the batch contract of the mutator itself. Non-string

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -98,7 +98,7 @@ def test_blank_document_constructor():
     assert doc.card_count == 0
     assert export_markdown(doc.body) == ""
     assert field_keys(doc.main) == []
-    doc.set_fields({"title": "Hello"})
+    doc.store_fields({"title": "Hello"})
     assert field(doc.main, "title") == "Hello"
     with pytest.raises(ValueError, match="QuillReference"):
         Document("not a valid ref!!")
@@ -110,7 +110,7 @@ def test_blank_document_renders(engine):
     quill = Quill.from_path(str(_latest_version(taro_dir)))
 
     doc = Document("taro")
-    doc.set_fields({"title": "Test", "author": "Test Author", "ice_cream": "Chocolate"})
+    doc.store_fields({"title": "Test", "author": "Test Author", "ice_cream": "Chocolate"})
     doc.replace_body("Content.")
 
     result = engine.render(quill, doc, OutputFormat.PDF)
@@ -151,14 +151,14 @@ Card two.
 def test_set_field_inserts():
     """set_field adds a new payload field."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_field("subtitle", "A subtitle")
+    doc.store_field("subtitle", "A subtitle")
     assert field(doc.main, "subtitle") == "A subtitle"
 
 
 def test_set_field_updates():
     """set_field updates an existing payload field."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_field("title", "New Title")
+    doc.store_field("title", "New Title")
     assert field(doc.main, "title") == "New Title"
 
 
@@ -167,7 +167,7 @@ def test_set_field_uppercase_accepted():
     but not enforced); only `$`-prefixed keys stay reserved."""
     doc = Document.from_markdown(SIMPLE_MD)
     for name in ("BODY", "CARDS", "Title", "MixedCase_1"):
-        doc.set_field(name, "value")
+        doc.store_field(name, "value")
         assert field(doc.main, name) == "value"
 
 
@@ -176,20 +176,20 @@ def test_set_field_dollar_prefix_rejected_matrix():
     for name in ("$body", "$cards", "$quill", "$kind"):
         doc = Document.from_markdown(SIMPLE_MD)
         with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-            doc.set_field(name, "value")
+            doc.store_field(name, "value")
 
 
 def test_set_field_invalid_field_name():
     """set_field raises EditError for an invalid name (hyphen not allowed)."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-        doc.set_field("bad-name", "value")
+        doc.store_field("bad-name", "value")
 
 
 def test_set_fields_inserts_batch_in_order():
     """set_fields applies every entry, in dict order."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_fields({"subtitle": "A subtitle", "pages": 3})
+    doc.store_fields({"subtitle": "A subtitle", "pages": 3})
     assert field(doc.main, "subtitle") == "A subtitle"
     assert field(doc.main, "pages") == 3
     assert field_keys(doc.main) == ["title", "author", "subtitle", "pages"]
@@ -200,7 +200,7 @@ def test_set_fields_reports_every_violation_and_applies_nothing():
     leaves the document untouched — including the batch's valid entries."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(QuillmarkError, match="InvalidFieldName") as exc_info:
-        doc.set_fields({"ok_field": "v", "bad-name": "v", "also bad": "v"})
+        doc.store_fields({"ok_field": "v", "bad-name": "v", "also bad": "v"})
     diags = exc_info.value.diagnostics
     assert [d.path for d in diags] == ["bad-name", "also bad"]
     assert not has_field(doc.main, "ok_field")
@@ -209,11 +209,11 @@ def test_set_fields_reports_every_violation_and_applies_nothing():
 def test_set_card_fields_batch():
     """set_card_fields is the card-indexed twin of set_fields."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.set_card_fields(0, {"foo": "baz", "extra": 1})
+    doc.store_card_fields(0, {"foo": "baz", "extra": 1})
     assert field(doc.cards[0], "foo") == "baz"
     assert field(doc.cards[0], "extra") == 1
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.set_card_fields(99, {"foo": "v"})
+        doc.store_card_fields(99, {"foo": "v"})
 
 
 def test_remove_field_existing():
@@ -369,7 +369,7 @@ def test_move_card_out_of_range():
 def test_set_card_field():
     """set_card_field sets a field on a specific card."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.set_card_field(0, "content", "hello")
+    doc.store_card_field(0, "content", "hello")
     assert field(doc.cards[0], "content") == "hello"
 
 
@@ -377,7 +377,7 @@ def test_set_card_field_out_of_range():
     """set_card_field raises EditError when card index is out of range."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.set_card_field(0, "title", "x")
+        doc.store_card_field(0, "title", "x")
 
 
 def test_get_card_field():
@@ -442,7 +442,7 @@ def test_update_card_body_deprecated_alias():
 def test_set_ext_adds_map():
     """set_ext stores an opaque map readable via card['ext']."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_ext({"presentation": {"title": "Greeting"}})
+    doc.store_ext({"presentation": {"title": "Greeting"}})
     assert doc.main["ext"] == {"presentation": {"title": "Greeting"}}
 
 
@@ -450,13 +450,13 @@ def test_set_ext_rejects_non_dict():
     """set_ext raises for non-dict values."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(ValueError, match="must be a dict"):
-        doc.set_ext("nope")
+        doc.store_ext("nope")
 
 
 def test_ext_round_trips_through_markdown():
     """$ext survives emit → re-parse."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_ext({"agent": {"pinned": True}})
+    doc.store_ext({"agent": {"pinned": True}})
     reparsed = Document.from_markdown(doc.to_markdown())
     assert reparsed.main["ext"]["agent"]["pinned"] is True
 
@@ -464,9 +464,9 @@ def test_ext_round_trips_through_markdown():
 def test_set_ext_namespace_preserves_siblings():
     """set_ext_namespace merges without clobbering other namespaces."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_ext_namespace("presentation", {"title": "A"})
-    doc.set_ext_namespace("agent", {"pinned": True})
-    doc.set_ext_namespace("presentation", {"title": "B"})
+    doc.store_ext_namespace("presentation", {"title": "A"})
+    doc.store_ext_namespace("agent", {"pinned": True})
+    doc.store_ext_namespace("presentation", {"title": "B"})
     assert doc.main["ext"] == {
         "presentation": {"title": "B"},
         "agent": {"pinned": True},
@@ -476,8 +476,8 @@ def test_set_ext_namespace_preserves_siblings():
 def test_remove_ext_namespace_clears_one_slot_and_drops_when_empty():
     """remove_ext_namespace clears one slot; the last one drops $ext."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_ext_namespace("presentation", {"title": "A"})
-    doc.set_ext_namespace("tutorial", ["step-1", "step-2"])
+    doc.store_ext_namespace("presentation", {"title": "A"})
+    doc.store_ext_namespace("tutorial", ["step-1", "step-2"])
     # Returns the removed value; siblings survive.
     assert doc.remove_ext_namespace("tutorial") == ["step-1", "step-2"]
     assert doc.main["ext"] == {"presentation": {"title": "A"}}
@@ -491,7 +491,7 @@ def test_remove_ext_namespace_clears_one_slot_and_drops_when_empty():
 def test_remove_ext_returns_previous_and_clears():
     """remove_ext returns the previous map, then None."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_ext({"agent": {"n": 1}})
+    doc.store_ext({"agent": {"n": 1}})
     assert doc.remove_ext() == {"agent": {"n": 1}}
     assert doc.main["ext"] is None
     assert doc.remove_ext() is None
@@ -500,7 +500,7 @@ def test_remove_ext_returns_previous_and_clears():
 def test_card_ext_mutators():
     """set_card_ext / remove_card_ext target the card at index."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.set_card_ext(0, {"agent": {"note": "y"}})
+    doc.store_card_ext(0, {"agent": {"note": "y"}})
     assert doc.cards[0]["ext"] == {"agent": {"note": "y"}}
     assert doc.remove_card_ext(0) == {"agent": {"note": "y"}}
     assert doc.cards[0]["ext"] is None
@@ -509,8 +509,8 @@ def test_card_ext_mutators():
 def test_card_ext_namespace_mutators():
     """set/remove_card_ext_namespace preserve siblings and clear when empty."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.set_card_ext_namespace(0, "presentation", {"title": "A"})
-    doc.set_card_ext_namespace(0, "tutorial", ["step-1"])
+    doc.store_card_ext_namespace(0, "presentation", {"title": "A"})
+    doc.store_card_ext_namespace(0, "tutorial", ["step-1"])
     assert doc.remove_card_ext_namespace(0, "tutorial") == ["step-1"]
     assert doc.cards[0]["ext"] == {"presentation": {"title": "A"}}
     doc.remove_card_ext_namespace(0, "presentation")
@@ -521,11 +521,11 @@ def test_card_ext_mutators_out_of_range():
     """Card ext mutators raise IndexOutOfRange for a bad index."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.set_card_ext(0, {})
+        doc.store_card_ext(0, {})
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         doc.remove_card_ext(0)
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.set_card_ext_namespace(0, "a", {})
+        doc.store_card_ext_namespace(0, "a", {})
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         doc.remove_card_ext_namespace(0, "a")
 
@@ -534,7 +534,7 @@ def test_mutators_do_not_touch_warnings():
     """Mutators must not modify the warnings list."""
     doc = Document.from_markdown(SIMPLE_MD)
     initial = list(doc.warnings)
-    doc.set_field("extra", "value")
+    doc.store_field("extra", "value")
     doc.replace_body("New body.")
     doc.push_card({"kind": "new_card"})
     assert list(doc.warnings) == initial
@@ -553,7 +553,7 @@ def test_invariants_after_mutation_sequence():
     doc.remove_card(2)                     # appendix, note, summary
 
     # Mutate payload
-    doc.set_field("extra_author", "Bob")
+    doc.store_field("extra_author", "Bob")
     doc.remove_field("extra_author")
 
     # Assertions: every payload key passes the user-field regex.
@@ -581,7 +581,7 @@ def test_to_markdown_general_round_trip():
     original_card_count = len(doc.cards)  # 0 for SIMPLE_MD
 
     # Mutate
-    doc.set_field("title", "New Title")
+    doc.store_field("title", "New Title")
     doc.push_card(Document.make_card("note", {"author": "Alice"}, "Hello"))
     doc.replace_body("Updated body")
 
@@ -608,15 +608,15 @@ def test_to_markdown_ambiguous_string_survival():
     so they survive through a re-parse as strings, not bools or null.
     """
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.set_field("flag_on", "on")
-    doc.set_field("flag_off", "off")
-    doc.set_field("flag_yes", "yes")
-    doc.set_field("flag_no", "no")
-    doc.set_field("str_true", "true")
-    doc.set_field("str_false", "false")
-    doc.set_field("str_null", "null")
-    doc.set_field("octal_str", "01234")
-    doc.set_field("date_str", "2024-01-15")
+    doc.store_field("flag_on", "on")
+    doc.store_field("flag_off", "off")
+    doc.store_field("flag_yes", "yes")
+    doc.store_field("flag_no", "no")
+    doc.store_field("str_true", "true")
+    doc.store_field("str_false", "false")
+    doc.store_field("str_null", "null")
+    doc.store_field("octal_str", "01234")
+    doc.store_field("date_str", "2024-01-15")
 
     emitted = doc.to_markdown()
     doc2 = Document.from_markdown(emitted)

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -197,7 +197,7 @@ def test_clone_isolates_mutations(taro_md):
     doc = Document.from_markdown(taro_md)
     cloned = doc.clone()
 
-    cloned.set_field("title", "Updated Title")
+    cloned.store_field("title", "Updated Title")
     assert field(doc.main, "title") != "Updated Title"
     assert field(cloned.main, "title") == "Updated Title"
 
@@ -214,7 +214,7 @@ def test_copy_module_clones(taro_md):
     assert shallow == doc
     assert deep == doc
 
-    shallow.set_field("title", "Shallow Edit")
+    shallow.store_field("title", "Shallow Edit")
     assert field(doc.main, "title") != "Shallow Edit"
 
 
@@ -232,7 +232,7 @@ def test_eq_after_mutation(taro_md):
     doc1 = Document.from_markdown(taro_md)
     doc2 = Document.from_markdown(taro_md)
 
-    doc2.set_field("title", "Different")
+    doc2.store_field("title", "Different")
     assert doc1 != doc2
 
 
@@ -394,15 +394,15 @@ def test_depth_bound_matches_core_container_levels():
     )
 
     # Scalar-terminated: 100 objects with a scalar leaf is at the limit.
-    doc.set_field("ok_scalar", _nest(100, 1))
+    doc.store_field("ok_scalar", _nest(100, 1))
     with pytest.raises((QuillmarkError, ValueError)):
-        doc.set_field("deep_scalar", _nest(101, 1))
+        doc.store_field("deep_scalar", _nest(101, 1))
 
     # Container-terminated: the deepest container, not its contents, occupies
     # the last level, so the boundary is identical.
-    doc.set_field("ok_container", _nest(99, [1, 2, 3]))
+    doc.store_field("ok_container", _nest(99, [1, 2, 3]))
     with pytest.raises((QuillmarkError, ValueError)):
-        doc.set_field("deep_container", _nest(100, [1, 2, 3]))
+        doc.store_field("deep_container", _nest(100, [1, 2, 3]))
 
 
 def test_nested_fill_push_card_round_trip():

--- a/crates/bindings/python/tests/test_validate.py
+++ b/crates/bindings/python/tests/test_validate.py
@@ -181,7 +181,7 @@ def test_document_seed_and_set_seed_namespace_round_trip(tmp_path):
     doc = Document.from_markdown(_md())  # empty main card
 
     assert seed_of(doc, "note") is None
-    doc.set_seed_namespace("note", {"tag": "WRITTEN"})
+    doc.store_seed_namespace("note", {"tag": "WRITTEN"})
     assert seed_of(doc, "note")["tag"] == "WRITTEN"
 
     card = quill.seed_card("note", seed_of(doc, "note"))

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -89,7 +89,7 @@ is resolved at render time, not here. Loads no backend binary.
 A blank document: a main card carrying only `$quill`, an empty body, and no
 composable cards — the programmatic blank canvas. Absent fields resolve at
 render time (schema `default`, else type-empty zero), so nothing the caller
-did not set reaches the output. Build it up with `setFields` / `insertCard`.
+did not set reaches the output. Build it up with `storeFields` / `insertCard`.
 For an example-filled starter use `quill.seedDocument()`. Throws on an
 invalid quill reference.
 
@@ -197,7 +197,7 @@ and compare instead of re-parsing on every keystroke.
 ### `doc.cardCount`
 O(1) getter for the number of composable cards (excluding the main card).
 Use this to validate indices before calling card mutators (`removeCard`,
-`setCardField`, etc.) without allocating the full `cards` array.
+`storeField({ card, field }, …)`, etc.) without allocating the full `cards` array.
 
 ### `quill.validate(doc)`
 
@@ -251,29 +251,39 @@ still takes exactly what `cards` / `removeCard` / `seedCard` return.
 Build a fresh card from a flat field map with
 `Document.makeCard(kind, fields?, body?)`.
 
-Batch mutation: `doc.setFields({...})` / `doc.setCardFields(index, {...})`
+**One address for the whole surface.** Reads and writes navigate by an `Addr` —
+`{ card?, field? }`, absent `card` = main, absent `field` = body — and a bare
+string is shorthand for `{ field }`. So `doc.storeField("qty", 3)` targets the
+main card's `qty`, `doc.storeField({ card: 2, field: "qty" }, 3)` a composable
+card's. Reads are total over the field axis (`get` / `getMarkdown` → `undefined`,
+`isFill` → `false` for an absent field; only an out-of-range card throws); field
+writes throw on a body address. Card-scoped verbs take a `CardAddr` (`{ card? }`)
+first: `doc.getExt({ card: 2 })`, and the batch below.
+
+Batch mutation: `doc.storeFields({}, {...})` / `doc.storeFields({ card: index }, {...})`
 apply a whole object atomically — on any invalid field nothing is applied and
 the thrown error carries one diagnostic per offending field (`path` = field
-name).
+name). The address is first (never shape-overloaded, since `card` is a legal
+field name).
 
-### Typed writes: `commit*` is the default, `set*` is the quill-free primitive
+### Typed writes: `commit*` is the default, `store*` is the quill-free primitive
 
 A `Document` holds only a `$quill` *reference*, not the resolved schema, so it
-mutates through two layers:
+mutates through two layers (**store** = verbatim, **set/commit** = typed):
 
 - **`commit*` — the schema-bound default whenever a quill is in hand.**
-  `doc.commitField(quill, name, value)` / `doc.commitFields(quill, {...})` (and
-  the `commitCard*` twins) resolve each field's schema `type`, coerce the value
-  to its canonical form (`"3"` → `3`, a markdown string → a richtext corpus),
-  and **fail now** on a mismatch instead of at render. A name the schema does
-  not declare throws `UnknownField` rather than falling to the opaque store — on
-  the typed path an undeclared name is a typo, not a fallback. The batch form is
-  all-or-nothing: an undeclared name aborts the whole write and its per-field
+  `doc.commitField(quill, addr, value)` / `doc.commitFields(quill, cardAddr, {...})`
+  (a card field is `{ card, field }`) resolve each field's schema `type`, coerce
+  the value to its canonical form (`"3"` → `3`, a markdown string → a richtext
+  corpus), and **fail now** on a mismatch instead of at render. A name the schema
+  does not declare throws `UnknownField` rather than falling to the opaque store —
+  on the typed path an undeclared name is a typo, not a fallback. The batch form
+  is all-or-nothing: an undeclared name aborts the whole write and its per-field
   diagnostics name every offending field, so a whole-form submit surfaces every
-  typo `setFields` would silently absorb.
+  typo `storeFields` would silently absorb.
 
-- **`set*` — the deliberate quill-free primitive.** `doc.setField(name, value)`
-  / `doc.setFields({...})` (and the `setCard*` twins) validate only the field
+- **`store*` — the deliberate quill-free primitive.** `doc.storeField(addr, value)`
+  / `doc.storeFields(cardAddr, {...})` (and `storeFill`) validate only the field
   name/depth/kind and store the value verbatim, no quill required. Reach for it
   on purpose when you *want* the opaque store: quill-agnostic storage/migration
   infra that has no bundle and must write regardless of a drifted schema;
@@ -446,7 +456,7 @@ compilation failures. The same shape applies to every throw site:
 
 - `Document.fromMarkdown` — parse errors (missing root `$quill` metadata, YAML
   errors, `parse::input_too_large` for inputs > 10 MB).
-- `Document` mutators (`setField`, `setCardField`, etc.) — `EditError`
+- `Document` mutators (`storeField`, `commitField`, etc.) — `EditError`
   variants (`InvalidFieldName`, `InvalidKindName`, `ReservedKind`,
   `IndexOutOfRange`, `ValueTooDeep`) appear in `diagnostics[0].message` with
   the `[EditError::<Variant>]` prefix.

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -171,7 +171,7 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
     const originalCardCount = doc.cards.length  // 0 for TEST_MARKDOWN
 
     // Mutate
-    doc.setField('title', 'New Title')
+    doc.storeField('title', 'New Title')
     doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'Hello'))
     doc.revise({}, 'Updated body')
 
@@ -201,15 +201,15 @@ describe('Document.toMarkdown — fromMarkdown → mutate → emit → re-parse'
     // in permissive parsers. The emitter must double-quote them so they survive
     // as strings through a re-parse.
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setField('flag_on', 'on')
-    doc.setField('flag_off', 'off')
-    doc.setField('flag_yes', 'yes')
-    doc.setField('flag_no', 'no')
-    doc.setField('str_true', 'true')
-    doc.setField('str_false', 'false')
-    doc.setField('str_null', 'null')
-    doc.setField('octal_str', '01234')
-    doc.setField('date_str', '2024-01-15')
+    doc.storeField('flag_on', 'on')
+    doc.storeField('flag_off', 'off')
+    doc.storeField('flag_yes', 'yes')
+    doc.storeField('flag_no', 'no')
+    doc.storeField('str_true', 'true')
+    doc.storeField('str_false', 'false')
+    doc.storeField('str_null', 'null')
+    doc.storeField('octal_str', '01234')
+    doc.storeField('date_str', '2024-01-15')
 
     const emitted = doc.toMarkdown()
     const doc2 = Document.fromMarkdown(emitted)
@@ -247,7 +247,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
 
   it('round-trips a mutated document with cards', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setField('title', 'New Title')
+    doc.storeField('title', 'New Title')
     doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'Hello'))
 
     const restored = Document.fromJson(doc.toJson())
@@ -281,7 +281,7 @@ describe('Document JSON DTO — toJson / fromJson', () => {
     // user fields — only `$`-prefixed keys are reserved — so a stored DTO
     // carrying one must deserialize and round-trip verbatim.
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setField('PRESENTATION', 'deck')
+    doc.storeField('PRESENTATION', 'deck')
     const restored = Document.fromJson(doc.toJson())
     expect(field(restored.main, 'PRESENTATION')).toBe('deck')
   })
@@ -475,20 +475,20 @@ title: Mismatch Test
 describe('Document editor surface — setField / removeField', () => {
   it('setField inserts a new payload field', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setField('subtitle', 'A subtitle')
+    doc.storeField('subtitle', 'A subtitle')
     expect(field(doc.main, 'subtitle')).toBe('A subtitle')
   })
 
   it('setField updates an existing field', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setField('title', 'Updated')
+    doc.storeField('title', 'Updated')
     expect(field(doc.main, 'title')).toBe('Updated')
   })
 
   it('setField accepts uppercase field names verbatim (lowercase is canonical, not enforced)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     for (const name of ['BODY', 'CARDS', 'Title', 'MixedCase_1']) {
-      doc.setField(name, 'x')
+      doc.storeField(name, 'x')
       expect(field(doc.main, name)).toBe('x')
     }
   })
@@ -496,13 +496,13 @@ describe('Document editor surface — setField / removeField', () => {
   it('setField throws EditError::InvalidFieldName for `$`-prefixed names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     for (const name of ['$body', '$cards', '$quill', '$kind']) {
-      expect(() => doc.setField(name, 'x')).toThrow(/InvalidFieldName/)
+      expect(() => doc.storeField(name, 'x')).toThrow(/InvalidFieldName/)
     }
   })
 
   it('setField throws EditError::InvalidFieldName for an invalid name (hyphen)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setField('bad-name', 'x')).toThrow(/InvalidFieldName/)
+    expect(() => doc.storeField('bad-name', 'x')).toThrow(/InvalidFieldName/)
   })
 
   it('removeField returns the removed value', () => {
@@ -531,7 +531,7 @@ describe('Document blank-canvas constructor', () => {
     expect(doc.quillRef).toBe('test_quill')
     expect(doc.cards.length).toBe(0)
     expect(exportMarkdown(doc.main.body)).toBe('')
-    doc.setFields({ title: 'Hello' })
+    doc.storeFields({}, { title: 'Hello' })
     expect(field(doc.main, 'title')).toBe('Hello')
   })
 
@@ -543,7 +543,7 @@ describe('Document blank-canvas constructor', () => {
 describe('Document editor surface — setFields / setCardFields', () => {
   it('setFields applies every entry, in object order', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setFields({ subtitle: 'A subtitle', pages: 3 })
+    doc.storeFields({}, { subtitle: 'A subtitle', pages: 3 })
     expect(field(doc.main, 'subtitle')).toBe('A subtitle')
     expect(field(doc.main, 'pages')).toBe(3)
   })
@@ -551,7 +551,7 @@ describe('Document editor surface — setFields / setCardFields', () => {
   it('a failed batch throws one diagnostic per bad field and applies nothing', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     try {
-      doc.setFields({ ok_field: 'v', 'bad-name': 'v', 'also bad': 'v' })
+      doc.storeFields({}, { ok_field: 'v', 'bad-name': 'v', 'also bad': 'v' })
       throw new Error('setFields should have thrown')
     } catch (err) {
       expect(err.diagnostics.map((d) => d.path)).toEqual(['bad-name', 'also bad'])
@@ -562,16 +562,16 @@ describe('Document editor surface — setFields / setCardFields', () => {
 
   it('setFields rejects a non-object argument', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setFields('not an object')).toThrow(/plain object/)
+    expect(() => doc.storeFields({}, 'not an object')).toThrow(/plain object/)
   })
 
   it('setCardFields is the card-indexed twin of setFields', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.insertCard(Document.makeCard('note', { foo: 'bar' }))
-    doc.setCardFields(0, { foo: 'baz', extra: 1 })
+    doc.storeFields({ card: 0 }, { foo: 'baz', extra: 1 })
     expect(field(doc.cards[0], 'foo')).toBe('baz')
     expect(field(doc.cards[0], 'extra')).toBe(1)
-    expect(() => doc.setCardFields(99, { foo: 'v' })).toThrow(/IndexOutOfRange/)
+    expect(() => doc.storeFields({ card: 99 }, { foo: 'v' })).toThrow(/IndexOutOfRange/)
   })
 })
 
@@ -683,7 +683,7 @@ card_kinds:
     expect(() => doc.commitField(quill, 'stray', 'x')).toThrow(/UnknownField/)
     expect(hasField(doc.main, 'stray')).toBe(false)
     // Opaque storage stays available on purpose through the raw verb.
-    doc.setField('stray', 'x')
+    doc.storeField('stray', 'x')
     expect(field(doc.main, 'stray')).toBe('x')
   })
 
@@ -693,7 +693,7 @@ card_kinds:
     // Absent field: the value is undefined, nothing to project.
     expect(field(doc.main, 'nonexistent')).toBeUndefined()
     // A non-richtext scalar is stored verbatim, not a corpus object.
-    doc.setField('count', 3)
+    doc.storeField('count', 3)
     expect(field(doc.main, 'count')).toBe(3)
     // A committed richtext field projects through the codec.
     doc.commitField(quill, 'intro', 'plain intro')
@@ -751,15 +751,15 @@ card_kinds:
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
-    doc.commitCardField(quill, 0, 'body', 'Card **body**.')
+    doc.commitField(quill, { card: 0, field: 'body' }, 'Card **body**.')
     expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.\n')
-    expect(() => doc.commitCardField(quill, 9, 'body', 'x')).toThrow(/IndexOutOfRange/)
+    expect(() => doc.commitField(quill, { card: 9, field: 'body' }, 'x')).toThrow(/IndexOutOfRange/)
   })
 
   it('commitFields typed-commits a batch', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    doc.commitFields(quill, { intro: 'A **bold** intro.', qty: '3' })
+    doc.commitFields(quill, {}, { intro: 'A **bold** intro.', qty: '3' })
     // The values were coerced, not stored verbatim.
     expect(exportMarkdown(field(doc.main, 'intro'))).toBe('A **bold** intro.\n')
     expect(field(doc.main, 'qty')).toBe(3)
@@ -770,7 +770,7 @@ card_kinds:
     const doc = blankDoc()
     // `qty` is a schema field; `titel` is a typo the schema does not own — the
     // undeclared name aborts the all-or-nothing batch and nothing is applied.
-    expect(() => doc.commitFields(quill, { qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
+    expect(() => doc.commitFields(quill, {}, { qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
     expect(hasField(doc.main, 'qty')).toBe(false)
     expect(hasField(doc.main, 'titel')).toBe(false)
   })
@@ -780,7 +780,7 @@ card_kinds:
     const doc = blankDoc()
     // `subject` is richtext(inline); a multi-block value violates it, so nothing
     // is applied — `qty` must not linger.
-    expect(() => doc.commitFields(quill, { qty: '5', subject: 'line one\n\nline two' }))
+    expect(() => doc.commitFields(quill, {}, { qty: '5', subject: 'line one\n\nline two' }))
       .toThrow(/FieldRichtextNotInline/)
     expect(hasField(doc.main, 'qty')).toBe(false)
   })
@@ -790,11 +790,11 @@ card_kinds:
     const doc = Document.fromMarkdown(
       '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
     )
-    doc.commitCardFields(quill, 0, { body: 'Card **body**.' })
+    doc.commitFields(quill, { card: 0 }, { body: 'Card **body**.' })
     expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.\n')
     // An undeclared field on the card aborts the batch.
-    expect(() => doc.commitCardFields(quill, 0, { stray: 'x' })).toThrow(/UnknownField/)
-    expect(() => doc.commitCardFields(quill, 9, { body: 'x' })).toThrow(/IndexOutOfRange/)
+    expect(() => doc.commitFields(quill, { card: 0 }, { stray: 'x' })).toThrow(/UnknownField/)
+    expect(() => doc.commitFields(quill, { card: 9 }, { body: 'x' })).toThrow(/IndexOutOfRange/)
   })
 })
 
@@ -966,7 +966,7 @@ describe('Document.equals', () => {
   it('returns false after a payload mutation', () => {
     const a = Document.fromMarkdown(TEST_MARKDOWN)
     const b = Document.fromMarkdown(TEST_MARKDOWN)
-    b.setField('title', 'Different')
+    b.storeField('title', 'Different')
     expect(a.equals(b)).toBe(false)
   })
 
@@ -1009,36 +1009,36 @@ Card body.
 
   it('setCardField sets a field on a card', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    doc.setCardField(0, 'content', 'hello')
+    doc.storeField({ card: 0, field: 'content' }, 'hello')
     expect(field(doc.cards[0], 'content')).toBe('hello')
   })
 
   it('setCardField accepts uppercase names verbatim', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    doc.setCardField(0, 'BODY', 'x')
+    doc.storeField({ card: 0, field: 'BODY' }, 'x')
     expect(field(doc.cards[0], 'BODY')).toBe('x')
   })
 
   it('setCardField throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.setCardField(0, 'title', 'x')).toThrow(/IndexOutOfRange/)
+    expect(() => doc.storeField({ card: 0, field: 'title' }, 'x')).toThrow(/IndexOutOfRange/)
   })
 
   it('removeCardField returns the removed value and deletes the key', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    const removed = doc.removeCardField(0, 'foo')
+    const removed = doc.removeField({ card: 0, field: 'foo' })
     expect(removed).toBe('bar')
     expect(hasField(doc.cards[0], 'foo')).toBe(false)
   })
 
   it('removeCardField returns undefined when field absent', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARD)
-    expect(doc.removeCardField(0, 'nonexistent')).toBeUndefined()
+    expect(doc.removeField({ card: 0, field: 'nonexistent' })).toBeUndefined()
   })
 
   it('removeCardField throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.removeCardField(0, 'foo')).toThrow(/IndexOutOfRange/)
+    expect(() => doc.removeField({ card: 0, field: 'foo' })).toThrow(/IndexOutOfRange/)
   })
 
   it('revise({card:0}, md) revises a card body and returns the delta', () => {
@@ -1080,7 +1080,7 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
 
     // Mutate
-    doc.setField('author', 'Bob')
+    doc.storeField('author', 'Bob')
     doc.revise({}, 'New body text.')
     doc.insertCard({ kind: 'note', body: 'Card content.' })
     doc.setQuillRef('updated_quill')
@@ -1104,50 +1104,50 @@ describe('Document editor surface — parse→mutate→read round-trip', () => {
 describe('Document editor surface — $ext mutators', () => {
   it('setExt adds an opaque map readable via card.ext', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExt({ editor: { title: 'Greeting' } })
+    doc.storeExt({}, { editor: { title: 'Greeting' } })
     expect(doc.main.ext.editor.title).toBe('Greeting')
   })
 
   it('setExt rejects non-object values', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setExt('nope')).toThrow(/must be a plain object/)
-    expect(() => doc.setExt(42)).toThrow(/must be a plain object/)
+    expect(() => doc.storeExt({}, 'nope')).toThrow(/must be a plain object/)
+    expect(() => doc.storeExt({}, 42)).toThrow(/must be a plain object/)
   })
 
   it('$ext round-trips through toMarkdown', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExt({ agent: { pinned: true } })
+    doc.storeExt({}, { agent: { pinned: true } })
     const reparsed = Document.fromMarkdown(doc.toMarkdown())
     expect(reparsed.main.ext.agent.pinned).toBe(true)
   })
 
   it('setExtNamespace preserves sibling namespaces', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExtNamespace('editor', { title: 'A' })
-    doc.setExtNamespace('agent', { pinned: true })
-    doc.setExtNamespace('editor', { title: 'B' })
+    doc.storeExtNamespace({}, 'editor', { title: 'A' })
+    doc.storeExtNamespace({}, 'agent', { pinned: true })
+    doc.storeExtNamespace({}, 'editor', { title: 'B' })
     expect(doc.main.ext.editor.title).toBe('B')
     expect(doc.main.ext.agent.pinned).toBe(true)
   })
 
   it('removeExtNamespace clears one slot and drops $ext once empty', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExtNamespace('editor', { title: 'A' })
-    doc.setExtNamespace('tutorial', ['step-1', 'step-2'])
+    doc.storeExtNamespace({}, 'editor', { title: 'A' })
+    doc.storeExtNamespace({}, 'tutorial', ['step-1', 'step-2'])
     // Returns the removed value; siblings survive.
-    expect(doc.removeExtNamespace('tutorial')).toEqual(['step-1', 'step-2'])
+    expect(doc.removeExtNamespace({}, 'tutorial')).toEqual(['step-1', 'step-2'])
     expect(doc.main.ext.editor.title).toBe('A')
     expect(doc.main.ext.tutorial).toBeUndefined()
     // Removing the last namespace clears $ext entirely.
-    doc.removeExtNamespace('editor')
+    doc.removeExtNamespace({}, 'editor')
     expect(doc.main.ext == null).toBe(true)
     // Absent namespace is a no-op returning undefined.
-    expect(doc.removeExtNamespace('nope')).toBeUndefined()
+    expect(doc.removeExtNamespace({}, 'nope')).toBeUndefined()
   })
 
   it('removeExt returns the previous map and clears it', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    doc.setExt({ agent: { n: 1 } })
+    doc.storeExt({}, { agent: { n: 1 } })
     expect(doc.removeExt().agent.n).toBe(1)
     expect(doc.main.ext == null).toBe(true)
     expect(doc.removeExt()).toBeUndefined()
@@ -1156,29 +1156,29 @@ describe('Document editor surface — $ext mutators', () => {
   it('card-level ext mutators target the card at index', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.insertCard({ kind: 'note', body: 'x' })
-    doc.setCardExt(0, { agent: { note: 'y' } })
+    doc.storeExt({ card: 0 }, { agent: { note: 'y' } })
     expect(doc.cards[0].ext.agent.note).toBe('y')
-    expect(doc.removeCardExt(0).agent.note).toBe('y')
+    expect(doc.removeExt({ card: 0 }).agent.note).toBe('y')
     expect(doc.cards[0].ext == null).toBe(true)
   })
 
   it('card-level namespace mutators preserve siblings and clear when empty', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     doc.insertCard({ kind: 'note', body: 'x' })
-    doc.setCardExtNamespace(0, 'editor', { title: 'A' })
-    doc.setCardExtNamespace(0, 'tutorial', ['step-1'])
-    expect(doc.removeCardExtNamespace(0, 'tutorial')).toEqual(['step-1'])
+    doc.storeExtNamespace({ card: 0 }, 'editor', { title: 'A' })
+    doc.storeExtNamespace({ card: 0 }, 'tutorial', ['step-1'])
+    expect(doc.removeExtNamespace({ card: 0 }, 'tutorial')).toEqual(['step-1'])
     expect(doc.cards[0].ext.editor.title).toBe('A')
-    doc.removeCardExtNamespace(0, 'editor')
+    doc.removeExtNamespace({ card: 0 }, 'editor')
     expect(doc.cards[0].ext == null).toBe(true)
   })
 
   it('card-level ext mutators throw IndexOutOfRange', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.setCardExt(5, {})).toThrow(/IndexOutOfRange/)
-    expect(() => doc.removeCardExt(5)).toThrow(/IndexOutOfRange/)
-    expect(() => doc.setCardExtNamespace(5, 'a', {})).toThrow(/IndexOutOfRange/)
-    expect(() => doc.removeCardExtNamespace(5, 'a')).toThrow(/IndexOutOfRange/)
+    expect(() => doc.storeExt({ card: 5 }, {})).toThrow(/IndexOutOfRange/)
+    expect(() => doc.removeExt({ card: 5 })).toThrow(/IndexOutOfRange/)
+    expect(() => doc.storeExtNamespace({ card: 5 }, 'a', {})).toThrow(/IndexOutOfRange/)
+    expect(() => doc.removeExtNamespace({ card: 5 }, 'a')).toThrow(/IndexOutOfRange/)
   })
 })
 
@@ -1306,7 +1306,7 @@ describe('Document.clone', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const clone = doc.clone()
 
-    clone.setField('title', 'Changed')
+    clone.storeField('title', 'Changed')
 
     expect(field(doc.main, 'title')).toBe('Test Document')
     expect(field(clone.main, 'title')).toBe('Changed')

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -119,7 +119,7 @@ card_kinds:
 
     // setSeedNamespace writes an overlay; main.seed reads it back; remove clears.
     const doc2 = Document.fromMarkdown('~~~\n$quill: seed_core@1.0.0\n$kind: main\n~~~\n')
-    doc2.setSeedNamespace('note', { author: 'Written' })
+    doc2.storeSeedNamespace('note', { author: 'Written' })
     expect(doc2.main.seed?.note.author).toBe('Written')
     doc2.removeSeedNamespace('note')
     expect(doc2.main.seed?.note).toBeUndefined()
@@ -150,16 +150,16 @@ title: Draft
 # Body`)
 
     // Edit the main card and append a composable card.
-    doc.setField('title', 'Final')
+    doc.storeField('title', 'Final')
     doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'A note.'))
     expect(doc.cardCount).toBe(1)
     expect(doc.cards[0].kind).toBe('note')
 
-    doc.setCardField(0, 'author', 'Bob')
+    doc.storeField({ card: 0, field: 'author' }, 'Bob')
     // Keyed card read (#953) — mirrors the write, no payloadItems walk. Agrees
     // with the hand-rolled projection it replaces.
-    expect(doc.getCardField(0, 'author')).toBe('Bob')
-    expect(doc.getCardField(0, 'author')).toBe(field(doc.cards[0], 'author'))
+    expect(doc.get({ card: 0, field: 'author' })).toBe('Bob')
+    expect(doc.get({ card: 0, field: 'author' })).toBe(field(doc.cards[0], 'author'))
 
     // Storage DTO round-trips losslessly — the editor's persistence path.
     const restored = Document.fromJson(doc.toJson())
@@ -181,19 +181,19 @@ title: Draft
     doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'A note body.'))
 
     // getCardField — value keyed by name; undefined when the field is absent.
-    expect(doc.getCardField(0, 'author')).toBe('Alice')
-    expect(doc.getCardField(0, 'missing')).toBeUndefined()
+    expect(doc.get({ card: 0, field: 'author' })).toBe('Alice')
+    expect(doc.get({ card: 0, field: 'missing' })).toBeUndefined()
 
     // getCardMarkdown — the card body when name omitted, the field projection
     // when named (a bare string field imports as markdown).
-    expect(doc.getCardMarkdown(0)).toContain('A note body.')
-    expect(doc.getCardMarkdown(0, 'author')).toContain('Alice')
-    expect(doc.getCardMarkdown(0, 'missing')).toBe('')
+    expect(doc.getMarkdown({ card: 0 })).toContain('A note body.')
+    expect(doc.getMarkdown({ card: 0, field: 'author' })).toContain('Alice')
+    expect(doc.getMarkdown({ card: 0, field: 'missing' })).toBeUndefined()
 
     // An out-of-range index is a boundary error — it throws, the way the card
     // write verbs do, rather than reading back as undefined/"".
-    expect(() => doc.getCardField(1, 'author')).toThrow()
-    expect(() => doc.getCardMarkdown(1)).toThrow()
+    expect(() => doc.get({ card: 1, field: 'author' })).toThrow()
+    expect(() => doc.getMarkdown({ card: 1 })).toThrow()
   })
 
   it('single-card, $id, and seed-overlay reads (#956)', () => {
@@ -220,7 +220,7 @@ title: Draft
 
     // seedOverlay reads one $seed[kind] entry off the main card cheaply, the
     // overlay you feed straight into quill.seedCard(kind, overlay).
-    doc.setSeedNamespace('note', { author: 'Seeded' })
+    doc.storeSeedNamespace('note', { author: 'Seeded' })
     expect(doc.seedOverlay('note')).toEqual({ author: 'Seeded' })
     expect(doc.seedOverlay('absent')).toBeUndefined()
   })

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -220,7 +220,7 @@ card_kinds:
     expect(ed.document.get('qty')).toBe(3)
     expect(ed.document.getMarkdown('subject')).toBe('Q3 **results**\n')
     expect(ed.document.get('missing')).toBeUndefined()
-    expect(ed.document.getMarkdown('missing')).toBe('')
+    expect(ed.document.getMarkdown('missing')).toBeUndefined()
   })
 })
 

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -482,7 +482,7 @@ declare module '../core/wasm.js' {
  * Typed commit is the default whenever a quill is in hand: it resolves each
  * field's schema type and strict-commits it, throwing `UnknownField` for a name
  * the schema does not declare — on the typed path an undeclared name is a typo,
- * not a fallback. The raw `Document.setField` / `setFields` verbs remain the
+ * not a fallback. The raw `Document.storeField` / `storeFields` verbs remain the
  * deliberate quill-free primitive (standalone data, storage/migration infra, or
  * holding not-yet-conforming in-progress input).
  */

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -531,7 +531,7 @@ export class LiveSession {
 // typed-committed (coerced to canonical form, mismatch throws now), and a name
 // the schema does not declare throws `UnknownField` rather than falling to the
 // opaque store — on the typed path an undeclared name is a typo. Opaque storage
-// stays available through the raw `Document.setField` / `setCardField` verbs.
+// stays available through the raw addressed `Document.storeField` verb.
 
 /**
  * A {@link Document} bound to its {@link Quill} for typed writes — the JS twin
@@ -573,7 +573,7 @@ export class DocumentWriter {
 	 * @returns {void}
 	 */
 	setAll(fields) {
-		return this.#doc.commitFields(this.#quill, fields);
+		return this.#doc.commitFields(this.#quill, {}, fields);
 	}
 	/**
 	 * Set the main body from markdown (edit semantics: surviving anchors rebase),
@@ -664,25 +664,26 @@ export class CardWriter {
 		return this.#doc.card(this.#index).kind;
 	}
 	/**
-	 * Typed-commit one field on this card, per `Document.commitCardField`.
-	 * Throws `UnknownField` for an undeclared name and `IndexOutOfRange` if the
-	 * bound index is out of range.
+	 * Typed-commit one field on this card, per `Document.commitField` addressed
+	 * at `{ card, field }`. Throws `UnknownField` for an undeclared name and
+	 * `IndexOutOfRange` if the bound index is out of range.
 	 * @param {string} name
 	 * @param {unknown} value
 	 * @returns {void}
 	 */
 	set(name, value) {
-		return this.#doc.commitCardField(this.#quill, this.#index, name, value);
+		return this.#doc.commitField(this.#quill, { card: this.#index, field: name }, value);
 	}
 	/**
 	 * Typed-commit several fields on this card atomically, per
-	 * `Document.commitCardFields`. Throws a per-field diagnostic bundle on error
-	 * and `IndexOutOfRange` if the bound index is out of range.
+	 * `Document.commitFields` addressed at `{ card }`. Throws a per-field
+	 * diagnostic bundle on error and `IndexOutOfRange` if the bound index is out
+	 * of range.
 	 * @param {Record<string, unknown>} fields
 	 * @returns {void}
 	 */
 	setAll(fields) {
-		return this.#doc.commitCardFields(this.#quill, this.#index, fields);
+		return this.#doc.commitFields(this.#quill, { card: this.#index }, fields);
 	}
 	/**
 	 * Set this card's body from markdown (edit semantics), discarding the delta —

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -911,10 +911,9 @@ impl Document {
     }
 
     /// The whole `$ext` map at `addr` (a card address, absent `card` = main), or
-    /// `undefined` when the card carries none. The fine-grained `$ext` read the
-    /// surface previously lacked: reading your own state no longer means
-    /// serializing the whole card. Throws on a present `field` (a card address
-    /// takes only `card`) or an out-of-range card.
+    /// `undefined` when the card carries none. The fine-grained `$ext` read —
+    /// your own state without serializing the whole card. Throws on a present
+    /// `field` (a card address takes only `card`) or an out-of-range card.
     #[wasm_bindgen(js_name = getExt, unchecked_return_type = "Record<string, unknown> | undefined")]
     pub fn get_ext(
         &self,
@@ -1031,10 +1030,9 @@ impl Document {
     }
 
     /// Store a field verbatim at `addr` and mark it `!must_fill` — the opaque
-    /// store's fill variant, now card-capable (a bare string or `{ field }` for
-    /// main, `{ card, field }` for a composable card, closing the card-scoped
-    /// fill gap). A body address throws. Same validation as
-    /// [`storeField`](Document::store_field).
+    /// store's fill variant, card-capable (a bare string or `{ field }` for main,
+    /// `{ card, field }` for a composable card). A body address throws. Same
+    /// validation as [`storeField`](Document::store_field).
     #[wasm_bindgen(js_name = storeFill)]
     pub fn store_fill(
         &mut self,

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -231,14 +231,30 @@ export interface RichTextIsland {
 }
 
 /**
- * A richtext write address. An absent `field` targets the card body; an absent
- * `card` targets the main card. `{}` is the main-card body; `{ card: 2 }` the
- * body of the composable card at index 2; `{ field: "intro" }` the main card's
- * `intro` richtext field; `{ card: 2, field: "intro" }` a card field.
+ * A write address — one navigation concept for the whole `Document` surface. An
+ * absent `field` targets the card body; an absent `card` targets the main card.
+ * `{}` is the main-card body; `{ card: 2 }` the body of the composable card at
+ * index 2; `{ field: "intro" }` the main card's `intro` field; `{ card: 2,
+ * field: "intro" }` a card field.
+ *
+ * On the `Addr`-taking verbs a **bare string** is shorthand for `{ field: name }`
+ * — `doc.storeField("qty", 3)`, `doc.revise("intro", md)` — the one coercion
+ * rule. A bare number is *not* an addr (`{ card: 2 }` is the self-documenting
+ * spelling), so no third navigation idiom re-fragments the surface.
  */
 export interface Addr {
     card?: number;
     field?: string;
+}
+
+/**
+ * A card-only address — the axis the card-scoped verbs (`storeFields`,
+ * `storeExt`, `getExt`, `commitFields`, …) take. An absent `card` targets the
+ * main card. A present `field` throws: a card address takes only `card`, and a
+ * would-be nested write is a bug the error names rather than silently ignores.
+ */
+export interface CardAddr {
+    card?: number;
 }
 
 /**
@@ -828,67 +844,106 @@ impl Document {
         serialize_or_throw(&cards, "cards")
     }
 
-    /// Read a main-card field's stored value — the raw payload value (a corpus
-    /// object for a richtext field, a scalar/array/object otherwise), or
-    /// `undefined` when the field is absent. The quill-free read: reads need no
-    /// schema, so they live on `Document`, not the typed writer. For the markdown
-    /// projection of a richtext value use [`getMarkdown`](Self::get_markdown).
-    #[wasm_bindgen(js_name = get)]
-    pub fn get(&self, name: &str) -> Result<JsValue, JsValue> {
-        match self.inner.main().payload().get(name) {
-            Some(v) => serialize_or_throw(v.as_json(), "get"),
-            None => Ok(JsValue::UNDEFINED),
+    /// Read the value at `addr` — the raw stored payload value of a field (a
+    /// corpus object for a richtext field, a scalar/array/object otherwise), or
+    /// the **body corpus** when `addr.field` is absent. A bare string is `Addr`
+    /// shorthand for `{ field }`. Reads are total over the field axis: an absent
+    /// field is `undefined`; only an out-of-range `addr.card` throws
+    /// `[EditError::IndexOutOfRange]`. Reads need no schema, so they live on
+    /// `Document`, not the typed writer; for the markdown projection of a
+    /// richtext value use [`getMarkdown`](Self::get_markdown).
+    #[wasm_bindgen(js_name = get, unchecked_return_type = "unknown")]
+    pub fn get(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let card = self.addr_card_ref(&addr)?;
+        match &addr.field {
+            None => serialize_or_throw(
+                &quillmark_richtext::serial::to_canonical_value(card.body()),
+                "get",
+            ),
+            Some(field) => match card.payload().get(field) {
+                Some(v) => serialize_or_throw(v.as_json(), "get"),
+                None => Ok(JsValue::UNDEFINED),
+            },
         }
     }
 
-    /// The markdown projection of a main-card field (`name` given) or the main
-    /// body (`name` omitted) — the on-demand, lossy export (corpus-only marks do
-    /// not survive markdown), returning `""` for an absent field. Re-coins,
-    /// lazily and by name, the projection the eager `fieldMarkdown` /
-    /// `bodyMarkdown` getters dropped in #925; call it only when markdown is what
-    /// you need out.
-    #[wasm_bindgen(js_name = getMarkdown)]
+    /// The markdown projection of the value at `addr` — a field's (given
+    /// `addr.field`) or the body's (absent) — the on-demand, lossy export
+    /// (corpus-only marks do not survive markdown). A bare string is `Addr`
+    /// shorthand for `{ field }`. Returns `undefined` for an absent field
+    /// (absence vs empty is real signal for must-fill / seeding UIs); a body is
+    /// never absent. Only an out-of-range `addr.card` throws.
+    #[wasm_bindgen(js_name = getMarkdown, unchecked_return_type = "string | undefined")]
     pub fn get_markdown(
         &self,
-        #[wasm_bindgen(unchecked_optional_param_type = "string")] name: Option<String>,
-    ) -> String {
-        match name {
-            Some(n) => self.inner.main().field_markdown(&n).unwrap_or_default(),
-            None => self.inner.main().body_markdown(),
-        }
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let card = self.addr_card_ref(&addr)?;
+        Ok(match &addr.field {
+            None => JsValue::from_str(&card.body_markdown()),
+            Some(field) => match card.field_markdown(field) {
+                Some(md) => JsValue::from_str(&md),
+                None => JsValue::UNDEFINED,
+            },
+        })
     }
 
-    /// Read a composable card's field value — the card-indexed twin of
-    /// [`get`](Self::get): the raw payload value (a corpus object for a richtext
-    /// field, a scalar/array/object otherwise), or `undefined` when the field is
-    /// absent. An out-of-range `index` throws `[EditError::IndexOutOfRange]`, as
-    /// the card write verbs do — a bad index is a boundary error, not an absent
-    /// field.
-    #[wasm_bindgen(js_name = getCardField)]
-    pub fn get_card_field(&self, index: usize, name: &str) -> Result<JsValue, JsValue> {
-        match self.card_or_throw(index)?.payload().get(name) {
-            Some(v) => serialize_or_throw(v.as_json(), "getCardField"),
+    /// Whether the field at `addr` is marked `!must_fill`. A bare string is `Addr`
+    /// shorthand for `{ field }`. `false` for an absent field (truthful — it isn't
+    /// marked) and for a body address (a body is never a fill). Only an
+    /// out-of-range `addr.card` throws.
+    #[wasm_bindgen(js_name = isFill)]
+    pub fn is_fill(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+    ) -> Result<bool, JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let card = self.addr_card_ref(&addr)?;
+        Ok(match &addr.field {
+            None => false,
+            Some(field) => card.payload().is_fill(field),
+        })
+    }
+
+    /// The whole `$ext` map at `addr` (a card address, absent `card` = main), or
+    /// `undefined` when the card carries none. The fine-grained `$ext` read the
+    /// surface previously lacked: reading your own state no longer means
+    /// serializing the whole card. Throws on a present `field` (a card address
+    /// takes only `card`) or an out-of-range card.
+    #[wasm_bindgen(js_name = getExt, unchecked_return_type = "Record<string, unknown> | undefined")]
+    pub fn get_ext(
+        &self,
+        #[wasm_bindgen(unchecked_optional_param_type = "CardAddr")] addr: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("getExt")?;
+        match self.addr_card_ref(&addr)?.ext() {
+            Some(map) => serialize_or_throw(map, "getExt"),
             None => Ok(JsValue::UNDEFINED),
         }
     }
 
-    /// The markdown projection of a composable card's field (`name` given) or its
-    /// body (`name` omitted) — the card-indexed twin of
-    /// [`getMarkdown`](Self::get_markdown), `""` for an absent field. An
-    /// out-of-range `index` throws `[EditError::IndexOutOfRange]`; that
-    /// fallibility is the one difference from the infallible main `getMarkdown`,
-    /// forced by the index.
-    #[wasm_bindgen(js_name = getCardMarkdown)]
-    pub fn get_card_markdown(
+    /// The value stored under `$ext[ns]` at `addr` (a card address, absent `card`
+    /// = main), or `undefined`. The namespace-scoped `$ext` read — your own slot
+    /// without a whole-card serialize, and non-destructive (unlike
+    /// `removeExtNamespace`). Throws on a present `field` or an out-of-range card.
+    #[wasm_bindgen(js_name = getExtNamespace, unchecked_return_type = "unknown")]
+    pub fn get_ext_namespace(
         &self,
-        index: usize,
-        #[wasm_bindgen(unchecked_optional_param_type = "string")] name: Option<String>,
-    ) -> Result<String, JsValue> {
-        let card = self.card_or_throw(index)?;
-        Ok(match name {
-            Some(n) => card.field_markdown(&n).unwrap_or_default(),
-            None => card.body_markdown(),
-        })
+        #[wasm_bindgen(unchecked_param_type = "CardAddr")] addr: JsValue,
+        ns: &str,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("getExtNamespace")?;
+        match self.addr_card_ref(&addr)?.ext().and_then(|m| m.get(ns)) {
+            Some(v) => serialize_or_throw(v, "getExtNamespace"),
+            None => Ok(JsValue::UNDEFINED),
+        }
     }
 
     /// Number of composable cards (excludes the main card). O(1).
@@ -952,60 +1007,85 @@ impl Document {
 
     // ── Mutators ──────────────────────────────────────────────────────────────
 
-    /// Update a payload field on the main card. Clears any existing `!must_fill` marker.
-    ///
-    /// Throws if `name` does not match `[A-Za-z_][A-Za-z0-9_]*`.
-    #[wasm_bindgen(js_name = setField)]
-    pub fn set_field(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
-        let json: serde_json::Value = serde_wasm_bindgen::from_value(value).map_err(|e| {
-            WasmError::from(format!("setField: invalid value: {}", e)).to_js_value()
-        })?;
-        let qv = quillmark_core::QuillValue::from_json(json);
-        self.inner
-            .main_mut()
-            .set_field(name, qv)
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
-    /// Update a payload field on the main card and mark it as `!must_fill`.
-    /// Throws on invalid name (see [`setField`](Document::set_field)).
-    #[wasm_bindgen(js_name = setFill)]
-    pub fn set_fill(&mut self, name: &str, value: JsValue) -> Result<(), JsValue> {
-        let json: serde_json::Value = serde_wasm_bindgen::from_value(value)
-            .map_err(|e| WasmError::from(format!("setFill: invalid value: {}", e)).to_js_value())?;
-        let qv = quillmark_core::QuillValue::from_json(json);
-        self.inner
-            .main_mut()
-            .set_fill(name, qv)
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
-    /// Set several main-card payload fields atomically from a plain object,
-    /// clearing any `!must_fill` marker on each key. Nothing is applied on
-    /// error; the thrown error's `diagnostics` array carries one entry per
-    /// offending field (`path` = field name), so externally-sourced names
-    /// (database columns, form keys) surface every violation in one pass.
-    /// Mirrors Python `set_fields`.
-    #[wasm_bindgen(js_name = setFields)]
-    pub fn set_fields(
+    /// Store a field verbatim at `addr` — the opaque store (**store** = verbatim,
+    /// coercion deferred to render; the typed write is
+    /// [`commitField`](Document::commit_field)). A bare string is `Addr`
+    /// shorthand for `{ field }`, so `doc.storeField("qty", 3)` reads as written;
+    /// `{ card: 2, field: "qty" }` targets a composable card. Clears any
+    /// `!must_fill` marker. A body address (no `field`) throws — a body is never
+    /// opaque; write it with `revise` / `install` / `writer.setBody`. Throws on
+    /// an out-of-range card or a malformed name.
+    #[wasm_bindgen(js_name = storeField)]
+    pub fn store_field(
         &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let field = addr.require_field("storeField")?.to_string();
+        let json = js_value_to_json(value, "storeField")?;
+        let qv = quillmark_core::QuillValue::from_json(json);
+        self.addr_card_mut(&addr)?
+            .store_field(&field, qv)
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// Store a field verbatim at `addr` and mark it `!must_fill` — the opaque
+    /// store's fill variant, now card-capable (a bare string or `{ field }` for
+    /// main, `{ card, field }` for a composable card, closing the card-scoped
+    /// fill gap). A body address throws. Same validation as
+    /// [`storeField`](Document::store_field).
+    #[wasm_bindgen(js_name = storeFill)]
+    pub fn store_fill(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let field = addr.require_field("storeFill")?.to_string();
+        let json = js_value_to_json(value, "storeFill")?;
+        let qv = quillmark_core::QuillValue::from_json(json);
+        self.addr_card_mut(&addr)?
+            .store_fill(&field, qv)
+            .map_err(|e| edit_error_to_js(&e))
+    }
+
+    /// Store several fields verbatim and atomically on the card `addr` targets —
+    /// the opaque store's batch. `addr` is a **card address** (`{ card }`, absent
+    /// = main); a present `field` throws. The batch verb takes the address first
+    /// and is never shape-overloaded, because `card` is a legal field name:
+    /// `storeFields({}, fields)` is the main card, `storeFields({ card: 2 },
+    /// fields)` a composable one — never ambiguous with "set field `card`".
+    /// Nothing is applied on error; the thrown error's `diagnostics` carry one
+    /// entry per offending field. Throws on an out-of-range card.
+    #[wasm_bindgen(js_name = storeFields)]
+    pub fn store_fields(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "CardAddr")] addr: JsValue,
         #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
     ) -> Result<(), JsValue> {
-        let batch = js_value_to_field_batch(&fields, "setFields")?;
-        self.inner
-            .main_mut()
-            .set_fields(batch)
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("storeFields")?;
+        let batch = js_value_to_field_batch(&fields, "storeFields")?;
+        self.addr_card_mut(&addr)?
+            .store_fields(batch)
             .map_err(edit_errors_to_js)
     }
 
-    /// Remove a payload field on the main card, returning the removed value or
-    /// `undefined`. Throws if `name` does not match `[A-Za-z_][A-Za-z0-9_]*`.
+    /// Remove a field at `addr`, returning the removed value or `undefined`. A
+    /// bare string is `Addr` shorthand for `{ field }`. Removal has no tier — the
+    /// one verb serves every write lane. A body address throws; throws on an
+    /// out-of-range card or a malformed name.
     #[wasm_bindgen(js_name = removeField)]
-    pub fn remove_field(&mut self, name: &str) -> Result<JsValue, JsValue> {
+    pub fn remove_field(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let field = addr.require_field("removeField")?.to_string();
         let removed = self
-            .inner
-            .main_mut()
-            .remove_field(name)
+            .addr_card_mut(&addr)?
+            .remove_field(&field)
             .map_err(|e| edit_error_to_js(&e))?;
         Ok(match removed {
             Some(v) => serialize_or_throw(v.as_json(), "removeField")?,
@@ -1013,124 +1093,97 @@ impl Document {
         })
     }
 
-    /// Replace the opaque `$ext` map on the main card. `value` must be a plain
-    /// object; throws otherwise. `$ext` carries out-of-band consumer state and
-    /// never reaches the rendered output. Pass `{}` to record an explicit
-    /// empty `$ext`.
-    #[wasm_bindgen(js_name = setExt)]
-    pub fn set_ext(&mut self, value: JsValue) -> Result<(), JsValue> {
-        let map = js_value_to_object(&value, "setExt")?;
-        self.inner
-            .main_mut()
-            .set_ext(map)
-            .map_err(|e| edit_error_to_js(&e))?;
-        Ok(())
+    /// Replace the opaque `$ext` map on the card `addr` targets (a card address,
+    /// absent `card` = main). `value` must be a plain object. `$ext` carries
+    /// out-of-band consumer state and never reaches the rendered output; pass
+    /// `{}` for an explicit empty `$ext`. Quill-free and verbatim — an opaque
+    /// `store` verb. Throws on a present `field` or an out-of-range card.
+    #[wasm_bindgen(js_name = storeExt)]
+    pub fn store_ext(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "CardAddr")] addr: JsValue,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("storeExt")?;
+        let map = js_value_to_object(&value, "storeExt")?;
+        self.addr_card_mut(&addr)?
+            .store_ext(map)
+            .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Remove the `$ext` map from the main card *entirely*, returning the
-    /// previous map or `undefined`. This is a blunt escape hatch that discards
-    /// every namespace at once — prefer `removeExtNamespace` to clear only your
-    /// own slot while leaving sibling consumers' state intact.
+    /// Remove the `$ext` map on the card `addr` targets *entirely*, returning the
+    /// previous map or `undefined` — a blunt escape hatch that discards every
+    /// namespace at once (prefer `removeExtNamespace`). `addr` is a card address
+    /// (absent = main). Throws on a present `field` or an out-of-range card.
     #[wasm_bindgen(js_name = removeExt, unchecked_return_type = "Record<string, unknown> | undefined")]
-    pub fn remove_ext(&mut self) -> Result<JsValue, JsValue> {
-        ext_map_to_js(self.inner.main_mut().remove_ext())
+    pub fn remove_ext(
+        &mut self,
+        #[wasm_bindgen(unchecked_optional_param_type = "CardAddr")] addr: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("removeExt")?;
+        ext_map_to_js(self.addr_card_mut(&addr)?.remove_ext())
     }
 
-    /// Merge `value` into the main card's `$ext` map under `namespace`, creating
-    /// the map when absent and replacing any existing value at that key. Sibling
-    /// namespaces are preserved, so independent consumers (`$ext.editor`,
-    /// `$ext.agent`, …) don't clobber each other.
-    #[wasm_bindgen(js_name = setExtNamespace)]
-    pub fn set_ext_namespace(&mut self, namespace: &str, value: JsValue) -> Result<(), JsValue> {
-        let json = js_value_to_json(value, "setExtNamespace")?;
-        self.inner
-            .main_mut()
-            .set_ext_namespace(namespace, json)
-            .map_err(|e| edit_error_to_js(&e))?;
-        Ok(())
+    /// Merge `value` into `$ext[ns]` on the card `addr` targets, preserving
+    /// sibling namespaces — the recommended `$ext` write. `addr` is a card
+    /// address (absent = main). Quill-free and verbatim — an opaque `store` verb.
+    /// Throws on a present `field` or an out-of-range card.
+    #[wasm_bindgen(js_name = storeExtNamespace)]
+    pub fn store_ext_namespace(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "CardAddr")] addr: JsValue,
+        ns: &str,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("storeExtNamespace")?;
+        let json = js_value_to_json(value, "storeExtNamespace")?;
+        self.addr_card_mut(&addr)?
+            .store_ext_namespace(ns, json)
+            .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Remove `namespace` from the main card's `$ext` map, returning the value
-    /// stored there or `undefined`. This is the recommended way to clear `$ext`
-    /// state: sibling namespaces survive, and when the last namespace is removed
-    /// the `$ext` entry is dropped entirely (not left as `$ext: {}`).
+    /// Remove `$ext[ns]` on the card `addr` targets, returning its value or
+    /// `undefined`; drops `$ext` once empty. `addr` is a card address (absent =
+    /// main). Preserves sibling namespaces. Throws on a present `field` or an
+    /// out-of-range card.
     #[wasm_bindgen(js_name = removeExtNamespace)]
-    pub fn remove_ext_namespace(&mut self, namespace: &str) -> Result<JsValue, JsValue> {
-        json_value_to_js(self.inner.main_mut().remove_ext_namespace(namespace))
+    pub fn remove_ext_namespace(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "CardAddr")] addr: JsValue,
+        ns: &str,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("removeExtNamespace")?;
+        json_value_to_js(self.addr_card_mut(&addr)?.remove_ext_namespace(ns))
     }
 
-    /// Merge a card-kind's seed `overlay` into the main card's `$seed` map
-    /// under `cardKind`, preserving sibling kinds. Sets the starting values
-    /// new cards of that kind spawn with. Throws if `overlay` cannot be
-    /// serialized or nests too deep.
-    #[wasm_bindgen(js_name = setSeedNamespace)]
-    pub fn set_seed_namespace(&mut self, card_kind: &str, overlay: JsValue) -> Result<(), JsValue> {
-        let json = js_value_to_json(overlay, "setSeedNamespace")?;
+    /// Merge a card-kind's seed `overlay` into the **main** card's `$seed` map
+    /// under `cardKind`, preserving sibling kinds — `$seed` lives on the main
+    /// card by model, so this takes no address. Sets the starting values new
+    /// cards of that kind spawn with. Quill-free and verbatim — an opaque `store`
+    /// verb. Throws if `overlay` cannot be serialized or nests too deep.
+    #[wasm_bindgen(js_name = storeSeedNamespace)]
+    pub fn store_seed_namespace(
+        &mut self,
+        card_kind: &str,
+        overlay: JsValue,
+    ) -> Result<(), JsValue> {
+        let json = js_value_to_json(overlay, "storeSeedNamespace")?;
         self.inner
             .main_mut()
-            .set_seed_namespace(card_kind, json)
-            .map_err(|e| edit_error_to_js(&e))?;
-        Ok(())
+            .store_seed_namespace(card_kind, json)
+            .map_err(|e| edit_error_to_js(&e))
     }
 
     /// Remove `cardKind` from the main card's `$seed` map, returning its
-    /// overlay or `undefined`; drops `$seed` entirely once empty. Sibling
-    /// kinds survive.
+    /// overlay or `undefined`; drops `$seed` entirely once empty. Sibling kinds
+    /// survive. `$seed` is main-only, so this takes no address.
     #[wasm_bindgen(js_name = removeSeedNamespace)]
     pub fn remove_seed_namespace(&mut self, card_kind: &str) -> Result<JsValue, JsValue> {
         json_value_to_js(self.inner.main_mut().remove_seed_namespace(card_kind))
-    }
-
-    /// Replace the `$ext` map on the composable card at `index`. Throws if out
-    /// of range or `value` is not a plain object. Named to mirror `setExt` on
-    /// the main card; `setCardExtNamespace` is the sibling-safe alternative.
-    #[wasm_bindgen(js_name = setCardExt)]
-    pub fn set_card_ext(&mut self, index: usize, value: JsValue) -> Result<(), JsValue> {
-        let map = js_value_to_object(&value, "setCardExt")?;
-        self.card_mut_or_throw(index)?
-            .set_ext(map)
-            .map_err(|e| edit_error_to_js(&e))?;
-        Ok(())
-    }
-
-    /// Remove the `$ext` map from the composable card at `index` *entirely*,
-    /// returning the previous map or `undefined`. Throws if out of range.
-    /// Prefer `removeCardExtNamespace` to clear only one consumer's slot.
-    #[wasm_bindgen(js_name = removeCardExt, unchecked_return_type = "Record<string, unknown> | undefined")]
-    pub fn remove_card_ext(&mut self, index: usize) -> Result<JsValue, JsValue> {
-        ext_map_to_js(self.card_mut_or_throw(index)?.remove_ext())
-    }
-
-    /// Merge `value` into the composable card's `$ext` map under `namespace`,
-    /// preserving sibling namespaces. The card-indexed twin of `setExtNamespace`.
-    /// Throws if out of range or `value` cannot be serialized.
-    #[wasm_bindgen(js_name = setCardExtNamespace)]
-    pub fn set_card_ext_namespace(
-        &mut self,
-        index: usize,
-        namespace: &str,
-        value: JsValue,
-    ) -> Result<(), JsValue> {
-        let json = js_value_to_json(value, "setCardExtNamespace")?;
-        self.card_mut_or_throw(index)?
-            .set_ext_namespace(namespace, json)
-            .map_err(|e| edit_error_to_js(&e))?;
-        Ok(())
-    }
-
-    /// Remove `namespace` from the composable card's `$ext` map, returning the
-    /// value stored there or `undefined`; clears `$ext` entirely once empty.
-    /// The card-indexed twin of `removeExtNamespace`. Throws if out of range.
-    #[wasm_bindgen(js_name = removeCardExtNamespace)]
-    pub fn remove_card_ext_namespace(
-        &mut self,
-        index: usize,
-        namespace: &str,
-    ) -> Result<JsValue, JsValue> {
-        json_value_to_js(
-            self.card_mut_or_throw(index)?
-                .remove_ext_namespace(namespace),
-        )
     }
 
     /// Replace the QUILL reference string. Throws if `ref_str` is invalid.
@@ -1166,10 +1219,10 @@ impl Document {
     #[wasm_bindgen(js_name = install)]
     pub fn install(
         &mut self,
-        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
         #[wasm_bindgen(unchecked_param_type = "RichText")] rt: JsValue,
     ) -> Result<(), JsValue> {
-        let addr = Addr::from_js(&addr)?;
+        let addr = Addr::from_js_or_string(&addr)?;
         let corpus = js_to_corpus(rt, "install")?;
         let card = self.addr_card_mut(&addr)?;
         match &addr.field {
@@ -1193,10 +1246,10 @@ impl Document {
     #[wasm_bindgen(js_name = revise, unchecked_return_type = "Delta")]
     pub fn revise(
         &mut self,
-        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
         markdown: &str,
     ) -> Result<JsValue, JsValue> {
-        let addr = Addr::from_js(&addr)?;
+        let addr = Addr::from_js_or_string(&addr)?;
         let card = self.addr_card_mut(&addr)?;
         let delta = match &addr.field {
             None => card.revise_body(markdown),
@@ -1204,6 +1257,62 @@ impl Document {
         }
         .map_err(|e| edit_error_to_js(&e))?;
         serialize_or_throw(&delta, "revise")
+    }
+
+    /// **Revise** the richtext **field** at `addr` from markdown *with schema
+    /// enforcement* — typed *and* anchor-preserving, the write [`revise`](Self::revise)
+    /// (schema-blind) and [`commitField`](Self::commit_field) (cold, anchors lost)
+    /// leave in a gap. Diffs the markdown against the field's current corpus so
+    /// surviving anchors rebase (as `revise`), then enforces the field's schema —
+    /// resolved from `quill` — on the *diffed result*: a `richtext(inline)` field
+    /// rejects a multi-block result with `[EditError::FieldRichtextNotInline]`
+    /// (the error surface `commitField` raises, unchanged) while anchors survive.
+    /// Returns the text [`Delta`].
+    ///
+    /// The receipt stays in the corpus lane — anchor preservation is a tier-2
+    /// concern, so the typed-anchor-preserving write lives here, not on the
+    /// receipt-free `writer.set`. `addr` must name a field (a bare string is
+    /// `{ field }`); a **body** address throws (a body carries no field schema —
+    /// use [`revise`](Self::revise)). A name the schema does not declare throws
+    /// `[EditError::UnknownField]`. Throws on an out-of-range card.
+    #[wasm_bindgen(js_name = reviseChecked, unchecked_return_type = "Delta")]
+    pub fn revise_checked(
+        &mut self,
+        quill: &Quill,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
+        markdown: &str,
+    ) -> Result<JsValue, JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let field = addr.require_field("reviseChecked")?.to_string();
+        // Resolve the field's schema (main card, or the addressed card's $kind)
+        // and clone it, dropping the quill borrow before the mutable card borrow.
+        let schema = {
+            let config = quill.inner.config();
+            match addr.card {
+                None => config.main.fields.get(&field).cloned(),
+                Some(index) => {
+                    let cards = self.inner.cards();
+                    let card = cards.get(index).ok_or_else(|| {
+                        edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange {
+                            index,
+                            len: cards.len(),
+                        })
+                    })?;
+                    card.kind()
+                        .and_then(|k| config.card_kind(k))
+                        .and_then(|s| s.fields.get(&field))
+                        .cloned()
+                }
+            }
+        };
+        let schema = schema.ok_or_else(|| {
+            edit_error_to_js(&quillmark_core::EditError::UnknownField(field.clone()))
+        })?;
+        let delta = self
+            .addr_card_mut(&addr)?
+            .revise_field_checked(&field, markdown, &schema)
+            .map_err(|e| edit_error_to_js(&e))?;
+        serialize_or_throw(&delta, "reviseChecked")
     }
 
     /// **Apply** a committed corpus edit `bundle` (`{ delta?, lineOps?, markOps? }`)
@@ -1217,10 +1326,10 @@ impl Document {
     #[wasm_bindgen(js_name = applyChange)]
     pub fn apply_change(
         &mut self,
-        #[wasm_bindgen(unchecked_param_type = "Addr")] addr: JsValue,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
         #[wasm_bindgen(unchecked_param_type = "ChangeBundle")] bundle: JsValue,
     ) -> Result<(), JsValue> {
-        let addr = Addr::from_js(&addr)?;
+        let addr = Addr::from_js_or_string(&addr)?;
         let (delta, line_ops, mark_ops) = parse_change_bundle(&bundle)?;
         let card = self.addr_card_mut(&addr)?;
         match &addr.field {
@@ -1232,23 +1341,27 @@ impl Document {
         .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Typed field write on the main card, resolving the field's schema `type`
-    /// from `quill` — the one write verb for **every** field type (richtext,
-    /// scalar, array, object). The schema carries the `inline` constraint, so no
-    /// type token or flag is passed. A richtext-typed field stores the canonical
-    /// corpus, so identity marks (anchors, island ids) and corpus-only marks
-    /// (e.g. `underline`) live on it and survive compiles and the storage DTO.
-    /// Values use the encoding the seam already speaks: a corpus object
-    /// or markdown string for richtext, a scalar/array/object otherwise.
+    /// Typed field write at `addr`, resolving the field's schema `type` from
+    /// `quill` — the stable ABI under the runtime `writer.set` / `writer.card(i).set`.
+    /// The one write verb for **every** field type (richtext, scalar, array,
+    /// object); the schema carries the `inline` constraint, so no type token or
+    /// flag is passed. A richtext-typed field stores the canonical corpus, so
+    /// identity marks (anchors, island ids) and corpus-only marks (e.g.
+    /// `underline`) live on it and survive compiles and the storage DTO. Values
+    /// use the encoding the seam already speaks: a corpus object or markdown
+    /// string for richtext, a scalar/array/object otherwise.
     ///
-    /// A field declared in the schema is strict-committed — a mismatch throws
-    /// now, not at render. A name the schema does not declare throws
-    /// `[EditError::UnknownField]` rather than falling to the opaque store: on
-    /// the typed path it is a typo. Use [`setField`](Document::set_field) when
-    /// opaque storage is the intent. Also throws `[EditError::FieldConform]` /
+    /// A bare string is `Addr` shorthand for `{ field }`; `{ card, field }`
+    /// targets a composable card (its `$kind` resolves the schema). A body
+    /// address throws — a body has no field schema; write it with `writer.setBody`
+    /// / `revise`. A field declared in the schema is strict-committed (a mismatch
+    /// throws now, not at render); a name the schema does not declare throws
+    /// `[EditError::UnknownField]` rather than falling to the opaque store — on
+    /// the typed path it is a typo. Use [`storeField`](Document::store_field) for
+    /// opaque storage. Also throws `[EditError::FieldConform]` /
     /// `[EditError::FieldRichtextDecode]` / `[EditError::FieldRichtextNotInline]`
-    /// on a typed mismatch and `[EditError::InvalidFieldName]` on a malformed
-    /// name.
+    /// on a typed mismatch, `[EditError::InvalidFieldName]` on a malformed name,
+    /// and `[EditError::IndexOutOfRange]` on an out-of-range card.
     ///
     /// The `quill` handle is passed per call because a `Document` carries only a
     /// `$quill` reference, not the resolved schema.
@@ -1256,37 +1369,53 @@ impl Document {
     pub fn commit_field(
         &mut self,
         quill: &Quill,
-        name: &str,
+        #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
         value: JsValue,
     ) -> Result<(), JsValue> {
+        let addr = Addr::from_js_or_string(&addr)?;
+        let field = addr.require_field("commitField")?.to_string();
         let json = js_value_to_json(value, "commitField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
-        quill
-            .inner
-            .writer(&mut self.inner)
-            .set(name, qv)
-            .map_err(|e| edit_error_to_js(&e))
+        let mut writer = quill.inner.writer(&mut self.inner);
+        match addr.card {
+            None => writer.set(&field, qv).map_err(|e| edit_error_to_js(&e)),
+            Some(index) => writer
+                .card(index)
+                .map_err(|e| edit_error_to_js(&e))?
+                .set(&field, qv)
+                .map_err(|e| edit_error_to_js(&e)),
+        }
     }
 
     /// Batched twin of [`commitField`](Document::commit_field): typed-commit
-    /// several main-card fields atomically, resolving each field's schema `type`
-    /// from `quill`. All-or-nothing with the same per-field-diagnostic error
-    /// contract as [`setFields`](Document::set_fields) — nothing is applied on
-    /// error and the thrown error's `diagnostics` carry one entry per offending
-    /// field, including an `[EditError::UnknownField]` for any name the schema
-    /// does not declare, so a whole-form submit sees every typo in one pass.
+    /// several fields on the card `addr` targets atomically, resolving each
+    /// field's schema `type` from `quill`. `addr` is a **card address**
+    /// (`{ card }`, absent = main; a present `field` throws). All-or-nothing with
+    /// the same per-field-diagnostic error contract as
+    /// [`storeFields`](Document::store_fields) — nothing is applied on error and
+    /// the thrown error's `diagnostics` carry one entry per offending field,
+    /// including an `[EditError::UnknownField]` for any name the schema does not
+    /// declare, so a whole-form submit sees every typo in one pass. Throws on an
+    /// out-of-range card.
     #[wasm_bindgen(js_name = commitFields)]
     pub fn commit_fields(
         &mut self,
         quill: &Quill,
+        #[wasm_bindgen(unchecked_param_type = "CardAddr")] addr: JsValue,
         #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
     ) -> Result<(), JsValue> {
+        let addr = Addr::from_js(&addr)?;
+        addr.require_card_only("commitFields")?;
         let batch = js_value_to_field_batch(&fields, "commitFields")?;
-        quill
-            .inner
-            .writer(&mut self.inner)
-            .set_all(batch)
-            .map_err(edit_errors_to_js)
+        let mut writer = quill.inner.writer(&mut self.inner);
+        match addr.card {
+            None => writer.set_all(batch).map_err(edit_errors_to_js),
+            Some(index) => writer
+                .card(index)
+                .map_err(|e| edit_error_to_js(&e))?
+                .set_all(batch)
+                .map_err(edit_errors_to_js),
+        }
     }
 
     /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
@@ -1423,99 +1552,6 @@ impl Document {
             .map_err(|e| edit_error_to_js(&e))
     }
 
-    /// Set a field on the card at `index` — the card-indexed twin of
-    /// [`setField`](Document::set_field). Stores the value opaquely.
-    /// Throws if `index` is out of range, `name` is reserved or invalid.
-    #[wasm_bindgen(js_name = setCardField)]
-    pub fn set_card_field(
-        &mut self,
-        index: usize,
-        name: &str,
-        value: JsValue,
-    ) -> Result<(), JsValue> {
-        let json = js_value_to_json(value, "setCardField")?;
-        let qv = quillmark_core::QuillValue::from_json(json);
-        self.card_mut_or_throw(index)?
-            .set_field(name, qv)
-            .map_err(|e| edit_error_to_js(&e))
-    }
-
-    /// Typed field write on the composable card at `index` — the card-indexed
-    /// twin of [`commitField`](Document::commit_field). Resolves the field's
-    /// type from the card's `$kind` schema in `quill` and strict-commits it.
-    ///
-    /// Throws `[EditError::IndexOutOfRange]` when `index` is out of range, and
-    /// the same typed-mismatch / name errors as `commitField` — including
-    /// `[EditError::UnknownField]` for a field the card-kind schema does not
-    /// declare (an unknown `$kind` has no schema, so every field is undeclared).
-    #[wasm_bindgen(js_name = commitCardField)]
-    pub fn commit_card_field(
-        &mut self,
-        quill: &Quill,
-        index: usize,
-        name: &str,
-        value: JsValue,
-    ) -> Result<(), JsValue> {
-        let json = js_value_to_json(value, "commitCardField")?;
-        let qv = quillmark_core::QuillValue::from_json(json);
-        let mut writer = quill.inner.writer(&mut self.inner);
-        let mut card = writer.card(index).map_err(|e| edit_error_to_js(&e))?;
-        card.set(name, qv).map_err(|e| edit_error_to_js(&e))
-    }
-
-    /// Batched twin of [`commitCardField`](Document::commit_card_field):
-    /// typed-commit several fields on the card at `index` atomically, resolving
-    /// each field's type from the card's `$kind` schema in `quill`. All-or-nothing
-    /// with the same per-field-diagnostic contract as
-    /// [`commitFields`](Document::commit_fields), including an
-    /// `[EditError::UnknownField]` diagnostic per undeclared name. Throws
-    /// `[EditError::IndexOutOfRange]` when `index` is out of range.
-    #[wasm_bindgen(js_name = commitCardFields)]
-    pub fn commit_card_fields(
-        &mut self,
-        quill: &Quill,
-        index: usize,
-        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
-    ) -> Result<(), JsValue> {
-        let batch = js_value_to_field_batch(&fields, "commitCardFields")?;
-        let mut writer = quill.inner.writer(&mut self.inner);
-        writer
-            .card(index)
-            .map_err(|e| edit_error_to_js(&e))?
-            .set_all(batch)
-            .map_err(edit_errors_to_js)
-    }
-
-    /// Batched twin of [`setCardField`](Document::set_card_field): set
-    /// several fields on the card at `index` atomically. Same all-or-nothing,
-    /// one-diagnostic-per-field contract as [`setFields`](Document::set_fields).
-    /// Throws if `index` is out of range.
-    #[wasm_bindgen(js_name = setCardFields)]
-    pub fn set_card_fields(
-        &mut self,
-        index: usize,
-        #[wasm_bindgen(unchecked_param_type = "Record<string, unknown>")] fields: JsValue,
-    ) -> Result<(), JsValue> {
-        let batch = js_value_to_field_batch(&fields, "setCardFields")?;
-        self.card_mut_or_throw(index)?
-            .set_fields(batch)
-            .map_err(edit_errors_to_js)
-    }
-
-    /// Remove a field on the card at `index`. Returns the removed value or
-    /// `undefined`. Throws if `index` is out of range or `name` is invalid.
-    #[wasm_bindgen(js_name = removeCardField)]
-    pub fn remove_card_field(&mut self, index: usize, name: &str) -> Result<JsValue, JsValue> {
-        let removed = self
-            .card_mut_or_throw(index)?
-            .remove_field(name)
-            .map_err(|e| edit_error_to_js(&e))?;
-        Ok(match removed {
-            Some(v) => serialize_or_throw(v.as_json(), "removeField")?,
-            None => JsValue::UNDEFINED,
-        })
-    }
-
 }
 
 impl Document {
@@ -1550,6 +1586,16 @@ impl Document {
             Some(index) => self.card_mut_or_throw(index),
         }
     }
+
+    /// Immutable twin of [`addr_card_mut`](Self::addr_card_mut): the main card
+    /// when `addr.card` is absent, else the composable card at that index
+    /// (out-of-range throws). Shared by the addressed reads.
+    fn addr_card_ref(&self, addr: &Addr) -> Result<&quillmark_core::Card, JsValue> {
+        match addr.card {
+            None => Ok(self.inner.main()),
+            Some(index) => self.card_or_throw(index),
+        }
+    }
 }
 
 // ── Addressed write surface ────────────────────────────────────────────────────
@@ -1573,6 +1619,48 @@ impl Addr {
         }
         serde_wasm_bindgen::from_value(value.clone())
             .map_err(|e| WasmError::from(format!("addr must be an Addr object: {e}")).to_js_value())
+    }
+
+    /// Accept a bare string — `Addr` shorthand for `{ field: name }`, the terse
+    /// common case — or an `Addr` object. The one coercion rule: only a string
+    /// collapses to `{ field }` (a bare number is not an addr), so a third
+    /// navigation idiom never re-fragments the surface.
+    fn from_js_or_string(value: &JsValue) -> Result<Addr, JsValue> {
+        match value.as_string() {
+            Some(field) => Ok(Addr {
+                card: None,
+                field: Some(field),
+            }),
+            None => Addr::from_js(value),
+        }
+    }
+
+    /// The field an opaque/typed field write targets. A body address (absent
+    /// `field`) is not a field write, so it throws naming the body verbs — reads
+    /// are total over the field axis, but a body has no field lane to write.
+    fn require_field(&self, ctx: &str) -> Result<&str, JsValue> {
+        self.field.as_deref().ok_or_else(|| {
+            WasmError::from(format!(
+                "{ctx}: a body address (no `field`) is not a field write — \
+                 write the body with revise / install / writer.setBody"
+            ))
+            .to_js_value()
+        })
+    }
+
+    /// Enforce that a card-scoped verb's address carries no `field`. A present
+    /// `field` is a caller who believes they are doing a nested write; the error
+    /// says so rather than silently ignoring it. TS types can't police this (an
+    /// `Addr` variable flows into a `CardAddr` slot), so the runtime check is the
+    /// contract.
+    fn require_card_only(&self, ctx: &str) -> Result<(), JsValue> {
+        if self.field.is_some() {
+            return Err(WasmError::from(format!(
+                "{ctx}: a card address takes only `card`, not `field`"
+            ))
+            .to_js_value());
+        }
+        Ok(())
     }
 }
 

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -445,7 +445,7 @@ fn test_quill_seed_main_and_card() {
 
 /// `$seed` overlays: the per-kind overlay is read off `Document.main`'s
 /// `seed` map, `Quill.seedCard(kind, overlay)` layers it over the schema
-/// example (overlay › example), and `setSeedNamespace` / `removeSeedNamespace`
+/// example (overlay › example), and `storeSeedNamespace` / `removeSeedNamespace`
 /// write and clear it.
 #[wasm_bindgen_test]
 fn test_seed_overlay_round_trip() {
@@ -496,12 +496,12 @@ fn test_seed_overlay_round_trip() {
         json(&bare)
     );
 
-    // setSeedNamespace writes an overlay; main.seed reads it back; remove clears.
+    // storeSeedNamespace writes an overlay; main.seed reads it back; remove clears.
     let mut doc2 =
         Document::from_markdown("~~~card-yaml\n$quill: seed_quill@1.0\n$kind: main\n~~~\n")
             .expect("fromMarkdown failed");
     let overlay_in = js_sys::JSON::parse("{\"text\":\"WRITTEN\"}").unwrap();
-    doc2.set_seed_namespace("note", overlay_in).unwrap();
+    doc2.store_seed_namespace("note", overlay_in).unwrap();
     assert!(json(&seed_of(&doc2, "note")).contains("WRITTEN"));
     doc2.remove_seed_namespace("note").unwrap();
     assert!(seed_of(&doc2, "note").is_undefined());
@@ -518,8 +518,8 @@ fn test_document_clone_independence() {
 
     // Mutate the clone; the original must keep its original title.
     clone
-        .set_field("title", JsValue::from_str("Changed"))
-        .expect("setField on clone");
+        .store_field(JsValue::from_str("title"), JsValue::from_str("Changed"))
+        .expect("storeField on clone");
 
     // Emit both and check the title survived on each side independently.
     let original_md = doc.to_markdown();

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -665,6 +665,33 @@ impl Card {
         Ok(delta)
     }
 
+    /// Decode the field's current corpus (an absent field imports from empty),
+    /// diff `body` against it so surviving anchors rebase, and return the new
+    /// corpus with its text [`Delta`] — the shared preamble of
+    /// [`revise_field`](Self::revise_field) and
+    /// [`revise_field_checked`](Self::revise_field_checked). Neither stores; the
+    /// caller lands the diffed corpus (raw, or schema-checked).
+    fn diff_field(
+        &self,
+        name: &str,
+        body: impl Into<String>,
+    ) -> Result<(RichText, Delta), EditError> {
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
+        }
+        let base = match self.field_richtext(name) {
+            Some(Ok(rt)) => rt,
+            Some(Err(e)) => {
+                return Err(EditError::FieldRichtextDecode {
+                    field: name.to_string(),
+                    message: e.into_message(),
+                })
+            }
+            None => RichText::empty(),
+        };
+        diff_import(&base, &body.into()).map_err(EditError::BodyImport)
+    }
+
     /// Revise a richtext field from an authored markdown string — the
     /// field-level twin of [`revise_body`](Self::revise_body), and the
     /// field-level `diff_import` the write surface previously lacked (the only
@@ -685,20 +712,7 @@ impl Card {
     /// richtext corpus (a scalar a `store_field` wrote), and
     /// [`EditError::BodyImport`] on an over-nested markdown input.
     pub fn revise_field(&mut self, name: &str, body: impl Into<String>) -> Result<Delta, EditError> {
-        if !is_valid_field_name(name) {
-            return Err(EditError::InvalidFieldName(name.to_string()));
-        }
-        let base = match self.field_richtext(name) {
-            Some(Ok(rt)) => rt,
-            Some(Err(e)) => {
-                return Err(EditError::FieldRichtextDecode {
-                    field: name.to_string(),
-                    message: e.into_message(),
-                })
-            }
-            None => RichText::empty(),
-        };
-        let (corpus, delta) = diff_import(&base, &body.into()).map_err(EditError::BodyImport)?;
+        let (corpus, delta) = self.diff_field(name, body)?;
         self.store_field_corpus(name, &corpus);
         Ok(delta)
     }
@@ -735,25 +749,11 @@ impl Card {
         body: impl Into<String>,
         schema: &FieldSchema,
     ) -> Result<Delta, EditError> {
-        if !is_valid_field_name(name) {
-            return Err(EditError::InvalidFieldName(name.to_string()));
-        }
-        let base = match self.field_richtext(name) {
-            Some(Ok(rt)) => rt,
-            Some(Err(e)) => {
-                return Err(EditError::FieldRichtextDecode {
-                    field: name.to_string(),
-                    message: e.into_message(),
-                })
-            }
-            None => RichText::empty(),
-        };
-        let (corpus, delta) = diff_import(&base, &body.into()).map_err(EditError::BodyImport)?;
-        // Enforce `schema` on the *diffed* corpus (anchor-rebased), not a cold
-        // import, through the same typed path `commit_field` uses — the inline
-        // check runs on the value anchors survived onto, so the error surface is
-        // identical. Re-canonicalizing a corpus object is anchor-preserving
-        // (`decode_richtext_value` keeps identity marks).
+        let (corpus, delta) = self.diff_field(name, body)?;
+        // Enforce `schema` on the diffed (anchor-rebased) corpus through the same
+        // typed path `commit_field` uses: re-canonicalizing a corpus object keeps
+        // its identity marks (`decode_richtext_value`), so the inline check fires
+        // on the value anchors survived onto and the error surface is identical.
         let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
         let stored = resolve_field_write(name, QuillValue::from_json(canonical), schema)?;
         self.payload_mut().insert_unchecked(name.to_string(), stored);

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -6,7 +6,7 @@
 //! [`Document::to_plate_json`]. Mutators never modify `warnings` — those
 //! are immutable parse-time observations.
 //!
-//! Payload/body mutators (field set/fill/remove, `$ext` and `$seed`
+//! Payload/body mutators (field store/fill/remove, `$ext` and `$seed`
 //! namespace writers, body replacement) live on [`Card`]; [`Document`] keeps
 //! document-level ops (quill-ref, push/insert/remove/move card).
 //!
@@ -63,7 +63,7 @@ pub enum EditError {
     /// no schema). The typed path resolves every name to a schema type, so an
     /// undeclared name is a typo, not a fallback — it fails here instead of
     /// landing silently in the opaque store. Reach for the raw
-    /// [`Card::set_field`](Card::set_field) when opaque storage is the intent.
+    /// [`Card::store_field`](Card::store_field) when opaque storage is the intent.
     #[error("field '{0}' is not declared in the schema")]
     UnknownField(String),
 
@@ -359,39 +359,43 @@ impl Card {
         ))
     }
 
-    /// Set a payload field, clearing any `!must_fill` marker on that key.
-    /// Scalars convert in place (`set_field("qty", 3)`); see the `From`
-    /// impls on [`QuillValue`].
+    /// Store a payload field verbatim, clearing any `!must_fill` marker on that
+    /// key — the opaque store (**store** = verbatim, coercion deferred to render;
+    /// contrast the typed [`TypedWriter::set`](crate::TypedWriter::set)). Scalars
+    /// convert in place (`store_field("qty", 3)`); see the `From` impls on
+    /// [`QuillValue`].
     ///
     /// Returns [`EditError::InvalidFieldName`] when `name` does not match
     /// `[A-Za-z_][A-Za-z0-9_]*`.
-    pub fn set_field(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
+    pub fn store_field(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
         self.payload_mut()
             .insert(name.to_string(), value.into())
             .map_err(|v| edit_error_from_violation(name, v))?;
         Ok(())
     }
 
-    /// Set a payload field and mark it as a `!must_fill` placeholder.
+    /// Store a payload field verbatim and mark it as a `!must_fill` placeholder.
     /// `Null` emits as `key: !must_fill`; scalars/sequences as `key: !must_fill <value>`.
-    /// Same validation as [`Card::set_field`].
-    pub fn set_fill(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
+    /// The opaque store's fill variant (quill-free, verbatim); same validation as
+    /// [`Card::store_field`].
+    pub fn store_fill(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
         self.payload_mut()
             .insert_fill(name.to_string(), value.into())
             .map_err(|v| edit_error_from_violation(name, v))?;
         Ok(())
     }
 
-    /// Set several payload fields atomically, clearing any `!must_fill`
-    /// marker on each key. The whole batch is validated first — on any
-    /// violation nothing is applied and every offending field is reported
-    /// as a `(name, error)` pair, so a caller feeding externally-sourced
-    /// names (database columns, form keys) sees all violations in one
-    /// pass instead of fix-rerun-repeat. Per-field rules are those of
-    /// [`Card::set_field`]; insertion order follows the iterator, and a
-    /// repeated name behaves like repeated `set_field` calls (last value
+    /// Store several payload fields verbatim and atomically, clearing any
+    /// `!must_fill` marker on each key — the opaque store's batch (contrast the
+    /// typed [`TypedWriter::set_all`](crate::TypedWriter::set_all)). The whole
+    /// batch is validated first — on any violation nothing is applied and every
+    /// offending field is reported as a `(name, error)` pair, so a caller feeding
+    /// externally-sourced names (database columns, form keys) sees all violations
+    /// in one pass instead of fix-rerun-repeat. Per-field rules are those of
+    /// [`Card::store_field`]; insertion order follows the iterator, and a
+    /// repeated name behaves like repeated `store_field` calls (last value
     /// wins, first position kept).
-    pub fn set_fields<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
+    pub fn store_fields<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
     where
         K: Into<String>,
         V: Into<QuillValue>,
@@ -421,7 +425,8 @@ impl Card {
     }
 
     /// Remove a payload field; returns `Ok(None)` if the name is absent.
-    /// Same validation as [`Card::set_field`].
+    /// Removal has no tier — the one verb serves every write lane. Same
+    /// validation as [`Card::store_field`].
     pub fn remove_field(&mut self, name: &str) -> Result<Option<QuillValue>, EditError> {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
@@ -441,7 +446,10 @@ impl Card {
     /// depth limit — `$ext` never reaches the plate JSON, but it does flow
     /// through the recursive emit and DTO paths, so it carries the same
     /// depth bound as user fields.
-    pub fn set_ext(
+    ///
+    /// Quill-free and never coerced — an opaque `store_*` verb by the vocabulary
+    /// rule, not a typed `set`.
+    pub fn store_ext(
         &mut self,
         value: serde_json::Map<String, serde_json::Value>,
     ) -> Result<(), EditError> {
@@ -466,9 +474,10 @@ impl Card {
     /// namespaces, so independent consumers keying on their own slot
     /// (`$ext.editor`, `$ext.agent`, …) don't clobber each other.
     /// Returns [`EditError::ValueTooDeep`] when the merged map nests past
-    /// the §8 depth limit (see [`Card::set_ext`]); the card's `$ext` is
-    /// unchanged on error.
-    pub fn set_ext_namespace(
+    /// the §8 depth limit (see [`Card::store_ext`]); the card's `$ext` is
+    /// unchanged on error. Quill-free and never coerced — an opaque `store_*`
+    /// verb.
+    pub fn store_ext_namespace(
         &mut self,
         namespace: impl Into<String>,
         value: serde_json::Value,
@@ -485,11 +494,11 @@ impl Card {
     /// that was stored there (or `None` when the map or the key was absent).
     ///
     /// This is the recommended way to clear `$ext` state: it is the
-    /// namespace-scoped inverse of [`Card::set_ext_namespace`] and preserves
+    /// namespace-scoped inverse of [`Card::store_ext_namespace`] and preserves
     /// sibling namespaces, where [`Card::remove_ext`] would wipe them all.
     /// When removing the last namespace empties the map, the `$ext` entry is
     /// dropped entirely (not left as `$ext: {}`), so
-    /// `set_ext_namespace(ns, v)` followed by `remove_ext_namespace(ns)`
+    /// `store_ext_namespace(ns, v)` followed by `remove_ext_namespace(ns)`
     /// restores a card that had no `$ext` to its original state.
     pub fn remove_ext_namespace(&mut self, namespace: &str) -> Option<serde_json::Value> {
         let mut map = self.payload_mut().take_ext()?;
@@ -511,13 +520,13 @@ impl Card {
     /// under `card_kind`, creating the map when absent and replacing any
     /// existing overlay for that kind. Sibling kinds are preserved — this is
     /// the per-kind-safe writer, the seed analogue of
-    /// [`Card::set_ext_namespace`]. `card_kind` must be a valid, non-reserved
+    /// [`Card::store_ext_namespace`]. `card_kind` must be a valid, non-reserved
     /// composable kind ([`EditError::InvalidKindName`] / [`EditError::ReservedKind`]
     /// otherwise) — `$seed` is keyed by composable card-kind, unlike the
     /// free-form namespaces of `$ext`. Returns [`EditError::ValueTooDeep`] when
     /// the merged map nests past the §8 depth limit; the card is unchanged on
-    /// error.
-    pub fn set_seed_namespace(
+    /// error. Quill-free and never coerced — an opaque `store_*` verb.
+    pub fn store_seed_namespace(
         &mut self,
         card_kind: impl Into<String>,
         value: serde_json::Value,
@@ -591,11 +600,11 @@ impl Card {
 
     /// Write-time commit: validate and normalize `value` per the field's schema
     /// `type` and store the canonical form. The typed sibling of the opaque
-    /// [`set_field`](Self::set_field) — the one write verb for *every* field
+    /// [`store_field`](Self::store_field) — the one write verb for *every* field
     /// type (richtext today, any future corpus model tomorrow), dispatching on
     /// the [`FieldSchema`] rather than growing a per-type method.
     ///
-    /// The two write disciplines: [`set_field`](Self::set_field) stores the
+    /// The two write disciplines: [`store_field`](Self::store_field) stores the
     /// value opaquely and defers coercion to render (keystroke-level state,
     /// data-in-flight); `commit_field` canonicalizes now and fails now (an
     /// editor blur/save, an agent write). Neither is forced on the other.
@@ -673,7 +682,7 @@ impl Card {
     ///
     /// Returns [`EditError::InvalidFieldName`] for a malformed name,
     /// [`EditError::FieldRichtextDecode`] when the field is present but is not a
-    /// richtext corpus (a scalar a `set_field` wrote), and
+    /// richtext corpus (a scalar a `store_field` wrote), and
     /// [`EditError::BodyImport`] on an over-nested markdown input.
     pub fn revise_field(&mut self, name: &str, body: impl Into<String>) -> Result<Delta, EditError> {
         if !is_valid_field_name(name) {
@@ -691,6 +700,63 @@ impl Card {
         };
         let (corpus, delta) = diff_import(&base, &body.into()).map_err(EditError::BodyImport)?;
         self.store_field_corpus(name, &corpus);
+        Ok(delta)
+    }
+
+    /// Revise a richtext field from markdown **with schema enforcement** — the
+    /// typed *and* anchor-preserving field write the tier split otherwise leaves
+    /// in a gap. [`revise_field`](Self::revise_field) rebases anchors but is
+    /// schema-blind; [`commit_field`](Self::commit_field) enforces the schema but
+    /// cold-imports (the previous value's anchors are gone). This does both: diff
+    /// the markdown against the field's current corpus so surviving anchors rebase
+    /// (as [`revise_field`](Self::revise_field)), then enforce `schema` on the
+    /// *diffed result* through the same typed-conform path
+    /// [`commit_field`](Self::commit_field) runs — so a `richtext(inline)` schema
+    /// rejects a multi-block result with [`EditError::FieldRichtextNotInline`],
+    /// the error surface unchanged, while the anchors survive. Returns the text
+    /// [`Delta`] receipt.
+    ///
+    /// This is the corpus lane's own verb (it returns a receipt and rebases
+    /// anchors), lifted to consult a schema — anchor preservation is a tier-2
+    /// concern, so the typed-anchor-preserving write lives here, not on the
+    /// receipt-free [`TypedWriter::set`](crate::TypedWriter::set). The schema runs
+    /// on the corpus the diff produced, so a non-richtext `schema` (nothing to
+    /// preserve) fails with the same [`EditError::FieldConform`]
+    /// [`commit_field`](Self::commit_field) would raise.
+    ///
+    /// Errors: [`EditError::InvalidFieldName`], [`EditError::FieldRichtextDecode`]
+    /// when the field is present but not a richtext corpus, [`EditError::BodyImport`]
+    /// on an over-nested markdown input, and the conform errors of
+    /// [`commit_field`](Self::commit_field) on the diffed result. On any error the
+    /// field is unchanged.
+    pub fn revise_field_checked(
+        &mut self,
+        name: &str,
+        body: impl Into<String>,
+        schema: &FieldSchema,
+    ) -> Result<Delta, EditError> {
+        if !is_valid_field_name(name) {
+            return Err(EditError::InvalidFieldName(name.to_string()));
+        }
+        let base = match self.field_richtext(name) {
+            Some(Ok(rt)) => rt,
+            Some(Err(e)) => {
+                return Err(EditError::FieldRichtextDecode {
+                    field: name.to_string(),
+                    message: e.into_message(),
+                })
+            }
+            None => RichText::empty(),
+        };
+        let (corpus, delta) = diff_import(&base, &body.into()).map_err(EditError::BodyImport)?;
+        // Enforce `schema` on the *diffed* corpus (anchor-rebased), not a cold
+        // import, through the same typed path `commit_field` uses — the inline
+        // check runs on the value anchors survived onto, so the error surface is
+        // identical. Re-canonicalizing a corpus object is anchor-preserving
+        // (`decode_richtext_value` keeps identity marks).
+        let canonical = quillmark_richtext::serial::to_canonical_value(&corpus);
+        let stored = resolve_field_write(name, QuillValue::from_json(canonical), schema)?;
+        self.payload_mut().insert_unchecked(name.to_string(), stored);
         Ok(delta)
     }
 

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -241,7 +241,7 @@ impl Card {
     /// - `None` — the field is absent.
     /// - `Some(Ok(rt))` — decoded corpus.
     /// - `Some(Err(_))` — the field is present but neither a corpus object nor
-    ///   an importable markdown string (e.g. a bare number a `set_field` wrote).
+    ///   an importable markdown string (e.g. a bare number a `store_field` wrote).
     ///
     /// A `Document` carries no schema, so this cannot itself tell a richtext
     /// field from a plain string field; the caller names a field it knows is

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -94,7 +94,7 @@ fn test_document_set_field_rejects_dollar_prefixed_names() {
     // field-name reservation (uppercase is accepted).
     for name in ["$body", "$cards", "$quill", "$kind"] {
         let mut doc = make_doc();
-        let result = doc.main_mut().set_field(name, qv("value"));
+        let result = doc.main_mut().store_field(name, qv("value"));
         assert_eq!(
             result,
             Err(EditError::InvalidFieldName(name.to_string())),
@@ -109,7 +109,7 @@ fn test_document_set_field_rejects_dollar_prefixed_names() {
 #[test]
 fn test_document_set_field_inserts() {
     let mut doc = make_doc();
-    doc.main_mut().set_field("author", qv("Alice")).unwrap();
+    doc.main_mut().store_field("author", qv("Alice")).unwrap();
     assert_eq!(
         doc.main().payload().get("author").unwrap().as_str(),
         Some("Alice")
@@ -119,7 +119,7 @@ fn test_document_set_field_inserts() {
 #[test]
 fn test_document_set_field_updates_existing() {
     let mut doc = make_doc();
-    doc.main_mut().set_field("title", qv("New Title")).unwrap();
+    doc.main_mut().store_field("title", qv("New Title")).unwrap();
     assert_eq!(
         doc.main().payload().get("title").unwrap().as_str(),
         Some("New Title")
@@ -151,7 +151,7 @@ fn test_document_field_legacy_uppercase_accepted() {
     let mut doc = make_doc();
     for name in ["BODY", "CARDS", "QUILL", "CARD"] {
         doc.main_mut()
-            .set_field(name, qv("v"))
+            .store_field(name, qv("v"))
             .unwrap_or_else(|e| panic!("expected {name} to be accepted, got {e:?}"));
         assert_eq!(
             doc.main().payload().get(name).unwrap().as_str().unwrap(),
@@ -377,7 +377,7 @@ fn test_card_new_invalid_kind_rejected() {
 #[test]
 fn test_card_set_field_valid() {
     let mut card = Card::new("note").unwrap();
-    card.set_field("content", qv("Some text")).unwrap();
+    card.store_field("content", qv("Some text")).unwrap();
     assert_eq!(
         card.payload().get("content").unwrap().as_str(),
         Some("Some text")
@@ -387,7 +387,7 @@ fn test_card_set_field_valid() {
 #[test]
 fn test_card_set_field_invalid_name() {
     let mut card = Card::new("note").unwrap();
-    let result = card.set_field("bad-name", qv("text"));
+    let result = card.store_field("bad-name", qv("text"));
     assert_eq!(
         result,
         Err(EditError::InvalidFieldName("bad-name".to_string()))
@@ -403,9 +403,9 @@ fn test_document_new_blank_canvas() {
     assert!(doc.cards().is_empty());
     assert_eq!(doc.main().body_markdown(), "");
 
-    doc.main_mut().set_fields([("title", "Hello")]).unwrap();
+    doc.main_mut().store_fields([("title", "Hello")]).unwrap();
     let mut card = Card::new("note").unwrap();
-    card.set_field("qty", 3).unwrap();
+    card.store_field("qty", 3).unwrap();
     doc.push_card(card).unwrap();
 
     // A built-from-blank document round-trips the canonical emitter.
@@ -418,7 +418,7 @@ fn test_document_new_blank_canvas() {
 #[test]
 fn test_card_set_fields_inserts_in_iterator_order() {
     let mut card = Card::new("note").unwrap();
-    card.set_fields([("b".to_string(), qv("two")), ("a".to_string(), qv("one"))])
+    card.store_fields([("b".to_string(), qv("two")), ("a".to_string(), qv("one"))])
         .unwrap();
     let keys: Vec<&String> = card.payload().iter().map(|(k, _)| k).collect();
     assert_eq!(keys, ["b", "a"]);
@@ -429,7 +429,7 @@ fn test_card_set_fields_inserts_in_iterator_order() {
 fn test_card_set_fields_collects_every_violation() {
     let mut card = Card::new("note").unwrap();
     let errors = card
-        .set_fields([
+        .store_fields([
             ("ok".to_string(), qv("fine")),
             ("bad-name".to_string(), qv("v")),
             ("also bad".to_string(), qv("v")),
@@ -455,8 +455,8 @@ fn test_card_set_fields_collects_every_violation() {
 #[test]
 fn test_card_set_fields_atomic_on_error() {
     let mut card = Card::new("note").unwrap();
-    card.set_field("existing", qv("old")).unwrap();
-    let result = card.set_fields([
+    card.store_field("existing", qv("old")).unwrap();
+    let result = card.store_fields([
         ("existing".to_string(), qv("new")),
         ("bad-name".to_string(), qv("v")),
     ]);
@@ -472,8 +472,8 @@ fn test_card_set_fields_atomic_on_error() {
 #[test]
 fn test_card_set_fields_clears_fill_and_repeated_name_last_wins() {
     let mut card = Card::new("note").unwrap();
-    card.set_fill("title", qv("draft")).unwrap();
-    card.set_fields([
+    card.store_fill("title", qv("draft")).unwrap();
+    card.store_fields([
         ("title".to_string(), qv("first")),
         ("title".to_string(), qv("final")),
     ])
@@ -487,13 +487,13 @@ fn test_card_set_fields_clears_fill_and_repeated_name_last_wins() {
 fn test_set_field_scalar_conversions() {
     // The `From` impls let scalars pass straight through `impl Into<QuillValue>`.
     let mut card = Card::new("note").unwrap();
-    card.set_field("name", "Alice").unwrap();
-    card.set_field("qty", 3).unwrap();
-    card.set_field("price", 2.5).unwrap();
-    card.set_field("active", true).unwrap();
-    card.set_field("tags", serde_json::json!(["a", "b"]))
+    card.store_field("name", "Alice").unwrap();
+    card.store_field("qty", 3).unwrap();
+    card.store_field("price", 2.5).unwrap();
+    card.store_field("active", true).unwrap();
+    card.store_field("tags", serde_json::json!(["a", "b"]))
         .unwrap();
-    card.set_fields([("count", 1), ("total", 2)]).unwrap();
+    card.store_fields([("count", 1), ("total", 2)]).unwrap();
     assert_eq!(card.payload().get("name").unwrap().as_str(), Some("Alice"));
     assert_eq!(card.payload().get("qty").unwrap().as_i64(), Some(3));
     assert_eq!(card.payload().get("price").unwrap().as_f64(), Some(2.5));
@@ -634,12 +634,73 @@ fn test_revise_field_diff_imports_and_returns_delta() {
         .any(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1")));
 
     // A present non-corpus scalar is a decode error.
-    card.set_field("count", crate::QuillValue::from_json(serde_json::json!(3)))
+    card.store_field("count", crate::QuillValue::from_json(serde_json::json!(3)))
         .unwrap();
     assert_eq!(
         card.revise_field("count", "x").unwrap_err().variant_name(),
         "FieldRichtextDecode"
     );
+}
+
+/// `revise_field_checked` is both anchor-preserving (rebases surviving anchors,
+/// like `revise_field`) and schema-enforcing (rejects a multi-block result on a
+/// `richtext(inline)` schema with `FieldRichtextNotInline`, like `commit_field`),
+/// returning the text delta — the typed, anchor-preserving field write.
+#[test]
+fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
+    use crate::quill::{FieldSchema, FieldType};
+    use quillmark_richtext::model::{Mark, MarkKind};
+
+    let inline = FieldSchema::new(
+        "subject".to_string(),
+        FieldType::RichText { inline: true },
+        None,
+    );
+
+    let mut card = Card::new("note").unwrap();
+    // Cold start against an absent field: a single line passes the inline check.
+    let delta = card
+        .revise_field_checked("subject", "hello target world", &inline)
+        .unwrap();
+    assert!(!delta.ops.is_empty());
+
+    // Anchor "target", then revise — the anchor rebases onto surviving text and
+    // the single-line result still conforms.
+    let mut base = card.field_richtext("subject").unwrap().unwrap();
+    base.marks.push(Mark {
+        start: 6,
+        end: 12, // "target"
+        kind: MarkKind::Anchor { id: "c1".into() },
+    });
+    base.normalize();
+    card.install_field("subject", base).unwrap();
+    card.revise_field_checked("subject", "why keep the target here", &inline)
+        .unwrap();
+    let read = card.field_richtext("subject").unwrap().unwrap();
+    assert!(
+        read.marks
+            .iter()
+            .any(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "c1")),
+        "anchor should rebase onto surviving text, unlike the cold commit_field"
+    );
+
+    // A multi-block result fails the inline check on the *diffed* corpus with the
+    // same FieldRichtextNotInline surface commit_field raises — and the field is
+    // left unchanged (the schema check runs before the store).
+    let before = card.field_markdown("subject").unwrap();
+    let err = card
+        .revise_field_checked("subject", "line one\n\nline two", &inline)
+        .unwrap_err();
+    assert_eq!(err.variant_name(), "FieldRichtextNotInline");
+    assert_eq!(card.field_markdown("subject").unwrap(), before);
+
+    // A block (non-inline) richtext schema accepts multi-block content.
+    let block = FieldSchema::new("body".to_string(), FieldType::RichText { inline: false }, None);
+    let d = card
+        .revise_field_checked("body", "para one\n\npara two", &block)
+        .unwrap();
+    assert!(!d.ops.is_empty());
+    assert!(card.field_markdown("body").unwrap().contains("para two"));
 }
 
 /// `commit_field` on a richtext field accepts a **canonical corpus object**,
@@ -841,7 +902,7 @@ fn test_field_richtext_absent_and_non_richtext() {
     assert!(card.field_richtext("missing").is_none());
     assert!(card.field_markdown("missing").is_none());
 
-    card.set_field("count", 3).unwrap();
+    card.store_field("count", 3).unwrap();
     assert!(card.field_richtext("count").unwrap().is_err());
     assert!(card.field_markdown("count").is_none());
 }
@@ -885,7 +946,7 @@ fn test_corpus_field_emits_as_markdown_projection() {
 fn test_non_corpus_object_field_emits_structurally() {
     let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
     doc.main_mut()
-        .set_field(
+        .store_field(
             "addr",
             QuillValue::from_json(serde_json::json!({ "city": "Paris" })),
         )
@@ -914,7 +975,7 @@ fn test_noncanonical_order_corpus_field_stays_structural() {
 
     let mut doc = Document::new(QuillReference::from_str("test_quill").unwrap());
     doc.main_mut()
-        .set_field(
+        .store_field(
             "intro",
             QuillValue::from_json(serde_json::Value::Object(scrambled)),
         )
@@ -1078,7 +1139,7 @@ fn test_apply_field_richtext_change_rejects_non_richtext() {
         "FieldRichtextDecode"
     );
 
-    card.set_field("count", 3).unwrap();
+    card.store_field("count", 3).unwrap();
     assert_eq!(
         card.apply_field_richtext_change("count", &identity, &[], &[])
             .unwrap_err()
@@ -1098,8 +1159,8 @@ fn test_invariants_after_mutation_sequence() {
     let mut doc = make_doc();
 
     // 1. Add some payload fields
-    doc.main_mut().set_field("author", qv("Alice")).unwrap();
-    doc.main_mut().set_field("version", qv_int(3)).unwrap();
+    doc.main_mut().store_field("author", qv("Alice")).unwrap();
+    doc.main_mut().store_field("version", qv_int(3)).unwrap();
 
     // 2. Add cards
     let c1 = Card::new("note").unwrap();
@@ -1112,7 +1173,7 @@ fn test_invariants_after_mutation_sequence() {
     // 3. Mutate a card field
     doc.card_mut(0)
         .unwrap()
-        .set_field("text", qv("Hello"))
+        .store_field("text", qv("Hello"))
         .unwrap();
 
     // 4. Move cards around
@@ -1171,7 +1232,7 @@ fn test_set_ext_adds_map_and_strips_from_plate() {
         "presentation".to_string(),
         serde_json::json!({ "title": "Greeting" }),
     );
-    doc.main_mut().set_ext(ext).expect("set_ext");
+    doc.main_mut().store_ext(ext).expect("set_ext");
 
     // Surfaced through the typed accessor.
     assert_eq!(
@@ -1190,7 +1251,7 @@ fn test_set_ext_round_trips_through_markdown() {
     let mut doc = make_doc();
     let mut ext = serde_json::Map::new();
     ext.insert("agent".to_string(), serde_json::json!({ "pinned": true }));
-    doc.main_mut().set_ext(ext).expect("set_ext");
+    doc.main_mut().store_ext(ext).expect("set_ext");
 
     let md = doc.to_markdown();
     let reparsed = Document::from_markdown(&md).unwrap();
@@ -1205,7 +1266,7 @@ fn test_remove_ext_returns_previous_and_clears() {
     let mut doc = make_doc();
     let mut ext = serde_json::Map::new();
     ext.insert("agent".to_string(), serde_json::json!(1));
-    doc.main_mut().set_ext(ext).expect("set_ext");
+    doc.main_mut().store_ext(ext).expect("set_ext");
 
     let removed = doc.main_mut().remove_ext().unwrap();
     assert_eq!(removed["agent"].as_i64(), Some(1));
@@ -1218,10 +1279,10 @@ fn test_remove_ext_returns_previous_and_clears() {
 fn test_set_ext_namespace_preserves_siblings() {
     let mut doc = make_doc();
     doc.main_mut()
-        .set_ext_namespace("presentation", serde_json::json!({ "title": "A" }))
+        .store_ext_namespace("presentation", serde_json::json!({ "title": "A" }))
         .expect("set_ext_namespace");
     doc.main_mut()
-        .set_ext_namespace("agent", serde_json::json!({ "pinned": true }))
+        .store_ext_namespace("agent", serde_json::json!({ "pinned": true }))
         .expect("set_ext_namespace");
 
     let ext = doc.main().ext().unwrap();
@@ -1230,7 +1291,7 @@ fn test_set_ext_namespace_preserves_siblings() {
 
     // Replacing one namespace leaves the other intact.
     doc.main_mut()
-        .set_ext_namespace("presentation", serde_json::json!({ "title": "B" }))
+        .store_ext_namespace("presentation", serde_json::json!({ "title": "B" }))
         .expect("set_ext_namespace");
     let ext = doc.main().ext().unwrap();
     assert_eq!(ext["presentation"]["title"].as_str(), Some("B"));
@@ -1241,10 +1302,10 @@ fn test_set_ext_namespace_preserves_siblings() {
 fn test_remove_ext_namespace_preserves_siblings() {
     let mut doc = make_doc();
     doc.main_mut()
-        .set_ext_namespace("presentation", serde_json::json!({ "title": "A" }))
+        .store_ext_namespace("presentation", serde_json::json!({ "title": "A" }))
         .expect("set_ext_namespace");
     doc.main_mut()
-        .set_ext_namespace("tutorial", serde_json::json!(["step-1", "step-2"]))
+        .store_ext_namespace("tutorial", serde_json::json!(["step-1", "step-2"]))
         .expect("set_ext_namespace");
 
     // Dropping one namespace returns its value and leaves the rest intact.
@@ -1259,7 +1320,7 @@ fn test_remove_ext_namespace_preserves_siblings() {
 fn test_remove_ext_namespace_drops_ext_when_empty() {
     let mut doc = make_doc();
     doc.main_mut()
-        .set_ext_namespace("tutorial", serde_json::json!(["step-1"]))
+        .store_ext_namespace("tutorial", serde_json::json!(["step-1"]))
         .expect("set_ext_namespace");
 
     // Removing the last namespace clears `$ext` entirely — set/remove of a
@@ -1277,7 +1338,7 @@ fn test_remove_ext_namespace_is_noop_when_absent() {
 
     // `$ext` present but without the requested key.
     doc.main_mut()
-        .set_ext_namespace("presentation", serde_json::json!({ "title": "A" }))
+        .store_ext_namespace("presentation", serde_json::json!({ "title": "A" }))
         .expect("set_ext_namespace");
     assert!(doc.main_mut().remove_ext_namespace("tutorial").is_none());
     // The unrelated namespace is untouched.
@@ -1291,7 +1352,7 @@ fn test_remove_ext_namespace_is_noop_when_absent() {
 fn test_set_empty_ext_is_preserved() {
     let mut doc = make_doc();
     doc.main_mut()
-        .set_ext(serde_json::Map::new())
+        .store_ext(serde_json::Map::new())
         .expect("set_ext");
     assert!(doc.main().ext().is_some());
     let md = doc.to_markdown();
@@ -1303,7 +1364,7 @@ fn test_ext_mutators_work_on_composable_cards() {
     let mut doc = make_doc_with_cards();
     doc.card_mut(0)
         .unwrap()
-        .set_ext_namespace("agent", serde_json::json!({ "note": "x" }))
+        .store_ext_namespace("agent", serde_json::json!({ "note": "x" }))
         .expect("set_ext_namespace");
     assert_eq!(
         doc.cards()[0].ext().unwrap()["agent"]["note"].as_str(),
@@ -1335,24 +1396,24 @@ fn set_field_rejects_value_past_depth_limit() {
     let mut doc =
         crate::document::Document::from_markdown("~~~\n$quill: q@1.0\n$kind: main\n~~~\n").unwrap();
     let ok = crate::value::QuillValue::from_json(deep_value(50));
-    assert!(doc.main_mut().set_field("x", ok).is_ok());
+    assert!(doc.main_mut().store_field("x", ok).is_ok());
 
     let too_deep = crate::value::QuillValue::from_json(deep_value(150));
-    let err = doc.main_mut().set_field("y", too_deep).unwrap_err();
+    let err = doc.main_mut().store_field("y", too_deep).unwrap_err();
     assert!(
         matches!(err, crate::document::EditError::ValueTooDeep { max: 100 }),
         "expected ValueTooDeep, got {err:?}"
     );
     // set_fill and set_ext carry the same bound.
     let too_deep = crate::value::QuillValue::from_json(deep_value(150));
-    assert!(doc.main_mut().set_fill("y", too_deep).is_err());
+    assert!(doc.main_mut().store_fill("y", too_deep).is_err());
     let serde_json::Value::Object(map) = deep_value(150) else {
         unreachable!()
     };
-    assert!(doc.main_mut().set_ext(map).is_err());
+    assert!(doc.main_mut().store_ext(map).is_err());
     assert!(doc
         .main_mut()
-        .set_ext_namespace("ns", deep_value(150))
+        .store_ext_namespace("ns", deep_value(150))
         .is_err());
 }
 

--- a/crates/core/src/document/tests/seed_tests.rs
+++ b/crates/core/src/document/tests/seed_tests.rs
@@ -315,9 +315,9 @@ $kind: main
 ",
     );
     let card = doc.main_mut();
-    card.set_seed_namespace("indorsement", json!({ "from": "A" }))
+    card.store_seed_namespace("indorsement", json!({ "from": "A" }))
         .unwrap();
-    card.set_seed_namespace("attachment", json!({ "label": "B" }))
+    card.store_seed_namespace("attachment", json!({ "label": "B" }))
         .unwrap();
     assert_eq!(card.seed().map(|m| m.len()), Some(2));
 
@@ -347,11 +347,11 @@ $kind: main
     let card = doc.main_mut();
 
     assert!(matches!(
-        card.set_seed_namespace("main", json!({ "from": "A" })),
+        card.store_seed_namespace("main", json!({ "from": "A" })),
         Err(crate::document::EditError::ReservedKind)
     ));
     assert!(matches!(
-        card.set_seed_namespace("Bad-Kind", json!({ "from": "A" })),
+        card.store_seed_namespace("Bad-Kind", json!({ "from": "A" })),
         Err(crate::document::EditError::InvalidKindName(_))
     ));
 

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -666,7 +666,7 @@ main:
     fn typed_card(tag: &str, fields: &[(&str, serde_json::Value)]) -> Card {
         let mut card = Card::new(tag).unwrap();
         for (k, v) in fields {
-            card.set_field(k, QuillValue::from_json(v.clone())).unwrap();
+            card.store_field(k, QuillValue::from_json(v.clone())).unwrap();
         }
         card
     }

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -298,7 +298,7 @@ impl QuillValue {
 /// Scalar conversions mirror [`serde_json::Value`]'s and produce `fill =
 /// false` nodes (like [`QuillValue::from_json`]); a non-finite `f64` maps to
 /// null, matching serde_json. These back the `impl Into<QuillValue>` mutator
-/// parameters, so `card.set_field("qty", 3)` reads as written.
+/// parameters, so `card.store_field("qty", 3)` reads as written.
 macro_rules! impl_from_scalar {
     ($($ty:ty),* $(,)?) => {$(
         impl From<$ty> for QuillValue {

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -9,7 +9,7 @@
 //! a schema field, and rejects a name the schema does not declare with
 //! [`EditError::UnknownField`] — on the typed path an undeclared name is a typo,
 //! not a fallback. Opaque storage stays available on purpose through the raw
-//! [`Card::set_field`](crate::Card::set_field) verb.
+//! [`Card::store_field`](crate::Card::store_field) verb.
 //!
 //! ```ignore
 //! let mut w = quill.writer(&mut doc);
@@ -48,7 +48,7 @@ impl<'a> TypedWriter<'a> {
     /// strict-commits it; a name the schema does not declare fails with
     /// [`EditError::UnknownField`] rather than falling to the opaque store — on
     /// the typed path it is a typo. For deliberate opaque storage use the raw
-    /// [`Card::set_field`](crate::Card::set_field). Other errors are those of
+    /// [`Card::store_field`](crate::Card::store_field). Other errors are those of
     /// [`Card::commit_field`](crate::Card::commit_field).
     pub fn set(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
         let config = self.config;
@@ -59,12 +59,12 @@ impl<'a> TypedWriter<'a> {
     }
 
     /// Write several main-card fields atomically — the typed twin of
-    /// [`Card::set_fields`](crate::Card::set_fields). Every field is resolved
+    /// [`Card::store_fields`](crate::Card::store_fields). Every field is resolved
     /// (strict conform, or [`EditError::UnknownField`] for a name the schema does
     /// not declare) before any is applied; on any violation nothing is written
     /// and every offending field is returned as a `(name, error)` pair, so a
     /// caller submitting a whole form sees every typo in one pass the way
-    /// [`Card::set_fields`](crate::Card::set_fields) does.
+    /// [`Card::store_fields`](crate::Card::store_fields) does.
     pub fn set_all<K, V, I>(&mut self, fields: I) -> Result<(), Vec<(String, EditError)>>
     where
         K: Into<String>,
@@ -136,7 +136,7 @@ impl<'a> TypedWriter<'a> {
     /// `$kind` resolves its [`CardSchema`]; an unknown kind carries no schema, so
     /// every field on it is undeclared and its typed writes fail with
     /// [`EditError::UnknownField`] (write such a card opaquely through
-    /// [`Card::set_field`](crate::Card::set_field)). Returns
+    /// [`Card::store_field`](crate::Card::store_field)). Returns
     /// [`EditError::IndexOutOfRange`] when `index` is out of range.
     pub fn card(&mut self, index: usize) -> Result<CardWriter<'_>, EditError> {
         let config = self.config;
@@ -292,7 +292,7 @@ card_kinds:
         let mut doc = blank_doc();
         let mut ed = TypedWriter::new(&config, &mut doc);
         // Unknown field on the typed path is a typo, not a fallback: it fails
-        // here and nothing is written. Opaque storage is the raw `set_field`.
+        // here and nothing is written. Opaque storage is the raw `store_field`.
         let err = ed.set("notafield", "x").unwrap_err();
         assert_eq!(err.variant_name(), "UnknownField");
         assert!(doc.main().payload().get("notafield").is_none());

--- a/docs/migrations/0.94-to-0.95.md
+++ b/docs/migrations/0.94-to-0.95.md
@@ -1,9 +1,118 @@
-# 0.94 → 0.95 — one insertion verb, a validating payload floor, and warnings off `Document`
+# 0.94 → 0.95 — the write surface reshapes: `store*` verbs, one address, a schema-checked revise
 
-Three breaking changes, all pre-1.0 cleanups. The WASM card surface loses a
-redundant verb, the core `Payload` map API grows a validation floor, and
-parse warnings stop living on `Document`. Everything else in the release is
-additive (new reads and a positioned insert) and needs no action.
+The headline of 0.95 is a coordinated reshaping of the mutation surface across
+core and both bindings (#955, #957, #960), landed as one sweep so nothing is
+written under a name it immediately loses. Alongside it: the WASM card surface
+loses a redundant verb, the core `Payload` map API grows a validation floor, and
+parse warnings stop living on `Document`. All breaking, all pre-1.0 cleanups;
+the rest of the release is additive.
+
+## The opaque store renames `set*` → `store*` (#960)
+
+The write surface has three lanes; the verb now carries which one. **store** =
+verbatim (quill-free, coercion deferred to render), **set** = typed (the writer,
+strict commit at the write), **install / revise / apply** = corpus
+(identity-aware). One sentence in BINDINGS.md states it; the names stop needing
+per-verb disambiguation. `remove_*` stays — removal has no tier.
+
+| Lane | 0.94 | 0.95 |
+|---|---|---|
+| Core `Card` | `set_field` / `set_fields` / `set_fill` / `set_ext` / `set_ext_namespace` / `set_seed_namespace` | `store_field` / `store_fields` / `store_fill` / `store_ext` / `store_ext_namespace` / `store_seed_namespace` |
+| WASM `Document` | `setField` / `setFields` / `setFill` / `setExt` / `setExtNamespace` / `setSeedNamespace` | `storeField` / `storeFields` / `storeFill` / `storeExt` / `storeExtNamespace` / `storeSeedNamespace` (and re-addressed — see below) |
+| Python `Document` | `set_field` / `set_fields` / `set_ext` / `set_card_field` / `set_card_ext` / … | `store_field` / `store_fields` / `store_ext` / `store_card_field` / `store_card_ext` / … |
+
+The typed writer (`set` / `set_all` / `set_body`) and the typed ABI (`commitField`
+/ `commitFields`) keep their names — they are the *typed* lane. `set_card_kind`
+(a `$kind` write, structural, not a field store) is unchanged. This makes the
+call #913 deferred for the Python mirror, globally.
+
+## WASM `Document` unifies on one address (#955)
+
+The WASM `Document` class encoded "main vs card at index" as verb duplication —
+22 methods for 11 concepts (`setField` / `setCardField`, `get` / `getCardField`,
+…). They collapse onto the `Addr` the corpus lane (`install` / `revise` /
+`applyChange`) already spoke: `{ card?, field? }`, absent `card` = main, absent
+`field` = body. A **bare string** is `Addr` shorthand for `{ field }`, so the
+common case stays terse.
+
+```
+0.94                                      0.95
+doc.setField("qty", 3)                    doc.storeField("qty", 3)
+doc.setCardField(2, "qty", 3)             doc.storeField({ card: 2, field: "qty" }, 3)
+doc.setFields(fields)                     doc.storeFields({}, fields)
+doc.setCardFields(2, fields)              doc.storeFields({ card: 2 }, fields)
+doc.get("qty")                            doc.get("qty")            // unchanged (string ⇒ {field})
+doc.getCardField(2, "qty")               doc.get({ card: 2, field: "qty" })
+doc.getMarkdown("intro")                  doc.getMarkdown("intro")  // unchanged
+doc.getCardMarkdown(2, "intro")           doc.getMarkdown({ card: 2, field: "intro" })
+doc.removeCardField(2, "qty")             doc.removeField({ card: 2, field: "qty" })
+doc.setExt(map)                           doc.storeExt({}, map)
+doc.setCardExt(2, map)                    doc.storeExt({ card: 2 }, map)
+doc.setExtNamespace(ns, v)                doc.storeExtNamespace({}, ns, v)
+doc.removeExtNamespace(ns)                doc.removeExtNamespace({}, ns)
+doc.removeCardExt(2)                      doc.removeExt({ card: 2 })
+doc.commitField(quill, "qty", v)          doc.commitField(quill, "qty", v)   // unchanged (string ⇒ {field})
+doc.commitCardField(quill, 2, "qty", v)   doc.commitField(quill, { card: 2, field: "qty" }, v)
+doc.commitFields(quill, fields)           doc.commitFields(quill, {}, fields)
+doc.commitCardFields(quill, 2, fields)    doc.commitFields(quill, { card: 2 }, fields)
+```
+
+Three rules govern the surface:
+
+- **Reads are total over the field axis.** `get` / `getMarkdown` / `isFill`
+  return the value / projection / fill-flag for a present field, and
+  `undefined` / `undefined` / `false` for an absent one — only an out-of-range
+  `card` throws. `getMarkdown` now returns **`undefined`, not `""`**, for an
+  absent field (absence vs empty is real signal for must-fill / seeding UIs); a
+  body address reads the body corpus (`get`) or its markdown (`getMarkdown`).
+- **Field writes require a field.** `storeField` / `storeFill` / `removeField` /
+  `commitField` throw on a body address (no `field`) — a body is never opaque
+  and has no field schema; write it with `revise` / `install` /
+  `writer.setBody`.
+- **Card-scoped verbs take a `CardAddr` (`{ card? }`) first and throw on a
+  present `field`.** `storeFields({}, fields)`, `storeExt({ card: 2 }, map)`,
+  `commitFields(quill, {}, fields)`. The address is first and never
+  shape-overloaded, because `card` is a legal field name (an optional-address
+  `storeFields({ card: 2 })` would be ambiguous with "set field `card`").
+
+New reach the twins never had: `getExt(addr?)` and `getExtNamespace(addr, ns)`
+(fine-grained, non-destructive `$ext` reads), `isFill(addr)`, and a card-capable
+`storeFill`.
+
+**Removed** (folded into the addressed verbs): `getCardField`, `getCardMarkdown`,
+`setCardField`, `setCardFields`, `setCardExt`, `removeCardExt`,
+`setCardExtNamespace`, `removeCardExtNamespace`, `removeCardField`,
+`commitCardField`, `commitCardFields`. `install` / `revise` / `applyChange` widen
+to accept the bare-string shorthand.
+
+Python does **not** take the address — it stays name-keyed, its `store_card_*`
+twins renamed from `set_card_*`. Core keeps borrow navigation (`main_mut()` /
+`card_mut(i)`); the `Addr` lives only in the bindings.
+
+## A typed, anchor-preserving field revise (#957)
+
+Two writes took markdown into a richtext field with opposite identity semantics:
+`writer.set_body(md)` (and `revise`) rebased surviving anchors, while
+`writer.set("subject", md)` → `commit_field` cold-imported and destroyed them.
+No write was both typed *and* anchor-preserving. New:
+
+- Core `Card::revise_field_checked(name, md, schema) -> Delta` — diff the
+  markdown against the field's current corpus so surviving anchors rebase (as
+  `revise_field`), then enforce the field `schema` on the **diffed result**
+  through the same typed-conform path `commit_field` runs, so a `richtext(inline)`
+  field rejects a multi-block result with `FieldRichtextNotInline` (the error
+  surface unchanged) while anchors survive.
+- WASM `reviseChecked(quill, addr, md) -> Delta` — the addressed spelling
+  (field-only; a body address throws, since a body carries no field schema).
+
+The `Delta` receipt stays in the corpus lane; the receipt-free `writer.set` is
+untouched, so a tier-1 consumer still never meets a `Delta`. This is a
+**deliberate change to the 0.93 → 0.94 allocation** (corpus lane =
+anchor-preserving + schema-blind, typed door = cold + schema-enforcing), not a
+restoration of it: the desired verb belongs to neither tier as they were
+axiomatized, and the call here spends "the corpus lane never consults a schema"
+rather than "tier 1 never speaks a receipt." `revise` / `revise_field` stay
+schema-blind; `commit_field` / `install_field` are unchanged.
 
 ## WASM: `pushCard` folds into `insertCard(card, at?)`; `replaceBody` is deleted (#961)
 

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -60,11 +60,11 @@ third lane — verbatim storage, coercion deferred to render.
 **The verb carries the lane.** One vocabulary rule, stated once here: **store**
 = verbatim (the quill-free opaque write, coercion deferred to render), **set** =
 typed (the writer's strict commit at the write), **install / revise / apply** =
-corpus (identity-aware). `remove_*` has no tier — one verb per lane serves it.
+corpus (identity-aware). `remove_*` has no tier — one verb serves every lane.
 So `store_field` / `store_fields` / `store_fill` (+ `store_ext` / `store_seed_*`)
 are the opaque store, `set` / `set_all` / `set_body` the typed writer, and a name
-never needs per-verb disambiguation against its neighbor (the `store_fields`
-opaque batch no longer near-homographs the `set_all` typed batch).
+never needs per-verb disambiguation against its neighbor (the opaque batch
+`store_fields` and the typed batch `set_all` are not near-homographs).
 
 **Writers and card cursors are ephemeral — bind, write, discard.** They hold an
 address (the quill + document, or an index), never a cache; every call reads

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -53,9 +53,18 @@ discarded; `writer.set` is `commitField` with the quill bound once. Anything
 tier 1 writes, tier 2 can write with more control, so the decision tree picks a
 *default*, not a *cage*: a live editor legitimately writes fields through the
 writer and bodies/splices through the addressed verbs in one interaction. Reads
-(`get` / `getMarkdown`) need no schema, so they sit on `Document`, not the
-writer. The quill-free `setField` / `setCardField` primitive stays the third
-lane — verbatim storage, coercion deferred to render.
+(`get` / `getMarkdown` / `isFill` / `getExt`) need no schema, so they sit on
+`Document`, not the writer. The quill-free `storeField` primitive stays the
+third lane — verbatim storage, coercion deferred to render.
+
+**The verb carries the lane.** One vocabulary rule, stated once here: **store**
+= verbatim (the quill-free opaque write, coercion deferred to render), **set** =
+typed (the writer's strict commit at the write), **install / revise / apply** =
+corpus (identity-aware). `remove_*` has no tier — one verb per lane serves it.
+So `store_field` / `store_fields` / `store_fill` (+ `store_ext` / `store_seed_*`)
+are the opaque store, `set` / `set_all` / `set_body` the typed writer, and a name
+never needs per-verb disambiguation against its neighbor (the `store_fields`
+opaque batch no longer near-homographs the `set_all` typed batch).
 
 **Writers and card cursors are ephemeral — bind, write, discard.** They hold an
 address (the quill + document, or an index), never a cache; every call reads
@@ -85,11 +94,10 @@ ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
 | Card removal (writer) | `writer.remove_card(i)` | `writer.removeCard(i)` | identical |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
 | Cursor kind | `writer.card(i)?.kind()` | `writer.card(i).kind` | identical — the JS getter reads through `doc.card(i)` |
-| Reads (main) | `card.field_markdown(..)` / `payload().get(..)` | `doc.getMarkdown(name?)` / `doc.get(name)` | **idiom** — the bindings fuse the read into one named verb on `Document` |
-| Reads (card) | `cards()[i].field_markdown(..)` / `payload().get(..)` | `doc.getCardMarkdown(i, name?)` / `doc.getCardField(i, name)` | **idiom** — the card-indexed twins of the main reads, mirroring the card write verbs; `getCardMarkdown` is a fallible `Result` (the index bounds-check) where main `getMarkdown` is infallible |
+| Reads (value / markdown / fill / `$ext`) | `field_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.get(addr?)` / `doc.getMarkdown(addr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS); name-keyed twins (py) | **idiom** / **FFI** — WASM fuses every read onto the one `Addr` (a bare string ⇒ `{field}`), *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); Python stays name-keyed |
 | Reads (whole card / `$id` / seed) | `card(i)` / `find_card(id)` / `main().seed()` | `doc.card(i)` / `doc.cardIndexById(id)` / `doc.seedOverlay(kind)` | **idiom** — the bindings fuse each into one named verb on `Document`; `card(i)` throws out of range, `find_card`/`cardIndexById` return the first `$id` match (non-unique by design) |
-| Richtext ops | `card.revise_field(name, md)?` (borrow chain) | `doc.revise({card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation |
-| Opaque primitive | `set_field` / `set_fields` | `setField` / `setCardField` (JS), `set_field` / `set_fields` (py) | identical |
+| Richtext ops | `revise_field(name, md)?` / `revise_field_checked(name, md, schema)?` (borrow chain) | `doc.revise({card, field}, md)` / `doc.reviseChecked(quill, {card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation; the `*_checked` verb enforces the field schema on the diffed result (typed *and* anchor-preserving), keeping the `Delta` in the corpus lane |
+| Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`), `store_field` / `store_fields` / `store_card_field` (py, name-keyed) | identical — the quill-free verbatim write; WASM addresses with `Addr`, Python stays name-keyed |
 
 The single **idiom** row on the front door is the honest cost: the typed writer
 is the one shape pyo3 carries worst, so its "identical" is qualified, not

--- a/prose/canon/PROGRAMMATIC.md
+++ b/prose/canon/PROGRAMMATIC.md
@@ -6,7 +6,7 @@
 
 A `Document` is built and mutated in memory — no Markdown text involved —
 through validated constructors and mutators: `Document::new` (blank canvas),
-`Card::new`, `set_field` / `set_fields`, `push_card`. Every mutator enforces
+`Card::new`, `store_field` / `store_fields`, `push_card`. Every mutator enforces
 the same field-name, depth, and kind invariants the Markdown parser does, so a
 constructed document cannot be invalid. This is the authoring surface for
 programs (database row → rendered PDF); Markdown serves human authoring and
@@ -18,7 +18,7 @@ the blueprint serves LLM/MCP consumers.
 |---|---|---|
 | card-yaml Markdown | humans | `Document::from_markdown` |
 | annotated blueprint | LLMs / MCP | `blueprint()` → fill → `from_markdown` |
-| structured mutators | programs | `Document::new` → `set_fields` / `push_card` |
+| structured mutators | programs | `Document::new` → `store_fields` / `push_card` |
 
 All three produce the same `Document`; render, validation, storage, and
 emission do not distinguish how it was built. `to_markdown()` emits canonical
@@ -45,7 +45,7 @@ Python shown; Rust and WASM mirror it method-for-method:
 
 ```python
 doc = Document("invoice")
-doc.set_fields({"customer": row.name, "total": row.total})
+doc.store_fields({"customer": row.name, "total": row.total})
 for item in row.items:
     doc.push_card(Document.make_card("line_item", {"desc": item.desc, "qty": item.qty}))
 result = engine.render(quill, doc, OutputFormat.PDF)
@@ -58,7 +58,7 @@ YAML or Markdown.
 ## Validation: batched, atomic, at the boundary
 
 Structural invariants (field-name grammar, value depth, card kind) are
-enforced per mutator call. `set_fields` validates its whole batch before
+enforced per mutator call. `store_fields` validates its whole batch before
 applying any of it: on violation nothing is applied and the single error
 carries one diagnostic per offending field with `path` set to the field name —
 externally sourced names (database columns, form keys) surface every violation
@@ -68,9 +68,10 @@ to the write by typed commit (below).
 
 ## Two write disciplines: opaque store vs typed commit
 
-Document mutation is a data primitive that never requires a Quill. `set_field` /
-`set_fields` hold only a `$quill` *reference*, enforce the structural invariants
-above, and store the value verbatim — coercion is deferred to render. Typed
+Document mutation is a data primitive that never requires a Quill. `store_field`
+/ `store_fields` (the opaque **store** — verbatim, coercion deferred) hold only a
+`$quill` *reference*, enforce the structural invariants above, and store the
+value verbatim — coercion is deferred to render. Typed
 commit is a schema-bound layer over that primitive: `Quill::writer(&mut doc)`
 binds the resolved schema, and its `set` / `set_all` resolve each field's `type`,
 coerce to the canonical form (`"3"` → `3`, a markdown string → a richtext
@@ -86,14 +87,16 @@ The primitive stays load-bearing — it is what lets a `Document` be constructed
 and `from_json`'d with no bundle (standalone data), what quill-agnostic
 storage/migration infra writes through, what a store-now-validate-later editor
 uses to hold not-yet-conforming input, and the way to store a value opaquely on
-purpose. Reach for the opaque `set_*` for those; reach for the writer by
+purpose. Reach for the opaque `store_*` for those; reach for the writer by
 default. `Quill::writer(&mut doc)` is the documented front door in every
 surface — `quill.writer(doc)` in WASM and Python alike (the schema-bound
 `DocumentWriter` / `Writer` with `set` / `set_all` / `set_body` /
-`add_card` / `card(i)`); the quill owns the schema, so it is the factory. The `commitField` / `commitFields` (+ `commitCard*`)
-verbs are the stable ABI underneath it, and `setField` / `setCardField` remain
-the quill-free opaque store. See [BINDINGS.md](BINDINGS.md) for the two-tier
-write surface and the core-vs-bindings parity table.
+`add_card` / `card(i)`); the quill owns the schema, so it is the factory. The
+`commitField` / `commitFields` verbs (addressed by `Addr`) are the stable ABI
+underneath it, and `storeField` / `storeFields` remain the quill-free opaque
+store. See [BINDINGS.md](BINDINGS.md) for the two-tier write surface, the
+`store` / `set` / `install·revise·apply` vocabulary rule, and the
+core-vs-bindings parity table.
 
 ## Addressing cards for re-render
 
@@ -103,7 +106,7 @@ the index when patching:
 
 ```python
 idx = next(i for i, c in enumerate(doc.cards) if c["id"] == row_id)
-doc.set_card_fields(idx, {"qty": new_qty})
+doc.store_card_fields(idx, {"qty": new_qty})
 ```
 
 `$id` is optional and opaque; the model imposes no uniqueness on it.


### PR DESCRIPTION
Implements #955, #957, and #960 as one coordinated pre-1.0 sweep — landing them together so nothing is written under a name it immediately loses, and reconciling the three where they conflicted.

## What changed

### #960 — the opaque store renames `set_* → store_*`
The verb now carries the lane: **store** = verbatim (quill-free, coercion deferred to render), **set** = typed (the writer's strict commit), **install / revise / apply** = corpus (identity-aware). `remove_*` has no tier. Applied to core `Card`, WASM, and Python (the rename #913 deferred for the Python mirror, made globally). The day-one exception the issue's review flagged is fixed: `$ext` / `$seed` opaque writes rename too (`store_ext` / `store_ext_namespace` / `store_seed_namespace`), so "set = typed" holds with no counterexample. `set_card_kind` (structural) and the typed `set` / `commit_field` keep their names.

### #955 — WASM `Document` unifies on one address
The 11 main/card twin pairs (22 methods) collapse onto the `Addr` `{ card?, field? }` the corpus lane already spoke; a bare string is shorthand for `{ field }`. Adopting the resolved edges from the issue's review comment:
- **Reads are total over the field axis** — `get` / `getMarkdown` / `isFill` return `undefined` / `undefined` / `false` for an absent field; only an out-of-range card throws. `getMarkdown` now returns `undefined` (not `""`) for an absent field.
- **Field writes require a field** — a body address throws (write a body with `revise` / `install` / `writer.setBody`).
- **Card-scoped verbs take a `CardAddr` first and throw on a present `field`** — the address is first and never shape-overloaded, since `card` is a legal field name. TS can't police `CardAddr` vs `Addr`, so the runtime check is the contract.
- Fills the gaps the twins never had: `getExt` / `getExtNamespace` reads, `isFill`, a card-capable `storeFill`.

Python stays name-keyed (no `Addr`); core keeps borrow navigation.

### #957 — a typed, anchor-preserving field revise
`revise` rebased anchors but was schema-blind; `commit_field` enforced the schema but cold-imported (anchors gone). Neither was both. Rather than the issue's original shape (a `Delta` on `set`, which breaks the tier-1 "no receipts" axiom **and** leaves `set_all` still cold, as the review established), this spends the *other* axiom: the typed anchor-preserving write lives in the corpus lane, so its `Delta` receipt stays there and the receipt-free `writer.set` is untouched.
- Core `Card::revise_field_checked(name, md, schema) -> Delta` — diff (anchors rebase), then enforce the schema on the **diffed result** through the same typed-conform path `commit_field` runs, so `richtext(inline)` → `FieldRichtextNotInline` is unchanged.
- WASM `reviseChecked(quill, addr, md)`.

This is a deliberate change to the ratified 0.93→0.94 allocation (documented as such in the migration guide), not a restoration of it.

### Naming collision resolved
#955's review wanted `commitField` / `commitFields`; #960's table wanted `commit` / `commitAll`. Kept `commitField` / `commitFields` — `commitAll` is a misnomer (it commits several *named* fields, not all) and the `Field`/`Fields` pair matches the `storeField`/`storeFields` family.

## Testing
- `cargo test --workspace` green on host (634 core tests + orchestration), including a new `revise_field_checked` test covering anchor-preservation + inline enforcement + the field-unchanged-on-error path.
- WASM (`basic`/`core`/`runtime` `.test.js`, 78 call sites migrated) and Python (pytest) binding suites run on CI.

## Docs
Working migration guide (`0.94-to-0.95.md`) gains three sections with before/after tables; BINDINGS.md states the `store` / `set` / `install·revise·apply` vocabulary rule once and updates the parity table; PROGRAMMATIC.md switches its opaque-store examples to `store_*`.

Closes #955
Closes #957
Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGB12AtaqHNpi5dMnxUfnb)_