### PR TITLE
release: strip the seed coverage comment by construction; fix blank-notes fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,28 @@ jobs:
       - name: Tests
         run: cargo test --workspace --all-features --locked
 
+  release-tooling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Guards scripts/strip-seed-comment.sh, the tool release.yml and
+      # release-prepare.yml rely on to keep the release-prepare coverage
+      # comment out of published Release notes and merged CHANGELOG.md.
+      - name: Test strip-seed-comment.sh strips the comment and collapses to one blank line
+        run: |
+          printf '## v1.0.0 - 2026-01-01\n\n- entry one\n\n<!-- seed: commits since v0.9.0 — confirm the entries above cover them, then delete this comment\n- commit a\n- commit b\n-->\n\n## v0.9.0 - 2025-12-01\n\n- old entry\n' > fixture.md
+          printf '## v1.0.0 - 2026-01-01\n\n- entry one\n\n## v0.9.0 - 2025-12-01\n\n- old entry\n' > fixture.expected.md
+          ./scripts/strip-seed-comment.sh fixture.md
+          diff fixture.expected.md fixture.md
+
+      - name: Test strip-seed-comment.sh is a no-op without a seed comment
+        run: |
+          printf '## v1.0.0 - 2026-01-01\n\n- entry one\n' > clean.md
+          cp clean.md clean.expected.md
+          ./scripts/strip-seed-comment.sh clean.md
+          diff clean.expected.md clean.md
+
   wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -111,6 +111,12 @@ jobs:
 
           [ -f CHANGELOG.md ] || printf '# Changelog\n\n' > CHANGELOG.md
 
+          # Defense in depth: a seed comment from a prior cycle should already
+          # be gone (release.yml strips it once that release publishes), but
+          # splicing a new section must never build on top of one that
+          # survived.
+          ./scripts/strip-seed-comment.sh CHANGELOG.md
+
           # A curated "## Unreleased" section is the seed body: its entries
           # become the version section (and the GitHub Release notes), with the
           # raw commit list riding below in an HTML comment as a coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,21 @@ jobs:
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Releasing v${NEXT}"
 
+      # release-prepare.yml seeds each version section with a coverage
+      # cross-check comment for the merging maintainer to delete; a skipped
+      # deletion must not reach main's CHANGELOG.md or the tagged commit, so
+      # strip it here unconditionally rather than leaving it a manual step.
+      - name: Strip leftover seed coverage comment
+        run: |
+          ./scripts/strip-seed-comment.sh CHANGELOG.md
+          if ! git diff --quiet -- CHANGELOG.md; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add CHANGELOG.md
+            git commit -m "chore(release): strip seed coverage comment"
+            git push origin main
+          fi
+
       - name: Tag and push
         run: |
           VERSION="${{ steps.version.outputs.next }}"
@@ -62,9 +77,15 @@ jobs:
           awk -v v="## v${VERSION}" \
             '$0 ~ "^"v {f=1; next} /^## / && f {exit} f {print}' \
             CHANGELOG.md > notes.md || true
-          # Fall back to a generic note if the section is missing or empty
-          # (e.g. an RC with no curated changelog).
-          [ -s notes.md ] || echo "Release v${VERSION}" > notes.md
+          # Defense in depth: the previous step already strips CHANGELOG.md,
+          # but the Release body must stay comment-free even if that step's
+          # push race-loses to a concurrent run.
+          ./scripts/strip-seed-comment.sh notes.md
+          # Fall back to a generic note if the section is missing or made of
+          # only whitespace (e.g. an RC with no curated changelog, or every
+          # curated line was the now-stripped seed comment) — `-s` alone is
+          # true for a whitespace-only file and would publish blank notes.
+          grep -q '[^[:space:]]' notes.md || echo "Release v${VERSION}" > notes.md
 
       - name: Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,49 +30,6 @@
 - feat(content,wasm,python): `LineOp::SetContinues { line, continues }` — hard breaks lower op-wise. Split, join, and a text-delta `\n` all mint `continues: false` lines, so a within-block hard break (a paragraph hard break, a code fence's interior line) had no op and fell back to a whole-install, losing that edit's identity anchors. Threaded through the wire codec into WASM `applyChange` (TS union updated) and Python; `continues: true` on line 0 is rejected with `ApplyError::FirstLineContinues` before the write, leaving the content untouched (#949)
 - feat(wasm): the runtime root re-exports the edit vocabulary its own signatures reference — `Content` / `ContentLine` / `ContentContainer` / `ContentMark` / `ContentIsland`, `Addr` / `Delta` / `Assoc` / `LineOp` / `MarkOp` / `ChangeBundle`, `CardInput` / `PathStep` — as type-only exports (single entry point preserved; no `/core` subpath), with a presence guard so a dropped re-export fails `npm run typecheck` (#948)
 
-<!-- seed: commits since v0.94.0 — confirm the entries above cover them, then delete this comment
-- chore: prune redundant logic and duplicate tests (post-0.94.0 residue scan) (#996)
-- release: unbreak the crates.io publish lane; fold curated notes into the seed (#995)
-- Emit date fields as click-to-edit value-objects (#990) (#994)
-- Split `datetime` into strict `date` and `datetime` types (#991) (#993)
-- Python binding: commit to the Tier-1 surface (#970) (#992)
-- audit #982: complete the Content-genus residual sweep (retire "corpus") (#989)
-- feat: schema-bound read view — `quill.view(doc)` and `TypedReader` (#988)
-- Rebase marks through line ops; collapse bundle normalize (#987)
-- core: retire the V0_81_0 and V0_82_0 storage read shims (#929) (#986)
-- Document binding build performance guidance in CLAUDE.md (#984)
-- richtext: to_markdown projects a value, not a file — no trailing newline (#965) (#977)
-- docs(markdown-spec): scope $body wire claim, fix lossless→lossy projection (#983)
-- Delete prose/review directory
-- rename: content genus off its codec's name — RichText → Content, crate → quillmark-content (#976) (#981)
-- Add note to not run cargo fmt (#980)
-- fix(core,wasm,python): getMarkdown surfaces present-but-not-richtext instead of blanking (#968) (#979)
-- docs: purge rogue .qmd file-extension mentions (#975)
-- Rewrite CLAUDE.md for density (#974)
-- docs: fix mkdocs strict build — drop cross-tree link to prose/canon
-- wasm: name the main-card address (MAIN_CARD_ADDR), reject unknown addr keys (#969)
-- core: collapse the two parse functions into one `Document::parse` -> `Parsed` (#964)
-- core,wasm: writer-level reviseField; hide the quill-taking Document ABI (#966)
-- core,wasm,docs: dense-prose pass over the #963 write surface
-- docs: document the write-surface reshape (#955, #957, #960)
-- python: rename opaque store verbs set_* → store_* (#960)
-- wasm: unify Document on Addr addressing; store_* verbs; reviseChecked (#955, #960, #957)
-- core: rename opaque store verbs set_* → store_*; add revise_field_checked (#960, #957)
-- core: collapse the Payload insert helpers; tighten prose
-- core: use plain code spans for pub(crate) refs in Payload::insert docs
-- docs: 0.94→0.95 migration guide and BINDINGS parity refresh (#956, #958, #959, #961)
-- wasm,core: writer/card-surface parity cleanups (#961)
-- wasm,core: single-card, $id, and seed-overlay reads (#956)
-- core: enforce field invariants at the Payload::insert boundary (#958)
-- core: make ParseOutput the single owner of parse warnings (#959)
-- docs(bindings): densify the card-read doc comments
-- feat(wasm,python): keyed card reads mirroring the card write verbs (#953)
-- docs: remove prose/simplifications backlog for greenfield re-analysis
-- Add setContinues line op so hard breaks lower op-wise (#949)
-- Re-export corpus edit vocabulary from @quillmark/wasm root (#948)
--->
-
-
 ## v0.94.0 - 2026-07-15
 
 These notes cover everything since v0.92.1. No 0.93.x was separately

--- a/scripts/strip-seed-comment.sh
+++ b/scripts/strip-seed-comment.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Strips the release-prepare seed coverage comment (`<!-- seed: … -->`, the
+# raw commit list release-prepare.yml appends below a curated changelog
+# section) from FILE, in place. Non-greedy and DOTALL so each block ends at
+# its own `-->`, and multiple blocks strip independently. Surrounding blank
+# lines collapse to the file's usual single-blank-line separator. A no-op
+# when FILE holds no such block.
+
+file="$1"
+perl -0777 -pi -e 's/\n*<!-- seed:.*?-->\n*/\n\n/gs' "$file"


### PR DESCRIPTION
`[ -s notes.md ]` is true for a whitespace-only file, so an empty version
section (v0.95.1's shape) published literally-blank Release notes instead of
falling back to `Release vX`. Swap to `grep -q '[^[:space:]]'`.

The release-prepare seed coverage comment depended on a maintainer deleting
it before merge; it wasn't, and rode live into both the v0.95.0 CHANGELOG.md
section and its GitHub Release body. Add scripts/strip-seed-comment.sh and
call it at every point the comment could leak: release-prepare's splice (in
case one persists from a prior cycle), release.yml's notes extraction (the
Release body), and a new step that strips it from main's CHANGELOG.md itself
right after a release PR merges, pushing a cleanup commit when needed. Clean
the existing v0.95.0 leftover the same way. A ci.yml job fixtures the script
against a seeded and a clean CHANGELOG section.

Orphaned quillmark-core@0.95.0 / quillmark-content@0.95.0 (crates.io, not
yanked) are out of scope here — no crates.io credentials in this session.

Fixes #1007