### PR TITLE
Open the block vocabulary; `Loss` describes fidelity, it does not gate export

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -388,8 +388,35 @@ impl<'a> Emit<'a> {
                 self.emit_quote(i..j, depth);
                 Some(j)
             }
+            // Open set: a container this build does not know is **transparent** —
+            // its run lowers at the next depth with no wrapper markup, so the
+            // blocks inside it render where they would without it. Consuming the
+            // whole run here (rather than falling through to the leaf path) keeps
+            // its lines grouped as one block instead of splitting them.
+            Some(key @ Container::Unknown { .. }) => {
+                let j = self.same_container_run_end(range.clone(), depth, &key, i);
+                self.emit_block_level(i..j, depth + 1);
+                Some(j)
+            }
             _ => None,
         }
+    }
+
+    /// End of the run starting at `i` whose container at `depth` equals `key` —
+    /// the whole-container-equality twin of [`Self::list_run_end`] (which matches
+    /// a list's shape, not an item) for containers with no shape of their own.
+    fn same_container_run_end(
+        &self,
+        range: Range<usize>,
+        depth: usize,
+        key: &Container,
+        i: usize,
+    ) -> usize {
+        let mut j = i + 1;
+        while j < range.end && self.rt.lines[j].containers.get(depth) == Some(key) {
+            j += 1;
+        }
+        j
     }
 
     /// End of the leaf segment starting at `i` at `depth`: `i` plus every
@@ -593,7 +620,10 @@ impl<'a> Emit<'a> {
                 let g0 = self.out.len();
                 (g0, self.emit_inline(lo, hi))
             }
-            LineKind::Island | LineKind::Para => {
+            // An unknown block role lowers as a paragraph — its inline content
+            // renders, its role is lost to the projection (it round-trips
+            // through storage).
+            LineKind::Island | LineKind::Para | LineKind::Unknown { .. } => {
                 let g0 = self.out.len();
                 (g0, self.emit_inline(lo, hi))
             }
@@ -1494,6 +1524,53 @@ mod tests {
         assert_eq!(out, "#strong[ab#emph[cd]]#emph[ef]\n\n");
         // Bracket-balanced regardless.
         assert_eq!(out.matches('[').count(), out.matches(']').count());
+    }
+
+    /// Issue #1054: the open block vocabulary lowers like prose — an unknown
+    /// line kind as a paragraph, an unknown container transparently (its run
+    /// lowers at the enclosing level, one block, no wrapper markup). A build
+    /// that predates a construct renders it plainly instead of failing.
+    #[test]
+    fn unknown_block_vocabulary_lowers_as_prose() {
+        use quillmark_content::model::Line;
+        let indent = || Container::Unknown {
+            tag: "indent".to_string(),
+            attrs: serde_json::Value::Null,
+        };
+        let mut rt = Content {
+            text: "heads up\nsecond".to_string(),
+            lines: vec![
+                Line {
+                    kind: LineKind::Unknown {
+                        tag: "callout".to_string(),
+                        attrs: serde_json::json!({"variant": "warn"}),
+                    },
+                    containers: vec![indent()],
+                    continues: false,
+                },
+                Line {
+                    kind: LineKind::Para,
+                    containers: vec![indent()],
+                    continues: true,
+                },
+            ],
+            marks: vec![],
+            islands: vec![],
+        };
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        // One block (the `continues` join is a hard break), no wrapper.
+        assert_eq!(
+            emit_content(&rt).unwrap().markup,
+            "heads up#linebreak()second\n\n"
+        );
+        // Inside a known container the known wrapper still renders.
+        rt.lines[0].containers.insert(0, Container::Quote);
+        rt.lines[1].containers.insert(0, Container::Quote);
+        assert_eq!(
+            emit_content(&rt).unwrap().markup,
+            "#quote(block: true)[\nheads up#linebreak()second\n\n]\n\n"
+        );
     }
 
     /// Build a single-paragraph content over `text` with hand-placed `marks`

--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -188,8 +188,18 @@ void mainCardAddrIsCardAddr;
 // `x.type === 'table'` check cannot (the residual `{ type: string; … }` arm
 // stays live). Each `if` body reads a payload reachable only after narrowing, so
 // a guard that stops narrowing fails `npm run typecheck`. `ContentIsland`,
-// `TableProps`, `ImageProps`, and `ContentMark` are the types imported above.
-import { isTableIsland, isImageIsland, isLinkMark, isAnchorMark } from '../../../pkg/runtime/runtime.js';
+// `TableProps`, `ImageProps`, `ContentMark`, `ContentLine`, and
+// `ContentContainer` are the types imported above. (#1054 opened the block
+// vocabulary — `kind` and `container` — on the same terms.)
+import {
+	isTableIsland,
+	isImageIsland,
+	isLinkMark,
+	isAnchorMark,
+	isHeadingLine,
+	isCodeLine,
+	isListItemContainer
+} from '../../../pkg/runtime/runtime.js';
 
 declare const guardIsland: ContentIsland;
 if (isTableIsland(guardIsland)) {
@@ -209,4 +219,20 @@ if (isLinkMark(guardMark)) {
 if (isAnchorMark(guardMark)) {
 	const id: string = guardMark.id;
 	void id;
+}
+
+declare const guardLine: ContentLine;
+if (isHeadingLine(guardLine)) {
+	const level: number = guardLine.level;
+	void level;
+}
+if (isCodeLine(guardLine)) {
+	const lang: string | undefined = guardLine.lang;
+	void lang;
+}
+
+declare const guardContainer: ContentContainer;
+if (isListItemContainer(guardContainer)) {
+	const ordinal: number = guardContainer.ordinal;
+	void ordinal;
 }

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -122,15 +122,24 @@ export interface QuillmarkError extends Error {
 export declare function isQuillmarkError(e: unknown): e is QuillmarkError;
 
 // ── Open-set discriminant guards ────────────────────────────────────────────
-// `ContentIsland.type` / `ContentMark.type` are open sets — each union has a
-// residual `{ type: string; … }` arm, so a bare discriminant check never narrows
-// the payload (TS keeps the residual arm live, since a `string` can equal the
-// literal). These guards are the checked narrowing path for the pinned arms; an
-// unrecognized `type` fails every guard and keeps its opaque payload. Only the
-// payload-carrying arms get a guard — the bare marks
-// (`strong`/`emph`/`underline`/`strike`/`code`) narrow to nothing.
+// `ContentIsland.type`, `ContentMark.type`, `ContentLine.kind`, and
+// `ContentContainer.container` are open sets — each union has a residual
+// `{ …: string; … }` arm, so a bare discriminant check never narrows the payload
+// (TS keeps the residual arm live, since a `string` can equal the literal).
+// These guards are the checked narrowing path for the pinned arms; an
+// unrecognized discriminant fails every guard and keeps its opaque payload. Only
+// the payload-carrying arms get a guard — the bare marks
+// (`strong`/`emph`/`underline`/`strike`/`code`), the payload-free lines
+// (`para`/`island`/`rule`), and `quote` narrow to nothing.
 
-import type { ContentIsland, TableProps, ImageProps, ContentMark } from '../core/wasm.js';
+import type {
+	ContentIsland,
+	TableProps,
+	ImageProps,
+	ContentMark,
+	ContentLine,
+	ContentContainer
+} from '../core/wasm.js';
 
 /** Narrow a {@link ContentIsland} to the pinned `table` arm (`props: TableProps`). */
 export declare function isTableIsland(
@@ -151,6 +160,26 @@ export declare function isLinkMark(
 export declare function isAnchorMark(
 	mark: ContentMark
 ): mark is ContentMark & { type: 'anchor'; id: string };
+
+/** Narrow a {@link ContentLine} to the `heading` arm (carries `level`). */
+export declare function isHeadingLine(
+	line: ContentLine
+): line is ContentLine & { kind: 'heading'; level: number };
+
+/** Narrow a {@link ContentLine} to the `code` arm (carries `lang`). */
+export declare function isCodeLine(
+	line: ContentLine
+): line is ContentLine & { kind: 'code'; lang?: string };
+
+/** Narrow a {@link ContentContainer} to the `list_item` arm (carries its shape). */
+export declare function isListItemContainer(
+	container: ContentContainer
+): container is ContentContainer & {
+	container: 'list_item';
+	ordered: boolean;
+	start: number;
+	ordinal: number;
+};
 
 // ── Canonical render-side types ─────────────────────────────────────────────
 // These are the BACKEND-NEUTRAL render contract of the plural-backend API. They

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -99,15 +99,19 @@ export function isQuillmarkError(e) {
 }
 
 // ── Open-set discriminant guards ────────────────────────────────────────────
-// `ContentIsland.type` and `ContentMark.type` are OPEN sets: each union carries
-// a residual `{ type: string; … }` arm, so a bare `x.type === 'table'` check
-// never narrows the payload — TS keeps the residual arm live (a `string` can be
-// `'table'`), leaving `props` / the mark payload opaque at every consumer. These
+// `ContentIsland.type`, `ContentMark.type`, `ContentLine.kind`, and
+// `ContentContainer.container` are OPEN sets: each union carries a residual
+// `{ …: string; … }` arm, so a bare `x.type === 'table'` check never narrows the
+// payload — TS keeps the residual arm live (a `string` can be `'table'`),
+// leaving `props` / the mark payload / `level` opaque at every consumer. These
 // are the checked narrowing path: on the true branch the payload's pinned shape
 // is asserted. Only the payload-carrying arms get a guard — an island always
-// carries `props`, a `link` mark carries `url`, an `anchor` mark carries `id`;
-// the bare marks (`strong`/`emph`/`underline`/`strike`/`code`) narrow to
-// nothing. An unrecognized `type` fails every guard and keeps its opaque payload.
+// carries `props`, a `link` mark carries `url`, an `anchor` mark carries `id`, a
+// `heading` line carries `level` and a `code` line `lang`, a `list_item`
+// container its shape; the payload-free arms (`strong`/`emph`/`underline`/
+// `strike`/`code` marks, `para`/`island`/`rule` lines, `quote`) narrow to
+// nothing. An unrecognized discriminant fails every guard and keeps its opaque
+// `attrs`/`props`.
 
 /**
  * @param {import('../core/wasm.js').ContentIsland} island
@@ -139,6 +143,30 @@ export function isLinkMark(mark) {
  */
 export function isAnchorMark(mark) {
 	return mark.type === 'anchor';
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentLine} line
+ * @returns {line is import('../core/wasm.js').ContentLine & { kind: 'heading'; level: number }}
+ */
+export function isHeadingLine(line) {
+	return line.kind === 'heading';
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentLine} line
+ * @returns {line is import('../core/wasm.js').ContentLine & { kind: 'code'; lang?: string }}
+ */
+export function isCodeLine(line) {
+	return line.kind === 'code';
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentContainer} container
+ * @returns {container is import('../core/wasm.js').ContentContainer & { container: 'list_item'; ordered: boolean; start: number; ordinal: number }}
+ */
+export function isListItemContainer(container) {
+	return container.container === 'list_item';
 }
 
 // Backend builds are NEVER statically imported here — that would pull a

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -209,7 +209,11 @@ export interface Content {
     islands: ContentIsland[];
 }
 
-/** One `\n`-separated segment of `Content.text`, in order. */
+/** One `\n`-separated segment of `Content.text`, in order. `kind` is an open set
+ * (as on `ContentIsland` and `ContentMark`): a role this build does not know
+ * round-trips with opaque `attrs` and renders as a paragraph, so a document
+ * carrying a future block construct still opens. The open arm blocks discriminant
+ * narrowing, so read `level`/`lang` behind a check of the arm you want. */
 export type ContentLine = {
     containers: ContentContainer[];
     /** A within-block hard line break rather than a new block. Omitted (false) in the common case. */
@@ -220,12 +224,16 @@ export type ContentLine = {
     | { kind: "code"; lang?: string }
     | { kind: "island" }
     | { kind: "rule" }
+    | { kind: string; attrs: unknown }
 );
 
-/** An ancestor block a line nests inside, outermost first. */
+/** An ancestor block a line nests inside, outermost first. Open like
+ * `ContentLine.kind`: an unrecognized container round-trips with opaque `attrs`
+ * and renders transparently (its lines sit at the enclosing level). */
 export type ContentContainer =
     | { container: "list_item"; ordered: boolean; start: number; ordinal: number }
-    | { container: "quote" };
+    | { container: "quote" }
+    | { container: string; attrs: unknown };
 
 /** A mark over char range `[start, end)` into `Content.text`. The open `type`
  * arm blocks discriminant narrowing (as on `ContentIsland`), so read a
@@ -352,6 +360,7 @@ export type LineOp =
           | { kind: "para" | "island" | "rule" }
           | { kind: "heading"; level: number }
           | { kind: "code"; lang?: string }
+          | { kind: string; attrs: unknown }
       ))
     | { op: "setContainers"; line: number; containers: ContentContainer[] }
     | { op: "setContinues"; line: number; continues: boolean };

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -1,10 +1,15 @@
-//! Markdown export: content → markdown, per island loss class.
+//! Markdown export: content → markdown, per island type.
 //!
-//! The projection back to markdown. Marks become syntax; islands are emitted per
-//! their [`Loss`] class; identity ([`MarkKind::Anchor`]) marks are **omitted** —
-//! they survive across edits via diff-rebase, not the projection (issue #831
-//! § Codecs). Anchors carry no markdown encoding, so dropping them here is by
-//! design, not loss.
+//! The projection back to markdown. Marks become syntax; islands are emitted
+//! per their type ([`Loss`](crate::model::Loss) describes fidelity, it does not
+//! gate the emit — see [`to_markdown`]); identity ([`MarkKind::Anchor`]) marks
+//! are **omitted** — they survive across edits via diff-rebase, not the
+//! projection (issue #831 § Codecs). Anchors carry no markdown encoding, so
+//! dropping them here is by design, not loss.
+//!
+//! The block vocabulary is open (issue #1054): a [`LineKind::Unknown`] projects
+//! as a paragraph and a [`Container::Unknown`] transparently, the block-axis
+//! twin of an unknown mark contributing no delimiters.
 //!
 //! The contract this crate pins is the **content fixed point**: for a content `rt`
 //! obtained from [`crate::import::from_markdown`],
@@ -30,8 +35,17 @@
 use crate::island::KnownIslandType;
 use crate::model::{Container, Island, LineKind, MarkKind, Content, ISLAND_SLOT};
 
-/// Render a content to markdown. Lossless/degraded islands emit their markdown;
-/// unrepresentable islands emit a placeholder comment.
+/// Render a content to markdown. An island projects by **type**: a type this
+/// build knows emits its markdown, any other a placeholder comment.
+///
+/// [`Loss`](crate::model::Loss) does not gate the emit and is not read here. It
+/// *describes* the projection's fidelity for a consumer to surface (issue
+/// #1043); the type is what decides whether a projection exists at all. Keeping
+/// the two apart is what makes a known type stamped `Unrepresentable` by a
+/// future writer's unrecognized loss class (`serial::loss_from_str` degrades to
+/// the safe end) still emit its table rather than swallow it behind a
+/// placeholder — the conservative default describes the value, it does not
+/// suppress it.
 pub fn to_markdown(rt: &Content) -> String {
     // Per-line char ranges, so global marks can be clipped to a line.
     let segments = line_segments(rt);
@@ -222,6 +236,11 @@ fn emit_container(
             // one quote on re-import.
             prefix_quote(&inner, out);
         }
+        // Open set: a container this build does not know has no markdown syntax
+        // to prefix with, so it projects transparently — its blocks land at the
+        // enclosing level. The container survives via storage, not the
+        // projection, exactly as an unknown island's props do.
+        Container::Unknown { .. } => out.push_str(&inner),
     }
 }
 
@@ -309,7 +328,9 @@ fn emit_leaf_block(ctx: &Ctx, range: std::ops::Range<usize>, out: &mut String) {
             }
             out.push_str(&inline);
         }
-        LineKind::Para => {
+        // An unknown block role projects as a paragraph — the role is lost to
+        // markdown (it round-trips through storage), the text is not.
+        LineKind::Para | LineKind::Unknown { .. } => {
             // Join continuation lines with a backslash hard break.
             let parts: Vec<String> = range.map(|i| render_inline(ctx, i, true)).collect();
             out.push_str(&parts.join("\\\n"));
@@ -965,6 +986,50 @@ mod tests {
         let rt2 = from_markdown(&md).unwrap();
         assert_eq!(rt2.text, rt.text);
         assert_eq!(rt2.islands.len(), 1);
+    }
+
+    /// Issue #1054: an unknown block role projects as a paragraph and an unknown
+    /// container projects transparently — the older reader renders a future
+    /// construct as plain prose instead of refusing it. Text and marks survive;
+    /// only the role/container is lost, and only to *markdown* (both round-trip
+    /// through storage).
+    #[test]
+    fn unknown_block_vocabulary_projects_as_prose() {
+        let mut rt = Content {
+            text: "heads up\nstill inside".into(),
+            lines: vec![
+                Line {
+                    kind: LineKind::Unknown {
+                        tag: "callout".into(),
+                        attrs: serde_json::json!({"variant": "warn"}),
+                    },
+                    containers: vec![Container::Unknown {
+                        tag: "indent".into(),
+                        attrs: serde_json::Value::Null,
+                    }],
+                    continues: false,
+                },
+                Line {
+                    kind: LineKind::Para,
+                    containers: vec![Container::Unknown {
+                        tag: "indent".into(),
+                        attrs: serde_json::Value::Null,
+                    }],
+                    continues: false,
+                },
+            ],
+            marks: vec![Mark { start: 0, end: 5, kind: MarkKind::Strong }],
+            islands: vec![],
+        };
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        // Two paragraphs at the top level: no container prefix, no placeholder.
+        assert_eq!(to_markdown(&rt), "**heads** up\n\nstill inside");
+        // An unknown container nested inside a known one keeps the known
+        // prefix and adds none of its own.
+        rt.lines[0].containers.insert(0, Container::Quote);
+        rt.lines[1].containers.insert(0, Container::Quote);
+        assert_eq!(to_markdown(&rt), "> **heads** up\n>\n> still inside");
     }
 
     /// [`to_plaintext`] keeps literal text, drops marks, and strips island

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -854,7 +854,9 @@ impl Builder {
             });
             // Degraded when a cell dropped an inline image's url — the projection
             // then carries the alt text but not the image (not a fixed point);
-            // otherwise the type's ceiling.
+            // otherwise the type's ceiling. Recorded, not acted on: `Loss`
+            // describes fidelity for a consumer to surface (issue #1043), and no
+            // projection branches on it (issue #1054).
             let loss = if acc.degraded {
                 Loss::Degraded
             } else {

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -46,7 +46,7 @@ pub struct Content {
 }
 
 /// A line's attributes: its block role plus the container path it sits in.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Line {
     pub kind: LineKind,
     /// Ancestor containers, outermost first. A multi-paragraph list item is two
@@ -67,7 +67,14 @@ pub struct Line {
 /// The block role of a line. The tree between lines is inferred: two adjacent
 /// lines with equal `kind`+`containers` are two blocks of that role (e.g. two
 /// paragraphs), never one.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// **Open**, on the same terms as [`MarkKind`]: an unrecognized role round-trips
+/// as [`LineKind::Unknown`] and *projects* as [`LineKind::Para`], so adding a
+/// block construct (a callout, a footnote, a task item) is not a document schema
+/// event — an older reader renders the future construct as a plain paragraph
+/// instead of refusing the whole document, and the opaque tag+attrs still reach a
+/// reader that understands them (`DOCUMENT_STORAGE.md` § Open vocabularies).
+#[derive(Debug, Clone, PartialEq)]
 pub enum LineKind {
     Para,
     /// ATX/Setext heading, level 1..=6.
@@ -85,10 +92,22 @@ pub enum LineKind {
     /// break is the line itself, parallel to how an island's content is its
     /// one slot char.
     Rule,
+    /// Open-set escape hatch — a block role this build does not know,
+    /// round-tripped opaque and projected as [`LineKind::Para`]. Carries
+    /// arbitrary text, like the `Para` it projects as, so no
+    /// [`LineKindMismatch`] constrains it.
+    Unknown {
+        tag: String,
+        attrs: JsonValue,
+    },
 }
 
 /// A container a line nests inside. The ancestor path is a `Vec<Container>`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// **Open**, on [`LineKind`]'s terms: an unrecognized container round-trips as
+/// [`Container::Unknown`] and projects *transparently* — its lines render at the
+/// enclosing level, with no prefix, no wrapper, and no grouping of their own.
+#[derive(Debug, Clone, PartialEq)]
 pub enum Container {
     /// A list item. `ordered` distinguishes `1.` from `-`; `start` is the list's
     /// first number (1 by default); `ordinal` is this item's 0-based index in
@@ -108,6 +127,14 @@ pub enum Container {
     /// quote; two adjacent separate quotes are not distinguished (they merge on
     /// round-trip — a documented canonicalization).
     Quote,
+    /// Open-set escape hatch — a container this build does not know, kept in the
+    /// path so it round-trips, transparent to both projections. Two adjacent
+    /// lines sit in the same one iff their whole `(tag, attrs)` is equal, the
+    /// path-plus-contiguity rule the known containers use.
+    Unknown {
+        tag: String,
+        attrs: JsonValue,
+    },
 }
 
 /// A mark over a char range `[start, end)`. `start == end` (zero-width) is legal
@@ -172,14 +199,19 @@ pub struct Island {
     pub loss: Loss,
 }
 
-/// The markdown-projection loss class of an island.
+/// The markdown-projection loss class of an island — a **description** of how
+/// faithfully the projection carries it, for a consumer to surface (a caller
+/// warned that a form field silently dropped a table, issue #1043). It is not a
+/// switch: [`crate::export::to_markdown`] dispatches on
+/// [`Island::island_type`], never on this.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Loss {
     /// Markdown carries it faithfully (round-trips identically).
     Lossless,
     /// Markdown carries an approximation (round-trips visibly, not identically).
     Degraded,
-    /// No markdown encoding; export emits a placeholder only.
+    /// No markdown encoding — what an island type with no projection carries,
+    /// and the safe default a decoder mints for an unrecognized loss class.
     Unrepresentable,
 }
 
@@ -321,6 +353,12 @@ pub enum Invariant {
     FirstLineContinues,
     /// An [`MarkKind::Unknown`] reused a reserved built-in `type` name.
     ReservedUnknownTag(String),
+    /// A [`LineKind::Unknown`] reused a reserved built-in `kind` name — its
+    /// serialization would parse back as the built-in, dropping its attrs.
+    ReservedUnknownLineKind(String),
+    /// A [`Container::Unknown`] reused a reserved built-in `container` name, the
+    /// same non-injectivity as [`Invariant::ReservedUnknownLineKind`].
+    ReservedUnknownContainer(String),
     /// A formatting mark edge sits on a `\n` (normalization should have trimmed
     /// it) — a hand-built content that skipped `normalize`.
     MarkEdgeOnNewline { at: Usv },
@@ -510,6 +548,24 @@ impl Content {
                 }
             }
         }
+        // The open block vocabulary carries the same opaque `attrs`, and it is
+        // hash input like every other field — canonicalize its key order too, or
+        // two equal contents whose unknown lines were built key-reversed
+        // serialize to different bytes.
+        for line in &mut self.lines {
+            if let LineKind::Unknown { attrs, .. } = &mut line.kind {
+                if !is_value_key_sorted(attrs) {
+                    *attrs = sorted_value(attrs);
+                }
+            }
+            for c in &mut line.containers {
+                if let Container::Unknown { attrs, .. } = c {
+                    if !is_value_key_sorted(attrs) {
+                        *attrs = sorted_value(attrs);
+                    }
+                }
+            }
+        }
         // A formatting mark's edges never sit on a line boundary: markdown can't
         // bold a `\n`, so two producers that disagree only about whether the
         // boundary is "inside" the mark must canonicalize to the same bounds.
@@ -544,6 +600,16 @@ impl Content {
         "link",
         "anchor",
     ];
+
+    /// Line `kind` names the projection reserves — the [`LineKind`] twin of
+    /// [`RESERVED_MARK_TYPES`](Self::RESERVED_MARK_TYPES), for the same
+    /// injectivity reason.
+    pub const RESERVED_LINE_KINDS: [&'static str; 5] =
+        ["para", "heading", "code", "island", "rule"];
+
+    /// Container names the projection reserves — the [`Container`] twin of
+    /// [`RESERVED_MARK_TYPES`](Self::RESERVED_MARK_TYPES).
+    pub const RESERVED_CONTAINERS: [&'static str; 2] = ["list_item", "quote"];
 
     /// Check every invariant. `Ok(())` on a well-formed content. Import
     /// guarantees this; a hand-built content should be run through it in tests.
@@ -619,9 +685,25 @@ impl Content {
         // One pass over the lines against their own text segment. `lines.len()`
         // already equals the segment count, so the zip is total.
         for (i, (line, seg)) in self.lines.iter().zip(self.text.split('\n')).enumerate() {
-            if let LineKind::Heading { level } = line.kind {
-                if !(1..=6).contains(&level) {
-                    return Err(Invariant::BadHeadingLevel(level));
+            match &line.kind {
+                LineKind::Heading { level } if !(1..=6).contains(level) => {
+                    return Err(Invariant::BadHeadingLevel(*level));
+                }
+                // An unknown role may not reuse a built-in `kind` name: it would
+                // serialize as the built-in and parse back as one, dropping its
+                // attrs — the mark-side rule, one axis over.
+                LineKind::Unknown { tag, .. }
+                    if Self::RESERVED_LINE_KINDS.contains(&tag.as_str()) =>
+                {
+                    return Err(Invariant::ReservedUnknownLineKind(tag.clone()));
+                }
+                _ => {}
+            }
+            for c in &line.containers {
+                if let Container::Unknown { tag, .. } = c {
+                    if Self::RESERVED_CONTAINERS.contains(&tag.as_str()) {
+                        return Err(Invariant::ReservedUnknownContainer(tag.clone()));
+                    }
                 }
             }
             if let Some(mismatch) = line_kind_mismatch(&line.kind, seg) {

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -969,6 +969,22 @@ mod tests {
                 line: 2,
                 containers: vec![Container::Quote],
             },
+            // The open block vocabulary rides the same op wire (issue #1054):
+            // a host can set a role or a container this build does not know.
+            LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Unknown {
+                    tag: "callout".into(),
+                    attrs: serde_json::json!({"variant": "warn"}),
+                },
+            },
+            LineOp::SetContainers {
+                line: 2,
+                containers: vec![Container::Unknown {
+                    tag: "indent".into(),
+                    attrs: serde_json::json!({"depth": 2}),
+                }],
+            },
             LineOp::SetContinues {
                 line: 1,
                 continues: true,

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -174,6 +174,13 @@ pub fn line_kind_to_value(kind: &LineKind) -> Value {
         LineKind::Rule => {
             m.insert("kind".into(), "rule".into());
         }
+        // Open set, the mark encoding one axis over: the tag *is* the
+        // discriminator and the payload rides one opaque `attrs` bag, so a
+        // reader that lacks the role still carries it whole.
+        LineKind::Unknown { tag, attrs } => {
+            m.insert("kind".into(), Value::String(tag.clone()));
+            m.insert("attrs".into(), sorted_value(attrs));
+        }
     }
     Value::Object(m)
 }
@@ -200,7 +207,14 @@ pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
         }),
         Some("island") => Ok(LineKind::Island),
         Some("rule") => Ok(LineKind::Rule),
-        _ => Err(ParseError::Shape("line kind")),
+        // Open set: any other name is a block role this build lacks, kept opaque
+        // and projected as `Para`. Only a missing/non-string `kind` is a shape
+        // error — the *document* still opens when its vocabulary grows.
+        Some(other) => Ok(LineKind::Unknown {
+            tag: other.to_string(),
+            attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
+        }),
+        None => Err(ParseError::Shape("line kind")),
     }
 }
 
@@ -257,6 +271,10 @@ pub fn container_to_value(c: &Container) -> Value {
         Container::Quote => {
             m.insert("container".into(), "quote".into());
         }
+        Container::Unknown { tag, attrs } => {
+            m.insert("container".into(), Value::String(tag.clone()));
+            m.insert("attrs".into(), sorted_value(attrs));
+        }
     }
     Value::Object(m)
 }
@@ -272,7 +290,13 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
             ordinal: o.get("ordinal").and_then(Value::as_u64).unwrap_or(0),
         }),
         Some("quote") => Ok(Container::Quote),
-        _ => Err(ParseError::Shape("container kind")),
+        // Open set, as for line kinds: an unrecognized container round-trips
+        // opaque and projects transparently.
+        Some(other) => Ok(Container::Unknown {
+            tag: other.to_string(),
+            attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
+        }),
+        None => Err(ParseError::Shape("container kind")),
     }
 }
 
@@ -721,6 +745,111 @@ mod tests {
         let json = r#"{"text":"￼","lines":[{"kind":"island","containers":[]}],"marks":[],"islands":[{"id":"i1","type":"widget","props":{},"loss":"future_class"}]}"#;
         let rt = Content::from_canonical_json(json).unwrap();
         assert_eq!(rt.islands[0].loss, Loss::Unrepresentable);
+    }
+
+    /// Issue #1054: the block vocabulary is open on the mark axis' terms. A
+    /// `kind`/`container` this build lacks decodes to `Unknown` — the document
+    /// **opens** — and re-encodes byte-identically, so a construct a future
+    /// reader understands survives the trip through this one.
+    #[test]
+    fn unknown_line_kind_and_container_round_trip_opaque() {
+        let json = concat!(
+            r#"{"islands":[],"lines":[{"attrs":{"variant":"warn"},"containers":"#,
+            r#"[{"attrs":{"depth":2},"container":"indent"}],"kind":"callout"}],"#,
+            r#""marks":[],"text":"heads up"}"#
+        );
+        let rt = Content::from_canonical_json(json).unwrap();
+        assert_eq!(
+            rt.lines[0].kind,
+            LineKind::Unknown {
+                tag: "callout".into(),
+                attrs: serde_json::json!({"variant": "warn"}),
+            }
+        );
+        assert_eq!(
+            rt.lines[0].containers,
+            vec![Container::Unknown {
+                tag: "indent".into(),
+                attrs: serde_json::json!({"depth": 2}),
+            }]
+        );
+        assert_eq!(rt.to_canonical_json(), json);
+        // An attrs-free unknown decodes too (`attrs` is null, not a shape error).
+        let bare = r#"{"islands":[],"lines":[{"containers":[],"kind":"footnote"}],"marks":[],"text":"x"}"#;
+        let rt = Content::from_canonical_json(bare).unwrap();
+        assert_eq!(
+            rt.lines[0].kind,
+            LineKind::Unknown {
+                tag: "footnote".into(),
+                attrs: Value::Null,
+            }
+        );
+        // A missing/non-string discriminator is still a shape error — the open
+        // set absorbs unknown *names*, not malformed objects.
+        for bad in [
+            r#"{"islands":[],"lines":[{"containers":[]}],"marks":[],"text":"x"}"#,
+            r#"{"islands":[],"lines":[{"containers":[{"container":7}],"kind":"para"}],"marks":[],"text":"x"}"#,
+        ] {
+            assert!(matches!(
+                Content::from_canonical_json(bad),
+                Err(ParseError::Shape(_))
+            ));
+        }
+    }
+
+    /// Issue #1054: an unknown line kind / container may not reuse a built-in
+    /// name — it would serialize as the built-in and parse back as one, dropping
+    /// its attrs (the `ReservedUnknownTag` rule, one axis over).
+    #[test]
+    fn reserved_block_vocabulary_names_rejected() {
+        let mut rt = Content::empty();
+        rt.text = "abcd".into();
+        rt.lines[0].kind = LineKind::Unknown {
+            tag: "heading".into(),
+            attrs: serde_json::json!({}),
+        };
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::ReservedUnknownLineKind("heading".into()))
+        );
+        rt.lines[0].kind = LineKind::Para;
+        rt.lines[0].containers = vec![Container::Unknown {
+            tag: "quote".into(),
+            attrs: serde_json::json!({}),
+        }];
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::ReservedUnknownContainer("quote".into()))
+        );
+    }
+
+    /// Issue #1054: opaque block attrs are hash input, so their key order must
+    /// not leak into the canonical bytes — the unknown-mark rule, one axis over.
+    #[test]
+    fn unknown_block_attrs_key_order_does_not_leak() {
+        let mut one = Content::empty();
+        one.text = "hi".into();
+        one.lines[0].kind = LineKind::Unknown {
+            tag: "callout".into(),
+            attrs: serde_json::json!({"b": 1, "a": 2}),
+        };
+        one.lines[0].containers = vec![Container::Unknown {
+            tag: "indent".into(),
+            attrs: serde_json::json!({"y": 1, "x": 2}),
+        }];
+        let mut two = one.clone();
+        two.lines[0].kind = LineKind::Unknown {
+            tag: "callout".into(),
+            attrs: serde_json::json!({"a": 2, "b": 1}),
+        };
+        two.lines[0].containers = vec![Container::Unknown {
+            tag: "indent".into(),
+            attrs: serde_json::json!({"x": 2, "y": 1}),
+        }];
+        assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+        one.normalize();
+        two.normalize();
+        assert_eq!(one, two, "normalize canonicalizes the live model too");
     }
 
     #[test]

--- a/docs/migrations/0.97-to-0.98.md
+++ b/docs/migrations/0.97-to-0.98.md
@@ -1,0 +1,80 @@
+# 0.97 → 0.98 — the block vocabulary opens
+
+A line's `kind` and a container's name join the mark `type` and island `type` as
+**open sets**: a value this build does not recognize round-trips opaque and
+renders as its nearest safe neighbor instead of failing the whole document
+(#1054). Adding a block construct — a callout, a footnote, a task item, an
+indent — is no longer a document schema-version event.
+
+Stored blobs are unaffected: every `0.97` document still loads byte-identically,
+and `0.98` writes the same bytes for the same content. Two surfaces change for
+hosts: the Rust enums gain a variant each, and the TypeScript unions gain an
+open arm each.
+
+## Why
+
+`MarkKind::Unknown` and an unknown island `type` already round-tripped opaque —
+the mark axis could grow without a schema bump. `LineKind` and `Container`
+instead returned a shape error on anything unrecognized, so an older reader
+rejected an entire document over one future construct, and every block-vocabulary
+addition was priced at a schema bump plus a migration. Blocks are where markdown
+grows; the split was an artifact, not a decision. Both axes are now open on the
+same terms, and `DOCUMENT_STORAGE.md` § Open vocabularies states the rule.
+
+The trade, stated: an older reader renders a future construct as a plain
+paragraph rather than refusing to open the document. No data is lost — the tag
+and its `attrs` still round-trip for a reader that understands them.
+
+## Rust: two new variants, and `Eq` drops
+
+```rust
+LineKind::Unknown  { tag: String, attrs: serde_json::Value }  // projects as `Para`
+Container::Unknown { tag: String, attrs: serde_json::Value }  // projects transparently
+```
+
+- **Exhaustive matches** on `LineKind` or `Container` need an `Unknown` arm.
+  Treat an unknown line as a paragraph and an unknown container as absent —
+  that is what both emitters do.
+- **`Line`, `LineKind`, and `Container` no longer derive `Eq`** (the opaque
+  `attrs` is a `serde_json::Value`, which is `PartialEq` only), matching
+  `MarkKind`. `==`, `assert_eq!`, and `Vec::contains` are unaffected; a
+  `HashSet<Line>`-style use is not, and none existed in the workspace.
+- **`Invariant` gains `ReservedUnknownLineKind` / `ReservedUnknownContainer`** —
+  an unknown may not reuse a built-in name (`heading`, `quote`, …), which would
+  serialize as the built-in and parse back as one, dropping its attrs. This is
+  the `ReservedUnknownTag` rule, one axis over.
+
+## TypeScript: the open arm blocks narrowing
+
+`ContentLine` and `ContentContainer` each carry a residual open arm, exactly as
+`ContentIsland` and `ContentMark` have since 0.97:
+
+```ts
+| { kind: string; attrs: unknown }         // ContentLine
+| { container: string; attrs: unknown }    // ContentContainer
+```
+
+A bare discriminant check no longer narrows the payload — a `string` can equal
+`'heading'`, so TS keeps the open arm live and `level` stays unreachable. Three
+guards join `isTableIsland` / `isImageIsland` / `isLinkMark` / `isAnchorMark` in
+`@quillmark/wasm/runtime`:
+
+```js
+import { isHeadingLine, isCodeLine, isListItemContainer } from '@quillmark/wasm/runtime';
+
+// 0.97
+if (line.kind === 'heading') indent(line.level);
+
+// 0.98
+if (isHeadingLine(line)) indent(line.level);
+```
+
+The payload-free arms (`para`, `island`, `rule`, `quote`) narrow to nothing, so
+a bare `line.kind === 'rule'` check still reads fine — only the arms carrying
+`level` / `lang` / a list item's shape need a guard.
+
+## Writing a new construct
+
+A construct added to either vocabulary must carry its payload under `attrs`, not
+in named sibling keys. A sibling key an older reader does not read is dropped
+when that reader re-encodes; `attrs` survives whole.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,6 +18,15 @@ guides in order.
 
 ## Available guides
 
+- [0.97 → 0.98](0.97-to-0.98.md) — the block vocabulary opens.
+  **Break:** `LineKind` and `Container` each gain an `Unknown { tag, attrs }`
+  variant (exhaustive matches need an arm) and `Line` / `LineKind` / `Container`
+  drop their `Eq` derive; `ContentLine.kind` and `ContentContainer.container`
+  gain an open TS arm, so a bare discriminant check no longer narrows — use the
+  new `isHeadingLine` / `isCodeLine` / `isListItemContainer` guards. Stored
+  documents are unaffected: an unrecognized line kind or container now
+  round-trips opaque and renders as a paragraph (or transparently) instead of
+  failing the load, so adding a block construct is no longer a schema event.
 - [0.96 → 0.97](0.96-to-0.97.md) — the WASM transport read renames; `$id`
   becomes the unique card handle.
   **Break:** `Document.get` → **`Document.getStored`** (JS) — the quill-free

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
+      - 0.97 → 0.98 (block vocabulary opens; LineKind/Container gain Unknown; TS narrowing guards): migrations/0.97-to-0.98.md
       - 0.96 → 0.97 (WASM Document.get → getStored; verbatim transport read gains its own verb): migrations/0.96-to-0.97.md
       - '0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified)': migrations/0.95-to-0.96.md
       - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -51,6 +51,7 @@ Two escapers guard the two Typst contexts; both live in `emit`:
 | `LineKind::Para` | inline content; a hard break (a `continues` line join) emits `#linebreak()`, a soft break is a space (both settled at import) |
 | `LineKind::Code{lang}` (code fence) | `#raw(block: true, lang: "…", "…")`; `lang:` emitted only when the language tag is non-empty |
 | `LineKind::Rule` (thematic break) | `#line(length: 100%)` |
+| `LineKind::Unknown` (open set) | inline content, as `Para` — the role is lost to the projection, not to storage |
 | `MarkKind::Strong` | `#strong[…]` |
 | `MarkKind::Emph` | `#emph[…]` |
 | `MarkKind::Underline` | `#underline[…]` |
@@ -61,6 +62,7 @@ Two escapers guard the two Typst contexts; both live in `emit`:
 | `Container::ListItem` (bullet) | `- ` |
 | `Container::ListItem` (ordered) | `+ ` auto-numbered; first item emits `N. ` when the list starts at `N ≠ 1` |
 | `Container::Quote` | `#quote(block: true)[…]` |
+| `Container::Unknown` (open set) | nothing — transparent; its run lowers at the enclosing level, one block, no wrapper |
 | `image` island | `#image("url", alt: "…")`; `alt:` omitted when empty |
 | `table` island | `#table(columns: N, align: (…), table.header(…), …)` |
 
@@ -75,7 +77,11 @@ divergence from a flat inline pass; a quote's inner blocks lower under the
 block-level discipline.
 
 Anchor and unknown marks emit nothing; unknown island types emit nothing
-(parallel to the HTML rule at import). Content that import never admits into the
+(parallel to the HTML rule at import). Unknown line kinds and containers lower
+as prose and as nothing respectively — every content vocabulary is open, so a
+build that predates a construct renders it plainly instead of failing
+([DOCUMENT_STORAGE § Open vocabularies](DOCUMENT_STORAGE.md#open-vocabularies)).
+Content that import never admits into the
 content — raw HTML other than `<u>`, HTML comments, `<br>`, math, footnotes, task
 lists, definition lists (markdown-spec §6.3) — is absent here.
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -133,6 +133,51 @@ change. Two ways to manage this:
   guarantee is required) or an accepted, logged hash movement on
   not-yet-migrated rows.
 
+## Open vocabularies
+
+The envelope's version-and-reject discipline covers the document's **shape** —
+the schema tag, the DTO tree, the keys a `body` object carries. It does *not*
+cover the content's **vocabularies**. Every discriminator inside a `body` is an
+open set: a mark `type`, an island `type`, a line `kind`, and a container name
+this build does not recognize each decode to an opaque `Unknown` carrying the
+tag plus its `attrs` (`props` for an island), round-trip byte-identically, and
+project as their nearest safe neighbor.
+
+| Axis | Unknown value projects as |
+|---|---|
+| Mark `type` | no delimiters (the text renders bare) |
+| Island `type` | a placeholder comment; the props survive in storage |
+| Line `kind` | a paragraph |
+| Container | transparent — its lines render at the enclosing level |
+
+The consequence, and the point: **adding a construct to any of these
+vocabularies is not a schema-version event.** An older reader degrades a future
+callout to a plain paragraph rather than refusing the document, and a reader
+that does understand it sees it whole, because the tag and attrs round-tripped
+untouched. The block axes were closed until issue #1054 — a new line kind or
+container was a schema bump plus a migration, while the same addition on the
+mark axis cost nothing; the split was an accident of implementation, not a
+decision, and this is it decided.
+
+Two rules bound the openness:
+
+- **Payload rides `attrs`.** A built-in carries its payload in named sibling
+  keys (`level`, `lang`, `url`); an unknown carries it in one opaque `attrs`
+  object. A *new* construct must therefore put its payload under `attrs` to
+  survive a reader that predates it — a sibling key an old reader does not
+  read is dropped on re-encode.
+- **No reserved name reuse.** An unknown may not take a built-in's name
+  (`heading`, `quote`, `link`, …): it would serialize as the built-in and parse
+  back as one, silently dropping its attrs. `Content::validate` rejects this
+  (`Invariant::ReservedUnknownTag` / `ReservedUnknownLineKind` /
+  `ReservedUnknownContainer`), so a non-injective blob cannot be stored.
+
+The opaque attrs are hash input like everything else in the canonical form, so
+they are recursively key-sorted along with the rest (see Byte-stability). What
+*does* remain a schema event is a change to the content object's own structure
+— a new top-level key beside `text`/`lines`/`marks`/`islands`, or a changed
+meaning for an existing discriminator.
+
 ## Island-id determinism
 
 An island's `id` is part of the canonical form (`{id, type, props, loss}`),


### PR DESCRIPTION
Two asymmetries in how the content form handles what it doesn't recognize
(#1054), now decided the same way on every axis.

**Line kinds and containers join the open set.** `MarkKind::Unknown` and an
unknown island `type` already round-tripped opaque, so the mark axis could grow
without a schema bump, while `line_kind_from_value`/`container_from_value`
returned a shape error on anything unrecognized — an older reader refused a
whole document over one future construct, and every block-vocabulary addition
was priced at a document schema bump plus a migration. Blocks are where markdown
grows. `LineKind::Unknown { tag, attrs }` and `Container::Unknown { tag, attrs }`
round-trip opaque and project as `Para` / transparently in both emitters: the
older reader degrades a future callout to a plain paragraph instead of refusing
to open the document, and the tag+attrs still reach a reader that understands
them. Reserved built-in names are refused (`ReservedUnknownLineKind` /
`ReservedUnknownContainer`, the `ReservedUnknownTag` rule one axis over) and the
opaque attrs are key-sorted like the rest of the canonical form. This unblocks
#1048, which was paying the schema-bump cost this removes.

`Line`/`LineKind`/`Container` drop their `Eq` derive — `attrs` is a
`serde_json::Value` — matching `MarkKind`. The WASM `ContentLine`/
`ContentContainer` unions gain their open arm, so narrowing needs a guard:
`isHeadingLine` / `isCodeLine` / `isListItemContainer` join the #1042 set.

**`Loss` is a description, not a switch.** `to_markdown`'s doc claimed
unrepresentable islands emit a placeholder, but `emit_island` dispatches on
island *type* and never reads `loss` — a table stamped `Unrepresentable` by a
future writer's unrecognized loss class still emits its markdown. That is the
right behavior (the conservative decode default describes the value, it must not
suppress it), so the docs now describe it: type decides whether a projection
exists, `loss` reports its fidelity for a consumer to surface. Full consumer
wiring stays with #1043, its named consumer.

Canon: DOCUMENT_STORAGE gains § Open vocabularies stating that vocabulary
additions are not schema events and that a new construct's payload must ride
`attrs`; CONVERT gains the two lowering rows. Adds the 0.97→0.98 migration guide.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VJwVSzyuS9Lajn5o4sDA54