### PR TITLE
canon: make the lint check truth, not only shape

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -82,7 +82,26 @@ Caution: `used to` often means "used **in order to**" — not history; read befo
 cutting. In consumer `docs/`, keep history a reader needs to *use* the feature
 (an accepted alias, a tolerated input) — reframe it, don't delete it.
 
-### 4. State the design, not the deliberation
+### 4. One claim per sentence — density is bytes-per-fact, not facts-per-line
+
+Cutting words is only half of density. A sentence carrying seven clauses, three
+parentheticals, and an em-dash chain is maximally compressed and unreadable —
+the reader has to decompress it to find the one fact they came for, which is the
+cost a comment exists to remove. Compression is not density.
+
+- One claim per sentence. A bullet that needs three clauses is three bullets, a
+  nested list, or a table.
+- A set of per-case rules (per type, per format, per backend) is a table. Table
+  rows are records, not sentences, and are exempt from the budget.
+- Prefer a paragraph break over a semicolon chain when the second half states a
+  separate fact.
+
+`prose/README.md` sets the numeric budget — 700 characters per prose line hard,
+300 soft — and `scripts/check-canon.mjs` enforces it over `prose/canon/` and
+`docs/`. The soft limit is a ratchet: it reports only on files a change already
+touches, so split a long line when you are editing near it, not in a sweep.
+
+### 5. State the design, not the deliberation
 
 Describe what is, not what was considered. Cut spike/deferred/rejected
 narration; keep the resulting fact and, when it explains a present choice, the

--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -113,14 +113,20 @@ rationale — minus the "we tried / earlier draft" framing.
   by design: <reason>."
 - Rejected-alternative rationale: "A sub-handle would be justified only if paint
   shipped with click()" — keeps the *why*, sheds the *when*.
+- Issue and PR numbers (`(#970)`, `tracked in #736`) are status markers: they
+  say work is in motion, which canon does not carry, and they date the sentence
+  around them. State the shape instead — "Python omits the opaque store by
+  intent" — and drop the number. Keep it only where the issue *is* the subject
+  (a CI or release doc describing a process).
 
 ## Voice
 
 Present tense. Lead with the invariant or contract, then the mechanism. Reuse
 the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam,
-Technique A*). Match the density of the best existing comments —
-`crates/core/src/value.rs`, `crates/core/src/document/fences.rs`, and
-`prose/canon/PREVIEW.md` are the exemplars.
+Technique A*). For the target density, read the comments in
+`crates/core/src/document/` and the Decisions section of `PREVIEW.md` — a
+rationale that names what it rejected and why, in the fewest words that stay
+correct.
 
 ## Scope
 
@@ -138,12 +144,12 @@ Technique A*). Match the density of the best existing comments —
    markers (`used to`, `no longer`, `previously`, `formerly`, `as of`,
    `removed in`, `renamed`, `we switched`, `legacy`, `deprecated`); and
    deliberation markers (`spike`, `deferred`, `considered`, `for now`,
-   `eventually`, `we tried`).
+   `eventually`, `we tried`); and status markers (`#\d+`, issue and PR links).
 2. **Triage** — each hit: violation, or load-bearing fact in costume?
 3. **Rewrite** in place — present tense, minimal, fact preserved. Fix a comment
    that contradicts the code rather than deleting it. Leave identifiers alone.
 4. **Verify** — build and tests pass; no doctest broken; no test asserted the
-   old wording.
+   old wording; `node scripts/check-canon.mjs` passes.
 
 ## Done when
 

--- a/.claude/skills/maintain-canon/SKILL.md
+++ b/.claude/skills/maintain-canon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintain-canon
-description: Maintain prose/canon/ — the canonical, high-level design documentation. Use when adding, consolidating, or auditing canon docs.
+description: Maintain prose/canon/ — the canonical, high-level design documentation. Use when adding, consolidating, or auditing canon docs, and when a code change makes a canon doc stale (a renamed API, a moved seam, a changed invariant).
 ---
 
 ## Purpose
@@ -10,16 +10,32 @@ high level — enough that a human or AI can get the gist without reading the
 whole codebase. Canon describes *what is* and points into the code; it does not
 re-document implementation detail that the code already carries.
 
-## Structure
+For comment and doc *content* — density, tense, voice — use **`dense-prose`**.
 
-`prose/README.md` is the single source of truth for prose structure — the four
-tiers, the canon doc spine, and the link invariants. Read it before editing
-canon; `scripts/check-canon.mjs` enforces it in CI.
+## The spine
+
+Every canon doc except `INDEX.md` opens:
+
+1. `# Title` on line 1.
+2. A blockquote anchor on line 3, carrying `> **Implementation**:` — the
+   navigational hook from concept to code. It points at a folder or module,
+   never a file and never a line number; files rot. `**Related**` and
+   `**Package**` lines are optional.
+3. `## TL;DR` as the first section — two or three sentences.
+
+Other sections (When to use, How, Gotchas, Links) are optional. No `Status`
+line, and no issue number: membership in canon means settled and implemented.
+A prose line caps at 700 characters and should stay under 300.
+
+`prose/README.md` is normative for all of this — the four tiers, the spine, the
+canon↔`docs/` division, and the link invariants. Read it before a structural
+edit. `scripts/check-canon.mjs` enforces what is mechanical, in CI.
 
 ## Principles
 
 One topic per page; one canonical per topic. Prefer deletion with consolidation
-over duplicates. Keep pages skimmable and high-level; include minimal code.
+over duplicates. Keep pages skimmable and high-level; include minimal code. A
+fact that belongs to a neighbouring page is a link, not a copy.
 
 ## Workflow
 
@@ -33,4 +49,5 @@ over duplicates. Keep pages skimmable and high-level; include minimal code.
 ## Done when
 
 No obvious duplicates. Everything discoverable from `INDEX.md`. Docs are short,
-skimmable, folder-anchored, and easy to maintain.
+skimmable, folder-anchored, and easy to maintain. `check-canon.mjs` passes, and
+any drift note it raises is either acted on or knowingly left.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Two commits so the lint can diff. On a PR the checkout is the merge
+          # commit, so `HEAD^1` is the base tip and the diff is the PR's whole
+          # change; on a push it is the pushed commit alone. Both are fine for
+          # an advisory drift report.
+          fetch-depth: 2
 
       # Canon spine lint (prose/README.md). Zero deps; runs before the Rust
-      # setup so it fails fast on a checkout-only step.
+      # setup so it fails fast on a checkout-only step. `--drift` adds the
+      # non-blocking anchor-drift and soft-line-budget notes as PR annotations.
       - name: Check canon spine
-        run: node scripts/check-canon.mjs
+        run: node scripts/check-canon.mjs --drift
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -147,6 +147,12 @@ quillmark info [OPTIONS] <QUILL_PATH>
 
 - `--json`: Output as machine-readable JSON instead of human-readable format
 
+**Fields shown:** name, description, version, author, backend, field count, and
+card count (when nonzero), plus a metadata section for any non-standard
+`Quill.yaml` keys — the standard keys (`backend`, `version`, `author`,
+`description`) are excluded from it. The text output additionally shows a
+defaults count when nonzero; `--json` has no defaults count.
+
 **Examples:**
 
 ```bash

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -78,8 +78,10 @@
     ## Live Preview (Canvas)
 
     For editor-style previews, paint pages directly into a `<canvas>` instead
-    of round-tripping through PNG/SVG. `paint` is Typst-only and WASM-only,
-    and shares the cached compile with the byte-output `render` path.
+    of round-tripping through PNG/SVG. `paint` is WASM-only — both the Typst
+    and `pdfform` backends support it; probe with `engine.supportsCanvas(quill)`
+    before mounting canvas UI — and shares the cached compile with the
+    byte-output `render` path.
 
     ```javascript
     const session = await engine.open(quill, doc);     // compile once (async)
@@ -118,5 +120,16 @@
       stable between edits, but re-read them after a committed `apply(doc)`,
       which recompiles in place and can change the page count
       (`ChangeSet.pageCount`).
+    - In an edit loop, repaint `dirtyPages ∩ visible` rather than every page:
+
+      ```javascript
+      function onEdit(editedDoc) {
+        const { pageCount, dirtyPages } = session.apply(editedDoc);
+        for (const p of dirtyPages) if (isVisible(p)) renderPage(canvases[p], p);
+      }
+      ```
+
+      `apply` is transactional: if it throws, the canvas still shows the
+      last-good compile, so keep it up and surface the diagnostics.
 
     Full design rationale: [PREVIEW.md](https://github.com/borb-sh/quillmark/blob/main/prose/canon/PREVIEW.md).

--- a/prose/README.md
+++ b/prose/README.md
@@ -66,7 +66,8 @@ are exempt: a table row is a record, not a sentence.
 `scripts/check-canon.mjs` runs in CI. It fails on a broken spine, a link into
 `proposals/`/`plans/`, a reference that links out, an `**Implementation**`
 anchor that names a file or no longer exists, a canon page missing from
-`INDEX.md`, a dead `INDEX.md` link, and a line over the hard budget.
+`INDEX.md`, a dead `INDEX.md` link, an issue or PR number in canon prose, and a
+line over the hard budget.
 
 It also *warns*, without failing, when a folder named in an
 `**Implementation**` anchor changed and the doc anchored there did not — the

--- a/prose/README.md
+++ b/prose/README.md
@@ -19,6 +19,23 @@ Long-form project documentation, in four tiers by maturity:
 Canonical docs never reference proposals or plans. References never link
 out to other prose docs.
 
+## Canon and `docs/`
+
+`prose/` is contributor-facing; [`docs/`](../docs/) is the published MkDocs site
+for quill authors and integrators. The two cover the same subjects from opposite
+ends, and the division is by *audience*, not by topic:
+
+- **Canon** documents the design contract — the model, the invariants, and why
+  a seam sits where it does. Its reader is changing the engine.
+- **`docs/`** documents the task — authoring a quill, filling a form, persisting
+  a document. Its reader is using the engine.
+
+Neither restates the other. A `docs/` page links up to its canon page for the
+full model (`Full model: [ERROR.md](…)`); a canon page links down to `docs/` for
+an authoring surface it deliberately does not carry. A canon page may *point at*
+a `docs/` page, but never depends on one to state a contract — a contract that
+exists only in `docs/` belongs in canon.
+
 ## Canon doc spine
 
 Every canon doc except `canon/INDEX.md` (the index) opens:
@@ -35,5 +52,24 @@ Gotchas, Links) are optional — add them when they help. No `Status` line:
 membership in canon means settled and implemented. Mark status only for
 genuine exceptions (e.g. a draft specification).
 
-`scripts/check-canon.mjs` enforces the spine and both link invariants in CI.
+## Line budget
+
+A prose line caps at **700 characters** and should stay under **300**. Past
+that, a line is a paragraph crammed onto one line — dense by the byte,
+unskimmable by the claim, and unreviewable in a diff, where a one-word fix
+rewrites the whole line. One claim per sentence; a bullet that needs three
+clauses is three bullets, a nested list, or a table. Fenced code and table rows
+are exempt: a table row is a record, not a sentence.
+
+## Enforcement
+
+`scripts/check-canon.mjs` runs in CI. It fails on a broken spine, a link into
+`proposals/`/`plans/`, a reference that links out, an `**Implementation**`
+anchor that names a file or no longer exists, a canon page missing from
+`INDEX.md`, a dead `INDEX.md` link, and a line over the hard budget.
+
+It also *warns*, without failing, when a folder named in an
+`**Implementation**` anchor changed and the doc anchored there did not — the
+anchor is a machine-readable code→doc back-pointer, and this is what reads it.
+Most such changes need no doc edit; the warning is a prompt, not a gate.
 

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -43,7 +43,18 @@ Implements `Backend` for PDF, SVG, and PNG. Lowers each content field's `Content
 
 ### `backends/quillmark-pdfform`
 
-The second backend: fills an existing AcroForm PDF rather than typesetting from scratch. Resolves card values against the quill's `form.json` spec and stamps them onto the base `form.pdf` as real interactive fields (Technique A — `NeedAppearances`, no baked appearance streams). The PDF deliverable is always an interactive AcroForm; the backend also emits SVG and PNG (and a WASM canvas raster) by pre-flattening values into the page content streams (hayro raster). Field geometry is a session-level query (`LiveSession::regions()`) — per-field geometry keyed on the schema field path, no bound value. See [docs/quills/pdfform-backend.md](../../docs/quills/pdfform-backend.md) and [PREVIEW.md](PREVIEW.md).
+The second backend: fills an existing AcroForm PDF rather than typesetting from
+scratch. It resolves card values against the quill's `form.json` spec and stamps
+them onto the base `form.pdf` as real interactive fields (Technique A —
+`NeedAppearances`, no baked appearance streams).
+
+The PDF deliverable is always an interactive AcroForm. The backend also emits
+SVG and PNG (and a WASM canvas raster) by pre-flattening values into the page
+content streams (hayro raster). Field geometry is a session-level query
+(`LiveSession::regions()`) — per-field geometry keyed on the schema field path,
+no bound value. Quill-authoring surface:
+[docs/quills/pdfform-backend.md](../../docs/quills/pdfform-backend.md); preview
+seam: [PREVIEW.md](PREVIEW.md).
 
 ### `quillmark-pdf`
 
@@ -68,7 +79,18 @@ Property-based fuzz tests (proptest): `parse_fuzz` (YAML/Markdown parsing), `con
 - **`Quillmark`** — Engine: a backend registry + render dispatcher. Auto-registers `TypstBackend` when the `typst` feature is enabled. Resolves a quill's declared backend at render time (erroring `engine::backend_not_found` on no match) and owns the backend-dependent surface — `render`, `open`, `supported_formats(&quill)`, `supports_canvas(&quill)`. It does not construct quills.
 - **`Quill`** — The single quill type in `quillmark-core`: portable, declarative data (file bundle + config + metadata, tagged with a declared backend id). Held by value. Exposes the pure config-read operations: `dry_run`, `compile_data`, `backend_id`, plus `validate` (editor-facing: returns every schema diagnostic, including the non-fatal `validation::must_fill` warning raised for each `!must_fill` marker) and the `seed_document` / `seed_main` / `seed_card` starters that emit committed example documents and cards. Construct with `Quill::from_tree` or `quillmark::quill_from_path`
 - **`Backend`** — Trait for output formats (`Send + Sync`): `id()`, `supported_formats()`, `open(&Quill, json)`. There is no universal template input: a backend reads whatever static inputs it needs (a Typst plate, a `form.pdf`) from the quill's own files. No canvas-capability method — capability is derived (`LiveSession::supports_canvas()` from the session seam; `formats_support_canvas()` as a pre-session hint)
-- **`LiveSession`** — Opaque live session returned by `Backend::open()`: a persistent compiler whose reads (`render(opts)`, the canvas seam, `regions()`/`field_at()`) serve its current compile, and whose `apply(json)` recompiles in place, transactionally (on `Err` reads keep serving the last-good compile) — returning a `ChangeSet` of dirty pages. Exposes `page_count()` and `warnings()` for consumers that don't go through `render()`. The canvas-preview seam lives on `SessionHandle` itself (`page_size_pt`/`render_rgba`, default `None`); a canvas backend overrides both, and the WASM painter dispatches generically through them — no per-backend downcast (Typst and pdfform both ride this seam — see [PREVIEW.md](PREVIEW.md)). A backend with a different richer typed surface can still downcast via `LiveSession::handle()` + `SessionHandle::as_any`.
+- **`LiveSession`** — Opaque live session returned by `Backend::open()`: a
+  persistent compiler whose reads (`render(opts)`, the canvas seam,
+  `regions()`/`field_at()`) serve its current compile, and whose `apply(json)`
+  recompiles in place, transactionally (on `Err` reads keep serving the
+  last-good compile) — returning a `ChangeSet` of dirty pages. It exposes
+  `page_count()` and `warnings()` for consumers that don't go through
+  `render()`. The canvas-preview seam lives on `SessionHandle` itself
+  (`page_size_pt`/`render_rgba`, default `None`): a canvas backend overrides
+  both, and the WASM painter dispatches generically through them, with no
+  per-backend downcast — Typst and pdfform both ride this seam (see
+  [PREVIEW.md](PREVIEW.md)). A backend with a richer typed surface can still
+  downcast via `LiveSession::handle()` + `SessionHandle::as_any`.
 - **`Document`** — Typed in-memory representation of a Quillmark Markdown file (root block, body, cards). Serializes via `serde` to a versioned JSON envelope (`StoredDocument`) for database persistence, decoupled from the evolving Markdown syntax — see [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md)
 - **`Diagnostic`** — Structured error with severity, code, message, location, hint, source chain
 - **`RenderResult`** — Output artifacts + accumulated warnings

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -16,11 +16,11 @@ Quillmark is a schema-driven document engine: it turns Markdown with card-yaml b
 
 ### `quillmark-core`
 
-Foundation types and traits; depends on `quillmark-content` (the leaf rich-text
-primitive one layer below it). No backend dependencies; backends depend on this
-crate.
-
-Key exports: `Backend`, `Artifact`, `OutputFormat`, `RenderOptions`, `LiveSession`, `Document`, `Quill`, `FileTreeNode`, `QuillIgnore`, `RenderError`, `Diagnostic`, `Severity`, `Location`, `RenderResult`, `QuillValue`, `QuillReference`, `Version`, `VersionSelector`. `Quill` is the single quill type — portable, validated data with the pure config-read operations (`validate`, `schema`, `metadata`, `blueprint`, `seed_*`, `compile_data`, `dry_run`); construct it with `Quill::from_tree`.
+Foundation types and traits: the render contract (`Backend` / `LiveSession`),
+the `Document` and `Quill` model, and the `Diagnostic` currency — see the
+crate's rustdoc for the full surface and Core Interfaces below for the
+load-bearing four. It depends on `quillmark-content` (the leaf rich-text
+primitive one layer below it) and on no backend; backends depend on it.
 
 ### `quillmark-content`
 
@@ -72,7 +72,9 @@ Test resources under `resources/`. Helper functions for test setup.
 
 ### `quillmark-fuzz`
 
-Property-based fuzz tests (proptest): `parse_fuzz` (YAML/Markdown parsing), `convert_fuzz` (Markdown→Typst conversion + escaping), `emit_roundtrip_fuzz` (emit roundtripping), `filter_fuzz` (filter injection safety), `coerce_fuzz` (type coercion).
+Property-based fuzz tests (proptest) over YAML/Markdown parsing, Markdown→Typst
+conversion and escaping, emit roundtripping, filter injection safety, and type
+coercion.
 
 ## Core Interfaces
 
@@ -105,6 +107,7 @@ See [PLATE_DATA.md](PLATE_DATA.md) for the Typst helper package.
 
 ## Backend Implementation
 
-Implement `id()`, `supported_formats()`, and `open()` of the `Backend` trait. To paint to a canvas, override the `SessionHandle` seam (`page_size_pt` / `render_rgba`) on the returned session — capability is derived from that seam, so there is no separate flag to set. Return a `LiveSession` wrapping a `SessionHandle` that handles format-specific rendering.
-
-See `backends/quillmark-typst` for the reference implementation.
+Implement the `Backend` trait and return a `LiveSession` wrapping a
+`SessionHandle` that does the format-specific rendering; to paint to a canvas,
+override that handle's `page_size_pt` / `render_rgba`. See
+`backends/quillmark-typst` for the reference implementation.

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -35,7 +35,9 @@ backends lower the content.
 
 ### `quillmark` (orchestration)
 
-High-level API: `Quillmark` (the engine — a backend registry + render dispatcher) plus the `quill_from_path` loader. Re-exports core's `Quill`. Handles backend resolution at render time and auto-registration. Filesystem walking for `quill_from_path` lives here; core is filesystem-agnostic (in-memory loading is `Quill::from_tree` in core). The engine does not construct quills — it only renders them.
+The `Quillmark` engine plus the `quill_from_path` loader; re-exports core's
+`Quill`. Filesystem walking lives here, so core stays filesystem-agnostic —
+in-memory loading is `Quill::from_tree` in core.
 
 ### `backends/quillmark-typst`
 
@@ -79,20 +81,9 @@ coercion.
 ## Core Interfaces
 
 - **`Quillmark`** — Engine: a backend registry + render dispatcher. Auto-registers `TypstBackend` when the `typst` feature is enabled. Resolves a quill's declared backend at render time (erroring `engine::backend_not_found` on no match) and owns the backend-dependent surface — `render`, `open`, `supported_formats(&quill)`, `supports_canvas(&quill)`. It does not construct quills.
-- **`Quill`** — The single quill type in `quillmark-core`: portable, declarative data (file bundle + config + metadata, tagged with a declared backend id). Held by value. Exposes the pure config-read operations: `dry_run`, `compile_data`, `backend_id`, plus `validate` (editor-facing: returns every schema diagnostic, including the non-fatal `validation::must_fill` warning raised for each `!must_fill` marker) and the `seed_document` / `seed_main` / `seed_card` starters that emit committed example documents and cards. Construct with `Quill::from_tree` or `quillmark::quill_from_path`
+- **`Quill`** — The single quill type in `quillmark-core`: portable, declarative data (file bundle + config + metadata, tagged with a declared backend id), held by value and carrying the pure config-read operations (`validate`, `schema`, `blueprint`, `seed_*`, `compile_data`, `dry_run`). Construct with `Quill::from_tree` or `quillmark::quill_from_path` — see [QUILL.md](QUILL.md)
 - **`Backend`** — Trait for output formats (`Send + Sync`): `id()`, `supported_formats()`, `open(&Quill, json)`. There is no universal template input: a backend reads whatever static inputs it needs (a Typst plate, a `form.pdf`) from the quill's own files. No canvas-capability method — capability is derived (`LiveSession::supports_canvas()` from the session seam; `formats_support_canvas()` as a pre-session hint)
-- **`LiveSession`** — Opaque live session returned by `Backend::open()`: a
-  persistent compiler whose reads (`render(opts)`, the canvas seam,
-  `regions()`/`field_at()`) serve its current compile, and whose `apply(json)`
-  recompiles in place, transactionally (on `Err` reads keep serving the
-  last-good compile) — returning a `ChangeSet` of dirty pages. It exposes
-  `page_count()` and `warnings()` for consumers that don't go through
-  `render()`. The canvas-preview seam lives on `SessionHandle` itself
-  (`page_size_pt`/`render_rgba`, default `None`): a canvas backend overrides
-  both, and the WASM painter dispatches generically through them, with no
-  per-backend downcast — Typst and pdfform both ride this seam (see
-  [PREVIEW.md](PREVIEW.md)). A backend with a richer typed surface can still
-  downcast via `LiveSession::handle()` + `SessionHandle::as_any`.
+- **`LiveSession`** — Opaque live session returned by `Backend::open()`: a persistent compiler whose reads serve its current compile and whose `apply(json)` recompiles in place, transactionally, returning a `ChangeSet` of dirty pages. The canvas seam lives on `SessionHandle` (`page_size_pt`/`render_rgba`), so a canvas backend overrides two methods and the WASM painter dispatches generically — see [PREVIEW.md](PREVIEW.md)
 - **`Document`** — Typed in-memory representation of a Quillmark Markdown file (root block, body, cards). Serializes via `serde` to a versioned JSON envelope (`StoredDocument`) for database persistence, decoupled from the evolving Markdown syntax — see [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md)
 - **`Diagnostic`** — Structured error with severity, code, message, location, hint, source chain
 - **`RenderResult`** — Output artifacts + accumulated warnings

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -18,8 +18,8 @@ Quillmark is a schema-driven document engine: it turns Markdown with card-yaml b
 
 Foundation types and traits: the render contract (`Backend` / `LiveSession`),
 the `Document` and `Quill` model, and the `Diagnostic` currency — see the
-crate's rustdoc for the full surface and Core Interfaces below for the
-load-bearing four. It depends on `quillmark-content` (the leaf rich-text
+crate's rustdoc for the full surface, and [Core Interfaces](#core-interfaces)
+below for the ones carrying the contract. It depends on `quillmark-content` (the leaf rich-text
 primitive one layer below it) and on no backend; backends depend on it.
 
 ### `quillmark-content`

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -111,14 +111,14 @@ is structural, not asserted.
 Every binding verb is *identical* to its core twin or names its one forced
 difference — **FFI** (a wasm-bindgen / pyo3 constraint), **idiom** (a language
 ergonomic), or **scope** (a lane a binding omits by intent — Python is Tier 1 +
-storage + render, [#970](https://github.com/borb-sh/quillmark/issues/970)),
-nothing else admitted. Drift is a reviewable diff to this table.
+storage + render), nothing else admitted. Drift is a reviewable diff to this
+table.
 
 | Concept | Core | Bindings | Class |
 |---|---|---|---|
 | Typed writer front door | `quill.writer(&mut doc)` | `quill.writer(doc)` | **idiom** — core holds `&mut Document` under the checker; the bindings re-borrow per call (pyo3/wasm objects carry no lifetime), so the guarantee becomes the ephemerality convention |
 | Typed reader front door | `quill.reader(&doc)` | `quill.reader(doc)` | **idiom** — the read twin; same re-borrow/ephemerality as the writer |
-| Interpreted read | `reader.get(name)?` → `ReadValue` (richtext → markdown, plaintext → literal text, else canonical); `reader.card(i)?.get(..)?` | `reader.get(addr)` / `reader.card(i).get(name)` (JS), `reader.get(name)` / `reader.card(i).get(name)` (py) | **idiom** / **FFI** — one `get` interprets by declared type; absent → `undefined`/`None`, unknown name → `UnknownField`, undecodable content → `FieldRichtextDecode`; a field's markdown reads here, not on the body-only `getMarkdown` (#978). Body read (`reader.getBody` / absent-field addr) stays quill-free |
+| Interpreted read | `reader.get(name)?` → `ReadValue` (richtext → markdown, plaintext → literal text, else canonical); `reader.card(i)?.get(..)?` | `reader.get(addr)` / `reader.card(i).get(name)` (JS), `reader.get(name)` / `reader.card(i).get(name)` (py) | **idiom** / **FFI** — one `get` interprets by declared type; absent → `undefined`/`None`, unknown name → `UnknownField`, undecodable content → `FieldRichtextDecode`; a field's markdown reads here, not on the body-only `getMarkdown`. Body read (`reader.getBody` / absent-field addr) stays quill-free |
 | Scalar / batch write | `set` / `set_all` | `set` / `setAll` (JS), `set` / `set_all` (py) | identical |
 | Receipt-free body write | `set_body(md)` | `setBody(md)` / `set_body(md)` | identical — core also exposes the delta via `revise_body` |
 | Typed richtext field revise | `TypedWriter::revise_field(name, md)?` / `CardWriter::revise_field(..)?` | `writer.reviseField(name, md)` / `writer.card(i).reviseField(..)` (JS); `writer.revise_field(name, md)` / `writer.card(i).revise_field(..)` (py) | **idiom** — typed *and* anchor-preserving; both wrap `Card::revise_field_checked`. JS returns the `Delta`; Python discards it (the position-mapping receipt is an editor concern, WASM-only) |
@@ -127,10 +127,10 @@ nothing else admitted. Drift is a reviewable diff to this table.
 | Card removal (writer) | `writer.remove_card(i)` | `writer.removeCard(i)` | identical |
 | Card cursor | `writer.card(i)?` (eager check) | `writer.card(i)` (lazy check) | **FFI** — no borrow to validate against; the index is checked at the write |
 | Cursor kind | `writer.card(i)?.kind()` | `writer.card(i).kind` | identical — the JS getter reads through `doc.card(i)` |
-| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.getStored(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `getStored`/`isFill`) and names the verbatim field read `getStored`, not `get`, so it never collides with the interpreted `reader.get` (core's `payload().get` has no such neighbor); *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.reader(doc).get` (#978, #970), and `$ext` / body content read off the `main` / `cards` dict snapshots |
+| Reads (value / body markdown / fill / `$ext`) | `body_markdown(..)` / `payload().get(..)` / `payload().is_fill(..)` / `card.ext()` (borrow chain; index for a card) | `doc.getStored(addr?)` / `doc.getMarkdown(cardAddr?)` / `doc.isFill(addr)` / `doc.getExt(cardAddr?)` / `doc.getExtNamespace(cardAddr, ns)` (JS) | **idiom** / **FFI** / **scope** — WASM fuses the transport reads onto the one `Addr` (a bare string ⇒ `{field}` for `getStored`/`isFill`) and names the verbatim field read `getStored`, not `get`, so it never collides with the interpreted `reader.get` (core's `payload().get` has no such neighbor); *total over the field axis* (absent field → `undefined`, `isFill` → `false`; only an out-of-range card throws); `getMarkdown` is the **body** read (a `CardAddr`; a present `field` throws). Python has no quill-free field read — interpreted field reads go through `quill.reader(doc).get`, and `$ext` / body content read off the `main` / `cards` dict snapshots |
 | Reads (whole card / `$id` / seed) | `card(i)` / `find_card(id)` / `main().seed()` | `doc.card(i)` / `doc.cardIndexById(id)` / `doc.seedOverlay(kind)` | **idiom** — the bindings fuse each into one named verb on `Document`; `card(i)` throws out of range, `find_card`/`cardIndexById` resolve the durable `$id` handle (unique per document — [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md) § Card-id identity) |
-| Richtext revise (content lane) | `Card::revise_field(name, md)?` (schema-blind, borrow chain) | `doc.revise({card, field}, md)` (addr literal, JS) | **FFI** / **scope** — same model, flattened navigation, schema-blind, `Delta` in hand; WASM-only. Python's anchor-preserving write is the typed `writer.revise_field` (#970) |
-| Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`) | **scope** — the quill-free verbatim write, WASM-only; Python has no opaque field store (the typed writer is the only field write, #970). A field write without a loadable quill operates on the storage DTO directly |
+| Richtext revise (content lane) | `Card::revise_field(name, md)?` (schema-blind, borrow chain) | `doc.revise({card, field}, md)` (addr literal, JS) | **FFI** / **scope** — same model, flattened navigation, schema-blind, `Delta` in hand; WASM-only. Python's anchor-preserving write is the typed `writer.revise_field` |
+| Opaque store | `store_field` / `store_fields` / `store_fill` | `storeField` / `storeFields` / `storeFill` (JS, `Addr`) | **scope** — the quill-free verbatim write, WASM-only; Python has no opaque field store (the typed writer is the only field write). A field write without a loadable quill operates on the storage DTO directly |
 | Parse + warnings | `Document::parse(md) -> Parsed { document, warnings }` | `Document.fromMarkdown(md)` → `doc.warnings` getter | **FFI** — the wrapper fuses `Parsed` + `Document` into one session object: `fromMarkdown` returns the document directly and stashes the parse `warnings` on it (`doc.warnings`). That getter is a deliberate asymmetry with core, where warnings live only on `Parsed`: it is session state, so `equals` and the storage DTO exclude it and `loadJson`/`fromJson` clear it (a reloaded document carries no parse warnings) |
 
 The single **idiom** row on the front door is the honest cost: the typed writer
@@ -142,7 +142,7 @@ claimed. See the as-built [0.93 → 0.94 migration](../../docs/migrations/0.93-t
 PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface over the
 shared model; one-shot `engine.render` (no canvas).
 
-> **Scope: Tier 1 + storage + render ([#970](https://github.com/borb-sh/quillmark/issues/970)).**
+> **Scope: Tier 1 + storage + render.**
 > Field I/O flows through `quill.writer(doc)` / `quill.reader(doc)` exclusively;
 > `Document` is quill-free data and structure (parse, the storage DTO,
 > `insert_card` / `remove_card` / `move_card` / `make_card`, `remove_field`,

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -280,8 +280,7 @@ shippable as-is; no `default:` is Unendorsed:
   annotations on each row). The outer key carries `# array<object>`.
 - `default: []` renders inline as `[]` with `# array<object>` —
   shippable empty. Inline row shape is not surfaced under an empty
-  default; use `example:` to document row shape (tracked in
-  [#736](https://github.com/borb-sh/quillmark/issues/736)).
+  default; use `example:` to document row shape.
 - No `default:` is Unendorsed: one synthetic row is emitted with each
   property carrying its own description, inline annotation, and the
   `!must_fill` marker on its leaf value. The container key itself is

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -436,10 +436,8 @@ contract**:
 > (zero) value in the plate projection, so an empty document is by
 > construction the *type-minimal valid input*.
 
-The zero-filled empty document is the *type-minimal valid input* — the
-worst-case-but-renderable document. A plate that renders it has shown it
-degrades gracefully on every type-valid input shape. The contract
-requires:
+It is the worst-case-but-renderable document, so a plate that renders it
+degrades gracefully on every type-valid input shape. The contract requires:
 
 - Templates treat type-empty values (`""`, `0`, `false`, `[]`, empty
   richtext body) as valid *present* input — read via `data.field`,
@@ -458,13 +456,11 @@ generated blueprint (`quiver_test.rs::every_quill_blueprint_round_trips_and_rend
 
 ## The blueprint and its filled-out twin
 
-The blueprint is the **one** annotated reference document — the authoring
-surface. Its "show me a filled-out one" counterpart is **seeding**, which
-materializes a real `Document` (committed, structured content for editor and
-render consumers) rather than a second annotated string. There is no
-annotated `example` *document*: nothing consumes a filled-out document for its
-annotations, so the filled-out projection is committed `Document` content, not
-prose.
+The blueprint is the **one** annotated reference document. Its "show me a
+filled-out one" counterpart is **seeding**, which materializes a real
+`Document` rather than a second annotated string: nothing consumes a
+filled-out document for its annotations, so that projection is committed
+content, not prose.
 
 | Projection | Intent | Value precedence | Output | Markers? |
 |---|---|---|---|---|
@@ -491,23 +487,7 @@ The Rust example `cargo run -p quillmark-core --example print_blueprint
 -- <quill_name> [<version>]` prints the blueprint for any bundled
 fixture.
 
-## Relationship to schema
-
-| Concern | Use |
-|---|---|
-| Validators, form builders, machine consumers | [SCHEMAS.md](SCHEMAS.md) — `schema()` |
-| LLM/MCP authoring, prompt-time reference document | this doc — `blueprint()` |
-
-## Authoring guidance
-
-Choosing **Unendorsed vs. Endorsed** per field (declare a `default:` or not)
-and **when to reach for `example:`** is schema-authoring guidance owned by
-[SCHEMAS.md](SCHEMAS.md) § "`default` and `example`" and § "Unendorsed vs.
-Endorsed fields". The blueprint is where that choice becomes visible: an
-Endorsed field renders its concrete default (shippable as-is); an Unendorsed
-field is stamped with the `!must_fill` marker.
-
-### Writing the literal text `!must_fill` as content
+## Writing the literal text `!must_fill` as content
 
 The placeholder is a YAML **tag**, not a string sentinel, so there is no
 collision and no quoting escape-hatch to learn. The literal text `!must_fill`

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -102,8 +102,12 @@ See [`markdown-spec.md`](../references/markdown-spec.md) §3 for the full syntax
 
 ## Backend Consumption
 
-- **All backends**: cards are delivered as `data.$cards`, an array of objects. Each carries its payload fields flat, a `$kind` discriminator when the card authors one, and a `$body` (canonical `Content` object, not a Markdown string) when the card's kind enables a body. `$`-metadata is present exactly where the schema defines it ("absent on undefined") — read it with a total accessor (`card.at("$body", default: "")`); see [PLATE_DATA.md](PLATE_DATA.md).
-- **`Quill::compile_data()`** returns the fully coerced and validated JSON, including `$cards`.
+Cards reach every backend as `data.$cards`, an array of one object per card:
+payload fields flat, `$kind` and `$body` present exactly where the schema
+defines them. A `$body` is a canonical `Content` object, never a Markdown
+string. [PLATE_DATA.md](PLATE_DATA.md) § Data Shape is the canonical
+shape and the accessor rules; `Quill::compile_data()` returns that JSON, fully
+coerced and validated.
 
 The sigiled `data.$cards` here is plate JSON — glue delivered to the backend. It is a **different namespace** from the unsigiled `cards` in a `Diagnostic.path` (`cards.<kind>[<index>]`, the document-model anchor — see [ERROR.md](ERROR.md) § "Document-model paths"). The plate key is not renamed off `$cards`; the two namespaces are documented apart.
 

--- a/prose/canon/CI_CD.md
+++ b/prose/canon/CI_CD.md
@@ -17,7 +17,7 @@ Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `q
 
 | Job | What it does |
 |-----|-------------|
-| `lint` | `cargo doc --no-deps --locked` with `RUSTDOCFLAGS=-Dwarnings` — the standing lint gate; clippy is deliberately not gated |
+| `lint` | `node scripts/check-canon.mjs --drift` (the canon spine, link, anchor, and line-budget gate — see [prose/README.md](../README.md); the drift and soft-budget notes are annotations, not failures), then `cargo doc --no-deps --locked` with `RUSTDOCFLAGS=-Dwarnings` — the standing lint gate; clippy is deliberately not gated |
 | `test` | `cargo test --workspace --all-features --locked` |
 | `wasm` | first asserts the no-default-features core graph excludes Typst (`cargo tree -i quillmark-typst` must fail), then builds via `./scripts/build-wasm.sh --ci`, then `npx vitest run` |
 

--- a/prose/canon/CLI.md
+++ b/prose/canon/CLI.md
@@ -5,64 +5,25 @@
 
 ## TL;DR
 
-`quillmark-cli` wraps the core engine in a standalone `quillmark` binary: `render` turns a quill + markdown into PDF/SVG/PNG/txt, and `schema`/`blueprint`/`validate`/`info` introspect a quill without rendering it.
+`quillmark-cli` is a `clap` surface over the engine holding no logic of its own:
+`render` turns a quill + markdown into PDF/SVG/PNG/txt, and
+`schema`/`blueprint`/`validate`/`info` introspect a quill without rendering it.
+Commands, options, and examples are the
+[CLI reference](../../docs/cli/reference.md); this page is the contract behind
+them.
 
-## Commands
+## Contract
 
-### `render`
-
-```
-quillmark render [OPTIONS] <QUILL_PATH> [MARKDOWN_FILE]
-```
-
-`QUILL_PATH` provides the local quill bundle used for rendering. `MARKDOWN_FILE` requires a root bare `~~~` block (`~~~card-yaml` is also accepted) with a `$quill` system-metadata line because parsing enforces it.
-
-When `MARKDOWN_FILE` is omitted, the quill's seeded document is rendered instead (each field's `example:` with `default:`/zero interpolated), so the quill renders with no input file. Output defaults to `example.{format}`.
-
-Options:
-- `-o, --output <FILE>` — output file path (default: derived from input filename)
-- `-f, --format <FORMAT>` — `pdf`, `svg`, `png`, or `txt` (default: `pdf`)
-- `--stdout` — write output to stdout
-- `--output-data <DATA_FILE>` — write compiled JSON data to file
-- `-v, --verbose` — detailed processing output
-- `--quiet` — suppress non-error output
-
-### `schema`
-
-```
-quillmark schema <QUILL_PATH> [-o <FILE>]
-```
-
-Outputs the Quill's public schema contract as YAML to stdout or file.
-
-### `blueprint`
-
-```
-quillmark blueprint <QUILL_PATH> [-o <FILE>]
-```
-
-Outputs the Quill's annotated Markdown blueprint (see [BLUEPRINT.md](BLUEPRINT.md)) to stdout or file.
-
-### `validate`
-
-```
-quillmark validate [OPTIONS] <QUILL_PATH>
-```
-
-Validates quill configuration.
-
-Options:
-- `-v, --verbose` — show all validation details including warnings
-
-### `info`
-
-```
-quillmark info <QUILL_PATH> [--json]
-```
-
-Displays quill metadata: name, description, version, author, backend, field count, card count (when nonzero), and any non-standard metadata keys; the text output also shows a defaults count (when nonzero). `--json` emits name, backend, version, author, description, `field_count`, `card_count` (when nonzero), and a `metadata` object for non-standard keys — it has no defaults count. Standard keys (`backend`, `version`, `author`, `description`) are excluded from the metadata section.
-
-## Implementation
-
-`clap` over the `quillmark` engine (default `typst`/`pdfform` features).
-Module layout and the dependency set are in `crates/bindings/cli/`.
+- **Only `render` needs the engine.** It constructs `Quillmark` to resolve the
+  quill's backend; the four introspection verbs load the quill with
+  `quillmark::quill_from_path` and read the pure config-read operations a
+  `Quill` already carries ([QUILL.md](QUILL.md)).
+- **Seeded fallback.** `render` with no `MARKDOWN_FILE` renders the quill's
+  seeded document — each field's `example:`, with `default:`/zero interpolated
+  — so a quill renders with no input file. Output defaults to
+  `example.{format}`.
+- **Parsing is not relaxed for the CLI.** A `MARKDOWN_FILE` needs a root bare
+  `~~~` block (`~~~card-yaml` is also accepted) carrying a `$quill` line,
+  exactly as every other surface requires.
+- **Both backends by default.** The binary inherits `quillmark`'s default
+  features, `typst` and `pdfform`.

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -179,8 +179,8 @@ from markdown.**
 
 - **Caller-supplied.** The engine mints no anchor id and cannot — only the
   consumer knows the referent. Each consumer (editor, MCP writer) supplies its
-  own; the runtime persists it verbatim. Engine-minting is a considered
-  non-goal: a counter is history-dependent (the same final content reached two
+  own; the runtime persists it verbatim. Engine-minting is a non-goal by
+  design: a counter is history-dependent (the same final content reached two
   ways carries different ids — the ambient source the twin rule forbids) and
   forfeits referent-convergence (two `add`s for one thread would mint two
   handles). A client wanting generated ids mints them client-side and supplies
@@ -294,8 +294,8 @@ When the `Document` wire format changes again:
 1. **Freeze** the current `DocumentV0_93_0` type tree — leave its struct
    /enum definitions and serde derives untouched so existing rows still parse.
 2. **Remove** the conversions binding the old DTO to the *live* `Document`
-   (`From<&Document>` and `TryFrom<… for Document>`); they no longer compile
-   and are superseded below.
+   (`From<&Document>` and `TryFrom<… for Document>`) — a frozen tree cannot
+   convert to a model it predates, and step 3 supersedes them.
 3. **Add** a new frozen tree `DocumentV0_NN_0` reflecting the new model,
    plus its `From<&Document>` and `TryFrom<… for Document>` conversions.
 4. **Add** the `StoredDocument::V0_NN_0` variant, tagged

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -191,8 +191,9 @@ confused with it:
 
 - **Plate JSON** — the sigiled `data.$cards` a template author composes
   ([CARDS.md](CARDS.md)), and the plate-space `$cards.<kind>.<ordinal>.<field>`
-  geometry address a plate's `$path` mints. Template-author contract; *not*
-  renamed (blast radius), and translated to `DocPath` before it crosses.
+  geometry address a plate's `$path` mints. A template-author contract, so it
+  keeps its own spelling (renaming it is a blast radius) and translates to
+  `DocPath` before it crosses.
 - **Schema-space coercion anchors** — `CoercionError` keeps its own
   `card_kinds.<kind>.<field>` / bare-field anchors, a schema-declaration
   namespace, not a document path. Where a coercion becomes an

--- a/prose/canon/INDEX.md
+++ b/prose/canon/INDEX.md
@@ -15,13 +15,18 @@
 - **[BLUEPRINT.md](BLUEPRINT.md)** - Annotated Markdown blueprint for LLM/MCP authoring
 - **[PROGRAMMATIC.md](PROGRAMMATIC.md)** - Building documents in memory (blank canvas, batched mutators) for automation
 - **[CARDS.md](CARDS.md)** - Composable cards delivered on the `$cards` plate-JSON array
-- **[PLATE_DATA.md](PLATE_DATA.md)** - Plate data injection
 
 ## Backends
 
+A backend's engine-side seam is canon; its quill-authoring surface is a `docs/`
+page and its internals are rustdoc.
+
 - **[CONVERT.md](CONVERT.md)** - How the Typst backend lowers a `Content` value to Typst markup
-- Typst backend internals: see `crates/backends/typst/` rustdoc
-- **[../../docs/quills/pdfform-backend.md](../../docs/quills/pdfform-backend.md)** - The `pdfform` backend: fill an existing AcroForm PDF (real interactive fields, Technique A), built on the `quillmark-pdf` stamp spine
+- **[PLATE_DATA.md](PLATE_DATA.md)** - Plate data injection: the Typst backend's data seam
+- The `pdfform` seam is [ARCHITECTURE.md](ARCHITECTURE.md) (`Backend::open`, the two-asset model) plus [PREVIEW.md](PREVIEW.md) (canvas paint, `regions()`)
+- Outbound — authoring a Typst quill: [docs/quills/typst-backend.md](../../docs/quills/typst-backend.md)
+- Outbound — authoring a `pdfform` quill: [docs/quills/pdfform-backend.md](../../docs/quills/pdfform-backend.md) (`form.pdf` + `form.json`, Technique A stamping, on the `quillmark-pdf` stamp spine)
+- Outbound — Typst backend internals: `crates/backends/typst/` rustdoc
 
 ## Bindings
 

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -41,11 +41,58 @@ The `$`-prefixed keys must be accessed via `.at("$...")` because Typst identifie
 Helper contents (generated in `backends/typst/helper.rs` from `lib.typ.template`):
 
 - `data`: a backend-generated Typst dictionary **literal** of all fields — no runtime processing, no `__meta__` sentinel. The backend classified and lowered every field at generation time, reading classification from the session's cached `SchemaMeta`.
-- Content fields lower to Typst content — each field's `Content` value lowered by `emit::emit_content`. Two schema shapes qualify (see `content_field_names`), both classified on `contentMediaType: application/quillmark-content+json`:
-  - a scalar richtext field (`{type: object, contentMediaType: application/quillmark-content+json}`) — one `Content` object, lowered in place.
-  - `array<richtext>` (`{type: array, items: {type: object, contentMediaType: application/quillmark-content+json}}`) — each array element lowered individually.
-  Each non-blank content is emitted as a markup **block** binding (`#let _qm_cN = [ .. ]`) that `data` references; a blank content stays an empty string literal. A `richtext(inline)` field (`quillmark:inline: true`, classified by `inline_field_names`) instead lowers via `emit::emit_content_inline` to **pure inline** markup — the single `Para`'s content with no block terminator, so no `parbreak` — so the value composes in an inline slot (`par(..)`, a grid cell) without Typst's "parbreak may not occur inside of a paragraph" warning. A `plaintext` field rides the *same* media type (plus an editor-only `quillmark:plain: true`), so `content_field_names` classifies it identically and it lowers through this exact path — the codec differs only at authoring/coercion (literal `from_plaintext`), never at codegen.
+- Content fields lower to Typst content — each field's `Content` value lowered
+  by `emit::emit_content`. Two schema shapes qualify (see
+  `content_field_names`), both classified on `contentMediaType:
+  application/quillmark-content+json`:
+  - a scalar richtext field (`{type: object, contentMediaType:
+    application/quillmark-content+json}`) — one `Content` object, lowered in
+    place.
+  - `array<richtext>` (`{type: array, items: {type: object, contentMediaType:
+    application/quillmark-content+json}}`) — each array element lowered
+    individually.
+
+  Each non-blank content is emitted as a markup **block** binding (`#let _qm_cN
+  = [ .. ]`) that `data` references; a blank content stays an empty string
+  literal.
+
+  A `richtext(inline)` field (`quillmark:inline: true`, classified by
+  `inline_field_names`) instead lowers via `emit::emit_content_inline` to **pure
+  inline** markup: the single `Para`'s content with no block terminator, so no
+  `parbreak`. The value therefore composes in an inline slot (`par(..)`, a grid
+  cell) without Typst's "parbreak may not occur inside of a paragraph" warning.
+
+  A `plaintext` field rides the *same* media type (plus an editor-only
+  `quillmark:plain: true`), so `content_field_names` classifies it identically
+  and it lowers through this exact path. The codec differs only at
+  authoring/coercion (literal `from_plaintext`), never at codegen.
 - `date` / `datetime` fields (`format: date` / `format: date-time`) lower to a **value-object** — a `#let _qm_dN = { let v = datetime(..); (value: v, display: (..args) => text(v.display(..args))) }` block the data cell references (blank ⇒ `none`). `v` is the three-component `datetime(year:, month:, day:)` for a `date`, the six-component `datetime(year:, .., second:)` (authored wall-clock, seconds zero-filled) for a `datetime` — the distinct transform-schema `format` stamps the backend keys its per-type lowering on. The object exposes two projections and is the date sibling of the content block ([`date_object`](../../crates/backends/typst/src/helper.rs)):
   - `value` — the native `datetime` `v`, for arithmetic, comparison, `.year()`/`.weekday()`/… components, and datetime-consuming packages. `.value.display(..)` is the native `str`.
-  - `display` — a closure `(..args) => text(v.display(..args))` called as `(data.<field>.display)(..)` (the paren form; Typst reserves dict-key method sugar). It returns *content*, so its glyphs are born at the generated `text(..)` node's site, inside a recorded **segment-less window** keyed by the field's schema path → one whole-placement **region** per emitted cell. This is what makes a date the first click-to-edit target: the region survives the value being laundered (`#let d = card.on`) or handed into a vendored package that formats it internally, because a closure's ink is born at its lexical definition site, not the reference. Emitting one `text(..)` node per cell manufactures the per-instance identity a shared loop variable (`card.<field>`) lacks — the case `span_scan`'s "Not chased" note describes — so each card's date surfaces its own region. Wrapping `v.display` (not a re-literalized date) inherits `v`'s type, so a `date`-only field's `display` throws Typst's native error on an `[hour]` pattern.
-- `plaintext(field)`: the sanctioned content→`str` coercion. Where `data.<field>` is Typst **content**, `plaintext(field)` returns the content field's plain text — the content text with island slots stripped and marks dropped (the same projection pdfform lowers a richtext field to). It reads a generated `_qm-plaintext` literal keyed by schema address (`subject`, `refs.2`, `$cards.<kind>.<n>.<field>`); `""` for a blank field or an address with no content. Use it when a plate/package needs a string (string ops, an `assert(type(item) == str)` consumer) for any content field (`richtext` or `plaintext`). Note the name collision: this Typst helper is distinct from the `plaintext` **field type** — the helper projects *any* content to a `str`, while the field type declares a field's content plain from the start.
+  - `display` — a closure `(..args) => text(v.display(..args))` called as
+    `(data.<field>.display)(..)` (the paren form; Typst reserves dict-key method
+    sugar). It returns *content*, so its glyphs are born at the generated
+    `text(..)` node's site, inside a recorded **segment-less window** keyed by
+    the field's schema path → one whole-placement **region** per emitted cell.
+
+    This is what makes a date the first click-to-edit target. A closure's ink is
+    born at its lexical definition site, not the reference, so the region
+    survives the value being laundered (`#let d = card.on`) or handed into a
+    vendored package that formats it internally. Emitting one `text(..)` node
+    per cell manufactures the per-instance identity a shared loop variable
+    (`card.<field>`) lacks — the case `span_scan`'s "Not chased" note describes
+    — so each card's date surfaces its own region. Wrapping `v.display` (not a
+    re-literalized date) inherits `v`'s type, so a `date`-only field's `display`
+    throws Typst's native error on an `[hour]` pattern.
+- `plaintext(field)`: the sanctioned content→`str` coercion. Where
+  `data.<field>` is Typst **content**, `plaintext(field)` returns the content
+  field's plain text — the content text with island slots stripped and marks
+  dropped (the same projection pdfform lowers a richtext field to). It reads a
+  generated `_qm-plaintext` literal keyed by schema address (`subject`,
+  `refs.2`, `$cards.<kind>.<n>.<field>`); `""` for a blank field or an address
+  with no content. Use it when a plate or package needs a string (string ops, an
+  `assert(type(item) == str)` consumer) for any content field — `richtext` or
+  `plaintext`.
+
+  Note the name collision: this Typst helper is distinct from the `plaintext`
+  **field type**. The helper projects *any* content to a `str`; the field type
+  declares a field's content plain from the start.

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -17,23 +17,14 @@ paints through one generic painter.
 
 ## Why
 
-For live previews of long documents, the byte-output formats are
-sub-optimal:
-
-- **Iframed SVG**: each iframe is its own browser document. N pages → N
-  documents; teardown and memory cost grow linearly.
-- **Inline SVG**: scales with content complexity (every glyph is a DOM
-  node); long, dense documents produce huge DOM trees.
-- **PNG**: pays zlib encode + decode on every render, and you typically
-  hold N decoded bitmaps.
-
-A canvas painter skips the encode/decode round-trip entirely — pixels go
-straight from the rasterizer into the canvas backing store. For long documents
-the consumer keeps memory bounded to the visible viewport — paint only pages
-near it, repaint as the user scrolls.
+Every byte-output format costs per page what canvas costs once: iframed SVG
+spends a browser document per page, inline SVG a DOM node per glyph, PNG a zlib
+encode and decode plus N decoded bitmaps. The painter writes rasterizer pixels
+straight into the backing store, so a consumer keeps memory bounded to the
+visible viewport.
 
 The edit loop is the second half of the argument. Re-opening a session per
-keystroke rebuilds the entire compilation world (fonts, packages, assets) and
+keystroke rebuilds the whole compilation world (fonts, packages, assets) and
 repaints every visible page whether or not it changed. A `LiveSession` keeps
 the world alive across edits and reports what an edit visibly changed, so the
 per-keystroke cost is *incremental recompile + repaint of `dirty ∩ visible`*.
@@ -141,7 +132,7 @@ compositing of its own. Backends satisfy it differently:
 
 `paint` writes the whole backing store with `put_image_data`, which bypasses
 the 2D context transform, `globalAlpha`, and clip. The painter therefore owns
-the entire canvas: **give each visible page its own `` element.** You
+the entire canvas: **give each visible page its own `<canvas>` element.** You
 cannot paint two pages into one canvas, paint into a sub-rect, or push a page
 through a context transform — the raster is complete precisely so you never
 need to composite, and the write ignores context state so you could not if you
@@ -347,16 +338,11 @@ renderScale = layoutScale × densityScale
 ```
 
 Fold `window.devicePixelRatio`, in-app zoom, and `visualViewport.scale` into
-`densityScale`. If the largest backing dimension would exceed
-**`MAX_BACKING_DIMENSION` (16384 px per side)** — the floor that works across
-browsers (Chrome/Firefox ~32k, Safari 16k, lower on memory-constrained mobile)
-— the painter clamps `densityScale` proportionally and reports the actual
-backing dimensions. `clamped` and `effectiveDensityScale` carry the fact and
-the applied density on the result, so the consumer reads the clamp off the
-return value rather than reconstructing it from
-`pixelWidth < round(layoutWidth × densityScale)`. A clamped page renders soft
-at the same `canvas.style` size; compare `effectiveDensityScale` to the
-requested `densityScale` to know by how much.
+`densityScale`. Past **`MAX_BACKING_DIMENSION` (16384 px per side)** — the
+floor that works across browsers — the painter clamps `densityScale`
+proportionally and reports the outcome on the result (`clamped`,
+`effectiveDensityScale`), so a consumer never reconstructs the clamp from the
+dimensions. A clamped page renders soft at the same `canvas.style` size.
 
 Each `paint` resets the backing store (writing `canvas.width` clears it), so
 paint is always a full repaint — consumers never call `clearRect`.
@@ -376,19 +362,11 @@ width_canvas  = (rect[2] − rect[0]) × renderScale
 height_canvas = (rect[3] − rect[1]) × renderScale
 ```
 
-For an **HTML/CSS overlay** on a `width:100%` canvas, prefer percentages of the
-page over device pixels — they track the displayed size across DPI and
-pane-resize for free, with no `renderScale` to thread; only the Y axis flips:
-
-```
-left%   = rect[0] / pageWidthPt  × 100
-top%    = (pageHeightPt − rect[3]) / pageHeightPt × 100
-width%  = (rect[2] − rect[0]) / pageWidthPt  × 100
-height% = (rect[3] − rect[1]) / pageHeightPt × 100
-```
-
-The device-pixel form above is still the right one for painting an overlay
-*into* a raster.
+That form is the one for painting an overlay *into* a raster. An HTML/CSS
+overlay on a `width:100%` canvas is better off in percentages of the page —
+`left% = rect[0] / pageWidthPt × 100`, `top% = (pageHeightPt − rect[3]) /
+pageHeightPt × 100`, and the extents likewise — because they track the
+displayed size across DPI and pane-resize with no `renderScale` to thread.
 
 ## Feature / build mapping
 
@@ -496,26 +474,7 @@ by `runtime.test.js`.
 
 ## Lifecycle and consumer flow
 
-```js
-import { Engine } from '@quillmark/wasm';      // single root export
-const engine = new Engine();
-
-if (!(await engine.supportsCanvas(quill))) return;   // non-canvas backends have no painter
-const session = await engine.open(quill, doc);       // compiles once; the session persists its world
-const densityScale = (window.devicePixelRatio || 1) * userZoom;  // userZoom is a UI control
-
-const result = session.paint(canvas.getContext('2d'), page, {
-  layoutScale: 1,                             // layout px per pt
-  densityScale,                               // includes devicePixelRatio + zoom
-});
-
-canvas.style.width  = `${result.layoutWidth}px`;   // CSS box, layout px
-canvas.style.height = `${result.layoutHeight}px`;
-
-// Edit loop: apply, repaint dirty ∩ visible. On throw, the canvas still
-// shows the last-good compile — keep it and surface the diagnostics.
-function onEdit(editedDoc) {
-  const { pageCount, dirtyPages } = session.apply(editedDoc);
-  for (const p of dirtyPages) if (isVisible(p)) repaint(p);
-}
-```
+`supportsCanvas` → `open` → `paint` per visible page → `apply` on edit →
+repaint `dirtyPages ∩ visible`. The [quickstart's canvas
+section](../../docs/getting-started/quickstart.md#live-preview-canvas) is the
+worked loop.

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -117,7 +117,7 @@ keeps the pageable document is a *mode* to add, not a second type.
 or selection across edits is the **editor's** job: its own transaction mapping
 (a ProseMirror / CodeMirror `StepMap`) carries positions through local edits, so
 the session holds no change log, no revision stamp, and no per-field delta path
-(#886 removed them; `FieldRegion` / `ContentHit` carry no `revision`). Geometry
+— `FieldRegion` / `ContentHit` carry no `revision`. Geometry
 (`regions`, `positionAt`, `locate`) is read against the current compile and
 re-read after each committed `apply`. `positionAt` (point → content position) and
 `locate` (content position → caret rect) are exact inverses over that compile —
@@ -212,9 +212,9 @@ field's `Content` that box covers. A scalar reference site and a widget carry
 no `span` (`undefined`): geometry with no content address.
 
 The whole-field highlight is **derived, not emitted**: per `(field, page)`,
-union the `span`-bearing segment rects. That is the point of #829 — the union
-is *striped*, leaving inter-paragraph whitespace uncovered, where the old
-single box painted over it. Emitting a field-level union from the *backend*
+union the `span`-bearing segment rects. The union is *striped*: it leaves
+inter-paragraph whitespace uncovered, which a single field-level box would
+paint over. Emitting a field-level union from the *backend*
 would reintroduce the lie the disjointness invariant exists to prevent, so the
 union stays out of `regions()`. But the derivation itself is subtle (which
 rects carry spans, first-placement-only, widget-vs-content), so a **convenience
@@ -418,9 +418,9 @@ by `runtime.test.js`.
 - Click handling in the painter. The painter is a dumb blit; it maps no
   clicks itself. Click→field lives on the **session** (`fieldAt`, hit-testing
   the compiled document) — a consumer converts the canvas click to PDF-pt
-  page coordinates (the inverse of the regions overlay transform) and asks
-  the session, keeping the painter free of interaction state — see
-  [SCHEMAS.md](SCHEMAS.md).
+  page coordinates (the inverse of the [regions overlay
+  transform](#regions-overlay-transform)) and asks the session, keeping the
+  painter free of interaction state.
 
 ## Decisions and rationale
 

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -71,46 +71,13 @@ inputs from the file bundle when it opens a session (the Typst backend reads its
 `typst.plate_file`; the pdfform backend reads `form.pdf` / `form.json`), so a
 missing or malformed template surfaces as a render-time error, not a load error.
 
-## `Quill.yaml` Structure
+## `Quill.yaml` Rules
 
-Required top-level sections: `quill` (bundle metadata). Optional: `main` (document fields), `card_kinds` (card kind definitions), `typst` (backend config).
-
-```yaml
-quill:
-  name: my_quill          # required; snake_case
-  backend: typst          # required
-  version: "1.0.0"        # required; semver (MAJOR.MINOR.PATCH or MAJOR.MINOR)
-  description: A beautiful format  # required; non-empty
-  author: Jane Doe        # optional; defaults to "Unknown"
-  ui:                     # optional; fallback for main.ui when absent
-    title: My Quill
-
-main:
-  fields:
-    title:
-      type: string
-      description: Document title
-    count:
-      type: integer
-      description: Whole-number count
-
-card_kinds:
-  quote:
-    description: A single pull quote
-    ui:
-      title: Quote block      # optional UI display label
-    body:
-      example: The quote text  # optional editor placeholder
-    fields:
-      author:
-        type: string
-        description: Quote author
-
-typst:
-  plate_file: plate.typ   # optional; path to the Typst template, read by the backend
-  packages:
-    - "@preview/some-package:1.0.0"
-```
+One required top-level section, `quill` (bundle metadata); optional `main`
+(document fields), `card_kinds` (card kind definitions), and a backend-named
+section (`typst`). Every key, type, and UI property is documented in the
+[Quill.yaml reference](../../docs/quills/quill-yaml-reference.md); what follows
+is what the engine enforces.
 
 Field names must be `snake_case` (match `[a-z][a-z0-9_]*`). Capitalized or `$`-prefixed keys are rejected at config parse time with `quill::invalid_field_name` — document-level metadata sits on dedicated `$`-prefixed keys in the plate JSON (`$quill`, `$body`, `$cards`, `$kind`), and user fields stay lowercase so they cannot shadow it. Standalone `object` fields require a `properties` map. Every `array` field requires an `items:` element schema: use `items: { type: string }` (or `integer`, `richtext`, …) for a list of scalars, and `items: { type: object, properties: … }` for a list of objects.
 
@@ -145,18 +112,11 @@ Construction:
 - `quillmark::quill_from_path(path)` — load from a filesystem directory (fs walk
   lives in `quillmark`, not core); returns `Result<Quill, RenderError>`.
 
-In-memory loading is `Quill::from_tree` directly; bindings map its
-`Vec<Diagnostic>` into their own error shape at the call site.
+The two differ in error shape: the pure constructor hands back the raw
+`Vec<Diagnostic>` and bindings map it at the call site, while the loader wraps
+it in `RenderError`. Either way the `Quill` carries no backend — rendering goes
+through the `Quillmark` engine (`engine.render` / `engine.open`).
 
-The `Quill` carries no backend; rendering goes through the `Quillmark` engine
-(`engine.render` / `engine.open`). Note: `Quill::from_json` is not part of the
-public API.
-
-File access on `FileTreeNode`:
-- `file_exists(path)` / `get_file(path)` — check/read file
-- `dir_exists(path)` / `list_files(path)` / `list_subdirectories(path)` — directory navigation
-
-Path rules:
-- Use forward slashes (`/`); absolute paths and `..` traversal are rejected
-- Root: use `""` (empty string)
-- `get_file()` returns `&[u8]` for all files
+`FileTreeNode` exposes the file and directory reads over the bundle. Paths use
+forward slashes, the root is `""`, absolute paths and `..` traversal are
+rejected, and every file reads back as `&[u8]`.

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -45,9 +45,33 @@ application/quillmark-content+json`); `plaintext` additionally carries
 - Returns `Result<IndexMap<String, QuillValue>, CoercionError>`
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
-- Coercion rules per type: array wrapping plus element-wise coercion against the `items` schema (a bad element fails at its indexed path, e.g. `counts[1]`); boolean from string/int/float; number/integer from string or from boolean (`true→1`, `false→0`); string unwraps a length-1 string array into the bare string (else identity); richtext commits the canonical content form (the model) — an authored markdown string imports (via `quillmark-content::import`), an editor-supplied content object revalidates and re-canonicalizes, and the length-1-array-unwrap / bare-scalar-stringify leniencies feed the import; `date`/`datetime` per-type strict-grammar validation, stored verbatim (a `date` rejects any time component, a `datetime` rejects offsets/space/fractional/bare-date; neither truncates); object property recursion
+Coercion rules per type:
+
+| Type | Rule |
+|---|---|
+| `array` | array wrapping plus element-wise coercion against the `items` schema; a bad element fails at its indexed path, e.g. `counts[1]` |
+| `boolean` | from string, int, or float |
+| `number` / `integer` | from string, or from boolean (`true→1`, `false→0`) |
+| `string` | unwraps a length-1 string array into the bare string; identity otherwise |
+| `richtext` | commits the canonical content form (the model): an authored markdown string imports via `quillmark-content::import`, an editor-supplied content object revalidates and re-canonicalizes. The length-1-array-unwrap and bare-scalar-stringify leniencies feed the import |
+| `date` / `datetime` | per-type strict-grammar validation, stored verbatim: a `date` rejects any time component, a `datetime` rejects offsets/space/fractional/bare-date. Neither truncates |
+| `object` | property recursion |
 - **`inline` richtext enforcement.** A `richtext` field with `inline: true` requires its content to be exactly one `Para` line, in no container, with no islands (`Content::is_inline`). The empty content satisfies it, so a blank or zero-filled inline field passes. The constraint is checked in three places: coercion (`CoercionError` for a document value), validation (`richtext::not_inline`, the `TypeMismatch` fatality class, as a backstop for a content that bypassed coercion), and load-time example import (a schema literal that violates it is a load error). Blueprint still annotates inline fields as `richtext(inline)<markdown>`; `build_transform_schema` emits `quillmark:inline: true`
-- **`plaintext` coercion and enforcement.** A `plaintext` value rides the same content as `richtext`, but a string is imported through the **literal** codec (`from_plaintext`, verbatim — no markdown parse, no escaping) and an editor-supplied content object is validated **plain** (`Content::is_plain`: no marks, no islands, all `Para` lines) rather than markdown-decoded. A formatted wire content is rejected, not stripped — mirroring the `inline` precedent, checked in the same three places (coercion `CoercionError`; validation `plaintext::not_plain`, `TypeMismatch` fatality class; load-time literal import). An `inline: true` plaintext field additionally requires a single line. The load-time content caches (`default_content`/`example_content`) and the render-floor zero (the empty content) cover `plaintext` exactly as `richtext` — both are content leaves (`field_contains_content`)
+- **`plaintext` coercion and enforcement.** A `plaintext` value rides the same
+  content as `richtext`, differing only at the codec:
+  - a string imports through the **literal** codec (`from_plaintext`, verbatim
+    — no markdown parse, no escaping);
+  - an editor-supplied content object is validated **plain**
+    (`Content::is_plain`: no marks, no islands, all `Para` lines) rather than
+    markdown-decoded. A formatted wire content is rejected, not stripped.
+
+  Enforcement mirrors the `inline` precedent, in the same three places:
+  coercion (`CoercionError`); validation (`plaintext::not_plain`, the
+  `TypeMismatch` fatality class); load-time literal import. An `inline: true`
+  plaintext field additionally requires a single line. The load-time content
+  caches (`default_content`/`example_content`) and the render-floor zero (the
+  empty content) cover `plaintext` exactly as `richtext` — both are content
+  leaves (`field_contains_content`)
 - **`enum` domain validation.** An `enum` field (or the deprecated `enum:` modifier on `string`) coerces as a string; domain membership is a *value* check (`validation::enum_violation`), not a type check, so an out-of-domain string is well-typed but invalid. `type: enum` requires a non-empty `values:` list; `enum:`/`values:` on any type other than `string`/`enum` is a load error (`quill::field_parse_error`), closing the pre-promotion silent no-op. Both spellings populate one carrier (`FieldSchema::enum_values`) and project identically to `{type: string, enum: […]}`
 - **Null short-circuits coercion.** A null value (`field:`, `field: null`,
   `field: ~`) passes coercion unchanged for *every* type — null ≡ absent, so
@@ -315,7 +339,20 @@ metadata, not schema fields, and do not appear in `fields`.
 
 For LLM/MCP authoring, see [BLUEPRINT.md](BLUEPRINT.md) — `blueprint()` emits a document-shaped, pre-filled Markdown reference that's denser than schema for prompt-time use.
 
-Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name). `main` and each entry in `card_kinds` share the same `CardSchema` shape: `fields` (map keyed by field name), optional `description`, optional `ui`, optional `body`. Each `FieldSchema` includes `type`, optional `description`/`default`/`example`/`enum`/`values`/`inline`/`properties`/`items`/`ui`. `inline` is valid only on the prose types (`richtext`, `plaintext`). `values` declares an `enum` field's domain (required there); `enum` is its deprecated one-release alias on `string`. `items` (the element schema, itself a `FieldSchema`) is required on `array` fields and rejected elsewhere; `properties` is used by `object` fields (and by an array's `object`-typed `items`).
+Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name).
+`main` and each entry in `card_kinds` share the same `CardSchema` shape:
+`fields` (map keyed by field name), optional `description`, optional `ui`,
+optional `body`. Each `FieldSchema` includes `type`, optional
+`description`/`default`/`example`/`enum`/`values`/`inline`/`properties`/`items`/`ui`.
+The type-gated keys:
+
+- `inline` — valid only on the prose types (`richtext`, `plaintext`).
+- `values` — declares an `enum` field's domain, required there.
+- `enum` — a deprecated one-release alias for `values` on `string`.
+- `items` — the element schema, itself a `FieldSchema`; required on `array`
+  fields and rejected elsewhere.
+- `properties` — used by `object` fields, and by an array's `object`-typed
+  `items`.
 
 ### `default` and `example`
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -207,14 +207,11 @@ site (the Tier-1 cut, [BINDINGS.md](BINDINGS.md)).
 ## Zero-filled render
 
 **A document need not be complete to render** — render success is not a
-completeness signal.
-Shippability is the author's judgment; the engine's only hard requirement
-is that the document be *well-formed* (values coerce). A `!must_fill` marker
-and a present-null cell are both renderable — neither gates render.
-Completeness is not surfaced as a diagnostic — `Quill::validate` raises no
-completeness/`field_absent` code (see [Native validation](#native-validation));
-the only authoring signal it raises is the non-fatal `validation::must_fill`
-warning for each outstanding marker.
+completeness signal. Shippability is the author's judgment; the engine's only
+hard requirement is that the document be *well-formed* (values coerce). A
+`!must_fill` marker and a present-null cell are both renderable, and neither
+surfaces as a diagnostic beyond the non-fatal `validation::must_fill` warning
+(see [Native validation](#native-validation)).
 
 Rendering and the *completeness verdict* are orthogonal. The render path
 (`compile_data` / `resolve_fields` in `quillmark::orchestration`) uses
@@ -225,13 +222,12 @@ backend **only, never in the persisted document**.
 
 - **Incomplete is renderable.** A document that merely omits an Unendorsed
   field — or leaves it present-null — renders fine: the field is zero-filled
-  in the projection. Such a document validates clean; completeness is not
-  surfaced as a diagnostic.
+  in the projection, and validates clean.
 - **Malformed is fatal.** The only malformed case is a value that cannot
   coerce to (or validate against) its declared type. Placeholders and null
-  are *not* malformed: a `!must_fill` marker renders (using its suggested
-  value or zero-filling) and raises only the non-fatal `validation::must_fill`
-  warning, and a present-null cell zero-fills like an absent field.
+  are *not* malformed: a `!must_fill` marker renders, using its suggested
+  value or zero-filling, and a present-null cell zero-fills like an absent
+  field.
 - **Non-persist invariant.** The zero-fill lives only in the ephemeral
   projection and must never be written back. A type-empty value is
   indistinguishable from authored-empty, so persisting it would erase the
@@ -380,9 +376,8 @@ has endorsed no value, so the blueprint stamps the `!must_fill` marker to
 ask an LLM or author to supply one. That is a *communication device on the
 blueprint surface*, not a requirement: a missing (or present-null) Unendorsed
 field zero-fills silently at render, and a surviving marker raises only the
-non-fatal `validation::must_fill` warning, never a render gate. "Must-fill"
-therefore lives solely on the blueprint/marker surface; the schema axis is
-endorsement, not obligation.
+non-fatal warning. "Must-fill" therefore lives solely on the blueprint/marker
+surface; the schema axis is endorsement, not obligation.
 
 A field is **Endorsed** when `default:` is declared; the rendered default
 is shippable as-is (the author can keep or override it).

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -1,6 +1,7 @@
 # Quill Versioning System
 
 > **Implementation**: `crates/core/src/`
+> **Related**: [QUILL.md](QUILL.md), [ERROR.md](ERROR.md)
 
 ## TL;DR
 
@@ -8,7 +9,10 @@ Quills declare a semantic `version` in `Quill.yaml`, and documents carry an opti
 
 ## Version Format
 
-Semantic versioning: `MAJOR.MINOR.PATCH` (two-segment `MAJOR.MINOR` also validates). Always quote the value in `Quill.yaml`: an unquoted `1.0` is read as a YAML number and stringified to `"1"`, which fails validation.
+Semantic versioning: `MAJOR.MINOR.PATCH`, with two-segment `MAJOR.MINOR` also
+valid. `version` is required in the `quill:` section, and an invalid or missing
+value fails at load. Always quote it: an unquoted `1.0` is read as a YAML number
+and stringified to `"1"`, which fails validation.
 
 | Increment | When |
 |-----------|------|
@@ -35,32 +39,17 @@ No registry consumes the selector — there is no collection of installed versio
 
 A quill mismatch is distinct from a validation failure (a malformed document): here the document is well-formed but paired with the wrong Quill, so the remedy is to render with the referenced Quill or amend `$quill`. A bare name or `@latest` matches any version, so correctly-targeted documents never trip either check.
 
-## Quill.yaml
-
-```yaml
-quill:
-  name: my_format
-  version: "2.1.0"
-  backend: typst
-  description: "Short description of this format"
-  author: "..."          # optional
-  ui: { ... }            # optional
-
-typst:
-  plate_file: "plate.typ" # optional; the Typst template, read by the backend
-```
-
-`name`, `backend`, `version`, and `description` are required. `author` and `ui` are optional. Unknown keys under `quill:` are a hard error. A backend's own settings (e.g. the Typst `plate_file`) live under the backend-named section, not in `quill:`. `version` must parse as `MAJOR.MINOR.PATCH` (or `MAJOR.MINOR`); an invalid or missing value fails at load.
-
 ## Error Handling
 
-Three distinct failure paths:
+Three distinct failure paths, and the parser owns one of them outright:
 
-- **`Quill.yaml` version invalid** → `quill::invalid_version` diagnostic → surfaces as `RenderError::QuillConfig` at Quill load.
-- **Document `$quill` reference invalid** (e.g. `my_format@bad`) → `ParseError::InvalidQuillReference`, returned directly by the parser, never as `RenderError::QuillConfig`.
-- **Loaded Quill does not satisfy a well-formed `$quill`** (wrong name, or version outside the selector — e.g. `my_format@2` against a `3.0.0` Quill) → `quill::name_mismatch` / `quill::version_mismatch` diagnostic → surfaces as a `RenderError` from `render`/`dry_run`.
-
-See [ERROR.md](ERROR.md) for error patterns.
+- **`Quill.yaml` version invalid** → `quill::invalid_version` → surfaces as
+  `RenderError::QuillConfig` at Quill load.
+- **Document `$quill` reference invalid** (e.g. `my_format@bad`) →
+  `ParseError::InvalidQuillReference`, returned directly by the parser, never as
+  `RenderError::QuillConfig`.
+- **Loaded Quill does not satisfy a well-formed `$quill`** → the two mismatch
+  codes above, as a `RenderError` from `render`/`dry_run`.
 
 ## Ref Immutability
 
@@ -83,8 +72,3 @@ ref, or a new `Quiver` — and the downstream caches follow automatically
 (WeakMap + weak refs). There is no invalidation API. One must arrive
 end-to-end with its first real consumer (republish-at-same-ref), which this
 immutability invariant deliberately rules out.
-
-## Links
-
-- [QUILL.md](QUILL.md) — Quill structure
-- [ERROR.md](ERROR.md) — error patterns

--- a/scripts/check-canon.mjs
+++ b/scripts/check-canon.mjs
@@ -1,13 +1,22 @@
 #!/usr/bin/env node
-// Canon spine lint — enforces the doc spine and link invariants specified in
-// prose/README.md ("Canon doc spine"). Zero dependencies.
+// Canon spine lint — enforces the doc spine, the link invariants, and the
+// prose line budget specified in prose/README.md. Zero dependencies.
 //
-// Usage: node scripts/check-canon.mjs
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+// Usage: node scripts/check-canon.mjs [--drift[=<base>]]
+//
+// `--drift` adds a non-blocking anchor-drift report: it diffs against <base>
+// (default `HEAD^1`) and names the canon docs whose `**Implementation**`
+// folder changed while the doc itself did not. Advisory only — most code
+// changes need no doc edit, and a hard gate here would only teach people to
+// write vague anchors.
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, posix, dirname } from 'node:path';
 
 const problems = [];
+const notices = [];
 const fail = (file, msg) => problems.push(`${file}: ${msg}`);
+const warn = (file, msg) => notices.push(`${file}: ${msg}`);
 
 // A file path — a slashed token with a dotted basename — inside an anchor.
 // Keys on path shape, not an extension list, so a new file type can't slip past.
@@ -17,9 +26,50 @@ const FILE_IN_ANCHOR = /[\w-]+\/[\w/-]*\.[a-z0-9]+\b/;
 const PLAN_LINK = /\]\([^)]*\/(?:proposals|plans)\//;
 // A relative markdown link target to a .md file (an outbound prose link).
 const PROSE_LINK = /\]\((?!https?:)[^)]*\.md(?=[)#])/;
+// A backticked slashed token — an anchor's folder reference.
+const ANCHOR_PATH = /`([\w.-]+\/[\w./-]*)`/g;
+// A relative markdown link target of any kind.
+const REL_LINK = /\]\((?!https?:|#)([^)\s]+)/g;
+
+// Line budget. A prose line past SOFT reads as a paragraph crammed onto one
+// line: dense by the byte, unskimmable by the claim. HARD is the gate; SOFT is
+// the ratchet, reported so the tail gets cleaned as docs are touched anyway.
+const HARD = 700;
+const SOFT = 300;
 
 const mdFiles = (dir) =>
   existsSync(dir) ? readdirSync(dir).filter((n) => n.endsWith('.md')).sort() : [];
+
+// Every .md under `dir`, minus `docs/migrations/` — released guides are
+// era-accurate and immutable, so no rule applies to them.
+const walkDocs = (dir) =>
+  !existsSync(dir)
+    ? []
+    : readdirSync(dir)
+        .sort()
+        .flatMap((name) => {
+          const p = join(dir, name);
+          if (statSync(p).isDirectory()) return name === 'migrations' ? [] : walkDocs(p);
+          return name.endsWith('.md') ? [p] : [];
+        });
+
+// Prose lines only: no fenced code, no table rows (a table row is a record, not
+// a sentence, and rewrapping one is worse than leaving it long).
+function proseLines(text) {
+  const out = [];
+  let fenced = false;
+  text.split('\n').forEach((line, i) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      fenced = !fenced;
+      return;
+    }
+    if (fenced || /^\s*\|/.test(line)) return;
+    out.push([i + 1, line]);
+  });
+  return out;
+}
+
+const anchors = []; // { doc, path } — one row per folder a canon doc claims
 
 for (const name of mdFiles('prose/canon')) {
   const file = join('prose/canon', name);
@@ -40,14 +90,35 @@ for (const name of mdFiles('prose/canon')) {
   } else {
     const quote = [];
     for (let i = 2; i < lines.length && lines[i].startsWith('>'); i++) quote.push(lines[i]);
-    if (!quote.some((l) => l.startsWith('> **Implementation**:')))
-      fail(file, 'anchor blockquote has no `> **Implementation**:` line');
+    const impl = quote.filter((l) => l.startsWith('> **Implementation**:'));
+    if (!impl.length) fail(file, 'anchor blockquote has no `> **Implementation**:` line');
     const m = quote.join('\n').match(FILE_IN_ANCHOR);
     if (m) fail(file, `Implementation anchor names a file (\`${m[0]}\`) — anchors point at folders or modules`);
+
+    // An anchor that no longer resolves is the rot the folder rule exists to
+    // prevent; it only prevents it if something checks.
+    for (const [, p] of impl.join('\n').matchAll(ANCHOR_PATH)) {
+      if (!existsSync(p)) fail(file, `Implementation anchor \`${p}\` does not exist`);
+      else anchors.push({ doc: file, path: p.endsWith('/') ? p : `${p}/` });
+    }
   }
 
   const firstH2 = lines.find((l) => l.startsWith('## '));
   if (firstH2 !== '## TL;DR') fail(file, `first section is \`${firstH2 ?? '(none)'}\` — canon docs open with \`## TL;DR\``);
+}
+
+// INDEX is the only entry point canon promises, so a page missing from it is
+// unreachable and a link out of it must resolve.
+if (existsSync('prose/canon/INDEX.md')) {
+  const index = readFileSync('prose/canon/INDEX.md', 'utf8');
+  for (const name of mdFiles('prose/canon')) {
+    if (name === 'INDEX.md') continue;
+    if (!index.includes(`(${name})`)) fail('prose/canon/INDEX.md', `does not link \`${name}\` — every canon page is reachable from the index`);
+  }
+  for (const [, target] of index.matchAll(REL_LINK)) {
+    const resolved = posix.normalize(join('prose/canon', target.split('#')[0]));
+    if (!existsSync(resolved)) fail('prose/canon/INDEX.md', `link target \`${target}\` does not resolve`);
+  }
 }
 
 for (const name of mdFiles('prose/references')) {
@@ -56,6 +127,63 @@ for (const name of mdFiles('prose/references')) {
   if (m) fail(file, `links to another prose doc (\`${m[0]}\`) — references are self-contained`);
 }
 
+// The diff, when one is available: scopes the soft limit and drives the drift
+// report. `--drift` without a base diffs the last commit.
+const driftArg = process.argv.slice(2).find((a) => a === '--drift' || a.startsWith('--drift='));
+const base = driftArg ? driftArg.split('=')[1] || 'HEAD^1' : null;
+let changed = null;
+if (base) {
+  try {
+    changed = new Set(
+      execFileSync('git', ['diff', '--name-only', base, 'HEAD'], { encoding: 'utf8' }).split('\n').filter(Boolean),
+    );
+  } catch {
+    console.log(`check-canon: no diff against ${base} — drift and soft-limit reporting skipped`);
+  }
+}
+
+// Line budget over canon and the consumer docs, minus migrations. The hard
+// limit is a gate everywhere; the soft limit is a ratchet, reported only for
+// files this change touches so the standing tail never becomes background noise.
+let softTotal = 0;
+for (const file of [...mdFiles('prose/canon').map((n) => join('prose/canon', n)), ...walkDocs('docs')]) {
+  for (const [n, line] of proseLines(readFileSync(file, 'utf8'))) {
+    if (line.length > HARD) fail(file, `line ${n} is ${line.length} chars (max ${HARD}) — one claim per sentence; split the clauses into bullets or a table`);
+    else if (line.length > SOFT) {
+      softTotal++;
+      if (changed?.has(file)) warn(file, `line ${n} is ${line.length} chars (soft limit ${SOFT}) — split it while you are here`);
+    }
+  }
+}
+if (softTotal) console.log(`check-canon: ${softTotal} lines over the ${SOFT}-char soft limit tree-wide`);
+
+// Anchor drift: the `**Implementation**` line is a machine-readable code→doc
+// back-pointer. Map each changed file to the *most specific* anchor claiming
+// it, so a change under `crates/core/src/quill/` doesn't also wake every doc
+// anchored at `crates/core/src/`.
+if (changed && anchors.length) {
+  const woken = new Map(); // doc -> Set of folders
+  for (const path of changed) {
+    let best = 0;
+    for (const { path: a } of anchors) if (path.startsWith(a) && a.length > best) best = a.length;
+    if (!best) continue;
+    for (const { doc, path: a } of anchors) {
+      if (a.length !== best || !path.startsWith(a) || changed.has(doc)) continue;
+      if (!woken.has(doc)) woken.set(doc, new Set());
+      woken.get(doc).add(a);
+    }
+  }
+  for (const [doc, folders] of [...woken].sort())
+    warn(doc, `${[...folders].join(', ')} changed since ${base}; this doc did not — check it still describes what is`);
+}
+
+for (const n of notices) {
+  console.log(`check-canon: note: ${n}`);
+  if (process.env.GITHUB_ACTIONS) {
+    const [file, ...rest] = n.split(': ');
+    console.log(`::warning file=${file}::${rest.join(': ')}`);
+  }
+}
 if (problems.length) {
   for (const p of problems) console.error(`check-canon: ${p}`);
   process.exit(1);

--- a/scripts/check-canon.mjs
+++ b/scripts/check-canon.mjs
@@ -26,6 +26,10 @@ const FILE_IN_ANCHOR = /[\w-]+\/[\w/-]*\.[a-z0-9]+\b/;
 const PLAN_LINK = /\]\([^)]*\/(?:proposals|plans)\//;
 // A relative markdown link target to a .md file (an outbound prose link).
 const PROSE_LINK = /\]\((?!https?:)[^)]*\.md(?=[)#])/;
+// An issue or PR reference. A status marker: it says work is in motion, which
+// canon does not carry, and it dates the sentence around it. Narrow enough to
+// miss heading anchors (`](#regions-overlay)`) and Typst code (`#let`, `#data`).
+const ISSUE_REF = /#\d+\b|github\.com\/[^)\s]+\/(?:issues|pull)\/\d+/;
 // A backticked slashed token — an anchor's folder reference.
 const ANCHOR_PATH = /`([\w.-]+\/[\w./-]*)`/g;
 // A relative markdown link target of any kind.
@@ -78,6 +82,11 @@ for (const name of mdFiles('prose/canon')) {
 
   const planLink = text.match(PLAN_LINK);
   if (planLink) fail(file, `links into proposals/ or plans/ (\`${planLink[0]}\`) — canon never references them`);
+
+  for (const [n, line] of proseLines(text)) {
+    const ref = line.match(ISSUE_REF);
+    if (ref) fail(file, `line ${n} cites \`${ref[0]}\` — canon states the shape, not the ticket tracking it`);
+  }
 
   if (name === 'INDEX.md') continue; // the index has no spine
 


### PR DESCRIPTION
check-canon.mjs validated line 1, line 3, TL;DR, and two link-tier rules —
every real failure mode of canon was invisible to it. Four additions, all
green on the tree as it stands:

- `**Implementation**` anchor paths must exist. The folder-not-file rule
  exists to survive renames; it only does if something reads it.
- Every canon page appears in INDEX.md, and every INDEX.md link resolves.
  INDEX is the only entry point canon promises.
- A prose line caps at 700 chars, soft-limits at 300. Fenced code and table
  rows are exempt — a table row is a record, not a sentence.
- `--drift` reports, without failing, canon docs whose anchor folder changed
  while the doc did not. Each changed path maps to the *most specific*
  anchor claiming it, so a change under crates/core/src/quill/ does not also
  wake every doc anchored at crates/core/src/.

Soft-limit notes are scoped to files the diff touches, so the standing tail
never becomes background noise. CI checks out two commits and passes
--drift; notes surface as PR annotations.

Splits the eight lines over the hard budget: the per-type coercion rules in
SCHEMAS.md become a table, and the plaintext, date-object, and LiveSession
bullets become paragraphs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MNDcK3HCMFj4GfVT2sLvnn