### PR TITLE
Correct the quill file-size cap doc and MiB units

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -96,7 +96,7 @@ invalid quill reference.
 ### `Document.fromMarkdown(markdown)`
 Parse markdown to a parsed document. Throws a JS `Error` (with `.diagnostics`
 attached, see [Errors](#errors)) on any parse failure, including a missing
-root `$quill` metadata line, malformed YAML, and inputs over the 10 MB
+root `$quill` metadata line, malformed YAML, and inputs over the 10 MiB
 `parse::input_too_large` limit.
 
 ### `doc.toMarkdown()`
@@ -462,7 +462,7 @@ Read `err.diagnostics[0]` for the primary diagnostic; iterate the array for
 compilation failures. The same shape applies to every throw site:
 
 - `Document.fromMarkdown` — parse errors (missing root `$quill` metadata, YAML
-  errors, `parse::input_too_large` for inputs > 10 MB).
+  errors, `parse::input_too_large` for inputs > 10 MiB).
 - `Document` mutators (`storeField`, the writer's `set`, etc.) — mutator
   failures carry a namespaced `edit::*` `code` on `diagnostics[0]`
   (`edit::invalid_field_name`, `edit::unknown_field`, `edit::index_out_of_range`,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -18,10 +18,10 @@
 
 use crate::OutputFormat;
 
-/// Maximum input size for markdown (10 MB)
+/// Maximum input size for markdown (10 MiB)
 pub const MAX_INPUT_SIZE: usize = 10 * 1024 * 1024;
 
-/// Maximum YAML size (1 MB)
+/// Maximum YAML size (1 MiB)
 pub const MAX_YAML_SIZE: usize = 1024 * 1024;
 
 /// Maximum nesting depth for markdown structures (100 levels). Owned by the

--- a/crates/quillmark/src/load.rs
+++ b/crates/quillmark/src/load.rs
@@ -60,9 +60,10 @@ fn load_tree_from_path(path: &Path) -> Result<FileTreeNode, Box<dyn StdError + S
     load_dir(path, path, &ignore)
 }
 
-/// Maximum size of a single file loaded from a quill directory. Guards against
-/// memory exhaustion when rendering a quill from an untrusted source; mirrors
-/// the `MAX_INPUT_SIZE` guard on `Document::parse`.
+/// Maximum size of a single file loaded from a quill directory. Bounds one
+/// oversize file from an untrusted bundle, not the tree's total footprint:
+/// neither file count nor aggregate bytes is capped. Core's `MAX_INPUT_SIZE`
+/// is the analogous, lower cap on whole-document markdown.
 const MAX_QUILL_FILE_SIZE: u64 = 50 * 1024 * 1024;
 
 fn load_dir(

--- a/docs/integration/error-handling.md
+++ b/docs/integration/error-handling.md
@@ -51,7 +51,7 @@ The `code` namespaces are the routing surface:
 
 `parse::*` · `validation::*` · `quill::*` · `edit::*` (mutators) · `typst::*` · `pdfform::*` · `backend::*` · `engine::*`.
 
-Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed document paired with the wrong quill — see [Versioning](../quills/versioning.md)); `engine::backend_not_found` (the quill's declared backend is not registered); `parse::input_too_large` (input over 10 MB).
+Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed document paired with the wrong quill — see [Versioning](../quills/versioning.md)); `engine::backend_not_found` (the quill's declared backend is not registered); `parse::input_too_large` (input over 10 MiB).
 
 ## Warnings vs errors
 

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -95,7 +95,7 @@ warnings in Typst sources).
 Python and WASM bindings delegate to core types:
 
 - **Python**: `PyDiagnostic` wraps `Diagnostic`. Every raised exception is `QuillmarkError` (a single type). Every exception carries a `diagnostics` list; `str(exc)` follows the shared count-based message rule.
-- **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics` by the same count-based rule. Consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for the rest. Parse failures (`Document.fromMarkdown`) carry the same shape — including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MB) and the `edit::*` codes for post-parse mutators.
+- **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics` by the same count-based rule. Consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for the rest. Parse failures (`Document.fromMarkdown`) carry the same shape — including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MiB) and the `edit::*` codes for post-parse mutators.
 
 ## Backend Error Mapping
 

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -449,8 +449,8 @@ error when any is exceeded:
 
 | Limit | Value |
 |---|---|
-| Document size | 10 MB |
-| YAML payload size per block | 1 MB |
+| Document size | 10 MiB |
+| YAML payload size per block | 1 MiB |
 | YAML nesting depth | 100 |
 | Field count per block | 1000 |
 | Card count per document | 1000 |


### PR DESCRIPTION
The `MAX_QUILL_FILE_SIZE` comment claimed it guards against memory
exhaustion and mirrors core's `MAX_INPUT_SIZE`. Neither holds: the cap is
per-file, with no bound on file count or aggregate bytes, and it differs
from `MAX_INPUT_SIZE` in value, scope, and error type. State what the
guard covers instead.

`MAX_INPUT_SIZE` and `MAX_YAML_SIZE` are powers of two, documented as MB
here and in the wasm README, markdown spec, ERROR.md, and the
error-handling guide.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwmTzKGsprG2YUcs9fQLtn