### PR TITLE
Rework document contract: one address grammar (DocPath), mutator paths, lean fieldStates

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -77,7 +77,6 @@ quill.metadata              # pure config snapshot of the quill: section (never 
 quill.quill_ref             # "name@version"
 
 diags   = quill.validate(parsed)          # list of validation::* diagnostic dicts ([] = valid)
-states  = quill.field_states(parsed)      # resolved-field view: value + source rung + diagnostics per field
 seed    = quill.seed_document()           # starter Document seeded from `example:` values
 main    = quill.seed_main()               # just the $kind: main card (dict, like doc.main)
 card    = quill.seed_card("note")         # one starter composable card (dict), None if kind undeclared

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -211,32 +211,6 @@ impl PyQuill {
         Ok(list.clone())
     }
 
-    /// The resolved-field view of `doc` against this quill's schema, as a nested
-    /// dict — `main` (its `fields` map plus a card-level `diagnostics` list),
-    /// the `cards` list (each with `kind`, `index`, `fields`, `diagnostics`),
-    /// and a document-level `diagnostics` list. Per field: `value`, `source`
-    /// (`"authored" | "default" | "zero"`), `diagnostics`, and `example`
-    /// (present only when the field declares one). The card body rides the
-    /// `fields` map under the `$body` key. Diagnostics are the standalone
-    /// `validate` contract bucketed by `DocPath` into per-field, per-card, and
-    /// document slots (plus a path-anchored `validation::coercion_failed` per
-    /// field whose render coercion fails). Mirrors WASM `fieldStates`.
-    fn field_states<'py>(
-        &self,
-        py: Python<'py>,
-        doc: PyRef<'_, PyDocument>,
-    ) -> PyResult<Bound<'py, PyDict>> {
-        let states = self.inner.field_states(&doc.inner);
-        let json_value = serde_json::to_value(&states).map_err(|e| {
-            PyValueError::new_err(format!("field_states: serialization failed: {e}"))
-        })?;
-        let py_obj = json_to_py(py, &json_value)?;
-        let dict = py_obj
-            .downcast::<PyDict>()
-            .map_err(|_| PyValueError::new_err("field_states: expected a dict at top level"))?;
-        Ok(dict.clone())
-    }
-
     /// Seed a starter `Document` from the schema — the main card plus one
     /// instance of each composable card kind, each committing its fields'
     /// `example` values and leaving every other field absent (interpolated at

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -431,10 +431,11 @@ describe('Quillmark.quill', () => {
     expect(svg.artifacts[0].mimeType).toBe('image/svg+xml')
   })
 
-  it('session.regions() is always a non-null array', () => {
+  it('session.regions() is always a non-null array, keyed by DocPath', () => {
     // Regions are a session-level query, not on the render result. The document
-    // body is a markdown content field, so it auto-tags one schema-field region
-    // keyed `$body`; the result is always an array, never undefined.
+    // body is a markdown content field, so it auto-tags one region; its address
+    // is the canonical DocPath `main.body` (the backend's plate-space `$body` is
+    // translated at the session boundary). The result is always an array.
     const engine = new Quillmark()
     const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
     const doc = Document.fromMarkdown(TEST_MARKDOWN)
@@ -442,7 +443,9 @@ describe('Quillmark.quill', () => {
     const session = engine.open(quill, doc)
     const regions = session.regions()
     expect(Array.isArray(regions)).toBe(true)
-    expect(regions.some((r) => r.field === '$body')).toBe(true)
+    expect(regions.some((r) => r.field === 'main.body')).toBe(true)
+    // No plate-space ordinal grammar crosses the boundary.
+    expect(regions.some((r) => r.field.startsWith('$cards.') || r.field === '$body')).toBe(false)
     session.free()
   })
 
@@ -828,6 +831,31 @@ card_kinds:
     doc._commitField(quill, { card: 0, field: 'body' }, 'Card **body**.')
     expect(exportMarkdown(field(doc.cards[0], 'body'))).toBe('Card **body**.')
     expectEditCode(() => doc._commitField(quill, { card: 9, field: 'body' }, 'x'), 'edit::index_out_of_range')
+  })
+
+  it('a mutator diagnostic carries the DocPath it anchors to', () => {
+    const quill = buildQuill()
+    const doc = Document.fromMarkdown(
+      '~~~card-yaml\n$quill: commit_test\n~~~\n\nMain.\n\n~~~card-yaml\n$kind: note\n~~~\n\nCard.',
+    )
+    // The path a diagnostic thrown by `fn` carries.
+    const pathOf = (fn) => {
+      try {
+        fn()
+      } catch (err) {
+        return err.diagnostics[0].path
+      }
+      throw new Error('expected a throw, got none')
+    }
+    // A main field conform error anchors at the bare field DocPath…
+    expect(pathOf(() => doc._commitField(quill, 'qty', 'not-a-number'))).toBe('qty')
+    // …a card field is kind-qualified with its absolute index…
+    expect(pathOf(() => doc._commitField(quill, { card: 0, field: 'stray' }, 'x'))).toBe(
+      'cards.note[0].stray',
+    )
+    // …and a structural out-of-range op anchors at the array slot.
+    expect(pathOf(() => doc.setCardKind(9, 'note'))).toBe('cards[9]')
+    expect(pathOf(() => doc.moveCard(9, 0))).toBe('cards[9]')
   })
 
   it('commitFields typed-commits a batch', () => {
@@ -1744,14 +1772,14 @@ addr:
 })
 
 // ---------------------------------------------------------------------------
-// quill.fieldStates — the resolved-field view
+// quill.fieldStates — the resolved-value view
 // ---------------------------------------------------------------------------
 //
-// For every declared field: the value the render projection would use, the
-// source rung it came from ("authored" | "default" | "zero"), the schema
-// `example:` as guidance (absent from the wire when the field declares none),
-// and the diagnostics bucketed onto it. The body rides the fields map under the
-// `$body` key. See prose/canon/SCHEMAS.md § "Value sources and projections".
+// For every declared field: the value the render projection would use and the
+// source rung it came from ("authored" | "default" | "zero"). Value and
+// provenance only — diagnostics stay validate(), guidance stays the schema. The
+// body rides the fields map under the `$body` key. See prose/canon/SCHEMAS.md
+// § "Value sources and projections".
 
 describe('quill.fieldStates', () => {
   const QUILL_YAML = `quill:
@@ -1829,7 +1857,7 @@ title: T
     expect(noBody.main.fields.$body.source).toBe('zero')
   })
 
-  it('includes example only on a field that declares one', () => {
+  it('carries value and source only — no diagnostics, no example', () => {
     const quill = buildQuill()
     const md = `~~~card-yaml
 $quill: field_states_test
@@ -1838,11 +1866,11 @@ title: T
 ~~~
 `
     const f = quill.fieldStates(Document.fromMarkdown(md)).main.fields
-    // `author` declares `example: A. Author` — the key is present.
-    expect('example' in f.author).toBe(true)
-    expect(f.author.example).toBe('A. Author')
-    // `title` declares none — the key is absent on the wire, not null.
-    expect('example' in f.title).toBe(false)
+    // Each row is exactly { value, source } — schema guidance (example:) and
+    // diagnostics are read from quill.schema / quill.validate, not duplicated here.
+    expect(Object.keys(f.author).sort()).toEqual(['source', 'value'])
+    expect('example' in f.author).toBe(false)
+    expect('diagnostics' in f.author).toBe(false)
   })
 
   it('reports kind and index on a card entry', () => {
@@ -1868,7 +1896,7 @@ Note body.
     expect(card.fields.label.value).toBe('L')
   })
 
-  it('buckets a type mismatch onto its field row', () => {
+  it('keeps a render-uncoercible value raw (byte-for-byte with the plate)', () => {
     const quill = buildQuill()
     const md = `~~~card-yaml
 $quill: field_states_test
@@ -1877,8 +1905,13 @@ title: T
 count: "not-a-number"
 ~~~
 `
+    // A value the render coercion cannot conform is kept raw and Authored,
+    // exactly as compile_data leaves it — the error surfaces via validate(),
+    // not this view (which carries no diagnostics).
     const row = quill.fieldStates(Document.fromMarkdown(md)).main.fields.count
-    expect(row.diagnostics.some((d) => d.code === 'validation::type_mismatch')).toBe(true)
+    expect(row.source).toBe('authored')
+    expect(row.value).toBe('not-a-number')
+    expect('diagnostics' in row).toBe(false)
   })
 
   it('result is JSON.stringify-able', () => {

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -128,9 +128,9 @@ describe('LiveSession canvas preview', () => {
     const session = openSession()
 
     // A content field surfaces one span-bearing region per segment (#829); the
-    // body's heading is one.
-    const bodyRegion = session.regions().find((r) => r.field === '$body' && r.span)
-    expect(bodyRegion, 'a $body segment region carries a span').toBeTruthy()
+    // body's heading is one. The address is the canonical DocPath `main.body`.
+    const bodyRegion = session.regions().find((r) => r.field === 'main.body' && r.span)
+    expect(bodyRegion, 'a main.body segment region carries a span').toBeTruthy()
     const [x0, y0, x1, y1] = bodyRegion.rect
     const cy = (y0 + y1) / 2
 
@@ -142,16 +142,16 @@ describe('LiveSession canvas preview', () => {
       hit = session.positionAt(bodyRegion.page, x0 + (x1 - x0) * f, cy)
     }
     expect(hit, 'positionAt resolves a point on the body ink').toBeTruthy()
-    expect(hit.field).toBe('$body')
+    expect(hit.field).toBe('main.body')
     expect(typeof hit.pos).toBe('number')
     const [start, end] = bodyRegion.span
     expect(hit.pos).toBeGreaterThanOrEqual(start)
     expect(hit.pos).toBeLessThanOrEqual(end)
 
-    // Reverse: content position → caret rect on the same field.
-    const caret = session.locate('$body', hit.pos)
+    // Reverse: content position → caret rect on the same field (DocPath in).
+    const caret = session.locate('main.body', hit.pos)
     expect(caret, 'locate reverses positionAt').toBeTruthy()
-    expect(caret.field).toBe('$body')
+    expect(caret.field).toBe('main.body')
     expect(caret.rect[2]).toBeGreaterThanOrEqual(caret.rect[0])
 
     // A click far off any ink resolves to nothing (wasm maps `None` to undefined).

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -671,10 +671,11 @@ A single line of body ink.`
       expect(typeof session.render).toBe('function')
       expect(session.render({ format: 'svg' }).artifacts.length).toBeGreaterThan(0)
 
-      // regions — the $body markdown content field auto-tags one region.
+      // regions — the body markdown content field auto-tags one region, keyed
+      // by the canonical DocPath `main.body`.
       expect(typeof session.regions).toBe('function')
       const regions = session.regions()
-      const body = regions.find((r) => r.field === '$body')
+      const body = regions.find((r) => r.field === 'main.body')
       expect(body).toBeDefined()
 
       // pageSize.
@@ -683,22 +684,22 @@ A single line of body ink.`
       expect(size.heightPt).toBeGreaterThan(0)
 
       // fieldAt — the delegation that was missing (#801). Hit-test the centre
-      // of the $body region's rect ([x0, y0, x1, y1], bottom-left PDF points)
+      // of the body region's rect ([x0, y0, x1, y1], bottom-left PDF points)
       // — guaranteed ink for the single-line body (see SMOKE_MARKDOWN above) —
-      // and expect it to resolve back through the wrapper. Off any field's ink
-      // (the page corner) the contract is undefined.
+      // and expect it to resolve back through the wrapper as its DocPath. Off
+      // any field's ink (the page corner) the contract is undefined.
       expect(typeof session.fieldAt).toBe('function')
       const [x0, y0, x1, y1] = body.rect
       const hit = session.fieldAt(body.page, (x0 + x1) / 2, (y0 + y1) / 2)
-      expect(hit).toBe('$body')
+      expect(hit).toBe('main.body')
       expect(session.fieldAt(body.page, 1, 1)).toBeUndefined()
 
       // fieldBoxes — the whole-field union helper. A single-line body has one
       // span-bearing segment, so its box unions to one rect covering that line.
       expect(typeof session.fieldBoxes).toBe('function')
-      const boxes = session.fieldBoxes('$body')
+      const boxes = session.fieldBoxes('main.body')
       expect(boxes.length).toBe(1)
-      expect(boxes[0].field).toBe('$body')
+      expect(boxes[0].field).toBe('main.body')
       expect(boxes[0].span).toBeDefined()
       // A field with no span-bearing region has no derived content box.
       expect(session.fieldBoxes('does_not_exist')).toEqual([])
@@ -707,7 +708,7 @@ A single line of body ink.`
       // signal. A hit on the single line's ink is cluster-exact.
       expect(typeof session.positionAt).toBe('function')
       const chit = session.positionAt(body.page, (x0 + x1) / 2, (y0 + y1) / 2)
-      expect(chit.field).toBe('$body')
+      expect(chit.field).toBe('main.body')
       expect(chit.granularity).toBe('cluster')
 
       // paint.

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -74,10 +74,11 @@ export type {
 	DocPathSeg
 } from '../core/wasm.js';
 
-// The resolved-field view — the return shape of `quill.fieldStates(doc)`. Value
-// + source rung + bucketed diagnostics per declared field (the body rides the
-// fields map under `$body`). Declared in the core build's generated `.d.ts` via
-// a `typescript_custom_section`; re-exported here so the single public entry
+// The resolved-value view — the return shape of `quill.fieldStates(doc)`. Value
+// + source rung per declared field (the body rides the fields map under
+// `$body`); diagnostics stay `quill.validate`, guidance stays `quill.schema`.
+// Declared in the core build's generated `.d.ts` via a
+// `typescript_custom_section`; re-exported here so the single public entry
 // point names them.
 export type {
 	FieldSource,

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -449,12 +449,18 @@ impl Quillmark {
         let mut warnings: Vec<Diagnostic> =
             doc.parse_warnings.iter().cloned().map(Into::into).collect();
         warnings.extend(result.warnings.into_iter().map(Into::into));
+        // The regions sidecar keys on `DocPath` like `session.regions()`, so a
+        // consumer sees one address grammar however it reads geometry.
+        let kinds: Vec<Option<&str>> = doc.inner.cards().iter().map(|c| c.kind()).collect();
         Ok(RenderResult {
             artifacts: result.artifacts.into_iter().map(Into::into).collect(),
             warnings,
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
-            regions: result.regions.into_iter().map(Into::into).collect(),
+            regions: regions_to_docpath(result.regions, &kinds)
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         })
     }
 
@@ -2337,37 +2343,50 @@ export interface PaintResult {
 }
 "#;
 
+/// A backend plate-space geometry address → its `DocPath` string, keeping the
+/// original when it does not fit the geometry grammar. `kinds` is the compile's
+/// ordered card kinds — build it once per query and pass the slice, never per
+/// region.
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+fn plate_to_docpath(addr: &str, kinds: &[Option<&str>]) -> String {
+    quillmark_core::plate_addr_to_doc_path(addr, kinds)
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| addr.to_string())
+}
+
+/// A `DocPath` address (from a consumer) → its plate-space form for the backend,
+/// keeping the original when it does not parse or place.
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+fn docpath_to_plate(addr: &str, kinds: &[Option<&str>]) -> String {
+    addr.parse::<quillmark_core::DocPath>()
+        .ok()
+        .and_then(|p| quillmark_core::doc_path_to_plate_addr(&p, kinds))
+        .unwrap_or_else(|| addr.to_string())
+}
+
+/// Rewrite every region's plate-space `field` to its `DocPath` string — the one
+/// funnel both the session queries (`regions`) and the render sidecar route
+/// through, so a `FieldRegion` that crosses the boundary always speaks `DocPath`.
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+fn regions_to_docpath(
+    regions: Vec<quillmark_core::RenderedRegion>,
+    kinds: &[Option<&str>],
+) -> Vec<quillmark_core::RenderedRegion> {
+    regions
+        .into_iter()
+        .map(|mut r| {
+            r.field = plate_to_docpath(&r.field, kinds);
+            r
+        })
+        .collect()
+}
+
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 impl LiveSession {
-    /// The card-kind lookup as `&[Option<&str>]` for the core translators.
+    /// The card-kind lookup as `&[Option<&str>]` for the core translators —
+    /// built once per query.
     fn kinds(&self) -> Vec<Option<&str>> {
         self.card_kinds.iter().map(|k| k.as_deref()).collect()
-    }
-
-    /// A backend plate-space geometry address → its `DocPath` string, keeping
-    /// the original when it does not fit the geometry grammar.
-    fn plate_to_docpath(&self, addr: &str) -> String {
-        quillmark_core::plate_addr_to_doc_path(addr, &self.kinds())
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| addr.to_string())
-    }
-
-    /// A `DocPath` address (from a consumer) → its plate-space form for the
-    /// backend, keeping the original when it does not parse or place.
-    fn docpath_to_plate(&self, addr: &str) -> String {
-        addr.parse::<quillmark_core::DocPath>()
-            .ok()
-            .and_then(|p| quillmark_core::doc_path_to_plate_addr(&p, &self.kinds()))
-            .unwrap_or_else(|| addr.to_string())
-    }
-
-    /// A region with its plate-space `field` rewritten to its `DocPath` string.
-    fn region_to_docpath(
-        &self,
-        mut r: quillmark_core::RenderedRegion,
-    ) -> quillmark_core::RenderedRegion {
-        r.field = self.plate_to_docpath(&r.field);
-        r
     }
 }
 
@@ -2446,7 +2465,11 @@ impl LiveSession {
             warnings: result.warnings.into_iter().map(Into::into).collect(),
             output_format: result.output_format.into(),
             render_time_ms: now_ms() - start,
-            regions: result.regions.into_iter().map(Into::into).collect(),
+            // Same `DocPath` grammar as `regions()` — one address grammar per session.
+            regions: regions_to_docpath(result.regions, &self.kinds())
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         })
     }
 
@@ -2461,11 +2484,9 @@ impl LiveSession {
     /// Empty for backends that place no schema fields.
     #[wasm_bindgen(js_name = regions, unchecked_return_type = "FieldRegion[]")]
     pub fn regions(&self) -> Result<JsValue, JsValue> {
-        let regions: Vec<FieldRegion> = self
-            .inner
-            .regions()
+        let regions: Vec<FieldRegion> = regions_to_docpath(self.inner.regions(), &self.kinds())
             .into_iter()
-            .map(|r| self.region_to_docpath(r).into())
+            .map(Into::into)
             .collect();
         serialize_or_throw(&regions, "regions")
     }
@@ -2482,12 +2503,11 @@ impl LiveSession {
     #[wasm_bindgen(js_name = fieldBoxes, unchecked_return_type = "FieldRegion[]")]
     pub fn field_boxes(&self, field: &str) -> Result<JsValue, JsValue> {
         // `field` is a DocPath address; the backend filters in plate space.
-        let plate = self.docpath_to_plate(field);
-        let boxes: Vec<FieldRegion> = self
-            .inner
-            .field_boxes(&plate)
+        let kinds = self.kinds();
+        let plate = docpath_to_plate(field, &kinds);
+        let boxes: Vec<FieldRegion> = regions_to_docpath(self.inner.field_boxes(&plate), &kinds)
             .into_iter()
-            .map(|r| self.region_to_docpath(r).into())
+            .map(Into::into)
             .collect();
         serialize_or_throw(&boxes, "fieldBoxes")
     }
@@ -2505,7 +2525,7 @@ impl LiveSession {
     pub fn field_at(&self, page: usize, x: f32, y: f32) -> Option<String> {
         self.inner
             .field_at(page, x, y)
-            .map(|f| self.plate_to_docpath(&f))
+            .map(|f| plate_to_docpath(&f, &self.kinds()))
     }
 
     /// A point → **content position** — the fine-grained click direction:
@@ -2519,7 +2539,7 @@ impl LiveSession {
     #[wasm_bindgen(js_name = positionAt)]
     pub fn position_at(&self, page: usize, x: f32, y: f32) -> Option<ContentHit> {
         self.inner.position_at(page, x, y).map(|mut hit| {
-            hit.field = self.plate_to_docpath(&hit.field);
+            hit.field = plate_to_docpath(&hit.field, &self.kinds());
             hit.into()
         })
     }
@@ -2533,10 +2553,12 @@ impl LiveSession {
     pub fn locate(&self, field: &str, pos: usize) -> Option<FieldRegion> {
         // `field` is a DocPath address; the backend resolves in plate space and
         // the returned region's field translates back.
-        let plate = self.docpath_to_plate(field);
-        self.inner
-            .locate(&plate, pos)
-            .map(|r| self.region_to_docpath(r).into())
+        let kinds = self.kinds();
+        let plate = docpath_to_plate(field, &kinds);
+        self.inner.locate(&plate, pos).map(|mut r| {
+            r.field = plate_to_docpath(&r.field, &kinds);
+            r.into()
+        })
     }
 
     /// Page dimensions in points (1 pt = 1/72 inch).

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -374,6 +374,20 @@ pub struct LiveSession {
     /// pipeline as `open`. The config alone — schemas, not the quill's
     /// font/package bytes, which the backend session already owns.
     config: quillmark_core::quill::QuillConfig,
+    /// The current compile's ordered card kinds (`None` = a kindless card), the
+    /// lookup that resolves a geometry region's plate-space per-kind ordinal to
+    /// its `DocPath` absolute index. Refreshed on every committed `apply`, so it
+    /// tracks the document the geometry reflects.
+    card_kinds: Vec<Option<String>>,
+}
+
+/// The ordered card kinds of `doc` — the geometry-translation lookup a
+/// [`LiveSession`] retains.
+fn card_kinds_of(doc: &quillmark_core::Document) -> Vec<Option<String>> {
+    doc.cards()
+        .iter()
+        .map(|c| c.kind().map(String::from))
+        .collect()
 }
 
 /// Typed in-memory Quillmark document.
@@ -412,6 +426,7 @@ impl Quillmark {
             inner: session,
             backend_id: quill.inner.backend_id().to_string(),
             config: quill.inner.config().clone(),
+            card_kinds: card_kinds_of(&doc.inner),
         })
     }
 
@@ -600,18 +615,14 @@ impl Quill {
         })
     }
 
-    /// The resolved-field view of `doc` against this quill's schema — for every
-    /// declared field the value the render projection would use, the
-    /// `FieldSource` rung it came from (`"authored" | "default" | "zero"`), the
-    /// diagnostics anchored to it, and the schema `example:` as guidance
-    /// (`example?` — absent from the wire when the field declares none), in one
-    /// call. The card body rides the `fields` map under the `$body` key.
+    /// The resolved-value view of `doc` against this quill's schema — for every
+    /// declared field the value the render projection would use and the
+    /// `FieldSource` rung it came from (`"authored" | "default" | "zero"`), in
+    /// one call. The card body rides the `fields` map under the `$body` key.
     ///
-    /// Diagnostics are the standalone `validate` contract, bucketed by their
-    /// `DocPath` into the per-field, per-card, and document slots (plus a
-    /// path-anchored `validation::coercion_failed` per field whose render
-    /// coercion fails), so a consumer reads value, provenance, and completeness
-    /// here instead of re-cutting the ladder and re-joining `validate` by path.
+    /// Value and provenance only: completeness and errors stay `validate`'s
+    /// (a consumer merges it with its own diagnostic producers regardless), and
+    /// schema guidance reads from `Quill.schema`.
     #[wasm_bindgen(js_name = fieldStates, unchecked_return_type = "FieldStates")]
     pub fn field_states(&self, doc: &Document) -> Result<JsValue, JsValue> {
         let states = self.inner.field_states(&doc.inner);
@@ -945,6 +956,7 @@ impl Document {
         #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
     ) -> Result<JsValue, JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
+        let base = self.addr_base(&addr);
         let view = quill.inner.view(&self.inner);
         match &addr.field {
             // Absent field = body: quill-free markdown, the getMarkdown body read.
@@ -952,17 +964,18 @@ impl Document {
                 None => view.get_body(),
                 Some(index) => view
                     .card(index)
-                    .map_err(|e| edit_error_to_js(&e))?
+                    .map_err(|e| edit_error_to_js(&e, &base))?
                     .get_body(),
             })),
             Some(field) => {
                 let read = match addr.card {
                     None => view.get(field),
-                    Some(index) => {
-                        view.card(index).map_err(|e| edit_error_to_js(&e))?.get(field)
-                    }
+                    Some(index) => view
+                        .card(index)
+                        .map_err(|e| edit_error_to_js(&e, &base))?
+                        .get(field),
                 }
-                .map_err(|e| edit_error_to_js(&e))?;
+                .map_err(|e| edit_error_to_js(&e, &base))?;
                 match read {
                     None => Ok(JsValue::UNDEFINED),
                     // Both content projections flatten to a JS string at the boundary.
@@ -1107,9 +1120,10 @@ impl Document {
         let field = addr.require_field("storeField")?.to_string();
         let json = js_value_to_json(value, "storeField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
+        let base = self.addr_base(&addr);
         self.addr_card_mut(&addr)?
             .store_field(&field, qv)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &base))
     }
 
     /// Store a field verbatim at `addr` and mark it `!must_fill` — the opaque
@@ -1126,9 +1140,10 @@ impl Document {
         let field = addr.require_field("storeFill")?.to_string();
         let json = js_value_to_json(value, "storeFill")?;
         let qv = quillmark_core::QuillValue::from_json(json);
+        let base = self.addr_base(&addr);
         self.addr_card_mut(&addr)?
             .store_fill(&field, qv)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &base))
     }
 
     /// Store several fields verbatim and atomically on the card `addr` targets —
@@ -1148,9 +1163,10 @@ impl Document {
         let addr = Addr::from_js(&addr)?;
         addr.require_card_only("storeFields")?;
         let batch = js_value_to_field_batch(&fields, "storeFields")?;
+        let base = self.addr_base(&addr);
         self.addr_card_mut(&addr)?
             .store_fields(batch)
-            .map_err(edit_errors_to_js)
+            .map_err(|errs| edit_errors_to_js(errs, &base))
     }
 
     /// Remove a field at `addr`, returning the removed value or `undefined`. A
@@ -1164,10 +1180,11 @@ impl Document {
     ) -> Result<JsValue, JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
         let field = addr.require_field("removeField")?.to_string();
+        let base = self.addr_base(&addr);
         let removed = self
             .addr_card_mut(&addr)?
             .remove_field(&field)
-            .map_err(|e| edit_error_to_js(&e))?;
+            .map_err(|e| edit_error_to_js(&e, &base))?;
         Ok(match removed {
             Some(v) => serialize_or_throw(v.as_json(), "removeField")?,
             None => JsValue::UNDEFINED,
@@ -1188,9 +1205,10 @@ impl Document {
         let addr = Addr::from_js(&addr)?;
         addr.require_card_only("storeExt")?;
         let map = js_value_to_object(&value, "storeExt")?;
+        let base = self.addr_base(&addr);
         self.addr_card_mut(&addr)?
             .store_ext(map)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &base))
     }
 
     /// Remove the `$ext` map on the card `addr` targets *entirely*, returning the
@@ -1221,9 +1239,10 @@ impl Document {
         let addr = Addr::from_js(&addr)?;
         addr.require_card_only("storeExtNamespace")?;
         let json = js_value_to_json(value, "storeExtNamespace")?;
+        let base = self.addr_base(&addr);
         self.addr_card_mut(&addr)?
             .store_ext_namespace(ns, json)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &base))
     }
 
     /// Remove `$ext[ns]` on the card `addr` targets, returning its value or
@@ -1253,10 +1272,12 @@ impl Document {
         overlay: JsValue,
     ) -> Result<(), JsValue> {
         let json = js_value_to_json(overlay, "storeSeedNamespace")?;
+        // Main-only: `$seed` is config-space, so a kind/depth error here carries
+        // no field anchor (empty base → `doc_path` returns `None`).
         self.inner
             .main_mut()
             .store_seed_namespace(card_kind, json)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &quillmark_core::DocPath::new()))
     }
 
     /// Remove `cardKind` from the main card's `$seed` map, returning its
@@ -1305,13 +1326,16 @@ impl Document {
     ) -> Result<(), JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
         let content = js_to_content(rt, "install")?;
+        let base = self.addr_base(&addr);
         let card = self.addr_card_mut(&addr)?;
         match &addr.field {
             None => {
                 card.install_body(content);
                 Ok(())
             }
-            Some(field) => card.install_field(field, content).map_err(|e| edit_error_to_js(&e)),
+            Some(field) => card
+                .install_field(field, content)
+                .map_err(|e| edit_error_to_js(&e, &base)),
         }
     }
 
@@ -1331,12 +1355,13 @@ impl Document {
         markdown: &str,
     ) -> Result<JsValue, JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
+        let base = self.addr_base(&addr);
         let card = self.addr_card_mut(&addr)?;
         let delta = match &addr.field {
             None => card.revise_body(markdown),
             Some(field) => card.revise_field(field, markdown),
         }
-        .map_err(|e| edit_error_to_js(&e))?;
+        .map_err(|e| edit_error_to_js(&e, &base))?;
         serialize_or_throw(&delta, "revise")
     }
 
@@ -1363,15 +1388,16 @@ impl Document {
     ) -> Result<JsValue, JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
         let field = addr.require_field("reviseField")?.to_string();
+        let base = self.addr_base(&addr);
         let mut writer = quill.inner.writer(&mut self.inner);
         let delta = match addr.card {
             None => writer.revise_field(&field, markdown),
             Some(index) => writer
                 .card(index)
-                .map_err(|e| edit_error_to_js(&e))?
+                .map_err(|e| edit_error_to_js(&e, &base))?
                 .revise_field(&field, markdown),
         }
-        .map_err(|e| edit_error_to_js(&e))?;
+        .map_err(|e| edit_error_to_js(&e, &base))?;
         serialize_or_throw(&delta, "reviseField")
     }
 
@@ -1391,6 +1417,7 @@ impl Document {
     ) -> Result<(), JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
         let (delta, line_ops, mark_ops) = parse_change_bundle(&bundle)?;
+        let base = self.addr_base(&addr);
         let card = self.addr_card_mut(&addr)?;
         match &addr.field {
             None => card.apply_body_change(&delta, &line_ops, &mark_ops),
@@ -1398,7 +1425,7 @@ impl Document {
                 card.apply_field_richtext_change(field, &delta, &line_ops, &mark_ops)
             }
         }
-        .map_err(|e| edit_error_to_js(&e))
+        .map_err(|e| edit_error_to_js(&e, &base))
     }
 
     /// Typed field write at `addr`, resolving the field's schema `type` from
@@ -1436,14 +1463,15 @@ impl Document {
         let field = addr.require_field("commitField")?.to_string();
         let json = js_value_to_json(value, "commitField")?;
         let qv = quillmark_core::QuillValue::from_json(json);
+        let base = self.addr_base(&addr);
         let mut writer = quill.inner.writer(&mut self.inner);
         match addr.card {
-            None => writer.set(&field, qv).map_err(|e| edit_error_to_js(&e)),
+            None => writer.set(&field, qv).map_err(|e| edit_error_to_js(&e, &base)),
             Some(index) => writer
                 .card(index)
-                .map_err(|e| edit_error_to_js(&e))?
+                .map_err(|e| edit_error_to_js(&e, &base))?
                 .set(&field, qv)
-                .map_err(|e| edit_error_to_js(&e)),
+                .map_err(|e| edit_error_to_js(&e, &base)),
         }
     }
 
@@ -1467,14 +1495,17 @@ impl Document {
         let addr = Addr::from_js(&addr)?;
         addr.require_card_only("commitFields")?;
         let batch = js_value_to_field_batch(&fields, "commitFields")?;
+        let base = self.addr_base(&addr);
         let mut writer = quill.inner.writer(&mut self.inner);
         match addr.card {
-            None => writer.set_all(batch).map_err(edit_errors_to_js),
+            None => writer
+                .set_all(batch)
+                .map_err(|errs| edit_errors_to_js(errs, &base)),
             Some(index) => writer
                 .card(index)
-                .map_err(|e| edit_error_to_js(&e))?
+                .map_err(|e| edit_error_to_js(&e, &base))?
                 .set_all(batch)
-                .map_err(edit_errors_to_js),
+                .map_err(|errs| edit_errors_to_js(errs, &base)),
         }
     }
 
@@ -1505,11 +1536,14 @@ impl Document {
             Some(f) => js_value_to_field_batch(&f, "addCard")?,
             None => Vec::new(),
         };
+        // The card is built before it joins the document, so its field errors
+        // anchor at bare names (empty base); `$kind` / `$body` structural keys
+        // ride the same serializer.
         quill
             .inner
             .writer(&mut self.inner)
             .add_card(kind, batch, body.as_deref(), at)
-            .map_err(edit_errors_to_js)
+            .map_err(|errs| edit_errors_to_js(errs, &quillmark_core::DocPath::new()))
     }
 
     /// Build a fresh `Card` from a kind and a flat field map — the ergonomic
@@ -1579,11 +1613,17 @@ impl Document {
         #[wasm_bindgen(unchecked_optional_param_type = "number")] at: Option<usize>,
     ) -> Result<(), JsValue> {
         let core_card = js_to_card(&card)?;
+        // A kind error anchors at the target slot; an out-of-range `at` at
+        // `cards[at]` via the error itself. `push` (append) has no slot yet, so
+        // its kind error carries no anchor (empty base).
+        let base = at.map_or_else(quillmark_core::DocPath::new, |i| {
+            quillmark_core::DocPath::card(None, i)
+        });
         match at {
             Some(index) => self.inner.insert_card(index, core_card),
             None => self.inner.push_card(core_card),
         }
-        .map_err(|e| edit_error_to_js(&e))
+        .map_err(|e| edit_error_to_js(&e, &base))
     }
 
     #[wasm_bindgen(js_name = removeCard, unchecked_return_type = "Card | undefined")]
@@ -1597,9 +1637,10 @@ impl Document {
     /// Move the card at `from` to position `to`. `from == to` is a no-op.
     #[wasm_bindgen(js_name = moveCard)]
     pub fn move_card(&mut self, from: usize, to: usize) -> Result<(), JsValue> {
+        // An out-of-range `from`/`to` anchors at `cards[index]` via the error.
         self.inner
             .move_card(from, to)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &quillmark_core::DocPath::new()))
     }
 
     /// Replace the kind of the card at `index`. Payload and body are untouched;
@@ -1607,9 +1648,11 @@ impl Document {
     /// Throws if `index` is out of range or `newKind` is invalid.
     #[wasm_bindgen(js_name = setCardKind)]
     pub fn set_card_kind(&mut self, index: usize, new_kind: &str) -> Result<(), JsValue> {
+        // Both an out-of-range index and an invalid `newKind` anchor at the
+        // target slot `cards[index]`.
         self.inner
             .set_card_kind(index, new_kind)
-            .map_err(|e| edit_error_to_js(&e))
+            .map_err(|e| edit_error_to_js(&e, &quillmark_core::DocPath::card(None, index)))
     }
 
 }
@@ -1621,7 +1664,10 @@ impl Document {
     fn card_mut_or_throw(&mut self, index: usize) -> Result<&mut quillmark_core::Card, JsValue> {
         let len = self.inner.cards().len();
         self.inner.card_mut(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+            edit_error_to_js(
+                &quillmark_core::EditError::IndexOutOfRange { index, len },
+                &quillmark_core::DocPath::new(),
+            )
         })
     }
 
@@ -1632,7 +1678,10 @@ impl Document {
     fn card_or_throw(&self, index: usize) -> Result<&quillmark_core::Card, JsValue> {
         let len = self.inner.cards().len();
         self.inner.cards().get(index).ok_or_else(|| {
-            edit_error_to_js(&quillmark_core::EditError::IndexOutOfRange { index, len })
+            edit_error_to_js(
+                &quillmark_core::EditError::IndexOutOfRange { index, len },
+                &quillmark_core::DocPath::new(),
+            )
         })
     }
 
@@ -1653,6 +1702,21 @@ impl Document {
         match addr.card {
             None => Ok(self.inner.main()),
             Some(index) => self.card_or_throw(index),
+        }
+    }
+
+    /// The `DocPath` card root an [`Addr`] targets — empty for the main card,
+    /// `cards.<kind>[i]` for a composable one (kind read off the live card,
+    /// `None` when the index is out of range, where the error self-anchors at
+    /// `cards[i]` anyway). The base every addressed mutator passes to
+    /// [`edit_error_to_js`], computed before the mutable borrow.
+    fn addr_base(&self, addr: &Addr) -> quillmark_core::DocPath {
+        match addr.card {
+            None => quillmark_core::DocPath::new(),
+            Some(index) => quillmark_core::DocPath::card(
+                self.inner.cards().get(index).and_then(|c| c.kind()),
+                index,
+            ),
         }
     }
 }
@@ -1840,61 +1904,52 @@ export type DocPathSeg =
     | { seg: "body" };
 "#;
 
-/// TypeScript declarations for the resolved-field view (`Quill.fieldStates`).
-/// Emitted here as the single source of truth; `Diagnostic` is already declared
-/// by the core build's generated `.d.ts`.
+/// TypeScript declarations for the resolved-value view (`Quill.fieldStates`).
+/// Emitted here as the single source of truth.
 #[wasm_bindgen(typescript_custom_section)]
 const FIELDSTATES_TS: &'static str = r#"
 /** The commitment-ladder rung that produced a `FieldState.value`. */
 export type FieldSource = "authored" | "default" | "zero";
 
 /**
- * One resolved field: the value the render projection would use, the
- * `FieldSource` rung it came from, the diagnostics anchored to it, and the
- * schema `example:` as authoring guidance (`example?` — absent from the wire,
- * never null, when the field declares none). The card body rides its card's
- * `fields` map under the `$body` key as an ordinary `FieldState`.
+ * One resolved field: the value the render projection would use and the
+ * `FieldSource` rung it came from. The card body rides its card's `fields` map
+ * under the `$body` key as an ordinary `FieldState`. Diagnostics stay
+ * `Quill.validate`'s; schema guidance (`example:`, labels) reads from
+ * `Quill.schema`.
  */
 export interface FieldState {
     value: unknown;
     source: FieldSource;
-    diagnostics: Diagnostic[];
-    example?: unknown;
 }
 
 /**
- * The main card's resolved fields (keyed by field name in declaration order,
- * with `$body` under its key when the main enables a body) plus a card-level
- * `diagnostics` slot for diagnostics anchored to the card but no field.
+ * The main card's resolved fields, keyed by field name in declaration order,
+ * with `$body` under its key when the main enables a body.
  */
 export interface MainFieldStates {
     fields: Record<string, FieldState>;
-    diagnostics: Diagnostic[];
 }
 
 /**
  * One composable card's resolved fields (`$body` under its key when the kind
- * enables a body), with its authored `kind` (`null` for an unknown-kind card),
- * its document-array `index`, and a card-level `diagnostics` slot
- * (`validation::unknown_card`, `validation::body_disabled`).
+ * enables a body), with its authored `kind` (`null` for an unknown-kind card)
+ * and its document-array `index`.
  */
 export interface CardFieldStates {
     kind: string | null;
     index: number;
     fields: Record<string, FieldState>;
-    diagnostics: Diagnostic[];
 }
 
 /**
- * The resolved-field view (`Quill.fieldStates`): the main card, every
- * composable card, and a document-level `diagnostics` slot (`$seed` overlays,
- * unanchored diagnostics). Every `Quill.validate` diagnostic lands in exactly
- * one slot.
+ * The resolved-value view (`Quill.fieldStates`): the main card and every
+ * composable card. Value and provenance only — completeness and errors stay
+ * `Quill.validate`.
  */
 export interface FieldStates {
     main: MainFieldStates;
     cards: CardFieldStates[];
-    diagnostics: Diagnostic[];
 }
 "#;
 
@@ -1966,13 +2021,17 @@ pub fn map_pos(
 // ── Edit helpers ──────────────────────────────────────────────────────────────
 
 /// Maps `EditError` to a JS `Error` carrying one diagnostic with the mutator's
-/// namespaced `edit::` code and its `Display` text as the message.
-fn edit_error_to_js(err: &quillmark_core::EditError) -> JsValue {
-    let diagnostic = quillmark_core::Diagnostic::new(
-        quillmark_core::Severity::Error,
-        err.to_string(),
-    )
-    .with_code(err.code().to_string());
+/// namespaced `edit::` code, its `Display` text as the message, and the
+/// `DocPath` it anchors to relative to `base` — the card root the mutator ran
+/// against (empty for main, `cards.<kind>[i]` for a card). One envelope shape
+/// for every producer: `{ severity, code, message, path? }`.
+fn edit_error_to_js(err: &quillmark_core::EditError, base: &quillmark_core::DocPath) -> JsValue {
+    let mut diagnostic =
+        quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, err.to_string())
+            .with_code(err.code().to_string());
+    if let Some(path) = err.doc_path(base) {
+        diagnostic = diagnostic.with_path(path.to_string());
+    }
     WasmError {
         diagnostics: vec![diagnostic],
     }
@@ -1980,14 +2039,19 @@ fn edit_error_to_js(err: &quillmark_core::EditError) -> JsValue {
 }
 
 /// Batched-mutator twin of [`edit_error_to_js`]: one diagnostic per offending
-/// field, each carrying the `edit::` code and `path` set to the field name.
-fn edit_errors_to_js(errors: Vec<(String, quillmark_core::EditError)>) -> JsValue {
+/// field, each carrying the `edit::` code and its `DocPath` — the field keyed
+/// under `base` (a `$kind` / `$body` structural batch key rides the same
+/// serializer as an opaque head).
+fn edit_errors_to_js(
+    errors: Vec<(String, quillmark_core::EditError)>,
+    base: &quillmark_core::DocPath,
+) -> JsValue {
     let diagnostics: Vec<quillmark_core::Diagnostic> = errors
         .into_iter()
         .map(|(name, err)| {
             quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, err.to_string())
                 .with_code(err.code().to_string())
-                .with_path(name)
+                .with_path(base.field(&name).to_string())
         })
         .collect();
     WasmError { diagnostics }.to_js_value()
@@ -2274,6 +2338,40 @@ export interface PaintResult {
 "#;
 
 #[cfg(any(feature = "typst", feature = "pdfform"))]
+impl LiveSession {
+    /// The card-kind lookup as `&[Option<&str>]` for the core translators.
+    fn kinds(&self) -> Vec<Option<&str>> {
+        self.card_kinds.iter().map(|k| k.as_deref()).collect()
+    }
+
+    /// A backend plate-space geometry address → its `DocPath` string, keeping
+    /// the original when it does not fit the geometry grammar.
+    fn plate_to_docpath(&self, addr: &str) -> String {
+        quillmark_core::plate_addr_to_doc_path(addr, &self.kinds())
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| addr.to_string())
+    }
+
+    /// A `DocPath` address (from a consumer) → its plate-space form for the
+    /// backend, keeping the original when it does not parse or place.
+    fn docpath_to_plate(&self, addr: &str) -> String {
+        addr.parse::<quillmark_core::DocPath>()
+            .ok()
+            .and_then(|p| quillmark_core::doc_path_to_plate_addr(&p, &self.kinds()))
+            .unwrap_or_else(|| addr.to_string())
+    }
+
+    /// A region with its plate-space `field` rewritten to its `DocPath` string.
+    fn region_to_docpath(
+        &self,
+        mut r: quillmark_core::RenderedRegion,
+    ) -> quillmark_core::RenderedRegion {
+        r.field = self.plate_to_docpath(&r.field);
+        r
+    }
+}
+
+#[cfg(any(feature = "typst", feature = "pdfform"))]
 #[wasm_bindgen]
 impl LiveSession {
     #[wasm_bindgen(getter, js_name = pageCount)]
@@ -2324,6 +2422,9 @@ impl LiveSession {
             .inner
             .apply(&json_data)
             .map_err(|e| WasmError::from(e).to_js_value())?;
+        // The apply committed, so geometry now reflects `doc` — refresh the
+        // card-kind lookup the address translation reads.
+        self.card_kinds = card_kinds_of(&doc.inner);
         Ok(ChangeSet {
             page_count: cs.page_count,
             dirty_pages: cs.dirty_pages,
@@ -2351,15 +2452,21 @@ impl LiveSession {
 
     /// Schema-field geometry for this compiled session — each content field's
     /// **first placement** (one region per page it touches) plus widget and
-    /// scalar-reference-site regions, keyed on the quill schema field path; a
-    /// field may still appear more than once (group by `field`, see
-    /// `FieldRegion`). A session-level query: no render, no byte artifact. An
-    /// interactive preview reads it to scroll to / highlight the focused
-    /// field over a `paint`-ed canvas; the click direction is `fieldAt`.
+    /// scalar-reference-site regions, keyed on the canonical `DocPath` address
+    /// (`parseDocPath`-routable; the session resolves the backend's plate-space
+    /// per-kind ordinal to it); a field may still appear more than once (group
+    /// by `field`, see `FieldRegion`). A session-level query: no render, no byte
+    /// artifact. An interactive preview reads it to scroll to / highlight the
+    /// focused field over a `paint`-ed canvas; the click direction is `fieldAt`.
     /// Empty for backends that place no schema fields.
     #[wasm_bindgen(js_name = regions, unchecked_return_type = "FieldRegion[]")]
     pub fn regions(&self) -> Result<JsValue, JsValue> {
-        let regions: Vec<FieldRegion> = self.inner.regions().into_iter().map(Into::into).collect();
+        let regions: Vec<FieldRegion> = self
+            .inner
+            .regions()
+            .into_iter()
+            .map(|r| self.region_to_docpath(r).into())
+            .collect();
         serialize_or_throw(&regions, "regions")
     }
 
@@ -2374,19 +2481,21 @@ impl LiveSession {
     /// `regions()`.
     #[wasm_bindgen(js_name = fieldBoxes, unchecked_return_type = "FieldRegion[]")]
     pub fn field_boxes(&self, field: &str) -> Result<JsValue, JsValue> {
+        // `field` is a DocPath address; the backend filters in plate space.
+        let plate = self.docpath_to_plate(field);
         let boxes: Vec<FieldRegion> = self
             .inner
-            .field_boxes(field)
+            .field_boxes(&plate)
             .into_iter()
-            .map(Into::into)
+            .map(|r| self.region_to_docpath(r).into())
             .collect();
         serialize_or_throw(&boxes, "fieldBoxes")
     }
 
     /// The schema field whose content is under a point on `page` — the
     /// forward (click → field) direction: hit-test a click against the
-    /// compiled document and get back the field address to focus in the
-    /// editor, or `undefined` off any field's ink. `x`/`y` are PDF points
+    /// compiled document and get back the `DocPath` field address to focus in
+    /// the editor, or `undefined` off any field's ink. `x`/`y` are PDF points
     /// with a **bottom-left** origin, the same space as `FieldRegion.rect` —
     /// from a canvas click, invert the overlay transform documented on
     /// `FieldRegion`: `x = clickPx.x / renderScale`,
@@ -2394,7 +2503,9 @@ impl LiveSession {
     /// *every* placement answers, not just the first.
     #[wasm_bindgen(js_name = fieldAt)]
     pub fn field_at(&self, page: usize, x: f32, y: f32) -> Option<String> {
-        self.inner.field_at(page, x, y)
+        self.inner
+            .field_at(page, x, y)
+            .map(|f| self.plate_to_docpath(&f))
     }
 
     /// A point → **content position** — the fine-grained click direction:
@@ -2407,7 +2518,10 @@ impl LiveSession {
     /// `ContentHit`.
     #[wasm_bindgen(js_name = positionAt)]
     pub fn position_at(&self, page: usize, x: f32, y: f32) -> Option<ContentHit> {
-        self.inner.position_at(page, x, y).map(Into::into)
+        self.inner.position_at(page, x, y).map(|mut hit| {
+            hit.field = self.plate_to_docpath(&hit.field);
+            hit.into()
+        })
     }
 
     /// A content position → **caret rect** — the reverse of `positionAt`: given
@@ -2417,7 +2531,12 @@ impl LiveSession {
     /// places no tracked content or the offset maps to no drawn glyph.
     #[wasm_bindgen(js_name = locate)]
     pub fn locate(&self, field: &str, pos: usize) -> Option<FieldRegion> {
-        self.inner.locate(field, pos).map(Into::into)
+        // `field` is a DocPath address; the backend resolves in plate space and
+        // the returned region's field translates back.
+        let plate = self.docpath_to_plate(field);
+        self.inner
+            .locate(&plate, pos)
+            .map(|r| self.region_to_docpath(r).into())
     }
 
     /// Page dimensions in points (1 pt = 1/72 inch).

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -242,9 +242,12 @@ pub struct ChangeSet {
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldRegion {
-    /// Quill schema field path (e.g. `"signature_block"`,
-    /// `"$cards.indorsement.1.from"`), not any backend widget name. The address
-    /// the editor uses for this field.
+    /// Canonical `DocPath` field address (e.g. `"signature_block"`,
+    /// `"cards.indorsement[1].from"`, `"main.body"`) — the same grammar
+    /// `parseDocPath` reads and `Diagnostic.path` carries. The session resolves
+    /// the backend's plate-space per-kind ordinal to this absolute-index form,
+    /// so one parser routes every address. Feed it back to `fieldBoxes` /
+    /// `locate`; hit-test the click direction with `fieldAt` / `positionAt`.
     pub field: String,
     /// 0-based page index.
     pub page: usize,
@@ -309,7 +312,7 @@ impl From<quillmark_core::HitGranularity> for HitGranularity {
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentHit {
-    /// Quill schema field path (same address space as `FieldRegion.field`).
+    /// Canonical `DocPath` field address (same grammar as `FieldRegion.field`).
     pub field: String,
     /// USV offset into the field's `Content`.
     pub pos: usize,

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -161,7 +161,8 @@ impl EditError {
         }
     }
 
-    /// The [`DocPath`] this error anchors to, relative to `base` — the card root
+    /// The [`DocPath`](crate::path::DocPath) this error anchors to, relative to
+    /// `base` — the card root
     /// the mutator ran against (empty for a main-card mutator, `cards.<kind>[i]`
     /// for a composable card, `cards[i]` for a structural op on the array).
     ///

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -179,9 +179,9 @@ impl EditError {
         match self {
             EditError::InvalidFieldName(f)
             | EditError::UnknownField(f)
-            | EditError::FieldRichtextNotInline(f) => Some(base.field(f)),
-            EditError::FieldConform { field, .. }
-            | EditError::FieldRichtextDecode { field, .. } => Some(base.field(field)),
+            | EditError::FieldRichtextNotInline(f)
+            | EditError::FieldConform { field: f, .. }
+            | EditError::FieldRichtextDecode { field: f, .. } => Some(base.field(f)),
             EditError::IndexOutOfRange { index, .. } => Some(DocPath::card(None, *index)),
             _ => (!base.segs().is_empty()).then(|| base.clone()),
         }

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -160,6 +160,32 @@ impl EditError {
             EditError::ContentApply(_) => "edit::content_apply",
         }
     }
+
+    /// The [`DocPath`] this error anchors to, relative to `base` — the card root
+    /// the mutator ran against (empty for a main-card mutator, `cards.<kind>[i]`
+    /// for a composable card, `cards[i]` for a structural op on the array).
+    ///
+    /// A field-named variant anchors at its field under `base`
+    /// (`cards.<kind>[i].<field>`, or a bare `<field>` when `base` is empty);
+    /// [`IndexOutOfRange`](Self::IndexOutOfRange) at the document-array slot
+    /// `cards[index]`, base-independent — a structural op names a slot, not a
+    /// field; and the remaining variants (kind errors, depth, content
+    /// apply/import) anchor at `base` itself when it names a card, else carry no
+    /// anchor (a main-card `$ext`/`$seed` depth error is config-space). Both
+    /// bindings route through this so a mutator diagnostic is addressable the
+    /// same way a validation diagnostic is.
+    pub fn doc_path(&self, base: &crate::path::DocPath) -> Option<crate::path::DocPath> {
+        use crate::path::DocPath;
+        match self {
+            EditError::InvalidFieldName(f)
+            | EditError::UnknownField(f)
+            | EditError::FieldRichtextNotInline(f) => Some(base.field(f)),
+            EditError::FieldConform { field, .. }
+            | EditError::FieldRichtextDecode { field, .. } => Some(base.field(field)),
+            EditError::IndexOutOfRange { index, .. } => Some(DocPath::card(None, *index)),
+            _ => (!base.segs().is_empty()).then(|| base.clone()),
+        }
+    }
 }
 
 /// A field-level invariant violation, shared by every payload ingestion path.
@@ -833,5 +859,67 @@ impl Card {
             .map_err(EditError::ContentApply)?;
         self.store_field_content(name, &content);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::path::DocPath;
+
+    #[test]
+    fn field_error_anchors_under_the_card_base() {
+        // A main field write: empty base → a bare field path.
+        let main = DocPath::new();
+        assert_eq!(
+            EditError::FieldConform {
+                field: "font_size".into(),
+                message: "x".into(),
+            }
+            .doc_path(&main)
+            .unwrap()
+            .to_string(),
+            "font_size"
+        );
+        // A card field write: the card root qualifies the field.
+        let card = DocPath::card(Some("indorsement"), 1);
+        assert_eq!(
+            EditError::UnknownField("signature_block".into())
+                .doc_path(&card)
+                .unwrap()
+                .to_string(),
+            "cards.indorsement[1].signature_block"
+        );
+    }
+
+    #[test]
+    fn index_out_of_range_anchors_at_the_array_slot() {
+        // Structural op: names a slot, base-independent.
+        for base in [DocPath::new(), DocPath::card(Some("note"), 0)] {
+            assert_eq!(
+                EditError::IndexOutOfRange { index: 4, len: 2 }
+                    .doc_path(&base)
+                    .unwrap()
+                    .to_string(),
+                "cards[4]"
+            );
+        }
+    }
+
+    #[test]
+    fn kind_and_depth_errors_anchor_at_base_or_nowhere() {
+        // A kind error on a structural op carries the slot base it was given.
+        assert_eq!(
+            EditError::ReservedKind
+                .doc_path(&DocPath::card(None, 2))
+                .unwrap()
+                .to_string(),
+            "cards[2]"
+        );
+        // A main-card depth error ($ext/$seed) is config-space — no anchor.
+        assert_eq!(
+            EditError::ValueTooDeep { max: 8 }.doc_path(&DocPath::new()),
+            None
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,7 +46,10 @@ pub mod types;
 pub use types::{Artifact, OutputFormat, RenderOptions};
 
 pub mod region;
-pub use region::{field_boxes, ContentHit, HitGranularity, RenderedRegion};
+pub use region::{
+    doc_path_to_plate_addr, field_boxes, plate_addr_to_doc_path, ContentHit, HitGranularity,
+    RenderedRegion,
+};
 
 pub mod session;
 pub use session::{ApplyError, Assoc, ChangeSet, Delta, LineOp, LiveSession, MarkOp, Op};

--- a/crates/core/src/quill/field_states.rs
+++ b/crates/core/src/quill/field_states.rs
@@ -1,37 +1,29 @@
-//! The resolved-field view — [`Quill::field_states`].
+//! The resolved-value view — [`Quill::field_states`].
 //!
 //! A projection that makes field resolution observable *data* rather than an
 //! inferred behavior chain: for every declared field, the value the render
-//! projection would use, the [`FieldSource`] rung it came from, any diagnostics
-//! anchored to it, and the schema `example:` as authoring guidance. It cuts the
+//! projection would use and the [`FieldSource`] rung it came from. It cuts the
 //! one commitment ladder (`prose/canon/SCHEMAS.md` § "Value sources and
 //! projections") through the shared producer [`resolve_value_sourced`], never a
 //! parallel precedence policy.
 //!
-//! It does not fully collapse [`Quill::validate`]: `unknown_card` and
-//! `body_disabled` are card/document-level, not per-field, so the view carries a
-//! diagnostics slot at each level and every `validate()` diagnostic is bucketed
-//! into exactly one of them.
-
-use std::collections::HashMap;
-use std::str::FromStr;
+//! Values only: diagnostics stay [`Quill::validate`]'s job (the editor merges
+//! `validate()` with its own producers regardless, so bucketing here would
+//! delete no consumer code), and schema guidance (`example:`, labels, groups)
+//! reads from [`Quill::schema`]. The view answers one question — what value
+//! renders, and from which rung.
 
 use indexmap::IndexMap;
 use serde::Serialize;
 
 use super::compose::resolve_value_sourced;
-use super::{CardSchema, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
-use crate::path::{DocPath, DocSeg};
-use crate::{Card, Diagnostic, Document, QuillValue, Severity};
+use super::{CardSchema, Leniency, Quill, QuillConfig};
+use crate::{Card, Document, QuillValue};
 
 /// Engine-owned universal key for a card's body row, collision-proof against a
 /// payload field literally named `body` — a user field can never be
 /// `$`-prefixed, and `Payload::to_index_map` drops `$` entries.
 const BODY_KEY: &str = "$body";
-
-/// Config-space head that anchors a `$seed` overlay diagnostic; routed to the
-/// document slot rather than any document field.
-const SEED_KEY: &str = "$seed";
 
 /// The rung of the commitment ladder that produced a [`FieldState::value`].
 /// Serializes lowercase (`"authored" | "default" | "zero"`).
@@ -46,69 +38,52 @@ pub enum FieldSource {
     Zero,
 }
 
-/// One resolved field: the value the render projection would use, its
-/// [`FieldSource`], the diagnostics anchored to it, and the schema `example:`
-/// (omitted from the wire when absent).
+/// One resolved field: the value the render projection would use and its
+/// [`FieldSource`].
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct FieldState {
     pub value: QuillValue,
     pub source: FieldSource,
-    pub diagnostics: Vec<Diagnostic>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub example: Option<QuillValue>,
 }
 
-/// The main card's resolved fields plus a card-level diagnostics slot for
-/// diagnostics that anchor to the card but no field (main body on a
-/// body-disabled main).
+/// The main card's resolved fields, keyed by name in declaration order (with
+/// `$body` under its key when the main enables a body).
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MainStates {
     pub fields: IndexMap<String, FieldState>,
-    pub diagnostics: Vec<Diagnostic>,
 }
 
 /// One composable card's resolved fields, with its authored `kind` (present even
-/// for an unknown kind, whose paths are the bare-index `cards[<i>]` form), its
-/// document-array `index`, and a card-level diagnostics slot (`unknown_card`,
-/// `body_disabled`).
+/// for an unknown kind, which carries its fields verbatim) and its
+/// document-array `index`.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct CardStates {
     pub kind: Option<String>,
     pub index: usize,
     pub fields: IndexMap<String, FieldState>,
-    pub diagnostics: Vec<Diagnostic>,
 }
 
-/// The whole resolved-field view: the main card, every composable card, and a
-/// document-level diagnostics slot (`$seed` overlays, unanchored diagnostics).
+/// The whole resolved-value view: the main card and every composable card.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct FieldStates {
     pub main: MainStates,
     pub cards: Vec<CardStates>,
-    pub diagnostics: Vec<Diagnostic>,
 }
 
 impl Quill {
-    /// The resolved-field view of `doc` against this quill's schema.
+    /// The resolved-value view of `doc` against this quill's schema.
     ///
-    /// Values are the render projection's per-field cut of the commitment
-    /// ladder — for every declared field, the value [`compile_data`] would emit
-    /// into the plate, tagged with the [`FieldSource`] rung it came from
-    /// (byte-for-byte with the plate on every fixture). Diagnostics are exactly
-    /// the standalone [`Quill::validate`] contract, bucketed by their
-    /// [`DocPath`] into the per-row, per-card, and document slots — so a
-    /// consumer reads value, provenance, and completeness from one call instead
-    /// of re-implementing the ladder and re-joining `validate()` by path.
+    /// For every declared field, the value [`compile_data`] would emit into the
+    /// plate (byte-for-byte with the plate on every fixture), tagged with the
+    /// [`FieldSource`] rung it came from — one call for value and provenance
+    /// instead of re-implementing the ladder. Completeness and errors stay
+    /// [`Quill::validate`]'s; this view carries no diagnostics.
     ///
     /// [`compile_data`]: Quill::compile_data
     pub fn field_states(&self, doc: &Document) -> FieldStates {
         let config = self.config();
-
-        // Values first: the main and each card resolved through the shared
-        // ladder producer. Diagnostics are attached in the bucketing pass below.
         let main = MainStates {
-            fields: resolve_card_fields(&config.main, doc.main(), &DocPath::new()),
-            diagnostics: Vec::new(),
+            fields: resolve_card_fields(&config.main, doc.main()),
         };
         let cards = doc
             .cards()
@@ -116,64 +91,30 @@ impl Quill {
             .enumerate()
             .map(|(index, card)| card_states(config, card, index))
             .collect();
-        let mut states = FieldStates {
-            main,
-            cards,
-            diagnostics: Vec::new(),
-        };
-
-        // Diagnostics = `validate()` verbatim (the raw doc, so the view's
-        // diagnostics are exactly the standalone contract), routed into slots.
-        for diag in self.validate(doc) {
-            bucket(&mut states, diag);
-        }
-        states
+        FieldStates { main, cards }
     }
 }
 
 /// Resolve one card (main or a schema-declared kind) into its ordered
-/// [`FieldState`] rows. `base` roots the field paths — empty for main, the
-/// `cards.<kind>[<i>]` card root otherwise.
-fn resolve_card_fields(
-    schema: &CardSchema,
-    card: &Card,
-    base: &DocPath,
-) -> IndexMap<String, FieldState> {
-    // Mirror `compile_data`'s pipeline per-field: coerce (the schema looked up
-    // by the authored name, as `coerce_payload` does), then NFC-normalize the
-    // key (`normalize_document` runs between coercion and the ladder), then
-    // resolve. Every validated ingress (parse, the mutators) restricts field
-    // names to ASCII — NFC-invariant — so the normalization only respells keys
-    // on a directly-constructed payload (`Payload::from_index_map`), under the
-    // same NFC key the plate carries.
-    //
-    // The coercion is the same `conform_value(Render)` `compile_data` runs over
-    // the whole payload, done here per-field so a failure anchors to its row:
-    // on `Ok` the coerced value feeds the ladder; on `Err` the raw authored
-    // value is kept (the ladder still reads it as Authored) and a
-    // `validation::coercion_failed` diagnostic is parked for the row. Same
-    // code/hint as compose.rs's `coercion_error`, but WITH a path — the
-    // compile-data coercion is pathless.
+/// [`FieldState`] rows.
+fn resolve_card_fields(schema: &CardSchema, card: &Card) -> IndexMap<String, FieldState> {
+    // Mirror `compile_data`'s pipeline per-field so the value is byte-for-byte
+    // with the plate: coerce under Render leniency (the schema looked up by the
+    // authored name, as `coerce_payload` does), then NFC-normalize the key
+    // (`normalize_document` runs between coercion and the ladder), then resolve.
+    // Every validated ingress (parse, the mutators) restricts field names to
+    // ASCII — NFC-invariant — so the normalization only respells keys on a
+    // directly-constructed payload (`Payload::from_index_map`), under the same
+    // NFC key the plate carries. A value the render coercion cannot conform is
+    // kept raw (the ladder reads it Authored), exactly as `compile_data` leaves
+    // it — the failure surfaces through `validate()`, not here.
     let mut resolved_input: IndexMap<String, QuillValue> = IndexMap::new();
-    let mut coercion_diags: HashMap<String, Diagnostic> = HashMap::new();
     for (raw_name, value) in card.payload().to_index_map() {
         let name = crate::normalize::normalize_field_name(&raw_name);
         let entry = match schema.fields.get(&raw_name) {
             Some(field_schema) => {
-                let field_path = base.field(&name);
-                match QuillConfig::conform_value(
-                    &value,
-                    field_schema,
-                    &field_path.to_string(),
-                    Leniency::Render,
-                ) {
-                    Ok(coerced_value) => coerced_value,
-                    Err(e) => {
-                        coercion_diags
-                            .insert(name.clone(), coercion_failed_diagnostic(&e, &field_path));
-                        value
-                    }
-                }
+                QuillConfig::conform_value(&value, field_schema, &name, Leniency::Render)
+                    .unwrap_or(value)
             }
             None => value,
         };
@@ -187,29 +128,17 @@ fn resolve_card_fields(
     // sorts alphabetically.)
     for (name, field_schema) in &schema.fields {
         let (value, source) = resolve_value_sourced(resolved_input.get(name), field_schema);
-        let mut diagnostics = Vec::new();
-        if let Some(d) = coercion_diags.remove(name) {
-            diagnostics.push(d);
-        }
-        fields.insert(
-            name.clone(),
-            FieldState {
-                value,
-                source,
-                diagnostics,
-                example: field_example(field_schema),
-            },
-        );
+        fields.insert(name.clone(), FieldState { value, source });
     }
 
     // The body row, present iff the kind enables a body.
     if schema.body_enabled() {
-        fields.insert(BODY_KEY.to_string(), body_state(schema, card));
+        fields.insert(BODY_KEY.to_string(), body_state(card));
     }
 
     // Undeclared authored fields, appended in authored order under their NFC
     // keys (matching the plate's): the schema is a floor, not an allowlist, so
-    // these reach the plate too — value verbatim, source Authored, no example.
+    // these reach the plate too — value verbatim, source Authored.
     for (name, value) in &resolved_input {
         if !schema.fields.contains_key(name) {
             fields.insert(
@@ -217,8 +146,6 @@ fn resolve_card_fields(
                 FieldState {
                     value: value.clone(),
                     source: FieldSource::Authored,
-                    diagnostics: Vec::new(),
-                    example: None,
                 },
             );
         }
@@ -230,18 +157,16 @@ fn resolve_card_fields(
 /// Resolve one composable card. A card whose `$kind` names a schema resolves
 /// through the ladder; an unknown-kind card (declared `$kind` with no schema, or
 /// a kindless card) carries its authored fields verbatim — no coercion, no
-/// ladder, no `$body` row — and its `unknown_card` diagnostic arrives via
-/// bucketing.
+/// ladder, no `$body` row.
 fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
     // The raw authored kind rides the entry even when it names no schema — the
-    // card reports what it *claimed* to be, though its paths are `cards[<i>]`.
+    // card reports what it *claimed* to be.
     let kind = card.kind().map(String::from);
     match card.kind().and_then(|k| config.card_kind(k)) {
         Some(schema) => CardStates {
             kind,
             index,
-            fields: resolve_card_fields(schema, card, &DocPath::card(card.kind(), index)),
-            diagnostics: Vec::new(),
+            fields: resolve_card_fields(schema, card),
         },
         None => {
             let fields = card
@@ -254,18 +179,11 @@ fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
                         FieldState {
                             value,
                             source: FieldSource::Authored,
-                            diagnostics: Vec::new(),
-                            example: None,
                         },
                     )
                 })
                 .collect();
-            CardStates {
-                kind,
-                index,
-                fields,
-                diagnostics: Vec::new(),
-            }
+            CardStates { kind, index, fields }
         }
     }
 }
@@ -273,127 +191,19 @@ fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
 /// The `$body` row. The value is byte-identical to the plate's `$body`
 /// (canonical Content-JSON of the card body). A body has no `default:` rung, so
 /// its source is only ever [`Authored`](FieldSource::Authored) (non-blank) or
-/// [`Zero`](FieldSource::Zero) (blank) — [`Default`](FieldSource::Default) is
-/// unreachable for it. The example is the body schema's `example_content`.
-fn body_state(schema: &CardSchema, card: &Card) -> FieldState {
+/// [`Zero`](FieldSource::Zero) (blank).
+fn body_state(card: &Card) -> FieldState {
     let value = QuillValue::from_json(quillmark_content::serial::to_canonical_value(card.body()));
     let source = if card.body().is_blank() {
         FieldSource::Zero
     } else {
         FieldSource::Authored
     };
-    FieldState {
-        value,
-        source,
-        diagnostics: Vec::new(),
-        example: schema.body.as_ref().and_then(|b| b.example_content.clone()),
-    }
-}
-
-/// A declared field's `example:` for the row — the same content-vs-scalar branch
-/// as the `default:` rung: a content field's example is its content form
-/// (`example_content`), every other field's is the raw `example`. `None` omits
-/// the row's `example`.
-fn field_example(field: &FieldSchema) -> Option<QuillValue> {
-    if matches!(
-        field.r#type,
-        FieldType::RichText { .. } | FieldType::PlainText { .. }
-    ) {
-        field.example_content.clone()
-    } else {
-        field.example.clone()
-    }
-}
-
-/// A `validation::coercion_failed` diagnostic for a field whose render coercion
-/// errored — same code and hint as compose.rs's pathless `coercion_error`, but
-/// anchored at the field's path.
-fn coercion_failed_diagnostic(e: &super::CoercionError, field_path: &DocPath) -> Diagnostic {
-    Diagnostic::new(Severity::Error, e.to_string())
-        .with_code("validation::coercion_failed".to_string())
-        .with_path(field_path.to_string())
-        .with_hint("Ensure all fields can be coerced to their declared types".to_string())
-}
-
-/// Route one `validate()` diagnostic into exactly one slot by parsing its
-/// `path` with [`DocPath::from_str`] — the phase-2 parser is total over every
-/// path `validate()` emits, so a parse failure only ever means "no structured
-/// anchor" and lands on the document slot.
-fn bucket(states: &mut FieldStates, diag: Diagnostic) {
-    let Some(path) = diag.path.as_deref().and_then(|p| DocPath::from_str(p).ok()) else {
-        // No path, or unparseable → document slot.
-        states.diagnostics.push(diag);
-        return;
-    };
-    match path.segs() {
-        // A `$seed` anchor is config-space (seed anchors never gate render), not
-        // a document field. Also the empty case, defensively.
-        [] => states.diagnostics.push(diag),
-        [DocSeg::Field { name }, ..] if name == SEED_KEY => states.diagnostics.push(diag),
-
-        // The main body is the sole `main`-headed form → main's `$body` row.
-        [DocSeg::Main, ..] => row_or_slot(
-            &mut states.main.fields,
-            &mut states.main.diagnostics,
-            BODY_KEY,
-            diag,
-        ),
-
-        // A bare field chain heads on its field: a nested path
-        // (`recipients[0].name`) buckets to the HEAD field's row.
-        [DocSeg::Field { name }, ..] => row_or_slot(
-            &mut states.main.fields,
-            &mut states.main.diagnostics,
-            name,
-            diag,
-        ),
-
-        // A card-rooted path: whole-card (`cards[<i>]`), body, or a field chain.
-        [DocSeg::Card { index, .. }, rest @ ..] => {
-            let Some(card) = states.cards.get_mut(*index) else {
-                // Out of range shouldn't happen — the walker indexes real cards.
-                states.diagnostics.push(diag);
-                return;
-            };
-            match rest {
-                [] => card.diagnostics.push(diag),
-                [DocSeg::Body, ..] => {
-                    row_or_slot(&mut card.fields, &mut card.diagnostics, BODY_KEY, diag)
-                }
-                [DocSeg::Field { name }, ..] => {
-                    row_or_slot(&mut card.fields, &mut card.diagnostics, name, diag)
-                }
-                // A card root followed by an index (unemittable) → card slot.
-                _ => card.diagnostics.push(diag),
-            }
-        }
-
-        // An index- or body-headed path is unemittable → document slot.
-        _ => states.diagnostics.push(diag),
-    }
-}
-
-/// Push `diag` onto the row named `key` if it exists, else onto the fallback
-/// `slot`.
-fn row_or_slot(
-    fields: &mut IndexMap<String, FieldState>,
-    slot: &mut Vec<Diagnostic>,
-    key: &str,
-    diag: Diagnostic,
-) {
-    match fields.get_mut(key) {
-        Some(row) => row.diagnostics.push(diag),
-        None => slot.push(diag),
-    }
+    FieldState { value, source }
 }
 
 #[cfg(test)]
 mod tests {
-    //! Coercion-failure coverage uses a `richtext` field authored as a
-    //! non-content JSON object: `conform_value(Render)` genuinely errors on it
-    //! (`from_canonical_value` rejects the shape), which is the reachable
-    //! render-leniency coercion failure.
-
     use super::*;
     use crate::quill::FileTreeNode;
     use crate::{Card, Document, Payload, Quill};
@@ -600,34 +410,24 @@ card_kinds:
 "#;
 
     #[test]
-    fn body_disabled_kind_omits_body_row_and_buckets_to_card_slot() {
+    fn body_disabled_kind_omits_body_row() {
         let quill = quill_from_yaml(BODY_DISABLED_QUILL);
-        // Stray prose authored on a body-disabled card.
         let doc = parse(
             "~~~card-yaml\n$quill: bd_test@1.0\n$kind: main\ntitle: T\n~~~\n\n\
              ~~~card-yaml\n$kind: stamp\nlabel: L\n~~~\nStray prose.\n",
         );
-        let states = quill.field_states(&doc);
-        let card = &states.cards[0];
-
+        let card = &quill.field_states(&doc).cards[0];
         assert!(
             !card.fields.contains_key(BODY_KEY),
             "a body-disabled kind has no `$body` row"
         );
         assert!(card.fields.contains_key("label"), "declared rows still present");
-        assert!(
-            card.diagnostics
-                .iter()
-                .any(|d| d.code.as_deref() == Some("validation::body_disabled")),
-            "body_disabled lands in the card slot: {:?}",
-            card.diagnostics
-        );
     }
 
     // ── Unknown-kind card ────────────────────────────────────────────────────
 
     #[test]
-    fn unknown_kind_card_shape_and_slot() {
+    fn unknown_kind_card_shape() {
         let quill = quill_from_yaml(QUILL);
         let doc = parse(
             "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n\n\
@@ -641,76 +441,6 @@ card_kinds:
         assert_eq!(card.fields["foo"].source, FieldSource::Authored);
         assert_eq!(card.fields["foo"].value.as_json(), &serde_json::json!("bar"));
         assert!(!card.fields.contains_key(BODY_KEY));
-        assert!(
-            card.diagnostics
-                .iter()
-                .any(|d| d.code.as_deref() == Some("validation::unknown_card")),
-            "unknown_card lands in the card slot: {:?}",
-            card.diagnostics
-        );
-    }
-
-    // ── Bucketing ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn type_mismatch_buckets_to_its_row() {
-        // A bare-field type mismatch routes to the field's row.
-        let q = quill_from_yaml(
-            "quill:\n  name: tm\n  version: \"1.0\"\n  backend: typst\n  description: tm\n\
-             main:\n  fields:\n    count:\n      type: integer\n",
-        );
-        let d = parse("~~~card-yaml\n$quill: tm@1.0\n$kind: main\ncount: \"not-a-number\"\n~~~\n");
-        let states = q.field_states(&d);
-        assert!(
-            states.main.fields["count"]
-                .diagnostics
-                .iter()
-                .any(|x| x.code.as_deref() == Some("validation::type_mismatch")),
-            "type_mismatch must land on the `count` row: {:?}",
-            states.main.fields["count"].diagnostics
-        );
-    }
-
-    #[test]
-    fn seed_warning_buckets_to_document_slot() {
-        let quill = quill_from_yaml(QUILL);
-        // A `$seed` overlay for an unknown kind → an advisory warning anchored at
-        // `$seed.bogus`, which is config-space → the document slot.
-        let doc = parse(
-            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n$seed:\n  bogus:\n    x: 1\n~~~\n",
-        );
-        let states = quill.field_states(&doc);
-        assert!(
-            states
-                .diagnostics
-                .iter()
-                .any(|d| d.path.as_deref() == Some("$seed.bogus")),
-            "a $seed warning belongs on the document slot: {:?}",
-            states.diagnostics
-        );
-    }
-
-    #[test]
-    fn nested_must_fill_buckets_to_head_field_row() {
-        let quill = quill_from_yaml(QUILL);
-        // `!must_fill` on `recipients[0].name` — a nested marker on the
-        // `recipients` field.
-        let doc = parse(
-            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n\
-             recipients:\n  - name: !must_fill\n~~~\n",
-        );
-        let states = quill.field_states(&doc);
-        let row = &states.main.fields["recipients"];
-        assert!(
-            row.diagnostics
-                .iter()
-                .any(|d| d.code.as_deref() == Some("validation::must_fill")),
-            "a nested must_fill buckets to the head field's row: {:?}",
-            row.diagnostics
-        );
-        // And nowhere else.
-        assert!(states.main.diagnostics.is_empty());
-        assert!(states.diagnostics.is_empty());
     }
 
     // ── Undeclared authored field ────────────────────────────────────────────
@@ -724,76 +454,9 @@ card_kinds:
         let row = &quill.field_states(&doc).main.fields["extra"];
         assert_eq!(row.source, FieldSource::Authored);
         assert_eq!(row.value.as_json(), &serde_json::json!("whatever"));
-        assert!(row.example.is_none());
     }
 
-    // ── Completeness ─────────────────────────────────────────────────────────
-
-    #[test]
-    fn every_validate_diagnostic_appears_exactly_once() {
-        let quill = quill_from_yaml(QUILL);
-        // A document that raises several diagnostics without any coercion
-        // failure (so no extra `coercion_failed` rows are added by the view):
-        // a nested must_fill, a $seed warning, and an unknown-kind card.
-        let doc = parse(
-            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n\
-             recipients:\n  - name: !must_fill\n$seed:\n  bogus:\n    x: 1\n~~~\n\n\
-             ~~~card-yaml\n$kind: mystery\nfoo: bar\n~~~\n",
-        );
-        let expected = quill.validate(&doc);
-        assert!(!expected.is_empty(), "the fixture must raise diagnostics");
-
-        let states = quill.field_states(&doc);
-        let mut collected: Vec<Diagnostic> = Vec::new();
-        collected.extend(states.diagnostics.iter().cloned());
-        collected.extend(states.main.diagnostics.iter().cloned());
-        for row in states.main.fields.values() {
-            collected.extend(row.diagnostics.iter().cloned());
-        }
-        for card in &states.cards {
-            collected.extend(card.diagnostics.iter().cloned());
-            for row in card.fields.values() {
-                collected.extend(row.diagnostics.iter().cloned());
-            }
-        }
-
-        assert_eq!(
-            collected.len(),
-            expected.len(),
-            "every validate() diagnostic lands in exactly one slot (no more, no less)"
-        );
-        for d in &expected {
-            assert!(
-                collected.contains(d),
-                "validate() diagnostic missing from the view: {d:?}"
-            );
-        }
-    }
-
-    // ── Coercion-failure row ─────────────────────────────────────────────────
-
-    #[test]
-    fn render_coercion_failure_parks_diagnostic_on_its_row() {
-        let quill = quill_from_yaml(QUILL);
-        // `intro` is richtext; a non-content JSON object cannot be coerced under
-        // Render leniency (`from_canonical_value` rejects the shape).
-        let doc = parse(
-            "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\nintro:\n  not: content\n~~~\n",
-        );
-        let intro = &quill.field_states(&doc).main.fields["intro"];
-        assert!(
-            intro
-                .diagnostics
-                .iter()
-                .any(|d| d.code.as_deref() == Some("validation::coercion_failed")
-                    && d.path.as_deref() == Some("intro")),
-            "a Render coercion failure parks a path-anchored diagnostic on the row: {:?}",
-            intro.diagnostics
-        );
-        // The raw authored value is kept (Authored), not dropped.
-        assert_eq!(intro.source, FieldSource::Authored);
-        assert_eq!(intro.value.as_json(), &serde_json::json!({ "not": "content" }));
-    }
+    // ── Wire shape ───────────────────────────────────────────────────────────
 
     #[test]
     fn field_source_serializes_lowercase() {
@@ -809,14 +472,14 @@ card_kinds:
     }
 
     #[test]
-    fn field_state_omits_absent_example_on_the_wire() {
+    fn field_state_is_value_and_source_only() {
         let state = FieldState {
             value: QuillValue::from_json(serde_json::json!("x")),
             source: FieldSource::Authored,
-            diagnostics: Vec::new(),
-            example: None,
         };
-        let json = serde_json::to_string(&state).unwrap();
-        assert!(!json.contains("example"), "absent example is skipped: {json}");
+        let json = serde_json::to_value(&state).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.len(), 2, "only value + source on the wire: {json}");
+        assert!(obj.contains_key("value") && obj.contains_key("source"));
     }
 }

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -94,11 +94,13 @@
 #[serde(rename_all = "camelCase")]
 pub struct RenderedRegion {
     /// The field's plate-space schema address as the backend keys it —
-    /// `"signature_block"` or `"$cards.<kind>.<ordinal>.<field>"`. Internal to
-    /// the region system: the session translates it to a canonical
-    /// [`DocPath`](crate::DocPath) before it crosses to a consumer (`regions` /
-    /// `fieldAt` / `positionAt` / `locate`), so no consumer sees the per-kind
-    /// ordinal grammar.
+    /// `"signature_block"` or `"$cards.<kind>.<ordinal>.<field>"` (a per-kind
+    /// ordinal). This is the backend-native form; a binding that owns the
+    /// document's card kinds translates it to a canonical
+    /// [`DocPath`](crate::DocPath) at its boundary
+    /// ([`plate_addr_to_doc_path`]), so its consumers see one absolute-index
+    /// grammar. A core consumer reading `RenderedRegion` directly sees the
+    /// plate-space form.
     pub field: String,
     /// 0-based page index.
     pub page: usize,

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -97,7 +97,7 @@ pub struct RenderedRegion {
     /// `"signature_block"` or `"$cards.<kind>.<ordinal>.<field>"` (a per-kind
     /// ordinal). This is the backend-native form; a binding that owns the
     /// document's card kinds translates it to a canonical
-    /// [`DocPath`](crate::DocPath) at its boundary
+    /// [`DocPath`] at its boundary
     /// ([`plate_addr_to_doc_path`]), so its consumers see one absolute-index
     /// grammar. A core consumer reading `RenderedRegion` directly sees the
     /// plate-space form.

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -93,10 +93,12 @@
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderedRegion {
-    /// Quill schema field path, e.g. `"signature_block"` or
-    /// `"$cards.indorsement.1.from"` — the author-facing field address (the
-    /// card form is kind + 0-based ordinal, `$cards.<kind>.<n>.<field>`), not
-    /// any backend widget name.
+    /// The field's plate-space schema address as the backend keys it —
+    /// `"signature_block"` or `"$cards.<kind>.<ordinal>.<field>"`. Internal to
+    /// the region system: the session translates it to a canonical
+    /// [`DocPath`](crate::DocPath) before it crosses to a consumer (`regions` /
+    /// `fieldAt` / `positionAt` / `locate`), so no consumer sees the per-kind
+    /// ordinal grammar.
     pub field: String,
     /// 0-based page index.
     pub page: usize,
@@ -173,6 +175,109 @@ pub fn field_boxes(regions: &[RenderedRegion], field: &str) -> Vec<RenderedRegio
     }
     by_page.sort_by_key(|r| r.page);
     by_page
+}
+
+// ── Address translation: plate-space geometry ⇄ DocPath ─────────────────────
+//
+// A backend keys a region on the **plate-space** address its compiled plate
+// composes (`$path` = `$cards.<kind>.<ordinal>.`, `crates/backends/typst`), a
+// grammar with a `$cards` sigil, dot separators, and **per-kind ordinals**.
+// That grammar is the template-author contract inside the plate and stays
+// there; it must not cross to a consumer, which speaks one canonical
+// [`DocPath`]. The session owns the translation, resolving the per-kind ordinal
+// to the document-array absolute index (and back) against the ordered card
+// kinds of the current compile — so `regions` / `fieldAt` / `positionAt` /
+// `locate` speak `DocPath`, never `$cards.` ordinals.
+
+use crate::path::{DocPath, DocSeg};
+
+/// The absolute document-array index of the `ord`-th (0-based) card of `kind`,
+/// scanning `card_kinds` (the current compile's ordered card kinds; `None` is a
+/// kindless card) in order. `None` when fewer than `ord + 1` cards of that kind
+/// exist.
+fn abs_card_index(card_kinds: &[Option<&str>], kind: &str, ord: usize) -> Option<usize> {
+    card_kinds
+        .iter()
+        .enumerate()
+        .filter(|(_, k)| **k == Some(kind))
+        .nth(ord)
+        .map(|(i, _)| i)
+}
+
+/// The per-kind ordinal of the card at absolute index `abs` — how many cards of
+/// the same kind precede it, matching the plate's `emit_cards` counter. `None`
+/// when `abs` is out of range or the card is kindless.
+fn per_kind_ordinal(card_kinds: &[Option<&str>], abs: usize) -> Option<usize> {
+    let kind = (*card_kinds.get(abs)?)?;
+    Some(
+        card_kinds[..abs]
+            .iter()
+            .filter(|k| **k == Some(kind))
+            .count(),
+    )
+}
+
+/// Translate a backend plate-space geometry address into a canonical
+/// [`DocPath`], resolving the per-kind ordinal to the absolute card index via
+/// `card_kinds`. The grammar handled is exactly what geometry emits: `$body`
+/// (main body), a bare `<field>` (main field), `$cards.<kind>.<ord>.<field>`
+/// (card field), and `$cards.<kind>.<ord>.$body` (card body). `None` for an
+/// address outside that grammar or one naming a card the kind list cannot
+/// place — the caller keeps the original string.
+pub fn plate_addr_to_doc_path(addr: &str, card_kinds: &[Option<&str>]) -> Option<DocPath> {
+    if addr == "$body" {
+        return Some(DocPath::main_body());
+    }
+    if let Some(rest) = addr.strip_prefix("$cards.") {
+        let mut it = rest.splitn(3, '.');
+        let kind = it.next()?;
+        let ord: usize = it.next()?.parse().ok()?;
+        let tail = it.next()?;
+        let abs = abs_card_index(card_kinds, kind, ord)?;
+        let card = DocPath::card(Some(kind), abs);
+        return Some(if tail == "$body" {
+            card.body()
+        } else {
+            card.field(tail)
+        });
+    }
+    // A bare main field is spelled identically in both grammars; route it
+    // through `DocPath` so a consumer always receives a parsed path. An
+    // unrecognized `$`-token (never a main field) does not translate.
+    if addr.starts_with('$') {
+        return None;
+    }
+    Some(DocPath::new().field(addr))
+}
+
+/// Translate a canonical [`DocPath`] geometry address back to the backend
+/// plate-space form (`main.body` → `$body`, `cards.<kind>[<abs>].<field>` →
+/// `$cards.<kind>.<ord>.<field>`), resolving the absolute card index to its
+/// per-kind ordinal via `card_kinds`. `None` when the path is not a geometry
+/// address (a document-model shape geometry never keys) or names a card the
+/// kind list cannot place. The inverse of [`plate_addr_to_doc_path`], for the
+/// `field`-taking queries (`locate`, `fieldBoxes`).
+pub fn doc_path_to_plate_addr(path: &DocPath, card_kinds: &[Option<&str>]) -> Option<String> {
+    match path.segs() {
+        [DocSeg::Main, DocSeg::Body] => Some("$body".to_string()),
+        [DocSeg::Field { name }] => Some(name.clone()),
+        [DocSeg::Card {
+            kind: Some(kind),
+            index,
+        }, rest @ ..] => {
+            // The path must actually name the card that sits at `index`.
+            if card_kinds.get(*index).copied().flatten() != Some(kind.as_str()) {
+                return None;
+            }
+            let ord = per_kind_ordinal(card_kinds, *index)?;
+            match rest {
+                [DocSeg::Field { name }] => Some(format!("$cards.{kind}.{ord}.{name}")),
+                [DocSeg::Body] => Some(format!("$cards.{kind}.{ord}.$body")),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 /// How precisely a [`ContentHit::pos`] resolved — the marker a caret UI reads to
@@ -347,5 +452,70 @@ mod tests {
             span: None,
         }];
         assert!(field_boxes(&regions, "subject").is_empty());
+    }
+
+    // ── Plate-space ⇄ DocPath translation ────────────────────────────────────
+
+    /// Two `note` cards interleaved with one `annotation`: the per-kind ordinal
+    /// is not the absolute index once kinds interleave, so the two grammars
+    /// genuinely differ and the kind list is load-bearing.
+    const KINDS: &[Option<&str>] = &[Some("note"), Some("annotation"), Some("note")];
+
+    fn to_doc(addr: &str) -> Option<String> {
+        plate_addr_to_doc_path(addr, KINDS).map(|p| p.to_string())
+    }
+    fn to_plate(path: &str) -> Option<String> {
+        doc_path_to_plate_addr(&path.parse().unwrap(), KINDS)
+    }
+
+    #[test]
+    fn plate_to_docpath_resolves_the_absolute_index() {
+        // The 2nd `note` (ordinal 1) sits at absolute index 2.
+        assert_eq!(to_doc("$cards.note.1.on").as_deref(), Some("cards.note[2].on"));
+        // The 1st `note` (ordinal 0) is absolute 0; the `annotation` is absolute 1.
+        assert_eq!(to_doc("$cards.note.0.on").as_deref(), Some("cards.note[0].on"));
+        assert_eq!(
+            to_doc("$cards.annotation.0.text").as_deref(),
+            Some("cards.annotation[1].text")
+        );
+        // Bodies and main.
+        assert_eq!(to_doc("$body").as_deref(), Some("main.body"));
+        assert_eq!(
+            to_doc("$cards.note.1.$body").as_deref(),
+            Some("cards.note[2].body")
+        );
+        // A bare main field is spelled the same in both grammars.
+        assert_eq!(to_doc("signature_block").as_deref(), Some("signature_block"));
+    }
+
+    #[test]
+    fn docpath_to_plate_is_the_inverse() {
+        for plate in [
+            "$body",
+            "signature_block",
+            "$cards.note.0.on",
+            "$cards.note.1.on",
+            "$cards.annotation.0.text",
+            "$cards.note.1.$body",
+        ] {
+            let doc = to_doc(plate).unwrap();
+            assert_eq!(to_plate(&doc).as_deref(), Some(plate), "round-trip {plate}");
+        }
+    }
+
+    #[test]
+    fn translation_rejects_unplaceable_and_foreign_shapes() {
+        // A 3rd `note` (ordinal 2) does not exist — only two notes.
+        assert_eq!(to_doc("$cards.note.2.on"), None);
+        // A DocPath whose kind disagrees with the slot does not translate back.
+        assert_eq!(
+            doc_path_to_plate_addr(&"cards.annotation[0].x".parse().unwrap(), KINDS),
+            None
+        );
+        // A document-model shape geometry never keys (nested main field).
+        assert_eq!(
+            doc_path_to_plate_addr(&"recipients[0].name".parse().unwrap(), KINDS),
+            None
+        );
     }
 }

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -1,4 +1,11 @@
-# 0.95 → 0.96 — mutator errors carry `edit::*` codes; the `[EditError::…]` prefix is gone; a `DocPath` parser lands
+# 0.95 → 0.96 — one address grammar (`DocPath`) on every boundary, mutator `edit::*` codes + paths, a leaner `fieldStates()`
+
+The headline break is **addressing**: every field address the engine hands a
+consumer — diagnostics *and* geometry — now speaks one canonical `DocPath`
+grammar, parsed by one exported parser. The plate-space `$cards.<kind>.<ordinal>`
+form the geometry queries used to emit no longer crosses the boundary. See
+[Geometry addresses are now `DocPath`](#break-geometry-addresses-are-now-docpath)
+— it changes the field strings your preview/overlay code reads.
 
 Mutator failures — the errors raised by `Document` and card mutators
 (`storeField`, the writer's `set` / `setAll` / `addCard`, `removeField`,
@@ -81,8 +88,8 @@ except QuillmarkError as exc:
 ```
 
 The batched mutators (`setAll` / `set_all`, `storeFields`) still emit one
-diagnostic per offending field with `path` set to the field name; each now also
-carries its `edit::*` code.
+diagnostic per offending field; each now carries its `edit::*` code, and its
+`path` is the field's full `DocPath` (see the next section).
 
 ## No action: null ≡ absent, ratified
 
@@ -129,19 +136,64 @@ No action if you already read `diagnostic.path` as an opaque string — it still
 is one. `ERROR.md`'s stale `cards[2].author` example (missing the kind segment)
 is corrected to `cards.indorsement[2].author`.
 
-Mutator (`edit::*`) diagnostics still carry only the bare field-name `path` the
-batched twins already set; per-variant paths on the single mutators ride a
-later slice of the contract rework.
+**Mutator (`edit::*`) diagnostics now carry a `DocPath` too.** Every mutator
+error is `{ severity, code, message, path }` (WASM): a field error anchors at its
+field (`font_size`, or `cards.<kind>[<index>].<field>` on a card), and a
+structural out-of-range op (`insertCard` / `moveCard` / `setCardKind`) at its
+array slot `cards[<index>]`. So a coercion failure on a card field routes to the
+exact card without the consumer reconstructing the address from call-site
+knowledge. (Python keeps its `edit::*` codes; the mutator-`path` retrofit is WASM
+only, pending a Python consumer that routes on it.)
 
-## New: `fieldStates()` — the resolved-field view
+## Break: geometry addresses are now `DocPath` {#break-geometry-addresses-are-now-docpath}
 
-`quill.fieldStates(doc)` (Python `quill.field_states(doc)`) is additive: the
-resolved-field view of a document against its quill schema. For every declared
-field it returns the value the render projection would use, the source rung it
-came from, the schema `example:` as guidance, and the diagnostics anchored to
-it — in one call, so you stop reading the value off the `Document` payload,
-re-deriving the `default:`/zero fallback yourself, and joining `validate()` by
-`path` to find each field's diagnostics.
+The `LiveSession` geometry queries — `regions()`, `fieldBoxes(field)`,
+`fieldAt()`, `positionAt()`, `locate(field, pos)` — used to key on the backend's
+**plate-space** address (`$body`, `$cards.<kind>.<ordinal>.<field>` with a
+per-kind ordinal). They now key on the canonical `DocPath` — the same grammar
+`Diagnostic.path` carries and `parseDocPath` reads. The session resolves the
+per-kind ordinal to the absolute card index, so one parser routes every address.
+
+| plate-space (0.95) | `DocPath` (0.96) |
+|---|---|
+| `$body` | `main.body` |
+| `subject` | `subject` (unchanged — a main field) |
+| `$cards.indorsement.1.from` | `cards.indorsement[<abs>].from` |
+| `$cards.note.0.$body` | `cards.note[<abs>].body` |
+
+`<abs>` is the card's **absolute** index in the document array, not its per-kind
+ordinal; when kinds interleave the two differ (the 2nd `note` may be `cards[3]`).
+
+Migrate the preview/overlay code that reads `region.field` / `hit.field` or
+passes a field to `fieldBoxes` / `locate`:
+
+```js
+// 0.95 — plate-space strings, parsed by hand
+const body = session.regions().find((r) => r.field === '$body')
+session.fieldBoxes('$cards.note.0.$body')
+
+// 0.96 — DocPath, routed through parseDocPath
+const body = session.regions().find((r) => r.field === 'main.body')
+session.fieldBoxes('cards.note[0].body')
+
+// A click resolves to a DocPath now; route it with the one parser:
+const field = session.fieldAt(page, x, y)          // e.g. "cards.note[2].body"
+const [head] = parseDocPath(field)                 // { seg: "card", kind: "note", index: 2 }
+```
+
+If you carried a hand-rolled `$cards.<kind>.<ordinal>` → card-index bridge (the
+per-kind ordinal is not the absolute index), delete it: the session does that
+translation now, and `parseDocPath` gives you `{ kind, index }` directly. The
+plate-side `$path` grammar is unchanged for **template authors** — a plate still
+composes `card.at("$path") + "from"`; only what crosses to a *consumer* moved.
+
+## New: `fieldStates()` — the resolved-value view
+
+`quill.fieldStates(doc)` is additive: the resolved-value view of a document
+against its quill schema. For every declared field it returns the value the
+render projection would use and the source rung it came from — in one call, so
+you stop reading the value off the `Document` payload and re-deriving the
+`default:`/zero fallback yourself.
 
 The shape is nested — a `main` card and a `cards` list, each field keyed by name
 in declaration order:
@@ -152,8 +204,6 @@ const states = quill.fieldStates(doc)
 const title = states.main.fields.title
 title.value        // the value the plate carries
 title.source       // "authored" | "default" | "zero"
-title.diagnostics  // the validate() diagnostics anchored to this field
-title.example      // the schema example:; the key is ABSENT when the field declares none
 
 for (const card of states.cards) {
   card.kind        // the card's $kind — null for an unknown-kind card
@@ -169,18 +219,14 @@ for (const card of states.cards) {
 - **The body rides the `fields` map** under the `$body` key as an ordinary field
   row — present iff the kind enables a body, its source only ever `"authored"`
   (non-blank) or `"zero"` (blank).
-- **`example` is absent, never null**, when the field declares no `example:` —
-  test `'example' in row`, not `row.example != null`.
-- **Diagnostics are one-call.** They are the standalone `validate()` contract,
-  bucketed by `DocPath` into the per-field, per-card (`validation::unknown_card`,
-  `validation::body_disabled`), and document (`$seed`) slots — every `validate()`
-  diagnostic lands in exactly one — plus a path-anchored
-  `validation::coercion_failed` per field whose render coercion fails. You no
-  longer re-join `validate()` by `path`.
-- **Python parity.** `quill.field_states(doc)` returns the same shape as a nested
-  dict; `main`, `cards`, and each field's `value` / `source` / `diagnostics` /
-  `example` match the WASM view key-for-key.
+- **Value and provenance only.** Each row is exactly `{ value, source }`.
+  Diagnostics stay `validate()`'s (which you merge with your own producers —
+  session warnings, render errors — regardless), and schema guidance
+  (`example:`, labels, groups) reads from `quill.schema`. A render-uncoercible
+  value is kept raw and `"authored"`, exactly as the plate carries it; the error
+  surfaces through `validate()`.
+- **WASM only.** There is no Python `field_states` — it awaits a Python consumer
+  that names a call site (the Tier-1 scope, `BINDINGS.md`).
 
 No action — purely additive. `validate()` is unchanged and remains the
-standalone completeness surface; `fieldStates()` folds its diagnostics in for a
-consumer that wants value, provenance, and completeness from one call.
+completeness surface.

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -163,6 +163,9 @@ per-kind ordinal to the absolute card index, so one parser routes every address.
 
 `<abs>` is the card's **absolute** index in the document array, not its per-kind
 ordinal; when kinds interleave the two differ (the 2nd `note` may be `cards[3]`).
+The one-shot render sidecar (`render({ regions: true }).regions`) keys on the
+same `DocPath` grammar, so a consumer sees one address grammar however it reads
+geometry.
 
 Migrate the preview/overlay code that reads `region.field` / `hit.field` or
 passes a field to `fieldBoxes` / `locate`:

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,18 +18,21 @@ guides in order.
 
 ## Available guides
 
-- [0.95 → 0.96](0.95-to-0.96.md) — mutator failures join the diagnostic
-  taxonomy: every `EditError` variant carries a namespaced `edit::*` `code`
-  (`edit::unknown_field`, `edit::field_conform`, …) in both bindings, and the
-  `[EditError::<Variant>]` message-prefix convention is deleted — route on
-  `diagnostics[0].code`, never on message text. `Diagnostic.path` gains an
-  exported `parseDocPath` / `formatDocPath` (route on `DocPathSeg[]`, not a
-  regex); the emitted path strings are unchanged. Canon ratifies null ≡ absent
-  as a 1.0 commitment (no behavior change). Adds `fieldStates()` (Python
-  `field_states`) — the resolved-field view: value, source rung
-  (`"authored" | "default" | "zero"`), the schema `example:`, and the
-  `validate()` diagnostics bucketed per field, in one call (additive, no
-  action).
+- [0.95 → 0.96](0.95-to-0.96.md) — one address grammar on every boundary.
+  **Break:** `LiveSession` geometry (`regions` / `fieldAt` / `positionAt` /
+  `locate`) now keys on the canonical `DocPath` (`main.body`,
+  `cards.<kind>[<abs>].<field>`) instead of the plate-space
+  `$cards.<kind>.<ordinal>` form — migrate the preview/overlay code that reads
+  `region.field`. Mutator failures join the diagnostic taxonomy: every
+  `EditError` variant carries a namespaced `edit::*` `code`
+  (`edit::unknown_field`, `edit::field_conform`, …) in both bindings, the
+  `[EditError::<Variant>]` message-prefix is deleted (route on
+  `diagnostics[0].code`), and each mutator diagnostic now carries a `DocPath`
+  `path` (WASM). `Diagnostic.path` gains an exported `parseDocPath` /
+  `formatDocPath` (route on `DocPathSeg[]`, not a regex). Canon ratifies
+  null ≡ absent as a 1.0 commitment (no behavior change). Adds `fieldStates()`
+  (WASM) — the resolved-value view: per field, value + source rung
+  (`"authored" | "default" | "zero"`), in one call (additive, no action).
 - [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
   `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to
   `(card, at?)`) and the deprecated `replaceBody` alias is deleted (use

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -165,15 +165,30 @@ the WASM build exports `parseDocPath` / `formatDocPath` (structured
 `DocPathSeg[]` ↔ string) so a consumer routes on segments instead of regexing
 the string.
 
-**Two path namespaces, not to be confused.** The unsigiled `cards` here is a
-document-model path. The sigiled `data.$cards` a template author sees
-([CARDS.md](CARDS.md)) is plate JSON — glue delivered to the backend, a
-different namespace. The plate key is *not* renamed (template-author blast
-radius); the two are documented apart. Config-space anchors
-(`$seed.<kind>.<field>`, Quill.yaml schema-literal owner labels) ride the
-same serializer with their prefix as a leading segment. The coercion layer
-(`CoercionError`) keeps its own schema-space anchors (`card_kinds.<kind>...`,
-bare field names) — a distinct namespace, not a document path.
+`DocPath` is the anchor on **every** address that crosses to a consumer, not
+only `Diagnostic.path`. Mutator (`edit::*`) diagnostics carry it (a field error
+at `cards.<kind>[<i>].<field>`, a structural out-of-range op at `cards[<i>]`);
+and `LiveSession` geometry (`regions` / `fieldAt` / `positionAt` / `locate`)
+keys on it — the session translates the backend's plate-space
+`$cards.<kind>.<ordinal>` form to the `DocPath` absolute index at the boundary,
+so one parser routes diagnostics and geometry alike.
+
+**Three grammars, one that crosses.** Only `DocPath` reaches a consumer. The
+other two stay backend/template-internal and are named here so they are not
+confused with it:
+
+- **Plate JSON** — the sigiled `data.$cards` a template author composes
+  ([CARDS.md](CARDS.md)), and the plate-space `$cards.<kind>.<ordinal>.<field>`
+  geometry address a plate's `$path` mints. Template-author contract; *not*
+  renamed (blast radius), and translated to `DocPath` before it crosses.
+- **Schema-space coercion anchors** — `CoercionError` keeps its own
+  `card_kinds.<kind>.<field>` / bare-field anchors, a schema-declaration
+  namespace, not a document path. Where a coercion becomes an
+  `edit::field_conform`, the binding re-anchors it in `DocPath` space at the
+  field being written; the raw schema-space anchor does not cross.
+
+Config-space anchors (`$seed.<kind>.<field>`, Quill.yaml schema-literal owner
+labels) ride the `DocPath` serializer with their prefix as a leading segment.
 
 ## Error Presentation
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -142,13 +142,14 @@ field maps rather than a sort key):
 | `blueprint` document | Endorsed: `default:`; Unendorsed: `example:` else zero, stamped `!must_fill` | zero (under the marker) | annotated string — [BLUEPRINT.md](BLUEPRINT.md) |
 | seeding | `example:` › absent | (deferred to render floor) | committed `Document` — [Document seeding](#document-seeding) |
 | add-card (into a document) | `$seed` overlay › `example:` › absent | (deferred to render floor) | a new composable `Card` — [Document seeding](#document-seeding) |
-| editor (consumer-side) | authored › `default:` › zero, resolved per field and **tagged with its source rung** (`example:` rides as guidance) | zero | the engine's [`fieldStates()`](#the-resolved-field-view-fieldstates) resolved-field view — value, source rung, and `validate()` diagnostics bucketed per field |
+| editor (consumer-side) | authored › `default:` › zero, resolved per field and **tagged with its source rung** | zero | the engine's [`fieldStates()`](#the-resolved-field-view-fieldstates) resolved-value view — value and source rung per field |
 
 The consumer-side `Document`-payload × schema join is a **non-goal**:
 [`fieldStates()`](#the-resolved-field-view-fieldstates) supersedes it. The
-editor reads value, source rung, and bucketed diagnostics from one engine call
-rather than re-cutting the ladder in consumer code and re-joining
-`Quill::validate` by path.
+editor reads value and source rung from one engine call rather than re-cutting
+the ladder in consumer code. Completeness and errors stay `Quill::validate`'s
+(a consumer merges it with its own diagnostic producers regardless), and schema
+guidance — `example:`, labels, groups — reads from `Quill::schema`.
 
 Two seams are deliberate, not uniform: on `blueprint` the floor still
 zero-fills like every other projection (an Unendorsed cell with no `example`
@@ -158,24 +159,25 @@ rides *alongside* the value rather than replacing it; and `zero` is honestly
 blank for every type except `enum`, whose zero is the first declared variant
 (there is no empty enum member). Both are detailed below.
 
-### The resolved-field view (`fieldStates()`)
+### The resolved-value view (`fieldStates()`)
 
-`Quill::field_states(doc)` (WASM `fieldStates`, Python `field_states`) cuts the
-render ladder into observable data: for every declared field, the value
-`compile_data` would emit into the plate, tagged with its source rung
-(`authored` / `default` / `zero`), the schema `example:` as guidance, and the
-diagnostics anchored to it — byte-for-byte with the plate on every fixture. The
-shape is nested: a `main` card and a `cards` list, each field keyed by name in
-declaration order. The card body rides the `fields` map under the universal
-`$body` key as an ordinary field row — present iff the kind enables a body
-(`enabled: false` undeclares it, so there is no row), its source only ever
-`authored` (non-blank) or `zero` (blank). Source is one **top-level** rung per
-field; a nested zero-fill inside an authored dict or array is a projection
-detail of the value, not a per-subpath source. Diagnostics are `Quill::validate`
-verbatim, bucketed by their [`DocPath`](ERROR.md#document-model-paths) into
-per-field, per-card, and document slots — every diagnostic in exactly one —
-plus a path-anchored `validation::coercion_failed` on any field whose render
-coercion fails.
+`Quill::field_states(doc)` (WASM `fieldStates`) cuts the render ladder into
+observable data: for every declared field, the value `compile_data` would emit
+into the plate, tagged with its source rung (`authored` / `default` / `zero`) —
+byte-for-byte with the plate on every fixture. The shape is nested: a `main`
+card and a `cards` list, each field keyed by name in declaration order. The card
+body rides the `fields` map under the universal `$body` key as an ordinary field
+row — present iff the kind enables a body (`enabled: false` undeclares it, so
+there is no row), its source only ever `authored` (non-blank) or `zero` (blank).
+Source is one **top-level** rung per field; a nested zero-fill inside an authored
+dict or array is a projection detail of the value, not a per-subpath source.
+
+Value and provenance only. The view carries no diagnostics — completeness and
+errors stay `Quill::validate`'s, which a consumer merges with its own producers
+(session warnings, render errors) regardless, so bucketing here would delete no
+consumer code. Schema guidance (`example:`, labels, groups) reads from
+`Quill::schema`. Python is out of scope until a Python consumer names a call
+site (the Tier-1 cut, [BINDINGS.md](BINDINGS.md)).
 
 ## Zero-filled render
 

--- a/prose/doc-contract-phases/README.md
+++ b/prose/doc-contract-phases/README.md
@@ -6,34 +6,48 @@
 
 ## Problem
 
-The editor (`borb-sh/quillmark-editor`) is a version-pinned downstream
-consumer of `@quillmark/wasm`. Three engine surfaces grew as implementation
-details, so the editor reverse-engineered them from tests — and any engine
-change to them breaks the pinned consumer while upstream CI stays green:
+One disease with several sites: the engine↔editor boundary carries surfaces
+that are not contracts. The editor (`borb-sh/quillmark-editor`) is a
+version-pinned downstream consumer of `@quillmark/wasm`; every non-contract
+surface is one it reverse-engineers from tests and probes, and an engine change
+to any of them breaks the pinned consumer while upstream CI stays green.
 
-- **Error identity** — mutator failures carry identity as an `[EditError::…]`
-  message prefix with `code: None`
-  (`crates/bindings/wasm/src/engine.rs:1829`,
-  `crates/bindings/python/src/errors.rs:14`). `edit::` is absent from
-  ERROR.md's namespace list, so "consumers route on codes, not on a type"
-  is false for the whole edit surface.
-- **Addressing** — `Diagnostic.path` strings are `format!()`-assembled per
-  site (`crates/core/src/quill/validation.rs:297,311`); the engine emits two
-  card-path shapes, the editor guesses a third, and ERROR.md's lone example
-  matches none of them.
-- **Resolution** — the commitment ladder (`authored › default: › zero`) is
-  engine semantics, but the editor re-implements it in TypeScript because
-  `SCHEMAS.md` blesses a consumer-side payload × schema join as the editor
-  projection.
+- **Error identity in prose** — mutator failures carry identity as an
+  `[EditError::…]` message prefix with `code: None`; `edit::` absent from
+  ERROR.md's namespace list, so "consumers route on codes" is false for the
+  edit surface. *Cured — phase 1.*
+- **Per-site path assembly** — `Diagnostic.path` strings `format!()`-assembled
+  per emit site; the engine emits two card shapes, the editor guesses a third.
+  *Cured for diagnostics — phase 2.*
+- **A second, untyped address grammar** — geometry (`FieldRegion.field`,
+  `ContentHit`) crosses the boundary as `$cards.<kind>.<ordinal>.<field>` with
+  **per-kind ordinals**: different syntax *and* different index semantics from
+  document-model paths. This is the boundary's highest-traffic parsed string —
+  the editor parses it on every diagnostic route and pointer interaction and
+  bridges ordinals→absolute indices itself. *Open — phase 2's remaining work.*
+- **Consumer-side resolution** — the commitment ladder is engine semantics, but
+  the editor shims the default rung (schema `default:` bound as a control
+  placeholder) because no engine projection exposes resolved values. *Phase 3.*
+- **Untyped reach-arounds** — the typed surface is narrower than what its
+  consumer reads: `QuillCardUi` omits `groups` (the editor casts around it),
+  `ContentIsland.props` is `unknown` (the codec keeps hand-written shapes the
+  surface does not pin). *Phase 4.*
+- **No executable cross-repo check** — nothing runs the same expectations in
+  both repos. *Phase 5.*
 
 ## Decision
 
-The editor stays downstream and pinned. The ladder *semantics* stay as canon
+The editor stays downstream and pinned. The ladder *semantics* stay canon
 (`SCHEMAS.md`: `authored › default: › zero`, null ≡ absent, the non-persist
-invariant). The *surfaces* pivot: instead of ratifying the observed shapes
-(#1004), the engine exports real contract surfaces — codes, a canonical path
-type, a resolved-field view — and freezes them behind an executable
-cross-repo conformance suite at 1.0. Pre-1.0 breaks cost a
+invariant). The *surfaces* pivot: the engine exports real contract surfaces —
+one address grammar, one diagnostic envelope, a resolved-value view, a typed
+surface with no reach-arounds — and freezes them behind an executable
+cross-repo conformance suite at 1.0.
+
+**0.96 is the one coordinated break.** Re-grammaring geometry addresses breaks
+the editor's live traffic, so everything the editor must absorb — codes, the
+prefix deletion, DocPath on both lanes — rides that single migration. Phases 3
+and 4 are additive and ship with it or after. Pre-1.0 breaks cost a
 `docs/migrations/` entry; the consumer never builds against HEAD, so the
 conformance suite is the only mechanism that keeps both repos honest.
 
@@ -41,31 +55,35 @@ conformance suite is the only mechanism that keeps both repos honest.
 
 | Phase | Gate | Delivers |
 |---|---|---|
-| [1 — `edit::` codes](phase-1-edit-codes.md) | none — ships now | Namespaced `code` on every mutator diagnostic, WASM + Python; prefix deleted; null ≡ absent ratified |
-| [2 — canonical `DocPath`](phase-2-docpath.md) | grammar design | One path type, one serializer, exported parser; path retrofit at every emit site; `$cards` namespaces documented |
-| [3 — `fieldStates()`](phase-3-field-states.md) | editor call sites | Resolved-field view with `source` provenance; consumer-side join becomes a non-goal |
-| [4 — conformance suite](phase-4-conformance.md) | phases 1–3 settled | Cross-repo fixture set + `contractVersion`; freezing it *is* the 1.0 release |
+| [1 — `edit::` codes](phase-1-edit-codes.md) | none — shipped | Namespaced `code` on every mutator diagnostic, WASM + Python; prefix deleted; null ≡ absent ratified |
+| [2 — one address grammar](phase-2-docpath.md) | geometry translation seam | `DocPath` on every boundary address, geometry included; mutator-path retrofit; coercion-namespace ruling |
+| [3 — `fieldStates()`](phase-3-field-states.md) | shape settled — lean | `{value, source}` per field; consumer-side join a non-goal |
+| [4 — typed-surface completion](phase-4-typed-surface.md) | editor's boundary ledger | `QuillCardUi.groups`; typed island props |
+| [5 — conformance suite](phase-5-conformance.md) | phases 1–4 settled | Cross-repo fixture set + `contractVersion`; freezing it *is* the 1.0 release |
 
 ## Dependency edges
 
 Edges, not a release train — each phase ships when ready:
 
-- **1 → 2**: phase 1 deliberately ships codes *without* paths; ad-hoc
-  `format!()` paths on edit diagnostics would recreate the disease at a new
-  site. All path work — including the edit-diagnostic retrofit — rides with
-  the `DocPath` type.
-- **2 → 3**: diagnostics inside the `fieldStates()` view carry
-  `DocPath`-grammar paths.
-- **1, 2, 3 → 4**: fixtures assert codes, paths, sources, and values, so
-  they are written against the settled surface — earlier means written
-  twice.
-
-Phase 1's null ≡ absent ratification is a standalone doc edit with no
-dependencies in either direction.
+- **1 → 2** *(discharged)*: phase 1 shipped codes without paths; all path
+  work — including the mutator retrofit — rides the `DocPath` type.
+- **2 ⇸ 3**: no edge. The lean view carries no diagnostics, so no paths; the
+  two phases couple only through the release that bundles them.
+- **4** is independent of 1–3 and additive (no break).
+- **1, 2, 3, 4 → 5**: fixtures assert codes, paths, sources, values, and typed
+  shapes, so they are written against the settled surface — earlier means
+  written twice.
 
 ## Non-goals (whole rework)
 
 - Changing ladder semantics or reopening null ≡ absent as tri-state.
 - Moving the editor in-tree.
-- Renaming the plate-JSON `$cards` key (template-author blast radius);
-  the two path namespaces are documented instead.
+- Renaming the plate-JSON `$cards` key or the plate-space per-kind address
+  grammar (template-author blast radius). Plate-space addressing stays
+  template-side and documented; phase 2 stops it from *crossing the consumer
+  boundary*, which is the actual defect.
+- Diagnostics bucketed inside `fieldStates()`, `example:` on the view, Python
+  `field_states` parity — cut from the rich shape implemented at `d079280`;
+  each returns only when a consumer names a call site
+  ([phase 3](phase-3-field-states.md) §Deferred).
+- Per-subpath provenance inside authored containers (consumer-evidence gate).

--- a/prose/doc-contract-phases/phase-1-edit-codes.md
+++ b/prose/doc-contract-phases/phase-1-edit-codes.md
@@ -66,3 +66,10 @@ YAML round-trip sanity and the simpler model, tri-state foreclosed.
 - ERROR.md lists `edit::`; the unreleased migration guide covers the break.
 - Consumer routing (coercion vs. undeclared — `edit::field_conform` vs.
   `edit::unknown_field`) needs only `code`, never message text.
+
+## Status
+
+**Shipped** at `4162ec2`: `EditError::code()` in core beside `variant_name()`,
+both binding converters set `code` and drop the prefix, `edit::*` in ERROR.md's
+namespace list with its own section, the migration entry, and the null ≡ absent
+ratification in `SCHEMAS.md`. All acceptance criteria hold; nothing remains.

--- a/prose/doc-contract-phases/phase-2-docpath.md
+++ b/prose/doc-contract-phases/phase-2-docpath.md
@@ -1,80 +1,87 @@
-# Phase 2 — canonical `DocPath`
+# Phase 2 — one address grammar (`DocPath`)
 
-> **Gate**: grammar design — the edge cases below are the actual work.
-> The wire format barely changes: the target grammar is what
-> `crates/core/src/quill/validation.rs:297,311` already emits. This phase
-> is a type, a parser export, a retrofit, and doc fixes.
+> **Gate**: the geometry translation seam — where plate-space per-kind keys
+> become `DocPath` (and back) inside the session. The diagnostic-lane grammar
+> is settled and shipped.
 
 ## Goal
 
 One typed document-model path with exactly one serializer and an exported
-parser, so no consumer ever regexes a `Diagnostic.path` string. Today paths
-are `format!()`-assembled per emit site: the engine ships two card shapes
-(`cards[<i>]` whole-card, `cards.<kind>[<i>].<field>` card field), the
-editor guesses a third (`$cards.<i>.<field>` — the plate-JSON array name in
-a document-model path), and ERROR.md's lone example drops the `<kind>`
-segment the engine emits.
+parser, on **every** address that crosses the WASM boundary — diagnostics and
+geometry both — so no consumer ever regexes a path string.
+
+The boundary today speaks two grammars with different index semantics:
+
+- **Diagnostics** — `Diagnostic.path` emits `DocPath`
+  (`cards.<kind>[<i>].<field>`, absolute indices). Shipped, zero live parsed
+  traffic: the reference fixture's `validate()` is empty.
+- **Geometry** — `FieldRegion.field` / `ContentHit` emit
+  `$cards.<kind>.<ordinal>.<field>` with **per-kind ordinals**, the plate-space
+  grammar minted for the `_qm-plaintext` table
+  (`crates/backends/typst/src/helper.rs:323`). This lane carries all the live
+  traffic: the editor parses it on every diagnostic route and pointer
+  interaction (`quillmark-editor src/lib/visual/diagnostics.ts`) and bridges
+  per-kind → absolute itself (`perKindCardIndex`), on the assumption — wrong
+  since the diagnostic retrofit — that the boundary has one grammar.
+
+Typing the diagnostic lane while geometry stays stringly is the disease
+surviving at the busier site.
 
 ## Grammar
 
-- Card fields are kind-qualified: `cards.<kind>[<i>].<field>`.
+- Card fields are kind-qualified: `cards.<kind>[<i>].<field>`; `<i>` is the
+  absolute card index.
 - A whole-card case whose `$kind` has no schema — absent, or present but not a
-  declared card kind — stays `cards[<i>]`; this is the only bare-index form.
-- Main-card fields are bare names (`recipient`); the main body is
-  `main.body`.
+  declared card kind — is `cards[<i>]`, the only bare-index form. Geometry
+  never emits it: an unschematized kind renders no fields.
+- Main-card fields are bare names (`recipient`); the main body is `main.body`;
+  card bodies are `cards.<kind>[<i>].body`.
+- Grammar edges — card bodies, `$ext` addressing (or an explicit "not
+  addressable" ruling), nested container indices — each becomes a phase-5
+  fixture.
 
-Edges to resolve before the type lands (each becomes a fixture in
-phase 4): card bodies (`cards.<kind>[<i>].body`), `$ext` addressing (or an
-explicit "not addressable" ruling), nested container indices inside a field
-value.
+## Shipped
 
-## Work
+- `DocPath` (`crates/core/src/path.rs`) — the type, the one serializer, the
+  `FromStr` parser.
+- The `validation.rs` + `compose.rs` retrofit: every document-model path built
+  through `DocPath`, no `format!`; fill paths resolve the card's `$kind`
+  against the schema, so an unschematized kind anchors bare-index.
+- WASM `parseDocPath` / `formatDocPath` (structured `DocPathSeg[]`).
+- Canon: ERROR.md's corrected example and `DocPath` grammar section; the
+  `$cards`/`cards` namespace split.
 
-- Core: `DocPath` — `Main | Card{kind, index} | Field(name) | Index(i) |
-  Body` — with the workspace's only serializer and parser. Every emit site
-  (`validation.rs`, edit mutators, coercion) constructs `DocPath`, never a
-  string.
-- Retrofit `path` onto edit diagnostics — the half deferred from phase 1.
-  This needs call-site plumbing, not just serialization: `IndexOutOfRange`
-  must learn which card array, `FieldConform` which card.
-- WASM: export the parser (string ↔ structured form). Whether `path`
-  crosses the boundary as string-plus-parser only or also as a structured
-  object is settled here.
-- Canon: fix ERROR.md's example (`cards[2].author` →
-  `cards.<kind>[2].author`); state the two path namespaces loudly —
-  plate JSON delivers sigiled `data.$cards` (template-author contract,
-  `CARDS.md`), document-model paths use unsigiled `cards`. No rename:
-  renaming the plate key breaks every existing Quill template, a blast
-  radius far beyond the editor.
+## Remaining
+
+1. **Geometry-lane unification** — the phase's completion criterion.
+   `regions()` / `fieldBoxes(field)` / `fieldAt` / `positionAt` / `locate`
+   speak `DocPath` strings in both directions (returns and arguments). The
+   plate-space per-kind grammar is untouched template-side — the
+   `_qm-plaintext` table contract stays — but it stops crossing the consumer
+   boundary: the session holds the composed document and owns the
+   plate-space ↔ `DocPath` translation, so per-kind ordinals never reach a
+   consumer. Editor payoff: `parsePath` and the ordinal bridge delete; every
+   address routes through `parseDocPath`. This is the 0.96 break's
+   centerpiece — the migration entry leads with it.
+2. **Mutator-path retrofit** — every edit diagnostic carries a `DocPath`:
+   `IndexOutOfRange` learns which card array, `FieldConform` which card,
+   threaded through the binding call sites. Completes the one-envelope
+   invariant: every diagnostic from every producer is
+   `{severity, code, message, path}`-addressable. (The batched twins carry a
+   bare field-name `path` from phase 1; the single mutators carry none.)
+3. **Coercion-namespace ruling** — `CoercionError` paths are schema-space
+   (`card_kinds.<kind>.<field>`, bare field names), not document-model
+   anchors. Fold them into `DocPath` space, or name them a distinct schema
+   namespace in ERROR.md; either way the ruling is written, not implied.
 
 ## Acceptance
 
-- Grepping the workspace for `format!` producing a document-model path
-  returns nothing; all sites go through the `DocPath` serializer.
-- The exported parser round-trips every emitted path; the editor's
-  `diagnostics.ts` routes card diagnostics through it with no best-effort
-  guessing left.
-- ERROR.md's example is correct and the `$cards`/`cards` namespace split is
-  canon.
-
-## Status
-
-**Shipped**: `DocPath` (`crates/core/src/path.rs`) — the type, the one
-serializer, the `FromStr` parser; the `validation.rs` + `compose.rs` retrofit
-(every document-model path now built through `DocPath`, no `format!`); the
-WASM `parseDocPath` / `formatDocPath` export (structured `DocPathSeg[]`);
-ERROR.md's corrected example, the `DocPath` grammar section, and the
-`$cards`/`cards` namespace split in canon.
-
-**Deferred** — a later slice, unblocked now that the type exists:
-
-- **Per-variant `path` on edit (mutator) diagnostics.** The batched twins keep
-  the bare field-name `path` phase 1 set; the single mutators still carry none.
-  Attaching kind-qualified paths needs the call-site plumbing this doc names —
-  `IndexOutOfRange` learning its card array, `FieldConform` its card — threaded
-  through ~50 binding call sites, so it lands on its own.
-- **The coercion namespace.** `CoercionError` paths are schema-space
-  (`card_kinds.<kind>.<field>`, bare field names), not document-model
-  (`cards[<i>]`) anchors, and are dropped where coercion becomes
-  `EditError::FieldConform`. They stay their own namespace; folding them (or
-  ruling them out) rides with the edit-diagnostic slice above.
+- No address string crosses the WASM boundary outside the `DocPath` grammar;
+  grepping the workspace for `format!` producing a boundary address returns
+  nothing.
+- The exported parser round-trips every emitted path — diagnostic and
+  geometry lanes; the editor routes both through it with no best-effort
+  parsing left.
+- ERROR.md states the grammar, the namespace split (plate-space `$cards`
+  template-side; `DocPath` consumer-side), and the coercion ruling.
+- The unreleased migration guide covers the geometry re-grammar.

--- a/prose/doc-contract-phases/phase-2-docpath.md
+++ b/prose/doc-contract-phases/phase-2-docpath.md
@@ -51,28 +51,31 @@ surviving at the busier site.
 - Canon: ERROR.md's corrected example and `DocPath` grammar section; the
   `$cards`/`cards` namespace split.
 
-## Remaining
+## Shipped — the 0.96 break
 
 1. **Geometry-lane unification** — the phase's completion criterion.
    `regions()` / `fieldBoxes(field)` / `fieldAt` / `positionAt` / `locate`
-   speak `DocPath` strings in both directions (returns and arguments). The
-   plate-space per-kind grammar is untouched template-side — the
-   `_qm-plaintext` table contract stays — but it stops crossing the consumer
-   boundary: the session holds the composed document and owns the
-   plate-space ↔ `DocPath` translation, so per-kind ordinals never reach a
-   consumer. Editor payoff: `parsePath` and the ordinal bridge delete; every
-   address routes through `parseDocPath`. This is the 0.96 break's
-   centerpiece — the migration entry leads with it.
-2. **Mutator-path retrofit** — every edit diagnostic carries a `DocPath`:
-   `IndexOutOfRange` learns which card array, `FieldConform` which card,
-   threaded through the binding call sites. Completes the one-envelope
-   invariant: every diagnostic from every producer is
-   `{severity, code, message, path}`-addressable. (The batched twins carry a
-   bare field-name `path` from phase 1; the single mutators carry none.)
-3. **Coercion-namespace ruling** — `CoercionError` paths are schema-space
-   (`card_kinds.<kind>.<field>`, bare field names), not document-model
-   anchors. Fold them into `DocPath` space, or name them a distinct schema
-   namespace in ERROR.md; either way the ruling is written, not implied.
+   speak `DocPath` in both directions. The plate-space per-kind grammar is
+   untouched template-side — the `$path` / `_qm-plaintext` contract stays — but
+   stops crossing the consumer boundary: the WASM `LiveSession` retains the
+   compile's ordered card kinds (refreshed on `apply`) and translates
+   plate-space ↔ `DocPath` (`plate_addr_to_doc_path` / `doc_path_to_plate_addr`
+   in `crates/core/src/region.rs`), so per-kind ordinals never reach a consumer.
+   Editor payoff: `parsePath` and the ordinal bridge delete; every address
+   routes through `parseDocPath`. The migration entry leads with it.
+2. **Mutator-path retrofit** (WASM) — every edit diagnostic carries a `DocPath`
+   via `EditError::doc_path(base)`: a field error at `cards.<kind>[i].<field>`,
+   a structural op at `cards[i]`, threaded through the binding call sites (the
+   binding computes the card-root `base` before the mutable borrow). Completes
+   the one-envelope invariant on the WASM surface: every diagnostic is
+   `{severity, code, message, path}`-addressable. Python keeps its phase-1
+   codes; the mutator-`path` retrofit waits for a Python consumer that routes on
+   it (the field_states cut, same reasoning).
+3. **Coercion-namespace ruling** — written in ERROR.md: `CoercionError` keeps
+   its schema-space anchors (`card_kinds.<kind>.<field>`, bare field names) as a
+   distinct namespace; where a coercion becomes `edit::field_conform` the
+   binding re-anchors it in `DocPath` space at the field written, so the raw
+   schema-space anchor never crosses.
 
 ## Acceptance
 

--- a/prose/doc-contract-phases/phase-3-field-states.md
+++ b/prose/doc-contract-phases/phase-3-field-states.md
@@ -1,88 +1,74 @@
-# Phase 3 — `fieldStates()`, the resolved-field view
+# Phase 3 — `fieldStates()`, the resolved-value view
 
-> **Gate**: consumer evidence. The shape (flat vs. nested main + `cards`,
-> whether `example:` rides along as guidance) is settled against the
-> editor's actual call sites, not engine-side taste.
+> **Gate**: consumer shape — settled **lean** against the editor's
+> architecture. The view answers one question: the value the render projection
+> uses and the rung that produced it. It does not absorb `validate()`.
 
 ## Goal
 
-An engine projection that makes field resolution observable data instead of
-an inferred behavior chain: per field,
-`{ value, source: "authored" | "default" | "zero", diagnostics }`.
-The editor deletes its TypeScript re-implementation of the commitment
-ladder, and `SCHEMAS.md`'s editor row — today "a `Document`-payload × schema
-join the UI consumer performs directly (no engine projection)" — flips to a
-non-goal. "removeField → default renders" stops being a four-step inference
-from tests: re-read the view, the field reports `source: "default"`.
+An engine projection that makes field resolution observable data instead of an
+inferred behavior chain: per declared field,
+`{ value, source: "authored" | "default" | "zero" }`, nested `main` + `cards`
+(the document's own two-level structure, fields in declaration order), the body
+rowed as `$body` (`enabled` ≡ declared; a body-disabled kind carries no row —
+collision-proof, since a user field can never be `$`-prefixed).
+
+The editor's default-rung shim — schema `default:` bound as a control
+placeholder, a second implementation of rung 2 — deletes; `SCHEMAS.md`'s
+editor row flips the consumer-side payload × schema join to a non-goal. First
+named consumer beyond the shim: the editor's `RESTING_FIELDS` design, whose
+resting typography typesets the *resolved* value.
 
 ## Constraints
 
-Three, or this surface becomes the drift it exists to kill:
-
-1. **Built from the shared rung producers** — `zero_value` for the floor,
-   the same precedence cut as the render projection. Canon's rule is that
-   no surface owns a precedence *policy* (`SCHEMAS.md` § "Value sources and
+1. **Built from the shared rung producers** — `resolve_value_sourced`, the
+   same commitment cut as the render projection. Canon's rule is that no
+   surface owns a precedence *policy* (`SCHEMAS.md` § "Value sources and
    projections"); this is an acceptance criterion, not a guideline.
-   Otherwise `fieldStates()` is another ladder implementation, not another
-   projection of the one ladder.
-2. **It does not fully collapse `validate()`.** `UnknownCard` and
-   `BodyDisabled` are document/card-level, not per-field — the view carries
-   a document- and card-level diagnostics slot for them, or the editor
-   keeps calling `validate()` and the one-call claim softens accordingly.
-   Bodies pose the same question: a card body has authored/absent state but
-   is not a field; decide whether the view carries a body row.
-3. **Shape from evidence.** Flat map vs. nested, `example:` included or
-   values-only, Python parity — each settled by reading the editor's call
-   sites before the WASM signature freezes.
+2. **No diagnostics in the view.** `validate()` stays the diagnostics door.
+   The editor merges three producers (`validate()`, session warnings, render
+   errors) and re-keys positional → stable session ids regardless; engine-side
+   bucketing of one producer deletes no consumer code while dragging
+   document- and card-level slot semantics into a value view.
+3. **Values only.** `example:` and other schema guidance read from
+   `quill.schema`, where the consumer already reads controls, labels, groups,
+   and enum domains. The view does not duplicate schema data.
+4. **WASM only.** Python parity waits for a Python consumer naming a call
+   site — the Tier-1 scope cut (#970) applies to new surfaces too.
+5. **Source is top-level only** — one rung per field; the zero-fill inside an
+   authored dict or array is a value detail, not a per-subpath source.
 
 ## Work
 
-- Core: the projection, assembled from the existing rung producers and the
-  validation pass; diagnostics inside the view carry phase-1 codes and
-  phase-2 `DocPath` paths.
-- WASM: `fieldStates()` on the engine surface. Python parity decided under
-  constraint 3.
-- Canon: the `SCHEMAS.md` editor-row flip lands *with* the surface, not
-  before — canon must not declare the only working mechanism a non-goal
-  while its replacement is unshipped.
+- Core: slim the projection to rows of `{ value, source }` — the per-row,
+  card-level, and document-level diagnostics slots, `$seed` routing, and
+  `example` come out.
+- WASM: `fieldStates()` returns the lean shape; the TS types shrink to match.
+- Python: remove `field_states`.
+- Canon: the `SCHEMAS.md` editor-row flip stands — it lands in the same
+  release as the surface.
+- Migration: re-cut the unreleased 0.96 entry to the lean shape.
 
 ## Acceptance
 
-- The editor's TS ladder is deletable: every value + provenance +
-  completeness question it answered is answered by `fieldStates()` (plus
-  `validate()` only if constraint 2 lands on the softer variant).
-- `source` provenance agrees with the render projection on every fixture —
-  same rung, same value, byte-for-byte on the zero floor.
+- The editor's placeholder shim is deletable: resolved value + provenance come
+  from `fieldStates()`; completeness and errors keep coming from `validate()`.
+- `source` agrees with the render projection on every fixture — same rung,
+  same value, byte-for-byte on the zero floor.
 - `SCHEMAS.md` names the consumer-side join a non-goal.
 
 ## Status
 
-**Shipped**: the core projection (`crates/core/src/quill/field_states.rs`) over
-the shared `resolve_value_sourced` ladder producer — one commitment cut, not a
-parallel precedence policy; the WASM `fieldStates` surface plus its
-`FieldSource` / `FieldState` / `MainFieldStates` / `CardFieldStates` /
-`FieldStates` TS types; the Python `field_states` parity; and the `SCHEMAS.md`
-editor-row flip (the consumer-side `Document`-payload × schema join named a
-non-goal, superseded by this view).
+The rich projection — per-row diagnostics bucketing, `$seed` and card-level
+slots, `example`, Python parity — is implemented at `d079280` on this branch
+(`crates/core/src/quill/field_states.rs` over `resolve_value_sourced`); the
+slim above lands before merge. Cut pieces resurrect from that commit when a
+consumer names them.
 
-**Gate resolution**: the gate was consumer evidence, but the editor is
-greenfield — no call sites exist to read the shape off. So the shape is settled
-engine-side and ratified by the owner:
+## Deferred
 
-- **Nested `main` + `cards`**, not a flat map — the document's own two-level
-  structure, each field keyed by name in declaration order.
-- **The body is a universal field**, rowed as `$body` in the `fields` map;
-  `enabled` ≡ declared (a body-disabled kind carries no `$body` row).
-- **`example?` rides as guidance** — the schema `example:` per row, absent from
-  the wire (not null) when the field declares none.
-- **One-call diagnostic bucketing** — every `validate()` diagnostic routed into
-  exactly one slot, with card-level (`unknown_card`, `body_disabled`) and
-  document-level (`$seed`) slots for diagnostics that anchor to no field, plus a
-  per-row `validation::coercion_failed` for render-coercion failures.
-- **Source is top-level only** — one rung per field; the nested zero-fill inside
-  an authored dict or array is a value detail, not a per-subpath source.
-
-**Deferred**: per-subpath provenance inside authored containers — a rung for
-each leaf of a nested dict/array rather than one rung for the field. It needs
-consumer evidence that a container-aware editor wants it; a phase-4 fixture pins
-the current top-level-only behavior meanwhile.
+- **Per-subpath provenance** inside authored containers — a rung per leaf of a
+  nested dict/array. Needs evidence that a container-aware editor wants it; a
+  phase-5 fixture pins top-level-only meanwhile.
+- **Diagnostics bucketing / a one-call view** — returns only with evidence
+  that a consumer deletes code by it (constraint 2's bar).

--- a/prose/doc-contract-phases/phase-3-field-states.md
+++ b/prose/doc-contract-phases/phase-3-field-states.md
@@ -59,11 +59,14 @@ resting typography typesets the *resolved* value.
 
 ## Status
 
-The rich projection — per-row diagnostics bucketing, `$seed` and card-level
-slots, `example`, Python parity — is implemented at `d079280` on this branch
-(`crates/core/src/quill/field_states.rs` over `resolve_value_sourced`); the
-slim above lands before merge. Cut pieces resurrect from that commit when a
-consumer names them.
+**Shipped** the lean shape: `field_states.rs` rows are `{ value, source }` over
+the shared `resolve_value_sourced` producer; the WASM `FieldState` /
+`MainFieldStates` / `CardFieldStates` / `FieldStates` types dropped
+`diagnostics` and `example`; Python `field_states` removed; `validate()` stays
+the diagnostics door; the `SCHEMAS.md` editor-row flip re-lands on the lean
+surface. The rich projection (per-row bucketing, `$seed`/card slots, `example`,
+Python parity) is preserved at `d079280` — resurrect from that commit when a
+consumer names a cut piece.
 
 ## Deferred
 

--- a/prose/doc-contract-phases/phase-4-typed-surface.md
+++ b/prose/doc-contract-phases/phase-4-typed-surface.md
@@ -1,0 +1,42 @@
+# Phase 4 — typed-surface completion
+
+> **Gate**: the editor's boundary ledger (quillmark-editor
+> `prose/canon/DOCUMENT_MODEL.md` § Stability seams) — both items are named
+> there, with live call sites shipping today.
+
+## Goal
+
+The typed WASM surface is as wide as what its consumer reads. A consumer
+casting around a type to reach schema JSON is a contract gap of the same
+species as an unstated grammar: behavior the pinned consumer depends on that no
+surface pins. Two known instances:
+
+1. **`QuillCardUi` omits `groups`.** The hand-written interface
+   (`crates/bindings/wasm/src/engine.rs`) carries only `title?`; real quills
+   carry `ui.groups`, and the editor reads group order by casting the schema
+   JSON around the type (quillmark-editor `src/lib/visual/structure.ts`).
+2. **`ContentIsland.props` is `unknown`.** The editor's codec keeps
+   hand-written table/image props schemas the surface does not pin.
+   `KnownIslandType` (`crates/content/src/island.rs`) already owns per-type
+   props dispatch (`normalize_props`, `cell_marks`); the canonical shapes
+   exist engine-side, untyped at the boundary. Prerequisite-adjacent to
+   island/table authoring (quillmark-editor #16).
+
+## Work
+
+- **Audit**: diff the schema JSON the editor consumes against the hand-written
+  TS interfaces (`QuillCardUi`, `QuillFieldUi`, `QuillCardSchema`); every
+  consumed key gets typed or gets an explicit not-contract ruling.
+- WASM: widen `QuillCardUi` with `groups`; export per-type island props
+  typings (`TableProps` / `ImageProps`, shapes from `KnownIslandType`'s
+  canonical forms) and narrow `ContentIsland.props` accordingly.
+- Canon: the boundary's island-props shape gets a home (CONVERT.md or
+  CARDS.md, wherever islands live); the editor's ledger drops both stability
+  seams once typed.
+
+## Acceptance
+
+- The editor deletes its `groups` cast; the codec's island schemas re-export
+  boundary types instead of tracking them by hand.
+- Additive only — no break. Ships with 0.96 or after, independent of
+  phases 1–3.

--- a/prose/doc-contract-phases/phase-5-conformance.md
+++ b/prose/doc-contract-phases/phase-5-conformance.md
@@ -1,6 +1,6 @@
-# Phase 4 — conformance suite, frozen at 1.0
+# Phase 5 — conformance suite, frozen at 1.0
 
-> **Gate**: phases 1–3 settled. Fixtures written against a moving surface
+> **Gate**: phases 1–4 settled. Fixtures written against a moving surface
 > get written twice.
 
 ## Goal
@@ -23,8 +23,22 @@ pre-1.0 the diffs are the pivot log.
   and the freeze signal dies. The Typst `typst::<message-prefix>`
   convention — identity derived from prose — is exactly what the frozen
   set excludes.
-- Every grammar edge ruled in phase 2 (card bodies, `$ext`, nested indices)
-  and both branches of every phase-3 constraint appear as fixtures.
+
+## Fixture inventory
+
+- Every grammar edge ruled in phase 2 (card bodies, `$ext`, nested indices,
+  the coercion ruling) and both sides of phase 3's top-level-only `source`
+  decision.
+- **The geometry lane** — the boundary's highest-traffic addresses:
+  per document, the `regions()` / `fieldAt` address strings parse as
+  `DocPath` and match expected paths. Address grammar and routing, not
+  pixels; paint stays outside the frozen set.
+- **A fixture quill whose `validate()` is non-empty** — `!must_fill` card
+  fields, so card-path diagnostics are exercised end-to-end. The reference
+  fixture cannot produce one, which is why the editor's `Diagnostic.path`
+  routing shipped best-effort (#1004); this fixture retires that caveat.
+- `fieldStates()` fixtures assert `{value, source}` rows only — the lean
+  shape is the frozen shape.
 
 ## Delivery
 


### PR DESCRIPTION
## What this does

Repivots the document-contract rework around the editor's real requirements and implements the settled shape. Nothing here was merged to `main`; this PR sits on top of `rework-document-contract` and carries the phase-doc repivot, the implementation, and a quality pass.

The organizing principle: the engine↔editor boundary carries surfaces that are not contracts (untyped address strings, a consumer-side resolution shim, identity-in-prose). The rework cures those, and nothing else.

## Phase docs (repivot)

- **README** reframed around one disease (surfaces that aren't contracts), with `0.96` named as the single coordinated break.
- **Phase 2** reopened: geometry-lane `DocPath` unification is the completion criterion, plus the mutator-path retrofit and the coercion-namespace ruling.
- **Phase 3** reshaped lean: `{ value, source }` only — diagnostics bucketing, `$seed`/card slots, `example`, and Python parity cut (resurrection point recorded at `d079280`).
- **Phase 4** (new) typed-surface completion; **Phase 5** (renamed) conformance, with the geometry lane and a non-empty-`validate()` fixture added to its inventory.

## Implementation

**Phase 3 — lean `fieldStates`.** `field_states.rs` rows are `{ value, source }` over the shared `resolve_value_sourced` producer; the WASM types drop `diagnostics`/`example`; Python `field_states` removed. `validate()` stays the one diagnostics door; schema guidance reads from `quill.schema`. Values stay byte-for-byte with the plate.

**Phase 2 — one address grammar (the 0.96 break).**
- *Geometry unification*: `regions`/`fieldBoxes`/`fieldAt`/`positionAt`/`locate` speak `DocPath` at the WASM boundary. New core translators (`plate_addr_to_doc_path` / `doc_path_to_plate_addr`, `region.rs`) resolve the plate-space per-kind ordinal to the absolute card index and back; the WASM `LiveSession` retains the compile's ordered card kinds (refreshed on `apply`). The plate-space `$path` grammar stays template-side — per-kind ordinals no longer cross to a consumer.
- *Mutator-path retrofit* (WASM): `EditError::doc_path(base)` anchors every mutator diagnostic — a field at `cards.<kind>[i].<field>`, a structural op at `cards[i]` — completing the `{ severity, code, message, path }` envelope.
- *Coercion-namespace ruling* written in `ERROR.md`.

## Scoping calls (both documented)

- **Translation home** is the WASM `LiveSession`, not core: the editor (WASM) is the DocPath consumer; core/backend/CLI legitimately use the backend-native plate-space grammar, and Python surfaces core regions verbatim (plate-space, outside the DocPath contract, like its mutator paths). So core/backend/CLI stay unchanged, `cargo test --workspace` stays locally verifiable, and per-kind ordinals never cross the WASM boundary. `RenderedRegion.field`'s doc states this split.
- **Python mutator paths** deferred (Python keeps its phase-1 codes): no Python consumer routes on them, mirroring the `field_states` cut.

## Testing

`cargo test --workspace` → **1150 passed, 0 failed**. New Rust unit tests cover `EditError::doc_path` anchoring and the plate⇄DocPath translation (interleaved-kind absolute-index resolution). WASM JS tests updated to the `DocPath` geometry grammar and lean `fieldStates` shape — deferred to PR CI per repo convention.

## Quality pass

A `/simplify` review (four cleanup agents) and a dense-prose pass ran over the diff. Applied: hoisted the per-region `kinds` allocation out of the live-preview geometry loop; routed both `render({regions:true})` sidecars through the same DocPath funnel as `session.regions()` (the `FieldRegion` DocPath invariant held on only 5 of 7 producers before); merged the two identical `EditError::doc_path` match arms; corrected the `RenderedRegion.field` doc to locate translation at the binding boundary. Skipped, with reason: the `addr_base` fold (would split one uniform mutator idiom into two) and the reuse findings (deliberate divergences bypassing no existing helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKbLBKXbXHNjgDyAGdsEi5)_