### PR TITLE
Deliver init's conflict as a rejection, and state the failure-delivery rule

### DIFF
--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -83,10 +83,12 @@ the builds are `--target web`, so nothing in the package graph imports a `.wasm`
 module or carries a top-level await, and a static `import` of this package is
 safe anywhere, SSR included.
 
-`init` is idempotent and concurrency-safe: every call returns the same promise,
-so several entry points may each `await init()` for one instantiation. A failed
-init clears the memo, so a retry works. Each realm initializes its own copy; a
-Worker calls `init()` too.
+`init` is idempotent and concurrency-safe: every non-conflicting call returns
+the same promise, so several entry points may each `await init()` for one
+instantiation. Call it at the top of **every** entry point — route loader,
+hydration path, worker — rather than trusting one startup site to run first. A
+failed init clears the memo, so a retry works. Each realm initializes its own
+copy; a Worker calls `init()` too.
 
 **Backends need nothing.** `Engine` instantiates a backend inside its lazy load,
 on the first render against it.
@@ -94,9 +96,14 @@ on the first render against it.
 **Overriding the source.** `init(source)` accepts bytes, a `Response`, a
 `WebAssembly.Module`, or a URL, for hosts that route assets themselves or embed
 the binary. Pass it on the first call; a later call passing a *different* source
-throws `runtime::init_conflict` rather than silently ignoring it. Passing the
-same value again is fine, so several entry points may each `await init(BYTES)`
-against one constant.
+rejects with `runtime::init_conflict` rather than silently ignoring it. Passing
+the same value again is fine, so several entry points may each
+`await init(BYTES)` against one constant.
+
+**Both failures reject.** `runtime::init_conflict` and `runtime::init_failed`
+alike ride the returned promise, so one `catch` around `await init(...)` — or
+one `.catch` on it — covers the gate. See [Errors](#errors) for the rule this
+follows.
 
 **If you forget.** Reaching the surface early throws a `QuillmarkError` coded
 `runtime::not_initialized` that names the fix, rather than a `TypeError` from
@@ -546,6 +553,14 @@ try {
   }
 }
 ```
+
+**Delivery follows the function, not the failure.** A synchronous method throws;
+a promise-returning one rejects. The promise-returning surface is `init` and the
+four `Engine` verbs (`render`, `open`, `supportedFormats`, `supportsCanvas`),
+and a programming error reached through one of them — a foreign handle, an
+unregistered backend — rejects like any other failure. Nothing on this surface
+both returns a promise and throws, so a `.catch` on a promise-returning call is
+never half a guard.
 
 `QuillmarkError` is a **structural interface, not a class**: the WASM layer
 throws a real `Error` and attaches the property, so there is no constructor to

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -85,8 +85,8 @@ safe anywhere, SSR included.
 
 `init` is idempotent and concurrency-safe: every non-conflicting call returns
 the same promise, so several entry points may each `await init()` for one
-instantiation. Call it at the top of **every** entry point — route loader,
-hydration path, worker — rather than trusting one startup site to run first. A
+instantiation. Call it at the top of **every** entry point (route loader,
+hydration path, worker) rather than trusting one startup site to run first. A
 failed init clears the memo, so a retry works. Each realm initializes its own
 copy; a Worker calls `init()` too.
 
@@ -101,9 +101,8 @@ the same value again is fine, so several entry points may each
 `await init(BYTES)` against one constant.
 
 **Both failures reject.** `runtime::init_conflict` and `runtime::init_failed`
-alike ride the returned promise, so one `catch` around `await init(...)` — or
-one `.catch` on it — covers the gate. See [Errors](#errors) for the rule this
-follows.
+alike ride the returned promise, so one `catch` around `await init(...)` covers
+the gate. See [Errors](#errors) for the rule this follows.
 
 **If you forget.** Reaching the surface early throws a `QuillmarkError` coded
 `runtime::not_initialized` that names the fix, rather than a `TypeError` from
@@ -556,11 +555,11 @@ try {
 
 **Delivery follows the function, not the failure.** A synchronous method throws;
 a promise-returning one rejects. The promise-returning surface is `init` and the
-four `Engine` verbs (`render`, `open`, `supportedFormats`, `supportsCanvas`),
-and a programming error reached through one of them — a foreign handle, an
-unregistered backend — rejects like any other failure. Nothing on this surface
-both returns a promise and throws, so a `.catch` on a promise-returning call is
-never half a guard.
+four `Engine` verbs (`render`, `open`, `supportedFormats`, `supportsCanvas`), so
+a programming error reached through one of them (a foreign handle, an
+unregistered backend) rejects like any other failure. Nothing here both returns
+a promise and throws, so a `.catch` on a promise-returning call is a whole
+guard.
 
 `QuillmarkError` is a **structural interface, not a class**: the WASM layer
 throws a real `Error` and attaches the property, so there is no constructor to

--- a/crates/bindings/wasm/init.test.js
+++ b/crates/bindings/wasm/init.test.js
@@ -49,6 +49,19 @@ const diagnosticFrom = (fn) => {
   return thrown.diagnostics[0]
 }
 
+/** Await `promise`, expect a rejection, and return its primary diagnostic. */
+const rejectionFrom = async (promise) => {
+  let thrown
+  try {
+    await promise
+  } catch (err) {
+    thrown = err
+  }
+  expect(thrown, 'expected a rejection, got none').toBeDefined()
+  expect(isQuillmarkError(thrown)).toBe(true)
+  return thrown.diagnostics[0]
+}
+
 // Reaching a build before `init` resolves is the one mistake the contract
 // invites, so it is the one that must not surface as a generated-code
 // `TypeError`. Every generated path reads the same module-level binding, so
@@ -73,6 +86,8 @@ describe('before init', () => {
 })
 
 describe('init', () => {
+  // Identity, not just equivalence: the memo is RETURNED, which is why `init`
+  // is not declared `async` (an `async` body wraps a fresh promise per call).
   it('memoizes the promise, so concurrent callers share one instantiation', async () => {
     const a = init()
     const b = init()
@@ -91,9 +106,24 @@ describe('init', () => {
 
   // Silently ignoring a second, different source would leave a consumer
   // believing they chose the binary they are running.
-  it('refuses a different source once initialized', () => {
-    const d = diagnosticFrom(() => init(new Uint8Array(8)))
+  it('refuses a different source once initialized', async () => {
+    const d = await rejectionFrom(init(new Uint8Array(8)))
     expect(d.code).toBe('runtime::init_conflict')
+  })
+
+  // The conflict rides the promise, never the caller's stack: `init` returns a
+  // `Promise<void>`, a type that cannot declare a synchronous throw, so a throw
+  // would escape the `init(BYTES).catch(...)` the declaration invites. This is
+  // the surface-wide rule (delivery follows the function kind) at the one
+  // export that could break it.
+  it('delivers the conflict as a rejection, not a synchronous throw', () => {
+    /** @type {Promise<void> | undefined} */
+    let returned
+    expect(() => {
+      returned = init(new Uint8Array(8))
+    }).not.toThrow()
+    expect(returned).toBeInstanceOf(Promise)
+    returned.catch(() => {})
   })
 })
 

--- a/crates/bindings/wasm/init.test.js
+++ b/crates/bindings/wasm/init.test.js
@@ -111,11 +111,9 @@ describe('init', () => {
     expect(d.code).toBe('runtime::init_conflict')
   })
 
-  // The conflict rides the promise, never the caller's stack: `init` returns a
-  // `Promise<void>`, a type that cannot declare a synchronous throw, so a throw
-  // would escape the `init(BYTES).catch(...)` the declaration invites. This is
-  // the surface-wide rule (delivery follows the function kind) at the one
-  // export that could break it.
+  // The rule (delivery follows the function kind) at the one export that could
+  // break it: `Promise<void>` cannot declare a synchronous throw, so a throw
+  // here would escape the `init(BYTES).catch(…)` the declaration invites.
   it('delivers the conflict as a rejection, not a synchronous throw', () => {
     /** @type {Promise<void> | undefined} */
     let returned

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -37,10 +37,16 @@ import type { InitInput } from '../core/wasm.js';
  * site is the same line. Reaching a class before this resolves throws
  * `runtime::not_initialized` naming the fix.
  *
- * Idempotent and concurrency-safe: every call returns the same promise, so
- * `await init()` at several entry points costs one instantiation. A failed init
+ * Idempotent and concurrency-safe: every non-conflicting call returns the same
+ * promise, so `await init()` at several entry points costs one instantiation.
+ * Call it at the top of EVERY entry point (route loader, hydration path,
+ * worker) rather than trusting one startup site to run first. A failed init
  * clears the memo, so a retry is possible. Per realm: a Worker loads and
  * initializes its own copy.
+ *
+ * Both failure codes REJECT, so one `catch` covers the gate. Delivery follows
+ * the function kind across this surface: a sync verb throws, a
+ * promise-returning verb rejects, and nothing does both.
  *
  * Backends are NOT initialized here. `Engine` instantiates a backend inside its
  * lazy load, on first render against it.
@@ -48,7 +54,7 @@ import type { InitInput } from '../core/wasm.js';
  * @param source override the binary's source (bytes, a `Response`, a
  *   `WebAssembly.Module`, a URL) for hosts that route assets themselves or
  *   embed the binary. Pass it on the FIRST call; a later call passing a
- *   different source throws `runtime::init_conflict` rather than silently
+ *   different source rejects with `runtime::init_conflict` rather than silently
  *   ignoring it. Passing the same value again is fine.
  */
 export declare function init(source?: InitInput): Promise<void>;

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -98,16 +98,13 @@ export { parseDocPath, formatDocPath } from '../core/wasm.js';
 // build is patched to throw `runtime::not_initialized` naming the fix
 // (runtime/uninit.js).
 //
-// FAILURE DELIVERY: both of `init`'s codes arrive as rejections, so one `catch`
-// covers the gate. `init` is the only promise-returning export not declared
-// `async` (the memo must be returned by identity, not re-wrapped per call), so
-// its conflict guard rejects explicitly where an `async` body would have
-// converted a throw. The surface-wide rule this keeps: delivery follows the
-// FUNCTION kind, not the failure kind. A sync verb throws, a promise-returning
-// verb rejects, and a programming error reached through a promise-returning
-// verb (`runtime::foreign_handle` inside `Engine.render`) rejects like any
-// other. Nothing both returns a promise and throws: `Promise<void>` cannot
-// declare a synchronous throw, so a type-directed `.catch` would miss it.
+// FAILURE DELIVERY follows the FUNCTION kind, not the failure kind: a sync verb
+// throws, a promise-returning verb rejects, and nothing does both. A
+// programming error reached through a promise-returning verb
+// (`runtime::foreign_handle` inside `Engine.render`) rejects like any other.
+// `init` is the one promise-returning export not declared `async`, because the
+// memo is returned by identity; its conflict guard rejects explicitly to hold
+// the rule, which `Promise<void>` cannot declare and a `.catch` would not see.
 
 /** The in-flight or settled core instantiation. The memo is the PROMISE, not a
  * boolean, so concurrent callers share one instantiation instead of racing. */
@@ -149,9 +146,9 @@ let coreInitSource;
 export function init(source) {
 	if (coreInit) {
 		if (source !== undefined && source !== coreInitSource) {
-			// A rejection, not a throw: this function returns a promise, so a throw
-			// here would be the one failure on the promise-returning surface that
-			// lands on the caller's stack and escapes `init(BYTES).catch(...)`.
+			// A rejection, not a throw: this is the one failure on the
+			// promise-returning surface that could land on the caller's stack, where
+			// `init(BYTES).catch(…)` would not see it.
 			return Promise.reject(
 				quillmarkError(
 					'runtime::init_conflict',

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -97,6 +97,17 @@ export { parseDocPath, formatDocPath } from '../core/wasm.js';
 // Reaching core before the gate resolves is not a silent wrong answer: the
 // build is patched to throw `runtime::not_initialized` naming the fix
 // (runtime/uninit.js).
+//
+// FAILURE DELIVERY: both of `init`'s codes arrive as rejections, so one `catch`
+// covers the gate. `init` is the only promise-returning export not declared
+// `async` (the memo must be returned by identity, not re-wrapped per call), so
+// its conflict guard rejects explicitly where an `async` body would have
+// converted a throw. The surface-wide rule this keeps: delivery follows the
+// FUNCTION kind, not the failure kind. A sync verb throws, a promise-returning
+// verb rejects, and a programming error reached through a promise-returning
+// verb (`runtime::foreign_handle` inside `Engine.render`) rejects like any
+// other. Nothing both returns a promise and throws: `Promise<void>` cannot
+// declare a synchronous throw, so a type-directed `.catch` would miss it.
 
 /** The in-flight or settled core instantiation. The memo is the PROMISE, not a
  * boolean, so concurrent callers share one instantiation instead of racing. */
@@ -116,25 +127,37 @@ let coreInitSource;
  * Identical in every environment: in a browser the binary is fetched and
  * streamed, under Node it is read off disk, and the call site is the same line.
  *
- * Idempotent and concurrency-safe: every call returns the same promise, so
- * `await init()` at each of several entry points costs one instantiation. A
+ * Idempotent and concurrency-safe: every non-conflicting call returns the same
+ * promise, so `await init()` at each of several entry points costs one
+ * instantiation. Call it at the top of EVERY entry point (route loader,
+ * hydration path, worker) rather than trusting one startup site to run first. A
  * failed init clears the memo, so a retry is possible.
+ *
+ * Both failures reject (§ "Initialization", FAILURE DELIVERY): one `catch`
+ * around `await init(...)` covers `runtime::init_conflict` and
+ * `runtime::init_failed` alike.
  *
  * @param {import('../core/wasm.js').InitInput} [source] override the binary's
  *   source (bytes, a `Response`, a `WebAssembly.Module`, a URL) for hosts that
  *   route assets themselves or embed the binary. Pass it on the FIRST call; a
- *   later call passing a *different* source throws `runtime::init_conflict`
- *   rather than silently ignoring it. Passing the same value again is fine, so
- *   several entry points may each `await init(BYTES)` against one constant.
+ *   later call passing a *different* source rejects with
+ *   `runtime::init_conflict` rather than silently ignoring it. Passing the same
+ *   value again is fine, so several entry points may each `await init(BYTES)`
+ *   against one constant.
  * @returns {Promise<void>} resolves when the sync surface is usable
  */
 export function init(source) {
 	if (coreInit) {
 		if (source !== undefined && source !== coreInitSource) {
-			throw quillmarkError(
-				'runtime::init_conflict',
-				'init(source): core is already initializing or initialized from a different source.',
-				'Pass a source on the first call only, or pass the same value every time.'
+			// A rejection, not a throw: this function returns a promise, so a throw
+			// here would be the one failure on the promise-returning surface that
+			// lands on the caller's stack and escapes `init(BYTES).catch(...)`.
+			return Promise.reject(
+				quillmarkError(
+					'runtime::init_conflict',
+					'init(source): core is already initializing or initialized from a different source.',
+					'Pass a source on the first call only, or pass the same value every time.'
+				)
 			);
 		}
 		return coreInit;

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -119,10 +119,11 @@ Every Python verb is identical to its core/WASM twin or names its one difference
 
 wasm-bindgen bindings published as `@quillmark/wasm`. Builds with `--target web` and `--weak-refs` so wasm-bindgen handles are reclaimed by `FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires Node 22+ / current evergreen browsers.
 
-**The runtime owns instantiation.** `--target web` emits no `.wasm` ESM import and no top-level await, so nothing in the package graph forces a bundler plugin and a static import of `@quillmark/wasm` is safe anywhere, SSR included. The cost is that instantiation becomes explicit: `await init()` once, before the sync surface is touched.
+**The runtime owns instantiation.** `--target web` emits no `.wasm` ESM import and no top-level await, so nothing in the package graph forces a bundler plugin and a static import of `@quillmark/wasm` is safe anywhere, SSR included. The cost is that instantiation becomes explicit: `await init()` before the sync surface is touched.
 
 - **Core only.** `Engine` instantiates each backend itself, inside the lazy load, so a consumer initializes core and nothing else.
-- **Memoized on the promise**, so several entry points may each await it for one instantiation.
+- **Memoized on the promise**, so several entry points may each await it for one instantiation: the pattern is a call at the top of every entry point, not one trusted startup site.
+- **Both failure codes reject**, `runtime::init_conflict` included, keeping the delivery rule in [ERROR.md](ERROR.md) § "Bindings Error Delegation" true at the one export that could break it.
 - **One contract everywhere.** The binary streams from a URL in a browser and is read off disk under Node, resolved through the `#quillmark-env` subpath import rather than a runtime `typeof process` branch.
 
 The `--target bundler` alternative emits `import * as wasm from "./wasm_bg.wasm"`, which no browser and no bundler resolves natively; the plugin that fixes it rewrites the import to a top-level await, and because the runtime statically re-exports core, that await lands on every consumer's static module graph. `build-wasm.sh` asserts the built artifacts carry neither form.

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -105,6 +105,12 @@ Python and WASM bindings delegate to core types:
 - **Python**: `PyDiagnostic` wraps `Diagnostic`. Every raised exception is `QuillmarkError` (a single type). Every exception carries a `diagnostics` list; `str(exc)` follows the shared count-based message rule.
 - **WASM**: `WasmError` carries a single `diagnostics: Vec<Diagnostic>` (always non-empty). The thrown JS `Error` has a `.diagnostics` array attached and a `.message` derived from `diagnostics` by the same count-based rule. Consumers read `err.diagnostics[0]` for the primary diagnostic and iterate `err.diagnostics` for the rest. Parse failures (`Document.fromMarkdown`) carry the same shape; including the `parse::input_too_large` diagnostic for inputs over `MAX_INPUT_SIZE` (10 MiB) and the `edit::*` codes for post-parse mutators.
 
+**WASM delivery follows the function kind, not the failure kind.** A synchronous verb throws; a promise-returning verb rejects; nothing does both.
+
+- The promise-returning surface is `init` plus the four `Engine` verbs (`render`, `open`, `supportedFormats`, `supportsCanvas`). A programming error reached through one of them (`runtime::foreign_handle`, an unregistered backend) arrives as a rejection like any other failure.
+- `init` is the one promise-returning export not declared `async`: its memo is returned by identity rather than re-wrapped per call. Its conflict guard therefore returns `Promise.reject(runtime::init_conflict)` where an `async` body would have converted a throw.
+- A synchronous throw from `init` would lose the rule at exactly one export, and silently: `Promise<void>` cannot declare it, so the declaration invites `init(BYTES).catch(…)` and the throw escapes.
+
 ## Backend Error Mapping
 
 ### Typst


### PR DESCRIPTION
Closes #1192, taking its option 2 in the form that preserves the memo's promise identity.

## What changes

`init(source)` delivers `runtime::init_conflict` as a rejection instead of a synchronous throw. Nothing else on the surface moves.

## Why

The issue frames the split as possibly principled: a conflicting source is a programming error at a known call site, and throwing on the caller's stack surfaces it at the offending line. The code does not support that reading. `Engine.render` / `open` / `supportedFormats` / `supportsCanvas` are all `async`, so `requireLocalQuill` throwing inside them produces a rejection — `runtime::foreign_handle`, the most programming-error-shaped code on the surface, already rejects.

The rule the surface actually keeps is mechanical: **delivery follows the function kind, not the failure kind.** A sync verb throws, a promise-returning verb rejects, and nothing does both. `init` was the sole exception, and the exception is invisible: `Promise<void>` cannot declare a synchronous throw, so the declaration invites `init(BYTES).catch(report)` and the conflict escapes it.

`init` stays non-`async`. The memo is returned by identity, which `init.test.js` pins ("memoizes the promise, so concurrent callers share one instantiation"); an `async` body would wrap a fresh promise per call. The guard returns `Promise.reject(...)` instead.

## Compatibility

No documented usage changes. Every example in the README, the migration guide, and the tests uses `await init(...)` inside a `try`, which catches both codes either way. Code that catches a synchronous throw *without* awaiting is the only form affected, and no documentation has ever shown it. Worth a changelog line on the next release; not a migration guide.

## Also in this PR

- The delivery rule stated once in `prose/canon/ERROR.md` § "Bindings Error Delegation", cross-referenced from `BINDINGS.md`, with the consumer-facing statement in the README's Errors section and the type doc.
- `init`'s documented pattern corrected from "once at startup" to a call at the top of every entry point (route loader, hydration path, worker). The memo makes it free, and one trusted startup site is the fragile part in a framework app with several entries.

## Tests

`init.test.js` gains a case asserting the conflict never lands on the caller's stack, alongside the existing conflict case rewritten to await the rejection. The suite is not run locally in this session (the container lacked the pinned `wasm-bindgen-cli` and the `wasm32-unknown-unknown` target); PR CI covers it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5oitV3RmoS3HfWW3d9SJQ)_