### PR TITLE
ci: cut the canon lint to gates only

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -96,10 +96,10 @@ cost a comment exists to remove. Compression is not density.
 - Prefer a paragraph break over a semicolon chain when the second half states a
   separate fact.
 
-`prose/README.md` sets the numeric budget — 700 characters per prose line hard,
-300 soft — and `scripts/check-canon.mjs` enforces it over `prose/canon/` and
-`docs/`. The soft limit is a ratchet: it reports only on files a change already
-touches, so split a long line when you are editing near it, not in a sweep.
+`prose/README.md` sets the numeric budget: 700 characters per prose line, which
+`scripts/check-canon.mjs` gates over `prose/canon/` and `docs/`, and 300 as the
+target you write to. Split a long line when you are editing near it — nothing
+mechanical will remind you.
 
 ### 5. State the design, not the deliberation
 

--- a/.claude/skills/maintain-canon/SKILL.md
+++ b/.claude/skills/maintain-canon/SKILL.md
@@ -49,5 +49,4 @@ fact that belongs to a neighbouring page is a link, not a copy.
 ## Done when
 
 No obvious duplicates. Everything discoverable from `INDEX.md`. Docs are short,
-skimmable, folder-anchored, and easy to maintain. `check-canon.mjs` passes, and
-any drift note it raises is either acted on or knowingly left.
+skimmable, folder-anchored, and easy to maintain. `check-canon.mjs` passes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Two commits so the lint can diff. On a PR the checkout is the merge
-          # commit, so `HEAD^1` is the base tip and the diff is the PR's whole
-          # change; on a push it is the pushed commit alone. Both are fine for
-          # an advisory drift report.
-          fetch-depth: 2
 
-      # Canon spine lint (prose/README.md). Zero deps; runs before the Rust
-      # setup so it fails fast on a checkout-only step. `--drift` adds the
-      # non-blocking anchor-drift and soft-line-budget notes as PR annotations.
+      # Canon spine lint (prose/README.md). Zero deps and no git history, so it
+      # runs before the Rust setup and fails fast on a checkout-only step.
       - name: Check canon spine
-        run: node scripts/check-canon.mjs --drift
+        run: node scripts/check-canon.mjs
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/prose/README.md
+++ b/prose/README.md
@@ -54,8 +54,9 @@ genuine exceptions (e.g. a draft specification).
 
 ## Line budget
 
-A prose line caps at **700 characters** and should stay under **300**. Past
-that, a line is a paragraph crammed onto one line — dense by the byte,
+A prose line caps at **700 characters** — the gate — and should stay under
+**300**, which is the target you write to. Past that, a line is a paragraph
+crammed onto one line — dense by the byte,
 unskimmable by the claim, and unreviewable in a diff, where a one-word fix
 rewrites the whole line. One claim per sentence; a bullet that needs three
 clauses is three bullets, a nested list, or a table. Fenced code and table rows
@@ -63,14 +64,8 @@ are exempt: a table row is a record, not a sentence.
 
 ## Enforcement
 
-`scripts/check-canon.mjs` runs in CI. It fails on a broken spine, a link into
-`proposals/`/`plans/`, a reference that links out, an `**Implementation**`
-anchor that names a file or no longer exists, a canon page missing from
-`INDEX.md`, a dead `INDEX.md` link, an issue or PR number in canon prose, and a
-line over the hard budget.
-
-It also *warns*, without failing, when a folder named in an
-`**Implementation**` anchor changed and the doc anchored there did not — the
-anchor is a machine-readable code→doc back-pointer, and this is what reads it.
-Most such changes need no doc edit; the warning is a prompt, not a gate.
+`scripts/check-canon.mjs` runs in CI and gates the mechanical half of the above:
+the spine, the link invariants, anchors that resolve, and the 700-character
+cap. It only ever fails — read the script for the rule list. The rest of this
+page is the writer's and the reviewer's, enforced by neither.
 

--- a/prose/canon/CI_CD.md
+++ b/prose/canon/CI_CD.md
@@ -4,7 +4,7 @@
 
 ## TL;DR
 
-Four workflows. `ci.yml` runs lint/test/wasm on every PR and non-tag push. `release-prepare.yml` computes the next version, bumps the workspace, and opens a release PR. `release.yml` tags and publishes to crates.io, npm, and PyPI when that PR merges. `docs.yml` builds MkDocs and deploys to GitHub Pages on stable releases.
+Four workflows. `ci.yml` gates docs, the workspace tests, both binding surfaces, and the release tooling on every PR and non-tag push. `release-prepare.yml` computes the next version, bumps the workspace, and opens a release PR. `release.yml` tags and publishes to crates.io, npm, and PyPI when that PR merges. `docs.yml` builds MkDocs and deploys to GitHub Pages on stable releases.
 
 Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `quillmark-pdf`, `quillmark-pdfform`, `quillmark-typst`, `quillmark`, `quillmark-cli`. Not published: `quillmark-fixtures`, `quillmark-fuzz`, `quillmark-python`, `quillmark-wasm`.
 
@@ -19,7 +19,9 @@ Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `q
 |-----|-------------|
 | `lint` | `node scripts/check-canon.mjs` (the canon spine and link gate — see [prose/README.md](../README.md)), then `cargo doc --no-deps --locked` with `RUSTDOCFLAGS=-Dwarnings` — the standing lint gate; clippy is deliberately not gated |
 | `test` | `cargo test --workspace --all-features --locked` |
+| `release-tooling` | asserts `scripts/strip-seed-comment.sh` both strips a seed block and collapses the surrounding blanks to one, and no-ops on a file without one. `release.yml` runs that script unattended against `CHANGELOG.md` between the version bump and the tag, so a regression corrupts a release commit |
 | `wasm` | first asserts the no-default-features core graph excludes Typst (`cargo tree -i quillmark-typst` must fail), then builds via `./scripts/build-wasm.sh --ci`, then `npx vitest run` |
+| `python` | `maturin develop` into a `uv` venv (Python 3.12, debug profile), then `pytest -q` |
 
 The `wasm` job caches `target/wasm32-unknown-unknown/wasm-ci` under key `wasm-ci-${os}-${hashFiles('Cargo.lock')}` (restore-prefix `wasm-ci-${os}-`), so a lockfile change takes a fresh key while source-only edits restore the prefix and rebuild incrementally. The `wasm-ci-` namespace is deliberately disjoint from `release.yml`'s `wasm-release-` cache so a CI build (debug `wasm-ci` profile) can never be restored into a release job and published to npm.
 

--- a/prose/canon/CI_CD.md
+++ b/prose/canon/CI_CD.md
@@ -17,7 +17,7 @@ Published crates, in dependency order: `quillmark-content`, `quillmark-core`, `q
 
 | Job | What it does |
 |-----|-------------|
-| `lint` | `node scripts/check-canon.mjs --drift` (the canon spine, link, anchor, and line-budget gate — see [prose/README.md](../README.md); the drift and soft-budget notes are annotations, not failures), then `cargo doc --no-deps --locked` with `RUSTDOCFLAGS=-Dwarnings` — the standing lint gate; clippy is deliberately not gated |
+| `lint` | `node scripts/check-canon.mjs` (the canon spine and link gate — see [prose/README.md](../README.md)), then `cargo doc --no-deps --locked` with `RUSTDOCFLAGS=-Dwarnings` — the standing lint gate; clippy is deliberately not gated |
 | `test` | `cargo test --workspace --all-features --locked` |
 | `wasm` | first asserts the no-default-features core graph excludes Typst (`cargo tree -i quillmark-typst` must fail), then builds via `./scripts/build-wasm.sh --ci`, then `npx vitest run` |
 

--- a/scripts/check-canon.mjs
+++ b/scripts/check-canon.mjs
@@ -1,22 +1,15 @@
 #!/usr/bin/env node
-// Canon spine lint — enforces the doc spine, the link invariants, and the
-// prose line budget specified in prose/README.md. Zero dependencies.
+// Canon spine lint — enforces the doc spine and the link invariants specified
+// in prose/README.md. Zero dependencies, no arguments.
 //
-// Usage: node scripts/check-canon.mjs [--drift[=<base>]]
-//
-// `--drift` adds a non-blocking anchor-drift report: it diffs against <base>
-// (default `HEAD^1`) and names the canon docs whose `**Implementation**`
-// folder changed while the doc itself did not. Advisory only — most code
-// changes need no doc edit, and a hard gate here would only teach people to
-// write vague anchors.
+// Every rule here is a gate, and every gate catches a dead link or a dead
+// anchor: rot no reader would notice. Taste is the writer's job and the
+// reviewer's. A check that can only warn does not belong.
 import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
-import { join, posix, dirname } from 'node:path';
+import { join, posix } from 'node:path';
 
 const problems = [];
-const notices = [];
 const fail = (file, msg) => problems.push(`${file}: ${msg}`);
-const warn = (file, msg) => notices.push(`${file}: ${msg}`);
 
 // A file path — a slashed token with a dotted basename — inside an anchor.
 // Keys on path shape, not an extension list, so a new file type can't slip past.
@@ -26,20 +19,15 @@ const FILE_IN_ANCHOR = /[\w-]+\/[\w/-]*\.[a-z0-9]+\b/;
 const PLAN_LINK = /\]\([^)]*\/(?:proposals|plans)\//;
 // A relative markdown link target to a .md file (an outbound prose link).
 const PROSE_LINK = /\]\((?!https?:)[^)]*\.md(?=[)#])/;
-// An issue or PR reference. A status marker: it says work is in motion, which
-// canon does not carry, and it dates the sentence around it. Narrow enough to
-// miss heading anchors (`](#regions-overlay)`) and Typst code (`#let`, `#data`).
-const ISSUE_REF = /#\d+\b|github\.com\/[^)\s]+\/(?:issues|pull)\/\d+/;
 // A backticked slashed token — an anchor's folder reference.
 const ANCHOR_PATH = /`([\w.-]+\/[\w./-]*)`/g;
 // A relative markdown link target of any kind.
 const REL_LINK = /\]\((?!https?:|#)([^)\s]+)/g;
 
-// Line budget. A prose line past SOFT reads as a paragraph crammed onto one
-// line: dense by the byte, unskimmable by the claim. HARD is the gate; SOFT is
-// the ratchet, reported so the tail gets cleaned as docs are touched anyway.
+// Line budget. Past this a line is a paragraph crammed onto one line, and a
+// one-word fix rewrites the whole of it in the diff. prose/README.md sets a
+// tighter target for writers; only the outer bound is mechanical.
 const HARD = 700;
-const SOFT = 300;
 
 const mdFiles = (dir) =>
   existsSync(dir) ? readdirSync(dir).filter((n) => n.endsWith('.md')).sort() : [];
@@ -73,8 +61,6 @@ function proseLines(text) {
   return out;
 }
 
-const anchors = []; // { doc, path } — one row per folder a canon doc claims
-
 for (const name of mdFiles('prose/canon')) {
   const file = join('prose/canon', name);
   const text = readFileSync(file, 'utf8');
@@ -82,11 +68,6 @@ for (const name of mdFiles('prose/canon')) {
 
   const planLink = text.match(PLAN_LINK);
   if (planLink) fail(file, `links into proposals/ or plans/ (\`${planLink[0]}\`) — canon never references them`);
-
-  for (const [n, line] of proseLines(text)) {
-    const ref = line.match(ISSUE_REF);
-    if (ref) fail(file, `line ${n} cites \`${ref[0]}\` — canon states the shape, not the ticket tracking it`);
-  }
 
   if (name === 'INDEX.md') continue; // the index has no spine
 
@@ -106,10 +87,8 @@ for (const name of mdFiles('prose/canon')) {
 
     // An anchor that no longer resolves is the rot the folder rule exists to
     // prevent; it only prevents it if something checks.
-    for (const [, p] of impl.join('\n').matchAll(ANCHOR_PATH)) {
+    for (const [, p] of impl.join('\n').matchAll(ANCHOR_PATH))
       if (!existsSync(p)) fail(file, `Implementation anchor \`${p}\` does not exist`);
-      else anchors.push({ doc: file, path: p.endsWith('/') ? p : `${p}/` });
-    }
   }
 
   const firstH2 = lines.find((l) => l.startsWith('## '));
@@ -136,63 +115,10 @@ for (const name of mdFiles('prose/references')) {
   if (m) fail(file, `links to another prose doc (\`${m[0]}\`) — references are self-contained`);
 }
 
-// The diff, when one is available: scopes the soft limit and drives the drift
-// report. `--drift` without a base diffs the last commit.
-const driftArg = process.argv.slice(2).find((a) => a === '--drift' || a.startsWith('--drift='));
-const base = driftArg ? driftArg.split('=')[1] || 'HEAD^1' : null;
-let changed = null;
-if (base) {
-  try {
-    changed = new Set(
-      execFileSync('git', ['diff', '--name-only', base, 'HEAD'], { encoding: 'utf8' }).split('\n').filter(Boolean),
-    );
-  } catch {
-    console.log(`check-canon: no diff against ${base} — drift and soft-limit reporting skipped`);
-  }
-}
-
-// Line budget over canon and the consumer docs, minus migrations. The hard
-// limit is a gate everywhere; the soft limit is a ratchet, reported only for
-// files this change touches so the standing tail never becomes background noise.
-let softTotal = 0;
-for (const file of [...mdFiles('prose/canon').map((n) => join('prose/canon', n)), ...walkDocs('docs')]) {
-  for (const [n, line] of proseLines(readFileSync(file, 'utf8'))) {
+for (const file of [...mdFiles('prose/canon').map((n) => join('prose/canon', n)), ...walkDocs('docs')])
+  for (const [n, line] of proseLines(readFileSync(file, 'utf8')))
     if (line.length > HARD) fail(file, `line ${n} is ${line.length} chars (max ${HARD}) — one claim per sentence; split the clauses into bullets or a table`);
-    else if (line.length > SOFT) {
-      softTotal++;
-      if (changed?.has(file)) warn(file, `line ${n} is ${line.length} chars (soft limit ${SOFT}) — split it while you are here`);
-    }
-  }
-}
-if (softTotal) console.log(`check-canon: ${softTotal} lines over the ${SOFT}-char soft limit tree-wide`);
 
-// Anchor drift: the `**Implementation**` line is a machine-readable code→doc
-// back-pointer. Map each changed file to the *most specific* anchor claiming
-// it, so a change under `crates/core/src/quill/` doesn't also wake every doc
-// anchored at `crates/core/src/`.
-if (changed && anchors.length) {
-  const woken = new Map(); // doc -> Set of folders
-  for (const path of changed) {
-    let best = 0;
-    for (const { path: a } of anchors) if (path.startsWith(a) && a.length > best) best = a.length;
-    if (!best) continue;
-    for (const { doc, path: a } of anchors) {
-      if (a.length !== best || !path.startsWith(a) || changed.has(doc)) continue;
-      if (!woken.has(doc)) woken.set(doc, new Set());
-      woken.get(doc).add(a);
-    }
-  }
-  for (const [doc, folders] of [...woken].sort())
-    warn(doc, `${[...folders].join(', ')} changed since ${base}; this doc did not — check it still describes what is`);
-}
-
-for (const n of notices) {
-  console.log(`check-canon: note: ${n}`);
-  if (process.env.GITHUB_ACTIONS) {
-    const [file, ...rest] = n.split(': ');
-    console.log(`::warning file=${file}::${rest.join(': ')}`);
-  }
-}
 if (problems.length) {
   for (const p of problems) console.error(`check-canon: ${p}`);
   process.exit(1);


### PR DESCRIPTION
The advisory half was half the script and all of its CI plumbing, and by
construction nobody had to act on any of it: the anchor-drift report, the
300-char soft ratchet, and the changed-file scoping that existed to keep
the ratchet bearable. Drift also computed a different baseline per trigger
(base tip on a PR, previous commit on a push), so the same commit produced
two reports — harmless, which was the point against it.

Also drops the issue/PR-number regex: a taste rule tuned to dodge Typst
`#let` and heading anchors, for a violation that costs a dated sentence.
It stays a writing rule in the dense-prose skill.

What remains only ever fails, and each rule catches rot a reader would not
notice: a dead `**Implementation**` anchor, a canon page unreachable from
INDEX, a dead INDEX link, a link into proposals/plans, a reference that
links out, a broken spine, a line past 700 chars. 200 lines to 126, and
the checkout no longer needs fetch-depth.

prose/README.md's rule list, restated in the script and rotting separately,
is now a pointer at the script.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Csjs3Rj4Xqombhg2Q8hxf5