### PR TITLE
Qualify card fill diagnostics by schema-declared kind only

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -77,6 +77,7 @@ quill.metadata              # pure config snapshot of the quill: section (never 
 quill.quill_ref             # "name@version"
 
 diags   = quill.validate(parsed)          # list of validation::* diagnostic dicts ([] = valid)
+states  = quill.field_states(parsed)      # resolved-field view: value + source rung + diagnostics per field
 seed    = quill.seed_document()           # starter Document seeded from `example:` values
 main    = quill.seed_main()               # just the $kind: main card (dict, like doc.main)
 card    = quill.seed_card("note")         # one starter composable card (dict), None if kind undeclared

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -211,6 +211,32 @@ impl PyQuill {
         Ok(list.clone())
     }
 
+    /// The resolved-field view of `doc` against this quill's schema, as a nested
+    /// dict — `main` (its `fields` map plus a card-level `diagnostics` list),
+    /// the `cards` list (each with `kind`, `index`, `fields`, `diagnostics`),
+    /// and a document-level `diagnostics` list. Per field: `value`, `source`
+    /// (`"authored" | "default" | "zero"`), `diagnostics`, and `example`
+    /// (present only when the field declares one). The card body rides the
+    /// `fields` map under the `$body` key. Diagnostics are the standalone
+    /// `validate` contract bucketed by `DocPath` into per-field, per-card, and
+    /// document slots (plus a path-anchored `validation::coercion_failed` per
+    /// field whose render coercion fails). Mirrors WASM `fieldStates`.
+    fn field_states<'py>(
+        &self,
+        py: Python<'py>,
+        doc: PyRef<'_, PyDocument>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let states = self.inner.field_states(&doc.inner);
+        let json_value = serde_json::to_value(&states).map_err(|e| {
+            PyValueError::new_err(format!("field_states: serialization failed: {e}"))
+        })?;
+        let py_obj = json_to_py(py, &json_value)?;
+        let dict = py_obj
+            .downcast::<PyDict>()
+            .map_err(|_| PyValueError::new_err("field_states: expected a dict at top level"))?;
+        Ok(dict.clone())
+    }
+
     /// Seed a starter `Document` from the schema — the main card plus one
     /// instance of each composable card kind, each committing its fields'
     /// `example` values and leaving every other field absent (interpolated at

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1742,3 +1742,154 @@ addr:
     expect(title.nestedFills).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// quill.fieldStates — the resolved-field view
+// ---------------------------------------------------------------------------
+//
+// For every declared field: the value the render projection would use, the
+// source rung it came from ("authored" | "default" | "zero"), the schema
+// `example:` as guidance (absent from the wire when the field declares none),
+// and the diagnostics bucketed onto it. The body rides the fields map under the
+// `$body` key. See prose/canon/SCHEMAS.md § "Value sources and projections".
+
+describe('quill.fieldStates', () => {
+  const QUILL_YAML = `quill:
+  name: field_states_test
+  version: "1.0"
+  backend: typst
+  description: Resolved-field view coverage
+
+main:
+  body:
+    example: "Example body prose."
+  fields:
+    title:
+      type: string
+    status:
+      type: string
+      default: draft
+    notes:
+      type: string
+    count:
+      type: integer
+    author:
+      type: string
+      example: A. Author
+
+card_kinds:
+  note:
+    fields:
+      label:
+        type: string
+`
+
+  const buildQuill = () =>
+    Quill.fromTree(makeQuill({ name: 'field_states_test', quillYaml: QUILL_YAML }))
+
+  it('tags main rows with their authored / default / zero source', () => {
+    const quill = buildQuill()
+    const md = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: Hello
+~~~
+`
+    const f = quill.fieldStates(Document.fromMarkdown(md)).main.fields
+
+    expect(f.title.source).toBe('authored')
+    expect(f.title.value).toBe('Hello')
+    expect(f.status.source).toBe('default')
+    expect(f.status.value).toBe('draft')
+    expect(f.notes.source).toBe('zero')
+    expect(f.notes.value).toBe('')
+  })
+
+  it('carries the body under the $body row with a source', () => {
+    const quill = buildQuill()
+    const authored = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: T
+~~~
+
+Hello body.
+`
+    const withBody = quill.fieldStates(Document.fromMarkdown(authored))
+    expect(withBody.main.fields.$body).toBeDefined()
+    expect(withBody.main.fields.$body.source).toBe('authored')
+
+    const blank = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: T
+~~~
+`
+    const noBody = quill.fieldStates(Document.fromMarkdown(blank))
+    expect(noBody.main.fields.$body.source).toBe('zero')
+  })
+
+  it('includes example only on a field that declares one', () => {
+    const quill = buildQuill()
+    const md = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: T
+~~~
+`
+    const f = quill.fieldStates(Document.fromMarkdown(md)).main.fields
+    // `author` declares `example: A. Author` — the key is present.
+    expect('example' in f.author).toBe(true)
+    expect(f.author.example).toBe('A. Author')
+    // `title` declares none — the key is absent on the wire, not null.
+    expect('example' in f.title).toBe(false)
+  })
+
+  it('reports kind and index on a card entry', () => {
+    const quill = buildQuill()
+    const md = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: T
+~~~
+
+~~~card-yaml
+$kind: note
+label: L
+~~~
+Note body.
+`
+    const states = quill.fieldStates(Document.fromMarkdown(md))
+    expect(states.cards.length).toBe(1)
+    const card = states.cards[0]
+    expect(card.kind).toBe('note')
+    expect(card.index).toBe(0)
+    expect(card.fields.label.source).toBe('authored')
+    expect(card.fields.label.value).toBe('L')
+  })
+
+  it('buckets a type mismatch onto its field row', () => {
+    const quill = buildQuill()
+    const md = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: T
+count: "not-a-number"
+~~~
+`
+    const row = quill.fieldStates(Document.fromMarkdown(md)).main.fields.count
+    expect(row.diagnostics.some((d) => d.code === 'validation::type_mismatch')).toBe(true)
+  })
+
+  it('result is JSON.stringify-able', () => {
+    const quill = buildQuill()
+    const md = `~~~card-yaml
+$quill: field_states_test
+$kind: main
+title: T
+~~~
+`
+    const states = quill.fieldStates(Document.fromMarkdown(md))
+    expect(typeof JSON.stringify(states)).toBe('string')
+  })
+})

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -701,6 +701,11 @@ describe('Document-model path — parseDocPath / formatDocPath', () => {
     expect(() => parseDocPath('cards[')).toThrow()
     expect(() => parseDocPath('')).toThrow()
   })
+
+  it('formatDocPath throws on an empty segment array', () => {
+    // Symmetric with parseDocPath(''), which throws "empty path".
+    expect(() => formatDocPath([])).toThrow()
+  })
 })
 
 // The typed-commit ABI is `_commitField` / `_commitFields` (hidden from the

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -74,6 +74,19 @@ export type {
 	DocPathSeg
 } from '../core/wasm.js';
 
+// The resolved-field view — the return shape of `quill.fieldStates(doc)`. Value
+// + source rung + bucketed diagnostics per declared field (the body rides the
+// fields map under `$body`). Declared in the core build's generated `.d.ts` via
+// a `typescript_custom_section`; re-exported here so the single public entry
+// point names them.
+export type {
+	FieldSource,
+	FieldState,
+	MainFieldStates,
+	CardFieldStates,
+	FieldStates
+} from '../core/wasm.js';
+
 // ── Error contract ──────────────────────────────────────────────────────────
 
 /**

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -600,6 +600,29 @@ impl Quill {
         })
     }
 
+    /// The resolved-field view of `doc` against this quill's schema — for every
+    /// declared field the value the render projection would use, the
+    /// `FieldSource` rung it came from (`"authored" | "default" | "zero"`), the
+    /// diagnostics anchored to it, and the schema `example:` as guidance
+    /// (`example?` — absent from the wire when the field declares none), in one
+    /// call. The card body rides the `fields` map under the `$body` key.
+    ///
+    /// Diagnostics are the standalone `validate` contract, bucketed by their
+    /// `DocPath` into the per-field, per-card, and document slots (plus a
+    /// path-anchored `validation::coercion_failed` per field whose render
+    /// coercion fails), so a consumer reads value, provenance, and completeness
+    /// here instead of re-cutting the ladder and re-joining `validate` by path.
+    #[wasm_bindgen(js_name = fieldStates, unchecked_return_type = "FieldStates")]
+    pub fn field_states(&self, doc: &Document) -> Result<JsValue, JsValue> {
+        let states = self.inner.field_states(&doc.inner);
+        let serializer = serde_wasm_bindgen::Serializer::new()
+            .serialize_maps_as_objects(true)
+            .serialize_missing_as_null(true);
+        states.serialize(&serializer).map_err(|e| {
+            WasmError::from(format!("fieldStates: serialization failed: {e}")).to_js_value()
+        })
+    }
+
     /// Seed a starter `Document` from the schema — the main card plus one
     /// instance of each composable card kind, each committing its fields'
     /// `example:` values and leaving every other field absent (interpolated at
@@ -1815,6 +1838,64 @@ export type DocPathSeg =
     | { seg: "field"; name: string }
     | { seg: "index"; index: number }
     | { seg: "body" };
+"#;
+
+/// TypeScript declarations for the resolved-field view (`Quill.fieldStates`).
+/// Emitted here as the single source of truth; `Diagnostic` is already declared
+/// by the core build's generated `.d.ts`.
+#[wasm_bindgen(typescript_custom_section)]
+const FIELDSTATES_TS: &'static str = r#"
+/** The commitment-ladder rung that produced a `FieldState.value`. */
+export type FieldSource = "authored" | "default" | "zero";
+
+/**
+ * One resolved field: the value the render projection would use, the
+ * `FieldSource` rung it came from, the diagnostics anchored to it, and the
+ * schema `example:` as authoring guidance (`example?` — absent from the wire,
+ * never null, when the field declares none). The card body rides its card's
+ * `fields` map under the `$body` key as an ordinary `FieldState`.
+ */
+export interface FieldState {
+    value: unknown;
+    source: FieldSource;
+    diagnostics: Diagnostic[];
+    example?: unknown;
+}
+
+/**
+ * The main card's resolved fields (keyed by field name in declaration order,
+ * with `$body` under its key when the main enables a body) plus a card-level
+ * `diagnostics` slot for diagnostics anchored to the card but no field.
+ */
+export interface MainFieldStates {
+    fields: Record<string, FieldState>;
+    diagnostics: Diagnostic[];
+}
+
+/**
+ * One composable card's resolved fields (`$body` under its key when the kind
+ * enables a body), with its authored `kind` (`null` for an unknown-kind card),
+ * its document-array `index`, and a card-level `diagnostics` slot
+ * (`validation::unknown_card`, `validation::body_disabled`).
+ */
+export interface CardFieldStates {
+    kind: string | null;
+    index: number;
+    fields: Record<string, FieldState>;
+    diagnostics: Diagnostic[];
+}
+
+/**
+ * The resolved-field view (`Quill.fieldStates`): the main card, every
+ * composable card, and a document-level `diagnostics` slot (`$seed` overlays,
+ * unanchored diagnostics). Every `Quill.validate` diagnostic lands in exactly
+ * one slot.
+ */
+export interface FieldStates {
+    main: MainFieldStates;
+    cards: CardFieldStates[];
+    diagnostics: Diagnostic[];
+}
 "#;
 
 /// Parse a canonical document-model `Diagnostic.path`

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1842,7 +1842,9 @@ pub fn parse_doc_path(path: &str) -> Result<JsValue, JsValue> {
 
 /// Serialize structured [`DocPathSeg`] segments back to the canonical path
 /// string — the inverse of `parseDocPath`, for a consumer that builds a path
-/// rather than reads one. Throws on a segment array the deserializer rejects.
+/// rather than reads one. Throws on a segment array the deserializer rejects,
+/// and on an empty segment array (symmetric with `parseDocPath("")`, which
+/// throws "empty path").
 #[wasm_bindgen(js_name = formatDocPath)]
 pub fn format_doc_path(
     #[wasm_bindgen(unchecked_param_type = "DocPathSeg[]")] segs: JsValue,
@@ -1850,6 +1852,9 @@ pub fn format_doc_path(
     let json = js_value_to_json(segs, "formatDocPath")?;
     let doc_path: quillmark_core::DocPath = serde_json::from_value(json)
         .map_err(|e| WasmError::from(format!("formatDocPath: {e}")).to_js_value())?;
+    if doc_path.segs().is_empty() {
+        return Err(WasmError::from("formatDocPath: empty path").to_js_value());
+    }
     Ok(doc_path.to_string())
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -57,7 +57,10 @@ pub use session::{ApplyError, Assoc, ChangeSet, Delta, LineOp, LiveSession, Mark
 pub use quillmark_content::Content;
 
 pub mod quill;
-pub use quill::{zero_value, FileTreeNode, Quill, QuillIgnore, STANDARD_METADATA_KEYS};
+pub use quill::{
+    zero_value, CardStates, FieldSource, FieldState, FieldStates, FileTreeNode, MainStates, Quill,
+    QuillIgnore, STANDARD_METADATA_KEYS,
+};
 
 pub mod value;
 pub use value::{json_depth_exceeds, PathSegment, QuillValue};

--- a/crates/core/src/path.rs
+++ b/crates/core/src/path.rs
@@ -23,8 +23,9 @@
 //! A bare main field carries no root (`recipient`, `recipients[0].name`); the
 //! main body is `main.body`. A card field is kind-qualified —
 //! `cards.<kind>[<i>].<field>` — so a consumer receives kind and array index
-//! without a second lookup; a card whose `$kind` has no schema stays
-//! `cards[<i>]`. Field names and card kinds exclude `.`, `[`, `]`, so the
+//! without a second lookup; a card whose `$kind` has no schema — absent, or
+//! present but not a declared card kind — stays `cards[<i>]`. Field names and
+//! card kinds exclude `.`, `[`, `]`, so the
 //! rendered form round-trips.
 //!
 //! `cards` and `main` are reserved roots and `body` a reserved terminal: a

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -3,6 +3,7 @@
 mod blueprint;
 mod compose;
 mod config;
+mod field_states;
 mod fill;
 mod formats;
 mod ignore;
@@ -17,6 +18,7 @@ pub(crate) mod validation;
 
 pub use config::{CoercionError, QuillConfig};
 pub(crate) use config::Leniency;
+pub use field_states::{CardStates, FieldSource, FieldState, FieldStates, MainStates};
 pub use fill::zero_value;
 pub use formats::{parse_date, parse_datetime};
 pub use ignore::QuillIgnore;

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -174,7 +174,7 @@ impl Quill {
             Ok(()) => Vec::new(),
             Err(errors) => errors.iter().map(|e| e.to_diagnostic()).collect(),
         };
-        diags.extend(validate_fills(doc));
+        diags.extend(validate_fills(self.config(), doc));
         diags.extend(self.validate_seed(doc));
         diags
     }
@@ -432,11 +432,15 @@ fn rebuild_payload_with_meta(source: &Card, fields: IndexMap<String, QuillValue>
 /// The marker fires whether or not the cell carries a suggested value, and never
 /// gates render (the cell zero-fills or uses its suggested value). A strict
 /// consumer treats any outstanding marker as "not done".
-fn validate_fills(doc: &Document) -> Vec<Diagnostic> {
+fn validate_fills(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
     collect_fill_diags(doc.main(), &DocPath::new(), &mut diags);
     for (index, card) in doc.cards().iter().enumerate() {
-        collect_fill_diags(card, &DocPath::card(card.kind(), index), &mut diags);
+        // A card whose declared `$kind` has no schema drops the kind segment and
+        // stays `cards[<i>]`, matching `validate_typed_document`; a
+        // schema-declared kind qualifies as `cards.<kind>[<i>]`.
+        let kind = card.kind().filter(|k| config.card_kind(k).is_some());
+        collect_fill_diags(card, &DocPath::card(kind, index), &mut diags);
     }
     diags
 }
@@ -503,6 +507,73 @@ properties:
         assert_eq!(
             resolved,
             json!({ "street": "1 Infinite Loop", "zip": 0, "note": "extra" })
+        );
+    }
+
+    // A card whose declared `$kind` has no schema anchors its `!must_fill`
+    // warning at the bare-index root `cards[<i>].<field>` — matching
+    // `validate_typed_document`'s unknown-card path — never `cards.<kind>[<i>]`.
+    // A truly kindless card (no `$kind`) stays bare-index the same way.
+    #[test]
+    fn unknown_kind_card_fill_path_is_bare_index() {
+        use crate::document::Payload;
+
+        let config = QuillConfig::from_yaml(
+            r#"
+quill:
+  name: fills_test
+  backend: typst
+  description: fill path tests
+  version: 1.0.0
+main:
+  fields:
+    title:
+      type: string
+      default: ""
+card_kinds:
+  known:
+    fields:
+      note:
+        type: string
+"#,
+        )
+        .unwrap();
+
+        let mut main = Payload::new();
+        main.set_quill("fills_test@1.0.0".parse().unwrap());
+        main.set_kind("main");
+        let main = Card::from_parts(main, quillmark_content::Content::empty());
+
+        // Index 0: a card whose `$kind` ("mystery") is not a declared card kind.
+        let mut unknown = Card::new("mystery").unwrap();
+        unknown
+            .store_fill("note", QuillValue::from_json(json!(null)))
+            .unwrap();
+
+        // Index 1: a kindless card (no `$kind` at all).
+        let mut kindless =
+            Card::from_parts(Payload::new(), quillmark_content::Content::empty());
+        kindless
+            .store_fill("memo", QuillValue::from_json(json!(null)))
+            .unwrap();
+
+        let doc = Document::from_main_and_cards(main, vec![unknown, kindless]);
+        let paths: Vec<String> = validate_fills(&config, &doc)
+            .iter()
+            .filter_map(|d| d.path.clone())
+            .collect();
+
+        assert!(
+            paths.contains(&"cards[0].note".to_string()),
+            "unknown-kind card fill must anchor at the bare index; got {paths:?}"
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with("cards.mystery")),
+            "unknown-kind card fill must NOT carry the kind segment; got {paths:?}"
+        );
+        assert!(
+            paths.contains(&"cards[1].memo".to_string()),
+            "kindless card fill must anchor at the bare index; got {paths:?}"
         );
     }
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 
 use indexmap::IndexMap;
 
+use super::field_states::FieldSource;
 use super::{seed, CardSchema, FieldSchema, FieldType, Quill, QuillConfig};
 use crate::normalize::normalize_document;
 use crate::quill::zero_value;
@@ -333,11 +334,21 @@ fn resolve_fields(
     result
 }
 
+/// The value half of [`resolve_value_sourced`], discarding the rung tag — the
+/// zero-filled render projection consumes only the value. `field_states`
+/// consumes both, so the source is produced by the one branch here rather than
+/// re-derived against a parallel ladder.
+fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue {
+    resolve_value_sourced(value, field).0
+}
+
 /// Resolve one (possibly absent or null) value against its field schema,
-/// applying null ≡ absent recursively so no bare null reaches the plate:
+/// reporting the [`FieldSource`] rung that produced it, and applying null ≡
+/// absent recursively so no bare null reaches the plate:
 ///
-/// - A null or absent value becomes the schema `default:`, else the type-empty
-///   [`zero_value`].
+/// - A null or absent value becomes the schema `default:`
+///   ([`Default`](FieldSource::Default)), else the type-empty [`zero_value`]
+///   ([`Zero`](FieldSource::Zero)).
 /// - A present **typed dictionary** is rebuilt from its declared properties so a
 ///   null/absent property zero-fills and the projection matches the schema shape.
 ///   Source keys the schema does not declare pass through verbatim, matching
@@ -347,7 +358,17 @@ fn resolve_fields(
 /// - A present **typed array** resolves each element against the item schema, so
 ///   a null element zero-fills in place.
 /// - Any other present value is returned unchanged.
-fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue {
+///
+/// Every present shape is [`Authored`](FieldSource::Authored) (the nested
+/// zero-fill inside a dict/array is a projection detail, not a source change).
+/// The source is the byproduct of the same branch that computes the value, so
+/// the render projection ([`resolve_value`]) and the field-state view cut the
+/// one commitment ladder rather than each re-deriving precedence
+/// (`prose/canon/SCHEMAS.md` § "Value sources and projections").
+pub(crate) fn resolve_value_sourced(
+    value: Option<&QuillValue>,
+    field: &FieldSchema,
+) -> (QuillValue, FieldSource) {
     let present = value.filter(|v| !v.as_json().is_null());
     let Some(v) = present else {
         // A content-bearing field (`richtext` or its literal sibling `plaintext`)
@@ -363,16 +384,19 @@ fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue 
             field.r#type,
             FieldType::RichText { .. } | FieldType::PlainText { .. }
         ) {
-            return field
-                .default_content
-                .clone()
-                .unwrap_or_else(|| zero_value(field));
+            return match field.default_content.clone() {
+                Some(content) => (content, FieldSource::Default),
+                None => (zero_value(field), FieldSource::Zero),
+            };
         }
         // Non-content: `default_content` is always `None`, so use the raw
         // `default`, then the type-empty zero.
-        return field.default.clone().unwrap_or_else(|| zero_value(field));
+        return match field.default.clone() {
+            Some(default) => (default, FieldSource::Default),
+            None => (zero_value(field), FieldSource::Zero),
+        };
     };
-    match (&field.r#type, &field.properties, &field.items) {
+    let resolved = match (&field.r#type, &field.properties, &field.items) {
         (FieldType::Object, Some(props), _) => {
             let obj = v.as_json().as_object();
             let mut out = serde_json::Map::new();
@@ -406,7 +430,8 @@ fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue 
             QuillValue::from_json(serde_json::Value::Array(out))
         }
         _ => v.clone(),
-    }
+    };
+    (resolved, FieldSource::Authored)
 }
 
 /// Build a [`Payload`] from a coerced/defaulted field map, re-attaching `$quill`

--- a/crates/core/src/quill/field_states.rs
+++ b/crates/core/src/quill/field_states.rs
@@ -139,36 +139,45 @@ fn resolve_card_fields(
     card: &Card,
     base: &DocPath,
 ) -> IndexMap<String, FieldState> {
-    let authored = card.payload().to_index_map();
-
-    // Per-field render-leniency coercion of the authored declared fields — the
-    // same `conform_value(Render)` `compile_data` runs over the whole payload,
-    // done here per-field so a failure anchors to its row. On `Ok` the coerced
-    // value feeds the ladder; on `Err` the raw authored value is kept (the
-    // ladder still reads it as Authored) and a `validation::coercion_failed`
-    // diagnostic is parked for the row. Same code/hint as compose.rs's
-    // `coercion_error`, but WITH a path — the compile-data coercion is pathless.
-    let mut coerced: IndexMap<String, QuillValue> = IndexMap::new();
+    // Mirror `compile_data`'s pipeline per-field: coerce (the schema looked up
+    // by the authored name, as `coerce_payload` does), then NFC-normalize the
+    // key (`normalize_document` runs between coercion and the ladder), then
+    // resolve. Every validated ingress (parse, the mutators) restricts field
+    // names to ASCII — NFC-invariant — so the normalization only respells keys
+    // on a directly-constructed payload (`Payload::from_index_map`), under the
+    // same NFC key the plate carries.
+    //
+    // The coercion is the same `conform_value(Render)` `compile_data` runs over
+    // the whole payload, done here per-field so a failure anchors to its row:
+    // on `Ok` the coerced value feeds the ladder; on `Err` the raw authored
+    // value is kept (the ladder still reads it as Authored) and a
+    // `validation::coercion_failed` diagnostic is parked for the row. Same
+    // code/hint as compose.rs's `coercion_error`, but WITH a path — the
+    // compile-data coercion is pathless.
+    let mut resolved_input: IndexMap<String, QuillValue> = IndexMap::new();
     let mut coercion_diags: HashMap<String, Diagnostic> = HashMap::new();
-    for (name, value) in &authored {
-        let Some(field_schema) = schema.fields.get(name) else {
-            continue;
+    for (raw_name, value) in card.payload().to_index_map() {
+        let name = crate::normalize::normalize_field_name(&raw_name);
+        let entry = match schema.fields.get(&raw_name) {
+            Some(field_schema) => {
+                let field_path = base.field(&name);
+                match QuillConfig::conform_value(
+                    &value,
+                    field_schema,
+                    &field_path.to_string(),
+                    Leniency::Render,
+                ) {
+                    Ok(coerced_value) => coerced_value,
+                    Err(e) => {
+                        coercion_diags
+                            .insert(name.clone(), coercion_failed_diagnostic(&e, &field_path));
+                        value
+                    }
+                }
+            }
+            None => value,
         };
-        let field_path = base.field(name);
-        match QuillConfig::conform_value(
-            value,
-            field_schema,
-            &field_path.to_string(),
-            Leniency::Render,
-        ) {
-            Ok(coerced_value) => {
-                coerced.insert(name.clone(), coerced_value);
-            }
-            Err(e) => {
-                coerced.insert(name.clone(), value.clone());
-                coercion_diags.insert(name.clone(), coercion_failed_diagnostic(&e, &field_path));
-            }
-        }
+        resolved_input.insert(name, entry);
     }
 
     let mut fields = IndexMap::new();
@@ -177,7 +186,7 @@ fn resolve_card_fields(
     // contract, carried by the `IndexMap`. (Not the validation walker, which
     // sorts alphabetically.)
     for (name, field_schema) in &schema.fields {
-        let (value, source) = resolve_value_sourced(coerced.get(name), field_schema);
+        let (value, source) = resolve_value_sourced(resolved_input.get(name), field_schema);
         let mut diagnostics = Vec::new();
         if let Some(d) = coercion_diags.remove(name) {
             diagnostics.push(d);
@@ -198,10 +207,10 @@ fn resolve_card_fields(
         fields.insert(BODY_KEY.to_string(), body_state(schema, card));
     }
 
-    // Undeclared authored fields, appended in authored order: the schema is a
-    // floor, not an allowlist, so these reach the plate too — value verbatim,
-    // source Authored, no example.
-    for (name, value) in &authored {
+    // Undeclared authored fields, appended in authored order under their NFC
+    // keys (matching the plate's): the schema is a floor, not an allowlist, so
+    // these reach the plate too — value verbatim, source Authored, no example.
+    for (name, value) in &resolved_input {
         if !schema.fields.contains_key(name) {
             fields.insert(
                 name.clone(),
@@ -387,7 +396,7 @@ mod tests {
 
     use super::*;
     use crate::quill::FileTreeNode;
-    use crate::{Document, Quill};
+    use crate::{Card, Document, Payload, Quill};
     use std::collections::HashMap as StdHashMap;
 
     /// Build a minimal [`Quill`] from inline `Quill.yaml` with no filesystem deps.
@@ -523,6 +532,33 @@ card_kinds:
             );
         }
         assert_eq!(card.fields[BODY_KEY].value.as_json(), &plate_card["$body"]);
+    }
+
+    #[test]
+    fn non_nfc_key_on_a_constructed_payload_rows_under_its_nfc_spelling() {
+        // Every validated ingress (parse, the mutators) restricts field names
+        // to ASCII, so a non-NFC key only enters through direct construction
+        // (`Payload::from_index_map`). Render NFC-normalizes it between
+        // coercion and the ladder; the view mirrors that, rowing it under the
+        // NFC key the plate carries — not the raw decomposed one.
+        let quill = quill_from_yaml(QUILL);
+        let mut map = IndexMap::new();
+        // `e` + U+0301 combining acute — NFC-composes to U+00E9.
+        map.insert(
+            "cafe\u{301}".to_string(),
+            QuillValue::from_json(serde_json::json!("hot")),
+        );
+        let mut payload = Payload::from_index_map(map);
+        payload.set_quill("fs_test@1.0".parse().unwrap());
+        payload.set_kind("main");
+        let main = Card::from_parts(payload, quillmark_content::Content::empty());
+        let doc = Document::from_main_and_cards(main, Vec::new());
+        let states = quill.field_states(&doc);
+
+        assert!(!states.main.fields.contains_key("cafe\u{301}"));
+        let row = &states.main.fields["caf\u{e9}"];
+        assert_eq!(row.source, FieldSource::Authored);
+        assert_eq!(row.value.as_json(), &serde_json::json!("hot"));
     }
 
     // ── The body row ─────────────────────────────────────────────────────────

--- a/crates/core/src/quill/field_states.rs
+++ b/crates/core/src/quill/field_states.rs
@@ -1,0 +1,786 @@
+//! The resolved-field view — [`Quill::field_states`].
+//!
+//! A projection that makes field resolution observable *data* rather than an
+//! inferred behavior chain: for every declared field, the value the render
+//! projection would use, the [`FieldSource`] rung it came from, any diagnostics
+//! anchored to it, and the schema `example:` as authoring guidance. It cuts the
+//! one commitment ladder (`prose/canon/SCHEMAS.md` § "Value sources and
+//! projections") through the shared producer [`resolve_value_sourced`], never a
+//! parallel precedence policy.
+//!
+//! It does not fully collapse [`Quill::validate`]: `unknown_card` and
+//! `body_disabled` are card/document-level, not per-field, so the view carries a
+//! diagnostics slot at each level and every `validate()` diagnostic is bucketed
+//! into exactly one of them.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use indexmap::IndexMap;
+use serde::Serialize;
+
+use super::compose::resolve_value_sourced;
+use super::{CardSchema, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
+use crate::path::{DocPath, DocSeg};
+use crate::{Card, Diagnostic, Document, QuillValue, Severity};
+
+/// Engine-owned universal key for a card's body row, collision-proof against a
+/// payload field literally named `body` — a user field can never be
+/// `$`-prefixed, and `Payload::to_index_map` drops `$` entries.
+const BODY_KEY: &str = "$body";
+
+/// Config-space head that anchors a `$seed` overlay diagnostic; routed to the
+/// document slot rather than any document field.
+const SEED_KEY: &str = "$seed";
+
+/// The rung of the commitment ladder that produced a [`FieldState::value`].
+/// Serializes lowercase (`"authored" | "default" | "zero"`).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FieldSource {
+    /// The authored value — the document's own content.
+    Authored,
+    /// The schema `default:` (or its content form for a content field).
+    Default,
+    /// The type-empty [`zero_value`](crate::quill::zero_value) floor.
+    Zero,
+}
+
+/// One resolved field: the value the render projection would use, its
+/// [`FieldSource`], the diagnostics anchored to it, and the schema `example:`
+/// (omitted from the wire when absent).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct FieldState {
+    pub value: QuillValue,
+    pub source: FieldSource,
+    pub diagnostics: Vec<Diagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<QuillValue>,
+}
+
+/// The main card's resolved fields plus a card-level diagnostics slot for
+/// diagnostics that anchor to the card but no field (main body on a
+/// body-disabled main).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MainStates {
+    pub fields: IndexMap<String, FieldState>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// One composable card's resolved fields, with its authored `kind` (present even
+/// for an unknown kind, whose paths are the bare-index `cards[<i>]` form), its
+/// document-array `index`, and a card-level diagnostics slot (`unknown_card`,
+/// `body_disabled`).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CardStates {
+    pub kind: Option<String>,
+    pub index: usize,
+    pub fields: IndexMap<String, FieldState>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// The whole resolved-field view: the main card, every composable card, and a
+/// document-level diagnostics slot (`$seed` overlays, unanchored diagnostics).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct FieldStates {
+    pub main: MainStates,
+    pub cards: Vec<CardStates>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl Quill {
+    /// The resolved-field view of `doc` against this quill's schema.
+    ///
+    /// Values are the render projection's per-field cut of the commitment
+    /// ladder — for every declared field, the value [`compile_data`] would emit
+    /// into the plate, tagged with the [`FieldSource`] rung it came from
+    /// (byte-for-byte with the plate on every fixture). Diagnostics are exactly
+    /// the standalone [`Quill::validate`] contract, bucketed by their
+    /// [`DocPath`] into the per-row, per-card, and document slots — so a
+    /// consumer reads value, provenance, and completeness from one call instead
+    /// of re-implementing the ladder and re-joining `validate()` by path.
+    ///
+    /// [`compile_data`]: Quill::compile_data
+    pub fn field_states(&self, doc: &Document) -> FieldStates {
+        let config = self.config();
+
+        // Values first: the main and each card resolved through the shared
+        // ladder producer. Diagnostics are attached in the bucketing pass below.
+        let main = MainStates {
+            fields: resolve_card_fields(&config.main, doc.main(), &DocPath::new()),
+            diagnostics: Vec::new(),
+        };
+        let cards = doc
+            .cards()
+            .iter()
+            .enumerate()
+            .map(|(index, card)| card_states(config, card, index))
+            .collect();
+        let mut states = FieldStates {
+            main,
+            cards,
+            diagnostics: Vec::new(),
+        };
+
+        // Diagnostics = `validate()` verbatim (the raw doc, so the view's
+        // diagnostics are exactly the standalone contract), routed into slots.
+        for diag in self.validate(doc) {
+            bucket(&mut states, diag);
+        }
+        states
+    }
+}
+
+/// Resolve one card (main or a schema-declared kind) into its ordered
+/// [`FieldState`] rows. `base` roots the field paths — empty for main, the
+/// `cards.<kind>[<i>]` card root otherwise.
+fn resolve_card_fields(
+    schema: &CardSchema,
+    card: &Card,
+    base: &DocPath,
+) -> IndexMap<String, FieldState> {
+    let authored = card.payload().to_index_map();
+
+    // Per-field render-leniency coercion of the authored declared fields — the
+    // same `conform_value(Render)` `compile_data` runs over the whole payload,
+    // done here per-field so a failure anchors to its row. On `Ok` the coerced
+    // value feeds the ladder; on `Err` the raw authored value is kept (the
+    // ladder still reads it as Authored) and a `validation::coercion_failed`
+    // diagnostic is parked for the row. Same code/hint as compose.rs's
+    // `coercion_error`, but WITH a path — the compile-data coercion is pathless.
+    let mut coerced: IndexMap<String, QuillValue> = IndexMap::new();
+    let mut coercion_diags: HashMap<String, Diagnostic> = HashMap::new();
+    for (name, value) in &authored {
+        let Some(field_schema) = schema.fields.get(name) else {
+            continue;
+        };
+        let field_path = base.field(name);
+        match QuillConfig::conform_value(
+            value,
+            field_schema,
+            &field_path.to_string(),
+            Leniency::Render,
+        ) {
+            Ok(coerced_value) => {
+                coerced.insert(name.clone(), coerced_value);
+            }
+            Err(e) => {
+                coerced.insert(name.clone(), value.clone());
+                coercion_diags.insert(name.clone(), coercion_failed_diagnostic(&e, &field_path));
+            }
+        }
+    }
+
+    let mut fields = IndexMap::new();
+
+    // Declared rows in schema **declaration order** — the canon ordering
+    // contract, carried by the `IndexMap`. (Not the validation walker, which
+    // sorts alphabetically.)
+    for (name, field_schema) in &schema.fields {
+        let (value, source) = resolve_value_sourced(coerced.get(name), field_schema);
+        let mut diagnostics = Vec::new();
+        if let Some(d) = coercion_diags.remove(name) {
+            diagnostics.push(d);
+        }
+        fields.insert(
+            name.clone(),
+            FieldState {
+                value,
+                source,
+                diagnostics,
+                example: field_example(field_schema),
+            },
+        );
+    }
+
+    // The body row, present iff the kind enables a body.
+    if schema.body_enabled() {
+        fields.insert(BODY_KEY.to_string(), body_state(schema, card));
+    }
+
+    // Undeclared authored fields, appended in authored order: the schema is a
+    // floor, not an allowlist, so these reach the plate too — value verbatim,
+    // source Authored, no example.
+    for (name, value) in &authored {
+        if !schema.fields.contains_key(name) {
+            fields.insert(
+                name.clone(),
+                FieldState {
+                    value: value.clone(),
+                    source: FieldSource::Authored,
+                    diagnostics: Vec::new(),
+                    example: None,
+                },
+            );
+        }
+    }
+
+    fields
+}
+
+/// Resolve one composable card. A card whose `$kind` names a schema resolves
+/// through the ladder; an unknown-kind card (declared `$kind` with no schema, or
+/// a kindless card) carries its authored fields verbatim — no coercion, no
+/// ladder, no `$body` row — and its `unknown_card` diagnostic arrives via
+/// bucketing.
+fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
+    // The raw authored kind rides the entry even when it names no schema — the
+    // card reports what it *claimed* to be, though its paths are `cards[<i>]`.
+    let kind = card.kind().map(String::from);
+    match card.kind().and_then(|k| config.card_kind(k)) {
+        Some(schema) => CardStates {
+            kind,
+            index,
+            fields: resolve_card_fields(schema, card, &DocPath::card(card.kind(), index)),
+            diagnostics: Vec::new(),
+        },
+        None => {
+            let fields = card
+                .payload()
+                .to_index_map()
+                .into_iter()
+                .map(|(name, value)| {
+                    (
+                        name,
+                        FieldState {
+                            value,
+                            source: FieldSource::Authored,
+                            diagnostics: Vec::new(),
+                            example: None,
+                        },
+                    )
+                })
+                .collect();
+            CardStates {
+                kind,
+                index,
+                fields,
+                diagnostics: Vec::new(),
+            }
+        }
+    }
+}
+
+/// The `$body` row. The value is byte-identical to the plate's `$body`
+/// (canonical Content-JSON of the card body). A body has no `default:` rung, so
+/// its source is only ever [`Authored`](FieldSource::Authored) (non-blank) or
+/// [`Zero`](FieldSource::Zero) (blank) — [`Default`](FieldSource::Default) is
+/// unreachable for it. The example is the body schema's `example_content`.
+fn body_state(schema: &CardSchema, card: &Card) -> FieldState {
+    let value = QuillValue::from_json(quillmark_content::serial::to_canonical_value(card.body()));
+    let source = if card.body().is_blank() {
+        FieldSource::Zero
+    } else {
+        FieldSource::Authored
+    };
+    FieldState {
+        value,
+        source,
+        diagnostics: Vec::new(),
+        example: schema.body.as_ref().and_then(|b| b.example_content.clone()),
+    }
+}
+
+/// A declared field's `example:` for the row — the same content-vs-scalar branch
+/// as the `default:` rung: a content field's example is its content form
+/// (`example_content`), every other field's is the raw `example`. `None` omits
+/// the row's `example`.
+fn field_example(field: &FieldSchema) -> Option<QuillValue> {
+    if matches!(
+        field.r#type,
+        FieldType::RichText { .. } | FieldType::PlainText { .. }
+    ) {
+        field.example_content.clone()
+    } else {
+        field.example.clone()
+    }
+}
+
+/// A `validation::coercion_failed` diagnostic for a field whose render coercion
+/// errored — same code and hint as compose.rs's pathless `coercion_error`, but
+/// anchored at the field's path.
+fn coercion_failed_diagnostic(e: &super::CoercionError, field_path: &DocPath) -> Diagnostic {
+    Diagnostic::new(Severity::Error, e.to_string())
+        .with_code("validation::coercion_failed".to_string())
+        .with_path(field_path.to_string())
+        .with_hint("Ensure all fields can be coerced to their declared types".to_string())
+}
+
+/// Route one `validate()` diagnostic into exactly one slot by parsing its
+/// `path` with [`DocPath::from_str`] — the phase-2 parser is total over every
+/// path `validate()` emits, so a parse failure only ever means "no structured
+/// anchor" and lands on the document slot.
+fn bucket(states: &mut FieldStates, diag: Diagnostic) {
+    let Some(path) = diag.path.as_deref().and_then(|p| DocPath::from_str(p).ok()) else {
+        // No path, or unparseable → document slot.
+        states.diagnostics.push(diag);
+        return;
+    };
+    match path.segs() {
+        // A `$seed` anchor is config-space (seed anchors never gate render), not
+        // a document field. Also the empty case, defensively.
+        [] => states.diagnostics.push(diag),
+        [DocSeg::Field { name }, ..] if name == SEED_KEY => states.diagnostics.push(diag),
+
+        // The main body is the sole `main`-headed form → main's `$body` row.
+        [DocSeg::Main, ..] => row_or_slot(
+            &mut states.main.fields,
+            &mut states.main.diagnostics,
+            BODY_KEY,
+            diag,
+        ),
+
+        // A bare field chain heads on its field: a nested path
+        // (`recipients[0].name`) buckets to the HEAD field's row.
+        [DocSeg::Field { name }, ..] => row_or_slot(
+            &mut states.main.fields,
+            &mut states.main.diagnostics,
+            name,
+            diag,
+        ),
+
+        // A card-rooted path: whole-card (`cards[<i>]`), body, or a field chain.
+        [DocSeg::Card { index, .. }, rest @ ..] => {
+            let Some(card) = states.cards.get_mut(*index) else {
+                // Out of range shouldn't happen — the walker indexes real cards.
+                states.diagnostics.push(diag);
+                return;
+            };
+            match rest {
+                [] => card.diagnostics.push(diag),
+                [DocSeg::Body, ..] => {
+                    row_or_slot(&mut card.fields, &mut card.diagnostics, BODY_KEY, diag)
+                }
+                [DocSeg::Field { name }, ..] => {
+                    row_or_slot(&mut card.fields, &mut card.diagnostics, name, diag)
+                }
+                // A card root followed by an index (unemittable) → card slot.
+                _ => card.diagnostics.push(diag),
+            }
+        }
+
+        // An index- or body-headed path is unemittable → document slot.
+        _ => states.diagnostics.push(diag),
+    }
+}
+
+/// Push `diag` onto the row named `key` if it exists, else onto the fallback
+/// `slot`.
+fn row_or_slot(
+    fields: &mut IndexMap<String, FieldState>,
+    slot: &mut Vec<Diagnostic>,
+    key: &str,
+    diag: Diagnostic,
+) {
+    match fields.get_mut(key) {
+        Some(row) => row.diagnostics.push(diag),
+        None => slot.push(diag),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Coercion-failure coverage uses a `richtext` field authored as a
+    //! non-content JSON object: `conform_value(Render)` genuinely errors on it
+    //! (`from_canonical_value` rejects the shape), which is the reachable
+    //! render-leniency coercion failure.
+
+    use super::*;
+    use crate::quill::FileTreeNode;
+    use crate::{Document, Quill};
+    use std::collections::HashMap as StdHashMap;
+
+    /// Build a minimal [`Quill`] from inline `Quill.yaml` with no filesystem deps.
+    fn quill_from_yaml(yaml: &str) -> Quill {
+        let mut files = StdHashMap::new();
+        files.insert(
+            "Quill.yaml".to_string(),
+            FileTreeNode::File {
+                contents: yaml.as_bytes().to_vec(),
+            },
+        );
+        let root = FileTreeNode::Directory { files };
+        Quill::from_tree(root).expect("quill_from_yaml: from_tree failed")
+    }
+
+    fn parse(md: &str) -> Document {
+        Document::parse(md).expect("document should parse").document
+    }
+
+    const QUILL: &str = r#"
+quill:
+  name: fs_test
+  version: "1.0"
+  backend: typst
+  description: Field-state tests
+main:
+  body:
+    example: "Example body prose."
+  fields:
+    title:
+      type: string
+    status:
+      type: string
+      default: draft
+    notes:
+      type: string
+    intro:
+      type: richtext
+      default: "**hi**"
+    recipients:
+      type: array
+      items:
+        type: object
+        properties:
+          name: { type: string }
+card_kinds:
+  note:
+    fields:
+      author:
+        type: string
+        example: A. Author
+      tag:
+        type: string
+"#;
+
+    // ── Sources ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn scalar_sources_authored_default_zero() {
+        let quill = quill_from_yaml(QUILL);
+        // title authored; status absent (has a default); notes absent (no default).
+        let doc = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: Hello\n~~~\n");
+        let states = quill.field_states(&doc);
+        let f = &states.main.fields;
+
+        assert_eq!(f["title"].source, FieldSource::Authored);
+        assert_eq!(f["title"].value.as_json(), &serde_json::json!("Hello"));
+
+        assert_eq!(f["status"].source, FieldSource::Default);
+        assert_eq!(f["status"].value.as_json(), &serde_json::json!("draft"));
+
+        assert_eq!(f["notes"].source, FieldSource::Zero);
+        assert_eq!(f["notes"].value.as_json(), &serde_json::json!(""));
+    }
+
+    #[test]
+    fn richtext_default_reports_default_and_matches_plate() {
+        let quill = quill_from_yaml(QUILL);
+        // intro absent → its richtext `default:` (committed as content).
+        let doc = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n");
+        let states = quill.field_states(&doc);
+        let intro = &states.main.fields["intro"];
+
+        assert_eq!(intro.source, FieldSource::Default);
+        // The value is the content form of the default, byte-equal to the plate.
+        let plate = quill.compile_data(&doc).expect("compile");
+        assert_eq!(intro.value.as_json(), &plate["intro"]);
+        // And it is content, not the raw markdown string.
+        assert!(intro.value.as_json().is_object());
+    }
+
+    #[test]
+    fn present_null_is_absent_takes_default_rung() {
+        let quill = quill_from_yaml(QUILL);
+        // `status:` is a present-null → treated as absent → default rung.
+        let doc = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\nstatus:\n~~~\n");
+        let status = &quill.field_states(&doc).main.fields["status"];
+        assert_eq!(status.source, FieldSource::Default);
+        assert_eq!(status.value.as_json(), &serde_json::json!("draft"));
+    }
+
+    // ── Byte-for-byte with the render projection (the phase's acceptance) ────
+
+    #[test]
+    fn every_row_is_byte_for_byte_with_compile_data() {
+        let quill = quill_from_yaml(QUILL);
+        let md = "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\n\
+                  title: Hello\nintro: \"**bold**\"\nrecipients:\n  - name: Alice\n~~~\n\n\
+                  Body prose here.\n\n\
+                  ~~~card-yaml\n$kind: note\nauthor: Zed\n~~~\nNote body.\n";
+        let doc = parse(md);
+        let states = quill.field_states(&doc);
+        let plate = quill.compile_data(&doc).expect("compile");
+
+        // Every declared main row equals its plate field; `$body` equals plate `$body`.
+        for name in ["title", "status", "notes", "intro", "recipients"] {
+            assert_eq!(
+                states.main.fields[name].value.as_json(),
+                &plate[name],
+                "main row `{name}` must be byte-for-byte with the plate"
+            );
+        }
+        assert_eq!(states.main.fields[BODY_KEY].value.as_json(), &plate["$body"]);
+
+        // The card's declared rows equal its plate card; `$body` equals plate `$body`.
+        let plate_card = &plate["$cards"][0];
+        let card = &states.cards[0];
+        for name in ["author", "tag"] {
+            assert_eq!(
+                card.fields[name].value.as_json(),
+                &plate_card[name],
+                "card row `{name}` must be byte-for-byte with the plate"
+            );
+        }
+        assert_eq!(card.fields[BODY_KEY].value.as_json(), &plate_card["$body"]);
+    }
+
+    // ── The body row ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn body_row_authored_vs_blank_source() {
+        let quill = quill_from_yaml(QUILL);
+
+        let authored =
+            parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n\nHello body.\n");
+        assert_eq!(
+            quill.field_states(&authored).main.fields[BODY_KEY].source,
+            FieldSource::Authored
+        );
+
+        let blank = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n");
+        let body = &quill.field_states(&blank).main.fields[BODY_KEY];
+        assert_eq!(body.source, FieldSource::Zero);
+        assert!(body.value.as_json().is_object(), "blank body is empty content");
+    }
+
+    const BODY_DISABLED_QUILL: &str = r#"
+quill:
+  name: bd_test
+  version: "1.0"
+  backend: typst
+  description: Body-disabled test
+main:
+  fields:
+    title:
+      type: string
+card_kinds:
+  stamp:
+    body:
+      enabled: false
+    fields:
+      label:
+        type: string
+"#;
+
+    #[test]
+    fn body_disabled_kind_omits_body_row_and_buckets_to_card_slot() {
+        let quill = quill_from_yaml(BODY_DISABLED_QUILL);
+        // Stray prose authored on a body-disabled card.
+        let doc = parse(
+            "~~~card-yaml\n$quill: bd_test@1.0\n$kind: main\ntitle: T\n~~~\n\n\
+             ~~~card-yaml\n$kind: stamp\nlabel: L\n~~~\nStray prose.\n",
+        );
+        let states = quill.field_states(&doc);
+        let card = &states.cards[0];
+
+        assert!(
+            !card.fields.contains_key(BODY_KEY),
+            "a body-disabled kind has no `$body` row"
+        );
+        assert!(card.fields.contains_key("label"), "declared rows still present");
+        assert!(
+            card.diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("validation::body_disabled")),
+            "body_disabled lands in the card slot: {:?}",
+            card.diagnostics
+        );
+    }
+
+    // ── Unknown-kind card ────────────────────────────────────────────────────
+
+    #[test]
+    fn unknown_kind_card_shape_and_slot() {
+        let quill = quill_from_yaml(QUILL);
+        let doc = parse(
+            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n\n\
+             ~~~card-yaml\n$kind: mystery\nfoo: bar\n~~~\nUnread body.\n",
+        );
+        let card = &quill.field_states(&doc).cards[0];
+
+        assert_eq!(card.kind.as_deref(), Some("mystery"));
+        assert_eq!(card.index, 0);
+        // Authored fields only — no `$body` row, no ladder.
+        assert_eq!(card.fields["foo"].source, FieldSource::Authored);
+        assert_eq!(card.fields["foo"].value.as_json(), &serde_json::json!("bar"));
+        assert!(!card.fields.contains_key(BODY_KEY));
+        assert!(
+            card.diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("validation::unknown_card")),
+            "unknown_card lands in the card slot: {:?}",
+            card.diagnostics
+        );
+    }
+
+    // ── Bucketing ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn type_mismatch_buckets_to_its_row() {
+        // A bare-field type mismatch routes to the field's row.
+        let q = quill_from_yaml(
+            "quill:\n  name: tm\n  version: \"1.0\"\n  backend: typst\n  description: tm\n\
+             main:\n  fields:\n    count:\n      type: integer\n",
+        );
+        let d = parse("~~~card-yaml\n$quill: tm@1.0\n$kind: main\ncount: \"not-a-number\"\n~~~\n");
+        let states = q.field_states(&d);
+        assert!(
+            states.main.fields["count"]
+                .diagnostics
+                .iter()
+                .any(|x| x.code.as_deref() == Some("validation::type_mismatch")),
+            "type_mismatch must land on the `count` row: {:?}",
+            states.main.fields["count"].diagnostics
+        );
+    }
+
+    #[test]
+    fn seed_warning_buckets_to_document_slot() {
+        let quill = quill_from_yaml(QUILL);
+        // A `$seed` overlay for an unknown kind → an advisory warning anchored at
+        // `$seed.bogus`, which is config-space → the document slot.
+        let doc = parse(
+            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n$seed:\n  bogus:\n    x: 1\n~~~\n",
+        );
+        let states = quill.field_states(&doc);
+        assert!(
+            states
+                .diagnostics
+                .iter()
+                .any(|d| d.path.as_deref() == Some("$seed.bogus")),
+            "a $seed warning belongs on the document slot: {:?}",
+            states.diagnostics
+        );
+    }
+
+    #[test]
+    fn nested_must_fill_buckets_to_head_field_row() {
+        let quill = quill_from_yaml(QUILL);
+        // `!must_fill` on `recipients[0].name` — a nested marker on the
+        // `recipients` field.
+        let doc = parse(
+            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n\
+             recipients:\n  - name: !must_fill\n~~~\n",
+        );
+        let states = quill.field_states(&doc);
+        let row = &states.main.fields["recipients"];
+        assert!(
+            row.diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("validation::must_fill")),
+            "a nested must_fill buckets to the head field's row: {:?}",
+            row.diagnostics
+        );
+        // And nowhere else.
+        assert!(states.main.diagnostics.is_empty());
+        assert!(states.diagnostics.is_empty());
+    }
+
+    // ── Undeclared authored field ────────────────────────────────────────────
+
+    #[test]
+    fn undeclared_authored_field_row_is_authored() {
+        let quill = quill_from_yaml(QUILL);
+        let doc = parse(
+            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\nextra: whatever\n~~~\n",
+        );
+        let row = &quill.field_states(&doc).main.fields["extra"];
+        assert_eq!(row.source, FieldSource::Authored);
+        assert_eq!(row.value.as_json(), &serde_json::json!("whatever"));
+        assert!(row.example.is_none());
+    }
+
+    // ── Completeness ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn every_validate_diagnostic_appears_exactly_once() {
+        let quill = quill_from_yaml(QUILL);
+        // A document that raises several diagnostics without any coercion
+        // failure (so no extra `coercion_failed` rows are added by the view):
+        // a nested must_fill, a $seed warning, and an unknown-kind card.
+        let doc = parse(
+            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n\
+             recipients:\n  - name: !must_fill\n$seed:\n  bogus:\n    x: 1\n~~~\n\n\
+             ~~~card-yaml\n$kind: mystery\nfoo: bar\n~~~\n",
+        );
+        let expected = quill.validate(&doc);
+        assert!(!expected.is_empty(), "the fixture must raise diagnostics");
+
+        let states = quill.field_states(&doc);
+        let mut collected: Vec<Diagnostic> = Vec::new();
+        collected.extend(states.diagnostics.iter().cloned());
+        collected.extend(states.main.diagnostics.iter().cloned());
+        for row in states.main.fields.values() {
+            collected.extend(row.diagnostics.iter().cloned());
+        }
+        for card in &states.cards {
+            collected.extend(card.diagnostics.iter().cloned());
+            for row in card.fields.values() {
+                collected.extend(row.diagnostics.iter().cloned());
+            }
+        }
+
+        assert_eq!(
+            collected.len(),
+            expected.len(),
+            "every validate() diagnostic lands in exactly one slot (no more, no less)"
+        );
+        for d in &expected {
+            assert!(
+                collected.contains(d),
+                "validate() diagnostic missing from the view: {d:?}"
+            );
+        }
+    }
+
+    // ── Coercion-failure row ─────────────────────────────────────────────────
+
+    #[test]
+    fn render_coercion_failure_parks_diagnostic_on_its_row() {
+        let quill = quill_from_yaml(QUILL);
+        // `intro` is richtext; a non-content JSON object cannot be coerced under
+        // Render leniency (`from_canonical_value` rejects the shape).
+        let doc = parse(
+            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\nintro:\n  not: content\n~~~\n",
+        );
+        let intro = &quill.field_states(&doc).main.fields["intro"];
+        assert!(
+            intro
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("validation::coercion_failed")
+                    && d.path.as_deref() == Some("intro")),
+            "a Render coercion failure parks a path-anchored diagnostic on the row: {:?}",
+            intro.diagnostics
+        );
+        // The raw authored value is kept (Authored), not dropped.
+        assert_eq!(intro.source, FieldSource::Authored);
+        assert_eq!(intro.value.as_json(), &serde_json::json!({ "not": "content" }));
+    }
+
+    #[test]
+    fn field_source_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&FieldSource::Authored).unwrap(),
+            "\"authored\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FieldSource::Default).unwrap(),
+            "\"default\""
+        );
+        assert_eq!(serde_json::to_string(&FieldSource::Zero).unwrap(), "\"zero\"");
+    }
+
+    #[test]
+    fn field_state_omits_absent_example_on_the_wire() {
+        let state = FieldState {
+            value: QuillValue::from_json(serde_json::json!("x")),
+            source: FieldSource::Authored,
+            diagnostics: Vec::new(),
+            example: None,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(!json.contains("example"), "absent example is skipped: {json}");
+    }
+}

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -132,3 +132,55 @@ is corrected to `cards.indorsement[2].author`.
 Mutator (`edit::*`) diagnostics still carry only the bare field-name `path` the
 batched twins already set; per-variant paths on the single mutators ride a
 later slice of the contract rework.
+
+## New: `fieldStates()` — the resolved-field view
+
+`quill.fieldStates(doc)` (Python `quill.field_states(doc)`) is additive: the
+resolved-field view of a document against its quill schema. For every declared
+field it returns the value the render projection would use, the source rung it
+came from, the schema `example:` as guidance, and the diagnostics anchored to
+it — in one call, so you stop reading the value off the `Document` payload,
+re-deriving the `default:`/zero fallback yourself, and joining `validate()` by
+`path` to find each field's diagnostics.
+
+The shape is nested — a `main` card and a `cards` list, each field keyed by name
+in declaration order:
+
+```js
+const states = quill.fieldStates(doc)
+
+const title = states.main.fields.title
+title.value        // the value the plate carries
+title.source       // "authored" | "default" | "zero"
+title.diagnostics  // the validate() diagnostics anchored to this field
+title.example      // the schema example:; the key is ABSENT when the field declares none
+
+for (const card of states.cards) {
+  card.kind        // the card's $kind — null for an unknown-kind card
+  card.index       // its position in the document's card array
+  card.fields      // same per-field shape as main.fields
+}
+```
+
+- **`source`** is the commitment-ladder rung (see `SCHEMAS.md` § "Value sources
+  and projections"): `"authored"` (the document's own value), `"default"` (the
+  schema `default:`), or `"zero"` (the type-empty floor). It agrees with the
+  render projection byte-for-byte on every fixture.
+- **The body rides the `fields` map** under the `$body` key as an ordinary field
+  row — present iff the kind enables a body, its source only ever `"authored"`
+  (non-blank) or `"zero"` (blank).
+- **`example` is absent, never null**, when the field declares no `example:` —
+  test `'example' in row`, not `row.example != null`.
+- **Diagnostics are one-call.** They are the standalone `validate()` contract,
+  bucketed by `DocPath` into the per-field, per-card (`validation::unknown_card`,
+  `validation::body_disabled`), and document (`$seed`) slots — every `validate()`
+  diagnostic lands in exactly one — plus a path-anchored
+  `validation::coercion_failed` per field whose render coercion fails. You no
+  longer re-join `validate()` by `path`.
+- **Python parity.** `quill.field_states(doc)` returns the same shape as a nested
+  dict; `main`, `cards`, and each field's `value` / `source` / `diagnostics` /
+  `example` match the WASM view key-for-key.
+
+No action — purely additive. `validate()` is unchanged and remains the
+standalone completeness surface; `fieldStates()` folds its diagnostics in for a
+consumer that wants value, provenance, and completeness from one call.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -25,7 +25,11 @@ guides in order.
   `diagnostics[0].code`, never on message text. `Diagnostic.path` gains an
   exported `parseDocPath` / `formatDocPath` (route on `DocPathSeg[]`, not a
   regex); the emitted path strings are unchanged. Canon ratifies null ≡ absent
-  as a 1.0 commitment (no behavior change).
+  as a 1.0 commitment (no behavior change). Adds `fieldStates()` (Python
+  `field_states`) — the resolved-field view: value, source rung
+  (`"authored" | "default" | "zero"`), the schema `example:`, and the
+  `validate()` diagnostics bucketed per field, in one call (additive, no
+  action).
 - [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
   `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to
   `(card, at?)`) and the deprecated `replaceBody` alias is deleted (use

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -142,7 +142,13 @@ field maps rather than a sort key):
 | `blueprint` document | Endorsed: `default:`; Unendorsed: `example:` else zero, stamped `!must_fill` | zero (under the marker) | annotated string — [BLUEPRINT.md](BLUEPRINT.md) |
 | seeding | `example:` › absent | (deferred to render floor) | committed `Document` — [Document seeding](#document-seeding) |
 | add-card (into a document) | `$seed` overlay › `example:` › absent | (deferred to render floor) | a new composable `Card` — [Document seeding](#document-seeding) |
-| editor (consumer-side) | authored / `default:` / missing (uncollapsed; `example:` as guidance) | — | a `Document`-payload × schema join the UI consumer performs directly (no engine projection); completeness comes from `Quill::validate` |
+| editor (consumer-side) | authored › `default:` › zero, resolved per field and **tagged with its source rung** (`example:` rides as guidance) | zero | the engine's [`fieldStates()`](#the-resolved-field-view-fieldstates) resolved-field view — value, source rung, and `validate()` diagnostics bucketed per field |
+
+The consumer-side `Document`-payload × schema join is a **non-goal**:
+[`fieldStates()`](#the-resolved-field-view-fieldstates) supersedes it. The
+editor reads value, source rung, and bucketed diagnostics from one engine call
+rather than re-cutting the ladder in consumer code and re-joining
+`Quill::validate` by path.
 
 Two seams are deliberate, not uniform: on `blueprint` the floor still
 zero-fills like every other projection (an Unendorsed cell with no `example`
@@ -151,6 +157,25 @@ carries bare null/empty under its marker), but the projection additionally
 rides *alongside* the value rather than replacing it; and `zero` is honestly
 blank for every type except `enum`, whose zero is the first declared variant
 (there is no empty enum member). Both are detailed below.
+
+### The resolved-field view (`fieldStates()`)
+
+`Quill::field_states(doc)` (WASM `fieldStates`, Python `field_states`) cuts the
+render ladder into observable data: for every declared field, the value
+`compile_data` would emit into the plate, tagged with its source rung
+(`authored` / `default` / `zero`), the schema `example:` as guidance, and the
+diagnostics anchored to it — byte-for-byte with the plate on every fixture. The
+shape is nested: a `main` card and a `cards` list, each field keyed by name in
+declaration order. The card body rides the `fields` map under the universal
+`$body` key as an ordinary field row — present iff the kind enables a body
+(`enabled: false` undeclares it, so there is no row), its source only ever
+`authored` (non-blank) or `zero` (blank). Source is one **top-level** rung per
+field; a nested zero-fill inside an authored dict or array is a projection
+detail of the value, not a per-subpath source. Diagnostics are `Quill::validate`
+verbatim, bucketed by their [`DocPath`](ERROR.md#document-model-paths) into
+per-field, per-card, and document slots — every diagnostic in exactly one —
+plus a path-anchored `validation::coercion_failed` on any field whose render
+coercion fails.
 
 ## Zero-filled render
 
@@ -235,12 +260,16 @@ path's "`default:` wins" rule applies to authored and blank documents, where no
   fills the body when bodies are enabled.
 - **The main card** carries `$quill` and `$kind: main`, so a seed round-trips
   through Markdown like an authored document.
-- **Provenance is untracked.** A seeded `example` is committed as ordinary
-  authored content, indistinguishable from hand-authored input. Carrying no
-  `!must_fill` marker, it reads as done — an Unendorsed field seeded with an
-  `example` raises no `validation::must_fill` warning. Whether a field's
-  value came from seeding or later authoring is not recorded; correctness
-  and renderability do not depend on the distinction.
+- **Provenance is untracked in the persisted document.** A seeded `example` is
+  committed as ordinary authored content, indistinguishable from hand-authored
+  input. Carrying no `!must_fill` marker, it reads as done — an Unendorsed field
+  seeded with an `example` raises no `validation::must_fill` warning. Whether a
+  field's value came from seeding or later authoring is not recorded; correctness
+  and renderability do not depend on the distinction. The commitment *rung* is a
+  separate axis and is reported on read: the
+  [`fieldStates()`](#the-resolved-field-view-fieldstates) projection tags each
+  field `authored` / `default` / `zero` — a seeded and a hand-authored value both
+  read as `authored`, both being document content.
 
 Seeding is the **filled-out twin of the blueprint**
 ([BLUEPRINT.md](BLUEPRINT.md) § "The blueprint and its filled-out twin"): the

--- a/prose/doc-contract-phases/phase-2-docpath.md
+++ b/prose/doc-contract-phases/phase-2-docpath.md
@@ -18,8 +18,8 @@ segment the engine emits.
 ## Grammar
 
 - Card fields are kind-qualified: `cards.<kind>[<i>].<field>`.
-- The unknown-kind whole-card case stays `cards[<i>]` — there is no kind to
-  qualify with; this is the only bare-index form.
+- A whole-card case whose `$kind` has no schema — absent, or present but not a
+  declared card kind — stays `cards[<i>]`; this is the only bare-index form.
 - Main-card fields are bare names (`recipient`); the main body is
   `main.body`.
 

--- a/prose/doc-contract-phases/phase-3-field-states.md
+++ b/prose/doc-contract-phases/phase-3-field-states.md
@@ -54,3 +54,35 @@ Three, or this surface becomes the drift it exists to kill:
 - `source` provenance agrees with the render projection on every fixture —
   same rung, same value, byte-for-byte on the zero floor.
 - `SCHEMAS.md` names the consumer-side join a non-goal.
+
+## Status
+
+**Shipped**: the core projection (`crates/core/src/quill/field_states.rs`) over
+the shared `resolve_value_sourced` ladder producer — one commitment cut, not a
+parallel precedence policy; the WASM `fieldStates` surface plus its
+`FieldSource` / `FieldState` / `MainFieldStates` / `CardFieldStates` /
+`FieldStates` TS types; the Python `field_states` parity; and the `SCHEMAS.md`
+editor-row flip (the consumer-side `Document`-payload × schema join named a
+non-goal, superseded by this view).
+
+**Gate resolution**: the gate was consumer evidence, but the editor is
+greenfield — no call sites exist to read the shape off. So the shape is settled
+engine-side and ratified by the owner:
+
+- **Nested `main` + `cards`**, not a flat map — the document's own two-level
+  structure, each field keyed by name in declaration order.
+- **The body is a universal field**, rowed as `$body` in the `fields` map;
+  `enabled` ≡ declared (a body-disabled kind carries no `$body` row).
+- **`example?` rides as guidance** — the schema `example:` per row, absent from
+  the wire (not null) when the field declares none.
+- **One-call diagnostic bucketing** — every `validate()` diagnostic routed into
+  exactly one slot, with card-level (`unknown_card`, `body_disabled`) and
+  document-level (`$seed`) slots for diagnostics that anchor to no field, plus a
+  per-row `validation::coercion_failed` for render-coercion failures.
+- **Source is top-level only** — one rung per field; the nested zero-fill inside
+  an authored dict or array is a value detail, not a per-subpath source.
+
+**Deferred**: per-subpath provenance inside authored containers — a rung for
+each leaf of a nested dict/array rather than one rung for the field. It needs
+consumer evidence that a container-aware editor wants it; a phase-4 fixture pins
+the current top-level-only behavior meanwhile.


### PR DESCRIPTION
## Summary

Updates the `validate_fills` function to accept a `QuillConfig` parameter and filter card kinds by schema declaration. This ensures that fill diagnostics for cards with undeclared or absent `$kind` values anchor at the bare-index path `cards[<i>].<field>` rather than the kind-qualified path `cards.<kind>[<i>].<field>`, matching the behavior of `validate_typed_document`.

## Changes

- **`crates/core/src/quill/compose.rs`**: 
  - Pass `self.config()` to `validate_fills()` call
  - Update `validate_fills()` signature to accept `&QuillConfig`
  - Filter card kinds through `config.card_kind(k).is_some()` before constructing the `DocPath`, so only schema-declared kinds qualify the path
  - Add comprehensive test `unknown_kind_card_fill_path_is_bare_index()` verifying that cards with unknown or absent kinds use bare-index paths

- **`crates/core/src/path.rs`**: 
  - Update module documentation to clarify that both absent and undeclared card kinds stay at `cards[<i>]`

- **`crates/bindings/wasm/src/engine.rs`**: 
  - Add validation to `format_doc_path()` to reject empty segment arrays, making it symmetric with `parseDocPath("")` which throws "empty path"
  - Update JSDoc to document this behavior

- **`crates/bindings/wasm/basic.test.js`**: 
  - Add test case verifying `formatDocPath([])` throws

- **`prose/doc-contract-phases/phase-2-docpath.md`**: 
  - Update grammar documentation to clarify the bare-index case covers both absent and undeclared kinds

## Implementation Details

The key insight is that `validate_fills` now mirrors the path-construction logic of `validate_typed_document` by checking `config.card_kind(k).is_some()`. This ensures diagnostic paths are consistent across validation passes and prevents spurious kind-qualified paths for cards that don't have a declared schema.

https://claude.ai/code/session_01MGxYTkKetGhnPHqo9gXUns