### PR TITLE
content: decide island-id ↔ content-hash determinism (#1002)

### DIFF
--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1436,14 +1436,9 @@ mod tests {
         let a = imp(md);
         let b = imp(md);
         assert_eq!(a.to_canonical_json(), b.to_canonical_json());
-        assert!(
-            a.islands.len() >= 2,
-            "expected an image and a table island, got {}",
-            a.islands.len()
-        );
-        for (i, island) in a.islands.iter().enumerate() {
-            assert_eq!(island.id, format!("isl-{i}"));
-        }
+        // Image slot then table island, minted in slot order.
+        let ids: Vec<&str> = a.islands.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, ["isl-0", "isl-1"]);
     }
 
     #[test]

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -26,9 +26,11 @@
 //!   empty paragraph, empty `- ` item, or empty `>` quote each yields one empty
 //!   line so the structure survives, rather than vanishing.
 //! - **Island ids are minted sequentially** (`isl-0`, `isl-1`, …) so import is a
-//!   pure, deterministic function. Real minting (the hash-nondeterminism source)
-//!   is not yet implemented; sequential ids round-trip (export drops them,
-//!   re-import re-mints the same sequence).
+//!   pure, deterministic function of its markdown. This positional scheme is
+//!   normative: ids are hash input, so a producer must derive them
+//!   deterministically and never from an ambient source (`DOCUMENT_STORAGE.md`
+//!   § Island-id determinism). Sequential ids round-trip — export drops them,
+//!   re-import re-mints the same sequence.
 //! - **Tables and images are islands.** Tables are block islands (their own
 //!   `Island` line); images are inline island slots. Both `Lossless` — pipe
 //!   tables and `![alt](url)` carry them faithfully.
@@ -404,7 +406,9 @@ impl Builder {
 
     /// Mint an island of a *known* type — the importer can only produce the
     /// closed set, so an unknown type can enter the system through storage
-    /// deserialization but never through import.
+    /// deserialization but never through import. The `isl-{seq}` id is the
+    /// normative deterministic scheme (`DOCUMENT_STORAGE.md` § Island-id
+    /// determinism); minting by position keeps import a pure function.
     fn mint_island(&mut self, kind: KnownIslandType, props: serde_json::Value, loss: Loss) {
         let id = format!("isl-{}", self.island_seq);
         self.island_seq += 1;
@@ -1419,6 +1423,27 @@ mod tests {
         assert_eq!(rt.islands.len(), 1);
         assert_eq!(rt.islands[0].island_type, "table");
         assert_eq!(rt.islands[0].loss, Loss::Lossless);
+    }
+
+    #[test]
+    fn island_ids_are_deterministic_and_positional() {
+        // Island-id determinism (DOCUMENT_STORAGE.md § Island-id determinism):
+        // ids derive from mint position, so the same markdown imports to
+        // byte-identical canonical JSON — ids included — and the ids are exactly
+        // the `isl-{n}` sequence. This is the contract that keeps content-hashes
+        // stable across producers; a random/ambient id would break it.
+        let md = "![a](x)\n\n| h |\n|---|\n| c |";
+        let a = imp(md);
+        let b = imp(md);
+        assert_eq!(a.to_canonical_json(), b.to_canonical_json());
+        assert!(
+            a.islands.len() >= 2,
+            "expected an image and a table island, got {}",
+            a.islands.len()
+        );
+        for (i, island) in a.islands.iter().enumerate() {
+            assert_eq!(island.id, format!("isl-{i}"));
+        }
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -152,8 +152,12 @@ pub enum MarkKind {
 /// embed — occupying one [`ISLAND_SLOT`] in the content.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Island {
-    /// Minted, `$id`-style stable id — once islands mint their own ids, this
-    /// becomes the sole source of hash nondeterminism; text stays deterministic.
+    /// Deterministically minted, session-stable id — `isl-{n}` by import
+    /// position (`import::mint_island`). Part of the canonical form and thus
+    /// hash input; deterministic by contract, never ambient, so equal content
+    /// hashes equal (`DOCUMENT_STORAGE.md` § Island-id determinism). Edits keep
+    /// it stable rather than re-deriving it, so [`Content::validate`] enforces
+    /// uniqueness, not positional equality.
     pub id: String,
     /// Island type discriminator (`"table"`, `"image"`, …). Unknown types
     /// round-trip opaque.
@@ -327,10 +331,12 @@ pub enum Invariant {
     /// would break the exported table). `cell` is the flat header-then-rows
     /// index; `normalize` rewrites the newline to a space.
     TableCellNewline { cell: usize },
-    /// Two islands share an `id`. Ids are a minted, stable identity (the sole
-    /// source of hash nondeterminism); import mints them by index so they never
-    /// collide, but a hand-built or round-tripped content can. Downstream code
-    /// that keys islands by id would otherwise silently pick the wrong one.
+    /// Two islands share an `id`. Ids are deterministic, session-stable
+    /// identities (hash input, so never ambient); import mints them by index so
+    /// they never collide, but a hand-built or round-tripped content can.
+    /// Downstream code that keys islands by id would otherwise silently pick the
+    /// wrong one. Uniqueness is the id invariant `validate` enforces — positional
+    /// equality is not, since edits keep an island's id stable across renumbers.
     IslandIdCollision { id: String },
     /// A table island's `header` prop is present but not a JSON array — it
     /// cannot carry column cells. `normalize` rewrites a non-array header to an
@@ -536,8 +542,9 @@ impl Content {
         // hold no `\n`, so the edge-on-newline rule does not apply.
         let mut seen_ids = std::collections::HashSet::with_capacity(self.islands.len());
         for island in &self.islands {
-            // Ids are a minted, stable identity — the sole source of hash
-            // nondeterminism — so two islands may not share one.
+            // Ids are deterministic, session-stable identities (hash input), so
+            // two islands may not share one. Uniqueness — not `id == isl-{i}` —
+            // is the invariant: edits keep an island's id across renumbers.
             if !seen_ids.insert(island.id.as_str()) {
                 return Err(Invariant::IslandIdCollision {
                     id: island.id.clone(),

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -154,11 +154,11 @@ checked by `Content::validate`, is therefore **uniqueness**
 (`Invariant::IslandIdCollision`), not `id == isl-{index}`: after an edit
 `isl-1` may legitimately sit at index 0.
 
-This resolves the id in favor of keeping "canonical bytes == hash input"
-exact — no id-stripping in the hash, no separate hash form. Any future
-id-minting producer (a live editor, a richer island type) is bound by the
-same rule: continue the positional sequence for appended islands; never mint
-an ambient id.
+The id stays in the hash input, so "canonical bytes == hash input" holds
+exact — no id-stripping, no separate hash form. Any future id-minting
+producer (a live editor, a richer island type) is bound by the same rule:
+continue the positional sequence for appended islands; never mint an ambient
+id.
 
 ## Schema Versioning
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -133,6 +133,33 @@ change. Two ways to manage this:
   guarantee is required) or an accepted, logged hash movement on
   not-yet-migrated rows.
 
+## Island-id determinism
+
+An island's `id` is part of the canonical form (`{id, type, props, loss}`),
+so it is hash input like every other field, and byte-stability's promise —
+equal content → equal bytes, *whatever the producer* — requires that equal
+islands carry equal ids. The rule: **an id is a deterministic function of
+content, never drawn from an ambient source** (RNG, wall-clock, UUID,
+allocation identity, session or process state). An ambient id would make
+re-importing the same markdown yield different bytes for the same document,
+silently breaking divergence detection and cache keys.
+
+The normative scheme is the importer's positional `isl-{n}` — the nth island
+minted takes `isl-{n-1}` (`mint_island`), so cold import is a pure function
+of its markdown; export drops ids and re-import re-mints the same sequence.
+Ids then travel with their island across edits — deleting a slot drops that
+island and survivors keep their ids — so an id is *stable within a session*,
+not re-derived from position. The invariant that holds for every `Content`,
+checked by `Content::validate`, is therefore **uniqueness**
+(`Invariant::IslandIdCollision`), not `id == isl-{index}`: after an edit
+`isl-1` may legitimately sit at index 0.
+
+This resolves the id in favor of keeping "canonical bytes == hash input"
+exact — no id-stripping in the hash, no separate hash form. Any future
+id-minting producer (a live editor, a richer island type) is bound by the
+same rule: continue the positional sequence for appended islands; never mint
+an ambient id.
+
 ## Schema Versioning
 
 The schema version is tied to the **crate version at which the `Document`


### PR DESCRIPTION
Closes #1002.

## The decision

Island ids are part of the canonical form (`{id, type, props, loss}`), so they are hash input, and byte-stability's promise — equal content → equal bytes, *whatever the producer* — requires equal islands to carry equal ids. This pins the contract:

**An id is a deterministic function of content, never drawn from an ambient source** (RNG, wall-clock, UUID, allocation identity, session/process state). The importer's positional `isl-{n}` is the normative minting scheme, so cold import is a pure function of its markdown. Because ids are deterministic, the island id is *not* a source of hash nondeterminism — "canonical bytes == hash input" stays exact, with no id-stripping and no separate hash form.

This is option 2 from the issue ("derive ids deterministically; forbid random ids"), chosen over stripping ids from the hash (option 1, which breaks the "canonical bytes are the hash input" simplicity for every external consumer) and tolerating id movement (option 3, which exports nondeterminism to consumers as false divergence and cache misses).

## One correction worth calling out

I did **not** add an `id == isl-{index}` check to `Content::validate`. The edit cascade (`sync_islands_for_delta` in `ops.rs`) keeps an island's minted id stable while positions renumber — after deleting the first of two islands, `isl-1` legitimately sits at index 0. A positional check in `validate` would reject correctly-edited content. The invariant that holds for *every* `Content` is **uniqueness** (already guarded by `Invariant::IslandIdCollision`); determinism is a producer-side discipline enforced at the import boundary and pinned by a test, which a single-value check can't observe anyway.

## Changes

- **`prose/canon/DOCUMENT_STORAGE.md`** — new `## Island-id determinism` section: the written decision (deterministic/never-ambient ids, positional `isl-{n}` normative, uniqueness — not positional equality — is the enforced invariant, binds future id-minting producers).
- **`crates/content/src/model.rs`** — rewrote the three "sole source of hash nondeterminism" landmine comments (`Island.id`, `IslandIdCollision`, the `validate` inline note) to state the resolved contract.
- **`crates/content/src/import.rs`** — module doc and `mint_island` doc now mark positional minting *normative*; added `island_ids_are_deterministic_and_positional` (same markdown → byte-identical canonical JSON, ids `isl-0`, `isl-1`).

The last two commits are a `/dense-prose` pass (state the design, drop deliberation framing) and a `/simplify` pass (collapse the test's guard + loop into one exact id assertion).

## Verification

- `cargo test --workspace` green (49 suite blocks, 0 failures); content crate 159 + 12 tests including the new one.
- Canon spine lint (`scripts/check-canon.mjs`) passes.
- CI doc build (`cargo doc --no-deps --locked -Dwarnings`, full workspace) passes.

## Out of scope

The #985 Problem 2 loose end (whether `Loss::Unrepresentable` should become a first-class island type) is a separate decision, flagged in the issue and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nHszSK3zzDDzfc5oiH8YV

---
_Generated by [Claude Code](https://claude.ai/code/session_018nHszSK3zzDDzfc5oiH8YV)_