### PR TITLE
core: silence unused_must_use on Payload::insert in tests

### DIFF
--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -742,7 +742,7 @@ mod tests {
         let mut fm = Payload::new();
         fm.set_quill("foo@0.1".parse().unwrap());
         fm.set_kind("main");
-        fm.insert("title", qv("Hello"));
+        let _ = fm.insert("title", qv("Hello"));
         let items = std::mem::take(&mut fm).items().to_vec();
         // Reconstruct with an interleaved comment.
         let mut items_with_comment = items;

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -734,7 +734,8 @@ fn inline_on_empty_mapping_degrades_to_own_line() {
     // Construct programmatically since `key: {}` doesn't appear in source.
     let src = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n";
     let mut doc = Document::parse(src).unwrap().document;
-    doc.main_mut()
+    let _ = doc
+        .main_mut()
         .payload_mut()
         .insert("empty", QuillValue::from_json(serde_json::json!({})));
     // Append an inline comment item right after the empty-mapping field.


### PR DESCRIPTION
Two call sites left over from #958 (Payload::insert -> Result)
discarded the result, tripping cargo check --workspace --all-targets.

Fixes #1010