### PR TITLE
Adopt the editor's dense-prose rewrite; compress and prune CLAUDE.md

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -1,159 +1,90 @@
 ---
 name: dense-prose
-description: Write comments and docs at high semantic density — terse, present-tense, unsold, mostly self-documenting. Use when writing or reviewing code comments, prose/canon/, or docs/ for density and a consistent voice, or when comments narrate change ("used to", "no longer", "renamed", "as of 0.x") instead of stating what is.
+description: Write comments and docs at high semantic density: terse, present-tense, unsold, mostly self-documenting. Use when writing or reviewing code comments, prose/canon/, or any doc for density and house voice, or when comments narrate change ("used to", "no longer", "renamed", "as of 0.x") instead of stating what is.
 ---
 
-## Purpose
+## The measure
 
-Comments and docs earn their bytes. Each should state a fact a reader cannot get
-faster from the code itself, in the fewest words that stay correct. This skill
-is the house voice: dense, present-tense, declarative, unsold.
+Density is facts per word. Cut words that carry no fact: the sell, the echo, the history, the deliberation (rules 1–4). Pack more fact into what survives (rule 5). A comment or doc earns its bytes when it states a fact the reader cannot get faster from the code, in the fewest words that stay correct.
 
-It covers comment and doc *content*. For canon *structure* — the `prose/canon/`
-doc spine and tiers — use **`maintain-canon`**.
+This skill is the house voice (dense, present-tense, declarative, unsold) and owns comment and doc *content*. Canon *structure* (Title → Implementation anchor → TL;DR, one concept per page) belongs to **`maintain-canon`**.
 
 ## Prime directive: correctness over brevity
 
-A comment makes a claim about code. Never shorten a claim you have not verified
-against the code. Cutting words must not silently change meaning. When unsure a
-statement is still true, leave it and keep the fact. Edits are surgical: touch a
-line only when it breaks a rule; do not churn prose that is already dense and
-correct. Over-editing is the main failure mode.
+Density has a numerator. A cut that drops a fact, or shifts a claim unverified against the code, is dilution, not compression. Unsure a statement still holds? Leave it. Edits are surgical: touch a line only when it breaks a rule. Prose already dense and correct is done; over-editing is the main failure mode.
 
-## What this skill owns
+## 1. No marketing or persuasion
 
-### 1. No marketing or persuasion
+A sell spends words on the reader's opinion instead of their knowledge. Cut *powerful, seamless, elegant, robust, flexible, blazing(-fast), cutting-edge, state-of-the-art, first-class (citizen), rich (set of), comprehensive, battle-tested, out of the box, leverage* (meaning "use"), and *simply / just / easily* when they only imply ease. State the capability plainly: "Partial documents are first-class citizens" → "A document need not be complete."
 
-Remove words that sell rather than inform: *powerful, seamless, elegant, robust,
-flexible, blazing(-fast), cutting-edge, state-of-the-art, first-class (citizen),
-rich (set of), comprehensive, battle-tested, out of the box, leverage* (meaning
-"use"), and *simply / just / easily* when they only imply ease. State the
-capability plainly.
+Keep *just / simply / only* when load-bearing ("just sugar for the `raw` element", "three or more tildes"). The word is not the violation; the sell is.
 
-- "Partial documents are first-class citizens" → "A document need not be
-  complete."
-- "opts into canvas simply by overriding the seam" → "opts into canvas by
-  overriding the seam."
+## 2. Self-documenting first
 
-Keep *just / simply / only* when they carry real meaning ("just sugar for the
-`raw` element", "three or more tildes"). The word is not the violation; the sell
-is.
+The code is the primary documentation; a comment restating it is noise.
 
-### 2. Self-documenting first — cut over-explanation
+- Delete echoes (`// increment i`; `/// The name` on a field named `name`); a clearer name beats the comment.
+- Collapse padded rustdoc scaffolding: "## Key Functions / ## Quick Example / ## Detailed Documentation / For comprehensive details including: …" becomes one tight paragraph and at most one runnable example.
+- Never enumerate a module's public items in its header; rustdoc lists them and the hand-list rots. Describe the module's job.
+- One good example beats three; "see X for comprehensive coverage" is filler.
+- One fact, one home. Cross-reference rather than restate; a fact copied twice drifts.
 
-The code is the primary documentation. A comment that restates it is noise.
+## 3. Present tense: what is, not how it got here
 
-- Delete comments that echo the code (`// increment i`; `/// The name` on a
-  field named `name`). Prefer a clearer name over a comment.
-- Collapse padded rustdoc scaffolding. A header of "## Key Functions / ## Quick
-  Example / ## Detailed Documentation / For comprehensive details including: …"
-  becomes a tight paragraph plus, at most, one runnable example.
-- Do not enumerate a module's public items in its header — rustdoc lists them,
-  and the hand-list rots. Describe the module's job instead.
-- One good example beats three; drop "see X for comprehensive coverage" filler.
+Evolutionary narration ("we used to X, now Y") makes the reader reconstruct history to learn the present, then ages badly. Triage every mention of the past:
 
-### 3. Present tense — describe what is, not how it got here
+1. **Pure narration: delete or restate.** "the heuristics that used to live here couldn't keep pace", "removed in 0.87.0", "we switched to X" carry no present-state value beyond the current description.
+2. **Current behavior in a historical costume: keep the fact, drop the framing.** A still-accepted compat alias *is* current behavior: "the legacy `~~~card-yaml` opener is still accepted but no longer canonical" → "`~~~card-yaml` is also accepted as a non-canonical alias."
+3. **Legacy load-bearing for the present: keep.** When the old pattern is required to read the current one, the history is the documentation: the versioned envelope in `crates/core/src/document/dto.rs` decodes stored old formats, so the legacy schema *is* current reader behavior.
 
-Evolutionary narration ("we used to X, now Y") adds words, ages badly, and makes
-the reader reconstruct history to understand the present. State the current
-invariant. But not every mention of the past is cruft — triage into three:
+Reframing moves: "used to X, now Y" → assert Y; "no longer / previously / formerly Z" → "is not Z", or drop; "as of 0.x / removed in 0.x" → state the current rule, no version; a regression-test comment states the invariant guarded ("X must not happen; would cause Y"), not the bug's history.
 
-1. **Pure narration → delete or restate.** "the heuristics that used to live
-   here couldn't keep pace" / "removed in 0.87.0" / "we switched to X". No
-   present-state value beyond what the current description already carries.
-2. **Current behavior in a historical costume → keep the fact, drop the
-   framing.** A backward-compat alias that is *still accepted* is current
-   behavior: "the legacy `~~~card-yaml` opener is still accepted but no longer
-   canonical" → "`~~~card-yaml` is also accepted as a non-canonical alias."
-3. **Legacy load-bearing for the present → keep.** When the old pattern is
-   *required* to understand the current one, the history is the documentation —
-   e.g. a versioned-storage envelope whose job is to read old formats: the
-   legacy schema *is* current reader behavior (`core/src/document/dto.rs`).
+Caution: `used to` often means "used **in order to**"; read before cutting. History a reader needs to *use* the thing (an accepted alias, a tolerated input) gets reframed, not deleted; that is most of what `docs/` carries.
 
-Reframing moves:
+## 4. State the design, not the deliberation
 
-- "used to X, now Y" → assert Y in present tense.
-- "no longer / previously / formerly Z" → "is not Z" / "does not Z", or drop.
-- "as of 0.x / removed in 0.x" → state the current rule, no version.
-- Regression-test comment → state the invariant guarded, not the bug's history:
-  "X must not happen (would cause Y)" not "X used to happen."
+Cut spike/deferred/rejected narration; keep the resulting fact, plus the rationale when it explains a present choice, minus the "we tried / earlier draft" framing.
 
-Caution: `used to` often means "used **in order to**" — not history; read before
-cutting. In consumer `docs/`, keep history a reader needs to *use* the feature
-(an accepted alias, a tolerated input) — reframe it, don't delete it.
+- "Investigated as a spike but deferred; not needed" → "Not supported; the preview does not require it."
+- "X was the deferred half and stays deferred by design" → "X is not carried, by design: <reason>."
+- Rejected-alternative rationale keeps the *why*, sheds the *when*: "A sub-handle would be justified only if paint shipped with `click()`."
+- Issue and PR numbers (`(#970)`, `tracked in #736`) are status markers: they say work is in motion, which canon does not carry, and they date the sentence around them. State the shape instead ("Python omits the opaque store by intent") and drop the number. Keep it only where the issue *is* the subject, in a CI or release doc describing a process.
 
-### 4. One claim per sentence — density is bytes-per-fact, not facts-per-line
+## 5. Compress what survives
 
-Cutting words is only half of density. A sentence carrying seven clauses, three
-parentheticals, and an em-dash chain is maximally compressed and unreadable —
-the reader has to decompress it to find the one fact they came for, which is the
-cost a comment exists to remove. Compression is not density.
+Deleting whole sentences is half the work; the other half is more fact per word.
 
-- One claim per sentence. A bullet that needs three clauses is three bullets, a
-  nested list, or a table.
-- A set of per-case rules (per type, per format, per backend) is a table. Table
-  rows are records, not sentences, and are exempt from the budget.
-- Prefer a paragraph break over a semicolon chain when the second half states a
-  separate fact.
-
-`prose/README.md` sets the numeric budget: 700 characters per prose line, which
-`scripts/check-canon.mjs` gates over `prose/canon/` and `docs/`, and 300 as the
-target you write to. Split a long line when you are editing near it — nothing
-mechanical will remind you.
-
-### 5. State the design, not the deliberation
-
-Describe what is, not what was considered. Cut spike/deferred/rejected
-narration; keep the resulting fact and, when it explains a present choice, the
-rationale — minus the "we tried / earlier draft" framing.
-
-- "Investigated as a spike but deferred — not needed" → "Not supported; the
-  preview does not require it."
-- "X was the deferred half and stays deferred by design" → "X is not carried,
-  by design: <reason>."
-- Rejected-alternative rationale: "A sub-handle would be justified only if paint
-  shipped with click()" — keeps the *why*, sheds the *when*.
-- Issue and PR numbers (`(#970)`, `tracked in #736`) are status markers: they
-  say work is in motion, which canon does not carry, and they date the sentence
-  around them. State the shape instead — "Python omits the opaque store by
-  intent" — and drop the number. Keep it only where the issue *is* the subject
-  (a CI or release doc describing a process).
+- **Losable test**: cut any sentence whose removal costs no fact. Length tracks surprise: the unobvious invariant gets the words, the obvious call gets none.
+- **No throat-clearing**: "Note that", "It is worth noting", "Basically", "In general", and a section's first line restating its own heading.
+- **No empty hedges**: *typically, essentially, somewhat, arguably, various*, unless the uncertainty is real and calibrated.
+- **Shrink phrases**: *in order to* → to; *is able to / has the ability to* → can; *due to the fact that* → because; *a number of* → the count; *performs validation of* → validates.
+- **Fold, don't append**: a second sentence qualifying the first becomes a clause of it.
+- **Name the thing**: the specific noun beats a category plus an example; the measured number beats a vague *several*.
+- **Compression is not density**: one claim per sentence. A sentence carrying seven clauses and three parentheticals is maximally compressed and unreadable, because the reader has to decompress it to reach the one fact they came for. A bullet needing three clauses is three bullets, a nested list, or a table; a set of per-case rules (per type, per format, per backend) is a table, and a table row is a record, not a sentence.
 
 ## Voice
 
-Present tense. Lead with the invariant or contract, then the mechanism. Reuse
-the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam,
-Technique A*). For the target density, read the comments in
-`crates/core/src/document/` and the Decisions section of `PREVIEW.md` — a
-rationale that names what it rejected and why, in the fewest words that stay
-correct.
+Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). No em-dashes: fold with a colon, semicolon, comma, or parentheses. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
+
+A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget. `prose/README.md` sets the numeric bound on a prose line: 700 characters, gated by `scripts/check-canon.mjs` over `prose/canon/` and `docs/`, with 300 as the target you write to. Split a long line when you are editing near it; below the gate, nothing mechanical reminds you.
 
 ## Scope
 
 | Surface | Rule |
 |---|---|
-| Code & test comments, `prose/canon/`, `docs/` (non-migration) | Apply in full. |
-| `docs/migrations/**` | **Never touch.** Era-accurate and immutable. |
-| `prose/references/`, `prose/proposals/` | Strip marketing only. Specs and proposals legitimately discuss other/future states — leave that framing. |
-| Load-bearing legacy (e.g. `core/src/document/dto.rs` versioned wire schemas) | Keep. The old-format description *is* current reader behavior; tighten wording, keep the fact. |
-| Identifiers (fn / test / var names) | Never rename — out of scope, churn. |
+| Code and test comments, `prose/canon/`, `docs/` (non-migration) | Apply in full. |
+| `docs/migrations/**`, and era-stamped records generally | **Never touch.** Accurate to their moment, immutable. |
+| `prose/references/`, `prose/proposals/`, `prose/plans/` | Strip marketing only; discussing other or future states is their job. |
+| Load-bearing legacy (`crates/core/src/document/dto.rs` versioned wire schemas) | Keep: the old-format description *is* current reader behavior. Tighten wording, keep the fact. |
+| Identifiers (fn / test / var names) | Never rename; out of scope, churn. |
 
 ## Workflow
 
-1. **Sweep** — grep comments/docs for: the marketing word-list above; history
-   markers (`used to`, `no longer`, `previously`, `formerly`, `as of`,
-   `removed in`, `renamed`, `we switched`, `legacy`, `deprecated`); and
-   deliberation markers (`spike`, `deferred`, `considered`, `for now`,
-   `eventually`, `we tried`); and status markers (`#\d+`, issue and PR links).
-2. **Triage** — each hit: violation, or load-bearing fact in costume?
-3. **Rewrite** in place — present tense, minimal, fact preserved. Fix a comment
-   that contradicts the code rather than deleting it. Leave identifiers alone.
-4. **Verify** — build and tests pass; no doctest broken; no test asserted the
-   old wording; `node scripts/check-canon.mjs` passes.
+1. **Sweep**: grep for the marketing list above; history markers (`used to`, `no longer`, `previously`, `formerly`, `as of`, `removed in`, `renamed`, `we switched`, `legacy`, `deprecated`); deliberation markers (`spike`, `deferred`, `considered`, `for now`, `eventually`, `we tried`); status markers (`#\d+`, issue and PR links); and filler (`Note that`, `in order to`, `is able to`).
+2. **Triage**: each hit is a violation or a load-bearing fact in costume.
+3. **Rewrite in place**: present tense, minimal, fact preserved. A comment contradicting the code gets fixed, not deleted. Identifiers stay.
+4. **Verify**: build and tests pass; no doctest broken; no test asserted the old wording; `node scripts/check-canon.mjs` passes.
 
 ## Done when
 
-Comments and docs state what is, in the house voice: dense, present-tense,
-unsold. No comment restates code; no header enumerates rotting lists; no prose
-narrates history or deliberation. Backward-compat facts survive as current-state
-statements.
+Comments and docs state what is, in the house voice: dense, present-tense, unsold. Nothing restates code, no header carries a rotting list, no prose narrates history or deliberation, and no surviving sentence sheds a word without shedding a fact. Backward-compat facts survive as current-state statements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 Schema-driven document engine: Markdown + YAML card metadata → rendered PDF/SVG/PNG via a Typst or PDF-form backend.
 
-Crates: `core` (parsing, schema, traits) · `quillmark` (orchestration) · `content` (`Content` content model; the workspace's only markdown parser) · `backends/{typst,pdfform}` · `quillmark-pdf` (Typst-free AcroForm stamping) · `bindings/{python,wasm,cli}` · `fixtures` (test Quills) · `fuzz` (property tests).
+Crates: `core` (parsing, schema, traits) · `quillmark` (orchestration) · `content` (the `Content` model; the workspace's only markdown parser) · `backends/{typst,pdfform}` · `quillmark-pdf` (Typst-free AcroForm stamping) · `bindings/{python,wasm,cli}` · `fixtures` (test Quills) · `fuzz` (property tests).
 
-Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill: dense, present-tense, unsold.
+Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
 
 - Released guides in [`docs/migrations/`](docs/migrations/) are immutable; edit only the unreleased one.
-- The `Cargo.toml` version is the last *released* version, not a working one; CI bumps it on release.
-- Commit early and often — CI runs builds and tests on push.
+- The `Cargo.toml` version is the last *released* one; CI bumps it on release.
+- Commit early and often: CI runs builds and tests on push.
 - Don't run `cargo fmt`.
 
 ## Tests
@@ -16,4 +16,4 @@ Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs f
 - `cargo test --workspace`
 - WASM: `./scripts/build-wasm.sh && cd crates/bindings/wasm && npm test`
 - Python: `cd crates/bindings/python && uv run maturin develop && uv run pytest`
-- Binding surfaces (`bindings/{python,wasm}`) are slow to build locally; defer to PR CI for tests.
+- Binding surfaces build slowly; defer `bindings/{python,wasm}` to PR CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 Schema-driven document engine: Markdown + YAML card metadata → rendered PDF/SVG/PNG via a Typst or PDF-form backend.
 
-Crates: `core` (parsing, schema, traits) · `quillmark` (orchestration) · `content` (the `Content` model; the workspace's only markdown parser) · `backends/{typst,pdfform}` · `quillmark-pdf` (Typst-free AcroForm stamping) · `bindings/{python,wasm,cli}` · `fixtures` (test Quills) · `fuzz` (property tests).
+Crates: `core` · `quillmark` · `content` · `backends/{typst,pdfform}` · `quillmark-pdf` · `bindings/{python,wasm,cli}` · `fixtures` · `fuzz`. What each carries: [`ARCHITECTURE.md`](prose/canon/ARCHITECTURE.md) §"Crate Structure".
 
 Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
 
 - Released guides in [`docs/migrations/`](docs/migrations/) are immutable; edit only the unreleased one.
 - The `Cargo.toml` version is the last *released* one; CI bumps it on release.
-- Commit early and often: CI runs builds and tests on push.
+- Commit early and often; CI gates every push.
 - Don't run `cargo fmt`.
 
 ## Tests


### PR DESCRIPTION
Takes `quillmark-editor`'s rewrite of the shared `dense-prose` skill, then runs it over `CLAUDE.md`.

## The skill

The editor's copy had diverged into a rewrite. What it adds:

- **A compression half.** Rules 1–4 cut words carrying no fact; new rule 5 packs more fact into what survives: the losable test, throat-clearing, empty hedges, phrase shrinking, fold-don't-append, name-the-thing. The previous version was all deletion rules, with nothing to say about a sentence that breaks no rule and is still half water.
- **Density as arithmetic.** "Density is facts per word", and the prime directive gains its numerator: a cut that drops a fact, or shifts a claim unverified against the code, is dilution, not compression.
- **One fact, one home.** Cross-reference rather than restate; a fact copied twice drifts.
- **No em-dashes**, and **a paragraph is one line** — the rule the canon corpus already follows, previously implicit in the 700-character gate.

Preserved against the editor's copy, which had dropped them: the issue-number rule (status markers date the sentence around them), the 700/300 line budget and its `check-canon.mjs` verify step, the `docs/migrations/**` and `prose/{references,proposals,plans}` scope rows, rustdoc wording, and the `crates/core/src/document/` exemplars. One rule from the old version survives the editor's cut: *one claim per sentence, a set of per-case rules is a table* — the counterweight to the new rule 5, and load-bearing here, since `check-canon.mjs` exempts table rows from the line budget for exactly that reason.

The no-em-dash rule ships without a corpus sweep. The 1216 existing instances under `prose/canon/` and `docs/` are untouched and now non-conforming; converting them is a separate mechanical commit if wanted.

## CLAUDE.md

149 → 121 words.

Compressed: the skill's own adjectives (they live in the skill), the entailed half of the `Cargo.toml` version bullet, the crate-name echo in `` `content` ``, and the binding-tests bullet.

Pruned as rottable:

- **The crate roster's annotations.** `ARCHITECTURE.md` §"Crate Structure" states every one in more depth, carrying the markdown-parser claim as a bolded invariant. Only canon is gated, so the `CLAUDE.md` copy is the one that drifts as crates change. Names stay as the navigational spine; the jobs are one link away.
- **"CI runs builds and tests on push."** It named a subset — CI also gates the canon spine, docs, packaging, MSRV, and semver — and re-rots whenever a job moves.

Audited and kept: `content` as the workspace's only markdown parser holds (`core`'s `pulldown-cmark` is a dev-dependency used by one fence-conformance test, so annotated in its `Cargo.toml`); `fuzz` really is proptest-based; every test command resolves; `cargo fmt` has no config and no CI job.

Not changed, worth a decision: `cargo test --workspace` overrides `default-members` and so builds exactly the Python and WASM bindings the next bullet says to defer to CI. Bare `cargo test` is the fast loop but skips `content`'s own tests.

`node scripts/check-canon.mjs` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZWEMuhqf8Xit9DLHKjYVA)_