### PR TITLE
content: close the three v1.0.0 codec gaps before the freeze

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -619,6 +619,14 @@ impl<'a> Emit<'a> {
                 (g0, Vec::new())
             }
             LineKind::Code { .. } => unreachable!("code handled by early return"),
+            // `LineKind` is open (`#[non_exhaustive]`): a block role added after
+            // this build lowers as a paragraph, the same projection
+            // `LineKind::Unknown` gets. Its inline content renders; its role is
+            // lost to the projection and survives in storage.
+            _ => {
+                let g0 = self.out.len();
+                (g0, self.emit_inline(lo, hi))
+            }
         };
         let g1 = self.out.len();
         self.segments.push(SegmentMap {
@@ -912,7 +920,12 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
                 ord: m.kind.ord(),
                 open: format!("#link(\"{}\")[", escape_string(url)),
             }),
+            // An anchor is identity, not formatting, and an unknown mark has no
+            // Typst spelling — both contribute no wrap. `MarkKind` is open
+            // (`#[non_exhaustive]`), so a kind added after this build takes the
+            // same nothing, matching `wrap_open`'s own fallthrough.
             MarkKind::Anchor { .. } | MarkKind::Unknown { .. } => {}
+            _ => {}
         }
     }
     codes.sort_unstable();

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -606,23 +606,16 @@ impl<'a> Emit<'a> {
                 let g0 = self.out.len();
                 (g0, self.emit_inline(lo, hi))
             }
-            // An unknown block role lowers as a paragraph — its inline content
-            // renders, its role is lost to the projection (it round-trips
-            // through storage).
-            LineKind::Island | LineKind::Para | LineKind::Unknown { .. } => {
-                let g0 = self.out.len();
-                (g0, self.emit_inline(lo, hi))
-            }
             LineKind::Rule => {
                 let g0 = self.out.len();
                 self.out.push_str("#line(length: 100%)");
                 (g0, Vec::new())
             }
             LineKind::Code { .. } => unreachable!("code handled by early return"),
-            // `LineKind` is open (`#[non_exhaustive]`): a block role added after
-            // this build lowers as a paragraph, the same projection
-            // `LineKind::Unknown` gets. Its inline content renders; its role is
-            // lost to the projection and survives in storage.
+            // `Island`, `Para`, `Unknown`, and — `LineKind` being
+            // `#[non_exhaustive]` — any role added after this build: all lower as
+            // a paragraph. The inline content renders; the role is lost to the
+            // projection and survives in storage.
             _ => {
                 let g0 = self.out.len();
                 (g0, self.emit_inline(lo, hi))
@@ -920,11 +913,10 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
                 ord: m.kind.ord(),
                 open: format!("#link(\"{}\")[", escape_string(url)),
             }),
-            // An anchor is identity, not formatting; an unknown mark has no
-            // Typst spelling. Neither contributes a wrap. `MarkKind` is open
-            // (`#[non_exhaustive]`), so a kind this build lacks contributes none
-            // either, matching `wrap_open`'s own fallthrough.
-            MarkKind::Anchor { .. } | MarkKind::Unknown { .. } => {}
+            // `Anchor` is identity, not formatting; `Unknown` has no Typst
+            // spelling; and `MarkKind` being `#[non_exhaustive]`, neither does a
+            // kind added after this build. None contributes a wrap, matching
+            // `wrap_open`'s own fallthrough.
             _ => {}
         }
     }

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -920,10 +920,10 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
                 ord: m.kind.ord(),
                 open: format!("#link(\"{}\")[", escape_string(url)),
             }),
-            // An anchor is identity, not formatting, and an unknown mark has no
-            // Typst spelling — both contribute no wrap. `MarkKind` is open
-            // (`#[non_exhaustive]`), so a kind added after this build takes the
-            // same nothing, matching `wrap_open`'s own fallthrough.
+            // An anchor is identity, not formatting; an unknown mark has no
+            // Typst spelling. Neither contributes a wrap. `MarkKind` is open
+            // (`#[non_exhaustive]`), so a kind this build lacks contributes none
+            // either, matching `wrap_open`'s own fallthrough.
             MarkKind::Anchor { .. } | MarkKind::Unknown { .. } => {}
             _ => {}
         }

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -285,8 +285,10 @@ export interface ImageProps {
  * `isImageIsland` guards (from `@quillmark/wasm/runtime`), which narrow it. */
 export type ContentIsland = {
     id: string;
-    /** How faithfully the markdown projection can carry this island. */
-    loss: "lossless" | "degraded" | "unrepresentable";
+    /** How faithfully the markdown projection can carry this island. Open like
+     * `type`: a class this build does not know round-trips verbatim, and reads
+     * as `unrepresentable`. */
+    loss: "lossless" | "degraded" | "unrepresentable" | (string & {});
 } & (
     | { type: "table"; props: TableProps }
     | { type: "image"; props: ImageProps }

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -57,6 +57,7 @@ pub struct Delta {
 /// (`{"retain": 5}`, `{"insert": "x"}`, `{"delete": 2}`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Op {
     /// Keep `n` chars of the base unchanged.
     Retain(usize),
@@ -70,6 +71,7 @@ pub enum Op {
 /// as `"before"` / `"after"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Assoc {
     /// Stay before inserted text.
     Before,

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -58,11 +58,11 @@ use crate::model::{Container, Island, LineKind, MarkKind, Content, ISLAND_SLOT};
 /// *describes* the projection's fidelity for a consumer to surface (issue
 /// #1043); the type decides whether a projection exists at all.
 ///
-/// Keeping the two apart is what makes a decode-time default safe. A known type
+/// Keeping the two apart is what makes a decode-time degrade safe. A known type
 /// a future writer stamped with a loss class this build lacks arrives as
-/// `Unrepresentable` (`serial::loss_from_str` degrades to the safe end) and
-/// still emits its table: the conservative default describes the value, it does
-/// not suppress it.
+/// `Loss::Unknown` — carried verbatim, reading as `Unrepresentable` through
+/// `Loss::fidelity` — and still emits its table: the conservative reading
+/// describes the value, it does not suppress it.
 pub fn to_markdown(rt: &Content) -> String {
     // Per-line char ranges, so global marks can be clipped to a line.
     let segments = line_segments(rt);

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -73,6 +73,7 @@ type UnderlineOpens = Rc<RefCell<HashSet<usize>>>;
 /// Import errors: just the nesting guard (mirrors the typst backend's
 /// `ConversionError::NestingTooDeep`).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ImportError {
     /// Container nesting exceeded [`MAX_NESTING_DEPTH`].
     NestingTooDeep { depth: usize, max: usize },

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -36,6 +36,14 @@ use serde_json::Value;
 /// Routing an internal exhaustive enum through a `#[non_exhaustive]` public
 /// re-export would buy the semver back and lose the guarantee — not the trade
 /// this module wants.
+///
+/// The trade runs the other way for [`MarkKind`](crate::model::MarkKind) and
+/// [`LineKind`](crate::model::LineKind), which do carry the attribute. What an
+/// unhandled arm costs there is decoration: the text still renders, the mark
+/// loses its delimiters, the line lowers as a paragraph. An unhandled island
+/// type costs the island — content leaves the projection entirely. A silent
+/// gap in a total function is worth a major bump; a silent gap in a
+/// degradation ladder that already has an `Unknown` rung is not.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KnownIslandType {
     /// `{header, rows, aligns}` with inline `{text, marks}` cells. Mark-carrying,

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -22,6 +22,20 @@ use serde_json::Value;
 /// string [`Island::island_type`](crate::model::Island::island_type); this is its
 /// closed parse. Adding a variant forces every dispatch arm — here and in the two
 /// emitters — to be supplied before the workspace compiles.
+///
+/// **Deliberately not `#[non_exhaustive]`**, unlike every other public enum in
+/// this crate. The attribute forces a `_` arm on downstream matchers, and two of
+/// the dispatch sites this enum exists to police — the typst backend's markdown
+/// and Typst emitters — are in another crate, where that `_` would swallow
+/// exactly the compile error described above.
+///
+/// The cost is that **adding a variant is a semver-major change**, since a
+/// downstream exhaustive match stops compiling. That is the price of the
+/// guarantee, paid on purpose: an island type wired into some emitters and not
+/// others projects the island away silently, which is worse than a major bump.
+/// Routing an internal exhaustive enum through a `#[non_exhaustive]` public
+/// re-export would buy the semver back and lose the guarantee — not the trade
+/// this module wants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KnownIslandType {
     /// `{header, rows, aligns}` with inline `{text, marks}` cells. Mark-carrying,

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -109,8 +109,13 @@ impl LineKind {
     /// `match` cannot serve — a `matches!(kind, Para)` that special-cases the
     /// paragraph (suppressing an empty block, say) reads as complete but drops
     /// the open arm, and the two emitters then drift on the construct neither
-    /// knows. An exhaustive `match` keeps listing both arms; the compiler polices
-    /// that one.
+    /// knows.
+    ///
+    /// An exhaustive `match` keeps listing both arms, and in this crate the
+    /// compiler still polices that — `#[non_exhaustive]` does not apply within
+    /// the defining crate. It does apply to the typst backend, whose emitter
+    /// folds both arms into one wildcard; there the ladder, not the compiler,
+    /// is what keeps a new role rendering.
     pub fn projects_as_para(&self) -> bool {
         matches!(self, LineKind::Para | LineKind::Unknown { .. })
     }
@@ -1225,39 +1230,24 @@ mod tests {
     }
 
     /// Issue #1092: a cell is canonicalized in place, so a key this build does
-    /// not recognize survives — the carriage every other opaque payload in the
-    /// model has. The rule has no slack: `normalize` runs on decode, on every op
-    /// apply, and on every serialize, so a cell rebuilt whole drops the key on
-    /// first contact and every contact after.
+    /// not recognize survives. The rule has no slack — `normalize` runs on
+    /// decode, on every op apply, and on every serialize, so a cell rebuilt
+    /// whole drops the key on first contact and every contact after.
     #[test]
     fn unrecognized_cell_key_survives_normalize() {
-        let mut rt = Content::empty();
-        rt.text = ISLAND_SLOT.to_string();
-        rt.lines = vec![Line {
-            kind: LineKind::Island,
-            containers: vec![],
-            continues: false,
-        }];
-        rt.islands = vec![Island {
-            id: "i".into(),
-            island_type: "table".into(),
-            props: serde_json::json!({
-                "aligns": ["none"],
-                "header": [{"text": "h", "marks": [], "colspan": 2}],
-                "rows": [[{"text": "a", "marks": []}]],
-            }),
-            loss: Loss::Lossless,
-        }];
+        // Two columns, one body cell: `pad_row` mints the second, so the same
+        // pass exercises both a carried cell and a synthesized one.
+        let mut rt = table_rt(serde_json::json!({
+            "aligns": ["none", "none"],
+            "header": [{"text": "h", "marks": [], "colspan": 2}, cell("h2")],
+            "rows": [[cell("a")]],
+        }));
         rt.normalize();
-        assert_eq!(rt.validate(), Ok(()));
         assert_eq!(rt.islands[0].props["header"][0]["colspan"], 2);
-        // The padded cell `pad_row` mints carries nothing, and should not.
-        assert!(rt.islands[0].props["rows"][0][0].get("colspan").is_none());
-        // Idempotent, and the carried key is hash input like any other.
-        let once = rt.to_canonical_json();
-        rt.normalize();
-        assert_eq!(rt.to_canonical_json(), once);
-        assert!(once.contains(r#""colspan":2"#));
+        // A minted cell has nothing to carry.
+        assert!(rt.islands[0].props["rows"][0][1].get("colspan").is_none());
+        // Hash input like any other key.
+        assert!(rt.to_canonical_json().contains(r#""colspan":2"#));
     }
 
     /// `validate` bounds a cell mark by its own cell's text length (in USV).

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -75,6 +75,7 @@ pub struct Line {
 /// instead of refusing the whole document, and the opaque tag+attrs still reach a
 /// reader that understands them (`DOCUMENT_STORAGE.md` § Open vocabularies).
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum LineKind {
     Para,
     /// ATX/Setext heading, level 1..=6.
@@ -121,6 +122,7 @@ impl LineKind {
 /// [`Container::Unknown`] and projects *transparently* — its lines render at the
 /// enclosing level, with no prefix, no wrapper, and no grouping of their own.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Container {
     /// A list item. `ordered` distinguishes `1.` from `-`; `start` is the list's
     /// first number (1 by default); `ordinal` is this item's 0-based index in
@@ -164,6 +166,7 @@ pub struct Mark {
 /// algebra classes: formatting is a property of a range (two coincident are
 /// redundant); identity is a handle (two over the same range are two things).
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum MarkKind {
     // Formatting — round-trippable projection marks. `is_formatting()`.
     Strong,
@@ -217,15 +220,45 @@ pub struct Island {
 /// warned that a form field silently dropped a table, issue #1043). It is not a
 /// switch: [`crate::export::to_markdown`] dispatches on
 /// [`Island::island_type`], never on this.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Loss {
     /// Markdown carries it faithfully (round-trips identically).
     Lossless,
     /// Markdown carries an approximation (round-trips visibly, not identically).
     Degraded,
-    /// No markdown encoding — what an island type with no projection carries,
-    /// and the safe default a decoder mints for an unrecognized loss class.
+    /// No markdown encoding — what an island type with no projection carries.
     Unrepresentable,
+    /// A class a future writer stamped that this build lacks, carried verbatim.
+    ///
+    /// The other four vocabularies in the canonical form — mark `type`, line
+    /// `kind`, container, island `type` — are open sets that round-trip an
+    /// unrecognized member opaque. `loss` was the one axis that rewrote instead,
+    /// so an older reader that merely opened a document destroyed the class and
+    /// moved the content hash of a document nobody edited, against
+    /// `DOCUMENT_STORAGE.md` § Byte-stability.
+    ///
+    /// Read fidelity through [`Loss::fidelity`], never by matching this arm: an
+    /// unrecognized class degrades to [`Unrepresentable`](Loss::Unrepresentable),
+    /// so nothing is ever claimed to carry faithfully on the strength of a name
+    /// this build cannot interpret.
+    Unknown(String),
+}
+
+impl Loss {
+    /// The fidelity this class describes, with an unrecognized class degraded to
+    /// the safe end.
+    ///
+    /// Carrying the raw tag is what preserves the byte round-trip; projecting it
+    /// through here is what keeps that carriage from being mistaken for a claim
+    /// about the projection. Never returns [`Unknown`](Loss::Unknown).
+    pub fn fidelity(&self) -> Loss {
+        match self {
+            Loss::Lossless => Loss::Lossless,
+            Loss::Degraded => Loss::Degraded,
+            Loss::Unrepresentable | Loss::Unknown(_) => Loss::Unrepresentable,
+        }
+    }
 }
 
 impl MarkKind {
@@ -356,6 +389,7 @@ pub(crate) fn sort_keys_owned(v: JsonValue) -> JsonValue {
 /// Ways a [`Content`] can violate its invariants. Returned by
 /// [`Content::validate`]; import normalization guarantees none of these.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Invariant {
     /// `\r` in the text (line endings must be normalized to `\n`).
     CarriageReturn,
@@ -431,6 +465,7 @@ pub enum Invariant {
 /// carry arbitrary text including slots (an inline image is a slot in a `Para`),
 /// so only the three kinds whose contract *names* their content constrain it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum LineKindMismatch {
     /// [`LineKind::Island`] whose text is not exactly one [`ISLAND_SLOT`].
     IslandNotOneSlot,
@@ -1188,6 +1223,43 @@ mod tests {
         let once = a.to_canonical_json();
         a.normalize();
         assert_eq!(a.to_canonical_json(), once);
+    }
+
+    /// Issue #1092: a cell is canonicalized in place, so a key this build does
+    /// not recognize survives — the carriage every other opaque payload in the
+    /// model already has. Without it the `table` type's likeliest extension
+    /// (`colspan`, a per-cell style handle) could not be added without a
+    /// schema-version event, and `normalize` runs on decode, on every op apply,
+    /// and on every serialize, so the loss was immediate and permanent.
+    #[test]
+    fn unrecognized_cell_key_survives_normalize() {
+        let mut rt = Content::empty();
+        rt.text = ISLAND_SLOT.to_string();
+        rt.lines = vec![Line {
+            kind: LineKind::Island,
+            containers: vec![],
+            continues: false,
+        }];
+        rt.islands = vec![Island {
+            id: "i".into(),
+            island_type: "table".into(),
+            props: serde_json::json!({
+                "aligns": ["none"],
+                "header": [{"text": "h", "marks": [], "colspan": 2}],
+                "rows": [[{"text": "a", "marks": []}]],
+            }),
+            loss: Loss::Lossless,
+        }];
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        assert_eq!(rt.islands[0].props["header"][0]["colspan"], 2);
+        // The padded cell `pad_row` mints carries nothing, and should not.
+        assert!(rt.islands[0].props["rows"][0][0].get("colspan").is_none());
+        // Idempotent, and the carried key is hash input like any other.
+        let once = rt.to_canonical_json();
+        rt.normalize();
+        assert_eq!(rt.to_canonical_json(), once);
+        assert!(once.contains(r#""colspan":2"#));
     }
 
     /// `validate` bounds a cell mark by its own cell's text length (in USV).

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -231,27 +231,26 @@ pub enum Loss {
     Unrepresentable,
     /// A class a future writer stamped that this build lacks, carried verbatim.
     ///
-    /// The other four vocabularies in the canonical form — mark `type`, line
-    /// `kind`, container, island `type` — are open sets that round-trip an
-    /// unrecognized member opaque. `loss` was the one axis that rewrote instead,
-    /// so an older reader that merely opened a document destroyed the class and
-    /// moved the content hash of a document nobody edited, against
-    /// `DOCUMENT_STORAGE.md` § Byte-stability.
+    /// `loss` is open on the terms the other four vocabularies use — mark
+    /// `type`, line `kind`, container, island `type` all round-trip an
+    /// unrecognized member opaque. Carrying the raw tag rather than rewriting it
+    /// is what keeps a reader that merely opens a document from moving that
+    /// document's content hash (`DOCUMENT_STORAGE.md` § Byte-stability).
     ///
     /// Read fidelity through [`Loss::fidelity`], never by matching this arm: an
     /// unrecognized class degrades to [`Unrepresentable`](Loss::Unrepresentable),
-    /// so nothing is ever claimed to carry faithfully on the strength of a name
-    /// this build cannot interpret.
+    /// so nothing is claimed to carry faithfully on the strength of a name this
+    /// build cannot interpret.
     Unknown(String),
 }
 
 impl Loss {
     /// The fidelity this class describes, with an unrecognized class degraded to
-    /// the safe end.
+    /// the safe end. Never returns [`Unknown`](Loss::Unknown).
     ///
-    /// Carrying the raw tag is what preserves the byte round-trip; projecting it
-    /// through here is what keeps that carriage from being mistaken for a claim
-    /// about the projection. Never returns [`Unknown`](Loss::Unknown).
+    /// Carrying the raw tag preserves the byte round-trip. Reading it through
+    /// here keeps that carriage from being mistaken for a claim about the
+    /// projection.
     pub fn fidelity(&self) -> Loss {
         match self {
             Loss::Lossless => Loss::Lossless,
@@ -1227,10 +1226,9 @@ mod tests {
 
     /// Issue #1092: a cell is canonicalized in place, so a key this build does
     /// not recognize survives — the carriage every other opaque payload in the
-    /// model already has. Without it the `table` type's likeliest extension
-    /// (`colspan`, a per-cell style handle) could not be added without a
-    /// schema-version event, and `normalize` runs on decode, on every op apply,
-    /// and on every serialize, so the loss was immediate and permanent.
+    /// model has. The rule has no slack: `normalize` runs on decode, on every op
+    /// apply, and on every serialize, so a cell rebuilt whole drops the key on
+    /// first contact and every contact after.
     #[test]
     fn unrecognized_cell_key_survives_normalize() {
         let mut rt = Content::empty();

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -21,6 +21,7 @@ use std::borrow::Cow;
 
 /// A mark edit in final-text coordinates (post-delta, post-line-op).
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum MarkOp {
     /// Add a mark over `[start, end)`. An anchor `kind` must carry a non-empty
     /// `id` not already live in the field — ids are caller-supplied and unique
@@ -50,6 +51,7 @@ pub enum MarkOp {
 /// A line/block edit. Split/join splice `\n` in `text`; set ops touch metadata
 /// only.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum LineOp {
     /// Paragraph break at `at`: insert `\n` and split the line metadata.
     Split { at: Usv },
@@ -277,6 +279,7 @@ fn op_array<T>(
 /// Why an apply failed — range or line index out of bounds, or invariants
 /// broken before normalization could repair them.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ApplyError {
     MarkOutOfRange {
         start: Usv,

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -482,12 +482,12 @@ fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
                 for cell in table_cell_values(props) {
                     for m in arr_or_empty(cell, "marks") {
                         reject_mark_attrs(m)?;
-                        // `parse_cell` drops a mark it cannot read, and
-                        // `canon_cell` then writes back only what parsed, so the
-                        // drop is permanent. Lenient is right for a blob at rest;
-                        // on the authored lane it means the host's malformed mark
-                        // disappears with no signal — the same reasoning that
-                        // makes `attrs` beside a built-in an error here.
+                        // `parse_cell` skips a mark it cannot read and
+                        // `canon_cell` writes back only what parsed, so the skip
+                        // is permanent. Leniency is right for a blob at rest. On
+                        // the authored lane it means the host's malformed mark
+                        // vanishes with no signal — the reserved-name rule's
+                        // reasoning, one field over.
                         mark_from_value(m)?;
                     }
                 }
@@ -692,13 +692,14 @@ fn pad_row(v: &mut Value, cols: usize) {
 /// and re-normalize its marks. Reached per-cell from [`normalize_table_props`].
 ///
 /// Writes `text` and `marks` back into the cell's **own** object rather than
-/// minting a fresh one, so a key this build does not recognize survives. A cell
-/// is the sub-structure the `table` type is likeliest to grow (`colspan`,
-/// `rowspan`, a per-cell alignment or style handle), and every other opaque
-/// payload in the model — unknown `attrs` on all three block axes, island
-/// `props`, a table's own top-level props — already round-trips untouched. A
-/// cell minted whole was the one exception, which made the likeliest extension
-/// the one that could not be added without a schema-version event.
+/// minting a fresh one, so a key this build does not recognize survives.
+///
+/// Every opaque payload in the model round-trips untouched: unknown `attrs` on
+/// all three block axes, island `props`, a table's own top-level props, and a
+/// cell's unrecognized keys. A cell earns the rule twice over — it is the
+/// sub-structure the `table` type is likeliest to grow (`colspan`, `rowspan`, a
+/// per-cell alignment or style handle), so a cell rebuilt whole would make that
+/// growth a schema-version event.
 fn canon_cell(cell: &mut Value) {
     let (text, marks) = parse_cell(cell);
     let text = if text.contains(['\n', '\r']) {
@@ -941,10 +942,10 @@ mod tests {
         ));
     }
 
-    /// Issue #1091: `loss` is the fifth open vocabulary, on the same terms as the
-    /// four below. A class this build lacks is **carried**, not rewritten, so a
-    /// reader that merely opened the document neither destroys the class nor
-    /// moves the content hash; reading it degrades to the safe end.
+    /// Issue #1091: `loss` is the fifth open vocabulary, on the terms the four
+    /// below use. A class this build lacks is **carried**, not rewritten, so a
+    /// reader that merely opens the document neither destroys the class nor
+    /// moves the content hash. Reading it degrades to the safe end.
     #[test]
     fn unknown_loss_class_round_trips_and_reads_unrepresentable() {
         let json = concat!(

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -354,17 +354,47 @@ pub fn mark_to_value(mark: &Mark) -> Value {
     Value::Object(m)
 }
 
+/// What every mark carries whatever its type: the object, the two positions, the
+/// type name.
+struct MarkShape<'a> {
+    fields: &'a Map<String, Value>,
+    start: Usv,
+    end: Usv,
+    ty: &'a str,
+}
+
+/// A mark's fallible half — the prologue of [`mark_from_value`], and on its own
+/// the *whole* of what a caller wanting only the verdict needs.
+///
+/// Building the [`MarkKind`] cannot fail, and for an unknown tag it deep-clones
+/// the opaque `attrs` bag: cost a validity check has no reason to pay
+/// ([`reject_unreadable_mark`]).
+fn mark_shape(v: &Value) -> Result<MarkShape<'_>, ParseError> {
+    let fields = v.as_object().ok_or(ParseError::Shape("mark"))?;
+    let start = usv_from(fields.get("start"), "mark start")?;
+    let end = usv_from(fields.get("end"), "mark end")?;
+    let ty = fields
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(ParseError::Shape("mark type"))?;
+    Ok(MarkShape {
+        fields,
+        start,
+        end,
+        ty,
+    })
+}
+
 /// Decode a [`Mark`] from its canonical wire object. The inverse of
 /// [`mark_to_value`]; the shared mark reader for the content decoder and the
 /// mark-op wire.
 pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
-    let o = v.as_object().ok_or(ParseError::Shape("mark"))?;
-    let start = usv_from(o.get("start"), "mark start")?;
-    let end = usv_from(o.get("end"), "mark end")?;
-    let ty = o
-        .get("type")
-        .and_then(Value::as_str)
-        .ok_or(ParseError::Shape("mark type"))?;
+    let MarkShape {
+        fields: o,
+        start,
+        end,
+        ty,
+    } = mark_shape(v)?;
     let kind = match ty {
         "strong" => MarkKind::Strong,
         "emph" => MarkKind::Emph,
@@ -441,6 +471,19 @@ pub(crate) fn mark_from_authored_value(v: &Value) -> Result<Mark, ParseError> {
     mark_from_value(v)
 }
 
+/// The authored lane's verdict on a mark, without building it — everything
+/// [`mark_from_authored_value`] would reject, for a caller that has no use for
+/// the `Mark` itself.
+///
+/// Table cells are that caller, and the only one: [`parse_cell`] reads their
+/// marks leniently, so unlike a prose mark, a cell mark reaches no strict decode
+/// that would raise the error on its own.
+pub(crate) fn reject_unreadable_mark(v: &Value) -> Result<(), ParseError> {
+    reject_mark_attrs(v)?;
+    mark_shape(v)?;
+    Ok(())
+}
+
 /// [`from_canonical_value`] for a content the **host authored just now** — the
 /// `install` input, not a blob read back from storage. Same decode, plus the
 /// reserved-name rule across the whole object, on every axis
@@ -454,11 +497,14 @@ pub fn from_authored_value(v: &Value) -> Result<Content, ParseError> {
     from_canonical_value(v)
 }
 
-/// The reserved-name scan [`from_authored_value`] runs, over the canonical
-/// content shape. Structural on purpose rather than a blind recursive walk: an
-/// unknown's `attrs` is opaque host payload that may legitimately contain an
-/// object spelled `{"type": "link", "attrs": …}`, and rejecting that would make
-/// the carrier unable to carry.
+/// The authored-lane scan [`from_authored_value`] runs, over the canonical
+/// content shape: the reserved-name rule on every axis, plus a readability check
+/// on table-cell marks, the one axis whose reader is lenient.
+///
+/// Structural on purpose rather than a blind recursive walk: an unknown's
+/// `attrs` is opaque host payload that may legitimately contain an object
+/// spelled `{"type": "link", "attrs": …}`, and rejecting that would make the
+/// carrier unable to carry.
 fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
     for line in arr_or_empty(v, "lines") {
         reject_line_kind_attrs(line)?;
@@ -466,10 +512,13 @@ fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
             reject_container_attrs(c)?;
         }
     }
+    // Only the reserved-name half here: a prose mark that will not parse is
+    // rejected by the strict decode `from_canonical_value` runs next.
     for m in arr_or_empty(v, "marks") {
         reject_mark_attrs(m)?;
     }
-    // Cell marks ride the prose mark shape, so the rule follows them in. The
+    // Cell marks ride the prose mark shape, so the rule follows them in — and
+    // the readability check with it, since no strict decode reaches them. The
     // dispatch goes through `KnownIslandType` like every other one, so a new
     // mark-carrying type is a compile error here rather than a silent skip.
     for island in arr_or_empty(v, "islands") {
@@ -481,14 +530,7 @@ fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
                 };
                 for cell in table_cell_values(props) {
                     for m in arr_or_empty(cell, "marks") {
-                        reject_mark_attrs(m)?;
-                        // `parse_cell` skips a mark it cannot read and
-                        // `canon_cell` writes back only what parsed, so the skip
-                        // is permanent. Leniency is right for a blob at rest. On
-                        // the authored lane it means the host's malformed mark
-                        // vanishes with no signal — the reserved-name rule's
-                        // reasoning, one field over.
-                        mark_from_value(m)?;
+                        reject_unreadable_mark(m)?;
                     }
                 }
             }
@@ -692,14 +734,9 @@ fn pad_row(v: &mut Value, cols: usize) {
 /// and re-normalize its marks. Reached per-cell from [`normalize_table_props`].
 ///
 /// Writes `text` and `marks` back into the cell's **own** object rather than
-/// minting a fresh one, so a key this build does not recognize survives.
-///
-/// Every opaque payload in the model round-trips untouched: unknown `attrs` on
-/// all three block axes, island `props`, a table's own top-level props, and a
-/// cell's unrecognized keys. A cell earns the rule twice over — it is the
-/// sub-structure the `table` type is likeliest to grow (`colspan`, `rowspan`, a
-/// per-cell alignment or style handle), so a cell rebuilt whole would make that
-/// growth a schema-version event.
+/// minting a fresh one, so a key this build does not recognize survives — a
+/// cell is an opaque carrier, not an envelope (`DOCUMENT_STORAGE.md` § Open
+/// vocabularies).
 fn canon_cell(cell: &mut Value) {
     let (text, marks) = parse_cell(cell);
     let text = if text.contains(['\n', '\r']) {
@@ -707,22 +744,14 @@ fn canon_cell(cell: &mut Value) {
     } else {
         text
     };
-    let marks = crate::model::normalize_marks(marks);
-    match cell.as_object_mut() {
-        Some(o) => {
-            o.insert("text".into(), Value::String(text));
-            o.insert(
-                "marks".into(),
-                Value::Array(marks.iter().map(mark_to_value).collect()),
-            );
-        }
-        // A non-object cell (a bare string, a null) holds no keys to preserve;
-        // rewriting it whole is what gives it the canonical shape at all. Same
-        // for the empty cells `pad_row` mints — synthesized, nothing to carry.
-        None => *cell = cell_to_value(&text, &marks),
+    let canon = cell_to_value(&text, &crate::model::normalize_marks(marks));
+    match (cell.as_object_mut(), canon) {
+        // Overwrite the canonical keys, leave the rest — the merge
+        // [`crate::ops`] does for a mark's fields on an op object.
+        (Some(o), Value::Object(fields)) => o.extend(fields),
+        // A non-object cell (a bare string, a null) holds no keys to preserve.
+        (_, canon) => *cell = canon,
     }
-    // Key order is restored by the recursive `canonicalize_keys` pass in
-    // `Content::normalize`, which runs over the whole props tree after this.
 }
 
 /// A table island's shape violation, if any — the widths the header, `aligns`,
@@ -1038,6 +1067,11 @@ mod tests {
     /// the decoders cannot — by the time a lenient reader has resolved `"para"`
     /// to `Para`, the `attrs` are gone and `validate` has nothing to object to.
     /// Every axis `validate` checks, including cell marks.
+    ///
+    /// Issue #1092 adds the last case: a cell mark that will not parse at all.
+    /// It is the one axis with no strict decode behind it — `parse_cell` skips
+    /// what it cannot read and `canon_cell` makes the skip permanent — so
+    /// without this the host's mark vanishes with no signal.
     #[test]
     fn authored_lane_rejects_attrs_beside_a_built_in_name() {
         let bad = [
@@ -1054,6 +1088,13 @@ mod tests {
                 r#""rows":[[{"marks":[],"text":"r"}]]},"type":"table"}],"#,
                 r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
             ),
+            // table cell mark with no `type` at all
+            concat!(
+                r#"{"islands":[{"id":"i1","loss":"lossless","props":{"aligns":["none"],"#,
+                r#""header":[{"marks":[{"end":1,"start":0}],"text":"h"}],"#,
+                r#""rows":[[{"marks":[],"text":"r"}]]},"type":"table"}],"#,
+                r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
+            ),
         ];
         for json in bad {
             let v: Value = serde_json::from_str(json).unwrap();
@@ -1061,34 +1102,16 @@ mod tests {
                 matches!(from_authored_value(&v), Err(ParseError::Shape(_))),
                 "accepted: {json}"
             );
-            // The storage lane opens all four — a document written before the
+            // The storage lane opens all five — a document written before the
             // name was built in must keep loading.
             assert!(
                 Content::from_canonical_json(json).is_ok(),
                 "storage lane rejected: {json}"
             );
         }
-    }
-
-    /// Issue #1092: a cell mark the reader cannot parse is dropped by
-    /// `parse_cell` and the drop made permanent by `canon_cell`, so the authored
-    /// lane refuses it on the same reasoning as the reserved-name rule — the
-    /// host's mark would otherwise vanish with no signal. Storage stays lenient:
-    /// a stored blob's unreadable mark must not make the document unopenable.
-    #[test]
-    fn authored_lane_rejects_an_unparseable_cell_mark() {
-        let json = concat!(
-            r#"{"islands":[{"id":"i1","loss":"lossless","props":{"aligns":["none"],"#,
-            r#""header":[{"marks":[{"end":1,"start":0}],"text":"h"}],"#,
-            r#""rows":[[{"marks":[],"text":"r"}]]},"type":"table"}],"#,
-            r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
-        );
-        let v: Value = serde_json::from_str(json).unwrap();
-        assert!(matches!(
-            from_authored_value(&v),
-            Err(ParseError::Shape(_))
-        ));
-        let rt = Content::from_canonical_json(json).unwrap();
+        // …and what storage does with the unreadable one: skips it, keeping the
+        // document openable.
+        let rt = Content::from_canonical_json(bad[4]).unwrap();
         assert!(rt.islands[0].props["header"][0]["marks"]
             .as_array()
             .unwrap()

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -20,6 +20,7 @@ use serde_json::{Map, Value};
 /// Why canonical-JSON parsing failed. Structural only — a well-formed producer
 /// (this crate's serializer, the seam, storage) never trips these.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ParseError {
     /// Top-level JSON was not an object, or a required key was missing/mistyped.
     Shape(&'static str),
@@ -481,6 +482,13 @@ fn reject_reserved_attrs_deep(v: &Value) -> Result<(), ParseError> {
                 for cell in table_cell_values(props) {
                     for m in arr_or_empty(cell, "marks") {
                         reject_mark_attrs(m)?;
+                        // `parse_cell` drops a mark it cannot read, and
+                        // `canon_cell` then writes back only what parsed, so the
+                        // drop is permanent. Lenient is right for a blob at rest;
+                        // on the authored lane it means the host's malformed mark
+                        // disappears with no signal — the same reasoning that
+                        // makes `attrs` beside a built-in an error here.
+                        mark_from_value(m)?;
                     }
                 }
             }
@@ -682,6 +690,15 @@ fn pad_row(v: &mut Value, cols: usize) {
 
 /// De-newline a cell's text (each `\n`/`\r` → a space, 1:1 so mark offsets hold)
 /// and re-normalize its marks. Reached per-cell from [`normalize_table_props`].
+///
+/// Writes `text` and `marks` back into the cell's **own** object rather than
+/// minting a fresh one, so a key this build does not recognize survives. A cell
+/// is the sub-structure the `table` type is likeliest to grow (`colspan`,
+/// `rowspan`, a per-cell alignment or style handle), and every other opaque
+/// payload in the model — unknown `attrs` on all three block axes, island
+/// `props`, a table's own top-level props — already round-trips untouched. A
+/// cell minted whole was the one exception, which made the likeliest extension
+/// the one that could not be added without a schema-version event.
 fn canon_cell(cell: &mut Value) {
     let (text, marks) = parse_cell(cell);
     let text = if text.contains(['\n', '\r']) {
@@ -689,7 +706,22 @@ fn canon_cell(cell: &mut Value) {
     } else {
         text
     };
-    *cell = cell_to_value(&text, &crate::model::normalize_marks(marks));
+    let marks = crate::model::normalize_marks(marks);
+    match cell.as_object_mut() {
+        Some(o) => {
+            o.insert("text".into(), Value::String(text));
+            o.insert(
+                "marks".into(),
+                Value::Array(marks.iter().map(mark_to_value).collect()),
+            );
+        }
+        // A non-object cell (a bare string, a null) holds no keys to preserve;
+        // rewriting it whole is what gives it the canonical shape at all. Same
+        // for the empty cells `pad_row` mints — synthesized, nothing to carry.
+        None => *cell = cell_to_value(&text, &marks),
+    }
+    // Key order is restored by the recursive `canonicalize_keys` pass in
+    // `Content::normalize`, which runs over the whole props tree after this.
 }
 
 /// A table island's shape violation, if any — the widths the header, `aligns`,
@@ -743,7 +775,7 @@ fn island_to_value(island: &Island) -> Value {
     m.insert("id".into(), Value::String(island.id.clone()));
     m.insert("type".into(), Value::String(island.island_type.clone()));
     m.insert("props".into(), sorted_value(&island.props));
-    m.insert("loss".into(), loss_to_str(island.loss).into());
+    m.insert("loss".into(), loss_to_str(&island.loss).into());
     Value::Object(m)
 }
 
@@ -765,11 +797,14 @@ fn island_from_value(v: &Value) -> Result<Island, ParseError> {
     })
 }
 
-fn loss_to_str(loss: Loss) -> &'static str {
+fn loss_to_str(loss: &Loss) -> &str {
     match loss {
         Loss::Lossless => "lossless",
         Loss::Degraded => "degraded",
         Loss::Unrepresentable => "unrepresentable",
+        // Verbatim, so a class this build lacks survives a reader that merely
+        // opened the document.
+        Loss::Unknown(raw) => raw,
     }
 }
 
@@ -777,9 +812,11 @@ fn loss_from_str(s: &str) -> Loss {
     match s {
         "lossless" => Loss::Lossless,
         "degraded" => Loss::Degraded,
-        // Unknown/future loss class defaults to the *safe* end: never claim a
-        // value the reader can't interpret "carries faithfully".
-        _ => Loss::Unrepresentable,
+        "unrepresentable" => Loss::Unrepresentable,
+        // Unknown/future loss class is carried, and reads through
+        // `Loss::fidelity` at the *safe* end: never claim a value the reader
+        // can't interpret "carries faithfully".
+        other => Loss::Unknown(other.to_string()),
     }
 }
 
@@ -904,11 +941,20 @@ mod tests {
         ));
     }
 
+    /// Issue #1091: `loss` is the fifth open vocabulary, on the same terms as the
+    /// four below. A class this build lacks is **carried**, not rewritten, so a
+    /// reader that merely opened the document neither destroys the class nor
+    /// moves the content hash; reading it degrades to the safe end.
     #[test]
-    fn unknown_loss_class_defaults_unrepresentable() {
-        let json = r#"{"text":"￼","lines":[{"kind":"island","containers":[]}],"marks":[],"islands":[{"id":"i1","type":"widget","props":{},"loss":"future_class"}]}"#;
+    fn unknown_loss_class_round_trips_and_reads_unrepresentable() {
+        let json = concat!(
+            r#"{"islands":[{"id":"i1","loss":"partial","props":{},"type":"widget"}],"#,
+            r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
+        );
         let rt = Content::from_canonical_json(json).unwrap();
-        assert_eq!(rt.islands[0].loss, Loss::Unrepresentable);
+        assert_eq!(rt.islands[0].loss, Loss::Unknown("partial".into()));
+        assert_eq!(rt.islands[0].loss.fidelity(), Loss::Unrepresentable);
+        assert_eq!(rt.to_canonical_json(), json);
     }
 
     /// Issue #1054: the block vocabulary is open on the mark axis' terms. A
@@ -1021,6 +1067,31 @@ mod tests {
                 "storage lane rejected: {json}"
             );
         }
+    }
+
+    /// Issue #1092: a cell mark the reader cannot parse is dropped by
+    /// `parse_cell` and the drop made permanent by `canon_cell`, so the authored
+    /// lane refuses it on the same reasoning as the reserved-name rule — the
+    /// host's mark would otherwise vanish with no signal. Storage stays lenient:
+    /// a stored blob's unreadable mark must not make the document unopenable.
+    #[test]
+    fn authored_lane_rejects_an_unparseable_cell_mark() {
+        let json = concat!(
+            r#"{"islands":[{"id":"i1","loss":"lossless","props":{"aligns":["none"],"#,
+            r#""header":[{"marks":[{"end":1,"start":0}],"text":"h"}],"#,
+            r#""rows":[[{"marks":[],"text":"r"}]]},"type":"table"}],"#,
+            r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
+        );
+        let v: Value = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            from_authored_value(&v),
+            Err(ParseError::Shape(_))
+        ));
+        let rt = Content::from_canonical_json(json).unwrap();
+        assert!(rt.islands[0].props["header"][0]["marks"]
+            .as_array()
+            .unwrap()
+            .is_empty());
     }
 
     /// Issue #1084: the authored lane's scan is structural, not a blind walk. An

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -191,11 +191,11 @@ Two rules bound the openness:
       An op or an `install` is host-authored now, so that shape means a stale
       copy of the built-in list, never a document from the past. Reads that hand
       back stored content — `exportMarkdown`, `rebase` — are storage-lane, not
-      this one. The same split governs an unreadable **table-cell mark**: the
-      storage lane skips it (`serial::parse_cell` is lenient, and normalization
-      then makes the drop permanent), while the authored lane refuses it, since
-      a host's malformed mark disappearing with no signal is the silent
-      corruption this rule exists to catch.
+      this one. The same split governs an unreadable **table-cell mark**.
+      Storage skips it: `serial::parse_cell` is lenient, and normalization makes
+      the skip permanent. The authored lane refuses it, because a host's
+      malformed mark vanishing with no signal is the silent corruption this rule
+      exists to catch.
     - **The storage lane accepts it, and must.** A blob written while `callout`
       was unknown carries `{"kind": "callout", "attrs": {…}}`; the release that
       promotes `callout` to a built-in has to keep opening it. Rejecting at

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -138,10 +138,10 @@ change. Two ways to manage this:
 The envelope's version-and-reject discipline covers the document's **shape** —
 the schema tag, the DTO tree, the keys a `body` object carries. It does *not*
 cover the content's **vocabularies**. Every discriminator inside a `body` is an
-open set: a mark `type`, an island `type`, a line `kind`, and a container name
-this build does not recognize each decode to an opaque `Unknown` carrying the
-tag plus its `attrs` (`props` for an island), round-trip byte-identically, and
-project as their nearest safe neighbor.
+open set: a mark `type`, an island `type`, a line `kind`, a container name, and
+an island's `loss` class this build does not recognize each decode to an opaque
+`Unknown` carrying the tag plus its `attrs` (`props` for an island), round-trip
+byte-identically, and project as their nearest safe neighbor.
 
 | Axis | Unknown value projects as |
 |---|---|
@@ -149,13 +149,24 @@ project as their nearest safe neighbor.
 | Island `type` | a placeholder comment; the props survive in storage |
 | Line `kind` | a paragraph |
 | Container | transparent — its lines render at the enclosing level |
+| Island `loss` | `Unrepresentable`, via `Loss::fidelity` — never a claim of fidelity on a name this build cannot read |
 
 The consequence, and the point: **adding a construct to any of these
 vocabularies is not a schema-version event.** An older reader degrades a future
 callout to a plain paragraph rather than refusing the document, and a reader
 that does understand it sees it whole, because the tag and attrs round-tripped
-untouched. The rule is the same on all four axes: the block axes are open on the
-mark axis' terms, not one step behind it.
+untouched. The rule is the same on all five axes: the block axes are open on the
+mark axis' terms, not one step behind it, and `loss` carries its raw tag rather
+than rewriting it — a reader that merely opens a document must not move its
+content hash (§ Byte-stability).
+
+Openness is a property of the *payload carriers*, not only the discriminators.
+Every opaque bag round-trips untouched through normalization — unknown `attrs`
+on all three block axes, island `props`, a table island's own top-level props,
+and a table **cell's** unrecognized keys. The cell is the sub-structure the
+`table` type is likeliest to grow (`colspan`, `rowspan`, a per-cell style
+handle), so canonicalization rewrites a cell's `text` and `marks` in place
+rather than minting a fresh `{text, marks}` object.
 
 Two rules bound the openness:
 
@@ -180,7 +191,11 @@ Two rules bound the openness:
       An op or an `install` is host-authored now, so that shape means a stale
       copy of the built-in list, never a document from the past. Reads that hand
       back stored content — `exportMarkdown`, `rebase` — are storage-lane, not
-      this one.
+      this one. The same split governs an unreadable **table-cell mark**: the
+      storage lane skips it (`serial::parse_cell` is lenient, and normalization
+      then makes the drop permanent), while the authored lane refuses it, since
+      a host's malformed mark disappearing with no signal is the silent
+      corruption this rule exists to catch.
     - **The storage lane accepts it, and must.** A blob written while `callout`
       was unknown carries `{"kind": "callout", "attrs": {…}}`; the release that
       promotes `callout` to a built-in has to keep opening it. Rejecting at

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -160,13 +160,23 @@ mark axis' terms, not one step behind it, and `loss` carries its raw tag rather
 than rewriting it — a reader that merely opens a document must not move its
 content hash (§ Byte-stability).
 
-Openness is a property of the *payload carriers*, not only the discriminators.
-Every opaque bag round-trips untouched through normalization — unknown `attrs`
-on all three block axes, island `props`, a table island's own top-level props,
-and a table **cell's** unrecognized keys. The cell is the sub-structure the
-`table` type is likeliest to grow (`colspan`, `rowspan`, a per-cell style
-handle), so canonicalization rewrites a cell's `text` and `marks` in place
-rather than minting a fresh `{text, marks}` object.
+Unknown *keys* survive in designated carriers only, and the boundary is worth
+stating because it is not the discriminator boundary:
+
+- **Opaque carriers keep what they hold.** Unknown `attrs` on all three block
+  axes, island `props`, a table island's top-level props, and a table **cell's**
+  own keys all round-trip untouched.
+- **Envelopes drop what they do not name, by design.** An island, line, mark, or
+  container object is decoded into a struct and re-minted from its fields, so an
+  unrecognized sibling key beside `id`/`kind`/`start` does not survive. Growing
+  those shapes is a schema event; that is what the envelope's version-and-reject
+  discipline is for.
+
+A table cell sits on the first side because it never became a struct, and it
+earns the place: cells are where the `table` type is likeliest to grow
+(`colspan`, `rowspan`, a per-cell style handle). Canonicalization therefore
+rewrites a cell's `text` and `marks` in place rather than minting a fresh
+`{text, marks}` object.
 
 Two rules bound the openness:
 


### PR DESCRIPTION
Closes #1090, closes #1091, closes #1092 — the three items from the v1.0.0 codec review that are localized enough to land as one change. Each was verified reproducing at `deb7802` before the fix.

The three share a thesis: the canonical form is built on open vocabularies, and each of these was a place where that openness had a hole.

## #1091 — island `loss` was the one closed axis

An unrecognized class was **rewritten**, not carried:

```
in   {"id":"i1","loss":"partial","props":{},"type":"widget"}
out  {"id":"i1","loss":"unrepresentable","props":{},"type":"widget"}
```

Every other discriminator in the canonical form — mark `type`, line `kind`, container, island `type` — round-trips opaque. `loss` discarded, so a future writer's class died on contact with an older reader, and the content hash moved for a document nobody edited, against `DOCUMENT_STORAGE.md` § Byte-stability.

Adds `Loss::Unknown(String)` plus `Loss::fidelity()`. The split is the point: carrying the raw tag preserves the byte round-trip, and reading through `fidelity` — which degrades an unknown class to `Unrepresentable` — keeps that carriage from being mistaken for a claim that the projection is faithful. The old decode-time degrade was the right instinct; only the discard was wrong.

`Loss` loses `Copy`. Nothing outside the crate referenced it.

The openness also has to reach the seam consumers actually read: the wasm TS surface declared `loss` as a closed literal union, so a carried class would round-trip through Rust and then fail to typecheck in the host. Now open, the way `type` one field over already is.

## #1092 — `normalize` destroyed unrecognized table-cell keys

`canon_cell` rebuilt each cell as a fresh `{text, marks}` map, so any other key was dropped. `Content::normalize` runs it on decode, on every op apply, and on every serialize.

```
in   header: [{"text":"h","marks":[],"colspan":2}]   props: {"caption":"Fig 1", …}
out  header: [{"marks":[],"text":"h"}]               props: {"caption":"Fig 1", …}
```

A new *table* prop survived; a new *cell* prop did not. Cells are where the `table` type is likeliest to grow (`colspan`, `rowspan`, per-cell alignment or style), so this made the likeliest extension the one thing that could not be added without a schema-version event.

Now merges the canonical fields into the cell's own object. A non-object cell, and the empty cells `pad_row` mints, are still built whole — neither has anything to preserve.

Also takes the second half of that issue: `from_authored_value` already walked cell marks for the reserved-name rule, so the lane split from #1084 now extends to them. Storage stays lenient (a stored blob's unreadable mark must not make the document unopenable); the authored lane refuses it, since `parse_cell` skips it and `canon_cell` makes the skip permanent. Prose marks need no equivalent — they meet a strict decode in `from_canonical_value` already.

## #1090 — no public enum carried `#[non_exhaustive]`

`quillmark-content` is published and `quillmark-core` depends on it, so at 1.0.0 every variant list freezes for downstream matchers — on vocabularies whose entire thesis is that they grow, and on error enums that have gained variants with nearly every hardening pass. The attribute cannot be added later without a major bump.

Applied to all thirteen. It does not affect in-crate matches, so `normalize`, `validate`, and the `serial` encoders keep their exhaustive ones.

`KnownIslandType` is deliberately exempt, and its rustdoc now carries both halves of the reasoning: why it opts out, and why the trade runs the other way for `MarkKind`/`LineKind`. An unhandled arm on those costs decoration — the text still renders, the mark loses its delimiters, the line lowers as a paragraph. An unhandled island type costs the island: content leaves the projection entirely.

Downstream cost measured across the whole workspace at `--all-features --all-targets`: **two match sites**, both in `typst/src/emit.rs`, each folded into the wildcard arm it duplicated.

## Canon

`DOCUMENT_STORAGE.md` § Open vocabularies gains `loss` as the fifth axis and extends the authored/storage lane split to cell marks.

It also now states where unknown **keys** survive, which is not the same boundary as the discriminators: opaque carriers (`attrs`, `props`, cell bodies) keep what they hold, while islands, lines, marks, and containers are envelopes — decoded into structs and re-minted, dropping unrecognized siblings by design. A cell sits on the carrier side because it never became a struct. Worth being precise about, so the cell fix doesn't read as a general promise the codec does not make.

## Testing

`cargo test --workspace --all-features`: **1073 passed, 0 failed** across 49 binaries. `node scripts/check-canon.mjs` passes. Clippy clean on the changed crates; the warnings that remain are pre-existing in `quillmark-core`.

- `unknown_loss_class_round_trips_and_reads_unrepresentable` replaces `unknown_loss_class_defaults_unrepresentable`, which pinned only the decode half and left the rewrite untested. Asserts byte-identity on re-emit.
- `unrecognized_cell_key_survives_normalize` carries `colspan` through normalize and checks a `pad_row`-minted cell stays bare.
- The unparseable-cell-mark case folds into `authored_lane_rejects_attrs_beside_a_built_in_name`, whose loop already asserts both halves of the lane split.

Net test count drops by one because that fold replaced a duplicated scaffold, not because coverage shrank.

## Not included

#1093 (unbounded JSON depth in the `Value` decode lane) and #1094 (vocabulary-promotion policy) stay open. #1093 needs an iterative walk plus a guard at the `serde_wasm_bindgen` boundary, since `Value`'s own `Drop` recurses; #1094 is policy and tests for an event that has not happened yet, and its load-bearing ask interacts with both #1090 and #1091.

One follow-up this branch surfaced and did not take: `Loss` gets the open variant and the verbatim carriage, but not the third part of the pattern the other four axes have — there is no `RESERVED_LOSS_CLASSES` or `Invariant::ReservedUnknownLoss`, so an in-process `Loss::Unknown("degraded")` serializes non-injectively. Harmless today (no in-workspace `loss` consumer, no binding constructor), but it is a new invariant rather than a cleanup, so it wants its own change.