### PR TITLE
docs(canon): name the equals change gate, unwrap BINDINGS prose

### DIFF
--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -4,118 +4,49 @@
 
 ## TL;DR
 
-Quillmark exposes one core engine through several language surfaces: Python
-(PyO3), WebAssembly (wasm-bindgen), and a CLI binary. Every surface drives the
-same `quillmark` core: the same
-`Document`/`Quill`/`Card` model, the same `serde` diagnostics, and the same
-capability principle. Surfaces differ only in language idiom, packaging, and
-which extras they expose (canvas preview is WASM-only).
+Quillmark exposes one core engine through several language surfaces: Python (PyO3), WebAssembly (wasm-bindgen), and a CLI binary. Every surface drives the same `quillmark` core: the same `Document`/`Quill`/`Card` model, the same `serde` diagnostics, and the same capability principle. Surfaces differ only in language idiom, packaging, and which extras they expose (canvas preview is WASM-only).
 
 ## Shared model
 
-- **Capability principle.** A `Quill` is portable, declarative config data.
-  Its format capability (`supportedFormats`) and rendering are resolved by the
-  `Quillmark` engine *against* a quill at render time: never by the quill
-  itself. So `quill.metadata` is a pure, infallible config snapshot, while
-  `render` / `supportedFormats` can fail for an unregistered backend.
-- **One model, serialized across every boundary.** The `Document`/`Card` model
-  and `Diagnostic`s cross each language boundary as the same core `serde`
-  shapes (`CardWire`, the versioned storage DTO, `Diagnostic`), so a card or
-  an error reads identically no matter which surface emits it. See
-  [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md), [CARDS.md](CARDS.md),
-  [ERROR.md](ERROR.md).
-- **Uniform errors.** Each binding raises a single error type that always
-  carries a non-empty diagnostic list (`QuillmarkError.diagnostics` /
-  thrown `Error.diagnostics`).
+- **Capability principle.** A `Quill` is portable, declarative config data. Its format capability (`supportedFormats`) and rendering are resolved by the `Quillmark` engine *against* a quill at render time: never by the quill itself. So `quill.metadata` is a pure, infallible config snapshot, while `render` / `supportedFormats` can fail for an unregistered backend.
+- **One model, serialized across every boundary.** The `Document`/`Card` model and `Diagnostic`s cross each language boundary as the same core `serde` shapes (`CardWire`, the versioned storage DTO, `Diagnostic`), so a card or an error reads identically no matter which surface emits it. See [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md), [CARDS.md](CARDS.md), [ERROR.md](ERROR.md).
+- **Uniform errors.** Each binding raises a single error type that always carries a non-empty diagnostic list (`QuillmarkError.diagnostics` / thrown `Error.diagnostics`).
 
-The WASM binding is the reference surface; Python mirrors it within its scope
-(Tier 1 + storage + render; see the scope note below). New contract work lands
-in WASM first.
+The WASM binding is the reference surface; Python mirrors it within its scope (Tier 1 + storage + render; see the scope note below). New contract work lands in WASM first.
 
 ## The write surface: object placement over one primitive
 
 Placement decides where a mutation verb lives, in one sentence:
 
-> **If a verb needs a schema, it lives on the writer. `Document` is quill-free
-> data.**
+> **If a verb needs a schema, it lives on the writer. `Document` is quill-free data.**
 
-`quill.writer(doc)` (mirroring core's `quill.writer(&mut doc)`) is the one
-schema-bound door: bare `set` / `set_all` / `setBody` / `reviseField` / `addCard`
-/ `card(i)`, names and markdown in, diagnostics out. It resolves each field's type
-from the bound quill, so a name the schema does not declare is a typo
-(`UnknownField`), not a fallback.
+`quill.writer(doc)` (mirroring core's `quill.writer(&mut doc)`) is the one schema-bound door: bare `set` / `set_all` / `setBody` / `reviseField` / `addCard` / `card(i)`, names and markdown in, diagnostics out. It resolves each field's type from the bound quill, so a name the schema does not declare is a typo (`UnknownField`), not a fallback.
 
-`Document` holds everything quill-free: the opaque `store*` primitive (verbatim,
-coercion deferred to render) and the addressed content lane: `install` / `revise`
-/ `applyChange` plus the `importMarkdown` / `exportMarkdown` / `rebase` / `mapPos`
-codec: which navigate by `Addr` and return `Delta` receipts but never consult a
-schema. **Transport** reads (`getStored` / `isFill` / `getExt`) return the stored
-value verbatim, need no schema, and sit on `Document` too.
+`Document` holds everything quill-free: the opaque `store*` primitive (verbatim, coercion deferred to render) and the addressed content lane: `install` / `revise` / `applyChange` plus the `importMarkdown` / `exportMarkdown` / `rebase` / `mapPos` codec: which navigate by `Addr` and return `Delta` receipts but never consult a schema. **Transport** reads (`getStored` / `isFill` / `getExt`) return the stored value verbatim, need no schema, and sit on `Document` too.
 
-The one **interpreting** read (projecting a field by its type) is a
-schema-shaped question ("this field's richtext, as markdown"), so it gains a
-schema-bound home: `quill.reader(doc)`, the read twin of `quill.writer(doc)`
-(mirroring core's `quill.reader(&doc)`). `reader.get(addr)` reads each field by its
-declared type: a `richtext` field to markdown, a `plaintext` field to its
-literal text (marks verbatim), every other type verbatim: with schema
-authority, so a name the schema does not declare throws `UnknownField` instead of
-reading back `undefined`, and a content field holding an undecodable value throws
-`FieldRichtextDecode`. A field's markdown lives here: `getMarkdown` /
-`get_markdown` / `get_card_markdown` are **body-only** (WASM `getMarkdown` takes a
-`CardAddr`; a present `field` throws), and the quill-free **body** projection
-stays on `Document` (a body's type is a format fact, not a schema fact, so
-`reader.getBody` mirrors it rather than gating it on the schema). The placement rule
-generalizes: *a verb that needs a schema lives on the writer (writes) or the view
-(reads); `Document` is quill-free data.*
+The one **interpreting** read (projecting a field by its type) is a schema-shaped question ("this field's richtext, as markdown"), so it gains a schema-bound home: `quill.reader(doc)`, the read twin of `quill.writer(doc)` (mirroring core's `quill.reader(&doc)`).
 
-`reviseField` is the writer verb that is both typed *and* anchor-preserving: it
-rebases surviving anchors like the content `revise`, then conforms the diffed
-result to the field schema like `set`. Because it needs the schema, it lives on
-the writer: wrapping core's `Card::revise_field_checked` primitive, which
-`Document` does not expose.
+`reader.get(addr)` reads each field by its declared type: a `richtext` field to markdown, a `plaintext` field to its literal text (marks verbatim), every other type verbatim: with schema authority, so a name the schema does not declare throws `UnknownField` instead of reading back `undefined`, and a content field holding an undecodable value throws `FieldRichtextDecode`.
 
-**The verb carries the lane.** One vocabulary rule, stated once here: **store**
-= verbatim (the quill-free opaque write, coercion deferred to render), **set** =
-typed (the writer's strict commit at the write), **install / revise / apply** =
-content (identity-aware). `remove_*` has no lane: one verb serves every write path.
-So `store_field` / `store_fields` / `store_fill` (+ `store_ext` / `store_seed_*`)
-are the opaque store, `set` / `set_all` / `set_body` the typed writer, and a name
-never needs per-verb disambiguation against its neighbor (the opaque batch
-`store_fields` and the typed batch `set_all` are not near-homographs).
+A field's markdown lives here: `getMarkdown` / `get_markdown` / `get_card_markdown` are **body-only** (WASM `getMarkdown` takes a `CardAddr`; a present `field` throws), and the quill-free **body** projection stays on `Document` (a body's type is a format fact, not a schema fact, so `reader.getBody` mirrors it rather than gating it on the schema). The placement rule generalizes: *a verb that needs a schema lives on the writer (writes) or the view (reads); `Document` is quill-free data.*
 
-**The read side mirrors it.** The verbatim read is `getStored`: the read echo of
-`store`, and the interpreted read is `reader.get`, the reader/writer twin of
-`set`. So the transport and schema-plane reads carry the lane in the verb the same
-way the writes do, rather than collapsing both onto one `get` where only the
-receiver (`doc` vs `reader`) tells them apart. (Core needs no such split: its
-verbatim read is the map-idiomatic `payload().get`, already lexically distinct from
-`reader.get`; the collision is a WASM/pyo3 artifact of fusing the read onto the one
-`Document` handle, so only the bindings rename it.)
+`reviseField` is the writer verb that is both typed *and* anchor-preserving: it rebases surviving anchors like the content `revise`, then conforms the diffed result to the field schema like `set`. Because it needs the schema, it lives on the writer: wrapping core's `Card::revise_field_checked` primitive, which `Document` does not expose.
+
+**The verb carries the lane.** One vocabulary rule, stated once here: **store** = verbatim (the quill-free opaque write, coercion deferred to render), **set** = typed (the writer's strict commit at the write), **install / revise / apply** = content (identity-aware). `remove_*` has no lane: one verb serves every write path. So `store_field` / `store_fields` / `store_fill` (+ `store_ext` / `store_seed_*`) are the opaque store, `set` / `set_all` / `set_body` the typed writer, and a name never needs per-verb disambiguation against its neighbor (the opaque batch `store_fields` and the typed batch `set_all` are not near-homographs).
+
+**The read side mirrors it.** The verbatim read is `getStored`: the read echo of `store`, and the interpreted read is `reader.get`, the reader/writer twin of `set`. So the transport and schema-plane reads carry the lane in the verb the same way the writes do, rather than collapsing both onto one `get` where only the receiver (`doc` vs `reader`) tells them apart. (Core needs no such split: its verbatim read is the map-idiomatic `payload().get`, already lexically distinct from `reader.get`; the collision is a WASM/pyo3 artifact of fusing the read onto the one `Document` handle, so only the bindings rename it.)
 
 **`equals` is the change gate.** A consumer driving a live preview gates `apply` on structural equality against a retained clone: `if (doc.equals(last)) return; last = doc.clone()`. It covers the document the consumer did not mutate itself: one swapped in from storage, or written through a writer held elsewhere. `toJson` is byte-deterministic within a schema version, for a consumer that prefers a hashed gate.
 
 **No revision counter.** Neither `Document` nor the session carries one ([PREVIEW.md](PREVIEW.md)). Equality answers whether this is the content last compiled. A counter answers only whether something was written, so it re-applies on a load that is content-identical to the live compile. Core cannot back one regardless: `main_mut` / `cards_mut` / `payload_mut` hand out raw `&mut`, so no bump site sees every write.
 
-**Writers and card cursors are ephemeral: bind, write, discard.** They hold an
-address (the quill + document, or an index), never a cache; every call reads
-through the document, so a `removeCard` / `addCard` between binding a cursor and
-writing through it silently retargets it. A caller whose cards move re-resolves
-the index at write time ([PROGRAMMATIC.md](PROGRAMMATIC.md)).
+**Writers and card cursors are ephemeral: bind, write, discard.** They hold an address (the quill + document, or an index), never a cache; every call reads through the document, so a `removeCard` / `addCard` between binding a cursor and writing through it silently retargets it. A caller whose cards move re-resolves the index at write time ([PROGRAMMATIC.md](PROGRAMMATIC.md)).
 
-**The hand-written runtime is the real API; the wasm class is its ABI.** The
-quill-taking `_commitField` / `_commitFields` / `_addCard` / `_reviseField`
-methods are the stable ABI under the writer's `set` / `set_all` / `addCard` /
-`reviseField`: underscored and dropped from the `.d.ts`, not from the binary.
-The visible `Document` class then carries zero quill-taking methods, so the split
-is structural, not asserted.
+**The hand-written runtime is the real API; the wasm class is its ABI.** The quill-taking `_commitField` / `_commitFields` / `_addCard` / `_reviseField` methods are the stable ABI under the writer's `set` / `set_all` / `addCard` / `reviseField`: underscored and dropped from the `.d.ts`, not from the binary. The visible `Document` class then carries zero quill-taking methods, so the split is structural, not asserted.
 
 ### Parity table
 
-Every binding verb is *identical* to its core twin or names its one forced
-difference: **FFI** (a wasm-bindgen / pyo3 constraint), **idiom** (a language
-ergonomic), or **scope** (a lane a binding omits by intent: Python is Tier 1 +
-storage + render), nothing else admitted. Drift is a reviewable diff to this
-table.
+Every binding verb is *identical* to its core twin or names its one forced difference: **FFI** (a wasm-bindgen / pyo3 constraint), **idiom** (a language ergonomic), or **scope** (a lane a binding omits by intent: Python is Tier 1 + storage + render), nothing else admitted. Drift is a reviewable diff to this table.
 
 | Concept | Core | Bindings | Class |
 |---|---|---|---|
@@ -137,71 +68,33 @@ table.
 | Parse + warnings | `Document::parse(md) -> Parsed { document, warnings }` | `Document.fromMarkdown(md)` → `doc.warnings` getter | **FFI**, the wrapper fuses `Parsed` + `Document` into one session object: `fromMarkdown` returns the document directly and stashes the parse `warnings` on it (`doc.warnings`). That getter is a deliberate asymmetry with core, where warnings live only on `Parsed`: it is session state, so `equals` and the storage DTO exclude it and `loadJson`/`fromJson` clear it (a reloaded document carries no parse warnings) |
 | Engine backend roster | `engine.registered_backends()` | `engine.registered_backends()` (py) | **scope**: Python only. WASM settles the same question at build time: `build-wasm.sh` emits a Typst-free `core` variant alongside the default one, so which backends exist is a property of the artifact a consumer imported, not a runtime read |
 
-The single **idiom** row on the front door is the honest cost: the typed writer
-is the one shape pyo3 carries worst, so its "identical" is qualified, not
-claimed.
+The single **idiom** row on the front door is the honest cost: the typed writer is the one shape pyo3 carries worst, so its "identical" is qualified, not claimed.
 
 ## Python: `bindings/quillmark-python`
 
-PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface over the
-shared model; one-shot `engine.render` (no canvas).
+PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface over the shared model; one-shot `engine.render` (no canvas).
 
-> **Scope: Tier 1 + storage + render.**
-> Field I/O flows through `quill.writer(doc)` / `quill.reader(doc)` exclusively;
-> `Document` is quill-free data and structure (parse, the storage DTO,
-> `insert_card` / `remove_card` / `move_card` / `make_card`, `remove_field`,
-> the `card` / `seed_overlay` reads, `$ext` / `$seed`).
-> The opaque store (`store_field` / `store_fields` /
-> `store_fill`) and the anchor-preserving content lane (`install` / `revise` /
-> `apply_change` + the `import_markdown` / `export_markdown` / `rebase` /
-> `map_pos` codec) are **WASM-only by scope, not by lag**: their audience,
-> storage/migration tooling holding no quill and live editors preserving anchor
-> identity, is not a Python audience. A field write without a loadable quill
-> operates on the storage DTO directly.
+> **Scope: Tier 1 + storage + render.** Field I/O flows through `quill.writer(doc)` / `quill.reader(doc)` exclusively; `Document` is quill-free data and structure (parse, the storage DTO, `insert_card` / `remove_card` / `move_card` / `make_card`, `remove_field`, the `card` / `seed_overlay` reads, `$ext` / `$seed`).
+>
+> The opaque store (`store_field` / `store_fields` / `store_fill`) and the anchor-preserving content lane (`install` / `revise` / `apply_change` + the `import_markdown` / `export_markdown` / `rebase` / `map_pos` codec) are **WASM-only by scope, not by lag**: their audience, storage/migration tooling holding no quill and live editors preserving anchor identity, is not a Python audience. A field write without a loadable quill operates on the storage DTO directly.
 
-Every Python verb is identical to its core/WASM twin or names its one difference
-in the parity table above: `card=None` selectors fold the composable-card `$ext`
-/ `remove_field` twins onto one axis, and `revise_field` discards the `Delta`
-(an editor receipt). No half-mirrored lane remains to drift.
+Every Python verb is identical to its core/WASM twin or names its one difference in the parity table above: `card=None` selectors fold the composable-card `$ext` / `remove_field` twins onto one axis, and `revise_field` discards the `Delta` (an editor receipt). No half-mirrored lane remains to drift.
 
-**The surface is typed.** pyo3 docstrings are runtime-only, so the wheel ships a
-`py.typed` marker beside a hand-written `_quillmark.pyi`: without them every
-class resolves to `Any`. The stub is signatures only, the prose staying in
-`src/`, and nothing gates the two together: unlike WASM's `runtime.d.ts`, which
-CI typechecks against the generated backend declarations, a Python verb can be
-added or resignatured without the stub following. `python -m mypy.stubtest
---ignore-disjoint-bases quillmark` is the check to run by hand when it changes.
+**The surface is typed.** pyo3 docstrings are runtime-only, so the wheel ships a `py.typed` marker beside a hand-written `_quillmark.pyi`: without them every class resolves to `Any`. The stub is signatures only, the prose staying in `src/`, and nothing gates the two together: unlike WASM's `runtime.d.ts`, which CI typechecks against the generated backend declarations, a Python verb can be added or resignatured without the stub following. `python -m mypy.stubtest --ignore-disjoint-bases quillmark` is the check to run by hand when it changes.
 
 ## WebAssembly: `bindings/quillmark-wasm`
 
-wasm-bindgen bindings published as `@quillmark/wasm`. Builds with
-`--target bundler` and `--weak-refs` so wasm-bindgen handles are reclaimed by
-`FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires
-Node 22+ / current evergreen browsers.
+wasm-bindgen bindings published as `@quillmark/wasm`. Builds with `--target bundler` and `--weak-refs` so wasm-bindgen handles are reclaimed by `FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires Node 22+ / current evergreen browsers.
 
-Ships **multiple artifacts from one crate** behind a single public root export.
-The root `@quillmark/wasm` is a hand-written **canonical runtime layer** that
-re-exports the internal Typst-less **core** build's `Document` + `Quill`
-(load / validate / schema / seed / blueprint) verbatim and adds an `Engine`
-render dispatcher. Each backend (Typst and pdfform) is a **private** build with
-its own linear memory, lazily loaded on the first render: there is no public
-`/core` or `/render` subpath. The core build is ~0.66 MB gzip; the Typst backend
-~8 MB (Typst dominates), loaded only when something renders. Backend handles
-never escape the `Engine`: it clones the quill tree + `doc.toJson()` into the
-backend's memory as serialized data and frees the clones.
+Ships **multiple artifacts from one crate** behind a single public root export. The root `@quillmark/wasm` is a hand-written **canonical runtime layer** that re-exports the internal Typst-less **core** build's `Document` + `Quill` (load / validate / schema / seed / blueprint) verbatim and adds an `Engine` render dispatcher.
 
-**Exactly one copy of the package per process.** Two copies are two core
-builds (two linear memories, two `Quill`/`Document` classes), and no topology
-legitimately loads a multi-megabyte binary twice and needs handles to cross
-between the copies. Every seam taking a core handle checks it and throws a
-`QuillmarkError` naming the duplicate install, including the ones that could
-cross as data (`Engine`, `LiveSession.apply`). Errors are the exception:
-`isQuillmarkError` stays structural, an error being data rather than a handle.
+Each backend (Typst and pdfform) is a **private** build with its own linear memory, lazily loaded on the first render: there is no public `/core` or `/render` subpath. The core build is ~0.66 MB gzip; the Typst backend ~8 MB (Typst dominates), loaded only when something renders.
 
-Beyond the byte-output verbs (`engine.render`, `LiveSession.render`), the
-canvas-capable backend builds (Typst, and pdfform under its preview seam)
-expose a **live preview** path on `LiveSession` (`apply`, `pageCount`,
-`pageSize`, `paint`, …). See [PREVIEW.md](PREVIEW.md).
+Backend handles never escape the `Engine`: it clones the quill tree + `doc.toJson()` into the backend's memory as serialized data and frees the clones.
+
+**Exactly one copy of the package per process.** Two copies are two core builds (two linear memories, two `Quill`/`Document` classes), and no topology legitimately loads a multi-megabyte binary twice and needs handles to cross between the copies. Every seam taking a core handle checks it and throws a `QuillmarkError` naming the duplicate install, including the ones that could cross as data (`Engine`, `LiveSession.apply`). Errors are the exception: `isQuillmarkError` stays structural, an error being data rather than a handle.
+
+Beyond the byte-output verbs (`engine.render`, `LiveSession.render`), the canvas-capable backend builds (Typst, and pdfform under its preview seam) expose a **live preview** path on `LiveSession` (`apply`, `pageCount`, `pageSize`, `paint`, …). See [PREVIEW.md](PREVIEW.md).
 
 ## CLI: `bindings/quillmark-cli`
 

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -92,6 +92,10 @@ verbatim read is the map-idiomatic `payload().get`, already lexically distinct f
 `reader.get`; the collision is a WASM/pyo3 artifact of fusing the read onto the one
 `Document` handle, so only the bindings rename it.)
 
+**`equals` is the change gate.** A consumer driving a live preview gates `apply` on structural equality against a retained clone (`if (doc.equals(last)) return; last = doc.clone()`), so a document it did not mutate itself, swapped in from storage or written through a writer held elsewhere, recompiles only when its content differs. The compare walks a kilobyte-scale document inside wasm linear memory, orders of magnitude under the recompile it skips; `toJson` is byte-deterministic within a schema version for a hashed gate instead.
+
+**No revision counter.** `Document` carries no mutation stamp and neither does the session ([PREVIEW.md](PREVIEW.md)). A counter reports that something was written where the consumer asks whether this is the content it last compiled: it re-applies on a load that is content-identical to the live compile, and core cannot back one regardless, since `main_mut` / `cards_mut` / `payload_mut` hand out raw `&mut` that no bump site sees.
+
 **Writers and card cursors are ephemeral: bind, write, discard.** They hold an
 address (the quill + document, or an index), never a cache; every call reads
 through the document, so a `removeCard` / `addCard` between binding a cursor and

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -92,9 +92,9 @@ verbatim read is the map-idiomatic `payload().get`, already lexically distinct f
 `reader.get`; the collision is a WASM/pyo3 artifact of fusing the read onto the one
 `Document` handle, so only the bindings rename it.)
 
-**`equals` is the change gate.** A consumer driving a live preview gates `apply` on structural equality against a retained clone (`if (doc.equals(last)) return; last = doc.clone()`), so a document it did not mutate itself, swapped in from storage or written through a writer held elsewhere, recompiles only when its content differs. The compare walks a kilobyte-scale document inside wasm linear memory, orders of magnitude under the recompile it skips; `toJson` is byte-deterministic within a schema version for a hashed gate instead.
+**`equals` is the change gate.** A consumer driving a live preview gates `apply` on structural equality against a retained clone: `if (doc.equals(last)) return; last = doc.clone()`. It covers the document the consumer did not mutate itself: one swapped in from storage, or written through a writer held elsewhere. `toJson` is byte-deterministic within a schema version, for a consumer that prefers a hashed gate.
 
-**No revision counter.** `Document` carries no mutation stamp and neither does the session ([PREVIEW.md](PREVIEW.md)). A counter reports that something was written where the consumer asks whether this is the content it last compiled: it re-applies on a load that is content-identical to the live compile, and core cannot back one regardless, since `main_mut` / `cards_mut` / `payload_mut` hand out raw `&mut` that no bump site sees.
+**No revision counter.** Neither `Document` nor the session carries one ([PREVIEW.md](PREVIEW.md)). Equality answers whether this is the content last compiled. A counter answers only whether something was written, so it re-applies on a load that is content-identical to the live compile. Core cannot back one regardless: `main_mut` / `cards_mut` / `payload_mut` hand out raw `&mut`, so no bump site sees every write.
 
 **Writers and card cursors are ephemeral: bind, write, discard.** They hold an
 address (the quill + document, or an index), never a cache; every call reads


### PR DESCRIPTION
Closes #1155 as answered rather than implemented, and records why in canon.

## The change gate (`0bd5169`, `b158f60`)

Two paragraphs in `BINDINGS.md` beside the lane vocabulary:

- **`equals` is the change gate.** The live-preview idiom, gating `apply` on structural equality against a retained clone. It covers the case that motivates a mutation counter: a `Document` the consumer did not mutate itself, swapped in from storage or written through a writer held elsewhere. `toJson` is named as the byte-deterministic escalation for a hashed gate.
- **No revision counter.** Neither `Document` nor the session carries one, which reconciles this page with `PREVIEW.md`, where the same stance is already stated for the session. Two reasons recorded: equality answers whether this is the content last compiled, where a counter answers only whether something was written and so re-applies on a content-identical load; and `main_mut` / `cards_mut` / `payload_mut` hand out raw `&mut`, so no core-side bump site sees every write.

No code changes. `Document.equals` / `__eq__` already ship on both binding surfaces.

## Unwrap (`04164a3`)

`BINDINGS.md` was hard-wrapped at ~80 characters, which makes a one-word fix rewrite the whole paragraph in the diff. Reflowed to one line per paragraph, list item, and blockquote, per `prose/README.md` §"Line budget".

Reflow only: no word is added, removed, or reordered. Verified by diffing the whitespace-normalized token streams, which are identical apart from the blockquote continuation markers that joining removes. Three paragraphs cleared the 700-character gate once joined and are split at their existing claim boundaries, again without rewording.

`node scripts/check-canon.mjs` passes.

Note for a reviewer: the unwrap leaves several paragraphs over the 300-character target that `prose/README.md` sets, the longest at 634. Bringing those down means restructuring claims rather than reflowing, so they are left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJMGCD8GZdTgn2wMnQ8Weq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJMGCD8GZdTgn2wMnQ8Weq)_