### PR TITLE
Clarify migration guide policy: repair, don't rewrite

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -73,7 +73,7 @@ A paragraph is one line: never hard-wrap prose at a column. A line break in mark
 | Surface | Rule |
 |---|---|
 | Code and test comments, `prose/canon/`, `docs/` (non-migration) | Apply in full. |
-| `docs/migrations/**`, `CHANGELOG.md`, and era-stamped records generally | **Never touch.** Accurate to their moment, immutable. |
+| `docs/migrations/**`, `CHANGELOG.md`, and era-stamped records generally | **Repair only.** Accurate to their moment: fix what was wrong when written, leave what was right in its era's vocabulary. |
 | An em-dash that is the subject, not punctuation (an encoding table, a Unicode fixture, rendered sample output) | Keep: it is data. `crates/quillmark-pdf/src/writer.rs` maps the character to its WinAnsi byte; `prescan.rs` parses it. |
 | `prose/references/`, `prose/proposals/`, `prose/plans/` | Strip marketing only; discussing other or future states is their job. |
 | Load-bearing legacy (`crates/core/src/document/dto.rs` versioned wire schemas) | Keep: the old-format description *is* current reader behavior. Tighten wording, keep the fact. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Crates: `core` · `quillmark` · `content` · `backends/{typst,pdfform}` · `qui
 
 Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
 
-- Released guides in [`docs/migrations/`](docs/migrations/) are immutable; edit only the unreleased one.
+- Released guides in [`docs/migrations/`](docs/migrations/) are era-stamped: repair a false statement in place, never restate a true one in a later version's vocabulary.
 - The `Cargo.toml` version is the last *released* one; CI bumps it on release.
 - Commit early and often; CI gates every push.
 - Don't run `cargo fmt`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Comments and docs are dense, present-tense, and unsold:
 
 - Say what the code can't say faster. Delete comments that restate the code; prefer a clearer name over a comment.
 - No marketing words (powerful, seamless, robust, first-class, simply…). State the capability plainly.
-- Describe what *is*, not how it got here: except `docs/migrations/` (immutable) and load-bearing legacy.
+- Describe what *is*, not how it got here: except `docs/migrations/` (era-stamped) and load-bearing legacy.
 - Minimal examples on public APIs; err toward brevity.
 
 Where things live:

--- a/scripts/check-canon.mjs
+++ b/scripts/check-canon.mjs
@@ -33,7 +33,7 @@ const mdFiles = (dir) =>
   existsSync(dir) ? readdirSync(dir).filter((n) => n.endsWith('.md')).sort() : [];
 
 // Every .md under `dir`, minus `docs/migrations/`: released guides are
-// era-accurate and immutable, so no rule applies to them.
+// era-stamped, so no rule applies to them.
 const walkDocs = (dir) =>
   !existsSync(dir)
     ? []


### PR DESCRIPTION
Revise the documentation policy for released migration guides to clarify that they are era-stamped records, not immutable artifacts. The distinction matters: false statements should be corrected in place, but true statements should retain their original vocabulary rather than being restated in later versions' terms.

**Changes:**
- Updated `SKILL.md` to replace "Never touch" with "Repair only" for `docs/migrations/`, `CHANGELOG.md`, and era-stamped records, with explicit guidance on the distinction between fixing errors and preserving era-appropriate language
- Aligned `CLAUDE.md` to describe released guides as "era-stamped" with the same repair-vs-restate principle
- Updated `CONTRIBUTING.md` to use "era-stamped" terminology consistently
- Simplified the comment in `scripts/check-canon.mjs` to reflect the era-stamped concept

This clarifies the intent: these records are accurate to their moment and should be preserved as written, except where they contain factual errors that need correction.

https://claude.ai/code/session_016MDrfMXo8LUNjHvTSMMQ3m