### PR TITLE
Rebase marks through line ops; collapse bundle normalize

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -475,7 +475,7 @@ impl PyDocument {
 
     /// **Apply** a committed content edit `bundle` (`{delta?, line_ops?, mark_ops?}`)
     /// at `(card, field)` — the editor splice: text delta, then line ops, then
-    /// mark ops (mark ranges in post-delta coordinates), each all-or-nothing. An
+    /// mark ops (mark ranges in final-text coordinates), each all-or-nothing. An
     /// absent `field` targets the body, an absent `card` the main card. The kwargs
     /// idiom of WASM `doc.applyChange(addr, bundle)`. Raises on an out-of-range
     /// card, a field that is not richtext, a malformed bundle, or an out-of-bounds

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -270,9 +270,9 @@ export interface Delta {
 export type Assoc = "before" | "after";
 
 /**
- * A mark edit in post-text-delta coordinates. `add` / `remove` carry the
- * `ContentMark` vocabulary (`{ type, … }`); `removeAnchor` drops one identity
- * anchor by id.
+ * A mark edit in final-text coordinates (post-delta, post-line-op). `add` /
+ * `remove` carry the `ContentMark` vocabulary (`{ type, … }`); `removeAnchor`
+ * drops one identity anchor by id.
  */
 export type MarkOp =
     | ({ op: "add" | "remove"; start: number; end: number } & (
@@ -1305,7 +1305,7 @@ impl Document {
 
     /// **Apply** a committed content edit `bundle` (`{ delta?, lineOps?, markOps? }`)
     /// at `addr` — the editor splice: text delta first, then line ops, then mark
-    /// ops (mark ranges in post-delta coordinates), each all-or-nothing. An absent
+    /// ops (mark ranges in final-text coordinates), each all-or-nothing. An absent
     /// `addr.field` targets the body, an absent `addr.card` the main card.
     ///
     /// Throws on an out-of-range card, a field that is not richtext, a malformed

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -135,10 +135,10 @@ impl Delta {
     /// trailing retain so a producer that names only the changed region need not
     /// pad a bare trailing [`Op::Retain`].
     ///
-    /// Cost of the leniency: strictness was a corruption tripwire, so a short
-    /// delta replayed against a wrong but *longer* base now applies silently
-    /// rather than erroring. An abbreviated delta forfeits that tripwire by
-    /// construction; it still fires on over-consumption.
+    /// Cost of the leniency: a short delta carries no full-base-length check, so
+    /// one replayed against a wrong but *longer* base applies silently instead
+    /// of failing. An abbreviated delta forfeits that tripwire by construction;
+    /// over-consumption still fails.
     pub fn try_apply(&self, base: &str) -> Result<String, BaseLengthMismatch> {
         let expected = self.expected_base_len();
         let actual = base.chars().count();

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -38,7 +38,6 @@
 use crate::model::{Mark, MarkKind, Content};
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
-use std::borrow::Cow;
 
 /// A per-field edit against a base content. Ops apply left-to-right, consuming
 /// base positions; `Retain`/`Delete` advance the base cursor, `Insert` adds new
@@ -99,57 +98,51 @@ impl Delta {
             .sum()
     }
 
-    /// Pad a *short* delta — one whose ops consume less base than `base_len` —
-    /// with a trailing [`Op::Retain`] over the untouched remainder, so a splice
-    /// that names only the region it changes (a bare prepend of a single
-    /// `Insert`, an edit near the start) applies against the whole base instead
-    /// of tripping [`try_apply`](Self::try_apply)'s base-length check. A delta
-    /// that already covers the base is returned unchanged; one that *overruns*
-    /// it (`expected_base_len() > base_len`) is left to fail as a genuine
-    /// [`BaseLengthMismatch`], since a delta consuming more base than exists is
-    /// built against the wrong revision, not merely abbreviated.
-    pub fn extend_to_base(&self, base_len: usize) -> Cow<'_, Delta> {
-        let consumed = self.expected_base_len();
-        if consumed < base_len {
-            let mut ops = self.ops.clone();
-            ops.push(Op::Retain(base_len - consumed));
-            Cow::Owned(Delta { ops })
-        } else {
-            Cow::Borrowed(self)
-        }
-    }
-
-    /// Apply to `base`, producing the new text. Ignores over-long
-    /// `Retain`/`Delete` gracefully (clamps), so a mismatched delta cannot
-    /// panic. Silently produces garbage on a length mismatch — use
-    /// [`Self::try_apply`] where the base's provenance isn't already trusted.
+    /// Apply to `base`, producing the new text. Base beyond what the ops
+    /// consume is retained implicitly — a *short* delta names only the region
+    /// it changes (a bare prepend, an edit near the start) and the untouched
+    /// remainder carries through. **Panics** if the ops consume *more* base than
+    /// exists (`expected_base_len() > base.chars().count()`): a delta built
+    /// against a longer revision. This is the trusted-provenance path; clamping
+    /// an over-long delta silently is corruption, so where the base's provenance
+    /// isn't already trusted use [`Self::try_apply`], which returns the mismatch
+    /// as an error instead.
     pub fn apply(&self, base: &str) -> String {
         let chars: Vec<char> = base.chars().collect();
         let mut out = String::new();
         let mut i = 0usize;
         for op in &self.ops {
             match op {
+                // Over-long Retain/Delete index past `chars` and panic here —
+                // the intended failure on a wrong-revision base.
                 Op::Retain(n) => {
-                    let end = (i + n).min(chars.len());
-                    out.extend(&chars[i..end]);
-                    i = end;
+                    out.extend(&chars[i..i + n]);
+                    i += n;
                 }
-                Op::Delete(n) => {
-                    i = (i + n).min(chars.len());
-                }
+                Op::Delete(n) => i += n,
                 Op::Insert(s) => out.push_str(s),
             }
         }
-        out.extend(&chars[i.min(chars.len())..]);
+        out.extend(&chars[i..]);
         out
     }
 
-    /// [`Self::apply`], but rejects a delta whose expected base length
-    /// disagrees with `base`'s actual length instead of clamping silently.
+    /// [`Self::apply`], but returns [`BaseLengthMismatch`] instead of panicking
+    /// when the ops consume *more* base than `base` has — a delta built against
+    /// a longer revision. Implicit trailing retain is the contract: a *short*
+    /// delta (ops consuming less than `base`) is accepted and the untouched
+    /// remainder is retained, matching [`map_pos`](Self::map_pos)'s implicit
+    /// trailing retain so a producer that names only the changed region need not
+    /// pad a bare trailing [`Op::Retain`].
+    ///
+    /// Cost of the leniency: strictness was a corruption tripwire, so a short
+    /// delta replayed against a wrong but *longer* base now applies silently
+    /// rather than erroring. An abbreviated delta forfeits that tripwire by
+    /// construction; it still fires on over-consumption.
     pub fn try_apply(&self, base: &str) -> Result<String, BaseLengthMismatch> {
         let expected = self.expected_base_len();
         let actual = base.chars().count();
-        if expected != actual {
+        if expected > actual {
             return Err(BaseLengthMismatch { expected, actual });
         }
         Ok(self.apply(base))
@@ -502,27 +495,54 @@ mod tests {
     }
 
     #[test]
-    fn extend_to_base_pads_short_delta() {
-        // A bare prepend gains a trailing retain over the untouched remainder.
+    fn try_apply_accepts_short_delta_with_implicit_trailing_retain() {
+        // A bare prepend consumes no base; the untouched remainder is retained
+        // implicitly rather than tripping the base-length check.
         let short = Delta {
             ops: vec![Op::Insert("NEW ".into())],
         };
-        let padded = short.extend_to_base(5);
-        assert!(matches!(padded, Cow::Owned(_)));
-        assert_eq!(padded.expected_base_len(), 5);
-        assert_eq!(padded.apply("hello"), "NEW hello");
+        assert_eq!(short.expected_base_len(), 0);
+        assert_eq!(short.try_apply("hello").unwrap(), "NEW hello");
 
-        // A base-covering delta is returned untouched, no clone.
-        let full = Delta {
-            ops: vec![Op::Retain(5)],
+        // An edit near the start, naming only its region, applies against the
+        // whole base — same result whether or not a trailing retain is written.
+        let partial = Delta {
+            ops: vec![Op::Retain(1), Op::Insert("X".into())],
         };
-        assert!(matches!(full.extend_to_base(5), Cow::Borrowed(_)));
+        assert_eq!(partial.try_apply("hello").unwrap(), "hXello");
+    }
 
-        // An over-long delta is left alone to fail at `try_apply`.
+    #[test]
+    fn try_apply_rejects_over_long_delta() {
+        // Consuming more base than exists is a wrong-revision delta, not an
+        // abbreviated one — it errors, it does not clamp.
         let over = Delta {
             ops: vec![Op::Retain(9)],
         };
-        assert!(matches!(over.extend_to_base(5), Cow::Borrowed(_)));
+        assert_eq!(
+            over.try_apply("hello"),
+            Err(BaseLengthMismatch {
+                expected: 9,
+                actual: 5,
+            })
+        );
+
+        // Over-consumption via Delete fails the same way.
+        let over_del = Delta {
+            ops: vec![Op::Delete(9)],
+        };
+        assert!(over_del.try_apply("hello").is_err());
+    }
+
+    #[test]
+    #[should_panic]
+    fn apply_panics_on_over_long_delta() {
+        // The trusted-provenance path panics rather than clamping an over-long
+        // delta to silent garbage.
+        let over = Delta {
+            ops: vec![Op::Retain(9)],
+        };
+        let _ = over.apply("hello");
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -556,12 +556,12 @@ impl Content {
     /// provoke.
     ///
     /// The stages run on their non-normalizing inner forms and `normalize` runs
-    /// once at the end. This is behavior-preserving because line split/join now
-    /// rebase marks through their `\n` splice ([`map_pos`](crate::delta::Delta::map_pos)
-    /// semantics): with that remap, `normalize`'s formatting-edge `\n`-trim
-    /// commutes with the line ops (trim-per-stage and trim-once converge), and
-    /// `MarkOp::Remove` is coverage-set subtraction, which commutes with the
-    /// same-kind union `normalize` would have run between stages
+    /// once at the end. One terminal normalize suffices because split/join
+    /// rebase marks through their `\n` splice
+    /// ([`map_pos`](crate::delta::Delta::map_pos) semantics): the
+    /// formatting-edge `\n`-trim then commutes with the line ops (trim-per-stage
+    /// and trim-once converge), and `MarkOp::Remove` is coverage-set
+    /// subtraction, which commutes with `normalize`'s same-kind union
     /// (`(A ∪ B) \ R = (A\R) ∪ (B\R)`). One canonicalization point, one pass.
     pub fn apply_field_change(
         &mut self,
@@ -717,12 +717,10 @@ fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
 /// original suffix (`rest`), because a split lands its clone right at the cursor
 /// and a delete drops the next original. So the three `\n` events reduce to:
 /// a retained `\n` finalizes `cur` and pulls the next original into it; a
-/// deleted `\n` drops the next original (merging it in) — the old
-/// `line_idx + 1 < lines.len()` guard becomes "a next original exists"; an
+/// deleted `\n` drops the next original (merging it in), when one exists; an
 /// inserted `\n` finalizes `cur` and makes a clone (its `continues` cleared) the
-/// new `cur`. `cur == None` is the past-the-end state the old code reached via
-/// `lines.get(line_idx)` returning `None` on a malformed corpus, where a split
-/// clones a default line.
+/// new `cur`. `cur == None` is the past-the-end state on a malformed corpus
+/// (more `\n` than lines), where a split clones a default line.
 fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta) -> Vec<Line> {
     let cap = old_lines.len();
     let mut rest = old_lines.into_iter();
@@ -750,8 +748,7 @@ fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta)
                         break;
                     }
                     // A deleted '\n' merges the next original into `cur` — drop
-                    // it. No next original: nothing to remove, matching the old
-                    // `line_idx + 1 < lines.len()` guard skipping the `remove`.
+                    // it. With no next original there is nothing to drop.
                     if old_chars[old] == '\n' {
                         rest.next();
                     }
@@ -1375,7 +1372,7 @@ mod tests {
     //
     // Pin the observable behavior of the line-sync walk — retain/insert/delete
     // interleavings, the split template-clone rule, and the malformed-corpus
-    // guards — so the O(n)-per-remove → O(1) rewrite is behavior-preserving.
+    // guards — against a silent change to its internals.
 
     /// A `Heading{level}` line, its level a visible tag so a test can trace
     /// which original line landed where; `continues` distinguishes a clone.
@@ -1585,7 +1582,7 @@ mod tests {
     fn sync_lines_select_all_delete_collapses_to_first_line() {
         // The motivating case (issue #926 finding 2): deleting a whole
         // multi-line body drops every line but the first (each deleted '\n'
-        // merges the next line away). Formerly O(n) per deleted '\n'.
+        // merges the next line away).
         let text: String = (0..50).map(|i| format!("line{i}\n")).collect();
         let old_chars: Vec<char> = text.chars().collect();
         let lines: Vec<Line> = (0..=50).map(|i| tag_line((i % 200) as u8, false)).collect();

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -1,10 +1,14 @@
 //! Mark and line op channels — structural edits separate from text splices.
 //!
 //! [`MarkOp`] and [`LineOp`] apply after [`Content::apply_text_delta`] in one
-//! bundle; mark ranges are in post-delta coordinates. Line split/join
-//! also splice `\n` in `text`; position mapping through the change log still
-//! composes [`Delta::map_pos`](crate::delta::Delta::map_pos) on the text delta
-//! channel — record `\n` edits there when mapping stale positions.
+//! bundle. Mark ranges are in **final-text coordinates**: mark ops run after
+//! line ops and validate against the post-line-op length, so a producer
+//! computes them in the only frame it can — the text as it stands once the
+//! delta and line ops have landed. Line split/join splice a `\n` in `text` and
+//! rebase marks through that one-char change with
+//! [`Delta::map_pos`](crate::delta::Delta::map_pos), the same mapping the
+//! text-delta channel uses, so a mark's coordinates track the splice rather
+//! than drifting.
 
 use crate::delta::{Assoc, Delta, Op};
 use crate::model::{Container, Island, Line, LineKind, Mark, MarkKind, Content, Usv, ISLAND_SLOT};
@@ -12,7 +16,7 @@ use crate::normalize::is_bidi_char;
 use crate::usv::char_to_byte;
 use std::borrow::Cow;
 
-/// A mark edit in post-text-delta coordinates.
+/// A mark edit in final-text coordinates (post-delta, post-line-op).
 #[derive(Debug, Clone, PartialEq)]
 pub enum MarkOp {
     /// Add a mark over `[start, end)`.
@@ -331,6 +335,16 @@ impl Content {
     /// insert of `\r` or a bidi control returned `Ok` while leaving a content
     /// that fails `validate()` (see issue #899).
     pub fn apply_text_delta(&mut self, delta: &Delta) -> Result<(), ApplyError> {
+        self.apply_text_delta_inner(delta)?;
+        self.normalize();
+        Ok(())
+    }
+
+    /// [`apply_text_delta`](Self::apply_text_delta) without the terminal
+    /// normalize — the stage [`apply_field_change`](Self::apply_field_change)
+    /// runs so a committed bundle canonicalizes once at the end, not after each
+    /// op.
+    fn apply_text_delta_inner(&mut self, delta: &Delta) -> Result<(), ApplyError> {
         // Reject before mutating: a raw slot in an insert would create a slot
         // with no backing island. Checked up front so the content is untouched
         // on this error.
@@ -365,16 +379,7 @@ impl Content {
                 actual: e.actual,
             })?;
 
-        for m in &mut self.marks {
-            if m.start == m.end {
-                let p = delta.map_pos(m.start, Assoc::Before);
-                m.start = p;
-                m.end = p;
-            } else {
-                m.start = delta.map_pos(m.start, Assoc::After);
-                m.end = delta.map_pos(m.end, Assoc::Before);
-            }
-        }
+        self.rebase_marks(delta);
         let new_len = new_text.chars().count();
         self.marks.retain(|m| {
             m.start <= m.end
@@ -392,12 +397,38 @@ impl Content {
                 segments: self.segment_count(),
             });
         }
+        Ok(())
+    }
+
+    /// Rebase every mark's range through `delta`'s
+    /// [`map_pos`](crate::delta::Delta::map_pos): a range mark's start biases
+    /// `After` and its end `Before` (an insertion at either edge grows text
+    /// *outside* the span), a point (zero-width) mark biases `Before`. The one
+    /// mapping the text-delta channel and line split/join both rebase marks by.
+    fn rebase_marks(&mut self, delta: &Delta) {
+        for m in &mut self.marks {
+            if m.start == m.end {
+                let p = delta.map_pos(m.start, Assoc::Before);
+                m.start = p;
+                m.end = p;
+            } else {
+                m.start = delta.map_pos(m.start, Assoc::After);
+                m.end = delta.map_pos(m.end, Assoc::Before);
+            }
+        }
+    }
+
+    /// Apply mark ops in final-text coordinates, then normalize.
+    pub fn apply_mark_ops(&mut self, ops: &[MarkOp]) -> Result<(), ApplyError> {
+        self.apply_mark_ops_inner(ops)?;
         self.normalize();
         Ok(())
     }
 
-    /// Apply mark ops in post-text-delta coordinates, then normalize.
-    pub fn apply_mark_ops(&mut self, ops: &[MarkOp]) -> Result<(), ApplyError> {
+    /// [`apply_mark_ops`](Self::apply_mark_ops) without the terminal normalize —
+    /// the bundle's final stage, canonicalized once by
+    /// [`apply_field_change`](Self::apply_field_change).
+    fn apply_mark_ops_inner(&mut self, ops: &[MarkOp]) -> Result<(), ApplyError> {
         let len = self.len_usv();
         for op in ops {
             match op {
@@ -469,12 +500,20 @@ impl Content {
                 }
             }
         }
-        self.normalize();
         Ok(())
     }
 
     /// Apply line ops — split/join splice `\n`; set ops touch metadata only.
     pub fn apply_line_ops(&mut self, ops: &[LineOp]) -> Result<(), ApplyError> {
+        self.apply_line_ops_inner(ops)?;
+        self.normalize();
+        Ok(())
+    }
+
+    /// [`apply_line_ops`](Self::apply_line_ops) without the terminal normalize —
+    /// a bundle stage canonicalized once by
+    /// [`apply_field_change`](Self::apply_field_change).
+    fn apply_line_ops_inner(&mut self, ops: &[LineOp]) -> Result<(), ApplyError> {
         for op in ops {
             match op {
                 LineOp::Split { at } => self.split_line(*at)?,
@@ -501,11 +540,11 @@ impl Content {
                 }
             }
         }
-        self.normalize();
         Ok(())
     }
 
-    /// One committed field edit bundle: text delta, then line ops, then marks.
+    /// One committed field edit bundle: text delta, then line ops, then marks,
+    /// canonicalized by a single terminal [`normalize`](Self::normalize).
     ///
     /// All-or-nothing: on any op's error `self` is left exactly as it was, so a
     /// caller need not snapshot-and-restore around a failed bundle. A bundle
@@ -515,6 +554,15 @@ impl Content {
     /// per-keystroke hot path) skips the clone: `apply_text_delta` validates the
     /// delta before mutating, so it is already atomic on the errors a caller can
     /// provoke.
+    ///
+    /// The stages run on their non-normalizing inner forms and `normalize` runs
+    /// once at the end. This is behavior-preserving because line split/join now
+    /// rebase marks through their `\n` splice ([`map_pos`](crate::delta::Delta::map_pos)
+    /// semantics): with that remap, `normalize`'s formatting-edge `\n`-trim
+    /// commutes with the line ops (trim-per-stage and trim-once converge), and
+    /// `MarkOp::Remove` is coverage-set subtraction, which commutes with the
+    /// same-kind union `normalize` would have run between stages
+    /// (`(A ∪ B) \ R = (A\R) ∪ (B\R)`). One canonicalization point, one pass.
     pub fn apply_field_change(
         &mut self,
         text_delta: &Delta,
@@ -525,9 +573,10 @@ impl Content {
             return self.apply_text_delta(text_delta);
         }
         let mut scratch = self.clone();
-        scratch.apply_text_delta(text_delta)?;
-        scratch.apply_line_ops(line_ops)?;
-        scratch.apply_mark_ops(mark_ops)?;
+        scratch.apply_text_delta_inner(text_delta)?;
+        scratch.apply_line_ops_inner(line_ops)?;
+        scratch.apply_mark_ops_inner(mark_ops)?;
+        scratch.normalize();
         *self = scratch;
         Ok(())
     }
@@ -560,6 +609,14 @@ impl Content {
         let line_idx = char_indices[..at].iter().filter(|&(_, c)| *c == '\n').count();
         self.text.insert(byte, '\n');
 
+        // Rebase marks through the one-char `\n` insertion — the same map_pos
+        // rule the text-delta channel uses, so a split does not drift a mark's
+        // coordinates (a mark spanning `at` grows by the inserted char; the
+        // terminal normalize trims any `\n` edge it lands on).
+        self.rebase_marks(&Delta {
+            ops: vec![Op::Retain(at), Op::Insert("\n".to_string())],
+        });
+
         let template = self
             .lines
             .get(line_idx)
@@ -588,6 +645,14 @@ impl Content {
         let nl = newline_at_line_boundary(&self.text, line)?;
         let byte = char_to_byte(&self.text, nl);
         self.text.remove(byte);
+
+        // Rebase marks through the one-char `\n` deletion, as the text-delta
+        // channel would: a mark spanning the boundary shrinks by one; one that
+        // covered only the `\n` collapses to zero-width and the terminal
+        // normalize drops it.
+        self.rebase_marks(&Delta {
+            ops: vec![Op::Retain(nl), Op::Delete(1)],
+        });
 
         self.lines.remove(line + 1);
 
@@ -1428,6 +1493,92 @@ mod tests {
             assert_eq!(l.containers, vec![Container::Quote]);
             assert!(!l.continues);
         }
+    }
+
+    // ── line-op mark remap + terminal-normalize collapse (issue #926 finding 3) ──
+
+    #[test]
+    fn split_line_rebases_mark_across_the_split_point() {
+        // A strong mark spanning the split point grows by the inserted `\n`
+        // rather than staying at its old coordinates. "abcd", strong[1..3)
+        // ("bc"); split at 2 → "ab\ncd"; the mark must still cover "b"+"c",
+        // i.e. [1..4) over "ab\ncd".
+        let mut rt = from_markdown("abcd").unwrap();
+        rt.apply_mark_ops(&[MarkOp::Add {
+            start: 1,
+            end: 3,
+            kind: MarkKind::Strong,
+        }])
+        .unwrap();
+        rt.apply_line_ops(&[LineOp::Split { at: 2 }]).unwrap();
+        assert_eq!(rt.text, "ab\ncd");
+        let strong: Vec<_> = rt
+            .marks
+            .iter()
+            .filter(|m| matches!(m.kind, MarkKind::Strong))
+            .map(|m| (m.start, m.end))
+            .collect();
+        // [1..4) spans "b\nc"; normalize keeps the interior `\n` (a mark may
+        // legitimately span lines), trimming only leading/trailing boundaries.
+        assert_eq!(strong, vec![(1, 4)]);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    #[test]
+    fn join_line_rebases_marks_to_final_text_coordinates() {
+        // The issue's concrete drift case: "ab\ncd", strong[2..4) (over "\nc").
+        // Joining line 0 removes the `\n`; the remap + terminal normalize must
+        // land strong on "c" — coordinate [2..3) over "abcd" — not on "d"
+        // (the un-remapped-mark bug) nor on "cd".
+        let mut rt = from_markdown("ab").unwrap();
+        rt.apply_text_delta(&diff("ab", "ab\ncd")).unwrap();
+        rt.marks.push(Mark {
+            start: 2,
+            end: 4,
+            kind: MarkKind::Strong,
+        });
+        rt.normalize();
+        // Post-normalize the `\n` edge trims to [3..4) ("c"); either way the
+        // join must converge to strong on "c".
+        rt.apply_line_ops(&[LineOp::Join { line: 0 }]).unwrap();
+        assert_eq!(rt.text, "abcd");
+        let strong: Vec<_> = rt
+            .marks
+            .iter()
+            .filter(|m| matches!(m.kind, MarkKind::Strong))
+            .map(|m| (m.start, m.end))
+            .collect();
+        assert_eq!(strong, vec![(2, 3)], "strong lands on 'c', not 'd' or 'cd'");
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    #[test]
+    fn field_change_terminal_normalize_matches_per_stage_normalize() {
+        // The collapse proof obligation: a bundle applied through
+        // `apply_field_change` (one terminal normalize) must equal applying the
+        // same stages each with its own normalize (the public wrappers). The
+        // remap through split/join is what makes the two converge.
+        let start = from_markdown("hello world").unwrap();
+        let text_delta = diff("hello world", "hello brave world");
+        let line_ops = vec![LineOp::Split { at: 5 }]; // after "hello"
+        let mark_ops = vec![MarkOp::Add {
+            start: 0,
+            end: 5,
+            kind: MarkKind::Strong,
+        }];
+
+        let mut bundled = start.clone();
+        bundled
+            .apply_field_change(&text_delta, &line_ops, &mark_ops)
+            .unwrap();
+
+        let mut staged = start;
+        staged.apply_text_delta(&text_delta).unwrap();
+        staged.apply_line_ops(&line_ops).unwrap();
+        staged.apply_mark_ops(&mark_ops).unwrap();
+
+        assert_eq!(bundled, staged, "terminal normalize diverged from per-stage");
+        assert_eq!(bundled.validate(), Ok(()));
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -644,11 +644,26 @@ fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
     Cow::Owned(Delta { ops })
 }
 
-/// Walk `delta` over `old_chars` and mirror `\n` insert/delete in `lines`.
+/// Walk `delta` over `old_chars` and mirror `\n` insert/delete in `lines`,
+/// building the result in one forward pass — O(old_chars walked + inserts),
+/// no per-`\n` mid-`Vec` `remove`/`insert`.
+///
+/// The cursor sits *in* a line, `cur`; downstream of it is always the untouched
+/// original suffix (`rest`), because a split lands its clone right at the cursor
+/// and a delete drops the next original. So the three `\n` events reduce to:
+/// a retained `\n` finalizes `cur` and pulls the next original into it; a
+/// deleted `\n` drops the next original (merging it in) — the old
+/// `line_idx + 1 < lines.len()` guard becomes "a next original exists"; an
+/// inserted `\n` finalizes `cur` and makes a clone (its `continues` cleared) the
+/// new `cur`. `cur == None` is the past-the-end state the old code reached via
+/// `lines.get(line_idx)` returning `None` on a malformed corpus, where a split
+/// clones a default line.
 fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta) -> Vec<Line> {
-    let mut lines = old_lines;
+    let cap = old_lines.len();
+    let mut rest = old_lines.into_iter();
+    let mut out: Vec<Line> = Vec::with_capacity(cap);
+    let mut cur: Option<Line> = rest.next();
     let mut old = 0usize;
-    let mut line_idx = 0usize;
 
     for op in &delta.ops {
         match op {
@@ -658,7 +673,8 @@ fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta)
                         break;
                     }
                     if old_chars[old] == '\n' {
-                        line_idx += 1;
+                        out.extend(cur.take());
+                        cur = rest.next();
                     }
                     old += 1;
                 }
@@ -668,8 +684,11 @@ fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta)
                     if old >= old_chars.len() {
                         break;
                     }
-                    if old_chars[old] == '\n' && line_idx + 1 < lines.len() {
-                        lines.remove(line_idx + 1);
+                    // A deleted '\n' merges the next original into `cur` — drop
+                    // it. No next original: nothing to remove, matching the old
+                    // `line_idx + 1 < lines.len()` guard skipping the `remove`.
+                    if old_chars[old] == '\n' {
+                        rest.next();
                     }
                     old += 1;
                 }
@@ -677,24 +696,25 @@ fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta)
             Op::Insert(s) => {
                 for c in s.chars() {
                     if c == '\n' {
-                        let template = lines
-                            .get(line_idx)
-                            .cloned()
-                            .unwrap_or_else(default_para_line);
-                        let mut new_line = template;
+                        let mut new_line = match cur.take() {
+                            Some(line) => {
+                                let clone = line.clone();
+                                out.push(line);
+                                clone
+                            }
+                            None => default_para_line(),
+                        };
                         new_line.continues = false;
-                        if line_idx < lines.len() {
-                            lines.insert(line_idx + 1, new_line);
-                        } else {
-                            lines.push(new_line);
-                        }
-                        line_idx += 1;
+                        cur = Some(new_line);
                     }
                 }
             }
         }
     }
-    lines
+
+    out.extend(cur);
+    out.extend(rest);
+    out
 }
 
 /// Walk `delta` over `old_chars` and drop any island whose [`ISLAND_SLOT`] char
@@ -1284,5 +1304,164 @@ mod tests {
         );
         assert!(matches!(err, Err(ApplyError::MarkOutOfRange { .. })));
         assert_eq!(rt, before, "failed bundle must not mutate the content");
+    }
+
+    // ── sync_lines_for_delta characterization (issue #926 finding 2) ─────────
+    //
+    // Pin the observable behavior of the line-sync walk — retain/insert/delete
+    // interleavings, the split template-clone rule, and the malformed-corpus
+    // guards — so the O(n)-per-remove → O(1) rewrite is behavior-preserving.
+
+    /// A `Heading{level}` line, its level a visible tag so a test can trace
+    /// which original line landed where; `continues` distinguishes a clone.
+    fn tag_line(level: u8, continues: bool) -> Line {
+        Line {
+            kind: LineKind::Heading { level },
+            containers: Vec::new(),
+            continues,
+        }
+    }
+
+    /// `(tag, continues)` per line — `Heading{level}` reads its level, `Para` is
+    /// tag 0 (the default line), any other kind is 255.
+    fn tags(lines: &[Line]) -> Vec<(u8, bool)> {
+        lines
+            .iter()
+            .map(|l| match l.kind {
+                LineKind::Heading { level } => (level, l.continues),
+                LineKind::Para => (0, l.continues),
+                _ => (255, l.continues),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn sync_lines_retain_only_is_identity() {
+        let old_chars: Vec<char> = "a\nb\nc".chars().collect();
+        let lines = vec![tag_line(1, false), tag_line(2, false), tag_line(3, false)];
+        let d = Delta {
+            ops: vec![Op::Retain(5)],
+        };
+        assert_eq!(sync_lines_for_delta(&old_chars, lines.clone(), &d), lines);
+    }
+
+    #[test]
+    fn sync_lines_insert_newline_clones_split_line_and_clears_continues() {
+        // Split line 1 ("bc") mid-line: the first half stays the original line
+        // (keeps kind, containers, and its `continues: true`); the second half
+        // is a clone of it with `continues` forced false.
+        let old_chars: Vec<char> = "a\nbc".chars().collect();
+        let l1 = Line {
+            kind: LineKind::Heading { level: 5 },
+            containers: vec![Container::Quote],
+            continues: true,
+        };
+        let lines = vec![tag_line(1, false), l1.clone()];
+        // Retain(3)[a\nb] moves to line 1; Insert("\n") splits it; Retain(1)[c].
+        let d = Delta {
+            ops: vec![Op::Retain(3), Op::Insert("\n".into()), Op::Retain(1)],
+        };
+        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[1], l1, "first half is the untouched original line");
+        assert_eq!(out[2].kind, LineKind::Heading { level: 5 });
+        assert_eq!(out[2].containers, vec![Container::Quote]);
+        assert!(!out[2].continues, "the split clone starts a new block");
+    }
+
+    #[test]
+    fn sync_lines_delete_newline_drops_following_line() {
+        // Delete the first '\n' of "a\nb\nc": lines 0 and 1 merge, dropping line
+        // 1; the current line (0) and line 2 survive.
+        let old_chars: Vec<char> = "a\nb\nc".chars().collect();
+        let lines = vec![tag_line(1, false), tag_line(2, false), tag_line(3, false)];
+        let d = Delta {
+            ops: vec![Op::Retain(1), Op::Delete(1), Op::Retain(3)],
+        };
+        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        assert_eq!(tags(&out), vec![(1, false), (3, false)]);
+    }
+
+    #[test]
+    fn sync_lines_delete_trailing_newline_without_following_line_is_guarded() {
+        // Malformed corpus: text "a\n" is two segments but `lines` has one
+        // entry. Deleting the '\n' when `line_idx + 1` is out of bounds removes
+        // nothing (the guard), leaving the single line intact.
+        let old_chars: Vec<char> = "a\n".chars().collect();
+        let lines = vec![tag_line(1, false)];
+        let d = Delta {
+            ops: vec![Op::Retain(1), Op::Delete(1)],
+        };
+        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        assert_eq!(tags(&out), vec![(1, false)]);
+    }
+
+    #[test]
+    fn sync_lines_stops_at_end_of_old_chars() {
+        // A retain running past the end of old_chars stops at the end rather
+        // than indexing out of bounds (the `old >= old_chars.len()` guard).
+        let old_chars: Vec<char> = "a\nb".chars().collect();
+        let lines = vec![tag_line(1, false), tag_line(2, false)];
+        let d = Delta {
+            ops: vec![Op::Retain(99)],
+        };
+        assert_eq!(sync_lines_for_delta(&old_chars, lines.clone(), &d), lines);
+    }
+
+    #[test]
+    fn sync_lines_insert_two_newlines_adds_two_clones() {
+        // Inserting "\n\n" mid-line adds two lines, each carrying the split
+        // line's kind and containers with `continues: false`.
+        let old_chars: Vec<char> = "abc".chars().collect();
+        let src = Line {
+            kind: LineKind::Heading { level: 7 },
+            containers: vec![Container::Quote],
+            continues: false,
+        };
+        let d = Delta {
+            ops: vec![Op::Retain(1), Op::Insert("\n\n".into()), Op::Retain(2)],
+        };
+        let out = sync_lines_for_delta(&old_chars, vec![src], &d);
+        assert_eq!(out.len(), 3);
+        for l in &out {
+            assert_eq!(l.kind, LineKind::Heading { level: 7 });
+            assert_eq!(l.containers, vec![Container::Quote]);
+            assert!(!l.continues);
+        }
+    }
+
+    #[test]
+    fn sync_lines_select_all_delete_collapses_to_first_line() {
+        // The motivating case (issue #926 finding 2): deleting a whole
+        // multi-line body drops every line but the first (each deleted '\n'
+        // merges the next line away). Formerly O(n) per deleted '\n'.
+        let text: String = (0..50).map(|i| format!("line{i}\n")).collect();
+        let old_chars: Vec<char> = text.chars().collect();
+        let lines: Vec<Line> = (0..=50).map(|i| tag_line((i % 200) as u8, false)).collect();
+        assert_eq!(lines.len(), old_chars.iter().filter(|&&c| c == '\n').count() + 1);
+        let d = Delta {
+            ops: vec![Op::Delete(old_chars.len())],
+        };
+        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        assert_eq!(tags(&out), vec![(0, false)], "only the first line survives");
+    }
+
+    #[test]
+    fn sync_lines_insert_newline_past_end_appends_default() {
+        // Malformed corpus: after a retain walks past the sole line (line_idx ==
+        // lines.len()), an inserted '\n' has no line to clone and appends a
+        // default Para.
+        let old_chars: Vec<char> = "a\n".chars().collect();
+        let lines = vec![tag_line(1, false)];
+        // Retain(2)[a\n] moves line_idx to 1 (== lines.len()); Insert("\n").
+        let d = Delta {
+            ops: vec![Op::Retain(2), Op::Insert("\n".into())],
+        };
+        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        assert_eq!(out.len(), 2);
+        assert_eq!(tags(&out)[0], (1, false));
+        assert_eq!(out[1].kind, LineKind::Para);
+        assert!(out[1].containers.is_empty());
+        assert!(!out[1].continues);
     }
 }

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -353,12 +353,11 @@ impl Content {
         let delta = sanitized.as_ref();
 
         let old_chars: Vec<char> = self.text.chars().collect();
-        // A splice may name only the region it changes: pad a short delta with a
-        // trailing retain over the untouched remainder so a bare prepend applies
-        // against the whole content. An over-long delta still fails the check.
-        let extended = delta.extend_to_base(old_chars.len());
-        let delta = extended.as_ref();
         let old_lines = self.lines.clone();
+        // A splice may name only the region it changes: `try_apply` retains the
+        // untouched remainder implicitly, so a bare prepend applies against the
+        // whole content. An over-long delta (consuming more base than exists)
+        // still fails the base-length check.
         let new_text = delta
             .try_apply(&self.text)
             .map_err(|e| ApplyError::DeltaBaseMismatch {

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -467,13 +467,13 @@ proptest! {
         }
     }
 
-    /// `apply_line_ops` preserves the structural invariants (line/segment sync
-    /// and island/slot sync) across an accepted split/join/set-kind. Marks are
-    /// cleared first: a split/join splices `\n` without rebasing marks (mark
-    /// rebasing rides the text-delta channel, per the `ops` module docs), so
-    /// asserting mark-range preservation here would test a guarantee this
-    /// channel does not make. Splicing `\n` never adds or removes a slot, so
-    /// island sync is a genuine post-condition to check.
+    /// `apply_line_ops` preserves `validate()` across an accepted
+    /// split/join/set-kind — line/segment sync, island/slot sync, and (marks
+    /// left in place) mark ranges. Split/join splice a `\n` and rebase marks
+    /// through that one-char change (`Delta::map_pos` semantics), so the
+    /// rebased marks must still normalize to a valid set; keeping the imported
+    /// marks exercises that remap in the fuzzer. Splicing `\n` never adds or
+    /// removes a slot, so island sync is a genuine post-condition too.
     #[test]
     fn apply_line_ops_preserves_validate(
         md in document(),
@@ -482,7 +482,6 @@ proptest! {
         which in 0u8..3,
     ) {
         let mut rt = from_markdown(&md).unwrap();
-        rt.marks.clear();
         let len = rt.len_usv();
         let nlines = rt.lines.len().max(1);
         let op = match which {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -762,9 +762,9 @@ impl Card {
     }
 
     /// Apply a committed field-change bundle to the body content — the native
-    /// form-editor writer. Order is text delta → line ops → mark ops, each
-    /// followed by normalization ([`Content::apply_field_change`]); mark
-    /// ranges are in post-text-delta coordinates. Returns
+    /// form-editor writer. Order is text delta → line ops → mark ops, then one
+    /// terminal normalization ([`Content::apply_field_change`]); mark ranges are
+    /// in final-text coordinates. Returns
     /// [`EditError::CorpusApply`] when an op is out of bounds; the apply is
     /// all-or-nothing ([`Content::apply_field_change`]), so the body is
     /// unchanged on error — apply the bundle against the body the delta was


### PR DESCRIPTION
## Summary

Refactors mark rebasing and bundle normalization to fix mark coordinate drift when line ops (split/join) modify text. Previously, line ops spliced `\n` without rebasing marks, causing marks to drift relative to the text they covered. Now marks are rebased through the one-character `\n` insertion/deletion using the same `Delta::map_pos` semantics as the text-delta channel, ensuring coordinates track the splice rather than drifting.

Additionally, collapses the three per-stage normalizations in `apply_field_change` into a single terminal normalization, improving performance and simplifying the contract. This is behavior-preserving because the mark remap makes `normalize`'s formatting-edge `\n`-trim commute with line ops, and `MarkOp::Remove` is coverage-set subtraction, which commutes with the union operations `normalize` performs.

## Key Changes

- **Mark rebasing through line ops**: `split_line` and `join_line` now call `rebase_marks` with a synthetic delta representing the one-character `\n` insertion/deletion, using `Delta::map_pos` to update mark coordinates. This ensures marks spanning the split/join point grow/shrink correctly rather than drifting.

- **Extracted inner apply methods**: Created `apply_text_delta_inner`, `apply_line_ops_inner`, and `apply_mark_ops_inner` that skip the terminal `normalize()`. The public wrappers call these inner forms and normalize, while `apply_field_change` calls the inner forms and normalizes once at the end.

- **Extracted `rebase_marks` helper**: Centralized mark rebasing logic (point marks bias `Before`, range marks bias `After`/`Before`) into a reusable method called by both text-delta application and line ops.

- **Optimized `sync_lines_for_delta`**: Rewrote the line-sync walk to build output in one forward pass using an iterator over the old lines, eliminating O(n) per-`\n` mid-`Vec` `remove`/`insert` operations. The cursor sits in a line; retained/deleted/inserted `\n` events reduce to finalizing the current line and pulling/dropping/cloning the next original.

- **Relaxed `Delta::try_apply` contract**: Removed `extend_to_base` and changed `try_apply` to accept short deltas (ops consuming less base than exists) with implicit trailing retain, matching `map_pos`'s contract. Over-consumption still errors; under-consumption is accepted. `apply` now panics on over-long deltas instead of clamping silently.

- **Updated documentation**: Clarified that mark ranges are in "final-text coordinates" (post-delta, post-line-op) and explained the remap semantics and normalization collapse proof.

## Notable Implementation Details

- The mark remap through line ops uses the same `Delta::map_pos` rule as the text-delta channel: point marks (zero-width) bias `Before`, range marks bias `After` at start and `Before` at end. This ensures insertions at mark edges grow text *outside* the span.

- The normalization collapse is behavior-preserving because:
  - `normalize`'s `\n`-trim at formatting edges commutes with line ops (trim-per-stage and trim-once converge)
  - `MarkOp::Remove` is coverage-set subtraction: `(A ∪ B) \ R = (A\R) ∪ (B\R)` (commutes with union)
  - One canonicalization point, one pass

- The `sync_lines_for_delta` rewrite maintains all observable behavior (retain/insert/delete interleavings, split template-clone rule, malformed-corpus guards) while improving from O(n) per deleted `\n` to O(1) per operation.

- Added comprehensive characterization tests for `sync_lines_for_delta` and mark remap behavior to pin the observable semantics of the refactored code.

https://claude.ai/code/session_01SApHnJx3oZMhVx8rtWAjaA