### PR TITLE
Contract phase 2 — canonical DocPath (+ phase 1 wasm test fix)

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -555,7 +555,10 @@ describe('Document editor surface — storeFields', () => {
       throw new Error('storeFields should have thrown')
     } catch (err) {
       expect(err.diagnostics.map((d) => d.path)).toEqual(['bad-name', 'also bad'])
-      expect(err.message).toMatch(/InvalidFieldName/)
+      expect(err.diagnostics.map((d) => d.code)).toEqual([
+        'edit::invalid_field_name',
+        'edit::invalid_field_name',
+      ])
     }
     expect(hasField(doc.main, 'ok_field')).toBe(false)
   })

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -16,6 +16,8 @@ import {
   exportMarkdown,
   rebase,
   mapPos,
+  parseDocPath,
+  formatDocPath,
 } from '@quillmark-wasm'
 import { makeQuill, expectEditCode } from './test-helpers.js'
 
@@ -651,6 +653,53 @@ describe('Content codec — importMarkdown / exportMarkdown / rebase / mapPos', 
     // A caret at the end of "hello " stays; one after "world" shifts past "brave ".
     expect(mapPos(delta, 6, 'before')).toBe(6)
     expect(mapPos(delta, 11, 'after')).toBe(17)
+  })
+})
+
+describe('Document-model path — parseDocPath / formatDocPath', () => {
+  // Every emitted shape routes on tagged segments, not on a regex.
+  const cases = [
+    ['title', [{ seg: 'field', name: 'title' }]],
+    [
+      'recipients[0].name',
+      [
+        { seg: 'field', name: 'recipients' },
+        { seg: 'index', index: 0 },
+        { seg: 'field', name: 'name' },
+      ],
+    ],
+    ['main.body', [{ seg: 'main' }, { seg: 'body' }]],
+    ['cards[3]', [{ seg: 'card', kind: null, index: 3 }]],
+    [
+      'cards.indorsement[0].signature_block',
+      [
+        { seg: 'card', kind: 'indorsement', index: 0 },
+        { seg: 'field', name: 'signature_block' },
+      ],
+    ],
+    [
+      'cards.skills[2].body',
+      [{ seg: 'card', kind: 'skills', index: 2 }, { seg: 'body' }],
+    ],
+  ]
+
+  it('parseDocPath and formatDocPath round-trip every emitted shape', () => {
+    for (const [rendered, segs] of cases) {
+      expect(parseDocPath(rendered)).toEqual(segs)
+      expect(formatDocPath(segs)).toBe(rendered)
+    }
+  })
+
+  it('a card diagnostic routes on the head segment, no string parsing', () => {
+    const [head] = parseDocPath('cards.indorsement[0].signature_block')
+    expect(head.seg).toBe('card')
+    expect(head.kind).toBe('indorsement')
+    expect(head.index).toBe(0)
+  })
+
+  it('parseDocPath throws on a malformed path', () => {
+    expect(() => parseDocPath('cards[')).toThrow()
+    expect(() => parseDocPath('')).toThrow()
   })
 })
 

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -16,6 +16,9 @@
 export { Quill, Document, init } from '../core/wasm.js';
 // The document-free content codec, re-exported from the core build.
 export { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js';
+// The document-model path parser/serializer — route on `Diagnostic.path`
+// segments instead of regexing the string.
+export { parseDocPath, formatDocPath } from '../core/wasm.js';
 
 import type { CardAddr } from '../core/wasm.js';
 
@@ -67,7 +70,8 @@ export type {
 	Assoc,
 	LineOp,
 	MarkOp,
-	ChangeBundle
+	ChangeBundle,
+	DocPathSeg
 } from '../core/wasm.js';
 
 // ── Error contract ──────────────────────────────────────────────────────────

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -63,6 +63,10 @@ export { Quill, Document, init };
 // projection), `importMarkdown`, and the position-mapping pair (`rebase`,
 // `mapPos`).
 export { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js';
+// The document-model path parser/serializer: `parseDocPath(str) => DocPathSeg[]`
+// and its inverse `formatDocPath`, so a consumer routes on `Diagnostic.path`
+// segments instead of reverse-engineering the grammar.
+export { parseDocPath, formatDocPath } from '../core/wasm.js';
 
 // ── The main-card address ───────────────────────────────────────────────────
 /**

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1798,6 +1798,55 @@ pub fn rebase(
     serialize_or_throw(&out, "rebase")
 }
 
+/// The structured form of a `Diagnostic.path` — one tagged segment per
+/// `DocPathSeg`. Emitted here as the single source of truth for the parser
+/// boundary so a consumer routes on segments instead of splitting the string.
+#[wasm_bindgen(typescript_custom_section)]
+const DOCPATH_TS: &'static str = r#"
+/**
+ * One segment of a parsed `Diagnostic.path` (see `parseDocPath`). The head
+ * carries the document-model root — `main` (only before `body`), a `card`
+ * (`kind: null` is the unknown-kind `cards[i]` form), or a `field`; the tail is
+ * `field` / `index` / a terminal `body`.
+ */
+export type DocPathSeg =
+    | { seg: "main" }
+    | { seg: "card"; kind: string | null; index: number }
+    | { seg: "field"; name: string }
+    | { seg: "index"; index: number }
+    | { seg: "body" };
+"#;
+
+/// Parse a canonical document-model `Diagnostic.path`
+/// (`cards.<kind>[<i>].<field>`, `main.body`, `recipients[0].name`) into its
+/// structured [`DocPathSeg`] segments — the exported inverse of the engine's
+/// one path serializer, so a consumer routes on segments instead of regexing
+/// the string. Throws on a malformed path.
+#[wasm_bindgen(js_name = parseDocPath, unchecked_return_type = "DocPathSeg[]")]
+pub fn parse_doc_path(path: &str) -> Result<JsValue, JsValue> {
+    let doc_path = path
+        .parse::<quillmark_core::DocPath>()
+        .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
+    // Via `serde_json::Value` so the tagged segments cross as plain objects,
+    // sidestepping serde-wasm-bindgen's tagged-enum handling.
+    let json = serde_json::to_value(&doc_path)
+        .map_err(|e| WasmError::from(format!("parseDocPath: {e}")).to_js_value())?;
+    serialize_or_throw(&json, "parseDocPath")
+}
+
+/// Serialize structured [`DocPathSeg`] segments back to the canonical path
+/// string — the inverse of `parseDocPath`, for a consumer that builds a path
+/// rather than reads one. Throws on a segment array the deserializer rejects.
+#[wasm_bindgen(js_name = formatDocPath)]
+pub fn format_doc_path(
+    #[wasm_bindgen(unchecked_param_type = "DocPathSeg[]")] segs: JsValue,
+) -> Result<String, JsValue> {
+    let json = js_value_to_json(segs, "formatDocPath")?;
+    let doc_path: quillmark_core::DocPath = serde_json::from_value(json)
+        .map_err(|e| WasmError::from(format!("formatDocPath: {e}")).to_js_value())?;
+    Ok(doc_path.to_string())
+}
+
 /// Map a base content position through a `delta` to its new position — the pure
 /// position-mapping codec an editor bridge composes to hold a caret stable
 /// across a `revise`. `assoc` decides the side of a same-position insertion

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1828,10 +1828,16 @@ pub fn parse_doc_path(path: &str) -> Result<JsValue, JsValue> {
         .parse::<quillmark_core::DocPath>()
         .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
     // Via `serde_json::Value` so the tagged segments cross as plain objects,
-    // sidestepping serde-wasm-bindgen's tagged-enum handling.
+    // sidestepping serde-wasm-bindgen's tagged-enum handling; `missing_as_null`
+    // so an unknown-kind card's `kind` is JS `null`, not `undefined` — the
+    // `DocPathSeg` contract is `kind: string | null`.
     let json = serde_json::to_value(&doc_path)
         .map_err(|e| WasmError::from(format!("parseDocPath: {e}")).to_js_value())?;
-    serialize_or_throw(&json, "parseDocPath")
+    let serializer = serde_wasm_bindgen::Serializer::new()
+        .serialize_maps_as_objects(true)
+        .serialize_missing_as_null(true);
+    json.serialize(&serializer)
+        .map_err(|e| WasmError::from(format!("parseDocPath: {e}")).to_js_value())
 }
 
 /// Serialize structured [`DocPathSeg`] segments back to the canonical path

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -22,6 +22,8 @@
 //!
 //! Because field names and card kinds are validated to charsets that exclude
 //! `.`, `[`, `]`, and whitespace, the dotted form round-trips unambiguously.
+//! [`DocPath`](crate::path::DocPath) is the one type that constructs, renders,
+//! and parses it — no site assembles a path with `format!`.
 //!
 //! | Anchor                     | Path                                      |
 //! |----------------------------|-------------------------------------------|

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -62,6 +62,9 @@ pub use quill::{zero_value, FileTreeNode, Quill, QuillIgnore, STANDARD_METADATA_
 pub mod value;
 pub use value::{json_depth_exceeds, PathSegment, QuillValue};
 
+pub mod path;
+pub use path::{DocPath, DocSeg};
+
 pub mod normalize;
 
 pub mod version;

--- a/crates/core/src/path.rs
+++ b/crates/core/src/path.rs
@@ -1,0 +1,409 @@
+//! Canonical document-model paths.
+//!
+//! [`DocPath`] is the workspace's one serializer and parser for
+//! [`Diagnostic::path`](crate::error::Diagnostic::path) — the anchor into a
+//! typed [`Document`](crate::document::Document). Every emit site (schema
+//! validation, `!must_fill` collection, coercion) constructs a `DocPath` and
+//! renders it once through [`Display`](std::fmt::Display); no site assembles a path with
+//! `format!`, and no consumer regexes one back apart — the exported
+//! [`FromStr`] parser is the inverse.
+//!
+//! # Grammar
+//!
+//! ```text
+//! path   := root? segment*
+//! root   := "main"                         // only as the main body head
+//!         | "cards" "." kind "[" index "]"  // typed card
+//!         | "cards" "[" index "]"           // unknown-kind card (the only bare-index root)
+//! segment:= "." field | "[" index "]" | ".body"
+//! kind   := [a-z_][a-z0-9_]*
+//! field  := [A-Za-z_][A-Za-z0-9_]*
+//! ```
+//!
+//! A bare main field carries no root (`recipient`, `recipients[0].name`); the
+//! main body is `main.body`. A card field is kind-qualified —
+//! `cards.<kind>[<i>].<field>` — so a consumer receives kind and array index
+//! without a second lookup; a card whose `$kind` has no schema stays
+//! `cards[<i>]`. Field names and card kinds exclude `.`, `[`, `]`, so the
+//! rendered form round-trips.
+//!
+//! `cards` and `main` are reserved roots and `body` a reserved terminal: a
+//! main field literally named `cards`/`main`, or a scalar field named `body`,
+//! collides with a root/terminal and does not round-trip. No fixture field
+//! uses these names; the collision is accepted, not guarded.
+//!
+//! This is the **document-model** namespace, distinct from the plate-JSON
+//! `data.$cards` array template authors see (`prose/canon/CARDS.md`): sigiled
+//! `$cards` is glue delivered to the backend, unsigiled `cards` is a path into
+//! the document. Config-space anchors (`$seed.<kind>.<field>`, Quill.yaml
+//! schema-literal owner labels) ride the same serializer with their prefix as
+//! a leading [`field`](DocPath::field) segment — verbatim, never parsed.
+
+use crate::value::PathSegment;
+use std::fmt;
+use std::str::FromStr;
+
+/// One segment of a [`DocPath`].
+///
+/// Serde-tagged (`{ "seg": "field", "name": "x" }`) so the WASM parser hands
+/// the editor a structured array it routes on, never a string it splits.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "seg", rename_all = "lowercase")]
+pub enum DocSeg {
+    /// The main card — only ever the head of `main.body`; a bare main field
+    /// carries no root segment.
+    Main,
+    /// A composable card by document-array index. `kind: None` is the
+    /// unknown-kind whole-card form (`cards[<i>]`), the only bare-index root.
+    Card { kind: Option<String>, index: usize },
+    /// An object field or map key.
+    Field { name: String },
+    /// An array index.
+    Index { index: usize },
+    /// A card or main body (`.body`), always terminal.
+    Body,
+}
+
+/// A canonical document-model path — an ordered [`DocSeg`] list with one
+/// [`Display`](std::fmt::Display) serializer and one [`FromStr`] parser. See the [module
+/// docs](self) for the grammar.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct DocPath {
+    segs: Vec<DocSeg>,
+}
+
+impl DocPath {
+    /// The empty path — the base a bare main field extends (`title`).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The main body anchor, `main.body`.
+    pub fn main_body() -> Self {
+        Self {
+            segs: vec![DocSeg::Main, DocSeg::Body],
+        }
+    }
+
+    /// A composable card root. `kind: None` is the unknown-kind whole-card
+    /// form `cards[<i>]`; `Some(k)` is `cards.<k>[<i>]`.
+    pub fn card(kind: Option<&str>, index: usize) -> Self {
+        Self {
+            segs: vec![DocSeg::Card {
+                kind: kind.map(str::to_owned),
+                index,
+            }],
+        }
+    }
+
+    /// This path extended by a field segment. The name is stored verbatim —
+    /// callers pass validated field names, or a config-space prefix
+    /// (`$seed.<kind>`) as an opaque head.
+    pub fn field(&self, name: &str) -> Self {
+        self.pushing(DocSeg::Field {
+            name: name.to_owned(),
+        })
+    }
+
+    /// This path extended by an array index segment.
+    pub fn index(&self, index: usize) -> Self {
+        self.pushing(DocSeg::Index { index })
+    }
+
+    /// This path extended by the terminal body segment.
+    pub fn body(&self) -> Self {
+        self.pushing(DocSeg::Body)
+    }
+
+    /// This path extended by a value-relative [`PathSegment`] — the bridge
+    /// from the value-tree walk (`!must_fill` collection): [`Key`] becomes a
+    /// field, [`Index`] an index.
+    ///
+    /// [`Key`]: PathSegment::Key
+    /// [`Index`]: PathSegment::Index
+    pub fn segment(&self, seg: &PathSegment) -> Self {
+        match seg {
+            PathSegment::Key(k) => self.field(k),
+            PathSegment::Index(i) => self.index(*i),
+        }
+    }
+
+    /// The segments, head first.
+    pub fn segs(&self) -> &[DocSeg] {
+        &self.segs
+    }
+
+    fn pushing(&self, seg: DocSeg) -> Self {
+        let mut segs = self.segs.clone();
+        segs.push(seg);
+        Self { segs }
+    }
+}
+
+impl fmt::Display for DocPath {
+    /// The one document-model path serializer. A `Field` takes a leading `.`
+    /// unless it heads the path; `Index` and `Body` never do; the card and
+    /// main roots are self-contained heads.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, seg) in self.segs.iter().enumerate() {
+            match seg {
+                DocSeg::Main => f.write_str("main")?,
+                DocSeg::Card { kind: Some(k), index } => write!(f, "cards.{k}[{index}]")?,
+                DocSeg::Card { kind: None, index } => write!(f, "cards[{index}]")?,
+                DocSeg::Field { name } => {
+                    if i != 0 {
+                        f.write_str(".")?;
+                    }
+                    f.write_str(name)?;
+                }
+                DocSeg::Index { index } => write!(f, "[{index}]")?,
+                DocSeg::Body => f.write_str(".body")?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A [`DocPath`] parse failure. Carries the offending input for a diagnostic
+/// message; the parser is total over every path [`Display`](std::fmt::Display) emits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocPathParseError {
+    pub input: String,
+    pub reason: &'static str,
+}
+
+impl fmt::Display for DocPathParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid document path '{}': {}", self.input, self.reason)
+    }
+}
+
+impl std::error::Error for DocPathParseError {}
+
+impl FromStr for DocPath {
+    type Err = DocPathParseError;
+
+    /// The inverse of [`Display`](std::fmt::Display), total over every emitted path. `main.body`
+    /// is the main body; a `cards`-headed shape matching a card root becomes a
+    /// [`Card`](DocSeg::Card); a trailing `.body` under a root is [`Body`](DocSeg::Body);
+    /// everything else is a bare field chain (`recipients[0].name`).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let err = |reason: &'static str| DocPathParseError {
+            input: s.to_owned(),
+            reason,
+        };
+        if s.is_empty() {
+            return Err(err("empty path"));
+        }
+
+        // The head word scans as a `Field`; a `main`/`cards` head is reclassed
+        // into its root below, otherwise it stays the field it names.
+        let segs = scan(s).map_err(err)?;
+
+        // `main.body` is the sole `main`-headed form.
+        if let [DocSeg::Field { name: a }, DocSeg::Field { name: b }] = segs.as_slice() {
+            if a == "main" && b == "body" {
+                return Ok(DocPath::main_body());
+            }
+        }
+
+        // A `cards` head that matches a card-root shape is a Card; the tail
+        // (a lone `body`, or fields/indices) follows. A `cards` word that does
+        // not fit — no index — is an ordinary field named `cards`.
+        if matches!(segs.first(), Some(DocSeg::Field { name }) if name == "cards") {
+            if let Some((card, rest)) = parse_card_root(&segs) {
+                let mut segs = vec![card];
+                segs.extend(tail_segs(rest));
+                return Ok(DocPath { segs });
+            }
+        }
+
+        // A bare field chain: the scanned segments already stand.
+        Ok(DocPath { segs })
+    }
+}
+
+/// Scan a path into segments: a leading word, then a run of `.word` (a `Field`)
+/// or `[index]` (an `Index`). Root/terminal words (`main`/`cards`/`body`) scan
+/// as fields and are reclassed by the caller. The round-trip charsets are
+/// enforced here only as "no empty word, digits inside brackets".
+fn scan(s: &str) -> Result<Vec<DocSeg>, &'static str> {
+    let mut segs = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    // Head word (paths never open with `.` or `[`).
+    if bytes[0] == b'.' || bytes[0] == b'[' {
+        return Err("path must start with a name");
+    }
+    while i < bytes.len() {
+        match bytes[i] {
+            b'[' => {
+                let end = s[i..].find(']').map(|o| i + o).ok_or("unclosed '['")?;
+                let digits = &s[i + 1..end];
+                if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+                    return Err("index is not a number");
+                }
+                let index = digits.parse().map_err(|_| "index out of range")?;
+                segs.push(DocSeg::Index { index });
+                i = end + 1;
+            }
+            b'.' => {
+                let start = i + 1;
+                i = word_end(bytes, start);
+                if i == start {
+                    return Err("empty segment after '.'");
+                }
+                segs.push(DocSeg::Field { name: s[start..i].to_owned() });
+            }
+            _ => {
+                let start = i;
+                i = word_end(bytes, start);
+                segs.push(DocSeg::Field { name: s[start..i].to_owned() });
+            }
+        }
+    }
+    Ok(segs)
+}
+
+/// The index just past a word — the run up to the next `.` or `[`.
+fn word_end(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while i < bytes.len() && bytes[i] != b'.' && bytes[i] != b'[' {
+        i += 1;
+    }
+    i
+}
+
+/// Match a `cards` head against the two card-root shapes, returning the root
+/// segment and the remaining segments. `None` when the shape does not fit —
+/// then `cards` is a field, not a root.
+fn parse_card_root(segs: &[DocSeg]) -> Option<(DocSeg, &[DocSeg])> {
+    match segs {
+        // cards[<i>] …
+        [DocSeg::Field { .. }, DocSeg::Index { index }, rest @ ..] => {
+            Some((DocSeg::Card { kind: None, index: *index }, rest))
+        }
+        // cards.<kind>[<i>] …
+        [DocSeg::Field { .. }, DocSeg::Field { name: kind }, DocSeg::Index { index }, rest @ ..] => {
+            Some((
+                DocSeg::Card {
+                    kind: Some(kind.clone()),
+                    index: *index,
+                },
+                rest,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// A card-root tail: a lone `body` is the card body; otherwise the scanned
+/// field/index chain stands (`.signature_block`, `.recipients[0].name`).
+fn tail_segs(rest: &[DocSeg]) -> Vec<DocSeg> {
+    match rest {
+        [DocSeg::Field { name }] if name == "body" => vec![DocSeg::Body],
+        _ => rest.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every form [`Display`](std::fmt::Display) emits round-trips through [`FromStr`].
+    fn round_trip(path: DocPath, rendered: &str) {
+        assert_eq!(path.to_string(), rendered, "serialize");
+        assert_eq!(
+            rendered.parse::<DocPath>().expect("parse"),
+            path,
+            "parse back"
+        );
+    }
+
+    #[test]
+    fn main_field_and_nested() {
+        round_trip(DocPath::new().field("title"), "title");
+        round_trip(
+            DocPath::new().field("recipients").index(0).field("name"),
+            "recipients[0].name",
+        );
+    }
+
+    #[test]
+    fn main_body() {
+        round_trip(DocPath::main_body(), "main.body");
+    }
+
+    #[test]
+    fn card_roots() {
+        round_trip(DocPath::card(Some("indorsement"), 0), "cards.indorsement[0]");
+        round_trip(DocPath::card(None, 3), "cards[3]");
+    }
+
+    #[test]
+    fn card_field_and_body() {
+        round_trip(
+            DocPath::card(Some("indorsement"), 0).field("signature_block"),
+            "cards.indorsement[0].signature_block",
+        );
+        round_trip(
+            DocPath::card(Some("skills"), 2).body(),
+            "cards.skills[2].body",
+        );
+        round_trip(
+            DocPath::card(Some("indorsement"), 0)
+                .field("recipients")
+                .index(1)
+                .field("name"),
+            "cards.indorsement[0].recipients[1].name",
+        );
+    }
+
+    #[test]
+    fn body_and_main_are_reserved_only_at_the_edges() {
+        // A non-terminal `body` under a card is an ordinary field named body.
+        round_trip(
+            DocPath::card(Some("k"), 0).field("body").field("x"),
+            "cards.k[0].body.x",
+        );
+        // A `main`-headed chain that is not `main.body` is a field chain.
+        round_trip(DocPath::new().field("main").field("x"), "main.x");
+        round_trip(DocPath::new().field("main"), "main");
+    }
+
+    #[test]
+    fn cards_as_a_field_name_when_no_index_follows() {
+        // `cards.foo` has no index → not a card root → a field chain.
+        round_trip(DocPath::new().field("cards").field("foo"), "cards.foo");
+    }
+
+    #[test]
+    fn segment_bridge() {
+        let base = DocPath::card(Some("k"), 0);
+        assert_eq!(
+            base.segment(&PathSegment::Key("addr".into()))
+                .segment(&PathSegment::Index(2))
+                .to_string(),
+            "cards.k[0].addr[2]",
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed() {
+        for bad in ["", ".foo", "[0]", "foo[", "foo[a]", "foo[]", "a..b", "a."] {
+            assert!(bad.parse::<DocPath>().is_err(), "expected error for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn serde_round_trips_as_tagged_array() {
+        let path = DocPath::card(Some("indorsement"), 0).field("sig");
+        let json = serde_json::to_string(&path).unwrap();
+        assert_eq!(
+            json,
+            r#"[{"seg":"card","kind":"indorsement","index":0},{"seg":"field","name":"sig"}]"#
+        );
+        assert_eq!(serde_json::from_str::<DocPath>(&json).unwrap(), path);
+    }
+}

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use super::{seed, CardSchema, FieldSchema, FieldType, Quill, QuillConfig};
 use crate::normalize::normalize_document;
 use crate::quill::zero_value;
-use crate::value::PathSegment;
+use crate::path::DocPath;
 use crate::{
     Card, Diagnostic, Document, Payload, QuillValue, RenderError, SeedOverlay, Severity, Version,
 };
@@ -204,7 +204,7 @@ impl Quill {
                         format!("`$seed` overlay targets unknown card kind `{kind}`"),
                     )
                     .with_code("validation::seed_unknown_kind".to_string())
-                    .with_path(format!("$seed.{kind}"))
+                    .with_path(DocPath::new().field("$seed").field(kind).to_string())
                     .with_hint(format!(
                         "Remove the `{kind}` overlay, or rename it to a declared card kind."
                     )),
@@ -218,7 +218,7 @@ impl Quill {
                         format!("`$seed.{kind}` must be a mapping of field overrides"),
                     )
                     .with_code("validation::seed_overlay_shape".to_string())
-                    .with_path(format!("$seed.{kind}")),
+                    .with_path(DocPath::new().field("$seed").field(kind).to_string()),
                 );
                 continue;
             };
@@ -226,7 +226,7 @@ impl Quill {
                 if field == "$body" {
                     continue;
                 }
-                let field_path = format!("$seed.{kind}.{field}");
+                let field_path = DocPath::new().field("$seed").field(kind).field(field);
                 let Some(field_schema) = card_schema.fields.get(field) else {
                     diags.push(
                         Diagnostic::new(
@@ -234,7 +234,7 @@ impl Quill {
                             format!("`$seed.{kind}.{field}` is not a field of card kind `{kind}`"),
                         )
                         .with_code("validation::seed_unknown_field".to_string())
-                        .with_path(field_path),
+                        .with_path(field_path.to_string()),
                     );
                     continue;
                 };
@@ -434,58 +434,38 @@ fn rebuild_payload_with_meta(source: &Card, fields: IndexMap<String, QuillValue>
 /// consumer treats any outstanding marker as "not done".
 fn validate_fills(doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
-    collect_fill_diags(doc.main(), "", &mut diags);
+    collect_fill_diags(doc.main(), &DocPath::new(), &mut diags);
     for (index, card) in doc.cards().iter().enumerate() {
-        let kind = card.kind().unwrap_or("");
-        let base = format!("cards.{kind}[{index}]");
-        collect_fill_diags(card, &base, &mut diags);
+        collect_fill_diags(card, &DocPath::card(card.kind(), index), &mut diags);
     }
     diags
 }
 
 /// Append a `validation::must_fill` warning for each marker in `card`'s fields.
-fn collect_fill_diags(card: &Card, base: &str, out: &mut Vec<Diagnostic>) {
+fn collect_fill_diags(card: &Card, base: &DocPath, out: &mut Vec<Diagnostic>) {
     let payload = card.payload();
     for (key, value) in payload {
-        let field_path = if base.is_empty() {
-            key.clone()
-        } else {
-            format!("{base}.{key}")
-        };
+        let field_path = base.field(key);
         // Root marker (the field-level `fill` flag) plus any nested markers
-        // carried on the value tree.
+        // carried on the value tree, each rebased onto the field path.
         if payload.is_fill(key) {
             out.push(fill_warning(&field_path));
         }
         for nested in value.nonroot_fill_paths() {
-            out.push(fill_warning(&render_fill_path(&field_path, &nested)));
+            let nested_path = nested.iter().fold(field_path.clone(), |p, s| p.segment(s));
+            out.push(fill_warning(&nested_path));
         }
     }
 }
 
-/// Render `base` extended by a value-relative path into the document-model path
-/// grammar (`addr.street`, `recipients[0].name`).
-fn render_fill_path(base: &str, segs: &[PathSegment]) -> String {
-    let mut s = base.to_string();
-    for seg in segs {
-        match seg {
-            PathSegment::Key(k) => {
-                s.push('.');
-                s.push_str(k);
-            }
-            PathSegment::Index(i) => s.push_str(&format!("[{i}]")),
-        }
-    }
-    s
-}
-
-fn fill_warning(path: &str) -> Diagnostic {
+fn fill_warning(path: &DocPath) -> Diagnostic {
+    let path = path.to_string();
     Diagnostic::new(
         Severity::Warning,
         format!("Field `{path}` is marked `!must_fill` — a placeholder awaiting a value."),
     )
     .with_code("validation::must_fill".to_string())
-    .with_path(path.to_string())
+    .with_path(path)
     .with_hint(
         "Replace the value and drop the `!must_fill` marker, or remove the marker if the \
          current value is intended."

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1053,7 +1053,11 @@ impl QuillConfig {
     ) {
         use super::validation::{validate_schema_literal, ValidationError};
 
-        for violation in validate_schema_literal(schema, value, owner_label) {
+        // A Quill.yaml schema-literal anchor (`$seed.<kind>`, a field label) is
+        // config-space, not a document path; it rides the one serializer with
+        // its prefix as an opaque head field.
+        let owner_path = crate::path::DocPath::new().field(owner_label);
+        for violation in validate_schema_literal(schema, value, &owner_path) {
             let diag = match &violation {
                 ValidationError::TypeMismatch {
                     path,

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -3421,7 +3421,7 @@ fn enum_membership_is_validated_on_a_document_value() {
     let errs = super::validation::validate_field(
         field,
         &QuillValue::from_json(serde_json::json!("green")),
-        "color",
+        &crate::path::DocPath::new().field("color"),
     );
     assert!(
         errs.iter().any(|e| e.code() == "validation::enum_violation"),
@@ -3431,7 +3431,7 @@ fn enum_membership_is_validated_on_a_document_value() {
     let ok = super::validation::validate_field(
         field,
         &QuillValue::from_json(serde_json::json!("red")),
-        "color",
+        &crate::path::DocPath::new().field("color"),
     );
     assert!(ok.is_empty(), "an in-domain value validates, got: {ok:?}");
 }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 
 use crate::document::Document;
 use crate::error::{Diagnostic, Severity};
+use crate::path::DocPath;
 use crate::quill::formats::{is_valid_date, is_valid_datetime};
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::QuillValue;
@@ -281,34 +282,32 @@ pub fn validate_typed_document(
     doc: &Document,
 ) -> Result<(), Vec<ValidationError>> {
     let main_fields = doc.main().payload().to_index_map();
-    let mut errors = validate_fields_for_card_indexmap(&config.main, &main_fields, "");
+    let mut errors = validate_fields_for_card_indexmap(&config.main, &main_fields, &DocPath::new());
 
     // Enforce body.enabled on the main card. Whitespace-only bodies are
     // treated as empty — only meaningful prose triggers the diagnostic.
     if !config.main.body_enabled() && !doc.main().body().is_blank() {
         errors.push(ValidationError::BodyDisabled {
-            path: "main.body".to_string(),
+            path: DocPath::main_body().to_string(),
             card: "main".to_string(),
         });
     }
 
     for (index, card) in doc.cards().iter().enumerate() {
         let card_name = card.kind().unwrap_or("").to_string();
-        let item_path = format!("cards[{index}]");
-        // NOTE: `cards[N]` is the document-instance-side path (the cards
-        // array on a Document). Card-kind definitions live under
-        // `card_kinds:` in Quill.yaml, but instances on a document are
-        // still a `cards` list.
 
         let Some(card_schema) = config.card_kind(card_name.as_str()) else {
+            // An unknown-kind card has no kind to qualify with: `cards[<i>]`,
+            // the sole bare-index root. (A document's cards are always a
+            // `cards` list; the kind *definitions* live under `card_kinds:`.)
             errors.push(ValidationError::UnknownCard {
-                path: item_path,
+                path: DocPath::card(None, index).to_string(),
                 card: card_name,
             });
             continue;
         };
 
-        let card_path = format!("cards.{card_name}[{index}]");
+        let card_path = DocPath::card(Some(&card_name), index);
         let card_fields = card.payload().to_index_map();
         errors.extend(validate_fields_for_card_indexmap(
             card_schema,
@@ -318,7 +317,7 @@ pub fn validate_typed_document(
 
         if !card_schema.body_enabled() && !card.body().is_blank() {
             errors.push(ValidationError::BodyDisabled {
-                path: format!("{card_path}.body"),
+                path: card_path.body().to_string(),
                 card: card_name,
             });
         }
@@ -334,7 +333,7 @@ pub fn validate_typed_document(
 fn validate_fields_for_card_indexmap(
     card: &CardSchema,
     fields: &IndexMap<String, QuillValue>,
-    base_path: &str,
+    base: &DocPath,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
     let mut field_names: Vec<&String> = card.fields.keys().collect();
@@ -342,7 +341,7 @@ fn validate_fields_for_card_indexmap(
 
     for field_name in field_names {
         let schema = &card.fields[field_name];
-        let path = child_path(base_path, field_name);
+        let path = base.field(field_name);
         // Absence is a completeness concern, not a well-formedness one: an
         // absent field — like a present-null one — is zero-filled at render and
         // raises nothing here.
@@ -375,7 +374,7 @@ enum ValueContext {
 fn validate_value(
     field: &FieldSchema,
     value: &QuillValue,
-    path: &str,
+    path: &DocPath,
     ctx: ValueContext,
 ) -> Vec<ValidationError> {
     // Null ≡ absent: a present-null value in a document is treated as omitted
@@ -450,7 +449,7 @@ fn validate_value(
                 // their properties via the Object branch.
                 if let Some(item_schema) = &field.items {
                     for (idx, item) in items.iter().enumerate() {
-                        let row_path = format!("{}[{}]", path, idx);
+                        let row_path = path.index(idx);
                         errors.extend(validate_value(
                             item_schema,
                             &QuillValue::from_json(item.clone()),
@@ -470,7 +469,7 @@ fn validate_value(
                     property_names.sort();
                     for property_name in property_names {
                         let property_schema = &properties[property_name];
-                        let property_path = child_path(path, property_name);
+                        let property_path = path.field(property_name);
                         // Absent object property: completeness, not
                         // well-formedness. Like a top-level absent field, it
                         // zero-fills at render and raises nothing here.
@@ -578,7 +577,7 @@ fn validate_value(
 pub(crate) fn validate_field(
     field: &FieldSchema,
     value: &QuillValue,
-    path: &str,
+    path: &DocPath,
 ) -> Vec<ValidationError> {
     validate_value(field, value, path, ValueContext::Document)
 }
@@ -593,7 +592,7 @@ pub(crate) fn validate_field(
 pub(crate) fn validate_schema_literal(
     schema: &FieldSchema,
     value: &QuillValue,
-    path: &str,
+    path: &DocPath,
 ) -> Vec<ValidationError> {
     validate_value(schema, value, path, ValueContext::SchemaLiteral)
 }
@@ -610,14 +609,6 @@ fn expected_type_name(field_type: &FieldType) -> &'static str {
         FieldType::Boolean => "boolean",
         FieldType::Array => "array",
         FieldType::Object => "object",
-    }
-}
-
-fn child_path(parent: &str, child: &str) -> String {
-    if parent.is_empty() {
-        child.to_string()
-    } else {
-        format!("{parent}.{child}")
     }
 }
 

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -1,4 +1,4 @@
-# 0.95 → 0.96 — mutator errors carry `edit::*` codes; the `[EditError::…]` prefix is gone
+# 0.95 → 0.96 — mutator errors carry `edit::*` codes; the `[EditError::…]` prefix is gone; a `DocPath` parser lands
 
 Mutator failures — the errors raised by `Document` and card mutators
 (`storeField`, the writer's `set` / `setAll` / `addCard`, `removeField`,
@@ -93,3 +93,42 @@ null ≡ absent as a chosen 1.0 commitment rather than an incidental rule:
 "cleared, not default" signal. The tri-state alternative (absent / null / value)
 is foreclosed. If your host code already treated present-null as absent — the
 engine's behavior since 0.92 — nothing changes.
+
+## New: `parseDocPath` — route on `Diagnostic.path` segments
+
+`Diagnostic.path` — the document-model anchor into a `Document`
+(`cards.<kind>[<index>].<field>`, `main.body`, `recipients[0].name`) — is now
+owned by one canonical type, `DocPath`, with one serializer and an exported
+parser. **The emitted strings are unchanged**: card fields were already
+kind-qualified, and no wire format moved. Two things are new:
+
+- **`parseDocPath(path)` / `formatDocPath(segs)`** on the WASM surface. Parse a
+  path into a structured `DocPathSeg[]` and route on it, instead of splitting
+  or regexing the string:
+
+  ```js
+  import { parseDocPath } from '@quillmark/wasm'
+
+  const [head] = parseDocPath(diagnostic.path)
+  if (head.seg === 'card') {
+    // head.kind (string | null), head.index (number) — no regex
+  }
+  ```
+
+  A `DocPathSeg` is a tagged union: `{ seg: "main" }`,
+  `{ seg: "card", kind, index }`, `{ seg: "field", name }`,
+  `{ seg: "index", index }`, `{ seg: "body" }`.
+
+- **The two path namespaces are stated in canon.** The unsigiled `cards` in a
+  `Diagnostic.path` is the document-model anchor; the sigiled `data.$cards` a
+  template author sees is plate JSON — a different namespace, not renamed. If
+  you built a path by hand from `data.$cards` array indices, switch to
+  `parseDocPath` on the emitted diagnostic instead.
+
+No action if you already read `diagnostic.path` as an opaque string — it still
+is one. `ERROR.md`'s stale `cards[2].author` example (missing the kind segment)
+is corrected to `cards.indorsement[2].author`.
+
+Mutator (`edit::*`) diagnostics still carry only the bare field-name `path` the
+batched twins already set; per-variant paths on the single mutators ride a
+later slice of the contract rework.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -22,8 +22,10 @@ guides in order.
   taxonomy: every `EditError` variant carries a namespaced `edit::*` `code`
   (`edit::unknown_field`, `edit::field_conform`, …) in both bindings, and the
   `[EditError::<Variant>]` message-prefix convention is deleted — route on
-  `diagnostics[0].code`, never on message text. Canon ratifies null ≡ absent as
-  a 1.0 commitment (no behavior change).
+  `diagnostics[0].code`, never on message text. `Diagnostic.path` gains an
+  exported `parseDocPath` / `formatDocPath` (route on `DocPathSeg[]`, not a
+  regex); the emitted path strings are unchanged. Canon ratifies null ≡ absent
+  as a 1.0 commitment (no behavior change).
 - [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
   `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to
   `(card, at?)`) and the deprecated `replaceBody` alias is deleted (use

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
-      - 0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; null ≡ absent ratified): migrations/0.95-to-0.96.md
+      - 0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified): migrations/0.95-to-0.96.md
       - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md
       - 0.93 → 0.94 (richtext(inline) token retires; ui.order removed, declaration order is the ordering contract): migrations/0.93-to-0.94.md
       - 0.92 → 0.93 (!must_fill marker; null ≡ absent; delete-ok removed): migrations/0.92-to-0.93.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
-      - 0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified): migrations/0.95-to-0.96.md
+      - '0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified)': migrations/0.95-to-0.96.md
       - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md
       - 0.93 → 0.94 (richtext(inline) token retires; ui.order removed, declaration order is the ordering contract): migrations/0.93-to-0.94.md
       - 0.92 → 0.93 (!must_fill marker; null ≡ absent; delete-ok removed): migrations/0.92-to-0.93.md

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -105,6 +105,8 @@ See [`markdown-spec.md`](../references/markdown-spec.md) §3 for the full syntax
 - **All backends**: cards are delivered as `data.$cards`, an array of objects each containing a `$kind` discriminator, the card's payload fields, and a `$body` key with the card's body Markdown.
 - **`Quill::compile_data()`** returns the fully coerced and validated JSON, including `$cards`.
 
+The sigiled `data.$cards` here is plate JSON — glue delivered to the backend. It is a **different namespace** from the unsigiled `cards` in a `Diagnostic.path` (`cards.<kind>[<index>]`, the document-model anchor — see [ERROR.md](ERROR.md) § "Document-model paths"). The plate key is not renamed off `$cards`; the two namespaces are documented apart.
+
 ## Out-of-band Metadata (`$ext`)
 
 Per-card editor state — display renames, collapse flags, agent

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -99,7 +99,8 @@ Field-level validation diagnostics — `validation::type_mismatch` (fatal) and
 canonical shape:
 
 - **Field path** — the document-model anchor of the offending field
-  (`recipient`, `cards[2].author`).
+  (`recipient`, `cards.indorsement[2].author`); see [Document-model
+  paths](#document-model-paths).
 - **Source token** — the YAML scalar that triggered the error, rendered
   verbatim in its YAML-canonical form (`42`, `null`, `true`, `""`). Strings
   appear quoted; primitives appear bare. (Absent fields have no source
@@ -137,6 +138,42 @@ Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and
 `crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning`, for
 `validation::must_fill`).
+
+## Document-model paths
+
+`Diagnostic.path` is a **document-model** anchor into a typed `Document`:
+one canonical grammar, one serializer, one parser — `DocPath`
+(`crates/core/src/path.rs`). Every emit site (schema validation,
+`!must_fill` collection) constructs a `DocPath`; no site assembles a path
+with `format!`, so the engine never ships two shapes for one anchor.
+
+| Anchor | Path |
+|---|---|
+| Main-card field | `recipient` |
+| Nested in an array of objects | `recipients[0].name` |
+| Main body | `main.body` |
+| Typed card (whole) | `cards.indorsement[0]` |
+| Field on a typed card | `cards.indorsement[0].signature_block` |
+| Body on a typed card | `cards.indorsement[0].body` |
+| Card with unknown kind | `cards[0]` |
+
+Card fields are **kind-qualified** — `cards.<kind>[<index>]` fuses kind and
+document-array index so a consumer gets both without a second lookup. The
+unknown-kind whole-card `cards[<index>]` is the only bare-index form. Field
+names and card kinds exclude `.`, `[`, `]`, so the rendered form round-trips;
+the WASM build exports `parseDocPath` / `formatDocPath` (structured
+`DocPathSeg[]` ↔ string) so a consumer routes on segments instead of regexing
+the string.
+
+**Two path namespaces, not to be confused.** The unsigiled `cards` here is a
+document-model path. The sigiled `data.$cards` a template author sees
+([CARDS.md](CARDS.md)) is plate JSON — glue delivered to the backend, a
+different namespace. The plate key is *not* renamed (template-author blast
+radius); the two are documented apart. Config-space anchors
+(`$seed.<kind>.<field>`, Quill.yaml schema-literal owner labels) ride the
+same serializer with their prefix as a leading segment. The coercion layer
+(`CoercionError`) keeps its own schema-space anchors (`card_kinds.<kind>...`,
+bare field names) — a distinct namespace, not a document path.
 
 ## Error Presentation
 

--- a/prose/doc-contract-phases/phase-2-docpath.md
+++ b/prose/doc-contract-phases/phase-2-docpath.md
@@ -56,3 +56,25 @@ value.
   guessing left.
 - ERROR.md's example is correct and the `$cards`/`cards` namespace split is
   canon.
+
+## Status
+
+**Shipped**: `DocPath` (`crates/core/src/path.rs`) — the type, the one
+serializer, the `FromStr` parser; the `validation.rs` + `compose.rs` retrofit
+(every document-model path now built through `DocPath`, no `format!`); the
+WASM `parseDocPath` / `formatDocPath` export (structured `DocPathSeg[]`);
+ERROR.md's corrected example, the `DocPath` grammar section, and the
+`$cards`/`cards` namespace split in canon.
+
+**Deferred** — a later slice, unblocked now that the type exists:
+
+- **Per-variant `path` on edit (mutator) diagnostics.** The batched twins keep
+  the bare field-name `path` phase 1 set; the single mutators still carry none.
+  Attaching kind-qualified paths needs the call-site plumbing this doc names —
+  `IndexOutOfRange` learning its card array, `FieldConform` its card — threaded
+  through ~50 binding call sites, so it lands on its own.
+- **The coercion namespace.** `CoercionError` paths are schema-space
+  (`card_kinds.<kind>.<field>`, bare field names), not document-model
+  (`cards[<i>]`) anchors, and are dropped where coercion becomes
+  `EditError::FieldConform`. They stay their own namespace; folding them (or
+  ruling them out) rides with the edit-diagnostic slice above.


### PR DESCRIPTION
Phase 2 of the document-contract rework ([plan](../blob/rework-document-contract/prose/doc-contract-phases/README.md), [#1005](https://github.com/borb-sh/quillmark/issues/1005)), plus a one-line fix for the red wasm job that shipped with phase 1 (#1006).

## Commit 1 — fix the phase-1 wasm test miss

`basic.test.js:558` still asserted `err.message` matched `/InvalidFieldName/` — the one edit-surface site the phase-1 migration missed. With the `[EditError::<Variant>]` prefix deleted, the batched message no longer carries the variant name, so the assertion failed and the `wasm` CI job went red (the PR merged anyway). Routed on `diagnostics[].code` like every other migrated edit test (both offending names are invalid → `edit::invalid_field_name`).

## Commit 2 — canonical `DocPath`

`Diagnostic.path` (the document-model anchor into a typed `Document`) gets a single owning type. Before, paths were `format!`-assembled per emit site: the engine shipped two card shapes (`cards[<i>]` whole-card, `cards.<kind>[<i>].<field>` card field) and a pinned consumer reverse-engineered a third.

- **core** — `DocPath` / `DocSeg` (`Main | Card{kind,index} | Field | Index | Body`), a serde-tagged segment array, with round-trip `Display` (the one serializer) and `FromStr` (the parser), plus a `PathSegment` bridge. The recursive validator (`validation.rs`) and `!must_fill` collection (`compose.rs`) now thread `&DocPath`; the scattered `child_path` / `render_fill_path` / `format!` sites are gone. A kindless card's must_fill path is `cards[<i>]`, not the malformed `cards.[<i>]`. Config-space anchors (`$seed.<kind>`, schema-literal owner labels) ride the same serializer with their prefix as a leading segment.
- **wasm** — export `parseDocPath` / `formatDocPath` (string ↔ structured `DocPathSeg[]`) so a consumer routes on segments, never a regex; re-exported through the runtime layer and typed in `runtime.d.ts`.
- **canon** — `ERROR.md` gains a "Document-model paths" section; its stale `cards[2].author` example is corrected to `cards.indorsement[2].author`; the `$cards` (plate-JSON glue) vs `cards` (document-model) namespace split is stated in `ERROR.md` + `CARDS.md`. The plate `$cards` key is **not** renamed (template-author blast radius), per the plan.
- **migration** — `0.95-to-0.96.md` documents the parser export and namespace split. **Emitted path strings are unchanged** — no wire break; card fields were already kind-qualified.

## Scope decisions (plan left these open; defaults taken)

- **Edit-diagnostic path retrofit deferred.** Attaching per-variant `path` to mutator diagnostics (`IndexOutOfRange`→which array, `FieldConform`→which card) needs call-site plumbing through ~50 binding sites, so it rides a later slice — mirroring how phase 1 deferred paths. The `DocPath` type now makes it mechanical. The coercion layer keeps its schema-space (`card_kinds.…`) anchors, a distinct namespace. Documented in `prose/doc-contract-phases/phase-2-docpath.md` § Status.
- **WASM shape: parser → structured object.** `parseDocPath` returns a tagged `DocPathSeg[]` mirroring the core enum; `formatDocPath` is the inverse.

## Acceptance

- [x] No `format!` produces a document-model path; every site goes through the `DocPath` serializer (the one remaining `main.body` `format!` is an error *message*, not a path).
- [x] The exported parser round-trips every emitted path (Rust + wasm tests).
- [x] `ERROR.md` example corrected; `$cards`/`cards` split is canon.

## Verification

- `cargo test -p quillmark-core` green (650 tests); `quillmark` validate tests green; `cargo clippy` clean for the change (only the pre-existing `result_large_err`); `cargo doc` intra-doc links resolve.
- Binding builds are slow locally (per `CLAUDE.md`) — the wasm JS test (`parseDocPath` / `formatDocPath` round-trip) is deferred to CI; the wasm Rust host-checks clean, and the tagged-enum boundary routes through the codebase's `serde_json` bridge for robustness.
- Ran the repo's dense-prose pass (new prose is already dense/present-tense) and a four-angle simplification pass (removed the redundant `Raw` lexer type + `seg_from_raw`; deduped the scan word-loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018CPyC4zGM1thaU4nTbR4Rx)_