### PR TITLE
Canon docs infra: single-source the spine in prose/README.md, enforce in CI

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -10,8 +10,7 @@ faster from the code itself, in the fewest words that stay correct. This skill
 is the house voice: dense, present-tense, declarative, unsold.
 
 It covers comment and doc *content*. For canon *structure* — the `prose/canon/`
-doc spine (Title → Implementation anchor → TL;DR), one concept per page — use
-**`maintain-canon`**.
+doc spine and tiers — use **`maintain-canon`**.
 
 ## Prime directive: correctness over brevity
 

--- a/.claude/skills/maintain-canon/SKILL.md
+++ b/.claude/skills/maintain-canon/SKILL.md
@@ -12,18 +12,14 @@ re-document implementation detail that the code already carries.
 
 ## Structure
 
-`prose/README.md` is the single source of truth for structure: the four prose
-tiers (`canon/`, `references/`, `proposals/`, `plans/`), the canon doc spine
-(Title → `Implementation` anchor → `## TL;DR`), and the link invariants (canon
-never references proposals or plans; references never link out to other prose
-docs). Read it before editing canon. `scripts/check-canon.mjs` enforces the
-spine and link invariants in CI.
+`prose/README.md` is the single source of truth for prose structure — the four
+tiers, the canon doc spine, and the link invariants. Read it before editing
+canon; `scripts/check-canon.mjs` enforces it in CI.
 
 ## Principles
 
 One topic per page; one canonical per topic. Prefer deletion with consolidation
 over duplicates. Keep pages skimmable and high-level; include minimal code.
-Reference folders, not files or line numbers — they rot.
 
 ## Workflow
 

--- a/.claude/skills/maintain-canon/SKILL.md
+++ b/.claude/skills/maintain-canon/SKILL.md
@@ -10,24 +10,14 @@ high level — enough that a human or AI can get the gist without reading the
 whole codebase. Canon describes *what is* and points into the code; it does not
 re-document implementation detail that the code already carries.
 
-## Meta-structure
+## Structure
 
-- `prose/canon/` — settled truth. One concept per page. Indexed by `INDEX.md`.
-- `prose/proposals/` — fleshed-out proposed changes, not yet implemented.
-
-Canon never references proposals or plans.
-
-## Doc spine
-
-Every canon doc opens with a `# Title`, then a one-line `Implementation`
-blockquote anchor, then a `## TL;DR` of two or three sentences. Title, the
-anchor, and the TL;DR are mandatory; other sections (When to use, How, Gotchas,
-Links) are optional — add them when they help.
-
-- The `Implementation` anchor points at a folder or module, never a file and
-  never a line number. It is the navigational hook from concept to code.
-- No `Status` line — membership in canon means settled and implemented. Mark
-  status only for genuine exceptions (e.g. a draft specification).
+`prose/README.md` is the single source of truth for structure: the four prose
+tiers (`canon/`, `references/`, `proposals/`, `plans/`), the canon doc spine
+(Title → `Implementation` anchor → `## TL;DR`), and the link invariants (canon
+never references proposals or plans; references never link out to other prose
+docs). Read it before editing canon. `scripts/check-canon.mjs` enforces the
+spine and link invariants in CI.
 
 ## Principles
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,15 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
-  canon:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # Enforces the canon doc spine and prose link invariants specified in
-      # prose/README.md. Zero deps; runs on the runner's preinstalled node.
-      - name: Check canon spine
-        run: node scripts/check-canon.mjs
-
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Canon spine lint (prose/README.md). Zero deps; runs before the Rust
+      # setup so it fails fast on a checkout-only step.
+      - name: Check canon spine
+        run: node scripts/check-canon.mjs
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
+  canon:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Enforces the canon doc spine and prose link invariants specified in
+      # prose/README.md. Zero deps; runs on the runner's preinstalled node.
+      - name: Check canon spine
+        run: node scripts/check-canon.mjs
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/prose/README.md
+++ b/prose/README.md
@@ -1,6 +1,6 @@
 # prose/
 
-Long-form project documentation, in three tiers by maturity:
+Long-form project documentation, in four tiers by maturity:
 
 - **`canon/`** — canonical documentation: high-level, stable captures of the
   codebase's systems, specifications, and intent. The settled truth. Start at
@@ -18,4 +18,22 @@ Long-form project documentation, in three tiers by maturity:
 
 Canonical docs never reference proposals or plans. References never link
 out to other prose docs.
+
+## Canon doc spine
+
+Every canon doc except `canon/INDEX.md` (the index) opens:
+
+1. `# Title` on line 1.
+2. A blockquote anchor on line 3. Its `**Implementation**` line is the
+   navigational hook from concept to code: it points at a folder or module,
+   never a file and never a line number — files rot. Other lines
+   (`**Related**`, `**Package**`) are optional.
+3. `## TL;DR` as the first section — two or three sentences.
+
+Title, anchor, and TL;DR are mandatory; other sections (When to use, How,
+Gotchas, Links) are optional — add them when they help. No `Status` line:
+membership in canon means settled and implemented. Mark status only for
+genuine exceptions (e.g. a draft specification).
+
+`scripts/check-canon.mjs` enforces the spine and both link invariants in CI.
 

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -3,7 +3,7 @@
 > **Implementation**: `crates/core/src/quill/`
 > **Related**: [SCHEMAS.md](SCHEMAS.md), [QUILL.md](QUILL.md)
 
-## Overview
+## TL;DR
 
 Cards are structured-data blocks inline within document content. All cards are stored in a single `$cards` array on the plate JSON, discriminated by each card's `$kind` value.
 

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -1,6 +1,6 @@
 # Content → Typst Lowering
 
-> **Implementation**: `crates/backends/typst/src/emit.rs`
+> **Implementation**: `crates/backends/typst/src/` (the `emit` module)
 
 ## TL;DR
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -2,7 +2,7 @@
 
 > **Implementation**: `crates/core/src/document/`
 
-## Overview
+## TL;DR
 
 `Document` is the typed in-memory model of a Quillmark Markdown file. Its
 layout tracks the evolving Quillmark model and is **not** a stable interface.

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -2,6 +2,14 @@
 
 > **Implementation**: `crates/core/src/`
 
+## TL;DR
+
+Every failure travels as a `Diagnostic`: severity, namespaced `code`, message,
+optional text `location` and document-model `path`. `RenderError` carries a
+non-empty `Vec<Diagnostic>` and has no failure taxonomy beyond them —
+consumers route on codes, not types. Warnings ride the same currency and
+never block.
+
 ## Types
 
 **`Severity`**: `Error` | `Warning`. Fatality is this two-value ladder and

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -1,7 +1,15 @@
 # Quill Resource File Structure and API
 
 > **Implementation**: `crates/core/src/quill/` (the `Quill` type and its
-> operations), `crates/quillmark/src/load.rs` (filesystem loading)
+> operations), `crates/quillmark/src/` (filesystem loading)
+
+## TL;DR
+
+A `Quill` is a loaded template bundle — file tree plus parsed `Quill.yaml`
+config — tagged with its declared backend id but holding no backend and
+needing no engine. It carries the pure config-read operations (`validate`,
+`schema`, `blueprint`, `seed_*`, `compile_data`, `dry_run`); rendering is the
+engine's job.
 
 ## The `Quill` type
 

--- a/scripts/check-canon.mjs
+++ b/scripts/check-canon.mjs
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
-// Canon spine lint. Enforces the doc spine and link invariants specified in
-// prose/README.md ("Canon doc spine"): every canon doc opens Title → anchor
-// blockquote (line 3, with an **Implementation** line pointing at a folder,
-// never a file) → `## TL;DR`; canon never links into proposals/ or plans/;
-// references never link out to other prose docs. Zero dependencies.
+// Canon spine lint — enforces the doc spine and link invariants specified in
+// prose/README.md ("Canon doc spine"). Zero dependencies.
 //
 // Usage: node scripts/check-canon.mjs
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
@@ -12,10 +9,12 @@ import { join } from 'node:path';
 const problems = [];
 const fail = (file, msg) => problems.push(`${file}: ${msg}`);
 
-// A path with a source-file extension inside an Implementation anchor.
-const FILE_IN_ANCHOR = /[\w/-]+\.(?:rs|m?[jt]s|py|typ|md|ya?ml|toml|json|sh|wasm)\b/;
-// A markdown link target into the proposal/plan tiers.
-const PLAN_LINK = /\]\([^)]*\b(?:proposals|plans)\//;
+// A file path — a slashed token with a dotted basename — inside an anchor.
+// Keys on path shape, not an extension list, so a new file type can't slip past.
+const FILE_IN_ANCHOR = /[\w-]+\/[\w/-]*\.[a-z0-9]+\b/;
+// A markdown link target into the proposal/plan tiers, segment-anchored so a
+// path like `parked-proposals/` doesn't trip it.
+const PLAN_LINK = /\]\([^)]*\/(?:proposals|plans)\//;
 // A relative markdown link target to a .md file (an outbound prose link).
 const PROSE_LINK = /\]\((?!https?:)[^)]*\.md(?=[)#])/;
 
@@ -34,22 +33,17 @@ for (const name of mdFiles('prose/canon')) {
 
   if (!lines[0]?.startsWith('# ')) fail(file, 'line 1 is not a `# Title`');
 
-  // Anchor blockquote: contiguous `>` lines from line 3. The **Implementation**
-  // entry is its line plus continuation lines up to the next `> **Key**:` line.
+  // Anchor blockquote: contiguous `>` lines from line 3. Only Implementation
+  // lines carry a path, so the file check scans the whole quote.
   if (!lines[2]?.startsWith('> ')) {
     fail(file, 'line 3 is not the anchor blockquote');
   } else {
-    let quote = [];
+    const quote = [];
     for (let i = 2; i < lines.length && lines[i].startsWith('>'); i++) quote.push(lines[i]);
-    const start = quote.findIndex((l) => l.startsWith('> **Implementation**:'));
-    if (start === -1) {
+    if (!quote.some((l) => l.startsWith('> **Implementation**:')))
       fail(file, 'anchor blockquote has no `> **Implementation**:` line');
-    } else {
-      let impl = quote[start];
-      for (let i = start + 1; i < quote.length && !/^> \*\*\w+\*\*:/.test(quote[i]); i++) impl += '\n' + quote[i];
-      const m = impl.match(FILE_IN_ANCHOR);
-      if (m) fail(file, `Implementation anchor names a file (\`${m[0]}\`) — anchors point at folders or modules`);
-    }
+    const m = quote.join('\n').match(FILE_IN_ANCHOR);
+    if (m) fail(file, `Implementation anchor names a file (\`${m[0]}\`) — anchors point at folders or modules`);
   }
 
   const firstH2 = lines.find((l) => l.startsWith('## '));

--- a/scripts/check-canon.mjs
+++ b/scripts/check-canon.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Canon spine lint. Enforces the doc spine and link invariants specified in
+// prose/README.md ("Canon doc spine"): every canon doc opens Title → anchor
+// blockquote (line 3, with an **Implementation** line pointing at a folder,
+// never a file) → `## TL;DR`; canon never links into proposals/ or plans/;
+// references never link out to other prose docs. Zero dependencies.
+//
+// Usage: node scripts/check-canon.mjs
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const problems = [];
+const fail = (file, msg) => problems.push(`${file}: ${msg}`);
+
+// A path with a source-file extension inside an Implementation anchor.
+const FILE_IN_ANCHOR = /[\w/-]+\.(?:rs|m?[jt]s|py|typ|md|ya?ml|toml|json|sh|wasm)\b/;
+// A markdown link target into the proposal/plan tiers.
+const PLAN_LINK = /\]\([^)]*\b(?:proposals|plans)\//;
+// A relative markdown link target to a .md file (an outbound prose link).
+const PROSE_LINK = /\]\((?!https?:)[^)]*\.md(?=[)#])/;
+
+const mdFiles = (dir) =>
+  existsSync(dir) ? readdirSync(dir).filter((n) => n.endsWith('.md')).sort() : [];
+
+for (const name of mdFiles('prose/canon')) {
+  const file = join('prose/canon', name);
+  const text = readFileSync(file, 'utf8');
+  const lines = text.split('\n');
+
+  const planLink = text.match(PLAN_LINK);
+  if (planLink) fail(file, `links into proposals/ or plans/ (\`${planLink[0]}\`) — canon never references them`);
+
+  if (name === 'INDEX.md') continue; // the index has no spine
+
+  if (!lines[0]?.startsWith('# ')) fail(file, 'line 1 is not a `# Title`');
+
+  // Anchor blockquote: contiguous `>` lines from line 3. The **Implementation**
+  // entry is its line plus continuation lines up to the next `> **Key**:` line.
+  if (!lines[2]?.startsWith('> ')) {
+    fail(file, 'line 3 is not the anchor blockquote');
+  } else {
+    let quote = [];
+    for (let i = 2; i < lines.length && lines[i].startsWith('>'); i++) quote.push(lines[i]);
+    const start = quote.findIndex((l) => l.startsWith('> **Implementation**:'));
+    if (start === -1) {
+      fail(file, 'anchor blockquote has no `> **Implementation**:` line');
+    } else {
+      let impl = quote[start];
+      for (let i = start + 1; i < quote.length && !/^> \*\*\w+\*\*:/.test(quote[i]); i++) impl += '\n' + quote[i];
+      const m = impl.match(FILE_IN_ANCHOR);
+      if (m) fail(file, `Implementation anchor names a file (\`${m[0]}\`) — anchors point at folders or modules`);
+    }
+  }
+
+  const firstH2 = lines.find((l) => l.startsWith('## '));
+  if (firstH2 !== '## TL;DR') fail(file, `first section is \`${firstH2 ?? '(none)'}\` — canon docs open with \`## TL;DR\``);
+}
+
+for (const name of mdFiles('prose/references')) {
+  const file = join('prose/references', name);
+  const m = readFileSync(file, 'utf8').match(PROSE_LINK);
+  if (m) fail(file, `links to another prose doc (\`${m[0]}\`) — references are self-contained`);
+}
+
+if (problems.length) {
+  for (const p of problems) console.error(`check-canon: ${p}`);
+  process.exit(1);
+}
+console.log('check-canon: canon spine OK');


### PR DESCRIPTION
prose/README.md is now the single source of truth for the four prose
tiers and the canon doc spine (Title → Implementation anchor → TL;DR);
the maintain-canon skill references it instead of restating (and
under-stating) the structure. Retrofit the four canon docs that led with
Overview/Types into real TL;DRs, re-point the two file-naming
Implementation anchors (CONVERT.md, QUILL.md) at folders, and add
scripts/check-canon.mjs — a zero-dep spine lint gating CI.

Closes #1013.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018GG2JvNJ2TSBdftbEtYJ3u