### PR TITLE
Condense migration guide index into a table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 **Quillmark is a schema-driven document engine.** Turn Markdown with card-yaml blocks into a fully typeset document — PDF, SVG, or PNG — with a Quill, via a Typst backend.
 
 !!! warning "Unstable APIs"
-    APIs may change between releases. Breaking changes are tracked in the [migration guides](migrations/index.md).
+    APIs may change between releases. Every break is covered by a guide under Migration.
 
 ## Choose your path
 

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -1,223 +1,40 @@
 # Migration Guides
 
-Quillmark evolves through deliberate, documented releases. When a release
-changes the document syntax, the plate-JSON wire format, or a public API in a
-way that is not backward compatible, it ships with a migration guide describing
-exactly what changed and how to update your documents, quills, and host code.
+A release that breaks the document syntax, the plate-JSON wire format, or a
+public API ships a guide for that version step. Most breaks are hard cutovers —
+the old form stops parsing or compiling — so the guide is the path forward, not
+an optional read.
 
-Many of these are **hard cutovers** — the old form stops parsing or compiling,
-so a guide is the path forward, not an optional read. Each guide is scoped to a
-single version step; to cross several versions, work through the relevant
-guides in order.
+Each guide covers one step. To cross several versions, work through them in
+order; each states its own breaks in full.
 
 !!! note "0.93 was never separately published"
 
     The 0.93 milestone folded into 0.94.0 — no 0.93.x release was tagged.
-    Upgrading from 0.92.1 means following the **0.92 → 0.93** and
-    **0.93 → 0.94** guides in sequence.
+    Upgrading from 0.92.1 means following **0.92 → 0.93** and **0.93 → 0.94**
+    in sequence.
 
-## Available guides
+## Guides
 
-- [0.97 → 0.98](0.97-to-0.98.md) — the block vocabulary opens, and `txt`
-  retires.
-  **Break:** `LineKind` and `Container` each gain an `Unknown { tag, attrs }`
-  variant (exhaustive matches need an arm) and `Line` / `LineKind` / `Container`
-  drop their `Eq` derive; `ContentLine.kind` and `ContentContainer.container`
-  gain an open TS arm, so a bare discriminant check no longer narrows — use the
-  new `isHeadingLine` / `isCodeLine` / `isListItemContainer` guards. Stored
-  documents are unaffected: an unrecognized line kind or container now
-  round-trips opaque and renders as a paragraph (or transparently) instead of
-  failing the load, so adding a block construct is no longer a schema event.
-  **Break:** `OutputFormat::Txt` is removed on every surface — the Rust variant,
-  Python's `OutputFormat.TXT`, the TS `'txt'` arm, CLI `--format txt`. No backend
-  ever produced it; there is no replacement.
-  **Break:** `typst::format_not_supported` and `pdfform::format_not_supported`
-  collapse into **`backend::format_not_supported`** — route on the one code.
-  **Break:** `ReadValue::as_text` / `as_value` and `Quill::list_files` /
-  `list_subdirectories` are removed (match the variant; walk `quill.files()`).
-  `QuillValue`'s eight removed accessors resolve unchanged through `Deref` — no
-  action.
-  **Break (Python):** `RenderResult.regions[].field` is a `DocPath`
-  (`main.body`, `cards.<kind>[<i>].<field>`), not a plate-space address, and its
-  card index is absolute rather than a per-kind ordinal; WASM was already
-  correct. No action: content decode enforces the nesting cap and refuses
-  out-of-range wire positions instead of truncating, and markdown import keeps a
-  literal `*` that abuts strong or emphasis.
-- [0.96 → 0.97](0.96-to-0.97.md) — the WASM transport read renames; `$id`
-  becomes the unique card handle.
-  **Break:** `Document.get` → **`Document.getStored`** (JS) — the quill-free
-  field/body read gains its own verb so it no longer collides with the interpreted
-  `quill.reader(doc).get`; semantics are unchanged, only the name. Rename
-  `doc.get(...)` call sites to `doc.getStored(...)`; `reader.get`, `getMarkdown`,
-  `getExt`, and `isFill` are untouched, and Python (no quill-free field read) is
-  unaffected.
-  **Break:** a card `$id` is now unique per document and never empty — parse
-  drops a duplicate or empty `$id` under a warning (first card keeps it),
-  card-insertion verbs throw `edit::card_id_collision` / `edit::empty_card_id`,
-  and a stored blob carrying a violation fails to load. New guarded verbs:
-  `Document::set_card_id` / `remove_card_id`. No writer up to 0.96 minted a
-  `$id`, so only documents hand-stamped with repeats are affected.
-- [0.95 → 0.96](0.95-to-0.96.md) — one address grammar on every boundary.
-  **Break:** `LiveSession` geometry (`regions` / `fieldAt` / `positionAt` /
-  `locate`) now keys on the canonical `DocPath` (`main.body`,
-  `cards.<kind>[<abs>].<field>`) instead of the plate-space
-  `$cards.<kind>.<ordinal>` form — migrate the preview/overlay code that reads
-  `region.field`. Mutator failures join the diagnostic taxonomy: every
-  `EditError` variant carries a namespaced `edit::*` `code`
-  (`edit::unknown_field`, `edit::field_conform`, …) in both bindings, the
-  `[EditError::<Variant>]` message-prefix is deleted (route on
-  `diagnostics[0].code`), and each mutator diagnostic now carries a `DocPath`
-  `path` (WASM). `Diagnostic.path` gains an exported `parseDocPath` /
-  `formatDocPath` (route on `DocPathSeg[]`, not a regex). Canon ratifies
-  null ≡ absent as a 1.0 commitment (no behavior change). The typed reader front
-  door is renamed `view()` → `reader()` (`DocumentView`/`CardView` → `*Reader`)
-  on every binding — migrate `.view(` call sites. The plate `$body` / `$kind`
-  become **absent on undefined**: a body-disabled kind or main drops `$body`, a
-  kindless card drops `$kind`, and a present `$body` is always a content object
-  (never a raw dict) — read plate metadata with a total accessor
-  (`card.at("$body", default: "")`). Adds `resolve()` (WASM) — the
-  resolved-value view: per field, value + source rung
-  (`"authored" | "default" | "zero"`), in one call (additive, no action).
-- [0.94 → 0.95](0.94-to-0.95.md) — WASM `pushCard` folds into
-  `insertCard(card, at?)` (one insertion verb; `insertCard`'s args reorder to
-  `(card, at?)`) and the deprecated `replaceBody` alias is deleted (use
-  `revise({}, md)` / `writer.setBody`); the typed `addCard` / `add_card` gains a
-  position, `TypedWriter::remove_card` and a JS `CardWriter.kind` getter close
-  writer/cursor asymmetries (#961). Core `Payload::insert` / `insert_fill`
-  validate the field-name/depth invariant at the boundary and return
-  `Result<_, FieldViolation>`, closing the `payload_mut().insert(...)` hole (a
-  `pub(crate)` `insert_unchecked` serves pre-validated callers; the `Card`/writer
-  mutators are unchanged) (#958). Parse warnings move fully onto `ParseOutput`:
-  `Document::warnings()` and the `from_main_and_cards` `warnings` param are
-  removed and `Document` `PartialEq` becomes a plain derive (#959); the two
-  parse functions then collapse into one entry `Document::parse(md) -> Parsed`
-  (`from_markdown` / `from_markdown_with_warnings` removed, `ParseOutput`
-  renamed `Parsed`; a document-only caller writes `parse(md)?.document`) (#964).
-  Additive, no action:
-  single-card reads `card(i)` / `cardIndexById(id)` / `seedOverlay(kind)` backed
-  by core `Document::card(i)` / `find_card(id)` (#956). The typed writer becomes
-  the one schema-bound door: `writer.reviseField` (typed *and* anchor-preserving)
-  lands, the quill-taking `commit*` ABI is underscored and hidden from the
-  `.d.ts`, and `EditError::BodyImport` renames to `Import` (#957, #966).
-  `getMarkdown` / `get_markdown` stop conflating absent with
-  present-but-not-richtext: a present field that does not decode now throws
-  `FieldRichtextDecode` instead of reading back blank — absence returns, mismatch
-  raises (#968). The `datetime` field type splits into strict `date` and
-  `datetime`: `date` accepts a bare `YYYY-MM-DD` and rejects any time component,
-  `datetime` accepts offset-less wall-clock `YYYY-MM-DDThh:mm[:ss]` and rejects
-  offsets/space/fractional/bare-date (offsets are rejected, never dropped). Most
-  `datetime` fields hold a bare date and rename to `type: date` with no data
-  change (#991). A present date field then arrives in the plate as a
-  click-to-edit **value-object**, not a bare `datetime`: render with
-  `(data.d.display)("…")` (parens required), reach the native datetime through
-  `data.d.value`, and audit vendored packages that call `.display()` on a date
-  (#990).
-- [0.93 → 0.94](0.93-to-0.94.md) — `type: richtext(inline)` retires; declare
-  `type: richtext` with `inline: true` instead. Blueprint still emits
-  `richtext(inline)<markdown>`; `build_transform_schema` gains
-  `quillmark:inline: true`. Typed field writes land: one schema-dispatched
-  writer (`Card::commit_field` / wasm `commitField` / Python `commit_field`) for
-  every field type, plus the schema-bound `TypedWriter`; strict writes fail a
-  mismatch at the write, not at render (#893). Live field edits go through the
-  writer + `apply(doc)` (the experimental `applyFieldDelta` / change-log surface
-  was removed, #886). Card-write verbs become mechanical twins of their
-  main-card names — `updateCardField`/`updateCardFields` rename to
-  `setCardField`/`setCardFields` (#895). The wasm `Card`
-  shape splits by direction: a read `Card` always has `body: Content`, while
-  `pushCard` / `insertCard` take a `CardInput` whose `body` still accepts a
-  markdown string and whose non-`kind` fields are optional (#917). The richtext
-  write grid then collapses into a document-free content codec (`importMarkdown`
-  / `exportMarkdown` / `rebase` / `mapPos`) plus the addressed content verbs
-  (`install` / `revise` / `applyChange`); the eager
-  `bodyMarkdown`/`fieldMarkdown` projections and the per-address body writers
-  retire pre-release, `replaceBody` / `replace_body` / `update_card_body` alias
-  for one cycle, and richtext fields gain the anchor-preserving `revise_field`
-  (#925). On-disk (markdown) identity stays markdown-lossy — the storage DTO is
-  the lossless carrier. The binding write surface then settles into two tiers:
-  `quill.writer(doc)` (WASM and Python alike) is the documented default —
-  typed `set` / `set_all` / `setBody` / `addCard` / `card(i)` and quill-free
-  `get` / `getMarkdown` reads — over the content lane and the opaque `setField`
-  primitive; the addressed `commit(addr, …)` is deleted (subsumed by the
-  writer) and a core-vs-bindings parity table governs drift (#932). Two field
-  types join the schema: `plaintext` (navigable unformatted prose over the
-  richtext content, via a literal codec) and a promoted first-class `enum`
-  (`type: enum` + `values:`, the `enum:` modifier on `string` deprecated for one
-  release); `string` narrows to open scalar data (#938). The `pdfform` backend's
-  `form.json` slims to a binding layer — `form@0.2.0`: bound `fields` drop
-  `type`/`options`/`multiline` (derived from the schema field's kind, `enum`
-  values, and `ui.multiline`), unbound widgets move to a `widgets` section,
-  binding runs at load so a bad `schema_field` fails with
-  `pdfform::dangling_binding` / `pdfform::unbindable_field` instead of a silent
-  blank, `form@0.1.0` is rejected, and `$cards` absolute-index addressing is
-  removed (#940). Groups gain a card-level `ui.groups` registry: `ui.group`
-  becomes a validated reference to a snake_case id (`quill::unknown_group`),
-  registry declaration order fixes display order, labels derive from ids with a
-  `title:` override, and bare label-as-identity groups are deprecated
-  (`quill::implicit_group`); plus two `ui.*` fixes — `ui.group` in a nested
-  position is now a load error (`quill::nested_group_not_supported`), and
-  typed-dictionary / typed-table-row properties render in declaration order
-  instead of alphabetically (#941). Field ordering then goes fully structural:
-  `ui.order` is removed (an authored `order:` is a load error), field and
-  card-kind display order becomes the key order of the emitted schema
-  (declaration order), and the auto-stamped `order:` integer disappears from
-  `QuillConfig::schema()` — consumers walk the maps in key order (#941).
-- [0.92 → 0.93](0.92-to-0.93.md) — the blueprint placeholder is rebuilt on two
-  orthogonal axes (value and marker): blueprints now stamp the `!must_fill` tag
-  instead of the `<must-fill>` string sentinel, and bare-null / `field:` now
-  falls back to default/zero instead of failing. The fatal
-  `validation::must_fill_sentinel` becomes the non-fatal `validation::must_fill`
-  warning (it never gates render), `validation::field_absent` is removed, and
-  bare scalars (`true`, `47`, `1.0`) coerce into `string` fields.
-- [0.91 → 0.92](0.91-to-0.92.md) — the additive `$seed` system key carries
-  per-card-kind seed overlays (`seedCard` gains an optional overlay argument);
-  **and** the placeholder tag `!fill` is renamed to `!must_fill` with no alias —
-  a stale `!fill` silently loses its placeholder status (warning, not error), so
-  rewrite your sources. The storage schema bumps to `quillmark/document@0.92.0`
-  (gaining `seed` and per-field `nested_fills`; old blobs migrate).
-- [0.90 → 0.91](0.90-to-0.91.md) — the closing `~~~` of a card-yaml block must
-  be at column zero (an indented `~~~` is payload, fixing silent truncation of
-  block-scalar values containing tilde fences); data-field names
-  (`[a-z_][a-z0-9_]*`) and the 100-level nesting limit are enforced on every
-  input path (parse, storage, wire, mutators — `set_ext` now returns
-  `Result`); quill loading skips symlinks and caps file size; Python binding
-  raises `ValueError` for non-finite floats, out-of-64-bit integers, and
-  over-deep values. Plus no-action round-trip/output fixes (YAML 1.2 comment
-  handling, image alt text, nested-key quoting).
-- [0.89 → 0.90](0.89-to-0.90.md) — `Quill` becomes engine-free data: the engine
-  no longer loads quills (`Quill.fromTree` / `quillmark::quill_from_path`
-  replace the factory) and now owns rendering and capability
-  (`engine.render` / `open` / `supportedFormats` / `supportsCanvas` take the
-  quill). The WASM package exposes a single root `@quillmark/wasm` import — the
-  canonical layer over an internal Typst-less core build, with the Typst backend
-  loaded lazily on first render; `supportedFormats` leaves
-  `Quill.metadata`;
-  the backend is resolved at render time; and `QuillSource` collapses into a
-  single core `Quill` (`Backend::open(&Quill)`).
-- [0.88 → 0.89](0.88-to-0.89.md) — `$quill` mismatches become hard errors: a
-  document rendered against a quill whose name differs, or whose version falls
-  outside the `$quill` selector, now fails (`quill::name_mismatch` /
-  `quill::version_mismatch` via the new `RenderError::QuillMismatch`) instead of
-  warning.
-- [0.87 → 0.88](0.87-to-0.88.md) — the schema-aware form view (`quill.form`,
-  `blankMain`, `blankCard`) is removed in favor of `quill.validate(doc)`; the
-  absence diagnostic is renamed `must_fill_absent` → `field_absent` (cell axis
-  "Must Fill" → **Unendorsed**); the `example` reference document folds into
-  `seedDocument()`; and a single `Card` shape flows in and out — the flat
-  `CardInput` is replaced by `Document.makeCard`, and `pushCard` / `insertCard`
-  accept the shape they return.
-- [0.86 → 0.87](0.86-to-0.87.md) — array fields require an `items` element
-  schema, `type: date` folds into a unified `type: datetime`, and schema load
-  rejects empty `properties` maps and deeper array nesting.
-- [0.85 → 0.86](0.85-to-0.86.md) — partial documents render without error, and
-  the canonical card-yaml fence becomes a bare `~~~`.
-- [0.83 → 0.84](0.83-to-0.84.md) — the Must Fill / Endorsed schema model
-  replaces `required:`, with Python ↔ WASM parity.
-- [0.82 → 0.83](0.82-to-0.83.md) — `$`-prefixed plate JSON wire format retires
-  the legacy uppercase reserved keys.
-- [0.81 → 0.82](0.81-to-0.82.md) — the card-yaml metadata syntax replaces the
-  `---`/`QUILL:` frontmatter and fenced cards.
-- [`@quillmark/wasm` 0.77 → 0.80](wasm-0.77-to-0.80.md) — migration notes for
-  WASM consumers crossing the card-syntax release.
+| Step | What changes |
+|---|---|
+| [0.97 → 0.98](0.97-to-0.98.md) | The block vocabulary opens — an unrecognized line kind or container round-trips opaque instead of failing the load. `OutputFormat::Txt` retires on every surface. |
+| [0.96 → 0.97](0.96-to-0.97.md) | The WASM transport read renames to `Document.getStored`. A card `$id` becomes unique per document and never empty. |
+| [0.95 → 0.96](0.95-to-0.96.md) | One address grammar (`DocPath`) on every boundary; mutator failures gain namespaced `edit::*` codes; `view()` renames to `reader()`. |
+| [0.94 → 0.95](0.94-to-0.95.md) | One insertion verb (`insertCard(card, at?)`) and one parse entry (`Document::parse`); the typed writer becomes the one schema-bound door; `datetime` splits into strict `date` and `datetime`. |
+| [0.93 → 0.94](0.93-to-0.94.md) | `type: richtext(inline)` retires for `inline: true`; typed field writes land; `ui.order` is removed — declaration order is the ordering contract. |
+| [0.92 → 0.93](0.92-to-0.93.md) | The blueprint placeholder splits into value and marker axes: the `!must_fill` tag replaces the `<must-fill>` string sentinel, and a bare null falls back to default/zero. |
+| [0.91 → 0.92](0.91-to-0.92.md) | `!fill` renames to `!must_fill` with no alias — a stale `!fill` silently loses placeholder status. `$seed` carries per-card-kind seed overlays. |
+| [0.90 → 0.91](0.90-to-0.91.md) | A card-yaml closing `~~~` must sit at column zero. Data-field names and the 100-level nesting limit are enforced on every input path. |
+| [0.89 → 0.90](0.89-to-0.90.md) | `Quill` becomes engine-free data — the engine takes the quill per call. The WASM package collapses to a single `@quillmark/wasm` root import. |
+| [0.88 → 0.89](0.88-to-0.89.md) | A `$quill` name or version mismatch fails the render instead of warning. |
+| [0.87 → 0.88](0.87-to-0.88.md) | The schema-aware form view gives way to `quill.validate(doc)`; one `Card` shape flows both in and out. |
+| [0.86 → 0.87](0.86-to-0.87.md) | Array fields require an `items` element schema; `type: date` folds into a unified `type: datetime`. |
+| [0.85 → 0.86](0.85-to-0.86.md) | A partial document renders without error; the canonical card-yaml fence becomes a bare `~~~`. |
+| [0.83 → 0.84](0.83-to-0.84.md) | The Must Fill / Endorsed schema model replaces `required:`. |
+| [0.82 → 0.83](0.82-to-0.83.md) | The `$`-prefixed plate JSON wire format retires the legacy uppercase reserved keys. |
+| [0.81 → 0.82](0.81-to-0.82.md) | card-yaml metadata replaces the `---` / `QUILL:` frontmatter and fenced cards. |
+| [`@quillmark/wasm` 0.77 → 0.80](wasm-0.77-to-0.80.md) | WASM consumers crossing the card-syntax release. |
 
 ## Related
 

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -160,7 +160,7 @@ A bound field's kind is derived from the **capability of the resolved schema fie
 
 ### Schema versioning and unknown keys
 
-`schema` follows the convention `quillmark/form@<version>`, hand-set at the last format change (never auto-derived from a crate version). The current format is **`quillmark/form@0.2.0`**. Unknown *keys* are **ignored, not rejected**, so the format can grow additively — but a retired *version* is rejected: a `form@0.1.0` file (which restated `type`/`options`/`multiline` on each field) fails to load with `pdfform::form_schema_version` and a pointer to the migration guide.
+`schema` follows the convention `quillmark/form@<version>`, hand-set at the last format change (never auto-derived from a crate version). The current format is **`quillmark/form@0.2.0`**. Unknown *keys* are **ignored, not rejected**, so the format can grow additively — but a retired *version* is rejected: a `form@0.1.0` file (which restated `type`/`options`/`multiline` on each field) fails to load with `pdfform::form_schema_version`.
 
 ### Opinionated styling
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,16 +54,10 @@ nav:
       - Reference: cli/reference.md
   - Reference:
       - Markdown Specification: reference/markdown-spec.md
-  - Migration:
-      - Overview: migrations/index.md
-      - 0.97 → 0.98 (block vocabulary opens; LineKind/Container gain Unknown; TS narrowing guards; OutputFormat::Txt retires; backend::format_not_supported): migrations/0.97-to-0.98.md
-      - 0.96 → 0.97 (WASM Document.get → getStored; verbatim transport read gains its own verb): migrations/0.96-to-0.97.md
-      - '0.95 → 0.96 (mutator edit:: codes; [EditError::…] prefix deleted; DocPath parser; null ≡ absent ratified)': migrations/0.95-to-0.96.md
-      - 0.94 → 0.95 (store* verbs; one WASM address; quill.view; RichText → Content; strict date/datetime): migrations/0.94-to-0.95.md
-      - 0.93 → 0.94 (richtext(inline) token retires; ui.order removed, declaration order is the ordering contract): migrations/0.93-to-0.94.md
+  - Migration: migrations/index.md
 
-# Superseded migration guides stay published — reachable from the Migration
-# overview and by URL — but are lifted out of the nav to keep it current.
+# The guides stay published — reachable from the Migration overview and by URL —
+# but the nav carries only the overview, which is the one list to maintain.
 not_in_nav: |
   /migrations/wasm-0.77-to-0.80.md
   /migrations/0.81-to-0.82.md
@@ -77,6 +71,11 @@ not_in_nav: |
   /migrations/0.90-to-0.91.md
   /migrations/0.91-to-0.92.md
   /migrations/0.92-to-0.93.md
+  /migrations/0.93-to-0.94.md
+  /migrations/0.94-to-0.95.md
+  /migrations/0.95-to-0.96.md
+  /migrations/0.96-to-0.97.md
+  /migrations/0.97-to-0.98.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -135,7 +135,7 @@ table.
 
 The single **idiom** row on the front door is the honest cost: the typed writer
 is the one shape pyo3 carries worst, so its "identical" is qualified, not
-claimed. See the as-built [0.93 → 0.94 migration](../../docs/migrations/0.93-to-0.94.md#the-two-tier-binding-surface-932).
+claimed.
 
 ## Python — `bindings/quillmark-python`
 
@@ -175,8 +175,7 @@ own linear memory, lazily loaded on the first render — there is no public
 `/core` or `/render` subpath. The core build is ~0.66 MB gzip; the Typst backend
 ~8 MB (Typst dominates), loaded only when something renders. Backend handles
 never escape the `Engine`: it clones the quill tree + `doc.toJson()` into the
-backend's memory as serialized data and frees the clones. See the
-[as-built 0.90 design](../../docs/migrations/0.89-to-0.90.md).
+backend's memory as serialized data and frees the clones.
 
 Beyond the byte-output verbs (`engine.render`, `LiveSession.render`), the
 canvas-capable backend builds (Typst, and pdfform under its preview seam)


### PR DESCRIPTION
Restructure the migration guides overview to improve scannability and reduce redundancy.

**Changes:**
- Replace the verbose bulleted list of migration guides with a compact table format that shows step, file link, and a one-line summary of what changes
- Simplify the introductory prose to be more concise while preserving the key message that breaks are hard cutovers
- Update `mkdocs.yml` to remove individual migration guide entries from the nav (keeping only the overview), since the overview now serves as the single authoritative list
- Add all recent migration guides (0.93–0.98) to the `not_in_nav` section to keep them published but out of the sidebar
- Remove stale migration guide references from `BINDINGS.md` and `pdfform-backend.md` that linked to specific sections

The table format makes it easier to scan all available guides at a glance and understand the scope of each step without having to parse dense prose descriptions.

https://claude.ai/code/session_019W9fKpojUxnSXKNCJD2EAs