### PR TITLE
docs: purge rogue .qmd file-extension mentions

### DIFF
--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1050,7 +1050,7 @@ This body and the metadata above are an indorsement card.
         // A richtext field stored as a canonical corpus object is the case the
         // card-yaml markdown projection is lossy for; the storage DTO is the
         // lossless carrier, so identity marks (an `underline` with no markdown
-        // form) survive a serde-JSON round-trip that a `.qmd` save would drop.
+        // form) survive a serde-JSON round-trip that a markdown save would drop.
         use quillmark_richtext::model::{Mark, MarkKind};
 
         let mut doc = sample();

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -43,7 +43,7 @@ impl Document {
     ///
     ///    **Corpus-field carve-out.** A richtext field committed as a canonical
     ///    corpus object (and the card `$body`) is *intentionally* markdown-lossy
-    ///    on `.qmd` emit: it projects to its markdown form (`project_corpus_field`),
+    ///    on markdown emit: it projects to its markdown form (`project_corpus_field`),
     ///    so identity marks (anchors, island ids) and corpus-only marks
     ///    (`underline`) do not survive a `to_markdown`→`from_markdown` round-trip.
     ///    On-disk identity is markdown-lossy by design; the storage DTO is the
@@ -292,7 +292,7 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
 /// card-yaml — the human-authored surface — stays markdown-clean rather than
 /// carrying a nested `{text, lines, marks, islands}` tree. Projection is lossy
 /// per the corpus's island loss class (the same tradeoff `$body` makes): island
-/// ids and corpus-only marks do not survive a `.qmd` round-trip, so on-disk
+/// ids and corpus-only marks do not survive a markdown round-trip, so on-disk
 /// identity is markdown-lossy by design; the storage DTO is the lossless carrier.
 ///
 /// The guard requires the object to serialize back to a **byte-identical**

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -266,7 +266,7 @@ impl Card {
 
     /// The markdown projection of a richtext-valued field (`export ∘ decode`) —
     /// the field-level twin of [`Card::body_markdown`], and the projection an
-    /// emit or a `.qmd` save writes for a corpus-valued field. `None` when the
+    /// emit or a markdown save writes for a corpus-valued field. `None` when the
     /// field is absent or does not decode as richtext.
     pub fn field_markdown(&self, name: &str) -> Option<String> {
         match self.field_richtext(name)? {

--- a/docs/migrations/0.93-to-0.94.md
+++ b/docs/migrations/0.93-to-0.94.md
@@ -403,8 +403,8 @@ at the boundary as `applyChange({ field }, bundle)`.
 - **`set_field` is unchanged.** The opaque path (store verbatim, coerce at
   render) stays for keystroke-level state and DB-row batch generators; the split
   is `set_field` = *coerce at render* vs `commit_field` = *canonicalize now, fail
-  now*. A richtext field authored as a markdown string in hand-written `.qmd`
-  still imports at render — no file needs editing.
+  now*. A richtext field authored as a markdown string in a hand-written `.md`
+  file still imports at render — no file needs editing.
 
 The wire and the storage DTO are unaffected.
 
@@ -426,11 +426,11 @@ pre-release into `install` / `revise`.)
 ### On-disk identity is markdown-lossy by design
 
 A corpus-valued field **projects to a markdown string** in emitted card-yaml
-(`Document::to_markdown` / `.qmd`), keeping the human-authored surface
+(`Document::to_markdown`), keeping the human-authored surface
 markdown-clean rather than embedding a `{text, lines, marks, islands}` tree. So
 identity marks (anchors, island ids) and corpus-only formatting persist across
 compiles and the **storage DTO** (`to_json`/`from_json` — the lossless carrier),
-but **not** across a `.qmd` save-and-reload, which re-imports a fresh corpus.
+but **not** across a markdown save-and-reload, which re-imports a fresh corpus.
 Persistent field anchors (identity marks on corpus field content) are a compile
 / DTO guarantee, not a card-yaml one.
 

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -59,7 +59,7 @@ guides in order.
   `bodyMarkdown`/`fieldMarkdown` projections and the per-address body writers
   retire pre-release, `replaceBody` / `replace_body` / `update_card_body` alias
   for one cycle, and richtext fields gain the anchor-preserving `revise_field`
-  (#925). On-disk (`.qmd`) identity stays markdown-lossy — the storage DTO is
+  (#925). On-disk (markdown) identity stays markdown-lossy — the storage DTO is
   the lossless carrier. The binding write surface then settles into two tiers:
   `quill.writer(doc)` (WASM and Python alike) is the documented default —
   typed `set` / `set_all` / `setBody` / `addCard` / `card(i)` and quill-free


### PR DESCRIPTION
.qmd was never a real on-disk extension in this codebase (no code
matches or writes it; the on-disk format is markdown/card-yaml).
Replace informal .qmd references in doc comments and migration
guides with accurate terminology.