### PR TITLE
content: split the wire lanes on reserved-name reuse (#1084, #1085, #1086)

### DIFF
--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -381,23 +381,20 @@ describe('@quillmark/wasm/runtime — MAIN_CARD_ADDR (the named main-card addres
 })
 
 describe('@quillmark/wasm/runtime — open-set membership guards (#1085)', () => {
+  // One known name per axis, not the whole table: membership is a `Set.has`,
+  // uniform across members, and the tables themselves are pinned against the
+  // Rust constants by `crates/bindings/wasm/tests/known_names_drift.rs`.
   it('answers known-vs-unknown on all four axes', () => {
-    for (const kind of ['para', 'heading', 'code', 'island', 'rule']) {
-      expect(isUnknownLine({ kind, containers: [] })).toBe(false)
-    }
+    expect(isUnknownLine({ kind: 'heading', level: 2, containers: [] })).toBe(false)
     expect(isUnknownLine({ kind: 'callout', attrs: {}, containers: [] })).toBe(true)
 
     expect(isUnknownContainer({ container: 'quote' })).toBe(false)
-    expect(isUnknownContainer({ container: 'list_item' })).toBe(false)
     expect(isUnknownContainer({ container: 'indent', attrs: {} })).toBe(true)
 
-    for (const type of ['strong', 'emph', 'underline', 'strike', 'code', 'link', 'anchor']) {
-      expect(isUnknownMark({ start: 0, end: 1, type })).toBe(false)
-    }
+    expect(isUnknownMark({ start: 0, end: 1, type: 'strong' })).toBe(false)
     expect(isUnknownMark({ start: 0, end: 1, type: 'highlight', attrs: {} })).toBe(true)
 
     expect(isUnknownIsland({ id: 'i1', type: 'table', props: {}, loss: 'lossless' })).toBe(false)
-    expect(isUnknownIsland({ id: 'i1', type: 'image', props: {}, loss: 'lossless' })).toBe(false)
     expect(isUnknownIsland({ id: 'i1', type: 'widget', props: {}, loss: 'lossless' })).toBe(true)
   })
 

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -22,7 +22,6 @@ import {
   MAIN_CARD_ADDR,
   isQuillmarkError,
   exportMarkdown,
-  isHeadingLine,
   isUnknownLine,
   isUnknownContainer,
   isUnknownMark,
@@ -400,14 +399,6 @@ describe('@quillmark/wasm/runtime — open-set membership guards (#1085)', () =>
     expect(isUnknownIsland({ id: 'i1', type: 'table', props: {}, loss: 'lossless' })).toBe(false)
     expect(isUnknownIsland({ id: 'i1', type: 'image', props: {}, loss: 'lossless' })).toBe(false)
     expect(isUnknownIsland({ id: 'i1', type: 'widget', props: {}, loss: 'lossless' })).toBe(true)
-  })
-
-  it('is the exact complement of the pinned-arm guards on the known names', () => {
-    // The point of the predicate: a consumer branches on membership rather than
-    // eliminating arm by arm against a hard-coded built-in list.
-    const line = { kind: 'heading', level: 2, containers: [] }
-    expect(isHeadingLine(line)).toBe(true)
-    expect(isUnknownLine(line)).toBe(false)
   })
 
   it('reports a missing or non-string discriminant as not-unknown, never throwing', () => {

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -22,6 +22,11 @@ import {
   MAIN_CARD_ADDR,
   isQuillmarkError,
   exportMarkdown,
+  isHeadingLine,
+  isUnknownLine,
+  isUnknownContainer,
+  isUnknownMark,
+  isUnknownIsland,
 } from '@quillmark-wasm/runtime'
 // Pin that the runtime's Quill IS the internal core build's class (re-export,
 // not a parallel wrapper). This imports the internal core artifact directly —
@@ -373,6 +378,44 @@ describe('@quillmark/wasm/runtime — MAIN_CARD_ADDR (the named main-card addres
     const doc = new Document('editor_test')
     doc.storeExt(MAIN_CARD_ADDR, { editor: { pinned: true } })
     expect(doc.main.ext.editor.pinned).toBe(true)
+  })
+})
+
+describe('@quillmark/wasm/runtime — open-set membership guards (#1085)', () => {
+  it('answers known-vs-unknown on all four axes', () => {
+    for (const kind of ['para', 'heading', 'code', 'island', 'rule']) {
+      expect(isUnknownLine({ kind, containers: [] })).toBe(false)
+    }
+    expect(isUnknownLine({ kind: 'callout', attrs: {}, containers: [] })).toBe(true)
+
+    expect(isUnknownContainer({ container: 'quote' })).toBe(false)
+    expect(isUnknownContainer({ container: 'list_item' })).toBe(false)
+    expect(isUnknownContainer({ container: 'indent', attrs: {} })).toBe(true)
+
+    for (const type of ['strong', 'emph', 'underline', 'strike', 'code', 'link', 'anchor']) {
+      expect(isUnknownMark({ start: 0, end: 1, type })).toBe(false)
+    }
+    expect(isUnknownMark({ start: 0, end: 1, type: 'highlight', attrs: {} })).toBe(true)
+
+    expect(isUnknownIsland({ id: 'i1', type: 'table', props: {}, loss: 'lossless' })).toBe(false)
+    expect(isUnknownIsland({ id: 'i1', type: 'image', props: {}, loss: 'lossless' })).toBe(false)
+    expect(isUnknownIsland({ id: 'i1', type: 'widget', props: {}, loss: 'lossless' })).toBe(true)
+  })
+
+  it('is the exact complement of the pinned-arm guards on the known names', () => {
+    // The point of the predicate: a consumer branches on membership rather than
+    // eliminating arm by arm against a hard-coded built-in list.
+    const line = { kind: 'heading', level: 2, containers: [] }
+    expect(isHeadingLine(line)).toBe(true)
+    expect(isUnknownLine(line)).toBe(false)
+  })
+
+  it('reports a missing or non-string discriminant as not-unknown, never throwing', () => {
+    // A malformed value is not an unknown construct — it is malformed, and the
+    // decoder rejects it. The guard must not turn one into the other.
+    for (const bad of [{}, { kind: 7 }, null, undefined]) {
+      expect(isUnknownLine(bad)).toBe(false)
+    }
   })
 })
 

--- a/crates/bindings/wasm/runtime.types.test-d.ts
+++ b/crates/bindings/wasm/runtime.types.test-d.ts
@@ -135,6 +135,7 @@ void contentHitKeys;
 import type {
 	Content,
 	ContentLine,
+	ContentLineKind,
 	ContentContainer,
 	ContentMark,
 	ContentIsland,
@@ -157,6 +158,7 @@ import type {
 export type ContentExportsPresent = [
 	Content,
 	ContentLine,
+	ContentLineKind,
 	ContentContainer,
 	ContentMark,
 	ContentIsland,
@@ -236,3 +238,47 @@ if (isListItemContainer(guardContainer)) {
 	const ordinal: number = guardContainer.ordinal;
 	void ordinal;
 }
+
+// ── Open-set membership guards (#1085) ──────────────────────────────────────
+// The negative predicates the pinned-arm guards above cannot express. Each `if`
+// body reads the open arm's opaque payload, reachable only after narrowing, so a
+// guard that stops narrowing fails `npm run typecheck`.
+import {
+	isUnknownLine,
+	isUnknownContainer,
+	isUnknownMark,
+	isUnknownIsland
+} from '../../../pkg/runtime/runtime.js';
+
+if (isUnknownLine(guardLine)) {
+	const attrs: unknown = guardLine.attrs;
+	void attrs;
+}
+if (isUnknownContainer(guardContainer)) {
+	const attrs: unknown = guardContainer.attrs;
+	void attrs;
+}
+if (isUnknownMark(guardMark)) {
+	const attrs: unknown = guardMark.attrs;
+	void attrs;
+}
+if (isUnknownIsland(guardIsland)) {
+	const props: unknown = guardIsland.props;
+	void props;
+}
+
+// ── ContentLineKind is nameable (#1086) ─────────────────────────────────────
+// `ContentLineKind` is exactly `setKind`'s payload, so building the op is a
+// whole-lift: drop a line's envelope, spread the rest. That spelling survives
+// every arm added upstream — including the open one, whose shape an arm-by-arm
+// switch would have to guess at. It only type-checks if the type is nameable
+// from the package entry point, which is the point of the re-export.
+function kindPart(line: ContentLine): ContentLineKind {
+	const { containers, continues, ...kind } = line;
+	void containers;
+	void continues;
+	return kind;
+}
+declare const liftLine: ContentLine;
+const liftedOp: LineOp = { op: 'setKind', line: 0, ...kindPart(liftLine) };
+void liftedOp;

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -57,9 +57,15 @@ export type {
 // `Content | string` — rather than forcing consumers to derive them structurally
 // off the `Document` handle. The content write path (a ProseMirror↔content codec)
 // must name all of them; they are its correctness core, not edge types.
+// `ContentLineKind` is the shared half of `ContentLine` and `setKind`, so lifting
+// a line's kind whole — destructure off `containers`/`continues`, spread the rest
+// into the op — is the version-proof spelling of building a `setKind`, and it is
+// nameable rather than cast-only (#1086). The alternative, an arm-by-arm switch,
+// means guessing at the open arm's shape and re-editing on every arm added.
 export type {
 	Content,
 	ContentLine,
+	ContentLineKind,
 	ContentContainer,
 	ContentMark,
 	ContentIsland,
@@ -180,6 +186,39 @@ export declare function isListItemContainer(
 	start: number;
 	ordinal: number;
 };
+
+// ── Open-set membership guards ──────────────────────────────────────────────
+// The guards above answer "is this arm X", one pinned arm at a time. These four
+// answer "is this a value this build knows?" — the question a read-modify-write
+// consumer must ask, since lowering an edit restates every line's kind and
+// containers, and a construct the consumer cannot hold is gone on write-back
+// unless it is carried inertly (#1085). Without a predicate a consumer
+// enumerates the built-in names itself and re-couples to a closed set, going
+// wrong at the first release that adds one.
+//
+// They classify unknown TAGS, not unknown payloads on known tags: a future
+// `kind: "footnote"` carrying a sibling `ref` loses `ref` at any consumer that
+// predates it, with or without these.
+
+/** True when this build does not know `line.kind` — the open arm, carrying opaque `attrs`. */
+export declare function isUnknownLine(
+	line: ContentLine
+): line is ContentLine & { kind: string; attrs: unknown };
+
+/** True when this build does not know `container.container`. See {@link isUnknownLine}. */
+export declare function isUnknownContainer(
+	container: ContentContainer
+): container is ContentContainer & { container: string; attrs: unknown };
+
+/** True when this build does not know `mark.type`. See {@link isUnknownLine}. */
+export declare function isUnknownMark(
+	mark: ContentMark
+): mark is ContentMark & { type: string; attrs: unknown };
+
+/** True when this build does not know `island.type` (its payload rides `props`, not `attrs`). */
+export declare function isUnknownIsland(
+	island: ContentIsland
+): island is ContentIsland & { type: string; props: unknown };
 
 // ── Canonical render-side types ─────────────────────────────────────────────
 // These are the BACKEND-NEUTRAL render contract of the plural-backend API. They

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -59,9 +59,10 @@ export type {
 // must name all of them; they are its correctness core, not edge types.
 // `ContentLineKind` is the shared half of `ContentLine` and `setKind`, so lifting
 // a line's kind whole — destructure off `containers`/`continues`, spread the rest
-// into the op — is the version-proof spelling of building a `setKind`, and it is
-// nameable rather than cast-only (#1086). The alternative, an arm-by-arm switch,
-// means guessing at the open arm's shape and re-editing on every arm added.
+// into the op — is the version-proof spelling of building a `setKind`. Naming it
+// is what makes that spelling type-check without a cast. The alternative, an
+// arm-by-arm switch, means guessing at the open arm's shape and re-editing on
+// every arm added.
 export type {
 	Content,
 	ContentLine,
@@ -192,9 +193,9 @@ export declare function isListItemContainer(
 // answer "is this a value this build knows?" — the question a read-modify-write
 // consumer must ask, since lowering an edit restates every line's kind and
 // containers, and a construct the consumer cannot hold is gone on write-back
-// unless it is carried inertly (#1085). Without a predicate a consumer
-// enumerates the built-in names itself and re-couples to a closed set, going
-// wrong at the first release that adds one.
+// unless it is carried inertly. Without a predicate a consumer enumerates the
+// built-in names itself and re-couples to a closed set, going wrong at the first
+// release that adds one.
 //
 // They classify unknown TAGS, not unknown payloads on known tags: a future
 // `kind: "footnote"` carrying a sibling `ref` loses `ref` at any consumer that

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -169,6 +169,65 @@ export function isListItemContainer(container) {
 	return container.container === 'list_item';
 }
 
+// ── Open-set membership guards ──────────────────────────────────────────────
+// The guards above each answer "is this arm X" — one pinned arm at a time. These
+// four answer the other question: "is this a value this build knows?" (#1085).
+// Without them a consumer that must branch known-vs-unknown — any
+// read-modify-write consumer, since lowering an edit restates every line's kind
+// and containers — enumerates the built-in names in its own source, recreating
+// the closed-set coupling the open set exists to remove. That list is correct
+// until the release that adds a built-in, at which point the new construct is
+// misclassified as unknown and round-trips through the consumer's unknown
+// carrier, losing any sibling-key payload.
+//
+// The known tables below are upstream's business, not a consumer's, which is why
+// this is a predicate rather than an exported name list. They are pinned against
+// the Rust source (`Content::RESERVED_*` and `KnownIslandType`) by the
+// `known_open_set_names_are_pinned` drift-guard test in
+// `crates/content/src/model.rs` — adding a built-in means editing there, here,
+// and the TS unions in `crates/bindings/wasm/src/engine.rs` in one commit.
+//
+// What these buy is narrower than it looks: they classify unknown *tags*, not
+// unknown *payloads on known tags*. A future `kind: "footnote"` with a sibling
+// `ref` loses `ref` at a consumer that predates it either way.
+
+const KNOWN_LINE_KINDS = new Set(['para', 'heading', 'code', 'island', 'rule']);
+const KNOWN_CONTAINERS = new Set(['list_item', 'quote']);
+const KNOWN_MARK_TYPES = new Set(['strong', 'emph', 'underline', 'strike', 'code', 'link', 'anchor']);
+const KNOWN_ISLAND_TYPES = new Set(['table', 'image']);
+
+/**
+ * @param {import('../core/wasm.js').ContentLine} line
+ * @returns {line is import('../core/wasm.js').ContentLine & { kind: string; attrs: unknown }}
+ */
+export function isUnknownLine(line) {
+	return typeof line?.kind === 'string' && !KNOWN_LINE_KINDS.has(line.kind);
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentContainer} container
+ * @returns {container is import('../core/wasm.js').ContentContainer & { container: string; attrs: unknown }}
+ */
+export function isUnknownContainer(container) {
+	return typeof container?.container === 'string' && !KNOWN_CONTAINERS.has(container.container);
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentMark} mark
+ * @returns {mark is import('../core/wasm.js').ContentMark & { type: string; attrs: unknown }}
+ */
+export function isUnknownMark(mark) {
+	return typeof mark?.type === 'string' && !KNOWN_MARK_TYPES.has(mark.type);
+}
+
+/**
+ * @param {import('../core/wasm.js').ContentIsland} island
+ * @returns {island is import('../core/wasm.js').ContentIsland & { type: string; props: unknown }}
+ */
+export function isUnknownIsland(island) {
+	return typeof island?.type === 'string' && !KNOWN_ISLAND_TYPES.has(island.type);
+}
+
 // Backend builds are NEVER statically imported here — that would pull a
 // multi-MB binary into the eager graph and defeat lazy loading. Each entry is a
 // DESCRIPTOR: `load` is a thunk returning a dynamic `import()` (a backend's

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -171,25 +171,25 @@ export function isListItemContainer(container) {
 
 // ── Open-set membership guards ──────────────────────────────────────────────
 // The guards above each answer "is this arm X" — one pinned arm at a time. These
-// four answer the other question: "is this a value this build knows?" (#1085).
-// Without them a consumer that must branch known-vs-unknown — any
-// read-modify-write consumer, since lowering an edit restates every line's kind
-// and containers — enumerates the built-in names in its own source, recreating
-// the closed-set coupling the open set exists to remove. That list is correct
-// until the release that adds a built-in, at which point the new construct is
-// misclassified as unknown and round-trips through the consumer's unknown
-// carrier, losing any sibling-key payload.
+// four answer the other question: "is this a value this build knows?" A consumer
+// that must branch known-vs-unknown — any read-modify-write consumer, since
+// lowering an edit restates every line's kind and containers — otherwise
+// enumerates the built-in names in its own source, recreating the closed-set
+// coupling the open set exists to remove. That list is correct until the release
+// that adds a built-in, at which point the new construct is misclassified as
+// unknown and round-trips through the consumer's unknown carrier, losing any
+// sibling-key payload.
 //
-// The known tables below are upstream's business, not a consumer's, which is why
-// this is a predicate rather than an exported name list. They are pinned against
-// the Rust source (`Content::RESERVED_*` and `KnownIslandType`) by the
+// A predicate rather than an exported name list, because the known tables below
+// are upstream's business. They are pinned against the Rust source
+// (`Content::RESERVED_*` and `KnownIslandType`) by the
 // `known_open_set_names_are_pinned` drift-guard test in
-// `crates/content/src/model.rs` — adding a built-in means editing there, here,
-// and the TS unions in `crates/bindings/wasm/src/engine.rs` in one commit.
+// `crates/content/src/model.rs`: adding a built-in means editing there, here, and
+// the TS unions in `crates/bindings/wasm/src/engine.rs` in one commit.
 //
-// What these buy is narrower than it looks: they classify unknown *tags*, not
-// unknown *payloads on known tags*. A future `kind: "footnote"` with a sibling
-// `ref` loses `ref` at a consumer that predates it either way.
+// These classify unknown *tags*, not unknown *payloads on known tags*. A future
+// `kind: "footnote"` with a sibling `ref` loses `ref` at a consumer that predates
+// it either way.
 
 const KNOWN_LINE_KINDS = new Set(['para', 'heading', 'code', 'island', 'rule']);
 const KNOWN_CONTAINERS = new Set(['list_item', 'quote']);

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1888,6 +1888,11 @@ impl Addr {
 /// Decode a JS value as a canonical `Content` content object — the `install`
 /// input (value semantics, content only). Rejects a markdown string: the cold
 /// path is spelled `install(addr, importMarkdown(md))`.
+///
+/// Reads through the **authored** lane, not the storage one: this content is
+/// something the host is writing now, so `attrs` beside a built-in discriminator
+/// is a stale built-in list rather than a document predating that built-in, and
+/// is reported instead of silently dropped (#1084).
 fn js_to_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, JsValue> {
     let json = js_value_to_json(value, ctx)?;
     if !json.is_object() {
@@ -1896,7 +1901,7 @@ fn js_to_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, J
         ))
         .to_js_value());
     }
-    quillmark_content::serial::from_canonical_value(&json)
+    quillmark_content::serial::from_authored_value(&json)
         .map_err(|e| WasmError::from(format!("{ctx}: not a canonical Content content: {e}")).to_js_value())
 }
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1396,7 +1396,7 @@ impl Document {
         #[wasm_bindgen(unchecked_param_type = "Content")] rt: JsValue,
     ) -> Result<(), JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
-        let content = js_to_content(rt, "install")?;
+        let content = js_to_authored_content(rt, "install")?;
         let base = self.addr_base(&addr);
         let card = self.addr_card_mut(&addr)?;
         match &addr.field {
@@ -1885,15 +1885,33 @@ impl Addr {
     }
 }
 
-/// Decode a JS value as a canonical `Content` content object — the `install`
-/// input (value semantics, content only). Rejects a markdown string: the cold
-/// path is spelled `install(addr, importMarkdown(md))`.
+/// Decode a JS value as a canonical `Content` content object (value semantics,
+/// content only). Rejects a markdown string: the cold path is spelled
+/// `install(addr, importMarkdown(md))`.
 ///
-/// Reads through the **authored** lane, not the storage one: this content is
-/// something the host is writing now, so `attrs` beside a built-in discriminator
-/// is a stale built-in list rather than a document predating that built-in, and
-/// is reported instead of silently dropped (#1084).
+/// The **storage** lane — `exportMarkdown(card.body)` and `rebase(base, md)` are
+/// handed content read back out of a document, which must keep opening whatever
+/// it was written as. A host authoring content goes through
+/// [`js_to_authored_content`].
 fn js_to_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, JsValue> {
+    js_to_content_with(value, ctx, quillmark_content::serial::from_canonical_value)
+}
+
+/// [`js_to_content`] on the **authored** lane — the `install` input. The host is
+/// writing this content now, so `attrs` beside a built-in discriminator is a
+/// stale copy of the built-in list rather than a document predating that
+/// built-in, and is reported instead of silently dropped.
+fn js_to_authored_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, JsValue> {
+    js_to_content_with(value, ctx, quillmark_content::serial::from_authored_value)
+}
+
+fn js_to_content_with(
+    value: JsValue,
+    ctx: &str,
+    read: fn(
+        &serde_json::Value,
+    ) -> Result<quillmark_core::Content, quillmark_content::serial::ParseError>,
+) -> Result<quillmark_core::Content, JsValue> {
     let json = js_value_to_json(value, ctx)?;
     if !json.is_object() {
         return Err(WasmError::from(format!(
@@ -1901,8 +1919,9 @@ fn js_to_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, J
         ))
         .to_js_value());
     }
-    quillmark_content::serial::from_authored_value(&json)
-        .map_err(|e| WasmError::from(format!("{ctx}: not a canonical Content content: {e}")).to_js_value())
+    read(&json).map_err(|e| {
+        WasmError::from(format!("{ctx}: not a canonical Content content: {e}")).to_js_value()
+    })
 }
 
 /// Lower a `ChangeBundle` (`{ delta?, lineOps?, markOps? }`) to core ops via the

--- a/crates/bindings/wasm/tests/known_names_drift.rs
+++ b/crates/bindings/wasm/tests/known_names_drift.rs
@@ -1,0 +1,85 @@
+//! Drift guard for the open sets' known halves.
+//!
+//! `runtime/runtime.js`'s `isUnknown*` guards decide known-vs-unknown from
+//! hand-spelled name tables. A table that lags a new built-in reports that
+//! built-in as unknown, and a read-modify-write consumer round-trips it through
+//! its unknown carrier, dropping the payload — silently, since the wire accepts
+//! the resulting write. So the tables are checked against the Rust constants
+//! they mirror rather than against a comment asking someone to remember.
+//!
+//! Native, not `wasm_bindgen_test`: this reads source text, so it needs no
+//! browser and no instantiated module.
+
+use quillmark_content::island::KnownIslandType;
+use quillmark_content::Content;
+
+const RUNTIME_JS: &str = include_str!("../runtime/runtime.js");
+
+/// The string literals of `const <name> = new Set([…]);`, in source order.
+fn js_set(name: &str) -> Vec<String> {
+    let decl = format!("const {name} = new Set([");
+    let start = RUNTIME_JS
+        .find(&decl)
+        .unwrap_or_else(|| panic!("runtime.js has no `{decl}…`"))
+        + decl.len();
+    let body = &RUNTIME_JS[start..];
+    let end = body.find("])").expect("unterminated Set literal");
+    body[..end]
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_matches('\'').trim_matches('"').to_string())
+        .collect()
+}
+
+#[test]
+fn js_known_name_tables_match_the_rust_open_sets() {
+    assert_eq!(js_set("KNOWN_LINE_KINDS"), Content::RESERVED_LINE_KINDS);
+    assert_eq!(js_set("KNOWN_CONTAINERS"), Content::RESERVED_CONTAINERS);
+    assert_eq!(js_set("KNOWN_MARK_TYPES"), Content::RESERVED_MARK_TYPES);
+    // The island axis has no reserved-name rule — its `type` is a bare `String`,
+    // never an `Unknown` variant — so `KnownIslandType` is the known half.
+    for ty in js_set("KNOWN_ISLAND_TYPES") {
+        assert!(
+            KnownIslandType::parse(&ty).is_some(),
+            "runtime.js knows an island type Rust does not: {ty}"
+        );
+    }
+    assert_eq!(js_set("KNOWN_ISLAND_TYPES").len(), 2, "island types added?");
+}
+
+/// The same names are spelled a third time as TypeScript unions in
+/// `src/engine.rs`. A union that lags a new built-in is a consumer that cannot
+/// narrow the new arm, so it is pinned here too — one place to look when adding
+/// a built-in. Arm *shape* varies (the payload-free mark types share one arm),
+/// so this asserts the name appears in the union, not how it is spelled there.
+#[test]
+fn ts_unions_name_every_built_in() {
+    const ENGINE_RS: &str = include_str!("../src/engine.rs");
+
+    /// The declaration body of `export type <name> = …`. Bounded by the blank
+    /// line before the next declaration, since an arm's own `;` separates its
+    /// members and cannot terminate the search.
+    fn ts_union(name: &str) -> &'static str {
+        let decl = format!("export type {name} =");
+        let start = ENGINE_RS
+            .find(&decl)
+            .unwrap_or_else(|| panic!("engine.rs has no `{decl}`"))
+            + decl.len();
+        let body = &ENGINE_RS[start..];
+        &body[..body.find("\n\n").expect("unterminated type alias")]
+    }
+
+    for (union, names) in [
+        (ts_union("ContentLineKind"), &Content::RESERVED_LINE_KINDS[..]),
+        (ts_union("ContentContainer"), &Content::RESERVED_CONTAINERS[..]),
+        (ts_union("ContentMark"), &Content::RESERVED_MARK_TYPES[..]),
+    ] {
+        for name in names {
+            assert!(
+                union.contains(&format!("\"{name}\"")),
+                "a TS union in engine.rs is missing the `{name}` arm"
+            );
+        }
+    }
+}

--- a/crates/bindings/wasm/tests/known_names_drift.rs
+++ b/crates/bindings/wasm/tests/known_names_drift.rs
@@ -39,13 +39,8 @@ fn js_known_name_tables_match_the_rust_open_sets() {
     assert_eq!(js_set("KNOWN_MARK_TYPES"), Content::RESERVED_MARK_TYPES);
     // The island axis has no reserved-name rule — its `type` is a bare `String`,
     // never an `Unknown` variant — so `KnownIslandType` is the known half.
-    for ty in js_set("KNOWN_ISLAND_TYPES") {
-        assert!(
-            KnownIslandType::parse(&ty).is_some(),
-            "runtime.js knows an island type Rust does not: {ty}"
-        );
-    }
-    assert_eq!(js_set("KNOWN_ISLAND_TYPES").len(), 2, "island types added?");
+    let island_types: Vec<_> = KnownIslandType::ALL.iter().map(|k| k.as_str()).collect();
+    assert_eq!(js_set("KNOWN_ISLAND_TYPES"), island_types);
 }
 
 /// The same names are spelled a third time as TypeScript unions in

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -32,6 +32,11 @@ pub enum KnownIslandType {
 }
 
 impl KnownIslandType {
+    /// Every known type. The one enumeration point, so a reader that needs the
+    /// closed set whole (the WASM guards' known-name table, say) asks rather than
+    /// re-spelling it.
+    pub const ALL: [KnownIslandType; 2] = [KnownIslandType::Table, KnownIslandType::Image];
+
     /// The wire discriminator; `parse(k.as_str()) == Some(k)` for every variant.
     pub fn as_str(self) -> &'static str {
         match self {

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -600,7 +600,15 @@ impl Content {
 
     /// Mark `type` names the projection reserves; an [`MarkKind::Unknown`] may
     /// not reuse one (its serialization would parse back as the built-in,
-    /// silently dropping its attrs — non-injective). Checked by [`Content::validate`].
+    /// silently dropping its attrs — non-injective).
+    ///
+    /// Two enforcement points, on two lanes (#1084). [`Content::validate`] catches
+    /// an in-process Rust construction. The wire never reaches it — a decoder
+    /// resolves the built-in name before the `Unknown` fallthrough, so a reserved
+    /// tag *becomes* the built-in rather than arriving as an `Unknown` — so the op
+    /// lane rejects the shape up front instead
+    /// ([`serial::mark_from_op_value`](crate::serial::mark_from_op_value) and its
+    /// two block-axis twins). Storage decode stays lenient by design; see there.
     pub const RESERVED_MARK_TYPES: [&'static str; 7] = [
         "strong",
         "emph",
@@ -844,6 +852,35 @@ mod tests {
 
     fn f(start: Usv, end: Usv, kind: MarkKind) -> Mark {
         Mark { start, end, kind }
+    }
+
+    /// Issue #1085: DRIFT GUARD. The four open sets' known halves are re-spelled
+    /// by hand on the TypeScript surface — the unions in
+    /// `crates/bindings/wasm/src/engine.rs` (`ContentLineKind`,
+    /// `ContentContainer`, `ContentMark`, `ContentIsland`) and the `isUnknown*`
+    /// guards' known-name tables in
+    /// `crates/bindings/wasm/runtime/runtime.js`. A guard whose table lags a new
+    /// built-in reports that built-in as unknown, and a consumer round-trips it
+    /// through its unknown carrier, dropping the payload. Adding a built-in means
+    /// editing this list and both of those sites in the same commit.
+    #[test]
+    fn known_open_set_names_are_pinned() {
+        assert_eq!(
+            Content::RESERVED_MARK_TYPES,
+            ["strong", "emph", "underline", "strike", "code", "link", "anchor"]
+        );
+        assert_eq!(
+            Content::RESERVED_LINE_KINDS,
+            ["para", "heading", "code", "island", "rule"]
+        );
+        assert_eq!(Content::RESERVED_CONTAINERS, ["list_item", "quote"]);
+        // The island axis has no reserved-name rule (its `type` is a bare
+        // `String`, never an `Unknown` variant), so `KnownIslandType` is the
+        // known half the guard mirrors.
+        for t in ["table", "image"] {
+            assert!(crate::island::KnownIslandType::parse(t).is_some());
+        }
+        assert!(crate::island::KnownIslandType::parse("widget").is_none());
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -602,13 +602,21 @@ impl Content {
     /// not reuse one (its serialization would parse back as the built-in,
     /// silently dropping its attrs — non-injective).
     ///
-    /// Two enforcement points, on two lanes (#1084). [`Content::validate`] catches
-    /// an in-process Rust construction. The wire never reaches it — a decoder
-    /// resolves the built-in name before the `Unknown` fallthrough, so a reserved
-    /// tag *becomes* the built-in rather than arriving as an `Unknown` — so the op
-    /// lane rejects the shape up front instead
-    /// ([`serial::mark_from_op_value`](crate::serial::mark_from_op_value) and its
-    /// two block-axis twins). Storage decode stays lenient by design; see there.
+    /// Two enforcement points, on two lanes. [`Content::validate`] catches an
+    /// in-process Rust construction. The wire never reaches it: a decoder resolves
+    /// the built-in name before the `Unknown` fallthrough, so a reserved tag
+    /// *becomes* the built-in rather than arriving as an `Unknown`. The authored
+    /// lane therefore rejects the shape up front
+    /// ([`serial::mark_from_op_value`](crate::serial::mark_from_op_value), its two
+    /// block-axis twins, and
+    /// [`serial::from_authored_value`](crate::serial::from_authored_value)), while
+    /// storage decode stays lenient by design — see there.
+    ///
+    /// This list and its two siblings are re-spelled by hand on the TypeScript
+    /// surface: the unions in `crates/bindings/wasm/src/engine.rs` and the
+    /// `isUnknown*` guards' tables in
+    /// `crates/bindings/wasm/runtime/runtime.js`. Both are pinned to these
+    /// constants by `crates/bindings/wasm/tests/known_names_drift.rs`.
     pub const RESERVED_MARK_TYPES: [&'static str; 7] = [
         "strong",
         "emph",
@@ -854,34 +862,6 @@ mod tests {
         Mark { start, end, kind }
     }
 
-    /// Issue #1085: DRIFT GUARD. The four open sets' known halves are re-spelled
-    /// by hand on the TypeScript surface — the unions in
-    /// `crates/bindings/wasm/src/engine.rs` (`ContentLineKind`,
-    /// `ContentContainer`, `ContentMark`, `ContentIsland`) and the `isUnknown*`
-    /// guards' known-name tables in
-    /// `crates/bindings/wasm/runtime/runtime.js`. A guard whose table lags a new
-    /// built-in reports that built-in as unknown, and a consumer round-trips it
-    /// through its unknown carrier, dropping the payload. Adding a built-in means
-    /// editing this list and both of those sites in the same commit.
-    #[test]
-    fn known_open_set_names_are_pinned() {
-        assert_eq!(
-            Content::RESERVED_MARK_TYPES,
-            ["strong", "emph", "underline", "strike", "code", "link", "anchor"]
-        );
-        assert_eq!(
-            Content::RESERVED_LINE_KINDS,
-            ["para", "heading", "code", "island", "rule"]
-        );
-        assert_eq!(Content::RESERVED_CONTAINERS, ["list_item", "quote"]);
-        // The island axis has no reserved-name rule (its `type` is a bare
-        // `String`, never an `Unknown` variant), so `KnownIslandType` is the
-        // known half the guard mirrors.
-        for t in ["table", "image"] {
-            assert!(crate::island::KnownIslandType::parse(t).is_some());
-        }
-        assert!(crate::island::KnownIslandType::parse("widget").is_none());
-    }
 
     #[test]
     fn is_blank_tracks_whitespace_and_islands() {

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -85,8 +85,8 @@ pub enum LineOp {
 // language bindings call them to lower a JS/Python bundle to core ops.
 
 use crate::serial::{
-    container_from_value, container_to_value, line_kind_from_value, line_kind_to_value,
-    mark_from_value, mark_to_value, usv_from, ParseError,
+    container_from_op_value, container_to_value, line_kind_from_op_value, line_kind_to_value,
+    mark_from_op_value, mark_to_value, usv_from, ParseError,
 };
 use serde_json::{Map, Value};
 
@@ -125,12 +125,12 @@ fn merge_mark(m: &mut Map<String, Value>, start: Usv, end: Usv, kind: &MarkKind)
 }
 
 /// Decode a [`MarkOp`] from its wire object. Dispatches on `op`; `add`/`remove`
-/// read the mark vocabulary through [`mark_from_value`].
+/// read the mark vocabulary through [`mark_from_op_value`].
 pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("mark op"))?;
     match o.get("op").and_then(Value::as_str) {
         Some("add") => {
-            let mark = mark_from_value(v)?;
+            let mark = mark_from_op_value(v)?;
             Ok(MarkOp::Add {
                 start: mark.start,
                 end: mark.end,
@@ -138,7 +138,7 @@ pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
             })
         }
         Some("remove") => {
-            let mark = mark_from_value(v)?;
+            let mark = mark_from_op_value(v)?;
             Ok(MarkOp::Remove {
                 start: mark.start,
                 end: mark.end,
@@ -204,7 +204,7 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
         Some("join") => Ok(LineOp::Join { line: line()? }),
         Some("setKind") => Ok(LineOp::SetKind {
             line: line()?,
-            kind: line_kind_from_value(v)?,
+            kind: line_kind_from_op_value(v)?,
         }),
         Some("setContainers") => Ok(LineOp::SetContainers {
             line: line()?,
@@ -213,7 +213,7 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
                 .and_then(Value::as_array)
                 .ok_or(ParseError::Shape("setContainers containers"))?
                 .iter()
-                .map(container_from_value)
+                .map(container_from_op_value)
                 .collect::<Result<_, _>>()?,
         }),
         Some("setContinues") => Ok(LineOp::SetContinues {
@@ -998,6 +998,55 @@ mod tests {
             let v = line_op_to_value(&op);
             assert_eq!(line_op_from_value(&v).unwrap(), op, "round-trip: {v}");
         }
+    }
+
+    /// Issue #1084: on the op lane, `attrs` beside a built-in discriminator is a
+    /// shape error. A host that emits one classified a built-in as unknown —
+    /// stale copy of the built-in list — and the lenient reader would resolve the
+    /// name and drop the payload unread, corrupting the line with no diagnostic.
+    #[test]
+    fn op_wire_rejects_attrs_beside_a_built_in_name() {
+        for bad in [
+            serde_json::json!({"op": "setKind", "line": 0, "kind": "para", "attrs": {"tone": "warn"}}),
+            serde_json::json!({"op": "setKind", "line": 0, "kind": "rule", "attrs": {}}),
+        ] {
+            assert!(
+                matches!(line_op_from_value(&bad), Err(ParseError::Shape(_))),
+                "accepted: {bad}"
+            );
+        }
+        let bad = serde_json::json!({
+            "op": "setContainers", "line": 0,
+            "containers": [{"container": "quote", "attrs": {"k": 1}}],
+        });
+        assert!(matches!(line_op_from_value(&bad), Err(ParseError::Shape(_))));
+        let bad = serde_json::json!({
+            "op": "add", "start": 0, "end": 1, "type": "strong", "attrs": {"k": 1},
+        });
+        assert!(matches!(mark_op_from_value(&bad), Err(ParseError::Shape(_))));
+
+        // An unknown name keeps carrying `attrs` — the rule is reserved-name
+        // reuse, not `attrs` itself — and a built-in without `attrs` is untouched.
+        for ok in [
+            serde_json::json!({"op": "setKind", "line": 0, "kind": "callout", "attrs": {"tone": "warn"}}),
+            serde_json::json!({"op": "setKind", "line": 0, "kind": "heading", "level": 2}),
+        ] {
+            assert!(line_op_from_value(&ok).is_ok(), "rejected: {ok}");
+        }
+    }
+
+    /// Issue #1084: the storage lane stays lenient, and must. A blob written
+    /// while `callout` was unknown carries `{kind: "callout", attrs}`; the
+    /// release that promotes `callout` to a built-in has to keep opening it, so
+    /// the op lane's strictness may not leak into `from_canonical_json`.
+    #[test]
+    fn storage_lane_still_opens_attrs_beside_a_built_in_name() {
+        let json = concat!(
+            r#"{"islands":[],"lines":[{"attrs":{"tone":"warn"},"containers":[],"#,
+            r#""kind":"para"}],"marks":[],"text":"x"}"#
+        );
+        let rt = crate::Content::from_canonical_json(json).unwrap();
+        assert_eq!(rt.lines[0].kind, LineKind::Para);
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -1006,15 +1006,10 @@ mod tests {
     /// name and drop the payload unread, corrupting the line with no diagnostic.
     #[test]
     fn op_wire_rejects_attrs_beside_a_built_in_name() {
-        for bad in [
-            serde_json::json!({"op": "setKind", "line": 0, "kind": "para", "attrs": {"tone": "warn"}}),
-            serde_json::json!({"op": "setKind", "line": 0, "kind": "rule", "attrs": {}}),
-        ] {
-            assert!(
-                matches!(line_op_from_value(&bad), Err(ParseError::Shape(_))),
-                "accepted: {bad}"
-            );
-        }
+        let bad = serde_json::json!({
+            "op": "setKind", "line": 0, "kind": "para", "attrs": {"tone": "warn"},
+        });
+        assert!(matches!(line_op_from_value(&bad), Err(ParseError::Shape(_))));
         let bad = serde_json::json!({
             "op": "setContainers", "line": 0,
             "containers": [{"container": "quote", "attrs": {"k": 1}}],

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -85,8 +85,8 @@ pub enum LineOp {
 // language bindings call them to lower a JS/Python bundle to core ops.
 
 use crate::serial::{
-    container_from_op_value, container_to_value, line_kind_from_op_value, line_kind_to_value,
-    mark_from_op_value, mark_to_value, usv_from, ParseError,
+    container_from_authored_value, container_to_value, line_kind_from_authored_value,
+    line_kind_to_value, mark_from_authored_value, mark_to_value, usv_from, ParseError,
 };
 use serde_json::{Map, Value};
 
@@ -125,12 +125,12 @@ fn merge_mark(m: &mut Map<String, Value>, start: Usv, end: Usv, kind: &MarkKind)
 }
 
 /// Decode a [`MarkOp`] from its wire object. Dispatches on `op`; `add`/`remove`
-/// read the mark vocabulary through [`mark_from_op_value`].
+/// read the mark vocabulary through [`mark_from_authored_value`].
 pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("mark op"))?;
     match o.get("op").and_then(Value::as_str) {
         Some("add") => {
-            let mark = mark_from_op_value(v)?;
+            let mark = mark_from_authored_value(v)?;
             Ok(MarkOp::Add {
                 start: mark.start,
                 end: mark.end,
@@ -138,7 +138,7 @@ pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
             })
         }
         Some("remove") => {
-            let mark = mark_from_op_value(v)?;
+            let mark = mark_from_authored_value(v)?;
             Ok(MarkOp::Remove {
                 start: mark.start,
                 end: mark.end,
@@ -204,7 +204,7 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
         Some("join") => Ok(LineOp::Join { line: line()? }),
         Some("setKind") => Ok(LineOp::SetKind {
             line: line()?,
-            kind: line_kind_from_op_value(v)?,
+            kind: line_kind_from_authored_value(v)?,
         }),
         Some("setContainers") => Ok(LineOp::SetContainers {
             line: line()?,
@@ -213,7 +213,7 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
                 .and_then(Value::as_array)
                 .ok_or(ParseError::Shape("setContainers containers"))?
                 .iter()
-                .map(container_from_op_value)
+                .map(container_from_authored_value)
                 .collect::<Result<_, _>>()?,
         }),
         Some("setContinues") => Ok(LineOp::SetContinues {

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -1035,20 +1035,6 @@ mod tests {
         }
     }
 
-    /// Issue #1084: the storage lane stays lenient, and must. A blob written
-    /// while `callout` was unknown carries `{kind: "callout", attrs}`; the
-    /// release that promotes `callout` to a built-in has to keep opening it, so
-    /// the op lane's strictness may not leak into `from_canonical_json`.
-    #[test]
-    fn storage_lane_still_opens_attrs_beside_a_built_in_name() {
-        let json = concat!(
-            r#"{"islands":[],"lines":[{"attrs":{"tone":"warn"},"containers":[],"#,
-            r#""kind":"para"}],"marks":[],"text":"x"}"#
-        );
-        let rt = crate::Content::from_canonical_json(json).unwrap();
-        assert_eq!(rt.lines[0].kind, LineKind::Para);
-    }
-
     #[test]
     fn delta_serde_shape() {
         let d = Delta {

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -146,6 +146,18 @@ fn arr<'a>(obj: &'a Map<String, Value>, key: &'static str) -> Result<&'a Vec<Val
         .ok_or(ParseError::Shape(key))
 }
 
+/// `v` as a slice, empty when it is not an array. The lenient counterpart to
+/// [`arr`], for a reader that only inspects what is there — [`from_canonical_value`]
+/// owns the shape errors.
+fn as_slice(v: &Value) -> &[Value] {
+    v.as_array().map(Vec::as_slice).unwrap_or_default()
+}
+
+/// `v[key]` as a slice, empty when the key is absent or not an array.
+fn arr_or_empty<'a>(v: &'a Value, key: &str) -> &'a [Value] {
+    v.get(key).map(as_slice).unwrap_or_default()
+}
+
 // ---- Line ----
 
 /// Encode a [`LineKind`] into its canonical `kind` fields (`"para"`,
@@ -382,79 +394,60 @@ pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
     Ok(Mark { start, end, kind })
 }
 
-// ---- Op-lane readers (strict about reserved-name reuse) ----
+// ---- Authored-lane readers (strict about reserved-name reuse) ----
 //
-// The three readers above resolve a built-in discriminator before the `Unknown`
+// The readers above resolve a built-in discriminator before the `Unknown`
 // fallthrough, so `{"kind": "para", "attrs": {…}}` decodes to `Para` and the
 // `attrs` are dropped unread. `Content::validate`'s reserved-name rule
-// (`Invariant::ReservedUnknownTag` and its two block-axis siblings) therefore
-// never sees such a value — it guards in-process Rust construction, not the wire
-// (#1084).
+// (`Invariant::ReservedUnknownTag` and its two block-axis siblings) never sees
+// such a value: it guards in-process Rust construction, not the wire.
 //
-// The two wire lanes want opposite answers to that drop:
+// The two wire lanes want opposite answers to that drop, and the seam between
+// them is not op-vs-content but authored-now vs read-back:
 //
-// - **Storage** (`Content::from_canonical_json`) must stay lenient. A blob
-//   written when `callout` was unknown carries `{"kind": "callout", "attrs":
-//   {…}}`; the release that makes `callout` a built-in must still open it.
-//   Rejecting `attrs` beside a built-in there would refuse documents at rest
-//   precisely when the vocabulary grows — the failure the open set exists to
-//   prevent.
-// - **Ops** (`crate::ops`) is ephemeral and host-built, so the same shape is
-//   never a document from the past, only a producer that classified a built-in
-//   as unknown — a host carrying a stale copy of the built-in list. There the
-//   drop is silent corruption, and a diagnostic costs nothing.
+// - **Storage** (`Content::from_canonical_json`) stays lenient. A blob written
+//   when `callout` was unknown carries `{"kind": "callout", "attrs": {…}}`, and
+//   the release that makes `callout` a built-in must still open it. Rejecting
+//   `attrs` beside a built-in here refuses documents at rest precisely when the
+//   vocabulary grows — the failure the open set exists to prevent.
+// - **Authored** (the `crate::ops` wire, and `install` through
+//   [`from_authored_value`]) rejects it. The host is writing now, so the shape
+//   means a stale copy of the built-in list, never a document from the past, and
+//   the drop is silent corruption.
 //
-// Hence one strict reader per axis, used only by the op wire. Narrow on purpose:
-// `attrs` beside a *reserved* name, nothing else. A stray sibling key is not
-// evidence of anything (a line object carries `containers`, an op carries
-// `op`/`line`), and only `attrs` is the unknown carrier's own spelling.
+// The rule is narrow on purpose: `attrs` beside a *reserved* name, nothing else.
+// A stray sibling key is evidence of nothing (a line object carries
+// `containers`, an op carries `op`/`line`), and `attrs` is the unknown carrier's
+// own spelling.
 
-/// [`line_kind_from_value`] for the op lane: `attrs` beside a built-in `kind` is
-/// a shape error rather than a silent drop.
-pub fn line_kind_from_op_value(v: &Value) -> Result<LineKind, ParseError> {
-    reject_reserved_attrs(
-        v,
-        "kind",
-        &Content::RESERVED_LINE_KINDS,
-        "attrs beside built-in kind",
-    )?;
+/// [`line_kind_from_value`] for the authored lane: `attrs` beside a built-in
+/// `kind` is a shape error rather than a silent drop.
+pub(crate) fn line_kind_from_authored_value(v: &Value) -> Result<LineKind, ParseError> {
+    reject_line_kind_attrs(v)?;
     line_kind_from_value(v)
 }
 
-/// [`container_from_value`] for the op lane. See [`line_kind_from_op_value`].
-pub fn container_from_op_value(v: &Value) -> Result<Container, ParseError> {
-    reject_reserved_attrs(
-        v,
-        "container",
-        &Content::RESERVED_CONTAINERS,
-        "attrs beside built-in container",
-    )?;
+/// [`container_from_value`] for the authored lane. See
+/// [`line_kind_from_authored_value`].
+pub(crate) fn container_from_authored_value(v: &Value) -> Result<Container, ParseError> {
+    reject_container_attrs(v)?;
     container_from_value(v)
 }
 
-/// [`mark_from_value`] for the op lane. See [`line_kind_from_op_value`].
-pub fn mark_from_op_value(v: &Value) -> Result<Mark, ParseError> {
-    reject_reserved_attrs(
-        v,
-        "type",
-        &Content::RESERVED_MARK_TYPES,
-        "attrs beside built-in mark type",
-    )?;
+/// [`mark_from_value`] for the authored lane. See [`line_kind_from_authored_value`].
+pub(crate) fn mark_from_authored_value(v: &Value) -> Result<Mark, ParseError> {
+    reject_mark_attrs(v)?;
     mark_from_value(v)
 }
 
 /// [`from_canonical_value`] for a content the **host authored just now** — the
-/// `install` input, not a blob read back from storage. Same decode, plus the op
-/// lane's reserved-name rule applied across the whole object, on every axis
+/// `install` input, not a blob read back from storage. Same decode, plus the
+/// reserved-name rule across the whole object, on every axis
 /// [`Content::validate`] checks: line kinds, containers, prose marks, and
 /// table-cell marks.
 ///
-/// The lane split is the one in [`line_kind_from_op_value`], drawn at the same
-/// seam: a value a host is writing *now* carrying `attrs` beside a built-in name
-/// is a stale built-in list, while the same bytes arriving from storage are a
-/// document from before that name was built in. An editor lowering a whole-field
-/// diff writes through here on every keystroke, so this is where the silent drop
-/// would do its damage.
+/// This is where the silent drop does its damage: an editor lowering a
+/// whole-field diff writes through here on every keystroke.
 pub fn from_authored_value(v: &Value) -> Result<Content, ParseError> {
     reject_reserved_attrs_deep(v)?;
     from_canonical_value(v)
@@ -466,64 +459,59 @@ pub fn from_authored_value(v: &Value) -> Result<Content, ParseError> {
 /// object spelled `{"type": "link", "attrs": …}`, and rejecting that would make
 /// the carrier unable to carry.
 fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
-    let Some(root) = v.as_object() else {
-        return Ok(());
-    };
-    let arr = |k: &str| root.get(k).and_then(Value::as_array).map(|a| a.as_slice());
-    for line in arr("lines").unwrap_or_default() {
-        reject_reserved_attrs(
-            line,
-            "kind",
-            &Content::RESERVED_LINE_KINDS,
-            "attrs beside built-in kind",
-        )?;
-        let containers = line
-            .get("containers")
-            .and_then(Value::as_array)
-            .map(|a| a.as_slice())
-            .unwrap_or_default();
-        for c in containers {
-            reject_reserved_attrs(
-                c,
-                "container",
-                &Content::RESERVED_CONTAINERS,
-                "attrs beside built-in container",
-            )?;
+    for line in arr_or_empty(v, "lines") {
+        reject_line_kind_attrs(line)?;
+        for c in arr_or_empty(line, "containers") {
+            reject_container_attrs(c)?;
         }
     }
-    for m in arr("marks").unwrap_or_default() {
+    for m in arr_or_empty(v, "marks") {
         reject_mark_attrs(m)?;
     }
-    // Cell marks ride the prose mark shape, so the rule follows them in. Only a
-    // table carries cells; any other `props` is opaque and left alone.
-    for island in arr("islands").unwrap_or_default() {
-        if island.get("type").and_then(Value::as_str) != Some("table") {
-            continue;
-        }
-        let props = island.get("props");
-        let header = props.and_then(|p| p.get("header")).and_then(Value::as_array);
-        let rows = props.and_then(|p| p.get("rows")).and_then(Value::as_array);
-        let cells = header
-            .into_iter()
-            .flatten()
-            .chain(rows.into_iter().flatten().filter_map(Value::as_array).flatten());
-        for cell in cells {
-            let marks = cell
-                .get("marks")
-                .and_then(Value::as_array)
-                .map(|a| a.as_slice())
-                .unwrap_or_default();
-            for m in marks {
-                reject_mark_attrs(m)?;
+    // Cell marks ride the prose mark shape, so the rule follows them in. The
+    // dispatch goes through `KnownIslandType` like every other one, so a new
+    // mark-carrying type is a compile error here rather than a silent skip.
+    for island in arr_or_empty(v, "islands") {
+        let ty = island.get("type").and_then(Value::as_str).unwrap_or_default();
+        match crate::island::KnownIslandType::parse(ty) {
+            Some(crate::island::KnownIslandType::Table) => {
+                let Some(props) = island.get("props") else {
+                    continue;
+                };
+                for cell in table_cell_values(props) {
+                    for m in arr_or_empty(cell, "marks") {
+                        reject_mark_attrs(m)?;
+                    }
+                }
             }
+            // No cells: an image's props are flat, an unknown type's are opaque.
+            Some(crate::island::KnownIslandType::Image) | None => {}
         }
     }
     Ok(())
 }
 
-fn reject_mark_attrs(m: &Value) -> Result<(), ParseError> {
+fn reject_line_kind_attrs(v: &Value) -> Result<(), ParseError> {
     reject_reserved_attrs(
-        m,
+        v,
+        "kind",
+        &Content::RESERVED_LINE_KINDS,
+        "attrs beside built-in kind",
+    )
+}
+
+fn reject_container_attrs(v: &Value) -> Result<(), ParseError> {
+    reject_reserved_attrs(
+        v,
+        "container",
+        &Content::RESERVED_CONTAINERS,
+        "attrs beside built-in container",
+    )
+}
+
+fn reject_mark_attrs(v: &Value) -> Result<(), ParseError> {
+    reject_reserved_attrs(
+        v,
         "type",
         &Content::RESERVED_MARK_TYPES,
         "attrs beside built-in mark type",
@@ -534,6 +522,9 @@ fn reject_mark_attrs(m: &Value) -> Result<(), ParseError> {
 /// built-in — the producer meant an unknown and named a known. A non-object or a
 /// missing/non-string discriminant is left to the reader that follows, which
 /// reports the shape error in its own terms.
+///
+/// `attrs` is tested first: it is absent on all but the unknown arms, and
+/// `serde_json` runs with `preserve_order`, so each key probe hashes.
 fn reject_reserved_attrs(
     v: &Value,
     discriminant: &str,
@@ -543,10 +534,13 @@ fn reject_reserved_attrs(
     let Some(o) = v.as_object() else {
         return Ok(());
     };
+    if !o.contains_key("attrs") {
+        return Ok(());
+    }
     let Some(tag) = o.get(discriminant).and_then(Value::as_str) else {
         return Ok(());
     };
-    if o.contains_key("attrs") && reserved.contains(&tag) {
+    if reserved.contains(&tag) {
         return Err(ParseError::Shape(err));
     }
     Ok(())
@@ -592,21 +586,21 @@ pub(crate) fn cell_to_value(text: &str, marks: &[Mark]) -> Value {
     Value::Object(m)
 }
 
+/// Every cell object in a table island's props — header then each body row, in
+/// order. The undecoded half of [`table_cells`], so a reader that needs the raw
+/// `Value` walks the same cells in the same order.
+pub(crate) fn table_cell_values(props: &Value) -> impl Iterator<Item = &Value> {
+    let header = arr_or_empty(props, "header").iter();
+    let rows = arr_or_empty(props, "rows")
+        .iter()
+        .flat_map(|row| as_slice(row).iter());
+    header.chain(rows)
+}
+
 /// Every cell's `(text, marks)` in a table island's props — header then each
 /// body row, in order. For [`Content::validate`]'s cell-mark invariant checks.
 pub(crate) fn table_cells(props: &Value) -> Vec<(String, Vec<Mark>)> {
-    let mut out = Vec::new();
-    if let Some(h) = props.get("header").and_then(Value::as_array) {
-        out.extend(h.iter().map(parse_cell));
-    }
-    if let Some(rows) = props.get("rows").and_then(Value::as_array) {
-        for row in rows {
-            if let Some(r) = row.as_array() {
-                out.extend(r.iter().map(parse_cell));
-            }
-        }
-    }
-    out
+    table_cell_values(props).map(parse_cell).collect()
 }
 
 // The `table` codec below (props normalize, shape-validate, cell extraction) is

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -382,6 +382,176 @@ pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
     Ok(Mark { start, end, kind })
 }
 
+// ---- Op-lane readers (strict about reserved-name reuse) ----
+//
+// The three readers above resolve a built-in discriminator before the `Unknown`
+// fallthrough, so `{"kind": "para", "attrs": {…}}` decodes to `Para` and the
+// `attrs` are dropped unread. `Content::validate`'s reserved-name rule
+// (`Invariant::ReservedUnknownTag` and its two block-axis siblings) therefore
+// never sees such a value — it guards in-process Rust construction, not the wire
+// (#1084).
+//
+// The two wire lanes want opposite answers to that drop:
+//
+// - **Storage** (`Content::from_canonical_json`) must stay lenient. A blob
+//   written when `callout` was unknown carries `{"kind": "callout", "attrs":
+//   {…}}`; the release that makes `callout` a built-in must still open it.
+//   Rejecting `attrs` beside a built-in there would refuse documents at rest
+//   precisely when the vocabulary grows — the failure the open set exists to
+//   prevent.
+// - **Ops** (`crate::ops`) is ephemeral and host-built, so the same shape is
+//   never a document from the past, only a producer that classified a built-in
+//   as unknown — a host carrying a stale copy of the built-in list. There the
+//   drop is silent corruption, and a diagnostic costs nothing.
+//
+// Hence one strict reader per axis, used only by the op wire. Narrow on purpose:
+// `attrs` beside a *reserved* name, nothing else. A stray sibling key is not
+// evidence of anything (a line object carries `containers`, an op carries
+// `op`/`line`), and only `attrs` is the unknown carrier's own spelling.
+
+/// [`line_kind_from_value`] for the op lane: `attrs` beside a built-in `kind` is
+/// a shape error rather than a silent drop.
+pub fn line_kind_from_op_value(v: &Value) -> Result<LineKind, ParseError> {
+    reject_reserved_attrs(
+        v,
+        "kind",
+        &Content::RESERVED_LINE_KINDS,
+        "attrs beside built-in kind",
+    )?;
+    line_kind_from_value(v)
+}
+
+/// [`container_from_value`] for the op lane. See [`line_kind_from_op_value`].
+pub fn container_from_op_value(v: &Value) -> Result<Container, ParseError> {
+    reject_reserved_attrs(
+        v,
+        "container",
+        &Content::RESERVED_CONTAINERS,
+        "attrs beside built-in container",
+    )?;
+    container_from_value(v)
+}
+
+/// [`mark_from_value`] for the op lane. See [`line_kind_from_op_value`].
+pub fn mark_from_op_value(v: &Value) -> Result<Mark, ParseError> {
+    reject_reserved_attrs(
+        v,
+        "type",
+        &Content::RESERVED_MARK_TYPES,
+        "attrs beside built-in mark type",
+    )?;
+    mark_from_value(v)
+}
+
+/// [`from_canonical_value`] for a content the **host authored just now** — the
+/// `install` input, not a blob read back from storage. Same decode, plus the op
+/// lane's reserved-name rule applied across the whole object, on every axis
+/// [`Content::validate`] checks: line kinds, containers, prose marks, and
+/// table-cell marks.
+///
+/// The lane split is the one in [`line_kind_from_op_value`], drawn at the same
+/// seam: a value a host is writing *now* carrying `attrs` beside a built-in name
+/// is a stale built-in list, while the same bytes arriving from storage are a
+/// document from before that name was built in. An editor lowering a whole-field
+/// diff writes through here on every keystroke, so this is where the silent drop
+/// would do its damage.
+pub fn from_authored_value(v: &Value) -> Result<Content, ParseError> {
+    reject_reserved_attrs_deep(v)?;
+    from_canonical_value(v)
+}
+
+/// The reserved-name scan [`from_authored_value`] runs, over the canonical
+/// content shape. Structural on purpose rather than a blind recursive walk: an
+/// unknown's `attrs` is opaque host payload that may legitimately contain an
+/// object spelled `{"type": "link", "attrs": …}`, and rejecting that would make
+/// the carrier unable to carry.
+fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
+    let Some(root) = v.as_object() else {
+        return Ok(());
+    };
+    let arr = |k: &str| root.get(k).and_then(Value::as_array).map(|a| a.as_slice());
+    for line in arr("lines").unwrap_or_default() {
+        reject_reserved_attrs(
+            line,
+            "kind",
+            &Content::RESERVED_LINE_KINDS,
+            "attrs beside built-in kind",
+        )?;
+        let containers = line
+            .get("containers")
+            .and_then(Value::as_array)
+            .map(|a| a.as_slice())
+            .unwrap_or_default();
+        for c in containers {
+            reject_reserved_attrs(
+                c,
+                "container",
+                &Content::RESERVED_CONTAINERS,
+                "attrs beside built-in container",
+            )?;
+        }
+    }
+    for m in arr("marks").unwrap_or_default() {
+        reject_mark_attrs(m)?;
+    }
+    // Cell marks ride the prose mark shape, so the rule follows them in. Only a
+    // table carries cells; any other `props` is opaque and left alone.
+    for island in arr("islands").unwrap_or_default() {
+        if island.get("type").and_then(Value::as_str) != Some("table") {
+            continue;
+        }
+        let props = island.get("props");
+        let header = props.and_then(|p| p.get("header")).and_then(Value::as_array);
+        let rows = props.and_then(|p| p.get("rows")).and_then(Value::as_array);
+        let cells = header
+            .into_iter()
+            .flatten()
+            .chain(rows.into_iter().flatten().filter_map(Value::as_array).flatten());
+        for cell in cells {
+            let marks = cell
+                .get("marks")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default();
+            for m in marks {
+                reject_mark_attrs(m)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_mark_attrs(m: &Value) -> Result<(), ParseError> {
+    reject_reserved_attrs(
+        m,
+        "type",
+        &Content::RESERVED_MARK_TYPES,
+        "attrs beside built-in mark type",
+    )
+}
+
+/// Error when `v` carries an `attrs` bag alongside a `discriminant` naming a
+/// built-in — the producer meant an unknown and named a known. A non-object or a
+/// missing/non-string discriminant is left to the reader that follows, which
+/// reports the shape error in its own terms.
+fn reject_reserved_attrs(
+    v: &Value,
+    discriminant: &str,
+    reserved: &[&str],
+    err: &'static str,
+) -> Result<(), ParseError> {
+    let Some(o) = v.as_object() else {
+        return Ok(());
+    };
+    let Some(tag) = o.get(discriminant).and_then(Value::as_str) else {
+        return Ok(());
+    };
+    if o.contains_key("attrs") && reserved.contains(&tag) {
+        return Err(ParseError::Shape(err));
+    }
+    Ok(())
+}
+
 // ---- Table cell {text, marks} ----
 //
 // A pipe-table cell is inline-only: its own plain `text` plus `marks` whose
@@ -821,6 +991,57 @@ mod tests {
             rt.validate(),
             Err(Invariant::ReservedUnknownContainer("quote".into()))
         );
+    }
+
+    /// Issue #1084: the authored lane (`install`) applies the reserved-name rule
+    /// the decoders cannot — by the time a lenient reader has resolved `"para"`
+    /// to `Para`, the `attrs` are gone and `validate` has nothing to object to.
+    /// Every axis `validate` checks, including cell marks.
+    #[test]
+    fn authored_lane_rejects_attrs_beside_a_built_in_name() {
+        let bad = [
+            // line kind
+            r#"{"islands":[],"lines":[{"attrs":{"tone":"warn"},"containers":[],"kind":"para"}],"marks":[],"text":"x"}"#,
+            // container
+            r#"{"islands":[],"lines":[{"containers":[{"attrs":{},"container":"quote"}],"kind":"para"}],"marks":[],"text":"x"}"#,
+            // prose mark
+            r#"{"islands":[],"lines":[{"containers":[],"kind":"para"}],"marks":[{"attrs":{},"end":1,"start":0,"type":"strong"}],"text":"x"}"#,
+            // table cell mark
+            concat!(
+                r#"{"islands":[{"id":"i1","loss":"lossless","props":{"aligns":["none"],"#,
+                r#""header":[{"marks":[{"attrs":{},"end":1,"start":0,"type":"emph"}],"text":"h"}],"#,
+                r#""rows":[[{"marks":[],"text":"r"}]]},"type":"table"}],"#,
+                r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
+            ),
+        ];
+        for json in bad {
+            let v: Value = serde_json::from_str(json).unwrap();
+            assert!(
+                matches!(from_authored_value(&v), Err(ParseError::Shape(_))),
+                "accepted: {json}"
+            );
+            // The storage lane opens all four — a document written before the
+            // name was built in must keep loading.
+            assert!(
+                Content::from_canonical_json(json).is_ok(),
+                "storage lane rejected: {json}"
+            );
+        }
+    }
+
+    /// Issue #1084: the authored lane's scan is structural, not a blind walk. An
+    /// unknown's `attrs` is opaque host payload and may contain an object spelled
+    /// like a reserved mark; rejecting that would make the carrier unable to
+    /// carry the thing it exists to carry.
+    #[test]
+    fn authored_lane_leaves_opaque_attrs_payload_alone() {
+        let json = concat!(
+            r#"{"islands":[],"lines":[{"attrs":{"nested":{"attrs":{},"type":"link"}},"#,
+            r#""containers":[],"kind":"callout"}],"marks":[],"text":"x"}"#
+        );
+        let v: Value = serde_json::from_str(json).unwrap();
+        let rt = from_authored_value(&v).unwrap();
+        assert_eq!(rt.to_canonical_json(), json);
     }
 
     /// Issue #1054: opaque block attrs are hash input, so their key order must

--- a/docs/migrations/0.98-to-0.99.md
+++ b/docs/migrations/0.98-to-0.99.md
@@ -1,0 +1,113 @@
+# 0.98 → 0.99 — the open sets get a membership question, and a strict write lane
+
+Stored blobs are unaffected: every `0.98` document still loads byte-identically,
+and `0.99` writes the same bytes for the same content. The one behavioral break
+is on the **write** lane, where a shape `0.98` accepted and silently emptied is
+now a diagnostic.
+
+| Break | Surface | Action |
+|---|---|---|
+| `attrs` beside a built-in discriminator rejected on write | TypeScript (`install` / `applyChange`), Rust (`quillmark-content` op wire) | Emit an unknown under a name this build does not use |
+
+New, no action required: `isUnknownLine` / `isUnknownContainer` /
+`isUnknownMark` / `isUnknownIsland` on the WASM surface, and `ContentLineKind`
+re-exported from the package entry point.
+
+## The reserved-name rule reaches the wire
+
+0.98 stated that an unknown may not reuse a built-in's name — `{kind: "para",
+attrs: {…}}` would serialize as the built-in and parse back as one, dropping the
+`attrs` — and enforced it in `Content::validate`. That check could not fire for
+anything arriving over the wire: a decoder resolves `"para"` to the built-in
+*before* the `Unknown` fallthrough, so the offending value never becomes an
+`Unknown` for `validate` to object to. The payload was dropped in silence
+(#1084).
+
+0.99 rejects the shape where a host authors it:
+
+```js
+// 0.98: accepted, stored as { kind: 'para' } — the attrs are gone, silently
+doc.applyChange(addr, { lineOps: [{ op: 'setKind', line: 0, kind: 'para', attrs: { tone: 'warn' } }] });
+
+// 0.99: throws — "content json shape: attrs beside built-in kind"
+```
+
+The rule is the same on all four axes and reads the same way each time: `attrs`
+next to a name this build has built in. It applies to `applyChange`'s line and
+mark ops and to `install` (whose scan covers line kinds, containers, prose marks,
+and table-cell marks — every axis `Content::validate` checks). In Rust the strict
+readers are `serial::{line_kind_from_op_value, container_from_op_value,
+mark_from_op_value}` and `serial::from_authored_value`; the lenient
+`*_from_value` readers keep their behavior and their names.
+
+**Reading a document never got stricter.** `Content::from_canonical_json` still
+accepts `{kind: "callout", attrs: {…}}` after `callout` becomes a built-in,
+because that blob is a document from before the promotion and must keep opening.
+Only a host writing the shape *now* is told, since only there does it mean a
+stale copy of the built-in list rather than a document from the past.
+
+If you hit this, you emitted an unknown under a name that is no longer unknown.
+The fix is the next section.
+
+## Asking whether a value is known
+
+0.98's guards each answer *"is this arm X"* — `isHeadingLine`, `isCodeLine`,
+`isListItemContainer`, `isTableIsland`, `isImageIsland`, `isLinkMark`,
+`isAnchorMark`. Nothing answered *"is this a value this build knows?"*, so a
+consumer that had to branch known-vs-unknown enumerated the built-in names in its
+own source — which is the closed-set coupling the open set was introduced to
+remove, and goes wrong at the first release that adds a built-in (#1085).
+
+```js
+import { isUnknownLine, isUnknownContainer, isUnknownMark, isUnknownIsland }
+  from '@quillmark/wasm/runtime';
+
+// 0.98 — correct today, stale at the next built-in
+const unknown = !['para', 'heading', 'code', 'island', 'rule'].includes(line.kind);
+
+// 0.99
+if (isUnknownLine(line)) carry(line.kind, line.attrs);
+```
+
+Each narrows to the open arm, so `attrs` (`props` on an island) is reachable in
+the true branch. The known names stay upstream's business, which is the point of
+an open set.
+
+## Render-only and read-modify-write read the guide differently
+
+0.98's advice — *treat unknown lines as paragraphs, unknown containers as
+absent* — is right for a **render-only** consumer and destructive for one that
+writes back. An editor lowers a whole-field diff, restating every line's `kind`
+and `containers` whenever any of them changed, so a construct its tree cannot
+hold is gone on the next keystroke: the document opens intact and saves mangled.
+
+A read-modify-write consumer carries unknowns **inertly** instead — a carrier per
+axis (an `unknown` mark, an `unknown` attribute on the paragraph, an
+`unknown_container` node) that renders as the nearest safe neighbor and re-emits
+the tag and `attrs` verbatim. `isUnknown*` is how it decides what to carry.
+
+The bound, stated once: **the carrier preserves unknown tags, not unknown
+payloads on known tags.** A future `kind: "footnote"` carrying a sibling `ref`
+loses `ref` at any consumer that predates it, guards or no. That is the other end
+of 0.98's *payload rides `attrs`* rule, and it is why the write lane now objects
+rather than dropping.
+
+## `ContentLineKind` is nameable
+
+`ContentLineKind` — the line-kind half `ContentLine` and `setKind` share — was
+declared in the generated `.d.ts` but not re-exported from the package entry
+point, and `package.json`'s `exports` map exposes only `"."`. It is now exported
+beside `ContentLine` and `LineOp` (#1086). No runtime change.
+
+That makes the whole-lift spelling of a `setKind` op type-check without a cast:
+
+```ts
+function kindPart(line: ContentLine): ContentLineKind {
+  const { containers, continues, ...kind } = line;
+  return kind;
+}
+const op: LineOp = { op: 'setKind', line, ...kindPart(line) };
+```
+
+The alternative — an arm-by-arm `switch` rebuilding the payload — means guessing
+at the open arm's shape and re-editing on every arm added upstream.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,6 +18,18 @@ guides in order.
 
 ## Available guides
 
+- [0.98 → 0.99](0.98-to-0.99.md) — the open sets get a membership question, and
+  a strict write lane.
+  **Break:** `attrs` beside a built-in discriminator (`{kind: "para", attrs:
+  {…}}`) is rejected where a host authors it — `install` and `applyChange`'s line
+  and mark ops — instead of resolving to the built-in and dropping the payload in
+  silence. Reading a stored document is unchanged and stays lenient by design.
+  New `isUnknownLine` / `isUnknownContainer` / `isUnknownMark` /
+  `isUnknownIsland` guards answer "is this a value this build knows?", so a
+  read-modify-write consumer no longer re-derives the built-in list; and
+  `ContentLineKind` is re-exported from the package entry point, making the
+  whole-lift spelling of a `setKind` op type-check without a cast. No action for
+  a render-only consumer.
 - [0.97 → 0.98](0.97-to-0.98.md) — the block vocabulary opens, and `txt`
   retires.
   **Break:** `LineKind` and `Container` each gain an `Unknown { tag, attrs }`

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -172,18 +172,20 @@ Two rules bound the openness:
   reaches that check on neither block axis nor the mark axis: a decoder resolves
   the built-in name *before* the `Unknown` fallthrough, so `{"kind": "para",
   "attrs": {…}}` decodes to `Para` and the attrs are dropped unread. The two
-  wire lanes therefore split (#1084):
+  wire lanes therefore split:
 
-    - **The op lane rejects it.** `attrs` beside a built-in discriminator is a
-      shape error (`serial::line_kind_from_op_value` and its two twins). An op
-      is ephemeral and host-built, so that shape is never a document from the
-      past — only a producer carrying a stale copy of the built-in list, whose
-      write would otherwise corrupt the line with no diagnostic.
+    - **The authored lane rejects it.** `attrs` beside a built-in discriminator
+      is a shape error (`serial::line_kind_from_authored_value` and its two
+      twins for the op wire, `serial::from_authored_value` for a whole content).
+      An op or an `install` is host-authored now, so that shape means a stale
+      copy of the built-in list, never a document from the past. Reads that hand
+      back stored content — `exportMarkdown`, `rebase` — are storage-lane, not
+      this one.
     - **The storage lane accepts it, and must.** A blob written while `callout`
       was unknown carries `{"kind": "callout", "attrs": {…}}`; the release that
       promotes `callout` to a built-in has to keep opening it. Rejecting at
       `from_canonical_json` would refuse documents at rest exactly when the
-      vocabulary grows — the failure this whole section exists to prevent.
+      vocabulary grows — the failure this section exists to prevent.
 
 The opaque attrs are hash input like everything else in the canonical form, so
 they are recursively key-sorted along with the rest (see Byte-stability). What
@@ -191,31 +193,31 @@ they are recursively key-sorted along with the rest (see Byte-stability). What
 — a new top-level key beside `text`/`lines`/`marks`/`islands`, or a changed
 meaning for an existing discriminator.
 
-### What openness buys a consumer, and what it does not
+### What openness buys a consumer
 
-Two consumer postures read this contract differently, and only one of them is
-served by "project an unknown as its nearest safe neighbor":
+"Project an unknown as its nearest safe neighbor" serves one consumer posture of
+two:
 
 - **Render-only.** Degrade and move on. An unknown line is a paragraph, an
   unknown container is absent; nothing is written back, so nothing is lost.
 - **Read-modify-write.** An editor lowers a whole-field diff, restating every
   line's `kind` and `containers` whenever any of them changed. A construct its
-  tree cannot hold is gone on the next keystroke — the document opens intact and
-  saves mangled. Such a consumer must carry unknowns *inertly*: a carrier node
-  per axis that renders as the nearest safe neighbor and re-emits the tag and
-  `attrs` verbatim.
+  tree cannot hold is gone on the next keystroke: the document opens intact and
+  saves mangled. Such a consumer carries unknowns *inertly* instead — a carrier
+  node per axis that renders as the nearest safe neighbor and re-emits the tag
+  and `attrs` verbatim.
 
 Classifying known-vs-unknown is therefore the read-modify-write consumer's
-problem, and the boundary answers it — `isUnknownLine` / `isUnknownContainer` /
+problem, and the boundary answers it: `isUnknownLine` / `isUnknownContainer` /
 `isUnknownMark` / `isUnknownIsland` on the WASM surface, `KnownIslandType::parse`
 and the `RESERVED_*` lists in Rust. A consumer that re-derives the built-in list
-instead has re-coupled to a closed set, and misreads the first release that adds
-a built-in.
+has re-coupled to a closed set, and misreads the first release that adds a
+built-in.
 
-The bound worth stating plainly: **the carrier preserves unknown tags, not
-unknown payloads on known tags.** A future `kind: "footnote"` carrying a sibling
-`ref` loses `ref` at any consumer that predates it, predicates or no — which is
-the first rule above (*payload rides `attrs`*) read from the other end.
+The bound: **the carrier preserves unknown tags, not unknown payloads on known
+tags.** A future `kind: "footnote"` carrying a sibling `ref` loses `ref` at any
+consumer that predates it, predicates or no — the first rule above (*payload
+rides `attrs`*) read from the other end.
 
 ## Island-id determinism
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -168,15 +168,54 @@ Two rules bound the openness:
   (`heading`, `quote`, `link`, …): it would serialize as the built-in and parse
   back as one, silently dropping its attrs. `Content::validate` rejects this
   (`Invariant::ReservedUnknownTag` / `ReservedUnknownLineKind` /
-  `ReservedUnknownContainer`). The enforcement point is **decode**, which every
-  read runs — a host that builds a non-injective tag through the op wire writes
-  a blob that saves and then fails to load, the same gap on all three axes.
+  `ReservedUnknownContainer`) for an in-process Rust construction. The wire
+  reaches that check on neither block axis nor the mark axis: a decoder resolves
+  the built-in name *before* the `Unknown` fallthrough, so `{"kind": "para",
+  "attrs": {…}}` decodes to `Para` and the attrs are dropped unread. The two
+  wire lanes therefore split (#1084):
+
+    - **The op lane rejects it.** `attrs` beside a built-in discriminator is a
+      shape error (`serial::line_kind_from_op_value` and its two twins). An op
+      is ephemeral and host-built, so that shape is never a document from the
+      past — only a producer carrying a stale copy of the built-in list, whose
+      write would otherwise corrupt the line with no diagnostic.
+    - **The storage lane accepts it, and must.** A blob written while `callout`
+      was unknown carries `{"kind": "callout", "attrs": {…}}`; the release that
+      promotes `callout` to a built-in has to keep opening it. Rejecting at
+      `from_canonical_json` would refuse documents at rest exactly when the
+      vocabulary grows — the failure this whole section exists to prevent.
 
 The opaque attrs are hash input like everything else in the canonical form, so
 they are recursively key-sorted along with the rest (see Byte-stability). What
 *does* remain a schema event is a change to the content object's own structure
 — a new top-level key beside `text`/`lines`/`marks`/`islands`, or a changed
 meaning for an existing discriminator.
+
+### What openness buys a consumer, and what it does not
+
+Two consumer postures read this contract differently, and only one of them is
+served by "project an unknown as its nearest safe neighbor":
+
+- **Render-only.** Degrade and move on. An unknown line is a paragraph, an
+  unknown container is absent; nothing is written back, so nothing is lost.
+- **Read-modify-write.** An editor lowers a whole-field diff, restating every
+  line's `kind` and `containers` whenever any of them changed. A construct its
+  tree cannot hold is gone on the next keystroke — the document opens intact and
+  saves mangled. Such a consumer must carry unknowns *inertly*: a carrier node
+  per axis that renders as the nearest safe neighbor and re-emits the tag and
+  `attrs` verbatim.
+
+Classifying known-vs-unknown is therefore the read-modify-write consumer's
+problem, and the boundary answers it — `isUnknownLine` / `isUnknownContainer` /
+`isUnknownMark` / `isUnknownIsland` on the WASM surface, `KnownIslandType::parse`
+and the `RESERVED_*` lists in Rust. A consumer that re-derives the built-in list
+instead has re-coupled to a closed set, and misreads the first release that adds
+a built-in.
+
+The bound worth stating plainly: **the carrier preserves unknown tags, not
+unknown payloads on known tags.** A future `kind: "footnote"` carrying a sibling
+`ref` loses `ref` at any consumer that predates it, predicates or no — which is
+the first rule above (*payload rides `attrs`*) read from the other end.
 
 ## Island-id determinism
 


### PR DESCRIPTION
Closes #1084, closes #1085, closes #1086.

All three findings verified against the tree; all three warranted. One of them asked for a fix I'd reject as written, and this takes the narrower version instead — see below.

## #1084 — the reserved-name rule never reached the wire

Confirmed. All three decoders resolve a built-in name *before* the `Unknown` fallthrough (`serial.rs` `line_kind_from_value` / `container_from_value` / `mark_from_value`), so `{kind: "para", attrs: {…}}` decodes to `Para` with `attrs` never read. `Content::validate`'s `ReservedUnknown*` guards therefore only ever see an in-process Rust construction — which is exactly what their tests build. The canon sentence claiming decode enforces the rule was false.

**Not taking the fix as proposed.** Rejecting `attrs` beside a built-in discriminator at *storage decode* breaks documents at rest across a vocabulary graduation: `{kind: "callout", attrs: {…}}` is a valid blob today, and the release that promotes `callout` to a built-in would hard-fail to load it. That manufactures the real version of the "saves then fails to load" failure the canon only imagined, aimed at legitimate old documents. The three decoders are also `pub` specifically so the op wire reuses them, so "reject at the wire decoder" cannot be scoped to ops without splitting them.

**Split the lanes instead**, at the seam that actually matters — not op-vs-content, but *host-authoring-now* vs *read-back-from-the-past*:

- `serial::{line_kind,container,mark}_from_authored_value` — the op wire. `attrs` beside a reserved name is `ParseError::Shape`.
- `serial::from_authored_value` — the `install` input, which is where the reported hazard actually bites (an editor lowers a whole-field diff on every keystroke). Scans every axis `validate` checks: line kinds, containers, prose marks, and table-cell marks.
- `from_canonical_json` / `from_canonical_value` — unchanged, lenient by design. `exportMarkdown` and `rebase` stay here too: both are handed content read back *out* of a document.

The scan is structural rather than a blind recursive walk: an unknown's `attrs` is opaque host payload that may legitimately contain an object spelled `{"type": "link", "attrs": …}`, and rejecting that would make the carrier unable to carry. Test pins both directions.

Narrow on purpose — `attrs` beside a *reserved* name, nothing else. A stray sibling key is not evidence of anything (a line object carries `containers`, an op carries `op`/`line`), and only `attrs` is the unknown carrier's own spelling.

## #1085 — no known-vs-unknown predicate

Confirmed: the eight exported guards are all pinned-arm positives, so a consumer that must branch known-vs-unknown enumerates the built-in names itself. Adds `isUnknownLine` / `isUnknownContainer` / `isUnknownMark` / `isUnknownIsland`, taking the predicate form over exported name lists — the known set stays upstream's business, which is the point of an open set.

Two things the issue did not cover:

- **The axes aren't symmetric.** `RESERVED_*` exists for marks, line kinds, and containers only; an island's `type` is a bare `String` with no `Unknown` variant and no reservation rule, so `isUnknownIsland` mirrors `KnownIslandType` instead (which gains an `ALL` enumeration point, as `OutputFormat::ALL` already sets precedent for).
- **Drift.** The known halves are re-spelled by hand in three places (Rust consts, the TS unions in `engine.rs`, the guards' tables). `crates/bindings/wasm/tests/known_names_drift.rs` parses the `KNOWN_*` Set literals out of `runtime.js` and the TS unions out of `engine.rs` and checks both against the Rust constants — verified it fails when a name is dropped from either side.

The secondary ask — amend `0.97-to-0.98.md` — **collides with a repo rule**: released migration guides are immutable and 0.98.0 is released. The diagnosis is right, so the correction lands in `DOCUMENT_STORAGE.md` and a new `0.98-to-0.99.md` instead, with the render-only vs read-modify-write split and the bound the issue closes on: *the carrier preserves unknown tags, not unknown payloads on known tags.*

## #1086 — `ContentLineKind` not re-exported

Confirmed and taken verbatim. Diffed every `export type` declared across `crates/bindings/wasm/src/*.rs` against `runtime.d.ts`: `ContentLineKind` is the **only** declared type absent from the entry point, so this was an oversight with no policy behind it. The whole-lift spelling is now a type test.

## Testing

- `cargo test --workspace` — 49 suites, all green.
- `npm test` (WASM) — 192 tests, all green.
- `npm run typecheck` — clean, which is what exercises the four guards' narrowing and the `ContentLineKind` whole-lift against the real generated types.
- `node scripts/check-canon.mjs` — clean.

New tests are scoped to what the code actually decides: the lane split in both directions on all four axes, the structural-not-recursive property of the scan, the op wire's wiring to the strict reader, and the drift guard. Membership enumeration is left to the drift guard rather than restated per-name in the JS suite.

## Note on scope

The issues describe Python as an affected wire host; it isn't. The content lane (`install` / `revise` / `applyChange`) is WASM-only by scope per `prose/canon/BINDINGS.md`, so there is no Python change here.

One thing deliberately left out: core's own strict-write boundary (`Leniency::Write` in `quill/config.rs`, `body_from_wire`) still reads through the storage lane. Routing those through the authored lane is defensible but changes behavior on surfaces nobody reported, so the canon states which doors the rule covers rather than widening the change.