### PR TITLE
wasm: rename Document.get → getStored so the verbatim read carries its lane

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -255,9 +255,10 @@ Build a fresh card from a flat field map with
 `{ card?, field? }`, absent `card` = main, absent `field` = body — and a bare
 string is shorthand for `{ field }`. So `doc.storeField("qty", 3)` targets the
 main card's `qty`, `doc.storeField({ card: 2, field: "qty" }, 3)` a composable
-card's. Reads are total over the field axis (`get` → `undefined`, `isFill` → `false` for
+card's. Reads are total over the field axis (`getStored` → `undefined`, `isFill` → `false` for
 an absent field; only an out-of-range card throws); field writes throw on a body
-address. `getMarkdown` is the body markdown read (a `CardAddr`; a field's
+address. `getStored` is the verbatim transport read, distinct from the interpreted
+`quill.reader(doc).get`; `getMarkdown` is the body markdown read (a `CardAddr`; a field's
 markdown is read through `quill.reader(doc).get(field)`). Card-scoped verbs take a
 `CardAddr` (`{ card? }`) first: `doc.getExt({ card: 2 })`, and the batch below.
 

--- a/crates/bindings/wasm/core.test.js
+++ b/crates/bindings/wasm/core.test.js
@@ -158,8 +158,8 @@ title: Draft
     doc.storeField({ card: 0, field: 'author' }, 'Bob')
     // Keyed card read (#953) — mirrors the write, no payloadItems walk. Agrees
     // with the hand-rolled projection it replaces.
-    expect(doc.get({ card: 0, field: 'author' })).toBe('Bob')
-    expect(doc.get({ card: 0, field: 'author' })).toBe(field(doc.cards[0], 'author'))
+    expect(doc.getStored({ card: 0, field: 'author' })).toBe('Bob')
+    expect(doc.getStored({ card: 0, field: 'author' })).toBe(field(doc.cards[0], 'author'))
 
     // Storage DTO round-trips losslessly — the editor's persistence path.
     const restored = Document.fromJson(doc.toJson())
@@ -180,9 +180,9 @@ title: Draft
 # Body`)
     doc.insertCard(Document.makeCard('note', { author: 'Alice' }, 'A note body.'))
 
-    // getCardField — value keyed by name; undefined when the field is absent.
-    expect(doc.get({ card: 0, field: 'author' })).toBe('Alice')
-    expect(doc.get({ card: 0, field: 'missing' })).toBeUndefined()
+    // getStored — value keyed by name; undefined when the field is absent.
+    expect(doc.getStored({ card: 0, field: 'author' })).toBe('Alice')
+    expect(doc.getStored({ card: 0, field: 'missing' })).toBeUndefined()
 
     // getMarkdown is the card body read (card address); a field address throws.
     // A field's markdown reads through the schema-plane view,
@@ -192,13 +192,13 @@ title: Draft
 
     // An out-of-range index is a boundary error — it throws, the way the card
     // write verbs do, rather than reading back as undefined/"".
-    expect(() => doc.get({ card: 1, field: 'author' })).toThrow()
+    expect(() => doc.getStored({ card: 1, field: 'author' })).toThrow()
     expect(() => doc.getMarkdown({ card: 1 })).toThrow()
 
-    // get still reads the raw value verbatim (transport) — including a scalar a
+    // getStored still reads the raw value verbatim (transport) — including a scalar a
     // storeField wrote under a would-be richtext field.
     doc.storeField({ card: 0, field: 'qty' }, 3)
-    expect(doc.get({ card: 0, field: 'qty' })).toBe(3)
+    expect(doc.getStored({ card: 0, field: 'qty' })).toBe(3)
   })
 
   it('single-card, $id, and seed-overlay reads (#956)', () => {

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -247,22 +247,22 @@ card_kinds:
     expectEditCode(() => cardEd.set('body', 'x'), 'edit::index_out_of_range')
   })
 
-  it('get reads raw values quill-free; getMarkdown is body-only (field half retired)', () => {
+  it('getStored reads raw values quill-free; getMarkdown is body-only (field half retired)', () => {
     const quill = buildQuill()
     const ed = quill.writer(blankDoc())
     ed.set('qty', '3')
     ed.set('subject', 'Q3 **results**')
     ed.setBody('Main **body**.')
     // Transport reads stay quill-free on the Document.
-    expect(ed.document.get('qty')).toBe(3)
-    expect(ed.document.get('missing')).toBeUndefined()
+    expect(ed.document.getStored('qty')).toBe(3)
+    expect(ed.document.getStored('missing')).toBeUndefined()
     // getMarkdown is the body read; a field address throws — a field's markdown
     // reads through the schema-plane view (#978).
     expect(ed.document.getMarkdown()).toBe('Main **body**.')
     expect(() => ed.document.getMarkdown({ field: 'subject' })).toThrow(/body-only/)
     expect(quill.reader(ed.document).get('subject')).toBe('Q3 **results**')
-    // view.get carries schema authority: an unknown name throws (vs `undefined`
-    // from the quill-free transport `Document.get` above).
+    // reader.get carries schema authority: an unknown name throws (vs `undefined`
+    // from the quill-free transport `Document.getStored` above).
     expectEditCode(() => quill.reader(ed.document).get('missing'), 'edit::unknown_field')
   })
 })

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -630,7 +630,7 @@ export declare class CardWriter {
  * text, every other type its canonical value verbatim. Holds both handles by
  * reference and owns neither — nothing to `free()`.
  *
- * The schema authority is the point: unlike the quill-free transport `Document.get`,
+ * The schema authority is the point: unlike the quill-free transport `Document.getStored`,
  * a name the schema does not declare throws `UnknownField` (a typo) rather than
  * reading back `undefined`, and a content field holding a value that does not
  * decode throws `FieldRichtextDecode`. A field's markdown lives here, not on the

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -754,7 +754,7 @@ Quill.prototype.writer = function writer(doc) {
 };
 
 // ── Typed-reader sugar: the schema-plane read surface ──────────────────────────
-// The read twin of the writer above. The transport `Document.get` is schema-free
+// The read twin of the writer above. The transport `Document.getStored` is schema-free
 // — a `Document` cannot say which fields are richtext, so an unknown field name
 // reads back `undefined` rather than as the typo it is. Binding the quill's
 // schema (`_readerGet` takes the handle, like the `commit*` verbs) lets one `get`

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1392,7 +1392,7 @@ impl Document {
     }
 
     /// **Revise** the richtext value at `addr` from a markdown string — **edit
-    /// semantics**, the default write path, returning the text [`Delta`]. Imports
+    /// semantics**, the default write path, returning the text `Delta`. Imports
     /// the markdown, diffs it against the current value, rebases surviving
     /// identity anchors, and returns the change an editor bridge maps its own
     /// positions through (`mapPos`). An absent `addr.field` targets the body, an
@@ -1424,7 +1424,7 @@ impl Document {
     /// surviving anchors rebase (as [`revise`](Self::revise)), then the diffed
     /// result is schema-conformed, so a `richtext(inline)` field rejects a
     /// multi-block result with `edit::field_richtext_not_inline`. Returns the
-    /// text [`Delta`].
+    /// text `Delta`.
     ///
     /// `addr` must name a field (a bare string is `{ field }`); a body address
     /// throws (a body carries no field schema — use [`revise`](Self::revise)). A

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -928,16 +928,18 @@ impl Document {
         serialize_or_throw(&cards, "cards")
     }
 
-    /// Read the value at `addr` — the raw stored payload value of a field (a
-    /// content object for a richtext field, a scalar/array/object otherwise), or
-    /// the **body content** when `addr.field` is absent. A bare string is `Addr`
-    /// shorthand for `{ field }`. Reads are total over the field axis: an absent
-    /// field is `undefined`; only an out-of-range `addr.card` throws
-    /// `edit::index_out_of_range`. Reads need no schema, so they live on
-    /// `Document`, not the typed writer; for the markdown projection of a
-    /// richtext value use [`getMarkdown`](Self::get_markdown).
-    #[wasm_bindgen(js_name = get, unchecked_return_type = "unknown")]
-    pub fn get(
+    /// Read the **verbatim stored value** at `addr` — the raw payload value of a
+    /// field (a content object for a richtext field, a scalar/array/object
+    /// otherwise), or the **body content** when `addr.field` is absent. A bare
+    /// string is `Addr` shorthand for `{ field }`. Reads are total over the field
+    /// axis: an absent field is `undefined`; only an out-of-range `addr.card`
+    /// throws `edit::index_out_of_range`. Needs no schema, so it lives on
+    /// `Document` — the read echo of the verbatim `store*` write, distinct from
+    /// the interpreted schema-plane [`reader.get`](Self::reader_get). For the
+    /// markdown projection use [`getMarkdown`](Self::get_markdown) (body) or
+    /// `reader.get` (a field's declared type).
+    #[wasm_bindgen(js_name = getStored, unchecked_return_type = "unknown")]
+    pub fn get_stored(
         &self,
         #[wasm_bindgen(unchecked_param_type = "Addr | string")] addr: JsValue,
     ) -> Result<JsValue, JsValue> {
@@ -946,10 +948,10 @@ impl Document {
         match &addr.field {
             None => serialize_or_throw(
                 &quillmark_content::serial::to_canonical_value(card.body()),
-                "get",
+                "getStored",
             ),
             Some(field) => match card.payload().get(field) {
-                Some(v) => serialize_or_throw(v.as_json(), "get"),
+                Some(v) => serialize_or_throw(v.as_json(), "getStored"),
                 None => Ok(JsValue::UNDEFINED),
             },
         }
@@ -982,7 +984,7 @@ impl Document {
 
     /// Interpreted read at `addr`, resolving the field's declared `type` from
     /// `quill` — the stable ABI under the runtime `reader.get` / `reader.card(i).get`.
-    /// The schema-plane twin of the quill-free [`get`](Self::get): a `richtext`
+    /// The schema-plane twin of the quill-free [`getStored`](Self::get_stored): a `richtext`
     /// field returns its markdown projection, every other declared type its
     /// canonical value verbatim, so a consumer holding the quill reads by field
     /// meaning rather than by wire shape.

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -2,9 +2,10 @@
 //! [`TypedWriter`](crate::TypedWriter).
 //!
 //! The read surface's verbs split by read-vs-write, but the deeper fault line is
-//! **interpret-vs-transport**. [`Document::get`](crate::Card::payload) is
-//! *transport*: it returns the stored value verbatim, schema-free and
-//! round-trippable — the disambiguation / debug read. Projecting a field to
+//! **interpret-vs-transport**. The verbatim [`payload().get`](crate::Card::payload)
+//! (the WASM binding's `Document.getStored`) is *transport*: it returns the stored
+//! value verbatim, schema-free and round-trippable — the disambiguation / debug
+//! read. Projecting a field to
 //! markdown is *interpretation*: a schema-shaped question ("this field's
 //! richtext, as markdown") that a schema-free `Document` cannot answer without
 //! guessing which fields are even richtext. [`Card::field_markdown`] carries the

--- a/docs/migrations/0.96-to-0.97.md
+++ b/docs/migrations/0.96-to-0.97.md
@@ -1,0 +1,64 @@
+# 0.96 → 0.97 — the WASM verbatim field read renames `Document.get` → `getStored`
+
+One rename on the WASM surface: the quill-free **transport** read `Document.get`
+becomes **`Document.getStored`**. The interpreted schema-plane read
+`quill.reader(doc).get` is unchanged. Python is unaffected (it has no quill-free
+field read). If your WASM host never calls `doc.get(...)`, there is nothing to do.
+
+## Why
+
+The write surface separates *verbatim* from *typed* on two axes — receiver **and**
+verb: verbatim writes are `store_field` / `store_fields` on `Document`; typed
+writes are `set` / `set_all` on `quill.writer(doc)`. "The verb carries the lane."
+
+The read surface used to separate the same two lanes on the receiver **alone** —
+verbatim `Document.get` vs. interpreted `reader.get`, one `get` doing both jobs.
+The two read rows in the bindings parity table read as near-duplicates, and the
+only thing distinguishing a total, returns-`undefined`-on-a-typo read from a
+schema-checked, throws-on-a-typo read was which object you called it on.
+
+`getStored` restores the write side's discipline to the read side: the verbatim
+read is the read echo of `store`, and `reader.get` stays the reader/writer twin of
+`set`. The lane now lives in the verb both ways.
+
+`getStored`'s semantics are byte-for-byte what `get` did — verbatim value for a
+field (a content object for a richtext field, a scalar/array/object otherwise),
+body content when `addr.field` is absent, `undefined` for an absent field, and a
+throw only for an out-of-range `addr.card`. Only the name changed.
+
+## Migrate: rename the call sites
+
+Every `doc.get(...)` transport read becomes `doc.getStored(...)`. The argument is
+the same `Addr | string` (a bare string is `{ field }` shorthand).
+
+```js
+// 0.96
+doc.get('qty')                       // 3
+doc.get('missing')                   // undefined
+doc.get({ card: 2, field: 'qty' })   // a composable card's field
+doc.get({})                          // main body content
+
+// 0.97
+doc.getStored('qty')                       // 3
+doc.getStored('missing')                   // undefined
+doc.getStored({ card: 2, field: 'qty' })   // a composable card's field
+doc.getStored({})                          // main body content
+```
+
+Leave `reader.get` alone — it was already the right name, and it is the read you
+want whenever a quill is in hand:
+
+```js
+quill.reader(doc).get('subject')        // richtext → markdown; unchanged
+quill.reader(doc).card(0).get('body')   // card field by its $kind; unchanged
+```
+
+`getMarkdown` (the body markdown read), `getExt` / `getExtNamespace`, and `isFill`
+keep their names.
+
+## Unaffected
+
+- **Python.** `quillmark` (PyO3) has no quill-free field read; interpreted field
+  reads already go through `quill.reader(doc).get`. No change.
+- **Core (Rust).** The transport read is the map-idiomatic `payload().get`, already
+  lexically distinct from `reader.get` — no collision, no rename.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,6 +18,13 @@ guides in order.
 
 ## Available guides
 
+- [0.96 → 0.97](0.96-to-0.97.md) — the WASM verbatim transport read renames.
+  **Break:** `Document.get` → **`Document.getStored`** (JS) — the quill-free
+  field/body read gains its own verb so it no longer collides with the interpreted
+  `quill.reader(doc).get`; semantics are unchanged, only the name. Rename
+  `doc.get(...)` call sites to `doc.getStored(...)`; `reader.get`, `getMarkdown`,
+  `getExt`, and `isFill` are untouched, and Python (no quill-free field read) is
+  unaffected.
 - [0.95 → 0.96](0.95-to-0.96.md) — one address grammar on every boundary.
   **Break:** `LiveSession` geometry (`regions` / `fieldAt` / `positionAt` /
   `locate`) now keys on the canonical `DocPath` (`main.body`,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
+      - 0.96 → 0.97 (WASM Document.get → getStored; verbatim transport read gains its own verb): migrations/0.96-to-0.97.md
       - '0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified)': migrations/0.95-to-0.96.md
       - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md
       - 0.93 → 0.94 (richtext(inline) token retires; ui.order removed, declaration order is the ordering contract): migrations/0.93-to-0.94.md

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -49,8 +49,8 @@ from the bound quill, so a name the schema does not declare is a typo
 coercion deferred to render) and the addressed content lane — `install` / `revise`
 / `applyChange` plus the `importMarkdown` / `exportMarkdown` / `rebase` / `mapPos`
 codec — which navigate by `Addr` and return `Delta` receipts but never consult a
-schema. **Transport** reads (`get` / `isFill` / `getExt`) return the stored value
-verbatim, need no schema, and sit on `Document` too.
+schema. **Transport** reads (`getStored` / `isFill` / `getExt`) return the stored
+value verbatim, need no schema, and sit on `Document` too.
 
 The one **interpreting** read — projecting a field by its type — is a
 schema-shaped question ("this field's richtext, as markdown"), so it gains a
@@ -82,6 +82,15 @@ So `store_field` / `store_fields` / `store_fill` (+ `store_ext` / `store_seed_*`
 are the opaque store, `set` / `set_all` / `set_body` the typed writer, and a name
 never needs per-verb disambiguation against its neighbor (the opaque batch
 `store_fields` and the typed batch `set_all` are not near-homographs).
+
+**The read side mirrors it.** The verbatim read is `getStored` — the read echo of
+`store` — and the interpreted read is `reader.get`, the reader/writer twin of
+`set`. So the transport and schema-plane reads carry the lane in the verb the same
+way the writes do, rather than collapsing both onto one `get` where only the
+receiver (`doc` vs `reader`) tells them apart. (Core needs no such split: its
+verbatim read is the map-idiomatic `payload().get`, already lexically distinct from
+`reader.get`; the collision is a WASM/pyo3 artifact of fusing the read onto the one
+`Document` handle, so only the bindings rename it.)
 
 **Writers and card cursors are ephemeral — bind, write, discard.** They hold an
 address (the quill + document, or an index), never a cache; every call reads
@@ -118,7 +127,7 @@ nothing else admitted. Drift is a reviewable diff to this table.
 | Card removal (writer) | `writer.remove_card(i)` | `writer.removeCard(i)` | identical |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
 | Cursor kind | `writer.card(i)?.kind()` | `writer.card(i).kind` | identical — the JS getter reads through `doc.card(i)` |
-| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.get(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `get`/`isFill`), *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.reader(doc).get` (#978, #970), and `$ext` / body content read off the `main` / `cards` dict snapshots |
+| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.getStored(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `getStored`/`isFill`) and names the verbatim field read `getStored`, not `get`, so it never collides with the interpreted `reader.get` (core's `payload().get` has no such neighbor); *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.reader(doc).get` (#978, #970), and `$ext` / body content read off the `main` / `cards` dict snapshots |
 | Reads (whole card / `$id` / seed) | `card(i)` / `find_card(id)` / `main().seed()` | `doc.card(i)` / `doc.cardIndexById(id)` / `doc.seedOverlay(kind)` | **idiom** — the bindings fuse each into one named verb on `Document`; `card(i)` throws out of range, `find_card`/`cardIndexById` return the first `$id` match (non-unique by design) |
 | Richtext revise (content lane) | `Card::revise_field(name, md)?` (schema-blind, borrow chain) | `doc.revise({card, field}, md)` (addr literal, JS) | **FFI** / **scope** — same model, flattened navigation, schema-blind, `Delta` in hand; WASM-only. Python's anchor-preserving write is the typed `writer.revise_field` (#970) |
 | Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`) | **scope** — the quill-free verbatim write, WASM-only; Python has no opaque field store (the typed writer is the only field write, #970). A field write without a loadable quill operates on the storage DTO directly |


### PR DESCRIPTION
The WASM surface had two `get`s split only by receiver — the quill-free
transport `Document.get` and the interpreted `quill.reader(doc).get` — while
the write surface separates the same verbatim/typed lanes by *verb* too
(`store_*` vs `set`). Give the transport read its own verb, `getStored` (the
read echo of `store`), and keep `reader.get` as the reader/writer twin of
`set`. The two read rows in the bindings parity table stop reading as
near-duplicates.

WASM-only: core keeps the map-idiomatic `payload().get` (already distinct
from `reader.get`) and Python has no quill-free field read. Semantics are
unchanged — only the name. Adds the 0.96→0.97 migration guide.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Apipng89CfhGPWuFDMRAYv