### PR TITLE
content: close three codec holes — island-swallowing marks, unchecked line kinds, unbounded decode

### DIFF
--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -752,13 +752,16 @@ fn split_around_slots(chars: &[char], start: usize, end: usize) -> Vec<(usize, u
     }
     let mut out = Vec::new();
     let mut run = start;
-    for i in start..end {
-        if chars[i] == ISLAND_SLOT {
-            if run < i {
-                out.push((run, i));
-            }
-            run = i + 1;
+    for (i, _) in chars[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (start + i, c))
+        .filter(|(_, &c)| c == ISLAND_SLOT)
+    {
+        if run < i {
+            out.push((run, i));
         }
+        run = i + 1;
     }
     if run < end {
         out.push((run, end));

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -553,6 +553,19 @@ fn render_marked_core(
 ) -> String {
     let n = chars.len();
 
+    // A code span cannot carry an island: the span is emitted verbatim between
+    // backticks, so a slot inside it lands raw in the output and re-imports as
+    // nothing — the island, its slot, and the code mark all vanish. Markdown has
+    // no honest encoding (`` `![x](y)` `` is the *literal* text), so split each
+    // code range around every slot it covers and let the island render as its own
+    // markup between the surviving code spans: text and island preserved, one
+    // mark lowered to several — the same trade the sweep makes for free overlap.
+    let code_ranges: Vec<(usize, usize)> = code_ranges
+        .iter()
+        .flat_map(|&(s, e)| split_around_slots(chars, s, e))
+        .collect();
+    let code_ranges = &code_ranges[..];
+
     // Clip the wrapping marks so the sweep only ever sees a representable shape.
     let mut fmt: Vec<(usize, usize, &MarkKind)> = fmt.to_vec();
     let mut atomics: Vec<(usize, usize)> = code_ranges.to_vec();
@@ -596,10 +609,22 @@ fn render_marked_core(
                 stack.push(fi);
             }
             // A link is emitted atomically as [text](url); its display text
-            // carries plain content (nested marks in link text are not supported).
+            // carries plain content (nested marks in link text are not supported)
+            // but does carry islands — a linked image is `[![alt](src)](url)`,
+            // plain CommonMark — so each char routes through `island_markup_at`
+            // the way the plain-text path below does. Emitting the slice raw
+            // would leak the slot char and lose the island with it.
             if let Some(&(ls, le, url)) = links.iter().find(|(s, _, _)| *s == pos) {
                 out.push('[');
-                out.push_str(&escape_run(&chars[ls..le], escape_pipe));
+                for (i, &c) in chars[ls..le].iter().enumerate() {
+                    if c == ISLAND_SLOT {
+                        if let Some(markup) = island_markup_at(ls + i) {
+                            out.push_str(&markup);
+                        }
+                    } else {
+                        escape_char_into(c, i == 0, escape_pipe, &mut out);
+                    }
+                }
                 out.push_str("](");
                 emit_url(url, &mut out);
                 out.push(')');
@@ -715,6 +740,30 @@ pub fn clip_range_to_atomic(start: &mut usize, end: &mut usize, atomics: &[(usiz
             *end = cs;
         }
     }
+}
+
+/// The maximal slot-free subranges of `[start, end)` — the range itself when it
+/// covers no [`ISLAND_SLOT`], else one range per run between slots (empty runs
+/// dropped). Used to keep a code span off an island it cannot represent.
+fn split_around_slots(chars: &[char], start: usize, end: usize) -> Vec<(usize, usize)> {
+    let end = end.min(chars.len());
+    if !chars[start.min(end)..end].contains(&ISLAND_SLOT) {
+        return vec![(start, end)];
+    }
+    let mut out = Vec::new();
+    let mut run = start;
+    for i in start..end {
+        if chars[i] == ISLAND_SLOT {
+            if run < i {
+                out.push((run, i));
+            }
+            run = i + 1;
+        }
+    }
+    if run < end {
+        out.push((run, end));
+    }
+    out
 }
 
 /// Nest `strong`/`emph` marks that partially overlap, by truncating the
@@ -881,6 +930,38 @@ mod tests {
             rt, rt2,
             "content not a fixed point.\n  in:  {md:?}\n  mid: {md2:?}"
         );
+    }
+
+    /// Issue #1049: a link over an island slot. A linked image is plain
+    /// CommonMark, so it sits inside the fixed-point domain — the link arm must
+    /// route its display text through the island renderer rather than emit the
+    /// slot char raw (which re-imports as nothing, losing island, link, and the
+    /// char with it).
+    #[test]
+    fn link_over_island_slot_round_trips() {
+        round_trips("[![a cat](cat.png)](https://e.com)");
+        round_trips("[a ![cat](cat.png) b](https://e.com)");
+        assert_eq!(
+            to_markdown(&from_markdown("[![a cat](cat.png)](https://e.com)").unwrap()),
+            "[![a cat](cat.png)](https://e.com)"
+        );
+    }
+
+    /// Issue #1049: a `Code` mark over an island slot — editor-buildable, not
+    /// importable. A code span is emitted verbatim, so it cannot carry the
+    /// island; the span splits around the slot, keeping both the text and the
+    /// island (one code mark lowered to two).
+    #[test]
+    fn code_mark_over_island_slot_keeps_the_island() {
+        let mut rt = from_markdown("a ![x](y.png) b").unwrap();
+        rt.marks.push(Mark { start: 0, end: 5, kind: MarkKind::Code });
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        let md = to_markdown(&rt);
+        assert_eq!(md, "`a `![x](y.png)` b`");
+        let rt2 = from_markdown(&md).unwrap();
+        assert_eq!(rt2.text, rt.text);
+        assert_eq!(rt2.islands.len(), 1);
     }
 
     /// [`to_plaintext`] keeps literal text, drops marks, and strips island

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1,6 +1,6 @@
 //! Markdown import (cold): `normalize → pulldown → content`.
 //!
-//! The one place the `<u>` allowlist and `***` fixups run — once, at the
+//! The one place the `<u>` allowlist runs — once, at the
 //! boundary (issue #831 § Codecs). Input is normalized by
 //! [`crate::normalize::normalize_markdown`] (CRLF→LF, bidi strip, HTML
 //! comment-fence repair) so the content invariants hold by construction, then
@@ -85,11 +85,7 @@ pub fn from_markdown(markdown: &str) -> Result<Content, ImportError> {
     options.insert(Options::ENABLE_TABLES);
     let parser = Parser::new_ext(&normalized, options);
     let underline_opens: UnderlineOpens = Rc::new(RefCell::new(HashSet::new()));
-    let fixer = MarkdownFixer::new(
-        parser.into_offset_iter(),
-        &normalized,
-        Rc::clone(&underline_opens),
-    );
+    let fixer = MarkdownFixer::new(parser.into_offset_iter(), Rc::clone(&underline_opens));
 
     let mut b = Builder::new(underline_opens);
     b.run(fixer)?;
@@ -788,8 +784,8 @@ impl Builder {
                 }
             }
             // Inline content of the open cell (pulldown already trimmed the cell's
-            // surrounding whitespace; the fixer already stripped non-`<u>` HTML
-            // and fixed `***`). A soft/hard break in a single-line cell is a space.
+            // surrounding whitespace; the fixer already stripped non-`<u>` HTML).
+            // A soft/hard break in a single-line cell is a space.
             Event::Text(t) => {
                 if let Some(c) = self.cell_mut() {
                     c.push_text(t);
@@ -914,11 +910,14 @@ fn sanitize_lang(lang: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// MarkdownFixer — the crate's single copy of the pulldown-cmark event fixups.
+// MarkdownFixer — the raw-HTML filter between pulldown and the builder.
 //
-// Two jobs before events reach the builder: allowlist `<u>…</u>` as underline
-// (rewrite to Strong start/end, detected by source peek) and strip all other
-// raw HTML; and fix `***`-adjacency runs pulldown splits awkwardly.
+// One job: allowlist `<u>…</u>` as underline (rewritten to Strong start/end,
+// the classification carried to the builder in `underline_opens`) and drop
+// every other raw HTML event. Delimiter arithmetic is pulldown's — a fixer that
+// re-segments `***` runs can only disagree with CommonMark, and disagreeing
+// means deleting an asterisk the author typed (`***a**` is a literal `*` then
+// strong `a`; `***bold italic***` parses natively).
 // ---------------------------------------------------------------------------
 
 fn is_u_open_tag(html: &str) -> bool {
@@ -940,195 +939,24 @@ fn is_u_close_tag(html: &str) -> bool {
 }
 
 struct MarkdownFixer<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>> {
-    inner: std::iter::Peekable<I>,
-    source: &'a str,
+    inner: I,
     /// Shared with the [`Builder`]: each `<u>` open this fixer converts to
     /// `Tag::Strong` records its `range.start` here, so the builder recovers the
     /// underline without a second source-byte test (see [`UnderlineOpens`]).
     underline_opens: UnderlineOpens,
-    buffer: Vec<(Event<'a>, Range<usize>)>,
-    emph_depth: usize,
-    strong_depth: usize,
+    _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a, I> MarkdownFixer<'a, I>
 where
     I: Iterator<Item = (Event<'a>, Range<usize>)>,
 {
-    fn new(inner: I, source: &'a str, underline_opens: UnderlineOpens) -> Self {
+    fn new(inner: I, underline_opens: UnderlineOpens) -> Self {
         Self {
-            inner: inner.peekable(),
-            source,
+            inner,
             underline_opens,
-            buffer: Vec::new(),
-            emph_depth: 0,
-            strong_depth: 0,
+            _marker: std::marker::PhantomData,
         }
-    }
-
-    fn events_for_stars(
-        star_count: usize,
-        is_start: bool,
-        start_idx: usize,
-    ) -> Vec<(Event<'a>, Range<usize>)> {
-        let mut events = Vec::new();
-        let mut offset = 0;
-        let mut remaining = star_count;
-
-        if remaining >= 2 {
-            let len = 2;
-            let range = start_idx + offset..start_idx + offset + len;
-            let event = if is_start {
-                Event::Start(Tag::Strong)
-            } else {
-                Event::End(TagEnd::Strong)
-            };
-            events.push((event, range));
-            remaining -= 2;
-            offset += 2;
-        }
-        if remaining >= 1 {
-            let len = 1;
-            let range = start_idx + offset..start_idx + offset + len;
-            let event = if is_start {
-                Event::Start(Tag::Emphasis)
-            } else {
-                Event::End(TagEnd::Emphasis)
-            };
-            events.push((event, range));
-        }
-        if !is_start {
-            events.reverse();
-        }
-        events
-    }
-
-    fn coalesce_text_range(&mut self, initial_range: Range<usize>) -> Range<usize> {
-        let mut merged_range = initial_range;
-        while let Some((next_event, next_range)) = self.inner.peek() {
-            if matches!(next_event, Event::Text(_)) && next_range.start == merged_range.end {
-                merged_range.end = next_range.end;
-                self.inner.next();
-            } else {
-                break;
-            }
-        }
-        merged_range
-    }
-
-    fn closable_star_count(&self, star_count: usize) -> usize {
-        let mut remaining = star_count;
-        let mut consumed = 0;
-        if remaining >= 2 && self.strong_depth > 0 {
-            remaining -= 2;
-            consumed += 2;
-        }
-        if remaining >= 1 && self.emph_depth > 0 {
-            consumed += 1;
-        }
-        consumed
-    }
-
-    fn handle_candidate(
-        &mut self,
-        candidate: (Event<'a>, Range<usize>),
-    ) -> Option<(Event<'a>, Range<usize>)> {
-        let (event, range) = candidate;
-
-        match &event {
-            Event::Start(Tag::Emphasis) => self.emph_depth += 1,
-            Event::Start(Tag::Strong) => self.strong_depth += 1,
-            Event::End(TagEnd::Emphasis) => self.emph_depth = self.emph_depth.saturating_sub(1),
-            Event::End(TagEnd::Strong) => self.strong_depth = self.strong_depth.saturating_sub(1),
-            _ => {}
-        }
-
-        match &event {
-            Event::Text(cow_str) => {
-                let s = cow_str.as_ref();
-                if s.ends_with('*') {
-                    let is_strong_start = if let Some(next) = self.buffer.last() {
-                        matches!(next.0, Event::Start(Tag::Strong))
-                    } else {
-                        matches!(self.inner.peek(), Some((Event::Start(Tag::Strong), _)))
-                    };
-                    if is_strong_start {
-                        let star_count = s.chars().rev().take_while(|c| *c == '*').count();
-                        if star_count > 0 && star_count <= 3 {
-                            let text_len = s.len() - star_count;
-                            let text_content = &s[..text_len];
-                            let star_events =
-                                Self::events_for_stars(star_count, true, range.start + text_len);
-                            let next_event = if !self.buffer.is_empty() {
-                                self.buffer.pop().unwrap()
-                            } else {
-                                self.inner.next().unwrap()
-                            };
-                            self.buffer.push(next_event);
-                            for ev in star_events.into_iter().rev() {
-                                self.buffer.push(ev);
-                            }
-                            if !text_content.is_empty() {
-                                return Some((
-                                    Event::Text(text_content.to_string().into()),
-                                    range.start..range.start + text_len,
-                                ));
-                            } else {
-                                return None;
-                            }
-                        }
-                    }
-                }
-            }
-            Event::End(TagEnd::Strong) | Event::End(TagEnd::Emphasis) => {
-                let has_open_tags = self.emph_depth > 0 || self.strong_depth > 0;
-                if !has_open_tags {
-                    return Some((event, range));
-                }
-                let next_is_star_text = if let Some((Event::Text(cow_str), _)) = self.buffer.last()
-                {
-                    cow_str.starts_with('*')
-                } else if let Some((Event::Text(cow_str), _)) = self.inner.peek() {
-                    cow_str.starts_with('*')
-                } else {
-                    false
-                };
-                if next_is_star_text {
-                    let (text_event, text_range) = if !self.buffer.is_empty() {
-                        self.buffer.pop().unwrap()
-                    } else {
-                        let (_ev, rng) = self.inner.next().unwrap();
-                        let merged_range = self.coalesce_text_range(rng);
-                        let text = self.source[merged_range.clone()].into();
-                        (Event::Text(text), merged_range)
-                    };
-                    if let Event::Text(cow_str) = text_event {
-                        let s = cow_str.as_ref();
-                        let star_count = s.chars().take_while(|c| *c == '*').count();
-                        let consumable = self.closable_star_count(star_count);
-                        if consumable > 0 {
-                            let star_events =
-                                Self::events_for_stars(consumable, false, text_range.start);
-                            let text_after = &s[consumable..];
-                            if !text_after.is_empty() {
-                                self.buffer.push((
-                                    Event::Text(text_after.to_string().into()),
-                                    text_range.start + consumable..text_range.end,
-                                ));
-                            }
-                            for ev in star_events.into_iter().rev() {
-                                self.buffer.push(ev);
-                            }
-                            return Some((event, range));
-                        } else {
-                            self.buffer.push((Event::Text(cow_str), text_range));
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-        Some((event, range))
     }
 }
 
@@ -1140,15 +968,8 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(event) = self.buffer.pop() {
-                if let Some(result) = self.handle_candidate(event) {
-                    return Some(result);
-                } else {
-                    continue;
-                }
-            }
             let (event, range) = self.inner.next()?;
-            let (event, range) = match event {
+            return Some(match event {
                 Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_open_tag(html) => {
                     // Carry the `<u>` classification to the builder keyed on the
                     // tag's start offset, so it need not re-sniff the source.
@@ -1160,12 +981,7 @@ where
                 }
                 Event::Html(_) | Event::InlineHtml(_) => continue,
                 other => (other, range),
-            };
-            if let Some(result) = self.handle_candidate((event, range)) {
-                return Some(result);
-            } else {
-                continue;
-            }
+            });
         }
     }
 }
@@ -1280,6 +1096,28 @@ mod tests {
     fn other_html_stripped() {
         let rt = imp("a <span>b</span> c");
         assert_eq!(rt.text, "a b c");
+    }
+
+    /// Issue #1053: an asterisk run the author typed reaches the content.
+    /// `***a**` is a literal `*` followed by strong `a` (CommonMark's rule of
+    /// three: the closing run matches two of the three), and every shape here
+    /// keeps its stars — a fixer re-segmenting the run deleted one.
+    #[test]
+    fn odd_asterisk_runs_keep_their_literal_star() {
+        for (src, text) in [
+            ("***a**", "*a"),
+            ("***aa**", "*aa"),
+            ("****a**", "**a"),
+            ("a***a**", "a*a"),
+        ] {
+            assert_eq!(imp(src).text, text, "literal star dropped from {src:?}");
+        }
+        // The shape the fixup read as its reason for existing: pulldown nests
+        // strong+emph natively, with no star left over.
+        let rt = imp("***bold italic***");
+        assert_eq!(rt.text, "bold italic");
+        assert!(rt.marks.iter().any(|m| m.kind == MarkKind::Strong));
+        assert!(rt.marks.iter().any(|m| m.kind == MarkKind::Emph));
     }
 
     /// A `<u>`-lookalike must not be read as underline. The fixer's single

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -48,7 +48,8 @@ pub use export::{to_markdown, to_plaintext};
 pub use import::{from_markdown, from_plaintext};
 pub use island::KnownIslandType;
 pub use model::{
-    Container, Invariant, Island, Line, LineKind, Loss, Mark, MarkKind, Content, Usv,
+    Container, Invariant, Island, Line, LineKind, LineKindMismatch, Loss, Mark, MarkKind, Content,
+    Usv,
 };
 pub use normalize::normalize_markdown;
 pub use ops::{

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -352,6 +352,53 @@ pub enum Invariant {
     /// cannot carry column cells. `normalize` rewrites a non-array header to an
     /// empty array (a zero-column, content-free table).
     TableHeaderNotArray,
+    /// A line's [`LineKind`] contradicts its text. Export trusts the kind and
+    /// never re-reads the segment, so an unchecked mismatch is silent text loss
+    /// (an `Island`-tagged prose line projects to its resolved island alone).
+    LineKindMismatch { line: usize, mismatch: LineKindMismatch },
+    /// A line's container path is nested deeper than [`MAX_NESTING_DEPTH`]. Both
+    /// emitters recurse one frame per container, so an unbounded path overflows
+    /// the stack; import caps it, and this is the same cap for the content that
+    /// never went through import (a decoded blob, a hand-built value).
+    NestingTooDeep {
+        line: usize,
+        depth: usize,
+        max: usize,
+    },
+}
+
+/// The way a line's text can contradict its [`LineKind`]. `Para` and `Heading`
+/// carry arbitrary text including slots (an inline image is a slot in a `Para`),
+/// so only the three kinds whose contract *names* their content constrain it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineKindMismatch {
+    /// [`LineKind::Island`] whose text is not exactly one [`ISLAND_SLOT`].
+    IslandNotOneSlot,
+    /// [`LineKind::Rule`] carrying text — the break is the line itself.
+    RuleNotEmpty,
+    /// [`LineKind::Code`] carrying an [`ISLAND_SLOT`]. A fence emits its text
+    /// verbatim, so the slot lands raw in the output and re-imports as nothing:
+    /// the island and its slot both vanish.
+    CodeHasSlot,
+}
+
+/// How a line's text contradicts `kind`, if it does — the single reading behind
+/// the [`Invariant::LineKindMismatch`] and
+/// [`ApplyError::LineKindMismatch`](crate::ops::ApplyError::LineKindMismatch)
+/// twins, so the validate-time and op-time checks cannot drift.
+pub fn line_kind_mismatch(kind: &LineKind, seg: &str) -> Option<LineKindMismatch> {
+    match kind {
+        LineKind::Island => {
+            let mut chars = seg.chars();
+            match (chars.next(), chars.next()) {
+                (Some(ISLAND_SLOT), None) => None,
+                _ => Some(LineKindMismatch::IslandNotOneSlot),
+            }
+        }
+        LineKind::Rule if !seg.is_empty() => Some(LineKindMismatch::RuleNotEmpty),
+        LineKind::Code { .. } if seg.contains(ISLAND_SLOT) => Some(LineKindMismatch::CodeHasSlot),
+        _ => None,
+    }
 }
 
 impl Content {
@@ -425,6 +472,22 @@ impl Content {
     /// props and unknown-mark attrs, then sort marks canonically. Idempotent —
     /// the fixed point the canonical serialization commits to.
     pub fn normalize(&mut self) {
+        // Line kinds whose contract names their content, against the content
+        // they now hold. A splice writes text, never kinds: typing into a table
+        // line leaves it `Island` over prose, joining a fence to an image line
+        // leaves it `Code` over a slot, and export reads the kind and not the
+        // text — so the un-repaired line projects its content away. Demote to
+        // `Para`, the kind that carries anything (an inline island is a slot in a
+        // `Para`), which is what re-importing the line's own markdown yields.
+        // The repair-side twin of the [`Invariant::LineKindMismatch`] check; the
+        // deliberate mis-tag is refused up front instead
+        // ([`ApplyError::LineKindMismatch`](crate::ops::ApplyError::LineKindMismatch)),
+        // since silently undoing an op the caller asked for is worse than an error.
+        for (line, seg) in self.lines.iter_mut().zip(self.text.split('\n')) {
+            if line_kind_mismatch(&line.kind, seg).is_some() {
+                line.kind = LineKind::Para;
+            }
+        }
         // Islands: canonicalize props key order. A table island's cells carry
         // inline `{text, marks}`; repair its shape (pad the header/rows/aligns to
         // one column count, rewrite any cell `\n` to a space) and canonicalize
@@ -553,11 +616,23 @@ impl Content {
                 _ => {}
             }
         }
-        for line in &self.lines {
+        // One pass over the lines against their own text segment. `lines.len()`
+        // already equals the segment count, so the zip is total.
+        for (i, (line, seg)) in self.lines.iter().zip(self.text.split('\n')).enumerate() {
             if let LineKind::Heading { level } = line.kind {
                 if !(1..=6).contains(&level) {
                     return Err(Invariant::BadHeadingLevel(level));
                 }
+            }
+            if let Some(mismatch) = line_kind_mismatch(&line.kind, seg) {
+                return Err(Invariant::LineKindMismatch { line: i, mismatch });
+            }
+            if line.containers.len() > crate::MAX_NESTING_DEPTH {
+                return Err(Invariant::NestingTooDeep {
+                    line: i,
+                    depth: line.containers.len(),
+                    max: crate::MAX_NESTING_DEPTH,
+                });
             }
         }
         // Table-cell marks: the prose range/zero-width/reserved-tag rules again,
@@ -707,6 +782,119 @@ mod tests {
         let mut island_only = Content::empty();
         island_only.text = ISLAND_SLOT.to_string();
         assert!(!island_only.is_blank());
+    }
+
+    /// A single-line content over `text` tagged `kind` — the shape a `SetKind`
+    /// or a splice can leave behind.
+    fn tagged(text: &str, kind: LineKind) -> Content {
+        Content {
+            text: text.to_string(),
+            lines: vec![Line {
+                kind,
+                containers: Vec::new(),
+                continues: false,
+            }],
+            marks: Vec::new(),
+            islands: Vec::new(),
+        }
+    }
+
+    /// Issue #1050: a line kind that contradicts the line's text is refused.
+    /// Export trusts the kind and never re-reads the segment, so `Island` over
+    /// prose projects to the island alone and `Rule` over prose to `---` — the
+    /// text silently gone.
+    #[test]
+    fn line_kind_must_agree_with_line_text() {
+        assert_eq!(
+            tagged("hello world", LineKind::Island).validate(),
+            Err(Invariant::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::IslandNotOneSlot
+            })
+        );
+        assert_eq!(
+            tagged("", LineKind::Island).validate(),
+            Err(Invariant::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::IslandNotOneSlot
+            })
+        );
+        assert_eq!(
+            tagged("important text", LineKind::Rule).validate(),
+            Err(Invariant::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::RuleNotEmpty
+            })
+        );
+        // `Para`/`Heading` carry slots — an inline image is a slot in prose —
+        // so only a fence, whose text is emitted verbatim, refuses one.
+        let mut code = tagged(&format!("a{ISLAND_SLOT}b"), LineKind::Code { lang: None });
+        code.islands = vec![Island {
+            id: "isl-0".into(),
+            island_type: "image".into(),
+            props: serde_json::json!({"alt": "x", "url": "y.png"}),
+            loss: Loss::Lossless,
+        }];
+        assert_eq!(
+            code.validate(),
+            Err(Invariant::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::CodeHasSlot
+            })
+        );
+        let mut para = code.clone();
+        para.lines[0].kind = LineKind::Para;
+        assert_eq!(para.validate(), Ok(()));
+        let mut heading = code.clone();
+        heading.lines[0].kind = LineKind::Heading { level: 1 };
+        assert_eq!(heading.validate(), Ok(()));
+        // The kinds that name their content, holding it.
+        assert_eq!(tagged("", LineKind::Rule).validate(), Ok(()));
+    }
+
+    /// Issue #1050: a splice writes text, never kinds, so it can strand an
+    /// `Island` line over prose. `normalize` demotes the stranded kind to `Para`
+    /// rather than let export drop the text — the repair-side twin of the
+    /// invariant, and what keeps every op path's terminal normalize total.
+    #[test]
+    fn normalize_demotes_a_stranded_line_kind() {
+        let mut rt = tagged("typed into a table line", LineKind::Island);
+        rt.normalize();
+        assert_eq!(rt.lines[0].kind, LineKind::Para);
+        assert_eq!(rt.validate(), Ok(()));
+        let mut rt = tagged("text on a rule line", LineKind::Rule);
+        rt.normalize();
+        assert_eq!(rt.lines[0].kind, LineKind::Para);
+        // A well-formed island line is left alone.
+        let mut rt = tagged(&ISLAND_SLOT.to_string(), LineKind::Island);
+        rt.islands = vec![Island {
+            id: "isl-0".into(),
+            island_type: "image".into(),
+            props: serde_json::json!({"alt": "x", "url": "y.png"}),
+            loss: Loss::Lossless,
+        }];
+        rt.normalize();
+        assert_eq!(rt.lines[0].kind, LineKind::Island);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// Issue #1051: container nesting is capped at the same depth import
+    /// enforces, so a content that never went through import cannot reach the
+    /// emitters — which recurse one frame per container — with an unbounded path.
+    #[test]
+    fn container_nesting_is_capped() {
+        let mut rt = tagged("hi", LineKind::Para);
+        rt.lines[0].containers = vec![Container::Quote; crate::MAX_NESTING_DEPTH];
+        assert_eq!(rt.validate(), Ok(()));
+        rt.lines[0].containers.push(Container::Quote);
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::NestingTooDeep {
+                line: 0,
+                depth: crate::MAX_NESTING_DEPTH + 1,
+                max: crate::MAX_NESTING_DEPTH,
+            })
+        );
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -11,7 +11,10 @@
 //! than drifting.
 
 use crate::delta::{Assoc, Delta, Op};
-use crate::model::{Container, Island, Line, LineKind, Mark, MarkKind, Content, Usv, ISLAND_SLOT};
+use crate::model::{
+    line_kind_mismatch, Container, Island, Line, LineKind, LineKindMismatch, Mark, MarkKind,
+    Content, Usv, ISLAND_SLOT,
+};
 use crate::normalize::is_bidi_char;
 use crate::usv::char_to_byte;
 use std::borrow::Cow;
@@ -83,7 +86,7 @@ pub enum LineOp {
 
 use crate::serial::{
     container_from_value, container_to_value, line_kind_from_value, line_kind_to_value,
-    mark_from_value, mark_to_value, ParseError,
+    mark_from_value, mark_to_value, usv_from, ParseError,
 };
 use serde_json::{Map, Value};
 
@@ -193,19 +196,10 @@ pub fn line_op_to_value(op: &LineOp) -> Value {
 /// Decode a [`LineOp`] from its wire object. Dispatches on `op`.
 pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("line op"))?;
-    let line = || {
-        o.get("line")
-            .and_then(Value::as_u64)
-            .map(|n| n as usize)
-            .ok_or(ParseError::Shape("line op line"))
-    };
+    let line = || usv_from(o.get("line"), "line op line");
     match o.get("op").and_then(Value::as_str) {
         Some("split") => Ok(LineOp::Split {
-            at: o
-                .get("at")
-                .and_then(Value::as_u64)
-                .map(|n| n as usize)
-                .ok_or(ParseError::Shape("split at"))?,
+            at: usv_from(o.get("at"), "split at")?,
         }),
         Some("join") => Ok(LineOp::Join { line: line()? }),
         Some("setKind") => Ok(LineOp::SetKind {
@@ -330,6 +324,24 @@ pub enum ApplyError {
     /// A [`MarkOp::Add`] of an anchor with the empty `id` — a degenerate handle,
     /// refused so every anchor carries a usable referent.
     EmptyAnchorId,
+    /// A [`LineOp::SetKind`] whose kind contradicts the line's text — tagging
+    /// prose `Island` or `Rule`, or a slot-bearing line `Code`. Export trusts the
+    /// kind over the text, so the write would silently drop the line's content;
+    /// the op-time twin of
+    /// [`Invariant::LineKindMismatch`](crate::model::Invariant::LineKindMismatch),
+    /// refused here because `normalize` does not repair it.
+    LineKindMismatch {
+        line: usize,
+        mismatch: LineKindMismatch,
+    },
+    /// A [`LineOp::SetContainers`] nested a line deeper than
+    /// [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH) — the op-time twin of
+    /// [`Invariant::NestingTooDeep`](crate::model::Invariant::NestingTooDeep).
+    NestingTooDeep {
+        line: usize,
+        depth: usize,
+        max: usize,
+    },
 }
 
 impl Content {
@@ -551,10 +563,39 @@ impl Content {
                 LineOp::Split { at } => self.split_line(*at)?,
                 LineOp::Join { line } => self.join_line(*line)?,
                 LineOp::SetKind { line, kind } => {
+                    // The kind must agree with the text already on the line:
+                    // export reads the kind and never the segment, so an
+                    // `Island`/`Rule` tag over prose projects the text away.
+                    // Checked before the write (line ops stage on a scratch copy,
+                    // so an error leaves the content untouched).
+                    let seg = self
+                        .text
+                        .split('\n')
+                        .nth(*line)
+                        .ok_or(ApplyError::LineOutOfRange {
+                            line: *line,
+                            lines: self.lines.len(),
+                        })?;
+                    if let Some(mismatch) = line_kind_mismatch(kind, seg) {
+                        return Err(ApplyError::LineKindMismatch {
+                            line: *line,
+                            mismatch,
+                        });
+                    }
                     let line = self.line_mut(*line)?;
                     line.kind = kind.clone();
                 }
                 LineOp::SetContainers { line, containers } => {
+                    // Both emitters recurse one frame per container, so an
+                    // over-deep path is a stack overflow at render, not a render
+                    // error. Same cap as import, refused before the write.
+                    if containers.len() > crate::MAX_NESTING_DEPTH {
+                        return Err(ApplyError::NestingTooDeep {
+                            line: *line,
+                            depth: containers.len(),
+                            max: crate::MAX_NESTING_DEPTH,
+                        });
+                    }
                     let line = self.line_mut(*line)?;
                     line.containers = containers.clone();
                 }
@@ -1156,6 +1197,73 @@ mod tests {
         }])
         .unwrap();
         assert!(matches!(rt.lines[0].kind, LineKind::Heading { level: 2 }));
+    }
+
+    /// Issue #1050: `SetKind` may not tag a line with a kind its text
+    /// contradicts — export reads the kind and not the segment, so the write
+    /// would project the line's content away. Refused before the write, so the
+    /// content is untouched.
+    #[test]
+    fn line_op_set_kind_refuses_a_kind_the_text_contradicts() {
+        let mut rt = from_markdown("hello world").unwrap();
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Island,
+            }]),
+            Err(ApplyError::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::IslandNotOneSlot,
+            })
+        );
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Rule,
+            }]),
+            Err(ApplyError::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::RuleNotEmpty,
+            })
+        );
+        assert_eq!(rt.text, "hello world");
+        assert_eq!(rt.lines[0].kind, LineKind::Para);
+        assert_eq!(rt.validate(), Ok(()));
+
+        // A table island's line tagged `Code` would fence the slot, which
+        // re-imports as nothing.
+        let mut tbl = from_markdown("| a | b |\n|---|---|\n| 1 | 2 |").unwrap();
+        assert_eq!(
+            tbl.apply_line_ops(&[LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Code { lang: None },
+            }]),
+            Err(ApplyError::LineKindMismatch {
+                line: 0,
+                mismatch: LineKindMismatch::CodeHasSlot,
+            })
+        );
+        assert_eq!(tbl.lines[0].kind, LineKind::Island);
+    }
+
+    /// Issue #1051: `SetContainers` is capped at the depth both emitters can
+    /// recurse — the op-time twin of the `validate` invariant.
+    #[test]
+    fn line_op_set_containers_is_depth_capped() {
+        let mut rt = from_markdown("hi").unwrap();
+        let deep = vec![Container::Quote; crate::MAX_NESTING_DEPTH + 1];
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContainers {
+                line: 0,
+                containers: deep,
+            }]),
+            Err(ApplyError::NestingTooDeep {
+                line: 0,
+                depth: crate::MAX_NESTING_DEPTH + 1,
+                max: crate::MAX_NESTING_DEPTH,
+            })
+        );
+        assert!(rt.lines[0].containers.is_empty());
     }
 
     #[test]

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -630,10 +630,7 @@ mod tests {
     /// `to_markdown`; the shared `validate` cap rejects it at the door.
     #[test]
     fn deep_container_nesting_is_rejected_at_decode() {
-        let containers = std::iter::repeat(r#"{"container":"quote"}"#)
-            .take(20_000)
-            .collect::<Vec<_>>()
-            .join(",");
+        let containers = vec![r#"{"container":"quote"}"#; 20_000].join(",");
         let json = format!(
             r#"{{"text":"hi","lines":[{{"kind":"para","containers":[{containers}]}}],"marks":[],"islands":[]}}"#
         );

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -13,7 +13,7 @@
 
 use crate::model::{
     sort_keys_owned, sorted_value, Container, Invariant, Island, Line, LineKind, Loss, Mark,
-    MarkKind, Content,
+    MarkKind, Content, Usv,
 };
 use serde_json::{Map, Value};
 
@@ -129,6 +129,15 @@ pub fn from_canonical_value(v: &Value) -> Result<Content, ParseError> {
     rt.normalize();
     rt.validate().map_err(ParseError::Invalid)?;
     Ok(rt)
+}
+
+/// Read a wire position as a [`Usv`] index. **Checked**, not `as usize`: the
+/// deployment target is wasm32, where the truncating cast turns `2^32 + 5` into
+/// an in-range `5` — a mark silently landing at the wrong position instead of a
+/// rejected document. Every position the decoder reads goes through here.
+pub(crate) fn usv_from(v: Option<&Value>, what: &'static str) -> Result<Usv, ParseError> {
+    let n = v.and_then(Value::as_u64).ok_or(ParseError::Shape(what))?;
+    Usv::try_from(n).map_err(|_| ParseError::Shape(what))
 }
 
 fn arr<'a>(obj: &'a Map<String, Value>, key: &'static str) -> Result<&'a Vec<Value>, ParseError> {
@@ -313,14 +322,8 @@ pub fn mark_to_value(mark: &Mark) -> Value {
 /// mark-op wire.
 pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("mark"))?;
-    let start = o
-        .get("start")
-        .and_then(Value::as_u64)
-        .ok_or(ParseError::Shape("mark start"))? as usize;
-    let end = o
-        .get("end")
-        .and_then(Value::as_u64)
-        .ok_or(ParseError::Shape("mark end"))? as usize;
+    let start = usv_from(o.get("start"), "mark start")?;
+    let end = usv_from(o.get("end"), "mark end")?;
     let ty = o
         .get("type")
         .and_then(Value::as_str)
@@ -619,6 +622,38 @@ mod tests {
             ],
             islands: vec![],
         }
+    }
+
+    /// Issue #1051: the decoder is the entry point for stored and
+    /// caller-supplied content, and export recurses one frame per container. A
+    /// 20 000-deep path used to decode clean and abort the process on
+    /// `to_markdown`; the shared `validate` cap rejects it at the door.
+    #[test]
+    fn deep_container_nesting_is_rejected_at_decode() {
+        let containers = std::iter::repeat(r#"{"container":"quote"}"#)
+            .take(20_000)
+            .collect::<Vec<_>>()
+            .join(",");
+        let json = format!(
+            r#"{{"text":"hi","lines":[{{"kind":"para","containers":[{containers}]}}],"marks":[],"islands":[]}}"#
+        );
+        assert!(matches!(
+            Content::from_canonical_json(&json),
+            Err(ParseError::Invalid(Invariant::NestingTooDeep { .. }))
+        ));
+    }
+
+    /// Issue #1051: a wire position past `usize` is refused, not truncated. On
+    /// wasm32 — the deployment target — `as usize` turned `2^32 + 5` into an
+    /// in-range `5`, landing a mark at the wrong position in a document that
+    /// then validated clean. Rejected on every target, by the checked read here
+    /// on 32-bit and by the range invariant on 64-bit.
+    #[test]
+    fn out_of_range_wire_position_is_refused() {
+        let json = r#"{"text":"hello","lines":[{"kind":"para","containers":[]}],"marks":[{"start":4294967301,"end":4294967302,"type":"strong"}],"islands":[]}"#;
+        assert!(Content::from_canonical_json(json).is_err());
+        assert!(usv_from(Some(&Value::from(u64::MAX)), "x").is_ok() || usize::BITS < 64);
+        assert!(usv_from(Some(&Value::from(-1i64)), "x").is_err());
     }
 
     #[test]

--- a/crates/content/tests/properties.proptest-regressions
+++ b/crates/content/tests/properties.proptest-regressions
@@ -10,3 +10,5 @@ cc 4d70741529d8bc55999e32baee1408f43fe4c56d89049d5507ce3e4fd45e4c70 # shrinks to
 cc 8847c015b9ea58761a4f5f8f293f74729e23a30e08ee1dbce6ae83139dde6b00 # shrinks to md = "- 0*你 a*~# a~"
 cc ff90f800ae8fe6d16e7adb6f38ebcf558488cade231db13d3705afc542faa985 # shrinks to chars = ['a', 'a', 'a', 'a', ' ', '.', 'a', 'a'], specs = [(28, 25, 0), (59, 45, 3)]
 cc 5e333ee554d5dea4ec07af36bca02d4e0494549dee880518d7fc5448d81a06d9 # shrinks to md = "# 0. **a**"
+cc 2982cbd9e43f39a2e5cd52a6c20fa4f7f521a65d08764f324d12f768952482a3 # shrinks to md = "| 0 | a |\n| --- | --- |\n| 1 | 2 |\n\n```\na\n```", ins = "a", pos_seed = 616, del_seed = 0, is_delete = false
+cc 2f2838066b598c521a9479d14f0330b1e2cc8988eca221f661b86a6292116257 # shrinks to md = "| a | a |\n| --- | --- |\n| 1 | 2 |", a_seed = 0, b_seed = 0, ins = "a", pos_seed = 0, del_seed = 0, is_delete = false

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -71,6 +71,12 @@ fn inline_token() -> impl Strategy<Value = String> {
         // in the alt), exercised in prose context (marks, lists, hard breaks).
         (clean_word(), special_url()).prop_map(|(t, u)| format!("[{t}](<{u}>)")),
         (special_alt(), special_url()).prop_map(|(a, u)| format!("![{a}](<{u}>)")),
+        // #1049: a link *over* an image — a linked logo, plain CommonMark. The
+        // generator never nested the two, so no generated document carried a
+        // mark over an island slot, and the link arm emitting its display text
+        // raw (slot char and all) went unseen.
+        (special_alt(), special_url(), clean_word())
+            .prop_map(|(a, u, l)| format!("[![{a}](<{u}>)](https://ex.com/{l})")),
     ]
 }
 


### PR DESCRIPTION
Export's link and code arms emitted their char slice directly, so an
`ISLAND_SLOT` inside either landed raw in the output and re-imported as
nothing — a linked image (plain CommonMark) lost the island, the link, and
the char. The link arm now routes each char through the island renderer; a
code span, which is emitted verbatim and cannot carry an island, splits
around every slot it covers. Closes #1049.

`validate` never checked a line's kind against its text, and `SetKind`
applied any kind to any line, so `Island` over prose exported to the island
alone and `Rule` over prose to `---` — silent text loss, one op from a valid
content. The kind↔content reading now lives in `line_kind_mismatch` and is
enforced three ways: `validate` rejects it, `SetKind` refuses it before the
write, and `normalize` demotes a *stranded* kind to `Para` (a splice writes
text, never kinds — typing into a table line or joining a fence onto an image
line strands one, and the terminal normalize on every op path must stay
total). `Para`/`Heading` still carry slots: an inline image is a slot in
prose, so only the kinds whose contract names their content constrain it.
Closes #1050.

The decoder let through what export cannot survive: 20 000 nested containers
decoded clean and aborted the process on `to_markdown`. The cap now sits in
`validate`, matching import's, so it closes for every consumer at once;
`SetContainers` refuses the same depth. Wire positions read checked instead
of `as usize`, which on wasm32 turned `2^32 + 5` into an in-range `5` — a
mark at the wrong position in a document that then validated clean. Closes
#1051.

`inline_token` gains a linked-image arm; the generator never nested a link
over an image, which is why no generated document ever carried a mark over a
slot.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014wGowHWre2ptUDFZuhkWk1