### PR TITLE
edit:: diagnostic codes on mutator failures (contract phase 1)

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -206,9 +206,11 @@ except QuillmarkError as exc:
         print(str(d))   # canonical pretty-printed text (matches CLI / WASM)
 ```
 
-`EditError`-shaped failures (invalid field names, kind names, out-of-range
-indices) prefix the message with `[EditError::<Variant>]` — the same format
-WASM uses — so callers can pattern-match on the message when they need to.
+Mutator failures (invalid field names, kind names, out-of-range indices) carry
+a namespaced `edit::*` `code` on `diagnostics[0]` — `edit::invalid_field_name`,
+`edit::unknown_field`, `edit::index_out_of_range`, `edit::field_conform`, … —
+the same taxonomy WASM uses. Route on `diagnostics[0].code`, never on message
+text.
 
 ## Changelog
 

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -12,27 +12,23 @@ use quillmark_core::{Diagnostic, EditError, RenderError, Severity};
 create_exception!(_quillmark, QuillmarkError, PyException);
 
 pub fn convert_edit_error(err: EditError) -> PyErr {
-    let message = format!("[EditError::{}] {}", err.variant_name(), err);
-    raise_with_diagnostics(
-        vec![Diagnostic::new(Severity::Error, message.clone())],
-        message,
-    )
+    let diagnostic =
+        Diagnostic::new(Severity::Error, err.to_string()).with_code(err.code().to_string());
+    let message = diagnostic.message.clone();
+    raise_with_diagnostics(vec![diagnostic], message)
 }
 
 /// Batched-mutator twin of [`convert_edit_error`]: one diagnostic per
-/// offending field, each with `path` set to the field name. The exception
-/// message embeds the first diagnostic (same shape as WASM's
-/// `WasmError::message`), so the `[EditError::<Variant>]` prefix contract
-/// holds for batches too.
+/// offending field, each carrying the `edit::` code and `path` set to the
+/// field name. The exception message follows the shared count-based rule
+/// (same shape as WASM's `WasmError::message`).
 pub fn convert_edit_errors(errors: Vec<(String, EditError)>) -> PyErr {
     let diags: Vec<Diagnostic> = errors
         .into_iter()
         .map(|(name, err)| {
-            Diagnostic::new(
-                Severity::Error,
-                format!("[EditError::{}] {}", err.variant_name(), err),
-            )
-            .with_path(name)
+            Diagnostic::new(Severity::Error, err.to_string())
+                .with_code(err.code().to_string())
+                .with_path(name)
         })
         .collect();
     let message = RenderError::summary_message(&diags);

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -688,7 +688,7 @@ impl PyWriter {
     }
 
     /// Typed-commit one main-card field (strict coerce, mismatch raises now).
-    /// Raises `[EditError::UnknownField]` for a name the schema does not declare.
+    /// Raises `edit::unknown_field` for a name the schema does not declare.
     fn set(&self, py: Python<'_>, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         let quill = self.quill.borrow(py);
@@ -702,7 +702,7 @@ impl PyWriter {
 
     /// Typed-commit several main-card fields atomically — nothing is applied on
     /// error, and the raised `QuillmarkError` carries one diagnostic per offending
-    /// field (an `[EditError::UnknownField]` per undeclared name).
+    /// field (an `edit::unknown_field` per undeclared name).
     fn set_all(&self, py: Python<'_>, fields: Bound<'_, PyDict>) -> PyResult<()> {
         let batch = pydict_to_field_batch(&fields)?;
         let quill = self.quill.borrow(py);
@@ -729,8 +729,8 @@ impl PyWriter {
     /// Revise the richtext main-card field `name` from markdown — typed *and*
     /// anchor-preserving. Surviving anchors rebase, then the diffed result is
     /// schema-conformed (a `richtext(inline)` field rejects a multi-block result
-    /// with `[EditError::FieldRichtextNotInline]`). Raises
-    /// `[EditError::UnknownField]` for a name the schema does not declare. The
+    /// with `edit::field_richtext_not_inline`). Raises
+    /// `edit::unknown_field` for a name the schema does not declare. The
     /// only field write that preserves a JS editor's anchors on a shared document
     /// (`set` cold-imports). The text `Delta` is discarded — the position-mapping
     /// receipt is an editor concern, and that lane is WASM-only; core and WASM
@@ -805,7 +805,7 @@ impl PyWriter {
 
 /// A composable card bound to its `Quill` for typed writes, from `Writer.card`.
 /// Same verbs as `Writer`, targeting the card at its bound index; each write
-/// raises `[EditError::IndexOutOfRange]` if that index is out of range.
+/// raises `edit::index_out_of_range` if that index is out of range.
 #[pyclass(name = "CardWriter")]
 pub struct PyCardWriter {
     quill: Py<PyQuill>,
@@ -822,7 +822,7 @@ impl PyCardWriter {
     }
 
     /// The bound card's `$kind`, or `None` when it carries none. Raises
-    /// `[EditError::IndexOutOfRange]` if the bound index is out of range. Mirrors
+    /// `edit::index_out_of_range` if the bound index is out of range. Mirrors
     /// core `CardWriter::kind()` / WASM `writer.card(i).kind`.
     #[getter]
     fn kind(&self, py: Python<'_>) -> PyResult<Option<String>> {
@@ -834,8 +834,8 @@ impl PyCardWriter {
     }
 
     /// Typed-commit one field on this card, resolving its type from the card's
-    /// `$kind` schema. Raises `[EditError::UnknownField]` for an undeclared name
-    /// and `[EditError::IndexOutOfRange]` for a bad index.
+    /// `$kind` schema. Raises `edit::unknown_field` for an undeclared name
+    /// and `edit::index_out_of_range` for a bad index.
     fn set(&self, py: Python<'_>, name: &str, value: Bound<'_, PyAny>) -> PyResult<()> {
         let qv = py_to_quillvalue(&value)?;
         let quill = self.quill.borrow(py);
@@ -878,8 +878,8 @@ impl PyCardWriter {
 
     /// Revise the richtext field `name` on this card from markdown — typed *and*
     /// anchor-preserving; the card twin of `Writer.revise_field`. Raises
-    /// `[EditError::UnknownField]` for an undeclared name and
-    /// `[EditError::IndexOutOfRange]` for a bad index. The `Delta` is discarded
+    /// `edit::unknown_field` for an undeclared name and
+    /// `edit::index_out_of_range` for a bad index. The `Delta` is discarded
     /// (see `Writer.revise_field`).
     fn revise_field(&self, py: Python<'_>, name: &str, markdown: &str) -> PyResult<()> {
         let quill = self.quill.borrow(py);
@@ -899,9 +899,9 @@ impl PyCardWriter {
 /// reads each field by its declared type: a richtext field to its markdown
 /// projection, a plaintext field to its literal text, every other type its
 /// canonical value verbatim. The schema authority is the point: a name the schema
-/// does not declare raises `[EditError::UnknownField]` (a typo, as on the write
+/// does not declare raises `edit::unknown_field` (a typo, as on the write
 /// side) rather than reading back `None`, and a content field holding an
-/// undecodable value raises `[EditError::FieldRichtextDecode]`. This is the field
+/// undecodable value raises `edit::field_richtext_decode`. This is the field
 /// read surface — `Document` carries no quill-free field read. Holds both objects
 /// by reference and re-borrows them per call (pyo3 objects carry no lifetime), so
 /// it is ephemeral by convention: bind, read, discard. Mirrors WASM
@@ -923,8 +923,8 @@ impl PyView {
     /// Read a main-card field, interpreted by its declared type: a richtext field
     /// to its markdown projection (a `str`), every other type its canonical value
     /// (scalar/list/dict), or `None` when the field is absent. Raises
-    /// `[EditError::UnknownField]` for a name the schema does not declare (a typo,
-    /// as on the write side) and `[EditError::FieldRichtextDecode]` for a richtext
+    /// `edit::unknown_field` for a name the schema does not declare (a typo,
+    /// as on the write side) and `edit::field_richtext_decode` for a richtext
     /// field holding a value that does not decode.
     fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
         let quill = self.quill.borrow(py);
@@ -958,7 +958,7 @@ impl PyView {
 
 /// A composable card bound to its `Quill` for interpreted reads, from
 /// `View.card`. Same verbs as `View`, reading the card at its bound index; each
-/// read raises `[EditError::IndexOutOfRange]` if that index is out of range.
+/// read raises `edit::index_out_of_range` if that index is out of range.
 #[pyclass(name = "CardView")]
 pub struct PyCardView {
     quill: Py<PyQuill>,
@@ -975,7 +975,7 @@ impl PyCardView {
     }
 
     /// The bound card's `$kind`, or `None` when it carries none. Raises
-    /// `[EditError::IndexOutOfRange]` if the bound index is out of range.
+    /// `edit::index_out_of_range` if the bound index is out of range.
     #[getter]
     fn kind(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let quill = self.quill.borrow(py);
@@ -986,8 +986,8 @@ impl PyCardView {
     }
 
     /// Read a field on this card, interpreted by its declared type — the
-    /// card-indexed twin of `View.get`. Raises `[EditError::UnknownField]` for an
-    /// undeclared name and `[EditError::IndexOutOfRange]` for a bad index.
+    /// card-indexed twin of `View.get`. Raises `edit::unknown_field` for an
+    /// undeclared name and `edit::index_out_of_range` for a bad index.
     fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
@@ -1001,7 +1001,7 @@ impl PyCardView {
     }
 
     /// This card's body markdown — the card twin of `View.get_body`. Raises
-    /// `[EditError::IndexOutOfRange]` if the bound index is out of range.
+    /// `edit::index_out_of_range` if the bound index is out of range.
     fn get_body(&self, py: Python<'_>) -> PyResult<String> {
         let doc = self.doc.borrow(py);
         let card = doc

--- a/crates/bindings/python/tests/conftest.py
+++ b/crates/bindings/python/tests/conftest.py
@@ -5,14 +5,25 @@ These fixtures prefer using the canonical repository fixtures located in
 original simple fallbacks are used so tests remain robust in odd layouts.
 """
 
+from contextlib import contextmanager
 from pathlib import Path
 import pytest
 
-from quillmark import Quillmark
+from quillmark import Quillmark, QuillmarkError
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[4]
 RESOURCES_PATH = WORKSPACE_ROOT / "crates" / "fixtures" / "resources"
 QUILLS_PATH = RESOURCES_PATH / "quills"
+
+
+@contextmanager
+def raises_edit_code(code):
+    """Assert the block raises `QuillmarkError` whose primary diagnostic carries
+    the given namespaced `edit::` code. Mutator identity rides on `code`, not on
+    message text, so tests route on it — see prose/canon/ERROR.md."""
+    with pytest.raises(QuillmarkError) as exc_info:
+        yield exc_info
+    assert exc_info.value.diagnostics[0].code == code
 
 
 def _latest_version(quill_dir: Path) -> Path:

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -15,7 +15,7 @@ from quillmark import (
     OutputFormat,
     QuillmarkError,
 )
-from conftest import QUILLS_PATH, _latest_version
+from conftest import QUILLS_PATH, _latest_version, raises_edit_code
 
 
 def field(card, key):
@@ -195,7 +195,7 @@ def test_insert_card_appends():
 def test_insert_card_invalid_kind():
     """insert_card raises EditError for an invalid kind."""
     doc = Document.from_markdown(SIMPLE_MD)
-    with pytest.raises(QuillmarkError, match="InvalidKindName"):
+    with raises_edit_code("edit::invalid_kind_name"):
         doc.insert_card({"kind": "BadKind"})
 
 
@@ -237,7 +237,7 @@ def test_make_card_accepts_any_kind_insert_card_is_the_gate():
     card = Document.make_card("BadKind", {"x": 1})
     assert card["kind"] == "BadKind"  # construction succeeds
     doc = Document.from_markdown(SIMPLE_MD)
-    with pytest.raises(QuillmarkError, match="InvalidKindName"):
+    with raises_edit_code("edit::invalid_kind_name"):
         doc.insert_card(card)
 
 
@@ -261,7 +261,7 @@ def test_insert_card_at_front():
 def test_insert_card_out_of_range():
     """insert_card raises EditError when at > len."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.insert_card({"kind": "note"}, at=5)
 
 
@@ -301,7 +301,7 @@ def test_move_card_last_to_first():
 def test_move_card_out_of_range():
     """move_card raises EditError for an out-of-range index."""
     doc = Document.from_markdown(MD_WITH_CARDS)
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.move_card(10, 0)
 
 
@@ -387,13 +387,13 @@ def test_card_ext_namespace_mutators():
 def test_card_ext_mutators_out_of_range():
     """Card ext mutators raise IndexOutOfRange for a bad card index."""
     doc = Document.from_markdown(SIMPLE_MD)  # 0 cards
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.store_ext({}, card=0)
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.remove_ext(card=0)
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.store_ext_namespace("a", {}, card=0)
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.remove_ext_namespace("a", card=0)
 
 
@@ -532,7 +532,7 @@ def test_writer_set_rejects_unknown_field():
     """An undeclared name is a typo on the typed path — it raises, nothing lands."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
-    with pytest.raises(QuillmarkError, match="UnknownField"):
+    with raises_edit_code("edit::unknown_field"):
         quill.writer(doc).set("stray", "x")
     assert not has_field(doc.main, "stray")
 
@@ -542,7 +542,7 @@ def test_writer_set_all_reports_every_unknown_field():
     (path = field name) — externally-sourced keys surface every violation at once."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
-    with pytest.raises(QuillmarkError, match="UnknownField") as exc_info:
+    with raises_edit_code("edit::unknown_field") as exc_info:
         quill.writer(doc).set_all({"title": "ok", "stray1": "x", "stray2": "y"})
     paths = [d.path for d in exc_info.value.diagnostics]
     assert "stray1" in paths and "stray2" in paths
@@ -558,7 +558,7 @@ def test_writer_add_card_transactional():
     ed.add_card("quotes", {"author": "Basho"}, "A quote body.")
     assert len(doc.cards) == 1
     assert field(doc.cards[0], "author") == "Basho"
-    with pytest.raises(QuillmarkError, match="UnknownField"):
+    with raises_edit_code("edit::unknown_field"):
         ed.add_card("quotes", {"stray": "x"})
     assert len(doc.cards) == 1  # nothing joined the document
 
@@ -572,7 +572,7 @@ def test_writer_add_card_positioned():
     ed.add_card("quotes", {"author": "Second"}, at=0)  # insert at the front
     assert field(doc.cards[0], "author") == "Second"
     assert field(doc.cards[1], "author") == "First"
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         ed.add_card("quotes", {"author": "x"}, at=99)
     assert len(doc.cards) == 2  # the out-of-range insert landed nothing
 
@@ -585,7 +585,7 @@ def test_writer_card_cursor_set_and_body():
     ed.add_card("quotes", {"author": "Basho"})
     ed.card(0).set("author", "Issa")
     assert field(doc.cards[0], "author") == "Issa"
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         ed.card(9).set("author", "x")
 
 
@@ -597,7 +597,7 @@ def test_writer_card_kind_getter():
     ed.add_card("quotes", {"author": "Basho"})
     assert ed.card(0).index == 0
     assert ed.card(0).kind == "quotes"
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         _ = ed.card(9).kind
 
 
@@ -615,7 +615,7 @@ def test_writer_set_rejects_inline_violation():
     """A richtext(inline) field rejects multi-block content at the write."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+    with raises_edit_code("edit::field_richtext_not_inline"):
         quill.writer(doc).set("headline", "line one\n\nline two")
 
 
@@ -623,7 +623,7 @@ def test_writer_set_all_is_all_or_nothing():
     """A mid-batch inline violation aborts set_all — nothing lingers."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+    with raises_edit_code("edit::field_richtext_not_inline"):
         quill.writer(doc).set_all({"bio": "ok", "headline": "line one\n\nline two"})
     assert not has_field(doc.main, "bio")
 
@@ -642,9 +642,9 @@ def test_writer_revise_field_rejects_inline_and_unknown():
     rejects an undeclared name — same guards as `set`."""
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
-    with pytest.raises(QuillmarkError, match="FieldRichtextNotInline"):
+    with raises_edit_code("edit::field_richtext_not_inline"):
         quill.writer(doc).revise_field("headline", "line one\n\nline two")
-    with pytest.raises(QuillmarkError, match="UnknownField"):
+    with raises_edit_code("edit::unknown_field"):
         quill.writer(doc).revise_field("nope", "x")
 
 
@@ -687,7 +687,7 @@ def test_view_absence_returns_none_unknown_name_raises():
     quill = _richtext_form_quill()
     v = quill.view(Document("richtext_form@0.1.0"))
     assert v.get("bio") is None  # absent, not a typo
-    with pytest.raises(QuillmarkError, match="UnknownField"):
+    with raises_edit_code("edit::unknown_field"):
         v.get("nope")  # typo, not absent
 
 
@@ -700,7 +700,7 @@ def test_view_richtext_holding_scalar_raises_mismatch():
     doc = Document.from_markdown(
         "~~~card-yaml\n$quill: richtext_form@0.1.0\n$kind: main\nbio: 3\n~~~\n"
     )
-    with pytest.raises(QuillmarkError, match="FieldRichtextDecode"):
+    with raises_edit_code("edit::field_richtext_decode"):
         quill.view(doc).get("bio")
 
 
@@ -722,7 +722,7 @@ def test_view_card_cursor_reads_through_kind_schema():
     assert v.card(0).kind == "quotes"
     assert v.card(0).get("author") == "Basho"
     assert v.card(0).get_body() == "A quote body."
-    with pytest.raises(QuillmarkError, match="UnknownField"):
+    with raises_edit_code("edit::unknown_field"):
         v.card(0).get("stray")
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         v.card(9).get("author")

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -5,6 +5,8 @@ import pytest
 
 from quillmark import Document, QuillmarkError
 
+from conftest import raises_edit_code
+
 from pathlib import Path
 
 
@@ -278,7 +280,7 @@ def test_remove_field_on_card_out_of_range():
     """remove_field(name, card=i) raises EditError for an out-of-range card index."""
     md = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n"
     doc = Document.from_markdown(md)
-    with pytest.raises(QuillmarkError, match="IndexOutOfRange"):
+    with raises_edit_code("edit::index_out_of_range"):
         doc.remove_field("foo", card=0)
 
 

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -462,10 +462,11 @@ compilation failures. The same shape applies to every throw site:
 
 - `Document.fromMarkdown` — parse errors (missing root `$quill` metadata, YAML
   errors, `parse::input_too_large` for inputs > 10 MB).
-- `Document` mutators (`storeField`, the writer's `set`, etc.) — `EditError`
-  variants (`InvalidFieldName`, `InvalidKindName`, `ReservedKind`,
-  `IndexOutOfRange`, `ValueTooDeep`, `Import`) appear in `diagnostics[0].message`
-  with the `[EditError::<Variant>]` prefix.
+- `Document` mutators (`storeField`, the writer's `set`, etc.) — mutator
+  failures carry a namespaced `edit::*` `code` on `diagnostics[0]`
+  (`edit::invalid_field_name`, `edit::unknown_field`, `edit::index_out_of_range`,
+  `edit::field_conform`, …). Route on `diagnostics[0].code`, never on message
+  text.
 - `engine.render` / `session.render` — backend compilation failures and
   validation errors.
 

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -17,7 +17,7 @@ import {
   rebase,
   mapPos,
 } from '@quillmark-wasm'
-import { makeQuill } from './test-helpers.js'
+import { makeQuill, expectEditCode } from './test-helpers.js'
 
 /** Read a field value from a card's payloadItems list by key. */
 const field = (card, key) =>
@@ -493,16 +493,16 @@ describe('Document editor surface — storeField / removeField', () => {
     }
   })
 
-  it('storeField throws EditError::InvalidFieldName for `$`-prefixed names', () => {
+  it('storeField throws edit::invalid_field_name for `$`-prefixed names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     for (const name of ['$body', '$cards', '$quill', '$kind']) {
-      expect(() => doc.storeField(name, 'x')).toThrow(/InvalidFieldName/)
+      expectEditCode(() => doc.storeField(name, 'x'), 'edit::invalid_field_name')
     }
   })
 
-  it('storeField throws EditError::InvalidFieldName for an invalid name (hyphen)', () => {
+  it('storeField throws edit::invalid_field_name for an invalid name (hyphen)', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.storeField('bad-name', 'x')).toThrow(/InvalidFieldName/)
+    expectEditCode(() => doc.storeField('bad-name', 'x'), 'edit::invalid_field_name')
   })
 
   it('removeField returns the removed value', () => {
@@ -517,10 +517,10 @@ describe('Document editor surface — storeField / removeField', () => {
     expect(doc.removeField('nonexistent')).toBeUndefined()
   })
 
-  it('removeField throws EditError::InvalidFieldName for `$`-prefixed names', () => {
+  it('removeField throws edit::invalid_field_name for `$`-prefixed names', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     for (const name of ['$body', '$cards', '$quill', '$kind']) {
-      expect(() => doc.removeField(name)).toThrow(/InvalidFieldName/)
+      expectEditCode(() => doc.removeField(name), 'edit::invalid_field_name')
     }
   })
 })
@@ -571,7 +571,7 @@ describe('Document editor surface — storeFields', () => {
     doc.storeFields({ card: 0 }, { foo: 'baz', extra: 1 })
     expect(field(doc.cards[0], 'foo')).toBe('baz')
     expect(field(doc.cards[0], 'extra')).toBe(1)
-    expect(() => doc.storeFields({ card: 99 }, { foo: 'v' })).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.storeFields({ card: 99 }, { foo: 'v' }), 'edit::index_out_of_range')
   })
 
   it('an address with an unknown key throws instead of parsing as {}', () => {
@@ -695,7 +695,7 @@ card_kinds:
   it('commitField rejects an unknown field as a typo and writes nothing', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    expect(() => doc._commitField(quill, 'stray', 'x')).toThrow(/UnknownField/)
+    expectEditCode(() => doc._commitField(quill, 'stray', 'x'), 'edit::unknown_field')
     expect(hasField(doc.main, 'stray')).toBe(false)
     // Opaque storage stays available on purpose through the raw verb.
     doc.storeField('stray', 'x')
@@ -718,9 +718,11 @@ card_kinds:
   it('commitField fails a strict mismatch and a richtext(inline) violation', () => {
     const quill = buildQuill()
     const doc = blankDoc()
-    expect(() => doc._commitField(quill, 'qty', 'not-a-number')).toThrow(/FieldConform/)
-    expect(() => doc._commitField(quill, 'subject', 'line one\n\nline two'))
-      .toThrow(/FieldRichtextNotInline/)
+    expectEditCode(() => doc._commitField(quill, 'qty', 'not-a-number'), 'edit::field_conform')
+    expectEditCode(
+      () => doc._commitField(quill, 'subject', 'line one\n\nline two'),
+      'edit::field_richtext_not_inline',
+    )
   })
 
   it('revise({field}) rebases a richtext field anchor and applyChange splices it', () => {
@@ -768,7 +770,7 @@ card_kinds:
     )
     doc._commitField(quill, { card: 0, field: 'body' }, 'Card **body**.')
     expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.')
-    expect(() => doc._commitField(quill, { card: 9, field: 'body' }, 'x')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc._commitField(quill, { card: 9, field: 'body' }, 'x'), 'edit::index_out_of_range')
   })
 
   it('commitFields typed-commits a batch', () => {
@@ -785,7 +787,7 @@ card_kinds:
     const doc = blankDoc()
     // `qty` is a schema field; `titel` is a typo the schema does not own — the
     // undeclared name aborts the all-or-nothing batch and nothing is applied.
-    expect(() => doc._commitFields(quill, {}, { qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
+    expectEditCode(() => doc._commitFields(quill, {}, { qty: '5', titel: 'oops' }), 'edit::unknown_field')
     expect(hasField(doc.main, 'qty')).toBe(false)
     expect(hasField(doc.main, 'titel')).toBe(false)
   })
@@ -795,8 +797,10 @@ card_kinds:
     const doc = blankDoc()
     // `subject` is richtext(inline); a multi-block value violates it, so nothing
     // is applied — `qty` must not linger.
-    expect(() => doc._commitFields(quill, {}, { qty: '5', subject: 'line one\n\nline two' }))
-      .toThrow(/FieldRichtextNotInline/)
+    expectEditCode(
+      () => doc._commitFields(quill, {}, { qty: '5', subject: 'line one\n\nline two' }),
+      'edit::field_richtext_not_inline',
+    )
     expect(hasField(doc.main, 'qty')).toBe(false)
   })
 
@@ -808,8 +812,8 @@ card_kinds:
     doc._commitFields(quill, { card: 0 }, { body: 'Card **body**.' })
     expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.')
     // An undeclared field on the card aborts the batch.
-    expect(() => doc._commitFields(quill, { card: 0 }, { stray: 'x' })).toThrow(/UnknownField/)
-    expect(() => doc._commitFields(quill, { card: 9 }, { body: 'x' })).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc._commitFields(quill, { card: 0 }, { stray: 'x' }), 'edit::unknown_field')
+    expectEditCode(() => doc._commitFields(quill, { card: 9 }, { body: 'x' }), 'edit::index_out_of_range')
   })
 })
 
@@ -845,7 +849,7 @@ Card two.
 
   it('insertCard throws on invalid kind', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.insertCard({ kind: 'BadKind' })).toThrow(/InvalidKindName/)
+    expectEditCode(() => doc.insertCard({ kind: 'BadKind' }), 'edit::invalid_kind_name')
   })
 
   it('removeCard → insertCard round-trips a card with fields (read shape == write shape)', () => {
@@ -870,7 +874,7 @@ Card two.
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
     const bad = Document.makeCard('BadKind', { x: 1 })
     expect(bad.kind).toBe('BadKind') // construction succeeds
-    expect(() => doc.insertCard(bad)).toThrow(/InvalidKindName/) // insertion rejects
+    expectEditCode(() => doc.insertCard(bad), 'edit::invalid_kind_name') // insertion rejects
   })
 
   it('makeCard treats fields and body as optional', () => {
@@ -897,7 +901,7 @@ Card two.
 
   it('insertCard throws IndexOutOfRange when at > len', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.insertCard({ kind: 'note' }, 5)).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.insertCard({ kind: 'note' }, 5), 'edit::index_out_of_range')
   })
 
   it('removeCard removes and returns the card', () => {
@@ -929,7 +933,7 @@ Card two.
 
   it('moveCard throws IndexOutOfRange on out-of-range index', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARDS) // 2 cards
-    expect(() => doc.moveCard(5, 0)).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.moveCard(5, 0), 'edit::index_out_of_range')
   })
 
   it('setCardKind renames the kind in place', () => {
@@ -943,13 +947,13 @@ Card two.
   it('setCardKind throws InvalidKindName for empty/uppercase/dashed kinds', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARDS)
     for (const bad of ['', 'BadKind', 'with-dash']) {
-      expect(() => doc.setCardKind(0, bad)).toThrow(/InvalidKindName/)
+      expectEditCode(() => doc.setCardKind(0, bad), 'edit::invalid_kind_name')
     }
   })
 
   it('setCardKind throws IndexOutOfRange when index >= len', () => {
     const doc = Document.fromMarkdown(MD_WITH_CARDS) // 2 cards
-    expect(() => doc.setCardKind(5, 'annotation')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.setCardKind(5, 'annotation'), 'edit::index_out_of_range')
   })
 
   it('cardCount reports composable card count without allocating', () => {
@@ -1036,7 +1040,7 @@ Card body.
 
   it('setCardField throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.storeField({ card: 0, field: 'title' }, 'x')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.storeField({ card: 0, field: 'title' }, 'x'), 'edit::index_out_of_range')
   })
 
   it('removeCardField returns the removed value and deletes the key', () => {
@@ -1053,7 +1057,7 @@ Card body.
 
   it('removeCardField throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.removeField({ card: 0, field: 'foo' })).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.removeField({ card: 0, field: 'foo' }), 'edit::index_out_of_range')
   })
 
   it('revise({card:0}, md) revises a card body and returns the delta', () => {
@@ -1065,7 +1069,7 @@ Card body.
 
   it('revise({card:0}, md) throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.revise({ card: 0 }, 'x')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.revise({ card: 0 }, 'x'), 'edit::index_out_of_range')
   })
 
   it('install({card:0}, rt) installs a content into a card body', () => {
@@ -1086,7 +1090,7 @@ Card body.
 
   it('install({card:0}, ...) throws IndexOutOfRange when card absent', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN) // 0 cards
-    expect(() => doc.install({ card: 0 }, importMarkdown('x'))).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.install({ card: 0 }, importMarkdown('x')), 'edit::index_out_of_range')
   })
 })
 
@@ -1190,10 +1194,10 @@ describe('Document editor surface — $ext mutators', () => {
 
   it('card-level ext mutators throw IndexOutOfRange', () => {
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
-    expect(() => doc.storeExt({ card: 5 }, {})).toThrow(/IndexOutOfRange/)
-    expect(() => doc.removeExt({ card: 5 })).toThrow(/IndexOutOfRange/)
-    expect(() => doc.storeExtNamespace({ card: 5 }, 'a', {})).toThrow(/IndexOutOfRange/)
-    expect(() => doc.removeExtNamespace({ card: 5 }, 'a')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => doc.storeExt({ card: 5 }, {}), 'edit::index_out_of_range')
+    expectEditCode(() => doc.removeExt({ card: 5 }), 'edit::index_out_of_range')
+    expectEditCode(() => doc.storeExtNamespace({ card: 5 }, 'a', {}), 'edit::index_out_of_range')
+    expectEditCode(() => doc.removeExtNamespace({ card: 5 }, 'a'), 'edit::index_out_of_range')
   })
 })
 

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -28,7 +28,12 @@ import {
 // `pkg/core` is NOT a public package subpath, it is the build the root
 // re-exports.
 import { Quill as CoreQuill, Document as CoreDocument } from '../../../pkg/core/wasm.js'
-import { makeQuill, makeSampleFormQuill, SAMPLE_FORM_MARKDOWN } from './test-helpers.js'
+import {
+  makeQuill,
+  makeSampleFormQuill,
+  SAMPLE_FORM_MARKDOWN,
+  expectEditCode,
+} from './test-helpers.js'
 
 const TEST_PLATE = `#import "@local/quillmark-helper:0.1.0": data
 #let title = data.title
@@ -163,13 +168,13 @@ card_kinds:
 
   it('set rejects an undeclared name as a typo, not a fallback', () => {
     const ed = buildQuill().writer(blankDoc())
-    expect(() => ed.set('stray', 'x')).toThrow(/UnknownField/)
+    expectEditCode(() => ed.set('stray', 'x'), 'edit::unknown_field')
     expect(fieldOf(ed.document.main, 'stray')).toBeUndefined()
   })
 
   it('setAll aborts the whole batch on a typo, applying nothing', () => {
     const ed = buildQuill().writer(blankDoc())
-    expect(() => ed.setAll({ qty: '5', titel: 'oops' })).toThrow(/UnknownField/)
+    expectEditCode(() => ed.setAll({ qty: '5', titel: 'oops' }), 'edit::unknown_field')
     expect(fieldOf(ed.document.main, 'qty')).toBeUndefined()
     expect(fieldOf(ed.document.main, 'titel')).toBeUndefined()
   })
@@ -191,10 +196,10 @@ card_kinds:
   it('reviseField rejects an undeclared name, and a non-inline result', () => {
     const quill = buildQuill()
     const ed = quill.writer(blankDoc())
-    expect(() => ed.reviseField('stray', 'x')).toThrow(/UnknownField/)
+    expectEditCode(() => ed.reviseField('stray', 'x'), 'edit::unknown_field')
     // `subject` is richtext(inline): a multi-block result is refused, field intact.
     ed.reviseField('subject', 'kept')
-    expect(() => ed.reviseField('subject', 'a\n\nb')).toThrow(/FieldRichtextNotInline/)
+    expectEditCode(() => ed.reviseField('subject', 'a\n\nb'), 'edit::field_richtext_not_inline')
     expect(quill.view(ed.document).get('subject')).toBe('kept')
   })
 
@@ -207,7 +212,7 @@ card_kinds:
     expect(exportMarkdown(fieldOf(ed.document.cards[0], 'body'))).toBe('Field **body**.')
     expect(exportMarkdown(ed.document.cards[0].body)).toBe('Card body text.')
     // A typo aborts the commit; the card never joins the document.
-    expect(() => ed.addCard('note', { stray: 'x' })).toThrow(/UnknownField/)
+    expectEditCode(() => ed.addCard('note', { stray: 'x' }), 'edit::unknown_field')
     expect(ed.document.cards).toHaveLength(1)
   })
 
@@ -232,14 +237,14 @@ card_kinds:
     const delta = ed.card(0).reviseField('body', 'Revised **field**.')
     expect(exportMarkdown(fieldOf(doc.cards[0], 'body'))).toBe('Revised **field**.')
     expect(delta).toBeTruthy()
-    expect(() => ed.card(0).reviseField('stray', 'x')).toThrow(/UnknownField/)
+    expectEditCode(() => ed.card(0).reviseField('stray', 'x'), 'edit::unknown_field')
   })
 
   it('a bad card index throws at write time, not at card()', () => {
     const ed = buildQuill().writer(blankDoc())
     const cardEd = ed.card(9) // lazy: constructing the CardWriter never throws
     expect(cardEd).toBeInstanceOf(CardWriter)
-    expect(() => cardEd.set('body', 'x')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => cardEd.set('body', 'x'), 'edit::index_out_of_range')
   })
 
   it('get reads raw values quill-free; getMarkdown is body-only (field half retired)', () => {
@@ -258,7 +263,7 @@ card_kinds:
     expect(quill.view(ed.document).get('subject')).toBe('Q3 **results**')
     // view.get carries schema authority: an unknown name throws (vs `undefined`
     // from the quill-free transport `Document.get` above).
-    expect(() => quill.view(ed.document).get('missing')).toThrow(/UnknownField/)
+    expectEditCode(() => quill.view(ed.document).get('missing'), 'edit::unknown_field')
   })
 })
 
@@ -321,14 +326,14 @@ card_kinds:
     const quill = buildQuill()
     const v = quill.view(Document.fromMarkdown('~~~card-yaml\n$quill: view_test\n~~~\n\nBody.'))
     expect(v.get('subject')).toBeUndefined() // absent, not a typo
-    expect(() => v.get('nope')).toThrow(/UnknownField/) // typo, not absent
+    expectEditCode(() => v.get('nope'), 'edit::unknown_field') // typo, not absent
   })
 
   it('a richtext field holding a scalar throws FieldRichtextDecode', () => {
     const quill = buildQuill()
     const doc = Document.fromMarkdown('~~~card-yaml\n$quill: view_test\n~~~\n\nBody.')
     doc.storeField('subject', 3) // opaque write puts a bare number under richtext
-    expect(() => quill.view(doc).get('subject')).toThrow(/FieldRichtextDecode/)
+    expectEditCode(() => quill.view(doc).get('subject'), 'edit::field_richtext_decode')
   })
 
   it('an absent field addr reads the body markdown, quill-free', () => {
@@ -344,14 +349,14 @@ card_kinds:
     expect(v.card(0).kind).toBe('note')
     expect(v.card(0).get('body')).toBe('A *card* field.')
     expect(v.card(0).getBody()).toBe('Card body.')
-    expect(() => v.card(0).get('nope')).toThrow(/UnknownField/)
+    expectEditCode(() => v.card(0).get('nope'), 'edit::unknown_field')
   })
 
   it('a bad card index throws at read time, not at card()', () => {
     const quill = buildQuill()
     const cardView = quill.view(seededDoc(quill)).card(9)
     expect(cardView).toBeInstanceOf(CardView)
-    expect(() => cardView.get('body')).toThrow(/IndexOutOfRange/)
+    expectEditCode(() => cardView.get('body'), 'edit::index_out_of_range')
   })
 })
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -849,7 +849,7 @@ impl Document {
     /// the **body content** when `addr.field` is absent. A bare string is `Addr`
     /// shorthand for `{ field }`. Reads are total over the field axis: an absent
     /// field is `undefined`; only an out-of-range `addr.card` throws
-    /// `[EditError::IndexOutOfRange]`. Reads need no schema, so they live on
+    /// `edit::index_out_of_range`. Reads need no schema, so they live on
     /// `Document`, not the typed writer; for the markdown projection of a
     /// richtext value use [`getMarkdown`](Self::get_markdown).
     #[wasm_bindgen(js_name = get, unchecked_return_type = "unknown")]
@@ -908,9 +908,9 @@ impl Document {
     /// `undefined` for an **absent** field. An absent `addr.field` reads the body
     /// markdown — quill-free, mirroring [`getMarkdown`](Self::get_markdown), since
     /// a body's type is a format fact, not a schema fact. A name the schema does
-    /// not declare throws `[EditError::UnknownField]` (the authority `getMarkdown`
+    /// not declare throws `edit::unknown_field` (the authority `getMarkdown`
     /// lacks — there an unknown name reads back `undefined`); a `richtext` field
-    /// holding a value that does not decode throws `[EditError::FieldRichtextDecode]`;
+    /// holding a value that does not decode throws `edit::field_richtext_decode`;
     /// an out-of-range `addr.card` throws.
     ///
     /// The `quill` handle is passed per call because a `Document` carries only a
@@ -1014,7 +1014,7 @@ impl Document {
     /// A single composable card by index — the whole `Card`, the card-indexed
     /// twin of the [`main`](Self::main) getter, so reading one card need not
     /// materialize every card via [`cards`](Self::cards). An out-of-range
-    /// `index` throws `[EditError::IndexOutOfRange]`, matching the card write
+    /// `index` throws `edit::index_out_of_range`, matching the card write
     /// verbs.
     #[wasm_bindgen(js_name = card, unchecked_return_type = "Card")]
     pub fn card(&self, index: usize) -> Result<JsValue, JsValue> {
@@ -1323,12 +1323,12 @@ impl Document {
     /// and defers to [`TypedWriter::revise_field`](quillmark_core::TypedWriter::revise_field):
     /// surviving anchors rebase (as [`revise`](Self::revise)), then the diffed
     /// result is schema-conformed, so a `richtext(inline)` field rejects a
-    /// multi-block result with `[EditError::FieldRichtextNotInline]`. Returns the
+    /// multi-block result with `edit::field_richtext_not_inline`. Returns the
     /// text [`Delta`].
     ///
     /// `addr` must name a field (a bare string is `{ field }`); a body address
     /// throws (a body carries no field schema — use [`revise`](Self::revise)). A
-    /// name the schema does not declare throws `[EditError::UnknownField]`. Throws
+    /// name the schema does not declare throws `edit::unknown_field`. Throws
     /// on an out-of-range card. Hidden from the `.d.ts`; the visible verb is
     /// `writer.reviseField` in the runtime layer.
     #[wasm_bindgen(js_name = _reviseField, skip_typescript, unchecked_return_type = "Delta")]
@@ -1393,12 +1393,12 @@ impl Document {
     /// address throws — a body has no field schema; write it with `writer.setBody`
     /// / `revise`. A field declared in the schema is strict-committed (a mismatch
     /// throws now, not at render); a name the schema does not declare throws
-    /// `[EditError::UnknownField]` rather than falling to the opaque store — on
+    /// `edit::unknown_field` rather than falling to the opaque store — on
     /// the typed path it is a typo. Use [`storeField`](Document::store_field) for
-    /// opaque storage. Also throws `[EditError::FieldConform]` /
-    /// `[EditError::FieldRichtextDecode]` / `[EditError::FieldRichtextNotInline]`
-    /// on a typed mismatch, `[EditError::InvalidFieldName]` on a malformed name,
-    /// and `[EditError::IndexOutOfRange]` on an out-of-range card.
+    /// opaque storage. Also throws `edit::field_conform` /
+    /// `edit::field_richtext_decode` / `edit::field_richtext_not_inline`
+    /// on a typed mismatch, `edit::invalid_field_name` on a malformed name,
+    /// and `edit::index_out_of_range` on an out-of-range card.
     ///
     /// The `quill` handle is passed per call because a `Document` carries only a
     /// `$quill` reference, not the resolved schema.
@@ -1431,7 +1431,7 @@ impl Document {
     /// the same per-field-diagnostic error contract as
     /// [`storeFields`](Document::store_fields) — nothing is applied on error and
     /// the thrown error's `diagnostics` carry one entry per offending field,
-    /// including an `[EditError::UnknownField]` for any name the schema does not
+    /// including an `edit::unknown_field` for any name the schema does not
     /// declare, so a whole-form submit sees every typo in one pass. Throws on an
     /// out-of-range card.
     #[wasm_bindgen(js_name = _commitFields, skip_typescript)]
@@ -1464,7 +1464,7 @@ impl Document {
     /// the document, so a rejected field (or an invalid kind, body, or
     /// out-of-range `at`) leaves the document untouched. Field errors throw the
     /// same per-field diagnostic bundle as [`commitFields`](Self::commit_fields),
-    /// including an `[EditError::UnknownField]` per undeclared name; an invalid
+    /// including an `edit::unknown_field` per undeclared name; an invalid
     /// kind or body, or an out-of-range position, throws a single-entry bundle
     /// keyed `$kind` / `$body`.
     #[wasm_bindgen(js_name = _addCard, skip_typescript)]
@@ -1824,22 +1824,29 @@ pub fn map_pos(
 
 // ── Edit helpers ──────────────────────────────────────────────────────────────
 
-/// Maps `EditError` to a JS `Error` with the variant name and details in the message.
+/// Maps `EditError` to a JS `Error` carrying one diagnostic with the mutator's
+/// namespaced `edit::` code and its `Display` text as the message.
 fn edit_error_to_js(err: &quillmark_core::EditError) -> JsValue {
-    WasmError::from(format!("[EditError::{}] {}", err.variant_name(), err)).to_js_value()
+    let diagnostic = quillmark_core::Diagnostic::new(
+        quillmark_core::Severity::Error,
+        err.to_string(),
+    )
+    .with_code(err.code().to_string());
+    WasmError {
+        diagnostics: vec![diagnostic],
+    }
+    .to_js_value()
 }
 
 /// Batched-mutator twin of [`edit_error_to_js`]: one diagnostic per offending
-/// field, each with `path` set to the field name.
+/// field, each carrying the `edit::` code and `path` set to the field name.
 fn edit_errors_to_js(errors: Vec<(String, quillmark_core::EditError)>) -> JsValue {
     let diagnostics: Vec<quillmark_core::Diagnostic> = errors
         .into_iter()
         .map(|(name, err)| {
-            quillmark_core::Diagnostic::new(
-                quillmark_core::Severity::Error,
-                format!("[EditError::{}] {}", err.variant_name(), err),
-            )
-            .with_path(name)
+            quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, err.to_string())
+                .with_code(err.code().to_string())
+                .with_path(name)
         })
         .collect();
     WasmError { diagnostics }.to_js_value()

--- a/crates/bindings/wasm/test-helpers.js
+++ b/crates/bindings/wasm/test-helpers.js
@@ -1,8 +1,25 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
+import { expect } from 'vitest'
 
 const enc = new TextEncoder()
+
+/**
+ * Invoke `fn`, expect it to throw, and assert the thrown error's primary
+ * diagnostic carries the namespaced `edit::*` `code`. Mutator identity rides on
+ * `diagnostics[0].code`, not on message text — see prose/canon/ERROR.md.
+ */
+export function expectEditCode(fn, code) {
+  let thrown
+  try {
+    fn()
+  } catch (err) {
+    thrown = err
+  }
+  expect(thrown, 'expected a throw, got none').toBeDefined()
+  expect(thrown.diagnostics[0].code).toBe(code)
+}
 
 // Minimal font shipped with quillmark fixtures, loaded once. The Typst world
 // rejects compilation when no fonts are present, so every test quill needs at

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -121,10 +121,9 @@ pub enum EditError {
 }
 
 impl EditError {
-    /// The bare variant name (e.g. `"InvalidFieldName"`). The wasm and Python
-    /// bindings each surface it as the `[EditError::<Variant>]` message prefix;
-    /// defined once here so a new variant cannot drift between the two
-    /// binding error mappers.
+    /// The bare variant name (e.g. `"InvalidFieldName"`). Retained as the
+    /// stable variant discriminator behind [`code`](Self::code); defined once
+    /// here so a new variant cannot drift between the two binding error mappers.
     pub fn variant_name(&self) -> &'static str {
         match self {
             EditError::InvalidFieldName(_) => "InvalidFieldName",
@@ -138,6 +137,27 @@ impl EditError {
             EditError::FieldRichtextNotInline(_) => "FieldRichtextNotInline",
             EditError::FieldConform { .. } => "FieldConform",
             EditError::ContentApply(_) => "ContentApply",
+        }
+    }
+
+    /// The namespaced diagnostic `code` (e.g. `"edit::invalid_field_name"`),
+    /// one per variant. This is the machine-routable identity both bindings
+    /// stamp onto the `Diagnostic` they raise — the `edit::*` peer of
+    /// `parse::*`, `validation::*`, and the rest of the taxonomy in
+    /// `prose/canon/ERROR.md`. Consumers route on this, not on message text.
+    pub fn code(&self) -> &'static str {
+        match self {
+            EditError::InvalidFieldName(_) => "edit::invalid_field_name",
+            EditError::UnknownField(_) => "edit::unknown_field",
+            EditError::InvalidKindName(_) => "edit::invalid_kind_name",
+            EditError::ReservedKind => "edit::reserved_kind",
+            EditError::IndexOutOfRange { .. } => "edit::index_out_of_range",
+            EditError::ValueTooDeep { .. } => "edit::value_too_deep",
+            EditError::Import(_) => "edit::import",
+            EditError::FieldRichtextDecode { .. } => "edit::field_richtext_decode",
+            EditError::FieldRichtextNotInline(_) => "edit::field_richtext_not_inline",
+            EditError::FieldConform { .. } => "edit::field_conform",
+            EditError::ContentApply(_) => "edit::content_apply",
         }
     }
 }

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -1,0 +1,95 @@
+# 0.95 → 0.96 — mutator errors carry `edit::*` codes; the `[EditError::…]` prefix is gone
+
+Mutator failures — the errors raised by `Document` and card mutators
+(`storeField`, the writer's `set` / `setAll` / `addCard`, `removeField`,
+`insertCard`, `moveCard`, `reviseField`, …) — become first-class members of the
+diagnostic taxonomy. Each now carries a namespaced `edit::*` `code`, the mutator
+peer of `parse::*`, `validation::*`, and `quill::*`. The old identity channel —
+an `[EditError::<Variant>]` prefix glued to the front of the message — is deleted
+outright. Route on `diagnostics[0].code`, never on message text.
+
+## What changed
+
+The thrown error shape is unchanged: still a single exception (WASM JS `Error`,
+Python `QuillmarkError`) carrying a non-empty `diagnostics` array/list, each a
+`Diagnostic` with `{ severity, code, message, path? }`. Two things move:
+
+- **`code` is now set.** Every mutator diagnostic carries its `edit::*` code
+  (previously `code` was `null` on the whole edit surface).
+- **The message drops the prefix.** `[EditError::UnknownField] field 'x' is not
+  declared in the schema` becomes `field 'x' is not declared in the schema`. The
+  display text is otherwise identical — only the bracketed prefix is gone.
+
+## Code map
+
+One code per `EditError` variant, produced once in core (`EditError::code()`,
+`crates/core/src/document/edit.rs`) so both bindings share the mapping:
+
+| Variant | Code |
+|---|---|
+| `InvalidFieldName` | `edit::invalid_field_name` |
+| `UnknownField` | `edit::unknown_field` |
+| `InvalidKindName` | `edit::invalid_kind_name` |
+| `ReservedKind` | `edit::reserved_kind` |
+| `IndexOutOfRange` | `edit::index_out_of_range` |
+| `ValueTooDeep` | `edit::value_too_deep` |
+| `Import` | `edit::import` |
+| `FieldRichtextDecode` | `edit::field_richtext_decode` |
+| `FieldRichtextNotInline` | `edit::field_richtext_not_inline` |
+| `FieldConform` | `edit::field_conform` |
+| `ContentApply` | `edit::content_apply` |
+
+## Migrate: route on `code`
+
+Any consumer that pattern-matched the message prefix to identify a mutator
+failure must read the code instead. The two most common routes — telling a typed
+coercion failure (`edit::field_conform`) from an undeclared name
+(`edit::unknown_field`) — need only `diagnostics[0].code`.
+
+WASM / TypeScript:
+
+```js
+// 0.95
+try { doc.storeField(name, value) }
+catch (err) {
+  if (/\[EditError::UnknownField\]/.test(err.message)) { /* … */ }
+}
+
+// 0.96
+try { doc.storeField(name, value) }
+catch (err) {
+  if (err.diagnostics[0].code === 'edit::unknown_field') { /* … */ }
+}
+```
+
+Python:
+
+```python
+# 0.95
+try:
+    quill.writer(doc).set(name, value)
+except QuillmarkError as exc:
+    if "[EditError::UnknownField]" in str(exc):  # …
+        ...
+
+# 0.96
+try:
+    quill.writer(doc).set(name, value)
+except QuillmarkError as exc:
+    if exc.diagnostics[0].code == "edit::unknown_field":  # …
+        ...
+```
+
+The batched mutators (`setAll` / `set_all`, `storeFields`) still emit one
+diagnostic per offending field with `path` set to the field name; each now also
+carries its `edit::*` code.
+
+## No action: null ≡ absent, ratified
+
+No behavior change — a clarification worth reading. `SCHEMAS.md` now states
+null ≡ absent as a chosen 1.0 commitment rather than an incidental rule:
+`field: null` and an omitted field are one indistinguishable state, so
+`removeField` (drop the key) stays the sole unset verb and there is no separate
+"cleared, not default" signal. The tri-state alternative (absent / null / value)
+is foreclosed. If your host code already treated present-null as absent — the
+engine's behavior since 0.92 — nothing changes.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,6 +18,12 @@ guides in order.
 
 ## Available guides
 
+- [0.95 → 0.96](0.95-to-0.96.md) — mutator failures join the diagnostic
+  taxonomy: every `EditError` variant carries a namespaced `edit::*` `code`
+  (`edit::unknown_field`, `edit::field_conform`, …) in both bindings, and the
+  `[EditError::<Variant>]` message-prefix convention is deleted — route on
+  `diagnostics[0].code`, never on message text. Canon ratifies null ≡ absent as
+  a 1.0 commitment (no behavior change).
 - [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
   `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to
   `(card, at?)`) and the deprecated `replaceBody` alias is deleted (use

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
+      - 0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; null ≡ absent ratified): migrations/0.95-to-0.96.md
       - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md
       - 0.93 → 0.94 (richtext(inline) token retires; ui.order removed, declaration order is the ordering contract): migrations/0.93-to-0.94.md
       - 0.92 → 0.93 (!must_fill marker; null ≡ absent; delete-ok removed): migrations/0.92-to-0.93.md

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -21,8 +21,8 @@ severity.
 `into_diagnostics()` consumes). There is no failure taxonomy beyond the
 diagnostics themselves: the machine-routable identity of a failure is each
 diagnostic's namespaced `code` (`parse::*`, `validation::*`, `quill::*`,
-`typst::*`, `pdfform::*`, `backend::*`, `engine::*`) — consumers route on
-codes, not on a type. Multi-problem stages (validation, quill config, backend
+`edit::*`, `typst::*`, `pdfform::*`, `backend::*`, `engine::*`) — consumers
+route on codes, not on a type. Multi-problem stages (validation, quill config, backend
 compilation) carry several diagnostics so every problem reaches the caller in
 one pass. `Display` follows the count-based message rule shared with both
 bindings: the primary diagnostic's message for a single diagnostic, an
@@ -34,6 +34,15 @@ document is well-formed but paired with the wrong quill (see
 for a backend session that does not override the incremental-`apply` seam
 (both built-in backends override it); `engine::backend_not_found` — the
 quill's declared backend is not registered.
+
+**`edit::*` — mutator diagnostics.** Document and card mutators fail with the
+`EditError` enum (`crates/core/src/document/edit.rs`), one namespaced code per
+variant via `EditError::code()` (`edit::invalid_field_name`,
+`edit::unknown_field`, `edit::index_out_of_range`, `edit::field_conform`, …).
+Both bindings stamp that code onto the `Diagnostic` they raise — the mutator
+peer of the render-path namespaces. Identity is the code, never message text:
+routing coercion-vs-undeclared is `edit::field_conform` vs.
+`edit::unknown_field`, read off `diagnostics[0].code`.
 
 **`RenderResult`**: successful result carrying artifacts, output format, and non-fatal `Vec<Diagnostic>` warnings
 
@@ -70,7 +79,7 @@ warnings in Typst sources).
 Python and WASM bindings delegate to core types:
 
 - **Python**: `PyDiagnostic` wraps `Diagnostic`. Every raised exception is `QuillmarkError` (a single type). Every exception carries a `diagnostics` list; `str(exc)` follows the shared count-based message rule.
-- **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics` by the same count-based rule. Consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for the rest. Parse failures (`Document.fromMarkdown`) carry the same shape — including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MB) and the various `EditError::*` variants for post-parse mutators.
+- **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics` by the same count-based rule. Consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for the rest. Parse failures (`Document.fromMarkdown`) carry the same shape — including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MB) and the `edit::*` codes for post-parse mutators.
 
 ## Backend Error Mapping
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -79,6 +79,17 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   It validates clean (no `TypeMismatch`) and zero-fills at render
   (authored › `default:` › type-zero — see
   [Zero-filled render](#zero-filled-render)).
+- **Null ≡ absent is a 1.0 commitment, not a stopgap.** The identification is
+  chosen and final: `field: null` and an omitted field are one state,
+  indistinguishable by design. The consequences are accepted, not worked
+  around — "explicitly cleared" and "never touched" cannot be told apart, so
+  there is no uniform "blank, not default" for a non-string type, and
+  `removeField` (drop the key) stays the sole unset verb; a present-null
+  carries no distinct "cleared" signal. The tri-state alternative (absent /
+  null / value) is foreclosed: it doubles every field's state space for one
+  rarely-authored distinction, breaks YAML round-trip sanity (a loaded-then-
+  saved document must not sprout `field: null` lines), and buys nothing the
+  ladder does not already give. The simpler model is the contract.
 - **`!must_fill` marker → non-fatal warning.** For every `!must_fill` marker
   present — root or nested, main card or composable card —
   `Quill::validate` emits `validation::must_fill` at **`Severity::Warning`**,


### PR DESCRIPTION
Phase 1 of the document-contract rework ([plan](../blob/rework-document-contract/prose/doc-contract-phases/README.md), [#1005](https://github.com/borb-sh/quillmark/issues/1005)). Ships now — no gate.

## What

Mutator failures (`EditError`) become first-class members of the diagnostic taxonomy. Every variant now carries a namespaced `edit::*` `code` on the raised `Diagnostic`, in both bindings. The `[EditError::<Variant>]` message-prefix convention — the shadow contract consumers had to parse — is deleted outright.

The thrown-error shape is unchanged (single exception, non-empty `diagnostics`, each `{ severity, code, message, path? }`). Two things move: `code` is now set (was `null` on the whole edit surface), and the message drops the bracketed prefix while keeping the `Display` text.

## Code map

One code per `EditError` variant, produced once in core (`EditError::code()`) so both bindings share the mapping.

| Variant | Code |
|---|---|
| `InvalidFieldName` | `edit::invalid_field_name` |
| `UnknownField` | `edit::unknown_field` |
| `InvalidKindName` | `edit::invalid_kind_name` |
| `ReservedKind` | `edit::reserved_kind` |
| `IndexOutOfRange` | `edit::index_out_of_range` |
| `ValueTooDeep` | `edit::value_too_deep` |
| `Import` | `edit::import` |
| `FieldRichtextDecode` | `edit::field_richtext_decode` |
| `FieldRichtextNotInline` | `edit::field_richtext_not_inline` |
| `FieldConform` | `edit::field_conform` |
| `ContentApply` | `edit::content_apply` |

## Changes

- **core** — `EditError::code()` beside `variant_name()`; `variant_name()` stays as the stable discriminator behind it (core tests still use it).
- **wasm** — `edit_error_to_js` / `edit_errors_to_js` build a `Diagnostic` with the `edit::` code; message loses the prefix.
- **python** — `convert_edit_error` / `convert_edit_errors`, same treatment.
- **tests** — WASM and Python suites route on `diagnostics[0].code` instead of matching the variant name in message text. Shared helpers `expectEditCode` (JS, in `test-helpers.js`) and `raises_edit_code` (py, in `conftest.py`). ~38 WASM sites + ~20 Python sites migrated. Binding builds are slow locally (per `CLAUDE.md`) — deferred to CI; verified statically (`cargo check --workspace --all-targets` green, JS/py syntax checks pass).
- **canon** — `ERROR.md` lists `edit::` in the namespace list and describes the namespace + its `EditError::code()` producer seam. `SCHEMAS.md` ratifies null ≡ absent as a chosen 1.0 commitment (tri-state foreclosed, `removeField` the sole unset verb) — the phase-1 rider, no behavior change.
- **migration** — `docs/migrations/0.95-to-0.96.md` (prefix removal, code table, route-on-`code` guidance) + `index.md` / `mkdocs.yml` nav entries.

## Not in this phase

No `path` work — the batched-mutator twins keep the bare field-name `path` they already set; everything else rides with `DocPath` (phase 2). Ad-hoc `format!()` paths on edit diagnostics would recreate the disease the rework exists to cure. Released migration guides that reference the old prefix historically (`0.94-to-0.95.md`) are immutable and left untouched.

## Acceptance

- [x] Every `EditError` surfaces with its `edit::` code in WASM and Python.
- [x] No `[EditError::` substring in code, message prefixes, or test expectations (only in the new migration guide documenting the removal).
- [x] `ERROR.md` lists `edit::`; the unreleased migration guide covers the break.
- [x] Consumer routing (`edit::field_conform` vs. `edit::unknown_field`) needs only `code`, never message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6ctm5qPxtTGSKReCKmVdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6ctm5qPxtTGSKReCKmVdD)_