### PR TITLE
Contract phase 5 — conformance suite + contractVersion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,12 @@ jobs:
         working-directory: crates/bindings/wasm
         run: npm run typecheck
 
+      # The engine-side conformance run is `cargo test --workspace` (the
+      # quillmark-conformance crate). This guards the @quillmark/conformance
+      # package itself — the module loads and its data is well-formed.
+      - name: Smoke-test @quillmark/conformance
+        run: node conformance/smoke.mjs
+
   python:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,26 @@ jobs:
             npm publish --access public --provenance
           fi
 
+      # @quillmark/conformance ships lockstep from the same commit: the fixtures
+      # a consumer runs must match the engine it pins. Stamp the release version
+      # in (conformance/ is committed source, not generated), then publish.
+      - name: Stamp @quillmark/conformance version
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          node -e "const f='conformance/package.json',p=require('./'+f);p.version=process.env.V;require('fs').writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
+        env:
+          V: ${{ needs.prepare.outputs.version }}
+
+      - name: Publish @quillmark/conformance
+        working-directory: conformance
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          if [[ "$VERSION" == *-* ]]; then
+            npm publish --access public --provenance --tag next
+          else
+            npm publish --access public --provenance
+          fi
+
   # ──────────────────────────────────────────────
   # Publish: Python → PyPI
   # ──────────────────────────────────────────────

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,6 +2304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quillmark-conformance"
+version = "0.95.1"
+dependencies = [
+ "indexmap",
+ "quillmark-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "quillmark-content"
 version = "0.95.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/backends/pdfform",
     "crates/content",
     "crates/fixtures",
+    "crates/conformance",
     "crates/bindings/wasm",
     "crates/fuzz",
     "crates/bindings/python",

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,66 @@
+# @quillmark/conformance
+
+The frozen engine↔consumer **contract** for Quillmark, as executable fixtures.
+One `conformance.json` both the engine (`borb-sh/quillmark`) and its pinned
+consumers run in CI — the general cure for "green upstream tests, broken pinned
+consumer." Published lockstep with `@quillmark/wasm` from the same commit; pin
+both to the same version.
+
+Freezing this set is what the 1.0 release *means*: post-1.0 a fixture diff is a
+breaking change by definition; pre-1.0 the diffs are the pivot log. See
+[`prose/canon/CONFORMANCE.md`](https://github.com/borb-sh/quillmark/blob/main/prose/canon/CONFORMANCE.md).
+
+## What it asserts
+
+- **`fieldStates()`** — per field, the resolved `{ value, source }` and
+  declaration order.
+- **`validate()`** — the diagnostic set (`severity`, `code`, `path`).
+- **Mutator errors** — the `edit::*` `code` and `DocPath` a failed operation
+  carries.
+- **The `DocPath` grammar** — every address parses to the expected
+  `DocPathSeg[]` and round-trips, geometry addresses included.
+
+A fixture asserts a diagnostic's `code`, `path`, and `severity` — **never its
+`message`**. A copyedit is not a formal break, so fixture diffs stay meaningful.
+
+## Usage
+
+Supply an adapter mapping the contract verbs to your integration layer (over
+`@quillmark/wasm`), then run the suite:
+
+```js
+import { runConformance, contractVersion } from '@quillmark/conformance'
+import { Quill, Document, parseDocPath, formatDocPath, contractVersion as engineVersion } from '@quillmark/wasm'
+
+const adapter = {
+  contractVersion: () => engineVersion(),
+  buildQuill: (files) =>
+    Quill.fromTree(new Map(Object.entries(files).map(([p, t]) => [p, new TextEncoder().encode(t)]))),
+  parseDocument: (md) => Document.fromMarkdown(md),
+  storeField: (doc, card, field, value) => doc.storeField({ card: card ?? undefined, field }, value),
+  storeFill: (doc, card, field, value) => doc.storeFill({ card: card ?? undefined, field }, value),
+  removeField: (doc, card, field) => doc.removeField({ card: card ?? undefined, field }),
+  commitField: (quill, doc, card, field, value) =>
+    quill.writer(doc)[card == null ? 'set' : 'card']?.(card ?? field, card == null ? value : undefined),
+  insertCard: (doc, kind, index, body) => doc.insertCard({ kind, body: body ?? undefined }, index ?? undefined),
+  removeCard: (doc, index) => doc.removeCard(index),
+  validate: (quill, doc) => quill.validate(doc),
+  fieldStates: (quill, doc) => quill.fieldStates(doc),
+  parseDocPath,
+  formatDocPath,
+}
+
+// In your test runner:
+runConformance(adapter) // throws an aggregate error naming every failure
+```
+
+The verb bindings above are sketches — adapt them to your surface's exact
+signatures. The `fixtures` / `paths` / `quills` arrays are also exported for
+per-fixture test cases (`runFixture` / `runPath`).
+
+## Contract version
+
+`contractVersion` is semver'd over `{ diagnostic taxonomy, DocPath grammar,
+fieldStates shape }`, independent of the package version. `runConformance`
+asserts your engine's `contractVersion()` matches the frozen value before
+running — a compatibility check at load time, not at bug-report time.

--- a/conformance/conformance.json
+++ b/conformance/conformance.json
@@ -1,0 +1,539 @@
+{
+  "contractVersion": "0.1.0",
+  "quills": {
+    "conf": {
+      "Quill.yaml": "quill:\n  name: conf\n  version: \"1.0.0\"\n  backend: typst\n  description: Conformance fixture quill\nmain:\n  body:\n    example: \"Body prose.\"\n  fields:\n    title:\n      type: string\n    status:\n      type: string\n      default: draft\n    notes:\n      type: string\n    priority:\n      type: enum\n      values:\n        - low\n        - high\n      default: low\n    font_size:\n      type: number\n      default: 12\n    intro:\n      type: richtext\n      default: \"**hi**\"\n    recipients:\n      type: array\n      items:\n        type: object\n        properties:\n          name:\n            type: string\ncard_kinds:\n  note:\n    fields:\n      author:\n        type: string\n        example: A. Author\n      tag:\n        type: string\n      count:\n        type: number\n  stamp:\n    body:\n      enabled: false\n    fields:\n      label:\n        type: string\n"
+    }
+  },
+  "fixtures": [
+    {
+      "name": "main-field-ladder",
+      "description": "The three source rungs on main scalars, plus enum/number default, richtext default, array zero, and the body row.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: Hello\n~~~\n\nBody prose here.\n",
+      "fieldStates": {
+        "main": {
+          "order": [
+            "title",
+            "status",
+            "notes",
+            "priority",
+            "font_size",
+            "intro",
+            "recipients",
+            "$body"
+          ],
+          "fields": {
+            "title": {
+              "source": "authored",
+              "value": "Hello"
+            },
+            "status": {
+              "source": "default",
+              "value": "draft"
+            },
+            "notes": {
+              "source": "zero",
+              "value": ""
+            },
+            "priority": {
+              "source": "default",
+              "value": "low"
+            },
+            "font_size": {
+              "source": "default"
+            },
+            "intro": {
+              "source": "default"
+            },
+            "recipients": {
+              "source": "zero",
+              "value": []
+            },
+            "$body": {
+              "source": "authored"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "main-body-zero",
+      "description": "A blank body rows as $body with source zero.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "fieldStates": {
+        "main": {
+          "fields": {
+            "$body": {
+              "source": "zero"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "array-authored-nested",
+      "description": "An authored array of objects rides through verbatim.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\nrecipients:\n  - name: Alice\n  - name: Bob\n~~~\n",
+      "fieldStates": {
+        "main": {
+          "fields": {
+            "recipients": {
+              "source": "authored",
+              "value": [
+                {
+                  "name": "Alice"
+                },
+                {
+                  "name": "Bob"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "nested-zero-fill-source-is-top-level",
+      "description": "A partially-authored container reports source authored at the top level; the nested zero-fill is a value detail, not a per-subpath source (phase-3 top-level-only decision).",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\nrecipients:\n  - {}\n~~~\n",
+      "fieldStates": {
+        "main": {
+          "fields": {
+            "recipients": {
+              "source": "authored"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "remove-field-unsets-to-default",
+      "description": "removeField is the sole unset verb: dropping an authored field returns it to its schema default rung (null == absent).",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\nstatus: custom\n~~~\n",
+      "steps": [
+        {
+          "op": "removeField",
+          "field": "status"
+        }
+      ],
+      "fieldStates": {
+        "main": {
+          "fields": {
+            "status": {
+              "source": "default",
+              "value": "draft"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "note-card-field-states",
+      "description": "A composable card reports kind, index, declaration order, the body row, and per-field rungs.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n\n~~~card-yaml\n$kind: note\nauthor: Zed\n~~~\nNote body.\n",
+      "fieldStates": {
+        "cards": [
+          {
+            "index": 0,
+            "kind": "note",
+            "order": [
+              "author",
+              "tag",
+              "count",
+              "$body"
+            ],
+            "fields": {
+              "author": {
+                "source": "authored",
+                "value": "Zed"
+              },
+              "tag": {
+                "source": "zero",
+                "value": ""
+              },
+              "count": {
+                "source": "zero"
+              },
+              "$body": {
+                "source": "authored"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "body-disabled-card-omits-body-row",
+      "description": "A body-disabled kind carries no $body row.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n\n~~~card-yaml\n$kind: stamp\nlabel: L\n~~~\n",
+      "fieldStates": {
+        "cards": [
+          {
+            "index": 0,
+            "kind": "stamp",
+            "order": [
+              "label"
+            ],
+            "fields": {
+              "label": {
+                "source": "authored",
+                "value": "L"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "unknown-kind-card",
+      "description": "A card whose $kind names no schema carries its authored fields verbatim \u2014 no ladder, no body row.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n\n~~~card-yaml\n$kind: mystery\nfoo: bar\n~~~\nUnread.\n",
+      "fieldStates": {
+        "cards": [
+          {
+            "index": 0,
+            "kind": "mystery",
+            "order": [
+              "foo"
+            ],
+            "fields": {
+              "foo": {
+                "source": "authored",
+                "value": "bar"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "clean-document-validates-empty",
+      "description": "A complete, well-typed document produces no diagnostics.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: Hello\n~~~\n\nBody.\n",
+      "validate": []
+    },
+    {
+      "name": "type-mismatch-is-fatal",
+      "description": "A string in a number field is a fatal validation error, anchored at the field.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\nfont_size: huge\n~~~\n",
+      "validate": [
+        {
+          "severity": "error",
+          "code": "validation::type_mismatch",
+          "path": "font_size"
+        }
+      ]
+    },
+    {
+      "name": "card-must-fill-is-nonempty-validate",
+      "description": "A !must_fill card field surfaces a non-fatal, card-path diagnostic end-to-end \u2014 the fixture the reference quill could not produce (#1004).",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "steps": [
+        {
+          "op": "insertCard",
+          "kind": "note"
+        },
+        {
+          "op": "storeFill",
+          "card": 0,
+          "field": "tag",
+          "value": ""
+        }
+      ],
+      "validate": [
+        {
+          "severity": "warning",
+          "code": "validation::must_fill",
+          "path": "cards.note[0].tag"
+        }
+      ]
+    },
+    {
+      "name": "commit-unknown-field",
+      "description": "A typed commit of an undeclared name is edit::unknown_field.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "steps": [
+        {
+          "op": "commitField",
+          "field": "nope",
+          "value": "x",
+          "error": {
+            "code": "edit::unknown_field",
+            "path": "nope"
+          }
+        }
+      ]
+    },
+    {
+      "name": "commit-conform-main",
+      "description": "A value that cannot conform is edit::field_conform, re-anchored in DocPath space (the coercion-namespace ruling).",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "steps": [
+        {
+          "op": "commitField",
+          "field": "font_size",
+          "value": "big",
+          "error": {
+            "code": "edit::field_conform",
+            "path": "font_size"
+          }
+        }
+      ]
+    },
+    {
+      "name": "commit-conform-card",
+      "description": "A card-field conform failure re-anchors at the card's DocPath, kind-qualified.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n\n~~~card-yaml\n$kind: note\n~~~\n",
+      "steps": [
+        {
+          "op": "commitField",
+          "card": 0,
+          "field": "count",
+          "value": "lots",
+          "error": {
+            "code": "edit::field_conform",
+            "path": "cards.note[0].count"
+          }
+        }
+      ]
+    },
+    {
+      "name": "store-invalid-field-name",
+      "description": "A malformed field name is edit::invalid_field_name.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "steps": [
+        {
+          "op": "storeField",
+          "field": "bad name",
+          "value": "x",
+          "error": {
+            "code": "edit::invalid_field_name",
+            "path": "bad name"
+          }
+        }
+      ]
+    },
+    {
+      "name": "insert-card-out-of-range",
+      "description": "A structural op past the array end is edit::index_out_of_range, anchored at the bare-index slot.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "steps": [
+        {
+          "op": "insertCard",
+          "kind": "note",
+          "index": 5,
+          "error": {
+            "code": "edit::index_out_of_range",
+            "path": "cards[5]"
+          }
+        }
+      ]
+    },
+    {
+      "name": "insert-card-invalid-kind",
+      "description": "An invalid card kind anchors at the target slot.",
+      "quill": "conf",
+      "document": "~~~card-yaml\n$quill: conf@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+      "steps": [
+        {
+          "op": "insertCard",
+          "kind": "Bad-Kind",
+          "index": 0,
+          "error": {
+            "code": "edit::invalid_kind_name",
+            "path": "cards[0]"
+          }
+        }
+      ]
+    }
+  ],
+  "paths": [
+    {
+      "name": "path-main-field",
+      "path": "title",
+      "segs": [
+        {
+          "seg": "field",
+          "name": "title"
+        }
+      ],
+      "plate": {
+        "addr": "title",
+        "cardKinds": []
+      }
+    },
+    {
+      "name": "path-nested-array-object",
+      "path": "recipients[0].name",
+      "segs": [
+        {
+          "seg": "field",
+          "name": "recipients"
+        },
+        {
+          "seg": "index",
+          "index": 0
+        },
+        {
+          "seg": "field",
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "name": "path-main-body",
+      "path": "main.body",
+      "segs": [
+        {
+          "seg": "main"
+        },
+        {
+          "seg": "body"
+        }
+      ],
+      "plate": {
+        "addr": "$body",
+        "cardKinds": []
+      }
+    },
+    {
+      "name": "path-typed-card-whole",
+      "path": "cards.note[0]",
+      "segs": [
+        {
+          "seg": "card",
+          "kind": "note",
+          "index": 0
+        }
+      ]
+    },
+    {
+      "name": "path-card-field",
+      "path": "cards.note[0].author",
+      "segs": [
+        {
+          "seg": "card",
+          "kind": "note",
+          "index": 0
+        },
+        {
+          "seg": "field",
+          "name": "author"
+        }
+      ],
+      "plate": {
+        "addr": "$cards.note.0.author",
+        "cardKinds": [
+          "note"
+        ]
+      }
+    },
+    {
+      "name": "path-card-body",
+      "path": "cards.note[0].body",
+      "segs": [
+        {
+          "seg": "card",
+          "kind": "note",
+          "index": 0
+        },
+        {
+          "seg": "body"
+        }
+      ],
+      "plate": {
+        "addr": "$cards.note.0.$body",
+        "cardKinds": [
+          "note"
+        ]
+      }
+    },
+    {
+      "name": "path-unknown-kind-card",
+      "path": "cards[0]",
+      "segs": [
+        {
+          "seg": "card",
+          "kind": null,
+          "index": 0
+        }
+      ]
+    },
+    {
+      "name": "path-interleaved-kind-absolute-index",
+      "path": "cards.note[2].author",
+      "segs": [
+        {
+          "seg": "card",
+          "kind": "note",
+          "index": 2
+        },
+        {
+          "seg": "field",
+          "name": "author"
+        }
+      ],
+      "plate": {
+        "addr": "$cards.note.1.author",
+        "cardKinds": [
+          "note",
+          "stamp",
+          "note"
+        ]
+      }
+    },
+    {
+      "name": "path-nested-index-under-card",
+      "path": "cards.note[0].tags[1]",
+      "segs": [
+        {
+          "seg": "card",
+          "kind": "note",
+          "index": 0
+        },
+        {
+          "seg": "field",
+          "name": "tags"
+        },
+        {
+          "seg": "index",
+          "index": 1
+        }
+      ]
+    },
+    {
+      "name": "path-config-space-seed-anchor",
+      "path": "$seed.note.author",
+      "segs": [
+        {
+          "seg": "field",
+          "name": "$seed"
+        },
+        {
+          "seg": "field",
+          "name": "note"
+        },
+        {
+          "seg": "field",
+          "name": "author"
+        }
+      ]
+    }
+  ]
+}

--- a/conformance/index.d.ts
+++ b/conformance/index.d.ts
@@ -1,0 +1,160 @@
+// Type surface for @quillmark/conformance — the frozen contract fixtures and
+// the runner over an adapter you supply. See prose/canon/CONFORMANCE.md.
+
+/** One segment of a parsed `DocPath` — mirrors `@quillmark/wasm`'s `DocPathSeg`
+ * (inlined so this package carries no type dependency on the engine). */
+export type DocPathSeg =
+  | { seg: 'main' }
+  | { seg: 'card'; kind: string | null; index: number }
+  | { seg: 'field'; name: string }
+  | { seg: 'index'; index: number }
+  | { seg: 'body' }
+
+/** The engine↔consumer contract version the fixtures were frozen against —
+ * semver'd over {diagnostic taxonomy, DocPath grammar, fieldStates shape}. Assert
+ * your engine's `contractVersion()` equals it before trusting the set. */
+export declare const contractVersion: string
+
+/** Named quills the fixtures build against, each a `path -> UTF-8 text` file
+ * tree. A conformance quill is `Quill.yaml`-only (the suite never renders). */
+export declare const quills: Record<string, Record<string, string>>
+
+/** The operation-script fixtures. */
+export declare const fixtures: Fixture[]
+
+/** The `DocPath` grammar fixtures. */
+export declare const paths: PathFixture[]
+
+// ── fixture format ──────────────────────────────────────────────────────────
+
+/** A diagnostic assertion — code, path, severity; never message text. */
+export interface ExpectDiag {
+  severity: 'error' | 'warning'
+  code: string
+  path?: string
+}
+
+/** A mutator-failure assertion on a step. */
+export interface ExpectError {
+  code: string
+  path?: string
+}
+
+/** One resolved row: the `source` rung (always) and, when deterministic, the
+ * exact `value`. */
+export interface ExpectFieldState {
+  source: 'authored' | 'default' | 'zero'
+  value?: unknown
+}
+
+/** One card's expected rows: an optional key-`order` assertion (the
+ * declaration-order contract) and a per-field `{source, value?}` map. */
+export interface ExpectCard {
+  order?: string[]
+  fields: Record<string, ExpectFieldState>
+}
+
+/** A composable card's expected rows, matched to the actual card by `index`;
+ * `kind` is `null` for an unknown-kind card. */
+export interface ExpectCardAt extends ExpectCard {
+  index: number
+  kind?: string | null
+}
+
+/** The resolved-value expectations for a fixture. */
+export interface ExpectFieldStates {
+  main?: ExpectCard
+  cards?: ExpectCardAt[]
+}
+
+/** One operation-script step, keyed by `op` (the WASM `Document` verb name).
+ * `card` absent targets the main card. An `error` asserts the op fails with that
+ * `{code, path}`; its absence asserts success. */
+export interface Step {
+  op: 'storeField' | 'storeFill' | 'removeField' | 'commitField' | 'insertCard'
+  card?: number
+  field?: string
+  value?: unknown
+  kind?: string
+  index?: number
+  body?: string
+  error?: ExpectError
+}
+
+/** One state fixture: parse `document` against `quill`, replay `steps`, then
+ * assert `validate` and `fieldStates`. */
+export interface Fixture {
+  name: string
+  description?: string
+  quill: string
+  document: string
+  steps?: Step[]
+  validate?: ExpectDiag[]
+  fieldStates?: ExpectFieldStates
+}
+
+/** A grammar fixture: a `DocPath` string and the segments it parses to. `plate`
+ * carries the plate-space geometry form the engine translates it from — an
+ * engine-side seam a consumer does not run (it reads already-translated
+ * addresses). */
+export interface PathFixture {
+  name: string
+  path: string
+  segs: DocPathSeg[]
+  plate?: { addr: string; cardKinds: (string | null)[] }
+}
+
+// ── adapter ─────────────────────────────────────────────────────────────────
+
+/** A diagnostic as the engine surfaces it — the shape `validate()` returns and a
+ * thrown mutator error carries on `.diagnostics[0]`. */
+export interface Diagnostic {
+  severity: 'error' | 'warning'
+  code?: string
+  path?: string
+  message?: string
+}
+
+/** The integration layer the runner drives. A `@quillmark/wasm` adapter maps
+ * each verb to the identically-named `Document` method; `Quill` / `Doc` are
+ * whatever handle types that layer uses. A mutator verb throws the engine's
+ * diagnostic-bearing error on failure. */
+export interface ConformanceAdapter<Quill = unknown, Doc = unknown> {
+  /** The engine's reported contract version (`contractVersion()`). */
+  contractVersion(): string
+  /** Build a quill from a `path -> text` file tree. */
+  buildQuill(files: Record<string, string>): Quill
+  /** Parse a document from Quillmark markdown. */
+  parseDocument(markdown: string): Doc
+  storeField(doc: Doc, card: number | null, field: string, value: unknown): void
+  storeFill(doc: Doc, card: number | null, field: string, value: unknown): void
+  removeField(doc: Doc, card: number | null, field: string): void
+  commitField(quill: Quill, doc: Doc, card: number | null, field: string, value: unknown): void
+  insertCard(doc: Doc, kind: string, index: number | null, body: string | null): void
+  validate(quill: Quill, doc: Doc): Diagnostic[]
+  fieldStates(quill: Quill, doc: Doc): {
+    main: { fields: Record<string, { value: unknown; source: string }> }
+    cards: { kind: string | null; index: number; fields: Record<string, { value: unknown; source: string }> }[]
+  }
+  parseDocPath(path: string): DocPathSeg[]
+  formatDocPath(segs: DocPathSeg[]): string
+  /** Extract `{code, path}` from a thrown mutator error. Defaults to reading
+   * `err.diagnostics[0]` (the WASM error shape); override for another surface. */
+  errorDiag?(err: unknown): { code?: string; path?: string }
+}
+
+/** Structural equality — primitives, arrays (order-sensitive), plain objects
+ * (key-order-independent). */
+export declare function deepEqual(a: unknown, b: unknown): boolean
+
+/** Run one state fixture; throws on mismatch. Pass a prebuilt `quill` to reuse
+ * one across fixtures; omit it to build the fixture's own. */
+export declare function runFixture(adapter: ConformanceAdapter, fx: Fixture, quill?: unknown): void
+
+/** Run one grammar fixture; throws on mismatch. */
+export declare function runPath(adapter: ConformanceAdapter, fx: PathFixture): void
+
+/** Run the whole suite: assert the engine's `contractVersion`, then every
+ * fixture. Returns `{ total }` on success; throws an aggregate error naming
+ * every failure otherwise. */
+export declare function runConformance(adapter: ConformanceAdapter): { total: number }

--- a/conformance/index.js
+++ b/conformance/index.js
@@ -1,0 +1,188 @@
+// @quillmark/conformance — the frozen engine↔consumer contract fixtures, and a
+// runner that replays them against an integration layer you supply (the
+// "adapter"). The engine repo runs the identical `conformance.json` against
+// `quillmark-core` (crates/conformance); a consumer runs it here against
+// `@quillmark/wasm`. One frozen set, both repos green.
+//
+// A fixture asserts a diagnostic's `code`, `path`, and `severity` — never its
+// `message`. See prose/canon/CONFORMANCE.md and ./index.d.ts.
+
+import suite from './conformance.json' with { type: 'json' }
+
+export const { contractVersion, quills, fixtures, paths } = suite
+
+// ── value comparison ────────────────────────────────────────────────────────
+
+/** Structural equality — primitives, arrays (order-sensitive), plain objects
+ * (key-order-independent). The one comparison every value/segment assertion
+ * shares. */
+export function deepEqual(a, b) {
+  if (a === b) return true
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false
+    return a.every((x, i) => deepEqual(x, b[i]))
+  }
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  if (ka.length !== kb.length) return false
+  return ka.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]))
+}
+
+function show(v) {
+  return typeof v === 'string' ? v : JSON.stringify(v)
+}
+
+class ConformanceError extends Error {}
+
+function fail(fixture, message) {
+  throw new ConformanceError(`${fixture}: ${message}`)
+}
+
+// ── operation dispatch ──────────────────────────────────────────────────────
+
+/** Apply one step through the adapter. `card` is a card index or null (main).
+ * Returns nothing; a mutator failure throws (the adapter surfaces the engine's
+ * diagnostic-bearing error). */
+function applyStep(adapter, quill, doc, step) {
+  const card = step.card ?? null
+  switch (step.op) {
+    case 'storeField': return adapter.storeField(doc, card, step.field, step.value)
+    case 'storeFill': return adapter.storeFill(doc, card, step.field, step.value)
+    case 'removeField': return adapter.removeField(doc, card, step.field)
+    case 'commitField': return adapter.commitField(quill, doc, card, step.field, step.value)
+    case 'insertCard': return adapter.insertCard(doc, step.kind, step.index ?? null, step.body ?? null)
+    default: throw new ConformanceError(`unknown op \`${step.op}\``)
+  }
+}
+
+/** The `{ code, path }` of a thrown mutator error. The WASM binding attaches a
+ * `.diagnostics` array (ERROR.md); an adapter over a different surface overrides
+ * `adapter.errorDiag`. */
+function errorDiag(adapter, err) {
+  if (adapter.errorDiag) return adapter.errorDiag(err)
+  const d = err?.diagnostics?.[0] ?? {}
+  return { code: d.code, path: d.path }
+}
+
+// ── expectation checks ──────────────────────────────────────────────────────
+
+function checkSteps(adapter, quill, doc, fx) {
+  fx.steps?.forEach((step, i) => {
+    const at = `${fx.name}: step ${i} (\`${step.op}\`)`
+    let error = null
+    try {
+      applyStep(adapter, quill, doc, step)
+    } catch (e) {
+      error = e
+    }
+    if (step.error) {
+      if (!error) fail(at, `expected error ${step.error.code}, got success`)
+      const got = errorDiag(adapter, error)
+      if (got.code !== step.error.code) fail(at, `error code: expected ${step.error.code}, got ${got.code}`)
+      const wantPath = step.error.path ?? undefined
+      const gotPath = got.path ?? undefined
+      if (gotPath !== wantPath) fail(at, `error path: expected ${show(wantPath)}, got ${show(gotPath)}`)
+    } else if (error) {
+      throw error
+    }
+  })
+}
+
+function checkCard(actual, expect, at) {
+  const fields = actual?.fields ?? {}
+  if (expect.order) {
+    const keys = Object.keys(fields)
+    if (!deepEqual(keys, expect.order)) {
+      fail(at, `field order (declaration-order contract): expected ${show(expect.order)}, got ${show(keys)}`)
+    }
+  }
+  for (const [name, exp] of Object.entries(expect.fields ?? {})) {
+    const row = fields[name]
+    if (!row) fail(at, `missing row \`${name}\``)
+    if (row.source !== exp.source) fail(at, `\`${name}\` source: expected ${exp.source}, got ${row.source}`)
+    if ('value' in exp && !deepEqual(row.value, exp.value)) {
+      fail(at, `\`${name}\` value: expected ${show(exp.value)}, got ${show(row.value)}`)
+    }
+  }
+}
+
+function checkValidate(adapter, quill, doc, fx) {
+  const key = (d) => `${d.severity}|${d.code}|${d.path ?? ''}`
+  const actual = adapter.validate(quill, doc).map(key).sort()
+  const want = fx.validate.map(key).sort()
+  if (!deepEqual(actual, want)) {
+    fail(fx.name, `validate() diagnostics: expected ${show(want)}, got ${show(actual)}`)
+  }
+}
+
+function checkFieldStates(adapter, quill, doc, fx) {
+  const states = adapter.fieldStates(quill, doc)
+  const expect = fx.fieldStates
+  if (expect.main) checkCard(states.main, expect.main, `${fx.name}: main`)
+  for (const exp of expect.cards ?? []) {
+    const card = states.cards.find((c) => c.index === exp.index)
+    if (!card) fail(fx.name, `no card at index ${exp.index}`)
+    if ('kind' in exp && !deepEqual(card.kind, exp.kind)) {
+      fail(fx.name, `card[${exp.index}] kind: expected ${show(exp.kind)}, got ${show(card.kind)}`)
+    }
+    checkCard(card, exp, `${fx.name}: card[${exp.index}]`)
+  }
+}
+
+// ── public runner ───────────────────────────────────────────────────────────
+
+/** Run one state fixture end to end; throws a `ConformanceError` on mismatch.
+ * Pass a prebuilt `quill` to reuse one across fixtures; omit it to build the
+ * fixture's own. */
+export function runFixture(adapter, fx, quill = adapter.buildQuill(quills[fx.quill])) {
+  const doc = adapter.parseDocument(fx.document)
+  checkSteps(adapter, quill, doc, fx)
+  if (fx.validate) checkValidate(adapter, quill, doc, fx)
+  if (fx.fieldStates) checkFieldStates(adapter, quill, doc, fx)
+}
+
+/** Run one grammar fixture: `parseDocPath` matches the expected segments and
+ * `formatDocPath` round-trips. The plate-space translation is engine-side (a
+ * consumer reads already-translated addresses), so it is not asserted here. */
+export function runPath(adapter, fx) {
+  const segs = adapter.parseDocPath(fx.path)
+  if (!deepEqual(segs, fx.segs)) {
+    fail(fx.name, `parseDocPath: expected ${show(fx.segs)}, got ${show(segs)}`)
+  }
+  const round = adapter.formatDocPath(fx.segs)
+  if (round !== fx.path) fail(fx.name, `formatDocPath round-trip: expected ${fx.path}, got ${round}`)
+}
+
+/** Run the whole suite. Asserts the adapter's engine reports the frozen
+ * `contractVersion`, then every fixture. Returns `{ total }` on success; throws
+ * an aggregate error naming every failure otherwise. */
+export function runConformance(adapter) {
+  const failures = []
+  const engineVersion = adapter.contractVersion()
+  if (engineVersion !== contractVersion) {
+    failures.push(`contractVersion: engine reports ${engineVersion}, fixtures frozen at ${contractVersion}`)
+  }
+  // Build each distinct quill once — many fixtures share one.
+  const built = {}
+  for (const fx of fixtures) {
+    try {
+      built[fx.quill] ??= adapter.buildQuill(quills[fx.quill])
+      runFixture(adapter, fx, built[fx.quill])
+    } catch (e) {
+      failures.push(e.message)
+    }
+  }
+  for (const fx of paths) {
+    try {
+      runPath(adapter, fx)
+    } catch (e) {
+      failures.push(e.message)
+    }
+  }
+  if (failures.length) {
+    throw new ConformanceError(`${failures.length} conformance failure(s):\n${failures.join('\n')}`)
+  }
+  return { total: fixtures.length + paths.length }
+}

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@quillmark/conformance",
+  "version": "0.95.1",
+  "description": "Cross-repo conformance fixtures for the Quillmark engine↔consumer contract",
+  "type": "module",
+  "license": "MIT OR Apache-2.0",
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/borb-sh/quillmark.git",
+    "directory": "conformance"
+  },
+  "files": [
+    "conformance.json",
+    "index.js",
+    "index.d.ts",
+    "README.md"
+  ],
+  "main": "./index.js",
+  "module": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    },
+    "./conformance.json": "./conformance.json"
+  },
+  "sideEffects": false
+}

--- a/conformance/smoke.mjs
+++ b/conformance/smoke.mjs
@@ -1,0 +1,42 @@
+// Engine-free smoke check for the @quillmark/conformance package: the module
+// loads, its data is well-formed, and the runner's plumbing (dispatch, the
+// contractVersion gate, aggregate failure reporting) works. The real
+// engine-backed run is the editor's `@quillmark/wasm` adapter and the engine's
+// Rust harness (crates/conformance); this only guards the package itself.
+//
+// Run: `node conformance/smoke.mjs` (exits non-zero on failure).
+
+import assert from 'node:assert/strict'
+import { contractVersion, quills, fixtures, paths, deepEqual, runConformance } from './index.js'
+
+// ── data shape ──────────────────────────────────────────────────────────────
+assert.match(contractVersion, /^\d+\.\d+\.\d+$/, 'contractVersion is a semver string')
+assert.ok(fixtures.length > 0 && paths.length > 0, 'suite is non-empty')
+
+const names = [...fixtures.map((f) => f.name), ...paths.map((p) => p.name)]
+assert.equal(new Set(names).size, names.length, 'fixture names are unique')
+
+for (const fx of fixtures) {
+  assert.ok(quills[fx.quill], `${fx.name}: references a known quill`)
+  assert.equal(typeof fx.document, 'string', `${fx.name}: has a document`)
+}
+for (const p of paths) {
+  assert.ok(typeof p.path === 'string' && Array.isArray(p.segs), `${p.name}: path + segs`)
+}
+
+// No fixture asserts message text — the freeze signal. The format has no message
+// field, so this checks the invariant is not smuggled in via an unknown key.
+const hasKey = (o, key) =>
+  o != null && typeof o === 'object' && Object.entries(o).some(([k, v]) => k === key || hasKey(v, key))
+assert.ok(!hasKey(fixtures, 'message'), 'no fixture asserts a diagnostic message')
+
+// ── runner plumbing: the contractVersion gate reports a mismatch ─────────────
+const stub = new Proxy(
+  { contractVersion: () => 'x.y.z' },
+  { get: (t, p) => (p in t ? t[p] : () => { throw new Error('unreached') }) },
+)
+assert.throws(() => runConformance(stub), /contractVersion/, 'a version mismatch is a failure')
+
+assert.ok(deepEqual({ a: [1, 2] }, { a: [1, 2] }) && !deepEqual([1], [1, 2]))
+
+console.log(`ok — ${fixtures.length} fixtures, ${paths.length} paths, contract ${contractVersion}`)

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -45,6 +45,13 @@ describe('@quillmark/wasm/core surface', () => {
     expect(core.LiveSession).toBeUndefined()
   })
 
+  it('exposes contractVersion() — the boundary-surface semver', () => {
+    // Present in the core build (the contract surface is engine-free), a
+    // dotted semver string a pinned consumer asserts compatibility against.
+    expect(typeof core.contractVersion).toBe('function')
+    expect(core.contractVersion()).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
   it('loads a quill via Quill.fromTree with no engine', () => {
     const quill = Quill.fromTree(makeCoreQuill())
     expect(quill.backendId).toBe('typst')

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -19,6 +19,10 @@ export { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js'
 // The document-model path parser/serializer — route on `Diagnostic.path`
 // segments instead of regexing the string.
 export { parseDocPath, formatDocPath } from '../core/wasm.js';
+// The engine↔consumer contract version — semver'd over the boundary surface
+// (diagnostic taxonomy, `DocPath` grammar, `fieldStates` shape); assert
+// compatibility at load time and against `@quillmark/conformance`.
+export { contractVersion } from '../core/wasm.js';
 
 import type { CardAddr } from '../core/wasm.js';
 

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -67,6 +67,9 @@ export { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js'
 // and its inverse `formatDocPath`, so a consumer routes on `Diagnostic.path`
 // segments instead of reverse-engineering the grammar.
 export { parseDocPath, formatDocPath } from '../core/wasm.js';
+// The engine↔consumer contract version — assert compatibility at load time and
+// against the `@quillmark/conformance` fixture set's stamped version.
+export { contractVersion } from '../core/wasm.js';
 
 // ── The main-card address ───────────────────────────────────────────────────
 /**

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2003,6 +2003,17 @@ export interface FieldStates {
 }
 "#;
 
+/// The engine↔consumer contract version (`quillmark_core::CONTRACT_VERSION`) —
+/// semver'd over the boundary surface (diagnostic taxonomy, `DocPath` grammar,
+/// `fieldStates` shape) independently of the npm package version. A pinned
+/// consumer asserts compatibility against it at load time, and the
+/// `@quillmark/conformance` fixture set is stamped with the value it was frozen
+/// against. Present in every build (the core build carries it too).
+#[wasm_bindgen(js_name = contractVersion)]
+pub fn contract_version() -> String {
+    quillmark_core::CONTRACT_VERSION.to_string()
+}
+
 /// Parse a canonical document-model `Diagnostic.path`
 /// (`cards.<kind>[<i>].<field>`, `main.body`, `recipients[0].name`) into its
 /// structured [`DocPathSeg`] segments — the exported inverse of the engine's

--- a/crates/conformance/Cargo.toml
+++ b/crates/conformance/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quillmark-conformance"
+version.workspace = true
+edition.workspace = true
+description = "Engine-side runner for the cross-repo conformance fixture set"
+license.workspace = true
+publish = false  # the harness reads ../../conformance/, outside the crate tree
+
+[dependencies]
+quillmark-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+indexmap = { workspace = true }

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -1,0 +1,472 @@
+//! Engine-side runner for the cross-repo conformance fixture set.
+//!
+//! The suite is the general cure for "green upstream tests, broken pinned
+//! consumer": one versioned fixture file (`conformance/conformance.json`) both
+//! the engine and the downstream `borb-sh/quillmark-editor` run in CI. Freezing
+//! it is what 1.0 means — post-1.0 a fixture diff is a breaking change by
+//! definition; pre-1.0 the diffs are the pivot log. See
+//! [`prose/canon/CONFORMANCE.md`](https://github.com/borb-sh/quillmark/blob/main/prose/canon/CONFORMANCE.md).
+//!
+//! This crate is the **engine** runner: it replays each fixture against
+//! `quillmark-core` — the same producers the WASM surface serializes — and
+//! asserts on codes, paths, sources, values, and the `DocPath` grammar. The
+//! `@quillmark/conformance` npm package ships the identical JSON with a JS
+//! runner over `@quillmark/wasm`; both repos run one frozen set green.
+//!
+//! **Never message text.** A fixture asserts a diagnostic's `code`, `path`, and
+//! `severity` — never its `message`. A copyedit must not be a formal break, or
+//! fixture diffs get rubber-stamped and the freeze signal dies (the Typst
+//! `typst::<message-prefix>` convention — identity derived from prose — is
+//! exactly what the frozen set excludes). The `Expect*` types below carry no
+//! message field, so the discipline is structural, not a review rule.
+
+use indexmap::IndexMap;
+use quillmark_core::quill::FileTreeNode;
+use quillmark_core::{
+    doc_path_to_plate_addr, plate_addr_to_doc_path, Card, DocPath, Document, EditError, Quill,
+    QuillValue, Severity,
+};
+use serde::Deserialize;
+use serde_json::Value as Json;
+use std::collections::HashMap;
+
+/// The frozen fixture file — the single source of truth both repos load. The
+/// engine embeds it at compile time; the npm package ships the same bytes.
+pub const SUITE_JSON: &str = include_str!("../../../conformance/conformance.json");
+
+// ── Fixture format (the DSL) ────────────────────────────────────────────────
+
+/// The whole suite: a `contractVersion` stamp, the quills fixtures build
+/// against, the operation-script fixtures, and the `DocPath` grammar fixtures.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Suite {
+    /// The [`quillmark_core::CONTRACT_VERSION`] this set was frozen against — a
+    /// consumer asserts its engine matches before trusting the fixtures.
+    pub contract_version: String,
+    /// Named quills, each a file tree (`path -> UTF-8 text`). A conformance
+    /// quill is `Quill.yaml`-only — the suite exercises validate / fieldStates /
+    /// mutators / paths, none of which render, so no plate or fonts are carried.
+    pub quills: IndexMap<String, IndexMap<String, String>>,
+    /// State fixtures: a document, an operation script, and expectations on the
+    /// resolved view, validation diagnostics, and mutator errors.
+    pub fixtures: Vec<Fixture>,
+    /// Grammar fixtures: a `DocPath` string, its parsed segments, and — for a
+    /// geometry address — the plate-space form it translates from.
+    pub paths: Vec<PathFixture>,
+}
+
+/// One state fixture: parse `document` against `quill`, replay `steps`, then
+/// assert `validate` and `fieldStates` on the resulting document.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Fixture {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub quill: String,
+    pub document: String,
+    #[serde(default)]
+    pub steps: Vec<Step>,
+    /// Expected `validate()` output as a set (order-independent) of
+    /// `{severity, code, path}`. Absent skips the check; `[]` asserts empty.
+    #[serde(default)]
+    pub validate: Option<Vec<ExpectDiag>>,
+    /// Expected `fieldStates()` rows. Absent skips the check.
+    #[serde(default)]
+    pub field_states: Option<ExpectFieldStates>,
+}
+
+/// One operation-script step, keyed by `op` (the WASM `Document` verb name).
+/// `card` absent targets the main card; `field` names the field; `value` /
+/// `kind` / `index` / `body` carry op-specific data. An `error` asserts the op
+/// fails with that `{code, path}`; its absence asserts the op succeeds.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Step {
+    pub op: String,
+    #[serde(default)]
+    pub card: Option<usize>,
+    #[serde(default)]
+    pub field: Option<String>,
+    #[serde(default)]
+    pub value: Option<Json>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub index: Option<usize>,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub error: Option<ExpectError>,
+}
+
+/// A mutator failure expectation: the namespaced `edit::*` code and the
+/// `DocPath` anchor (absent when the error carries none).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectError {
+    pub code: String,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+/// A validation-diagnostic expectation — code, path, severity; never message.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectDiag {
+    pub severity: String,
+    pub code: String,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+/// Expected resolved-value rows: the main card and any composable cards.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExpectFieldStates {
+    #[serde(default)]
+    pub main: Option<ExpectCard>,
+    #[serde(default)]
+    pub cards: Vec<ExpectCardAt>,
+}
+
+/// One card's expected rows: an optional key-`order` assertion (the declaration
+/// -order contract) and a per-field `{source, value?}` map.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectCard {
+    #[serde(default)]
+    pub order: Option<Vec<String>>,
+    #[serde(default)]
+    pub fields: IndexMap<String, ExpectFieldState>,
+}
+
+/// A composable card's expected rows, matched to the actual card by `index`;
+/// `kind` optionally asserts the reported `$kind` (JSON `null` for unknown-kind).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectCardAt {
+    pub index: usize,
+    #[serde(default)]
+    pub kind: Option<Json>,
+    #[serde(default)]
+    pub order: Option<Vec<String>>,
+    #[serde(default)]
+    pub fields: IndexMap<String, ExpectFieldState>,
+}
+
+/// One resolved row: the `source` rung (always asserted) and, when the value is
+/// deterministic enough to pin, the exact `value`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectFieldState {
+    pub source: String,
+    #[serde(default)]
+    pub value: Option<Json>,
+}
+
+/// A grammar fixture: a `DocPath` string, the segments it parses to, and — when
+/// the address is a geometry one — the plate-space form the session translates
+/// it from. The parse + round-trip is the universal check both repos run; the
+/// `plate` translation is the engine-side seam (the editor consumes already
+/// -translated addresses, so it runs only the parse half).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PathFixture {
+    pub name: String,
+    pub path: String,
+    /// The expected `DocPathSeg[]` — the tagged-segment JSON `parseDocPath`
+    /// returns and `DocPath` serializes to.
+    pub segs: Json,
+    #[serde(default)]
+    pub plate: Option<PlateCase>,
+}
+
+/// The plate-space geometry address for a [`PathFixture`], with the ordered card
+/// kinds that resolve its per-kind ordinal to an absolute index.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PlateCase {
+    pub addr: String,
+    pub card_kinds: Vec<Option<String>>,
+}
+
+// ── Runner ──────────────────────────────────────────────────────────────────
+
+/// Parse the embedded suite.
+pub fn suite() -> Suite {
+    serde_json::from_str(SUITE_JSON).expect("conformance.json is valid JSON matching the format")
+}
+
+/// Build a [`Quill`] from a `path -> text` file tree.
+fn build_quill(files: &IndexMap<String, String>) -> Quill {
+    let mut tree = HashMap::new();
+    for (path, text) in files {
+        tree.insert(
+            path.clone(),
+            FileTreeNode::File {
+                contents: text.clone().into_bytes(),
+            },
+        );
+    }
+    Quill::from_tree(FileTreeNode::Directory { files: tree })
+        .unwrap_or_else(|d| panic!("quill build failed: {d:?}"))
+}
+
+/// The `DocPath` base a step's error resolves against, mirroring the WASM
+/// binding's per-verb base computed before the mutable borrow. An addressed
+/// mutator uses its card root (empty for main, `cards.<kind>[i]` for a
+/// composable one, kind read off the live card); the structural `insertCard`
+/// anchors at its target slot `cards[index]`, and an appending `insertCard`
+/// (no index) has no slot yet.
+fn base_of(doc: &Document, step: &Step) -> DocPath {
+    match step.op.as_str() {
+        "insertCard" => match step.index {
+            Some(i) => DocPath::card(None, i),
+            None => DocPath::new(),
+        },
+        _ => match step.card {
+            None => DocPath::new(),
+            Some(i) => DocPath::card(doc.cards().get(i).and_then(|c| c.kind()), i),
+        },
+    }
+}
+
+/// The mutable card a step targets, mapping an out-of-range index to the same
+/// `IndexOutOfRange` the WASM card verbs throw.
+fn card_mut<'a>(doc: &'a mut Document, card: Option<usize>) -> Result<&'a mut Card, EditError> {
+    match card {
+        None => Ok(doc.main_mut()),
+        Some(i) => {
+            let len = doc.cards().len();
+            doc.card_mut(i).ok_or(EditError::IndexOutOfRange { index: i, len })
+        }
+    }
+}
+
+fn qv(step: &Step) -> QuillValue {
+    QuillValue::from_json(step.value.clone().unwrap_or(Json::Null))
+}
+
+/// Run one operation-script step against `doc`, dispatching `op` to the core
+/// mutator the identically-named WASM verb wraps.
+fn run_step(quill: &Quill, doc: &mut Document, step: &Step) -> Result<(), EditError> {
+    let field = || step.field.clone().expect("op needs a field");
+    match step.op.as_str() {
+        "storeField" => card_mut(doc, step.card)?.store_field(&field(), qv(step)),
+        "storeFill" => card_mut(doc, step.card)?.store_fill(&field(), qv(step)),
+        "removeField" => card_mut(doc, step.card)?.remove_field(&field()).map(|_| ()),
+        "commitField" => {
+            let f = field();
+            let v = qv(step);
+            let mut w = quill.writer(doc);
+            match step.card {
+                None => w.set(&f, v),
+                Some(i) => w.card(i)?.set(&f, v),
+            }
+        }
+        "insertCard" => {
+            let mut card = Card::new(step.kind.clone().expect("insertCard needs a kind"))?;
+            if let Some(body) = &step.body {
+                card.revise_body(body.clone())?;
+            }
+            match step.index {
+                Some(i) => doc.insert_card(i, card),
+                None => doc.push_card(card),
+            }
+        }
+        other => panic!("fixture uses an unknown op `{other}`"),
+    }
+}
+
+/// Replay a fixture's steps, asserting each step's success or expected error.
+fn run_steps(quill: &Quill, doc: &mut Document, fx: &Fixture) {
+    for (i, step) in fx.steps.iter().enumerate() {
+        let base = base_of(doc, step);
+        let result = run_step(quill, doc, step);
+        let at = format!("{}: step {} (`{}`)", fx.name, i, step.op);
+        match (&step.error, result) {
+            (None, Ok(())) => {}
+            (None, Err(e)) => panic!("{at}: expected success, got {} ({e})", e.code()),
+            (Some(exp), Ok(())) => panic!("{at}: expected error {}, got success", exp.code),
+            (Some(exp), Err(e)) => {
+                assert_eq!(e.code(), exp.code, "{at}: error code");
+                let got = e.doc_path(&base).map(|p| p.to_string());
+                assert_eq!(got, exp.path, "{at}: error path");
+            }
+        }
+    }
+}
+
+/// Assert `validate()` matches the expected diagnostic set (code/path/severity,
+/// order-independent). Compares as sorted multisets so a missing *or* extra
+/// diagnostic fails.
+fn check_validate(quill: &Quill, doc: &Document, fx: &Fixture, expected: &[ExpectDiag]) {
+    let mut actual: Vec<(String, Option<String>, String)> = quill
+        .validate(doc)
+        .into_iter()
+        .map(|d| {
+            let sev = match d.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+            };
+            (
+                d.code.unwrap_or_default(),
+                d.path,
+                sev.to_string(),
+            )
+        })
+        .collect();
+    let mut want: Vec<(String, Option<String>, String)> = expected
+        .iter()
+        .map(|e| (e.code.clone(), e.path.clone(), e.severity.clone()))
+        .collect();
+    actual.sort();
+    want.sort();
+    assert_eq!(actual, want, "{}: validate() diagnostics", fx.name);
+}
+
+/// Assert one card's resolved rows against `expect`, reading the serialized
+/// `fieldStates` (`serde_json` preserves the `IndexMap` key order, the
+/// declaration-order contract).
+fn check_card(card: &Json, order: &Option<Vec<String>>, fields: &IndexMap<String, ExpectFieldState>, at: &str) {
+    let actual = card["fields"]
+        .as_object()
+        .unwrap_or_else(|| panic!("{at}: fields is not an object"));
+    if let Some(order) = order {
+        let keys: Vec<&String> = actual.keys().collect();
+        let want: Vec<&String> = order.iter().collect();
+        assert_eq!(keys, want, "{at}: field order (declaration-order contract)");
+    }
+    for (name, exp) in fields {
+        let row = actual
+            .get(name)
+            .unwrap_or_else(|| panic!("{at}: missing row `{name}`"));
+        assert_eq!(row["source"], Json::String(exp.source.clone()), "{at}: `{name}` source");
+        if let Some(value) = &exp.value {
+            assert_eq!(&row["value"], value, "{at}: `{name}` value");
+        }
+    }
+}
+
+/// Assert the whole `fieldStates()` projection against `expect`.
+fn check_field_states(quill: &Quill, doc: &Document, fx: &Fixture, expect: &ExpectFieldStates) {
+    let states = quill.field_states(doc);
+    let json = serde_json::to_value(&states).expect("field_states serializes");
+    if let Some(main) = &expect.main {
+        check_card(&json["main"], &main.order, &main.fields, &format!("{}: main", fx.name));
+    }
+    let cards = json["cards"].as_array().expect("cards is an array");
+    for exp in &expect.cards {
+        let card = cards
+            .iter()
+            .find(|c| c["index"] == Json::from(exp.index))
+            .unwrap_or_else(|| panic!("{}: no card at index {}", fx.name, exp.index));
+        if let Some(kind) = &exp.kind {
+            assert_eq!(&card["kind"], kind, "{}: card[{}] kind", fx.name, exp.index);
+        }
+        check_card(
+            card,
+            &exp.order,
+            &exp.fields,
+            &format!("{}: card[{}]", fx.name, exp.index),
+        );
+    }
+}
+
+/// Run one state fixture end to end.
+fn run_fixture(quills: &IndexMap<String, Quill>, fx: &Fixture) {
+    let quill = quills
+        .get(&fx.quill)
+        .unwrap_or_else(|| panic!("{}: unknown quill `{}`", fx.name, fx.quill));
+    let mut doc = Document::parse(&fx.document)
+        .unwrap_or_else(|e| panic!("{}: document parse failed: {e}", fx.name))
+        .document;
+    run_steps(quill, &mut doc, fx);
+    if let Some(expected) = &fx.validate {
+        check_validate(quill, &doc, fx, expected);
+    }
+    if let Some(expect) = &fx.field_states {
+        check_field_states(quill, &doc, fx, expect);
+    }
+}
+
+/// Run one grammar fixture: parse + round-trip (the universal check), then the
+/// plate-space translation (the engine-side seam) when present.
+fn run_path_fixture(fx: &PathFixture) {
+    let parsed: DocPath = fx
+        .path
+        .parse()
+        .unwrap_or_else(|e| panic!("{}: `{}` does not parse: {e}", fx.name, fx.path));
+    assert_eq!(parsed.to_string(), fx.path, "{}: round-trip", fx.name);
+    let segs = serde_json::to_value(&parsed).expect("DocPath serializes");
+    assert_eq!(segs, fx.segs, "{}: parsed segments", fx.name);
+
+    if let Some(plate) = &fx.plate {
+        let kinds: Vec<Option<&str>> = plate.card_kinds.iter().map(|k| k.as_deref()).collect();
+        assert_eq!(
+            plate_addr_to_doc_path(&plate.addr, &kinds),
+            Some(parsed.clone()),
+            "{}: plate `{}` -> DocPath",
+            fx.name,
+            plate.addr,
+        );
+        assert_eq!(
+            doc_path_to_plate_addr(&parsed, &kinds),
+            Some(plate.addr.clone()),
+            "{}: DocPath -> plate (inverse)",
+            fx.name,
+        );
+    }
+}
+
+/// Run the whole suite — the entry point the workspace test drives.
+pub fn run() {
+    let suite = suite();
+    assert_eq!(
+        suite.contract_version,
+        quillmark_core::CONTRACT_VERSION,
+        "conformance.json contractVersion must match the engine's CONTRACT_VERSION",
+    );
+    let quills: IndexMap<String, Quill> = suite
+        .quills
+        .iter()
+        .map(|(name, files)| (name.clone(), build_quill(files)))
+        .collect();
+    for fx in &suite.fixtures {
+        run_fixture(&quills, fx);
+    }
+    for fx in &suite.paths {
+        run_path_fixture(fx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole frozen set runs green against the engine — the acceptance
+    /// gate's engine half (the editor runs the identical JSON against
+    /// `@quillmark/wasm`).
+    #[test]
+    fn conformance_suite_is_green() {
+        run();
+    }
+
+    /// Every fixture is uniquely named — a duplicate would let a broken fixture
+    /// hide behind a passing namesake.
+    #[test]
+    fn fixture_names_are_unique() {
+        let suite = suite();
+        let mut seen = std::collections::HashSet::new();
+        for name in suite
+            .fixtures
+            .iter()
+            .map(|f| &f.name)
+            .chain(suite.paths.iter().map(|p| &p.name))
+        {
+            assert!(seen.insert(name), "duplicate fixture name `{name}`");
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -75,3 +75,17 @@ pub mod normalize;
 
 pub mod version;
 pub use version::{quill_ref_hint, QuillReference, Version, VersionSelector};
+
+/// The engine↔consumer **contract** version, semver'd over the boundary
+/// surface — the diagnostic taxonomy (codes), the [`DocPath`] grammar, and the
+/// [`field_states`](quill::Quill::field_states) shape — independently of crate
+/// semver. A pinned consumer asserts compatibility against it at load time
+/// rather than discovering a boundary break at bug-report time; the WASM
+/// surface re-exports it as `contractVersion()`, and the conformance suite
+/// (`prose/canon/CONFORMANCE.md`) stamps every fixture set with the value it was
+/// frozen against.
+///
+/// Mostly a pre-1.0 signal: while crate versions break freely, this moves only
+/// when a boundary surface does. Post-freeze, package semver plus the fixtures
+/// nearly subsume it.
+pub const CONTRACT_VERSION: &str = "0.1.0";

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -256,3 +256,38 @@ action unless you reach for the newly named types (all re-exported from
   means TS does not auto-narrow `props` on a discriminant check; key off `type`
   and read `props` as the matching type. The win is single-source shapes: a codec
   re-exports `TableProps` / `ImageProps` instead of hand-tracking them.
+
+## New: the conformance suite and `contractVersion`
+
+The boundary surfaces the four breaks above settle — one diagnostic envelope,
+one `DocPath` grammar, the `fieldStates()` view, the widened typed surface — are
+now frozen behind an executable, cross-repo check. A pinned consumer stops
+reverse-engineering them from probes and instead runs the same fixtures the
+engine does.
+
+- **`contractVersion()`** on the WASM surface (`quillmark_core::CONTRACT_VERSION`
+  in core) — a semver over `{diagnostic taxonomy, DocPath grammar, fieldStates
+  shape}`, independent of the package version. Assert compatibility at load time
+  rather than at bug-report time:
+
+  ```js
+  import { contractVersion } from '@quillmark/wasm'
+  if (contractVersion() !== expected) { /* boundary drift — fail loud */ }
+  ```
+
+  Present in every build, including the Typst-less `@quillmark/wasm/core`.
+
+- **`@quillmark/conformance`** — a new package, published lockstep with
+  `@quillmark/wasm` from the same commit. It ships one `conformance.json`
+  (fieldStates rows, validation diagnostics, mutator errors, and the `DocPath`
+  grammar) plus a runner over an adapter you supply. Pin both to the same
+  version and run the suite against your integration layer; the runner asserts
+  your engine's `contractVersion()` matches the frozen set first. Fixtures assert
+  `code` / `path` / `severity` / `value` / `source` — never a diagnostic's
+  message, so a copyedit is never a false break. See
+  [`prose/canon/CONFORMANCE.md`](https://github.com/borb-sh/quillmark/blob/main/prose/canon/CONFORMANCE.md).
+
+No action if you do not consume the boundary programmatically. If you do, the
+suite is the mechanism that keeps your pin honest: freezing it is what the 1.0
+release will mean, and post-1.0 a fixture diff is a breaking change by
+definition.

--- a/prose/canon/CI_CD.md
+++ b/prose/canon/CI_CD.md
@@ -6,7 +6,7 @@
 
 Four workflows. `ci.yml` runs lint/test/wasm on every PR and non-tag push. `release-prepare.yml` computes the next version, bumps the workspace, and opens a release PR. `release.yml` tags and publishes to crates.io, npm, and PyPI when that PR merges. `docs.yml` builds MkDocs and deploys to GitHub Pages on stable releases.
 
-Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `quillmark-pdf`, `quillmark-pdfform`, `quillmark-typst`, `quillmark`, `quillmark-cli`. Not published: `quillmark-fixtures`, `quillmark-fuzz`, `quillmark-python`, `quillmark-wasm`.
+Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `quillmark-pdf`, `quillmark-pdfform`, `quillmark-typst`, `quillmark`, `quillmark-cli`. Not published to crates.io: `quillmark-fixtures`, `quillmark-conformance`, `quillmark-fuzz`, `quillmark-python`, `quillmark-wasm`. Two npm packages publish lockstep: `@quillmark/wasm` and `@quillmark/conformance` (the frozen contract fixtures, [CONFORMANCE.md](CONFORMANCE.md)).
 
 ---
 
@@ -18,8 +18,8 @@ Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `q
 | Job | What it does |
 |-----|-------------|
 | `lint` | `cargo doc --no-deps --locked` with `RUSTDOCFLAGS=-Dwarnings` — the standing lint gate; clippy is deliberately not gated |
-| `test` | `cargo test --workspace --all-features --locked` |
-| `wasm` | first asserts the no-default-features core graph excludes Typst (`cargo tree -i quillmark-typst` must fail), then builds via `./scripts/build-wasm.sh --ci`, then `npx vitest run` |
+| `test` | `cargo test --workspace --all-features --locked` — includes the `quillmark-conformance` crate, the engine-side run of the frozen fixtures ([CONFORMANCE.md](CONFORMANCE.md)) |
+| `wasm` | first asserts the no-default-features core graph excludes Typst (`cargo tree -i quillmark-typst` must fail), then builds via `./scripts/build-wasm.sh --ci`, then `npx vitest run`, then `node conformance/smoke.mjs` (the `@quillmark/conformance` package loads and its data is well-formed) |
 
 The `wasm` job caches `target/wasm32-unknown-unknown/wasm-ci` under key `wasm-ci-${os}-${hashFiles('Cargo.lock')}` (restore-prefix `wasm-ci-${os}-`), so a lockfile change takes a fresh key while source-only edits restore the prefix and rebuild incrementally. The `wasm-ci-` namespace is deliberately disjoint from `release.yml`'s `wasm-release-` cache so a CI build (debug `wasm-ci` profile) can never be restored into a release job and published to npm.
 
@@ -53,10 +53,12 @@ The PR uses a GitHub App token (`TAGGER_APP_ID`/`TAGGER_PRIVATE_KEY`) so CI runs
 |--------|----------|---------|
 | Rust crates | crates.io | `cargo publish --workspace --locked --no-verify` via `rust-lang/crates-io-auth-action` |
 | WASM | npm | `npm publish --access public --provenance` (Trusted Publisher) |
+| Conformance | npm | `npm publish --access public --provenance` from `conformance/`, version stamped to the release tag (Trusted Publisher) |
 | Python | PyPI | `pypa/gh-action-pypi-publish` over prebuilt wheels |
 
 - **Rust crates**: `--workspace` reaches every publishable member, including `quillmark-content` — the leaf the default-members exclude — and skips the `publish = false` members (fixtures, fuzz, bindings). Cargo orders the rest by dependency and skips any version already on the registry with a warning, so re-running resumes a partially-uploaded release instead of erroring.
 - **WASM**: restores the `wasm-release-` cache (`wasm-release` profile), builds via `./scripts/build-wasm.sh`, runs `npx vitest run`, publishes `@quillmark/wasm`. Pre-release versions (containing `-`) publish with `--tag next` so they land on the `next` dist-tag instead of `latest`.
+- **Conformance**: the same job then stamps `conformance/package.json`'s version to the release tag (it is committed source, not generated like `pkg/`) and publishes `@quillmark/conformance` — the same JSON the `quillmark-conformance` crate runs against `quillmark-core`, so a consumer's pin and the engine agree. Same `--tag next` rule. Being a distinct npm package, its **first** publish needs a Trusted Publisher config on npm, like a new crate on crates.io (below).
 - **Python**: `maturin-action` builds wheels for Linux (x86_64, aarch64), Windows (x64), macOS (aarch64) across Python 3.10–3.12, plus an sdist; artifacts are gathered and uploaded with `skip-existing`.
 
 ### Trusted Publishing scope (crates.io)

--- a/prose/canon/CONFORMANCE.md
+++ b/prose/canon/CONFORMANCE.md
@@ -1,0 +1,77 @@
+# Conformance Suite
+
+> **Implementation**: `crates/conformance/` (engine runner) ·
+> `conformance/` (fixtures + `@quillmark/conformance` package)
+
+The engine↔consumer boundary carries contract surfaces — one diagnostic
+envelope, one address grammar, a resolved-value view, a typed surface. The
+conformance suite freezes them behind an executable, cross-repo check: one
+versioned fixture file both `borb-sh/quillmark` and its pinned consumers run in
+CI. It is the general cure for "green upstream tests, broken pinned consumer" —
+the disease the document-contract rework diagnosed (`prose/doc-contract-phases/`).
+
+Freezing the set is what the 1.0 release **means**. Post-1.0 a fixture diff is a
+breaking change by definition; pre-1.0 the diffs are the pivot log.
+
+## The fixture file
+
+`conformance/conformance.json` is the single language-neutral source of truth —
+the engine embeds it (`include_str!`), the npm package ships it verbatim. It
+carries a `contractVersion` stamp, the quills fixtures build against (each a
+`Quill.yaml`-only file tree — the suite never renders), and two fixture arrays.
+
+**State fixtures** (`fixtures`) are an operation-script DSL over
+`(document + schema)`: parse a document, replay `steps` (the WASM `Document`
+verbs — `storeField`, `commitField`, `insertCard`, …), then assert on the
+resolved view (`fieldStates()` values + sources, in declaration order),
+validation diagnostics, and mutator errors. A step's `error` asserts an
+`edit::*` failure with its `code` and `DocPath`; its absence asserts success.
+
+**Grammar fixtures** (`paths`) pin the `DocPath` grammar: a path string, the
+`DocPathSeg[]` it parses to, and — for a geometry address — the plate-space
+form (`$cards.<kind>.<ordinal>`) it translates from. The parse + round-trip is
+the universal check both repos run; the plate translation is the engine-side
+seam (a consumer reads already-translated addresses, so it runs only the parse
+half).
+
+## Codes, paths, sources, values — never message text
+
+A fixture asserts a diagnostic's `code`, `path`, and `severity`, a field's
+`value` and `source`, a path's segments — never a `message`. A message copyedit
+must not be a formal break, or fixture diffs get rubber-stamped and the freeze
+signal dies. The Typst `typst::<message-prefix>` convention — identity derived
+from prose ([ERROR.md](ERROR.md)) — is exactly what the frozen set excludes; the
+fixture format carries no message field, so the discipline is structural, not a
+review rule.
+
+## Two runners, one set
+
+- **Engine** — `crates/conformance` replays each fixture against
+  `quillmark-core` (the same producers the WASM surface serializes) and runs in
+  the workspace tests (`cargo test --workspace`). A fixture change in a PR is
+  reviewable as a contract change, not a test update.
+- **Consumer** — `@quillmark/conformance` ships the identical JSON with a runner
+  over an adapter the consumer supplies (its `@quillmark/wasm` integration
+  layer). Published lockstep with `@quillmark/wasm` from the same commit; a
+  consumer pins both. This keeps fixture bytes off runtime consumers while the
+  editor asserts the contract against its own layer.
+
+Acceptance: both repos run the suite green from the same published fixture
+version.
+
+## `contractVersion`
+
+`quillmark_core::CONTRACT_VERSION` (WASM `contractVersion()`) is semver'd over
+`{diagnostic taxonomy, DocPath grammar, fieldStates shape}`, independently of
+crate/package semver. A consumer asserts compatibility at load time rather than
+at bug-report time, and the fixture set is stamped with the value it was frozen
+against — the engine runner refuses a mismatch. Its value is mostly a pre-1.0
+signal: while crate versions break freely, it moves only when a boundary surface
+does. Post-freeze, package semver plus the fixtures nearly subsume it.
+
+## Post-1.0 policy
+
+Once frozen at 1.0, a change to `conformance.json` **is** a contract break: it
+bumps the major (or `contractVersion`) and lands a `docs/migrations/` entry, the
+same as any other breaking change. Adding a fixture that pins behavior the set
+did not yet cover is additive; changing an existing assertion is not.

--- a/prose/canon/INDEX.md
+++ b/prose/canon/INDEX.md
@@ -33,3 +33,4 @@
 ## Infrastructure
 
 - **[CI_CD.md](CI_CD.md)** - CI/CD workflows
+- **[CONFORMANCE.md](CONFORMANCE.md)** - Cross-repo contract fixtures (`@quillmark/conformance`) and `contractVersion`, frozen at 1.0

--- a/prose/doc-contract-phases/phase-5-conformance.md
+++ b/prose/doc-contract-phases/phase-5-conformance.md
@@ -64,3 +64,33 @@ the fixtures nearly subsume it. A rider here, not a centerpiece.
 - No fixture asserts message text.
 - The 1.0 release notes name the fixture freeze as the release's meaning;
   the migration-guide policy for post-1.0 fixture diffs is written down.
+
+## Status
+
+**Shipped** the engine half. `conformance/conformance.json` is the
+language-neutral source of truth: a `contractVersion` stamp, one `Quill.yaml`
+-only conformance quill, an operation-script DSL of state fixtures (fieldStates
+values + sources, validation diagnostics, mutator `edit::*` errors), and
+`DocPath` grammar fixtures (parse + round-trip, plus the plate-space geometry
+translation for interleaved-kind absolute indices). The inventory is covered:
+the ladder's three sources on scalars/enum/number, richtext default, array zero,
+the body row, a body-disabled kind, an unknown-kind card, the top-level-only
+`source` decision, the coercion-namespace ruling (`edit::field_conform`
+re-anchored in `DocPath` space), and — the fixture the reference quill could not
+produce (#1004) — a `!must_fill` **card** field whose `validate()` is non-empty
+with a `cards.<kind>[i].<field>` path.
+
+Two runners share the one file: `crates/conformance` replays it against
+`quillmark-core` in the workspace tests (`cargo test --workspace`), and
+`@quillmark/conformance` ships the identical JSON with a JS runner over a
+consumer-supplied adapter, published lockstep with `@quillmark/wasm`.
+`contractVersion` lives on the WASM surface (`quillmark_core::CONTRACT_VERSION`),
+the engine runner refusing a fixture-set mismatch. Fixtures assert
+code/path/source/value, never message text — the format carries no message
+field. Canon: [CONFORMANCE.md](../canon/CONFORMANCE.md); the post-1.0 fixture
+-diff policy is written there and in the 0.96 migration guide.
+
+The **consumer half** — the editor's `@quillmark/conformance` adapter and its CI
+run — lands in `quillmark-editor`, as phase 2's `parsePath` removal and phase 4's
+codec deletions do. Freezing the set (dropping `contractVersion` to `1.0.0`) is
+the 1.0 release itself; pre-1.0 the fixture diffs stay the pivot log.


### PR DESCRIPTION
Implements [phase 5](https://github.com/borb-sh/quillmark/blob/rework-document-contract/prose/doc-contract-phases/phase-5-conformance.md) of the document-contract rework (#1005): the cross-repo conformance suite that freezes the engine↔consumer boundary, and the `contractVersion` rider.

Freezing the fixture set is what 1.0 will *mean* — post-1.0 a fixture diff is a breaking change by definition; pre-1.0 the diffs are the pivot log. This ships the **engine half**; the editor's adapter and its CI run land in `quillmark-editor`, as phase 2's `parsePath` removal and phase 4's codec deletions do.

## What's here

- **`conformance/conformance.json`** — the language-neutral source of truth both repos run. A `contractVersion` stamp, one `Quill.yaml`-only conformance quill, **17 state fixtures** (an operation-script DSL: parse a document, replay `steps` — the WASM `Document` verbs — then assert `fieldStates()` values + sources in declaration order, `validate()` diagnostics, and `edit::*` mutator errors), and **10 `DocPath` grammar fixtures** (parse + round-trip, plus the plate-space geometry translation where per-kind ordinal ≠ absolute index).

  Inventory covered: the three source rungs on scalars/enum/number, richtext default, array zero, the body row, a body-disabled kind, an unknown-kind card, the top-level-only `source` decision, the coercion-namespace ruling (`edit::field_conform` re-anchored in `DocPath` space), `removeField` as the unset verb, and — the fixture the reference quill could not produce (#1004) — a `!must_fill` **card** field whose `validate()` is non-empty with a `cards.<kind>[i].<field>` path.

  Fixtures assert `code` / `path` / `severity` / `value` / `source` — **never message text**. The format carries no message field, so the discipline is structural.

- **`crates/conformance/`** — the engine runner. Replays every fixture against `quillmark-core` (the producers the WASM surface serializes) inside `cargo test --workspace`. A fixture change in a PR is reviewable as a contract change, not a test update.

- **`@quillmark/conformance`** (`conformance/`) — ships the identical JSON with a JS runner over a consumer-supplied adapter, published **lockstep** with `@quillmark/wasm` from the same commit (wired into `release.yml`; a Node smoke check in `ci.yml`).

- **`contractVersion`** — `quillmark_core::CONTRACT_VERSION`, re-exported on the WASM surface as `contractVersion()` (present in the Typst-less core build too). Semver'd over `{diagnostic taxonomy, DocPath grammar, fieldStates shape}` independently of crate/package semver: the engine runner refuses a fixture-set mismatch, and a consumer asserts compatibility at load time.

- **Docs** — new `prose/canon/CONFORMANCE.md` (+ `INDEX`, `CI_CD`); the 0.96 migration guide and the phase-5 doc carry the surface and the **post-1.0 fixture-diff policy**.

## Verification

- `cargo test --workspace --all-features --locked` — green (includes the new `quillmark-conformance` crate).
- `node conformance/smoke.mjs` — the package loads and its data is well-formed.
- `cargo doc` lint (`-Dwarnings`) clean on the new crate and core.
- A `/dense-prose` pass over the new prose and a `/simplify` review (reuse/simplification/efficiency/altitude) applied: memoized the JS runner's quill build, dropped an unused `removeCard` op and its runner-specific error special-case, and tightened the smoke check.

Ships with 0.96 (independent of phases 3–4). Being a new npm package, `@quillmark/conformance`'s first publish needs a Trusted Publisher config on npm — noted in `CI_CD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D87w7Hy2hF5AnGpyD9dVew

---
_Generated by [Claude Code](https://claude.ai/code/session_01D87w7Hy2hF5AnGpyD9dVew)_