### PR TITLE
Fix stale resolve() docs: body is a sibling, not a `$body` row

### DIFF
--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -79,8 +79,9 @@ export type {
 } from '../core/wasm.js';
 
 // The resolved-value view — the return shape of `quill.resolve(doc)`. Value
-// + source rung per declared field (the body rides the fields map under
-// `$body`); diagnostics stay `quill.validate`, guidance stays `quill.schema`.
+// + source rung per declared field (the body is a `body` sibling on its card,
+// never a row in `fields`); diagnostics stay `quill.validate`, guidance stays
+// `quill.schema`.
 // Declared in the core build's generated `.d.ts` via a
 // `typescript_custom_section`; re-exported here so the single public entry
 // point names them.

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -668,7 +668,8 @@ impl Quill {
     /// The resolved-value view of `doc` against this quill's schema — for every
     /// declared field the value the render projection would use and the
     /// `FieldSource` rung it came from (`"authored" | "default" | "zero"`), in
-    /// one call. The card body rides the `fields` map under the `$body` key.
+    /// one call. The card body is a `body` sibling on its card (row `name`
+    /// `"body"`), never a row in `fields` — `null` when the kind enables no body.
     ///
     /// Value and provenance only: completeness and errors stay `validate`'s
     /// (a consumer merges it with its own diagnostic producers regardless), and


### PR DESCRIPTION
Two WASM doc comments described a superseded shape where the card body
rode the `fields` map under a `$body` key. The current view (core
`resolved.rs`, the canonical `RESOLVED_TS` types, and `SCHEMAS.md`) makes
`body` a typed sibling on `ResolvedMain`/`ResolvedCard` — row `name`
`"body"`, `null` when the kind enables no body — never a row in `fields`.
Correct both comments to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0186AZs59HbLqFFQCYaK5WbJ