### PR TITLE
Close the content model over #[non_exhaustive]

### DIFF
--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -1488,27 +1488,11 @@ mod tests {
     #[test]
     fn overlapping_marks_close_and_reopen() {
         use quillmark_content::model::{Line, Mark};
-        let mut rt = Content {
-            text: "abcdef".to_string(),
-            lines: vec![Line {
-                kind: LineKind::Para,
-                containers: vec![],
-                continues: false,
-            }],
-            marks: vec![
-                Mark {
-                    start: 0,
-                    end: 4,
-                    kind: MarkKind::Strong,
-                },
-                Mark {
-                    start: 2,
-                    end: 6,
-                    kind: MarkKind::Emph,
-                },
-            ],
-            islands: vec![],
-        };
+        let mut rt = Content::new("abcdef".to_string(), vec![Line::new(LineKind::Para)])
+            .with_marks(vec![
+                Mark::new(0, 4, MarkKind::Strong),
+                Mark::new(2, 6, MarkKind::Emph),
+            ]);
         rt.normalize();
         assert_eq!(rt.validate(), Ok(()));
         let out = emit_content(&rt).unwrap().markup;
@@ -1528,26 +1512,19 @@ mod tests {
             tag: "indent".to_string(),
             attrs: serde_json::Value::Null,
         };
-        let mut rt = Content {
-            text: "heads up\nsecond".to_string(),
-            lines: vec![
-                Line {
-                    kind: LineKind::Unknown {
-                        tag: "callout".to_string(),
-                        attrs: serde_json::json!({"variant": "warn"}),
-                    },
-                    containers: vec![indent()],
-                    continues: false,
-                },
-                Line {
-                    kind: LineKind::Para,
-                    containers: vec![indent()],
-                    continues: true,
-                },
+        let mut rt = Content::new(
+            "heads up\nsecond".to_string(),
+            vec![
+                Line::new(LineKind::Unknown {
+                    tag: "callout".to_string(),
+                    attrs: serde_json::json!({"variant": "warn"}),
+                })
+                .with_containers(vec![indent()]),
+                Line::new(LineKind::Para)
+                    .with_containers(vec![indent()])
+                    .with_continues(true),
             ],
-            marks: vec![],
-            islands: vec![],
-        };
+        );
         rt.normalize();
         assert_eq!(rt.validate(), Ok(()));
         // One block (the `continues` join is a hard break), no wrapper.
@@ -1569,16 +1546,8 @@ mod tests {
     /// normalize + validate it, and lower it.
     fn emit_marked(text: &str, marks: Vec<Mark>) -> String {
         use quillmark_content::model::Line;
-        let mut rt = Content {
-            text: text.to_string(),
-            lines: vec![Line {
-                kind: LineKind::Para,
-                containers: vec![],
-                continues: false,
-            }],
-            marks,
-            islands: vec![],
-        };
+        let mut rt =
+            Content::new(text.to_string(), vec![Line::new(LineKind::Para)]).with_marks(marks);
         rt.normalize();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
         emit_content(&rt).unwrap().markup
@@ -1602,11 +1571,7 @@ mod tests {
         ] {
             let out = emit_marked(
                 "abc",
-                vec![Mark {
-                    start: 0,
-                    end: 3,
-                    kind: kind.clone(),
-                }],
+                vec![Mark::new(0, 3, kind.clone())],
             );
             assert_eq!(out, expected, "{kind:?} lowers wrong");
         }
@@ -1619,16 +1584,8 @@ mod tests {
         let nested = emit_marked(
             "abc",
             vec![
-                Mark {
-                    start: 0,
-                    end: 3,
-                    kind: MarkKind::Strong,
-                },
-                Mark {
-                    start: 0,
-                    end: 3,
-                    kind: MarkKind::Underline,
-                },
+                Mark::new(0, 3, MarkKind::Strong),
+                Mark::new(0, 3, MarkKind::Underline),
             ],
         );
         assert!(
@@ -1640,11 +1597,7 @@ mod tests {
         // Intraword: a strike over the middle character only.
         let intraword = emit_marked(
             "abc",
-            vec![Mark {
-                start: 1,
-                end: 2,
-                kind: MarkKind::Strike,
-            }],
+            vec![Mark::new(1, 2, MarkKind::Strike)],
         );
         assert_eq!(intraword, "a#strike[b]c\n\n");
     }
@@ -1664,16 +1617,8 @@ mod tests {
         let out = emit_marked(
             "abcdef",
             vec![
-                Mark {
-                    start: 0,
-                    end: 4,
-                    kind: MarkKind::Strong,
-                },
-                Mark {
-                    start: 2,
-                    end: 6,
-                    kind: MarkKind::Code,
-                },
+                Mark::new(0, 4, MarkKind::Strong),
+                Mark::new(2, 6, MarkKind::Code),
             ],
         );
         assert_eq!(out, "#strong[ab]#raw(\"cdef\")\n\n");
@@ -1683,16 +1628,8 @@ mod tests {
         let out = emit_marked(
             "abcdef",
             vec![
-                Mark {
-                    start: 0,
-                    end: 4,
-                    kind: MarkKind::Code,
-                },
-                Mark {
-                    start: 2,
-                    end: 6,
-                    kind: MarkKind::Strong,
-                },
+                Mark::new(0, 4, MarkKind::Code),
+                Mark::new(2, 6, MarkKind::Strong),
             ],
         );
         assert_eq!(out, "#raw(\"abcd\")#strong[ef]\n\n");
@@ -1703,16 +1640,8 @@ mod tests {
         let out = emit_marked(
             "abcdef",
             vec![
-                Mark {
-                    start: 0,
-                    end: 6,
-                    kind: MarkKind::Strong,
-                },
-                Mark {
-                    start: 2,
-                    end: 4,
-                    kind: MarkKind::Code,
-                },
+                Mark::new(0, 6, MarkKind::Strong),
+                Mark::new(2, 4, MarkKind::Code),
             ],
         );
         assert_eq!(out, "#strong[ab#raw(\"cd\")ef]\n\n");
@@ -1725,11 +1654,7 @@ mod tests {
     fn wrap_trailing_to_end_closes() {
         let out = emit_marked(
             "abcdef",
-            vec![Mark {
-                start: 0,
-                end: 6,
-                kind: MarkKind::Strong,
-            }],
+            vec![Mark::new(0, 6, MarkKind::Strong)],
         );
         assert_eq!(out, "#strong[abcdef]\n\n");
         assert!(balanced(&out));
@@ -1746,25 +1671,13 @@ mod tests {
         let out = emit_marked(
             "abcdef",
             vec![
-                Mark {
-                    start: 0,
-                    end: 6,
-                    kind: MarkKind::Link {
+                Mark::new(0, 6, MarkKind::Link {
                         url: "wrong".into(),
-                    },
-                },
-                Mark {
-                    start: 0,
-                    end: 4,
-                    kind: MarkKind::Strong,
-                },
-                Mark {
-                    start: 2,
-                    end: 6,
-                    kind: MarkKind::Link {
+                    }),
+                Mark::new(0, 4, MarkKind::Strong),
+                Mark::new(2, 6, MarkKind::Link {
                         url: "right".into(),
-                    },
-                },
+                    }),
             ],
         );
         // The reopened tail after the strong closes carries the inner link's URL.
@@ -1857,7 +1770,7 @@ mod tests {
         assert_eq!(
             emit_marked(
                 "= x",
-                vec![Mark { start: 0, end: 3, kind: MarkKind::Strong }],
+                vec![Mark::new(0, 3, MarkKind::Strong)],
             ),
             "#strong[= x]\n\n",
         );
@@ -1865,12 +1778,7 @@ mod tests {
         // Source-map integrity: every run's generated slice equals the escape of
         // its content, and the leading `\` is not inside any run.
         use quillmark_content::model::Line;
-        let mut rt = Content {
-            text: "= x".to_string(),
-            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
-            marks: vec![],
-            islands: vec![],
-        };
+        let mut rt = Content::new("= x".to_string(), vec![Line::new(LineKind::Para)]);
         rt.normalize();
         let ec = emit_content(&rt).unwrap();
         let chars: Vec<char> = rt.text.chars().collect();

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -982,13 +982,11 @@ mod tests {
         // import would instead parse `- `/`+ `/`N. ` as real lists, which is not
         // the bug). Each line is its own paragraph, so each starts at column 0.
         use quillmark_content::model::{Line, LineKind, Content};
-        let para = |_: usize| Line { kind: LineKind::Para, containers: vec![], continues: false };
-        let mut rt = Content {
-            text: "= Heading\n- bullet\n+ numbered\n1. dotted\n/ term: desc".to_string(),
-            lines: (0..5).map(para).collect(),
-            marks: vec![],
-            islands: vec![],
-        };
+        let para = |_: usize| Line::new(LineKind::Para);
+        let mut rt = Content::new(
+            "= Heading\n- bullet\n+ numbered\n1. dotted\n/ term: desc".to_string(),
+            (0..5).map(para).collect(),
+        );
         rt.normalize();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
         let q = quill();

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -1016,20 +1016,8 @@ main:
         // part a suspended run would swallow.
         const TEXT: &str = "Start uline and then a long trailing plain run of text.";
         let region_width = |kind: MarkKind| -> f32 {
-            let rt = Content {
-                text: TEXT.to_string(),
-                lines: vec![Line {
-                    containers: vec![],
-                    kind: LineKind::Para,
-                    continues: false,
-                }],
-                marks: vec![Mark {
-                    start: 6,
-                    end: 11,
-                    kind,
-                }],
-                islands: vec![],
-            };
+            let rt = Content::new(TEXT.to_string(), vec![Line::new(LineKind::Para)])
+                .with_marks(vec![Mark::new(6, 11, kind)]);
             let q = quill(YAML, PLATE);
             let plate = crate::read_plate(&q).expect("plate");
             let schema = quillmark_core::quill::build_transform_schema(q.config());

--- a/crates/backends/typst/tests/overlap_compile.rs
+++ b/crates/backends/typst/tests/overlap_compile.rs
@@ -18,27 +18,10 @@ use common::quill_with_plate as quill;
 /// `to_canonical_value`).
 fn overlap_content() -> serde_json::Value {
     use quillmark_content::model::Mark;
-    let rt = Content {
-        text: "abcdef".to_string(),
-        lines: vec![Line {
-            kind: LineKind::Para,
-            containers: vec![],
-            continues: false,
-        }],
-        marks: vec![
-            Mark {
-                start: 0,
-                end: 4,
-                kind: MarkKind::Strong,
-            },
-            Mark {
-                start: 2,
-                end: 6,
-                kind: MarkKind::Code,
-            },
-        ],
-        islands: vec![],
-    };
+    let rt = Content::new("abcdef".to_string(), vec![Line::new(LineKind::Para)]).with_marks(vec![
+        Mark::new(0, 4, MarkKind::Strong),
+        Mark::new(2, 6, MarkKind::Code),
+    ]);
     // The overlap survives normalize/validate (there is no cross-kind overlap
     // invariant) so the seam carries it straight to the emitter.
     quillmark_content::serial::to_canonical_value(&rt)

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -47,6 +47,12 @@ use similar::{ChangeTag, TextDiff};
 /// record and maps its own positions through ([`map_pos`](Self::map_pos)). The
 /// serde shape is the wire the `rebase` codec and `applyChange` bundle carry
 /// across the language bindings.
+///
+/// **Deliberately not `#[non_exhaustive]`**, unlike the model types. The
+/// attribute buys exactly one freedom, adding a field, and this type cannot
+/// spend it: `{ops}` *is* the wire, so a second field is a wire change every
+/// binding's codec has to learn either way. Paying the literal's cost for a
+/// freedom the serde shape already denies buys nothing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Delta {
     pub ops: Vec<Op>,
@@ -80,6 +86,11 @@ pub enum Assoc {
 
 /// A delta's expected base length disagreed with the text it was applied to:
 /// the delta was built against a different revision of the base.
+///
+/// **Deliberately not `#[non_exhaustive]`**, unlike the model types. The two
+/// lengths are the whole of the disagreement, and a caller that reports it
+/// destructures both; there is no third thing this comparison can grow. A new
+/// field is a semver-major.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BaseLengthMismatch {
     pub expected: usize,

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -51,8 +51,7 @@ use similar::{ChangeTag, TextDiff};
 /// **Deliberately not `#[non_exhaustive]`**, unlike the model types. The
 /// attribute buys exactly one freedom, adding a field, and this type cannot
 /// spend it: `{ops}` *is* the wire, so a second field is a wire change every
-/// binding's codec has to learn either way. Paying the literal's cost for a
-/// freedom the serde shape already denies buys nothing.
+/// binding's codec has to learn either way.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Delta {
     pub ops: Vec<Op>,

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -108,6 +108,13 @@ struct Ctx<'a> {
 /// One line's char range `[start, end)` into the content, with the matching byte
 /// range and the count of island slots before the line, so a caller indexes
 /// the content text and the island list in O(1) without rescanning.
+///
+/// **Deliberately not `#[non_exhaustive]`**, unlike the model types it indexes.
+/// It is a derived view, not a stored one: [`line_segments`] recomputes the
+/// whole of it from a [`Content`], and the five fields are one line's position
+/// in the two coordinate spaces the model has. A sixth would mean a third
+/// space, which moves the model before it moves this, so the literal is worth
+/// keeping and a new field is a semver-major.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Segment {
     /// USV index of the line's first char.

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -112,9 +112,9 @@ struct Ctx<'a> {
 /// **Deliberately not `#[non_exhaustive]`**, unlike the model types it indexes.
 /// It is a derived view, not a stored one: [`line_segments`] recomputes the
 /// whole of it from a [`Content`], and the five fields are one line's position
-/// in the two coordinate spaces the model has. A sixth would mean a third
-/// space, which moves the model before it moves this, so the literal is worth
-/// keeping and a new field is a semver-major.
+/// in the two coordinate spaces the model has. A sixth field means a third
+/// space, which moves the model first, so the literal stays and a new field is
+/// a semver-major.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Segment {
     /// USV index of the line's first char.

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -199,8 +199,8 @@ pub struct Mark {
 }
 
 impl Mark {
-    /// A mark of `kind` over `[start, end)`. All three are what a mark is, so
-    /// there is nothing optional to set beside them.
+    /// A mark of `kind` over `[start, end)`. The three fields are the whole of a
+    /// mark: nothing optional sits beside them.
     pub fn new(start: Usv, end: Usv, kind: MarkKind) -> Self {
         Mark { start, end, kind }
     }
@@ -689,9 +689,9 @@ impl Content {
     /// [`with_islands`](Self::with_islands) beside them.
     ///
     /// Constructing does not normalize or check: the invariants in this type's
-    /// docs are still the caller's until [`validate`](Self::validate) runs. The
-    /// codecs ([`crate::import`], [`Content::from_canonical_json`]) are the paths
-    /// that establish them, and are what a consumer normally builds through.
+    /// docs are the caller's until [`validate`](Self::validate) runs. The codecs
+    /// ([`crate::import`], [`Content::from_canonical_json`]) establish them, and
+    /// are what a consumer normally builds through.
     pub fn new(text: String, lines: Vec<Line>) -> Self {
         Content {
             text,

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -31,6 +31,7 @@ pub const ISLAND_SLOT: char = '\u{FFFC}';
 /// count of [`ISLAND_SLOT`] equals `islands.len()`; `lines.len()` equals the
 /// number of `\n`-separated segments; marks are normalized (sorted, unioned).
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct Content {
     /// The content. `\n` is a line boundary; [`ISLAND_SLOT`] is an island slot.
     pub text: String,
@@ -48,6 +49,7 @@ pub struct Content {
 
 /// A line's attributes: its block role plus the container path it sits in.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct Line {
     pub kind: LineKind,
     /// Ancestor containers, outermost first. A multi-paragraph list item is two
@@ -63,6 +65,34 @@ pub struct Line {
     /// the freeze, and what groups a code fence's lines without an
     /// adjacency heuristic.
     pub continues: bool,
+}
+
+impl Line {
+    /// A line of `kind` at the top level: no containers, starting a new block.
+    /// Both defaults are what the wire reads off an absent key (`containers`
+    /// empty, `continues` omitted); set either with
+    /// [`with_containers`](Self::with_containers) /
+    /// [`with_continues`](Self::with_continues).
+    pub fn new(kind: LineKind) -> Self {
+        Line {
+            kind,
+            containers: Vec::new(),
+            continues: false,
+        }
+    }
+
+    /// Set [`containers`](Self::containers), the ancestor path, outermost first.
+    pub fn with_containers(mut self, containers: Vec<Container>) -> Self {
+        self.containers = containers;
+        self
+    }
+
+    /// Set [`continues`](Self::continues): `true` makes this line a within-block
+    /// break off the previous one rather than a new block.
+    pub fn with_continues(mut self, continues: bool) -> Self {
+        self.continues = continues;
+        self
+    }
 }
 
 /// The block role of a line. The tree between lines is inferred: two adjacent
@@ -161,10 +191,19 @@ pub enum Container {
 /// A mark over a char range `[start, end)`. `start == end` (zero-width) is legal
 /// only for [`MarkKind::Anchor`]; normalization drops zero-width formatting.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct Mark {
     pub start: Usv,
     pub end: Usv,
     pub kind: MarkKind,
+}
+
+impl Mark {
+    /// A mark of `kind` over `[start, end)`. All three are what a mark is, so
+    /// there is nothing optional to set beside them.
+    pub fn new(start: Usv, end: Usv, kind: MarkKind) -> Self {
+        Mark { start, end, kind }
+    }
 }
 
 /// The mark set, **open**: an unknown kind round-trips as [`MarkKind::Unknown`],
@@ -203,6 +242,7 @@ pub enum MarkKind {
 /// A structured object with no honest text encoding (a table, figure, or future
 /// embed) occupying one [`ISLAND_SLOT`] in the content.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct Island {
     /// Deterministically minted, session-stable id: `isl-{n}` by import
     /// position (`import::mint_island`). Part of the canonical form and thus
@@ -219,6 +259,34 @@ pub struct Island {
     pub props: JsonValue,
     /// How faithfully the markdown projection can carry this island.
     pub loss: Loss,
+}
+
+impl Island {
+    /// An island of `island_type` under `id`, carrying no payload and claiming
+    /// no projection loss. Both defaults are what the wire reads off an absent
+    /// key: `props` absent is `Null`, and a missing `loss` is the faithful
+    /// class, which is what an island with no loss recorded means. Set either
+    /// with [`with_props`](Self::with_props) / [`with_loss`](Self::with_loss).
+    pub fn new(id: String, island_type: String) -> Self {
+        Island {
+            id,
+            island_type,
+            props: JsonValue::Null,
+            loss: Loss::LOSSLESS,
+        }
+    }
+
+    /// Set [`props`](Self::props), the typed payload.
+    pub fn with_props(mut self, props: JsonValue) -> Self {
+        self.props = props;
+        self
+    }
+
+    /// Set [`loss`](Self::loss), how faithfully markdown carries this island.
+    pub fn with_loss(mut self, loss: Loss) -> Self {
+        self.loss = loss;
+        self
+    }
 }
 
 /// The markdown-projection loss class of an island: a **description** of how
@@ -616,18 +684,38 @@ pub fn line_kind_mismatch(kind: &LineKind, seg: &str) -> Option<LineKindMismatch
 }
 
 impl Content {
-    /// An empty content: one empty `Para` line, no marks, no islands.
-    pub fn empty() -> Self {
+    /// The text and its per-line attributes: what a content always carries.
+    /// Marks and islands start empty and have [`with_marks`](Self::with_marks) /
+    /// [`with_islands`](Self::with_islands) beside them.
+    ///
+    /// Constructing does not normalize or check: the invariants in this type's
+    /// docs are still the caller's until [`validate`](Self::validate) runs. The
+    /// codecs ([`crate::import`], [`Content::from_canonical_json`]) are the paths
+    /// that establish them, and are what a consumer normally builds through.
+    pub fn new(text: String, lines: Vec<Line>) -> Self {
         Content {
-            text: String::new(),
-            lines: vec![Line {
-                kind: LineKind::Para,
-                containers: Vec::new(),
-                continues: false,
-            }],
+            text,
+            lines,
             marks: Vec::new(),
             islands: Vec::new(),
         }
+    }
+
+    /// Set [`marks`](Self::marks), the range-anchored marks over the text.
+    pub fn with_marks(mut self, marks: Vec<Mark>) -> Self {
+        self.marks = marks;
+        self
+    }
+
+    /// Set [`islands`](Self::islands), one per [`ISLAND_SLOT`] in slot order.
+    pub fn with_islands(mut self, islands: Vec<Island>) -> Self {
+        self.islands = islands;
+        self
+    }
+
+    /// An empty content: one empty `Para` line, no marks, no islands.
+    pub fn empty() -> Self {
+        Content::new(String::new(), vec![Line::new(LineKind::Para)])
     }
 
     /// Total length in USV.

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -16,7 +16,7 @@ use quillmark_content::delta::diff_import;
 use quillmark_content::export::to_markdown;
 use quillmark_content::import::from_markdown;
 use quillmark_content::model::{Line, Mark, MarkKind};
-use quillmark_content::{Delta, Island, LineKind, LineOp, Loss, MarkOp, Op, Content};
+use quillmark_content::{Content, Delta, Island, LineKind, LineOp, MarkOp, Op};
 use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
@@ -206,15 +206,10 @@ proptest! {
         let e2 = n;
 
         let marks = vec![
-            Mark { start: s1, end: e1, kind: ov_kind(k1i) },
-            Mark { start: s2, end: e2, kind: ov_kind(k2i) },
+            Mark::new(s1, e1, ov_kind(k1i)),
+            Mark::new(s2, e2, ov_kind(k2i)),
         ];
-        let mut rt = Content {
-            text: text.clone(),
-            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
-            marks,
-            islands: vec![],
-        };
+        let mut rt = Content::new(text.clone(), vec![Line::new(LineKind::Para)]).with_marks(marks);
         rt.normalize();
         prop_assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
 
@@ -268,12 +263,7 @@ proptest! {
             .chain(std::iter::once('a'))
             .collect();
         let n = text.chars().count();
-        let mut rt = Content {
-            text: text.clone(),
-            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
-            marks: vec![],
-            islands: vec![],
-        };
+        let mut rt = Content::new(text.clone(), vec![Line::new(LineKind::Para)]);
         rt.normalize();
         // Stay in the valid domain and only mark when the text length is intact
         // (normalization can reshape whitespace-only content).
@@ -328,18 +318,11 @@ proptest! {
         // that so the hand-built content stays inside the fixed-point domain.
         let alt = alt.trim().to_string();
         let text = "lnk\u{FFFC}".to_string(); // link over "lnk", image slot after
-        let mut rt = Content {
-            text,
-            lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
-            marks: vec![Mark { start: 0, end: 3, kind: MarkKind::Link { url: link_url } }],
-            islands: vec![Island {
-                // The id import mints for the first island, so re-import compares equal.
-                id: "isl-0".into(),
-                island_type: "image".into(),
-                props: json!({ "alt": alt, "url": img_url }),
-                loss: Loss::LOSSLESS,
-            }],
-        };
+        let mut rt = Content::new(text, vec![Line::new(LineKind::Para)])
+            .with_marks(vec![Mark::new(0, 3, MarkKind::Link { url: link_url })])
+            // The id import mints for the first island, so re-import compares equal.
+            .with_islands(vec![Island::new("isl-0".into(), "image".into())
+                .with_props(json!({ "alt": alt, "url": img_url }))]);
         rt.normalize();
         prop_assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
         let md = to_markdown(&rt);
@@ -378,7 +361,7 @@ proptest! {
         let start = 5;
         let end = 5 + a.chars().count();
         prop_assert_eq!(&base.text[start..end], a.as_str());
-        base.marks.push(Mark { start, end, kind: MarkKind::Anchor { id: "c1".into() } });
+        base.marks.push(Mark::new(start, end, MarkKind::Anchor { id: "c1".into() }));
         base.normalize();
 
         // Rewrite prepends `b` (edit before the anchor); anchored text unchanged.
@@ -475,11 +458,7 @@ proptest! {
         let len = rt.len_usv();
         let a = a_seed % (len + 1);
         let b = b_seed % (len + 1);
-        rt.marks.push(Mark {
-            start: a.min(b),
-            end: a.max(b),
-            kind: MarkKind::Anchor { id: ID.into() },
-        });
+        rt.marks.push(Mark::new(a.min(b), a.max(b), MarkKind::Anchor { id: ID.into() }));
         rt.normalize();
         prop_assert_eq!(rt.validate(), Ok(()), "seeded content invalid for {:?}", md);
 
@@ -620,21 +599,10 @@ fn import_row(contents: &[String]) -> Vec<Value> {
 /// A single-table content with the given (possibly ill-shaped) props. `id` is the
 /// first-island id import mints (`isl-0`), so a re-imported table compares equal.
 fn table_content(aligns: Vec<&str>, header: Vec<Value>, rows: Vec<Vec<Value>>) -> Content {
-    Content {
-        text: "\u{FFFC}".into(),
-        lines: vec![Line {
-            kind: LineKind::Island,
-            containers: vec![],
-            continues: false,
-        }],
-        marks: vec![],
-        islands: vec![Island {
-            id: "isl-0".into(),
-            island_type: "table".into(),
-            props: json!({ "aligns": aligns, "header": header, "rows": rows }),
-            loss: Loss::LOSSLESS,
-        }],
-    }
+    Content::new("\u{FFFC}".into(), vec![Line::new(LineKind::Island)]).with_islands(vec![
+        Island::new("isl-0".into(), "table".into())
+            .with_props(json!({ "aligns": aligns, "header": header, "rows": rows })),
+    ])
 }
 
 proptest! {

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -708,11 +708,7 @@ This body and the metadata above are an indorsement card.
 
         let mut doc = sample();
         let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
-        content.marks.push(Mark {
-            start: 0,
-            end: 10,
-            kind: MarkKind::Underline,
-        });
+        content.marks.push(Mark::new(0, 10, MarkKind::Underline));
         content.normalize();
         let json = quillmark_content::serial::to_canonical_value(&content);
         let schema = crate::quill::FieldSchema::new(

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -487,11 +487,7 @@ fn test_install_body_sets_directly() {
 
     let mut content = quillmark_content::import::from_markdown("underlined body").unwrap();
     // An `underline` mark has no markdown projection: the content path must keep it.
-    content.marks.push(Mark {
-        start: 0,
-        end: 10,
-        kind: MarkKind::Underline,
-    });
+    content.marks.push(Mark::new(0, 10, MarkKind::Underline));
     content.normalize();
 
     let mut card = Card::new("note").unwrap();
@@ -512,11 +508,7 @@ fn test_install_field_sets_directly() {
     use quillmark_content::model::{Mark, MarkKind};
 
     let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
-    content.marks.push(Mark {
-        start: 0,
-        end: 10,
-        kind: MarkKind::Underline,
-    });
+    content.marks.push(Mark::new(0, 10, MarkKind::Underline));
     content.normalize();
 
     let mut card = Card::new("note").unwrap();
@@ -547,11 +539,9 @@ fn test_revise_field_diff_imports_and_returns_delta() {
 
     // Anchor the field, then revise: the anchor rebases onto surviving text.
     let mut base = card.field_richtext("intro").unwrap().unwrap();
-    base.marks.push(Mark {
-        start: 6,
-        end: 12, // "target"
-        kind: MarkKind::Anchor { id: "c1".into() },
-    });
+    // 6..12 is "target".
+    base.marks
+        .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
     base.normalize();
     card.install_field("intro", base).unwrap();
     card.revise_field("intro", "why keep the target here").unwrap();
@@ -595,11 +585,9 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
     // Anchor "target", then revise: the anchor rebases onto surviving text and
     // the single-line result still conforms.
     let mut base = card.field_richtext("subject").unwrap().unwrap();
-    base.marks.push(Mark {
-        start: 6,
-        end: 12, // "target"
-        kind: MarkKind::Anchor { id: "c1".into() },
-    });
+    // 6..12 is "target".
+    base.marks
+        .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
     base.normalize();
     card.install_field("subject", base).unwrap();
     card.revise_field_checked("subject", "why keep the target here", &inline)
@@ -641,11 +629,7 @@ fn test_commit_field_richtext_content_object_reads_back() {
 
     let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
     // `underline` has no markdown projection: the content store must keep it.
-    content.marks.push(Mark {
-        start: 0,
-        end: 10,
-        kind: MarkKind::Underline,
-    });
+    content.marks.push(Mark::new(0, 10, MarkKind::Underline));
     content.normalize();
     let json = quillmark_content::serial::to_canonical_value(&content);
 
@@ -943,11 +927,7 @@ fn test_revise_body_rebases_anchor() {
 
     let mut base = quillmark_content::import::from_markdown("keep the target word").unwrap();
     // Anchor over "target" (chars 9..15).
-    base.marks.push(Mark {
-        start: 9,
-        end: 15,
-        kind: MarkKind::Anchor { id: "c1".into() },
-    });
+    base.marks.push(Mark::new(9, 15, MarkKind::Anchor { id: "c1".into() }));
     base.normalize();
     let mut card = Card::new("note").unwrap();
     card.install_body(base);

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -397,11 +397,7 @@ mod tests {
 
         let mut card = Card::new("note").unwrap();
         let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
-        content.marks.push(Mark {
-            start: 0,
-            end: 10,
-            kind: MarkKind::Underline,
-        });
+        content.marks.push(Mark::new(0, 10, MarkKind::Underline));
         content.normalize();
         let json = quillmark_content::serial::to_canonical_value(&content);
         let schema = crate::quill::FieldSchema::new(

--- a/docs/migrations/0.99-to-0.100.md
+++ b/docs/migrations/0.99-to-0.100.md
@@ -1,4 +1,4 @@
-# 0.99 → 0.100 — card `$id` is removed
+# 0.99 → 0.100 — card `$id` is removed, and the content model closes
 
 `$id` is gone from the document model: the reserved key, its resolver, its
 uniqueness contract, and its projection on both bindings. Nothing in the engine
@@ -110,3 +110,49 @@ Unknown `$id` system-metadata key: the card-yaml block accepts only
 
 The unsigiled `id` is unaffected: it was always an ordinary user field, and a
 schema declaring `id` keeps working unchanged.
+
+## The content model takes `#[non_exhaustive]`
+
+`Content`, `Line`, `Mark`, and `Island` were the four public structs the 0.99
+sweep missed: the pass ran as two issues split by crate, and `quillmark-content`
+had only its enums covered. They carry the attribute now, on the same terms as
+the rest of the API, so a struct literal outside `quillmark-content` gives way to
+`new` plus the `with_*` setters. Nothing about the wire, the canonical bytes, or
+the stored form moves: this is a Rust source break only, and the bindings are
+untouched.
+
+| Break | Surface | Action |
+|---|---|---|
+| `Content { .. }` literal | Rust | `Content::new(text, lines)`, then `.with_marks(…)` / `.with_islands(…)` |
+| `Line { .. }` literal | Rust | `Line::new(kind)`, then `.with_containers(…)` / `.with_continues(true)` |
+| `Mark { .. }` literal | Rust | `Mark::new(start, end, kind)` |
+| `Island { .. }` literal | Rust | `Island::new(id, island_type)`, then `.with_props(…)` / `.with_loss(…)` |
+
+Every field stays `pub`, so reading and assigning are unchanged; only the literal
+and an exhaustive destructuring are forbidden. A consumer normally builds through
+`from_markdown` / `from_canonical_json` / the op channels, which are unaffected.
+
+```rust
+// 0.99
+let rt = Content {
+    text: "abcdef".to_string(),
+    lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
+    marks: vec![Mark { start: 0, end: 4, kind: MarkKind::Strong }],
+    islands: vec![],
+};
+
+// 0.100
+let rt = Content::new("abcdef".to_string(), vec![Line::new(LineKind::Para)])
+    .with_marks(vec![Mark::new(0, 4, MarkKind::Strong)]);
+```
+
+Each `new` takes what the value always carries and every optional field starts
+absent, so the defaults are the wire's own reading of an omitted key: a `Line`
+with no containers that starts a new block, and an `Island` with `Null` props
+whose `loss` is the faithful class. Set anything else with the setter.
+
+`Delta`, `Segment`, and `BaseLengthMismatch` stay open deliberately, and now say
+so in their rustdoc — `Delta` because `{ops}` *is* the serde wire, where a second
+field is a wire change regardless of the attribute, and the other two because
+they are small derived shapes with nothing to grow. For those three a new field
+would be a semver-major.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -18,7 +18,7 @@ order; each states its own breaks in full.
 
 | Step | What changes |
 |---|---|
-| [0.99 → 0.100](0.99-to-0.100.md) | Card `$id` is removed: the reserved key, `find_card` / `set_card_id` / `remove_card_id`, the collision errors, and `cardIndexById` / `card_index_by_id` plus the projected `id` on both bindings. Per-card consumer keys move to `$ext` under a namespace you own, with no uniqueness guarantee. |
+| [0.99 → 0.100](0.99-to-0.100.md) | Card `$id` is removed: the reserved key, `find_card` / `set_card_id` / `remove_card_id`, the collision errors, and `cardIndexById` / `card_index_by_id` plus the projected `id` on both bindings. Per-card consumer keys move to `$ext` under a namespace you own, with no uniqueness guarantee. `Content`, `Line`, `Mark`, and `Island` take `#[non_exhaustive]`, the four the 0.99 sweep missed, so their literals give way to `new` plus `with_*` setters. |
 | [0.98 → 0.99](0.98-to-0.99.md) | The Rust API opens ahead of 1.0.0: `#[non_exhaustive]` across the published crates, so an exhaustive `match` needs a `_` arm and a struct literal gives way to `new` plus `with_*` setters. `attrs` beside a built-in discriminator is rejected where a host authors it, instead of resolving to the built-in and dropping the payload in silence. Island `loss` opens; a handle from a second copy of `@quillmark/wasm` is refused. |
 | [0.97 → 0.98](0.97-to-0.98.md) | The block vocabulary opens — an unrecognized line kind or container round-trips opaque instead of failing the load. `OutputFormat::Txt` retires on every surface. |
 | [0.96 → 0.97](0.96-to-0.97.md) | The WASM transport read renames to `Document.getStored`. A card `$id` becomes unique per document and never empty. |

--- a/prose/canon/COMPATIBILITY.md
+++ b/prose/canon/COMPATIBILITY.md
@@ -97,6 +97,18 @@ Constructor shape: `new` takes the fields a value *always* carries; everything
 optional starts absent and has a `with_*` setter beside it. A `new` that takes
 every field is exactly as brittle as the literal it replaced.
 
+Three structs keep the exemption, each saying so in its own rustdoc:
+
+| Struct | Why the literal is worth keeping |
+|---|---|
+| `Delta` | `{ops}` *is* the serde wire, so a second field is a wire change every binding's codec learns either way: the one freedom the attribute buys, this type cannot spend. |
+| `Segment` | A derived view `line_segments` recomputes whole, holding one line's position in the two coordinate spaces the model has. A third space moves the model first. |
+| `BaseLengthMismatch` | Two lengths are the whole of one comparison. |
+
+For all three a new field is a semver-major. Note the seam an integration test
+sits on: `crates/content/tests/` is out-of-crate, so the crate's own property
+tests build through the constructors like any consumer.
+
 `RenderOptions` is the type this cost is real for. `#[non_exhaustive]` forbids
 functional update, so `RenderOptions { .., ..Default::default() }` does not
 compile out-of-crate and `RenderOptions::default().with_output_format(…)` is the

--- a/prose/canon/COMPATIBILITY.md
+++ b/prose/canon/COMPATIBILITY.md
@@ -101,13 +101,15 @@ Three structs keep the exemption, each saying so in its own rustdoc:
 
 | Struct | Why the literal is worth keeping |
 |---|---|
-| `Delta` | `{ops}` *is* the serde wire, so a second field is a wire change every binding's codec learns either way: the one freedom the attribute buys, this type cannot spend. |
+| `Delta` | The one freedom the attribute buys, this type cannot spend: `{ops}` *is* the serde wire, so a second field is a wire change every binding's codec learns either way. |
 | `Segment` | A derived view `line_segments` recomputes whole, holding one line's position in the two coordinate spaces the model has. A third space moves the model first. |
 | `BaseLengthMismatch` | Two lengths are the whole of one comparison. |
 
-For all three a new field is a semver-major. Note the seam an integration test
-sits on: `crates/content/tests/` is out-of-crate, so the crate's own property
-tests build through the constructors like any consumer.
+For all three a new field is a semver-major.
+
+An integration test sits out-of-crate, so `crates/content/tests/` builds through
+the constructors like any consumer, and the attribute is under test where the
+crate's own unit tests cannot reach it.
 
 `RenderOptions` is the type this cost is real for. `#[non_exhaustive]` forbids
 functional update, so `RenderOptions { .., ..Default::default() }` does not


### PR DESCRIPTION
Closes #1146.

`Content`, `Line`, `Mark`, and `Island` were the four public structs the 0.99 sweep missed: it ran as two issues split by crate, so `quillmark-content` had only its enums covered (#1090) while the struct pass (#1103) listed the `core` / `pdf` / `pdfform` types. They carry the attribute now, with the `new` + `with_*` constructors `COMPATIBILITY.md` asks for.

Option 2 from the issue: the model four take it, the other three stay open with the exemption recorded in rustdoc. Option 1 (all seven) buys `Delta` a freedom it cannot spend.

## What changes

| Type | Constructor | Setters |
|---|---|---|
| `Content` | `new(text, lines)` | `with_marks`, `with_islands` |
| `Line` | `new(kind)` | `with_containers`, `with_continues` |
| `Mark` | `new(start, end, kind)` | — the three fields are the whole of a mark |
| `Island` | `new(id, island_type)` | `with_props`, `with_loss` |

Every field stays `pub`, so reading and assigning are unchanged; only the literal and an exhaustive destructuring are forbidden. Nothing on the wire, in the canonical bytes, or in the stored form moves, and neither binding is touched: this is a Rust source break only.

The defaults are not new. Each optional field starts absent at the wire's own reading of an omitted key, so a hand-built value and a decoded one agree: `containers` empty and `continues` false on a line, `Null` props and the faithful loss class on an island (`serial.rs`: "a missing key is the faithful class, which is what an island with no loss recorded means").

## The three that stay open

`Delta`, `Segment`, and `BaseLengthMismatch` keep the exemption and now say so in rustdoc, the convention every deliberate exemption in the tree follows (`KnownIslandType`, `Fidelity`, `quillmark_pdf::FieldType`). `Delta` is the clearest: the attribute buys exactly one freedom, adding a field, and `{ops}` *is* the serde wire, so a second field is a wire change every binding's codec learns either way. `Segment` is a derived view `line_segments` recomputes whole; `BaseLengthMismatch` is two lengths describing one comparison. `COMPATIBILITY.md` gains the struct table beside the enum one.

## Call sites

58 literals across 8 files, rewritten to builders: `quillmark-typst` (`emit.rs`, `overlay/span_scan.rs`, `lib.rs`, `tests/overlap_compile.rs`), `quillmark-core` (`document/dto.rs`, `wire.rs`, `tests/edit_tests.rs`), and `crates/content/tests/properties.rs`.

That last one is worth noting: an integration test is a separate crate, so content's own property tests build through the constructors like any consumer, and the attribute is under test where a unit test cannot reach it.

## Docs

`docs/migrations/0.99-to-0.100.md` gains a section and the title broadens to cover both topics; `docs/migrations/index.md` gains the summary. No `CHANGELOG.md` entry: it has no unreleased section, and the `$id` removal already sitting unreleased has none either, so release notes stay curated at tag time. Say the word if you want it recorded now instead.

## Verification

- `cargo test --workspace` green: 49 suites, 0 failures
- `cargo check --workspace --all-targets` warning-free
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`, the standing lint gate, clean
- `node scripts/check-canon.mjs` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUTfK8K4THaNy25pMobUdu)_