### PR TITLE
Table-drive test clusters for issue #1060 (partial)

### DIFF
--- a/crates/backends/pdfform/src/form.rs
+++ b/crates/backends/pdfform/src/form.rs
@@ -335,21 +335,16 @@ mod tests {
     }
 
     #[test]
-    fn rejects_foreign_schema_tag() {
-        let json = br#"{ "schema": "something/else@1", "fields": [] }"#;
-        assert!(matches!(
-            FormSpec::parse(json),
-            Err(FormParseError::BadSchema(_))
-        ));
-    }
-
-    #[test]
-    fn rejects_unknown_form_version_as_bad_schema() {
-        let json = br#"{ "schema": "quillmark/form@9.9.9", "fields": [] }"#;
-        assert!(matches!(
-            FormSpec::parse(json),
-            Err(FormParseError::BadSchema(_))
-        ));
+    fn rejects_bad_schema_tag() {
+        for json in [
+            br#"{ "schema": "something/else@1", "fields": [] }"#.as_slice(),
+            br#"{ "schema": "quillmark/form@9.9.9", "fields": [] }"#.as_slice(),
+        ] {
+            assert!(matches!(
+                FormSpec::parse(json),
+                Err(FormParseError::BadSchema(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -1453,19 +1453,18 @@ main:
             .collect()
     }
 
-    /// The crux: transparent same-window ink between two hits of one segment
-    /// keeps the run — both accrue into one unioned box — while foreign ink in
-    /// the identical shape ends it, leaving only the first hit's extent.
-    /// Distinct rects make the difference visible (same-page union vs.
-    /// suppressed second hit).
-    #[test]
-    fn field_only_ink_is_transparent_but_foreign_ink_is_not() {
+    /// Shared crux for both ink-transparency tests below: `interrupt` between
+    /// two boxable hits of one segment keeps the run (both accrue into one
+    /// unioned box), while identically-placed foreign ink ends it, leaving
+    /// only the first hit's extent. Distinct rects make the difference
+    /// visible (same-page union vs. suppressed second hit).
+    fn assert_transparent_but_foreign_ink_is_not(interrupt: Hit) {
         let keys = vec![(0usize, Some(0usize))];
         let (a, b) = (aabb(0.0, 0.0, 1.0, 1.0), aabb(10.0, 10.0, 11.0, 11.0));
 
         let transparent = vec![
             boxable_hit(0, (0, Some(0)), a),
-            transparent_hit(0, 0),
+            interrupt,
             boxable_hit(0, (0, Some(0)), b),
         ];
         let boxes = run_scan_machine(&keys, &transparent);
@@ -1490,42 +1489,21 @@ main:
         );
     }
 
+    #[test]
+    fn field_only_ink_is_transparent_but_foreign_ink_is_not() {
+        assert_transparent_but_foreign_ink_is_not(transparent_hit(0, 0));
+    }
+
     /// #936: detached decoration ink (a `#underline`/`#strike` line) drawn
-    /// between two hits of one segment must keep the run — both accrue into one
-    /// unioned box — where identically-placed *foreign* ink would end it. The
-    /// underline case is exactly this shape: `Start `, then the decorated run's
-    /// glyphs, then the decoration `Shape` (detached span), then the trailing
-    /// plain run, all one segment. Foreign ink here would truncate the region
-    /// at the decoration, orphaning the trailing run.
+    /// between two hits of one segment must keep the run, where identically
+    /// placed *foreign* ink would end it. The underline case is exactly this
+    /// shape: `Start `, then the decorated run's glyphs, then the decoration
+    /// `Shape` (detached span), then the trailing plain run, all one segment.
+    /// Foreign ink here would truncate the region at the decoration,
+    /// orphaning the trailing run.
     #[test]
     fn anonymous_ink_is_transparent_but_foreign_ink_is_not() {
-        let keys = vec![(0usize, Some(0usize))];
-        let (a, b) = (aabb(0.0, 0.0, 1.0, 1.0), aabb(10.0, 10.0, 11.0, 11.0));
-
-        let anonymous = vec![
-            boxable_hit(0, (0, Some(0)), a),
-            anonymous_hit(0), // the underline/strike decoration Shape
-            boxable_hit(0, (0, Some(0)), b),
-        ];
-        let boxes = run_scan_machine(&keys, &anonymous);
-        assert_eq!(boxes[0].len(), 1, "one page-0 box");
-        let (_, bx) = boxes[0][0];
-        assert!(
-            bx.min_x <= 0.0 && bx.max_x >= 11.0,
-            "the box unions both hits — the decoration did not break the run"
-        );
-
-        let foreign = vec![
-            boxable_hit(0, (0, Some(0)), a),
-            foreign_hit(0),
-            boxable_hit(0, (0, Some(0)), b),
-        ];
-        let boxes = run_scan_machine(&keys, &foreign);
-        let (_, bx) = boxes[0][0];
-        assert!(
-            bx.max_x < 11.0,
-            "foreign ink still ends the run — only detached ink is exempt"
-        );
+        assert_transparent_but_foreign_ink_is_not(anonymous_hit(0)); // the underline/strike decoration Shape
     }
 
     /// Two adjacent segments of one field are tracked independently, exactly as

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -372,46 +372,32 @@ describe('Quillmark.quill', () => {
     expect(() => Quill.fromTree(null)).toThrow()
   })
 
-  it('should render markdown to PDF via quill.render(doc) with default opts', () => {
-    const engine = new Quillmark()
-    const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+  // Table-driven: quill.render(doc, opts) with each format literal, asserting
+  // the resulting artifact shape and mime type. `opts: undefined` covers the
+  // default-opts (implicit pdf) call form.
+  const RENDER_FORMAT_CASES = [
+    { opts: undefined, mimeType: 'application/pdf' },
+    { opts: { format: 'pdf' }, mimeType: 'application/pdf' },
+    { opts: { format: 'svg' }, mimeType: 'image/svg+xml' },
+  ]
 
-    const result = engine.render(quill, doc)
+  it('should render markdown via quill.render(doc, opts) for each format', () => {
+    for (const { opts, mimeType } of RENDER_FORMAT_CASES) {
+      const engine = new Quillmark()
+      const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
+      const doc = Document.fromMarkdown(TEST_MARKDOWN)
 
-    expect(result).toBeDefined()
-    expect(result.artifacts).toBeDefined()
-    expect(result.artifacts.length).toBeGreaterThan(0)
-    // The declared TS type is Uint8Array — assert the runtime matches so
-    // consumers don't need to defensively coerce `new Uint8Array(bytes)`.
-    expect(result.artifacts[0].bytes).toBeInstanceOf(Uint8Array)
-    expect(result.artifacts[0].bytes.length).toBeGreaterThan(0)
-    expect(result.artifacts[0].mimeType).toBe('application/pdf')
-  })
+      const result = opts === undefined ? engine.render(quill, doc) : engine.render(quill, doc, opts)
 
-  it('should render markdown to PDF via quill.render(doc, opts)', () => {
-    const engine = new Quillmark()
-    const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-
-    const result = engine.render(quill, doc, { format: 'pdf' })
-
-    expect(result).toBeDefined()
-    expect(result.artifacts).toBeDefined()
-    expect(result.artifacts.length).toBeGreaterThan(0)
-    expect(result.artifacts[0].bytes.length).toBeGreaterThan(0)
-    expect(result.artifacts[0].mimeType).toBe('application/pdf')
-  })
-
-  it('should render markdown to SVG via quill.render(doc)', () => {
-    const engine = new Quillmark()
-    const quill = Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
-    const doc = Document.fromMarkdown(TEST_MARKDOWN)
-
-    const result = engine.render(quill, doc, { format: 'svg' })
-
-    expect(result.artifacts.length).toBeGreaterThan(0)
-    expect(result.artifacts[0].mimeType).toBe('image/svg+xml')
+      expect(result).toBeDefined()
+      expect(result.artifacts).toBeDefined()
+      expect(result.artifacts.length).toBeGreaterThan(0)
+      // The declared TS type is Uint8Array — assert the runtime matches so
+      // consumers don't need to defensively coerce `new Uint8Array(bytes)`.
+      expect(result.artifacts[0].bytes).toBeInstanceOf(Uint8Array)
+      expect(result.artifacts[0].bytes.length).toBeGreaterThan(0)
+      expect(result.artifacts[0].mimeType).toBe(mimeType)
+    }
   })
 
   it('should allow rendering the same Document multiple times', () => {

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -372,9 +372,7 @@ describe('Quillmark.quill', () => {
     expect(() => Quill.fromTree(null)).toThrow()
   })
 
-  // Table-driven: quill.render(doc, opts) with each format literal, asserting
-  // the resulting artifact shape and mime type. `opts: undefined` covers the
-  // default-opts (implicit pdf) call form.
+  // `opts: undefined` is the two-argument call form, whose default is pdf.
   const RENDER_FORMAT_CASES = [
     { opts: undefined, mimeType: 'application/pdf' },
     { opts: { format: 'pdf' }, mimeType: 'application/pdf' },

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -108,6 +108,23 @@ function openSession() {
   return engine.open(quill, Document.fromMarkdown(TEST_MARKDOWN))
 }
 
+/** Asserts a captured `putImageData` call's RGBA buffer carries both visible
+ * ink (non-white, opaque pixels) and opaque background — catches a rasterizer
+ * regression that wrote zeros, swapped channels, or skipped demultiply.
+ * Shared by the typst and pdfform paint tests below; the two rasterizers
+ * differ, but this ink/opacity scan is the same check on either buffer. */
+function expectInkAndOpaquePixels(call) {
+  let inkPixels = 0
+  let opaquePixels = 0
+  for (let i = 0; i < call.data.length; i += 4) {
+    const [r, g, b, a] = [call.data[i], call.data[i + 1], call.data[i + 2], call.data[i + 3]]
+    if (a > 0 && (r < 250 || g < 250 || b < 250)) inkPixels++
+    if (a === 255) opaquePixels++
+  }
+  expect(inkPixels).toBeGreaterThan(0)
+  expect(opaquePixels).toBeGreaterThan(0)
+}
+
 describe('LiveSession canvas preview', () => {
   it('exposes pageCount, backendId, supportsCanvas, warnings, and pageSize on a Typst session', () => {
     const { engine, quill } = openQuill()
@@ -199,18 +216,8 @@ describe('LiveSession canvas preview', () => {
 
     // Pixel-content sanity. The test plate renders a title heading, so the
     // rasterized buffer must contain non-white pixels (visible glyph ink)
-    // *and* opaque pixels (page background). A regression that wrote zeros,
-    // swapped channels, or skipped demultiply would fail at least one of
-    // these.
-    let inkPixels = 0
-    let opaquePixels = 0
-    for (let i = 0; i < call.data.length; i += 4) {
-      const [r, g, b, a] = [call.data[i], call.data[i + 1], call.data[i + 2], call.data[i + 3]]
-      if (a > 0 && (r < 250 || g < 250 || b < 250)) inkPixels++
-      if (a === 255) opaquePixels++
-    }
-    expect(inkPixels).toBeGreaterThan(0)
-    expect(opaquePixels).toBeGreaterThan(0)
+    // *and* opaque pixels (page background).
+    expectInkAndOpaquePixels(call)
   })
 
   it('paint defaults layoutScale and densityScale to 1 when opts are omitted', () => {
@@ -344,15 +351,7 @@ describe('LiveSession canvas preview (pdfform backend)', () => {
     // baked into the page, so the buffer must carry non-white opaque ink
     // (field values + form lines) AND opaque page background. A backend that
     // returned only a blank background (no values) would fail the ink check.
-    let inkPixels = 0
-    let opaquePixels = 0
-    for (let i = 0; i < call.data.length; i += 4) {
-      const [r, g, b, a] = [call.data[i], call.data[i + 1], call.data[i + 2], call.data[i + 3]]
-      if (a > 0 && (r < 250 || g < 250 || b < 250)) inkPixels++
-      if (a === 255) opaquePixels++
-    }
-    expect(inkPixels).toBeGreaterThan(0)
-    expect(opaquePixels).toBeGreaterThan(0)
+    expectInkAndOpaquePixels(call)
   })
 })
 

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -147,59 +147,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_strip_bidi_no_change() {
-        assert_eq!(strip_bidi_formatting("hello world"), "hello world");
-        assert_eq!(strip_bidi_formatting(""), "");
-        assert_eq!(strip_bidi_formatting("**bold** text"), "**bold** text");
-    }
+    fn test_strip_bidi_formatting_cases() {
+        let cases: &[(&str, &str)] = &[
+            ("hello world", "hello world"),
+            ("", ""),
+            ("**bold** text", "**bold** text"),
+            ("he\u{202D}llo", "hello"),
+            ("**asdf** or \u{202D}**(1234**", "**asdf** or **(1234**"),
+            ("a\u{200E}b\u{200F}c", "abc"),
+            ("\u{202A}text\u{202B}more\u{202C}", "textmore"),
+            ("\u{2066}a\u{2067}b\u{2068}c\u{2069}", "abc"),
+            (
+                "\u{061C}\u{200E}\u{200F}\u{202A}\u{202B}\u{202C}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{2069}",
+                "",
+            ),
+            ("hello\u{061C}world", "helloworld"),
+            ("\u{061C}**bold**", "**bold**"),
+            ("你好世界", "你好世界"),
+            ("مرحبا", "مرحبا"),
+            ("🎉", "🎉"),
+        ];
 
-    #[test]
-    fn test_strip_bidi_lro() {
-        assert_eq!(strip_bidi_formatting("he\u{202D}llo"), "hello");
-        assert_eq!(
-            strip_bidi_formatting("**asdf** or \u{202D}**(1234**"),
-            "**asdf** or **(1234**"
-        );
-    }
-
-    #[test]
-    fn test_strip_bidi_marks() {
-        assert_eq!(strip_bidi_formatting("a\u{200E}b\u{200F}c"), "abc");
-    }
-
-    #[test]
-    fn test_strip_bidi_embeddings() {
-        assert_eq!(
-            strip_bidi_formatting("\u{202A}text\u{202B}more\u{202C}"),
-            "textmore"
-        );
-    }
-
-    #[test]
-    fn test_strip_bidi_isolates() {
-        assert_eq!(
-            strip_bidi_formatting("\u{2066}a\u{2067}b\u{2068}c\u{2069}"),
-            "abc"
-        );
-    }
-
-    #[test]
-    fn test_strip_bidi_all_chars() {
-        let all_bidi = "\u{061C}\u{200E}\u{200F}\u{202A}\u{202B}\u{202C}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{2069}";
-        assert_eq!(strip_bidi_formatting(all_bidi), "");
-    }
-
-    #[test]
-    fn test_strip_bidi_arabic_letter_mark() {
-        assert_eq!(strip_bidi_formatting("hello\u{061C}world"), "helloworld");
-        assert_eq!(strip_bidi_formatting("\u{061C}**bold**"), "**bold**");
-    }
-
-    #[test]
-    fn test_strip_bidi_unicode_preserved() {
-        assert_eq!(strip_bidi_formatting("你好世界"), "你好世界");
-        assert_eq!(strip_bidi_formatting("مرحبا"), "مرحبا");
-        assert_eq!(strip_bidi_formatting("🎉"), "🎉");
+        for (input, expected) in cases {
+            assert_eq!(strip_bidi_formatting(input), *expected, "input: {:?}", input);
+        }
     }
 
     #[test]
@@ -220,103 +191,63 @@ mod tests {
     }
 
     #[test]
-    fn test_fix_html_comment_no_comment() {
-        assert_eq!(fix_html_comment_fences("hello world"), "hello world");
-        assert_eq!(fix_html_comment_fences("**bold** text"), "**bold** text");
-        assert_eq!(fix_html_comment_fences(""), "");
-    }
+    fn test_fix_html_comment_fences_cases() {
+        let cases: &[(&str, &str)] = &[
+            ("hello world", "hello world"),
+            ("**bold** text", "**bold** text"),
+            ("", ""),
+            (
+                "<!-- comment -->Same line text",
+                "<!-- comment -->\nSame line text",
+            ),
+            (
+                "<!-- comment -->\nNext line text",
+                "<!-- comment -->\nNext line text",
+            ),
+            (
+                "<!-- comment -->   \nSome text",
+                "<!-- comment -->   \nSome text",
+            ),
+            (
+                "<!--\nmultiline\ncomment\n-->Trailing text",
+                "<!--\nmultiline\ncomment\n-->\nTrailing text",
+            ),
+            (
+                "<!--\nmultiline\n-->\n\nParagraph text",
+                "<!--\nmultiline\n-->\n\nParagraph text",
+            ),
+            (
+                "<!-- first -->Text\n\n<!-- second -->More text",
+                "<!-- first -->\nText\n\n<!-- second -->\nMore text",
+            ),
+            (
+                "Some text before <!-- comment -->",
+                "Some text before <!-- comment -->",
+            ),
+            ("-->some text", "-->some text"),
+            // The first <!-- opens, the first --> closes; inner <!-- is just text.
+            ("<!-- <!-- -->Trailing", "<!-- <!-- -->\nTrailing"),
+            (
+                "<!-- valid -->FixMe\ntext --> Ignore\n<!-- valid2 -->FixMe2",
+                "<!-- valid -->\nFixMe\ntext --> Ignore\n<!-- valid2 -->\nFixMe2",
+            ),
+            (
+                "<!-- comment -->\r\nSome text",
+                "<!-- comment -->\r\nSome text",
+            ),
+            (
+                "<!--- comment --->Trailing text",
+                "<!--- comment --->\nTrailing text",
+            ),
+        ];
 
-    #[test]
-    fn test_fix_html_comment_single_line_trailing_text() {
-        assert_eq!(
-            fix_html_comment_fences("<!-- comment -->Same line text"),
-            "<!-- comment -->\nSame line text"
-        );
+        for (input, expected) in cases {
+            assert_eq!(
+                fix_html_comment_fences(input),
+                *expected,
+                "input: {:?}",
+                input
+            );
+        }
     }
-
-    #[test]
-    fn test_fix_html_comment_already_newline() {
-        assert_eq!(
-            fix_html_comment_fences("<!-- comment -->\nNext line text"),
-            "<!-- comment -->\nNext line text"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_only_whitespace_after() {
-        assert_eq!(
-            fix_html_comment_fences("<!-- comment -->   \nSome text"),
-            "<!-- comment -->   \nSome text"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_multiline_trailing_text() {
-        assert_eq!(
-            fix_html_comment_fences("<!--\nmultiline\ncomment\n-->Trailing text"),
-            "<!--\nmultiline\ncomment\n-->\nTrailing text"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_multiline_proper() {
-        assert_eq!(
-            fix_html_comment_fences("<!--\nmultiline\n-->\n\nParagraph text"),
-            "<!--\nmultiline\n-->\n\nParagraph text"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_multiple_comments() {
-        assert_eq!(
-            fix_html_comment_fences("<!-- first -->Text\n\n<!-- second -->More text"),
-            "<!-- first -->\nText\n\n<!-- second -->\nMore text"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_end_of_string() {
-        assert_eq!(
-            fix_html_comment_fences("Some text before <!-- comment -->"),
-            "Some text before <!-- comment -->"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_arrow_not_comment() {
-        assert_eq!(fix_html_comment_fences("-->some text"), "-->some text");
-    }
-
-    #[test]
-    fn test_fix_html_comment_nested_opener() {
-        // The first <!-- opens, the first --> closes; inner <!-- is just text.
-        assert_eq!(
-            fix_html_comment_fences("<!-- <!-- -->Trailing"),
-            "<!-- <!-- -->\nTrailing"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_multiple_valid_invalid() {
-        let input = "<!-- valid -->FixMe\ntext --> Ignore\n<!-- valid2 -->FixMe2";
-        let expected = "<!-- valid -->\nFixMe\ntext --> Ignore\n<!-- valid2 -->\nFixMe2";
-        assert_eq!(fix_html_comment_fences(input), expected);
-    }
-
-    #[test]
-    fn test_fix_html_comment_crlf() {
-        assert_eq!(
-            fix_html_comment_fences("<!-- comment -->\r\nSome text"),
-            "<!-- comment -->\r\nSome text"
-        );
-    }
-
-    #[test]
-    fn test_fix_html_comment_triple_hyphen_single_line() {
-        assert_eq!(
-            fix_html_comment_fences("<!--- comment --->Trailing text"),
-            "<!--- comment --->\nTrailing text"
-        );
-    }
-
 }

--- a/crates/core/src/document/tests/ambiguous_strings_tests.rs
+++ b/crates/core/src/document/tests/ambiguous_strings_tests.rs
@@ -9,6 +9,9 @@
 //! JSON-style escaping, which is what buys the round-trip guarantee tested
 //! here.
 //!
+//! `ambiguous_strings.md` declares every ambiguous field in one fixture, so
+//! all categories below share a single parse → emit → re-parse cycle instead
+//! of each re-parsing the fixture from scratch.
 
 use crate::document::Document;
 
@@ -39,133 +42,108 @@ fn parse_fixture() -> Document {
 }
 
 /// Assert that a payload field is `QuillValue::String` with exactly the
-/// expected bytes, then perform a round-trip and assert byte-identical.
-fn assert_string_field_round_trips(doc: &Document, key: &str, expected: &str) {
+/// expected bytes. `when` names which parse (first parse vs. post-round-trip)
+/// this check belongs to, for failure messages.
+fn assert_string_field(doc: &Document, key: &str, expected: &str, when: &str) {
     let value = doc
         .main()
         .payload()
         .get(key)
-        .unwrap_or_else(|| panic!("field '{}' not found in payload", key));
+        .unwrap_or_else(|| panic!("field '{}' not found in payload ({})", key, when));
 
     // Must be a string, not a bool / number / null.
     assert!(
         value.as_str().is_some(),
-        "field '{}': expected QuillValue::String, got {:?}",
+        "field '{}' ({}): expected QuillValue::String, got {:?}",
         key,
+        when,
         value
     );
     assert_eq!(
         value.as_str().unwrap(),
         expected,
-        "field '{}': string value mismatch",
-        key
+        "field '{}' ({}): string value mismatch",
+        key,
+        when
     );
 }
 
-/// Full round-trip: parse → emit → re-parse → assert each field still string.
-fn assert_round_trip_strings(keys_and_values: &[(&str, &str)]) {
-    let doc = parse_fixture();
-    let emitted = doc.to_markdown();
-    let doc2 = Document::parse(&emitted)
-        .unwrap_or_else(|e| panic!("re-parse after emit failed: {}\nEmitted:\n{}", e, emitted))
-        .document;
-
-    for (key, expected) in keys_and_values {
-        // First parse: string type.
-        assert_string_field_round_trips(&doc, key, expected);
-        // Re-parsed: byte-identical.
-        let v2 = doc2
-            .main()
-            .payload()
-            .get(key)
-            .unwrap_or_else(|| panic!("field '{}' missing after round-trip", key));
-        assert!(
-            v2.as_str().is_some(),
-            "field '{}' is not a string after round-trip; value = {:?}",
-            key,
-            v2
-        );
-        assert_eq!(
-            v2.as_str().unwrap(),
-            *expected,
-            "field '{}': value changed on round-trip",
-            key
-        );
-    }
-}
-
-// ── Category: Word booleans ───────────────────────────────────────────────────
-
-/// `on`, `off`, `yes`, `no`, `true`, `false` are YAML 1.1 booleans.
-/// Quillmark always emits them double-quoted so they re-parse as strings.
+/// Every ambiguous-string field declared in the fixture, grouped by the YAML
+/// 1.1 hazard it exercises, checked against one shared parse → emit →
+/// re-parse cycle. Previously each category below was its own `#[test]` that
+/// re-parsed the identical fixture solely to check its own slice of fields;
+/// merging them drops the redundant re-parses without dropping any
+/// assertion pair.
 #[test]
-fn ambiguous_word_booleans_round_trip() {
-    assert_round_trip_strings(&[
+fn ambiguous_strings_round_trip() {
+    // `on`, `off`, `yes`, `no`, `true`, `false` are YAML 1.1 booleans.
+    // Quillmark always emits them double-quoted so they re-parse as strings.
+    let word_booleans: &[(&str, &str)] = &[
         ("on_word", "on"),
         ("off_word", "off"),
         ("yes_word", "yes"),
         ("no_word", "no"),
         ("true_word", "true"),
         ("false_word", "false"),
-    ]);
-}
+    ];
 
-// ── Category: Null-like strings ───────────────────────────────────────────────
+    // `null` and `~` parse as YAML null in many parsers.
+    let null_like: &[(&str, &str)] = &[("null_word", "null"), ("tilde", "~")];
 
-/// `null` and `~` parse as YAML null in many parsers.
-#[test]
-fn ambiguous_null_like_round_trip() {
-    assert_round_trip_strings(&[("null_word", "null"), ("tilde", "~")]);
-}
-
-// ── Category: Numeric-like strings ───────────────────────────────────────────
-
-/// `01234` (octal-like), `1e10` (scientific notation), `0x1F` (hex-like).
-/// A YAML 1.1 parser would silently coerce these to integers or floats.
-#[test]
-fn ambiguous_numeric_like_round_trip() {
-    assert_round_trip_strings(&[
+    // `01234` (octal-like), `1e10` (scientific notation), `0x1F` (hex-like).
+    // A YAML 1.1 parser would silently coerce these to integers or floats.
+    let numeric_like: &[(&str, &str)] = &[
         ("leading_zeros", "01234"),
         ("exponential", "1e10"),
         ("hex_like", "0x1F"),
-    ]);
-}
+    ];
 
-// ── Category: Date-like string ────────────────────────────────────────────────
+    // ISO 8601 date strings look like YAML dates in YAML 1.1.
+    let iso_date: &[(&str, &str)] = &[("iso_date", "2024-01-15")];
 
-/// ISO 8601 date strings look like YAML dates in YAML 1.1.
-#[test]
-fn ambiguous_iso_date_round_trip() {
-    assert_round_trip_strings(&[("iso_date", "2024-01-15")]);
-}
-
-// ── Category: Special characters ─────────────────────────────────────────────
-
-/// Empty string, single space, embedded newline, embedded quote, backslash.
-#[test]
-fn ambiguous_special_characters_round_trip() {
-    assert_round_trip_strings(&[
+    // Empty string, single space, embedded newline, embedded quote, backslash.
+    let special_characters: &[(&str, &str)] = &[
         ("empty_string", ""),
         ("single_space", " "),
         ("embedded_newline", "line1\nline2"),
         ("embedded_quote", "he said \"hi\""),
         ("embedded_backslash", "a\\b"),
-    ]);
-}
+    ];
 
-// ── Category: YAML syntax strings ────────────────────────────────────────────
-
-/// Strings that look like YAML structural tokens: map entries, sequence
-/// markers, comments, anchors, aliases, tags.
-#[test]
-fn ambiguous_yaml_syntax_round_trip() {
-    assert_round_trip_strings(&[
+    // Strings that look like YAML structural tokens: map entries, sequence
+    // markers, comments, anchors, aliases, tags.
+    let yaml_syntax: &[(&str, &str)] = &[
         ("looks_like_map", "key: value"),
         ("looks_like_seq", "- item"),
         ("hash_comment", "#comment"),
         ("yaml_anchor", "&anchor"),
         ("yaml_alias", "*alias"),
         ("yaml_tag", "!tag"),
-    ]);
-}
+    ];
 
+    let all_categories: &[&[(&str, &str)]] = &[
+        word_booleans,
+        null_like,
+        numeric_like,
+        iso_date,
+        special_characters,
+        yaml_syntax,
+    ];
+
+    // One parse, one emit, one re-parse for the whole fixture: every
+    // category above reads from these two documents instead of re-parsing.
+    let doc = parse_fixture();
+    let emitted = doc.to_markdown();
+    let doc2 = Document::parse(&emitted)
+        .unwrap_or_else(|e| panic!("re-parse after emit failed: {}\nEmitted:\n{}", e, emitted))
+        .document;
+
+    for category in all_categories {
+        for (key, expected) in *category {
+            // First parse: string type + value.
+            assert_string_field(&doc, key, expected, "first parse");
+            // Re-parsed after emit: still a byte-identical string.
+            assert_string_field(&doc2, key, expected, "after round-trip");
+        }
+    }
+}

--- a/crates/core/src/document/tests/ambiguous_strings_tests.rs
+++ b/crates/core/src/document/tests/ambiguous_strings_tests.rs
@@ -10,8 +10,7 @@
 //! here.
 //!
 //! `ambiguous_strings.md` declares every ambiguous field in one fixture, so
-//! all categories below share a single parse → emit → re-parse cycle instead
-//! of each re-parsing the fixture from scratch.
+//! all categories below share a single parse → emit → re-parse cycle.
 
 use crate::document::Document;
 
@@ -70,10 +69,7 @@ fn assert_string_field(doc: &Document, key: &str, expected: &str, when: &str) {
 
 /// Every ambiguous-string field declared in the fixture, grouped by the YAML
 /// 1.1 hazard it exercises, checked against one shared parse → emit →
-/// re-parse cycle. Previously each category below was its own `#[test]` that
-/// re-parsed the identical fixture solely to check its own slice of fields;
-/// merging them drops the redundant re-parses without dropping any
-/// assertion pair.
+/// re-parse cycle.
 #[test]
 fn ambiguous_strings_round_trip() {
     // `on`, `off`, `yes`, `no`, `true`, `false` are YAML 1.1 booleans.

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -321,9 +321,50 @@ Body of item 1.";
     assert_eq!(card.body_markdown(), "Body of item 1.");
 }
 
+// ── "N composable cards parse with correct kind/payload/order" (table-driven) ─
+// Each row parses `markdown` and checks the subset of {quill reference, main
+// payload fields, main body, per-card kind/fields/body in order} it sets. An
+// unset/`None` entry is not checked.
 #[test]
-fn test_multiple_card_blocks() {
-    let markdown = "~~~card-yaml
+fn cards_parse_with_correct_kind_payload_and_order() {
+    enum Expect {
+        Str(&'static str),
+        I64(i64),
+        F64(f64),
+    }
+
+    fn check_field(payload: &crate::document::Payload, key: &str, expect: &Expect, ctx: &str) {
+        let v = payload
+            .get(key)
+            .unwrap_or_else(|| panic!("{ctx}: missing field {key:?}"));
+        match expect {
+            Expect::Str(s) => assert_eq!(v.as_str().unwrap(), *s, "{ctx}: field {key:?}"),
+            Expect::I64(i) => assert_eq!(v.as_i64().unwrap(), *i, "{ctx}: field {key:?}"),
+            Expect::F64(f) => assert_eq!(v.as_f64().unwrap(), *f, "{ctx}: field {key:?}"),
+        }
+    }
+
+    struct ExpectedCard {
+        kind: Option<&'static str>,
+        fields: Vec<(&'static str, Expect)>,
+        body: Option<&'static str>,
+    }
+
+    struct Case {
+        name: &'static str,
+        markdown: &'static str,
+        quill: Option<&'static str>,
+        main_fields: Vec<(&'static str, Expect)>,
+        main_payload_len: Option<usize>,
+        main_body_eq: Option<&'static str>,
+        main_body_contains: Vec<&'static str>,
+        cards: Vec<ExpectedCard>,
+    }
+
+    let cases = vec![
+        Case {
+            name: "multiple_card_blocks",
+            markdown: "~~~card-yaml
 $quill: test_quill
 $kind: main
 ~~~
@@ -342,29 +383,28 @@ name: Item 2
 tags: [c, d]
 ~~~
 
-Second item body.";
-
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.cards().len(), 2);
-
-    let card1 = &doc.cards()[0];
-    assert_eq!(card1.kind(), Some("items"));
-    assert_eq!(
-        card1.payload().get("name").unwrap().as_str().unwrap(),
-        "Item 1"
-    );
-
-    let card2 = &doc.cards()[1];
-    assert_eq!(card2.kind(), Some("items"));
-    assert_eq!(
-        card2.payload().get("name").unwrap().as_str().unwrap(),
-        "Item 2"
-    );
-}
-
-#[test]
-fn test_mixed_global_and_cards() {
-    let markdown = "~~~card-yaml
+Second item body.",
+            quill: None,
+            main_fields: vec![],
+            main_payload_len: None,
+            main_body_eq: None,
+            main_body_contains: vec![],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("items"),
+                    fields: vec![("name", Expect::Str("Item 1"))],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("items"),
+                    fields: vec![("name", Expect::Str("Item 2"))],
+                    body: None,
+                },
+            ],
+        },
+        Case {
+            name: "mixed_global_and_cards",
+            markdown: "~~~card-yaml
 $quill: test_quill
 $kind: main
 title: Global
@@ -385,17 +425,373 @@ $kind: sections
 title: Section 2
 ~~~
 
-Section 2 content.";
+Section 2 content.",
+            quill: None,
+            main_fields: vec![("title", Expect::Str("Global"))],
+            main_payload_len: None,
+            main_body_eq: Some("Global body."),
+            main_body_contains: vec![],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("sections"),
+                    fields: vec![],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: None,
+                    fields: vec![],
+                    body: None,
+                },
+            ],
+        },
+        Case {
+            name: "adjacent_blocks_different_kinds",
+            markdown: "~~~card-yaml
+$quill: test_quill
+$kind: main
+~~~
 
-    let doc = decompose(markdown).unwrap();
+~~~card-yaml
+$kind: items
+name: Item 1
+~~~
 
-    assert_eq!(
-        doc.main().payload().get("title").unwrap().as_str().unwrap(),
-        "Global"
-    );
-    assert_eq!(doc.main().body_markdown(), "Global body.");
-    assert_eq!(doc.cards().len(), 2);
-    assert_eq!(doc.cards()[0].kind(), Some("sections"));
+Item 1 body
+
+~~~card-yaml
+$kind: sections
+title: Section 1
+~~~
+
+Section 1 body",
+            quill: None,
+            main_fields: vec![],
+            main_payload_len: None,
+            main_body_eq: None,
+            main_body_contains: vec![],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("items"),
+                    fields: vec![("name", Expect::Str("Item 1"))],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("sections"),
+                    fields: vec![("title", Expect::Str("Section 1"))],
+                    body: None,
+                },
+            ],
+        },
+        Case {
+            name: "order_preservation",
+            markdown: "~~~card-yaml
+$quill: test_quill
+$kind: main
+~~~
+
+~~~card-yaml
+$kind: items
+id: 1
+~~~
+
+First
+
+~~~card-yaml
+$kind: items
+id: 2
+~~~
+
+Second
+
+~~~card-yaml
+$kind: items
+id: 3
+~~~
+
+Third",
+            quill: None,
+            main_fields: vec![],
+            main_payload_len: None,
+            main_body_eq: None,
+            main_body_contains: vec![],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("items"),
+                    fields: vec![("id", Expect::I64(1))],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("items"),
+                    fields: vec![("id", Expect::I64(2))],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("items"),
+                    fields: vec![("id", Expect::I64(3))],
+                    body: None,
+                },
+            ],
+        },
+        Case {
+            name: "product_catalog_integration",
+            markdown: "~~~card-yaml
+$quill: test_quill
+$kind: main
+title: Product Catalog
+author: John Doe
+date: 2024-01-01
+~~~
+
+This is the main catalog description.
+
+~~~card-yaml
+$kind: products
+name: Widget A
+price: 19.99
+sku: WID-001
+~~~
+
+The **Widget A** is our most popular product.
+
+~~~card-yaml
+$kind: products
+name: Gadget B
+price: 29.99
+sku: GAD-002
+~~~
+
+The **Gadget B** is perfect for professionals.
+
+~~~card-yaml
+$kind: reviews
+product: Widget A
+rating: 5
+~~~
+
+\"Excellent product! Highly recommended.\"
+
+~~~card-yaml
+$kind: reviews
+product: Gadget B
+rating: 4
+~~~
+
+\"Very good, but a bit pricey.\"",
+            quill: None,
+            main_fields: vec![
+                ("title", Expect::Str("Product Catalog")),
+                ("author", Expect::Str("John Doe")),
+                ("date", Expect::Str("2024-01-01")),
+            ],
+            main_payload_len: Some(3),
+            main_body_eq: None,
+            main_body_contains: vec!["main catalog description"],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("products"),
+                    fields: vec![
+                        ("name", Expect::Str("Widget A")),
+                        ("price", Expect::F64(19.99)),
+                    ],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("products"),
+                    fields: vec![("name", Expect::Str("Gadget B"))],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("reviews"),
+                    fields: vec![
+                        ("product", Expect::Str("Widget A")),
+                        ("rating", Expect::I64(5)),
+                    ],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: None,
+                    fields: vec![],
+                    body: None,
+                },
+            ],
+        },
+        Case {
+            name: "quill_with_card_blocks",
+            markdown: "~~~card-yaml
+$quill: document
+$kind: main
+title: Test Document
+~~~
+
+Main body.
+
+~~~card-yaml
+$kind: sections
+name: Section 1
+~~~
+
+Section 1 body.",
+            quill: Some("document"),
+            main_fields: vec![("title", Expect::Str("Test Document"))],
+            main_payload_len: None,
+            main_body_eq: Some("Main body."),
+            main_body_contains: vec![],
+            cards: vec![ExpectedCard {
+                kind: Some("sections"),
+                fields: vec![],
+                body: None,
+            }],
+        },
+        Case {
+            name: "card_consecutive_blocks",
+            markdown: "~~~card-yaml
+$quill: test_quill
+$kind: main
+~~~
+
+~~~card-yaml
+$kind: a
+id: 1
+~~~
+
+~~~card-yaml
+$kind: a
+id: 2
+~~~",
+            quill: None,
+            main_fields: vec![],
+            main_payload_len: None,
+            main_body_eq: None,
+            main_body_contains: vec![],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("a"),
+                    fields: vec![],
+                    body: None,
+                },
+                ExpectedCard {
+                    kind: Some("a"),
+                    fields: vec![],
+                    body: None,
+                },
+            ],
+        },
+        // A multi-card document (root + two composable cards, prose thematic
+        // break in the root body) exercising the shapes described in
+        // markdown-spec.md. `***` (thematic break) has no content
+        // representation and is dropped by the projection; the surrounding
+        // paragraphs survive — hence `main_body_contains` rather than
+        // `main_body_eq`.
+        Case {
+            name: "spec_example",
+            markdown: "~~~card-yaml
+$quill: blog_post
+$kind: main
+title: My Document
+~~~
+
+Main document body.
+
+***
+
+More content after horizontal rule.
+
+~~~card-yaml
+$kind: section
+heading: Introduction
+~~~
+
+Introduction content.
+
+~~~card-yaml
+$kind: section
+heading: Conclusion
+~~~
+
+Conclusion content.
+",
+            quill: Some("blog_post"),
+            main_fields: vec![("title", Expect::Str("My Document"))],
+            main_payload_len: None,
+            main_body_eq: None,
+            main_body_contains: vec![
+                "Main document body.",
+                "More content after horizontal rule.",
+            ],
+            cards: vec![
+                ExpectedCard {
+                    kind: Some("section"),
+                    fields: vec![("heading", Expect::Str("Introduction"))],
+                    body: Some("Introduction content."),
+                },
+                ExpectedCard {
+                    kind: Some("section"),
+                    fields: vec![("heading", Expect::Str("Conclusion"))],
+                    body: Some("Conclusion content."),
+                },
+            ],
+        },
+    ];
+
+    for case in &cases {
+        let doc = decompose(case.markdown)
+            .unwrap_or_else(|e| panic!("{}: parse failed: {e}", case.name));
+
+        if let Some(quill) = case.quill {
+            assert_eq!(
+                doc.quill_reference().name,
+                quill,
+                "{}: quill name",
+                case.name
+            );
+        }
+        for (key, expect) in &case.main_fields {
+            check_field(
+                doc.main().payload(),
+                key,
+                expect,
+                &format!("{}: main", case.name),
+            );
+        }
+        if let Some(len) = case.main_payload_len {
+            assert_eq!(
+                doc.main().payload().len(),
+                len,
+                "{}: main payload len",
+                case.name
+            );
+        }
+        if let Some(body) = case.main_body_eq {
+            assert_eq!(doc.main().body_markdown(), body, "{}: main body", case.name);
+        }
+        for needle in &case.main_body_contains {
+            assert!(
+                doc.main().body_markdown().contains(needle),
+                "{}: main body missing {needle:?}",
+                case.name
+            );
+        }
+
+        assert_eq!(
+            doc.cards().len(),
+            case.cards.len(),
+            "{}: cards len",
+            case.name
+        );
+        for (i, expected) in case.cards.iter().enumerate() {
+            let card = &doc.cards()[i];
+            let ctx = format!("{}: card[{i}]", case.name);
+            if let Some(kind) = expected.kind {
+                assert_eq!(card.kind(), Some(kind), "{ctx} kind");
+            }
+            for (key, expect) in &expected.fields {
+                check_field(card.payload(), key, expect, &ctx);
+            }
+            if let Some(body) = expected.body {
+                assert_eq!(card.body_markdown(), body, "{ctx} body");
+            }
+        }
+    }
 }
 
 #[test]
@@ -438,9 +834,15 @@ name: Item
     assert_eq!(card.body_markdown(), ""); // empty, not absent
 }
 
+// ── card-kind / global-field name collision: is_ok()-only cases (table-driven) ─
+// `test_allowed_card_field_collision` (below) exercises the same collision
+// shape and additionally checks the resulting values.
 #[test]
-fn test_name_collision_global_and_card() {
-    let markdown = "~~~card-yaml
+fn card_kind_global_field_name_collision_is_allowed() {
+    let cases: &[(&str, &str)] = &[
+        (
+            "scalar global field",
+            "~~~card-yaml
 $quill: test_quill
 $kind: main
 items: \"global value\"
@@ -453,16 +855,11 @@ $kind: items
 name: Item
 ~~~
 
-Item body";
-
-    let result = decompose(markdown);
-    assert!(result.is_ok(), "Name collision should be allowed now");
-}
-
-#[test]
-fn test_card_name_collision_with_array_field() {
-    // Card kind names CAN conflict with payload field names.
-    let markdown = "~~~card-yaml
+Item body",
+        ),
+        (
+            "array-valued global field",
+            "~~~card-yaml
 $quill: test_quill
 $kind: main
 items:
@@ -477,18 +874,11 @@ $kind: items
 name: Scope Item 1
 ~~~
 
-Scope item 1 body";
-
-    let result = decompose(markdown);
-    assert!(
-        result.is_ok(),
-        "Collision with array field should be allowed"
-    );
-}
-
-#[test]
-fn test_empty_global_array_with_card() {
-    let markdown = "~~~card-yaml
+Scope item 1 body",
+        ),
+        (
+            "empty-array global field",
+            "~~~card-yaml
 $quill: test_quill
 $kind: main
 items: []
@@ -501,13 +891,16 @@ $kind: items
 name: Item 1
 ~~~
 
-Item 1 body";
+Item 1 body",
+        ),
+    ];
 
-    let result = decompose(markdown);
-    assert!(
-        result.is_ok(),
-        "Collision with empty array field should be allowed"
-    );
+    for (label, markdown) in cases {
+        assert!(
+            decompose(markdown).is_ok(),
+            "{label}: name collision should be allowed"
+        );
+    }
 }
 
 #[test]
@@ -570,216 +963,6 @@ More content.
     assert_eq!(doc.cards().len(), 0);
 }
 
-#[test]
-fn test_adjacent_blocks_different_kinds() {
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-~~~
-
-~~~card-yaml
-$kind: items
-name: Item 1
-~~~
-
-Item 1 body
-
-~~~card-yaml
-$kind: sections
-title: Section 1
-~~~
-
-Section 1 body";
-
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.cards().len(), 2);
-
-    let card0 = &doc.cards()[0];
-    assert_eq!(card0.kind(), Some("items"));
-    assert_eq!(
-        card0.payload().get("name").unwrap().as_str().unwrap(),
-        "Item 1"
-    );
-
-    let card1 = &doc.cards()[1];
-    assert_eq!(card1.kind(), Some("sections"));
-    assert_eq!(
-        card1.payload().get("title").unwrap().as_str().unwrap(),
-        "Section 1"
-    );
-}
-
-#[test]
-fn test_order_preservation() {
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-~~~
-
-~~~card-yaml
-$kind: items
-id: 1
-~~~
-
-First
-
-~~~card-yaml
-$kind: items
-id: 2
-~~~
-
-Second
-
-~~~card-yaml
-$kind: items
-id: 3
-~~~
-
-Third";
-
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.cards().len(), 3);
-
-    for (i, card) in doc.cards().iter().enumerate() {
-        assert_eq!(card.kind(), Some("items"));
-        let id = card.payload().get("id").unwrap().as_i64().unwrap();
-        assert_eq!(id, (i + 1) as i64);
-    }
-}
-
-#[test]
-fn test_product_catalog_integration() {
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-title: Product Catalog
-author: John Doe
-date: 2024-01-01
-~~~
-
-This is the main catalog description.
-
-~~~card-yaml
-$kind: products
-name: Widget A
-price: 19.99
-sku: WID-001
-~~~
-
-The **Widget A** is our most popular product.
-
-~~~card-yaml
-$kind: products
-name: Gadget B
-price: 29.99
-sku: GAD-002
-~~~
-
-The **Gadget B** is perfect for professionals.
-
-~~~card-yaml
-$kind: reviews
-product: Widget A
-rating: 5
-~~~
-
-\"Excellent product! Highly recommended.\"
-
-~~~card-yaml
-$kind: reviews
-product: Gadget B
-rating: 4
-~~~
-
-\"Very good, but a bit pricey.\"";
-
-    let doc = decompose(markdown).unwrap();
-
-    // Verify global payload
-    assert_eq!(
-        doc.main().payload().get("title").unwrap().as_str().unwrap(),
-        "Product Catalog"
-    );
-    assert_eq!(
-        doc.main()
-            .payload()
-            .get("author")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "John Doe"
-    );
-    assert_eq!(
-        doc.main().payload().get("date").unwrap().as_str().unwrap(),
-        "2024-01-01"
-    );
-
-    // Verify global body
-    assert!(doc
-        .main()
-        .body_markdown()
-        .contains("main catalog description"));
-
-    // 4 cards total
-    assert_eq!(doc.cards().len(), 4);
-
-    // First 2 are products
-    assert_eq!(doc.cards()[0].kind(), Some("products"));
-    assert_eq!(
-        doc.cards()[0]
-            .payload()
-            .get("name")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Widget A"
-    );
-    assert_eq!(
-        doc.cards()[0]
-            .payload()
-            .get("price")
-            .unwrap()
-            .as_f64()
-            .unwrap(),
-        19.99
-    );
-
-    assert_eq!(doc.cards()[1].kind(), Some("products"));
-    assert_eq!(
-        doc.cards()[1]
-            .payload()
-            .get("name")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Gadget B"
-    );
-
-    // Last 2 are reviews
-    assert_eq!(doc.cards()[2].kind(), Some("reviews"));
-    assert_eq!(
-        doc.cards()[2]
-            .payload()
-            .get("product")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Widget A"
-    );
-    assert_eq!(
-        doc.cards()[2]
-            .payload()
-            .get("rating")
-            .unwrap()
-            .as_i64()
-            .unwrap(),
-        5
-    );
-
-    // Payload has 3 fields: title, author, date
-    assert_eq!(doc.main().payload().len(), 3);
-}
-
 /// Flow-sequence YAML (`[a, b]`) reaches the payload as an array — the block
 /// form is covered by `emit_tests.rs::round_trip_sequence`.
 #[test]
@@ -798,34 +981,6 @@ This is the memo body.";
     assert_eq!(items.len(), 2);
     assert_eq!(items[0].as_str().unwrap(), "ORG/SYMBOL");
     assert_eq!(items[1].as_str().unwrap(), "OTHER/SYMBOL");
-}
-
-#[test]
-fn test_quill_with_card_blocks() {
-    let markdown = "~~~card-yaml
-$quill: document
-$kind: main
-title: Test Document
-~~~
-
-Main body.
-
-~~~card-yaml
-$kind: sections
-name: Section 1
-~~~
-
-Section 1 body.";
-
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.quill_reference().name, "document");
-    assert_eq!(
-        doc.main().payload().get("title").unwrap().as_str().unwrap(),
-        "Test Document"
-    );
-    assert_eq!(doc.cards().len(), 1);
-    assert_eq!(doc.cards()[0].kind(), Some("sections"));
-    assert_eq!(doc.main().body_markdown(), "Main body.");
 }
 
 #[test]
@@ -1509,9 +1664,23 @@ fn test_unicode_in_body() {
 
 // YAML edge cases
 
+// ── Single-field YAML scalar types (table-driven) ────────────────────────────
+// `|` (literal) and `>` (folded) block scalars are exercised nowhere else in
+// the workspace — keep them as explicit rows here.
 #[test]
-fn test_yaml_multiline_string() {
-    let markdown = "~~~card-yaml
+fn single_field_yaml_scalar_types() {
+    enum Check {
+        StrEq(&'static str),
+        StrContains(&'static [&'static str]),
+        I64Eq(i64),
+        F64Eq(f64),
+        BoolEq(bool),
+    }
+
+    let cases: &[(&str, &str, &[(&str, Check)])] = &[
+        (
+            "literal block scalar (`|`)",
+            "~~~card-yaml
 $quill: test_quill
 $kind: main
 description: |
@@ -1520,22 +1689,15 @@ description: |
   with preserved newlines.
 ~~~
 
-Body.";
-    let doc = decompose(markdown).unwrap();
-    let desc = doc
-        .main()
-        .payload()
-        .get("description")
-        .unwrap()
-        .as_str()
-        .unwrap();
-    assert!(desc.contains("multiline string"));
-    assert!(desc.contains('\n'));
-}
-
-#[test]
-fn test_yaml_folded_string() {
-    let markdown = "~~~card-yaml
+Body.",
+            &[(
+                "description",
+                Check::StrContains(&["multiline string", "\n"]),
+            )],
+        ),
+        (
+            "folded block scalar (`>`)",
+            "~~~card-yaml
 $quill: test_quill
 $kind: main
 description: >
@@ -1544,49 +1706,67 @@ description: >
   a single line.
 ~~~
 
-Body.";
-    let doc = decompose(markdown).unwrap();
-    let desc = doc
-        .main()
-        .payload()
-        .get("description")
-        .unwrap()
-        .as_str()
-        .unwrap();
-    assert!(desc.contains("folded"));
-}
+Body.",
+            &[("description", Check::StrContains(&["folded"]))],
+        ),
+        (
+            "empty string",
+            "~~~card-yaml\n$quill: test_quill\n$kind: main\nempty: \"\"\n~~~\n\nBody.",
+            &[("empty", Check::StrEq(""))],
+        ),
+        (
+            "special characters in a quoted string",
+            "~~~card-yaml\n$quill: test_quill\n$kind: main\nspecial: \"colon: here, and [brackets]\"\n~~~\n\nBody.",
+            &[(
+                "special",
+                Check::StrEq("colon: here, and [brackets]"),
+            )],
+        ),
+        (
+            "int/float/bool scalars",
+            "~~~card-yaml
+$quill: test_quill
+$kind: main
+count: 42
+price: 19.99
+active: true
+items:
+  - first
+  - 100
+  - true
+~~~
 
-#[test]
-fn test_yaml_null_value() {
-    let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\noptional: null\n~~~\n\nBody.";
-    let doc = decompose(markdown).unwrap();
-    assert!(doc.main().payload().get("optional").unwrap().is_null());
-}
+Body.",
+            &[
+                ("count", Check::I64Eq(42)),
+                ("price", Check::F64Eq(19.99)),
+                ("active", Check::BoolEq(true)),
+            ],
+        ),
+    ];
 
-#[test]
-fn test_yaml_empty_string_value() {
-    let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\nempty: \"\"\n~~~\n\nBody.";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(
-        doc.main().payload().get("empty").unwrap().as_str().unwrap(),
-        ""
-    );
-}
-
-#[test]
-fn test_yaml_special_characters_in_string() {
-    let markdown =
-        "~~~card-yaml\n$quill: test_quill\n$kind: main\nspecial: \"colon: here, and [brackets]\"\n~~~\n\nBody.";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(
-        doc.main()
-            .payload()
-            .get("special")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "colon: here, and [brackets]"
-    );
+    for (label, markdown, fields) in cases {
+        let doc = decompose(markdown).unwrap_or_else(|e| panic!("{label}: parse failed: {e}"));
+        for (key, check) in *fields {
+            let v = doc
+                .main()
+                .payload()
+                .get(key)
+                .unwrap_or_else(|| panic!("{label}: missing field {key:?}"));
+            match check {
+                Check::StrEq(s) => assert_eq!(v.as_str().unwrap(), *s, "{label}: {key}"),
+                Check::StrContains(needles) => {
+                    let s = v.as_str().unwrap();
+                    for n in *needles {
+                        assert!(s.contains(n), "{label}: {key} missing {n:?} in {s:?}");
+                    }
+                }
+                Check::I64Eq(i) => assert_eq!(v.as_i64().unwrap(), *i, "{label}: {key}"),
+                Check::F64Eq(f) => assert_eq!(v.as_f64().unwrap(), *f, "{label}: {key}"),
+                Check::BoolEq(b) => assert_eq!(v.as_bool().unwrap(), *b, "{label}: {key}"),
+            }
+        }
+    }
 }
 
 #[test]
@@ -1617,28 +1797,6 @@ Body.";
 }
 
 // Card block edge cases
-
-#[test]
-fn test_card_consecutive_blocks() {
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-~~~
-
-~~~card-yaml
-$kind: a
-id: 1
-~~~
-
-~~~card-yaml
-$kind: a
-id: 2
-~~~";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(doc.cards().len(), 2);
-    assert_eq!(doc.cards()[0].kind(), Some("a"));
-    assert_eq!(doc.cards()[1].kind(), Some("a"));
-}
 
 #[test]
 fn test_card_with_body_containing_dashes() {
@@ -1782,39 +1940,6 @@ fn test_kind_name_validator() {
     }
 }
 
-#[test]
-fn test_scalar_types_survive_yaml_preprocessing() {
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-count: 42
-price: 19.99
-active: true
-items:
-  - first
-  - 100
-  - true
-~~~
-
-Body.";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(
-        doc.main().payload().get("count").unwrap().as_i64().unwrap(),
-        42
-    );
-    assert_eq!(
-        doc.main().payload().get("price").unwrap().as_f64().unwrap(),
-        19.99
-    );
-    assert!(doc
-        .main()
-        .payload()
-        .get("active")
-        .unwrap()
-        .as_bool()
-        .unwrap());
-}
-
 // Guillemet preprocessing
 
 #[test]
@@ -1864,108 +1989,6 @@ Body
             .unwrap(),
         "My Card"
     );
-}
-
-#[test]
-fn test_yaml_custom_tags_in_payload() {
-    let markdown = "~~~card-yaml
-$quill: test_quill
-$kind: main
-memo_from: !must_fill 2d lt example
-regular_field: normal value
-~~~
-
-Body content.";
-    let doc = decompose(markdown).unwrap();
-    assert_eq!(
-        doc.main()
-            .payload()
-            .get("memo_from")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "2d lt example"
-    );
-    assert_eq!(
-        doc.main()
-            .payload()
-            .get("regular_field")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "normal value"
-    );
-    assert_eq!(doc.main().body_markdown(), "Body content.");
-}
-
-/// A multi-card document (root + two composable cards, prose thematic break
-/// in the root body) exercising the shapes described in markdown-spec.md.
-#[test]
-fn test_spec_example() {
-    let markdown = "~~~card-yaml
-$quill: blog_post
-$kind: main
-title: My Document
-~~~
-
-Main document body.
-
-***
-
-More content after horizontal rule.
-
-~~~card-yaml
-$kind: section
-heading: Introduction
-~~~
-
-Introduction content.
-
-~~~card-yaml
-$kind: section
-heading: Conclusion
-~~~
-
-Conclusion content.
-";
-
-    let doc = decompose(markdown).unwrap();
-
-    assert_eq!(
-        doc.main().payload().get("title").unwrap().as_str().unwrap(),
-        "My Document"
-    );
-    assert_eq!(doc.quill_reference().name, "blog_post");
-
-    let body = doc.main().body_markdown();
-    assert!(body.contains("Main document body."));
-    // `***` (thematic break) has no content representation and is dropped by the
-    // projection; the surrounding paragraphs survive.
-    assert!(body.contains("More content after horizontal rule."));
-
-    assert_eq!(doc.cards().len(), 2);
-    assert_eq!(doc.cards()[0].kind(), Some("section"));
-    assert_eq!(
-        doc.cards()[0]
-            .payload()
-            .get("heading")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Introduction"
-    );
-    assert_eq!(doc.cards()[0].body_markdown(), "Introduction content.");
-    assert_eq!(doc.cards()[1].kind(), Some("section"));
-    assert_eq!(
-        doc.cards()[1]
-            .payload()
-            .get("heading")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Conclusion"
-    );
-    assert_eq!(doc.cards()[1].body_markdown(), "Conclusion content.");
 }
 
 // ── to_plate_json round-trip snapshot ─────────────────────────────────────────

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -94,16 +94,6 @@ fn test_document_store_field_rejects_dollar_prefixed_names() {
 // ── Document::store_field (happy path) ─────────────────────────────────────────
 
 #[test]
-fn test_document_store_field_inserts() {
-    let mut doc = make_doc();
-    doc.main_mut().store_field("author", qv("Alice")).unwrap();
-    assert_eq!(
-        doc.main().payload().get("author").unwrap().as_str(),
-        Some("Alice")
-    );
-}
-
-#[test]
 fn test_document_store_field_updates_existing() {
     let mut doc = make_doc();
     doc.main_mut().store_field("title", qv("New Title")).unwrap();
@@ -114,21 +104,6 @@ fn test_document_store_field_updates_existing() {
 }
 
 // ── Document::remove_field ───────────────────────────────────────────────────
-
-#[test]
-fn test_document_remove_field_existing() {
-    let mut doc = make_doc();
-    let removed = doc.main_mut().remove_field("title").unwrap();
-    assert_eq!(removed.unwrap().as_str(), Some("Hello"));
-    assert!(doc.main().payload().get("title").is_none());
-}
-
-#[test]
-fn test_document_remove_field_absent() {
-    let mut doc = make_doc();
-    let removed = doc.main_mut().remove_field("nonexistent").unwrap();
-    assert!(removed.is_none());
-}
 
 #[test]
 fn test_document_field_legacy_uppercase_accepted() {
@@ -149,15 +124,6 @@ fn test_document_field_legacy_uppercase_accepted() {
     }
 }
 
-#[test]
-fn test_document_remove_field_invalid_name_throws() {
-    let mut doc = make_doc();
-    match doc.main_mut().remove_field("Bad-Name") {
-        Err(EditError::InvalidFieldName(name)) => assert_eq!(name, "Bad-Name"),
-        other => panic!("expected InvalidFieldName, got {other:?}"),
-    }
-}
-
 // ── Document::set_quill_ref ──────────────────────────────────────────────────
 
 #[test]
@@ -166,15 +132,6 @@ fn test_document_set_quill_ref() {
     let new_ref = QuillReference::from_str("new_quill").unwrap();
     doc.set_quill_ref(new_ref);
     assert_eq!(doc.quill_reference().name, "new_quill");
-}
-
-// ── Document::replace_body ───────────────────────────────────────────────────
-
-#[test]
-fn test_document_replace_body() {
-    let mut doc = make_doc();
-    doc.main_mut().revise_body("New body content.").unwrap();
-    assert_eq!(doc.main().body_markdown(), "New body content.");
 }
 
 // ── Document::push_card ──────────────────────────────────────────────────────
@@ -257,45 +214,29 @@ fn test_document_card_mut_out_of_range() {
 // ── Document::move_card ──────────────────────────────────────────────────────
 
 #[test]
-fn test_move_card_no_op_same_index() {
-    let mut doc = make_doc_with_cards(); // note(0), summary(1)
-    let result = doc.move_card(0, 0);
-    assert_eq!(result, Ok(()));
-    assert_eq!(doc.cards()[0].kind(), Some("note"));
-    assert_eq!(doc.cards()[1].kind(), Some("summary"));
+fn test_move_card_reorders() {
+    // note(0), summary(1) before every move; `want` is the resulting order.
+    for (from, to, want) in [
+        (0, 0, ["note", "summary"]), // no-op, same index
+        (1, 0, ["summary", "note"]), // last to first
+        (0, 1, ["summary", "note"]), // first to last
+    ] {
+        let mut doc = make_doc_with_cards();
+        doc.move_card(from, to).unwrap();
+        assert_eq!(doc.cards()[0].kind(), Some(want[0]));
+        assert_eq!(doc.cards()[1].kind(), Some(want[1]));
+    }
 }
 
 #[test]
-fn test_move_card_last_to_first() {
-    let mut doc = make_doc_with_cards(); // note(0), summary(1)
-    doc.move_card(1, 0).unwrap();
-    assert_eq!(doc.cards()[0].kind(), Some("summary"));
-    assert_eq!(doc.cards()[1].kind(), Some("note"));
-}
-
-#[test]
-fn test_move_card_first_to_last() {
-    let mut doc = make_doc_with_cards(); // note(0), summary(1)
-    let last = doc.cards().len() - 1;
-    doc.move_card(0, last).unwrap();
-    assert_eq!(doc.cards()[0].kind(), Some("summary"));
-    assert_eq!(doc.cards()[last].kind(), Some("note"));
-}
-
-#[test]
-fn test_move_card_from_out_of_range() {
-    let mut doc = make_doc_with_cards(); // 2 cards
-    let len = doc.cards().len();
-    let result = doc.move_card(len, 0);
-    assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
-}
-
-#[test]
-fn test_move_card_to_out_of_range() {
-    let mut doc = make_doc_with_cards(); // 2 cards
-    let len = doc.cards().len();
-    let result = doc.move_card(0, len);
-    assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
+fn test_move_card_index_out_of_range() {
+    let len = make_doc_with_cards().cards().len(); // 2
+    for (from, to) in [(len, 0), (0, len)] {
+        // from out of range, then to out of range
+        let mut doc = make_doc_with_cards();
+        let result = doc.move_card(from, to);
+        assert_eq!(result, Err(EditError::IndexOutOfRange { index: len, len }));
+    }
 }
 
 // ── Document::set_card_kind ───────────────────────────────────────────────────

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -130,39 +130,31 @@ fn fixtures_round_trip() {
 // ── Value type unit tests ─────────────────────────────────────────────────────
 
 #[test]
-fn round_trip_booleans() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nflag_true: true\nflag_false: false\n~~~\n";
-    assert_round_trip("booleans", src);
-}
-
-#[test]
-fn round_trip_null() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nnull_field: null\n~~~\n";
-    assert_round_trip("null", src);
-}
-
-#[test]
-fn round_trip_nested_map() {
-    let src =
-        "~~~card-yaml\n$quill: q\n$kind: main\nsender:\n  name: Alice\n  city: Springfield\n~~~\n";
-    assert_round_trip("nested map", src);
-}
-
-#[test]
-fn round_trip_sequence() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\ntags:\n  - demo\n  - test\n~~~\n";
-    assert_round_trip("sequence", src);
-}
-
-#[test]
-fn round_trip_empty_sequence() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nempty: []\n~~~\n";
-    assert_round_trip("empty sequence", src);
-}
-
-#[test]
-fn round_trip_cards() {
-    let src = "\
+fn round_trip_value_types() {
+    let cases: &[(&str, &str)] = &[
+        (
+            "booleans",
+            "~~~card-yaml\n$quill: q\n$kind: main\nflag_true: true\nflag_false: false\n~~~\n",
+        ),
+        (
+            "null",
+            "~~~card-yaml\n$quill: q\n$kind: main\nnull_field: null\n~~~\n",
+        ),
+        (
+            "nested map",
+            "~~~card-yaml\n$quill: q\n$kind: main\nsender:\n  name: Alice\n  city: Springfield\n~~~\n",
+        ),
+        (
+            "sequence",
+            "~~~card-yaml\n$quill: q\n$kind: main\ntags:\n  - demo\n  - test\n~~~\n",
+        ),
+        (
+            "empty sequence",
+            "~~~card-yaml\n$quill: q\n$kind: main\nempty: []\n~~~\n",
+        ),
+        (
+            "cards",
+            "\
 ~~~card-yaml
 $quill: q
 $kind: main
@@ -177,13 +169,11 @@ heading: Chapter 1
 ~~~
 
 Card body here.
-";
-    assert_round_trip("cards", src);
-}
-
-#[test]
-fn round_trip_card_empty_body() {
-    let src = "\
+",
+        ),
+        (
+            "card with empty body",
+            "\
 ~~~card-yaml
 $quill: q
 $kind: main
@@ -194,22 +184,23 @@ title: Test
 $kind: empty_body_card
 title: No body
 ~~~
-";
-    assert_round_trip("card with empty body", src);
-}
+",
+        ),
+        // String containing backslash and quotes — must survive as a string.
+        (
+            "string with backslash",
+            "~~~card-yaml\n$quill: q\n$kind: main\npath: \"C:\\\\Users\\\\test\"\n~~~\n",
+        ),
+        // A string containing a literal newline.
+        (
+            "multiline string",
+            "~~~card-yaml\n$quill: q\n$kind: main\nbio: \"Line one\\nLine two\"\n~~~\n",
+        ),
+    ];
 
-#[test]
-fn round_trip_string_with_escapes() {
-    // String containing backslash and quotes — must survive as a string.
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\npath: \"C:\\\\Users\\\\test\"\n~~~\n";
-    assert_round_trip("string with backslash", src);
-}
-
-#[test]
-fn round_trip_multiline_string() {
-    // A string containing a literal newline.
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nbio: \"Line one\\nLine two\"\n~~~\n";
-    assert_round_trip("multiline string", src);
+    for (label, src) in cases {
+        assert_round_trip(label, src);
+    }
 }
 
 #[test]

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -14,69 +14,6 @@
 
 use crate::document::Document;
 
-// ── Category: YAML comments ───────────────────────────────────────────────────
-
-/// Top-level YAML comments survive a round-trip.
-#[test]
-fn top_level_comments_round_trip() {
-    let src =
-        "~~~card-yaml\n$quill: q\n$kind: main\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n~~~\n\nBody.\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-
-    assert!(
-        emitted.contains("# recipient's full name"),
-        "top-level YAML comment must survive round-trip\nGot:\n{}",
-        emitted
-    );
-
-    // Value remains intact.
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    assert_eq!(
-        doc2.main()
-            .payload()
-            .get("recipient")
-            .and_then(|v| v.as_str()),
-        Some("Jane"),
-    );
-
-    // Comment idempotent across repeated round-trips.
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
-
-/// Trailing inline comments on top-level fields round-trip inline.
-#[test]
-fn top_level_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\ntitle: My Document # this is a comment\n~~~\n\nBody.\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-
-    assert!(
-        emitted.contains("title: My Document # this is a comment"),
-        "trailing inline comment must round-trip on the same line\nGot:\n{}",
-        emitted
-    );
-    assert!(
-        !emitted.contains("My Document\n# this is a comment"),
-        "trailing inline comment must NOT degrade to own-line\nGot:\n{}",
-        emitted
-    );
-
-    // Value still intact.
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    assert_eq!(
-        doc2.main().payload().get("title").and_then(|v| v.as_str()),
-        Some("My Document"),
-    );
-
-    // Idempotent across repeated round-trips.
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
-
 // ── Category: Block scalars ───────────────────────────────────────────────────
 
 /// A block-scalar value (markdown) whose content contains `#` heading lines
@@ -298,93 +235,6 @@ fn nested_must_fill_on_mapping_is_rejected() {
     );
 }
 
-/// `!must_fill` on a bare key (no value) emits `key: !must_fill` and preserves null.
-#[test]
-fn fill_tag_bare_null_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nrecipient: !must_fill\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let fm = doc.main().payload();
-
-    assert!(fm.get("recipient").map(|v| v.is_null()).unwrap_or(false));
-    assert!(fm.is_fill("recipient"));
-
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("recipient: !must_fill\n"),
-        "bare `!must_fill` must round-trip as `key: !must_fill`\nGot:\n{}",
-        emitted
-    );
-}
-
-/// `!must_fill` on a top-level block sequence round-trips, preserving items and
-/// the fill marker.
-#[test]
-fn fill_tag_block_sequence_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nrecipient: !must_fill\n  - Dr. Who\n  - 1 TARDIS Lane\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let fm = doc.main().payload();
-
-    assert!(fm.is_fill("recipient"));
-    let arr = fm.get("recipient").and_then(|v| v.as_array()).unwrap();
-    assert_eq!(arr.len(), 2);
-    assert_eq!(arr[0].as_str(), Some("Dr. Who"));
-    assert_eq!(arr[1].as_str(), Some("1 TARDIS Lane"));
-
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("recipient: !must_fill\n"),
-        "`!must_fill` on sequence must emit `key: !must_fill` before the block\nGot:\n{}",
-        emitted
-    );
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    assert!(doc2.main().payload().is_fill("recipient"));
-    assert_eq!(doc2, doc, "full round-trip must be equal");
-}
-
-/// `!must_fill` on a flow sequence round-trips (normalised to block form).
-#[test]
-fn fill_tag_flow_sequence_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\ntags: !must_fill [a, b, c]\n~~~\n";
-    let doc = Document::parse(src).unwrap().document;
-    let fm = doc.main().payload();
-    assert!(fm.is_fill("tags"));
-    assert_eq!(
-        fm.get("tags").and_then(|v| v.as_array()).map(|a| a.len()),
-        Some(3)
-    );
-
-    let emitted = doc.to_markdown();
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    assert!(doc2.main().payload().is_fill("tags"));
-    assert_eq!(doc2, doc);
-}
-
-/// `!must_fill` on an empty sequence round-trips as `key: !must_fill []`.
-#[test]
-fn fill_tag_empty_sequence_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nitems: !must_fill []\n~~~\n";
-    let doc = Document::parse(src).unwrap().document;
-    let fm = doc.main().payload();
-    assert!(fm.is_fill("items"));
-    assert_eq!(
-        fm.get("items").and_then(|v| v.as_array()).map(|a| a.len()),
-        Some(0)
-    );
-
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("items: !must_fill []\n"),
-        "empty fill-sequence must round-trip as `key: !must_fill []`\nGot:\n{}",
-        emitted
-    );
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    assert_eq!(doc2, doc);
-}
-
 /// `!must_fill` on a top-level mapping is rejected at parse.
 #[test]
 fn fill_tag_mapping_rejected() {
@@ -397,7 +247,12 @@ fn fill_tag_mapping_rejected() {
     );
 }
 
-/// `!must_fill` on every supported scalar type round-trips with the correct type.
+/// `!must_fill` round-trips across every supported shape: each scalar type
+/// on a shared document (including the bare-null form, `key: !must_fill`
+/// with no value), and top-level sequences in block, flow, and empty form.
+/// Sequences get their own sibling table below — each needs its own document
+/// and a full-document equality check, which doesn't fit the shared-document
+/// loop the scalar types use.
 #[test]
 fn fill_tag_all_scalar_types_round_trip() {
     let src = concat!(
@@ -426,6 +281,14 @@ fn fill_tag_all_scalar_types_round_trip() {
     }
 
     let emitted = doc.to_markdown();
+    // Bare-null shape (`n`): emits `key: !must_fill` with no trailing value,
+    // same shape a standalone top-level bare-null field takes.
+    assert!(
+        emitted.contains("n: !must_fill\n"),
+        "bare `!must_fill` must round-trip as `key: !must_fill`\nGot:\n{}",
+        emitted
+    );
+
     let doc2 = Document::parse(&emitted).unwrap().document;
     for key in ["s", "i", "f", "b", "n"] {
         assert!(
@@ -433,6 +296,84 @@ fn fill_tag_all_scalar_types_round_trip() {
             "{} must remain fill-tagged after round-trip",
             key
         );
+    }
+
+    // Sequence shapes: block, flow (normalises to block on emit), and empty.
+    // Each needs its own document and a full-document equality check, so they
+    // get a sibling loop rather than a row in the scalar loop above.
+    struct SeqCase {
+        label: &'static str,
+        key: &'static str,
+        src: &'static str,
+        expected_items: &'static [&'static str],
+        emitted_contains: &'static str,
+    }
+
+    let seq_cases = [
+        SeqCase {
+            label: "block sequence",
+            key: "recipient",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nrecipient: !must_fill\n  - Dr. Who\n  - 1 TARDIS Lane\n~~~\n",
+            expected_items: &["Dr. Who", "1 TARDIS Lane"],
+            emitted_contains: "recipient: !must_fill\n",
+        },
+        SeqCase {
+            label: "flow sequence normalises to block form",
+            key: "tags",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\ntags: !must_fill [a, b, c]\n~~~\n",
+            expected_items: &["a", "b", "c"],
+            emitted_contains: "tags: !must_fill",
+        },
+        SeqCase {
+            label: "empty sequence",
+            key: "items",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nitems: !must_fill []\n~~~\n",
+            expected_items: &[],
+            emitted_contains: "items: !must_fill []\n",
+        },
+    ];
+
+    for case in seq_cases {
+        let doc = Document::parse(case.src).unwrap().document;
+        let fm = doc.main().payload();
+        assert!(
+            fm.is_fill(case.key),
+            "[{}] key must be fill-tagged",
+            case.label
+        );
+
+        let arr = fm.get(case.key).and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            arr.len(),
+            case.expected_items.len(),
+            "[{}] array length",
+            case.label
+        );
+        for (item, expected) in arr.iter().zip(case.expected_items) {
+            assert_eq!(
+                item.as_str(),
+                Some(*expected),
+                "[{}] array element",
+                case.label
+            );
+        }
+
+        let emitted = doc.to_markdown();
+        assert!(
+            emitted.contains(case.emitted_contains),
+            "[{}] must emit `{}`\nGot:\n{}",
+            case.label,
+            case.emitted_contains,
+            emitted
+        );
+
+        let doc2 = Document::parse(&emitted).unwrap().document;
+        assert!(
+            doc2.main().payload().is_fill(case.key),
+            "[{}] fill marker must survive round-trip",
+            case.label
+        );
+        assert_eq!(doc2, doc, "[{}] full round-trip must be equal", case.label);
     }
 }
 
@@ -492,162 +433,160 @@ fn quoting_normalises_to_canonical_form_with_type_fidelity() {
     assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
-// ── Category: Nested comments round-trip ─────────────────────────────────────
+// ── Category: Comment positions round-trip ───────────────────────────────────
 
-/// Comments inside nested sequences round-trip at the matching position.
+/// A comment placed at each of these structural positions in a card-yaml
+/// document survives a markdown round-trip: parse, emit, and confirm the
+/// comment (and any position-specific marker) lands where it should; then
+/// re-parse the emission and re-emit — a stable second round confirms the
+/// first is idempotent.
 #[test]
-fn nested_sequence_comments_round_trip() {
-    let src =
-        "~~~card-yaml\n$quill: q\n$kind: main\nitems:\n  # before-first\n  - a\n  # between\n  - b\n  # after-last\n~~~\n";
+fn comment_position_round_trips() {
+    struct Case {
+        label: &'static str,
+        src: &'static str,
+        /// Substrings that must appear in the first emission.
+        contains: &'static [&'static str],
+        /// Substrings that must NOT appear (guards against a comment
+        /// degrading to a different position, e.g. inline -> own-line).
+        not_contains: &'static [&'static str],
+        /// A field whose string value must remain intact after the
+        /// round-trip (guards against comment parsing corrupting the value).
+        value_check: Option<(&'static str, &'static str)>,
+        /// This case must not raise the nested-comments-dropped warning.
+        no_drop_warning: bool,
+    }
 
-    let out = Document::parse(src).unwrap();
-    assert!(
-        !out.warnings
-            .iter()
-            .any(|w| w.code.as_deref() == Some("parse::comments_in_nested_yaml_dropped")),
-        "no dropped-comment warning expected; nested comments are now preserved"
-    );
+    let cases = [
+        Case {
+            label: "top-level own-line comment",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\n# recipient's full name\nrecipient: Jane\nauthor: Alice\n~~~\n\nBody.\n",
+            contains: &["# recipient's full name"],
+            not_contains: &[],
+            value_check: Some(("recipient", "Jane")),
+            no_drop_warning: false,
+        },
+        Case {
+            label: "top-level trailing inline comment",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\ntitle: My Document # this is a comment\n~~~\n\nBody.\n",
+            contains: &["title: My Document # this is a comment"],
+            not_contains: &["My Document\n# this is a comment"],
+            value_check: Some(("title", "My Document")),
+            no_drop_warning: false,
+        },
+        Case {
+            label: "nested sequence comments (leading/between/trailing)",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nitems:\n  # before-first\n  - a\n  # between\n  - b\n  # after-last\n~~~\n",
+            contains: &["# before-first", "# between", "# after-last"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: true,
+        },
+        Case {
+            label: "nested mapping comments (leading/trailing)",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nouter:\n  # leading\n  inner: 1\n  # trailing\n~~~\n",
+            contains: &["# leading", "# trailing"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+        Case {
+            label: "nested sequence item trailing inline comment",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nitems:\n  - a # inline\n  - b\n~~~\n",
+            contains: &["- a # inline"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+        Case {
+            label: "nested mapping field trailing inline comment",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nouter:\n  inner: 1 # tail\n~~~\n",
+            contains: &["inner: 1 # tail"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+        Case {
+            label: "inline comment on a container key",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\nouter: # describes outer\n  inner: 1\n~~~\n",
+            contains: &["outer: # describes outer\n  inner: 1"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+        Case {
+            label: "own-line comment below $quill header (root payload)",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\n# main entry\ntitle: Hi\n~~~\n",
+            contains: &["~~~\n$quill: q\n$kind: main\n# main entry\n"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+        Case {
+            label: "own-line comment below $kind header (card payload)",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\n~~~card-yaml\n$kind: foo\n# the foo card\nx: 1\n~~~\n",
+            contains: &["~~~\n$kind: foo\n# the foo card\n"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+        Case {
+            label: "own-line comments flanking an inline comment",
+            src: "~~~card-yaml\n$quill: q\n$kind: main\n# header\ntitle: Hi # tail\n# footer\n~~~\n",
+            contains: &["# header\n", "title: Hi # tail\n", "# footer\n"],
+            not_contains: &[],
+            value_check: None,
+            no_drop_warning: false,
+        },
+    ];
 
-    let emitted = out.document.to_markdown();
-    assert!(
-        emitted.contains("# before-first"),
-        "leading nested comment must round-trip\nGot:\n{}",
-        emitted
-    );
-    assert!(
-        emitted.contains("# between"),
-        "between-items nested comment must round-trip\nGot:\n{}",
-        emitted
-    );
-    assert!(
-        emitted.contains("# after-last"),
-        "trailing nested comment must round-trip\nGot:\n{}",
-        emitted
-    );
+    for case in cases {
+        let out = Document::parse(case.src).unwrap();
+        if case.no_drop_warning {
+            assert!(
+                !out.warnings
+                    .iter()
+                    .any(|w| w.code.as_deref() == Some("parse::comments_in_nested_yaml_dropped")),
+                "[{}] no dropped-comment warning expected; nested comments are now preserved",
+                case.label
+            );
+        }
 
-    // Round-trip is idempotent across repeated parse/emit cycles.
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
+        let emitted = out.document.to_markdown();
+        for needle in case.contains {
+            assert!(
+                emitted.contains(needle),
+                "[{}] comment must survive round-trip at its position\nGot:\n{}",
+                case.label,
+                emitted
+            );
+        }
+        for needle in case.not_contains {
+            assert!(
+                !emitted.contains(needle),
+                "[{}] comment must not degrade to a different position\nGot:\n{}",
+                case.label,
+                emitted
+            );
+        }
 
-/// Comments inside nested mappings round-trip at the matching position.
-#[test]
-fn nested_mapping_comments_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nouter:\n  # leading\n  inner: 1\n  # trailing\n~~~\n";
+        let doc2 = Document::parse(&emitted).unwrap().document;
+        if let Some((field, expected)) = case.value_check {
+            assert_eq!(
+                doc2.main().payload().get(field).and_then(|v| v.as_str()),
+                Some(expected),
+                "[{}] value must remain intact after round-trip",
+                case.label
+            );
+        }
 
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("# leading"),
-        "leading nested mapping comment must round-trip\nGot:\n{}",
-        emitted
-    );
-    assert!(
-        emitted.contains("# trailing"),
-        "trailing nested mapping comment must round-trip\nGot:\n{}",
-        emitted
-    );
-
-    // Re-parse and idempotency.
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2);
-}
-
-/// Trailing inline comments on nested sequence items round-trip inline.
-#[test]
-fn nested_sequence_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nitems:\n  - a # inline\n  - b\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("- a # inline"),
-        "trailing inline comment on a sequence item must round-trip on the same line\nGot:\n{}",
-        emitted
-    );
-
-    // Idempotent across repeated round-trips.
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
-
-/// Trailing inline comments on nested mapping fields round-trip inline.
-#[test]
-fn nested_mapping_inline_comments_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nouter:\n  inner: 1 # tail\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("inner: 1 # tail"),
-        "trailing inline comment on a nested mapping field must round-trip\nGot:\n{}",
-        emitted
-    );
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
-
-/// Inline comment on a container key (`outer: # tail`) lands on the key
-/// line, before the indented children.
-#[test]
-fn inline_on_container_key_round_trips() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\nouter: # describes outer\n  inner: 1\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("outer: # describes outer\n  inner: 1"),
-        "inline comment on a container key must land on the key line\nGot:\n{}",
-        emitted
-    );
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
-
-/// An own-line comment in the root payload — directly below the `$quill`
-/// metadata header — round-trips at its source position.
-#[test]
-fn root_payload_comment_round_trips() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\n# main entry\ntitle: Hi\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.starts_with("~~~\n$quill: q\n$kind: main\n# main entry\n"),
-        "own-line comment below the `$quill` header must round-trip\nGot:\n{}",
-        emitted
-    );
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
-}
-
-/// An own-line comment in a card payload — directly below the `$kind`
-/// metadata header — round-trips at its source position.
-#[test]
-fn card_payload_comment_round_trips() {
-    let src =
-        "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n\n~~~card-yaml\n$kind: foo\n# the foo card\nx: 1\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-    assert!(
-        emitted.contains("~~~\n$kind: foo\n# the foo card\n"),
-        "own-line comment below the `$kind` header must round-trip\nGot:\n{}",
-        emitted
-    );
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
+        let emitted2 = doc2.to_markdown();
+        assert_eq!(
+            emitted, emitted2,
+            "[{}] round-trip must be idempotent",
+            case.label
+        );
+    }
 }
 
 /// Inline comment with `!must_fill` round-trips with the tag intact.
@@ -759,23 +698,6 @@ fn inline_on_empty_mapping_degrades_to_own_line() {
         "inline trailer for an omitted host must degrade to own-line\nGot:\n{}",
         emitted
     );
-}
-
-/// Mixed: own-line and inline comments referencing the same field.
-#[test]
-fn own_line_then_inline_round_trip() {
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\n# header\ntitle: Hi # tail\n# footer\n~~~\n";
-
-    let doc = Document::parse(src).unwrap().document;
-    let emitted = doc.to_markdown();
-
-    assert!(emitted.contains("# header\n"));
-    assert!(emitted.contains("title: Hi # tail\n"));
-    assert!(emitted.contains("# footer\n"));
-
-    let doc2 = Document::parse(&emitted).unwrap().document;
-    let emitted2 = doc2.to_markdown();
-    assert_eq!(emitted, emitted2, "round-trip must be idempotent");
 }
 
 /// A `!must_fill` marker on the *first* key of a sequence-item mapping

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -299,8 +299,6 @@ fn fill_tag_all_scalar_types_round_trip() {
     }
 
     // Sequence shapes: block, flow (normalises to block on emit), and empty.
-    // Each needs its own document and a full-document equality check, so they
-    // get a sibling loop rather than a row in the scalar loop above.
     struct SeqCase {
         label: &'static str,
         key: &'static str,

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2890,42 +2890,84 @@ main:
 }
 
 #[test]
-fn example_integer_type_rejects_float_example() {
-    // type: integer with example: 20.04 fails — float is not an integer.
-    let yaml = example_default_yaml("    year:\n      type: integer\n      example: 20.04\n");
-    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
-    assert!(
-        errors.iter().any(
-            |d| d.code.as_deref() == Some("quill::example_type_mismatch")
-                && d.message.contains("year")
-                && d.message.contains("integer")
-                && d.message.contains("float")
-        ),
-        "expected example_type_mismatch error for integer/float, got: {:?}",
-        errors
-    );
-}
+fn example_default_type_mismatch_cases() {
+    // A field whose declared `type` doesn't match its `example`/`default`
+    // value fails with a targeted diagnostic naming the field, the declared
+    // type, and the value's actual type — across every scalar/compound type
+    // and both the `example` and `default` slots.
+    struct Case {
+        field_yaml: &'static str,
+        code: &'static str,
+        message_contains: &'static [&'static str],
+        hint_contains: &'static [&'static str],
+    }
 
-#[test]
-fn example_string_type_rejects_unquoted_decimal_example() {
-    // The canonical bug: type: string with example: 20.04 — YAML parses the
-    // bare token as a float, and the LLM would copy it back unquoted.
-    let yaml =
-        example_default_yaml("    min_os_version:\n      type: string\n      example: 20.04\n");
-    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
-    let diag = errors
-        .iter()
-        .find(|d| d.code.as_deref() == Some("quill::example_type_mismatch"))
-        .expect("expected example_type_mismatch error");
-    assert!(diag.message.contains("min_os_version"));
-    assert!(diag.message.contains("string"));
-    assert!(diag.message.contains("float"));
-    let hint = diag.hint.as_deref().unwrap_or("");
-    assert!(
-        hint.contains("Quote") && hint.contains("\"20.04\""),
-        "hint should suggest quoting, got: {}",
-        hint
-    );
+    let cases = [
+        Case {
+            // type: integer with example: 20.04 fails — float is not an integer.
+            field_yaml: "    year:\n      type: integer\n      example: 20.04\n",
+            code: "quill::example_type_mismatch",
+            message_contains: &["year", "integer", "float"],
+            hint_contains: &[],
+        },
+        Case {
+            // The canonical bug: type: string with example: 20.04 — YAML parses
+            // the bare token as a float, and the LLM would copy it back unquoted.
+            field_yaml: "    min_os_version:\n      type: string\n      example: 20.04\n",
+            code: "quill::example_type_mismatch",
+            message_contains: &["min_os_version", "string", "float"],
+            hint_contains: &["Quote", "\"20.04\""],
+        },
+        Case {
+            // type: boolean with example: "true" — the LLM would emit it as a string.
+            field_yaml: "    flag:\n      type: boolean\n      example: \"true\"\n",
+            code: "quill::example_type_mismatch",
+            message_contains: &["flag", "boolean", "string"],
+            hint_contains: &[],
+        },
+        Case {
+            // type: array with example: foo — a sequence is required.
+            field_yaml: "    tags:\n      type: array\n      items:\n        type: string\n      example: foo\n",
+            code: "quill::example_type_mismatch",
+            message_contains: &["tags", "array", "string"],
+            hint_contains: &[],
+        },
+        Case {
+            // Defaults are validated the same way as examples.
+            field_yaml: "    version:\n      type: string\n      default: 20.04\n",
+            code: "quill::default_type_mismatch",
+            message_contains: &["version", "string", "float"],
+            hint_contains: &[],
+        },
+    ];
+
+    for case in cases {
+        let yaml = example_default_yaml(case.field_yaml);
+        let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+        let diag = errors
+            .iter()
+            .find(|d| d.code.as_deref() == Some(case.code))
+            .unwrap_or_else(|| panic!("expected {} error, got: {:?}", case.code, errors));
+        for needle in case.message_contains {
+            assert!(
+                diag.message.contains(needle),
+                "expected message to contain {:?}, got: {}",
+                needle,
+                diag.message
+            );
+        }
+        if !case.hint_contains.is_empty() {
+            let hint = diag.hint.as_deref().unwrap_or("");
+            for needle in case.hint_contains {
+                assert!(
+                    hint.contains(needle),
+                    "expected hint to contain {:?}, got: {}",
+                    needle,
+                    hint
+                );
+            }
+        }
+    }
 }
 
 #[test]
@@ -2934,42 +2976,6 @@ fn example_string_type_accepts_quoted_decimal_example() {
     let yaml =
         example_default_yaml("    min_os_version:\n      type: string\n      example: \"20.04\"\n");
     QuillConfig::from_yaml(&yaml).expect("quoted string example should load");
-}
-
-#[test]
-fn example_boolean_type_rejects_string_example() {
-    // type: boolean with example: "true" — the LLM would emit it as a string.
-    let yaml = example_default_yaml("    flag:\n      type: boolean\n      example: \"true\"\n");
-    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
-    assert!(
-        errors.iter().any(
-            |d| d.code.as_deref() == Some("quill::example_type_mismatch")
-                && d.message.contains("flag")
-                && d.message.contains("boolean")
-                && d.message.contains("string")
-        ),
-        "expected example_type_mismatch error for boolean/string, got: {:?}",
-        errors
-    );
-}
-
-#[test]
-fn example_array_type_rejects_string_example() {
-    // type: array with example: foo — a sequence is required.
-    let yaml = example_default_yaml(
-        "    tags:\n      type: array\n      items:\n        type: string\n      example: foo\n",
-    );
-    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
-    assert!(
-        errors.iter().any(
-            |d| d.code.as_deref() == Some("quill::example_type_mismatch")
-                && d.message.contains("tags")
-                && d.message.contains("array")
-                && d.message.contains("string")
-        ),
-        "expected example_type_mismatch error for array/string, got: {:?}",
-        errors
-    );
 }
 
 #[test]
@@ -2993,20 +2999,6 @@ fn example_in_enum_loads_successfully() {
         "    color:\n      type: string\n      enum: [a, b]\n      example: a\n",
     );
     QuillConfig::from_yaml(&yaml).expect("enum-member example should load");
-}
-
-#[test]
-fn default_with_type_mismatch_is_rejected() {
-    // Defaults are validated the same way as examples.
-    let yaml = example_default_yaml("    version:\n      type: string\n      default: 20.04\n");
-    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
-    let diag = errors
-        .iter()
-        .find(|d| d.code.as_deref() == Some("quill::default_type_mismatch"))
-        .expect("expected default_type_mismatch error");
-    assert!(diag.message.contains("version"));
-    assert!(diag.message.contains("string"));
-    assert!(diag.message.contains("float"));
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -767,43 +767,30 @@ fields:
 }
 
 #[test]
-fn test_quill_config_rejects_root_level_fields() {
-    let yaml = r#"
-quill:
-  name: root_fields_test
-  version: "1.0"
-  backend: typst
-  description: Root fields must not be used
+fn test_quill_config_rejects_non_snake_case_identifiers() {
+    // Each slot where a bare identifier appears — quill name, card-kind name,
+    // main field key, card field key — must reject non-snake_case input and
+    // name the offending identifier in the error.
+    struct Case {
+        yaml: &'static str,
+        bad_identifier: &'static str,
+        extra_contains: &'static str,
+    }
 
-fields:
-  title:
-    type: string
-"#;
-    let result = QuillConfig::from_yaml(yaml);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("main.fields"));
-}
-
-#[test]
-fn test_quill_config_rejects_non_snake_case_quill_name() {
-    let yaml = r#"
+    let cases = [
+        Case {
+            yaml: r#"
 quill:
   name: BadQuill
   version: "1.0"
   backend: typst
   description: Bad quill name
-"#;
-
-    let result = QuillConfig::from_yaml(yaml);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains("BadQuill"));
-    assert!(err.contains("snake_case"));
-}
-
-#[test]
-fn test_quill_config_rejects_non_snake_case_card_name() {
-    let yaml = r#"
+"#,
+            bad_identifier: "BadQuill",
+            extra_contains: "snake_case",
+        },
+        Case {
+            yaml: r#"
 quill:
   name: good_quill
   version: "1.0"
@@ -815,13 +802,62 @@ card_kinds:
     fields:
       title:
         type: string
-"#;
+"#,
+            bad_identifier: "BadCard",
+            extra_contains: "[a-z_][a-z0-9_]*",
+        },
+        Case {
+            yaml: r#"
+quill:
+  name: bad_field_key
+  version: "1.0"
+  backend: typst
+  description: Bad main field key
 
-    let result = QuillConfig::from_yaml(yaml);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains("BadCard"));
-    assert!(err.contains("[a-z_][a-z0-9_]*"));
+main:
+  fields:
+    BadField:
+      type: string
+"#,
+            bad_identifier: "BadField",
+            extra_contains: "snake_case",
+        },
+        Case {
+            yaml: r#"
+quill:
+  name: bad_card_field_key
+  version: "1.0"
+  backend: typst
+  description: Bad card field key
+
+card_kinds:
+  profile:
+    fields:
+      DisplayName:
+        type: string
+"#,
+            bad_identifier: "DisplayName",
+            extra_contains: "snake_case",
+        },
+    ];
+
+    for case in cases {
+        let result = QuillConfig::from_yaml(case.yaml);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains(case.bad_identifier),
+            "expected error to contain {:?}, got: {}",
+            case.bad_identifier,
+            err
+        );
+        assert!(
+            err.contains(case.extra_contains),
+            "expected error to contain {:?}, got: {}",
+            case.extra_contains,
+            err
+        );
+    }
 }
 
 #[test]
@@ -842,51 +878,6 @@ card_kinds:
 
     let result = QuillConfig::from_yaml(yaml);
     assert!(result.is_ok());
-}
-
-#[test]
-fn test_quill_config_rejects_non_snake_case_main_field_keys() {
-    let yaml = r#"
-quill:
-  name: bad_field_key
-  version: "1.0"
-  backend: typst
-  description: Bad main field key
-
-main:
-  fields:
-    BadField:
-      type: string
-"#;
-
-    let result = QuillConfig::from_yaml(yaml);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains("BadField"));
-    assert!(err.contains("snake_case"));
-}
-
-#[test]
-fn test_quill_config_rejects_non_snake_case_card_field_keys() {
-    let yaml = r#"
-quill:
-  name: bad_card_field_key
-  version: "1.0"
-  backend: typst
-  description: Bad card field key
-
-card_kinds:
-  profile:
-    fields:
-      DisplayName:
-        type: string
-"#;
-
-    let result = QuillConfig::from_yaml(yaml);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains("DisplayName"));
-    assert!(err.contains("snake_case"));
 }
 
 #[test]


### PR DESCRIPTION
Consolidates near-identical test functions into table-driven tests
in pdfform::form, typst::overlay::span_scan, content::normalize,
core emit_tests, and core ambiguous_strings_tests. No coverage change.