### PR TITLE
Document Rust crate publishing and Trusted Publisher setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,13 @@ jobs:
         # --workspace: bare `cargo publish` operates on default-members, which
         # exclude crates/content — the leaf every published crate depends on.
         # publish = false members (fixtures, fuzz, bindings) are skipped; cargo
-        # orders the rest by dependency.
+        # orders the rest by dependency and skips versions already on the
+        # registry, so a re-run resumes a partially-uploaded release.
+        #
+        # Each published crate needs its own crates.io Trusted Publisher (this
+        # repo + this workflow + the Publish environment). A crate missing one
+        # 403s ("access token is not valid for crate <name>") when the ordered
+        # publish reaches it — add the config on crates.io, then re-run.
         run: cargo publish --workspace --locked --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}

--- a/prose/canon/CI_CD.md
+++ b/prose/canon/CI_CD.md
@@ -6,7 +6,7 @@
 
 Four workflows. `ci.yml` runs lint/test/wasm on every PR and non-tag push. `release-prepare.yml` computes the next version, bumps the workspace, and opens a release PR. `release.yml` tags and publishes to crates.io, npm, and PyPI when that PR merges. `docs.yml` builds MkDocs and deploys to GitHub Pages on stable releases.
 
-Published crates: `quillmark-core`, `quillmark`, `quillmark-pdf`, `quillmark-typst`, `quillmark-pdfform`, `quillmark-cli`. Not published: `quillmark-fixtures`, `quillmark-fuzz`, `quillmark-python`, `quillmark-wasm`.
+Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `quillmark-pdf`, `quillmark-pdfform`, `quillmark-typst`, `quillmark`, `quillmark-cli`. Not published: `quillmark-fixtures`, `quillmark-fuzz`, `quillmark-python`, `quillmark-wasm`.
 
 ---
 
@@ -51,12 +51,17 @@ The PR uses a GitHub App token (`TAGGER_APP_ID`/`TAGGER_PRIVATE_KEY`) so CI runs
 
 | Target | Registry | Command |
 |--------|----------|---------|
-| Rust crates | crates.io | `cargo publish --locked --no-verify` via `rust-lang/crates-io-auth-action` |
+| Rust crates | crates.io | `cargo publish --workspace --locked --no-verify` via `rust-lang/crates-io-auth-action` |
 | WASM | npm | `npm publish --access public --provenance` (Trusted Publisher) |
 | Python | PyPI | `pypa/gh-action-pypi-publish` over prebuilt wheels |
 
+- **Rust crates**: `--workspace` reaches every publishable member, including `quillmark-content` — the leaf the default-members exclude — and skips the `publish = false` members (fixtures, fuzz, bindings). Cargo orders the rest by dependency and skips any version already on the registry with a warning, so re-running resumes a partially-uploaded release instead of erroring.
 - **WASM**: restores the `wasm-release-` cache (`wasm-release` profile), builds via `./scripts/build-wasm.sh`, runs `npx vitest run`, publishes `@quillmark/wasm`. Pre-release versions (containing `-`) publish with `--tag next` so they land on the `next` dist-tag instead of `latest`.
 - **Python**: `maturin-action` builds wheels for Linux (x86_64, aarch64), Windows (x64), macOS (aarch64) across Python 3.10–3.12, plus an sdist; artifacts are gathered and uploaded with `skip-existing`.
+
+### Trusted Publishing scope (crates.io)
+
+`crates-io-auth-action` mints an OIDC token scoped to exactly the crates carrying a matching Trusted Publisher config — repo `borb-sh/quillmark`, workflow `release.yml`, environment `Publish`. That config is **per crate**. A publishable crate without one draws `403 … the provided access token is not valid for crate <name>` the moment the dependency-ordered publish reaches it, after earlier crates have already gone up (crates.io versions are immutable, so those uploads stand). Every crate in the published list carries its own config; a new publishable crate needs one added on crates.io before its first release, and the partial-upload skip above makes the re-run that finishes the batch safe.
 
 ---
 


### PR DESCRIPTION
Updates CI/CD documentation and workflow comments to clarify the Rust crate publishing process, particularly around the `--workspace` flag and per-crate Trusted Publisher configuration on crates.io.

**Changes:**

- **CI_CD.md**: Updated the published crates list to reflect dependency order and include `quillmark-content` (the leaf dependency that default-members exclude). Added a new section explaining Trusted Publisher scope per crate and the implications of partial uploads when a crate lacks its config.

- **release.yml**: Expanded inline comments on the `cargo publish` step to document:
  - How `--workspace` reaches all publishable members including `quillmark-content`
  - How cargo skips versions already on the registry, allowing re-runs to resume a partially-uploaded release
  - The per-crate Trusted Publisher requirement and the `403` error that occurs when a crate lacks its config
  - The recovery path: add the config on crates.io, then re-run

**Context:**

The `cargo publish --workspace` command depends on each crate having its own Trusted Publisher configuration on crates.io (scoped to this repo, the `release.yml` workflow, and the `Publish` environment). If a new publishable crate is added without this config, the ordered publish will fail partway through with a `403` error after earlier crates have already uploaded. The documentation now makes this explicit so future maintainers understand the setup requirement and the safe recovery path.

https://claude.ai/code/session_012vLbN9F75B7UX7b9ZZqAVX