### PR TITLE
Carry a diagnostic's substitution facts in `Diagnostic.args`

### DIFF
--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -13,7 +13,9 @@ create_exception!(_quillmark, QuillmarkError, PyException);
 
 pub fn convert_edit_error(err: EditError) -> PyErr {
     let diagnostic =
-        Diagnostic::new(Severity::Error, err.to_string()).with_code(err.code().to_string());
+        Diagnostic::new(Severity::Error, err.to_string())
+            .with_code(err.code().to_string())
+            .with_args(err.args());
     let message = diagnostic.message.clone();
     raise_with_diagnostics(vec![diagnostic], message)
 }
@@ -28,6 +30,7 @@ pub fn convert_edit_errors(errors: Vec<(String, EditError)>) -> PyErr {
         .map(|(name, err)| {
             Diagnostic::new(Severity::Error, err.to_string())
                 .with_code(err.code().to_string())
+                .with_args(err.args())
                 .with_path(name)
         })
         .collect();

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1216,6 +1216,22 @@ impl PyDiagnostic {
     fn source_chain(&self) -> Vec<String> {
         self.inner.source_chain.clone()
     }
+
+    /// The facts `message` interpolates, keyed by name. With `code`, the
+    /// substitution unit needed to word this diagnostic in another language.
+    /// Empty for any code outside the structured surface, which is the signal
+    /// to render `message` verbatim. `prose/canon/ERROR.md` tabulates the keys
+    /// per code.
+    #[getter]
+    fn args<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let map = serde_json::Map::from_iter(
+            self.inner
+                .args
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone())),
+        );
+        json_to_py(py, &serde_json::Value::Object(map))
+    }
 }
 
 #[pyclass(name = "Location", from_py_object)]

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1218,10 +1218,8 @@ impl PyDiagnostic {
     }
 
     /// The facts `message` interpolates, keyed by name. With `code`, the
-    /// substitution unit needed to word this diagnostic in another language.
-    /// Empty for any code outside the structured surface, which is the signal
-    /// to render `message` verbatim. `prose/canon/ERROR.md` tabulates the keys
-    /// per code.
+    /// substitution unit needed to word this diagnostic in another language;
+    /// `prose/canon/ERROR.md` § "Diagnostic args" tabulates the keys per code.
     #[getter]
     fn args<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let map = serde_json::Map::from_iter(

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2136,7 +2136,8 @@ pub fn map_pos(
 fn edit_error_to_js(err: &quillmark_core::EditError, base: &quillmark_core::DocPath) -> JsValue {
     let mut diagnostic =
         quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, err.to_string())
-            .with_code(err.code().to_string());
+            .with_code(err.code().to_string())
+            .with_args(err.args());
     if let Some(path) = err.doc_path(base) {
         diagnostic = diagnostic.with_path(path.to_string());
     }
@@ -2159,6 +2160,7 @@ fn edit_errors_to_js(
         .map(|(name, err)| {
             quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, err.to_string())
                 .with_code(err.code().to_string())
+                .with_args(err.args())
                 .with_path(base.field(&name).to_string())
         })
         .collect();

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -121,6 +121,19 @@ pub struct Diagnostic {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
+    /// The facts `message` interpolates, keyed by name. With `code`, the
+    /// substitution unit a consumer needs to word this diagnostic itself.
+    /// Absent for any code outside the structured surface, which is the signal
+    /// to render `message` verbatim. See the Rust `Diagnostic::args` docs and
+    /// `prose/canon/ERROR.md` for the per-code keys.
+    ///
+    /// Declared optional explicitly: `tsify` does not read
+    /// `skip_serializing_if`, so a field omitted at runtime is declared
+    /// required unless said so here (`sourceChain` predates this and still
+    /// carries that mismatch).
+    #[tsify(optional, type = "Record<string, unknown>")]
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty", default)]
+    pub args: std::collections::BTreeMap<String, serde_json::Value>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub source_chain: Vec<String>,
 }
@@ -134,6 +147,7 @@ impl From<quillmark_core::Diagnostic> for Diagnostic {
             location: diag.location.map(Into::into),
             path: diag.path,
             hint: diag.hint,
+            args: diag.args,
             source_chain: diag.source_chain,
         }
     }
@@ -146,6 +160,7 @@ impl From<Diagnostic> for quillmark_core::Diagnostic {
         out.location = diag.location.map(Into::into);
         out.path = diag.path;
         out.hint = diag.hint;
+        out.args = diag.args;
         out.source_chain = diag.source_chain;
         out
     }

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -122,15 +122,12 @@ pub struct Diagnostic {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
     /// The facts `message` interpolates, keyed by name. With `code`, the
-    /// substitution unit a consumer needs to word this diagnostic itself.
-    /// Absent for any code outside the structured surface, which is the signal
-    /// to render `message` verbatim. See the Rust `Diagnostic::args` docs and
-    /// `prose/canon/ERROR.md` for the per-code keys.
+    /// substitution unit needed to word this diagnostic in another language;
+    /// `prose/canon/ERROR.md` § "Diagnostic args" tabulates the keys per code.
     ///
-    /// Declared optional explicitly: `tsify` does not read
-    /// `skip_serializing_if`, so a field omitted at runtime is declared
-    /// required unless said so here (`sourceChain` predates this and still
-    /// carries that mismatch).
+    /// Declared optional explicitly because `tsify` does not read
+    /// `skip_serializing_if`: without this, a field the runtime omits is
+    /// declared required. `sourceChain` carries that mismatch.
     #[tsify(optional, type = "Record<string, unknown>")]
     #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty", default)]
     pub args: std::collections::BTreeMap<String, serde_json::Value>,

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -114,7 +114,14 @@ pub enum EditError {
     /// [`FieldRichtextNotInline`](Self::FieldRichtextNotInline) variants
     /// instead, so the richtext write surface is unchanged.
     #[error("field '{field}' does not conform to its schema type: {message}")]
-    FieldConform { field: String, message: String },
+    FieldConform {
+        field: String,
+        /// The schema type the write was conformed against, carried across
+        /// from [`CoercionError`](crate::quill::CoercionError) so the failure
+        /// states what the value had to become. `message` alone is English.
+        target: String,
+        message: String,
+    },
 
     /// A content field-change bundle (text delta, line ops, mark ops) applied
     /// out of bounds or broke an invariant normalization could not repair.
@@ -160,6 +167,54 @@ impl EditError {
             EditError::FieldRichtextNotInline(_) => "edit::field_richtext_not_inline",
             EditError::FieldConform { .. } => "edit::field_conform",
             EditError::ContentApply(_) => "edit::content_apply",
+        }
+    }
+
+    /// The facts this error's message interpolates. See
+    /// [`Diagnostic::args`](crate::error::Diagnostic::args).
+    ///
+    /// Arms bind every field rather than eliding with `..`, so a new field on
+    /// a variant does not compile until this decides about it.
+    ///
+    /// `field` and `kind` ride here even though [`doc_path`](Self::doc_path)
+    /// also folds them into the diagnostic's anchor, which is not the
+    /// duplication the no-anchor-in-args rule forbids: that rule bars the
+    /// assembled `path` string, and recovering a name from one is not sound in
+    /// general. [`DocPath`] renders field segments unescaped and parses on `.`
+    /// and `[`, so precisely the malformed names `InvalidFieldName` reports can
+    /// round-trip into different segments.
+    ///
+    /// The message-only variants carry prose: `Import` and `ContentApply` wrap
+    /// another codec's error, and the two `message` fields hold the coercion
+    /// `reason` (see [`CoercionError::args`](crate::quill::CoercionError::args)).
+    /// `ReservedKind` is a fixed sentence a consumer writes from the code
+    /// alone.
+    pub fn args(&self) -> std::collections::BTreeMap<String, serde_json::Value> {
+        use crate::error::diag_args;
+        match self {
+            EditError::InvalidFieldName(field) => diag_args! { "field" => field },
+            EditError::UnknownField(field) => diag_args! { "field" => field },
+            EditError::InvalidKindName(kind) => diag_args! { "kind" => kind },
+            EditError::ReservedKind => diag_args! {},
+            EditError::IndexOutOfRange { index, len } => diag_args! {
+                "index" => index,
+                "len" => len,
+            },
+            EditError::ValueTooDeep { max } => diag_args! { "max" => max },
+            EditError::Import(_) => diag_args! {},
+            EditError::FieldRichtextDecode { field, message: _ } => diag_args! {
+                "field" => field,
+            },
+            EditError::FieldRichtextNotInline(field) => diag_args! { "field" => field },
+            EditError::FieldConform {
+                field,
+                target,
+                message: _,
+            } => diag_args! {
+                "field" => field,
+                "target" => target,
+            },
+            EditError::ContentApply(_) => diag_args! {},
         }
     }
 
@@ -259,17 +314,25 @@ pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldV
 /// (see `QuillConfig::conform_value`); every other target uses the general
 /// [`EditError::FieldConform`].
 fn conform_error_to_edit(name: &str, err: CoercionError) -> EditError {
-    let CoercionError::Uncoercible { target, reason, .. } = err;
-    match target.as_str() {
-        "richtext(inline)" => EditError::FieldRichtextNotInline(name.to_string()),
-        "richtext" => EditError::FieldRichtextDecode {
+    let CoercionError::Uncoercible {
+        path: _,
+        value: _,
+        target,
+        reason,
+    } = err;
+    if target == "richtext(inline)" {
+        EditError::FieldRichtextNotInline(name.to_string())
+    } else if target == "richtext" {
+        EditError::FieldRichtextDecode {
             field: name.to_string(),
             message: reason,
-        },
-        _ => EditError::FieldConform {
+        }
+    } else {
+        EditError::FieldConform {
             field: name.to_string(),
+            target,
             message: reason,
-        },
+        }
     }
 }
 
@@ -893,6 +956,7 @@ mod tests {
         assert_eq!(
             EditError::FieldConform {
                 field: "font_size".into(),
+                target: "integer".into(),
                 message: "x".into(),
             }
             .doc_path(&main)

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -15,6 +15,8 @@
 //! enforce the §8 value-depth bound: `$ext` flows through the recursive
 //! emit and DTO paths like any other value.
 
+use std::collections::BTreeMap;
+
 use unicode_normalization::UnicodeNormalization;
 
 use quillmark_content::delta::diff_import;
@@ -22,6 +24,7 @@ use quillmark_content::import::ImportError;
 use quillmark_content::{ApplyError, Delta, LineOp, MarkOp, Content};
 
 use crate::document::meta::{validate_composable_kind, CardKindError};
+use crate::error::diag_args;
 use crate::document::payload::MetaKey;
 use crate::document::{Card, Document, Payload};
 use crate::quill::{CoercionError, FieldSchema, Leniency, QuillConfig};
@@ -117,7 +120,7 @@ pub enum EditError {
     FieldConform {
         field: String,
         /// The schema type the write was conformed against, carried across
-        /// from [`CoercionError`](crate::quill::CoercionError) so the failure
+        /// from [`CoercionError`] so the failure
         /// states what the value had to become. `message` alone is English.
         target: String,
         message: String,
@@ -171,26 +174,17 @@ impl EditError {
     }
 
     /// The facts this error's message interpolates. See
-    /// [`Diagnostic::args`](crate::error::Diagnostic::args).
+    /// [`Diagnostic::args`](crate::error::Diagnostic::args); `ERROR.md`
+    /// § "Diagnostic args" says per code whether an empty map means a fixed
+    /// sentence or a fallback to `message`.
     ///
-    /// Arms bind every field rather than eliding with `..`, so a new field on
-    /// a variant does not compile until this decides about it.
-    ///
-    /// `field` and `kind` ride here even though [`doc_path`](Self::doc_path)
-    /// also folds them into the diagnostic's anchor, which is not the
-    /// duplication the no-anchor-in-args rule forbids: that rule bars the
-    /// assembled `path` string, and recovering a name from one is not sound in
-    /// general. [`DocPath`] renders field segments unescaped and parses on `.`
-    /// and `[`, so precisely the malformed names `InvalidFieldName` reports can
-    /// round-trip into different segments.
-    ///
-    /// The message-only variants carry prose: `Import` and `ContentApply` wrap
-    /// another codec's error, and the two `message` fields hold the coercion
-    /// `reason` (see [`CoercionError::args`](crate::quill::CoercionError::args)).
-    /// `ReservedKind` is a fixed sentence a consumer writes from the code
-    /// alone.
-    pub fn args(&self) -> std::collections::BTreeMap<String, serde_json::Value> {
-        use crate::error::diag_args;
+    /// `field` and `kind` ride here despite [`doc_path`](Self::doc_path) also
+    /// folding them into the anchor. The rule against duplicating an anchor
+    /// bars the assembled `path` string, and recovering a name from one is
+    /// unsound anyway: [`DocPath`](crate::path::DocPath) renders field
+    /// segments unescaped and parses on `.` and `[`, so exactly the malformed
+    /// names `InvalidFieldName` reports can round-trip into other segments.
+    pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
         match self {
             EditError::InvalidFieldName(field) => diag_args! { "field" => field },
             EditError::UnknownField(field) => diag_args! { "field" => field },

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -16,7 +16,23 @@
 //! and parses the path, no site assembles one with `format!`. Its module doc
 //! carries the grammar; `prose/canon/ERROR.md` tabulates the anchors.
 
+use std::collections::BTreeMap;
+
 use crate::OutputFormat;
+
+/// Build a [`Diagnostic::args`] map. Values pass through `serde_json`, so a
+/// list arrives as a list and a count as a number: the shapes a consumer
+/// needs to join and pluralize in its own locale.
+macro_rules! diag_args {
+    ($($key:literal => $value:expr),* $(,)?) => {{
+        #[allow(unused_mut)]
+        let mut map = ::std::collections::BTreeMap::<String, ::serde_json::Value>::new();
+        $(map.insert($key.to_string(), ::serde_json::json!($value));)*
+        map
+    }};
+}
+
+pub(crate) use diag_args;
 
 /// Maximum input size for markdown (10 MiB)
 pub const MAX_INPUT_SIZE: usize = 10 * 1024 * 1024;
@@ -204,7 +220,23 @@ pub struct Diagnostic {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
-    /// Flattened cause chain (outermost first).
+    /// The facts [`Self::message`] interpolates, keyed by name. With
+    /// [`Self::code`], the substitution unit a consumer needs to word this
+    /// diagnostic in its own language.
+    ///
+    /// One code carries one key set, tabulated per code in
+    /// `prose/canon/ERROR.md`. Values keep their JSON shape: a list stays a
+    /// list and a count stays a number, so joining and pluralizing remain the
+    /// consumer's locale decisions rather than the engine's.
+    ///
+    /// Empty for any code outside the structured surface, which is the signal
+    /// to render `message` verbatim. Engine prose never rides under a key; a
+    /// consumer's own sentence may be coarser than ours, never
+    /// half-translated.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub args: BTreeMap<String, serde_json::Value>,
+    /// Flattened cause chain (outermost first). Upstream English, and
+    /// untranslatable for the same reason the prose it wraps is.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub source_chain: Vec<String>,
 }
@@ -218,6 +250,7 @@ impl Diagnostic {
             location: None,
             path: None,
             hint: None,
+            args: BTreeMap::new(),
             source_chain: Vec::new(),
         }
     }
@@ -242,6 +275,12 @@ impl Diagnostic {
 
     pub fn with_hint(mut self, hint: String) -> Self {
         self.hint = Some(hint);
+        self
+    }
+
+    /// Attach the message's substitution facts. See [`Self::args`].
+    pub fn with_args(mut self, args: BTreeMap<String, serde_json::Value>) -> Self {
+        self.args = args;
         self
     }
 
@@ -347,8 +386,50 @@ pub enum ParseError {
 }
 
 impl ParseError {
-    pub fn to_diagnostic(&self) -> Diagnostic {
+    /// The facts this error's message interpolates. See [`Diagnostic::args`].
+    ///
+    /// Arms bind every field rather than eliding with `..`, so a new field on
+    /// a variant does not compile until this decides about it.
+    ///
+    /// Four variants carry only prose and so contribute no keys. `EmptyInput`
+    /// is a single fixed sentence a consumer writes from the code alone;
+    /// `InvalidStructure` and `BodyImport` wrap messages minted at ~20 sites
+    /// and by the content importer; `MissingQuill` selects one of three
+    /// sentences by inspecting the source, a branch no structured field
+    /// records. All four render `message` verbatim (see `ERROR.md`
+    /// § "Diagnostic args").
+    pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
         match self {
+            ParseError::InputTooLarge { size, max } => diag_args! {
+                "size" => size,
+                "max" => max,
+            },
+            ParseError::InvalidStructure(_) => diag_args! {},
+            ParseError::EmptyInput(_) => diag_args! {},
+            ParseError::MissingQuill(_) => diag_args! {},
+            ParseError::BodyImport(_) => diag_args! {},
+            // `reason` is the `from_str` violation in English, so it stays in
+            // `message`; `value` alone carries the consumer's sentence.
+            ParseError::InvalidQuillReference { value, reason: _ } => diag_args! {
+                "value" => value,
+            },
+            // No `location` is set on this diagnostic, so `args` is the only
+            // structured route to the coordinates the message names. `message`
+            // is the YAML engine's own prose and keeps no key.
+            ParseError::YamlErrorWithLocation {
+                message: _,
+                line,
+                block_index,
+                hint: _,
+            } => diag_args! {
+                "line" => line,
+                "blockIndex" => block_index,
+            },
+        }
+    }
+
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        let diag = match self {
             ParseError::InputTooLarge { size, max } => Diagnostic::new(
                 Severity::Error,
                 format!("Input too large: {} bytes (max: {} bytes)", size, max),
@@ -387,7 +468,8 @@ impl ParseError {
                 }
                 d
             }
-        }
+        };
+        diag.with_args(self.args())
     }
 }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -220,19 +220,19 @@ pub struct Diagnostic {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hint: Option<String>,
-    /// The facts [`Self::message`] interpolates, keyed by name. With
+    /// The facts [`Self::message`] interpolates, keyed by name: with
     /// [`Self::code`], the substitution unit a consumer needs to word this
     /// diagnostic in its own language.
     ///
     /// One code carries one key set, tabulated per code in
-    /// `prose/canon/ERROR.md`. Values keep their JSON shape: a list stays a
-    /// list and a count stays a number, so joining and pluralizing remain the
-    /// consumer's locale decisions rather than the engine's.
+    /// `prose/canon/ERROR.md` § "Diagnostic args" and tested against it.
+    /// Values keep their JSON shape, so joining and pluralizing stay the
+    /// consumer's locale decisions.
     ///
-    /// Empty for any code outside the structured surface, which is the signal
-    /// to render `message` verbatim. Engine prose never rides under a key; a
-    /// consumer's own sentence may be coarser than ours, never
-    /// half-translated.
+    /// Empty either because the code is outside the structured surface or
+    /// because its sentence needs no facts beyond the code; canon tells the
+    /// two apart. Engine prose never rides under a key: a consumer's sentence
+    /// may be coarser than ours, never half-translated.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub args: BTreeMap<String, serde_json::Value>,
     /// Flattened cause chain (outermost first). Upstream English, and
@@ -388,16 +388,11 @@ pub enum ParseError {
 impl ParseError {
     /// The facts this error's message interpolates. See [`Diagnostic::args`].
     ///
-    /// Arms bind every field rather than eliding with `..`, so a new field on
-    /// a variant does not compile until this decides about it.
-    ///
-    /// Four variants carry only prose and so contribute no keys. `EmptyInput`
-    /// is a single fixed sentence a consumer writes from the code alone;
-    /// `InvalidStructure` and `BodyImport` wrap messages minted at ~20 sites
-    /// and by the content importer; `MissingQuill` selects one of three
-    /// sentences by inspecting the source, a branch no structured field
-    /// records. All four render `message` verbatim (see `ERROR.md`
-    /// § "Diagnostic args").
+    /// The four `String` variants contribute no keys, for two different
+    /// reasons canon distinguishes: `EmptyInput` is one fixed sentence, while
+    /// `InvalidStructure`, `BodyImport`, and `MissingQuill` carry prose minted
+    /// per-site. `MissingQuill` looks fixed and is not: it picks one of three
+    /// sentences by re-reading the source, and no field records which.
     pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
         match self {
             ParseError::InputTooLarge { size, max } => diag_args! {
@@ -408,14 +403,14 @@ impl ParseError {
             ParseError::EmptyInput(_) => diag_args! {},
             ParseError::MissingQuill(_) => diag_args! {},
             ParseError::BodyImport(_) => diag_args! {},
-            // `reason` is the `from_str` violation in English, so it stays in
+            // `reason` is the `from_str` violation in English and stays in
             // `message`; `value` alone carries the consumer's sentence.
             ParseError::InvalidQuillReference { value, reason: _ } => diag_args! {
                 "value" => value,
             },
-            // No `location` is set on this diagnostic, so `args` is the only
-            // structured route to the coordinates the message names. `message`
-            // is the YAML engine's own prose and keeps no key.
+            // This diagnostic sets no `location`, so `args` is the only
+            // structured route to the coordinates the message names. The
+            // message is the YAML engine's own prose and keeps no key.
             ParseError::YamlErrorWithLocation {
                 message: _,
                 line,

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use indexmap::IndexMap;
 
 use super::resolved::FieldSource;
-use super::{seed, CardSchema, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
+use super::{seed, CardSchema, CoercionError, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
 use crate::normalize::{normalize_document, normalize_field_name};
 use crate::quill::zero_value;
 use crate::path::DocPath;
@@ -318,7 +318,8 @@ fn quill_mismatch(message: String, code: &str, hint: &str) -> RenderError {
 fn seed_violation_diagnostic(v: &super::validation::ValidationError) -> Diagnostic {
     let mut diag = Diagnostic::new(Severity::Warning, v.to_string())
         .with_code(v.code().to_string())
-        .with_path(v.path().to_string());
+        .with_path(v.path().to_string())
+        .with_args(v.args());
     if let Some(hint) = v.hint() {
         diag = diag.with_hint(hint);
     }
@@ -326,11 +327,14 @@ fn seed_violation_diagnostic(v: &super::validation::ValidationError) -> Diagnost
 }
 
 /// Wrap a coercion error into a `validation::coercion_failed` failure.
-/// `Diagnostic::path` is unset: coercion runs before structured validation.
-fn coercion_error(e: impl std::fmt::Display) -> RenderError {
+/// `Diagnostic::path` is unset: coercion runs before structured validation, and
+/// the anchor the error does carry is schema-space (see
+/// [`CoercionError::args`](super::config::CoercionError::args)).
+fn coercion_error(e: CoercionError) -> RenderError {
     RenderError::from_diag(
         Diagnostic::new(Severity::Error, e.to_string())
             .with_code("validation::coercion_failed".to_string())
+            .with_args(e.args())
             .with_hint("Ensure all fields can be coerced to their declared types".to_string()),
     )
 }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -140,16 +140,15 @@ impl CoercionError {
     /// [`Diagnostic::args`](crate::error::Diagnostic::args).
     ///
     /// Two of the four fields stay behind. `path` is a schema-space anchor
-    /// (`card_kinds.<kind>.<field>`), which `ERROR.md` § "Three grammars, one
-    /// that crosses" keeps engine-internal; an args key would re-open that
-    /// door under a new name. `reason` is English minted at ~20 coercion arms
-    /// and sometimes wraps a decode error's own prose, so it stays in
-    /// `message` where a consumer reads it as a whole or not at all; carrying
-    /// it under a key would invite it into a translated sentence.
+    /// (`card_kinds.<kind>.<field>`) that `ERROR.md` § "Three grammars, one
+    /// that crosses" keeps engine-internal, and an args key would re-open that
+    /// door under a new name. `reason` is English minted at ~20 coercion arms,
+    /// sometimes wrapping a decode error's own prose; under a key it would be
+    /// interpolated into a translated sentence, so it stays in `message` where
+    /// a consumer takes it whole or not at all.
     ///
     /// What remains states the failure at lower resolution than the English
-    /// does ("`{value}` is not a `{target}`"), which is the contract: a
-    /// consumer's sentence may be coarser than ours, never half-translated.
+    /// does ("`{value}` is not a `{target}`"), which is the contract.
     pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
         match self {
             CoercionError::Uncoercible {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1,12 +1,12 @@
 //! Quill configuration parsing and normalization.
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::error::Error as StdError;
 
 use indexmap::IndexMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Diagnostic, Severity};
+use crate::error::{Diagnostic, Severity, diag_args};
 use crate::value::QuillValue;
 
 use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG};
@@ -133,6 +133,36 @@ pub enum CoercionError {
         target: String,
         reason: String,
     },
+}
+
+impl CoercionError {
+    /// The facts this error's message interpolates. See
+    /// [`Diagnostic::args`](crate::error::Diagnostic::args).
+    ///
+    /// Two of the four fields stay behind. `path` is a schema-space anchor
+    /// (`card_kinds.<kind>.<field>`), which `ERROR.md` § "Three grammars, one
+    /// that crosses" keeps engine-internal; an args key would re-open that
+    /// door under a new name. `reason` is English minted at ~20 coercion arms
+    /// and sometimes wraps a decode error's own prose, so it stays in
+    /// `message` where a consumer reads it as a whole or not at all; carrying
+    /// it under a key would invite it into a translated sentence.
+    ///
+    /// What remains states the failure at lower resolution than the English
+    /// does ("`{value}` is not a `{target}`"), which is the contract: a
+    /// consumer's sentence may be coarser than ours, never half-translated.
+    pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
+        match self {
+            CoercionError::Uncoercible {
+                path: _,
+                value,
+                target,
+                reason: _,
+            } => diag_args! {
+                "value" => value,
+                "target" => target,
+            },
+        }
+    }
 }
 
 /// Write-side leniency mode for [`QuillConfig::conform_value`]: the one axis

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -1061,3 +1061,213 @@ main:
         assert!(validate_typed_document(&config, &doc).is_ok());
     }
 }
+
+/// The canon table in `prose/canon/ERROR.md` § "Diagnostic args" is the contract
+/// a consumer writes its string table against, so it is tested like one rather
+/// than maintained by hand beside the code.
+#[cfg(test)]
+mod args_canon {
+    use std::collections::BTreeMap;
+
+    use super::ValidationError;
+    use crate::document::EditError;
+    use crate::error::ParseError;
+    use crate::quill::CoercionError;
+
+    /// `code` → its arg keys, sorted. Every variant of every enum on the
+    /// structured surface appears once.
+    fn minted() -> BTreeMap<String, Vec<String>> {
+        let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut add = |code: &str, args: BTreeMap<String, serde_json::Value>| {
+            let keys: Vec<String> = args.keys().cloned().collect();
+            assert!(
+                out.insert(code.to_string(), keys).is_none(),
+                "two samples for `{code}` — one code carries one payload"
+            );
+        };
+
+        for e in [
+            ValidationError::TypeMismatch {
+                path: "main.n".into(),
+                expected: "string".into(),
+                actual: "integer".into(),
+                source_token: "42".into(),
+                default: Some("\"x\"".into()),
+            },
+            ValidationError::EnumViolation {
+                path: "main.tone".into(),
+                value: "loud".into(),
+                allowed: vec!["quiet".into()],
+            },
+            ValidationError::FormatViolation {
+                path: "main.when".into(),
+                format: "date".into(),
+            },
+            ValidationError::UnknownCard {
+                path: "cards[0]".into(),
+                card: "ghost".into(),
+            },
+            ValidationError::BodyDisabled {
+                path: "cards.sig[0].body".into(),
+                card: "sig".into(),
+            },
+            ValidationError::NotInline {
+                path: "main.title".into(),
+            },
+            ValidationError::NotPlain {
+                path: "main.title".into(),
+            },
+        ] {
+            add(e.code(), e.args());
+        }
+
+        for e in [
+            EditError::InvalidFieldName("9bad".into()),
+            EditError::UnknownField("nope".into()),
+            EditError::InvalidKindName("Bad".into()),
+            EditError::ReservedKind,
+            EditError::IndexOutOfRange { index: 3, len: 1 },
+            EditError::CardIdCollision { id: "a".into() },
+            EditError::EmptyCardId,
+            EditError::ValueTooDeep { max: 8 },
+            EditError::Import(quillmark_content::import::ImportError::NestingTooDeep {
+                depth: 9,
+                max: 8,
+            }),
+            EditError::FieldRichtextDecode {
+                field: "body".into(),
+                message: "x".into(),
+            },
+            EditError::FieldRichtextNotInline("body".into()),
+            EditError::FieldConform {
+                field: "n".into(),
+                target: "integer".into(),
+                message: "x".into(),
+            },
+            EditError::ContentApply(quillmark_content::ApplyError::LineOutOfRange {
+                line: 3,
+                lines: 1,
+            }),
+        ] {
+            add(e.code(), e.args());
+        }
+
+        for e in [
+            ParseError::InputTooLarge { size: 2, max: 1 },
+            ParseError::InvalidStructure("x".into()),
+            ParseError::EmptyInput("x".into()),
+            ParseError::MissingQuill("x".into()),
+            ParseError::BodyImport("x".into()),
+            ParseError::InvalidQuillReference {
+                value: "a@b".into(),
+                reason: "x".into(),
+            },
+            ParseError::YamlErrorWithLocation {
+                message: "x".into(),
+                line: 3,
+                block_index: 1,
+                hint: None,
+            },
+        ] {
+            let diag = e.to_diagnostic();
+            add(diag.code.as_deref().expect("parse errors carry a code"), diag.args);
+        }
+
+        // Two codes are minted beside their error rather than from a variant:
+        // `compose::coercion_error` wraps the whole `CoercionError`, and
+        // `compose::fill_warning` has no error type at all.
+        add(
+            "validation::coercion_failed",
+            CoercionError::Uncoercible {
+                path: "card_kinds.sig.n".into(),
+                value: "\"x\"".into(),
+                target: "integer".into(),
+                reason: "string is not a valid integer".into(),
+            }
+            .args(),
+        );
+        add("validation::must_fill", BTreeMap::new());
+
+        out
+    }
+
+    /// The `| code | args | outcome |` rows of the canon table, keyed the same
+    /// way. `—` is no keys; a trailing `?` marks a conditional key, which the
+    /// sample above supplies.
+    fn declared() -> BTreeMap<String, Vec<String>> {
+        let canon = include_str!("../../../../prose/canon/ERROR.md");
+        let mut rows = canon
+            .lines()
+            .skip_while(|l| !l.starts_with("| Code | Args | Outcome |"))
+            .skip(2)
+            .take_while(|l| l.starts_with('|'));
+
+        let mut out = BTreeMap::new();
+        for row in &mut rows {
+            let cells: Vec<&str> = row.trim_matches('|').split('|').map(str::trim).collect();
+            assert_eq!(cells.len(), 3, "malformed canon row: {row}");
+            let code = cells[0].trim_matches('`').to_string();
+            let keys = if cells[1] == "—" {
+                Vec::new()
+            } else {
+                let mut keys: Vec<String> = cells[1]
+                    .split(',')
+                    .map(|k| k.trim().trim_end_matches('?').trim_matches('`').to_string())
+                    .collect();
+                keys.sort();
+                keys
+            };
+            assert!(out.insert(code, keys).is_none(), "duplicate canon row: {row}");
+        }
+        assert!(!out.is_empty(), "canon args table not found in ERROR.md");
+        out
+    }
+
+    /// The other direction: a code off the table carries no args, so a
+    /// consumer's template falls back rather than half-filling. `quill::*` is
+    /// the largest such family and the one with `format!`-built codes.
+    #[test]
+    fn out_of_scope_codes_carry_no_args() {
+        let diags = crate::quill::QuillConfig::from_yaml_with_warnings(
+            r#"
+Quill:
+  name: t
+  version: "1.0"
+  backend: typst
+  description: A slot whose literal contradicts its declared type
+
+main:
+  fields:
+    title:
+      type: string
+      default: 42
+"#,
+        )
+        .expect_err("a default that contradicts its type fails config validation");
+
+        assert!(
+            diags.iter().any(|d| d
+                .code
+                .as_deref()
+                .is_some_and(|c| c.starts_with("quill::"))),
+            "expected a quill:: diagnostic, got {:?}",
+            diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+        );
+        for d in &diags {
+            assert!(
+                d.args.is_empty(),
+                "`{:?}` is off the canon table and must carry no args",
+                d.code
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostic_args_match_canon() {
+        assert_eq!(
+            declared(),
+            minted(),
+            "`ERROR.md` § \"Diagnostic args\" and the minted args disagree"
+        );
+    }
+}

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -213,19 +213,15 @@ impl ValidationError {
     /// The facts this error's message interpolates. See
     /// [`Diagnostic::args`](crate::error::Diagnostic::args).
     ///
-    /// Arms bind every field rather than eliding with `..`, so a new field on
-    /// a variant does not compile until this decides about it.
-    ///
-    /// `path` is deliberately absent: it is the diagnostic's anchor, and an
-    /// anchor reachable by two routes acquires two spellings. `NotInline` and
+    /// `path` stays out: it is the diagnostic's anchor, and an anchor
+    /// reachable by two routes acquires two spellings. `NotInline` and
     /// `NotPlain` carry nothing else, so their sentence follows from the code
     /// and the anchor alone.
     ///
-    /// `default` is present only when the schema declares one: the same
-    /// condition [`type_mismatch_hint`] branches on, so a consumer selects its
-    /// own exit clause from the key's presence rather than re-deriving the
-    /// branch. Emitting it as `null` instead would read as a default spelled
-    /// `null`.
+    /// `default` is present only when the schema declares one, the same
+    /// condition `type_mismatch_hint` branches on, so a consumer picks its
+    /// own exit clause from the key's presence instead of re-deriving the
+    /// branch. Emitting `null` instead would read as a default spelled `null`.
     pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
         match self {
             ValidationError::TypeMismatch {
@@ -1082,7 +1078,7 @@ mod args_canon {
             let keys: Vec<String> = args.keys().cloned().collect();
             assert!(
                 out.insert(code.to_string(), keys).is_none(),
-                "two samples for `{code}` — one code carries one payload"
+                "two samples for `{code}`: one code carries one payload"
             );
         };
 
@@ -1127,8 +1123,6 @@ mod args_canon {
             EditError::InvalidKindName("Bad".into()),
             EditError::ReservedKind,
             EditError::IndexOutOfRange { index: 3, len: 1 },
-            EditError::CardIdCollision { id: "a".into() },
-            EditError::EmptyCardId,
             EditError::ValueTooDeep { max: 8 },
             EditError::Import(quillmark_content::import::ImportError::NestingTooDeep {
                 depth: 9,

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
+
 use indexmap::IndexMap;
 
 use crate::document::Document;
-use crate::error::{Diagnostic, Severity};
+use crate::error::{Diagnostic, Severity, diag_args};
 use crate::path::DocPath;
 use crate::quill::formats::{is_valid_date, is_valid_datetime};
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
@@ -208,6 +210,63 @@ impl ValidationError {
         }
     }
 
+    /// The facts this error's message interpolates. See
+    /// [`Diagnostic::args`](crate::error::Diagnostic::args).
+    ///
+    /// Arms bind every field rather than eliding with `..`, so a new field on
+    /// a variant does not compile until this decides about it.
+    ///
+    /// `path` is deliberately absent: it is the diagnostic's anchor, and an
+    /// anchor reachable by two routes acquires two spellings. `NotInline` and
+    /// `NotPlain` carry nothing else, so their sentence follows from the code
+    /// and the anchor alone.
+    ///
+    /// `default` is present only when the schema declares one: the same
+    /// condition [`type_mismatch_hint`] branches on, so a consumer selects its
+    /// own exit clause from the key's presence rather than re-deriving the
+    /// branch. Emitting it as `null` instead would read as a default spelled
+    /// `null`.
+    pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
+        match self {
+            ValidationError::TypeMismatch {
+                path: _,
+                expected,
+                actual,
+                source_token,
+                default,
+            } => {
+                let mut args = diag_args! {
+                    "expected" => expected,
+                    "actual" => actual,
+                    "sourceToken" => source_token,
+                };
+                if let Some(default) = default {
+                    args.insert("default".to_string(), serde_json::json!(default));
+                }
+                args
+            }
+            ValidationError::EnumViolation {
+                path: _,
+                value,
+                allowed,
+            } => diag_args! {
+                "value" => value,
+                "allowed" => allowed,
+            },
+            ValidationError::FormatViolation { path: _, format } => diag_args! {
+                "format" => format,
+            },
+            ValidationError::UnknownCard { path: _, card } => diag_args! {
+                "card" => card,
+            },
+            ValidationError::BodyDisabled { path: _, card } => diag_args! {
+                "card" => card,
+            },
+            ValidationError::NotInline { path: _ } => diag_args! {},
+            ValidationError::NotPlain { path: _ } => diag_args! {},
+        }
+    }
+
     /// Actionable hint for this error, when defined for the variant: the same
     /// string the `Display` impl bakes in, exposed so consumers can surface it
     /// without re-parsing prose.
@@ -234,7 +293,8 @@ impl ValidationError {
     pub fn to_diagnostic(&self) -> Diagnostic {
         let mut diag = Diagnostic::new(Severity::Error, self.to_string())
             .with_code(self.code().to_string())
-            .with_path(self.path().to_string());
+            .with_path(self.path().to_string())
+            .with_args(self.args());
         if let Some(hint) = self.hint() {
             diag = diag.with_hint(hint);
         }

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -220,6 +220,124 @@ confused with it:
 Config-space anchors (`$seed.<kind>.<field>`, Quill.yaml schema-literal owner
 labels) ride the `DocPath` serializer with their prefix as a leading segment.
 
+## Diagnostic args
+
+`message` is the canonical English rendering. `args` is what it interpolates,
+keyed by name, so a consumer with its own string table selects a sentence by
+`code` and fills it itself. `code` + `args` is the substitution unit; `code` +
+`message` is not.
+
+Values keep their JSON shape — `allowed` arrives as a list, `len` as a number —
+because joining and pluralizing are locale decisions, not the engine's.
+
+**Engine prose never rides under a key.** Where a message bottoms out in text
+minted per-site — `CoercionError`'s `reason`, the ~20 `parse::invalid_structure`
+sites, another codec's error — that text stays in `message` and contributes no
+arg. A consumer's own sentence is then coarser than ours (`edit::field_conform`
+says which field and which target type, not which of a dozen ways the value
+failed to become one). That is the contract, not a gap in it: a coarser sentence
+a consumer owns beats a fluent one half in the wrong language. The full-fidelity
+alternative — a key holding English — is worse than omission, because the
+fallback below cannot fire on a key that is present.
+
+**Falling back is wholesale.** A formatter whose template needs a key that is
+absent renders `message`, never a sentence with a hole in it. It takes `hint`
+from the engine in the same breath: the hint is the same English as the message
+tail (`ValidationError`'s `Display` appends it verbatim), so translating one and
+passing the other through ships a two-language diagnostic. Localize a code and
+you own both sentences; fall back and you take both.
+
+**`hint` needs no code of its own.** It is a function of `code` and `args`:
+three of the four hinted variants are per-variant constants, and
+`type_mismatch_hint` branches only on whether a default exists — which is why
+`default` is present as a key exactly when the schema declares one, rather than
+present-and-null. Any datum a hint branches on is message-relevant by
+definition and belongs in `args`; a parallel `hint_code` would be derived state
+on the wire, free to drift.
+
+**Anchors do not travel twice.** `path` is never an arg. `field` and `kind` are,
+even though `doc_path` also folds them into the anchor — the rule bars the
+assembled path string, and recovering a name from one is unsound anyway, since
+`DocPath` renders field segments unescaped and parses on `.` and `[`, so exactly
+the malformed names `edit::invalid_field_name` reports can round-trip into
+different segments. `CoercionError`'s `path` stays out for the separate reason
+below in § "Three grammars": it is a schema-space anchor and does not cross.
+
+**Growth is additive.** Per code, keys are append-only and never retyped, and
+value spellings are as frozen as the keys — `sourceToken`'s verbatim-YAML form
+(`42`, `null`, `""`), `actual`'s `integer`-vs-`number` vocabulary. Codes
+themselves are governed the same way, which is what makes them safe to key a
+string table on. Without that, an upgrade turns into a silent English
+regression in every localized consumer.
+
+### Coverage
+
+The table is the contract; `diagnostic_args_match_canon` in
+`crates/core/src/quill/validation.rs` fails if code and canon disagree.
+Each error enum's `args()` binds every field rather than eliding with `..`, so a
+new field on a variant does not compile until it decides whether it is
+message-relevant.
+
+Three outcomes, and the wire tells them apart only with this table in hand —
+"no keys" reads identically for the second and third:
+
+- **structured** — keys present; the consumer writes the whole sentence.
+- **code-determined** — no keys needed; the sentence follows from `code` and the
+  anchor alone. Fully localizable.
+- **fallback** — render `message`.
+
+| Code | Args | Outcome |
+|---|---|---|
+| `validation::type_mismatch` | `expected`, `actual`, `sourceToken`, `default`? | structured |
+| `validation::enum_violation` | `value`, `allowed` | structured |
+| `validation::format_violation` | `format` | structured |
+| `validation::unknown_card` | `card` | structured |
+| `validation::body_disabled` | `card` | structured |
+| `validation::coercion_failed` | `value`, `target` | structured, coarser |
+| `validation::must_fill` | — | code-determined |
+| `richtext::not_inline` | — | code-determined |
+| `plaintext::not_plain` | — | code-determined |
+| `edit::invalid_field_name` | `field` | structured |
+| `edit::unknown_field` | `field` | structured |
+| `edit::invalid_kind_name` | `kind` | structured |
+| `edit::index_out_of_range` | `index`, `len` | structured |
+| `edit::card_id_collision` | `id` | structured |
+| `edit::value_too_deep` | `max` | structured |
+| `edit::field_richtext_not_inline` | `field` | structured |
+| `edit::field_conform` | `field`, `target` | structured, coarser |
+| `edit::field_richtext_decode` | `field` | structured, coarser |
+| `edit::reserved_kind` | — | code-determined |
+| `edit::empty_card_id` | — | code-determined |
+| `edit::import` | — | fallback |
+| `edit::content_apply` | — | fallback |
+| `parse::input_too_large` | `size`, `max` | structured |
+| `parse::invalid_quill_reference` | `value` | structured, coarser |
+| `parse::yaml_error_with_location` | `line`, `blockIndex` | structured, coarser |
+| `parse::empty_input` | — | code-determined |
+| `parse::invalid_structure` | — | fallback |
+| `parse::missing_quill` | — | fallback |
+| `parse::body_import` | — | fallback |
+
+`parse::missing_quill` looks code-determined and is not: it picks one of three
+sentences by re-reading the source, and no field records which.
+
+### Scope
+
+`validation::*`, `edit::*`, and `parse::*` are the codes an end user meets, and
+the table covers them. The rest carry no args, which is the domain's shape
+rather than a phase of the work:
+
+- **`quill::*`** is quill-authoring. Its reader is a template author debugging
+  `Quill.yaml`, the one audience for whom canonical English is the deliverable.
+  Three of its codes are `format!`-built per slot besides.
+- **`typst::*`** is an open set — the code is Typst's own message text up to the
+  first `:` (`error_mapping.rs`), so it re-spells itself whenever Typst rewords
+  a diagnostic and cannot key a string table at all.
+
+Because those codes carry no args, every consumer template falls back on them by
+the rule above. That is what makes a surface covering a third of the codes total
+rather than partial.
+
 ## Error Presentation
 
 **Pretty printing** (`Diagnostic::fmt_pretty()`):

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -222,69 +222,29 @@ labels) ride the `DocPath` serializer with their prefix as a leading segment.
 
 ## Diagnostic args
 
-`message` is the canonical English rendering. `args` is what it interpolates,
-keyed by name, so a consumer with its own string table selects a sentence by
-`code` and fills it itself. `code` + `args` is the substitution unit; `code` +
-`message` is not.
+`message` is the canonical English rendering. `args` is what it interpolates, keyed by name, so a consumer with its own string table selects a sentence by `code` and fills it itself. `code` + `args` is the substitution unit; `code` + `message` is not.
 
-Values keep their JSON shape — `allowed` arrives as a list, `len` as a number —
-because joining and pluralizing are locale decisions, not the engine's.
+Values keep their JSON shape (`allowed` arrives as a list, `len` as a number) because joining and pluralizing are locale decisions, not the engine's.
 
-**Engine prose never rides under a key.** Where a message bottoms out in text
-minted per-site — `CoercionError`'s `reason`, the ~20 `parse::invalid_structure`
-sites, another codec's error — that text stays in `message` and contributes no
-arg. A consumer's own sentence is then coarser than ours (`edit::field_conform`
-says which field and which target type, not which of a dozen ways the value
-failed to become one). That is the contract, not a gap in it: a coarser sentence
-a consumer owns beats a fluent one half in the wrong language. The full-fidelity
-alternative — a key holding English — is worse than omission, because the
-fallback below cannot fire on a key that is present.
+**Engine prose never rides under a key.** Where a message bottoms out in text minted per-site (`CoercionError`'s `reason`, the ~20 `parse::invalid_structure` sites, another codec's error), that text stays in `message` and contributes no arg. A consumer's own sentence is then coarser than ours (`edit::field_conform` says which field and which target type, not which of a dozen ways the value failed to become one). That is the contract, not a gap in it: a coarser sentence a consumer owns beats a fluent one half in the wrong language. The full-fidelity alternative (a key holding English) is worse than omission, because the fallback below cannot fire on a key that is present.
 
-**Falling back is wholesale.** A formatter whose template needs a key that is
-absent renders `message`, never a sentence with a hole in it. It takes `hint`
-from the engine in the same breath: the hint is the same English as the message
-tail (`ValidationError`'s `Display` appends it verbatim), so translating one and
-passing the other through ships a two-language diagnostic. Localize a code and
-you own both sentences; fall back and you take both.
+**Falling back is wholesale.** A formatter whose template needs a key that is absent renders `message`, never a sentence with a hole in it. It takes `hint` from the engine in the same breath: the hint is the same English as the message tail (`ValidationError`'s `Display` appends it verbatim), so translating one and passing the other through ships a two-language diagnostic. Localize a code and you own both sentences; fall back and you take both.
 
-**`hint` needs no code of its own.** It is a function of `code` and `args`:
-three of the four hinted variants are per-variant constants, and
-`type_mismatch_hint` branches only on whether a default exists — which is why
-`default` is present as a key exactly when the schema declares one, rather than
-present-and-null. Any datum a hint branches on is message-relevant by
-definition and belongs in `args`; a parallel `hint_code` would be derived state
-on the wire, free to drift.
+**`hint` needs no code of its own.** It is a function of `code` and `args`: three of the four hinted variants are per-variant constants, and `type_mismatch_hint` branches only on whether a default exists, which is why `default` is present as a key exactly when the schema declares one, rather than present-and-null. Any datum a hint branches on is message-relevant by definition and belongs in `args`; a parallel `hint_code` would be derived state on the wire, free to drift.
 
-**Anchors do not travel twice.** `path` is never an arg. `field` and `kind` are,
-even though `doc_path` also folds them into the anchor — the rule bars the
-assembled path string, and recovering a name from one is unsound anyway, since
-`DocPath` renders field segments unescaped and parses on `.` and `[`, so exactly
-the malformed names `edit::invalid_field_name` reports can round-trip into
-different segments. `CoercionError`'s `path` stays out for the separate reason
-below in § "Three grammars": it is a schema-space anchor and does not cross.
+**Anchors do not travel twice.** `path` is never an arg. `field` and `kind` are, even though `doc_path` also folds them into the anchor; the rule bars the assembled path string, and recovering a name from one is unsound anyway, since `DocPath` renders field segments unescaped and parses on `.` and `[`, so exactly the malformed names `edit::invalid_field_name` reports can round-trip into different segments. `CoercionError`'s `path` stays out for the separate reason below in § "Three grammars": it is a schema-space anchor and does not cross.
 
-**Growth is additive.** Per code, keys are append-only and never retyped, and
-value spellings are as frozen as the keys — `sourceToken`'s verbatim-YAML form
-(`42`, `null`, `""`), `actual`'s `integer`-vs-`number` vocabulary. Codes
-themselves are governed the same way, which is what makes them safe to key a
-string table on. Without that, an upgrade turns into a silent English
-regression in every localized consumer.
+**Growth is additive.** Per code, keys are append-only and never retyped, and value spellings are as frozen as the keys: `sourceToken`'s verbatim-YAML form (`42`, `null`, `""`), `actual`'s `integer`-vs-`number` vocabulary. Codes themselves are governed the same way, which is what makes them safe to key a string table on. Without that, an upgrade turns into a silent English regression in every localized consumer.
 
 ### Coverage
 
-The table is the contract; `diagnostic_args_match_canon` in
-`crates/core/src/quill/validation.rs` fails if code and canon disagree.
-Each error enum's `args()` binds every field rather than eliding with `..`, so a
-new field on a variant does not compile until it decides whether it is
-message-relevant.
+The table is the contract, so it is tested like one: `diagnostic_args_match_canon` in `crates/core/src/quill/validation.rs` fails if code and canon disagree, and its twin asserts the codes off the table carry nothing. Each `args()` binds every field rather than eliding with `..`, so a new field on a variant does not compile until it decides whether it is message-relevant.
 
-Three outcomes, and the wire tells them apart only with this table in hand —
-"no keys" reads identically for the second and third:
+Three outcomes, and the wire tells them apart only with this table in hand, since "no keys" reads identically for the second and third:
 
-- **structured** — keys present; the consumer writes the whole sentence.
-- **code-determined** — no keys needed; the sentence follows from `code` and the
-  anchor alone. Fully localizable.
-- **fallback** — render `message`.
+- **structured**: keys present; the consumer writes the whole sentence.
+- **code-determined**: no keys needed; the sentence follows from `code` and the anchor alone. Fully localizable.
+- **fallback**: render `message`.
 
 | Code | Args | Outcome |
 |---|---|---|
@@ -301,13 +261,11 @@ Three outcomes, and the wire tells them apart only with this table in hand —
 | `edit::unknown_field` | `field` | structured |
 | `edit::invalid_kind_name` | `kind` | structured |
 | `edit::index_out_of_range` | `index`, `len` | structured |
-| `edit::card_id_collision` | `id` | structured |
 | `edit::value_too_deep` | `max` | structured |
 | `edit::field_richtext_not_inline` | `field` | structured |
 | `edit::field_conform` | `field`, `target` | structured, coarser |
 | `edit::field_richtext_decode` | `field` | structured, coarser |
 | `edit::reserved_kind` | — | code-determined |
-| `edit::empty_card_id` | — | code-determined |
 | `edit::import` | — | fallback |
 | `edit::content_apply` | — | fallback |
 | `parse::input_too_large` | `size`, `max` | structured |
@@ -318,25 +276,16 @@ Three outcomes, and the wire tells them apart only with this table in hand —
 | `parse::missing_quill` | — | fallback |
 | `parse::body_import` | — | fallback |
 
-`parse::missing_quill` looks code-determined and is not: it picks one of three
-sentences by re-reading the source, and no field records which.
+`parse::missing_quill` looks code-determined and is not: it picks one of three sentences by re-reading the source, and no field records which.
 
 ### Scope
 
-`validation::*`, `edit::*`, and `parse::*` are the codes an end user meets, and
-the table covers them. The rest carry no args, which is the domain's shape
-rather than a phase of the work:
+`validation::*`, `edit::*`, and `parse::*` are the codes an end user meets, and the table covers them. The rest carry no args, which is the domain's shape rather than a phase of the work:
 
-- **`quill::*`** is quill-authoring. Its reader is a template author debugging
-  `Quill.yaml`, the one audience for whom canonical English is the deliverable.
-  Three of its codes are `format!`-built per slot besides.
-- **`typst::*`** is an open set — the code is Typst's own message text up to the
-  first `:` (`error_mapping.rs`), so it re-spells itself whenever Typst rewords
-  a diagnostic and cannot key a string table at all.
+- **`quill::*`** is quill-authoring. Its reader is a template author debugging `Quill.yaml`, the one audience for whom canonical English is the deliverable. Three of its codes are `format!`-built per slot besides.
+- **`typst::*`** is an open set: the code is Typst's own message text up to the first `:` (`error_mapping.rs`), so it re-spells itself whenever Typst rewords a diagnostic and cannot key a string table at all.
 
-Because those codes carry no args, every consumer template falls back on them by
-the rule above. That is what makes a surface covering a third of the codes total
-rather than partial.
+Because those codes carry no args, every consumer template falls back on them by the rule above. That is what makes a surface covering a third of the codes total rather than partial.
 
 ## Error Presentation
 


### PR DESCRIPTION
Closes #1130. Supersedes #1131, whose branch this rebases onto current `main`.

A consumer with its own wording contract could route a diagnostic by `code` but never word one: every fact the message interpolates was rendered into English at the mint site and dropped. `args` keeps them, so `code` + `args` is a complete substitution unit where `code` + `message` was not.

## Shape

`Diagnostic.args: BTreeMap<String, serde_json::Value>`, skipped when empty, with `with_args` beside `with_hint`. Populated from an exhaustive `args()` beside `code()` on `ValidationError`, `EditError`, `ParseError`, and `CoercionError`.

`serde_json::Value` rather than `QuillValue`: the latter's only addition is the `!must_fill` annotation, which is document semantics, meaningless on a diagnostic arg, and dropped on deserialize anyway. It buys nothing at either binding boundary, `quillvalue_to_py` already being `json_to_py(value.as_json())`. Values keep their JSON shape so `allowed` stays a list and `len` stays a number, leaving joining and pluralizing to the consumer's locale.

Arms bind every field rather than eliding with `..`, so a new field on a variant does not compile until it decides whether it is message-relevant.

## Engine prose never rides under a key

`CoercionError::reason` is English minted at ~20 coercion arms and reaches three codes; the `parse::invalid_structure` message is minted at ~20 more. That text stays in `message` and contributes no arg. A consumer's sentence is then coarser than ours (`edit::field_conform` names the field and the target type, not which of a dozen ways the value failed to become one), which is the contract rather than a gap in it. A key holding English is worse than omission, because the wholesale-fallback rule cannot fire on a key that is present.

## Scope

`validation::*`, `edit::*`, `parse::*`. `quill::*` is quill-authoring, whose reader is the one audience for which canonical English is the deliverable; `typst::*` is an open set derived from Typst's own message text and cannot key a string table at all. Both carry no args, so every consumer template falls back on them by rule, which is what makes a surface covering a third of the codes total rather than partial.

## Canon

`ERROR.md` gains the per-code args table and the rules that make it usable: fallback is wholesale and takes `hint` with it (the hint is the same English as the message tail, so translating one and passing the other through ships a two-language diagnostic); `hint` needs no code of its own, being a function of `code` and `args`; anchors do not travel twice; keys grow append-only.

## What the rebase changed

- **`EditError::CardIdCollision` and `EmptyCardId` are gone**, deleted with card `$id` in #1151. That produces no merge conflict, `edit.rs` auto-merges clean, and breaks the build instead: the exhaustive `args()` still matched both. Removed at four sites (the two arms, the rustdoc naming `EmptyCardId`, the two drift-test fixtures) plus the two now-orphaned `ERROR.md` rows, which the drift test would have failed on.
- **Prose folded to the current punctuation rule.** The branch predates fbe17fe, so its ~550 new doc lines were written under the old one. The `—` cells in the args table stay: `diagnostic_args_match_canon` reads them as the "no keys" marker (`cells[1] == "—"`), so that character is data.
- **Two doc-gate failures fixed**, both predating the rebase: public docs on `args` linked the private `type_mismatch_hint`, and `[`CoercionError`](crate::quill::CoercionError)` was a redundant explicit link target.

## Changes worth a second look

- **`EditError::FieldConform` gains `target`.** It was already structured on the coercion error and discarded at the `conform_error_to_edit` boundary. Without it the code is close to unlocalizable. This widens a variant of a `#[non_exhaustive]` enum; in-tree matchers all use `{ .. }` or `variant_name()`.
- **`compose::coercion_error` takes `CoercionError` instead of `impl Display`**, since it could not reach the structured fields otherwise. Both call sites already passed that type.
- **`field` and `kind` are args on `edit::*` despite `doc_path` also folding them into the anchor.** The no-anchor-in-args rule bars the assembled `path` string; recovering a name from one is unsound regardless, since `DocPath` renders field segments unescaped and parses on `.` and `[`, so precisely the malformed names `edit::invalid_field_name` reports can round-trip into different segments. That is a latent defect in the anchor, independent of this PR.
- **`parse::missing_quill` is fallback, not code-determined.** It picks one of three sentences by re-reading the source and no field records which.

## Tests

`cargo test --workspace` (49 suites, 0 failures), `cargo check --workspace --all-features`, `node scripts/check-canon.mjs`, and `cargo doc --no-deps --locked --workspace` under `RUSTDOCFLAGS=-Dwarnings`, which is the standing lint gate. Clippy is unchanged and ungated per the policy note in `ci.yml`.

Two new tests hold the table to the code: one asserting every minted key set matches its canon row, one asserting codes off the table carry nothing, so "args present" is itself a trustworthy signal. The first is verified non-vacuous by injecting a bogus key into the `edit::unknown_field` row and watching it fail. The table covers 27 codes and agrees with the four enums exactly.

The generated `.d.ts` is unverified locally: this container's `wasm-bindgen-cli` (0.2.122) does not match the lockfile (0.2.118), so `scripts/build-wasm.sh` refuses to run. The field carries `#[tsify(optional, type = "Record<string, unknown>")]`, since `tsify` does not read `skip_serializing_if`, which is why `sourceChain` is declared required today while the runtime omits it when empty. Worth a look at the CI-generated TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hj4HTVv4U78UA9LgQ4XidX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hj4HTVv4U78UA9LgQ4XidX)_