### PR TITLE
Tolerate foreign core handles on the by-reference methods

### DIFF
--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -889,22 +889,22 @@ main:
 })
 
 // A duplicate install is two copies of this package: two core builds, two
-// linear memories, two distinct `Document` classes. `Engine` already tolerates
-// that crossing (it is duck-typed and clones as data); the three core methods
-// taking another core handle BY REFERENCE did not, because wasm-bindgen's
-// generated `_assertClass` rejects the foreign class before any of our code
-// runs. These pin the one policy the runtime layer now applies everywhere: a
-// foreign handle crosses as data. See runtime.js § "Foreign core handles".
+// linear memories, two distinct `Document` classes. `Engine` tolerates that
+// crossing (duck-typed, clones as data); the core methods taking another core
+// handle BY REFERENCE do not, because wasm-bindgen's generated `_assertClass`
+// rejects the foreign class before any of our code runs. These pin the runtime
+// layer's policy: reads cross as data, writes refuse at the bind. See
+// runtime.js § "Foreign core handles".
 //
 // A foreign `Document` is modelled two ways: a duck-typed stand-in (anything
-// carrying `toJson`, the contract the patches actually check) and — closer to
-// the real thing — a SECOND core instance loaded under a cache-busting query,
-// which is genuinely a different class over a different linear memory.
+// carrying `toJson`, the contract the checks actually apply) and a second copy
+// of the built core artifact on disk, which is a different class over a
+// different linear memory.
 describe('@quillmark/wasm/runtime — foreign core handles (duplicate install)', () => {
   const foreignOf = (doc) => ({ toJson: () => doc.toJson() })
 
   // The reader verbs are schema-bound, so they need a quill that DECLARES the
-  // fields TEST_MARKDOWN sets — the default test quill declares none.
+  // fields TEST_MARKDOWN sets; the default test quill declares none.
   const READER_QUILL_YAML = `quill:
   name: test_quill
   version: "1.0"
@@ -972,8 +972,8 @@ main:
       } catch (e) {
         caught = e
       }
-      // The failure stays inside this package's error contract — the thing the
-      // raw `_assertClass` throw escaped.
+      // The failure stays inside this package's error contract, which the raw
+      // `_assertClass` throw escapes.
       expect(isQuillmarkError(caught)).toBe(true)
       expect(caught.message).toContain(method)
       expect(caught.diagnostics[0].code).toBe('runtime::not_a_document')
@@ -1034,9 +1034,10 @@ main:
   })
 
   // The real shape: a SECOND COPY of the built core artifact on disk, which is
-  // what npm produces. A query suffix is not enough — `wasm.js?x` re-evaluates
-  // but still imports the cached `./wasm_bg.js`, so the classes stay identical.
-  // Copying the whole directory forks the module graph and the linear memory.
+  // what npm produces. A query suffix is not enough, since `wasm.js?x`
+  // re-evaluates but still imports the cached `./wasm_bg.js`, leaving the
+  // classes identical. Copying the directory forks the module graph and the
+  // linear memory.
   describe('against a second copy of the core build on disk', () => {
     let copyB
     beforeAll(async () => {
@@ -1065,7 +1066,7 @@ main:
         const rq = readerQuill()
         expect(rq.reader(docB).get('title')).toEqual(rq.reader(docA).get('title'))
         expect(rq.reader(docB).getBody()).toEqual(rq.reader(docA).getBody())
-        // The foreign handle is never freed by us — it is the caller's.
+        // The foreign handle is never freed by us: it is the caller's.
         expect(docB.quillRef).toBe('test_quill')
       } finally {
         warn.mockRestore()
@@ -1079,11 +1080,11 @@ main:
     })
   })
 
-  // Re-evaluating the runtime module against an already-patched (because
-  // cached) core build must not wrap the wrappers — the Vite HMR / shared
-  // Vitest worker case the `Symbol.for` marker exists for. A copy of
-  // runtime.js beside the original re-evaluates while its relative
-  // `../core/wasm.js` import still resolves to the cached module.
+  // Re-evaluating the runtime module against a cached, and so already patched,
+  // core build must not wrap the wrappers: the Vite HMR / shared Vitest worker
+  // case the `Symbol.for` marker exists for. A copy of runtime.js beside the
+  // original re-evaluates while its relative `../core/wasm.js` import still
+  // resolves to the cached module.
   it('patches once across a re-evaluation of the runtime module', async () => {
     const before = Document.prototype.equals
     expect(before[Symbol.for('@quillmark/wasm:foreign-tolerant')]).toBe(true)

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -10,7 +10,7 @@
  *
  * Aliased to pkg/runtime/runtime.js in vitest.config.js.
  */
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import {
   Quill,
   Document,
@@ -881,5 +881,131 @@ main:
     const quill = makeRuntimeQuill()
     const badDoc = { backendId: 'typst', toJson: () => '{"not":"a valid storage DTO"}' }
     await expect(engine.render(quill, badDoc)).rejects.toThrow()
+  })
+})
+
+// A duplicate install is two copies of this package: two core builds, two
+// linear memories, two distinct `Document` classes. `Engine` already tolerates
+// that crossing (it is duck-typed and clones as data); the three core methods
+// taking another core handle BY REFERENCE did not, because wasm-bindgen's
+// generated `_assertClass` rejects the foreign class before any of our code
+// runs. These pin the one policy the runtime layer now applies everywhere: a
+// foreign handle crosses as data. See runtime.js § "Foreign core handles".
+//
+// A foreign `Document` is modelled two ways: a duck-typed stand-in (anything
+// carrying `toJson`, the contract the patches actually check) and — closer to
+// the real thing — a SECOND core instance loaded under a cache-busting query,
+// which is genuinely a different class over a different linear memory.
+describe('@quillmark/wasm/runtime — foreign core handles (duplicate install)', () => {
+  const foreignOf = (doc) => ({ toJson: () => doc.toJson() })
+
+  it('accepts a foreign Document on equals, and warns exactly once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const doc = Document.fromMarkdown(TEST_MARKDOWN)
+      const same = Document.fromMarkdown(TEST_MARKDOWN)
+      const other = Document.fromMarkdown(TEST_MARKDOWN.replace('Test Document', 'Other'))
+
+      expect(doc.equals(foreignOf(same))).toBe(true)
+      expect(doc.equals(foreignOf(other))).toBe(false)
+      // Local handles keep the generated fast path and never warn.
+      expect(doc.equals(same)).toBe(true)
+
+      // Warn-once: a broken install would otherwise warn per keystroke. This
+      // is the first foreign handle in the file, so the count is exact.
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toMatch(/npm ls @quillmark\/wasm/)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('accepts a foreign Document on validate and resolve, matching the local answer', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const quill = makeRuntimeQuill()
+      const doc = Document.fromMarkdown(TEST_MARKDOWN)
+      expect(quill.validate(foreignOf(doc))).toEqual(quill.validate(doc))
+      expect(quill.resolve(foreignOf(doc))).toEqual(quill.resolve(doc))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('rejects a non-document argument with a QuillmarkError naming the method', () => {
+    const quill = makeRuntimeQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    for (const [call, method] of [
+      [() => doc.equals(null), 'Document.equals'],
+      [() => quill.validate({}), 'Quill.validate'],
+      [() => quill.resolve(42), 'Quill.resolve'],
+    ]) {
+      let caught
+      try {
+        call()
+      } catch (e) {
+        caught = e
+      }
+      // The failure stays inside this package's error contract — the thing the
+      // raw `_assertClass` throw escaped.
+      expect(isQuillmarkError(caught)).toBe(true)
+      expect(caught.message).toContain(method)
+      expect(caught.diagnostics[0].code).toBe('runtime::not_a_document')
+    }
+  })
+
+  it('reports both schema versions when the foreign DTO is unreadable', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const quill = makeRuntimeQuill()
+      const fromTheFuture = { toJson: () => '{"schema":"v99.0.0"}' }
+      let caught
+      try {
+        quill.validate(fromTheFuture)
+      } catch (e) {
+        caught = e
+      }
+      expect(isQuillmarkError(caught)).toBe(true)
+      expect(caught.diagnostics[0].code).toBe('runtime::foreign_document')
+      expect(caught.message).toContain('v99.0.0')
+      expect(caught.message).toContain(Document.currentSchemaVersion())
+      expect(caught.diagnostics[0].hint).toMatch(/npm ls @quillmark\/wasm/)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('handles a Document from a genuinely separate core instance', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // A query suffix makes vite resolve a distinct module id, so this is a
+      // second core build with its own WASM memory — the real duplicate-install
+      // shape, not a stand-in.
+      const copyB = await import('../../../pkg/core/wasm.js?duplicate-install')
+      expect(copyB.Document).not.toBe(Document)
+
+      const quill = makeRuntimeQuill()
+      const docB = copyB.Document.fromMarkdown(TEST_MARKDOWN)
+      const docA = Document.fromMarkdown(TEST_MARKDOWN)
+
+      expect(docA.equals(docB)).toBe(true)
+      expect(quill.validate(docB)).toEqual(quill.validate(docA))
+      expect(quill.resolve(docB)).toEqual(quill.resolve(docA))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  // Re-evaluating the runtime module against an already-patched (because
+  // cached) core build must not wrap the wrappers — the Vite HMR / shared
+  // Vitest worker case the `Symbol.for` marker exists for.
+  it('patches once across a re-evaluation of the runtime module', async () => {
+    const before = Document.prototype.equals
+    expect(before[Symbol.for('@quillmark/wasm:foreign-tolerant')]).toBe(true)
+
+    const reevaluated = await import('@quillmark-wasm/runtime?hmr')
+    expect(reevaluated.Document).toBe(Document)
+    expect(Document.prototype.equals).toBe(before)
+    expect(Quill.prototype.validate[Symbol.for('@quillmark/wasm:foreign-tolerant')]).toBe(true)
   })
 })

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -11,6 +11,8 @@
  * Aliased to pkg/runtime/runtime.js in vitest.config.js.
  */
 import { describe, it, expect, beforeAll, vi } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
 import {
   Quill,
   Document,
@@ -61,6 +63,8 @@ This is a test document.`
 function makeRuntimeQuill() {
   return Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
 }
+
+const PKG_DIR = path.resolve(import.meta.dirname, '..', '..', '..', 'pkg')
 
 /** Read a field value from a card's payloadItems list by key. */
 const fieldOf = (card, key) =>
@@ -899,6 +903,28 @@ main:
 describe('@quillmark/wasm/runtime — foreign core handles (duplicate install)', () => {
   const foreignOf = (doc) => ({ toJson: () => doc.toJson() })
 
+  // The reader verbs are schema-bound, so they need a quill that DECLARES the
+  // fields TEST_MARKDOWN sets — the default test quill declares none.
+  const READER_QUILL_YAML = `quill:
+  name: test_quill
+  version: "1.0"
+  backend: typst
+  description: Foreign-handle reader test
+
+main:
+  fields:
+    title:
+      type: richtext
+      inline: true
+    author:
+      type: richtext
+      inline: true
+`
+  const readerQuill = () =>
+    Quill.fromTree(
+      makeQuill({ name: 'test_quill', plate: TEST_PLATE, quillYaml: READER_QUILL_YAML })
+    )
+
   it('accepts a foreign Document on equals, and warns exactly once', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
@@ -975,35 +1001,106 @@ describe('@quillmark/wasm/runtime — foreign core handles (duplicate install)',
     }
   })
 
-  it('handles a Document from a genuinely separate core instance', async () => {
+  it('refuses to bind a foreign Document for typed writes, naming why', () => {
+    const quill = makeRuntimeQuill()
+    const doc = Document.fromMarkdown(TEST_MARKDOWN)
+    let caught
+    try {
+      quill.writer(foreignOf(doc))
+    } catch (e) {
+      caught = e
+    }
+    // Writes are the one crossing that is NOT transparent: the write-back would
+    // clear parse-time warnings. Fail at the bind, in contract, naming the cause.
+    expect(isQuillmarkError(caught)).toBe(true)
+    expect(caught.diagnostics[0].code).toBe('runtime::foreign_document')
+    expect(caught.message).toMatch(/writes do not/)
+    expect(caught.diagnostics[0].hint).toMatch(/npm ls @quillmark\/wasm/)
+  })
+
+  it('reads a foreign Document through the reader lane', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
-      // A query suffix makes vite resolve a distinct module id, so this is a
-      // second core build with its own WASM memory — the real duplicate-install
-      // shape, not a stand-in.
-      const copyB = await import('../../../pkg/core/wasm.js?duplicate-install')
-      expect(copyB.Document).not.toBe(Document)
-
-      const quill = makeRuntimeQuill()
-      const docB = copyB.Document.fromMarkdown(TEST_MARKDOWN)
-      const docA = Document.fromMarkdown(TEST_MARKDOWN)
-
-      expect(docA.equals(docB)).toBe(true)
-      expect(quill.validate(docB)).toEqual(quill.validate(docA))
-      expect(quill.resolve(docB)).toEqual(quill.resolve(docA))
+      const quill = readerQuill()
+      const doc = Document.fromMarkdown(TEST_MARKDOWN)
+      // Reads are read-only, so they cross like validate/resolve do.
+      expect(quill.reader(foreignOf(doc)).get('title')).toEqual(
+        quill.reader(doc).get('title')
+      )
+      expect(quill.reader(foreignOf(doc)).getBody()).toEqual(quill.reader(doc).getBody())
     } finally {
       warn.mockRestore()
     }
   })
 
+  // The real shape: a SECOND COPY of the built core artifact on disk, which is
+  // what npm produces. A query suffix is not enough — `wasm.js?x` re-evaluates
+  // but still imports the cached `./wasm_bg.js`, so the classes stay identical.
+  // Copying the whole directory forks the module graph and the linear memory.
+  describe('against a second copy of the core build on disk', () => {
+    let copyB
+    beforeAll(async () => {
+      const src = path.join(PKG_DIR, 'core')
+      const dst = path.join(PKG_DIR, 'dup-core')
+      fs.rmSync(dst, { recursive: true, force: true })
+      fs.cpSync(src, dst, { recursive: true })
+      copyB = await import(/* @vite-ignore */ path.join(dst, 'wasm.js'))
+    })
+
+    it('is genuinely a different class over a different memory', () => {
+      expect(copyB.Document).not.toBe(Document)
+      expect(copyB.Quill).not.toBe(Quill)
+    })
+
+    it('crosses on equals, validate, resolve and the reader lane', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const quill = makeRuntimeQuill()
+        const docA = Document.fromMarkdown(TEST_MARKDOWN)
+        const docB = copyB.Document.fromMarkdown(TEST_MARKDOWN)
+
+        expect(docA.equals(docB)).toBe(true)
+        expect(quill.validate(docB)).toEqual(quill.validate(docA))
+        expect(quill.resolve(docB)).toEqual(quill.resolve(docA))
+        const rq = readerQuill()
+        expect(rq.reader(docB).get('title')).toEqual(rq.reader(docA).get('title'))
+        expect(rq.reader(docB).getBody()).toEqual(rq.reader(docA).getBody())
+        // The foreign handle is never freed by us — it is the caller's.
+        expect(docB.quillRef).toBe('test_quill')
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('refuses the write bind', () => {
+      const quill = makeRuntimeQuill()
+      const docB = copyB.Document.fromMarkdown(TEST_MARKDOWN)
+      expect(() => quill.writer(docB)).toThrow(/writes do not/)
+    })
+  })
+
   // Re-evaluating the runtime module against an already-patched (because
   // cached) core build must not wrap the wrappers — the Vite HMR / shared
-  // Vitest worker case the `Symbol.for` marker exists for.
+  // Vitest worker case the `Symbol.for` marker exists for. A copy of
+  // runtime.js beside the original re-evaluates while its relative
+  // `../core/wasm.js` import still resolves to the cached module.
   it('patches once across a re-evaluation of the runtime module', async () => {
     const before = Document.prototype.equals
     expect(before[Symbol.for('@quillmark/wasm:foreign-tolerant')]).toBe(true)
 
-    const reevaluated = await import('@quillmark-wasm/runtime?hmr')
+    // The twin has to sit BESIDE the original for its `../core/wasm.js` import
+    // to resolve to the same cached module. `pkg/runtime/` is a published
+    // directory, so remove it as soon as it is loaded rather than leave a stray
+    // file that a publish from an unrebuilt pkg/ would ship.
+    const twin = path.join(PKG_DIR, 'runtime', 'runtime.hmr.js')
+    fs.copyFileSync(path.join(PKG_DIR, 'runtime', 'runtime.js'), twin)
+    let reevaluated
+    try {
+      reevaluated = await import(/* @vite-ignore */ twin)
+    } finally {
+      fs.rmSync(twin, { force: true })
+    }
+
     expect(reevaluated.Document).toBe(Document)
     expect(Document.prototype.equals).toBe(before)
     expect(Quill.prototype.validate[Symbol.for('@quillmark/wasm:foreign-tolerant')]).toBe(true)

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -166,7 +166,7 @@ function foreignDocJson(value, method) {
 	if (!warnedForeignHandle) {
 		warnedForeignHandle = true;
 		console.warn(
-			`@quillmark/wasm: ${method} received a Document minted by a DIFFERENT copy of this package — two copies are installed. Handling it by value, which works but is slower, and Engine's quill clone cache is split per copy. Run \`npm ls @quillmark/wasm\` and dedupe to one. Further occurrences are not reported.`
+			`@quillmark/wasm: ${method} received a Document that is not this copy's Document class — the usual cause is two copies of @quillmark/wasm installed. Handling it by value: correct, but slower, and Engine's quill clone cache is split per copy. Run \`npm ls @quillmark/wasm\` and dedupe to one. Further occurrences are not reported.`
 		);
 	}
 	return /** @type {any} */ (value).toJson();
@@ -211,6 +211,8 @@ function patchForeignTolerant(proto, name, wrap) {
 	if (typeof original !== 'function' || original[FOREIGN_TOLERANT]) return;
 	const patched = wrap(original);
 	/** @type {any} */ (patched)[FOREIGN_TOLERANT] = true;
+	// Keep the method's name so a stack trace still reads `Quill.validate`.
+	Object.defineProperty(patched, 'name', { value: name, configurable: true });
 	/** @type {any} */ (proto)[name] = patched;
 }
 

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -104,7 +104,7 @@ export function isQuillmarkError(e) {
 }
 
 /**
- * Build a `QuillmarkError` JS-side — a real `Error` carrying `diagnostics`, the
+ * Build a `QuillmarkError` JS-side: a real `Error` carrying `diagnostics`, the
  * shape `isQuillmarkError` narrows and the shape Rust's `WasmError::to_js_value`
  * produces. Errors raised by this hand-written layer belong to the same contract
  * as the ones raised across the WASM boundary.
@@ -122,40 +122,37 @@ function quillmarkError(code, message, hint) {
 // ── Foreign core handles: the duplicate-install lane ────────────────────────
 // A duplicate install (two copies of this package in one `node_modules` tree)
 // is two `core` builds: two linear memories and two distinct `Quill`/`Document`
-// classes. `Engine` already tolerates that crossing — it is duck-typed on
+// classes. `Engine` already tolerates that crossing, being duck-typed on
 // `.toTree()`/`.toJson()`/`.backendId` and clones into backend memory as data,
 // so a `Quill` from copy A renders on an `Engine` from copy B.
 //
-// The core methods that take ANOTHER core handle do not, and they fail worse
-// than they need to. `Document.equals(&Document)`, `Quill.validate(&Document)`,
-// `Quill.resolve(&Document)`, and the five writer/reader primitives that take
-// `&Quill` (`Document._commitField` and friends) take the handle by reference,
-// so wasm-bindgen's generated glue runs `_assertClass` before any of our code
-// (emitted unconditionally, not gated on the build profile). The throw is
-// `expected instance of Document` — at a value that IS a `Document`, from the
-// other copy — and it is a bare `Error`, so `isQuillmarkError` says false and the
-// failure escapes this package's error contract entirely.
+// The core methods taking ANOTHER core handle do not. `Document.equals`,
+// `Quill.validate`, `Quill.resolve` and the five writer/reader primitives that
+// take `&Quill` (`Document._commitField` and friends) declare a reference
+// parameter, so wasm-bindgen's generated glue runs `_assertClass` before any of
+// our code (emitted unconditionally, not gated on the build profile). It throws
+// `expected instance of Document` at a value that IS a `Document` from the other
+// copy, as a bare `Error`: `isQuillmarkError` returns false and the failure
+// leaves this package's error contract.
 //
-// So the split-brain is: render works, validate explodes, and the message names
-// neither the cause nor the cure. This section picks ONE policy along the line
-// the codebase already draws — READ-ONLY crossings are transparent, mutating
-// ones are not:
+// The policy follows the line the codebase already draws, every existing
+// crossing (`render`, `open`, `apply`) being read-only: READ-ONLY crossings are
+// transparent, mutating ones are not.
 //
 //   - Reads (`equals`, `validate`, `resolve`, the reader verbs) admit anything
 //     carrying `.toJson()`, route it through the storage DTO, and warn once.
-//     Nothing is written back, so the caller's handle is untouched. This is what
-//     `Engine` already does to reach backend memory.
+//     Nothing is written back, so the caller's handle is untouched.
 //
 //   - Writes (the writer verbs) refuse, at the bind rather than at the first
-//     write. See `requireLocalDoc` for why a write-back cannot be transparent.
+//     write. `requireLocalDoc` carries why a write-back cannot be transparent.
 //
-// A value that is not document-shaped at all, or a DTO this build cannot read,
-// throws a `QuillmarkError` naming the duplicate install either way.
+// A value that is not document-shaped, or a DTO this build cannot read, throws a
+// `QuillmarkError` naming the duplicate install either way.
 //
-// This is a safety net, not an API widening: the declared parameter types stay
-// `Document`, and the fast path is an `instanceof` that costs nothing.
+// A safety net, not an API widening: the declared parameter types stay
+// `Document`, and the local path is an `instanceof`.
 
-/** Warn once per copy — a broken install would otherwise warn per keystroke. */
+/** Warn once per copy: a broken install would otherwise warn per keystroke. */
 let warnedForeignHandle = false;
 
 /**
@@ -179,8 +176,8 @@ function isLocalDoc(value, method) {
 }
 
 /**
- * A foreign document's storage DTO, warning once on the way. Call only after
- * `isLocalDoc` has returned false.
+ * A foreign document's storage DTO, warning once. Call only after `isLocalDoc`
+ * has returned false.
  * @param {any} value
  * @param {string} method
  * @returns {string}
@@ -189,7 +186,7 @@ function foreignDocJson(value, method) {
 	if (!warnedForeignHandle) {
 		warnedForeignHandle = true;
 		console.warn(
-			`@quillmark/wasm: ${method} received a Document that is not this copy's Document class — the usual cause is two copies of @quillmark/wasm installed. Handling it by value: correct, but slower, and Engine's quill clone cache is split per copy. Run \`npm ls @quillmark/wasm\` and dedupe to one. Further occurrences are not reported.`
+			`@quillmark/wasm: ${method} received a Document that is not this copy's Document class. The usual cause is two copies of @quillmark/wasm installed. Handling it by value: correct, but slower, and Engine's quill clone cache is split per copy. Run \`npm ls @quillmark/wasm\` and dedupe to one. Further occurrences are not reported.`
 		);
 	}
 	return value.toJson();
@@ -197,9 +194,9 @@ function foreignDocJson(value, method) {
 
 /**
  * Materialize a foreign DTO as a local `Document`. The caller owns the handle
- * and must `free()` it. A DTO this build cannot read means the two copies are
- * far enough apart to disagree on the wire format — report that, with both
- * schema versions, rather than the raw parse error.
+ * and must `free()` it. A DTO this build cannot read means the two copies
+ * disagree on the wire format: report that, with both schema versions, rather
+ * than the raw parse error.
  * @param {string} json
  * @param {string} method
  * @returns {Document}
@@ -218,9 +215,9 @@ function adoptForeignDoc(json, method) {
 }
 
 /**
- * Run `fn` against a LOCAL `Document`, adopting a foreign one for the duration
- * and freeing it after. READ-ONLY: nothing is written back, so the caller's
- * handle is untouched and a stale clone cannot outlive the call.
+ * Run `fn` against a LOCAL `Document`, adopting a foreign one for the call and
+ * freeing it after. READ-ONLY: nothing is written back, so the caller's handle
+ * is untouched and no clone outlives the call.
  * @template T
  * @param {any} doc
  * @param {string} method
@@ -240,13 +237,12 @@ function readOnLocalDoc(doc, method, fn) {
 /**
  * Reject a foreign `Document` at a MUTATING seam.
  *
- * Reads, renders and validations cross as data because they are read-only —
- * the adopted clone is freed and nothing about the caller's handle changes. A
- * typed write cannot: it would run on the clone and be written back with
- * `loadJson`, which CLEARS the document's parse-time warnings. Silently
- * dropping `doc.warnings` on the primary write path is worse than not crossing,
- * so fail at the bind, where the message can still name the cause. `Engine`'s
- * render path is unaffected — it never writes back either.
+ * Reads, renders and validations cross as data because they are read-only: the
+ * adopted clone is freed and the caller's handle is untouched. A typed write
+ * cannot. It would run on the clone and be written back with `loadJson`, which
+ * CLEARS the document's parse-time warnings. Silently dropping `doc.warnings` on
+ * the primary write path is worse than not crossing, so fail at the bind, where
+ * the message can still name the cause.
  * @param {any} doc
  * @param {string} method
  */
@@ -260,8 +256,8 @@ function requireLocalDoc(doc, method) {
 }
 
 // Marker for the patches below. `Symbol.for`, not a module-local `Symbol()`:
-// a re-evaluation of THIS module (Vite HMR, a Vitest worker sharing a module
-// graph) against an already-patched — because cached — core build must see the
+// re-evaluating THIS module (Vite HMR, a Vitest worker sharing a module graph)
+// against a core build that is cached, and so already patched, must see the
 // existing marker, or each pass wraps the previous wrapper.
 const FOREIGN_TOLERANT = Symbol.for('@quillmark/wasm:foreign-tolerant');
 
@@ -281,14 +277,13 @@ function patchForeignTolerant(proto, name, wrap) {
 	/** @type {any} */ (proto)[name] = patched;
 }
 
-// `equals` needs no handle at all on the foreign path. `toJson` is
-// byte-deterministic within a schema version and excludes parse-time warnings —
-// exactly the equality `equals` documents — so comparing DTOs answers it without
-// allocating into this memory. Across MISMATCHED schema versions the tags differ
-// and equal documents can compare unequal; that direction is safe (`equals` is a
-// debounce primitive, so a false "changed" costs a redundant re-parse) and the
-// unsafe direction cannot happen, since differing versions never produce equal
-// bytes.
+// `equals` adopts nothing on the foreign path. `toJson` is byte-deterministic
+// within a schema version and excludes parse-time warnings, which is exactly the
+// equality `equals` documents, so comparing DTOs answers it without a handle.
+// Across MISMATCHED schema versions the tags differ, so equal documents can
+// compare unequal. That direction is safe: `equals` is a debounce primitive, so
+// a false "changed" costs a redundant re-parse. The unsafe direction cannot
+// happen, since differing versions never produce equal bytes.
 patchForeignTolerant(Document.prototype, 'equals', (original) =>
 	function equals(/** @type {any} */ other) {
 		if (isLocalDoc(other, 'Document.equals')) return original.call(this, other);
@@ -297,7 +292,7 @@ patchForeignTolerant(Document.prototype, 'equals', (original) =>
 );
 
 // `validate` and `resolve` read the document's model, so they need a real local
-// handle: adopt, use, free. Only the argument can be foreign — the receiver is
+// handle: adopt, use, free. Only the argument can be foreign, the receiver being
 // whichever copy the caller reached for.
 for (const name of /** @type {const} */ (['validate', 'resolve'])) {
 	patchForeignTolerant(Quill.prototype, name, (original) =>
@@ -309,9 +304,9 @@ for (const name of /** @type {const} */ (['validate', 'resolve'])) {
 
 // The typed writer/reader primitives (`Document._commitField` and friends) take
 // the QUILL by reference, so they hit the same `_assertClass` from the other
-// direction — and the quill is unreachable in the foreign document's memory
-// (nothing hands out that copy's `Quill` class). The document is the side that
-// can move, so the reader lane adopts it per call and the writer lane refuses.
+// direction, and the quill is the unreachable side (nothing hands out the
+// foreign document's copy of the `Quill` class). The document is what can move,
+// so the reader lane adopts it per call and the writer lane refuses.
 // Wired at the four writer/reader classes below, not patched onto `Document`:
 // a foreign document carries its OWN prototype, so patching this copy's would
 // never run.

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -53,6 +53,10 @@
 // "re-exports the internal core build classes verbatim" case
 // (`Quill === CoreQuill`) is the executable guard for this invariant.
 //
+// Tolerating a foreign handle is a WHOLE-LAYER policy, not an `Engine` quirk:
+// the core methods that take another core handle by reference are patched to
+// accept one by value too. See § "Foreign core handles" below.
+//
 // Imported (not bare re-exported) so `Quill` is a local binding this module can
 // augment — `quill.writer(doc)` is patched onto its prototype below. The
 // re-export keeps the identity: the exported `Quill` IS the core class.
@@ -96,6 +100,151 @@ export const MAIN_CARD_ADDR = Object.freeze({});
  */
 export function isQuillmarkError(e) {
 	return e instanceof Error && Array.isArray(/** @type {any} */ (e).diagnostics);
+}
+
+/**
+ * Build a `QuillmarkError` JS-side — a real `Error` carrying `diagnostics`, the
+ * shape `isQuillmarkError` narrows and the shape Rust's `WasmError::to_js_value`
+ * produces. Errors raised by this hand-written layer belong to the same contract
+ * as the ones raised across the WASM boundary.
+ * @param {string} code
+ * @param {string} message
+ * @param {string} hint
+ * @returns {Error & { diagnostics: import('../core/wasm.js').Diagnostic[] }}
+ */
+function quillmarkError(code, message, hint) {
+	const err = /** @type {any} */ (new Error(message));
+	err.diagnostics = [{ severity: 'error', code, message, hint }];
+	return err;
+}
+
+// ── Foreign core handles: the duplicate-install lane ────────────────────────
+// A duplicate install (two copies of this package in one `node_modules` tree)
+// is two `core` builds: two linear memories and two distinct `Quill`/`Document`
+// classes. `Engine` already tolerates that crossing — it is duck-typed on
+// `.toTree()`/`.toJson()`/`.backendId` and clones into backend memory as data,
+// so a `Quill` from copy A renders on an `Engine` from copy B.
+//
+// The three core methods that take ANOTHER core handle do not, and they fail
+// worse than they need to. `Document.equals(&Document)`,
+// `Quill.validate(&Document)` and `Quill.resolve(&Document)` take the handle by
+// reference, so wasm-bindgen's generated glue runs `_assertClass` before any of
+// our code (emitted unconditionally, not gated on the build profile). The throw
+// is `expected instance of Document` — at a value that IS a `Document`, from the
+// other copy — and it is a bare `Error`, so `isQuillmarkError` says false and the
+// failure escapes this package's error contract entirely.
+//
+// So the split-brain is: render works, validate explodes, and the message names
+// neither the cause nor the cure. These patches pick ONE policy, the one the
+// `Engine` lane already picked: a foreign handle crosses AS DATA. Each method
+// admits anything carrying `.toJson()`, routes it through the storage DTO, and
+// warns once. A value that is not document-shaped at all, or a DTO this build
+// cannot read, throws a `QuillmarkError` naming the duplicate install.
+//
+// This is a safety net, not an API widening: the declared parameter types stay
+// `Document`, and the fast path is an `instanceof` that costs nothing.
+
+/** Warn once per copy — a broken install would otherwise warn per keystroke. */
+let warnedForeignHandle = false;
+
+/**
+ * The foreign handle's storage DTO, or `null` when `value` is a local
+ * `Document` (call straight through). Throws when `value` is not a document.
+ * @param {unknown} value
+ * @param {string} method
+ * @returns {string | null}
+ */
+function foreignDocJson(value, method) {
+	if (value instanceof Document) return null;
+	if (!value || typeof (/** @type {any} */ (value).toJson) !== 'function') {
+		throw quillmarkError(
+			'runtime::not_a_document',
+			`${method}: expected a Document, got ${value === null ? 'null' : typeof value}.`,
+			'Pass a Document built by Document.fromMarkdown / fromJson or quill.seedDocument.'
+		);
+	}
+	if (!warnedForeignHandle) {
+		warnedForeignHandle = true;
+		console.warn(
+			`@quillmark/wasm: ${method} received a Document minted by a DIFFERENT copy of this package — two copies are installed. Handling it by value, which works but is slower, and Engine's quill clone cache is split per copy. Run \`npm ls @quillmark/wasm\` and dedupe to one. Further occurrences are not reported.`
+		);
+	}
+	return /** @type {any} */ (value).toJson();
+}
+
+/**
+ * Materialize a foreign DTO as a local `Document`. The caller owns the handle
+ * and must `free()` it. A DTO this build cannot read means the two copies are
+ * far enough apart to disagree on the wire format — report that, with both
+ * schema versions, rather than the raw parse error.
+ * @param {string} json
+ * @param {string} method
+ * @returns {Document}
+ */
+function adoptForeignDoc(json, method) {
+	try {
+		return Document.fromJson(json);
+	} catch {
+		const theirs = Document.schemaVersionOf(json) ?? 'unknown';
+		throw quillmarkError(
+			'runtime::foreign_document',
+			`${method}: the Document came from a different copy of @quillmark/wasm whose storage format this build cannot read (it wrote schema ${theirs}, this build reads ${Document.currentSchemaVersion()}).`,
+			'Two copies of @quillmark/wasm are installed. Run `npm ls @quillmark/wasm` and dedupe to one.'
+		);
+	}
+}
+
+// Marker for the patches below. `Symbol.for`, not a module-local `Symbol()`:
+// a re-evaluation of THIS module (Vite HMR, a Vitest worker sharing a module
+// graph) against an already-patched — because cached — core build must see the
+// existing marker, or each pass wraps the previous wrapper.
+const FOREIGN_TOLERANT = Symbol.for('@quillmark/wasm:foreign-tolerant');
+
+/**
+ * Replace `proto[name]` with `wrap(original)`, once.
+ * @param {object} proto
+ * @param {string} name
+ * @param {(original: Function) => Function} wrap
+ */
+function patchForeignTolerant(proto, name, wrap) {
+	const original = /** @type {any} */ (proto)[name];
+	if (typeof original !== 'function' || original[FOREIGN_TOLERANT]) return;
+	const patched = wrap(original);
+	/** @type {any} */ (patched)[FOREIGN_TOLERANT] = true;
+	/** @type {any} */ (proto)[name] = patched;
+}
+
+// `equals` needs no handle at all on the foreign path. `toJson` is
+// byte-deterministic within a schema version and excludes parse-time warnings —
+// exactly the equality `equals` documents — so comparing DTOs answers it without
+// allocating into this memory. Across MISMATCHED schema versions the tags differ
+// and equal documents can compare unequal; that direction is safe (`equals` is a
+// debounce primitive, so a false "changed" costs a redundant re-parse) and the
+// unsafe direction cannot happen, since differing versions never produce equal
+// bytes.
+patchForeignTolerant(Document.prototype, 'equals', (original) =>
+	function equals(/** @type {any} */ other) {
+		const json = foreignDocJson(other, 'Document.equals');
+		return json === null ? original.call(this, other) : this.toJson() === json;
+	}
+);
+
+// `validate` and `resolve` read the document's model, so they need a real local
+// handle: adopt, use, free. Only the argument can be foreign — the receiver is
+// whichever copy the caller reached for.
+for (const name of /** @type {const} */ (['validate', 'resolve'])) {
+	patchForeignTolerant(Quill.prototype, name, (original) =>
+		function (/** @type {any} */ doc) {
+			const json = foreignDocJson(doc, `Quill.${name}`);
+			if (json === null) return original.call(this, doc);
+			const local = adoptForeignDoc(json, `Quill.${name}`);
+			try {
+				return original.call(this, local);
+			} finally {
+				local.free();
+			}
+		}
+	);
 }
 
 // ── Open-set discriminant guards ────────────────────────────────────────────

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -54,8 +54,9 @@
 // (`Quill === CoreQuill`) is the executable guard for this invariant.
 //
 // Tolerating a foreign handle is a WHOLE-LAYER policy, not an `Engine` quirk:
-// the core methods that take another core handle by reference are patched to
-// accept one by value too. See § "Foreign core handles" below.
+// every read that takes another core handle by reference accepts one by value
+// too. Writes are the one exception, and refuse at the bind. See § "Foreign
+// core handles" below.
 //
 // Imported (not bare re-exported) so `Quill` is a local binding this module can
 // augment — `quill.writer(doc)` is patched onto its prototype below. The
@@ -125,21 +126,31 @@ function quillmarkError(code, message, hint) {
 // `.toTree()`/`.toJson()`/`.backendId` and clones into backend memory as data,
 // so a `Quill` from copy A renders on an `Engine` from copy B.
 //
-// The three core methods that take ANOTHER core handle do not, and they fail
-// worse than they need to. `Document.equals(&Document)`,
-// `Quill.validate(&Document)` and `Quill.resolve(&Document)` take the handle by
-// reference, so wasm-bindgen's generated glue runs `_assertClass` before any of
-// our code (emitted unconditionally, not gated on the build profile). The throw
-// is `expected instance of Document` — at a value that IS a `Document`, from the
+// The core methods that take ANOTHER core handle do not, and they fail worse
+// than they need to. `Document.equals(&Document)`, `Quill.validate(&Document)`,
+// `Quill.resolve(&Document)`, and the five writer/reader primitives that take
+// `&Quill` (`Document._commitField` and friends) take the handle by reference,
+// so wasm-bindgen's generated glue runs `_assertClass` before any of our code
+// (emitted unconditionally, not gated on the build profile). The throw is
+// `expected instance of Document` — at a value that IS a `Document`, from the
 // other copy — and it is a bare `Error`, so `isQuillmarkError` says false and the
 // failure escapes this package's error contract entirely.
 //
 // So the split-brain is: render works, validate explodes, and the message names
-// neither the cause nor the cure. These patches pick ONE policy, the one the
-// `Engine` lane already picked: a foreign handle crosses AS DATA. Each method
-// admits anything carrying `.toJson()`, routes it through the storage DTO, and
-// warns once. A value that is not document-shaped at all, or a DTO this build
-// cannot read, throws a `QuillmarkError` naming the duplicate install.
+// neither the cause nor the cure. This section picks ONE policy along the line
+// the codebase already draws — READ-ONLY crossings are transparent, mutating
+// ones are not:
+//
+//   - Reads (`equals`, `validate`, `resolve`, the reader verbs) admit anything
+//     carrying `.toJson()`, route it through the storage DTO, and warn once.
+//     Nothing is written back, so the caller's handle is untouched. This is what
+//     `Engine` already does to reach backend memory.
+//
+//   - Writes (the writer verbs) refuse, at the bind rather than at the first
+//     write. See `requireLocalDoc` for why a write-back cannot be transparent.
+//
+// A value that is not document-shaped at all, or a DTO this build cannot read,
+// throws a `QuillmarkError` naming the duplicate install either way.
 //
 // This is a safety net, not an API widening: the declared parameter types stay
 // `Document`, and the fast path is an `instanceof` that costs nothing.
@@ -148,14 +159,15 @@ function quillmarkError(code, message, hint) {
 let warnedForeignHandle = false;
 
 /**
- * The foreign handle's storage DTO, or `null` when `value` is a local
- * `Document` (call straight through). Throws when `value` is not a document.
+ * `true` when `value` is THIS copy's `Document` (take the generated fast path),
+ * `false` when it is a document from another copy. Throws when it is not a
+ * document at all.
  * @param {unknown} value
  * @param {string} method
- * @returns {string | null}
+ * @returns {boolean}
  */
-function foreignDocJson(value, method) {
-	if (value instanceof Document) return null;
+function isLocalDoc(value, method) {
+	if (value instanceof Document) return true;
 	if (!value || typeof (/** @type {any} */ (value).toJson) !== 'function') {
 		throw quillmarkError(
 			'runtime::not_a_document',
@@ -163,13 +175,24 @@ function foreignDocJson(value, method) {
 			'Pass a Document built by Document.fromMarkdown / fromJson or quill.seedDocument.'
 		);
 	}
+	return false;
+}
+
+/**
+ * A foreign document's storage DTO, warning once on the way. Call only after
+ * `isLocalDoc` has returned false.
+ * @param {any} value
+ * @param {string} method
+ * @returns {string}
+ */
+function foreignDocJson(value, method) {
 	if (!warnedForeignHandle) {
 		warnedForeignHandle = true;
 		console.warn(
 			`@quillmark/wasm: ${method} received a Document that is not this copy's Document class — the usual cause is two copies of @quillmark/wasm installed. Handling it by value: correct, but slower, and Engine's quill clone cache is split per copy. Run \`npm ls @quillmark/wasm\` and dedupe to one. Further occurrences are not reported.`
 		);
 	}
-	return /** @type {any} */ (value).toJson();
+	return value.toJson();
 }
 
 /**
@@ -192,6 +215,48 @@ function adoptForeignDoc(json, method) {
 			'Two copies of @quillmark/wasm are installed. Run `npm ls @quillmark/wasm` and dedupe to one.'
 		);
 	}
+}
+
+/**
+ * Run `fn` against a LOCAL `Document`, adopting a foreign one for the duration
+ * and freeing it after. READ-ONLY: nothing is written back, so the caller's
+ * handle is untouched and a stale clone cannot outlive the call.
+ * @template T
+ * @param {any} doc
+ * @param {string} method
+ * @param {(doc: Document) => T} fn
+ * @returns {T}
+ */
+function readOnLocalDoc(doc, method, fn) {
+	if (isLocalDoc(doc, method)) return fn(doc);
+	const local = adoptForeignDoc(foreignDocJson(doc, method), method);
+	try {
+		return fn(local);
+	} finally {
+		local.free();
+	}
+}
+
+/**
+ * Reject a foreign `Document` at a MUTATING seam.
+ *
+ * Reads, renders and validations cross as data because they are read-only —
+ * the adopted clone is freed and nothing about the caller's handle changes. A
+ * typed write cannot: it would run on the clone and be written back with
+ * `loadJson`, which CLEARS the document's parse-time warnings. Silently
+ * dropping `doc.warnings` on the primary write path is worse than not crossing,
+ * so fail at the bind, where the message can still name the cause. `Engine`'s
+ * render path is unaffected — it never writes back either.
+ * @param {any} doc
+ * @param {string} method
+ */
+function requireLocalDoc(doc, method) {
+	if (isLocalDoc(doc, method)) return;
+	throw quillmarkError(
+		'runtime::foreign_document',
+		`${method}: cannot bind a Document from a different copy of @quillmark/wasm for typed writes. Reads and renders cross between copies; writes do not, because the round-trip would clear the document's parse-time warnings.`,
+		'Two copies of @quillmark/wasm are installed. Run `npm ls @quillmark/wasm` and dedupe to one.'
+	);
 }
 
 // Marker for the patches below. `Symbol.for`, not a module-local `Symbol()`:
@@ -226,8 +291,8 @@ function patchForeignTolerant(proto, name, wrap) {
 // bytes.
 patchForeignTolerant(Document.prototype, 'equals', (original) =>
 	function equals(/** @type {any} */ other) {
-		const json = foreignDocJson(other, 'Document.equals');
-		return json === null ? original.call(this, other) : this.toJson() === json;
+		if (isLocalDoc(other, 'Document.equals')) return original.call(this, other);
+		return this.toJson() === foreignDocJson(other, 'Document.equals');
 	}
 );
 
@@ -237,17 +302,19 @@ patchForeignTolerant(Document.prototype, 'equals', (original) =>
 for (const name of /** @type {const} */ (['validate', 'resolve'])) {
 	patchForeignTolerant(Quill.prototype, name, (original) =>
 		function (/** @type {any} */ doc) {
-			const json = foreignDocJson(doc, `Quill.${name}`);
-			if (json === null) return original.call(this, doc);
-			const local = adoptForeignDoc(json, `Quill.${name}`);
-			try {
-				return original.call(this, local);
-			} finally {
-				local.free();
-			}
+			return readOnLocalDoc(doc, `Quill.${name}`, (d) => original.call(this, d));
 		}
 	);
 }
+
+// The typed writer/reader primitives (`Document._commitField` and friends) take
+// the QUILL by reference, so they hit the same `_assertClass` from the other
+// direction — and the quill is unreachable in the foreign document's memory
+// (nothing hands out that copy's `Quill` class). The document is the side that
+// can move, so the reader lane adopts it per call and the writer lane refuses.
+// Wired at the four writer/reader classes below, not patched onto `Document`:
+// a foreign document carries its OWN prototype, so patching this copy's would
+// never run.
 
 // ── Open-set discriminant guards ────────────────────────────────────────────
 // `ContentIsland.type`, `ContentMark.type`, `ContentLine.kind`, and
@@ -844,6 +911,7 @@ export class DocumentWriter {
 	 * @param {Document} doc the document to mutate, held by reference (not owned)
 	 */
 	constructor(quill, doc) {
+		requireLocalDoc(doc, 'quill.writer(doc)');
 		this.#quill = quill;
 		this.#doc = doc;
 	}
@@ -953,6 +1021,7 @@ export class CardWriter {
 	 * @param {number} index the composable card's index
 	 */
 	constructor(quill, doc, index) {
+		requireLocalDoc(doc, 'writer.card(index)');
 		this.#quill = quill;
 		this.#doc = doc;
 		this.#index = index;
@@ -1077,7 +1146,7 @@ export class DocumentReader {
 	 * @returns {unknown}
 	 */
 	get(addr) {
-		return this.#doc._readerGet(this.#quill, addr);
+		return readOnLocalDoc(this.#doc, 'reader.get(addr)', (d) => d._readerGet(this.#quill, addr));
 	}
 	/**
 	 * The main body's markdown — the quill-free body read (a body's type is a
@@ -1085,7 +1154,7 @@ export class DocumentReader {
 	 * @returns {string}
 	 */
 	getBody() {
-		return this.#doc._readerGet(this.#quill, {});
+		return readOnLocalDoc(this.#doc, 'reader.getBody()', (d) => d._readerGet(this.#quill, {}));
 	}
 	/**
 	 * A {@link CardReader} bound to the composable card at `index`. Index validity
@@ -1140,14 +1209,18 @@ export class CardReader {
 	 * @returns {unknown}
 	 */
 	get(name) {
-		return this.#doc._readerGet(this.#quill, { card: this.#index, field: name });
+		return readOnLocalDoc(this.#doc, 'cardReader.get(name)', (d) =>
+			d._readerGet(this.#quill, { card: this.#index, field: name })
+		);
 	}
 	/**
 	 * This card's body markdown — the card twin of {@link DocumentReader.getBody}.
 	 * @returns {string}
 	 */
 	getBody() {
-		return this.#doc._readerGet(this.#quill, { card: this.#index });
+		return readOnLocalDoc(this.#doc, 'cardReader.getBody()', (d) =>
+			d._readerGet(this.#quill, { card: this.#index })
+		);
 	}
 }
 

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -18,9 +18,11 @@ set -o pipefail
 #                           private backend binary, NOT a public export)
 #
 # These generated artifacts plus the hand-written canonical layer ship as one
-# npm package. Public surface: the root `.` export (`@quillmark/wasm`) is the
-# canonical `Quill`/`Document`/`Engine` API (see pkg/runtime/), and `./core` is
-# the render-free escape hatch. The backends are reached only internally, by the
+# npm package with exactly ONE public entry: the root `.` export
+# (`@quillmark/wasm`), the canonical `Quill`/`Document`/`Engine` API (see
+# pkg/runtime/). `core` and the backends ship as files but are absent from the
+# package.json `exports` map, so no consumer can import them by subpath — core
+# is reached through the root's re-export, the backends only internally, by the
 # canonical layer's lazy `import("../backends/<id>/wasm.js")`.
 #
 # Profile selection. Default is the size-optimized release build used for

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -21,8 +21,8 @@ set -o pipefail
 # npm package with exactly ONE public entry: the root `.` export
 # (`@quillmark/wasm`), the canonical `Quill`/`Document`/`Engine` API (see
 # pkg/runtime/). `core` and the backends ship as files but are absent from the
-# package.json `exports` map, so no consumer can import them by subpath — core
-# is reached through the root's re-export, the backends only internally, by the
+# package.json `exports` map, so no consumer can import them by subpath: core is
+# reached through the root's re-export, the backends only internally, by the
 # canonical layer's lazy `import("../backends/<id>/wasm.js")`.
 #
 # Profile selection. Default is the size-optimized release build used for


### PR DESCRIPTION
A duplicate install is two copies of the package: two core builds, two
linear memories, two distinct `Quill`/`Document` classes. `Engine`
already crosses that seam — duck-typed on `.toTree()`/`.toJson()`/
`.backendId`, cloning as data — so a handle from copy A renders on an
engine from copy B.

The three core methods taking another core handle by reference did not.
`Document.equals`, `Quill.validate` and `Quill.resolve` meet
wasm-bindgen's generated `_assertClass` (emitted unconditionally, not
gated on the build profile) before any of our code runs, so they throw
`expected instance of Document` at a value that IS a Document, as a bare
`Error` that `isQuillmarkError` rejects — outside this package's own
error contract.

Apply one policy across the layer instead of splitting render from
validate: a foreign handle crosses as data. Each method admits anything
carrying `toJson()` and warns once. `equals` compares storage DTOs
directly (`toJson` is byte-deterministic per schema version and excludes
parse warnings — the equality it documents), so it allocates nothing;
`validate`/`resolve` adopt, use, and free a local handle. A value that
is not document-shaped, or a DTO this build cannot read, throws a
QuillmarkError naming the duplicate install and `npm ls`.

The declared parameter types stay `Document` — a safety net, not an API
widening. The patches are marked with a `Symbol.for` so re-evaluating
the module against a cached core build cannot wrap the wrappers.

Also correct build-wasm.sh's claim that `./core` is a public subpath:
the exports map has only `.`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018cfGwmnL5cGA443Hx5pWMy