### PR TITLE
Shape the island ALL as a slice; list the 0.99 guide as published

### DIFF
--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -57,7 +57,11 @@ impl KnownIslandType {
     /// Every known type. The one enumeration point, so a reader that needs the
     /// closed set whole (the WASM guards' known-name table, say) asks rather than
     /// re-spelling it.
-    pub const ALL: [KnownIslandType; 2] = [KnownIslandType::Table, KnownIslandType::Image];
+    ///
+    /// A slice, not an array: an array's length is part of its type, so a third
+    /// island type would break every caller that names this constant's type on
+    /// top of the exhaustive-match break the enum already promises.
+    pub const ALL: &'static [KnownIslandType] = &[KnownIslandType::Table, KnownIslandType::Image];
 
     /// The wire discriminator; `parse(k.as_str()) == Some(k)` for every variant.
     pub fn as_str(self) -> &'static str {

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -709,7 +709,10 @@ impl Content {
     /// `isUnknown*` guards' tables in
     /// `crates/bindings/wasm/runtime/runtime.js`. Both are pinned to these
     /// constants by `crates/bindings/wasm/tests/known_names_drift.rs`.
-    pub const RESERVED_MARK_TYPES: [&'static str; 7] = [
+    /// Slices, not arrays, on all three: an array's length is part of its type,
+    /// and promoting a name into the projection is the motion these lists exist
+    /// to absorb.
+    pub const RESERVED_MARK_TYPES: &'static [&'static str] = &[
         "strong",
         "emph",
         "underline",
@@ -722,12 +725,12 @@ impl Content {
     /// Line `kind` names the projection reserves — the [`LineKind`] twin of
     /// [`RESERVED_MARK_TYPES`](Self::RESERVED_MARK_TYPES), for the same
     /// injectivity reason.
-    pub const RESERVED_LINE_KINDS: [&'static str; 5] =
-        ["para", "heading", "code", "island", "rule"];
+    pub const RESERVED_LINE_KINDS: &'static [&'static str] =
+        &["para", "heading", "code", "island", "rule"];
 
     /// Container names the projection reserves — the [`Container`] twin of
     /// [`RESERVED_MARK_TYPES`](Self::RESERVED_MARK_TYPES).
-    pub const RESERVED_CONTAINERS: [&'static str; 2] = ["list_item", "quote"];
+    pub const RESERVED_CONTAINERS: &'static [&'static str] = &["list_item", "quote"];
 
     /// Check every invariant. `Ok(())` on a well-formed content. Import
     /// guarantees this; a hand-built content should be run through it in tests.

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -273,7 +273,7 @@ pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
         .get("kind")
         .and_then(Value::as_str)
         .ok_or(ParseError::Shape("line kind"))?;
-    let o = fold_legacy_attrs(o, tag, &Content::RESERVED_LINE_KINDS, "line attrs")?;
+    let o = fold_legacy_attrs(o, tag, Content::RESERVED_LINE_KINDS, "line attrs")?;
     match tag {
         "para" => Ok(LineKind::Para),
         "heading" => {
@@ -370,7 +370,7 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
         .get("container")
         .and_then(Value::as_str)
         .ok_or(ParseError::Shape("container kind"))?;
-    let o = fold_legacy_attrs(o, tag, &Content::RESERVED_CONTAINERS, "container attrs")?;
+    let o = fold_legacy_attrs(o, tag, Content::RESERVED_CONTAINERS, "container attrs")?;
     match tag {
         "list_item" => Ok(Container::ListItem {
             ordered: o.get("ordered").and_then(Value::as_bool).unwrap_or(false),
@@ -471,7 +471,7 @@ pub fn mark_from_value(v: &Value) -> Result<Mark, ParseError> {
     } = mark_shape(v)?;
     // After the shape read, not inside it: the fold's clone is exactly the cost
     // `mark_shape` exists to let a verdict-only caller skip.
-    let o = fold_legacy_attrs(o, ty, &Content::RESERVED_MARK_TYPES, "mark attrs")?;
+    let o = fold_legacy_attrs(o, ty, Content::RESERVED_MARK_TYPES, "mark attrs")?;
     let kind = match ty {
         "strong" => MarkKind::Strong,
         "emph" => MarkKind::Emph,
@@ -622,7 +622,7 @@ fn reject_line_kind_attrs(v: &Value) -> Result<(), ParseError> {
     reject_reserved_attrs(
         v,
         "kind",
-        &Content::RESERVED_LINE_KINDS,
+        Content::RESERVED_LINE_KINDS,
         "attrs beside built-in kind",
     )
 }
@@ -631,7 +631,7 @@ fn reject_container_attrs(v: &Value) -> Result<(), ParseError> {
     reject_reserved_attrs(
         v,
         "container",
-        &Content::RESERVED_CONTAINERS,
+        Content::RESERVED_CONTAINERS,
         "attrs beside built-in container",
     )
 }
@@ -640,7 +640,7 @@ fn reject_mark_attrs(v: &Value) -> Result<(), ParseError> {
     reject_reserved_attrs(
         v,
         "type",
-        &Content::RESERVED_MARK_TYPES,
+        Content::RESERVED_MARK_TYPES,
         "attrs beside built-in mark type",
     )
 }

--- a/docs/migrations/0.98-to-0.99.md
+++ b/docs/migrations/0.98-to-0.99.md
@@ -15,6 +15,7 @@ now a diagnostic.
 | Most public structs become `#[non_exhaustive]` | Rust (same crates) | Build through `new` + the `with_*` setters instead of a struct literal |
 | `RenderOptions { .., ..Default::default() }` no longer compiles | Rust (every render caller) | `RenderOptions::default().with_output_format(fmt)` |
 | `Backend` is sealed | Rust (backend implementors only) | None — implementing it outside the workspace was already unsupported |
+| `Content::RESERVED_{MARK_TYPES,LINE_KINDS,CONTAINERS}` become slices | Rust (`quillmark-content`) | Name the slice type; iterate by reference |
 
 New, no action required: `isUnknownLine` / `isUnknownContainer` /
 `isUnknownMark` / `isUnknownIsland` on the WASM surface, and `ContentLineKind`
@@ -314,3 +315,21 @@ for &fmt in OutputFormat::ALL { … }
 An array's length is part of its type, so a fourth format would have broken
 every caller naming it — `#[non_exhaustive]` on the enum alone would not have
 helped.
+
+`quillmark-content`'s three known-name lists take the same shape for the same
+reason: `Content::RESERVED_MARK_TYPES`, `RESERVED_LINE_KINDS`, and
+`RESERVED_CONTAINERS` are `&'static [&'static str]`. Each names the known half
+of an open set, so it grows whenever a construct is promoted into the
+projection — the motion the open sets were introduced to make routine. Pinning
+a list's length in its type made that routine change a major.
+
+`.contains(…)` and `.iter()` read the same. A `for` loop over one now binds
+`&&str`, and a signature naming the type takes the slice:
+
+```rust
+// 0.98
+fn reserved() -> [&'static str; 5] { Content::RESERVED_LINE_KINDS }
+
+// 0.99
+fn reserved() -> &'static [&'static str] { Content::RESERVED_LINE_KINDS }
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ not_in_nav: |
   /migrations/0.95-to-0.96.md
   /migrations/0.96-to-0.97.md
   /migrations/0.97-to-0.98.md
+  /migrations/0.98-to-0.99.md
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
`KnownIslandType::ALL` landed this cycle as `[KnownIslandType; 2]`, the shape
`OutputFormat::ALL` gave up for the 1.0.0 freeze: an array's length is part of
its type, so a third island type breaks every caller naming the constant. The
enum is deliberately exhaustive, which makes the array an extra break rather
than a redundant one. Never released in the array form, so no guide entry.

`mkdocs.yml`'s `not_in_nav` carries every migration guide from 0.81 up; the
unreleased 0.98 → 0.99 one was missing. The page built and published either way
— the omission is INFO, not a warning — so this is the list catching up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pWbFJWnmBF4AvrUFd9ERN