### PR TITLE
refactor(typst): re-export span_scan/extract instead of forwarding

### DIFF
--- a/crates/backends/typst/src/overlay/mod.rs
+++ b/crates/backends/typst/src/overlay/mod.rs
@@ -8,6 +8,9 @@
 //! ownership lives here, in the backend, so the spine never imports
 //! `typst_layout`. [`default_producer`] (called from `compile.rs`) supplies
 //! the default `/Info` `/Producer` string the product layer threads down.
+//!
+//! [`span_scan`] recovers schema-field geometry and content positions from
+//! glyph spans. Its entry points re-export from this module.
 
 use quillmark_core::{Diagnostic, RenderError, Severity};
 use quillmark_pdf::{FieldSpec, FieldType, CHECKBOX_ON_STATE};
@@ -16,73 +19,10 @@ use typst_layout::PagedDocument;
 mod extract;
 mod span_scan;
 
-pub(crate) use span_scan::FieldWindow;
-
-/// Regions for content fields and direct scalar references, read from the
-/// laid-out frames' glyph spans and keyed on the schema path — each tracked
-/// window's first placement, one region per page it touches. `helper` is the
-/// helper `lib.typ` [`Source`](typst::syntax::Source) snapshot the served
-/// document was compiled from — never the world's live copy, which a failed
-/// apply may have already replaced. See [`span_scan`].
-pub(crate) fn scan_content_regions(
-    doc: &PagedDocument,
-    world: &crate::world::QuillWorld,
-    helper: &typst::syntax::Source,
-    windows: &[FieldWindow],
-) -> Vec<quillmark_core::RenderedRegion> {
-    span_scan::scan(doc, world, helper, windows)
-}
-
-/// The schema field under a point (PDF points, bottom-left origin) — the
-/// forward click→field direction. Every placement answers, not just the
-/// first. See [`span_scan::field_at`].
-pub(crate) fn field_at(
-    doc: &PagedDocument,
-    world: &crate::world::QuillWorld,
-    helper: &typst::syntax::Source,
-    windows: &[FieldWindow],
-    page: usize,
-    x: f32,
-    y: f32,
-) -> Option<String> {
-    span_scan::field_at(doc, world, helper, windows, page, x, y)
-}
-
-/// A point → content position in a content field (field + USV offset). The
-/// fine-grained click direction, cluster-exact. See [`span_scan::position_at`].
-pub(crate) fn position_at(
-    doc: &PagedDocument,
-    world: &crate::world::QuillWorld,
-    helper: &typst::syntax::Source,
-    windows: &[FieldWindow],
-    page: usize,
-    x: f32,
-    y: f32,
-) -> Option<quillmark_core::ContentHit> {
-    span_scan::position_at(doc, world, helper, windows, page, x, y)
-}
-
-/// A content position → caret rect in a content field. The reverse of
-/// [`position_at`]. See [`span_scan::locate`].
-pub(crate) fn locate(
-    doc: &PagedDocument,
-    world: &crate::world::QuillWorld,
-    helper: &typst::syntax::Source,
-    windows: &[FieldWindow],
-    field: &str,
-    pos: usize,
-) -> Option<quillmark_core::RenderedRegion> {
-    span_scan::locate(doc, world, helper, windows, field, pos)
-}
-
-/// Byte windows for the plate's direct `data.<field>` scalar references. See
-/// [`span_scan::scalar_windows`].
-pub(crate) fn scalar_windows(
-    source: &typst::syntax::Source,
-    fields: &[String],
-) -> Vec<(String, std::ops::Range<usize>)> {
-    span_scan::scalar_windows(source, fields)
-}
+pub(crate) use extract::extract;
+pub(crate) use span_scan::{
+    field_at, locate, position_at, scalar_windows, scan_content_regions, FieldWindow,
+};
 
 /// The kind of form field a placement declares, plus its per-kind payload.
 /// Mirrors the spine's [`FieldType`] but carries the *resolved* Typst value so
@@ -133,10 +73,6 @@ pub(crate) fn err(code: &'static str, msg: impl Into<String>) -> RenderError {
 /// (the product layer), never defaulted from the leaf spine's version.
 pub(crate) fn default_producer() -> String {
     format!("Quillmark {}", env!("CARGO_PKG_VERSION"))
-}
-
-pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, RenderError> {
-    extract::extract(doc)
 }
 
 /// Convert form-field placements into spine [`FieldSpec`]s, flipping each rect

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -399,7 +399,7 @@ enum Run {
 /// one [`RenderedRegion`] per page the placement's run touches, PDF
 /// bottom-left rects, sorted (page, field, window order). Best-effort like the
 /// widget path: an unresolvable span simply matches no window.
-pub(crate) fn scan(
+pub(crate) fn scan_content_regions(
     doc: &PagedDocument,
     world: &QuillWorld,
     helper: &Source,
@@ -540,11 +540,11 @@ fn accrue(boxes: &mut Vec<(usize, Aabb)>, hit: &Hit) {
 
 /// The schema field under a point — the forward (click → field) direction.
 /// `x`/`y` are PDF points with a **bottom-left** origin, the same convention
-/// as [`RenderedRegion::rect`]. Unlike [`scan`], every placement answers, not
-/// just the first: a concrete point identifies one frame item, whose span is
-/// unambiguous however many times its field is placed. Among tracked ink the
-/// later-painted item wins; untracked ink never occludes — a decorative
-/// overlay does not swallow clicks on the field beneath it.
+/// as [`RenderedRegion::rect`]. Unlike [`scan_content_regions`], every
+/// placement answers, not just the first: a concrete point identifies one frame
+/// item, whose span is unambiguous however many times its field is placed.
+/// Among tracked ink the later-painted item wins; untracked ink never occludes
+/// — a decorative overlay does not swallow clicks on the field beneath it.
 pub(crate) fn field_at(
     doc: &PagedDocument,
     world: &QuillWorld,
@@ -1056,7 +1056,7 @@ main:
             let helper = world
                 .source(QuillWorld::helper_fid("lib.typ"))
                 .expect("helper source");
-            let regions = scan(&doc, &world, &helper, &windows);
+            let regions = scan_content_regions(&doc, &world, &helper, &windows);
             regions
                 .iter()
                 .filter(|r| r.field == "body")
@@ -1860,7 +1860,7 @@ main:
             range: window_range,
             segments: vec![],
         }];
-        let regions = scan(&doc, &world, &helper, &windows);
+        let regions = scan_content_regions(&doc, &world, &helper, &windows);
         let issued: Vec<_> = regions.iter().filter(|r| r.field == "issued").collect();
         assert_eq!(
             issued.len(),


### PR DESCRIPTION
The last open removal on #1066 — the one item both status comments on that issue silently skipped.

`crates/backends/typst/src/overlay/mod.rs` wrapped five `span_scan` entry points (`scan_content_regions`, `field_at`, `position_at`, `locate`, `scalar_windows`) plus `extract` in bodies of exactly one call. The `span_scan` functions were already `pub(crate)`, so the wrappers bought nothing but a second copy of six- and seven-parameter signatures that had to be edited twice. All five call sites are in `lib.rs` (`:409, 435, 454, 469, 548`) and compile unchanged against the re-export.

`extract` was the same pattern one item further down (`mod.rs:77-79`, an undocumented forward to `extract::extract`) — not in the issue, found while removing the others.

`span_scan::scan` is renamed to `scan_content_regions` so the re-export needs no `as` alias and the function greps to one name.

## Docs

The wrapper doc comments were summaries of the `span_scan` docs and are dropped; the implementations keep the full versions. The one fact that lived only on a wrapper — that `helper` is the compile's own `Source` snapshot, never the world's live copy a failed apply may have replaced — is already stated at length in `span_scan`'s module header ("Resolution goes through the compile's own helper source"), so nothing is lost.

The `overlay` module header gains a two-sentence pointer at `span_scan` rather than a list of the re-exported names, per `dense-prose`'s rule against hand-maintained item lists in module headers.

## Verification

- `cargo test --workspace` — 48 suites, 0 failures
- `cargo clippy -p quillmark-typst --all-targets` — clean
- `cargo doc -p quillmark-typst --document-private-items` — 5 warnings, all pre-existing on `main` (verified by stashing), none new
- `node scripts/check-canon.mjs` — OK

Backend-internal (`pub(crate)`) throughout; no public API change, no migration entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192BizUqo4p4pFboBS8bR2J

---
_Generated by [Claude Code](https://claude.ai/code/session_0192BizUqo4p4pFboBS8bR2J)_