### PR TITLE
Canonize anchor-id policy: caller-supplied, unique, invariant

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -227,7 +227,11 @@ export type ContentContainer =
     | { container: "list_item"; ordered: boolean; start: number; ordinal: number }
     | { container: "quote" };
 
-/** A mark over char range `[start, end)` into `Content.text`. */
+/** A mark over char range `[start, end)` into `Content.text`. An `anchor`'s
+ * `id` is a caller-supplied, opaque handle, unique per `Content` and invariant
+ * while the mark lives (positions rebase, the id never does); it has no markdown
+ * projection and survives only through the edit lane. See DOCUMENT_STORAGE
+ * § Anchor-id identity. */
 export type ContentMark = { start: number; end: number } & (
     | { type: "strong" | "emph" | "underline" | "strike" | "code" }
     | { type: "link"; url: string }
@@ -316,7 +320,10 @@ export type Assoc = "before" | "after";
 /**
  * A mark edit in final-text coordinates (post-delta, post-line-op). `add` /
  * `remove` carry the `ContentMark` vocabulary (`{ type, … }`); `removeAnchor`
- * drops one identity anchor by id.
+ * drops one identity anchor by id. An `add` of an `anchor` requires a non-empty
+ * `id` not already live in the field — a collision or the empty id throws
+ * (ids are caller-supplied and unique per `Content`; DOCUMENT_STORAGE
+ * § Anchor-id identity).
  */
 export type MarkOp =
     | ({ op: "add" | "remove"; start: number; end: number } & (

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -136,8 +136,11 @@ pub enum MarkKind {
     },
     // Identity — a handle, not a property. Never merged, may be zero-width.
     /// A comment thread or stable anchor, carried by id and rebased across
-    /// edits like any position. No markdown projection (omitted on export;
-    /// survives via diff-rebase).
+    /// edits like any position. The id is caller-supplied, unique per `Content`,
+    /// opaque and invariant while the mark lives; positions rebase, the id never
+    /// does, and moved-and-rewritten text drops the mark whole
+    /// (`DOCUMENT_STORAGE.md` § Anchor-id identity). No markdown projection
+    /// (omitted on export; survives via diff-rebase).
     Anchor {
         id: String,
     },
@@ -338,6 +341,13 @@ pub enum Invariant {
     /// wrong one. Uniqueness is the id invariant `validate` enforces — positional
     /// equality is not, since edits keep an island's id stable across renumbers.
     IslandIdCollision { id: String },
+    /// Two prose anchors share an `id`, or one carries the empty id. An anchor
+    /// id is a caller-supplied, opaque handle, unique per `Content` (hash input,
+    /// never ambient in the twin's sense; `DOCUMENT_STORAGE.md` § Anchor-id
+    /// identity). `RemoveAnchor { id }` retains-out *every* match, so a shared id
+    /// makes removing one destroy both; the empty id is a degenerate handle.
+    /// Scope is prose marks — cell anchors are outside the op surface.
+    AnchorIdCollision { id: String },
     /// A table island's `header` prop is present but not a JSON array — it
     /// cannot carry column cells. `normalize` rewrites a non-array header to an
     /// empty array (a zero-column, content-free table).
@@ -505,6 +515,11 @@ impl Content {
         }
         let len = self.len_usv();
         let chars: Vec<char> = self.text.chars().collect();
+        // Prose anchor ids: unique, non-empty, caller-supplied opaque handles
+        // (`DOCUMENT_STORAGE.md` § Anchor-id identity). Uniqueness — the same
+        // invariant the island loop enforces below — is what `RemoveAnchor`
+        // presumes; scope is prose marks, cell anchors excluded by construction.
+        let mut seen_anchor_ids = std::collections::HashSet::new();
         for m in &self.marks {
             if m.start > m.end || m.end > len {
                 return Err(Invariant::MarkOutOfRange {
@@ -524,10 +539,18 @@ impl Content {
                     return Err(Invariant::MarkEdgeOnNewline { at: m.end - 1 });
                 }
             }
-            if let MarkKind::Unknown { tag, .. } = &m.kind {
-                if Self::RESERVED_MARK_TYPES.contains(&tag.as_str()) {
-                    return Err(Invariant::ReservedUnknownTag(tag.clone()));
+            match &m.kind {
+                MarkKind::Unknown { tag, .. } => {
+                    if Self::RESERVED_MARK_TYPES.contains(&tag.as_str()) {
+                        return Err(Invariant::ReservedUnknownTag(tag.clone()));
+                    }
                 }
+                MarkKind::Anchor { id } => {
+                    if id.is_empty() || !seen_anchor_ids.insert(id.as_str()) {
+                        return Err(Invariant::AnchorIdCollision { id: id.clone() });
+                    }
+                }
+                _ => {}
             }
         }
         for line in &self.lines {
@@ -1063,6 +1086,36 @@ mod tests {
         // Distinct ids validate.
         rt.islands = vec![table("a"), table("b")];
         assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// Two prose anchors sharing an `id` at different ranges violate the
+    /// anchor-id uniqueness invariant, as does the empty id. (Byte-identical
+    /// anchors `normalize` already dedupes; this is the surviving collision.)
+    /// Issue #1039.
+    #[test]
+    fn duplicate_or_empty_anchor_id_is_rejected() {
+        let mut rt = Content::empty();
+        rt.text = "abcd".into();
+        let anchor = |start, end, id: &str| Mark {
+            start,
+            end,
+            kind: MarkKind::Anchor { id: id.into() },
+        };
+        // Same id at two ranges — `RemoveAnchor` can't disambiguate them.
+        rt.marks = vec![anchor(0, 2, "x"), anchor(2, 4, "x")];
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::AnchorIdCollision { id: "x".into() })
+        );
+        // Distinct ids over distinct ranges validate.
+        rt.marks = vec![anchor(0, 2, "x"), anchor(2, 4, "y")];
+        assert_eq!(rt.validate(), Ok(()));
+        // The empty id is a degenerate handle.
+        rt.marks = vec![anchor(0, 2, "")];
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::AnchorIdCollision { id: String::new() })
+        );
     }
 
     /// `normalize` drops a byte-identical duplicate identity mark (same range,

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -19,7 +19,11 @@ use std::borrow::Cow;
 /// A mark edit in final-text coordinates (post-delta, post-line-op).
 #[derive(Debug, Clone, PartialEq)]
 pub enum MarkOp {
-    /// Add a mark over `[start, end)`.
+    /// Add a mark over `[start, end)`. An anchor `kind` must carry a non-empty
+    /// `id` not already live in the field — ids are caller-supplied and unique
+    /// per `Content` (`DOCUMENT_STORAGE.md` § Anchor-id identity); a collision or
+    /// the empty id is rejected ([`ApplyError::AnchorIdCollision`] /
+    /// [`ApplyError::EmptyAnchorId`]), never replaced or coexisted.
     Add {
         start: Usv,
         end: Usv,
@@ -316,6 +320,16 @@ pub enum ApplyError {
     /// backing [`Island`], an orphaned-slot invariant violation. Islands are
     /// created through their own channel, never a text splice.
     IslandSlotInInsert,
+    /// A [`MarkOp::Add`] of an anchor whose `id` is already live in the field.
+    /// An anchor id is a caller-supplied handle, unique per `Content`
+    /// (`DOCUMENT_STORAGE.md` § Anchor-id identity); `add` rejects a collision
+    /// rather than replace (which would silently retarget a live thread) or
+    /// coexist (which `RemoveAnchor` cannot disambiguate). The op-time twin of
+    /// [`Invariant::AnchorIdCollision`](crate::model::Invariant::AnchorIdCollision).
+    AnchorIdCollision { id: String },
+    /// A [`MarkOp::Add`] of an anchor with the empty `id` — a degenerate handle,
+    /// refused so every anchor carries a usable referent.
+    EmptyAnchorId,
 }
 
 impl Content {
@@ -446,6 +460,24 @@ impl Content {
                             end: *end,
                             len,
                         });
+                    }
+                    // Anchor id: caller-supplied, unique per `Content`, non-empty
+                    // (`DOCUMENT_STORAGE.md` § Anchor-id identity). Reject a live
+                    // collision — `RemoveAnchor` cannot tell two same-id anchors
+                    // apart — and the empty degenerate handle. Ops apply in
+                    // sequence, so a `RemoveAnchor` earlier in the bundle frees
+                    // the id for re-add here.
+                    if let MarkKind::Anchor { id } = kind {
+                        if id.is_empty() {
+                            return Err(ApplyError::EmptyAnchorId);
+                        }
+                        if self
+                            .marks
+                            .iter()
+                            .any(|m| matches!(&m.kind, MarkKind::Anchor { id: aid } if aid == id))
+                        {
+                            return Err(ApplyError::AnchorIdCollision { id: id.clone() });
+                        }
                     }
                     self.marks.push(Mark {
                         start: *start,
@@ -1366,6 +1398,54 @@ mod tests {
         );
         assert!(matches!(err, Err(ApplyError::MarkOutOfRange { .. })));
         assert_eq!(rt, before, "failed bundle must not mutate the content");
+    }
+
+    /// `add` of an anchor rejects a live id collision and the empty id, but
+    /// re-adds an id freed by an earlier `RemoveAnchor` in the same bundle.
+    /// Issue #1039.
+    #[test]
+    fn add_anchor_id_uniqueness() {
+        let anchor = |id: &str| MarkKind::Anchor { id: id.into() };
+        let add = |start, end, id: &str| MarkOp::Add {
+            start,
+            end,
+            kind: anchor(id),
+        };
+
+        // First anchor lands; a second `add` of the same id is a collision.
+        let mut rt = from_markdown("abcd").unwrap();
+        rt.apply_field_change(&diff("abcd", "abcd"), &[], &[add(0, 2, "x")])
+            .unwrap();
+        assert_eq!(
+            rt.apply_field_change(&diff("abcd", "abcd"), &[], &[add(2, 4, "x")]),
+            Err(ApplyError::AnchorIdCollision { id: "x".into() })
+        );
+
+        // The empty id is refused.
+        let mut rt = from_markdown("abcd").unwrap();
+        assert_eq!(
+            rt.apply_field_change(&diff("abcd", "abcd"), &[], &[add(0, 2, "")]),
+            Err(ApplyError::EmptyAnchorId)
+        );
+
+        // Remove-then-add of the same id in one bundle is allowed — ops apply in
+        // sequence, so the id is free by the time the `add` runs.
+        let mut rt = from_markdown("abcd").unwrap();
+        rt.apply_field_change(&diff("abcd", "abcd"), &[], &[add(0, 2, "x")])
+            .unwrap();
+        rt.apply_field_change(
+            &diff("abcd", "abcd"),
+            &[],
+            &[MarkOp::RemoveAnchor { id: "x".into() }, add(2, 4, "x")],
+        )
+        .unwrap();
+        let anchors: Vec<_> = rt
+            .marks
+            .iter()
+            .filter(|m| matches!(m.kind, MarkKind::Anchor { .. }))
+            .collect();
+        assert_eq!(anchors.len(), 1);
+        assert_eq!((anchors[0].start, anchors[0].end), (2, 4));
     }
 
     // ── sync_lines_for_delta characterization (issue #926 finding 2) ─────────

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -448,6 +448,63 @@ proptest! {
         }
     }
 
+    /// Property (issue #1039): an anchor's `id` is bit-invariant under a random
+    /// splice + rebase. The mark may drop (its anchored text deleted) or move
+    /// (its range rebases through `map_pos`), but any *surviving* anchor carries
+    /// the exact id it started with — the runtime never rewrites an id. Import
+    /// mints no anchor, so the one id seeded here is the only one that can appear;
+    /// an astral char in it would expose any byte-level munging.
+    #[test]
+    fn anchor_id_bit_invariant_under_splice(
+        md in document(),
+        a_seed in 0usize..4096,
+        b_seed in 0usize..4096,
+        ins in "[a-z0-9 \n]{0,10}",
+        pos_seed in 0usize..4096,
+        del_seed in 0usize..4096,
+        is_delete in any::<bool>(),
+    ) {
+        const ID: &str = "anchor-\u{1f4a1}-42";
+        let mut rt = from_markdown(&md).unwrap();
+        let len = rt.len_usv();
+        let a = a_seed % (len + 1);
+        let b = b_seed % (len + 1);
+        rt.marks.push(Mark {
+            start: a.min(b),
+            end: a.max(b),
+            kind: MarkKind::Anchor { id: ID.into() },
+        });
+        rt.normalize();
+        prop_assert_eq!(rt.validate(), Ok(()), "seeded content invalid for {:?}", md);
+
+        let len = rt.len_usv();
+        let pos = pos_seed % (len + 1);
+        let delta = if is_delete {
+            let k = del_seed % (len - pos + 1);
+            let ops = retain(pos)
+                .into_iter()
+                .chain(std::iter::once(Op::Delete(k)))
+                .chain(retain(len - pos - k))
+                .collect();
+            Delta { ops }
+        } else {
+            let ops = retain(pos)
+                .into_iter()
+                .chain(std::iter::once(Op::Insert(ins.clone())))
+                .chain(retain(len - pos))
+                .collect();
+            Delta { ops }
+        };
+        if rt.apply_text_delta(&delta).is_ok() {
+            for m in &rt.marks {
+                if let MarkKind::Anchor { id } = &m.kind {
+                    prop_assert_eq!(id.as_str(), ID, "rebase rewrote an anchor id");
+                }
+            }
+            prop_assert_eq!(rt.validate(), Ok(()), "splice broke an invariant");
+        }
+    }
+
     /// `apply_mark_ops` preserves `validate()`: an accepted Add over a clamped
     /// range leaves the content valid (normalization trims edges / drops
     /// zero-width).

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -160,6 +160,54 @@ producer (a live editor, a richer island type) is bound by the same rule:
 continue the positional sequence for appended islands; never mint an ambient
 id.
 
+## Anchor-id identity
+
+An anchor (`MarkKind::Anchor { id }`) and an island id are the *same handle* —
+opaque, unique per `Content`, hash input, session-stable, rebased not rewritten
+— differing on exactly one axis: **derivability at the markdown boundary**. An
+island projects to markdown, so its id is a pure function of that projection
+(§ Island-id determinism); an anchor has **no** projection — it names an
+external referent (a comment thread, an editor bookmark) that no content
+determines. The never-ambient rule therefore cannot apply, and need not: that
+rule exists to keep *import* a pure function of markdown, and import mints no
+anchor, so equal markdown still imports to equal bytes. The two sections read as
+one handle model, not a contradiction.
+
+The policy: **an anchor id is caller-supplied, unique per `Content`, opaque and
+invariant while the mark lives; the mark is best-effort under edits and absent
+from markdown.**
+
+- **Caller-supplied.** The engine mints no anchor id and cannot — only the
+  consumer knows the referent. Each consumer (editor, MCP writer) supplies its
+  own; the runtime persists it verbatim. Engine-minting is a considered
+  non-goal: a counter is history-dependent (the same final content reached two
+  ways carries different ids — the ambient source the twin rule forbids) and
+  forfeits referent-convergence (two `add`s for one thread would mint two
+  handles). A client wanting generated ids mints them client-side and supplies
+  them; the auto-fallback middle ground (engine mints when the caller omits) is
+  a non-goal too.
+- **Unique per `Content`.** `add` *rejects* a collision — not replace (which
+  silently retargets a live thread) nor coexist (already incoherent: an anchor
+  is *the* handle `RemoveAnchor { id }` retains-out, so a shared id makes
+  removing one destroy both). The empty id is rejected as a degenerate handle.
+  Enforced at op time in the `Add` arm and as a `Content::validate` invariant
+  (`Invariant::AnchorIdCollision`, the uniqueness scan the island check shares).
+  Scope is prose `marks`: an anchor inside an island cell is unreachable by
+  `RemoveAnchor` (it scans prose marks only), so it sits outside the op surface
+  and outside this uniqueness check — explicit partial enforcement, not silent
+  half-enforcement.
+- **Opaque and invariant.** The runtime never rewrites an id. Positions rebase
+  through splices (`map_pos`); the id passes untouched. A mark whose text is
+  deleted, or moved-and-rewritten in one round, drops *whole* — never
+  partially, never re-id'd (the documented diff-rebase residual).
+
+No markdown round-trip guarantee: export emits nothing for an anchor and import
+mints none, so a cold export→import loses every anchor. Anchors are edit-lane
+infrastructure — they survive only through diff-rebase (`revise` / `rebase`).
+Non-rendering is a property of review-time metadata, not a gap; a future render
+projection (proof annotations, PDF destinations) would render the referent or a
+position, never the id, so this policy holds either way.
+
 ## Schema Versioning
 
 The schema version is tied to the **crate version at which the `Document`


### PR DESCRIPTION
Anchor marks (`MarkKind::Anchor { id }`) carried an id with no settled
minting/uniqueness/stability policy. The code already presumed uniqueness
(`RemoveAnchor { id }` retains-out every match) and id-opacity (`rebase_marks`
never touches ids), but nothing enforced or documented it.

Settle the policy (issue #1039) and enforce it:

- Canon: new `## Anchor-id identity` in DOCUMENT_STORAGE.md, after its twin
  § Island-id determinism. One handle model differing on a single axis —
  markdown-derivability — so the never-ambient rule stays island-scoped
  (import purity) and the sections don't contradict.
- `Invariant::AnchorIdCollision`: `validate` rejects duplicate or empty prose
  anchor ids, sharing the island uniqueness scan. Scope is prose marks;
  island-cell anchors are outside the op surface.
- `apply_mark_ops_inner` `Add` arm rejects a live id collision
  (`ApplyError::AnchorIdCollision`) and the empty id (`ApplyError::EmptyAnchorId`).
- Policy doc comments on `MarkKind::Anchor`, `MarkOp::Add`, and the wasm wire docs.
- Tests: validate rejects collision/empty; add rejects duplicate/empty and
  allows remove-then-readd in one bundle; a property that an anchor id is
  bit-invariant under random splice/rebase.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ngwMd2LRTy22NbvprpZLM