### PR TITLE
content: centralize island type dispatch behind KnownIslandType (#985)

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -735,8 +735,8 @@ impl<'a> Emit<'a> {
         match KnownIslandType::parse(&isl.island_type) {
             Some(KnownIslandType::Image) => image_markup(&isl.props),
             Some(KnownIslandType::Table) => table_markup(&isl.props),
-            // Genuinely-unknown island types emit nothing (parallel to the HTML
-            // rule). A new *known* type is a compile error here, not silence.
+            // Unknown island types emit nothing (parallel to the HTML rule). A
+            // new known type is a compile error here, not silence.
             None => String::new(),
         }
     }

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -46,6 +46,7 @@
 //! escape-rule change fails loud.
 
 use quillmark_core::error::MAX_NESTING_DEPTH;
+use quillmark_content::island::KnownIslandType;
 use quillmark_content::model::{Container, LineKind, Mark, MarkKind, Content, ISLAND_SLOT};
 use std::ops::Range;
 
@@ -731,11 +732,12 @@ impl<'a> Emit<'a> {
         let Some(isl) = self.rt.islands.get(idx) else {
             return String::new();
         };
-        match isl.island_type.as_str() {
-            "image" => image_markup(&isl.props),
-            "table" => table_markup(&isl.props),
-            // Unknown island types emit nothing (parallel to the HTML rule).
-            _ => String::new(),
+        match KnownIslandType::parse(&isl.island_type) {
+            Some(KnownIslandType::Image) => image_markup(&isl.props),
+            Some(KnownIslandType::Table) => table_markup(&isl.props),
+            // Genuinely-unknown island types emit nothing (parallel to the HTML
+            // rule). A new *known* type is a compile error here, not silence.
+            None => String::new(),
         }
     }
 }

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -27,6 +27,7 @@
 //! markdown or a form editor. Neither is hardened — no live editor yet defines
 //! what it can produce.
 
+use crate::island::KnownIslandType;
 use crate::model::{Container, Island, LineKind, MarkKind, Content, ISLAND_SLOT};
 
 /// Render a content to markdown. Lossless/degraded islands emit their markdown;
@@ -328,14 +329,16 @@ fn slot_island<'a>(ctx: &'a Ctx, i: usize) -> Option<&'a Island> {
 }
 
 fn emit_island(isl: &Island, out: &mut String) {
-    match isl.island_type.as_str() {
-        "table" => emit_table(isl, out),
-        "image" => emit_image(isl, out),
-        _ => {
-            // Unknown island / unrepresentable: a comment placeholder that
+    match KnownIslandType::parse(&isl.island_type) {
+        Some(KnownIslandType::Table) => emit_table(isl, out),
+        Some(KnownIslandType::Image) => emit_image(isl, out),
+        None => {
+            // Genuinely-unknown island (the open set): a comment placeholder that
             // survives round-trip as no content text (HTML comments are stripped
             // on re-import). The island itself is preserved via storage, not the
-            // projection.
+            // projection. A *known* type can't land here — [`KnownIslandType`] is
+            // exhaustive above, so a new type is a compile error, not a silent
+            // placeholder.
             out.push_str(&format!("<!-- island:{} -->", isl.island_type));
         }
     }

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -333,12 +333,11 @@ fn emit_island(isl: &Island, out: &mut String) {
         Some(KnownIslandType::Table) => emit_table(isl, out),
         Some(KnownIslandType::Image) => emit_image(isl, out),
         None => {
-            // Genuinely-unknown island (the open set): a comment placeholder that
-            // survives round-trip as no content text (HTML comments are stripped
-            // on re-import). The island itself is preserved via storage, not the
-            // projection. A *known* type can't land here — [`KnownIslandType`] is
-            // exhaustive above, so a new type is a compile error, not a silent
-            // placeholder.
+            // Unknown island (the open set): a comment placeholder that survives
+            // round-trip as no content text (HTML comments are stripped on
+            // re-import). The island is preserved via storage, not the projection.
+            // A known type can't reach here — the match is exhaustive, so a new
+            // type is a compile error, not a silent placeholder.
             out.push_str(&format!("<!-- island:{} -->", isl.island_type));
         }
     }

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -40,6 +40,7 @@
 use crate::model::{
     Container, Island, Line, LineKind, Loss, Mark, MarkKind, Content, ISLAND_SLOT,
 };
+use crate::island::KnownIslandType;
 use crate::normalize::normalize_markdown;
 use crate::MAX_NESTING_DEPTH;
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
@@ -401,12 +402,15 @@ impl Builder {
         self.inline.close_mark();
     }
 
-    fn mint_island(&mut self, island_type: &str, props: serde_json::Value, loss: Loss) {
+    /// Mint an island of a *known* type — the importer can only produce the
+    /// closed set, so an unknown type can enter the system through storage
+    /// deserialization but never through import.
+    fn mint_island(&mut self, kind: KnownIslandType, props: serde_json::Value, loss: Loss) {
         let id = format!("isl-{}", self.island_seq);
         self.island_seq += 1;
         self.islands.push(Island {
             id,
-            island_type: island_type.to_string(),
+            island_type: kind.as_str().to_string(),
             props,
             loss,
         });
@@ -839,13 +843,14 @@ impl Builder {
                 "rows": acc.rows,
             });
             // Degraded when a cell dropped an inline image's url — the projection
-            // then carries the alt text but not the image (not a fixed point).
+            // then carries the alt text but not the image (not a fixed point);
+            // otherwise the type's ceiling.
             let loss = if acc.degraded {
                 Loss::Degraded
             } else {
-                Loss::Lossless
+                KnownIslandType::Table.default_loss()
             };
-            self.mint_island("table", props, loss);
+            self.mint_island(KnownIslandType::Table, props, loss);
         }
     }
 
@@ -856,7 +861,7 @@ impl Builder {
             "url": self.image_url,
             "alt": self.image_alt.trim(),
         });
-        self.mint_island("image", props, Loss::Lossless);
+        self.mint_island(KnownIslandType::Image, props, KnownIslandType::Image.default_loss());
     }
 
     fn finish(mut self) -> Content {

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -1,0 +1,143 @@
+//! Island types — the closed dispatch authority.
+//!
+//! [`Island::island_type`](crate::model::Island::island_type) stays an **open**
+//! string on the wire: a genuinely-unknown type (one this build was never taught,
+//! arriving via storage) round-trips opaque. [`KnownIslandType`] is that string's
+//! *parse* into the closed set this build understands, and every site that
+//! dispatches on a type matches [`KnownIslandType::parse`]. The `Some(k)` arm is
+//! exhaustive over the enum, so **adding a variant is a compile error at every
+//! dispatch site** — a known type wired into only some sites cannot reach the
+//! `None` path, which is reserved for the open set.
+//!
+//! The behavior a type must supply lives here as one method per seam
+//! ([`default_loss`](KnownIslandType::default_loss),
+//! [`cell_marks`](KnownIslandType::cell_marks),
+//! [`normalize_props`](KnownIslandType::normalize_props),
+//! [`shape_error`](KnownIslandType::shape_error)); the two projections that can't
+//! live in this crate — markdown emit ([`crate::export`]) and Typst emit (the
+//! typst backend) — match on the enum where they are, so the exhaustiveness
+//! guarantee still crosses the crate boundary. The table codec itself stays in
+//! [`crate::serial`]; this module dispatches into it.
+
+use crate::model::{Invariant, Island, Loss, Mark};
+use serde_json::Value;
+
+/// The island types this build understands. The wire discriminator is the open
+/// string [`Island::island_type`](crate::model::Island::island_type); this is its
+/// closed parse. Adding a variant forces every dispatch arm — here and in the two
+/// emitters — to be supplied before the workspace compiles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KnownIslandType {
+    /// `{header, rows, aligns}` with inline `{text, marks}` cells. Mark-carrying,
+    /// shape-validated (one column count, `\n`-free cells).
+    Table,
+    /// `{url, alt}`. No cell model, no shape invariants.
+    Image,
+}
+
+impl KnownIslandType {
+    /// The wire discriminator. `parse(k.as_str()) == Some(k)` for every variant
+    /// (the [`known_types_round_trip`](self) test pins it).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::Image => "image",
+        }
+    }
+
+    /// Parse a wire discriminator into the closed set. `None` is the open-set
+    /// escape hatch — a genuinely-unknown type, round-tripped opaque — never a
+    /// known type wired into only some sites.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "table" => Some(Self::Table),
+            "image" => Some(Self::Image),
+            _ => None,
+        }
+    }
+
+    /// The best markdown-projection loss class this type achieves — the ceiling
+    /// the importer stamps at mint. A per-island [`Loss`] may sit *below* it (a
+    /// table cell dropping an inline image's url degrades that instance) but never
+    /// above; centralizing the ceiling here keeps the mint sites from disagreeing.
+    pub fn default_loss(self) -> Loss {
+        match self {
+            Self::Table => Loss::Lossless,
+            Self::Image => Loss::Lossless,
+        }
+    }
+
+    /// This type's `(text, marks)` cells — the set that participates in mark
+    /// normalization and cell-mark validation. Empty for a type with no cell
+    /// model, so neither normalize nor validate can silently skip a new type
+    /// (which would void the canonical-bytes guarantee for its cells).
+    pub fn cell_marks(self, props: &Value) -> Vec<(String, Vec<Mark>)> {
+        match self {
+            Self::Table => crate::serial::table_cells(props),
+            Self::Image => Vec::new(),
+        }
+    }
+
+    /// Repair this type's props to canonical shape in place (a no-op for a type
+    /// with no shape invariants) — the normalize-side dispatch.
+    pub fn normalize_props(self, props: &mut Value) {
+        match self {
+            Self::Table => crate::serial::normalize_table_props(props),
+            Self::Image => {}
+        }
+    }
+
+    /// This type's shape violation, if any (`None` for a well-formed or shape-free
+    /// island) — the validate-side twin of [`normalize_props`](Self::normalize_props),
+    /// which guarantees this returns `None`.
+    pub fn shape_error(self, props: &Value) -> Option<Invariant> {
+        match self {
+            Self::Table => crate::serial::table_shape_error(props),
+            Self::Image => None,
+        }
+    }
+}
+
+/// Repair an island's props to its type's canonical shape in place (a no-op for
+/// an unknown type — its opaque props are preserved verbatim). The normalize-side
+/// island-type dispatch, called from [`Content::normalize`](crate::Content).
+pub(crate) fn normalize_island_structure(island: &mut Island) {
+    if let Some(k) = KnownIslandType::parse(&island.island_type) {
+        k.normalize_props(&mut island.props);
+    }
+}
+
+/// An island's `(text, marks)` cells for validation (empty for a type with no
+/// cell model, and for an unknown type). The validate-side twin of
+/// [`normalize_island_structure`].
+pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
+    match KnownIslandType::parse(&island.island_type) {
+        Some(k) => k.cell_marks(&island.props),
+        None => Vec::new(),
+    }
+}
+
+/// An island's shape violation, if any (`None` for a well-formed, shape-free, or
+/// unknown island). For a known type, [`normalize_island_structure`] guarantees
+/// this returns `None`.
+pub(crate) fn island_shape_error(island: &Island) -> Option<Invariant> {
+    KnownIslandType::parse(&island.island_type).and_then(|k| k.shape_error(&island.props))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_types_round_trip() {
+        for k in [KnownIslandType::Table, KnownIslandType::Image] {
+            assert_eq!(KnownIslandType::parse(k.as_str()), Some(k));
+        }
+    }
+
+    #[test]
+    fn unknown_type_parses_to_none() {
+        assert_eq!(KnownIslandType::parse("figure"), None);
+        assert_eq!(KnownIslandType::parse(""), None);
+    }
+}

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -1,23 +1,19 @@
 //! Island types — the closed dispatch authority.
 //!
 //! [`Island::island_type`](crate::model::Island::island_type) stays an **open**
-//! string on the wire: a genuinely-unknown type (one this build was never taught,
-//! arriving via storage) round-trips opaque. [`KnownIslandType`] is that string's
-//! *parse* into the closed set this build understands, and every site that
-//! dispatches on a type matches [`KnownIslandType::parse`]. The `Some(k)` arm is
-//! exhaustive over the enum, so **adding a variant is a compile error at every
-//! dispatch site** — a known type wired into only some sites cannot reach the
-//! `None` path, which is reserved for the open set.
+//! string on the wire: an unknown type (one this build lacks, arriving via
+//! storage) round-trips opaque. [`KnownIslandType`] is that string's *parse* into
+//! the closed set, and every site that dispatches on a type matches
+//! [`KnownIslandType::parse`]. The `Some(k)` arm is exhaustive, so **adding a
+//! variant is a compile error at every dispatch site**; a known type wired into
+//! only some sites cannot reach the `None` path, which is the open set's alone.
 //!
-//! The behavior a type must supply lives here as one method per seam
-//! ([`default_loss`](KnownIslandType::default_loss),
-//! [`cell_marks`](KnownIslandType::cell_marks),
-//! [`normalize_props`](KnownIslandType::normalize_props),
-//! [`shape_error`](KnownIslandType::shape_error)); the two projections that can't
+//! Behavior a type must supply lives on the enum, one method per seam (loss
+//! class, cell marks, shape normalize/validate). The two projections that can't
 //! live in this crate — markdown emit ([`crate::export`]) and Typst emit (the
-//! typst backend) — match on the enum where they are, so the exhaustiveness
-//! guarantee still crosses the crate boundary. The table codec itself stays in
-//! [`crate::serial`]; this module dispatches into it.
+//! typst backend) — match on the enum where they are, so the guarantee crosses
+//! the crate boundary. The `table` codec stays in [`crate::serial`]; this module
+//! dispatches into it.
 
 use crate::model::{Invariant, Island, Loss, Mark};
 use serde_json::Value;
@@ -36,8 +32,7 @@ pub enum KnownIslandType {
 }
 
 impl KnownIslandType {
-    /// The wire discriminator. `parse(k.as_str()) == Some(k)` for every variant
-    /// (the [`known_types_round_trip`](self) test pins it).
+    /// The wire discriminator; `parse(k.as_str()) == Some(k)` for every variant.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Table => "table",
@@ -58,8 +53,7 @@ impl KnownIslandType {
 
     /// The best markdown-projection loss class this type achieves — the ceiling
     /// the importer stamps at mint. A per-island [`Loss`] may sit *below* it (a
-    /// table cell dropping an inline image's url degrades that instance) but never
-    /// above; centralizing the ceiling here keeps the mint sites from disagreeing.
+    /// table cell dropping an inline image's url) but never above.
     pub fn default_loss(self) -> Loss {
         match self {
             Self::Table => Loss::Lossless,

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -17,6 +17,8 @@
 //!   Spike-A rules), and invariants. The freeze.
 //! - [`serial`] — canonical, byte-deterministic JSON. One encoding for the seam
 //!   and for storage.
+//! - [`island`] — [`KnownIslandType`], the closed dispatch authority for island
+//!   types; adding a type is one variant and the compiler enforces every arm.
 //! - [`import`] — markdown → content (normalize → pulldown → content).
 //! - [`export`] — content → markdown, per island loss class.
 //! - [`delta`] — the per-field edit surface: a text-splice change set
@@ -34,6 +36,7 @@
 pub mod delta;
 pub mod export;
 pub mod import;
+pub mod island;
 pub mod model;
 pub mod normalize;
 pub mod ops;
@@ -43,6 +46,7 @@ pub mod usv;
 pub use delta::{diff_import, Assoc, Delta, Op};
 pub use export::{to_markdown, to_plaintext};
 pub use import::{from_markdown, from_plaintext};
+pub use island::KnownIslandType;
 pub use model::{
     Container, Invariant, Island, Line, LineKind, Loss, Mark, MarkKind, Content, Usv,
 };

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -416,7 +416,7 @@ impl Content {
         // serialize to equal bytes and `validate` holds — the props are
         // otherwise opaque here.
         for island in &mut self.islands {
-            crate::serial::normalize_island_structure(island);
+            crate::island::normalize_island_structure(island);
             // Rebuild props only when a key is actually out of order — an
             // untouched island (a pure text splice) stays sorted, so this skips
             // the deep clone on the common per-keystroke path.
@@ -546,10 +546,10 @@ impl Content {
             // Structural shape (table column/row/aligns consistency, `\n`-free
             // cells) before the per-cell mark ranges — a ragged island is
             // ill-formed regardless of its marks.
-            if let Some(e) = crate::serial::island_shape_error(island) {
+            if let Some(e) = crate::island::island_shape_error(island) {
                 return Err(e);
             }
-            for (text, marks) in crate::serial::island_cell_marks(island) {
+            for (text, marks) in crate::island::island_cell_marks(island) {
                 let clen = text.chars().count();
                 for m in &marks {
                     if m.start > m.end || m.end > clen {

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -413,9 +413,8 @@ pub(crate) fn table_cells(props: &Value) -> Vec<(String, Vec<Mark>)> {
 }
 
 // The `table` codec below (props normalize, shape-validate, cell extraction) is
-// the primitive the [`crate::island`] dispatch table calls for
-// [`KnownIslandType::Table`](crate::island::KnownIslandType); island-type
-// dispatch itself lives there, not here.
+// the primitive `crate::island` dispatches into for `KnownIslandType::Table`;
+// island-type dispatch itself lives there, not here.
 
 /// Repair a table island's props in place to the canonical shape:
 ///

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -412,46 +412,10 @@ pub(crate) fn table_cells(props: &Value) -> Vec<(String, Vec<Mark>)> {
     out
 }
 
-/// Islands whose props carry inline `{text, marks}` cells — the set that
-/// participates in mark normalization and cell-mark validation. Adding a
-/// mark-carrying island type is a single edit here;
-/// [`normalize_island_cell_marks`] and [`island_cell_marks`] both route through
-/// it, so neither `normalize` nor `validate` can silently skip a new type
-/// (which would void the canonical-bytes guarantee for its cells).
-fn island_is_mark_carrying(island_type: &str) -> bool {
-    matches!(island_type, "table")
-}
-
-/// Repair a mark-carrying island's structure in place (a no-op for a
-/// non-mark-carrying type) — the normalize-side island-type dispatch, kept
-/// beside the table codec rather than as a bare `"table"` match in `model`.
-pub(crate) fn normalize_island_structure(island: &mut Island) {
-    if island_is_mark_carrying(&island.island_type) {
-        normalize_table_props(&mut island.props);
-    }
-}
-
-/// A mark-carrying island's `(text, marks)` cells for validation (empty for a
-/// non-mark-carrying type) — the validate-side twin of
-/// [`normalize_island_structure`].
-pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
-    if island_is_mark_carrying(&island.island_type) {
-        table_cells(&island.props)
-    } else {
-        Vec::new()
-    }
-}
-
-/// A mark-carrying island's shape violation, if any (`None` for a well-formed
-/// or non-mark-carrying island) — the validate-side twin of the shape repair in
-/// [`normalize_island_structure`]. `normalize` guarantees this returns `None`.
-pub(crate) fn island_shape_error(island: &Island) -> Option<Invariant> {
-    if island_is_mark_carrying(&island.island_type) {
-        table_shape_error(&island.props)
-    } else {
-        None
-    }
-}
+// The `table` codec below (props normalize, shape-validate, cell extraction) is
+// the primitive the [`crate::island`] dispatch table calls for
+// [`KnownIslandType::Table`](crate::island::KnownIslandType); island-type
+// dispatch itself lives there, not here.
 
 /// Repair a table island's props in place to the canonical shape:
 ///
@@ -465,7 +429,7 @@ pub(crate) fn island_shape_error(island: &Island) -> Option<Invariant> {
 ///   offsets stable, so the cell's marks stay in range.
 /// - **Canonical cell marks.** Each cell's marks are re-normalized (sort,
 ///   same-kind union, drop zero-width) so equal cells serialize to equal bytes.
-fn normalize_table_props(props: &mut Value) {
+pub(crate) fn normalize_table_props(props: &mut Value) {
     let cols = table_cols(props);
     let Some(obj) = props.as_object_mut() else {
         return;
@@ -541,7 +505,7 @@ fn canon_cell(cell: &mut Value) {
 /// A table island's shape violation, if any — the widths the header, `aligns`,
 /// and each body row must share (the header width), plus the `\n`-free-cell rule.
 /// The validate-side twin of [`normalize_table_props`].
-fn table_shape_error(props: &Value) -> Option<Invariant> {
+pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
     // A present-but-non-array header can't carry column cells — `normalize`
     // rewrites it to an empty array, so an un-normalized one is a hand-built
     // degenerate island. (An absent header is a zero-column table, which is


### PR DESCRIPTION
Island type behavior was matched independently at four sites across two
crates (mint in import, normalize/validate in serial, markdown emit in
export, Typst emit in the backend), each with its own default for an
unrecognized type. A type minted in import but forgotten in an emit arm
silently degraded to a placeholder-comment or nothing — no compile error,
no test failure, because the `_ =>` fallthrough that legitimately serves
the open set also swallowed half-wired known types.

Introduce `crate::island::KnownIslandType`, the closed parse of the still-open
`island_type` wire string. Every dispatch site now matches
`KnownIslandType::parse(..)`: the `Some(k)` arm is exhaustive, so adding a
variant is a compile error at every site, while `None` is provably the
open-set opaque path — a known type can no longer reach it. The per-type
contract (default loss, cell marks, shape normalize/validate) lives as one
method per seam on the enum; the two projections that can't live in `content`
(markdown, Typst) match on the enum where they are, so the guarantee crosses
the crate boundary. `mint_island` now takes the enum, so the importer can only
mint the closed set — unknown types enter only via storage.

The `table` codec stays in serial as the primitive the dispatch table calls.
No wire-format change, no new island types, no behavioral change (loss values
are identical, just sourced from `default_loss`). Problems 2/3 of the issue
(richer per-type shape contracts, the id-vs-hash determinism decision) are
left for follow-up.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XGgD1oVHAmSnw9v78wQGE2