### PR TITLE
Read surface: reader() / resolve() rename + one shared resolver

### DIFF
--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -35,7 +35,7 @@ result.artifacts[0].save("output.pdf")
 ## API surface
 
 Python is a **Tier-1 binding**: field I/O flows through `quill.writer(doc)` and
-`quill.view(doc)`, the schema-bound write/read front doors. `Document` carries
+`quill.reader(doc)`, the schema-bound write/read front doors. `Document` carries
 the quill-free surface — parse, storage, structure, `$ext` / `$seed`, and
 `remove_field`. There is no opaque field store and no anchor-preserving content
 lane (`install` / `revise` / `apply_change` + the `import_markdown` /
@@ -82,7 +82,7 @@ main    = quill.seed_main()               # just the $kind: main card (dict, lik
 card    = quill.seed_card("note")         # one starter composable card (dict), None if kind undeclared
 
 writer  = quill.writer(doc)               # schema-bound typed write front door
-reader  = quill.view(doc)                 # schema-bound interpreted read front door
+reader  = quill.reader(doc)                 # schema-bound interpreted read front door
 ```
 
 ### `Writer` — `quill.writer(doc)`
@@ -103,14 +103,14 @@ w.remove_card(0)
 w.card(0).set("author", "Issa")           # a CardWriter: .index, .kind, .set, .set_all, .set_body, .revise_field
 ```
 
-### `View` — `quill.view(doc)`
+### `Reader` — `quill.reader(doc)`
 
 The interpreted read front door and the read twin of `Writer`. One `get` reads
 each field by its declared type: a richtext field to its markdown projection,
 every other type its canonical value verbatim.
 
 ```python
-v = quill.view(doc)
+v = quill.reader(doc)
 v.get("bio")                              # richtext → markdown str; scalar → its value; absent → None
                                           # undeclared name raises UnknownField; undecodable content raises FieldRichtextDecode
 v.get_body()                              # the main body markdown (quill-free body read)
@@ -173,7 +173,7 @@ doc.remove_seed_namespace("note")
 
 Setting a field's value is the writer's job (`quill.writer(doc).set(...)`) — a
 field write needs the schema, and `Document` is quill-free. Reading a field's
-interpreted value is the view's (`quill.view(doc).get(...)`).
+interpreted value is the reader's (`quill.reader(doc).get(...)`).
 
 ## Schema model
 

--- a/crates/bindings/python/python/quillmark/__init__.py
+++ b/crates/bindings/python/python/quillmark/__init__.py
@@ -2,7 +2,7 @@
 
 from ._quillmark import (
     Artifact,
-    CardView,
+    CardReader,
     CardWriter,
     Diagnostic,
     Document,
@@ -11,15 +11,15 @@ from ._quillmark import (
     Quill,
     Quillmark,
     QuillmarkError,
+    Reader,
     RenderResult,
     Severity,
-    View,
     Writer,
 )
 
 __all__ = [
     "Artifact",
-    "CardView",
+    "CardReader",
     "CardWriter",
     "Diagnostic",
     "Document",
@@ -28,9 +28,9 @@ __all__ = [
     "Quill",
     "Quillmark",
     "QuillmarkError",
+    "Reader",
     "RenderResult",
     "Severity",
-    "View",
     "Writer",
 ]
 

--- a/crates/bindings/python/src/lib.rs
+++ b/crates/bindings/python/src/lib.rs
@@ -7,12 +7,12 @@ mod types;
 pub use enums::{PyOutputFormat, PySeverity};
 pub use errors::QuillmarkError;
 pub use types::{
-    PyArtifact, PyCardView, PyCardWriter, PyDiagnostic, PyDocument, PyLocation, PyQuill,
-    PyQuillmark, PyRenderResult, PyView, PyWriter,
+    PyArtifact, PyCardReader, PyCardWriter, PyDiagnostic, PyDocument, PyLocation, PyQuill,
+    PyQuillmark, PyRenderResult, PyReader, PyWriter,
 };
 
 // Python is Tier 1 + storage + render: field I/O flows through `quill.writer(doc)`
-// / `quill.view(doc)`. The opaque store and the anchor-preserving content lane
+// / `quill.reader(doc)`. The opaque store and the anchor-preserving content lane
 // (`install` / `revise` / `apply_change` + the `importMarkdown` / `exportMarkdown`
 // / `rebase` / `mapPos` codec) are WASM-only by scope. See prose/canon/BINDINGS.md.
 
@@ -23,8 +23,8 @@ fn _quillmark(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDocument>()?;
     m.add_class::<PyWriter>()?;
     m.add_class::<PyCardWriter>()?;
-    m.add_class::<PyView>()?;
-    m.add_class::<PyCardView>()?;
+    m.add_class::<PyReader>()?;
+    m.add_class::<PyCardReader>()?;
     m.add_class::<PyRenderResult>()?;
     m.add_class::<PyArtifact>()?;
     m.add_class::<PyDiagnostic>()?;

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -124,12 +124,12 @@ impl PyQuill {
     }
 
     /// Bind this quill's schema to `doc` for interpreted reads — the read twin of
-    /// `writer`, mirroring core `quill.view(&doc)` and WASM `quill.view(doc)`.
+    /// `writer`, mirroring core `quill.reader(&doc)` and WASM `quill.reader(doc)`.
     /// Each field reads by its declared type (a richtext field to markdown, every
-    /// other type verbatim) with schema authority. See [`PyView`] for the
+    /// other type verbatim) with schema authority. See [`PyReader`] for the
     /// re-borrow/ephemerality contract.
-    fn view(slf: Py<Self>, doc: Py<PyDocument>) -> PyView {
-        PyView { quill: slf, doc }
+    fn reader(slf: Py<Self>, doc: Py<PyDocument>) -> PyReader {
+        PyReader { quill: slf, doc }
     }
 
     #[getter]
@@ -425,7 +425,7 @@ impl PyDocument {
     /// Main card's global body as canonical Content-JSON — the source-of-truth
     /// content model (a content dict, `{text, lines, marks, islands}`). The
     /// quill-free total-read snapshot; for the markdown projection use
-    /// `quill.view(doc).get_body()`.
+    /// `quill.reader(doc).get_body()`.
     #[getter]
     fn body<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let wire = quillmark_core::CardWire::from(self.inner.main());
@@ -895,7 +895,7 @@ impl PyCardWriter {
 }
 
 /// A `Document` bound to its `Quill` for interpreted reads — the schema-plane
-/// read view, from `Quill.view(doc)` and the read twin of `Writer`. One `get`
+/// read surface, from `Quill.reader(doc)` and the read twin of `Writer`. One `get`
 /// reads each field by its declared type: a richtext field to its markdown
 /// projection, a plaintext field to its literal text, every other type its
 /// canonical value verbatim. The schema authority is the point: a name the schema
@@ -905,15 +905,15 @@ impl PyCardWriter {
 /// read surface — `Document` carries no quill-free field read. Holds both objects
 /// by reference and re-borrows them per call (pyo3 objects carry no lifetime), so
 /// it is ephemeral by convention: bind, read, discard. Mirrors WASM
-/// `quill.view(doc)`.
-#[pyclass(name = "View")]
-pub struct PyView {
+/// `quill.reader(doc)`.
+#[pyclass(name = "Reader")]
+pub struct PyReader {
     quill: Py<PyQuill>,
     doc: Py<PyDocument>,
 }
 
 #[pymethods]
-impl PyView {
+impl PyReader {
     /// The bound document — the same object passed in.
     #[getter]
     fn document(&self, py: Python<'_>) -> Py<PyDocument> {
@@ -931,7 +931,7 @@ impl PyView {
         let doc = self.doc.borrow(py);
         let read = quill
             .inner
-            .view(&doc.inner)
+            .reader(&doc.inner)
             .get(name)
             .map_err(convert_edit_error)?;
         read_value_to_py(py, read)
@@ -944,11 +944,11 @@ impl PyView {
         doc.inner.main().body_markdown()
     }
 
-    /// A `CardView` for the composable card at `index`. The index is checked
+    /// A `CardReader` for the composable card at `index`. The index is checked
     /// lazily at the read, so this never raises. The cursor is ephemeral — a
     /// `remove_card`/`add_card` between binding and reading silently retargets it.
-    fn card(&self, py: Python<'_>, index: usize) -> PyCardView {
-        PyCardView {
+    fn card(&self, py: Python<'_>, index: usize) -> PyCardReader {
+        PyCardReader {
             quill: self.quill.clone_ref(py),
             doc: self.doc.clone_ref(py),
             index,
@@ -957,17 +957,17 @@ impl PyView {
 }
 
 /// A composable card bound to its `Quill` for interpreted reads, from
-/// `View.card`. Same verbs as `View`, reading the card at its bound index; each
+/// `Reader.card`. Same verbs as `Reader`, reading the card at its bound index; each
 /// read raises `edit::index_out_of_range` if that index is out of range.
-#[pyclass(name = "CardView")]
-pub struct PyCardView {
+#[pyclass(name = "CardReader")]
+pub struct PyCardReader {
     quill: Py<PyQuill>,
     doc: Py<PyDocument>,
     index: usize,
 }
 
 #[pymethods]
-impl PyCardView {
+impl PyCardReader {
     /// The bound card index.
     #[getter]
     fn index(&self) -> usize {
@@ -980,19 +980,19 @@ impl PyCardView {
     fn kind(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
-        let view = quill.inner.view(&doc.inner);
-        let card = view.card(self.index).map_err(convert_edit_error)?;
+        let reader = quill.inner.reader(&doc.inner);
+        let card = reader.card(self.index).map_err(convert_edit_error)?;
         Ok(card.kind().map(|k| k.to_string()))
     }
 
     /// Read a field on this card, interpreted by its declared type — the
-    /// card-indexed twin of `View.get`. Raises `edit::unknown_field` for an
+    /// card-indexed twin of `Reader.get`. Raises `edit::unknown_field` for an
     /// undeclared name and `edit::index_out_of_range` for a bad index.
     fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
-        let view = quill.inner.view(&doc.inner);
-        let read = view
+        let reader = quill.inner.reader(&doc.inner);
+        let read = reader
             .card(self.index)
             .map_err(convert_edit_error)?
             .get(name)
@@ -1000,7 +1000,7 @@ impl PyCardView {
         read_value_to_py(py, read)
     }
 
-    /// This card's body markdown — the card twin of `View.get_body`. Raises
+    /// This card's body markdown — the card twin of `Reader.get_body`. Raises
     /// `edit::index_out_of_range` if the bound index is out of range.
     fn get_body(&self, py: Python<'_>) -> PyResult<String> {
         let doc = self.doc.borrow(py);
@@ -1214,7 +1214,7 @@ fn quillvalue_to_py<'py>(
 }
 
 /// Flatten a [`ReadValue`](quillmark_core::ReadValue) into a Python object for
-/// the `View.get` surfaces: a richtext projection becomes a `str`, a canonical
+/// the `Reader.get` surfaces: a richtext projection becomes a `str`, a canonical
 /// value its scalar/list/dict shape, and an absent field `None`. The schema-plane
 /// twin of `quillvalue_to_py`, which knows only the transport shape.
 fn read_value_to_py<'py>(
@@ -1300,7 +1300,7 @@ fn card_to_pydict<'py>(
     }
 
     // `body` is the canonical content (source of truth); the markdown projection
-    // is the schema-plane `quill.view(doc).get_body()` read. The reverse path
+    // is the schema-plane `quill.reader(doc).get_body()` read. The reverse path
     // (`py_dict_to_card`) reads `body`.
     d.set_item("body", json_to_py(py, &wire.body)?)?;
     Ok(d)

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -1,7 +1,7 @@
 """Tests for the API requirements.
 
 Python is a Tier-1 binding: field I/O flows through `quill.writer(doc)` /
-`quill.view(doc)`. `Document` carries the quill-free surface — parse, storage,
+`quill.reader(doc)`. `Document` carries the quill-free surface — parse, storage,
 structure, `$ext` / `$seed`, and `remove_field`. There is no opaque field store
 and no content lane (`install` / `revise` / `apply_change` + codec); those are
 WASM-only by scope.
@@ -513,7 +513,7 @@ def test_to_markdown_ambiguous_string_survival():
 
 
 def test_writer_front_door_set_and_reads():
-    """quill.writer(doc).set writes; the reads live on quill.view(doc)."""
+    """quill.writer(doc).set writes; the reads live on quill.reader(doc)."""
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     ed = quill.writer(doc)
@@ -521,7 +521,7 @@ def test_writer_front_door_set_and_reads():
     ed.set_all({"title": "On Taro"})
     assert ed.document is doc  # holds the same object, mutated in place
 
-    v = quill.view(doc)
+    v = quill.reader(doc)
     assert v.get("author") == "Ada"
     assert v.get("ice_cream") is None  # declared but absent → None
     ed.set_body("A **taro** essay.")
@@ -634,7 +634,7 @@ def test_writer_revise_field_typed_and_anchor_preserving():
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
     quill.writer(doc).revise_field("bio", "make it **bold**")
-    assert quill.view(doc).get("bio") == "make it **bold**"
+    assert quill.reader(doc).get("bio") == "make it **bold**"
 
 
 def test_writer_revise_field_rejects_inline_and_unknown():
@@ -664,7 +664,7 @@ def test_typed_set_clears_must_fill_marker():
     assert field(doc.main, "title") == "Real Title"
 
 
-# ── Tier-1 typed reader — quill.view(doc) front door ──────────────────────────
+# ── Tier-1 typed reader — quill.reader(doc) front door ──────────────────────────
 
 
 def test_view_interprets_by_declared_type():
@@ -672,20 +672,20 @@ def test_view_interprets_by_declared_type():
     quill = _richtext_form_quill()
     doc = Document("richtext_form@0.1.0")
     quill.writer(doc).set("bio", "A **bold** intro.")
-    v = quill.view(doc)
+    v = quill.reader(doc)
     assert v.document is doc  # holds the same object
     assert v.get("bio") == "A **bold** intro."  # richtext → markdown
 
     taro = _taro_quill()
     tdoc = Document("taro@0.1.0")
     taro.writer(tdoc).set("author", "Ada")
-    assert taro.view(tdoc).get("author") == "Ada"  # scalar → canonical
+    assert taro.reader(tdoc).get("author") == "Ada"  # scalar → canonical
 
 
 def test_view_absence_returns_none_unknown_name_raises():
     """Absent → None; a name the schema does not declare raises (the schema authority)."""
     quill = _richtext_form_quill()
-    v = quill.view(Document("richtext_form@0.1.0"))
+    v = quill.reader(Document("richtext_form@0.1.0"))
     assert v.get("bio") is None  # absent, not a typo
     with raises_edit_code("edit::unknown_field"):
         v.get("nope")  # typo, not absent
@@ -701,7 +701,7 @@ def test_view_richtext_holding_scalar_raises_mismatch():
         "~~~card-yaml\n$quill: richtext_form@0.1.0\n$kind: main\nbio: 3\n~~~\n"
     )
     with raises_edit_code("edit::field_richtext_decode"):
-        quill.view(doc).get("bio")
+        quill.reader(doc).get("bio")
 
 
 def test_view_body_read_is_quill_free():
@@ -709,7 +709,7 @@ def test_view_body_read_is_quill_free():
     quill = _taro_quill()
     doc = Document("taro@0.1.0")
     quill.writer(doc).set_body("A **taro** essay.")
-    assert quill.view(doc).get_body() == "A **taro** essay."
+    assert quill.reader(doc).get_body() == "A **taro** essay."
 
 
 def test_view_card_cursor_reads_through_kind_schema():
@@ -718,7 +718,7 @@ def test_view_card_cursor_reads_through_kind_schema():
     doc = Document("taro@0.1.0")
     ed = quill.writer(doc)
     ed.add_card("quotes", {"author": "Basho"}, "A quote body.")
-    v = quill.view(doc)
+    v = quill.reader(doc)
     assert v.card(0).kind == "quotes"
     assert v.card(0).get("author") == "Basho"
     assert v.card(0).get_body() == "A quote body."

--- a/crates/bindings/python/tests/test_parse.py
+++ b/crates/bindings/python/tests/test_parse.py
@@ -43,7 +43,7 @@ def test_payload_access(taro_md):
 def test_body_is_content_dict(taro_md):
     """`body` is the canonical content dict (source of truth); its `text` carries
     the plain USV text quill-free. The markdown projection is
-    `quill.view(doc).get_body()`."""
+    `quill.reader(doc).get_body()`."""
     doc = Document.from_markdown(taro_md)
     assert isinstance(doc.body, dict)
     assert "nutty" in doc.body["text"]

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -258,7 +258,7 @@ main card's `qty`, `doc.storeField({ card: 2, field: "qty" }, 3)` a composable
 card's. Reads are total over the field axis (`get` → `undefined`, `isFill` → `false` for
 an absent field; only an out-of-range card throws); field writes throw on a body
 address. `getMarkdown` is the body markdown read (a `CardAddr`; a field's
-markdown is read through `quill.view(doc).get(field)`). Card-scoped verbs take a
+markdown is read through `quill.reader(doc).get(field)`). Card-scoped verbs take a
 `CardAddr` (`{ card? }`) first: `doc.getExt({ card: 2 })`, and the batch below.
 
 Batch mutation: `doc.storeFields({}, {...})` / `doc.storeFields({ card: index }, {...})`

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1773,7 +1773,7 @@ addr:
 })
 
 // ---------------------------------------------------------------------------
-// quill.fieldStates — the resolved-value view
+// quill.resolve — the resolved-value view
 // ---------------------------------------------------------------------------
 //
 // For every declared field: the value the render projection would use and the
@@ -1783,7 +1783,7 @@ addr:
 // validate(), guidance stays the schema. See prose/canon/SCHEMAS.md
 // § "Value sources and projections".
 
-describe('quill.fieldStates', () => {
+describe('quill.resolve', () => {
   const QUILL_YAML = `quill:
   name: field_states_test
   version: "1.0"
@@ -1828,7 +1828,7 @@ $kind: main
 title: Hello
 ~~~
 `
-    const f = quill.fieldStates(Document.fromMarkdown(md)).main.fields
+    const f = quill.resolve(Document.fromMarkdown(md)).main.fields
 
     // Declaration order is structural — the array order is the contract.
     expect(f.map((r) => r.name)).toEqual(['title', 'status', 'notes', 'count', 'author'])
@@ -1851,7 +1851,7 @@ title: T
 
 Hello body.
 `
-    const withBody = quill.fieldStates(Document.fromMarkdown(authored))
+    const withBody = quill.resolve(Document.fromMarkdown(authored))
     expect(withBody.main.body).toBeDefined()
     expect(withBody.main.body.source).toBe('authored')
     // Not smuggled into the fields array under any `body` / `$body` name.
@@ -1864,7 +1864,7 @@ $kind: main
 title: T
 ~~~
 `
-    const noBody = quill.fieldStates(Document.fromMarkdown(blank))
+    const noBody = quill.resolve(Document.fromMarkdown(blank))
     expect(noBody.main.body.source).toBe('zero')
   })
 
@@ -1876,7 +1876,7 @@ $kind: main
 title: T
 ~~~
 `
-    const f = quill.fieldStates(Document.fromMarkdown(md)).main.fields
+    const f = quill.resolve(Document.fromMarkdown(md)).main.fields
     // Each row is exactly { name, value, source } — schema guidance (example:)
     // and diagnostics read from quill.schema / quill.validate, not duplicated.
     const author = byName(f, 'author')
@@ -1899,7 +1899,7 @@ label: L
 ~~~
 Note body.
 `
-    const states = quill.fieldStates(Document.fromMarkdown(md))
+    const states = quill.resolve(Document.fromMarkdown(md))
     expect(states.cards.length).toBe(1)
     const card = states.cards[0]
     expect(card.kind).toBe('note')
@@ -1920,7 +1920,7 @@ count: "not-a-number"
     // A value the render coercion cannot conform is kept raw and Authored,
     // exactly as compile_data leaves it — the error surfaces via validate(),
     // not this view (which carries no diagnostics).
-    const row = byName(quill.fieldStates(Document.fromMarkdown(md)).main.fields, 'count')
+    const row = byName(quill.resolve(Document.fromMarkdown(md)).main.fields, 'count')
     expect(row.source).toBe('authored')
     expect(row.value).toBe('not-a-number')
     expect('diagnostics' in row).toBe(false)
@@ -1934,7 +1934,7 @@ $kind: main
 title: T
 ~~~
 `
-    const states = quill.fieldStates(Document.fromMarkdown(md))
+    const states = quill.resolve(Document.fromMarkdown(md))
     expect(typeof JSON.stringify(states)).toBe('string')
   })
 })

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -186,7 +186,7 @@ title: Draft
 
     // getMarkdown is the card body read (card address); a field address throws.
     // A field's markdown reads through the schema-plane view,
-    // quill.view(doc).card(i).get(name) (#978).
+    // quill.reader(doc).card(i).get(name) (#978).
     expect(doc.getMarkdown({ card: 0 })).toContain('A note body.')
     expect(() => doc.getMarkdown({ card: 0, field: 'author' })).toThrow(/body-only/)
 

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -17,8 +17,8 @@ import {
   Engine,
   DocumentWriter,
   CardWriter,
-  DocumentView,
-  CardView,
+  DocumentReader,
+  CardReader,
   MAIN_CARD_ADDR,
   isQuillmarkError,
   exportMarkdown,
@@ -189,7 +189,7 @@ card_kinds:
     const quill = buildQuill()
     const ed = quill.writer(blankDoc())
     const delta = ed.reviseField('subject', 'Q3 **results**')
-    expect(quill.view(ed.document).get('subject')).toBe('Q3 **results**')
+    expect(quill.reader(ed.document).get('subject')).toBe('Q3 **results**')
     expect(delta).toBeTruthy() // the anchor-preserving receipt
   })
 
@@ -200,7 +200,7 @@ card_kinds:
     // `subject` is richtext(inline): a multi-block result is refused, field intact.
     ed.reviseField('subject', 'kept')
     expectEditCode(() => ed.reviseField('subject', 'a\n\nb'), 'edit::field_richtext_not_inline')
-    expect(quill.view(ed.document).get('subject')).toBe('kept')
+    expect(quill.reader(ed.document).get('subject')).toBe('kept')
   })
 
   it('addCard fuses make + typed commit + push, transactionally', () => {
@@ -260,10 +260,10 @@ card_kinds:
     // reads through the schema-plane view (#978).
     expect(ed.document.getMarkdown()).toBe('Main **body**.')
     expect(() => ed.document.getMarkdown({ field: 'subject' })).toThrow(/body-only/)
-    expect(quill.view(ed.document).get('subject')).toBe('Q3 **results**')
+    expect(quill.reader(ed.document).get('subject')).toBe('Q3 **results**')
     // view.get carries schema authority: an unknown name throws (vs `undefined`
     // from the quill-free transport `Document.get` above).
-    expectEditCode(() => quill.view(ed.document).get('missing'), 'edit::unknown_field')
+    expectEditCode(() => quill.reader(ed.document).get('missing'), 'edit::unknown_field')
   })
 })
 
@@ -271,7 +271,7 @@ card_kinds:
 // once and read each field by its declared type — a richtext field to markdown,
 // every other type verbatim — with schema authority, so an unknown field name
 // throws rather than reading back `undefined` off the quill-free `Document`.
-describe('@quillmark/wasm/runtime — DocumentView / CardView (the schema-plane read)', () => {
+describe('@quillmark/wasm/runtime — DocumentReader / CardReader (the schema-plane read)', () => {
   const VIEW_QUILL_YAML = `quill:
   name: view_test
   version: "1.0"
@@ -305,18 +305,18 @@ card_kinds:
     return doc
   }
 
-  it('quill.view(doc) is the front door and returns a DocumentView', () => {
+  it('quill.reader(doc) is the front door and returns a DocumentReader', () => {
     const quill = buildQuill()
-    const v = quill.view(seededDoc(quill))
-    expect(v).toBeInstanceOf(DocumentView)
-    expect(new DocumentView(quill, seededDoc(quill))).toBeInstanceOf(DocumentView)
+    const v = quill.reader(seededDoc(quill))
+    expect(v).toBeInstanceOf(DocumentReader)
+    expect(new DocumentReader(quill, seededDoc(quill))).toBeInstanceOf(DocumentReader)
   })
 
   it('interprets by declared type: richtext → markdown, plaintext → literal, scalar → canonical', () => {
     const quill = buildQuill()
     const doc = seededDoc(quill)
     quill.writer(doc).set('note', 'a *literal* line') // marks verbatim under plaintext
-    const v = quill.view(doc)
+    const v = quill.reader(doc)
     expect(v.get('subject')).toBe('Q3 **results**') // richtext projects to markdown
     expect(v.get('note')).toBe('a *literal* line') // plaintext projects verbatim
     expect(v.get('qty')).toBe(3) // scalar returns canonical
@@ -324,7 +324,7 @@ card_kinds:
 
   it('absence returns undefined; an unknown name throws (schema authority)', () => {
     const quill = buildQuill()
-    const v = quill.view(Document.fromMarkdown('~~~card-yaml\n$quill: view_test\n~~~\n\nBody.'))
+    const v = quill.reader(Document.fromMarkdown('~~~card-yaml\n$quill: view_test\n~~~\n\nBody.'))
     expect(v.get('subject')).toBeUndefined() // absent, not a typo
     expectEditCode(() => v.get('nope'), 'edit::unknown_field') // typo, not absent
   })
@@ -333,19 +333,19 @@ card_kinds:
     const quill = buildQuill()
     const doc = Document.fromMarkdown('~~~card-yaml\n$quill: view_test\n~~~\n\nBody.')
     doc.storeField('subject', 3) // opaque write puts a bare number under richtext
-    expectEditCode(() => quill.view(doc).get('subject'), 'edit::field_richtext_decode')
+    expectEditCode(() => quill.reader(doc).get('subject'), 'edit::field_richtext_decode')
   })
 
   it('an absent field addr reads the body markdown, quill-free', () => {
     const quill = buildQuill()
-    const v = quill.view(seededDoc(quill))
+    const v = quill.reader(seededDoc(quill))
     expect(v.getBody()).toBe('Main **body**.')
     expect(v.get({})).toBe('Main **body**.') // {} = main body, equals getBody()
   })
 
   it('card(i).get reads a card field through its $kind schema', () => {
     const quill = buildQuill()
-    const v = quill.view(seededDoc(quill))
+    const v = quill.reader(seededDoc(quill))
     expect(v.card(0).kind).toBe('note')
     expect(v.card(0).get('body')).toBe('A *card* field.')
     expect(v.card(0).getBody()).toBe('Card body.')
@@ -354,9 +354,9 @@ card_kinds:
 
   it('a bad card index throws at read time, not at card()', () => {
     const quill = buildQuill()
-    const cardView = quill.view(seededDoc(quill)).card(9)
-    expect(cardView).toBeInstanceOf(CardView)
-    expectEditCode(() => cardView.get('body'), 'edit::index_out_of_range')
+    const cardReader = quill.reader(seededDoc(quill)).card(9)
+    expect(cardReader).toBeInstanceOf(CardReader)
+    expectEditCode(() => cardReader.get('body'), 'edit::index_out_of_range')
   })
 })
 

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -78,7 +78,7 @@ export type {
 	DocPathSeg
 } from '../core/wasm.js';
 
-// The resolved-value view — the return shape of `quill.fieldStates(doc)`. Value
+// The resolved-value view — the return shape of `quill.resolve(doc)`. Value
 // + source rung per declared field (the body rides the fields map under
 // `$body`); diagnostics stay `quill.validate`, guidance stays `quill.schema`.
 // Declared in the core build's generated `.d.ts` via a
@@ -86,10 +86,10 @@ export type {
 // point names them.
 export type {
 	FieldSource,
-	FieldState,
-	MainFieldStates,
-	CardFieldStates,
-	FieldStates
+	ResolvedField,
+	ResolvedMain,
+	ResolvedCard,
+	Resolved
 } from '../core/wasm.js';
 
 // ── Error contract ──────────────────────────────────────────────────────────
@@ -519,14 +519,14 @@ declare module '../core/wasm.js' {
 		writer(doc: Document): DocumentWriter;
 		/**
 		 * Bind this quill's schema to `doc` for interpreted reads — the read twin of
-		 * {@link Quill.writer}, mirroring core's `quill.view(&doc)`. Each field is
+		 * {@link Quill.writer}, mirroring core's `quill.reader(&doc)`. Each field is
 		 * read by its declared type (a richtext field to markdown, every other type
 		 * verbatim) with schema authority, so a name the schema does not declare
 		 * throws rather than reading back `undefined`. Holds both handles by
 		 * reference and owns neither (nothing to `free()`); ephemeral by convention —
 		 * bind, read, discard.
 		 */
-		view(doc: Document): DocumentView;
+		reader(doc: Document): DocumentReader;
 	}
 }
 
@@ -624,7 +624,7 @@ export declare class CardWriter {
 
 /**
  * A `Document` bound to its `Quill` for interpreted reads — the schema-plane read
- * view, constructed via {@link Quill.view} and the read twin of
+ * surface, constructed via {@link Quill.reader} and the read twin of
  * {@link DocumentWriter}. One `get` reads each field by its declared type: a
  * richtext field to its markdown projection, a plaintext field to its literal
  * text, every other type its canonical value verbatim. Holds both handles by
@@ -637,7 +637,7 @@ export declare class CardWriter {
  * body-only `Document.getMarkdown`. The body read stays quill-free (a body's type
  * is a format fact) and never throws.
  */
-export declare class DocumentView {
+export declare class DocumentReader {
 	constructor(quill: Quill, doc: Document);
 	/** The bound document — the instance passed in. */
 	readonly document: Document;
@@ -653,20 +653,20 @@ export declare class DocumentView {
 	/** The main body's markdown — the quill-free body read. Equals `get({})`. */
 	getBody(): string;
 	/**
-	 * A {@link CardView} for the composable card at `index`. Index validity is
+	 * A {@link CardReader} for the composable card at `index`. Index validity is
 	 * checked lazily at read time, so this never throws. The cursor is ephemeral —
 	 * a `removeCard`/`addCard` between binding and reading silently retargets it.
 	 */
-	card(index: number): CardView;
+	card(index: number): CardReader;
 }
 
 /**
  * A composable card bound to its `Quill` for interpreted reads, from
- * {@link DocumentView.card}. Same verbs as {@link DocumentView}, reading the card
+ * {@link DocumentReader.card}. Same verbs as {@link DocumentReader}, reading the card
  * at its bound index; each read throws `IndexOutOfRange` if that index is out of
  * range.
  */
-export declare class CardView {
+export declare class CardReader {
 	constructor(quill: Quill, doc: Document, index: number);
 	/** The bound card index. */
 	readonly index: number;
@@ -681,6 +681,6 @@ export declare class CardView {
 	 * `IndexOutOfRange` for a bad index.
 	 */
 	get(name: string): unknown;
-	/** This card's body markdown — the card twin of {@link DocumentView.getBody}. */
+	/** This card's body markdown — the card twin of {@link DocumentReader.getBody}. */
 	getBody(): string;
 }

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -753,11 +753,11 @@ Quill.prototype.writer = function writer(doc) {
 	return new DocumentWriter(this, doc);
 };
 
-// ── Typed-reader sugar: the schema-plane read view ──────────────────────────
+// ── Typed-reader sugar: the schema-plane read surface ──────────────────────────
 // The read twin of the writer above. The transport `Document.get` is schema-free
 // — a `Document` cannot say which fields are richtext, so an unknown field name
 // reads back `undefined` rather than as the typo it is. Binding the quill's
-// schema (`_viewGet` takes the handle, like the `commit*` verbs) lets one `get`
+// schema (`_readerGet` takes the handle, like the `commit*` verbs) lets one `get`
 // interpret by declared type: a richtext field to markdown, a plaintext field to
 // its literal text, every other type verbatim, and an unknown name throws
 // `UnknownField`. A field's markdown lives here, not on the body-only
@@ -766,11 +766,11 @@ Quill.prototype.writer = function writer(doc) {
 
 /**
  * A {@link Document} bound to its {@link Quill} for typed reads — the JS twin of
- * Rust's `quill.view(&doc)` and the read counterpart of {@link DocumentWriter}.
+ * Rust's `quill.reader(&doc)` and the read counterpart of {@link DocumentWriter}.
  * Reads target the main card; use {@link card} for a composable card. Holds both
  * handles by reference and owns neither, so there is nothing to `free()`.
  */
-export class DocumentView {
+export class DocumentReader {
 	#quill;
 	#doc;
 	/**
@@ -796,7 +796,7 @@ export class DocumentView {
 	 * @returns {unknown}
 	 */
 	get(addr) {
-		return this.#doc._viewGet(this.#quill, addr);
+		return this.#doc._readerGet(this.#quill, addr);
 	}
 	/**
 	 * The main body's markdown — the quill-free body read (a body's type is a
@@ -804,28 +804,28 @@ export class DocumentView {
 	 * @returns {string}
 	 */
 	getBody() {
-		return this.#doc._viewGet(this.#quill, {});
+		return this.#doc._readerGet(this.#quill, {});
 	}
 	/**
-	 * A {@link CardView} bound to the composable card at `index`. Index validity
+	 * A {@link CardReader} bound to the composable card at `index`. Index validity
 	 * is checked lazily by the underlying read (it throws `IndexOutOfRange` at read
 	 * time), so constructing one never throws. Ephemeral like the writer cursor —
 	 * it holds `index`, not the card, so a `removeCard`/`addCard` between binding
 	 * and reading silently retargets it.
 	 * @param {number} index
-	 * @returns {CardView}
+	 * @returns {CardReader}
 	 */
 	card(index) {
-		return new CardView(this.#quill, this.#doc, index);
+		return new CardReader(this.#quill, this.#doc, index);
 	}
 }
 
 /**
  * A single composable card bound to its {@link Quill} for typed reads, from
- * {@link DocumentView.card}. Same `get` / `getBody` verbs as
- * {@link DocumentView}, reading the card at its bound index.
+ * {@link DocumentReader.card}. Same `get` / `getBody` verbs as
+ * {@link DocumentReader}, reading the card at its bound index.
  */
-export class CardView {
+export class CardReader {
 	#quill;
 	#doc;
 	#index;
@@ -859,30 +859,30 @@ export class CardView {
 	 * @returns {unknown}
 	 */
 	get(name) {
-		return this.#doc._viewGet(this.#quill, { card: this.#index, field: name });
+		return this.#doc._readerGet(this.#quill, { card: this.#index, field: name });
 	}
 	/**
-	 * This card's body markdown — the card twin of {@link DocumentView.getBody}.
+	 * This card's body markdown — the card twin of {@link DocumentReader.getBody}.
 	 * @returns {string}
 	 */
 	getBody() {
-		return this.#doc._viewGet(this.#quill, { card: this.#index });
+		return this.#doc._readerGet(this.#quill, { card: this.#index });
 	}
 }
 
-// ── `quill.view(doc)` — the schema-plane read front door ─────────────────────
+// ── `quill.reader(doc)` — the schema-plane read front door ─────────────────────
 // The read twin of `quill.writer(doc)`, patched onto the same re-exported `Quill`
 // prototype (the `Quill === CoreQuill` identity invariant holds — this only adds
-// a method constructing the pure-JS view, which owns no WASM handle).
+// a method constructing the pure-JS reader, which owns no WASM handle).
 /**
- * A {@link DocumentView} binding this quill's schema to `doc` for interpreted
- * reads — the read front door, mirroring core's `quill.view(&doc)`. The returned
- * view holds both handles by reference and owns neither, so there is nothing to
+ * A {@link DocumentReader} binding this quill's schema to `doc` for interpreted
+ * reads — the read front door, mirroring core's `quill.reader(&doc)`. The returned
+ * reader holds both handles by reference and owns neither, so there is nothing to
  * `free()`. Ephemeral by convention: bind, read, discard.
  * @this {Quill}
  * @param {Document} doc the document to read, held by reference (not owned)
- * @returns {DocumentView}
+ * @returns {DocumentReader}
  */
-Quill.prototype.view = function view(doc) {
-	return new DocumentView(this, doc);
+Quill.prototype.reader = function reader(doc) {
+	return new DocumentReader(this, doc);
 };

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -673,14 +673,14 @@ impl Quill {
     /// Value and provenance only: completeness and errors stay `validate`'s
     /// (a consumer merges it with its own diagnostic producers regardless), and
     /// schema guidance reads from `Quill.schema`.
-    #[wasm_bindgen(js_name = fieldStates, unchecked_return_type = "FieldStates")]
-    pub fn field_states(&self, doc: &Document) -> Result<JsValue, JsValue> {
-        let states = self.inner.field_states(&doc.inner);
+    #[wasm_bindgen(js_name = resolve, unchecked_return_type = "Resolved")]
+    pub fn resolve(&self, doc: &Document) -> Result<JsValue, JsValue> {
+        let states = self.inner.resolve(&doc.inner);
         let serializer = serde_wasm_bindgen::Serializer::new()
             .serialize_maps_as_objects(true)
             .serialize_missing_as_null(true);
         states.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("fieldStates: serialization failed: {e}")).to_js_value()
+            WasmError::from(format!("resolve: serialization failed: {e}")).to_js_value()
         })
     }
 
@@ -962,7 +962,7 @@ impl Document {
     ///
     /// `addr` is an optional **card address** (`{ card }`, absent = main). A
     /// present `field` throws — a field's markdown is read through the
-    /// schema-plane `quill.view(doc).get(field)`, which interprets by declared
+    /// schema-plane `quill.reader(doc).get(field)`, which interprets by declared
     /// type (#978). An out-of-range `addr.card` throws.
     #[wasm_bindgen(js_name = getMarkdown, unchecked_return_type = "string")]
     pub fn get_markdown(
@@ -973,7 +973,7 @@ impl Document {
         if addr.field.is_some() {
             return Err(WasmError::from(
                 "getMarkdown is body-only — read a field's markdown with \
-                 quill.view(doc).get(field)",
+                 quill.reader(doc).get(field)",
             )
             .to_js_value());
         }
@@ -981,7 +981,7 @@ impl Document {
     }
 
     /// Interpreted read at `addr`, resolving the field's declared `type` from
-    /// `quill` — the stable ABI under the runtime `view.get` / `view.card(i).get`.
+    /// `quill` — the stable ABI under the runtime `reader.get` / `reader.card(i).get`.
     /// The schema-plane twin of the quill-free [`get`](Self::get): a `richtext`
     /// field returns its markdown projection, every other declared type its
     /// canonical value verbatim, so a consumer holding the quill reads by field
@@ -999,28 +999,28 @@ impl Document {
     ///
     /// The `quill` handle is passed per call because a `Document` carries only a
     /// `$quill` reference, not the resolved schema.
-    #[wasm_bindgen(js_name = _viewGet, skip_typescript, unchecked_return_type = "unknown")]
-    pub fn view_get(
+    #[wasm_bindgen(js_name = _readerGet, skip_typescript, unchecked_return_type = "unknown")]
+    pub fn reader_get(
         &self,
         quill: &Quill,
         #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
     ) -> Result<JsValue, JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
         let base = self.addr_base(&addr);
-        let view = quill.inner.view(&self.inner);
+        let reader = quill.inner.reader(&self.inner);
         match &addr.field {
             // Absent field = body: quill-free markdown, the getMarkdown body read.
             None => Ok(JsValue::from_str(&match addr.card {
-                None => view.get_body(),
-                Some(index) => view
+                None => reader.get_body(),
+                Some(index) => reader
                     .card(index)
                     .map_err(|e| edit_error_to_js(&e, &base))?
                     .get_body(),
             })),
             Some(field) => {
                 let read = match addr.card {
-                    None => view.get(field),
-                    Some(index) => view
+                    None => reader.get(field),
+                    Some(index) => reader
                         .card(index)
                         .map_err(|e| edit_error_to_js(&e, &base))?
                         .get(field),
@@ -1032,7 +1032,7 @@ impl Document {
                     Some(quillmark_core::ReadValue::Markdown(s))
                     | Some(quillmark_core::ReadValue::Plaintext(s)) => Ok(JsValue::from_str(&s)),
                     Some(quillmark_core::ReadValue::Value(v)) => {
-                        serialize_or_throw(v.as_json(), "view.get")
+                        serialize_or_throw(v.as_json(), "reader.get")
                     }
                 }
             }
@@ -1954,11 +1954,11 @@ export type DocPathSeg =
     | { seg: "body" };
 "#;
 
-/// TypeScript declarations for the resolved-value view (`Quill.fieldStates`).
+/// TypeScript declarations for the resolved-value view (`Quill.resolve`).
 /// Emitted here as the single source of truth.
 #[wasm_bindgen(typescript_custom_section)]
-const FIELDSTATES_TS: &'static str = r#"
-/** The commitment-ladder rung that produced a `FieldState.value`. */
+const RESOLVED_TS: &'static str = r#"
+/** The commitment-ladder rung that produced a `ResolvedField.value`. */
 export type FieldSource = "authored" | "default" | "zero";
 
 /**
@@ -1968,7 +1968,7 @@ export type FieldSource = "authored" | "default" | "zero";
  * on its card, never a row in `fields`. Diagnostics stay `Quill.validate`'s;
  * schema guidance (`example:`, labels) reads from `Quill.schema`.
  */
-export interface FieldState {
+export interface ResolvedField {
     name: string;
     value: unknown;
     source: FieldSource;
@@ -1978,9 +1978,9 @@ export interface FieldState {
  * The main card's resolved rows in declaration order, plus its body row —
  * `null` when the main enables no body.
  */
-export interface MainFieldStates {
-    fields: FieldState[];
-    body: FieldState | null;
+export interface ResolvedMain {
+    fields: ResolvedField[];
+    body: ResolvedField | null;
 }
 
 /**
@@ -1988,21 +1988,21 @@ export interface MainFieldStates {
  * `kind` (`null` for an unknown-kind card), its document-array `index`, and its
  * body row — `null` when the kind enables no body.
  */
-export interface CardFieldStates {
+export interface ResolvedCard {
     kind: string | null;
     index: number;
-    fields: FieldState[];
-    body: FieldState | null;
+    fields: ResolvedField[];
+    body: ResolvedField | null;
 }
 
 /**
- * The resolved-value view (`Quill.fieldStates`): the main card and every
+ * The resolved-value view (`Quill.resolve`): the main card and every
  * composable card. Value and provenance only — completeness and errors stay
  * `Quill.validate`.
  */
-export interface FieldStates {
-    main: MainFieldStates;
-    cards: CardFieldStates[];
+export interface Resolved {
+    main: ResolvedMain;
+    cards: ResolvedCard[];
 }
 "#;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -61,7 +61,7 @@ pub use quillmark_content::Content;
 
 pub mod quill;
 pub use quill::{
-    zero_value, CardStates, FieldSource, FieldState, FieldStates, FileTreeNode, MainStates, Quill,
+    zero_value, FieldSource, FileTreeNode, Quill, Resolved, ResolvedCard, ResolvedField, ResolvedMain,
     QuillIgnore, STANDARD_METADATA_KEYS,
 };
 

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -3,7 +3,7 @@
 mod blueprint;
 mod compose;
 mod config;
-mod field_states;
+mod resolved;
 mod fill;
 mod formats;
 mod ignore;
@@ -18,7 +18,7 @@ pub(crate) mod validation;
 
 pub use config::{CoercionError, QuillConfig};
 pub(crate) use config::Leniency;
-pub use field_states::{CardStates, FieldSource, FieldState, FieldStates, MainStates};
+pub use resolved::{FieldSource, Resolved, ResolvedCard, ResolvedField, ResolvedMain};
 pub use fill::zero_value;
 pub use formats::{parse_date, parse_datetime};
 pub use ignore::QuillIgnore;
@@ -89,7 +89,7 @@ impl Quill {
     /// type (a `richtext` field to markdown, every other type verbatim) with
     /// schema authority: a name the schema does not declare reads as the typo it
     /// is rather than as absent. See the [`reader`](crate::reader) module.
-    pub fn view<'a>(&'a self, doc: &'a crate::document::Document) -> crate::TypedReader<'a> {
+    pub fn reader<'a>(&'a self, doc: &'a crate::document::Document) -> crate::TypedReader<'a> {
         crate::TypedReader::new(&self.config, doc)
     }
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use indexmap::IndexMap;
 
-use super::field_states::FieldSource;
+use super::resolved::FieldSource;
 use super::{seed, CardSchema, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
 use crate::normalize::normalize_field_name;
 use crate::quill::zero_value;
@@ -320,7 +320,7 @@ fn coercion_error(e: impl std::fmt::Display) -> RenderError {
 
 /// The one total resolver both canon projections cut — the render-fidelity plate
 /// ([`compile_data`](QuillConfig::compile_data)) and the consumer-side
-/// resolved-value view ([`Quill::field_states`](crate::Quill::field_states)). For
+/// resolved-value view ([`Quill::resolve`](crate::Quill::resolve)). For
 /// one card it owns the whole per-field walk: conform each authored value under
 /// Render leniency (keep-raw on failure — a branch the validation gate makes
 /// unreachable on a rendered document), NFC-normalize the key (what

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 
 use super::resolved::FieldSource;
 use super::{seed, CardSchema, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
-use crate::normalize::normalize_field_name;
+use crate::normalize::{normalize_document, normalize_field_name};
 use crate::quill::zero_value;
 use crate::path::DocPath;
 use crate::{
@@ -47,27 +47,34 @@ impl QuillConfig {
     /// it surfaces as a non-fatal warning from `validate`. See
     /// `prose/canon/SCHEMAS.md`.
     pub fn compile_data(&self, doc: &Document) -> Result<serde_json::Value, RenderError> {
-        // Validation gate: only a *malformed* document (a value that won't
-        // coerce/validate) is fatal. A document that passes never takes the
-        // keep-raw branch inside [`resolve_card_sourced`], so the total resolver
-        // below reproduces the gated, coerced, NFC-normalized values
-        // byte-for-byte — the render plate is the resolved-value view with its
-        // source rungs dropped, not a second walk of the same ladder.
-        self.coerce_and_validate(doc)?;
+        // The gate is the **one** coercion pass: `coerce_and_validate` conforms
+        // every field (Render leniency, fallible) and validates, erroring on a
+        // malformed document. The ladder below consumes its coerced, NFC-normalized
+        // output rather than re-conforming — a document that reaches the ladder is
+        // already Render-conformed, so the plate is the sourced ladder with its
+        // rungs dropped. `resolve()` runs the total (keep-raw) conform for its own
+        // fallibility-free path; both cut the same [`ladder_sourced`].
+        let coerced = self.coerce_and_validate(doc)?;
+        let normalized = normalize_document(coerced)?;
 
         let final_main = Card::from_parts(
             rebuild_payload_with_meta(
-                doc.main(),
-                plate_fields(resolve_card_sourced(&self.main, doc.main())),
+                normalized.main(),
+                plate_fields(ladder_sourced(
+                    &self.main,
+                    &normalized.main().payload().to_index_map(),
+                )),
             ),
-            doc.main().body().clone(),
+            normalized.main().body().clone(),
         );
-        let cards_resolved: Vec<Card> = doc
+        let cards_resolved: Vec<Card> = normalized
             .cards()
             .iter()
             .map(|card| {
                 let fields = match self.card_kind(card.kind().unwrap_or("")) {
-                    Some(schema) => plate_fields(resolve_card_sourced(schema, card)),
+                    Some(schema) => {
+                        plate_fields(ladder_sourced(schema, &card.payload().to_index_map()))
+                    }
                     // Unknown-kind card: authored fields verbatim, no ladder — as
                     // the resolved-value view leaves it (`card_states`).
                     None => card.payload().to_index_map(),
@@ -318,36 +325,32 @@ fn coercion_error(e: impl std::fmt::Display) -> RenderError {
     )
 }
 
-/// The one total resolver both canon projections cut — the render-fidelity plate
-/// ([`compile_data`](QuillConfig::compile_data)) and the consumer-side
-/// resolved-value view ([`Quill::resolve`](crate::Quill::resolve)). For
-/// one card it owns the whole per-field walk: conform each authored value under
-/// Render leniency (keep-raw on failure — a branch the validation gate makes
-/// unreachable on a rendered document), NFC-normalize the key (what
-/// `normalize_document` did between coercion and the ladder), then cut the
-/// **sourced** commitment ladder over the declared fields. Undeclared authored
-/// fields carry through verbatim ([`Authored`](FieldSource::Authored)) — the
-/// schema is a floor, not an allowlist.
-///
-/// Field order is authored-first with declared-but-absent fields appended: the
-/// render plate's order. Each projection re-cuts the presentation order it wants
-/// from this one value-and-source map — the view rows declared fields first in
-/// declaration order — rather than re-deriving the ladder against a parallel
-/// precedence policy (`prose/canon/SCHEMAS.md` § "Value sources and
-/// projections"). Null ≡ absent applies recursively inside
-/// [`resolve_value_sourced`], so no bare null reaches either projection.
+/// The total (keep-raw) resolver behind [`Quill::resolve`](crate::Quill::resolve):
+/// conform each authored value under Render leniency (keep-raw on failure — the
+/// fallibility-free path a consumer-side view needs), NFC-normalize the key, then
+/// cut the shared [`ladder_sourced`]. The render plate reaches the same rows by a
+/// different route — its gate does the fallible conform, and `compile_data` hands
+/// the coerced result straight to `ladder_sourced` — so the two cut one ladder
+/// over equal input (a document that passes the gate never takes the keep-raw
+/// branch), never a parallel precedence policy.
 pub(crate) fn resolve_card_sourced(
     schema: &CardSchema,
     card: &Card,
 ) -> IndexMap<String, (QuillValue, FieldSource)> {
-    // conform + NFC, per field — the gated-and-coerced input, reproduced. Every
-    // validated ingress (parse, the mutators) restricts field names to ASCII
-    // (NFC-invariant), so the normalization only respells keys on a
-    // directly-constructed payload (`Payload::from_index_map`), under the same
-    // NFC key the plate carries. A value Render coercion cannot conform is kept
-    // raw (the ladder reads it Authored); on a document that passes the gate that
-    // branch never fires, so this equals the gated path byte-for-byte.
-    let mut resolved_input: IndexMap<String, QuillValue> = IndexMap::new();
+    ladder_sourced(schema, &conform_card_render(schema, card))
+}
+
+/// Conform one card's authored fields under Render leniency, keep-raw on failure,
+/// NFC-normalizing each key — the total (infallible) coercion the resolved-value
+/// view runs in place of the render gate's fallible one. Every validated ingress
+/// (parse, the mutators) restricts field names to ASCII (NFC-invariant), so the
+/// normalization only respells keys on a directly-constructed payload
+/// (`Payload::from_index_map`), under the same NFC key the plate carries. A value
+/// Render coercion cannot conform is kept raw (the ladder reads it Authored); on a
+/// document that passes the gate that branch never fires, so this equals the gated
+/// path byte-for-byte.
+fn conform_card_render(schema: &CardSchema, card: &Card) -> IndexMap<String, QuillValue> {
+    let mut coerced: IndexMap<String, QuillValue> = IndexMap::new();
     for (raw_name, value) in card.payload().to_index_map() {
         let name = normalize_field_name(&raw_name);
         let entry = match schema.fields.get(&raw_name) {
@@ -357,22 +360,43 @@ pub(crate) fn resolve_card_sourced(
             }
             None => value,
         };
-        resolved_input.insert(name, entry);
+        coerced.insert(name, entry);
     }
+    coerced
+}
 
+/// The shared sourced ladder both canon projections cut — the render-fidelity
+/// plate ([`compile_data`](QuillConfig::compile_data)) and the resolved-value view
+/// ([`Quill::resolve`](crate::Quill::resolve)) — over an already-coerced,
+/// NFC-normalized field map. For every declared field it reports the value the
+/// render projection uses and the [`FieldSource`] rung that produced it; undeclared
+/// authored fields carry through verbatim ([`Authored`](FieldSource::Authored)) —
+/// the schema is a floor, not an allowlist.
+///
+/// Field order is authored-first with declared-but-absent fields appended: the
+/// render plate's order. Each projection re-cuts the presentation order it wants
+/// from this one value-and-source map — the view rows declared fields first in
+/// declaration order — rather than re-deriving the ladder against a parallel
+/// precedence policy (`prose/canon/SCHEMAS.md` § "Value sources and projections").
+/// Null ≡ absent applies recursively inside [`resolve_value_sourced`], so no bare
+/// null reaches either projection.
+pub(crate) fn ladder_sourced(
+    schema: &CardSchema,
+    coerced: &IndexMap<String, QuillValue>,
+) -> IndexMap<String, (QuillValue, FieldSource)> {
     // Undeclared authored fields seed the map in authored order (verbatim,
     // Authored); the declared fields then overlay in place — or append when
     // absent — each carrying its ladder value and the source rung that produced
     // it. Insert on an existing key preserves its authored position, so the
     // order is authored-first, declared-but-absent appended.
-    let mut out: IndexMap<String, (QuillValue, FieldSource)> = resolved_input
+    let mut out: IndexMap<String, (QuillValue, FieldSource)> = coerced
         .iter()
         .map(|(name, value)| (name.clone(), (value.clone(), FieldSource::Authored)))
         .collect();
     for (name, field_schema) in &schema.fields {
         out.insert(
             name.clone(),
-            resolve_value_sourced(resolved_input.get(name), field_schema),
+            resolve_value_sourced(coerced.get(name), field_schema),
         );
     }
     out

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -7,8 +7,8 @@ use std::str::FromStr;
 use indexmap::IndexMap;
 
 use super::field_states::FieldSource;
-use super::{seed, CardSchema, FieldSchema, FieldType, Quill, QuillConfig};
-use crate::normalize::normalize_document;
+use super::{seed, CardSchema, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
+use crate::normalize::normalize_field_name;
 use crate::quill::zero_value;
 use crate::path::DocPath;
 use crate::{
@@ -47,29 +47,36 @@ impl QuillConfig {
     /// it surfaces as a non-fatal warning from `validate`. See
     /// `prose/canon/SCHEMAS.md`.
     pub fn compile_data(&self, doc: &Document) -> Result<serde_json::Value, RenderError> {
-        let coerced = self.coerce_and_validate(doc)?;
-        let normalized = normalize_document(coerced)?;
+        // Validation gate: only a *malformed* document (a value that won't
+        // coerce/validate) is fatal. A document that passes never takes the
+        // keep-raw branch inside [`resolve_card_sourced`], so the total resolver
+        // below reproduces the gated, coerced, NFC-normalized values
+        // byte-for-byte — the render plate is the resolved-value view with its
+        // source rungs dropped, not a second walk of the same ladder.
+        self.coerce_and_validate(doc)?;
 
-        let main_resolved = resolve_fields(&normalized.main().payload().to_index_map(), &self.main);
-        let cards_resolved: Vec<Card> = normalized
+        let final_main = Card::from_parts(
+            rebuild_payload_with_meta(
+                doc.main(),
+                plate_fields(resolve_card_sourced(&self.main, doc.main())),
+            ),
+            doc.main().body().clone(),
+        );
+        let cards_resolved: Vec<Card> = doc
             .cards()
             .iter()
             .map(|card| {
                 let fields = match self.card_kind(card.kind().unwrap_or("")) {
-                    Some(schema) => resolve_fields(&card.payload().to_index_map(), schema),
+                    Some(schema) => plate_fields(resolve_card_sourced(schema, card)),
+                    // Unknown-kind card: authored fields verbatim, no ladder — as
+                    // the resolved-value view leaves it (`card_states`).
                     None => card.payload().to_index_map(),
                 };
                 Card::from_parts(rebuild_payload_with_meta(card, fields), card.body().clone())
             })
             .collect();
 
-        let final_main = Card::from_parts(
-            rebuild_payload_with_meta(normalized.main(), main_resolved),
-            normalized.main().body().clone(),
-        );
-        let final_doc = Document::from_main_and_cards(final_main, cards_resolved);
-
-        Ok(final_doc.to_plate_json())
+        Ok(Document::from_main_and_cards(final_main, cards_resolved).to_plate_json())
     }
 
     /// Validate without backend compilation.
@@ -311,33 +318,83 @@ fn coercion_error(e: impl std::fmt::Display) -> RenderError {
     )
 }
 
-/// Resolve every schema field absent from `fields`, by precedence: an authored
-/// value wins; else the schema `default:`; else the type-empty [`zero_value`].
-/// This is the zero-filled render projection — the fill lives only here and is
-/// never persisted (see `prose/canon/SCHEMAS.md`). Non-schema fields already
-/// present are preserved untouched.
+/// The one total resolver both canon projections cut — the render-fidelity plate
+/// ([`compile_data`](QuillConfig::compile_data)) and the consumer-side
+/// resolved-value view ([`Quill::field_states`](crate::Quill::field_states)). For
+/// one card it owns the whole per-field walk: conform each authored value under
+/// Render leniency (keep-raw on failure — a branch the validation gate makes
+/// unreachable on a rendered document), NFC-normalize the key (what
+/// `normalize_document` did between coercion and the ladder), then cut the
+/// **sourced** commitment ladder over the declared fields. Undeclared authored
+/// fields carry through verbatim ([`Authored`](FieldSource::Authored)) — the
+/// schema is a floor, not an allowlist.
 ///
-/// Null ≡ absent **at every level**: a null or absent value — top-level field,
-/// typed-dictionary property, or typed-table cell — carries no data and resolves
-/// like an omitted one (default, else zero) rather than projecting a bare null
-/// into the plate. A `!must_fill` placeholder is a present-null (or a suggested
-/// value) on this path; its marker is render-irrelevant.
-fn resolve_fields(
-    fields: &IndexMap<String, QuillValue>,
+/// Field order is authored-first with declared-but-absent fields appended: the
+/// render plate's order. Each projection re-cuts the presentation order it wants
+/// from this one value-and-source map — the view rows declared fields first in
+/// declaration order — rather than re-deriving the ladder against a parallel
+/// precedence policy (`prose/canon/SCHEMAS.md` § "Value sources and
+/// projections"). Null ≡ absent applies recursively inside
+/// [`resolve_value_sourced`], so no bare null reaches either projection.
+pub(crate) fn resolve_card_sourced(
     schema: &CardSchema,
-) -> IndexMap<String, QuillValue> {
-    let mut result = fields.clone();
-    for (name, field) in &schema.fields {
-        let resolved = resolve_value(result.get(name), field);
-        result.insert(name.clone(), resolved);
+    card: &Card,
+) -> IndexMap<String, (QuillValue, FieldSource)> {
+    // conform + NFC, per field — the gated-and-coerced input, reproduced. Every
+    // validated ingress (parse, the mutators) restricts field names to ASCII
+    // (NFC-invariant), so the normalization only respells keys on a
+    // directly-constructed payload (`Payload::from_index_map`), under the same
+    // NFC key the plate carries. A value Render coercion cannot conform is kept
+    // raw (the ladder reads it Authored); on a document that passes the gate that
+    // branch never fires, so this equals the gated path byte-for-byte.
+    let mut resolved_input: IndexMap<String, QuillValue> = IndexMap::new();
+    for (raw_name, value) in card.payload().to_index_map() {
+        let name = normalize_field_name(&raw_name);
+        let entry = match schema.fields.get(&raw_name) {
+            Some(field_schema) => {
+                QuillConfig::conform_value(&value, field_schema, &name, Leniency::Render)
+                    .unwrap_or(value)
+            }
+            None => value,
+        };
+        resolved_input.insert(name, entry);
     }
-    result
+
+    // Undeclared authored fields seed the map in authored order (verbatim,
+    // Authored); the declared fields then overlay in place — or append when
+    // absent — each carrying its ladder value and the source rung that produced
+    // it. Insert on an existing key preserves its authored position, so the
+    // order is authored-first, declared-but-absent appended.
+    let mut out: IndexMap<String, (QuillValue, FieldSource)> = resolved_input
+        .iter()
+        .map(|(name, value)| (name.clone(), (value.clone(), FieldSource::Authored)))
+        .collect();
+    for (name, field_schema) in &schema.fields {
+        out.insert(
+            name.clone(),
+            resolve_value_sourced(resolved_input.get(name), field_schema),
+        );
+    }
+    out
+}
+
+/// Drop the source rungs from [`resolve_card_sourced`]'s map — the render plate
+/// consumes the value half only; the resolved-value view keeps both.
+fn plate_fields(
+    sourced: IndexMap<String, (QuillValue, FieldSource)>,
+) -> IndexMap<String, QuillValue> {
+    sourced
+        .into_iter()
+        .map(|(name, (value, _source))| (name, value))
+        .collect()
 }
 
 /// The value half of [`resolve_value_sourced`], discarding the rung tag — the
-/// zero-filled render projection consumes only the value. `field_states`
-/// consumes both, so the source is produced by the one branch here rather than
-/// re-derived against a parallel ladder.
+/// nested-recursion helper for a typed dictionary's properties and a typed
+/// array's elements, where the source of an inner cell is not surfaced (a
+/// present dict/array is [`Authored`](FieldSource::Authored) as a whole). Both
+/// canon projections cut the sourced ladder through [`resolve_card_sourced`];
+/// this is the inner value-only cut beneath it.
 fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue {
     resolve_value_sourced(value, field).0
 }
@@ -375,8 +432,9 @@ pub(crate) fn resolve_value_sourced(
         // commits the *content* form of its default (`default_content`, cached at
         // load by `from_yaml`), so the seam carries canonical Content-JSON the
         // backend can classify. It must NOT fall through to the raw `default`:
-        // `resolve_fields` runs after `coerce_and_validate`, so a bare authored
-        // string injected here would reach the plate uncoerced and be misread. A
+        // the ladder injects this default without re-coercing it (coercion
+        // touched only authored values), so a bare authored string here would
+        // reach the plate uncoerced and be misread. A
         // content field with no cached `default_content` (only reachable via a
         // serde-built `QuillConfig`, never `from_yaml`) zero-fills to the empty
         // content.

--- a/crates/core/src/quill/field_states.rs
+++ b/crates/core/src/quill/field_states.rs
@@ -4,8 +4,9 @@
 //! inferred behavior chain: for every declared field, the value the render
 //! projection would use and the [`FieldSource`] rung it came from. It cuts the
 //! one commitment ladder (`prose/canon/SCHEMAS.md` § "Value sources and
-//! projections") through the shared producer [`resolve_value_sourced`], never a
-//! parallel precedence policy.
+//! projections") through the shared producer
+//! [`resolve_card_sourced`](super::compose::resolve_card_sourced) — the same
+//! resolver the render plate cuts — never a parallel precedence policy.
 //!
 //! Values only: diagnostics stay [`Quill::validate`]'s job (the editor merges
 //! `validate()` with its own producers regardless, so bucketing here would
@@ -16,8 +17,8 @@
 use indexmap::IndexMap;
 use serde::Serialize;
 
-use super::compose::resolve_value_sourced;
-use super::{CardSchema, Leniency, Quill, QuillConfig};
+use super::compose::resolve_card_sourced;
+use super::{CardSchema, Quill, QuillConfig};
 use crate::{Card, Document, QuillValue};
 
 /// The rung of the commitment ladder that produced a [`FieldState::value`].
@@ -75,11 +76,12 @@ pub struct FieldStates {
 impl Quill {
     /// The resolved-value view of `doc` against this quill's schema.
     ///
-    /// For every declared field, the value [`compile_data`] would emit into the
-    /// plate (byte-for-byte with the plate on every fixture), tagged with the
-    /// [`FieldSource`] rung it came from — one call for value and provenance
-    /// instead of re-implementing the ladder. Completeness and errors stay
-    /// [`Quill::validate`]'s; this view carries no diagnostics.
+    /// For every declared field, the value [`compile_data`] emits into the plate
+    /// — the two cut the *same* resolver
+    /// ([`resolve_card_sourced`](super::compose::resolve_card_sourced)), so the
+    /// value is the plate's by construction — tagged with the [`FieldSource`]
+    /// rung it came from. Completeness and errors stay [`Quill::validate`]'s;
+    /// this view carries no diagnostics.
     ///
     /// [`compile_data`]: Quill::compile_data
     pub fn field_states(&self, doc: &Document) -> FieldStates {
@@ -98,37 +100,27 @@ impl Quill {
 
 /// Resolve one card (main or a schema-declared kind) into its ordered
 /// [`FieldState`] rows and its body row (present iff the kind enables a body).
+///
+/// The value and source of every field come from the one shared resolver
+/// [`resolve_card_sourced`] — the same producer [`compile_data`] cuts for the
+/// plate — so the two projections cannot drift. This layer only re-cuts the
+/// **presentation order**: declared fields first in declaration order (the canon
+/// ordering contract, carried structurally by the row array — not the validation
+/// walker's alphabetical sort), then undeclared authored fields in authored
+/// order. The body is a sibling row, never an entry in `fields`.
+///
+/// [`compile_data`]: crate::Quill::compile_data
 fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<FieldState>, Option<FieldState>) {
-    // Mirror `compile_data`'s pipeline per-field so the value is byte-for-byte
-    // with the plate: coerce under Render leniency (the schema looked up by the
-    // authored name, as `coerce_payload` does), then NFC-normalize the key
-    // (`normalize_document` runs between coercion and the ladder), then resolve.
-    // Every validated ingress (parse, the mutators) restricts field names to
-    // ASCII — NFC-invariant — so the normalization only respells keys on a
-    // directly-constructed payload (`Payload::from_index_map`), under the same
-    // NFC key the plate carries. A value the render coercion cannot conform is
-    // kept raw (the ladder reads it Authored), exactly as `compile_data` leaves
-    // it — the failure surfaces through `validate()`, not here.
-    let mut resolved_input: IndexMap<String, QuillValue> = IndexMap::new();
-    for (raw_name, value) in card.payload().to_index_map() {
-        let name = crate::normalize::normalize_field_name(&raw_name);
-        let entry = match schema.fields.get(&raw_name) {
-            Some(field_schema) => {
-                QuillConfig::conform_value(&value, field_schema, &name, Leniency::Render)
-                    .unwrap_or(value)
-            }
-            None => value,
-        };
-        resolved_input.insert(name, entry);
-    }
-
+    let sourced: IndexMap<String, (QuillValue, FieldSource)> = resolve_card_sourced(schema, card);
     let mut fields = Vec::new();
 
-    // Declared rows in schema **declaration order** — the canon ordering
-    // contract, now carried structurally by the row array. (Not the validation
-    // walker, which sorts alphabetically.)
-    for (name, field_schema) in &schema.fields {
-        let (value, source) = resolve_value_sourced(resolved_input.get(name), field_schema);
+    // Declared rows in schema declaration order. Every declared field is present
+    // in the map — the resolver's ladder inserts each one — so the lookup holds.
+    for (name, _field_schema) in &schema.fields {
+        let (value, source) = sourced
+            .get(name)
+            .cloned()
+            .expect("resolve_card_sourced emits every declared field");
         fields.push(FieldState {
             name: name.clone(),
             value,
@@ -137,20 +129,18 @@ fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<FieldState>, Op
     }
 
     // Undeclared authored fields, appended in authored order under their NFC
-    // keys (matching the plate's): the schema is a floor, not an allowlist, so
-    // these reach the plate too — value verbatim, source Authored.
-    for (name, value) in &resolved_input {
+    // keys: the schema is a floor, not an allowlist, so these reach both
+    // projections too — value verbatim, source Authored.
+    for (name, (value, source)) in &sourced {
         if !schema.fields.contains_key(name) {
             fields.push(FieldState {
                 name: name.clone(),
                 value: value.clone(),
-                source: FieldSource::Authored,
+                source: *source,
             });
         }
     }
 
-    // The body is a sibling row, not an entry in `fields` — present iff the kind
-    // enables a body.
     let body = schema.body_enabled().then(|| body_state(card));
     (fields, body)
 }
@@ -333,7 +323,10 @@ card_kinds:
         assert_eq!(status.value.as_json(), &serde_json::json!("draft"));
     }
 
-    // ── Byte-for-byte with the render projection (the phase's acceptance) ────
+    // ── Byte-for-byte with the render projection ─────────────────────────────
+    // Both projections now cut the one shared resolver, so agreement is
+    // structural rather than mirrored; this guards against a future re-fork and
+    // pins the plate-build wiring (order, meta, body) against the row view.
 
     #[test]
     fn every_row_is_byte_for_byte_with_compile_data() {

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -5,8 +5,9 @@
 //! projection would use and the [`FieldSource`] rung it came from. It cuts the
 //! one commitment ladder (`prose/canon/SCHEMAS.md` § "Value sources and
 //! projections") through the shared producer
-//! `resolve_card_sourced` (in `super::compose`) — the same resolver the render
-//! plate cuts — never a parallel precedence policy.
+//! `resolve_card_sourced` (in `super::compose`), whose sourced ladder
+//! (`ladder_sourced`) the render plate cuts too — never a parallel precedence
+//! policy.
 //!
 //! Values only: diagnostics stay [`Quill::validate`]'s job (the editor merges
 //! `validate()` with its own producers regardless, so bucketing here would
@@ -77,10 +78,10 @@ impl Quill {
     /// The resolved-value view of `doc` against this quill's schema.
     ///
     /// For every declared field, the value [`compile_data`] emits into the plate
-    /// — the two cut the *same* resolver (`resolve_card_sourced`), so the value
-    /// is the plate's by construction — tagged with the [`FieldSource`] rung it
-    /// came from. Completeness and errors stay [`Quill::validate`]'s; this view
-    /// carries no diagnostics.
+    /// — the two cut the *same* sourced ladder (`ladder_sourced`) over equal
+    /// coerced input, so the value is the plate's by construction — tagged with
+    /// the [`FieldSource`] rung it came from. Completeness and errors stay
+    /// [`Quill::validate`]'s; this view carries no diagnostics.
     ///
     /// [`compile_data`]: Quill::compile_data
     pub fn resolve(&self, doc: &Document) -> Resolved {
@@ -323,9 +324,11 @@ card_kinds:
     }
 
     // ── Byte-for-byte with the render projection ─────────────────────────────
-    // Both projections now cut the one shared resolver, so agreement is
-    // structural rather than mirrored; this guards against a future re-fork and
-    // pins the plate-build wiring (order, meta, body) against the row view.
+    // Both projections cut the one shared ladder (`ladder_sourced`), but over
+    // separately-conformed input — the render gate's fallible conform vs the
+    // view's keep-raw `conform_card_render`. This pins that those two conform
+    // paths agree on a gated document, plus the plate-build wiring (order, meta,
+    // body) against the row view.
 
     #[test]
     fn every_row_is_byte_for_byte_with_compile_data() {

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -1,12 +1,12 @@
-//! The resolved-value view — [`Quill::field_states`].
+//! The resolved-value view — [`Quill::resolve`].
 //!
 //! A projection that makes field resolution observable *data* rather than an
 //! inferred behavior chain: for every declared field, the value the render
 //! projection would use and the [`FieldSource`] rung it came from. It cuts the
 //! one commitment ladder (`prose/canon/SCHEMAS.md` § "Value sources and
 //! projections") through the shared producer
-//! [`resolve_card_sourced`](super::compose::resolve_card_sourced) — the same
-//! resolver the render plate cuts — never a parallel precedence policy.
+//! `resolve_card_sourced` (in `super::compose`) — the same resolver the render
+//! plate cuts — never a parallel precedence policy.
 //!
 //! Values only: diagnostics stay [`Quill::validate`]'s job (the editor merges
 //! `validate()` with its own producers regardless, so bucketing here would
@@ -21,7 +21,7 @@ use super::compose::resolve_card_sourced;
 use super::{CardSchema, Quill, QuillConfig};
 use crate::{Card, Document, QuillValue};
 
-/// The rung of the commitment ladder that produced a [`FieldState::value`].
+/// The rung of the commitment ladder that produced a [`ResolvedField::value`].
 /// Serializes lowercase (`"authored" | "default" | "zero"`).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -37,11 +37,11 @@ pub enum FieldSource {
 /// One resolved row: its `name`, the value the render projection would use, and
 /// the [`FieldSource`] rung that value came from. A row carries its own name so
 /// declaration order is structural — an ordered array, not JSON object key
-/// order. The card body is a [`MainStates::body`] / [`CardStates::body`]
+/// order. The card body is a [`ResolvedMain::body`] / [`ResolvedCard::body`]
 /// sibling, never a row in `fields`, so a consumer iterating declared fields
 /// never trips over it.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct FieldState {
+pub struct ResolvedField {
     pub name: String,
     pub value: QuillValue,
     pub source: FieldSource,
@@ -50,56 +50,55 @@ pub struct FieldState {
 /// The main card's resolved rows in declaration order, plus its body row when
 /// the main enables a body.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct MainStates {
-    pub fields: Vec<FieldState>,
-    pub body: Option<FieldState>,
+pub struct ResolvedMain {
+    pub fields: Vec<ResolvedField>,
+    pub body: Option<ResolvedField>,
 }
 
 /// One composable card's resolved rows, with its authored `kind` (present even
 /// for an unknown kind, which carries its fields verbatim), its document-array
 /// `index`, and its body row when the kind enables a body.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct CardStates {
+pub struct ResolvedCard {
     pub kind: Option<String>,
     pub index: usize,
-    pub fields: Vec<FieldState>,
-    pub body: Option<FieldState>,
+    pub fields: Vec<ResolvedField>,
+    pub body: Option<ResolvedField>,
 }
 
 /// The whole resolved-value view: the main card and every composable card.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct FieldStates {
-    pub main: MainStates,
-    pub cards: Vec<CardStates>,
+pub struct Resolved {
+    pub main: ResolvedMain,
+    pub cards: Vec<ResolvedCard>,
 }
 
 impl Quill {
     /// The resolved-value view of `doc` against this quill's schema.
     ///
     /// For every declared field, the value [`compile_data`] emits into the plate
-    /// — the two cut the *same* resolver
-    /// ([`resolve_card_sourced`](super::compose::resolve_card_sourced)), so the
-    /// value is the plate's by construction — tagged with the [`FieldSource`]
-    /// rung it came from. Completeness and errors stay [`Quill::validate`]'s;
-    /// this view carries no diagnostics.
+    /// — the two cut the *same* resolver (`resolve_card_sourced`), so the value
+    /// is the plate's by construction — tagged with the [`FieldSource`] rung it
+    /// came from. Completeness and errors stay [`Quill::validate`]'s; this view
+    /// carries no diagnostics.
     ///
     /// [`compile_data`]: Quill::compile_data
-    pub fn field_states(&self, doc: &Document) -> FieldStates {
+    pub fn resolve(&self, doc: &Document) -> Resolved {
         let config = self.config();
         let (fields, body) = resolve_card_fields(&config.main, doc.main());
-        let main = MainStates { fields, body };
+        let main = ResolvedMain { fields, body };
         let cards = doc
             .cards()
             .iter()
             .enumerate()
             .map(|(index, card)| card_states(config, card, index))
             .collect();
-        FieldStates { main, cards }
+        Resolved { main, cards }
     }
 }
 
 /// Resolve one card (main or a schema-declared kind) into its ordered
-/// [`FieldState`] rows and its body row (present iff the kind enables a body).
+/// [`ResolvedField`] rows and its body row (present iff the kind enables a body).
 ///
 /// The value and source of every field come from the one shared resolver
 /// [`resolve_card_sourced`] — the same producer [`compile_data`] cuts for the
@@ -110,7 +109,7 @@ impl Quill {
 /// order. The body is a sibling row, never an entry in `fields`.
 ///
 /// [`compile_data`]: crate::Quill::compile_data
-fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<FieldState>, Option<FieldState>) {
+fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<ResolvedField>, Option<ResolvedField>) {
     let sourced: IndexMap<String, (QuillValue, FieldSource)> = resolve_card_sourced(schema, card);
     let mut fields = Vec::new();
 
@@ -121,7 +120,7 @@ fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<FieldState>, Op
             .get(name)
             .cloned()
             .expect("resolve_card_sourced emits every declared field");
-        fields.push(FieldState {
+        fields.push(ResolvedField {
             name: name.clone(),
             value,
             source,
@@ -133,7 +132,7 @@ fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<FieldState>, Op
     // projections too — value verbatim, source Authored.
     for (name, (value, source)) in &sourced {
         if !schema.fields.contains_key(name) {
-            fields.push(FieldState {
+            fields.push(ResolvedField {
                 name: name.clone(),
                 value: value.clone(),
                 source: *source,
@@ -149,14 +148,14 @@ fn resolve_card_fields(schema: &CardSchema, card: &Card) -> (Vec<FieldState>, Op
 /// through the ladder; an unknown-kind card (declared `$kind` with no schema, or
 /// a kindless card) carries its authored fields verbatim — no coercion, no
 /// ladder, no `$body` row.
-fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
+fn card_states(config: &QuillConfig, card: &Card, index: usize) -> ResolvedCard {
     // The raw authored kind rides the entry even when it names no schema — the
     // card reports what it *claimed* to be.
     let kind = card.kind().map(String::from);
     match card.kind().and_then(|k| config.card_kind(k)) {
         Some(schema) => {
             let (fields, body) = resolve_card_fields(schema, card);
-            CardStates {
+            ResolvedCard {
                 kind,
                 index,
                 fields,
@@ -170,13 +169,13 @@ fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
                 .payload()
                 .to_index_map()
                 .into_iter()
-                .map(|(name, value)| FieldState {
+                .map(|(name, value)| ResolvedField {
                     name,
                     value,
                     source: FieldSource::Authored,
                 })
                 .collect();
-            CardStates {
+            ResolvedCard {
                 kind,
                 index,
                 fields,
@@ -190,14 +189,14 @@ fn card_states(config: &QuillConfig, card: &Card, index: usize) -> CardStates {
 /// `$body` (canonical Content-JSON of the card body). A body has no `default:`
 /// rung, so its source is only ever [`Authored`](FieldSource::Authored)
 /// (non-blank) or [`Zero`](FieldSource::Zero) (blank).
-fn body_state(card: &Card) -> FieldState {
+fn body_state(card: &Card) -> ResolvedField {
     let value = QuillValue::from_json(quillmark_content::serial::to_canonical_value(card.body()));
     let source = if card.body().is_blank() {
         FieldSource::Zero
     } else {
         FieldSource::Authored
     };
-    FieldState {
+    ResolvedField {
         name: "body".to_string(),
         value,
         source,
@@ -229,14 +228,14 @@ mod tests {
     }
 
     /// Look up a resolved row by name — rows are an ordered array now.
-    fn row<'a>(fields: &'a [FieldState], name: &str) -> &'a FieldState {
+    fn row<'a>(fields: &'a [ResolvedField], name: &str) -> &'a ResolvedField {
         fields
             .iter()
             .find(|f| f.name == name)
             .unwrap_or_else(|| panic!("no row `{name}`"))
     }
 
-    fn has_row(fields: &[FieldState], name: &str) -> bool {
+    fn has_row(fields: &[ResolvedField], name: &str) -> bool {
         fields.iter().any(|f| f.name == name)
     }
 
@@ -283,7 +282,7 @@ card_kinds:
         let quill = quill_from_yaml(QUILL);
         // title authored; status absent (has a default); notes absent (no default).
         let doc = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: Hello\n~~~\n");
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let f = &states.main.fields;
 
         assert_eq!(row(f, "title").source, FieldSource::Authored);
@@ -301,7 +300,7 @@ card_kinds:
         let quill = quill_from_yaml(QUILL);
         // intro absent → its richtext `default:` (committed as content).
         let doc = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n");
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let intro = row(&states.main.fields, "intro");
 
         assert_eq!(intro.source, FieldSource::Default);
@@ -317,7 +316,7 @@ card_kinds:
         let quill = quill_from_yaml(QUILL);
         // `status:` is a present-null → treated as absent → default rung.
         let doc = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\nstatus:\n~~~\n");
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let status = row(&states.main.fields, "status");
         assert_eq!(status.source, FieldSource::Default);
         assert_eq!(status.value.as_json(), &serde_json::json!("draft"));
@@ -336,7 +335,7 @@ card_kinds:
                   Body prose here.\n\n\
                   ~~~card-yaml\n$kind: note\nauthor: Zed\n~~~\nNote body.\n";
         let doc = parse(md);
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let plate = quill.compile_data(&doc).expect("compile");
 
         // Every declared main row equals its plate field; the body equals plate `$body`.
@@ -387,7 +386,7 @@ card_kinds:
         payload.set_kind("main");
         let main = Card::from_parts(payload, quillmark_content::Content::empty());
         let doc = Document::from_main_and_cards(main, Vec::new());
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
 
         assert!(!has_row(&states.main.fields, "cafe\u{301}"));
         let r = row(&states.main.fields, "caf\u{e9}");
@@ -404,12 +403,12 @@ card_kinds:
         let authored =
             parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n\nHello body.\n");
         assert_eq!(
-            quill.field_states(&authored).main.body.unwrap().source,
+            quill.resolve(&authored).main.body.unwrap().source,
             FieldSource::Authored
         );
 
         let blank = parse("~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n");
-        let states = quill.field_states(&blank);
+        let states = quill.resolve(&blank);
         let body = states.main.body.as_ref().unwrap();
         assert_eq!(body.source, FieldSource::Zero);
         assert!(body.value.as_json().is_object(), "blank body is empty content");
@@ -441,7 +440,7 @@ card_kinds:
             "~~~card-yaml\n$quill: bd_test@1.0\n$kind: main\ntitle: T\n~~~\n\n\
              ~~~card-yaml\n$kind: stamp\nlabel: L\n~~~\nStray prose.\n",
         );
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let card = &states.cards[0];
         assert!(card.body.is_none(), "a body-disabled kind has no body row");
         assert!(has_row(&card.fields, "label"), "declared rows still present");
@@ -456,7 +455,7 @@ card_kinds:
             "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\n~~~\n\n\
              ~~~card-yaml\n$kind: mystery\nfoo: bar\n~~~\nUnread body.\n",
         );
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let card = &states.cards[0];
 
         assert_eq!(card.kind.as_deref(), Some("mystery"));
@@ -475,7 +474,7 @@ card_kinds:
         let doc = parse(
             "~~~card-yaml\n$quill: fs_test@1.0\n$kind: main\ntitle: T\nextra: whatever\n~~~\n",
         );
-        let states = quill.field_states(&doc);
+        let states = quill.resolve(&doc);
         let r = row(&states.main.fields, "extra");
         assert_eq!(r.source, FieldSource::Authored);
         assert_eq!(r.value.as_json(), &serde_json::json!("whatever"));
@@ -498,7 +497,7 @@ card_kinds:
 
     #[test]
     fn field_state_is_name_value_and_source_only() {
-        let state = FieldState {
+        let state = ResolvedField {
             name: "x".to_string(),
             value: QuillValue::from_json(serde_json::json!("v")),
             source: FieldSource::Authored,

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -428,7 +428,7 @@ pub struct FieldSchema {
     pub items: Option<Box<FieldSchema>>,
     /// Canonical-content form of [`default`](Self::default) for a richtext-bearing
     /// field, imported once at quill load and cached — never serialized. The
-    /// render floor (`resolve_fields`) commits this for an absent field, so a
+    /// render floor (`resolve_value_sourced`) commits this for an absent field, so a
     /// richtext default crosses the seam as content, not a re-imported string.
     /// `None` for a non-richtext field, a null/absent default, or a schema built
     /// outside the loader.

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -11,12 +11,12 @@
 //! projection but has no schema to name the field set, so an unknown field name
 //! reads back as absent rather than as the typo it is.
 //!
-//! [`Quill::view`](crate::Quill::view) binds the schema — where the authority
+//! [`Quill::reader`](crate::Quill::reader) binds the schema — where the authority
 //! already lives, the writer's twin — so a single verb interprets by the field's
 //! declared type:
 //!
 //! ```ignore
-//! let v = quill.view(&doc);
+//! let v = quill.reader(&doc);
 //! v.get("subject")?;            // richtext → Some(Markdown(..))
 //! v.get("qty")?;                // integer  → Some(Value(3))
 //! v.get("absent")?;             // absent   → None
@@ -90,7 +90,7 @@ impl ReadValue {
 }
 
 /// A [`Document`] bound to its [`QuillConfig`] for typed reads. Construct with
-/// [`Quill::view`](crate::Quill::view). Reads target the main card; use
+/// [`Quill::reader`](crate::Quill::reader). Reads target the main card; use
 /// [`card`](Self::card) for a composable card. The read twin of
 /// [`TypedWriter`](crate::TypedWriter).
 pub struct TypedReader<'a> {
@@ -99,7 +99,7 @@ pub struct TypedReader<'a> {
 }
 
 impl<'a> TypedReader<'a> {
-    /// Bind `doc` to `config`. Prefer [`Quill::view`](crate::Quill::view).
+    /// Bind `doc` to `config`. Prefer [`Quill::reader`](crate::Quill::reader).
     pub fn new(config: &'a QuillConfig, doc: &'a Document) -> Self {
         Self { config, doc }
     }

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -1,4 +1,4 @@
-# 0.95 → 0.96 — one address grammar (`DocPath`) on every boundary, mutator `edit::*` codes + paths, a leaner `fieldStates()`
+# 0.95 → 0.96 — one address grammar (`DocPath`) on every boundary, mutator `edit::*` codes + paths, the resolved-value view `resolve()`, the typed reader front door `reader()`
 
 The headline break is **addressing**: every field address the engine hands a
 consumer — diagnostics *and* geometry — now speaks one canonical `DocPath`
@@ -200,9 +200,59 @@ translation now, and `parseDocPath` gives you `{ kind, index }` directly. The
 plate-side `$path` grammar is unchanged for **template authors** — a plate still
 composes `card.at("$path") + "from"`; only what crosses to a *consumer* moved.
 
-## New: `fieldStates()` — the resolved-value view
+## Break: the typed reader front door is `reader()`, not `view()`
 
-`quill.fieldStates(doc)` is additive: the resolved-value view of a document
+The schema-bound read front door — the read twin of `writer()` — is renamed
+`view()` → **`reader()`** on every binding, so the entry point is named after
+the type it hands you (`writer()` returns a writer; `reader()` now returns a
+reader) rather than being the one verb that wasn't. Behavior is unchanged: it
+still interprets each field by its declared type (a `richtext` field to
+markdown, every other type verbatim), still throws `edit::unknown_field` for a
+name the schema does not declare. Only the name moved.
+
+| 0.95 | 0.96 |
+|---|---|
+| Rust `quill.view(&doc)` | `quill.reader(&doc)` |
+| WASM `quill.view(doc)` → `DocumentView` / `CardView` | `quill.reader(doc)` → `DocumentReader` / `CardReader` |
+| Python `quill.view(doc)` → `View` / `CardView` | `quill.reader(doc)` → `Reader` / `CardReader` |
+
+```js
+// 0.95
+const subject = quill.view(doc).get('subject')
+// 0.96
+const subject = quill.reader(doc).get('subject')
+```
+
+```python
+# 0.95
+subject = quill.view(doc).get("subject")
+# 0.96
+subject = quill.reader(doc).get("subject")
+```
+
+Migrate every `.view(` call site to `.reader(`, and any type reference to the
+returned class (`DocumentView`/`CardView`, Python `View`/`CardView`) to its
+`*Reader` name. The core Rust `TypedReader` / `CardReader` types were already
+reader-named and are unchanged.
+
+**Also renamed: the resolved-value view's types.** The [`resolve()`](#new-resolve-the-resolved-value-view)
+rows and containers below carry reader-consistent names: WASM `FieldState` →
+`ResolvedField`, `MainFieldStates` → `ResolvedMain`, `CardFieldStates` →
+`ResolvedCard`, `FieldStates` → `Resolved` (Rust `FieldState`/`FieldStates`/
+`MainStates`/`CardStates` likewise → `ResolvedField`/`Resolved`/`ResolvedMain`/
+`ResolvedCard`). `FieldSource` keeps its name. Since `resolve()` itself is new in
+0.96, these names never shipped under the old spelling — only a consumer tracking
+this release from a pre-release build needs to know.
+
+Internally, `compile_data` (render) and `resolve()` now cut **one** shared
+resolver instead of mirroring the coerce → NFC → ladder pipeline twice; the plate
+bytes and the resolved rows are byte-for-byte what 0.95's render path produced —
+no observable change, listed here only because it is the reason the two surfaces
+can no longer drift.
+
+## New: `resolve()` — the resolved-value view
+
+`quill.resolve(doc)` is additive: the resolved-value view of a document
 against its quill schema. For every declared field it returns the value the
 render projection would use and the source rung it came from — in one call, so
 you stop reading the value off the `Document` payload and re-deriving the
@@ -214,7 +264,7 @@ an **ordered array** of rows in declaration order, every row carrying its own
 on the card, not a row in `fields`:
 
 ```js
-const states = quill.fieldStates(doc)
+const states = quill.resolve(doc)
 
 const title = states.main.fields.find((r) => r.name === 'title')
 title.value        // the value the plate carries
@@ -225,7 +275,7 @@ states.main.body   // { name: "body", value, source } | null
 for (const card of states.cards) {
   card.kind        // the card's $kind — null for an unknown-kind card
   card.index       // its position in the document's card array
-  card.fields      // ordered FieldState[] — same row shape as main.fields
+  card.fields      // ordered ResolvedField[] — same row shape as main.fields
   card.body        // its body row, or null when the kind enables no body
 }
 ```
@@ -245,7 +295,7 @@ for (const card of states.cards) {
   (`example:`, labels, groups) reads from `quill.schema`. A render-uncoercible
   value is kept raw and `"authored"`, exactly as the plate carries it; the error
   surfaces through `validate()`.
-- **WASM only.** There is no Python `field_states` — it awaits a Python consumer
+- **WASM only.** There is no Python `resolve` — it awaits a Python consumer
   that names a call site (the Tier-1 scope, `BINDINGS.md`).
 
 No action — purely additive. `validate()` is unchanged and remains the

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -30,8 +30,10 @@ guides in order.
   `diagnostics[0].code`), and each mutator diagnostic now carries a `DocPath`
   `path` (WASM). `Diagnostic.path` gains an exported `parseDocPath` /
   `formatDocPath` (route on `DocPathSeg[]`, not a regex). Canon ratifies
-  null ≡ absent as a 1.0 commitment (no behavior change). Adds `fieldStates()`
-  (WASM) — the resolved-value view: per field, value + source rung
+  null ≡ absent as a 1.0 commitment (no behavior change). The typed reader front
+  door is renamed `view()` → `reader()` (`DocumentView`/`CardView` → `*Reader`)
+  on every binding — migrate `.view(` call sites. Adds `resolve()` (WASM) — the
+  resolved-value view: per field, value + source rung
   (`"authored" | "default" | "zero"`), in one call (additive, no action).
 - [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
   `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -54,8 +54,8 @@ verbatim, need no schema, and sit on `Document` too.
 
 The one **interpreting** read — projecting a field by its type — is a
 schema-shaped question ("this field's richtext, as markdown"), so it gains a
-schema-bound home: `quill.view(doc)`, the read twin of `quill.writer(doc)`
-(mirroring core's `quill.view(&doc)`). `view.get(addr)` reads each field by its
+schema-bound home: `quill.reader(doc)`, the read twin of `quill.writer(doc)`
+(mirroring core's `quill.reader(&doc)`). `reader.get(addr)` reads each field by its
 declared type — a `richtext` field to markdown, a `plaintext` field to its
 literal text (marks verbatim), every other type verbatim — with schema
 authority, so a name the schema does not declare throws `UnknownField` instead of
@@ -64,7 +64,7 @@ reading back `undefined`, and a content field holding an undecodable value throw
 `get_markdown` / `get_card_markdown` are **body-only** (WASM `getMarkdown` takes a
 `CardAddr`; a present `field` throws), and the quill-free **body** projection
 stays on `Document` (a body's type is a format fact, not a schema fact, so
-`view.getBody` mirrors it rather than gating it on the schema). The placement rule
+`reader.getBody` mirrors it rather than gating it on the schema). The placement rule
 generalizes: *a verb that needs a schema lives on the writer (writes) or the view
 (reads); `Document` is quill-free data.*
 
@@ -108,8 +108,8 @@ nothing else admitted. Drift is a reviewable diff to this table.
 | Concept | Core | Bindings | Class |
 |---|---|---|---|
 | Typed writer front door | `quill.writer(&mut doc)` | `quill.writer(doc)` | **idiom** — core holds `&mut Document` under the checker; the bindings re-borrow per call (pyo3/wasm objects carry no lifetime), so the guarantee becomes the ephemerality convention |
-| Typed reader front door | `quill.view(&doc)` | `quill.view(doc)` | **idiom** — the read twin; same re-borrow/ephemerality as the writer |
-| Interpreted read | `view.get(name)?` → `ReadValue` (richtext → markdown, plaintext → literal text, else canonical); `view.card(i)?.get(..)?` | `view.get(addr)` / `view.card(i).get(name)` (JS), `view.get(name)` / `view.card(i).get(name)` (py) | **idiom** / **FFI** — one `get` interprets by declared type; absent → `undefined`/`None`, unknown name → `UnknownField`, undecodable content → `FieldRichtextDecode`; a field's markdown reads here, not on the body-only `getMarkdown` (#978). Body read (`view.getBody` / absent-field addr) stays quill-free |
+| Typed reader front door | `quill.reader(&doc)` | `quill.reader(doc)` | **idiom** — the read twin; same re-borrow/ephemerality as the writer |
+| Interpreted read | `reader.get(name)?` → `ReadValue` (richtext → markdown, plaintext → literal text, else canonical); `reader.card(i)?.get(..)?` | `reader.get(addr)` / `reader.card(i).get(name)` (JS), `reader.get(name)` / `reader.card(i).get(name)` (py) | **idiom** / **FFI** — one `get` interprets by declared type; absent → `undefined`/`None`, unknown name → `UnknownField`, undecodable content → `FieldRichtextDecode`; a field's markdown reads here, not on the body-only `getMarkdown` (#978). Body read (`reader.getBody` / absent-field addr) stays quill-free |
 | Scalar / batch write | `set` / `set_all` | `set` / `setAll` (JS), `set` / `set_all` (py) | identical |
 | Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
 | Typed richtext field revise | `TypedWriter::revise_field(name, md)?` / `CardWriter::revise_field(..)?` | `writer.reviseField(name, md)` / `writer.card(i).reviseField(..)` (JS); `writer.revise_field(name, md)` / `writer.card(i).revise_field(..)` (py) | **idiom** — typed *and* anchor-preserving; both wrap `Card::revise_field_checked`. JS returns the `Delta`; Python discards it (the position-mapping receipt is an editor concern, WASM-only) |
@@ -118,7 +118,7 @@ nothing else admitted. Drift is a reviewable diff to this table.
 | Card removal (writer) | `writer.remove_card(i)` | `writer.removeCard(i)` | identical |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
 | Cursor kind | `writer.card(i)?.kind()` | `writer.card(i).kind` | identical — the JS getter reads through `doc.card(i)` |
-| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.get(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `get`/`isFill`), *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.view(doc).get` (#978, #970), and `$ext` / body content read off the `main` / `cards` dict snapshots |
+| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.get(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `get`/`isFill`), *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.reader(doc).get` (#978, #970), and `$ext` / body content read off the `main` / `cards` dict snapshots |
 | Reads (whole card / `$id` / seed) | `card(i)` / `find_card(id)` / `main().seed()` | `doc.card(i)` / `doc.cardIndexById(id)` / `doc.seedOverlay(kind)` | **idiom** — the bindings fuse each into one named verb on `Document`; `card(i)` throws out of range, `find_card`/`cardIndexById` return the first `$id` match (non-unique by design) |
 | Richtext revise (content lane) | `Card::revise_field(name, md)?` (schema-blind, borrow chain) | `doc.revise({card, field}, md)` (addr literal, JS) | **FFI** / **scope** — same model, flattened navigation, schema-blind, `Delta` in hand; WASM-only. Python's anchor-preserving write is the typed `writer.revise_field` (#970) |
 | Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`) | **scope** — the quill-free verbatim write, WASM-only; Python has no opaque field store (the typed writer is the only field write, #970). A field write without a loadable quill operates on the storage DTO directly |
@@ -134,7 +134,7 @@ PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface over the
 shared model; one-shot `engine.render` (no canvas).
 
 > **Scope: Tier 1 + storage + render ([#970](https://github.com/borb-sh/quillmark/issues/970)).**
-> Field I/O flows through `quill.writer(doc)` / `quill.view(doc)` exclusively;
+> Field I/O flows through `quill.writer(doc)` / `quill.reader(doc)` exclusively;
 > `Document` is quill-free data and structure (parse, the storage DTO,
 > `insert_card` / `remove_card` / `move_card` / `make_card`, `remove_field`,
 > `$ext` / `$seed`). The opaque store (`store_field` / `store_fields` /

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -142,10 +142,10 @@ field maps rather than a sort key):
 | `blueprint` document | Endorsed: `default:`; Unendorsed: `example:` else zero, stamped `!must_fill` | zero (under the marker) | annotated string — [BLUEPRINT.md](BLUEPRINT.md) |
 | seeding | `example:` › absent | (deferred to render floor) | committed `Document` — [Document seeding](#document-seeding) |
 | add-card (into a document) | `$seed` overlay › `example:` › absent | (deferred to render floor) | a new composable `Card` — [Document seeding](#document-seeding) |
-| editor (consumer-side) | authored › `default:` › zero, resolved per field and **tagged with its source rung** | zero | the engine's [`fieldStates()`](#the-resolved-field-view-fieldstates) resolved-value view — value and source rung per field |
+| editor (consumer-side) | authored › `default:` › zero, resolved per field and **tagged with its source rung** | zero | the engine's [`resolve()`](#the-resolved-value-view-resolve) resolved-value view — value and source rung per field |
 
 The consumer-side `Document`-payload × schema join is a **non-goal**:
-[`fieldStates()`](#the-resolved-field-view-fieldstates) supersedes it. The
+[`resolve()`](#the-resolved-value-view-resolve) supersedes it. The
 editor reads value and source rung from one engine call rather than re-cutting
 the ladder in consumer code. Completeness and errors stay `Quill::validate`'s
 (a consumer merges it with its own diagnostic producers regardless), and schema
@@ -159,9 +159,9 @@ rides *alongside* the value rather than replacing it; and `zero` is honestly
 blank for every type except `enum`, whose zero is the first declared variant
 (there is no empty enum member). Both are detailed below.
 
-### The resolved-value view (`fieldStates()`)
+### The resolved-value view (`resolve()`)
 
-`Quill::field_states(doc)` (WASM `fieldStates`) cuts the render ladder into
+`Quill::resolve(doc)` (WASM `resolve`) cuts the render ladder into
 observable data: for every declared field, the value `compile_data` would emit
 into the plate, tagged with its source rung (`authored` / `default` / `zero`) —
 byte-for-byte with the plate on every fixture. The shape is nested: a `main`
@@ -270,7 +270,7 @@ path's "`default:` wins" rule applies to authored and blank documents, where no
   field's value came from seeding or later authoring is not recorded; correctness
   and renderability do not depend on the distinction. The commitment *rung* is a
   separate axis and is reported on read: the
-  [`fieldStates()`](#the-resolved-field-view-fieldstates) projection tags each
+  [`resolve()`](#the-resolved-value-view-resolve) projection tags each
   field `authored` / `default` / `zero` — a seeded and a hand-authored value both
   read as `authored`, both being document content.
 


### PR DESCRIPTION
Implements the Option B decision from #1026: keep both schema-bound read surfaces, renamed so each entry point is named after what it hands you, and unify the resolver they and the render path share.

## What changed

Three commits, smallest-blast-radius first:

1. **`core: one shared resolver behind compile_data and field_states`** — non-breaking. `compile_data` (render plate) and the resolved-value view orchestrated the same coerce → NFC → ladder cut twice, coupled only by a hand-maintained mirror comment and the byte-for-byte acceptance test. Extract one sourced ladder both projections cut. This commit stands alone if a reviewer wants to land it independently of the rename.
2. **`rename: view()→reader(), fieldStates()→resolve()`** — breaking. The read front door `view()`→`reader()` (the read twin of `writer()`, now named after its type); the resolved-value view `fieldStates()`→`resolve()`; types `FieldState`/`FieldStates`→`ResolvedField`/`Resolved` (and, for consistency, `MainStates`/`CardStates`→`ResolvedMain`/`ResolvedCard`); `FieldSource` keeps its name. Across core, WASM (Rust + runtime JS + `.d.ts` + tests), Python (Rust + package re-exports + tests), and canon.
3. **`core: compile_data conforms once`** — non-breaking. The render path conformed each field twice (validation gate + resolver); the gate is now the single coercion pass and the ladder consumes its output. `resolve()` keeps its own total keep-raw conform; both cut the one `ladder_sourced` and agree on any gated document.

Behavior is byte-for-byte identical throughout — every rename is mechanical and the plate/rows are unchanged.

## Release / migration

Folded into the **unreleased 0.96 cycle** rather than a separate release, so `fieldStates()` / `view()` never ship under the old names (the "don't churn consumers through two renames" goal). `docs/migrations/0.95-to-0.96.md` and its index entry now ship `resolve()` / `reader()` from the start; a new `## Break: the typed reader front door is reader(), not view()` section documents the `view()`→`reader()` migration and the type renames. Python still exposes no `resolve()` — it never had `fieldStates()`, and adding one is a feature, not this rename.

## Validation

- Core + full workspace `cargo test` — green, unchanged (the render path is byte-identical).
- Python `maturin develop` + `pytest` — 113 pass.
- Both binding Rust surfaces `cargo check` — clean.
- Core rustdoc intra-doc links — clean.
- WASM JS suite defers to CI (`wasm-pack` unavailable locally); the JS / Rust / TS names are renamed in lockstep.

## Deferred

One design question is intentionally left open and tracked in #1030: whether the render plate and `resolve()` should **converge** at the `$body` / `$kind` card edges (unknown-kind / body-disabled cards, kindless `$kind`). The inversion does not force it — the ladder is shared but the `$body` / `$kind` wrappers are per-projection — so both are kept byte-identical to 0.95 here, and the convergence choice (plate- or view-observable, and needing a backend audit in one direction) is its own change.

Closes #1026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReqYnzGJ83KzDCaaGPGCog