### PR TITLE
ci: lint the wasm binding's rustdoc to catch intra-doc breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --no-deps --locked
 
+      # The step above walks default-members, which omits the binding crates —
+      # crates/bindings/wasm is a wasm32 cdylib excluded from default-members —
+      # so their rustdoc, intra-doc links included, is never linted by it. That
+      # blind spot let two broken `Delta` links accumulate on the JS surface
+      # (#1034). quillmark-wasm also carries an rlib target, so it documents on
+      # the host toolchain; lint it explicitly to catch such breakage going
+      # forward. Separate step so a wasm-only doc failure is legible in the log.
+      - name: Build docs (wasm binding)
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo doc --no-deps --locked -p quillmark-wasm
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The standing `cargo doc -Dwarnings` gate walks default-members, which
omits crates/bindings/wasm (a wasm32 cdylib), so its rustdoc was never
linted on the host toolchain. That blind spot let two broken `Delta`
intra-doc links accumulate on the JS surface (#1034). The crate carries
an rlib target too, so it documents on host; add an explicit
`-p quillmark-wasm` doc step to the lint job to close the gap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KmUxbuxVQigFov1VuV7xGW