### PR TITLE
core: plate $body/$kind absent on undefined (#1030)

### DIFF
--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -479,10 +479,9 @@ impl Document {
     /// `$kind` is document-defined and omitted for a kindless card (never a
     /// fabricated `""`). This method is schema-free and emits `$body` for every
     /// card and the root; the schema-gated render plate
-    /// (`QuillConfig::compile_data`) instead calls
-    /// [`to_plate_json_gated`](Self::to_plate_json_gated) with the per-card
-    /// body-presence it resolved, so a card whose kind enables no body carries no
-    /// `$body` — issue 1030's "absent on undefined".
+    /// (`QuillConfig::compile_data`) instead calls `to_plate_json_gated` with the
+    /// per-card body-presence it resolved, so a card whose kind enables no body
+    /// carries no `$body` — issue 1030's "absent on undefined".
     pub fn to_plate_json(&self) -> serde_json::Value {
         // Schema-free: the root and every card carry `$body`.
         self.to_plate_json_gated(true, None)
@@ -491,7 +490,7 @@ impl Document {
     /// [`to_plate_json`](Self::to_plate_json) with the body-presence decision
     /// supplied by the caller: the root carries `$body` iff `main_body`, and card
     /// *i* iff `card_bodies` is `None` (all present) or `card_bodies[i]` holds.
-    /// The schema-gated render plate ([`QuillConfig::compile_data`]) passes the
+    /// The schema-gated render plate (`QuillConfig::compile_data`) passes the
     /// body-enabled bit it already resolved per card, so a body-disabled card
     /// never carries `$body` (issue 1030, "absent on undefined") and the decision
     /// is never re-derived from the serialized plate. `Document` stays schema-free

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -475,6 +475,13 @@ impl Document {
     /// text, card list, card kind). User payload fields stay flat at the
     /// root — they cannot collide with `$` keys because user field names are
     /// never `$`-prefixed (they match `[A-Za-z_][A-Za-z0-9_]*`).
+    ///
+    /// `$kind` is document-defined and omitted for a kindless card (never a
+    /// fabricated `""`). This raw serializer is schema-free, so it emits
+    /// `$body` for every card and the root; the schema-gated render plate
+    /// (`QuillConfig::compile_data`) additionally drops `$body` wherever the
+    /// schema defines no body — a body-disabled or unknown kind — per issue
+    /// 1030's "absent on undefined".
     pub fn to_plate_json(&self) -> serde_json::Value {
         let mut map = serde_json::Map::new();
 
@@ -497,10 +504,17 @@ impl Document {
             .iter()
             .map(|card| {
                 let mut card_map = serde_json::Map::new();
-                card_map.insert(
-                    "$kind".to_string(),
-                    serde_json::Value::String(card.kind().unwrap_or("").to_string()),
-                );
+                // `$kind` is document-defined: present exactly when the card
+                // authors one. A kindless card carries no `$kind` — the raw
+                // serializer never fabricates `$kind: ""` — matching the
+                // resolved-value view's `kind: None` (issue 1030, "absent on
+                // undefined").
+                if let Some(kind) = card.kind() {
+                    card_map.insert(
+                        "$kind".to_string(),
+                        serde_json::Value::String(kind.to_string()),
+                    );
+                }
                 card_map.insert(
                     "$body".to_string(),
                     quillmark_content::serial::to_canonical_value(card.body()),

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -504,11 +504,8 @@ impl Document {
             .iter()
             .map(|card| {
                 let mut card_map = serde_json::Map::new();
-                // `$kind` is document-defined: present exactly when the card
-                // authors one. A kindless card carries no `$kind` — the raw
-                // serializer never fabricates `$kind: ""` — matching the
-                // resolved-value view's `kind: None` (issue 1030, "absent on
-                // undefined").
+                // A kindless card carries no `$kind`, never a fabricated `""` —
+                // matching the resolved view's `kind: None`.
                 if let Some(kind) = card.kind() {
                     card_map.insert(
                         "$kind".to_string(),

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -477,12 +477,30 @@ impl Document {
     /// never `$`-prefixed (they match `[A-Za-z_][A-Za-z0-9_]*`).
     ///
     /// `$kind` is document-defined and omitted for a kindless card (never a
-    /// fabricated `""`). This raw serializer is schema-free, so it emits
-    /// `$body` for every card and the root; the schema-gated render plate
-    /// (`QuillConfig::compile_data`) additionally drops `$body` wherever the
-    /// schema defines no body — a body-disabled or unknown kind — per issue
-    /// 1030's "absent on undefined".
+    /// fabricated `""`). This method is schema-free and emits `$body` for every
+    /// card and the root; the schema-gated render plate
+    /// (`QuillConfig::compile_data`) instead calls
+    /// [`to_plate_json_gated`](Self::to_plate_json_gated) with the per-card
+    /// body-presence it resolved, so a card whose kind enables no body carries no
+    /// `$body` — issue 1030's "absent on undefined".
     pub fn to_plate_json(&self) -> serde_json::Value {
+        // Schema-free: the root and every card carry `$body`.
+        self.to_plate_json_gated(true, None)
+    }
+
+    /// [`to_plate_json`](Self::to_plate_json) with the body-presence decision
+    /// supplied by the caller: the root carries `$body` iff `main_body`, and card
+    /// *i* iff `card_bodies` is `None` (all present) or `card_bodies[i]` holds.
+    /// The schema-gated render plate ([`QuillConfig::compile_data`]) passes the
+    /// body-enabled bit it already resolved per card, so a body-disabled card
+    /// never carries `$body` (issue 1030, "absent on undefined") and the decision
+    /// is never re-derived from the serialized plate. `Document` stays schema-free
+    /// — it receives the decision, not a schema.
+    pub(crate) fn to_plate_json_gated(
+        &self,
+        main_body: bool,
+        card_bodies: Option<&[bool]>,
+    ) -> serde_json::Value {
         let mut map = serde_json::Map::new();
 
         map.insert(
@@ -494,15 +512,18 @@ impl Document {
         // nested content object, byte-identical to `to_canonical_json`, never a lossy
         // markdown string. Backends lower the content (typst → markup + source
         // map; pdfform → `.text`); the markdown projection is `body_markdown`.
-        map.insert(
-            "$body".to_string(),
-            quillmark_content::serial::to_canonical_value(self.main.body()),
-        );
+        if main_body {
+            map.insert(
+                "$body".to_string(),
+                quillmark_content::serial::to_canonical_value(self.main.body()),
+            );
+        }
 
         let cards_array: Vec<serde_json::Value> = self
             .cards
             .iter()
-            .map(|card| {
+            .enumerate()
+            .map(|(i, card)| {
                 let mut card_map = serde_json::Map::new();
                 // A kindless card carries no `$kind`, never a fabricated `""` —
                 // matching the resolved view's `kind: None`.
@@ -512,10 +533,13 @@ impl Document {
                         serde_json::Value::String(kind.to_string()),
                     );
                 }
-                card_map.insert(
-                    "$body".to_string(),
-                    quillmark_content::serial::to_canonical_value(card.body()),
-                );
+                // `$body` iff the caller's schema defines a body for this card.
+                if card_bodies.map_or(true, |f| f.get(i).copied().unwrap_or(true)) {
+                    card_map.insert(
+                        "$body".to_string(),
+                        quillmark_content::serial::to_canonical_value(card.body()),
+                    );
+                }
                 for (key, value) in card.payload.iter() {
                     card_map.insert(key.clone(), value.as_json().clone());
                 }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -2031,6 +2031,34 @@ Card body here.
     assert_eq!(cards[0]["$body"]["text"], "Card body here.");
 }
 
+/// A kindless composable card (no `$kind`) carries no `$kind` key in the raw
+/// plate — the serializer never fabricates `$kind: ""` (issue 1030, "absent on
+/// undefined"). The schema-free serializer still emits `$body` for every card;
+/// the schema-gated body drop is the render plate's job (`compile_data`).
+#[test]
+fn test_to_plate_json_kindless_card_omits_kind() {
+    use crate::{Card, Payload};
+
+    let mut doc = Document::parse("~~~card-yaml\n$quill: my_quill\n$kind: main\n~~~\n\nBody.\n")
+        .unwrap()
+        .document;
+    doc.cards_vec_mut().push(Card::from_parts(
+        Payload::new(),
+        quillmark_content::Content::empty(),
+    ));
+
+    let json = doc.to_plate_json();
+    let card = &json["$cards"][0];
+    assert!(
+        card.get("$kind").is_none(),
+        "a kindless card must carry no $kind: {card}"
+    );
+    assert!(
+        card.get("$body").is_some(),
+        "the schema-free serializer still emits $body: {card}"
+    );
+}
+
 /// to_plate_json parity: the `$quill` key appears first.
 #[test]
 fn test_to_plate_json_quill_first() {

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -67,11 +67,20 @@ impl QuillConfig {
             ),
             normalized.main().body().clone(),
         );
+        // A card's `$body` is defined for the plate iff its kind resolves to a
+        // body-enabled schema — the `$body` half of issue 1030's "absent on
+        // undefined". Capture it here, where the schema is already in hand for
+        // field lowering, and hand it to the plate builder, so the decision is
+        // never re-derived from the serialized plate. (`$kind`, the document-
+        // defined half, is gated structurally by `to_plate_json`.)
+        let mut card_bodies: Vec<bool> = Vec::with_capacity(normalized.cards().len());
         let cards_resolved: Vec<Card> = normalized
             .cards()
             .iter()
             .map(|card| {
-                let fields = match self.card_kind(card.kind().unwrap_or("")) {
+                let schema = self.card_kind(card.kind().unwrap_or(""));
+                card_bodies.push(schema.is_some_and(|s| s.body_enabled()));
+                let fields = match schema {
                     Some(schema) => {
                         plate_fields(ladder_sourced(schema, &card.payload().to_index_map()))
                     }
@@ -83,10 +92,8 @@ impl QuillConfig {
             })
             .collect();
 
-        let mut plate =
-            Document::from_main_and_cards(final_main, cards_resolved).to_plate_json();
-        gate_undefined_body(self, &mut plate);
-        Ok(plate)
+        Ok(Document::from_main_and_cards(final_main, cards_resolved)
+            .to_plate_json_gated(self.main.body_enabled(), Some(&card_bodies)))
     }
 
     /// Validate without backend compilation.
@@ -416,51 +423,6 @@ fn plate_fields(
         .collect()
 }
 
-/// Drop `$body` from the render plate wherever the schema defines no body — the
-/// `$body` half of issue 1030's **absent on undefined**: a `$`-metadata field
-/// appears on a card exactly when the schema defines it there. [`to_plate_json`]
-/// is schema-free and emits `$body` for every card and the root; this is the one
-/// place that knows [`body_enabled`], so it applies the schema gate here.
-///
-/// - Root `$body`: kept iff the main card enables a body.
-/// - Card `$body`: kept iff the card's `$kind` names a declared, **body-enabled**
-///   kind. A body-disabled kind, an unknown kind (no schema), and a kindless card
-///   (no `$kind` key — [`to_plate_json`] already omitted it, its document-defined
-///   half) all resolve to "no body slot", matching the resolved-value view
-///   ([`Quill::resolve`](crate::Quill::resolve) omits the body row) and the
-///   transform schema ([`build_transform_schema`](crate::quill::build_transform_schema)
-///   drops `$body` for a body-disabled kind). Unknown-kind and kindless cards are
-///   unreachable on this path — `validate_document` rejects them before render —
-///   so in practice only the body-disabled edge fires; the rest is the rule made
-///   total.
-///
-/// [`to_plate_json`]: crate::Document::to_plate_json
-/// [`body_enabled`]: crate::quill::CardSchema::body_enabled
-fn gate_undefined_body(config: &QuillConfig, plate: &mut serde_json::Value) {
-    let Some(obj) = plate.as_object_mut() else {
-        return;
-    };
-    if !config.main.body_enabled() {
-        obj.shift_remove("$body");
-    }
-    let Some(cards) = obj.get_mut("$cards").and_then(|v| v.as_array_mut()) else {
-        return;
-    };
-    for card in cards {
-        let Some(card_obj) = card.as_object_mut() else {
-            continue;
-        };
-        let body_defined = card_obj
-            .get("$kind")
-            .and_then(|v| v.as_str())
-            .and_then(|kind| config.card_kind(kind))
-            .is_some_and(|schema| schema.body_enabled());
-        if !body_defined {
-            card_obj.shift_remove("$body");
-        }
-    }
-}
-
 /// The value half of [`resolve_value_sourced`], discarding the rung tag — the
 /// nested-recursion helper for a typed dictionary's properties and a typed
 /// array's elements, where the source of an inner cell is not surfaced (a
@@ -751,7 +713,7 @@ items:
         assert_eq!(resolved, json!([{ "name": "ACME", "year": 2020 }]));
     }
 
-    // ── "Absent on undefined": the render plate drops `$body` wherever the
+    // ── "Absent on undefined": the render plate omits `$body` wherever the
     //    schema defines none (issue 1030). The `$kind` half is structural in
     //    `to_plate_json`; these pin the schema-gated `$body` half. Only the
     //    body-disabled edge is reachable here — `validate_document` rejects an

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -83,7 +83,10 @@ impl QuillConfig {
             })
             .collect();
 
-        Ok(Document::from_main_and_cards(final_main, cards_resolved).to_plate_json())
+        let mut plate =
+            Document::from_main_and_cards(final_main, cards_resolved).to_plate_json();
+        gate_undefined_body(self, &mut plate);
+        Ok(plate)
     }
 
     /// Validate without backend compilation.
@@ -413,6 +416,51 @@ fn plate_fields(
         .collect()
 }
 
+/// Drop `$body` from the render plate wherever the schema defines no body — the
+/// `$body` half of issue 1030's **absent on undefined**: a `$`-metadata field
+/// appears on a card exactly when the schema defines it there. [`to_plate_json`]
+/// is schema-free and emits `$body` for every card and the root; this is the one
+/// place that knows [`body_enabled`], so it applies the schema gate here.
+///
+/// - Root `$body`: kept iff the main card enables a body.
+/// - Card `$body`: kept iff the card's `$kind` names a declared, **body-enabled**
+///   kind. A body-disabled kind, an unknown kind (no schema), and a kindless card
+///   (no `$kind` key — [`to_plate_json`] already omitted it, its document-defined
+///   half) all resolve to "no body slot", matching the resolved-value view
+///   ([`Quill::resolve`](crate::Quill::resolve) omits the body row) and the
+///   transform schema ([`build_transform_schema`](crate::quill::build_transform_schema)
+///   drops `$body` for a body-disabled kind). Unknown-kind and kindless cards are
+///   unreachable on this path — `validate_document` rejects them before render —
+///   so in practice only the body-disabled edge fires; the rest is the rule made
+///   total.
+///
+/// [`to_plate_json`]: crate::Document::to_plate_json
+/// [`body_enabled`]: crate::quill::CardSchema::body_enabled
+fn gate_undefined_body(config: &QuillConfig, plate: &mut serde_json::Value) {
+    let Some(obj) = plate.as_object_mut() else {
+        return;
+    };
+    if !config.main.body_enabled() {
+        obj.shift_remove("$body");
+    }
+    let Some(cards) = obj.get_mut("$cards").and_then(|v| v.as_array_mut()) else {
+        return;
+    };
+    for card in cards {
+        let Some(card_obj) = card.as_object_mut() else {
+            continue;
+        };
+        let body_defined = card_obj
+            .get("$kind")
+            .and_then(|v| v.as_str())
+            .and_then(|kind| config.card_kind(kind))
+            .is_some_and(|schema| schema.body_enabled());
+        if !body_defined {
+            card_obj.shift_remove("$body");
+        }
+    }
+}
+
 /// The value half of [`resolve_value_sourced`], discarding the rung tag — the
 /// nested-recursion helper for a typed dictionary's properties and a typed
 /// array's elements, where the source of an inner cell is not surfaced (a
@@ -701,5 +749,92 @@ items:
         let resolved = resolve_value(Some(&input), &schema).into_json();
 
         assert_eq!(resolved, json!([{ "name": "ACME", "year": 2020 }]));
+    }
+
+    // ── "Absent on undefined": the render plate drops `$body` wherever the
+    //    schema defines none (issue 1030). The `$kind` half is structural in
+    //    `to_plate_json`; these pin the schema-gated `$body` half. Only the
+    //    body-disabled edge is reachable here — `validate_document` rejects an
+    //    unknown-kind or kindless card before render.
+
+    fn plate_of(yaml: &str, md: &str) -> serde_json::Value {
+        let config = QuillConfig::from_yaml(yaml).expect("valid quill");
+        let doc = Document::parse(md).expect("parse").document;
+        config.compile_data(&doc).expect("compile")
+    }
+
+    #[test]
+    fn body_disabled_kind_omits_dollar_body() {
+        let plate = plate_of(
+            r#"
+quill: { name: bd, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+card_kinds:
+  stamp:
+    body:
+      enabled: false
+    fields:
+      label: { type: string }
+"#,
+            "~~~card-yaml\n$quill: bd@1.0.0\n$kind: main\ntitle: T\n~~~\n\n\
+             ~~~card-yaml\n$kind: stamp\nlabel: L\n~~~\n",
+        );
+        let card = &plate["$cards"][0];
+        assert_eq!(card["$kind"], "stamp", "$kind is document-defined, kept");
+        assert_eq!(card["label"], "L", "declared fields kept");
+        assert!(
+            card.get("$body").is_none(),
+            "a body-disabled kind carries no $body in the plate; got {card}"
+        );
+    }
+
+    #[test]
+    fn body_disabled_main_omits_root_dollar_body() {
+        let plate = plate_of(
+            r#"
+quill: { name: bdm, version: 1.0.0, backend: typst, description: x }
+main:
+  body:
+    enabled: false
+  fields:
+    title: { type: string }
+"#,
+            "~~~card-yaml\n$quill: bdm@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+        );
+        assert_eq!(plate["title"], "T");
+        assert!(
+            plate.get("$body").is_none(),
+            "a body-disabled main carries no root $body; got {plate}"
+        );
+    }
+
+    #[test]
+    fn body_enabled_keeps_dollar_body() {
+        let plate = plate_of(
+            r#"
+quill: { name: be, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+card_kinds:
+  note:
+    fields:
+      tag: { type: string }
+"#,
+            "~~~card-yaml\n$quill: be@1.0.0\n$kind: main\ntitle: T\n~~~\n\n\
+             Main body.\n\n\
+             ~~~card-yaml\n$kind: note\ntag: x\n~~~\nNote body.\n",
+        );
+        assert_eq!(
+            plate["$body"]["text"], "Main body.",
+            "a body-enabled main keeps its $body"
+        );
+        let card = &plate["$cards"][0];
+        assert_eq!(
+            card["$body"]["text"], "Note body.",
+            "a body-enabled kind keeps its $body content object"
+        );
     }
 }

--- a/docs/migrations/0.95-to-0.96.md
+++ b/docs/migrations/0.95-to-0.96.md
@@ -200,6 +200,44 @@ translation now, and `parseDocPath` gives you `{ kind, index }` directly. The
 plate-side `$path` grammar is unchanged for **template authors** — a plate still
 composes `card.at("$path") + "from"`; only what crosses to a *consumer* moved.
 
+## Break: plate `$body` / `$kind` are absent on undefined
+
+The render plate (`compile_data` — the JSON your Typst plate reads as `data`) now
+carries a `$`-metadata key on a card **exactly where the schema defines it** — the
+"absent on undefined" rule, split by which definition gates the key:
+
+- **`$kind` is document-defined** — present iff the card authors one. A kindless
+  card now carries **no `$kind`** (previously a fabricated `$kind: ""`).
+- **`$body` is schema-defined** — present iff the card's kind is declared and
+  enables a body. A **body-disabled** kind, an unknown kind, and a body-disabled
+  **main** now carry **no `$body`** (previously an always-present body object).
+
+This also removes a silent type hazard. On a body-disabled or unknown kind the
+plate used to ship `$body` as a raw content-JSON **object** — not a lowered,
+renderable content block — so `card.$body` was renderable content on one card and
+an inert dict on the next. A present `$body` is now **always** a content object.
+
+**Who is affected.** Only a body-disabled card or a body-disabled main reaches an
+engine-compiled plate — an unknown-kind or kindless card is a hard
+`validation::unknown_card` error before render, so those rows appear only if you
+call `Document::to_plate_json` directly. A plate that read a body-disabled card's
+`$body` was already reading the inert dict; nothing was rendering it.
+
+**Migrate.** Read `$`-metadata with Typst's total accessor, never a bare field:
+
+```typst
+// 0.95 — a body-disabled / kindless card ships a raw dict (or a "" $kind)
+#card.$body
+#card.$kind
+
+// 0.96 — total, absence-safe
+#card.at("$body", default: "")
+#card.at("$kind", default: none)
+```
+
+A plate that already guards with `card.at("$body", default: "")` — the documented
+idiom, and what the shipped fixtures use — needs no change.
+
 ## Break: the typed reader front door is `reader()`, not `view()`
 
 The schema-bound read front door — the read twin of `writer()` — is renamed

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -32,7 +32,11 @@ guides in order.
   `formatDocPath` (route on `DocPathSeg[]`, not a regex). Canon ratifies
   null ≡ absent as a 1.0 commitment (no behavior change). The typed reader front
   door is renamed `view()` → `reader()` (`DocumentView`/`CardView` → `*Reader`)
-  on every binding — migrate `.view(` call sites. Adds `resolve()` (WASM) — the
+  on every binding — migrate `.view(` call sites. The plate `$body` / `$kind`
+  become **absent on undefined**: a body-disabled kind or main drops `$body`, a
+  kindless card drops `$kind`, and a present `$body` is always a content object
+  (never a raw dict) — read plate metadata with a total accessor
+  (`card.at("$body", default: "")`). Adds `resolve()` (WASM) — the
   resolved-value view: per field, value + source rung
   (`"authored" | "default" | "zero"`), in one call (additive, no action).
 - [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -102,7 +102,7 @@ See [`markdown-spec.md`](../references/markdown-spec.md) §3 for the full syntax
 
 ## Backend Consumption
 
-- **All backends**: cards are delivered as `data.$cards`, an array of objects each containing a `$kind` discriminator, the card's payload fields, and a `$body` key with the card's body Markdown.
+- **All backends**: cards are delivered as `data.$cards`, an array of objects. Each carries its payload fields flat, a `$kind` discriminator when the card authors one, and a `$body` (canonical `Content` object, not a Markdown string) when the card's kind enables a body. `$`-metadata is present exactly where the schema defines it ("absent on undefined") — read it with a total accessor (`card.at("$body", default: "")`); see [PLATE_DATA.md](PLATE_DATA.md).
 - **`Quill::compile_data()`** returns the fully coerced and validated JSON, including `$cards`.
 
 The sigiled `data.$cards` here is plate JSON — glue delivered to the backend. It is a **different namespace** from the unsigiled `cards` in a `Diagnostic.path` (`cards.<kind>[<index>]`, the document-model anchor — see [ERROR.md](ERROR.md) § "Document-model paths"). The plate key is not renamed off `$cards`; the two namespaces are documented apart.

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -13,8 +13,9 @@ Plates get document data through a backend-injected virtual Typst package, not a
 
 ### Data Shape
 
-- Document-level metadata uses `$`-prefixed keys: `$quill` (quill ref string), `$body` (root prose body, a canonical `Content` object), `$cards` (array of card objects)
-- Each card object carries `$kind` (discriminator), `$body` (card prose body, a content object), and the card's user fields flat
+- Document-level metadata uses `$`-prefixed keys: `$quill` (quill ref string), `$body` (root prose body, a canonical `Content` object, present when the main enables a body), `$cards` (array of card objects)
+- Each card object carries its user fields flat, a `$kind` discriminator when the card authors one, and a `$body` (card prose body, a content object) when the card's kind enables a body
+- **`$`-metadata is present exactly where the schema defines it** ("absent on undefined"). The rule splits by which definition gates the key: `$kind` is *document-defined* — present iff the card authors one, absent for a kindless card; `$body` is *schema-defined* — present (and, when present, always a content object) iff a declared kind enables a body, absent for a body-disabled or unknown kind. So a present `$body` is never a raw object needing a type check, and absence is the signal. Read `$`-metadata with a total accessor — `card.at("$kind", default: none)`, `card.at("$body", default: "")` — never a bare `card.$body`
 - User payload fields sit flat at the root next to the `$` keys; field names match `[a-z_][a-z0-9_]*` and therefore never collide with `$` metadata
 
 ## Typst Helper Package
@@ -25,11 +26,12 @@ The Typst backend injects a virtual package `@local/quillmark-helper:<version>` 
 #import "@local/quillmark-helper:0.1.0": data
 
 #data.title                  // plain field access
-#data.at("$body")            // $body is automatically converted to content
+#data.at("$body")            // root $body: a content object when the main enables a body
 #(data.date.display)("…")    // date/datetime fields are value-objects; .value is the native datetime
 #for card in data.at("$cards") {
-  if card.at("$kind") == "indorsement" {
-    // ... per-kind handling using card.<field> and card.at("$body")
+  if card.at("$kind", default: none) == "indorsement" {
+    // per-kind handling; $kind/$body are present only where the schema
+    // defines them, so read them totally: card.<field>, card.at("$body", default: "")
   }
 }
 ```

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -367,18 +367,27 @@ the `$` sigil.
 ```typescript
 interface PlateJson {
   $quill: string;         // quill name@version, from the root block $quill
-  $body: object;          // root-block body as canonical Content-JSON on the plate wire (backends lower it directly); markdown consumers get a lossy projection via exportMarkdown
+  $body?: object;         // root-block body as canonical Content-JSON on the plate wire (backends lower it directly); present when the main enables a body; markdown consumers get a lossy projection via exportMarkdown
   $cards: Card[];         // zero or more cards, in document order
   [field: string]: any;   // root-block payload fields, flat
 }
 
 interface Card {
-  $kind: string;          // card kind, matches /^[a-z_][a-z0-9_]*$/
-  $body: object;          // card body as canonical Content-JSON on the plate wire (backends lower it directly); markdown consumers get a lossy projection via exportMarkdown
+  $kind?: string;         // card kind, matches /^[a-z_][a-z0-9_]*$/; absent for a kindless card
+  $body?: object;         // card body as canonical Content-JSON on the plate wire (backends lower it directly); present when the card's kind enables a body; markdown consumers get a lossy projection via exportMarkdown
   [field: string]: any;   // card payload fields, flat
 }
 ```
 
+- `$`-metadata is **present exactly where the schema defines it** ("absent on
+  undefined"): `$kind` is document-defined (absent for a kindless card), `$body`
+  is schema-defined (absent for a body-disabled or unknown kind, and for a
+  body-disabled main). The raw `to_plate_json` is schema-free and omits only the
+  document-defined `$kind`; the render plate the backend receives
+  (`compile_data`) additionally drops `$body` where the schema defines none. Read
+  plate metadata with a total accessor (`card.at("$body", default: "")`); a
+  present `$body` is always a content object. See
+  [PLATE_DATA.md](../canon/PLATE_DATA.md).
 - `$cards` is always present, possibly empty.
 - Root-block fields and card-field names may collide freely; each card is its
   own scope.

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -386,8 +386,7 @@ interface Card {
   document-defined `$kind`; the render plate the backend receives
   (`compile_data`) additionally drops `$body` where the schema defines none. Read
   plate metadata with a total accessor (`card.at("$body", default: "")`); a
-  present `$body` is always a content object. See
-  [PLATE_DATA.md](../canon/PLATE_DATA.md).
+  present `$body` is always a content object.
 - `$cards` is always present, possibly empty.
 - Root-block fields and card-field names may collide freely; each card is its
   own scope.


### PR DESCRIPTION
The render plate now carries a $-metadata key on a card exactly where the
schema defines it, split by which definition gates the key:

- $kind is document-defined: to_plate_json omits it for a kindless card
  (never a fabricated ""), matching resolve()'s kind: None.
- $body is schema-defined: compile_data drops it wherever the schema
  defines no body — a body-disabled kind, an unknown kind, or a
  body-disabled main — matching resolve()'s omitted body row and
  build_transform_schema's $body drop.

A present $body is now always a content object: the polymorphism where a
body-disabled/unknown kind shipped $body as a raw content-JSON dict (never
a lowered content block) is gone, since those $body keys no longer reach the
plate. Only the body-disabled edge is reachable via compile_data —
validate_document rejects unknown-kind/kindless cards before render — so the
unknown/kindless handling is the rule made total.

Docs: PLATE_DATA.md, CARDS.md (also un-stales "body Markdown"),
markdown-spec.md, and the 0.95->0.96 migration guide adopt the two-rule
wording and the card.at("$body", default: "") total-accessor idiom.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014FeLg6zNm6yXmFwNfNHxwR