### PR TITLE
content: close the last two codec-freeze blockers, and the simplification pass beside them

### DIFF
--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -543,6 +543,28 @@ describe('Document editor surface — setQuillRef / install / revise', () => {
     expect(() => doc.install({}, 'plain markdown')).toThrow()
     expect(() => doc.install({}, { not: 'a content' })).toThrow()
   })
+
+  // Issue #1093: island `props` and unknown `attrs` are opaque host payload with
+  // no depth limit, and every consumer of them — key canonicalization, the hash
+  // key, the JS→JSON conversion, the tree's own drop — recurses one frame per
+  // level. On wasm32 the stack is 1 MB and an overflow is a trap that takes the
+  // module down rather than an error the host can catch, so this must throw and
+  // then keep working. `install` is the reachable door: the value arrives from JS
+  // and one loop builds it.
+  it('install rejects a deeply nested props instead of trapping the module', () => {
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    let deep = []
+    for (let i = 0; i < 5000; i++) deep = [deep]
+    const rt = importMarkdown('body')
+    rt.islands = [{ id: 'i1', type: 'widget', loss: 'lossless', props: deep }]
+    // Matched on the message: a slot/shape complaint would pass a bare toThrow
+    // while the depth door stayed open.
+    expect(() => doc.install({}, rt)).toThrow(/nests deeper/)
+    // Still alive: the guard errored rather than trapping, so the module keeps
+    // serving. A trap would fail every later call in the file, not just this one.
+    doc.install({}, importMarkdown('after'))
+    expect(doc.main.body.text).toBe('after')
+  })
 })
 
 describe('Content codec — importMarkdown / exportMarkdown / rebase / mapPos', () => {

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2185,8 +2185,49 @@ fn js_value_to_field_batch(
 /// mutators take any shape (the consumer's slot may hold an array, scalar, or
 /// map); `js_value_to_object` adds the object constraint on top.
 fn js_value_to_json(value: JsValue, ctx: &str) -> Result<serde_json::Value, JsValue> {
+    reject_deep_js_value(&value, ctx)?;
     serde_wasm_bindgen::from_value(value)
         .map_err(|e| WasmError::from(format!("{}: invalid value: {}", ctx, e)).to_js_value())
+}
+
+/// Refuse a JS value nesting past [`MAX_JSON_DEPTH`] **before**
+/// `serde_wasm_bindgen` builds it.
+///
+/// The Rust-side depth guards in `quillmark_content` cannot cover this frame:
+/// `serde_wasm_bindgen::from_value` recurses one frame per level while
+/// constructing the `serde_json::Value`, so a deep enough input overflows during
+/// conversion, before any decoder sees a tree to check. On wasm32 the stack is
+/// 1 MB and an overflow is a trap that takes the module down — not a `WasmError`
+/// the host can catch. `let v = []; for (…) v = [v]` builds such a value in one
+/// loop, so the check belongs on the JS side of the boundary or nowhere.
+///
+/// Iterative, and early-exits at the first over-deep container, so it neither
+/// overflows on the input it detects nor walks past the limit. Arrays, plain
+/// objects, and `Map`s are the three containers `serde_wasm_bindgen` descends
+/// into, and each is charged one level — the reading in
+/// [`quillmark_content::MAX_JSON_DEPTH`].
+fn reject_deep_js_value(value: &JsValue, ctx: &str) -> Result<(), JsValue> {
+    const MAX: usize = quillmark_content::MAX_JSON_DEPTH;
+    let mut stack: Vec<(JsValue, usize)> = vec![(value.clone(), 0)];
+    while let Some((v, depth)) = stack.pop() {
+        let children = if Array::is_array(&v) {
+            Array::from(&v)
+        } else if v.is_instance_of::<js_sys::Map>() {
+            js_sys::Array::from(&v.unchecked_into::<js_sys::Map>().values())
+        } else if v.is_object() && !v.is_null() {
+            js_sys::Object::values(&v.unchecked_into::<js_sys::Object>())
+        } else {
+            continue;
+        };
+        if depth + 1 > MAX {
+            return Err(WasmError::from(format!(
+                "{ctx}: value nests deeper than {MAX} levels"
+            ))
+            .to_js_value());
+        }
+        stack.extend(children.iter().map(|c| (c, depth + 1)));
+    }
+    Ok(())
 }
 
 /// Deserialize a JS value into a JSON object map, rejecting non-objects. Used by

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -846,13 +846,8 @@ fn render_marked_core(
 /// marks are thrown at it.
 const PROBE_BUDGET: usize = 64;
 
-/// Clip wrapping marks so none crosses the interior of an atomic span (`code` or
-/// a `link`'s text). A wrap edge landing strictly inside a `[cs, ce)` span is
-/// pulled to that span's boundary (`start`→`ce`, `end`→`cs`); a wrap swallowed
-/// whole collapses and drops. An atomic span can't carry partial styling, and
-/// the sweep's cursor jumps its interior start→end, so a wrap `end` hiding inside
-/// would be missed and left unbalanced (the #846 shape). A wrap that strictly
-/// *contains* a span keeps both edges, so the span still nests inside it.
+/// [`clip_range_to_atomic`] over every wrapping mark, dropping the ones an
+/// atomic span swallowed whole.
 fn clip_fmt_to_atomic(fmt: &mut Vec<(usize, usize, &MarkKind)>, atomics: &[(usize, usize)]) {
     for m in fmt.iter_mut() {
         clip_range_to_atomic(&mut m.0, &mut m.1, atomics);

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -59,16 +59,6 @@ fn image_alt_text<'e>(event: &'e Event<'e>) -> Option<&'e str> {
     }
 }
 use serde_json::json;
-use std::cell::RefCell;
-use std::collections::HashSet;
-use std::ops::Range;
-use std::rc::Rc;
-
-/// Byte offsets at which the [`MarkdownFixer`] converted a `<u>` open tag into a
-/// `Tag::Strong` event. The fixer is the one place that classifies `<u>` (via
-/// [`is_u_open_tag`]); it records the fact here so the [`Builder`] can tell a
-/// `<u>`-derived strong from a real `**` one without re-sniffing source bytes.
-type UnderlineOpens = Rc<RefCell<HashSet<usize>>>;
 
 /// Import errors: just the nesting guard (mirrors the typst backend's
 /// `ConversionError::NestingTooDeep`).
@@ -96,11 +86,9 @@ pub fn from_markdown(markdown: &str) -> Result<Content, ImportError> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
-    let parser = Parser::new_ext(&normalized, options);
-    let underline_opens: UnderlineOpens = Rc::new(RefCell::new(HashSet::new()));
-    let fixer = MarkdownFixer::new(parser.into_offset_iter(), Rc::clone(&underline_opens));
+    let fixer = MarkdownFixer::new(Parser::new_ext(&normalized, options));
 
-    let mut b = Builder::new(underline_opens);
+    let mut b = Builder::new();
     b.run(fixer)?;
     let mut rt = b.finish();
     rt.normalize();
@@ -236,11 +224,6 @@ impl Inline {
 }
 
 struct Builder {
-    /// A `Tag::Strong` whose `range.start` is here was a `<u>` in source (the
-    /// fixer recorded it); the [`Builder`] opens [`MarkKind::Underline`] for it
-    /// instead of [`MarkKind::Strong`] — the carried form of the distinction the
-    /// fixer would otherwise erase.
-    underline_opens: UnderlineOpens,
     /// The content text + marks; the [`Builder`] adds line/block structure around
     /// it (a `\n` boundary is [`Inline::push_raw`], inline content is the mark
     /// machinery). A table cell reuses the same [`Inline`] in isolation.
@@ -313,9 +296,8 @@ fn align_str(a: &pulldown_cmark::Alignment) -> &'static str {
 }
 
 impl Builder {
-    fn new(underline_opens: UnderlineOpens) -> Self {
+    fn new() -> Self {
         Builder {
-            underline_opens,
             inline: Inline::default(),
             lines: Vec::new(),
             cur: None,
@@ -442,22 +424,11 @@ impl Builder {
         Ok(())
     }
 
-    /// [`MarkKind::Underline`] if the fixer converted a `<u>` open at `start`,
-    /// else [`MarkKind::Strong`] — reads the classification the fixer carried,
-    /// no source re-sniff.
-    fn strong_kind(&self, start: usize) -> MarkKind {
-        if self.underline_opens.borrow().contains(&start) {
-            MarkKind::Underline
-        } else {
-            MarkKind::Strong
-        }
-    }
-
     fn run<'a, I>(&mut self, iter: I) -> Result<(), ImportError>
     where
-        I: Iterator<Item = (Event<'a>, Range<usize>)>,
+        I: Iterator<Item = (Event<'a>, bool)>,
     {
-        for (event, range) in iter {
+        for (event, underline) in iter {
             // Image alt collection intercepts everything until the image closes.
             if self.image_depth > 0 {
                 match &event {
@@ -482,7 +453,7 @@ impl Builder {
             // cell is stored as canonical `{text, marks}` — no markdown re-parse
             // downstream.
             if self.table.is_some() {
-                self.table_event(&event, &range);
+                self.table_event(&event, underline);
                 if matches!(event, Event::End(TagEnd::Table)) {
                     self.emit_table();
                 }
@@ -490,7 +461,7 @@ impl Builder {
             }
 
             match event {
-                Event::Start(tag) => self.start_tag(tag, range)?,
+                Event::Start(tag) => self.start_tag(tag, underline)?,
                 Event::End(tag) => self.end_tag(tag),
                 Event::Text(t) => {
                     if self.in_code {
@@ -533,7 +504,7 @@ impl Builder {
         Ok(())
     }
 
-    fn start_tag<'a>(&mut self, tag: Tag<'a>, range: Range<usize>) -> Result<(), ImportError> {
+    fn start_tag<'a>(&mut self, tag: Tag<'a>, underline: bool) -> Result<(), ImportError> {
         match tag {
             // Block starts arm a pending line (new block, continues = false);
             // the next inline content opens it.
@@ -623,7 +594,7 @@ impl Builder {
                 self.check_depth()?;
             }
             Tag::Strong => {
-                let kind = self.strong_kind(range.start);
+                let kind = strong_kind(underline);
                 self.open_mark(kind);
                 self.check_depth()?;
             }
@@ -719,7 +690,7 @@ impl Builder {
     /// the accumulator; inline events (text/code/marks) build the open cell with
     /// the SAME [`Inline`] machinery prose uses — a cell is flat inline (no lines,
     /// no nested islands), so its marks are USV offsets into its own text.
-    fn table_event(&mut self, event: &Event, range: &Range<usize>) {
+    fn table_event(&mut self, event: &Event, underline: bool) {
         // An image open inside the current cell intercepts everything until it
         // closes: the alt text lands in the cell as plain text (marks flattened,
         // like the top-level image path), the url is dropped, and the island is
@@ -818,7 +789,7 @@ impl Builder {
                 }
             }
             Event::Start(Tag::Strong) => {
-                let kind = self.strong_kind(range.start);
+                let kind = strong_kind(underline);
                 if let Some(c) = self.cell_mut() {
                     c.open_mark(kind);
                 }
@@ -926,8 +897,8 @@ fn sanitize_lang(lang: &str) -> String {
 // MarkdownFixer — the raw-HTML filter between pulldown and the builder.
 //
 // One job: allowlist `<u>…</u>` as underline (rewritten to Strong start/end,
-// the classification carried to the builder in `underline_opens`) and drop
-// every other raw HTML event. Delimiter arithmetic is pulldown's — a fixer that
+// the classification riding the rewritten event) and drop every other raw HTML
+// event. Delimiter arithmetic is pulldown's — a fixer that
 // re-segments `***` runs can only disagree with CommonMark, and disagreeing
 // means deleting an asterisk the author typed (`***a**` is a literal `*` then
 // strong `a`; `***bold italic***` parses natively).
@@ -951,23 +922,29 @@ fn is_u_close_tag(html: &str) -> bool {
     }
 }
 
-struct MarkdownFixer<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>> {
+/// [`MarkKind::Underline`] when the fixer rewrote a `<u>` open into this
+/// `Tag::Strong`, else [`MarkKind::Strong`] — the classification rides the
+/// event, so no site re-sniffs source bytes.
+fn strong_kind(underline: bool) -> MarkKind {
+    if underline {
+        MarkKind::Underline
+    } else {
+        MarkKind::Strong
+    }
+}
+
+struct MarkdownFixer<'a, I: Iterator<Item = Event<'a>>> {
     inner: I,
-    /// Shared with the [`Builder`]: each `<u>` open this fixer converts to
-    /// `Tag::Strong` records its `range.start` here, so the builder recovers the
-    /// underline without a second source-byte test (see [`UnderlineOpens`]).
-    underline_opens: UnderlineOpens,
     _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a, I> MarkdownFixer<'a, I>
 where
-    I: Iterator<Item = (Event<'a>, Range<usize>)>,
+    I: Iterator<Item = Event<'a>>,
 {
-    fn new(inner: I, underline_opens: UnderlineOpens) -> Self {
+    fn new(inner: I) -> Self {
         Self {
             inner,
-            underline_opens,
             _marker: std::marker::PhantomData,
         }
     }
@@ -975,25 +952,23 @@ where
 
 impl<'a, I> Iterator for MarkdownFixer<'a, I>
 where
-    I: Iterator<Item = (Event<'a>, Range<usize>)>,
+    I: Iterator<Item = Event<'a>>,
 {
-    type Item = (Event<'a>, Range<usize>);
+    /// The event, plus whether a `Tag::Strong` start was rewritten from `<u>`
+    /// (always `false` for every other event).
+    type Item = (Event<'a>, bool);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let (event, range) = self.inner.next()?;
-            return Some(match event {
+            return Some(match self.inner.next()? {
                 Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_open_tag(html) => {
-                    // Carry the `<u>` classification to the builder keyed on the
-                    // tag's start offset, so it need not re-sniff the source.
-                    self.underline_opens.borrow_mut().insert(range.start);
-                    (Event::Start(Tag::Strong), range)
+                    (Event::Start(Tag::Strong), true)
                 }
                 Event::InlineHtml(ref html) | Event::Html(ref html) if is_u_close_tag(html) => {
-                    (Event::End(TagEnd::Strong), range)
+                    (Event::End(TagEnd::Strong), false)
                 }
                 Event::Html(_) | Event::InlineHtml(_) => continue,
-                other => (other, range),
+                other => (other, false),
             });
         }
     }
@@ -1274,6 +1249,20 @@ mod tests {
         assert_eq!(rt.islands.len(), 1);
         assert_eq!(rt.islands[0].island_type, "table");
         assert_eq!(rt.islands[0].loss, Loss::Lossless);
+    }
+
+    /// The cell lane's own `<u>` classification. A cell reuses the prose mark
+    /// machinery through a second `Tag::Strong` site, so the two must agree:
+    /// `<u>` opens [`MarkKind::Underline`], `**` opens [`MarkKind::Strong`],
+    /// in the same cell.
+    #[test]
+    fn underline_from_u_tag_in_table_cell() {
+        let rt = imp("| h |\n|---|\n| <u>a</u> **b** |");
+        let cells = crate::serial::table_cells(&rt.islands[0].props);
+        let (text, marks) = cells.iter().find(|(t, _)| t == "a b").expect("cell");
+        assert_eq!(text, "a b");
+        let kinds: Vec<&MarkKind> = marks.iter().map(|m| &m.kind).collect();
+        assert_eq!(kinds, [&MarkKind::Underline, &MarkKind::Strong]);
     }
 
     #[test]

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -119,18 +119,19 @@ impl KnownIslandType {
     }
 }
 
-/// Repair an island's props to its type's canonical shape in place (a no-op for
-/// an unknown type — its opaque props are preserved verbatim). The normalize-side
-/// island-type dispatch, called from [`Content::normalize`](crate::Content).
+// The three `Island`-taking wrappers below are where the open set's `None` arm
+// is answered — once each, so `model.rs` calls a total function and no site
+// re-decides what an unknown type does.
+
+/// [`KnownIslandType::normalize_props`] for a known type; for an unknown one, a
+/// no-op that leaves the opaque props verbatim.
 pub(crate) fn normalize_island_structure(island: &mut Island) {
     if let Some(k) = KnownIslandType::parse(&island.island_type) {
         k.normalize_props(&mut island.props);
     }
 }
 
-/// An island's `(text, marks)` cells for validation (empty for a type with no
-/// cell model, and for an unknown type). The validate-side twin of
-/// [`normalize_island_structure`].
+/// [`KnownIslandType::cell_marks`] for a known type; empty for an unknown one.
 pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
     match KnownIslandType::parse(&island.island_type) {
         Some(k) => k.cell_marks(&island.props),
@@ -138,9 +139,8 @@ pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
     }
 }
 
-/// An island's shape violation, if any (`None` for a well-formed, shape-free, or
-/// unknown island). For a known type, [`normalize_island_structure`] guarantees
-/// this returns `None`.
+/// [`KnownIslandType::shape_error`] for a known type; `None` for an unknown one.
+/// [`normalize_island_structure`] guarantees `None` for the known ones too.
 pub(crate) fn island_shape_error(island: &Island) -> Option<Invariant> {
     KnownIslandType::parse(&island.island_type).and_then(|k| k.shape_error(&island.props))
 }

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -69,9 +69,9 @@ pub const MAX_NESTING_DEPTH: usize = 100;
 /// unknown line/container/mark's `attrs` — measured in container levels from the
 /// bag itself.
 ///
-/// The payload axis of [`MAX_NESTING_DEPTH`]: `sorted_value`,
-/// `is_value_key_sorted`, `sort_keys_owned`, and `serde_json::Value`'s own
-/// `Drop` each recurse one frame per level, so an unbounded bag overflows the
+/// The payload axis of [`MAX_NESTING_DEPTH`]: `is_value_key_sorted`,
+/// `sort_keys_owned`, and `serde_json::Value`'s own `Drop` each recurse one
+/// frame per level, so an unbounded bag overflows the
 /// stack — on wasm32, an unrecoverable trap rather than a catchable error. The
 /// bag is refused at the decode boundary, before it is cloned out of the wire,
 /// and [`Content::validate`](model::Content::validate) restates it as an

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -64,3 +64,21 @@ pub use serial::ParseError;
 /// `quillmark_core::error::MAX_NESTING_DEPTH`), so a document that imports also
 /// renders.
 pub const MAX_NESTING_DEPTH: usize = 100;
+
+/// Maximum nesting depth of an opaque JSON payload — an island's `props`, an
+/// unknown line/container/mark's `attrs` — measured in container levels from the
+/// bag itself.
+///
+/// The payload axis of [`MAX_NESTING_DEPTH`]: `sorted_value`,
+/// `is_value_key_sorted`, `sort_keys_owned`, and `serde_json::Value`'s own
+/// `Drop` each recurse one frame per level, so an unbounded bag overflows the
+/// stack — on wasm32, an unrecoverable trap rather than a catchable error. The
+/// bag is refused at the decode boundary, before it is cloned out of the wire,
+/// and [`Content::validate`](model::Content::validate) restates it as an
+/// invariant for the hand-built content that never went through a decoder.
+///
+/// 128 is what `serde_json::from_str` already enforces, so nothing a stored blob
+/// can carry is refused. The string lane counts from the document root rather
+/// than the bag, so it admits ~3 levels fewer; both bound the recursion, and the
+/// per-bag reading is the one the recursive consumers actually walk.
+pub const MAX_JSON_DEPTH: usize = 128;

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -329,33 +329,12 @@ impl MarkKind {
 /// A `serde_json::Value` rendered to a string with object keys recursively
 /// sorted — order-insensitive, so it is a stable comparison/grouping key.
 fn canonical_json_string(v: &JsonValue) -> String {
-    serde_json::to_string(&sorted_value(v)).unwrap_or_default()
-}
-
-/// Rebuild `v` with every object's keys sorted, recursively. Pins island
-/// `props` (and unknown-mark attrs) against `preserve_order` leaking insertion
-/// order into the canonical bytes / content hash (Spike C carry-forward). For
-/// an owned tree, prefer [`sort_keys_owned`] — it reorders in place without
-/// cloning the leaves.
-pub(crate) fn sorted_value(v: &JsonValue) -> JsonValue {
-    match v {
-        JsonValue::Array(items) => JsonValue::Array(items.iter().map(sorted_value).collect()),
-        JsonValue::Object(map) => {
-            let mut keys: Vec<&String> = map.keys().collect();
-            keys.sort();
-            let mut out = serde_json::Map::with_capacity(map.len());
-            for k in keys {
-                out.insert(k.clone(), sorted_value(&map[k]));
-            }
-            JsonValue::Object(out)
-        }
-        other => other.clone(),
-    }
+    serde_json::to_string(&sort_keys_owned(v.clone())).unwrap_or_default()
 }
 
 /// Whether every object in `v` already has its keys in ascending order,
 /// recursively — the cheap allocation-free check that lets a re-normalize skip
-/// rebuilding an already-canonical `props`/`attrs` tree via [`sorted_value`].
+/// rebuilding an already-canonical `props`/`attrs` tree.
 /// Once normalized, an untouched tree stays sorted, so a per-keystroke
 /// re-normalize pays a scan instead of a full clone.
 pub(crate) fn is_value_key_sorted(v: &JsonValue) -> bool {
@@ -370,8 +349,8 @@ pub(crate) fn is_value_key_sorted(v: &JsonValue) -> bool {
 }
 
 /// `true` when `v` nests deeper than `max` container levels — the guard that
-/// keeps the recursive walkers above ([`sorted_value`], [`is_value_key_sorted`],
-/// [`sort_keys_owned`]) and `Value`'s own `Drop` inside a bounded frame count.
+/// keeps the recursive walkers above ([`is_value_key_sorted`], [`sort_keys_owned`])
+/// and `Value`'s own `Drop` inside a bounded frame count.
 ///
 /// The walk is iterative (explicit stack), so the check itself cannot overflow on
 /// the adversarially deep input it exists to detect. The unit is **container
@@ -423,16 +402,20 @@ pub(crate) fn check_json_depth(v: &JsonValue, what: &'static str) -> Result<(), 
 /// per-keystroke path pays the scan and skips the deep clone.
 pub(crate) fn canonicalize_keys(v: &mut JsonValue) {
     if !is_value_key_sorted(v) {
-        *v = sorted_value(v);
+        *v = sort_keys_owned(std::mem::take(v));
     }
 }
 
-/// The owned twin of [`sorted_value`]: reorder every object's keys by **moving**
-/// each entry into a freshly key-sorted map, recursively. Same canonical result
-/// — the fixed struct keys land alphabetically and any already-sorted `props`/
-/// `attrs` re-sort to themselves — but the leaves (the `text` string, mark
-/// attrs, arrays) are moved rather than deep-cloned, so a tree built once by
-/// `to_value` is canonicalized without a second full clone. Re-sorting a new
+/// The crate's one key sorter: reorder every object's keys by **moving** each
+/// entry into a freshly key-sorted map, recursively. Pins island `props` (and
+/// unknown line/container/mark `attrs`) against `preserve_order` leaking
+/// insertion order into the canonical bytes / content hash (Spike C
+/// carry-forward). The fixed struct keys land alphabetically and any
+/// already-sorted `props`/`attrs` re-sort to themselves; the leaves (the `text`
+/// string, mark attrs, arrays) are moved rather than deep-cloned, so a tree
+/// built once by `to_value` is canonicalized without a second full clone. The
+/// encoders therefore emit their payload bags verbatim — one pass over the
+/// finished tree, not one per bag. Re-sorting a new
 /// `serde_json::Map` (not sorting in place) keeps this independent of whether
 /// `serde_json`'s `preserve_order` feature is on in the crate graph.
 pub(crate) fn sort_keys_owned(v: JsonValue) -> JsonValue {

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -264,6 +264,12 @@ impl Loss {
 impl MarkKind {
     /// Formatting marks are a property of a range and union when coincident;
     /// identity/unknown marks are handles and never merge (Spike-A rules).
+    ///
+    /// Class membership is stored meaning, not presentation: promoting an
+    /// open-set tag *into* this class starts unioning adjacent runs that
+    /// round-tripped as two marks, so the promotion moves the canonical bytes of
+    /// documents nobody edited (`DOCUMENT_STORAGE.md` § Promoting a vocabulary
+    /// member).
     pub fn is_formatting(&self) -> bool {
         matches!(
             self,
@@ -278,6 +284,14 @@ impl MarkKind {
 
     /// Total order over kinds for the canonical sort tie-break, after
     /// `(start, end)`. Stable across releases — part of the freeze.
+    ///
+    /// A new variant takes the slot immediately **before** [`MarkKind::Unknown`],
+    /// pushing `Unknown` up by one. That is the only placement where a build that
+    /// knows the type and a build that reads it as `Unknown` order it identically
+    /// against every built-in; anywhere else is two canonical forms for one
+    /// document, one per reader (`DOCUMENT_STORAGE.md` § Promoting a vocabulary
+    /// member). The block axes sort by nothing, so the rule is the mark axis'
+    /// alone.
     pub fn ord(&self) -> u8 {
         match self {
             MarkKind::Strong => 0,

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -351,6 +351,55 @@ pub(crate) fn is_value_key_sorted(v: &JsonValue) -> bool {
     }
 }
 
+/// `true` when `v` nests deeper than `max` container levels — the guard that
+/// keeps the recursive walkers above ([`sorted_value`], [`is_value_key_sorted`],
+/// [`sort_keys_owned`]) and `Value`'s own `Drop` inside a bounded frame count.
+///
+/// The walk is iterative (explicit stack), so the check itself cannot overflow on
+/// the adversarially deep input it exists to detect. The unit is **container
+/// levels**, not nodes: only arrays and objects are charged a level and the
+/// scalar leaf at the bottom of a chain is never checked, so `max` nested
+/// containers are accepted whether the deepest holds a scalar, is empty, or holds
+/// another container, and `max + 1` is rejected in every case. Level-charging
+/// matches [`quillmark_core::json_depth_exceeds`], the document-side twin, so the
+/// two boundaries reject the identical shape.
+pub(crate) fn json_depth_exceeds(v: &JsonValue, max: usize) -> bool {
+    // (value, depth) pairs; depth counts container levels entered.
+    let mut stack: Vec<(&JsonValue, usize)> = vec![(v, 0)];
+    while let Some((v, depth)) = stack.pop() {
+        match v {
+            JsonValue::Array(items) => {
+                if depth + 1 > max {
+                    return true;
+                }
+                stack.extend(items.iter().map(|c| (c, depth + 1)));
+            }
+            JsonValue::Object(map) => {
+                if depth + 1 > max {
+                    return true;
+                }
+                stack.extend(map.values().map(|c| (c, depth + 1)));
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// [`json_depth_exceeds`] against [`MAX_JSON_DEPTH`](crate::MAX_JSON_DEPTH) as an
+/// [`Invariant`] result, `what` naming the bag. The one spelling shared by
+/// [`Content::validate`] and the decoders in [`crate::serial`], so the wire and
+/// in-process readings of the limit cannot drift.
+pub(crate) fn check_json_depth(v: &JsonValue, what: &'static str) -> Result<(), Invariant> {
+    if json_depth_exceeds(v, crate::MAX_JSON_DEPTH) {
+        return Err(Invariant::JsonTooDeep {
+            what,
+            max: crate::MAX_JSON_DEPTH,
+        });
+    }
+    Ok(())
+}
+
 /// Put `v` in canonical key order, rebuilding it only when a key is actually out
 /// of order — an untouched tree (a pure text splice) stays sorted, so the
 /// per-keystroke path pays the scan and skips the deep clone.
@@ -459,6 +508,14 @@ pub enum Invariant {
         depth: usize,
         max: usize,
     },
+    /// An opaque JSON payload — an island's `props`, an unknown line/container/
+    /// mark's `attrs` — nests deeper than [`MAX_JSON_DEPTH`](crate::MAX_JSON_DEPTH).
+    /// [`Invariant::NestingTooDeep`] on the payload axis: key-canonicalization,
+    /// the hash key, and `Value`'s own `Drop` each recurse one frame per level, so
+    /// an unbounded bag overflows the stack instead of erroring. `what` names the
+    /// bag. No true depth: the check bails at the first over-deep container rather
+    /// than measuring past the limit.
+    JsonTooDeep { what: &'static str, max: usize },
 }
 
 /// The way a line's text can contradict its [`LineKind`]. `Para` and `Heading`
@@ -730,10 +787,11 @@ impl Content {
                 }
             }
             match &m.kind {
-                MarkKind::Unknown { tag, .. } => {
+                MarkKind::Unknown { tag, attrs } => {
                     if Self::RESERVED_MARK_TYPES.contains(&tag.as_str()) {
                         return Err(Invariant::ReservedUnknownTag(tag.clone()));
                     }
+                    check_json_depth(attrs, "mark attrs")?;
                 }
                 MarkKind::Anchor { id } => {
                     if id.is_empty() || !seen_anchor_ids.insert(id.as_str()) {
@@ -753,18 +811,20 @@ impl Content {
                 // An unknown role may not reuse a built-in `kind` name: it would
                 // serialize as the built-in and parse back as one, dropping its
                 // attrs — the mark-side rule, one axis over.
-                LineKind::Unknown { tag, .. }
-                    if Self::RESERVED_LINE_KINDS.contains(&tag.as_str()) =>
-                {
-                    return Err(Invariant::ReservedUnknownLineKind(tag.clone()));
+                LineKind::Unknown { tag, attrs } => {
+                    if Self::RESERVED_LINE_KINDS.contains(&tag.as_str()) {
+                        return Err(Invariant::ReservedUnknownLineKind(tag.clone()));
+                    }
+                    check_json_depth(attrs, "line attrs")?;
                 }
                 _ => {}
             }
             for c in &line.containers {
-                if let Container::Unknown { tag, .. } = c {
+                if let Container::Unknown { tag, attrs } = c {
                     if Self::RESERVED_CONTAINERS.contains(&tag.as_str()) {
                         return Err(Invariant::ReservedUnknownContainer(tag.clone()));
                     }
+                    check_json_depth(attrs, "container attrs")?;
                 }
             }
             if let Some(mismatch) = line_kind_mismatch(&line.kind, seg) {
@@ -791,6 +851,10 @@ impl Content {
                     id: island.id.clone(),
                 });
             }
+            // Payload depth before any pass that walks `props`. A cell's own
+            // `attrs` is a subtree of `props`, so one check bounds the cell marks
+            // the loop below reads as well.
+            check_json_depth(&island.props, "island props")?;
             // Structural shape (table column/row/aligns consistency, `\n`-free
             // cells) before the per-cell mark ranges — a ragged island is
             // ill-formed regardless of its marks.
@@ -1039,6 +1103,67 @@ mod tests {
                 max: crate::MAX_NESTING_DEPTH,
             })
         );
+    }
+
+    /// Issue #1093: [`container_nesting_is_capped`] on the payload axis. The
+    /// decoders refuse an over-deep bag at the wire, and this is the same cap for
+    /// the content that never went through a decoder — key canonicalization, the
+    /// hash key, and `Value`'s own `Drop` recurse one frame per level whatever
+    /// built the tree.
+    #[test]
+    fn json_payload_depth_is_capped() {
+        let nested = |depth: usize| {
+            let mut v = JsonValue::Null;
+            for _ in 0..depth {
+                v = JsonValue::Array(vec![v]);
+            }
+            v
+        };
+        let too_deep = |what: &'static str| {
+            Err(Invariant::JsonTooDeep {
+                what,
+                max: crate::MAX_JSON_DEPTH,
+            })
+        };
+
+        let mut rt = tagged("hi", LineKind::Para);
+        rt.lines[0].kind = LineKind::Unknown {
+            tag: "callout".into(),
+            attrs: nested(crate::MAX_JSON_DEPTH),
+        };
+        assert_eq!(rt.validate(), Ok(()));
+        rt.lines[0].kind = LineKind::Unknown {
+            tag: "callout".into(),
+            attrs: nested(crate::MAX_JSON_DEPTH + 1),
+        };
+        assert_eq!(rt.validate(), too_deep("line attrs"));
+
+        let mut rt = tagged("hi", LineKind::Para);
+        rt.lines[0].containers = vec![Container::Unknown {
+            tag: "indent".into(),
+            attrs: nested(crate::MAX_JSON_DEPTH + 1),
+        }];
+        assert_eq!(rt.validate(), too_deep("container attrs"));
+
+        let mut rt = tagged("hi", LineKind::Para);
+        rt.marks = vec![Mark {
+            start: 0,
+            end: 2,
+            kind: MarkKind::Unknown {
+                tag: "sparkle".into(),
+                attrs: nested(crate::MAX_JSON_DEPTH + 1),
+            },
+        }];
+        assert_eq!(rt.validate(), too_deep("mark attrs"));
+
+        let mut rt = tagged("\u{fffc}", LineKind::Island);
+        rt.islands = vec![Island {
+            id: "i1".into(),
+            island_type: "widget".into(),
+            props: nested(crate::MAX_JSON_DEPTH + 1),
+            loss: Loss::Lossless,
+        }];
+        assert_eq!(rt.validate(), too_deep("island props"));
     }
 
     #[test]

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -16,6 +16,7 @@ use crate::model::{
     MarkKind, Content, Usv,
 };
 use serde_json::{Map, Value};
+use std::borrow::Cow;
 
 /// Why canonical-JSON parsing failed. Structural only — a well-formed producer
 /// (this crate's serializer, the seam, storage) never trips these.
@@ -159,6 +160,41 @@ fn arr_or_empty<'a>(v: &'a Value, key: &str) -> &'a [Value] {
     v.get(key).map(as_slice).unwrap_or_default()
 }
 
+/// Fold a legacy `attrs` bag into the object when `tag` names a **built-in** —
+/// the storage lane's promotion path. A blob written while `callout` was outside
+/// this build's vocabulary carries `{"kind":"callout","attrs":{…}}`; the release
+/// that promotes `callout` to a built-in reads named siblings that blob never had
+/// and would drop its payload unread. Folding the bag's entries in before the
+/// built-in arms run makes each promotion carry its own legacy form structurally,
+/// rather than as something the promoting author has to remember
+/// (`DOCUMENT_STORAGE.md` § Promoting a vocabulary member).
+///
+/// Three bounds. A named sibling wins over an `attrs` entry — the built-in
+/// encoding is canonical wherever both spellings are present. Only a reserved
+/// name folds, so an unknown's bag stays its opaque payload. The discriminator is
+/// read from the *original* object, so a bag holding a `kind`/`type`/`container`
+/// key cannot re-target the match.
+///
+/// The authored lane never arrives here with this shape: it rejects `attrs`
+/// beside a built-in up front.
+fn fold_legacy_attrs<'a>(
+    o: &'a Map<String, Value>,
+    tag: &str,
+    reserved: &[&str],
+) -> Cow<'a, Map<String, Value>> {
+    let Some(Value::Object(attrs)) = o.get("attrs") else {
+        return Cow::Borrowed(o);
+    };
+    if attrs.is_empty() || !reserved.contains(&tag) {
+        return Cow::Borrowed(o);
+    }
+    let mut folded = o.clone();
+    for (k, v) in attrs {
+        folded.entry(k.clone()).or_insert_with(|| v.clone());
+    }
+    Cow::Owned(folded)
+}
+
 // ---- Line ----
 
 /// Encode a [`LineKind`] into its canonical `kind` fields (`"para"`,
@@ -203,9 +239,16 @@ pub fn line_kind_to_value(kind: &LineKind) -> Value {
 /// [`line_from_value`] and the line-op wire.
 pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("line"))?;
-    match o.get("kind").and_then(Value::as_str) {
-        Some("para") => Ok(LineKind::Para),
-        Some("heading") => {
+    // A missing/non-string `kind` is the one shape error here — the open set
+    // absorbs unknown *names*, not malformed objects.
+    let tag = o
+        .get("kind")
+        .and_then(Value::as_str)
+        .ok_or(ParseError::Shape("line kind"))?;
+    let o = fold_legacy_attrs(o, tag, &Content::RESERVED_LINE_KINDS);
+    match tag {
+        "para" => Ok(LineKind::Para),
+        "heading" => {
             let level = o
                 .get("level")
                 .and_then(Value::as_u64)
@@ -215,19 +258,18 @@ pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
             }
             Ok(LineKind::Heading { level: level as u8 })
         }
-        Some("code") => Ok(LineKind::Code {
+        "code" => Ok(LineKind::Code {
             lang: o.get("lang").and_then(Value::as_str).map(str::to_string),
         }),
-        Some("island") => Ok(LineKind::Island),
-        Some("rule") => Ok(LineKind::Rule),
+        "island" => Ok(LineKind::Island),
+        "rule" => Ok(LineKind::Rule),
         // Open set: any other name is a block role this build lacks, kept opaque
-        // and projected as `Para`. Only a missing/non-string `kind` is a shape
-        // error — the *document* still opens when its vocabulary grows.
-        Some(other) => Ok(LineKind::Unknown {
+        // and projected as `Para` — the *document* still opens when its
+        // vocabulary grows.
+        other => Ok(LineKind::Unknown {
             tag: other.to_string(),
             attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
         }),
-        None => Err(ParseError::Shape("line kind")),
     }
 }
 
@@ -296,20 +338,24 @@ pub fn container_to_value(c: &Container) -> Value {
 /// [`container_to_value`].
 pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("container"))?;
-    match o.get("container").and_then(Value::as_str) {
-        Some("list_item") => Ok(Container::ListItem {
+    let tag = o
+        .get("container")
+        .and_then(Value::as_str)
+        .ok_or(ParseError::Shape("container kind"))?;
+    let o = fold_legacy_attrs(o, tag, &Content::RESERVED_CONTAINERS);
+    match tag {
+        "list_item" => Ok(Container::ListItem {
             ordered: o.get("ordered").and_then(Value::as_bool).unwrap_or(false),
             start: o.get("start").and_then(Value::as_u64).unwrap_or(1),
             ordinal: o.get("ordinal").and_then(Value::as_u64).unwrap_or(0),
         }),
-        Some("quote") => Ok(Container::Quote),
+        "quote" => Ok(Container::Quote),
         // Open set, as for line kinds: an unrecognized container round-trips
         // opaque and projects transparently.
-        Some(other) => Ok(Container::Unknown {
+        other => Ok(Container::Unknown {
             tag: other.to_string(),
             attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
         }),
-        None => Err(ParseError::Shape("container kind")),
     }
 }
 
@@ -365,6 +411,7 @@ pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
         .get("type")
         .and_then(Value::as_str)
         .ok_or(ParseError::Shape("mark type"))?;
+    let o = fold_legacy_attrs(o, ty, &Content::RESERVED_MARK_TYPES);
     let kind = match ty {
         "strong" => MarkKind::Strong,
         "emph" => MarkKind::Emph,
@@ -1153,5 +1200,172 @@ mod tests {
         let json = rt.to_canonical_json();
         let back = Content::from_canonical_json(&json).unwrap();
         assert_eq!(back.marks[0].kind, rt.marks[0].kind);
+    }
+
+    /// Issue #1094: promotion moves a construct's payload from the opaque bag to
+    /// named siblings, and every blob written before it still spells the payload
+    /// the old way. The storage lane folds the bag in, so the promoted decoder
+    /// reads what the unknown wrote instead of dropping it. Pinned on the
+    /// built-ins carrying payload today — the fold keys off `RESERVED_*`, so a
+    /// promoted name joins it by the same edit that promotes it.
+    #[test]
+    fn built_in_decoders_read_the_legacy_attrs_form() {
+        let cases: [(Value, LineKind); 2] = [
+            (
+                serde_json::json!({"kind": "heading", "attrs": {"level": 2}}),
+                LineKind::Heading { level: 2 },
+            ),
+            (
+                serde_json::json!({"kind": "code", "attrs": {"lang": "rust"}}),
+                LineKind::Code {
+                    lang: Some("rust".into()),
+                },
+            ),
+        ];
+        for (v, want) in cases {
+            assert_eq!(line_kind_from_value(&v).unwrap(), want);
+        }
+        let item = serde_json::json!({
+            "container": "list_item",
+            "attrs": {"ordered": true, "start": 3, "ordinal": 1}
+        });
+        assert_eq!(
+            container_from_value(&item).unwrap(),
+            Container::ListItem {
+                ordered: true,
+                start: 3,
+                ordinal: 1,
+            }
+        );
+        let link = serde_json::json!({"start": 0, "end": 1, "type": "link", "attrs": {"url": "u"}});
+        assert_eq!(
+            mark_from_value(&link).unwrap().kind,
+            MarkKind::Link { url: "u".into() }
+        );
+        // Both spellings present: the named sibling is the canonical one.
+        let both = serde_json::json!({"kind": "heading", "level": 3, "attrs": {"level": 2}});
+        assert_eq!(
+            line_kind_from_value(&both).unwrap(),
+            LineKind::Heading { level: 3 }
+        );
+        // An unknown's bag is payload, not a source of named fields — including a
+        // key that would re-target the match if the fold read the discriminator
+        // back out of it.
+        let unknown = serde_json::json!({"kind": "callout", "attrs": {"kind": "heading", "level": 2}});
+        assert_eq!(
+            line_kind_from_value(&unknown).unwrap(),
+            LineKind::Unknown {
+                tag: "callout".into(),
+                attrs: serde_json::json!({"kind": "heading", "level": 2}),
+            }
+        );
+        // Re-encode is the promoted spelling, so opening a legacy blob under the
+        // release that promotes its tag moves the document's canonical bytes —
+        // the read-repair / accepted-movement case § Byte-stability governs.
+        let legacy = r#"{"islands":[],"lines":[{"attrs":{"level":2},"containers":[],"kind":"heading"}],"marks":[],"text":"hi"}"#;
+        assert_eq!(
+            Content::from_canonical_json(legacy)
+                .unwrap()
+                .to_canonical_json(),
+            r#"{"islands":[],"lines":[{"containers":[],"kind":"heading","level":2}],"marks":[],"text":"hi"}"#
+        );
+    }
+
+    /// Issue #1094: `ord` is part of the freeze, and a promoted type takes the
+    /// slot `Unknown` held. Anywhere else and a build that knows the type orders
+    /// it against the built-ins differently from a build that reads it as
+    /// `Unknown` — one document, two canonical forms.
+    #[test]
+    fn unknown_holds_the_last_mark_ordinal() {
+        let all = [
+            MarkKind::Strong,
+            MarkKind::Emph,
+            MarkKind::Underline,
+            MarkKind::Strike,
+            MarkKind::Code,
+            MarkKind::Link { url: "u".into() },
+            MarkKind::Anchor { id: "a".into() },
+            MarkKind::Unknown {
+                tag: "kbd".into(),
+                attrs: Value::Null,
+            },
+        ];
+        // Exhaustive on purpose: a new variant is a compile error here, which is
+        // where the placement rule gets read, rather than a slot silently taken
+        // after `Unknown`.
+        for k in &all {
+            match k {
+                MarkKind::Strong
+                | MarkKind::Emph
+                | MarkKind::Underline
+                | MarkKind::Strike
+                | MarkKind::Code
+                | MarkKind::Link { .. }
+                | MarkKind::Anchor { .. }
+                | MarkKind::Unknown { .. } => {}
+            }
+        }
+        let ords: Vec<u8> = all.iter().map(MarkKind::ord).collect();
+        assert_eq!(ords, (0..all.len() as u8).collect::<Vec<_>>());
+        assert!(matches!(all.last(), Some(MarkKind::Unknown { .. })));
+    }
+
+    /// Issue #1094: formatting-class membership is stored meaning. Two adjacent
+    /// unknowns are two marks; two adjacent formatting marks are one. Promoting a
+    /// tag into the class therefore rewrites documents nobody edited, which makes
+    /// it a canonical-byte event rather than a silent widening.
+    #[test]
+    fn formatting_class_membership_decides_adjacent_union() {
+        let mut rt = Content::empty();
+        rt.text = "abcd".into();
+        let unknown = |start, end| Mark {
+            start,
+            end,
+            kind: MarkKind::Unknown {
+                tag: "kbd".into(),
+                attrs: serde_json::json!({}),
+            },
+        };
+        rt.marks = vec![unknown(0, 2), unknown(2, 4)];
+        rt.normalize();
+        assert_eq!(rt.marks.len(), 2);
+        rt.marks = vec![
+            Mark {
+                start: 0,
+                end: 2,
+                kind: MarkKind::Strong,
+            },
+            Mark {
+                start: 2,
+                end: 4,
+                kind: MarkKind::Strong,
+            },
+        ];
+        rt.normalize();
+        assert_eq!(rt.marks.len(), 1);
+    }
+
+    /// Issue #1094: promotion grows `RESERVED_*`, and the authored lane then
+    /// refuses a shape it accepted the release before. By design — a host still
+    /// authoring the unknown spelling of a name that now means the built-in is
+    /// writing the silent drop the rule exists to catch — but from the host's
+    /// side it reads as a release breaking its writes.
+    #[test]
+    fn reserved_growth_flips_authored_acceptance() {
+        let doc = |kind: &str| {
+            serde_json::json!({
+                "islands": [],
+                "lines": [{"attrs": {"level": 2}, "containers": [], "kind": kind}],
+                "marks": [],
+                "text": "hi",
+            })
+        };
+        // Outside `RESERVED_LINE_KINDS` today: an unknown carrying its payload.
+        assert!(from_authored_value(&doc("callout")).is_ok());
+        // Inside it: what `"callout"` becomes the release it is promoted.
+        assert!(matches!(
+            from_authored_value(&doc("heading")),
+            Err(ParseError::Shape(_))
+        ));
     }
 }

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -12,7 +12,7 @@
 //! canonical form — one serializer, not two to keep aligned.
 
 use crate::model::{
-    sort_keys_owned, sorted_value, Container, Invariant, Island, Line, LineKind, Loss, Mark,
+    sort_keys_owned, Container, Invariant, Island, Line, LineKind, Loss, Mark,
     MarkKind, Content, Usv,
 };
 use serde_json::{Map, Value};
@@ -256,7 +256,7 @@ pub fn line_kind_to_value(kind: &LineKind) -> Value {
         // reader that lacks the role still carries it whole.
         LineKind::Unknown { tag, attrs } => {
             m.insert("kind".into(), Value::String(tag.clone()));
-            m.insert("attrs".into(), sorted_value(attrs));
+            m.insert("attrs".into(), attrs.clone());
         }
     }
     Value::Object(m)
@@ -356,7 +356,7 @@ pub fn container_to_value(c: &Container) -> Value {
         }
         Container::Unknown { tag, attrs } => {
             m.insert("container".into(), Value::String(tag.clone()));
-            m.insert("attrs".into(), sorted_value(attrs));
+            m.insert("attrs".into(), attrs.clone());
         }
     }
     Value::Object(m)
@@ -422,7 +422,7 @@ pub fn mark_to_value(mark: &Mark) -> Value {
         }
         MarkKind::Unknown { tag, attrs } => {
             m.insert("type".into(), Value::String(tag.clone()));
-            m.insert("attrs".into(), sorted_value(attrs));
+            m.insert("attrs".into(), attrs.clone());
         }
     }
     Value::Object(m)
@@ -701,8 +701,8 @@ pub fn parse_cell(v: &Value) -> (String, Vec<Mark>) {
 }
 
 /// Build a table-cell object `{text, marks}` — the inverse of [`parse_cell`],
-/// reusing [`mark_to_value`]. Key order is fixed by the recursive
-/// [`sorted_value`] pass in [`Content::normalize`], not here.
+/// reusing [`mark_to_value`]. Key order is fixed by the recursive key-sort in
+/// [`Content::normalize`], not here.
 pub(crate) fn cell_to_value(text: &str, marks: &[Mark]) -> Value {
     let mut m = Map::new();
     m.insert("text".into(), Value::String(text.to_string()));
@@ -881,7 +881,7 @@ fn island_to_value(island: &Island) -> Value {
     let mut m = Map::new();
     m.insert("id".into(), Value::String(island.id.clone()));
     m.insert("type".into(), Value::String(island.island_type.clone()));
-    m.insert("props".into(), sorted_value(&island.props));
+    m.insert("props".into(), island.props.clone());
     m.insert("loss".into(), loss_to_str(&island.loss).into());
     Value::Object(m)
 }

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -132,6 +132,28 @@ pub fn from_canonical_value(v: &Value) -> Result<Content, ParseError> {
     Ok(rt)
 }
 
+/// Read an opaque payload bag (`attrs`, `props`) off the wire, absent → `Null`.
+/// **Depth-checked before the clone**, against
+/// [`MAX_JSON_DEPTH`](crate::MAX_JSON_DEPTH): `Value::clone` recurses one frame
+/// per level, as do the key-canonicalization passes, the hash key, and the tree's
+/// own `Drop`, so an over-deep bag must be refused while it is still borrowed from
+/// the caller's `Value` — by the time it is owned, the frames have already been
+/// spent and dropping it spends them again. The wire twin of the
+/// [`Invariant::JsonTooDeep`] check in
+/// [`Content::validate`](crate::model::Content::validate), and every bag every
+/// decoder retains comes through here.
+fn bag_from_wire(
+    o: &Map<String, Value>,
+    key: &'static str,
+    what: &'static str,
+) -> Result<Value, ParseError> {
+    let Some(v) = o.get(key) else {
+        return Ok(Value::Null);
+    };
+    crate::model::check_json_depth(v, what).map_err(ParseError::Invalid)?;
+    Ok(v.clone())
+}
+
 /// Read a wire position as a [`Usv`] index. **Checked**, not `as usize`: the
 /// deployment target is wasm32, where the truncating cast turns `2^32 + 5` into
 /// an in-range `5` — a mark silently landing at the wrong position instead of a
@@ -225,7 +247,7 @@ pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
         // error — the *document* still opens when its vocabulary grows.
         Some(other) => Ok(LineKind::Unknown {
             tag: other.to_string(),
-            attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
+            attrs: bag_from_wire(o, "attrs", "line attrs")?,
         }),
         None => Err(ParseError::Shape("line kind")),
     }
@@ -307,7 +329,7 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
         // opaque and projects transparently.
         Some(other) => Ok(Container::Unknown {
             tag: other.to_string(),
-            attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
+            attrs: bag_from_wire(o, "attrs", "container attrs")?,
         }),
         None => Err(ParseError::Shape("container kind")),
     }
@@ -389,7 +411,7 @@ pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
         // with whatever `attrs` it carried.
         other => MarkKind::Unknown {
             tag: other.to_string(),
-            attrs: o.get("attrs").cloned().unwrap_or(Value::Null),
+            attrs: bag_from_wire(o, "attrs", "mark attrs")?,
         },
     };
     Ok(Mark { start, end, kind })
@@ -792,7 +814,7 @@ fn island_from_value(v: &Value) -> Result<Island, ParseError> {
             .and_then(Value::as_str)
             .ok_or(ParseError::Shape("island type"))?
             .to_string(),
-        props: o.get("props").cloned().unwrap_or(Value::Null),
+        props: bag_from_wire(o, "props", "island props")?,
         loss: loss_from_str(o.get("loss").and_then(Value::as_str).unwrap_or("lossless")),
     })
 }
@@ -862,6 +884,121 @@ mod tests {
         assert!(matches!(
             Content::from_canonical_json(&json),
             Err(ParseError::Invalid(Invariant::NestingTooDeep { .. }))
+        ));
+    }
+
+    /// Build a `Value` nesting `depth` array levels — iteratively, so *building*
+    /// the fixture cannot overflow. Handling it still can: `Value`'s `Clone` and
+    /// `Drop` both recurse, which is why the tests below probe just past the cap
+    /// (1 000, the depth issue #1093 measured as safe to hold) rather than at the
+    /// 5 000 that aborted. A depth the guard must reject is a depth the test
+    /// cannot pass around either — the reason the limit exists.
+    fn nested_arrays(depth: usize) -> Value {
+        let mut v = Value::Null;
+        for _ in 0..depth {
+            v = Value::Array(vec![v]);
+        }
+        v
+    }
+
+    /// Issue #1093: [`deep_container_nesting_is_rejected_at_decode`] on the
+    /// payload axis, through the `Value` lane. The string lane was already safe
+    /// by accident (`serde_json::from_str` refuses past 128), but the `Value` lane
+    /// is the host-authored one — `install` reaches it — and had no guard, so a
+    /// 5 000-deep `props` aborted the process instead of erroring.
+    #[test]
+    fn deep_json_payload_is_rejected_at_decode_on_the_value_lane() {
+        let deep = nested_arrays(1_000);
+        let cases: [(Value, &'static str); 4] = [
+            (
+                serde_json::json!({"text":"\u{fffc}","lines":[{"kind":"island","containers":[]}],
+                  "marks":[],"islands":[{"id":"i1","type":"widget","loss":"lossless","props":deep}]}),
+                "island props",
+            ),
+            (
+                serde_json::json!({"text":"x","lines":[{"kind":"para","containers":[]}],
+                  "marks":[{"start":0,"end":1,"type":"sparkle","attrs":deep}],"islands":[]}),
+                "mark attrs",
+            ),
+            (
+                serde_json::json!({"text":"x","lines":[{"kind":"callout","containers":[],"attrs":deep}],
+                  "marks":[],"islands":[]}),
+                "line attrs",
+            ),
+            (
+                serde_json::json!({"text":"x","lines":[{"kind":"para",
+                  "containers":[{"container":"indent","attrs":deep}]}],"marks":[],"islands":[]}),
+                "container attrs",
+            ),
+        ];
+        for (v, what) in cases {
+            assert_eq!(
+                from_canonical_value(&v),
+                Err(ParseError::Invalid(Invariant::JsonTooDeep {
+                    what,
+                    max: crate::MAX_JSON_DEPTH,
+                })),
+                "{what} accepted a 1 000-deep payload"
+            );
+            // The authored lane funnels through the same decode, so it refuses
+            // the same shape rather than trapping on the reserved-name scan.
+            assert!(matches!(
+                from_authored_value(&v),
+                Err(ParseError::Invalid(Invariant::JsonTooDeep { .. }))
+            ));
+        }
+    }
+
+    /// The cap admits every payload a stored blob can carry, so closing the
+    /// `Value` lane costs no stored population. Stated as the implication rather
+    /// than an offset: `serde_json::from_str`'s own limit counts from the document
+    /// root, not from the bag, so the wrapper levels it also charges are its
+    /// business — what must hold is that anything the string lane delivers, the
+    /// per-bag cap accepts.
+    #[test]
+    fn json_depth_cap_admits_every_storable_payload() {
+        let content = |props: Value| {
+            serde_json::json!({"text":"\u{fffc}","lines":[{"kind":"island","containers":[]}],
+              "marks":[],"islands":[{"id":"i1","type":"widget","loss":"lossless","props":props}]})
+        };
+        assert!(from_canonical_value(&content(nested_arrays(crate::MAX_JSON_DEPTH))).is_ok());
+        assert!(from_canonical_value(&content(nested_arrays(crate::MAX_JSON_DEPTH + 1))).is_err());
+
+        // Across the whole boundary region, string-lane-accepted implies
+        // `Value`-lane-accepted. The converse does not hold and need not: the
+        // string lane's root-relative count refuses a few depths the bag cap
+        // allows, which is where it was accidentally safe all along.
+        let mut storable = 0;
+        for d in 1..=crate::MAX_JSON_DEPTH + 8 {
+            let v = content(nested_arrays(d));
+            if Content::from_canonical_json(&v.to_string()).is_ok() {
+                storable = d;
+                assert!(
+                    from_canonical_value(&v).is_ok(),
+                    "the bag cap refused a {d}-deep props the string lane accepts"
+                );
+            }
+        }
+        assert!(
+            storable > 0 && storable <= crate::MAX_JSON_DEPTH,
+            "string lane's deepest storable props was {storable}"
+        );
+    }
+
+    /// Issue #1093: an over-deep bag is refused whichever door it arrives at, so
+    /// the op wire cannot install one either.
+    #[test]
+    fn deep_json_payload_is_rejected_on_the_op_wire() {
+        let deep = nested_arrays(1_000);
+        let op = serde_json::json!({"op":"add","start":0,"end":1,"type":"sparkle","attrs":deep});
+        assert!(matches!(
+            crate::ops::mark_op_from_value(&op),
+            Err(ParseError::Invalid(Invariant::JsonTooDeep { .. }))
+        ));
+        let op = serde_json::json!({"op":"setKind","line":0,"kind":"callout","attrs":deep});
+        assert!(matches!(
+            crate::ops::line_op_from_value(&op),
+            Err(ParseError::Invalid(Invariant::JsonTooDeep { .. }))
         ));
     }
 

--- a/docs/migrations/0.98-to-0.99.md
+++ b/docs/migrations/0.98-to-0.99.md
@@ -9,6 +9,7 @@ now a diagnostic.
 |---|---|---|
 | `attrs` beside a built-in discriminator rejected on write | TypeScript (`install` / `applyChange`), Rust (`quillmark-content` op wire) | Emit an unknown under a name this build does not use |
 | An opaque payload nesting past 128 levels rejected on decode | TypeScript (`install` / `applyChange`), Rust (`serial::from_canonical_value`, the op wire) | Nothing — no storable blob reaches the limit |
+| An unknown's `attrs` emitted in caller key order, not sorted | Rust (`serial::{mark,line_kind,container}_to_value`) | Nothing — canonical content bytes are unchanged |
 
 New, no action required: `isUnknownLine` / `isUnknownContainer` /
 `isUnknownMark` / `isUnknownIsland` on the WASM surface, and `ContentLineKind`
@@ -141,3 +142,17 @@ const op: LineOp = { op: 'setKind', line, ...kindPart(line) };
 
 The alternative — an arm-by-arm `switch` rebuilding the payload — means guessing
 at the open arm's shape and re-editing on every arm added upstream.
+
+## Op-wire key order follows the caller
+
+`serial::to_canonical_value` used to sort each opaque payload bag three times —
+once in `normalize`, once per encoder, once in the terminal `sort_keys_owned`.
+The per-encoder pass is gone, so `mark_to_value`, `line_kind_to_value`, and
+`container_to_value` now emit an unknown's `attrs` in the caller's key order
+rather than sorted (#1095).
+
+Canonical content bytes are unchanged — the terminal sort still runs, and
+`to_canonical_json` is byte-identical for every document. The difference is
+visible only to a Rust caller that encodes an op through those three functions
+directly and compares the JSON as bytes. Nothing hashes the op wire; if a
+consumer does, sort at its own top level.

--- a/docs/migrations/0.98-to-0.99.md
+++ b/docs/migrations/0.98-to-0.99.md
@@ -8,6 +8,7 @@ now a diagnostic.
 | Break | Surface | Action |
 |---|---|---|
 | `attrs` beside a built-in discriminator rejected on write | TypeScript (`install` / `applyChange`), Rust (`quillmark-content` op wire) | Emit an unknown under a name this build does not use |
+| An opaque payload nesting past 128 levels rejected on decode | TypeScript (`install` / `applyChange`), Rust (`serial::from_canonical_value`, the op wire) | Nothing — no storable blob reaches the limit |
 
 New, no action required: `isUnknownLine` / `isUnknownContainer` /
 `isUnknownMark` / `isUnknownIsland` on the WASM surface, and `ContentLineKind`
@@ -48,6 +49,35 @@ stale copy of the built-in list rather than a document from the past.
 
 If you hit this, you emitted an unknown under a name that is no longer unknown.
 The fix is the next section.
+
+## Payload depth is bounded, on the lane that was not
+
+0.98 capped container nesting (`Invariant::NestingTooDeep`) and left the payload
+axis open. An island's `props` and an unknown's `attrs` are opaque host JSON, and
+every consumer of one recurses a frame per level: key canonicalization, the
+content-hash key, and `serde_json::Value`'s own `Drop`. `Content::from_canonical_json`
+was safe by accident — `serde_json::from_str` refuses past 128 — but the
+`Value` lane had no limit, and that is the host-authored one (#1093):
+
+```js
+// 0.98: aborts the WASM module — a stack-overflow trap, not a catchable error
+let v = []; for (let i = 0; i < 5000; i++) v = [v];
+doc.install(addr, { …, islands: [{ id: 'i1', type: 'widget', loss: 'lossless', props: v }] });
+
+// 0.99: throws — "install: value nests deeper than 128 levels"
+```
+
+`MAX_JSON_DEPTH` is 128, the limit the string lane already enforced, so nothing a
+stored blob can carry is refused and no stored population is affected. The bag is
+checked where it is read off the wire, **before** it is cloned into the model —
+the clone spends the frames too, and so does dropping the result — and
+`Content::validate` restates it as `Invariant::JsonTooDeep` for content that never
+went through a decoder. On the WASM surface the check sits on the JS side of the
+boundary, because `serde_wasm_bindgen` recurses while *building* the value and
+would trap before any Rust guard could run.
+
+A `quillmark-content` dependent matching exhaustively on `Invariant` needs a
+`JsonTooDeep` arm; `#[non_exhaustive]` (also new in 0.99) makes that a wildcard.
 
 ## Asking whether a value is known
 

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,7 +18,7 @@ order; each states its own breaks in full.
 
 | Step | What changes |
 |---|---|
-| [0.98 → 0.99](0.98-to-0.99.md) | `attrs` beside a built-in discriminator is rejected where a host authors it, instead of resolving to the built-in and dropping the payload in silence. `isUnknown*` guards answer known-vs-unknown on each open set; `ContentLineKind` is re-exported. |
+| [0.98 → 0.99](0.98-to-0.99.md) | `attrs` beside a built-in discriminator is rejected where a host authors it, instead of resolving to the built-in and dropping the payload in silence. `isUnknown*` guards answer known-vs-unknown on each open set; `ContentLineKind` is re-exported. Opaque payload depth is bounded at 128 on the `Value` lane, where an unbounded one trapped the WASM module. |
 | [0.97 → 0.98](0.97-to-0.98.md) | The block vocabulary opens — an unrecognized line kind or container round-trips opaque instead of failing the load. `OutputFormat::Txt` retires on every surface. |
 | [0.96 → 0.97](0.96-to-0.97.md) | The WASM transport read renames to `Document.getStored`. A card `$id` becomes unique per document and never empty. |
 | [0.95 → 0.96](0.95-to-0.96.md) | One address grammar (`DocPath`) on every boundary; mutator failures gain namespaced `edit::*` codes; `view()` renames to `reader()`. |

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -200,7 +200,9 @@ Two rules bound the openness:
       was unknown carries `{"kind": "callout", "attrs": {…}}`; the release that
       promotes `callout` to a built-in has to keep opening it. Rejecting at
       `from_canonical_json` would refuse documents at rest exactly when the
-      vocabulary grows — the failure this section exists to prevent.
+      vocabulary grows — the failure this section exists to prevent. Opening it
+      is half: the promoted arm also *reads* the bag rather than dropping it, see
+      Promoting a vocabulary member.
 
 The opaque attrs are hash input like everything else in the canonical form, so
 they are recursively key-sorted along with the rest (see Byte-stability). What
@@ -233,6 +235,57 @@ The bound: **the carrier preserves unknown tags, not unknown payloads on known
 tags.** A future `kind: "footnote"` carrying a sibling `ref` loses `ref` at any
 consumer that predates it, predicates or no — the first rule above (*payload
 rides `attrs`*) read from the other end.
+
+## Promoting a vocabulary member
+
+Adding an unknown is not a schema event; the reverse trip — a later release
+**promoting** a tag to a built-in, which is what the open set exists for — moves
+four things at once.
+
+| What moves | How |
+|---|---|
+| Encoding | `{"kind":"callout","attrs":{…}}` becomes `{"kind":"callout",…}` with named siblings. |
+| Stored blobs | The decoder resolves the built-in name *before* the `Unknown` fallthrough, so the stored `attrs` reach an arm that reads siblings. |
+| Normalization | A promoted mark that `is_formatting()` unions adjacent runs that were two marks. |
+| Sort order | `attrs_key` is `tag\0{json}` for an `Unknown` and whatever its own arm returns for a built-in, so the `(start, end, ord)` tie-break can reorder. |
+
+The first two are data loss on exactly the documents the open set protects; the
+last two move canonical bytes for a document nobody edited. Four rules bound
+them.
+
+**A promoted built-in's decoder also reads the legacy `attrs` form.** This is
+the load-bearing one — without it the first promotion eats every stored blob's
+payload, silently. It is structural rather than a discipline: `fold_legacy_attrs`
+folds an `attrs` bag into the object whenever the discriminator names a reserved
+member, before the built-in arms run, on all three block-and-mark axes. A named
+sibling wins over a bag entry, only reserved names fold, and the discriminator is
+read from the original object. A promotion adds its name to `RESERVED_*` in the
+same edit that adds its arm, so it inherits the fold and carries its own legacy
+form. Re-encoding a folded blob writes the promoted spelling, so the read is a
+byte movement of the read-repair kind § Byte-stability governs.
+
+The island axis has no such gap: `props` is the payload carrier for known and
+unknown types alike, so a promoted island type reads what its unknown wrote. Nor
+does `loss`, which carries no payload.
+
+**A new `MarkKind` takes the ordinal immediately before `Unknown`.** That is the
+one placement where a build that knows the type and a build that reads it as
+`Unknown` order the mark identically against every built-in; any other slot gives
+one document two canonical forms, one per reader. The rule is stated on
+`MarkKind::ord` itself. It is the mark axis' alone — the block axes sort by
+nothing.
+
+**Promoting a mark into the formatting class changes stored meaning**, since
+adjacent runs that round-tripped as two marks begin to union. It is a
+canonical-byte event, and takes the read-repair-or-accept-the-movement treatment
+§ Byte-stability sets out for migrated rows.
+
+**`RESERVED_*` growth rejects previously-valid authored content**, by design. A
+host still authoring `Unknown { tag: "callout" }` after the promotion gets
+`ReservedUnknownLineKind`, and `from_authored_value` starts refusing `attrs`
+beside `"callout"` — the reserved-name rule above, applied to a name that changed
+sides. From the host's seat it reads as a release breaking its writes, so it is a
+release note, not a silent tightening.
 
 ## Island-id determinism
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -310,6 +310,25 @@ beside `"callout"` — the reserved-name rule above, applied to a name that chan
 sides. From the host's seat it reads as a release breaking its writes, so it is a
 release note, not a silent tightening.
 
+## The three id handles
+
+Islands, anchors, and cards each carry an id, and all three are the same handle:
+**opaque, unique within a scope, hash input, stable for the session, rebased
+through edits and never rewritten.** They differ on one axis — **who mints one,
+and why only they can.** Uniqueness scope, collision response, and markdown
+round-trip all follow from that.
+
+|                     | Island `id`                                        | Anchor `id`                                        | Card `$id`                                                            |
+| ------------------- | -------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
+| Minted by           | the engine, at import                              | the caller                                         | the caller                                                            |
+| Because             | content determines it — the nth island minted      | the referent is external; no content determines it | nothing external does, but the scope that validates it is out of view |
+| Unique across       | the `Content`'s islands                            | the `Content`'s prose marks                        | the document's composable cards                                       |
+| Required            | yes                                                | yes — the empty id is rejected                     | no; the handle is opt-in                                              |
+| On collision        | unreachable — mint is sequential; `validate` scans | `add` rejects                                      | parse repairs, mutators and storage reject                            |
+| Markdown round-trip | re-minted identically                              | lost — export emits none, import mints none        | carried verbatim                                                      |
+
+Each section below states one handle's policy whole.
+
 ## Island-id determinism
 
 An island's `id` is part of the canonical form (`{id, type, props, loss}`),
@@ -339,16 +358,12 @@ id.
 
 ## Anchor-id identity
 
-An anchor (`MarkKind::Anchor { id }`) and an island id are the *same handle* —
-opaque, unique per `Content`, hash input, session-stable, rebased not rewritten
-— differing on exactly one axis: **derivability at the markdown boundary**. An
-island projects to markdown, so its id is a pure function of that projection
-(§ Island-id determinism); an anchor has **no** projection — it names an
-external referent (a comment thread, an editor bookmark) that no content
-determines. The never-ambient rule therefore cannot apply, and need not: that
-rule exists to keep *import* a pure function of markdown, and import mints no
-anchor, so equal markdown still imports to equal bytes. The two sections read as
-one handle model, not a contradiction.
+An anchor (`MarkKind::Anchor { id }`) sits at the caller-minted end of the mint
+axis (§ The three id handles) because it has **no markdown projection** — it
+names an external referent (a comment thread, an editor bookmark) that no
+content determines. The never-ambient rule therefore cannot apply, and need not:
+that rule exists to keep *import* a pure function of markdown, and import mints
+no anchor, so equal markdown still imports to equal bytes.
 
 The policy: **an anchor id is caller-supplied, unique per `Content`, opaque and
 invariant while the mark lives; the mark is best-effort under edits and absent
@@ -387,17 +402,13 @@ position, never the id, so this policy holds either way.
 
 ## Card-id identity
 
-A card's `$id` is the third id-bearing handle beside island and anchor ids:
-the **durable card handle** — the address that survives reorder, kind change,
-and both round-trips, where a card's index does not (`Document::find_card`
-resolves it). The three handles differ on one stated axis — *who can know
-the id*. An island id is determined by content, so the engine mints it at
-import (§ Island-id determinism). An anchor id is determined by an external
-referent only the caller knows (§ Anchor-id identity). A card id is
-determined by nothing external — but the scope that makes one valid, the
-document, is out of view at the creation site (`Quill::seed_card` returns a
-detached card), so the caller mints here too: the engine lacks the scope,
-not the referent.
+A card's `$id` is the **durable card handle** — the address that survives
+reorder, kind change, and both round-trips, where a card's index does not
+(`Document::find_card` resolves it). Unlike an anchor's referent, nothing
+external determines it; the caller still mints it because the scope that makes
+one valid, the document, is out of view at the creation site (`Quill::seed_card`
+returns a detached card). The engine lacks the scope, not the referent — the
+third position on the mint axis (§ The three id handles).
 
 The policy: **a card `$id` is caller-supplied, optional, unique across the
 document's composable cards, opaque and invariant while the card lives;

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -168,7 +168,20 @@ and a table **cell's** unrecognized keys. The cell is the sub-structure the
 handle), so canonicalization rewrites a cell's `text` and `marks` in place
 rather than minting a fresh `{text, marks}` object.
 
-Two rules bound the openness:
+Three rules bound the openness:
+
+- **Payload depth is capped at `MAX_JSON_DEPTH` (128).** An opaque bag is host
+  JSON of arbitrary shape, but not arbitrary depth: key canonicalization, the
+  content-hash key, and `serde_json::Value`'s own `Drop` each recurse one frame
+  per level, so an unbounded bag overflows the stack — on wasm32, a trap that
+  takes the module down rather than an error the host can catch. The cap is the
+  one `serde_json::from_str` already enforces, so it refuses nothing a stored blob
+  can carry; it exists because the `Value` lane (the host-authored one, which
+  `install` reaches) is not parsed from a string and had no limit of its own. A
+  bag is refused where the decoder reads it off the wire, before it is cloned into
+  the model, and `Content::validate` restates it as `Invariant::JsonTooDeep` for
+  content that never went through a decoder. This is
+  `Invariant::NestingTooDeep`'s container cap on the payload axis.
 
 - **Payload rides `attrs`.** A built-in carries its payload in named sibling
   keys (`level`, `lang`, `url`); an unknown carries it in one opaque `attrs`


### PR DESCRIPTION
Closes #1094. Closes #1093. Closes #1095.

The two remaining v1.0.0 freeze blockers from `prose/proposals/content-codec-v1.md`, plus the simplification pass filed beside them. The blockers are both about the opaque payload bag — one that it can be *lost*, one that it can *abort the process* — and both land in `serial.rs`'s decode path, which is why they share a branch. #1095 joins them because its § 1 touches `serial.rs` in the same lines, and the issue asks for it to land first or last rather than concurrently; #1091 and #1092 are already in `main`, so this is last.

## #1094 — a promotion carries its own legacy form

Adding an unknown to a vocabulary was covered; promoting one to a built-in was not. A decoder resolves a built-in name *before* the `Unknown` fallthrough, so the first promotion after the freeze would read named siblings a stored blob never had and drop its payload unread — silent loss on exactly the documents the open set exists to protect.

`fold_legacy_attrs` folds an `attrs` bag into the object when the discriminator names a reserved member, on all three block-and-mark axes, before the built-in arms run. Three bounds: a named sibling wins over an `attrs` entry, only reserved names fold, and the discriminator is read from the *original* object so a bag holding a `kind`/`type`/`container` key cannot re-target the match. A promotion joins `RESERVED_*` by the same edit that adds its arm, so it inherits the fold structurally rather than as something the promoting author has to remember — the issue's "mechanism rather than a discipline" option.

The three disciplines around it are written down with a test each: a new `MarkKind` takes the ordinal immediately before `Unknown`, promoting a mark into the formatting class is a canonical-byte event, and `RESERVED_*` growth rejects previously-valid authored content by design. Canon gains `DOCUMENT_STORAGE.md` § Promoting a vocabulary member.

## #1093 — payload depth is bounded on the `Value` lane

Island `props` and unknown `attrs` had no depth limit, and every consumer of one recurses a frame per level: key canonicalization, the content-hash key, and `serde_json::Value`'s own `Drop`. `from_canonical_json` was safe by accident — `serde_json::from_str` refuses past 128 — but the `Value` lane had no guard, and that is the host-authored one. `install` reaches it, and a JS caller builds a 5 000-deep value in one loop. On wasm32 the stack is 1 MB and the overflow is a trap that takes the module down, not an error the host can catch.

`MAX_JSON_DEPTH` is 128, the limit the string lane already enforced, so nothing a stored blob can carry is refused and no stored population is affected.

The issue asks for the check in `Content::validate`. That alone would not have closed it — `validate` runs *fourth* on the reachable path, after three frames that each recurse first. The guard sits at all four:

| Frame | Placement | Why it can't be later |
|---|---|---|
| `serde_wasm_bindgen` building the `Value` | `js_value_to_json`, JS-side, iterative | Recurses while constructing; traps before any Rust guard has a tree to check |
| `Value::clone` out of the wire | `serial::bag_from_wire`, on the borrow | The clone spends the frames, and dropping the result spends them again |
| `fold_legacy_attrs`' deep clone | Before the clone | Runs for a *built-in* name, where no `Unknown` arm reads the bag at all |
| `normalize` → `validate` | `Invariant::JsonTooDeep` | The backstop for content that never went through a decoder |

One choke point covers the storage, authored, and op lanes, since all three read their bags through it; a table cell's `attrs` is a subtree of the island's `props`, so the props check bounds it too. Both checks are iterative — a recursive guard overflows on exactly the input it exists to detect — and charge container levels the way `quillmark_core::json_depth_exceeds` does, so the content and document boundaries reject identical shapes.

Python needs nothing: the content lane is WASM-only by scope, and `py_to_json_at` already refuses past `MAX_YAML_DEPTH` on the container branch before recursing, so it cannot build a tree deeper than its own cap. That answers the issue's open question.

## #1095 — the simplification pass

Six sections, each with its own disposition. Two are rejected with reasons; the rest are applied. **§ 4 is left standing** — see below.

| § | Ask | Disposition |
|---|---|---|
| 1 | Drop four `sorted_value` calls | Applied, and extended — the function is gone |
| 2 | Inline the three `island.rs` wrappers | Docs trimmed; seam kept (premise miscounted, below) |
| 3 | Fold `usv.rs` into `model.rs` | **Not done** — breaks a public path before a freeze |
| 4 | Revisit the verify-and-drop net later | **Not done**, and the reasoning has moved — below |
| 5 | The `<u>` plumbing | Applied, and it reached further than filed |
| 5 | `fix_html_comment_fences`, image-collection dedup | **Not done** — a spec change and a bad trade respectively |
| 6 | `clip_*` docs, the three id sections | Applied; the id sections had a different defect |

**§ 1 holds, and for a stronger reason than filed.** The issue justifies the cut by pointing at `normalize` having already sorted the bags. That argument has a hole — `normalize` zips `lines` against `text.split('\n')` and truncates silently on an invalid `Content` — but the terminal `sort_keys_owned` makes the four inner calls redundant *unconditionally*, whatever `normalize` did. With the encoders no longer calling it, `sorted_value` has two remaining callers and both are better served by the owned sorter, which moves leaves instead of deep-cloning them. Five functions become three, and the per-keystroke re-normalize gets cheaper rather than just the serialization.

On the op-wire question the issue asks to decide rather than assume: `mark_op_to_value` and `line_op_to_value` have **no encoding consumer in the workspace** — the WASM binding calls `change_bundle_from_value` only. Op-wire key order is unobservable here, so no speculative sort was added. It is a public-API behavior change, so it is a row in the migration guide.

**§ 2's premise doesn't hold.** `island.rs` is 51 comment lines over 98 code (34%, not 45%), and the three wrappers account for **6** of those 51 — the bulk is the module doc and the `#[non_exhaustive]` rationale, which is the most load-bearing prose in the crate. Inlining also costs something the issue doesn't price: the wrappers are the one place the open set's `None` arm is answered, and inlining moves that policy to three sites in `model.rs`. Docs trimmed to what the enum methods don't already say; the seam stays, with the `None` policy stated once above the trio.

**§ 5's `<u>` plumbing reached further than filed.** The `Rc<RefCell<HashSet<usize>>>` was keyed on *byte offsets*, which is why `into_offset_iter()` and a `Range` parameter on both `start_tag` and `table_event` existed at all. `MarkdownFixer` is a strict 1:1 iterator that inserts at the same event `Builder` reads back, so a flag on the item is exactly equivalent — `Item = (Event<'a>, bool)` — and the ranges go with the set. `import.rs` nets −30 lines. Adds the test the offset scheme never had: `<u>` and `**` in one table cell, through the second `Tag::Strong` site.

**§ 6's storage-doc finding is real, but it isn't the reported one.** The three id sections are not ~130 lines of restatement — it is one sentence in § Anchor-id and four in § Card-id, and the bullets under each are genuinely different policy. What *is* wrong: both sections claim to name **the** axis the three handles differ on, and name a different axis each ("derivability at the markdown boundary" vs. "who can know the id"). The mint axis holds for all three, so it is stated once with a table for the differences, and each section gives its own reason instead of re-deriving the model. All three headings are unchanged, so the ten cross-references from `ops.rs`, `model.rs`, `BINDINGS.md`, and the 0.96→0.97 guide still resolve.

**§ 3 is declined.** `quillmark_content::usv::char_to_byte` is public and consumed from `quillmark-core`. Breaking a public path to save 34 lines immediately before a 1.0 freeze is the wrong trade, and `model.rs` is already the largest concept file at 1637 lines. If anything the move runs the other way — `pub type Usv` belongs in `usv.rs`, and that direction is non-breaking.

### § 4 — the argument has moved, and it points at cutting now

The issue defers the verify-and-drop net until the editor's producible-mark set is pinned down. Its own numbers argue otherwise. Binary re-add costs `[2 … 2m−2]` probes; plain linear re-add costs exactly `m` and yields a maximal text-safe set the same way. At realistic per-line flanking-mark counts (m ≈ 1–5) the two are indistinguishable — at m=4, linear is 4 probes against a binary worst case of 6. The logarithmic advantage only appears at large `m`, which is precisely the adversarial case the module doc says does not arise from clean markdown or a form editor. And under `PROBE_BUDGET = 64`, linear guarantees 63 marks resolved where binary guarantees 32.

So the `known_bad_at` sentinel and the work-stack DFS — ~40 lines, the hardest code in the crate — collapse to a ~6-line loop that is *better* on the guarantee that matters, with no editor pinned down first. The one caveat is that text-safety is not provably monotone under subset, so chunk-acceptance and one-at-a-time could select different mark sets; the two property tests would gate that but would not prove equivalence.

Not done here. It reverses a deliberate decision from #1052 (now closed), so it wants its own issue and its own review rather than riding a merge that closes the issue proposing it. **Flagging it explicitly so closing #1095 does not bury it.**

## Notes for review

- **The depth tests probe just past the cap, not at 5 000.** A fixture that deep cannot be cloned or dropped by the test harness either — which is the reason for the limit, so the fixture states it in a comment rather than working around it.
- **The boundary test asserts an implication, not an offset.** `serde_json`'s limit counts from the document root and the bag cap counts from the bag, so the test asserts *string-lane-accepted ⇒ bag-cap-accepted* across the whole boundary region rather than hardcoding the wrapper depth.
- **Two semantic conflicts, resolved in the merge commits.** `fold_legacy_attrs`' clone was a frame the depth branch's guard did not cover, and `main`'s simplify pass had extracted `mark_shape` in the same lines the fold call occupies — the fold now runs after the shape read rather than inside it, so the deep-clone cost `mark_shape` exists to let a verdict-only caller skip stays skipped. Both merged cleanly to git and failed to compile; worth a look if you review by parent.
- **Review the two simplification commits separately if you review by commit.** `f5fe168` is § 1 alone; `a00204d` carries § 2, § 5, and § 6 together because each is a few lines.

## Verification

`cargo test --workspace` — 49 suites green, re-run after each simplification commit. `cargo clippy -p quillmark-content --all-targets` clean; `cargo check -p quillmark-wasm --target wasm32-unknown-unknown --features typst` clean. The one clippy warning in the tree (`core/src/document/mod.rs:549`) predates this branch. `cargo doc -p quillmark-content` emits the same four pre-existing warnings as `main` — verified against a stash, none added.

Per `CLAUDE.md` the npm and pytest binding suites are deferred to CI here — the added JS test (`basic.test.js`, #1093's exact reproduction, asserting the module still serves afterward) has not been run locally.

Migration guide: `docs/migrations/0.98-to-0.99.md`, the unreleased one, gains a row and a section for each of the three issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FGH8HEX5BmJVvzQfh1CL1)_