### PR TITLE
Make an island's loss class injective instead of guarded

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -283,12 +283,14 @@ export interface ImageProps {
  * `ContentMark`, the open `type` arm means a discriminant check does not itself
  * narrow `props`: read `props` as the matching shape behind the `isTableIsland` /
  * `isImageIsland` guards (from `@quillmark/wasm/runtime`), which narrow it. */
+/** How faithfully the markdown projection can carry an island. Open like an
+ * island `type`: a class this build does not know round-trips verbatim, and
+ * reads as `unrepresentable`. */
+export type ContentLossClass = "lossless" | "degraded" | "unrepresentable" | (string & {});
+
 export type ContentIsland = {
     id: string;
-    /** How faithfully the markdown projection can carry this island. Open like
-     * `type`: a class this build does not know round-trips verbatim, and reads
-     * as `unrepresentable`. */
-    loss: "lossless" | "degraded" | "unrepresentable" | (string & {});
+    loss: ContentLossClass;
 } & (
     | { type: "table"; props: TableProps }
     | { type: "image"; props: ImageProps }

--- a/crates/bindings/wasm/tests/known_names_drift.rs
+++ b/crates/bindings/wasm/tests/known_names_drift.rs
@@ -11,7 +11,7 @@
 //! browser and no instantiated module.
 
 use quillmark_content::island::KnownIslandType;
-use quillmark_content::{Content, Fidelity, Loss};
+use quillmark_content::{Content, Fidelity};
 
 const RUNTIME_JS: &str = include_str!("../runtime/runtime.js");
 
@@ -65,10 +65,9 @@ fn ts_unions_name_every_built_in() {
         &body[..body.find("\n\n").expect("unterminated type alias")]
     }
 
-    // The loss axis names its closed view's classes, not a reserved list: it has
-    // no reserved list, being injective (one `Loss` per wire string).
-    let loss_classes: Vec<_> = Fidelity::ALL.iter().map(|f| f.class()).collect();
-    let loss_names: Vec<_> = loss_classes.iter().map(Loss::as_str).collect();
+    // The loss axis has no reserved list to mirror, being injective (one `Loss`
+    // per wire string), so what it pins is its closed view's spellings.
+    let loss_names: Vec<_> = Fidelity::ALL.iter().map(|f| f.as_str()).collect();
 
     for (union, names) in [
         (ts_union("ContentLineKind"), Content::RESERVED_LINE_KINDS),

--- a/crates/bindings/wasm/tests/known_names_drift.rs
+++ b/crates/bindings/wasm/tests/known_names_drift.rs
@@ -11,7 +11,7 @@
 //! browser and no instantiated module.
 
 use quillmark_content::island::KnownIslandType;
-use quillmark_content::Content;
+use quillmark_content::{Content, Fidelity, Loss};
 
 const RUNTIME_JS: &str = include_str!("../runtime/runtime.js");
 
@@ -65,10 +65,16 @@ fn ts_unions_name_every_built_in() {
         &body[..body.find("\n\n").expect("unterminated type alias")]
     }
 
+    // The loss axis names its closed view's classes, not a reserved list: it has
+    // no reserved list, being injective (one `Loss` per wire string).
+    let loss_classes: Vec<_> = Fidelity::ALL.iter().map(|f| f.class()).collect();
+    let loss_names: Vec<_> = loss_classes.iter().map(Loss::as_str).collect();
+
     for (union, names) in [
-        (ts_union("ContentLineKind"), &Content::RESERVED_LINE_KINDS[..]),
-        (ts_union("ContentContainer"), &Content::RESERVED_CONTAINERS[..]),
-        (ts_union("ContentMark"), &Content::RESERVED_MARK_TYPES[..]),
+        (ts_union("ContentLineKind"), Content::RESERVED_LINE_KINDS),
+        (ts_union("ContentContainer"), Content::RESERVED_CONTAINERS),
+        (ts_union("ContentMark"), Content::RESERVED_MARK_TYPES),
+        (ts_union("ContentLossClass"), loss_names.as_slice()),
     ] {
         for name in names {
             assert!(

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -59,10 +59,10 @@ use crate::model::{Container, Island, LineKind, MarkKind, Content, ISLAND_SLOT};
 /// decides whether a projection exists at all.
 ///
 /// Keeping the two apart is what makes a decode-time degrade safe. A known type
-/// a future writer stamped with a loss class this build lacks arrives as
-/// `Loss::Unknown` (carried verbatim, reading as `Unrepresentable` through
-/// `Loss::fidelity`) and still emits its table: the conservative reading
-/// describes the value, it does not suppress it.
+/// a future writer stamped with a loss class this build lacks keeps that class
+/// verbatim (reading as `Fidelity::Unrepresentable` through `Loss::fidelity`)
+/// and still emits its table: the conservative reading describes the value, it
+/// does not suppress it.
 pub fn to_markdown(rt: &Content) -> String {
     // Per-line char ranges, so global marks can be clipped to a line.
     let segments = line_segments(rt);
@@ -1165,7 +1165,7 @@ mod tests {
                 id: String::new(),
                 island_type: "image".into(),
                 props: serde_json::Value::Null,
-                loss: Loss::Unrepresentable,
+                loss: Loss::UNREPRESENTABLE,
             }],
         };
         rt.normalize();

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -281,7 +281,7 @@ struct TableAcc {
     /// url is dropped. Mirrors the top-level `image_depth` interception.
     img_depth: usize,
     /// Whether any cell dropped an image's url, the island is then minted
-    /// [`Loss::DEGRADED`], not `Lossless`: the markdown/Typst projection carries
+    /// [`Loss::DEGRADED`], not `LOSSLESS`: the markdown/Typst projection carries
     /// the alt text but not the image.
     degraded: bool,
 }

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -281,7 +281,7 @@ struct TableAcc {
     /// url is dropped. Mirrors the top-level `image_depth` interception.
     img_depth: usize,
     /// Whether any cell dropped an image's url, the island is then minted
-    /// [`Loss::Degraded`], not `Lossless`: the markdown/Typst projection carries
+    /// [`Loss::DEGRADED`], not `Lossless`: the markdown/Typst projection carries
     /// the alt text but not the image.
     degraded: bool,
 }
@@ -830,7 +830,7 @@ impl Builder {
             // describes fidelity for a consumer to surface; no
             // projection branches on it.
             let loss = if acc.degraded {
-                Loss::Degraded
+                Loss::DEGRADED
             } else {
                 KnownIslandType::Table.default_loss()
             };
@@ -1248,7 +1248,7 @@ mod tests {
         assert_eq!(rt.lines[0].kind, LineKind::Island);
         assert_eq!(rt.islands.len(), 1);
         assert_eq!(rt.islands[0].island_type, "table");
-        assert_eq!(rt.islands[0].loss, Loss::Lossless);
+        assert_eq!(rt.islands[0].loss, Loss::LOSSLESS);
     }
 
     /// The cell lane's own `<u>` classification. A cell reuses the prose mark
@@ -1289,12 +1289,12 @@ mod tests {
         let rt = imp("| a | b |\n|---|---|\n| ![a cat](cat.png) | 2 |");
         assert_eq!(rt.islands.len(), 1);
         assert_eq!(rt.islands[0].island_type, "table");
-        assert_eq!(rt.islands[0].loss, Loss::Degraded);
+        assert_eq!(rt.islands[0].loss, Loss::DEGRADED);
         // The dropped image left no nested island; alt survived as cell text.
         assert_eq!(rt.islands[0].props["rows"][0][0]["text"], "a cat");
         // A table with no cell image stays Lossless (regression guard).
         let plain = imp("| a | b |\n|---|---|\n| 1 | 2 |");
-        assert_eq!(plain.islands[0].loss, Loss::Lossless);
+        assert_eq!(plain.islands[0].loss, Loss::LOSSLESS);
     }
 
     #[test]

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -87,8 +87,8 @@ impl KnownIslandType {
     /// table cell dropping an inline image's url) but never above.
     pub fn default_loss(self) -> Loss {
         match self {
-            Self::Table => Loss::Lossless,
-            Self::Image => Loss::Lossless,
+            Self::Table => Loss::LOSSLESS,
+            Self::Image => Loss::LOSSLESS,
         }
     }
 

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -48,8 +48,8 @@ pub use export::{to_markdown, to_plaintext};
 pub use import::{from_markdown, from_plaintext};
 pub use island::KnownIslandType;
 pub use model::{
-    Container, Invariant, Island, Line, LineKind, LineKindMismatch, Loss, Mark, MarkKind, Content,
-    Usv,
+    Container, Fidelity, Invariant, Island, Line, LineKind, LineKindMismatch, Loss, Mark, MarkKind,
+    Content, Usv,
 };
 pub use normalize::normalize_markdown;
 pub use ops::{

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -11,6 +11,7 @@
 
 use crate::normalize::is_bidi_char;
 use serde_json::Value as JsonValue;
+use std::borrow::Cow;
 
 /// A position in a [`Content`], counted in Unicode scalar values (USV): never
 /// bytes, never UTF-16 units. One astral char is 1 USV / 4 UTF-8 bytes / 2
@@ -225,42 +226,92 @@ pub struct Island {
 /// warned that a form field silently dropped a table). It is not a
 /// switch: [`crate::export::to_markdown`] dispatches on
 /// [`Island::island_type`], never on this.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Loss {
-    /// Markdown carries it faithfully (round-trips identically).
-    Lossless,
-    /// Markdown carries an approximation (round-trips visibly, not identically).
-    Degraded,
-    /// No markdown encoding: what an island type with no projection carries.
-    Unrepresentable,
-    /// A class a future writer stamped that this build lacks, carried verbatim.
-    ///
-    /// `loss` is open on the terms the other four vocabularies use: mark
-    /// `type`, line `kind`, container, island `type` all round-trip an
-    /// unrecognized member opaque. Carrying the raw tag rather than rewriting it
-    /// is what keeps a reader that merely opens a document from moving that
-    /// document's content hash (`DOCUMENT_STORAGE.md` § Byte-stability).
-    ///
-    /// Read fidelity through [`Loss::fidelity`], never by matching this arm: an
-    /// unrecognized class degrades to [`Unrepresentable`](Loss::Unrepresentable),
-    /// so nothing is claimed to carry faithfully on the strength of a name this
-    /// build cannot interpret.
-    Unknown(String),
-}
+///
+/// Open on [`Island::island_type`]'s terms: the wire string *is* the stored
+/// value, and [`Fidelity`] is the closed view over it. A class this build lacks
+/// is carried verbatim, so a reader that merely opens a document does not move
+/// its content hash (`DOCUMENT_STORAGE.md` § Byte-stability).
+///
+/// One value per wire string, so the encoding is injective and the
+/// reserved-name rule the payload-carrying axes need
+/// ([`Invariant::ReservedUnknownTag`] and its two siblings) has nothing to bite
+/// on here: there is no second spelling of `"lossless"` to collide with the
+/// first. Read fidelity through [`Loss::fidelity`], never by comparing against
+/// [`Loss::LOSSLESS`]: an unrecognized class degrades to
+/// [`Fidelity::Unrepresentable`], so nothing is claimed to carry faithfully on
+/// the strength of a name this build cannot interpret.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Loss(Cow<'static, str>);
 
 impl Loss {
-    /// The fidelity this class describes, with an unrecognized class degraded to
-    /// the safe end. Never returns [`Unknown`](Loss::Unknown).
+    /// Markdown carries it faithfully (round-trips identically).
+    pub const LOSSLESS: Loss = Loss(Cow::Borrowed("lossless"));
+    /// Markdown carries an approximation (round-trips visibly, not identically).
+    pub const DEGRADED: Loss = Loss(Cow::Borrowed("degraded"));
+    /// No markdown encoding: what an island type with no projection carries.
+    pub const UNREPRESENTABLE: Loss = Loss(Cow::Borrowed("unrepresentable"));
+
+    /// Wrap a wire class. Every string is a class, including one this build
+    /// cannot interpret; [`Loss::fidelity`] is where that is resolved. Equality
+    /// is by class name, so `Loss::new("lossless") == Loss::LOSSLESS`.
+    pub fn new(class: impl Into<String>) -> Loss {
+        Loss(Cow::Owned(class.into()))
+    }
+
+    /// The wire discriminator, and the canonical-form bytes.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The fidelity this class describes, with a class this build cannot
+    /// interpret degraded to the safe end.
     ///
-    /// Carrying the raw tag preserves the byte round-trip. Reading it through
+    /// Carrying the raw class preserves the byte round-trip. Reading it through
     /// here keeps that carriage from being mistaken for a claim about the
     /// projection.
-    pub fn fidelity(&self) -> Loss {
+    pub fn fidelity(&self) -> Fidelity {
+        match self.as_str() {
+            "lossless" => Fidelity::Lossless,
+            "degraded" => Fidelity::Degraded,
+            _ => Fidelity::Unrepresentable,
+        }
+    }
+}
+
+/// How faithfully the markdown projection carries an island: the closed view
+/// over [`Loss`], and what a consumer switches on.
+///
+/// The [`KnownIslandType`](crate::island::KnownIslandType) twin, one axis over,
+/// and exhaustive for the same reason: a consumer that ladders on fidelity has
+/// no safe fallthrough for a rung it does not know, so a new rung is a major
+/// bump rather than a silent gap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fidelity {
+    /// Round-trips identically.
+    Lossless,
+    /// Round-trips visibly, not identically.
+    Degraded,
+    /// No markdown encoding, and where an uninterpretable class lands.
+    Unrepresentable,
+}
+
+impl Fidelity {
+    /// Every level, faithful first. The one enumeration point, so a reader that
+    /// needs the closed set whole (the WASM surface's class union, say) asks
+    /// rather than re-spelling it.
+    pub const ALL: &'static [Fidelity] = &[
+        Fidelity::Lossless,
+        Fidelity::Degraded,
+        Fidelity::Unrepresentable,
+    ];
+
+    /// The class naming this level: `l.class().fidelity() == l` for every level,
+    /// and the three classes this build interprets are exactly `ALL`'s images.
+    pub fn class(self) -> Loss {
         match self {
-            Loss::Lossless => Loss::Lossless,
-            Loss::Degraded => Loss::Degraded,
-            Loss::Unrepresentable | Loss::Unknown(_) => Loss::Unrepresentable,
+            Fidelity::Lossless => Loss::LOSSLESS,
+            Fidelity::Degraded => Loss::DEGRADED,
+            Fidelity::Unrepresentable => Loss::UNREPRESENTABLE,
         }
     }
 }
@@ -1045,7 +1096,7 @@ mod tests {
             id: "isl-0".into(),
             island_type: "image".into(),
             props: serde_json::json!({"alt": "x", "url": "y.png"}),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }];
         assert_eq!(
             code.validate(),
@@ -1083,7 +1134,7 @@ mod tests {
             id: "isl-0".into(),
             island_type: "image".into(),
             props: serde_json::json!({"alt": "x", "url": "y.png"}),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }];
         rt.normalize();
         assert_eq!(rt.lines[0].kind, LineKind::Island);
@@ -1164,7 +1215,7 @@ mod tests {
             id: "i1".into(),
             island_type: "widget".into(),
             props: nested(crate::MAX_JSON_DEPTH + 1),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }];
         assert_eq!(rt.validate(), too_deep("island props"));
     }
@@ -1323,7 +1374,7 @@ mod tests {
                     "header": [{"text": "abcd", "marks": cell_marks}],
                     "rows": [],
                 }),
-                loss: Loss::Lossless,
+                loss: Loss::LOSSLESS,
             }];
             rt
         }
@@ -1393,7 +1444,7 @@ mod tests {
                 "header": [{"text": "ab", "marks": [{"start": 0, "end": 5, "type": "strong"}]}],
                 "rows": [],
             }),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }];
         assert_eq!(
             rt.validate(),
@@ -1419,7 +1470,7 @@ mod tests {
             id: "i".into(),
             island_type: "table".into(),
             props,
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }];
         rt
     }
@@ -1556,7 +1607,7 @@ mod tests {
             id: id.into(),
             island_type: "table".into(),
             props: serde_json::json!({ "header": [cell("h")], "aligns": ["none"], "rows": [] }),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         };
         rt.islands = vec![table("dup"), table("dup")];
         assert_eq!(

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -232,30 +232,37 @@ pub struct Island {
 /// is carried verbatim, so a reader that merely opens a document does not move
 /// its content hash (`DOCUMENT_STORAGE.md` § Byte-stability).
 ///
-/// One value per wire string, so the encoding is injective and the
-/// reserved-name rule the payload-carrying axes need
-/// ([`Invariant::ReservedUnknownTag`] and its two siblings) has nothing to bite
-/// on here: there is no second spelling of `"lossless"` to collide with the
-/// first. Read fidelity through [`Loss::fidelity`], never by comparing against
-/// [`Loss::LOSSLESS`]: an unrecognized class degrades to
+/// One value per wire string, so the encoding is injective: a built-in's name
+/// spells that built-in and nothing else, and the reserved-name rule the
+/// payload-carrying axes need ([`Invariant::ReservedUnknownTag`] and its two
+/// siblings) has nothing to guard here.
+///
+/// Read fidelity through [`Loss::fidelity`], never by comparing against
+/// [`Loss::LOSSLESS`]: an uninterpretable class degrades to
 /// [`Fidelity::Unrepresentable`], so nothing is claimed to carry faithfully on
-/// the strength of a name this build cannot interpret.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// the strength of a name this build cannot read.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Loss(Cow<'static, str>);
 
 impl Loss {
     /// Markdown carries it faithfully (round-trips identically).
-    pub const LOSSLESS: Loss = Loss(Cow::Borrowed("lossless"));
+    pub const LOSSLESS: Loss = Loss(Cow::Borrowed(Fidelity::Lossless.as_str()));
     /// Markdown carries an approximation (round-trips visibly, not identically).
-    pub const DEGRADED: Loss = Loss(Cow::Borrowed("degraded"));
+    pub const DEGRADED: Loss = Loss(Cow::Borrowed(Fidelity::Degraded.as_str()));
     /// No markdown encoding: what an island type with no projection carries.
-    pub const UNREPRESENTABLE: Loss = Loss(Cow::Borrowed("unrepresentable"));
+    pub const UNREPRESENTABLE: Loss = Loss(Cow::Borrowed(Fidelity::Unrepresentable.as_str()));
 
-    /// Wrap a wire class. Every string is a class, including one this build
-    /// cannot interpret; [`Loss::fidelity`] is where that is resolved. Equality
-    /// is by class name, so `Loss::new("lossless") == Loss::LOSSLESS`.
-    pub fn new(class: impl Into<String>) -> Loss {
-        Loss(Cow::Owned(class.into()))
+    /// Wrap a wire class. Every string is a class, uninterpretable ones included;
+    /// [`Loss::fidelity`] is where that is resolved.
+    ///
+    /// An interpretable class borrows its `'static` spelling, so decoding an
+    /// island allocates only for the uninterpretable. Equality is by name either
+    /// way, so `Loss::new("lossless") == Loss::LOSSLESS`.
+    pub fn new(class: &str) -> Loss {
+        match Fidelity::parse(class) {
+            Some(f) => Loss(Cow::Borrowed(f.as_str())),
+            None => Loss(Cow::Owned(class.to_string())),
+        }
     }
 
     /// The wire discriminator, and the canonical-form bytes.
@@ -263,18 +270,14 @@ impl Loss {
         &self.0
     }
 
-    /// The fidelity this class describes, with a class this build cannot
-    /// interpret degraded to the safe end.
+    /// The fidelity this class describes, with an uninterpretable class degraded
+    /// to the safe end.
     ///
     /// Carrying the raw class preserves the byte round-trip. Reading it through
     /// here keeps that carriage from being mistaken for a claim about the
     /// projection.
     pub fn fidelity(&self) -> Fidelity {
-        match self.as_str() {
-            "lossless" => Fidelity::Lossless,
-            "degraded" => Fidelity::Degraded,
-            _ => Fidelity::Unrepresentable,
-        }
+        Fidelity::parse(self.as_str()).unwrap_or(Fidelity::Unrepresentable)
     }
 }
 
@@ -282,9 +285,9 @@ impl Loss {
 /// over [`Loss`], and what a consumer switches on.
 ///
 /// The [`KnownIslandType`](crate::island::KnownIslandType) twin, one axis over,
-/// and exhaustive for the same reason: a consumer that ladders on fidelity has
-/// no safe fallthrough for a rung it does not know, so a new rung is a major
-/// bump rather than a silent gap.
+/// and exhaustive for the same reason: a consumer laddering on fidelity has no
+/// safe fallthrough for a rung it does not know, so a new rung is a major bump
+/// rather than a silent gap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Fidelity {
     /// Round-trips identically.
@@ -305,14 +308,21 @@ impl Fidelity {
         Fidelity::Unrepresentable,
     ];
 
-    /// The class naming this level: `l.class().fidelity() == l` for every level,
-    /// and the three classes this build interprets are exactly `ALL`'s images.
-    pub fn class(self) -> Loss {
+    /// The wire class naming this level: the one place a class is spelled, which
+    /// [`Loss`]'s consts and [`Fidelity::parse`] both read.
+    pub const fn as_str(self) -> &'static str {
         match self {
-            Fidelity::Lossless => Loss::LOSSLESS,
-            Fidelity::Degraded => Loss::DEGRADED,
-            Fidelity::Unrepresentable => Loss::UNREPRESENTABLE,
+            Self::Lossless => "lossless",
+            Self::Degraded => "degraded",
+            Self::Unrepresentable => "unrepresentable",
         }
+    }
+
+    /// Parse a wire class into the closed view. `None` is the open-set escape
+    /// hatch (an uninterpretable class), which [`Loss::fidelity`] reads as
+    /// [`Unrepresentable`](Fidelity::Unrepresentable).
+    pub fn parse(class: &str) -> Option<Fidelity> {
+        Self::ALL.iter().copied().find(|f| f.as_str() == class)
     }
 }
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -1377,7 +1377,7 @@ mod tests {
             id: id.into(),
             island_type: "image".into(),
             props: serde_json::json!({}),
-            loss: crate::model::Loss::Lossless,
+            loss: crate::model::Loss::LOSSLESS,
         }
     }
 

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -882,7 +882,7 @@ fn island_to_value(island: &Island) -> Value {
     m.insert("id".into(), Value::String(island.id.clone()));
     m.insert("type".into(), Value::String(island.island_type.clone()));
     m.insert("props".into(), island.props.clone());
-    m.insert("loss".into(), loss_to_str(&island.loss).into());
+    m.insert("loss".into(), island.loss.as_str().into());
     Value::Object(m)
 }
 
@@ -900,37 +900,21 @@ fn island_from_value(v: &Value) -> Result<Island, ParseError> {
             .ok_or(ParseError::Shape("island type"))?
             .to_string(),
         props: bag_from_wire(o, "props", "island props")?,
-        loss: loss_from_str(o.get("loss").and_then(Value::as_str).unwrap_or("lossless")),
+        // The class is carried whether or not this build interprets it, and
+        // reads through `Loss::fidelity` at the *safe* end: never claim a class
+        // the reader cannot interpret "carries faithfully". A missing key is the
+        // faithful class, which is what an island with no loss recorded means.
+        loss: o
+            .get("loss")
+            .and_then(Value::as_str)
+            .map_or(Loss::LOSSLESS, Loss::new),
     })
-}
-
-fn loss_to_str(loss: &Loss) -> &str {
-    match loss {
-        Loss::Lossless => "lossless",
-        Loss::Degraded => "degraded",
-        Loss::Unrepresentable => "unrepresentable",
-        // Verbatim, so a class this build lacks survives a reader that merely
-        // opened the document.
-        Loss::Unknown(raw) => raw,
-    }
-}
-
-fn loss_from_str(s: &str) -> Loss {
-    match s {
-        "lossless" => Loss::Lossless,
-        "degraded" => Loss::Degraded,
-        "unrepresentable" => Loss::Unrepresentable,
-        // Unknown/future loss class is carried, and reads through
-        // `Loss::fidelity` at the *safe* end: never claim a value the reader
-        // can't interpret "carries faithfully".
-        other => Loss::Unknown(other.to_string()),
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{Line, LineKind};
+    use crate::model::{Fidelity, Line, LineKind};
 
     fn sample() -> Content {
         Content {
@@ -1136,7 +1120,7 @@ mod tests {
             id: "i1".into(),
             island_type: "table".into(),
             props: serde_json::json!({"b": 1, "a": 2}),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }];
         let mut two = one.clone();
         two.islands[0].props = serde_json::json!({"a": 2, "b": 1}); // keys reversed
@@ -1186,8 +1170,8 @@ mod tests {
         ));
     }
 
-    /// `loss` is the fifth open vocabulary, on the terms the four
-    /// below use. A class this build lacks is **carried**, not rewritten, so a
+    /// `loss` is an open vocabulary on [`Island::island_type`]'s terms, not the
+    /// block axes'. A class this build lacks is **carried**, not rewritten, so a
     /// reader that merely opens the document neither destroys the class nor
     /// moves the content hash. Reading it degrades to the safe end.
     #[test]
@@ -1197,9 +1181,45 @@ mod tests {
             r#""lines":[{"containers":[],"kind":"island"}],"marks":[],"text":"￼"}"#
         );
         let rt = Content::from_canonical_json(json).unwrap();
-        assert_eq!(rt.islands[0].loss, Loss::Unknown("partial".into()));
-        assert_eq!(rt.islands[0].loss.fidelity(), Loss::Unrepresentable);
+        assert_eq!(rt.islands[0].loss, Loss::new("partial"));
+        assert_eq!(rt.islands[0].loss.fidelity(), Fidelity::Unrepresentable);
         assert_eq!(rt.to_canonical_json(), json);
+    }
+
+    /// The class is the stored value, so there is one `Loss` per wire string and
+    /// no second spelling of a class this build interprets. What the block axes
+    /// need `Invariant::ReservedUnknownTag` and its siblings for is unreachable
+    /// here: the value a caller hand-builds from a built-in's name **is** that
+    /// built-in, and survives the round trip as itself.
+    #[test]
+    fn a_built_in_class_name_has_one_spelling() {
+        assert_eq!(Loss::new("lossless"), Loss::LOSSLESS);
+        let mut rt = Content::empty();
+        rt.text = "\u{FFFC}".into();
+        rt.lines = vec![Line {
+            kind: LineKind::Island,
+            containers: vec![],
+            continues: false,
+        }];
+        rt.islands = vec![Island {
+            id: "i1".into(),
+            island_type: "widget".into(),
+            props: serde_json::json!({}),
+            loss: Loss::new("lossless"),
+        }];
+        assert_eq!(rt.validate(), Ok(()));
+        let back = Content::from_canonical_json(&rt.to_canonical_json()).unwrap();
+        assert_eq!(back.islands[0].loss, rt.islands[0].loss);
+        assert_eq!(back.islands[0].loss.fidelity(), Fidelity::Lossless);
+    }
+
+    /// Every class `Fidelity` names round-trips to its own level, so the closed
+    /// view and the wire spellings cannot drift apart.
+    #[test]
+    fn every_fidelity_level_round_trips_through_its_class() {
+        for &f in Fidelity::ALL {
+            assert_eq!(f.class().fidelity(), f);
+        }
     }
 
     /// The block vocabulary is open on the mark axis' terms. A

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -1186,11 +1186,10 @@ mod tests {
         assert_eq!(rt.to_canonical_json(), json);
     }
 
-    /// The class is the stored value, so there is one `Loss` per wire string and
-    /// no second spelling of a class this build interprets. What the block axes
-    /// need `Invariant::ReservedUnknownTag` and its siblings for is unreachable
-    /// here: the value a caller hand-builds from a built-in's name **is** that
-    /// built-in, and survives the round trip as itself.
+    /// The class is the stored value, so a built-in's name has one spelling and
+    /// the reserved-name rule the block axes need has nothing to guard: what a
+    /// caller hand-builds from that name **is** the built-in, and survives the
+    /// round trip as itself.
     #[test]
     fn a_built_in_class_name_has_one_spelling() {
         assert_eq!(Loss::new("lossless"), Loss::LOSSLESS);
@@ -1218,7 +1217,7 @@ mod tests {
     #[test]
     fn every_fidelity_level_round_trips_through_its_class() {
         for &f in Fidelity::ALL {
-            assert_eq!(f.class().fidelity(), f);
+            assert_eq!(Loss::new(f.as_str()).fidelity(), f);
         }
     }
 

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -5,8 +5,16 @@
 //! insensitive to the order marks/islands were discovered in. Three order
 //! sources are closed here and in `normalize`: mark order (canonical sort),
 //! island order (slot position), and object-key order inside island `props` /
-//! unknown-mark `attrs` (recursively sorted). `deserialize ∘ serialize` is a
-//! fixed point on canonical bytes.
+//! unknown-mark `attrs` (recursively sorted).
+//!
+//! Two fixed points, and they are not the same promise. **Bytes**:
+//! `to_canonical_json(from_canonical_json(b)) == b` for canonical `b`, which is
+//! what a consumer hashing stored documents spends (`DOCUMENT_STORAGE.md` §
+//! Byte-stability). **Values**: `from_canonical_json(to_canonical_json(rt)) == rt`
+//! for a normalized `rt`, which is what an in-process producer spends, and which
+//! holds only while every discriminator's encoding is injective. An axis can keep
+//! the first and lose the second: a value that encodes to some *other* value's
+//! bytes moves nothing on disk and still fails to survive its own round trip.
 //!
 //! The seam encoding (Option A) and the storage encoding are the *same*
 //! canonical form: one serializer, not two to keep aligned.

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -337,7 +337,7 @@ proptest! {
                 id: "isl-0".into(),
                 island_type: "image".into(),
                 props: json!({ "alt": alt, "url": img_url }),
-                loss: Loss::Lossless,
+                loss: Loss::LOSSLESS,
             }],
         };
         rt.normalize();
@@ -632,7 +632,7 @@ fn table_content(aligns: Vec<&str>, header: Vec<Value>, rows: Vec<Vec<Value>>) -
             id: "isl-0".into(),
             island_type: "table".into(),
             props: json!({ "aligns": aligns, "header": header, "rows": rows }),
-            loss: Loss::Lossless,
+            loss: Loss::LOSSLESS,
         }],
     }
 }

--- a/docs/migrations/0.98-to-0.99.md
+++ b/docs/migrations/0.98-to-0.99.md
@@ -124,39 +124,60 @@ Each narrows to the open arm, so `attrs` (`props` on an island) is reachable in
 the true branch. The known names stay upstream's business, which is the point of
 an open set.
 
-## `loss` becomes the fifth open set
+## `loss` becomes an open set, and `Loss` stops being an enum
 
-0.98 opened four vocabularies — mark `type`, island `type`, line `kind`,
-container — and left an island's `loss` class closed. Its decoder mapped anything
-unrecognized to `unrepresentable`:
+0.98 opened four vocabularies (mark `type`, island `type`, line `kind`,
+container) and left an island's `loss` class closed. Its decoder mapped anything
+unrecognized to `unrepresentable`, so a reader that merely *opened* a document a
+later build wrote, then saved it, moved that document's content hash. 0.99
+carries the class verbatim instead.
+
+`loss` opens on the **island `type`** axis' terms, not the block axes': it
+carries no payload, so the wire string is the stored value and the closed set is
+a view over it. `Loss` is therefore an opaque string wrapper, not an enum with an
+`Unknown` arm:
 
 ```rust
 // 0.98
-_ => Loss::Unrepresentable,      // the tag is gone
+pub enum Loss { Lossless, Degraded, Unrepresentable }
 
 // 0.99
-other => Loss::Unknown(other.to_string()),
+pub struct Loss(/* private */);
+impl Loss {
+    pub const LOSSLESS: Loss;
+    pub const DEGRADED: Loss;
+    pub const UNREPRESENTABLE: Loss;
+    pub fn new(class: impl Into<String>) -> Loss;
+    pub fn as_str(&self) -> &str;
+    pub fn fidelity(&self) -> Fidelity;
+}
 ```
 
-Rewriting the tag on the way in meant a reader that merely *opened* a document a
-later build wrote, then saved it, moved that document's content hash. Carrying
-the tag verbatim is what makes opening a document byte-neutral, which is the rule
-the other four axes already followed.
+Three consequences for a Rust consumer:
 
-Two consequences for a Rust consumer:
+- **The variants become associated consts.** `Loss::Lossless` → `Loss::LOSSLESS`,
+  and likewise `DEGRADED` / `UNREPRESENTABLE`.
+- **`Loss` no longer derives `Copy`**, and no longer matches. A
+  `let l = island.loss;` off a borrow moves or needs `.clone()`; a
+  `match island.loss { … }` becomes a match on `island.loss.fidelity()`.
+- **`Fidelity` is the new closed view**, with the three levels 0.98's enum had.
+  It is exhaustive, so a match on it needs no `_` arm and a future level is a
+  major bump rather than a silent gap.
 
-- **`Loss` no longer derives `Copy`** — the `Unknown(String)` payload cannot. A
-  `let l = island.loss;` off a borrow now moves or needs `.clone()`.
-- **`Loss` is `#[non_exhaustive]`**, so an exhaustive match needs a `_` arm.
+Read fidelity through `Loss::fidelity`, never by comparing against
+`Loss::LOSSLESS`: a class this build cannot interpret degrades to
+`Fidelity::Unrepresentable`, so nothing is ever claimed to carry faithfully on
+the strength of a name this build cannot read.
 
-Read fidelity through `Loss::fidelity`, never by matching the arm: an
-unrecognized class degrades to `Unrepresentable`, so nothing is ever claimed to
-carry faithfully on the strength of a name this build cannot interpret. Matching
-`Loss::Lossless` directly is what breaks when a class arrives that this build
-does not know.
+An unrecognized class is reachable only from a document a *future* build wrote:
+`0.98` flattened one on the way in, so nothing it wrote can carry one.
 
-The new arm is reachable only from a document a *future* build wrote: `0.98`
-flattened an unknown class on the way in, so nothing it wrote can carry one.
+There is no reserved-name rule on this axis and none is needed. The block axes
+guard one (`Invariant::ReservedUnknownTag` and its two siblings) because their
+`Unknown { tag, attrs }` arm gives a built-in's name a second spelling that
+serializes to the built-in and parses back as it, dropping the attrs. `Loss` has
+one value per wire string, so `Loss::new("lossless") == Loss::LOSSLESS` and the
+collision is unspellable.
 
 ## Render-only and read-modify-write read the guide differently
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -211,8 +211,8 @@ Three rules bound the openness:
   (`Invariant::ReservedUnknownTag` / `ReservedUnknownLineKind` /
   `ReservedUnknownContainer`) for an in-process Rust construction. The rule is
   the three carrier axes' alone, and the `Unknown` arm is what makes it
-  necessary: a view axis has one value per wire string, so a built-in's name
-  simply *is* that built-in, with no second spelling to collide with it. The wire
+  necessary: a view axis has one value per wire string, so a built-in's name *is*
+  that built-in, with no second spelling to collide with it. The wire
   reaches that check on neither block axis nor the mark axis: a decoder resolves
   the built-in name *before* the `Unknown` fallthrough, so `{"kind": "para",
   "attrs": {…}}` decodes to `Para` and the attrs are dropped unread. The two

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -139,26 +139,33 @@ The envelope's version-and-reject discipline covers the document's **shape**:
 the schema tag, the DTO tree, the keys a `body` object carries. It does *not*
 cover the content's **vocabularies**. Every discriminator inside a `body` is an
 open set: a mark `type`, an island `type`, a line `kind`, a container name, and
-an island's `loss` class this build does not recognize each decode to an opaque
-`Unknown` carrying the tag plus its `attrs` (`props` for an island), round-trip
-byte-identically, and project as their nearest safe neighbor.
+an island's `loss` class this build does not recognize each round-trip
+byte-identically and project as their nearest safe neighbor.
 
-| Axis | Unknown value projects as |
-|---|---|
-| Mark `type` | no delimiters (the text renders bare) |
-| Island `type` | a placeholder comment; the props survive in storage |
-| Line `kind` | a paragraph |
-| Container | transparent: its lines render at the enclosing level |
-| Island `loss` | `Unrepresentable`, via `Loss::fidelity`: never a claim of fidelity on a name this build cannot read |
+**Two mechanisms, split by payload.** A block axis carries one, so its built-ins
+decode eagerly into typed fields (`LineKind::Heading { level }`) and an
+unrecognized member needs a sibling `Unknown` arm to hold its `attrs`. The two
+island axes carry none, so the wire string *is* the stored value and the closed
+set is a **view** over it (`KnownIslandType::parse`, `Loss::fidelity`). The
+split decides which axes need the reserved-name rule below: a carrier axis has
+two spellings of a built-in's name and must reject one, a view axis has one.
+
+| Axis | Carrier | Unknown value projects as |
+|---|---|---|
+| Mark `type` | `Unknown { tag, attrs }` | no delimiters (the text renders bare) |
+| Line `kind` | `Unknown { tag, attrs }` | a paragraph |
+| Container | `Unknown { tag, attrs }` | transparent: its lines render at the enclosing level |
+| Island `type` | the `String` itself | a placeholder comment; the props survive in storage |
+| Island `loss` | the `String` itself | `Fidelity::Unrepresentable`, via `Loss::fidelity`: never a claim of fidelity on a class this build cannot read |
 
 The consequence, and the point: **adding a construct to any of these
 vocabularies is not a schema-version event.** An older reader degrades a future
 callout to a plain paragraph rather than refusing the document, and a reader
 that does understand it sees it whole, because the tag and attrs round-tripped
-untouched. The rule is the same on all five axes: the block axes are open on the
-mark axis' terms, not one step behind it, and `loss` carries its raw tag rather
-than rewriting it: a reader that merely opens a document must not move its
-content hash (§ Byte-stability).
+untouched. Openness is the same on all five axes: the block axes are open on the
+mark axis' terms, not one step behind it, and both island axes carry their raw
+string rather than rewriting it: a reader that merely opens a document must not
+move its content hash (§ Byte-stability).
 
 Unknown *keys* survive in designated carriers only, and the boundary is worth
 stating because it is not the discriminator boundary:
@@ -202,7 +209,10 @@ Three rules bound the openness:
   (`heading`, `quote`, `link`, …): it would serialize as the built-in and parse
   back as one, silently dropping its attrs. `Content::validate` rejects this
   (`Invariant::ReservedUnknownTag` / `ReservedUnknownLineKind` /
-  `ReservedUnknownContainer`) for an in-process Rust construction. The wire
+  `ReservedUnknownContainer`) for an in-process Rust construction. The rule is
+  the three carrier axes' alone, and the `Unknown` arm is what makes it
+  necessary: a view axis has one value per wire string, so a built-in's name
+  simply *is* that built-in, with no second spelling to collide with it. The wire
   reaches that check on neither block axis nor the mark axis: a decoder resolves
   the built-in name *before* the `Unknown` fallthrough, so `{"kind": "para",
   "attrs": {…}}` decodes to `Para` and the attrs are dropped unread. The two


### PR DESCRIPTION
Fixes #1142.

## The bug, and why the suggested fix is not the one here

`Loss::Unknown("lossless")` passed `validate`, serialized to `"lossless"`, and read back as `Loss::Lossless`. The value was not recoverable from its own encoding.

The issue proposes an `Invariant::ReservedUnknownLoss` beside the other three. This PR does not add one, because the missing rule is a symptom rather than the defect.

The crate already carries a two-mechanism design, split by whether an axis has a payload:

| | Carrier | Reserved-name rule |
|---|---|---|
| Mark `type`, line `kind`, container | `Unknown { tag, attrs }` | needed, and present |
| Island `type` | the `String` itself | not expressible |
| Island `loss` | the `String` itself (now) | not expressible |

A block axis decodes its built-ins eagerly into typed fields (`LineKind::Heading { level }`), so an unrecognized member needs a sibling `Unknown` arm to hold its `attrs`. That arm is what gives a built-in's name a second spelling, and the reserved-name rule exists to reject it. An axis with no payload does not need the arm: the wire string is the stored value and the closed set is a *view* over it (`KnownIslandType::parse`).

`loss` carries no payload, so it belongs on the second side. #1091 correctly made it open but imported the enum-with-`Unknown` shape from the first side, which is how the collision became expressible and the guard got forgotten.

## The change

`Loss` becomes an opaque string wrapper with `LOSSLESS` / `DEGRADED` / `UNREPRESENTABLE` consts; `Fidelity` is the closed view `fidelity()` returns, taking the `KnownIslandType` shape it is the twin of (`ALL` / `as_str` / `parse`). One value per wire string, so `Loss::new("lossless") == Loss::LOSSLESS` and the collision is unspellable.

Canonical bytes are unchanged, and so is the missing-key default (`"lossless"`). An interpretable class borrows its `'static` spelling, so decoding an island allocates only for a class this build cannot interpret, matching what the enum did.

This is not a breaking change: `Cargo.toml` is at 0.98.0, so 0.99 is unreleased and `Loss::Unknown(String)` has never shipped. The unreleased migration guide is updated in place.

## Also

- **Pins the TypeScript loss union.** Hoisted out of `ContentIsland` into `ContentLossClass` so `known_names_drift` can reach it: the other three axes were pinned, and this one was hand-spelled and checked by nothing. Verified non-vacuous by deleting an arm and watching it fail.
- **Canon**: `DOCUMENT_STORAGE.md` § Open vocabularies stated "the rule is the same on all five axes," which this issue disproves. It now states the payload split and which axes the reserved-name rule governs.

## Testing

- `cargo test --workspace`: 49 suites green.
- `node scripts/check-canon.mjs`: passes.
- Clippy: per-crate warning counts identical to `main`, minus 3 pre-existing `redundant_slicing` warnings in `known_names_drift` that the edit let me drop.
- npm and pytest binding suites deferred to CI per `CLAUDE.md`.

## One judgment call

No non-empty check on `Loss`. `Loss::new("")` round-trips injectively and reads as `Unrepresentable`, so it is not a codec defect, and adding an invariant here when `island_type` (the axis this now models) has none would introduce a fresh asymmetry of exactly the kind this issue is about.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KRA7hu6oZf2fMi92Sg6fb)_