### PR TITLE
Python binding: commit to the Tier-1 surface (#970)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,13 +140,19 @@ jobs:
         with:
           enable-cache: true
 
-      # Builds the pyo3 extension (maturin backend) and installs pytest + the
-      # Tier-1 binding into a fresh venv — the documented dev flow (README).
-      - name: Build extension + install dev deps
+      # `maturin develop` builds the pyo3 extension in the DEBUG (dev) profile —
+      # far faster to compile than the release build a `pip install -e` (maturin
+      # PEP-517 default) would trigger, and opt-level is irrelevant to test
+      # outcomes. Matches `cargo test --workspace` (also debug) and the documented
+      # dev flow (CLAUDE.md / README). The top-level CARGO_PROFILE_DEV_DEBUG=0 env
+      # strips debuginfo, so this stays lean.
+      - name: Build extension (debug)
         working-directory: crates/bindings/python
         run: |
           uv venv --python 3.12
-          uv pip install -e ".[dev]"
+          source .venv/bin/activate
+          uv pip install pytest maturin
+          maturin develop
 
       - name: Test Python
         working-directory: crates/bindings/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,31 @@ jobs:
         working-directory: crates/bindings/wasm
         run: npm run typecheck
 
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      # Builds the pyo3 extension (maturin backend) and installs pytest + the
+      # Tier-1 binding into a fresh venv — the documented dev flow (README).
+      - name: Build extension + install dev deps
+        working-directory: crates/bindings/python
+        run: |
+          uv venv --python 3.12
+          uv pip install -e ".[dev]"
+
+      - name: Test Python
+        working-directory: crates/bindings/python
+        run: .venv/bin/pytest -q
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,6 @@ version = "0.94.0"
 dependencies = [
  "pyo3",
  "quillmark",
- "quillmark-content",
  "quillmark-core",
  "serde_json",
 ]

--- a/crates/bindings/python/Cargo.toml
+++ b/crates/bindings/python/Cargo.toml
@@ -14,7 +14,4 @@ crate-type = ["cdylib"]
 pyo3 = { version = "~0.26", features = ["extension-module", "abi3-py310"] }
 quillmark = { workspace = true, default-features = true }
 quillmark-core = { workspace = true }
-# The content codec (import_markdown / export_markdown / rebase / map_pos) and
-# the change-bundle op wire; the addressed write surface lowers to it.
-quillmark-content = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -34,11 +34,20 @@ result.artifacts[0].save("output.pdf")
 
 ## API surface
 
-The Python surface mirrors the [`@quillmark/wasm`](../wasm) package for the
-shared document model. Names follow `snake_case` conventions; the underlying
-concepts (and shapes of return values) are the same. Python renders in one
-shot via `engine.render`; the iterative render-session and canvas-preview
-surface is WASM-only (see `prose/canon/PREVIEW.md`).
+Python is a **Tier-1 binding**: field I/O flows through `quill.writer(doc)` and
+`quill.view(doc)`, the schema-bound write/read front doors. `Document` carries
+the quill-free surface — parse, storage, structure, `$ext` / `$seed`, and
+`remove_field`. There is no opaque field store and no anchor-preserving content
+lane (`install` / `revise` / `apply_change` + the `import_markdown` /
+`export_markdown` / `rebase` / `map_pos` codec); those are WASM-only by scope,
+serving live editors that Python does not target. See
+[`prose/canon/BINDINGS.md`](../../../prose/canon/BINDINGS.md).
+
+Names follow `snake_case`; the shared model (the `Document` / `Card` shapes,
+`Diagnostic`s, the storage DTO) is identical to the
+[`@quillmark/wasm`](../wasm) package's. Python renders in one shot via
+`engine.render`; the iterative render-session and canvas-preview surface is
+WASM-only (see `prose/canon/PREVIEW.md`).
 
 **Capability principle:** a `Quill` is portable, declarative config data —
 `quill.metadata` is a pure, infallible snapshot of the `quill:` section.
@@ -71,6 +80,43 @@ diags   = quill.validate(parsed)          # list of validation::* diagnostic dic
 seed    = quill.seed_document()           # starter Document seeded from `example:` values
 main    = quill.seed_main()               # just the $kind: main card (dict, like doc.main)
 card    = quill.seed_card("note")         # one starter composable card (dict), None if kind undeclared
+
+writer  = quill.writer(doc)               # schema-bound typed write front door
+reader  = quill.view(doc)                 # schema-bound interpreted read front door
+```
+
+### `Writer` — `quill.writer(doc)`
+
+The typed write front door. Resolves each field's type from the bound quill, so a
+name the schema does not declare is a typo (`UnknownField`), not a fallback. Holds
+both handles by reference and owns neither — ephemeral by convention: bind, write,
+discard.
+
+```python
+w = quill.writer(doc)
+w.set("title", "On Taro")                 # typed-commit one field (mismatch raises now)
+w.set_all({"title": "T", "author": "A"})  # atomic batch; one diagnostic per bad field
+w.set_body("A **taro** essay.")           # typed body write (edit semantics)
+w.revise_field("bio", "make it **bold**") # typed *and* anchor-preserving richtext write
+w.add_card("quotes", {"author": "Basho"}, "…", at=None)  # make + typed commit + insert (at appends/inserts)
+w.remove_card(0)
+w.card(0).set("author", "Issa")           # a CardWriter: .index, .kind, .set, .set_all, .set_body, .revise_field
+```
+
+### `View` — `quill.view(doc)`
+
+The interpreted read front door and the read twin of `Writer`. One `get` reads
+each field by its declared type: a richtext field to its markdown projection,
+every other type its canonical value verbatim.
+
+```python
+v = quill.view(doc)
+v.get("bio")                              # richtext → markdown str; scalar → its value; absent → None
+                                          # undeclared name raises UnknownField; undecodable content raises FieldRichtextDecode
+v.get_body()                              # the main body markdown (quill-free body read)
+v.card(0).kind                            # the composable card's $kind
+v.card(0).get("author")                   # a card field, interpreted by its $kind schema
+v.card(0).get_body()
 ```
 
 ### `RenderResult` / `Artifact`
@@ -108,14 +154,26 @@ Document.blueprint_instruction("taro")           # LLM/MCP blueprint header for 
 doc.clone()
 doc.equals(other)
 doc.card_count
-doc.main; doc.cards; doc.body; doc.warnings
+doc.main; doc.cards; doc.body; doc.warnings      # total-read snapshots (dicts); body is a content dict
+doc.set_quill_ref("other@1.0")
 
-doc.store_field("title", "New")                  # opaque store (store = verbatim; the typed write is the writer)
-doc.store_fields({"title": "New", "author": "A"})  # atomic batch; one diagnostic per bad field
-doc.push_card(Document.make_card("note", {"x": 1}, "..."))  # or pass a Card from cards/remove_card/seed_card
-# insert_card, remove_card, move_card, set_card_kind,
-# store_card_field, store_card_fields, remove_card_field, replace_card_body, ...
+# Structure (quill-free — a card kind is a name, not a schema fact):
+doc.insert_card(Document.make_card("note", {"x": 1}, "..."), at=None)  # at appends/inserts
+doc.remove_card(0)                               # returns the Card dict, or None
+doc.move_card(2, 0); doc.set_card_kind(0, "summary")
+doc.remove_field("title")                        # remove has no lane; card=i targets a composable card
+
+# Out-of-band consumer state (never rendered):
+doc.store_ext({"agent": {"pinned": True}})       # whole $ext map; card=i for a composable card
+doc.store_ext_namespace("agent", {"n": 1})       # one slot, siblings preserved; card=i too
+doc.remove_ext_namespace("agent"); doc.remove_ext()
+doc.store_seed_namespace("note", {"tag": "T"})   # per-kind $seed overlay; new cards spawn with it
+doc.remove_seed_namespace("note")
 ```
+
+Setting a field's value is the writer's job (`quill.writer(doc).set(...)`) — a
+field write needs the schema, and `Document` is quill-free. Reading a field's
+interpreted value is the view's (`quill.view(doc).get(...)`).
 
 ## Schema model
 

--- a/crates/bindings/python/python/quillmark/__init__.py
+++ b/crates/bindings/python/python/quillmark/__init__.py
@@ -2,6 +2,8 @@
 
 from ._quillmark import (
     Artifact,
+    CardView,
+    CardWriter,
     Diagnostic,
     Document,
     Location,
@@ -11,14 +13,14 @@ from ._quillmark import (
     QuillmarkError,
     RenderResult,
     Severity,
-    import_markdown,
-    export_markdown,
-    rebase,
-    map_pos,
+    View,
+    Writer,
 )
 
 __all__ = [
     "Artifact",
+    "CardView",
+    "CardWriter",
     "Diagnostic",
     "Document",
     "Location",
@@ -28,10 +30,14 @@ __all__ = [
     "QuillmarkError",
     "RenderResult",
     "Severity",
-    "import_markdown",
-    "export_markdown",
-    "rebase",
-    "map_pos",
+    "View",
+    "Writer",
 ]
 
-__version__ = "0.1.0"
+try:
+    from importlib.metadata import version as _version
+
+    __version__ = _version("quillmark")
+except Exception:  # pragma: no cover — source tree without installed metadata
+    __version__ = "0.0.0"
+

--- a/crates/bindings/python/src/lib.rs
+++ b/crates/bindings/python/src/lib.rs
@@ -11,6 +11,11 @@ pub use types::{
     PyQuillmark, PyRenderResult, PyView, PyWriter,
 };
 
+// Python is Tier 1 + storage + render: field I/O flows through `quill.writer(doc)`
+// / `quill.view(doc)`. The opaque store and the anchor-preserving content lane
+// (`install` / `revise` / `apply_change` + the `importMarkdown` / `exportMarkdown`
+// / `rebase` / `mapPos` codec) are WASM-only by scope. See prose/canon/BINDINGS.md.
+
 #[pymodule]
 fn _quillmark(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyQuillmark>()?;
@@ -27,13 +32,6 @@ fn _quillmark(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<PyOutputFormat>()?;
     m.add_class::<PySeverity>()?;
-
-    // The document-free content codec — the on-demand markdown projection
-    // (`export_markdown`) plus `import_markdown` / `rebase` / `map_pos`.
-    m.add_function(wrap_pyfunction!(types::import_markdown, m)?)?;
-    m.add_function(wrap_pyfunction!(types::export_markdown, m)?)?;
-    m.add_function(wrap_pyfunction!(types::rebase, m)?)?;
-    m.add_function(wrap_pyfunction!(types::map_pos, m)?)?;
 
     m.add("QuillmarkError", m.py().get_type::<QuillmarkError>())?;
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -423,88 +423,13 @@ impl PyDocument {
     }
 
     /// Main card's global body as canonical Content-JSON — the source-of-truth
-    /// content model (a content dict, `{text, lines, marks, islands}`). For the
-    /// markdown projection call the codec `export_markdown(doc.body)`.
+    /// content model (a content dict, `{text, lines, marks, islands}`). The
+    /// quill-free total-read snapshot; for the markdown projection use
+    /// `quill.view(doc).get_body()`.
     #[getter]
     fn body<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let wire = quillmark_core::CardWire::from(self.inner.main());
         json_to_py(py, &wire.body)
-    }
-
-    /// **Install** a richtext value at the address `(card, field)` — value
-    /// semantics, content only. `rt` is a canonical content dict; the identity
-    /// anchors of any previous value are gone. An absent `field` targets the
-    /// body, an absent `card` the main card. For "here's new markdown," use
-    /// [`revise`](Self::revise); the cold path is `install(import_markdown(md))`,
-    /// which spells anchor loss at the call site. The kwargs idiom of WASM
-    /// `doc.install(addr, rt)`. Raises on an out-of-range card, a malformed field
-    /// name, or an `rt` that is not a canonical content dict.
-    #[pyo3(signature = (rt, card=None, field=None))]
-    fn install(
-        &mut self,
-        rt: Bound<'_, PyAny>,
-        card: Option<usize>,
-        field: Option<&str>,
-    ) -> PyResult<()> {
-        let content = py_to_content(&rt)?;
-        let target = self.addr_card_mut(card)?;
-        match field {
-            None => {
-                target.install_body(content);
-                Ok(())
-            }
-            Some(name) => target.install_field(name, content).map_err(convert_edit_error),
-        }
-    }
-
-    /// **Revise** the richtext value at `(card, field)` from a markdown string —
-    /// edit semantics, the default write path, returning the text `Delta` dict.
-    /// Imports the markdown, diffs it against the current value, rebases surviving
-    /// anchors, and returns the change to map positions through (`map_pos`). An
-    /// absent `field` targets the body, an absent `card` the main card; an absent
-    /// field cold-imports from empty. The kwargs idiom of WASM
-    /// `doc.revise(addr, md)`. Raises on an out-of-range card, a malformed field
-    /// name, a present non-content field value, or an over-nested markdown input.
-    #[pyo3(signature = (markdown, card=None, field=None))]
-    fn revise<'py>(
-        &mut self,
-        py: Python<'py>,
-        markdown: &str,
-        card: Option<usize>,
-        field: Option<&str>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let target = self.addr_card_mut(card)?;
-        let delta = match field {
-            None => target.revise_body(markdown),
-            Some(name) => target.revise_field(name, markdown),
-        }
-        .map_err(convert_edit_error)?;
-        json_to_py(py, &delta_to_json(&delta))
-    }
-
-    /// **Apply** a committed content edit `bundle` (`{delta?, line_ops?, mark_ops?}`)
-    /// at `(card, field)` — the editor splice: text delta, then line ops, then
-    /// mark ops (mark ranges in final-text coordinates), each all-or-nothing. An
-    /// absent `field` targets the body, an absent `card` the main card. The kwargs
-    /// idiom of WASM `doc.applyChange(addr, bundle)`. Raises on an out-of-range
-    /// card, a field that is not richtext, a malformed bundle, or an out-of-bounds
-    /// op (the value is unchanged on a failed apply).
-    #[pyo3(signature = (bundle, card=None, field=None))]
-    fn apply_change(
-        &mut self,
-        bundle: Bound<'_, PyAny>,
-        card: Option<usize>,
-        field: Option<&str>,
-    ) -> PyResult<()> {
-        let (delta, line_ops, mark_ops) = parse_change_bundle(&bundle)?;
-        let target = self.addr_card_mut(card)?;
-        match field {
-            None => target.apply_body_change(&delta, &line_ops, &mark_ops),
-            Some(name) => {
-                target.apply_field_richtext_change(name, &delta, &line_ops, &mark_ops)
-            }
-        }
-        .map_err(convert_edit_error)
     }
 
     /// Main (entry) card as a dict with `kind`, `quill`, `id`, `payload_items`,
@@ -525,102 +450,19 @@ impl PyDocument {
     }
 
 
-    /// Read a main-card field's stored value — a dict for a richtext content, a
-    /// scalar/list/dict otherwise, or `None` when the field is absent. The
-    /// quill-free transport read: it needs no schema, so it lives on `Document`,
-    /// not the typed writer. For the interpreted read (a richtext field projected
-    /// to markdown, a scalar as its value) use `quill.view(doc).get(name)`.
-    /// Mirrors WASM `Document.get`.
-    fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
-        match self.inner.main().payload().get(name) {
-            Some(v) => Ok(Some(quillvalue_to_py(py, v)?)),
-            None => Ok(None),
-        }
-    }
-
-    /// The main **body**'s markdown projection — the on-demand, lossy export
-    /// (content-only marks do not survive markdown). A body's type is a format
-    /// fact, not a schema fact, so this read stays quill-free. A field's markdown
-    /// is read through the schema-plane `quill.view(doc).get(name)`, which
-    /// interprets by declared type (#978). Mirrors WASM `Document.getMarkdown`.
-    fn get_markdown(&self) -> String {
-        self.inner.main().body_markdown()
-    }
-
-    /// Read a composable card's field value — the card-indexed twin of `get`: a
-    /// dict for a richtext content, a scalar/list/dict otherwise, or `None` when
-    /// the field is absent. An out-of-range `index` raises `IndexOutOfRange`, as
-    /// the card write verbs do — a bad index is a boundary error, not an absent
-    /// field. Mirrors WASM `Document.getCardField`.
-    fn get_card_field<'py>(
-        &self,
+    /// Remove a payload field, returning its previous value (or `None` when
+    /// absent). `card` selects the target: `None` the main card, `Some(i)` the
+    /// composable card at `i` (out-of-range raises `IndexOutOfRange`). `remove`
+    /// has no lane — one verb serves every write path.
+    #[pyo3(signature = (name, card=None))]
+    fn remove_field<'py>(
+        &mut self,
         py: Python<'py>,
-        index: usize,
         name: &str,
-    ) -> PyResult<Option<Bound<'py, PyAny>>> {
-        match self.card_or_raise(index)?.payload().get(name) {
-            Some(v) => Ok(Some(quillvalue_to_py(py, v)?)),
-            None => Ok(None),
-        }
-    }
-
-    /// A composable card's **body** markdown — the card-indexed twin of
-    /// `get_markdown`. A card field's markdown is read through
-    /// `quill.view(doc).card(index).get(name)` (#978). An out-of-range `index`
-    /// raises `IndexOutOfRange`. Mirrors WASM `Document.getCardMarkdown`.
-    fn get_card_markdown(&self, index: usize) -> PyResult<String> {
-        Ok(self.card_or_raise(index)?.body_markdown())
-    }
-
-    /// Store an opaque value on a main-card field, clearing any `!must_fill`
-    /// marker. The quill-free primitive: it holds only the `$quill` *reference*,
-    /// stores the value verbatim, and defers coercion/validation to render.
-    /// Reach for it deliberately — standalone data with no quill in hand,
-    /// quill-agnostic storage/migration, or a store-now-validate-later editor
-    /// holding not-yet-conforming input. When a quill *is* in hand, prefer the
-    /// typed writer (`quill.writer(doc).set(name, value)`) so a mismatch surfaces
-    /// at the write. Raises `QuillmarkError` on a malformed name. Mirrors WASM
-    /// `storeField`.
-    fn store_field(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let qv = py_to_quillvalue(&value)?;
-        self.inner
-            .main_mut()
-            .store_field(name, qv)
-            .map_err(convert_edit_error)
-    }
-
-    fn store_fill(&mut self, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let qv = py_to_quillvalue(&value)?;
-        self.inner
-            .main_mut()
-            .store_fill(name, qv)
-            .map_err(convert_edit_error)
-    }
-
-    /// Set several main-card payload fields atomically from a mapping,
-    /// clearing any `!must_fill` marker on each key. Nothing is applied on
-    /// error; the raised `QuillmarkError` carries one diagnostic per
-    /// offending field (`path` = field name), so externally-sourced names
-    /// (database columns, form keys) surface every violation in one pass.
-    ///
-    /// The batched quill-free primitive (see `store_field`) — stores every value
-    /// opaquely, deferring coercion to render. Prefer the typed writer
-    /// (`quill.writer(doc).set_all(fields)`) whenever a quill is in hand: it
-    /// typed-commits the batch and reports per-field routing, so a form
-    /// submitting a card is not silently stripped of schema typing. Mirrors WASM
-    /// `storeFields`.
-    fn store_fields(&mut self, fields: Bound<'_, PyDict>) -> PyResult<()> {
-        let batch = pydict_to_field_batch(&fields)?;
-        self.inner
-            .main_mut()
-            .store_fields(batch)
-            .map_err(convert_edit_errors)
-    }
-
-    fn remove_field<'py>(&mut self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        card: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         match self
-            .inner
-            .main_mut()
+            .addr_card_mut(card)?
             .remove_field(name)
             .map_err(convert_edit_error)?
         {
@@ -629,49 +471,67 @@ impl PyDocument {
         }
     }
 
-    /// Replace the opaque `$ext` map on the main card. `value` must be a dict;
-    /// raises `ValueError` otherwise. `$ext` carries out-of-band consumer state
-    /// and never reaches the rendered output. Pass `{}` for an explicit empty
-    /// `$ext`.
-    fn store_ext(&mut self, value: Bound<'_, PyAny>) -> PyResult<()> {
+    /// Replace the opaque `$ext` map on a card. `value` must be a dict; raises
+    /// `ValueError` otherwise. `card` selects the target: `None` the main card,
+    /// `Some(i)` the composable card at `i` (out-of-range raises `IndexOutOfRange`).
+    /// `$ext` carries out-of-band consumer state and never reaches the rendered
+    /// output; pass `{}` for an explicit empty `$ext`. Prefer `store_ext_namespace`
+    /// to write one slot without clobbering sibling consumers'.
+    #[pyo3(signature = (value, card=None))]
+    fn store_ext(&mut self, value: Bound<'_, PyAny>, card: Option<usize>) -> PyResult<()> {
         let map = py_to_object(&value, "store_ext")?;
-        self.inner
-            .main_mut()
+        self.addr_card_mut(card)?
             .store_ext(map)
             .map_err(convert_edit_error)?;
         Ok(())
     }
 
-    /// Remove the `$ext` map from the main card *entirely*, returning the
-    /// previous map or `None`. This is a blunt escape hatch that discards every
-    /// namespace at once — prefer `remove_ext_namespace` to clear only your own
-    /// slot while leaving sibling consumers' state intact.
-    fn remove_ext<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        ext_map_to_py(py, self.inner.main_mut().remove_ext())
+    /// Remove the `$ext` map from a card *entirely*, returning the previous map or
+    /// `None`. `card` selects the target (`None` main, `Some(i)` composable,
+    /// out-of-range raises). A blunt escape hatch that discards every namespace at
+    /// once — prefer `remove_ext_namespace` to clear only your own slot.
+    #[pyo3(signature = (card=None))]
+    fn remove_ext<'py>(
+        &mut self,
+        py: Python<'py>,
+        card: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let prev = self.addr_card_mut(card)?.remove_ext();
+        ext_map_to_py(py, prev)
     }
 
-    /// Merge `value` into the main card's `$ext` map under `namespace`, creating
-    /// the map when absent and replacing any existing value at that key. Sibling
+    /// Merge `value` into a card's `$ext` map under `namespace`, creating the map
+    /// when absent and replacing any existing value at that key. Sibling
     /// namespaces are preserved so independent consumers don't clobber each other.
-    fn store_ext_namespace(&mut self, namespace: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
+    /// `card` selects the target (`None` main, `Some(i)` composable, out-of-range
+    /// raises).
+    #[pyo3(signature = (namespace, value, card=None))]
+    fn store_ext_namespace(
+        &mut self,
+        namespace: &str,
+        value: Bound<'_, PyAny>,
+        card: Option<usize>,
+    ) -> PyResult<()> {
         let json = py_to_json(&value)?;
-        self.inner
-            .main_mut()
+        self.addr_card_mut(card)?
             .store_ext_namespace(namespace, json)
             .map_err(convert_edit_error)?;
         Ok(())
     }
 
-    /// Remove `namespace` from the main card's `$ext` map, returning the value
-    /// stored there or `None`. This is the recommended way to clear `$ext`
-    /// state: sibling namespaces survive, and when the last namespace is removed
-    /// the `$ext` entry is dropped entirely (not left as `$ext: {}`).
+    /// Remove `namespace` from a card's `$ext` map, returning the value stored
+    /// there or `None`; sibling namespaces survive, and the `$ext` entry drops
+    /// entirely once its last namespace is removed (not left as `$ext: {}`).
+    /// `card` selects the target (`None` main, `Some(i)` composable, out-of-range
+    /// raises).
+    #[pyo3(signature = (namespace, card=None))]
     fn remove_ext_namespace<'py>(
         &mut self,
         py: Python<'py>,
         namespace: &str,
+        card: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        ext_value_to_py(py, self.inner.main_mut().remove_ext_namespace(namespace))
+        ext_value_to_py(py, self.addr_card_mut(card)?.remove_ext_namespace(namespace))
     }
 
     /// Merge a card-kind's seed `overlay` into the main card's `$seed` map
@@ -697,60 +557,6 @@ impl PyDocument {
         ext_value_to_py(py, self.inner.main_mut().remove_seed_namespace(card_kind))
     }
 
-    /// Replace the `$ext` map on the composable card at `index`. Raises on
-    /// out-of-range index or non-dict value. Named to mirror `store_ext` on the
-    /// main card; `set_card_ext_namespace` is the sibling-safe alternative.
-    fn store_card_ext(&mut self, index: usize, value: Bound<'_, PyAny>) -> PyResult<()> {
-        let map = py_to_object(&value, "store_card_ext")?;
-        self.card_mut_or_raise(index)?
-            .store_ext(map)
-            .map_err(convert_edit_error)?;
-        Ok(())
-    }
-
-    /// Remove the `$ext` map from the composable card at `index` *entirely*,
-    /// returning the previous map or `None`. Raises if `index` is out of range.
-    /// Prefer `remove_card_ext_namespace` to clear only one consumer's slot.
-    fn remove_card_ext<'py>(
-        &mut self,
-        py: Python<'py>,
-        index: usize,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let prev = self.card_mut_or_raise(index)?.remove_ext();
-        ext_map_to_py(py, prev)
-    }
-
-    /// Merge `value` into the composable card's `$ext` map under `namespace`,
-    /// preserving sibling namespaces. The card-indexed twin of
-    /// `store_ext_namespace`. Raises if `index` is out of range.
-    fn store_card_ext_namespace(
-        &mut self,
-        index: usize,
-        namespace: &str,
-        value: Bound<'_, PyAny>,
-    ) -> PyResult<()> {
-        let json = py_to_json(&value)?;
-        self.card_mut_or_raise(index)?
-            .store_ext_namespace(namespace, json)
-            .map_err(convert_edit_error)?;
-        Ok(())
-    }
-
-    /// Remove `namespace` from the composable card's `$ext` map, returning the
-    /// value stored there or `None`; clears `$ext` entirely once empty. The
-    /// card-indexed twin of `remove_ext_namespace`. Raises if out of range.
-    fn remove_card_ext_namespace<'py>(
-        &mut self,
-        py: Python<'py>,
-        index: usize,
-        namespace: &str,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let removed = self
-            .card_mut_or_raise(index)?
-            .remove_ext_namespace(namespace);
-        ext_value_to_py(py, removed)
-    }
-
     fn set_quill_ref(&mut self, ref_str: &str) -> PyResult<()> {
         let qr: quillmark_core::QuillReference = ref_str.parse().map_err(|e| {
             PyValueError::new_err(format!("invalid QuillReference '{}': {}", ref_str, e))
@@ -759,32 +565,11 @@ impl PyDocument {
         Ok(())
     }
 
-    /// **Deprecated** — alias for `revise(markdown)`, kept one release cycle.
-    /// Revise the main card's body from a markdown string (edit semantics, a
-    /// `diff_import` that rebases surviving anchors). Discards the text delta;
-    /// call [`revise`](Self::revise) to receive it.
-    fn replace_body(&mut self, body: &str) -> PyResult<()> {
-        self.inner
-            .main_mut()
-            .revise_body(body)
-            .map(|_| ())
-            .map_err(convert_edit_error)
-    }
-
-    /// **Deprecated** — alias for `revise(markdown, card=index)`, kept one
-    /// release cycle. Revise the composable card body from a markdown string.
-    fn update_card_body(&mut self, index: usize, body: &str) -> PyResult<()> {
-        self.card_mut_or_raise(index)?
-            .revise_body(body)
-            .map(|_| ())
-            .map_err(convert_edit_error)
-    }
-
     /// Build a fresh `Card` dict from a kind and a flat field mapping — the
-    /// ergonomic constructor for `push_card` / `insert_card`. `fields` maps
-    /// field name → value (each becomes a card field, in insertion order);
-    /// `body` defaults to `""`. Kind validity is checked by `push_card` /
-    /// `insert_card`, not here. Mirrors WASM `Document.makeCard`.
+    /// ergonomic constructor for `insert_card`. `fields` maps field name → value
+    /// (each becomes a card field, in insertion order); `body` defaults to `""`.
+    /// Kind validity is checked by `insert_card`, not here. Mirrors WASM
+    /// `Document.makeCard`.
     #[staticmethod]
     #[pyo3(signature = (kind, fields=None, body=None))]
     fn make_card<'py>(
@@ -821,16 +606,19 @@ impl PyDocument {
         card_to_pydict(py, &card)
     }
 
-    fn push_card(&mut self, card: Bound<'_, PyAny>) -> PyResult<()> {
+    /// Place a composable card. `at` picks the position: `None` appends, `Some(i)`
+    /// inserts at index `i` (`0..=card_count`; out of range raises
+    /// `IndexOutOfRange`). `card` is a `Card` dict — from `make_card`, `cards`,
+    /// `remove_card`, or `seed_card`. The one insertion verb per lane, folding
+    /// core's `push_card` + `insert_card`. Mirrors WASM `insertCard(card, at?)`.
+    #[pyo3(signature = (card, at=None))]
+    fn insert_card(&mut self, card: Bound<'_, PyAny>, at: Option<usize>) -> PyResult<()> {
         let core_card = py_dict_to_card(&card)?;
-        self.inner.push_card(core_card).map_err(convert_edit_error)
-    }
-
-    fn insert_card(&mut self, index: usize, card: Bound<'_, PyAny>) -> PyResult<()> {
-        let core_card = py_dict_to_card(&card)?;
-        self.inner
-            .insert_card(index, core_card)
-            .map_err(convert_edit_error)
+        match at {
+            None => self.inner.push_card(core_card),
+            Some(index) => self.inner.insert_card(index, core_card),
+        }
+        .map_err(convert_edit_error)
     }
 
     fn remove_card<'py>(
@@ -856,57 +644,11 @@ impl PyDocument {
             .map_err(convert_edit_error)
     }
 
-    /// Store an opaque value on the composable card at `index` — the
-    /// card-indexed twin of `store_field`, and the same quill-free primitive.
-    /// Prefer the typed writer (`quill.writer(doc).card(index).set(...)`) when a
-    /// quill is in hand. Raises on an out-of-range index or a malformed name.
-    /// Mirrors WASM `storeField` with a card address.
-    fn store_card_field(
-        &mut self,
-        index: usize,
-        name: &str,
-        value: Bound<'_, PyAny>,
-    ) -> PyResult<()> {
-        let qv = py_to_quillvalue(&value)?;
-        self.card_mut_or_raise(index)?
-            .store_field(name, qv)
-            .map_err(convert_edit_error)
-    }
-
-    /// Batched twin of `store_card_field`: set several fields on the composable
-    /// card at `index` atomically. Same all-or-nothing, one-diagnostic-per-field
-    /// contract as `store_fields`, and the same quill-free-primitive framing —
-    /// prefer the typed writer (`quill.writer(doc).card(index).set_all(...)`)
-    /// when a quill is in hand. Mirrors WASM `storeFields` with a card address.
-    fn store_card_fields(&mut self, index: usize, fields: Bound<'_, PyDict>) -> PyResult<()> {
-        let batch = pydict_to_field_batch(&fields)?;
-        self.card_mut_or_raise(index)?
-            .store_fields(batch)
-            .map_err(convert_edit_errors)
-    }
-
-    fn remove_card_field<'py>(
-        &mut self,
-        py: Python<'py>,
-        index: usize,
-        name: &str,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        match self
-            .card_mut_or_raise(index)?
-            .remove_field(name)
-            .map_err(convert_edit_error)?
-        {
-            Some(v) => quillvalue_to_py(py, &v),
-            None => py.None().into_bound_py_any(py),
-        }
-    }
-
 }
 
 impl PyDocument {
     /// Resolve a mutable composable card by index, raising the same
-    /// `IndexOutOfRange` error the other card mutators raise. Shared by the
-    /// card-indexed `$ext` mutators so they don't each re-spell the bounds check.
+    /// `IndexOutOfRange` error the other card mutators raise.
     fn card_mut_or_raise(&mut self, index: usize) -> PyResult<&mut quillmark_core::Card> {
         let len = self.inner.cards().len();
         self.inner.card_mut(index).ok_or_else(|| {
@@ -914,19 +656,9 @@ impl PyDocument {
         })
     }
 
-    /// Resolve a composable card by index for a read, raising the same
-    /// `IndexOutOfRange` error the card mutators raise. The immutable twin of
-    /// `card_mut_or_raise`, shared by the card-indexed reads.
-    fn card_or_raise(&self, index: usize) -> PyResult<&quillmark_core::Card> {
-        let len = self.inner.cards().len();
-        self.inner.cards().get(index).ok_or_else(|| {
-            convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
-        })
-    }
-
-    /// Resolve the card an address targets: the main card when `card` is `None`,
-    /// else the composable card at that index (out-of-range raises). The static
-    /// address axis the addressed content verbs share.
+    /// Resolve the card a `card=` selector targets: the main card when `None`,
+    /// else the composable card at that index (out-of-range raises). The shared
+    /// address axis of the `card=`-parametrized `$ext` / `remove_field` verbs.
     fn addr_card_mut(&mut self, card: Option<usize>) -> PyResult<&mut quillmark_core::Card> {
         match card {
             None => Ok(self.inner.main_mut()),
@@ -983,8 +715,7 @@ impl PyWriter {
     }
 
     /// Set the main body from markdown (edit semantics: anchors rebase),
-    /// discarding the delta — the receipt-free body write. Use `doc.revise(md)`
-    /// for the delta receipt.
+    /// discarding the delta — the receipt-free body write.
     fn set_body(&self, py: Python<'_>, markdown: &str) -> PyResult<()> {
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
@@ -995,17 +726,41 @@ impl PyWriter {
             .map_err(convert_edit_error)
     }
 
+    /// Revise the richtext main-card field `name` from markdown — typed *and*
+    /// anchor-preserving. Surviving anchors rebase, then the diffed result is
+    /// schema-conformed (a `richtext(inline)` field rejects a multi-block result
+    /// with `[EditError::FieldRichtextNotInline]`). Raises
+    /// `[EditError::UnknownField]` for a name the schema does not declare. The
+    /// only field write that preserves a JS editor's anchors on a shared document
+    /// (`set` cold-imports). The text `Delta` is discarded — the position-mapping
+    /// receipt is an editor concern, and that lane is WASM-only; core and WASM
+    /// return it.
+    fn revise_field(&self, py: Python<'_>, name: &str, markdown: &str) -> PyResult<()> {
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        quill
+            .inner
+            .writer(&mut doc.inner)
+            .revise_field(name, markdown)
+            .map(|_| ())
+            .map_err(convert_edit_error)
+    }
+
     /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
-    /// body from optional markdown, and append it — the fused `make_card` + typed
-    /// commit + `push_card`. Transactional: a rejected field (raises a per-field
-    /// diagnostic bundle) or an invalid kind/body leaves the document untouched.
-    #[pyo3(signature = (kind, fields=None, body=None))]
+    /// body from optional markdown, and place it — the fused `make_card` + typed
+    /// commit + insertion. `at` picks the position: `None` appends, `Some(i)`
+    /// inserts at index `i`, so a positioned typed insert is one atomic call
+    /// rather than `add_card` + `move_card`. Transactional: a rejected field
+    /// (raises a per-field diagnostic bundle) or an invalid kind/body/position
+    /// leaves the document untouched.
+    #[pyo3(signature = (kind, fields=None, body=None, at=None))]
     fn add_card(
         &self,
         py: Python<'_>,
         kind: &str,
         fields: Option<Bound<'_, PyDict>>,
         body: Option<String>,
+        at: Option<usize>,
     ) -> PyResult<()> {
         let batch = match fields {
             Some(f) => pydict_to_field_batch(&f)?,
@@ -1016,7 +771,7 @@ impl PyWriter {
         quill
             .inner
             .writer(&mut doc.inner)
-            .add_card(kind, batch, body.as_deref(), None)
+            .add_card(kind, batch, body.as_deref(), at)
             .map_err(convert_edit_errors)
     }
 
@@ -1066,6 +821,18 @@ impl PyCardWriter {
         self.index
     }
 
+    /// The bound card's `$kind`, or `None` when it carries none. Raises
+    /// `[EditError::IndexOutOfRange]` if the bound index is out of range. Mirrors
+    /// core `CardWriter::kind()` / WASM `writer.card(i).kind`.
+    #[getter]
+    fn kind(&self, py: Python<'_>) -> PyResult<Option<String>> {
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        let mut writer = quill.inner.writer(&mut doc.inner);
+        let card = writer.card(self.index).map_err(convert_edit_error)?;
+        Ok(card.kind().map(|k| k.to_string()))
+    }
+
     /// Typed-commit one field on this card, resolving its type from the card's
     /// `$kind` schema. Raises `[EditError::UnknownField]` for an undeclared name
     /// and `[EditError::IndexOutOfRange]` for a bad index.
@@ -1108,16 +875,34 @@ impl PyCardWriter {
             .set_body(markdown)
             .map_err(convert_edit_error)
     }
+
+    /// Revise the richtext field `name` on this card from markdown — typed *and*
+    /// anchor-preserving; the card twin of `Writer.revise_field`. Raises
+    /// `[EditError::UnknownField]` for an undeclared name and
+    /// `[EditError::IndexOutOfRange]` for a bad index. The `Delta` is discarded
+    /// (see `Writer.revise_field`).
+    fn revise_field(&self, py: Python<'_>, name: &str, markdown: &str) -> PyResult<()> {
+        let quill = self.quill.borrow(py);
+        let mut doc = self.doc.borrow_mut(py);
+        let mut writer = quill.inner.writer(&mut doc.inner);
+        writer
+            .card(self.index)
+            .map_err(convert_edit_error)?
+            .revise_field(name, markdown)
+            .map(|_| ())
+            .map_err(convert_edit_error)
+    }
 }
 
 /// A `Document` bound to its `Quill` for interpreted reads — the schema-plane
 /// read view, from `Quill.view(doc)` and the read twin of `Writer`. One `get`
 /// reads each field by its declared type: a richtext field to its markdown
 /// projection, a plaintext field to its literal text, every other type its
-/// canonical value verbatim. The schema authority is the point — unlike the
-/// quill-free transport `Document.get`, a name the schema does not declare raises
-/// `[EditError::UnknownField]` rather than reading back `None`. A field's markdown
-/// lives here, not on the body-only `Document.get_markdown`. Holds both objects
+/// canonical value verbatim. The schema authority is the point: a name the schema
+/// does not declare raises `[EditError::UnknownField]` (a typo, as on the write
+/// side) rather than reading back `None`, and a content field holding an
+/// undecodable value raises `[EditError::FieldRichtextDecode]`. This is the field
+/// read surface — `Document` carries no quill-free field read. Holds both objects
 /// by reference and re-borrows them per call (pyo3 objects carry no lifetime), so
 /// it is ephemeral by convention: bind, read, discard. Mirrors WASM
 /// `quill.view(doc)`.
@@ -1515,7 +1300,7 @@ fn card_to_pydict<'py>(
     }
 
     // `body` is the canonical content (source of truth); the markdown projection
-    // is the on-demand `export_markdown(body)` codec. The reverse path
+    // is the schema-plane `quill.view(doc).get_body()` read. The reverse path
     // (`py_dict_to_card`) reads `body`.
     d.set_item("body", json_to_py(py, &wire.body)?)?;
     Ok(d)
@@ -1561,11 +1346,11 @@ fn py_to_quillvalue(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::QuillV
     Ok(quillmark_core::QuillValue::from_json(json))
 }
 
-/// Convert a Python mapping to the `(name, value)` batch `Card::store_fields`
-/// consumes. Value-conversion failures (depth bound, unsupported type) are
-/// collected — not fail-fast — into one `QuillmarkError` with a per-field
-/// `path`, matching the batch contract of the mutator itself. Non-string
-/// keys are a caller bug and raise `ValueError` directly.
+/// Convert a Python mapping to the `(name, value)` batch the typed writer's
+/// `set_all` / `add_card` consume. Value-conversion failures (depth bound,
+/// unsupported type) are collected — not fail-fast — into one `QuillmarkError`
+/// with a per-field `path`, matching the batch contract of the writer itself.
+/// Non-string keys are a caller bug and raise `ValueError` directly.
 fn pydict_to_field_batch(
     fields: &Bound<'_, PyDict>,
 ) -> PyResult<Vec<(String, quillmark_core::QuillValue)>> {
@@ -1737,98 +1522,3 @@ fn py_dict_to_card(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::Card> {
     quillmark_core::Card::try_from(wire).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
-// ── Addressed-write helpers + content codec ──────────────────────────────────────
-
-/// Decode a Python value as a canonical `Content` content dict — the `install`
-/// input (value semantics, content only). Rejects a markdown string: the cold
-/// path is `install(import_markdown(md))`.
-fn py_to_content(value: &Bound<'_, PyAny>) -> PyResult<quillmark_core::Content> {
-    let json = py_to_json(value)?;
-    if !json.is_object() {
-        return Err(PyValueError::new_err(
-            "expected a Content content dict; for markdown use import_markdown(md) first",
-        ));
-    }
-    quillmark_content::serial::from_canonical_value(&json)
-        .map_err(|e| PyValueError::new_err(format!("not a canonical Content content: {e}")))
-}
-
-/// Serialize a [`Delta`](quillmark_core::Delta) to its JSON wire (`{ops: [...]}`).
-fn delta_to_json(delta: &quillmark_core::Delta) -> serde_json::Value {
-    serde_json::to_value(delta).unwrap_or(serde_json::Value::Null)
-}
-
-/// Lower an `apply_change` bundle (`{delta?, line_ops?, mark_ops?}`) to core ops
-/// via the shared richtext reader (which accepts both snake_case and camelCase
-/// keys), mapping its message to a `ValueError`.
-fn parse_change_bundle(
-    value: &Bound<'_, PyAny>,
-) -> PyResult<(
-    quillmark_core::Delta,
-    Vec<quillmark_core::LineOp>,
-    Vec<quillmark_core::MarkOp>,
-)> {
-    let json = py_to_json(value)?;
-    quillmark_content::change_bundle_from_value(&json).map_err(PyValueError::new_err)
-}
-
-/// Import a markdown string to a canonical `Content` content dict — the pure,
-/// document-free codec. Pair with `install(import_markdown(md))` to spell the
-/// cold (anchor-losing) write; prefer `revise` for edit semantics. Raises on an
-/// over-nested input.
-#[pyfunction]
-pub fn import_markdown<'py>(py: Python<'py>, markdown: &str) -> PyResult<Bound<'py, PyAny>> {
-    let content = quillmark_content::from_markdown(markdown)
-        .map_err(|e| PyValueError::new_err(format!("import_markdown: {e}")))?;
-    json_to_py(py, &quillmark_content::serial::to_canonical_value(&content))
-}
-
-/// Export a canonical `Content` content dict to its markdown projection — the
-/// pure codec that replaces the eager `body_markdown` / `field_markdown`
-/// precomputes (`export_markdown(doc.body)`). Raises if `rt` is not a content.
-#[pyfunction]
-pub fn export_markdown(rt: Bound<'_, PyAny>) -> PyResult<String> {
-    let content = py_to_content(&rt)?;
-    Ok(quillmark_content::to_markdown(&content))
-}
-
-/// Rebase `markdown` onto a `base` content dict — the pure, document-free twin of
-/// `revise`: cold-import + `diff_import`, returning `{content, delta}` (surviving
-/// anchors rebased). Raises on an over-nested input or a non-content `base`.
-#[pyfunction]
-pub fn rebase<'py>(
-    py: Python<'py>,
-    base: Bound<'_, PyAny>,
-    markdown: &str,
-) -> PyResult<Bound<'py, PyAny>> {
-    let base = py_to_content(&base)?;
-    let (content, delta) = quillmark_content::diff_import(&base, markdown)
-        .map_err(|e| PyValueError::new_err(format!("rebase: {e}")))?;
-    let out = serde_json::json!({
-        "content": quillmark_content::serial::to_canonical_value(&content),
-        "delta": delta_to_json(&delta),
-    });
-    json_to_py(py, &out)
-}
-
-/// Map a base content position through a `delta` (a `{ops: [...]}` dict) to its
-/// new position — the pure position-mapping codec for holding a caret stable
-/// across a `revise`. `assoc` is `"before"` or `"after"` (`"after"` moves past a
-/// same-position insertion). Raises on a malformed `delta`.
-#[pyfunction]
-#[pyo3(signature = (delta, pos, assoc="before"))]
-pub fn map_pos(delta: Bound<'_, PyAny>, pos: usize, assoc: &str) -> PyResult<usize> {
-    let json = py_to_json(&delta)?;
-    let delta: quillmark_core::Delta = serde_json::from_value(json)
-        .map_err(|e| PyValueError::new_err(format!("map_pos: invalid delta: {e}")))?;
-    let assoc = match assoc {
-        "before" => quillmark_core::Assoc::Before,
-        "after" => quillmark_core::Assoc::After,
-        _ => {
-            return Err(PyValueError::new_err(
-                "map_pos: assoc must be \"before\" or \"after\"",
-            ))
-        }
-    };
-    Ok(delta.map_pos(pos, assoc))
-}

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -1,6 +1,11 @@
-"""Tests for the API requirements."""
+"""Tests for the API requirements.
 
-import re
+Python is a Tier-1 binding: field I/O flows through `quill.writer(doc)` /
+`quill.view(doc)`. `Document` carries the quill-free surface — parse, storage,
+structure, `$ext` / `$seed`, and `remove_field`. There is no opaque field store
+and no content lane (`install` / `revise` / `apply_change` + codec); those are
+WASM-only by scope.
+"""
 
 import pytest
 from quillmark import (
@@ -9,10 +14,6 @@ from quillmark import (
     Document,
     OutputFormat,
     QuillmarkError,
-    import_markdown,
-    export_markdown,
-    rebase,
-    map_pos,
 )
 from conftest import QUILLS_PATH, _latest_version
 
@@ -35,6 +36,16 @@ def has_field(card, key):
 def field_keys(card):
     """Iterable of all field keys in a card, in source order."""
     return [i["key"] for i in card["payload_items"] if i["type"] == "field"]
+
+
+def _richtext_form_quill():
+    """The richtext_form fixture quill (headline: richtext inline, bio: richtext)."""
+    return Quill.from_path(str(_latest_version(QUILLS_PATH / "richtext_form")))
+
+
+def _taro_quill():
+    """The taro fixture quill (main string fields; a `quotes` card kind)."""
+    return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
 
 
 def test_parsed_document_quill_ref():
@@ -92,26 +103,29 @@ def test_full_workflow(engine):
 
 
 def test_blank_document_constructor():
-    """Document(quill_ref) starts blank: main card only, no fields, no cards."""
-    doc = Document("test_quill")
-    assert doc.quill_ref == "test_quill"
+    """Document(quill_ref) starts blank: main card only, no fields, no cards. A
+    field write needs a quill (the writer); the blank canvas itself is quill-free."""
+    doc = Document("taro@0.1.0")
+    assert doc.quill_ref == "taro@0.1.0"
     assert doc.card_count == 0
-    assert export_markdown(doc.body) == ""
+    assert doc.body["text"] == ""
     assert field_keys(doc.main) == []
-    doc.store_fields({"title": "Hello"})
+
+    _taro_quill().writer(doc).set("title", "Hello")
     assert field(doc.main, "title") == "Hello"
+
     with pytest.raises(ValueError, match="QuillReference"):
         Document("not a valid ref!!")
 
 
 def test_blank_document_renders(engine):
-    """The programmatic flow end-to-end: blank canvas → set_fields → render."""
-    taro_dir = QUILLS_PATH / "taro"
-    quill = Quill.from_path(str(_latest_version(taro_dir)))
+    """The programmatic flow end-to-end: blank canvas → typed writer → render."""
+    quill = _taro_quill()
 
-    doc = Document("taro")
-    doc.store_fields({"title": "Test", "author": "Test Author", "ice_cream": "Chocolate"})
-    doc.replace_body("Content.")
+    doc = Document("taro@0.1.0")
+    w = quill.writer(doc)
+    w.set_all({"title": "Test", "author": "Test Author", "ice_cream": "Chocolate"})
+    w.set_body("Content.")
 
     result = engine.render(quill, doc, OutputFormat.PDF)
     assert len(result.artifacts) > 0
@@ -119,7 +133,7 @@ def test_blank_document_renders(engine):
 
 
 # ---------------------------------------------------------------------------
-# Editor surface tests
+# Document surface — quill-free structure, removal, and $ext
 # ---------------------------------------------------------------------------
 
 SIMPLE_MD = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Hello\nauthor: Alice\n~~~\n\nBody text.\n"
@@ -148,76 +162,8 @@ Card two.
 """
 
 
-def test_set_field_inserts():
-    """set_field adds a new payload field."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    doc.store_field("subtitle", "A subtitle")
-    assert field(doc.main, "subtitle") == "A subtitle"
-
-
-def test_set_field_updates():
-    """set_field updates an existing payload field."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    doc.store_field("title", "New Title")
-    assert field(doc.main, "title") == "New Title"
-
-
-def test_set_field_uppercase_accepted():
-    """set_field accepts uppercase field names verbatim (lowercase is canonical
-    but not enforced); only `$`-prefixed keys stay reserved."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    for name in ("BODY", "CARDS", "Title", "MixedCase_1"):
-        doc.store_field(name, "value")
-        assert field(doc.main, name) == "value"
-
-
-def test_set_field_dollar_prefix_rejected_matrix():
-    """set_field raises InvalidFieldName for `$`-prefixed names."""
-    for name in ("$body", "$cards", "$quill", "$kind"):
-        doc = Document.from_markdown(SIMPLE_MD)
-        with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-            doc.store_field(name, "value")
-
-
-def test_set_field_invalid_field_name():
-    """set_field raises EditError for an invalid name (hyphen not allowed)."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    with pytest.raises(QuillmarkError, match="InvalidFieldName"):
-        doc.store_field("bad-name", "value")
-
-
-def test_set_fields_inserts_batch_in_order():
-    """set_fields applies every entry, in dict order."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    doc.store_fields({"subtitle": "A subtitle", "pages": 3})
-    assert field(doc.main, "subtitle") == "A subtitle"
-    assert field(doc.main, "pages") == 3
-    assert field_keys(doc.main) == ["title", "author", "subtitle", "pages"]
-
-
-def test_set_fields_reports_every_violation_and_applies_nothing():
-    """A failed batch raises one diagnostic per bad field (path = name) and
-    leaves the document untouched — including the batch's valid entries."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    with pytest.raises(QuillmarkError, match="InvalidFieldName") as exc_info:
-        doc.store_fields({"ok_field": "v", "bad-name": "v", "also bad": "v"})
-    diags = exc_info.value.diagnostics
-    assert [d.path for d in diags] == ["bad-name", "also bad"]
-    assert not has_field(doc.main, "ok_field")
-
-
-def test_set_card_fields_batch():
-    """set_card_fields is the card-indexed twin of set_fields."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.store_card_fields(0, {"foo": "baz", "extra": 1})
-    assert field(doc.cards[0], "foo") == "baz"
-    assert field(doc.cards[0], "extra") == 1
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.store_card_fields(99, {"foo": "v"})
-
-
 def test_remove_field_existing():
-    """remove_field removes and returns an existing field."""
+    """remove_field removes and returns an existing main-card field."""
     doc = Document.from_markdown(SIMPLE_MD)
     val = doc.remove_field("title")
     assert val == "Hello"
@@ -237,69 +183,62 @@ def test_set_quill_ref():
     assert doc.quill_ref == "new_quill"
 
 
-def test_replace_body():
-    """replace_body replaces the global Markdown body."""
+def test_insert_card_appends():
+    """insert_card (absent `at`) appends a card to the list."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.replace_body("New body content.")
-    assert export_markdown(doc.body) == "New body content."
-
-
-def test_push_card():
-    """push_card appends a card to the list."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    doc.push_card({"kind": "note", "body": "Card body."})
+    doc.insert_card({"kind": "note", "body": "Card body."})
     assert len(doc.cards) == 1
     assert doc.cards[0]["kind"] == "note"
-    assert export_markdown(doc.cards[0]["body"]) == "Card body."
+    assert doc.cards[0]["body"]["text"] == "Card body."
 
 
-def test_push_card_invalid_kind():
-    """push_card raises EditError for an invalid kind."""
+def test_insert_card_invalid_kind():
+    """insert_card raises EditError for an invalid kind."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(QuillmarkError, match="InvalidKindName"):
-        doc.push_card({"kind": "BadKind"})
+        doc.insert_card({"kind": "BadKind"})
 
 
-def test_remove_card_then_push_card_round_trips_fields():
-    """A card returned by remove_card feeds straight back into push_card with
+def test_remove_card_then_insert_card_round_trips_fields():
+    """A card returned by remove_card feeds straight back into insert_card with
     its fields intact — the one-Card-shape contract. Exercises the explicit
     quill/id/ext=None keys the dict carries against `deny_unknown_fields`."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.push_card(Document.make_card("note", {"author": "Alice"}, "Body"))
+    doc.insert_card(Document.make_card("note", {"author": "Alice"}, "Body"))
 
     removed = doc.remove_card(0)
     # The returned dict carries explicit None for the absent $ entries.
     assert removed["quill"] is None and removed["id"] is None
     assert field(removed, "author") == "Alice"
 
-    doc.push_card(removed)  # must not raise (deny_unknown_fields accepts the shape)
+    doc.insert_card(removed)  # must not raise (deny_unknown_fields accepts the shape)
     assert len(doc.cards) == 1
     assert doc.cards[0]["kind"] == "note"
     assert field(doc.cards[0], "author") == "Alice"  # field survived the round-trip
-    assert export_markdown(doc.cards[0]["body"]) == "Body"
+    assert doc.cards[0]["body"]["text"] == "Body"
 
 
-def test_push_card_accepts_content_dict_body():
-    """`body` on a pushed card may be the canonical content dict (the shape
+def test_insert_card_accepts_content_dict_body():
+    """`body` on an inserted card may be the canonical content dict (the shape
     `cards()`/`remove_card` emit), not just a markdown string — exercises
     `py_dict_to_card`'s content-dict input path."""
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.push_card({"kind": "note", "body": "**Bold** body."})
+    doc.insert_card({"kind": "note", "body": "**Bold** body."})
     content_body = doc.cards[0]["body"]
     assert isinstance(content_body, dict)
 
-    doc.push_card({"kind": "note", "body": content_body})
-    assert export_markdown(doc.cards[1]["body"]) == export_markdown(doc.cards[0]["body"])
+    doc.insert_card({"kind": "note", "body": content_body})
+    assert doc.cards[1]["body"]["text"] == doc.cards[0]["body"]["text"]
 
 
-def test_make_card_accepts_any_kind_push_card_is_the_gate():
+def test_make_card_accepts_any_kind_insert_card_is_the_gate():
     """make_card is permissive data-shaping; the kind invariant is enforced at
-    push_card, not construction."""
+    insert_card, not construction."""
     card = Document.make_card("BadKind", {"x": 1})
     assert card["kind"] == "BadKind"  # construction succeeds
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(QuillmarkError, match="InvalidKindName"):
-        doc.push_card(card)
+        doc.insert_card(card)
 
 
 def test_stale_flat_input_is_a_loud_error():
@@ -308,22 +247,22 @@ def test_stale_flat_input_is_a_loud_error():
     key at deserialize time (a ValueError), before any edit."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(ValueError, match="fields"):
-        doc.push_card({"kind": "note", "fields": {"x": 1}})
+        doc.insert_card({"kind": "note", "fields": {"x": 1}})
 
 
 def test_insert_card_at_front():
-    """insert_card at index 0 prepends the card."""
+    """insert_card(card, at=0) prepends the card."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.insert_card(0, {"kind": "intro"})
+    doc.insert_card({"kind": "intro"}, at=0)
     assert doc.cards[0]["kind"] == "intro"
     assert doc.cards[1]["kind"] == "note"
 
 
 def test_insert_card_out_of_range():
-    """insert_card raises EditError when index > len."""
+    """insert_card raises EditError when at > len."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.insert_card(5, {"kind": "note"})
+        doc.insert_card({"kind": "note"}, at=5)
 
 
 def test_remove_card():
@@ -366,83 +305,15 @@ def test_move_card_out_of_range():
         doc.move_card(10, 0)
 
 
-def test_set_card_field():
-    """set_card_field sets a field on a specific card."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.store_card_field(0, "content", "hello")
-    assert field(doc.cards[0], "content") == "hello"
-
-
-def test_set_card_field_out_of_range():
-    """set_card_field raises EditError when card index is out of range."""
-    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.store_card_field(0, "title", "x")
-
-
-def test_get_card_field():
-    """get_card_field reads a card field by name — the card-indexed twin of get,
-    agreeing with the payload_items projection it replaces."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    assert doc.get_card_field(0, "foo") == "bar"
-    assert doc.get_card_field(0, "foo") == field(doc.cards[0], "foo")
-    # A valid card with no such field reads back as None (not an error).
-    assert doc.get_card_field(0, "missing") is None
-
-
-def test_get_card_field_out_of_range():
-    """get_card_field raises IndexOutOfRange for a bad card index — a boundary
-    error, the way the card write verbs surface it, not an absent field."""
-    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.get_card_field(0, "foo")
-
-
-def test_get_card_markdown_body():
-    """get_card_markdown reads a card's body markdown. A card field's markdown is
-    read via quill.view(doc).card(i).get(name) (#978)."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    assert "Card one." in doc.get_card_markdown(0)
-
-
-def test_get_card_markdown_out_of_range():
-    """get_card_markdown raises IndexOutOfRange for a bad card index."""
-    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.get_card_markdown(0)
-
-
-def test_revise_card_body():
-    """revise(md, card=i) revises a card body and returns the text delta."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    delta = doc.revise("New card body.", card=0)
-    assert export_markdown(doc.cards[0]["body"]) == "New card body."
-    assert isinstance(delta["ops"], list)
-
-
-def test_revise_card_body_out_of_range():
-    """revise(md, card=i) raises EditError when card index is out of range."""
-    doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.revise("x", card=0)
-
-
-def test_update_card_body_deprecated_alias():
-    """update_card_body (deprecated alias for revise(md, card=i)) still works."""
-    doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.update_card_body(0, "New card body.")
-    assert export_markdown(doc.cards[0]["body"]) == "New card body."
-
-
 def test_set_ext_adds_map():
-    """set_ext stores an opaque map readable via card['ext']."""
+    """store_ext stores an opaque map readable via card['ext']."""
     doc = Document.from_markdown(SIMPLE_MD)
     doc.store_ext({"presentation": {"title": "Greeting"}})
     assert doc.main["ext"] == {"presentation": {"title": "Greeting"}}
 
 
 def test_set_ext_rejects_non_dict():
-    """set_ext raises for non-dict values."""
+    """store_ext raises for non-dict values."""
     doc = Document.from_markdown(SIMPLE_MD)
     with pytest.raises(ValueError, match="must be a dict"):
         doc.store_ext("nope")
@@ -457,7 +328,7 @@ def test_ext_round_trips_through_markdown():
 
 
 def test_set_ext_namespace_preserves_siblings():
-    """set_ext_namespace merges without clobbering other namespaces."""
+    """store_ext_namespace merges without clobbering other namespaces."""
     doc = Document.from_markdown(SIMPLE_MD)
     doc.store_ext_namespace("presentation", {"title": "A"})
     doc.store_ext_namespace("agent", {"pinned": True})
@@ -493,63 +364,65 @@ def test_remove_ext_returns_previous_and_clears():
 
 
 def test_card_ext_mutators():
-    """set_card_ext / remove_card_ext target the card at index."""
+    """store_ext / remove_ext with card=i target the composable card at index —
+    the same verbs the main card uses, one `card=` selector over the whole axis."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.store_card_ext(0, {"agent": {"note": "y"}})
+    doc.store_ext({"agent": {"note": "y"}}, card=0)
     assert doc.cards[0]["ext"] == {"agent": {"note": "y"}}
-    assert doc.remove_card_ext(0) == {"agent": {"note": "y"}}
+    assert doc.remove_ext(card=0) == {"agent": {"note": "y"}}
     assert doc.cards[0]["ext"] is None
 
 
 def test_card_ext_namespace_mutators():
-    """set/remove_card_ext_namespace preserve siblings and clear when empty."""
+    """store/remove_ext_namespace with card=i preserve siblings and clear when empty."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    doc.store_card_ext_namespace(0, "presentation", {"title": "A"})
-    doc.store_card_ext_namespace(0, "tutorial", ["step-1"])
-    assert doc.remove_card_ext_namespace(0, "tutorial") == ["step-1"]
+    doc.store_ext_namespace("presentation", {"title": "A"}, card=0)
+    doc.store_ext_namespace("tutorial", ["step-1"], card=0)
+    assert doc.remove_ext_namespace("tutorial", card=0) == ["step-1"]
     assert doc.cards[0]["ext"] == {"presentation": {"title": "A"}}
-    doc.remove_card_ext_namespace(0, "presentation")
+    doc.remove_ext_namespace("presentation", card=0)
     assert doc.cards[0]["ext"] is None
 
 
 def test_card_ext_mutators_out_of_range():
-    """Card ext mutators raise IndexOutOfRange for a bad index."""
+    """Card ext mutators raise IndexOutOfRange for a bad card index."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.store_card_ext(0, {})
+        doc.store_ext({}, card=0)
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.remove_card_ext(0)
+        doc.remove_ext(card=0)
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.store_card_ext_namespace(0, "a", {})
+        doc.store_ext_namespace("a", {}, card=0)
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.remove_card_ext_namespace(0, "a")
+        doc.remove_ext_namespace("a", card=0)
 
 
 def test_mutators_do_not_touch_warnings():
     """Mutators must not modify the warnings list."""
     doc = Document.from_markdown(SIMPLE_MD)
     initial = list(doc.warnings)
-    doc.store_field("extra", "value")
-    doc.replace_body("New body.")
-    doc.push_card({"kind": "new_card"})
+    doc.remove_field("title")
+    doc.insert_card({"kind": "new_card"})
+    doc.store_ext_namespace("agent", {"n": 1})
     assert list(doc.warnings) == initial
 
 
 def test_invariants_after_mutation_sequence():
     """After a sequence of mutations the document must be internally consistent."""
+    import re
+
     doc = Document.from_markdown(SIMPLE_MD)
 
     # Add and manipulate cards
-    doc.push_card(Document.make_card("note", {"text": "hi"}))
-    doc.push_card({"kind": "summary"})
-    doc.push_card({"kind": "appendix"})
-    doc.insert_card(1, {"kind": "intro"})  # note, intro, summary, appendix
-    doc.move_card(3, 0)                    # appendix, note, intro, summary
-    doc.remove_card(2)                     # appendix, note, summary
+    doc.insert_card(Document.make_card("note", {"text": "hi"}))
+    doc.insert_card({"kind": "summary"})
+    doc.insert_card({"kind": "appendix"})
+    doc.insert_card({"kind": "intro"}, at=1)  # note, intro, summary, appendix
+    doc.move_card(3, 0)                        # appendix, note, intro, summary
+    doc.remove_card(2)                         # appendix, note, summary
 
-    # Mutate payload
-    doc.store_field("extra_author", "Bob")
-    doc.remove_field("extra_author")
+    # Mutate payload (quill-free removal)
+    doc.remove_field("author")
 
     # Assertions: every payload key passes the user-field regex.
     field_name_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -571,88 +444,88 @@ def test_invariants_after_mutation_sequence():
 
 
 def test_to_markdown_general_round_trip():
-    """Mutated document survives emit → re-parse with structure intact."""
-    doc = Document.from_markdown(SIMPLE_MD)
-    original_card_count = len(doc.cards)  # 0 for SIMPLE_MD
+    """A typed-writer mutation survives emit → re-parse with structure intact."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
 
-    # Mutate
-    doc.store_field("title", "New Title")
-    doc.push_card(Document.make_card("note", {"author": "Alice"}, "Hello"))
-    doc.replace_body("Updated body")
+    # Mutate: typed field + typed body + a quill-free card.
+    quill.writer(doc).set("title", "New Title")
+    doc.insert_card(Document.make_card("note", {"author": "Alice"}, "Hello"))
+    quill.writer(doc).set_body("Updated body")
 
     # Emit
     emitted = doc.to_markdown()
-    assert isinstance(emitted, str)
-    assert len(emitted) > 0
+    assert isinstance(emitted, str) and len(emitted) > 0
 
     # Re-parse and assert structure survives
     doc2 = Document.from_markdown(emitted)
     assert field(doc2.main, "title") == "New Title"
-    assert export_markdown(doc2.body).rstrip("\n") == "Updated body"
-    assert len(doc2.cards) == original_card_count + 1
+    assert doc2.body["text"].rstrip("\n") == "Updated body"
+    assert len(doc2.cards) == 1
     assert doc2.cards[0]["kind"] == "note"
     assert field(doc2.cards[0], "author") == "Alice"
-    assert export_markdown(doc2.cards[0]["body"]) == "Hello"
+    assert doc2.cards[0]["body"]["text"] == "Hello"
 
 
 def test_to_markdown_ambiguous_string_survival():
-    """YAML-keyword values set via set_field survive emit → re-parse as strings.
+    """YAML-keyword string values survive emit → re-parse as strings.
 
     "on", "off", "yes", "no", "true", "false", "null" are all YAML
     booleans/null in permissive parsers. The emitter must double-quote them
-    so they survive through a re-parse as strings, not bools or null.
+    so they survive a re-parse as strings, not bools or null. Seated as card
+    fields via the quill-free `make_card`, whose values emit through the same
+    card-yaml writer the main card uses.
     """
     doc = Document.from_markdown(SIMPLE_MD)
-    doc.store_field("flag_on", "on")
-    doc.store_field("flag_off", "off")
-    doc.store_field("flag_yes", "yes")
-    doc.store_field("flag_no", "no")
-    doc.store_field("str_true", "true")
-    doc.store_field("str_false", "false")
-    doc.store_field("str_null", "null")
-    doc.store_field("octal_str", "01234")
-    doc.store_field("date_str", "2024-01-15")
+    doc.insert_card(
+        Document.make_card(
+            "note",
+            {
+                "flag_on": "on",
+                "flag_off": "off",
+                "flag_yes": "yes",
+                "flag_no": "no",
+                "str_true": "true",
+                "str_false": "false",
+                "str_null": "null",
+                "octal_str": "01234",
+                "date_str": "2024-01-15",
+            },
+        )
+    )
 
-    emitted = doc.to_markdown()
-    doc2 = Document.from_markdown(emitted)
+    doc2 = Document.from_markdown(doc.to_markdown())
+    card = doc2.cards[0]
 
     # Every value must survive as a string, not be re-interpreted
-    assert field(doc2.main, "flag_on") == "on"
-    assert field(doc2.main, "flag_off") == "off"
-    assert field(doc2.main, "flag_yes") == "yes"
-    assert field(doc2.main, "flag_no") == "no"
-    assert field(doc2.main, "str_true") == "true"
-    assert field(doc2.main, "str_false") == "false"
-    assert field(doc2.main, "str_null") == "null"
-    assert field(doc2.main, "octal_str") == "01234"
-    assert field(doc2.main, "date_str") == "2024-01-15"
+    assert field(card, "flag_on") == "on"
+    assert field(card, "flag_off") == "off"
+    assert field(card, "flag_yes") == "yes"
+    assert field(card, "flag_no") == "no"
+    assert field(card, "str_true") == "true"
+    assert field(card, "str_false") == "false"
+    assert field(card, "str_null") == "null"
+    assert field(card, "octal_str") == "01234"
+    assert field(card, "date_str") == "2024-01-15"
 
 
 # ── Tier-1 typed writer — quill.writer(doc) front door ────────────────────────
 
 
-def _richtext_form_quill():
-    """The richtext_form fixture quill (headline: richtext inline, bio: richtext)."""
-    return Quill.from_path(str(_latest_version(QUILLS_PATH / "richtext_form")))
-
-
-def _taro_quill():
-    """The taro fixture quill (main string fields; a `quotes` card kind)."""
-    return Quill.from_path(str(_latest_version(QUILLS_PATH / "taro")))
-
-
 def test_writer_front_door_set_and_reads():
-    """quill.writer(doc).set writes; the reads live quill-free on the Document."""
+    """quill.writer(doc).set writes; the reads live on quill.view(doc)."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     ed = quill.writer(doc)
     ed.set("author", "Ada")
     ed.set_all({"title": "On Taro"})
     assert ed.document is doc  # holds the same object, mutated in place
-    assert doc.get("author") == "Ada"
-    assert doc.get("missing") is None
+
+    v = quill.view(doc)
+    assert v.get("author") == "Ada"
+    assert v.get("ice_cream") is None  # declared but absent → None
     ed.set_body("A **taro** essay.")
-    assert doc.get_markdown() == "A **taro** essay."
+    assert v.get_body() == "A **taro** essay."
 
 
 def test_writer_set_rejects_unknown_field():
@@ -664,8 +537,21 @@ def test_writer_set_rejects_unknown_field():
     assert not has_field(doc.main, "stray")
 
 
+def test_writer_set_all_reports_every_unknown_field():
+    """set_all is all-or-nothing and reports one diagnostic per undeclared name
+    (path = field name) — externally-sourced keys surface every violation at once."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    with pytest.raises(QuillmarkError, match="UnknownField") as exc_info:
+        quill.writer(doc).set_all({"title": "ok", "stray1": "x", "stray2": "y"})
+    paths = [d.path for d in exc_info.value.diagnostics]
+    assert "stray1" in paths and "stray2" in paths
+    # All-or-nothing: even the valid `title` did not land.
+    assert not has_field(doc.main, "title")
+
+
 def test_writer_add_card_transactional():
-    """add_card fuses make + typed commit + push; a typo leaves the doc untouched."""
+    """add_card fuses make + typed commit + insert; a typo leaves the doc untouched."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     ed = quill.writer(doc)
@@ -675,6 +561,20 @@ def test_writer_add_card_transactional():
     with pytest.raises(QuillmarkError, match="UnknownField"):
         ed.add_card("quotes", {"stray": "x"})
     assert len(doc.cards) == 1  # nothing joined the document
+
+
+def test_writer_add_card_positioned():
+    """add_card(..., at=i) is one atomic positioned typed insert."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    ed = quill.writer(doc)
+    ed.add_card("quotes", {"author": "First"})
+    ed.add_card("quotes", {"author": "Second"}, at=0)  # insert at the front
+    assert field(doc.cards[0], "author") == "Second"
+    assert field(doc.cards[1], "author") == "First"
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        ed.add_card("quotes", {"author": "x"}, at=99)
+    assert len(doc.cards) == 2  # the out-of-range insert landed nothing
 
 
 def test_writer_card_cursor_set_and_body():
@@ -687,6 +587,18 @@ def test_writer_card_cursor_set_and_body():
     assert field(doc.cards[0], "author") == "Issa"
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         ed.card(9).set("author", "x")
+
+
+def test_writer_card_kind_getter():
+    """writer.card(i).kind reads the bound card's $kind; a bad index raises."""
+    quill = _taro_quill()
+    doc = Document("taro@0.1.0")
+    ed = quill.writer(doc)
+    ed.add_card("quotes", {"author": "Basho"})
+    assert ed.card(0).index == 0
+    assert ed.card(0).kind == "quotes"
+    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+        _ = ed.card(9).kind
 
 
 def test_writer_set_coerces_richtext_to_content():
@@ -714,6 +626,42 @@ def test_writer_set_all_is_all_or_nothing():
     with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
         quill.writer(doc).set_all({"bio": "ok", "headline": "line one\n\nline two"})
     assert not has_field(doc.main, "bio")
+
+
+def test_writer_revise_field_typed_and_anchor_preserving():
+    """writer.revise_field is the typed, anchor-preserving richtext field write —
+    diff-imports the markdown and schema-conforms the result."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    quill.writer(doc).revise_field("bio", "make it **bold**")
+    assert quill.view(doc).get("bio") == "make it **bold**"
+
+
+def test_writer_revise_field_rejects_inline_and_unknown():
+    """revise_field conforms to the field schema (inline rejects multi-block) and
+    rejects an undeclared name — same guards as `set`."""
+    quill = _richtext_form_quill()
+    doc = Document("richtext_form@0.1.0")
+    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+        quill.writer(doc).revise_field("headline", "line one\n\nline two")
+    with pytest.raises(QuillmarkError, match="UnknownField"):
+        quill.writer(doc).revise_field("nope", "x")
+
+
+def test_typed_set_clears_must_fill_marker():
+    """With the opaque store gone, seed → validate(must_fill) → typed `set` is the
+    fill lifecycle: the typed commit lands a real value and clears the marker."""
+    quill = _taro_quill()
+    doc = Document.from_markdown(
+        "~~~card-yaml\n$quill: taro@0.1.0\n$kind: main\ntitle: !must_fill\n~~~\n"
+    )
+    codes = [d.get("code") for d in quill.validate(doc)]
+    assert "validation::must_fill" in codes
+
+    quill.writer(doc).set("title", "Real Title")
+    codes_after = [d.get("code") for d in quill.validate(doc)]
+    assert "validation::must_fill" not in codes_after
+    assert field(doc.main, "title") == "Real Title"
 
 
 # ── Tier-1 typed reader — quill.view(doc) front door ──────────────────────────
@@ -744,16 +692,20 @@ def test_view_absence_returns_none_unknown_name_raises():
 
 
 def test_view_richtext_holding_scalar_raises_mismatch():
-    """A present value that does not decode as richtext raises FieldRichtextDecode."""
+    """A present value that does not decode as richtext raises FieldRichtextDecode.
+
+    Seated quill-free via `from_markdown` (a bare number under a richtext field),
+    since the opaque store is gone."""
     quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    doc.store_field("bio", 3)  # opaque write puts a bare number under a richtext field
+    doc = Document.from_markdown(
+        "~~~card-yaml\n$quill: richtext_form@0.1.0\n$kind: main\nbio: 3\n~~~\n"
+    )
     with pytest.raises(QuillmarkError, match="FieldRichtextDecode"):
         quill.view(doc).get("bio")
 
 
 def test_view_body_read_is_quill_free():
-    """view.get_body mirrors get_markdown() — the quill-free body read."""
+    """view.get_body reads the main body markdown — the quill-free body read."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     quill.writer(doc).set_body("A **taro** essay.")
@@ -774,31 +726,3 @@ def test_view_card_cursor_reads_through_kind_schema():
         v.card(0).get("stray")
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
         v.card(9).get("author")
-
-
-# ── Addressed content verbs — revise / apply_change ───────────────────────────
-
-
-def test_revise_field_and_apply_change_splice():
-    """revise({field}) diff-imports a richtext field; apply_change splices marks."""
-    quill = _richtext_form_quill()
-    doc = Document("richtext_form@0.1.0")
-    doc.revise("make it bold here", field="bio")
-    doc.apply_change(
-        {"mark_ops": [{"op": "add", "start": 8, "end": 12, "type": "strong"}]},
-        field="bio",
-    )
-    assert export_markdown(field(doc.main, "bio")) == "make it **bold** here"
-
-
-def test_content_codec_rebase_and_map_pos():
-    """The document-free codec round-trips and maps a position through a rebase."""
-    rt = import_markdown("hello world")
-    assert rt["text"] == "hello world"
-    assert export_markdown(rt) == "hello world"
-    out = rebase(rt, "hello brave world")
-    assert out["content"]["text"] == "hello brave world"
-    assert map_pos(out["delta"], 6, "before") == 6
-    assert map_pos(out["delta"], 11, "after") == 17
-
-

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -1,17 +1,10 @@
-"""Tests for Document."""
+"""Tests for Document — the quill-free transport surface (parse, storage,
+structure). Field I/O is the writer/view surface; see test_api_requirements.py."""
 
 import pytest
 
-from quillmark import (
-    Document,
-    QuillmarkError,
-    import_markdown,
-    export_markdown,
-    rebase,
-    map_pos,
-)
+from quillmark import Document, QuillmarkError
 
-import os
 from pathlib import Path
 
 
@@ -29,6 +22,7 @@ def has_field(card, key):
         i["type"] == "field" and i["key"] == key for i in card["payload_items"]
     )
 
+
 WORKSPACE_ROOT = Path(__file__).resolve().parents[4]
 RESOURCES_PATH = WORKSPACE_ROOT / "crates" / "fixtures" / "resources"
 QUILLS_PATH = RESOURCES_PATH / "quills"
@@ -44,21 +38,20 @@ def test_payload_access(taro_md):
     assert not has_field(doc.main, "$quill")
 
 
-def test_body_is_str(taro_md):
-    """Test that body is a str (not None)."""
+def test_body_is_content_dict(taro_md):
+    """`body` is the canonical content dict (source of truth); its `text` carries
+    the plain USV text quill-free. The markdown projection is
+    `quill.view(doc).get_body()`."""
     doc = Document.from_markdown(taro_md)
-    # `body` is the canonical content (a dict); its markdown projection is the
-    # on-demand `export_markdown(body)` codec.
     assert isinstance(doc.body, dict)
-    assert isinstance(export_markdown(doc.body), str)
-    assert "nutty" in export_markdown(doc.body)
+    assert "nutty" in doc.body["text"]
 
 
 def test_body_empty_when_absent():
-    """Test that body is empty string when no body content."""
+    """Test that body text is empty when no body content."""
     md = "~~~card-yaml\n$quill: taro\n$kind: main\nauthor: Test\ntitle: Test\nice_cream: Vanilla\n~~~\n"
     doc = Document.from_markdown(md)
-    assert export_markdown(doc.body) == ""
+    assert doc.body["text"] == ""
 
 
 def test_cards_access():
@@ -72,7 +65,7 @@ def test_cards_access():
     card = doc.cards[0]
     assert card["kind"] == "note"
     assert field(card, "foo") == "bar"
-    assert "Card body." in export_markdown(card["body"])
+    assert "Card body." in card["body"]["text"]
 
 
 def test_cards_empty_when_none():
@@ -197,9 +190,9 @@ def test_clone_isolates_mutations(taro_md):
     doc = Document.from_markdown(taro_md)
     cloned = doc.clone()
 
-    cloned.store_field("title", "Updated Title")
-    assert field(doc.main, "title") != "Updated Title"
-    assert field(cloned.main, "title") == "Updated Title"
+    cloned.remove_field("title")
+    assert has_field(doc.main, "title")
+    assert not has_field(cloned.main, "title")
 
 
 def test_copy_module_clones(taro_md):
@@ -214,8 +207,8 @@ def test_copy_module_clones(taro_md):
     assert shallow == doc
     assert deep == doc
 
-    shallow.store_field("title", "Shallow Edit")
-    assert field(doc.main, "title") != "Shallow Edit"
+    shallow.remove_field("title")
+    assert has_field(doc.main, "title")
 
 
 def test_equals_and_eq(taro_md):
@@ -232,7 +225,7 @@ def test_eq_after_mutation(taro_md):
     doc1 = Document.from_markdown(taro_md)
     doc2 = Document.from_markdown(taro_md)
 
-    doc2.store_field("title", "Different")
+    doc2.remove_field("title")
     assert doc1 != doc2
 
 
@@ -256,37 +249,37 @@ def test_repr_includes_quill_ref(taro_md):
     assert "taro" in text
 
 
-def test_remove_card_field_returns_value():
-    """remove_card_field removes and returns the field's value."""
+def test_remove_field_on_card_returns_value():
+    """remove_field(name, card=i) removes and returns a composable card field's
+    value — `remove` has no lane, one verb over the whole card axis."""
     md = (
         "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\nBody.\n\n"
         "~~~card-yaml\n$kind: note\nfoo: bar\nbaz: qux\n~~~\n"
     )
     doc = Document.from_markdown(md)
 
-    removed = doc.remove_card_field(0, "foo")
+    removed = doc.remove_field("foo", card=0)
     assert removed == "bar"
     assert not has_field(doc.cards[0], "foo")
     assert field(doc.cards[0], "baz") == "qux"
 
 
-def test_remove_card_field_absent_returns_none():
-    """remove_card_field returns None when the field doesn't exist."""
+def test_remove_field_on_card_absent_returns_none():
+    """remove_field(name, card=i) returns None when the field doesn't exist."""
     md = (
         "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\nBody.\n\n"
         "~~~card-yaml\n$kind: note\n~~~\n"
     )
     doc = Document.from_markdown(md)
-    assert doc.remove_card_field(0, "missing") is None
+    assert doc.remove_field("missing", card=0) is None
 
 
-def test_remove_card_field_out_of_range():
-    """remove_card_field raises EditError for an out-of-range card index."""
-
+def test_remove_field_on_card_out_of_range():
+    """remove_field(name, card=i) raises EditError for an out-of-range card index."""
     md = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n"
     doc = Document.from_markdown(md)
     with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
-        doc.remove_card_field(0, "foo")
+        doc.remove_field("foo", card=0)
 
 
 def test_diagnostic_str_is_canonical_pretty_text():
@@ -317,44 +310,33 @@ def test_document_authoring_text_helpers():
     assert isinstance(instr, str) and "taro" in instr
 
 
-def test_install_body_content_round_trip():
-    """`install(rt)` installs the content dict `body` reads back — value semantics,
-    lossless (not markdown-forced). The kwargs idiom of WASM `install`."""
-    doc = Document.from_markdown(
-        "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: T\n~~~\n\n**bold** body\n"
-    )
-    content = doc.body
-    assert isinstance(content, dict)
-    # Install the read-back content into a fresh doc: lossless.
-    doc2 = Document.from_markdown("~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: T\n~~~\n")
-    doc2.install(content)
-    assert doc2.body == content
-    # The cold markdown path is spelled with the codec; clearing installs empty.
-    doc2.install(import_markdown("plain text"))
-    assert "plain text" in export_markdown(doc2.body)
-    doc2.install(import_markdown(""))
-    assert export_markdown(doc2.body) == ""
-    # A markdown string cannot be installed directly (value semantics, content only).
+def _nest(levels, leaf):
+    """Wrap `leaf` in `levels` nested {"a": …} objects, built iteratively."""
+    v = leaf
+    for _ in range(levels):
+        v = {"a": v}
+    return v
+
+
+def test_depth_bound_matches_core_container_levels():
+    """py_to_json_at and core's json_depth_exceeds reject the identical shape.
+
+    The cutoff is container levels (100), not nodes: a scalar leaf at the
+    bottom is not charged a level, so exactly 100 nested objects are accepted
+    and 101 are rejected — whether the deepest container holds a scalar or
+    another (non-empty) container. Exercised through `make_card`, whose field
+    values cross the same `py_to_json` boundary the writer's `set` does.
+    """
+    # Scalar-terminated: 100 objects with a scalar leaf is at the limit.
+    Document.make_card("note", {"ok_scalar": _nest(100, 1)})
     with pytest.raises((QuillmarkError, ValueError)):
-        doc2.install("plain markdown")
+        Document.make_card("note", {"deep_scalar": _nest(101, 1)})
 
-
-def test_addressed_card_body_and_field_projection():
-    """`install(rt, card=i)` writes a composable card's content body; a committed
-    richtext field projects through `export_markdown` (the codec that replaces
-    the retired `field_markdown` / `card_field_markdown`)."""
-    md = (
-        "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: Main\n~~~\n\nMain body.\n\n"
-        "~~~card-yaml\n$kind: note\nfoo: bar\n~~~\n\nCard body.\n"
-    )
-    doc = Document.from_markdown(md)
-    doc.install(import_markdown("**new** card body"), card=0)
-    assert "**new** card body" in export_markdown(doc.cards[0]["body"])
-    # A revise on a card body returns a Delta receipt.
-    delta = doc.revise("plain card body", card=0)
-    assert isinstance(delta["ops"], list)
-    # An absent field has no value to project.
-    assert field(doc.main, "missing") is None
+    # Container-terminated: the deepest container, not its contents, occupies
+    # the last level, so the boundary is identical.
+    Document.make_card("note", {"ok_container": _nest(99, [1, 2, 3])})
+    with pytest.raises((QuillmarkError, ValueError)):
+        Document.make_card("note", {"deep_container": _nest(100, [1, 2, 3])})
 
 
 def test_nested_fill_exposed_as_nested_fills():
@@ -372,46 +354,13 @@ def test_nested_fill_exposed_as_nested_fills():
     assert "street: !must_fill" in restored.to_markdown()
 
 
-def _nest(levels, leaf):
-    """Wrap `leaf` in `levels` nested {"a": …} objects, built iteratively."""
-    v = leaf
-    for _ in range(levels):
-        v = {"a": v}
-    return v
-
-
-def test_depth_bound_matches_core_container_levels():
-    """py_to_json_at and core's json_depth_exceeds reject the identical shape.
-
-    The cutoff is container levels (100), not nodes: a scalar leaf at the
-    bottom is not charged a level, so exactly 100 nested objects are accepted
-    and 101 are rejected — whether the deepest container holds a scalar or
-    another (non-empty) container. Pins the scalar-leaf boundary the core test
-    `value.rs::depth_check_counts_container_levels_not_the_scalar_leaf` also pins.
-    """
-    doc = Document.from_markdown(
-        "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: x\n~~~\n"
-    )
-
-    # Scalar-terminated: 100 objects with a scalar leaf is at the limit.
-    doc.store_field("ok_scalar", _nest(100, 1))
-    with pytest.raises((QuillmarkError, ValueError)):
-        doc.store_field("deep_scalar", _nest(101, 1))
-
-    # Container-terminated: the deepest container, not its contents, occupies
-    # the last level, so the boundary is identical.
-    doc.store_field("ok_container", _nest(99, [1, 2, 3]))
-    with pytest.raises((QuillmarkError, ValueError)):
-        doc.store_field("deep_container", _nest(100, [1, 2, 3]))
-
-
-def test_nested_fill_push_card_round_trip():
-    """A card dict carrying `nestedFills` can be pushed and the nested marker
+def test_nested_fill_insert_card_round_trip():
+    """A card dict carrying `nestedFills` can be inserted and the nested marker
     is reconstructed on emit (the dict -> Card serde path reads it back)."""
     doc = Document.from_markdown(
         "~~~card-yaml\n$quill: q@0.1\n$kind: main\ntitle: x\n~~~\n"
     )
-    doc.push_card(
+    doc.insert_card(
         {
             "kind": "note",
             "payload_items": [

--- a/docs/migrations/0.94-to-0.95.md
+++ b/docs/migrations/0.94-to-0.95.md
@@ -432,9 +432,62 @@ quill.view(doc).card(2).get('body')               // now
 (`to_plaintext`): a `*hi*` reads back as four characters, not emphasis — the same
 codec the write path uses, in reverse.
 
-## Python
+## Python commits to Tier 1 + storage + render (#970)
 
-The Python surface trails on this release (per its second-class status): the
-positioned `add_card(at)`, the single-card reads, and a cursor `kind` getter are
-not yet mirrored. Python's `Payload` is not exposed, so #958 does not affect it;
-its `doc.warnings` getter is unchanged by #959.
+Rather than mirror the reshaped `store*` / `Addr` / content-lane surface, the
+Python binding cuts to its lanes. Field I/O flows through `quill.writer(doc)` /
+`quill.view(doc)` exclusively; `Document` is quill-free data and structure. The
+opaque store and the anchor-preserving content lane are **WASM-only by scope,
+not by lag** — their audience (storage/migration tooling holding no quill, live
+editors preserving anchor identity) is not a Python audience. This resolves the
+half-mirror drift #970 priced: no lane that could drift remains in Python.
+
+**Removed.** The opaque field store, the content lane, the quill-free field
+reads, and the document-free codec:
+
+| 0.94 (Python) | 0.95 replacement |
+|---|---|
+| `doc.store_field(name, v)` / `doc.store_fields(m)` / `doc.store_fill(name, v)` | `quill.writer(doc).set(name, v)` / `.set_all(m)`; a fill lands through a typed `set` (which clears the `!must_fill` marker) |
+| `doc.store_card_field(i, name, v)` / `doc.store_card_fields(i, m)` | `quill.writer(doc).card(i).set(name, v)` / `.set_all(m)` |
+| `doc.get(name)` / `doc.get_card_field(i, name)` | `quill.view(doc).get(name)` / `quill.view(doc).card(i).get(name)` |
+| `doc.get_markdown()` / `doc.get_card_markdown(i)` | `quill.view(doc).get_body()` / `quill.view(doc).card(i).get_body()` |
+| `doc.install(rt, …)` / `doc.revise(md, …)` / `doc.apply_change(b, …)` | none (WASM-only); the typed `writer.revise_field` is the anchor-preserving field write |
+| `import_markdown` / `export_markdown` / `rebase` / `map_pos` (module fns) | none (WASM-only); read body markdown via `quill.view(doc).get_body()`, and `doc.body` is the content dict (`{text, lines, marks, islands}`) |
+| `doc.replace_body(md)` / `doc.update_card_body(i, md)` (deprecated aliases) | `quill.writer(doc).set_body(md)` / `.card(i).set_body(md)` |
+
+A field write without a loadable quill operates on the storage DTO directly
+(`to_json` / `from_json`), or through core / WASM / the CLI, where the store lane
+remains.
+
+**Changed** — the composable-card twins fold onto one `card=` selector, and the
+insertion verbs fold to one:
+
+```
+0.94                                  0.95
+doc.store_card_ext(i, v)              doc.store_ext(v, card=i)
+doc.remove_card_ext(i)               doc.remove_ext(card=i)
+doc.store_card_ext_namespace(i,n,v)  doc.store_ext_namespace(n, v, card=i)
+doc.remove_card_ext_namespace(i,n)   doc.remove_ext_namespace(n, card=i)
+doc.remove_card_field(i, name)       doc.remove_field(name, card=i)
+doc.push_card(card)                  doc.insert_card(card)          # absent at appends
+doc.insert_card(i, card)             doc.insert_card(card, at=i)
+```
+
+`store_ext` / `remove_ext` / `store_ext_namespace` / `remove_ext_namespace` and
+`remove_field` gain a trailing `card=None` (main) selector; the whole-map ext
+verbs and `$seed` namespace verbs are otherwise unchanged.
+
+**Added** — the 0.95 additive surface, now mirrored:
+
+- `quill.writer(doc).revise_field(name, md)` / `writer.card(i).revise_field(..)` —
+  the typed, anchor-preserving richtext field write (#957, #966). Python discards
+  the `Delta` it returns in core / WASM (the position-mapping receipt is an editor
+  concern, and that lane is WASM-only).
+- `quill.writer(doc).add_card(kind, fields?, body?, at=None)` — the positioned
+  typed insert (#961); absent `at` appends.
+- `writer.card(i).kind` — the cursor `kind` getter (#961).
+- The typed handle classes `Writer` / `CardWriter` / `View` / `CardView` are
+  exported from the `quillmark` package (for `isinstance` / typing).
+
+Python's `Payload` is not exposed, so #958 does not affect it; its `doc.warnings`
+getter is unchanged by #959.

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -100,8 +100,10 @@ is structural, not asserted.
 ### Parity table
 
 Every binding verb is *identical* to its core twin or names its one forced
-difference — **FFI** (a wasm-bindgen / pyo3 constraint) or **idiom** (a language
-ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
+difference — **FFI** (a wasm-bindgen / pyo3 constraint), **idiom** (a language
+ergonomic), or **scope** (a lane a binding omits by intent — Python is Tier 1 +
+storage + render, [#970](https://github.com/borb-sh/quillmark/issues/970)),
+nothing else admitted. Drift is a reviewable diff to this table.
 
 | Concept | Core | Bindings | Class |
 |---|---|---|---|
@@ -110,16 +112,16 @@ ergonomic), nothing else admitted. Drift is a reviewable diff to this table.
 | Interpreted read | `view.get(name)?` → `ReadValue` (richtext → markdown, plaintext → literal text, else canonical); `view.card(i)?.get(..)?` | `view.get(addr)` / `view.card(i).get(name)` (JS), `view.get(name)` / `view.card(i).get(name)` (py) | **idiom** / **FFI** — one `get` interprets by declared type; absent → `undefined`/`None`, unknown name → `UnknownField`, undecodable content → `FieldRichtextDecode`; a field's markdown reads here, not on the body-only `getMarkdown` (#978). Body read (`view.getBody` / absent-field addr) stays quill-free |
 | Scalar / batch write | `set` / `set_all` | `set` / `setAll` (JS), `set` / `set_all` (py) | identical |
 | Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
-| Typed richtext field revise | `TypedWriter::revise_field(name, md)?` / `CardWriter::revise_field(..)?` | `writer.reviseField(name, md)` / `writer.card(i).reviseField(..)` | identical — typed *and* anchor-preserving, returns the `Delta`; both wrap the `Card::revise_field_checked` primitive |
+| Typed richtext field revise | `TypedWriter::revise_field(name, md)?` / `CardWriter::revise_field(..)?` | `writer.reviseField(name, md)` / `writer.card(i).reviseField(..)` (JS); `writer.revise_field(name, md)` / `writer.card(i).revise_field(..)` (py) | **idiom** — typed *and* anchor-preserving; both wrap `Card::revise_field_checked`. JS returns the `Delta`; Python discards it (the position-mapping receipt is an editor concern, WASM-only) |
 | Card creation | `add_card(kind, fields, body?, at?)` | `addCard(kind, fields?, body?, at?)` | identical — fused make + typed-commit + insert, transactional (`at` appends when absent, else inserts at the index — one atomic positioned insert, not `addCard` + `moveCard`) |
 | Card insertion | `push_card(card)` / `insert_card(i, card)` | `insertCard(card, at?)` | **idiom** — the binding folds core's append + positional-insert verbs into one; absent `at` appends |
 | Card removal (writer) | `writer.remove_card(i)` | `writer.removeCard(i)` | identical |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
 | Cursor kind | `writer.card(i)?.kind()` | `writer.card(i).kind` | identical — the JS getter reads through `doc.card(i)` |
-| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.get(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS); name-keyed twins (py) | **idiom** / **FFI** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `get`/`isFill`), *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws). `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws) — a field's markdown reads through the schema-plane `view.get` (#978); Python stays name-keyed |
+| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.get(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `get`/`isFill`), *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.view(doc).get` (#978, #970), and `$ext` / body content read off the `main` / `cards` dict snapshots |
 | Reads (whole card / `$id` / seed) | `card(i)` / `find_card(id)` / `main().seed()` | `doc.card(i)` / `doc.cardIndexById(id)` / `doc.seedOverlay(kind)` | **idiom** — the bindings fuse each into one named verb on `Document`; `card(i)` throws out of range, `find_card`/`cardIndexById` return the first `$id` match (non-unique by design) |
-| Richtext revise (content lane) | `Card::revise_field(name, md)?` (schema-blind, borrow chain) | `doc.revise({card, field}, md)` (addr literal) | **FFI** — same model, flattened navigation; schema-blind, `Delta` in hand |
-| Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`), `store_field` / `store_fields` / `store_card_field` (py, name-keyed) | identical — the quill-free verbatim write; WASM addresses with `Addr`, Python stays name-keyed |
+| Richtext revise (content lane) | `Card::revise_field(name, md)?` (schema-blind, borrow chain) | `doc.revise({card, field}, md)` (addr literal, JS) | **FFI** / **scope** — same model, flattened navigation, schema-blind, `Delta` in hand; WASM-only. Python's anchor-preserving write is the typed `writer.revise_field` (#970) |
+| Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`) | **scope** — the quill-free verbatim write, WASM-only; Python has no opaque field store (the typed writer is the only field write, #970). A field write without a loadable quill operates on the storage DTO directly |
 | Parse + warnings | `Document::parse(md) -> Parsed { document, warnings }` | `Document.fromMarkdown(md)` → `doc.warnings` getter | **FFI** — the wrapper fuses `Parsed` + `Document` into one session object: `fromMarkdown` returns the document directly and stashes the parse `warnings` on it (`doc.warnings`). That getter is a deliberate asymmetry with core, where warnings live only on `Parsed`: it is session state, so `equals` and the storage DTO exclude it and `loadJson`/`fromJson` clear it (a reloaded document carries no parse warnings) |
 
 The single **idiom** row on the front door is the honest cost: the typed writer
@@ -128,12 +130,25 @@ claimed. See the as-built [0.93 → 0.94 migration](../../docs/migrations/0.93-t
 
 ## Python — `bindings/quillmark-python`
 
-PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface mirroring
-the shared model; one-shot `engine.render` (no canvas).
+PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface over the
+shared model; one-shot `engine.render` (no canvas).
 
-> **Status: experimental, second-class binding.** The Python surface lags the
-> WASM binding in coverage and in error-shape uniformity. Do not gate releases
-> on Python parity.
+> **Scope: Tier 1 + storage + render ([#970](https://github.com/borb-sh/quillmark/issues/970)).**
+> Field I/O flows through `quill.writer(doc)` / `quill.view(doc)` exclusively;
+> `Document` is quill-free data and structure (parse, the storage DTO,
+> `insert_card` / `remove_card` / `move_card` / `make_card`, `remove_field`,
+> `$ext` / `$seed`). The opaque store (`store_field` / `store_fields` /
+> `store_fill`) and the anchor-preserving content lane (`install` / `revise` /
+> `apply_change` + the `import_markdown` / `export_markdown` / `rebase` /
+> `map_pos` codec) are **WASM-only by scope, not by lag** — their audience,
+> storage/migration tooling holding no quill and live editors preserving anchor
+> identity, is not a Python audience. A field write without a loadable quill
+> operates on the storage DTO directly.
+
+Every Python verb is identical to its core/WASM twin or names its one difference
+in the parity table above: `card=None` selectors fold the composable-card `$ext`
+/ `remove_field` twins onto one axis, and `revise_field` discards the `Delta`
+(an editor receipt). No half-mirrored lane remains to drift.
 
 ## WebAssembly — `bindings/quillmark-wasm`
 


### PR DESCRIPTION
Resolves the decision in #970 as **position (1), sharpened**: Python is **Tier 1 + storage + render**. Field I/O flows through `quill.writer(doc)` / `quill.view(doc)` exclusively; `Document` is quill-free data and structure. The opaque store and the anchor-preserving content lane are **WASM-only by scope, not by lag** — their audience (storage/migration tooling holding no quill; live editors preserving anchor identity) is a JS audience today. This removes every half-mirrored lane that could drift, which is the cost #970 priced.

Rationale and the accepted trade-offs are recorded in [#970 (comment)](https://github.com/borb-sh/quillmark/issues/970#issuecomment-5013607176).

## Removed (WASM-only by scope)

- Opaque field store — `store_field` / `store_fields` / `store_fill` (+ card twins)
- Content lane — `install` / `revise` / `apply_change`
- Document-free codec — `import_markdown` / `export_markdown` / `rebase` / `map_pos`
- Quill-free field reads — `get` / `get_markdown` / `get_card_field` / `get_card_markdown`
- Deprecated aliases — `replace_body` / `update_card_body`
- The now-unused `quillmark-content` dependency

## Changed (twins fold onto one axis)

- The composable-card `$ext` twins and `remove_card_field` fold onto one trailing `card=None` selector (`store_ext(v, card=i)`, `remove_field(name, card=i)`, …) — the idiom the content lane already proved.
- `push_card` folds into `insert_card(card, at=None)`.

## Added (0.95 additive surface, now mirrored)

- `writer.revise_field(name, md)` / `writer.card(i).revise_field(..)` — the typed, anchor-preserving richtext field write. Python discards the `Delta` (an editor receipt; that lane is WASM-only).
- `writer.add_card(kind, fields?, body?, at=None)` — positioned typed insert.
- `writer.card(i).kind` getter.
- `Writer` / `CardWriter` / `View` / `CardView` are exported from the `quillmark` package.
- `__version__` now derives from installed package metadata (was a stale `"0.1.0"` literal against a `dynamic` version).

## The one accepted cost

A field write without a loadable quill loses its lane. Such tooling operates on the storage DTO directly (`to_json` / `from_json`), or through core / WASM / the CLI, where the store lane remains.

## Tests / CI

- Python binding tests **were never run in CI**. This PR adds a `python` job to `ci.yml` that builds the pyo3 extension and runs `pytest` on every PR.
- `test_api_requirements.py` and `test_parse.py` are rewritten to the Tier-1 surface against the real fixture quills (`taro`, `richtext_form`), including a fill-lifecycle test (seed → `validate(must_fill)` → typed `set` clears the marker) that replaces the removed `store_fill` path. The other test files needed no change.
- `cargo check -p quillmark-python` is clean; the pyo3 extension builds under `maturin`. Full pytest runs in the new CI job.

## Docs

- `README.md` — rewritten API surface (writer/view front doors), removed the reference to the nonexistent `replace_card_body`.
- `prose/canon/BINDINGS.md` — Python scope statement; parity table admits a **scope** difference-kind and marks the WASM-only lanes.
- `docs/migrations/0.94-to-0.95.md` — a full Python migration table (removed / changed / added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMXQPZPtADfU4xADiW9inP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMXQPZPtADfU4xADiW9inP)_