### PR TITLE
wasm: add island/mark discriminant guards; USV docs on mapPos/rebase

### DIFF
--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -182,3 +182,31 @@ export type ContentExportsPresent = [
 type MainCardAddrType = typeof import('../../../pkg/runtime/runtime.d.ts').MAIN_CARD_ADDR;
 const mainCardAddrIsCardAddr: CardAddr = {} as MainCardAddrType;
 void mainCardAddrIsCardAddr;
+
+// ── Open-set discriminant guards (#1042) ────────────────────────────────────
+// The guards must NARROW the open `type` unions — the whole point, since a bare
+// `x.type === 'table'` check cannot (the residual `{ type: string; … }` arm
+// stays live). Each `if` body reads a payload reachable only after narrowing, so
+// a guard that stops narrowing fails `npm run typecheck`. `ContentIsland`,
+// `TableProps`, `ImageProps`, and `ContentMark` are the types imported above.
+import { isTableIsland, isImageIsland, isLinkMark, isAnchorMark } from '../../../pkg/runtime/runtime.js';
+
+declare const guardIsland: ContentIsland;
+if (isTableIsland(guardIsland)) {
+	const tableProps: TableProps = guardIsland.props;
+	void tableProps;
+}
+if (isImageIsland(guardIsland)) {
+	const imageProps: ImageProps = guardIsland.props;
+	void imageProps;
+}
+
+declare const guardMark: ContentMark;
+if (isLinkMark(guardMark)) {
+	const url: string = guardMark.url;
+	void url;
+}
+if (isAnchorMark(guardMark)) {
+	const id: string = guardMark.id;
+	void id;
+}

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -121,6 +121,37 @@ export interface QuillmarkError extends Error {
  */
 export declare function isQuillmarkError(e: unknown): e is QuillmarkError;
 
+// ── Open-set discriminant guards ────────────────────────────────────────────
+// `ContentIsland.type` / `ContentMark.type` are open sets — each union has a
+// residual `{ type: string; … }` arm, so a bare discriminant check never narrows
+// the payload (TS keeps the residual arm live, since a `string` can equal the
+// literal). These guards are the checked narrowing path for the pinned arms; an
+// unrecognized `type` fails every guard and keeps its opaque payload. Only the
+// payload-carrying arms get a guard — the bare marks
+// (`strong`/`emph`/`underline`/`strike`/`code`) narrow to nothing.
+
+import type { ContentIsland, TableProps, ImageProps, ContentMark } from '../core/wasm.js';
+
+/** Narrow a {@link ContentIsland} to the pinned `table` arm (`props: TableProps`). */
+export declare function isTableIsland(
+	island: ContentIsland
+): island is ContentIsland & { type: 'table'; props: TableProps };
+
+/** Narrow a {@link ContentIsland} to the pinned `image` arm (`props: ImageProps`). */
+export declare function isImageIsland(
+	island: ContentIsland
+): island is ContentIsland & { type: 'image'; props: ImageProps };
+
+/** Narrow a {@link ContentMark} to the `link` arm (carries `url`). */
+export declare function isLinkMark(
+	mark: ContentMark
+): mark is ContentMark & { type: 'link'; url: string };
+
+/** Narrow a {@link ContentMark} to the `anchor` arm (carries `id`). */
+export declare function isAnchorMark(
+	mark: ContentMark
+): mark is ContentMark & { type: 'anchor'; id: string };
+
 // ── Canonical render-side types ─────────────────────────────────────────────
 // These are the BACKEND-NEUTRAL render contract of the plural-backend API. They
 // are defined HERE (not re-exported from one private backend) because no single

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -98,6 +98,49 @@ export function isQuillmarkError(e) {
 	return e instanceof Error && Array.isArray(/** @type {any} */ (e).diagnostics);
 }
 
+// ── Open-set discriminant guards ────────────────────────────────────────────
+// `ContentIsland.type` and `ContentMark.type` are OPEN sets: each union carries
+// a residual `{ type: string; … }` arm, so a bare `x.type === 'table'` check
+// never narrows the payload — TS keeps the residual arm live (a `string` can be
+// `'table'`), leaving `props` / the mark payload opaque at every consumer. These
+// are the checked narrowing path: on the true branch the payload's pinned shape
+// is asserted. Only the payload-carrying arms get a guard — an island always
+// carries `props`, a `link` mark carries `url`, an `anchor` mark carries `id`;
+// the bare marks (`strong`/`emph`/`underline`/`strike`/`code`) narrow to
+// nothing. An unrecognized `type` fails every guard and keeps its opaque payload.
+
+/**
+ * @param {import('../core/wasm.js').ContentIsland} island
+ * @returns {island is import('../core/wasm.js').ContentIsland & { type: 'table'; props: import('../core/wasm.js').TableProps }}
+ */
+export function isTableIsland(island) {
+	return island.type === 'table';
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentIsland} island
+ * @returns {island is import('../core/wasm.js').ContentIsland & { type: 'image'; props: import('../core/wasm.js').ImageProps }}
+ */
+export function isImageIsland(island) {
+	return island.type === 'image';
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentMark} mark
+ * @returns {mark is import('../core/wasm.js').ContentMark & { type: 'link'; url: string }}
+ */
+export function isLinkMark(mark) {
+	return mark.type === 'link';
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentMark} mark
+ * @returns {mark is import('../core/wasm.js').ContentMark & { type: 'anchor'; id: string }}
+ */
+export function isAnchorMark(mark) {
+	return mark.type === 'anchor';
+}
+
 // Backend builds are NEVER statically imported here — that would pull a
 // multi-MB binary into the eager graph and defeat lazy loading. Each entry is a
 // DESCRIPTOR: `load` is a thunk returning a dynamic `import()` (a backend's

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -227,10 +227,13 @@ export type ContentContainer =
     | { container: "list_item"; ordered: boolean; start: number; ordinal: number }
     | { container: "quote" };
 
-/** A mark over char range `[start, end)` into `Content.text`. An `anchor`'s
- * `id` is a caller-supplied, opaque handle, unique per `Content` and invariant
- * while the mark lives (positions rebase, the id never does); it has no markdown
- * projection and survives only through the edit lane. See DOCUMENT_STORAGE
+/** A mark over char range `[start, end)` into `Content.text`. The open `type`
+ * arm blocks discriminant narrowing (as on `ContentIsland`), so read a
+ * payload-carrying arm behind its guard — `isLinkMark` (`url`) / `isAnchorMark`
+ * (`id`), from `@quillmark/wasm/runtime`; the bare arms carry no payload. An
+ * `anchor`'s `id` is a caller-supplied, opaque handle, unique per `Content` and
+ * invariant while the mark lives (positions rebase, the id never does); it has no
+ * markdown projection and survives only through the edit lane. See DOCUMENT_STORAGE
  * § Anchor-id identity. */
 export type ContentMark = { start: number; end: number } & (
     | { type: "strong" | "emph" | "underline" | "strike" | "code" }
@@ -267,7 +270,8 @@ export interface ImageProps {
  * open set: the engine pins `props` as `TableProps` for `table` and `ImageProps`
  * for `image`; an island of any other type round-trips with opaque `props`. Like
  * `ContentMark`, the open `type` arm means a discriminant check does not itself
- * narrow `props` — key off `type` and read `props` as the matching shape. */
+ * narrow `props` — read `props` as the matching shape behind the `isTableIsland` /
+ * `isImageIsland` guards (from `@quillmark/wasm/runtime`), which narrow it. */
 export type ContentIsland = {
     id: string;
     /** How faithfully the markdown projection can carry this island. */
@@ -1927,9 +1931,10 @@ pub fn export_markdown(
 
 /// Rebase `markdown` onto a `base` content — the pure, document-free twin of
 /// `revise`: cold-import + `diff_import`, returning the new `content` and the
-/// text `delta` (surviving anchors rebased). Use it to compute a revise without
-/// a document in hand; `revise(addr, md)` fuses this with the store for
-/// atomicity. Throws on an over-nested markdown input or a non-content `base`.
+/// text `delta` (its offsets USV indices into `Content.text`, surviving anchors
+/// rebased). Use it to compute a revise without a document in hand; `revise(addr,
+/// md)` fuses this with the store for atomicity. Throws on an over-nested
+/// markdown input or a non-content `base`.
 #[wasm_bindgen(js_name = rebase, unchecked_return_type = "{ content: Content; delta: Delta }")]
 pub fn rebase(
     #[wasm_bindgen(unchecked_param_type = "Content")] base: JsValue,
@@ -2057,10 +2062,11 @@ pub fn format_doc_path(
     Ok(doc_path.to_string())
 }
 
-/// Map a base content position through a `delta` to its new position — the pure
-/// position-mapping codec an editor bridge composes to hold a caret stable
-/// across a `revise`. `assoc` decides the side of a same-position insertion
-/// (`"after"` moves past it). Throws on a malformed `delta`.
+/// Map a base content position — a USV index into `Content.text`, not a UTF-16
+/// offset — through a `delta` to its new USV position: the pure position-mapping
+/// codec an editor bridge composes to hold a caret stable across a `revise`.
+/// `assoc` decides the side of a same-position insertion (`"after"` moves past
+/// it). Throws on a malformed `delta`.
 #[wasm_bindgen(js_name = mapPos)]
 pub fn map_pos(
     #[wasm_bindgen(unchecked_param_type = "Delta")] delta: JsValue,


### PR DESCRIPTION
Boundary hygiene from #1042, trimmed to the warranted slice.

Item 1 (island type guards): the open `type` arm on `ContentIsland` /
`ContentMark` carries a residual `{ type: string; … }` member, so a bare
`x.type === 'table'` check cannot narrow the payload — TS keeps the residual
arm live. Add checked guards to the runtime layer: `isTableIsland` /
`isImageIsland` (narrow `props`) and, for consistency with the identical
footgun on marks, `isLinkMark` / `isAnchorMark` (narrow the payload-carrying
arms; the bare marks narrow to nothing, so they get no guard). Covered by
narrowing assertions in `runtime.types.test-d.ts`, and the type docs now point
at the guards.

Item 2 (USV doc audit): the coordinate space is already documented on the
`Content` interface, so restate the unit only on the standalone codec verbs a
consumer reaches without that context — `mapPos` and `rebase`.

Item 3 (`$id` first-match) dropped: `cardIndexById` (and core `find_card`, and
its test) already document first-match / non-unique-by-design, and `Document`
is re-exported verbatim so there is no separate runtime typing to amend.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M2ZFUwqfXzNVeQQr2fTPnR