### PR TITLE
v0.98.0: block vocabulary opens, Txt format removed, surface cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,81 @@
 
 ## v0.98.0 - 2026-07-28
 
-- Simplification pass over the integration merge
-- Dense-prose pass over the integration merge
-- Open the block vocabulary; `Loss` describes fidelity, it does not gate export
-- content: bound export's verify-and-drop net — close #1052
-- Point the schema-model note at the ladder's real owner
-- Trim binding tests to marshalling altitude (issue #1056)
-- Move wrong-altitude tests down to core (issue #1056)
-- Table-drive assemble_tests.rs clusters; dense-prose pass on issue #1060 tests
-- Table-drive lossiness_tests.rs clusters for issue #1060 (partial)
-- Table-drive edit_tests.rs, quill/tests.rs, and wasm test clusters for issue #1060 (partial)
-- Table-drive quill/tests.rs clusters for issue #1060 (partial)
-- Table-drive test clusters for issue #1060 (partial)
-- dense-prose: fix an ambiguous reading in the validation-line docs
-- Document the construction-vs-insertion validation line
-- Revert the `$kind` wire check: construction is permissive by design
-- api: close the straightforward gaps from the public-API sweep
-- hygiene: production-side duplication from #1067
-- hygiene: drop tests that pin foreign behavior or assert nothing — close #1065
-- hygiene: one walker, one quill builder — close #1062
-- content: delete the `***` fixup — its only effect was dropping a literal asterisk
-- content: close three codec holes — island-swallowing marks, unchecked line kinds, unbounded decode
-- hygiene: close #1070, #1069; CI zero-backend gate; dead surface from #1066
-- canon: the CI job table lists every CI job
-- ci: cut the canon lint to gates only
-- canon: aggressive prune — overview stops re-documenting its own docs
-- canon: cut what docs/ already owns; state each fact once
-- canon: state the shape, not the ticket; drop the rotting export list
-- ci_cd: record the canon lint in the lint-job row
-- canon: make the lint check truth, not only shape
+Five breaking changes, all covered by `docs/migrations/0.97-to-0.98.md`.
+Stored documents are unaffected: a `0.97` blob loads byte-identically and
+`0.98` writes the same bytes for the same content.
+
+- feat(core,content,wasm)!: the block vocabulary opens. A line's `kind` and a
+  container's name join the mark `type` and island `type` as open sets — an
+  unrecognized value round-trips opaque and renders as its nearest safe
+  neighbor instead of failing the load, so adding a block construct is no
+  longer a document schema-version event. `LineKind` and `Container` each gain
+  an `Unknown { tag, attrs }` variant (exhaustive matches need an arm) and
+  `Line` / `LineKind` / `Container` drop their `Eq` derive, matching `MarkKind`;
+  `Invariant` gains `ReservedUnknownLineKind` / `ReservedUnknownContainer`, so
+  an unknown may not reuse a built-in name. `ContentLine.kind` and
+  `ContentContainer.container` gain an open TS arm, so a bare discriminant check
+  no longer narrows — `isHeadingLine` / `isCodeLine` / `isListItemContainer`
+  join the existing guards in `@quillmark/wasm/runtime`. `Loss` describes
+  fidelity; it does not gate export (#1054). See
+  `docs/migrations/0.97-to-0.98.md`
+- refactor(core,wasm,python,cli)!: `OutputFormat::Txt` is removed. No backend
+  listed it in `SUPPORTED_FORMATS`, so every path reaching it — `--format txt`,
+  `from_str("txt")`, iterating `ALL` — failed at render time. The Rust variant,
+  Python's `OutputFormat.TXT`, and the TS `'txt'` arm all go; `--format txt` now
+  fails argument parsing instead of the render (#1058). See
+  `docs/migrations/0.97-to-0.98.md`
+- refactor(typst,pdfform)!: `format_not_supported` was three codes for one
+  condition. Both backends now emit `backend::format_not_supported`, alongside
+  the sibling `backend::apply_unsupported` — route on the namespaced code
+  (#1057). See `docs/migrations/0.97-to-0.98.md`
+- refactor(core)!: dead public surface is removed — `ReadValue::as_text` /
+  `as_value` (match the variants), `Quill::list_files` / `list_subdirectories`
+  (`quill.files()` owns the walk), and `QuillValue`'s eight `Deref`-shadowed
+  accessors (`QuillValue: Deref<Target = serde_json::Value>` resolves each call
+  unchanged — no action). `prescan`'s helpers and `reader::err` drop to
+  `pub(crate)` (#1066, #1064). See `docs/migrations/0.97-to-0.98.md`
+- fix(python)!: rendered regions cross the boundary as `DocPath`. Python
+  returned plate-space addresses no document API accepts; the plate→`DocPath`
+  translation now lives in core as `regions_to_doc_path` and both bindings call
+  it, so `RenderResult.regions[].field` reads `main.body` /
+  `cards.<kind>[<i>].<field>` as WASM already did (#1063). See
+  `docs/migrations/0.97-to-0.98.md`
+- fix(content): three codec holes close. A mark spanning an island slot no
+  longer swallows it, `LineKind`/segment mismatches are checked
+  (`Invariant::LineKindMismatch`, with a `LineKindMismatch` reason enum), and
+  decode is bounded — `MAX_NESTING_DEPTH` is enforced at the door and wire
+  positions are read checked rather than `as usize`, which on wasm32 turned
+  `2^32 + 5` into an in-range `5` (#1051)
+- fix(content): export's verify-and-drop safety net is bounded per line rather
+  than per mark; `CONVERT.md` states the import↔export coupling the net implies
+  (#1052)
+- fix(content): the `***` fixup is deleted — its only effect was dropping a
+  literal asterisk
+- feat(core): `FileTreeNode`, `QuillIgnore`, `QuillConfig`, the schema types,
+  and `ValidationError` are nameable from `quillmark` and from `quillmark_core`'s
+  root, so in-memory quill construction and schema reading need no direct core
+  dependency (#1055)
+- refactor(core,pdfform): `From<PdfError> for RenderError` replaces two
+  byte-identical `map_pdf_err` copies; `lopdf`, `js-sys` and `wasm-bindgen`
+  hoist into `[workspace.dependencies]`, the no-op `default-features = false`
+  pins drop, and `publish` is explicit on every crate (#1070, #1064)
+- docs(core): the card-kind validation line is documented where it lives —
+  construction (`Document::make_card`, `TryFrom<CardWire>`) is permissive
+  data-shaping and insertion is the gate, returning `edit::invalid_kind_name`
+- docs(canon): `ERROR.md` stops documenting a `fmt_pretty_with_source()` that
+  does not exist and states what carries the source chain: serialization to
+  both bindings, no Rust formatter. `error.rs`'s divergent path-grammar copy
+  gives way to a pointer at `path.rs` and the canon anchor table (#1061, #1069)
+- docs(canon): prune — canon stops re-documenting what `docs/` owns and states
+  each fact once; the lint checks truth rather than shape, and the CI job table
+  lists every job
+- test: test clusters go table-driven, wrong-altitude binding tests move down to
+  core, tests that pin foreign behavior or assert nothing are dropped, and one
+  walker and one quill builder replace the per-suite copies (#1060, #1056,
+  #1065, #1062, #1067)
+- ci: the zero-backend configuration is built and tested — `--workspace
+  --all-features` forces `typst` on, so that branch never compiled (#1068)
 
 
 ## v0.97.0 - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ Stored documents are unaffected: a `0.97` blob loads byte-identically and
   join the existing guards in `@quillmark/wasm/runtime`. `Loss` describes
   fidelity; it does not gate export (#1054). See
   `docs/migrations/0.97-to-0.98.md`
-- refactor(core,wasm,python,cli)!: `OutputFormat::Txt` is removed. No backend
-  listed it in `SUPPORTED_FORMATS`, so every path reaching it — `--format txt`,
-  `from_str("txt")`, iterating `ALL` — failed at render time. The Rust variant,
-  Python's `OutputFormat.TXT`, and the TS `'txt'` arm all go; `--format txt` now
-  fails argument parsing instead of the render (#1058). See
+- refactor(core,wasm,python,cli)!: `OutputFormat::Txt` is removed — the Rust
+  variant, Python's `OutputFormat.TXT`, the TS `'txt'` arm. No backend listed it
+  in `SUPPORTED_FORMATS`, so every path reaching it failed at render time;
+  `--format txt` and `from_str("txt")` now fail at the argument instead, and
+  there is no replacement format (#1058). See
   `docs/migrations/0.97-to-0.98.md`
 - refactor(typst,pdfform)!: `format_not_supported` was three codes for one
   condition. Both backends now emit `backend::format_not_supported`, alongside
@@ -43,16 +43,18 @@ Stored documents are unaffected: a `0.97` blob loads byte-identically and
   `cards.<kind>[<i>].<field>` as WASM already did (#1063). See
   `docs/migrations/0.97-to-0.98.md`
 - fix(content): three codec holes close. A mark spanning an island slot no
-  longer swallows it, `LineKind`/segment mismatches are checked
-  (`Invariant::LineKindMismatch`, with a `LineKindMismatch` reason enum), and
-  decode is bounded — `MAX_NESTING_DEPTH` is enforced at the door and wire
-  positions are read checked rather than `as usize`, which on wasm32 turned
-  `2^32 + 5` into an in-range `5` (#1051)
+  longer swallows it; a `LineKind` that disagrees with its segment is caught
+  (`Invariant::LineKindMismatch`, carrying a `LineKindMismatch` reason); and
+  decode is bounded — `MAX_NESTING_DEPTH` is enforced at the door, and a wire
+  position is read checked rather than `as usize`, which on wasm32 landed
+  `2^32 + 5` at position `5` (#1051)
 - fix(content): export's verify-and-drop safety net is bounded per line rather
   than per mark; `CONVERT.md` states the import↔export coupling the net implies
   (#1052)
-- fix(content): the `***` fixup is deleted — its only effect was dropping a
-  literal asterisk
+- fix(content): markdown import keeps a literal `*` that abuts strong or
+  emphasis — `a***a**` imports as `a`, `*`, strong `a`, where the deleted fixup
+  dropped the typed star. Removing it also fixes a backslash escape or entity in
+  such a span re-entering the content as literal source bytes (#1053)
 - feat(core): `FileTreeNode`, `QuillIgnore`, `QuillConfig`, the schema types,
   and `ValidationError` are nameable from `quillmark` and from `quillmark_core`'s
   root, so in-memory quill construction and schema reading need no direct core

--- a/docs/migrations/0.97-to-0.98.md
+++ b/docs/migrations/0.97-to-0.98.md
@@ -1,4 +1,20 @@
-# 0.97 → 0.98 — the block vocabulary opens
+# 0.97 → 0.98 — the block vocabulary opens, and `txt` retires
+
+Stored blobs are unaffected: every `0.97` document still loads byte-identically,
+and `0.98` writes the same bytes for the same content. Every break in this
+release is a compile-time or call-site one.
+
+| Break | Surface | Action |
+|---|---|---|
+| `LineKind` / `Container` gain `Unknown` | Rust | Add an arm to exhaustive matches |
+| `Line` / `LineKind` / `Container` drop `Eq` | Rust | Only a hash-set use is affected; none existed |
+| `ContentLine` / `ContentContainer` gain an open arm | TypeScript | Use the new narrowing guards |
+| `OutputFormat::Txt` removed | Rust, Python, TS, CLI | Pick `pdf` / `svg` / `png` |
+| `format_not_supported` unified | Diagnostic codes | Route on `backend::format_not_supported` |
+| `ReadValue` / `Quill` accessors removed | Rust | Match the variant; walk `quill.files()` |
+| Python regions carry `DocPath` | Python | Read `main.body` / `cards.<kind>[<i>].<field>` |
+
+## The block vocabulary opens
 
 A line's `kind` and a container's name join the mark `type` and island `type` as
 **open sets**: a value this build does not recognize round-trips opaque and
@@ -6,12 +22,10 @@ renders as its nearest safe neighbor instead of failing the whole document
 (#1054). Adding a block construct — a callout, a footnote, a task item, an
 indent — is no longer a document schema-version event.
 
-Stored blobs are unaffected: every `0.97` document still loads byte-identically,
-and `0.98` writes the same bytes for the same content. Two surfaces change for
-hosts: the Rust enums gain a variant each, and the TypeScript unions gain an
-open arm each.
+Two surfaces change for hosts: the Rust enums gain a variant each, and the
+TypeScript unions gain an open arm each.
 
-## Why
+### Why
 
 `MarkKind::Unknown` and an unknown island `type` already round-tripped opaque —
 the mark axis could grow without a schema bump. `LineKind` and `Container`
@@ -25,7 +39,7 @@ The trade, stated: an older reader renders a future construct as a plain
 paragraph rather than refusing to open the document. No data is lost — the tag
 and its `attrs` still round-trip for a reader that understands them.
 
-## Rust: two new variants, and `Eq` drops
+### Rust: two new variants, and `Eq` drops
 
 ```rust
 LineKind::Unknown  { tag: String, attrs: serde_json::Value }  // projects as `Para`
@@ -44,7 +58,7 @@ Container::Unknown { tag: String, attrs: serde_json::Value }  // projects transp
   serialize as the built-in and parse back as one, dropping its attrs. This is
   the `ReservedUnknownTag` rule, one axis over.
 
-## TypeScript: the open arm blocks narrowing
+### TypeScript: the open arm blocks narrowing
 
 `ContentLine` and `ContentContainer` each carry a residual open arm, exactly as
 `ContentIsland` and `ContentMark` have since 0.97:
@@ -73,8 +87,110 @@ The payload-free arms (`para`, `island`, `rule`, `quote`) narrow to nothing, so
 a bare `line.kind === 'rule'` check still reads fine — only the arms carrying
 `level` / `lang` / a list item's shape need a guard.
 
-## Writing a new construct
+### Writing a new construct
 
 A construct added to either vocabulary must carry its payload under `attrs`, not
 in named sibling keys. A sibling key an older reader does not read is dropped
 when that reader re-encodes; `attrs` survives whole.
+
+## `OutputFormat::Txt` retires
+
+No backend listed `Txt` in `SUPPORTED_FORMATS`, so every path that reached it
+failed at render time (#1058). The variant is removed rather than left as a
+guaranteed error.
+
+| Surface | 0.97 | 0.98 |
+|---|---|---|
+| Rust | `OutputFormat::{Pdf, Svg, Txt, Png}`, `ALL: [_; 4]` | `{Pdf, Svg, Png}`, `ALL: [_; 3]` |
+| Python | `OutputFormat.TXT` | removed — `AttributeError` |
+| TypeScript | `'pdf' \| 'svg' \| 'txt' \| 'png'` | `'pdf' \| 'svg' \| 'png'` |
+| CLI | `--format txt` fails at render | fails argument parsing |
+
+`OutputFormat::from_str("txt")` returns `ParseOutputFormatError`, whose message
+lists the three live formats. Exhaustive Rust matches over `OutputFormat` lose
+an arm; there is no replacement format, so a caller that asked for `txt` picks
+one of `pdf` / `svg` / `png`.
+
+## One `backend::format_not_supported`
+
+The Typst backend emitted `typst::format_not_supported` and pdfform emitted
+`pdfform::format_not_supported` for the same condition — an output format the
+backend does not produce. Both now emit **`backend::format_not_supported`**,
+alongside the sibling `backend::apply_unsupported` (#1057).
+
+```js
+// 0.97
+if (d.code === 'typst::format_not_supported' || d.code === 'pdfform::format_not_supported')
+
+// 0.98
+if (d.code === 'backend::format_not_supported')
+```
+
+A backend outside this workspace that mints its own code for the condition
+should follow, so a host routes on one string regardless of which backend ran.
+
+## Removed Rust surface
+
+Accessors with no caller and a live equivalent are gone (#1066, #1064):
+
+| Removed | Use instead |
+|---|---|
+| `ReadValue::as_text()` | match `ReadValue::Markdown(s)` / `ReadValue::Plaintext(s)` |
+| `ReadValue::as_value()` | match `ReadValue::Value(v)` |
+| `Quill::list_files(dir)` | `quill.files().list_files(dir)` |
+| `Quill::list_subdirectories(dir)` | `quill.list_directories(dir)` (full paths) or `quill.files().list_subdirectories(dir)` (names) |
+
+`QuillValue`'s `is_null` / `as_str` / `as_bool` / `as_i64` / `as_u64` / `as_f64`
+/ `as_array` / `as_object` are also gone, but they shadowed identical methods on
+the `Deref` target — `QuillValue: Deref<Target = serde_json::Value>` resolves
+every one of those calls unchanged. **No action.**
+
+`prescan`'s `PreItem` / `PreScan` / `prescan_fence_content` and `reader::err`
+drop to `pub(crate)`. Both were reachable but internal; nothing outside the
+workspace can have depended on them without also depending on private shapes.
+
+## Python: regions carry `DocPath`
+
+The `RenderedRegion` contract puts the plate→`DocPath` translation at the
+binding boundary. WASM did it; Python did not, so a Python caller got an address
+no document API accepts (#1063). The translation now lives in core as
+`regions_to_doc_path` and both bindings call it.
+
+| 0.97 — plate-space | 0.98 — `DocPath` |
+|---|---|
+| `$body` | `main.body` |
+| `title` | `main.title` |
+| `$cards.recipient.0.name` | `cards.recipient[<abs>].name` |
+| `$cards.recipient.0.$body` | `cards.recipient[<abs>].body` |
+
+The card index changes meaning as well as spelling: the plate form carries a
+**per-kind ordinal** (the *n*th `recipient`), the `DocPath` form an **absolute
+card index** (the *n*th card in the document). The two coincide only when a
+single kind is present; the binding resolves one to the other. Code that
+string-matched the plate form, or fed `region["field"]` back into a document API
+and worked around the rejection, should read the `DocPath` form directly. WASM
+is unchanged.
+
+## No action: the content decoder gets stricter
+
+`Content::from_canonical_json` rejects two inputs it used to accept (#1051).
+Neither is producible by a Quillmark writer; both are reachable from a
+hand-built or hostile blob.
+
+- **Nesting past `MAX_NESTING_DEPTH` (100)** fails with
+  `Invariant::NestingTooDeep`. Export recurses one frame per container, so a
+  20 000-deep path decoded clean and then aborted the process on `to_markdown`.
+- **A wire position past `usize`** fails instead of truncating. On wasm32 — the
+  deployment target — `as usize` turned `2^32 + 5` into an in-range `5`, landing
+  a mark at the wrong position in a document that then validated clean.
+
+A mark spanning an island slot no longer swallows it, and a `LineKind` that
+disagrees with its segment is caught by `Invariant::LineKindMismatch`, carrying
+a `LineKindMismatch` reason (`IslandNotOneSlot` / `RuleNotEmpty` / `CodeHasSlot`).
+A direct `quillmark-content` dependent matching exhaustively on `Invariant` or
+`ApplyError` needs arms for the new variants.
+
+Export's verify-and-drop safety net — which settles a line's markdown by
+re-importing it and dropping marks until the text comes back intact — is now
+bounded per line rather than per mark (#1052). The `***` fixup is deleted; its
+only effect was dropping a literal asterisk.

--- a/docs/migrations/0.97-to-0.98.md
+++ b/docs/migrations/0.97-to-0.98.md
@@ -7,7 +7,8 @@ release is a compile-time or call-site one.
 | Break | Surface | Action |
 |---|---|---|
 | `LineKind` / `Container` gain `Unknown` | Rust | Add an arm to exhaustive matches |
-| `Line` / `LineKind` / `Container` drop `Eq` | Rust | Only a hash-set use is affected; none existed |
+| `Invariant` / `ApplyError` gain variants | Rust (`quillmark-content`) | Add an arm to exhaustive matches |
+| `Line` / `LineKind` / `Container` drop `Eq` | Rust | Affects a hash-set element or map key only |
 | `ContentLine` / `ContentContainer` gain an open arm | TypeScript | Use the new narrowing guards |
 | `OutputFormat::Txt` removed | Rust, Python, TS, CLI | Pick `pdf` / `svg` / `png` |
 | `format_not_supported` unified | Diagnostic codes | Route on `backend::format_not_supported` |
@@ -22,17 +23,11 @@ renders as its nearest safe neighbor instead of failing the whole document
 (#1054). Adding a block construct — a callout, a footnote, a task item, an
 indent — is no longer a document schema-version event.
 
-Two surfaces change for hosts: the Rust enums gain a variant each, and the
-TypeScript unions gain an open arm each.
-
 ### Why
 
-`MarkKind::Unknown` and an unknown island `type` already round-tripped opaque —
-the mark axis could grow without a schema bump. `LineKind` and `Container`
-instead returned a shape error on anything unrecognized, so an older reader
-rejected an entire document over one future construct, and every block-vocabulary
-addition was priced at a schema bump plus a migration. Blocks are where markdown
-grows; the split was an artifact, not a decision. Both axes are now open on the
+The mark axis was already open: `MarkKind::Unknown` and an unknown island `type`
+round-trip opaque. `LineKind` and `Container` returned a shape error instead, so
+one future construct cost a reader the whole document. Both axes now open on the
 same terms, and `DOCUMENT_STORAGE.md` § Open vocabularies states the rule.
 
 The trade, stated: an older reader renders a future construct as a plain
@@ -52,7 +47,7 @@ Container::Unknown { tag: String, attrs: serde_json::Value }  // projects transp
 - **`Line`, `LineKind`, and `Container` no longer derive `Eq`** (the opaque
   `attrs` is a `serde_json::Value`, which is `PartialEq` only), matching
   `MarkKind`. `==`, `assert_eq!`, and `Vec::contains` are unaffected; a
-  `HashSet<Line>`-style use is not, and none existed in the workspace.
+  `HashSet<Line>` or a `Line`-keyed map is not.
 - **`Invariant` gains `ReservedUnknownLineKind` / `ReservedUnknownContainer`** —
   an unknown may not reuse a built-in name (`heading`, `quote`, …), which would
   serialize as the built-in and parse back as one, dropping its attrs. This is
@@ -87,17 +82,16 @@ The payload-free arms (`para`, `island`, `rule`, `quote`) narrow to nothing, so
 a bare `line.kind === 'rule'` check still reads fine — only the arms carrying
 `level` / `lang` / a list item's shape need a guard.
 
-### Writing a new construct
+### Minting your own construct
 
-A construct added to either vocabulary must carry its payload under `attrs`, not
-in named sibling keys. A sibling key an older reader does not read is dropped
-when that reader re-encodes; `attrs` survives whole.
+An unknown tag must carry its payload under `attrs`, not in named sibling keys.
+A sibling key a reader does not know is dropped when that reader re-encodes;
+`attrs` survives whole.
 
 ## `OutputFormat::Txt` retires
 
 No backend listed `Txt` in `SUPPORTED_FORMATS`, so every path that reached it
-failed at render time (#1058). The variant is removed rather than left as a
-guaranteed error.
+failed at render time (#1058).
 
 | Surface | 0.97 | 0.98 |
 |---|---|---|
@@ -106,10 +100,9 @@ guaranteed error.
 | TypeScript | `'pdf' \| 'svg' \| 'txt' \| 'png'` | `'pdf' \| 'svg' \| 'png'` |
 | CLI | `--format txt` fails at render | fails argument parsing |
 
-`OutputFormat::from_str("txt")` returns `ParseOutputFormatError`, whose message
-lists the three live formats. Exhaustive Rust matches over `OutputFormat` lose
-an arm; there is no replacement format, so a caller that asked for `txt` picks
-one of `pdf` / `svg` / `png`.
+There is no replacement format. `OutputFormat::from_str("txt")` returns
+`ParseOutputFormatError`, whose message lists the three live formats, and
+exhaustive Rust matches over `OutputFormat` lose an arm.
 
 ## One `backend::format_not_supported`
 
@@ -126,12 +119,12 @@ if (d.code === 'typst::format_not_supported' || d.code === 'pdfform::format_not_
 if (d.code === 'backend::format_not_supported')
 ```
 
-A backend outside this workspace that mints its own code for the condition
-should follow, so a host routes on one string regardless of which backend ran.
+A backend of your own should mint the same code, so a host routes on one string
+whichever backend ran.
 
 ## Removed Rust surface
 
-Accessors with no caller and a live equivalent are gone (#1066, #1064):
+Four accessors are removed, each with a live equivalent (#1066, #1064):
 
 | Removed | Use instead |
 |---|---|
@@ -145,16 +138,12 @@ Accessors with no caller and a live equivalent are gone (#1066, #1064):
 the `Deref` target — `QuillValue: Deref<Target = serde_json::Value>` resolves
 every one of those calls unchanged. **No action.**
 
-`prescan`'s `PreItem` / `PreScan` / `prescan_fence_content` and `reader::err`
-drop to `pub(crate)`. Both were reachable but internal; nothing outside the
-workspace can have depended on them without also depending on private shapes.
-
 ## Python: regions carry `DocPath`
 
 The `RenderedRegion` contract puts the plate→`DocPath` translation at the
 binding boundary. WASM did it; Python did not, so a Python caller got an address
-no document API accepts (#1063). The translation now lives in core as
-`regions_to_doc_path` and both bindings call it.
+no document API accepts (#1063). Both bindings now call the shared
+`regions_to_doc_path`.
 
 | 0.97 — plate-space | 0.98 — `DocPath` |
 |---|---|
@@ -165,32 +154,33 @@ no document API accepts (#1063). The translation now lives in core as
 
 The card index changes meaning as well as spelling: the plate form carries a
 **per-kind ordinal** (the *n*th `recipient`), the `DocPath` form an **absolute
-card index** (the *n*th card in the document). The two coincide only when a
-single kind is present; the binding resolves one to the other. Code that
-string-matched the plate form, or fed `region["field"]` back into a document API
-and worked around the rejection, should read the `DocPath` form directly. WASM
-is unchanged.
+card index** (the *n*th card in the document). The two coincide only when one
+kind is present. Code that string-matched the plate form, or worked around a
+document API rejecting `region["field"]`, reads the `DocPath` form directly
+instead. WASM is unchanged.
 
-## No action: the content decoder gets stricter
+## Stricter decode, and one markdown fix
 
-`Content::from_canonical_json` rejects two inputs it used to accept (#1051).
+`Content::from_canonical_json` rejects two inputs `0.97` accepted (#1051).
 Neither is producible by a Quillmark writer; both are reachable from a
 hand-built or hostile blob.
 
 - **Nesting past `MAX_NESTING_DEPTH` (100)** fails with
   `Invariant::NestingTooDeep`. Export recurses one frame per container, so a
-  20 000-deep path decoded clean and then aborted the process on `to_markdown`.
-- **A wire position past `usize`** fails instead of truncating. On wasm32 — the
-  deployment target — `as usize` turned `2^32 + 5` into an in-range `5`, landing
-  a mark at the wrong position in a document that then validated clean.
+  deep enough path decoded clean and then aborted the process on `to_markdown`.
+- **A wire position past `usize`** fails instead of truncating. On wasm32,
+  `as usize` landed `2^32 + 5` at position `5` — a mark at the wrong place in a
+  document that then validated clean.
 
 A mark spanning an island slot no longer swallows it, and a `LineKind` that
 disagrees with its segment is caught by `Invariant::LineKindMismatch`, carrying
 a `LineKindMismatch` reason (`IslandNotOneSlot` / `RuleNotEmpty` / `CodeHasSlot`).
 A direct `quillmark-content` dependent matching exhaustively on `Invariant` or
-`ApplyError` needs arms for the new variants.
+`ApplyError` needs arms for these.
 
-Export's verify-and-drop safety net — which settles a line's markdown by
-re-importing it and dropping marks until the text comes back intact — is now
-bounded per line rather than per mark (#1052). The `***` fixup is deleted; its
-only effect was dropping a literal asterisk.
+Markdown import keeps a literal `*` that abuts strong or emphasis. Under
+CommonMark's rule of three, `a***a**` is `a`, a literal `*`, then a strong `a`;
+the deleted fixup dropped the typed star and imported `aa` (#1053).
+`***bold italic***` is unaffected — it nests natively either way. The same
+removal fixes a backslash escape or entity in one of those spans re-entering
+the content as literal source bytes.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -29,8 +29,8 @@ guides in order.
   round-trips opaque and renders as a paragraph (or transparently) instead of
   failing the load, so adding a block construct is no longer a schema event.
   **Break:** `OutputFormat::Txt` is removed on every surface — the Rust variant,
-  Python's `OutputFormat.TXT`, the TS `'txt'` arm, and CLI `--format txt`. No
-  backend ever produced it, so every path reaching it failed at render.
+  Python's `OutputFormat.TXT`, the TS `'txt'` arm, CLI `--format txt`. No backend
+  ever produced it; there is no replacement.
   **Break:** `typst::format_not_supported` and `pdfform::format_not_supported`
   collapse into **`backend::format_not_supported`** — route on the one code.
   **Break:** `ReadValue::as_text` / `as_value` and `Quill::list_files` /
@@ -38,9 +38,11 @@ guides in order.
   `QuillValue`'s eight removed accessors resolve unchanged through `Deref` — no
   action.
   **Break (Python):** `RenderResult.regions[].field` is a `DocPath`
-  (`main.body`, `cards.<kind>[<i>].<field>`), not a plate-space address; WASM
-  was already correct. Additive: the content decoder enforces the nesting cap
-  and refuses out-of-range wire positions instead of truncating them.
+  (`main.body`, `cards.<kind>[<i>].<field>`), not a plate-space address, and its
+  card index is absolute rather than a per-kind ordinal; WASM was already
+  correct. No action: content decode enforces the nesting cap and refuses
+  out-of-range wire positions instead of truncating, and markdown import keeps a
+  literal `*` that abuts strong or emphasis.
 - [0.96 → 0.97](0.96-to-0.97.md) — the WASM transport read renames; `$id`
   becomes the unique card handle.
   **Break:** `Document.get` → **`Document.getStored`** (JS) — the quill-free

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,7 +18,8 @@ guides in order.
 
 ## Available guides
 
-- [0.97 → 0.98](0.97-to-0.98.md) — the block vocabulary opens.
+- [0.97 → 0.98](0.97-to-0.98.md) — the block vocabulary opens, and `txt`
+  retires.
   **Break:** `LineKind` and `Container` each gain an `Unknown { tag, attrs }`
   variant (exhaustive matches need an arm) and `Line` / `LineKind` / `Container`
   drop their `Eq` derive; `ContentLine.kind` and `ContentContainer.container`
@@ -27,6 +28,19 @@ guides in order.
   documents are unaffected: an unrecognized line kind or container now
   round-trips opaque and renders as a paragraph (or transparently) instead of
   failing the load, so adding a block construct is no longer a schema event.
+  **Break:** `OutputFormat::Txt` is removed on every surface — the Rust variant,
+  Python's `OutputFormat.TXT`, the TS `'txt'` arm, and CLI `--format txt`. No
+  backend ever produced it, so every path reaching it failed at render.
+  **Break:** `typst::format_not_supported` and `pdfform::format_not_supported`
+  collapse into **`backend::format_not_supported`** — route on the one code.
+  **Break:** `ReadValue::as_text` / `as_value` and `Quill::list_files` /
+  `list_subdirectories` are removed (match the variant; walk `quill.files()`).
+  `QuillValue`'s eight removed accessors resolve unchanged through `Deref` — no
+  action.
+  **Break (Python):** `RenderResult.regions[].field` is a `DocPath`
+  (`main.body`, `cards.<kind>[<i>].<field>`), not a plate-space address; WASM
+  was already correct. Additive: the content decoder enforces the nesting cap
+  and refuses out-of-range wire positions instead of truncating them.
 - [0.96 → 0.97](0.96-to-0.97.md) — the WASM transport read renames; `$id`
   becomes the unique card handle.
   **Break:** `Document.get` → **`Document.getStored`** (JS) — the quill-free

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -210,8 +210,10 @@ The widget is unsigned: Quillmark performs no cryptography. To produce a signed 
 | **SVG** | A `render()` output format — one SVG document per page. |
 | **PNG** | A `render()` output format — one raster per page at `RenderOptions::ppi` (default 144). |
 
-The backend's formats are `[Pdf, Svg, Png]`; `render` with any other
-`output_format` errors with `pdfform::format_not_supported`.
+The backend's formats are `[Pdf, Svg, Png]` — every `OutputFormat` there is. The
+guard behind them stays, so a format added to the enum and not to this backend
+errors with `backend::format_not_supported`, the code both built-in backends
+share.
 
 **Canvas** is a separate surface from the `render()` output formats above: it is
 the WASM `paint()` raster path (`render_rgba`), not an `OutputFormat`. See

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
       - Markdown Specification: reference/markdown-spec.md
   - Migration:
       - Overview: migrations/index.md
-      - 0.97 → 0.98 (block vocabulary opens; LineKind/Container gain Unknown; TS narrowing guards): migrations/0.97-to-0.98.md
+      - 0.97 → 0.98 (block vocabulary opens; LineKind/Container gain Unknown; TS narrowing guards; OutputFormat::Txt retires; backend::format_not_supported): migrations/0.97-to-0.98.md
       - 0.96 → 0.97 (WASM Document.get → getStored; verbatim transport read gains its own verb): migrations/0.96-to-0.97.md
       - '0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified)': migrations/0.95-to-0.96.md
       - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md


### PR DESCRIPTION
Release v0.98.0 with five breaking changes, all documented in the migration guide. Stored documents remain unaffected — a 0.97 blob loads byte-identically and 0.98 writes the same bytes for the same content.

## Key changes

- **Block vocabulary opens** (`LineKind` and `Container` gain `Unknown` variants): An unrecognized line kind or container name now round-trips opaque and renders as its nearest safe neighbor instead of failing the load. This makes adding a block construct no longer a schema-version event. Exhaustive Rust matches need an arm for the new variant; `Line` / `LineKind` / `Container` drop their `Eq` derive. TypeScript `ContentLine.kind` and `ContentContainer.container` gain an open arm, requiring narrowing guards for discriminant checks.

- **`OutputFormat::Txt` removed** across all surfaces: The Rust variant, Python's `OutputFormat.TXT`, TypeScript's `'txt'` arm, and CLI `--format txt` are all removed. No backend listed `Txt` in `SUPPORTED_FORMATS`, so every path reaching it failed at render time. Callers must pick `pdf` / `svg` / `png` instead.

- **Unified `format_not_supported` diagnostic code**: Both Typst and pdfform backends now emit `backend::format_not_supported` instead of their own codes, alongside the sibling `backend::apply_unsupported`. Route on the single namespaced code.

- **Dead public surface removed**: `ReadValue::as_text()` / `as_value()` (match the variants instead), `Quill::list_files()` / `list_subdirectories()` (use `quill.files()` instead). `QuillValue`'s eight removed accessors resolve unchanged through `Deref<Target = serde_json::Value>` — no action required. `prescan`'s helpers and `reader::err` drop to `pub(crate)`.

- **Python regions carry `DocPath`**: Rendered regions now cross the binding boundary as `DocPath` (`main.body`, `cards.<kind>[<i>].<field>`) instead of plate-space addresses. The plate→`DocPath` translation now lives in core as `regions_to_doc_path` and both bindings call it, matching WASM's behavior.

- **Content codec strictness**: Decode now enforces `MAX_NESTING_DEPTH` at the door and rejects out-of-range wire positions instead of truncating them (which on wasm32 turned `2^32 + 5` into an in-range `5`). A mark spanning an island slot no longer swallows it. `LineKind`/segment mismatches are caught with `Invariant::LineKindMismatch` carrying a reason enum.

- **Export safety net bounded per line**: The verify-and-drop safety net is now bounded per line rather than per mark. The `***` fixup is deleted — its only effect was dropping a literal asterisk.

- **Additive improvements**: `FileTreeNode`, `QuillIgnore`, `QuillConfig`, schema types, and `ValidationError` are now nameable from `quillmark` root and `quillmark_core` root. `From<PdfError> for RenderError` replaces two byte-identical copies. Workspace dependencies and publish metadata consolidated.

## Documentation

Migration guide at `docs/migrations/0.97-to-0.98.md` covers all breaking changes with code examples and action items. CHANGELOG and migration index updated.

Version bumped to 0.98.0 in `Cargo.toml` and all intra-project dependency pins.

https://claude.ai/code/session_013K27r3VoT5MPwmtVWiBpPA