### PR TITLE
dense-prose: wrong is worse than missing; relax em-dash ban

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -9,9 +9,11 @@ Density is facts per word. Cut words that carry no fact: the sell, the echo, the
 
 This skill is the house voice (dense, present-tense, declarative, unsold) and owns comment and doc *content*. Canon *structure* (Title → Implementation anchor → TL;DR, one concept per page) belongs to **`maintain-canon`**.
 
-## Prime directive: correctness over brevity
+## Prime directive: wrong is worse than missing
 
-Density has a numerator. A cut that drops a fact, or shifts a claim unverified against the code, is dilution, not compression. Unsure a statement still holds? Leave it. Edits are surgical: touch a line only when it breaks a rule. Prose already dense and correct is done; over-editing is the main failure mode.
+Density has a numerator, and only true facts count toward it. Something left unsaid is better than something said wrong: an unsaid fact costs the reader a lookup; a wrong one is believed. Bloat and rot are both made of claims that outran verification: the sentence nobody checked, the hand-kept list, the copied number. A claim is verified against the code or left unsaid.
+
+The bar cuts both ways. A cut that drops a fact, or shifts a claim unverified against the code, is dilution, not compression. Unsure a statement still holds? Verify, or leave it: uncertainty licenses a cut no more than it licenses a claim. Edits are surgical: touch a line only when it breaks a rule. Prose already dense and correct is done; over-editing is the main failure mode.
 
 ## 1. No marketing or persuasion
 
@@ -64,9 +66,9 @@ Deleting whole sentences is half the work; the other half is more fact per word.
 
 ## Voice
 
-Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). No em-dashes: fold to a colon when what follows names or explains what precedes it, a comma before a conjunction, a semicolon before an independent clause, and parentheses for a matched pair. One colon per sentence. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
+Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). In new prose, prefer the joint that names the relation over an em-dash: a colon when what follows names or explains what precedes it, a comma before a conjunction, a semicolon before an independent clause, parentheses for an aside. An em-dash already on the page is not a violation; removing one is never worth a pass. One colon per sentence. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
 
-A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget. `prose/README.md` sets the numeric bound on a prose line: 700 characters, gated by `scripts/check-canon.mjs` over `prose/canon/` and `docs/`, with 300 as the target you write to. Split a long line when you are editing near it; below the gate, nothing mechanical reminds you.
+A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget. The numeric bounds on a prose line live in `prose/README.md` §"Line budget"; `scripts/check-canon.mjs` gates the cap. Split a long line when you are editing near it; below the gate, nothing mechanical reminds you.
 
 ## Scope
 
@@ -74,7 +76,6 @@ A paragraph is one line: never hard-wrap prose at a column. A line break in mark
 |---|---|
 | Code and test comments, `prose/canon/`, `docs/` (non-migration) | Apply in full. |
 | `docs/migrations/**`, `CHANGELOG.md`, and era-stamped records generally | **Repair only.** Accurate to their moment: fix what was wrong when written, leave what was right in its era's vocabulary. |
-| An em-dash that is the subject, not punctuation (an encoding table, a Unicode fixture, rendered sample output) | Keep: it is data. `crates/quillmark-pdf/src/writer.rs` maps the character to its WinAnsi byte; `prescan.rs` parses it. |
 | `prose/references/`, `prose/proposals/`, `prose/plans/` | Strip marketing only; discussing other or future states is their job. |
 | Load-bearing legacy (`crates/core/src/document/dto.rs` versioned wire schemas) | Keep: the old-format description *is* current reader behavior. Tighten wording, keep the fact. |
 | Identifiers (fn / test / var names) | Never rename; out of scope, churn. |
@@ -88,4 +89,4 @@ A paragraph is one line: never hard-wrap prose at a column. A line break in mark
 
 ## Done when
 
-Comments and docs state what is, in the house voice: dense, present-tense, unsold. Nothing restates code, no header carries a rotting list, no prose narrates history or deliberation, and no surviving sentence sheds a word without shedding a fact. Backward-compat facts survive as current-state statements.
+Comments and docs state what is, in the house voice: dense, present-tense, unsold. Nothing restates code, nothing outruns what was verified, no header carries a rotting list, no prose narrates history or deliberation, and no surviving sentence sheds a word without shedding a fact. Backward-compat facts survive as current-state statements.

--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -68,7 +68,7 @@ Deleting whole sentences is half the work; the other half is more fact per word.
 
 Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). In new prose, prefer the joint that names the relation over an em-dash: a colon when what follows names or explains what precedes it, a comma before a conjunction, a semicolon before an independent clause, parentheses for an aside. An em-dash already on the page is not a violation; removing one is never worth a pass. One colon per sentence. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
 
-A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget. The numeric bounds on a prose line live in `prose/README.md` §"Line budget"; `scripts/check-canon.mjs` gates the cap. Split a long line when you are editing near it; below the gate, nothing mechanical reminds you.
+A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget.
 
 ## Scope
 

--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -66,7 +66,7 @@ Deleting whole sentences is half the work; the other half is more fact per word.
 
 ## Voice
 
-Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). In new prose, prefer the joint that names the relation over an em-dash: a colon when what follows names or explains what precedes it, a comma before a conjunction, a semicolon before an independent clause, parentheses for an aside. An em-dash already on the page is not a violation; removing one is never worth a pass. One colon per sentence. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
+Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). One colon per sentence. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
 
 A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget.
 

--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -17,7 +17,7 @@ The bar cuts both ways. A cut that drops a fact, or shifts a claim unverified ag
 
 ## 1. No marketing or persuasion
 
-A sell spends words on the reader's opinion instead of their knowledge. Cut *powerful, seamless, elegant, robust, flexible, blazing(-fast), cutting-edge, state-of-the-art, first-class (citizen), rich (set of), comprehensive, battle-tested, out of the box, leverage* (meaning "use"), and *simply / just / easily* when they only imply ease. State the capability plainly: "Partial documents are first-class citizens" → "A document need not be complete."
+A sell spends words on the reader's opinion instead of their knowledge. Cut praise (*powerful, seamless, battle-tested*) and ease (*simply, easily*) when they only sell. State the capability plainly: "Partial documents are first-class citizens" → "A document need not be complete."
 
 Keep *just / simply / only* when load-bearing ("just sugar for the `raw` element", "three or more tildes"). The word is not the violation; the sell is.
 
@@ -26,7 +26,7 @@ Keep *just / simply / only* when load-bearing ("just sugar for the `raw` element
 The code is the primary documentation; a comment restating it is noise.
 
 - Delete echoes (`// increment i`; `/// The name` on a field named `name`); a clearer name beats the comment.
-- Collapse padded rustdoc scaffolding: "## Key Functions / ## Quick Example / ## Detailed Documentation / For comprehensive details including: …" becomes one tight paragraph and at most one runnable example.
+- Collapse padded rustdoc scaffolding to one tight paragraph and at most one runnable example.
 - Never enumerate a module's public items in its header; rustdoc lists them and the hand-list rots. Describe the module's job.
 - One good example beats three; "see X for comprehensive coverage" is filler.
 - One fact, one home. Cross-reference rather than restate; a fact copied twice drifts.
@@ -57,16 +57,15 @@ Cut spike/deferred/rejected narration; keep the resulting fact, plus the rationa
 Deleting whole sentences is half the work; the other half is more fact per word.
 
 - **Losable test**: cut any sentence whose removal costs no fact. Length tracks surprise: the unobvious invariant gets the words, the obvious call gets none.
-- **No throat-clearing**: "Note that", "It is worth noting", "Basically", "In general", and a section's first line restating its own heading.
-- **No empty hedges**: *typically, essentially, somewhat, arguably, various*, unless the uncertainty is real and calibrated.
-- **Shrink phrases**: *in order to* → to; *is able to / has the ability to* → can; *due to the fact that* → because; *a number of* → the count; *performs validation of* → validates.
+- **No throat-clearing**: no "Note that", and no first line restating the section's own heading.
+- **No empty hedges**: hedge only when the uncertainty is real and calibrated.
 - **Fold, don't append**: a second sentence qualifying the first becomes a clause of it.
 - **Name the thing**: the specific noun beats a category plus an example; the measured number beats a vague *several*.
 - **Compression is not density**: one claim per sentence. A sentence carrying seven clauses and three parentheticals is maximally compressed and unreadable, because the reader has to decompress it to reach the one fact they came for. A bullet needing three clauses is three bullets, a nested list, or a table; a set of per-case rules (per type, per format, per backend) is a table, and a table row is a record, not a sentence.
 
 ## Voice
 
-Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). One colon per sentence. Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
+Present tense. Lead with the invariant or contract, then the mechanism. Reuse the codebase's terms-of-art (*card-yaml block, plate, quill, backend, seam*). Match the density of the exemplars: the comments in `crates/core/src/document/` and the "Decisions and rationale" section of `prose/canon/PREVIEW.md`.
 
 A paragraph is one line: never hard-wrap prose at a column. A line break in markdown means a new paragraph, list item, or table row; nothing else. Comments wrap to the code's line budget.
 
@@ -82,7 +81,7 @@ A paragraph is one line: never hard-wrap prose at a column. A line break in mark
 
 ## Workflow
 
-1. **Sweep**: grep for the marketing list above; history markers (`used to`, `no longer`, `previously`, `formerly`, `as of`, `removed in`, `renamed`, `we switched`, `legacy`, `deprecated`); deliberation markers (`spike`, `deferred`, `considered`, `for now`, `eventually`, `we tried`); status markers (`#\d+`, issue and PR links); and filler (`Note that`, `in order to`, `is able to`).
+1. **Sweep**: grep for sells; history markers (`used to`, `no longer`, `previously`, `formerly`, `as of`, `removed in`, `renamed`, `we switched`, `legacy`, `deprecated`); deliberation markers (`spike`, `deferred`, `considered`, `for now`, `eventually`, `we tried`); and status markers (`#\d+`, issue and PR links).
 2. **Triage**: each hit is a violation or a load-bearing fact in costume.
 3. **Rewrite in place**: present tense, minimal, fact preserved. A comment contradicting the code gets fixed, not deleted. Identifiers stay.
 4. **Verify**: build and tests pass; no doctest broken; no test asserted the old wording; `node scripts/check-canon.mjs` passes.

--- a/.claude/skills/maintain-canon/SKILL.md
+++ b/.claude/skills/maintain-canon/SKILL.md
@@ -12,23 +12,11 @@ re-document implementation detail that the code already carries.
 
 For comment and doc *content* (density, tense, voice) use **`dense-prose`**.
 
-## The spine
+## Structure
 
-Every canon doc except `INDEX.md` opens:
-
-1. `# Title` on line 1.
-2. A blockquote anchor on line 3, carrying `> **Implementation**:`: the
-   navigational hook from concept to code. It points at a folder or module,
-   never a file and never a line number; files rot. `**Related**` and
-   `**Package**` lines are optional.
-3. `## TL;DR` as the first section: two or three sentences.
-
-Other sections (When to use, How, Gotchas, Links) are optional. No `Status`
-line, and no issue number: membership in canon means settled and implemented.
-
-`prose/README.md` is normative for all of this: the four tiers, the spine, the
-canon↔`docs/` division, and the link invariants. Read it before a structural
-edit. `scripts/check-canon.mjs` enforces what is mechanical, in CI.
+`prose/README.md` is normative for structure: the four tiers, the canon doc
+spine, the canon↔`docs/` division, and the link invariants. Read it before a
+structural edit. `scripts/check-canon.mjs` enforces what is mechanical, in CI.
 
 ## Principles
 

--- a/.claude/skills/maintain-canon/SKILL.md
+++ b/.claude/skills/maintain-canon/SKILL.md
@@ -25,7 +25,6 @@ Every canon doc except `INDEX.md` opens:
 
 Other sections (When to use, How, Gotchas, Links) are optional. No `Status`
 line, and no issue number: membership in canon means settled and implemented.
-A prose line caps at 700 characters and should stay under 300.
 
 `prose/README.md` is normative for all of this: the four tiers, the spine, the
 canon↔`docs/` division, and the link invariants. Read it before a structural

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ Crate layout and what each crate carries: [`ARCHITECTURE.md`](prose/canon/ARCHIT
 
 Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
 
-- Released guides in [`docs/migrations/`](docs/migrations/) are era-stamped: repair a false statement in place, never restate a true one in a later version's vocabulary.
 - The `Cargo.toml` version is the last *released* one; CI bumps it on release.
 - Commit early and often; CI gates every push.
 - Don't run `cargo fmt`.
@@ -17,4 +16,4 @@ Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs f
 - Binding surfaces compile in minutes and PR CI runs both on every push. Build one locally only to reproduce a red CI job, or when the change is in that binding's own code and no Rust test reaches it.
 - WASM: `./scripts/build-wasm.sh --ci && cd crates/bindings/wasm && npm test`. `--ci` is the fast-compile profile; bare `build-wasm.sh` is the publish build.
 - Python: `cd crates/bindings/python && uv venv && source .venv/bin/activate && uv pip install maturin pytest && maturin develop && pytest`. `maturin develop` builds debug.
-- `uv run` in that directory syncs the project first, and the sync is maturin's PEP 517 backend building release: `uv run maturin --version` compiles the extension to print a version string. `--release` and `pip install -e .` reach the same build by hand. The flow above is CI's (`.github/workflows/ci.yml`) and never syncs.
+- `uv run` in that directory syncs the project first, and the sync is maturin's PEP 517 backend building release: `uv run maturin --version` compiles the extension to print a version string. The flow above is CI's (`.github/workflows/ci.yml`) and never syncs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Schema-driven document engine: Markdown + YAML card metadata → rendered PDF/SVG/PNG via a Typst or PDF-form backend.
 
-Crates: `core` · `quillmark` · `content` · `backends/{typst,pdfform}` · `quillmark-pdf` · `bindings/{python,wasm,cli}` · `fixtures` · `fuzz`. What each carries: [`ARCHITECTURE.md`](prose/canon/ARCHITECTURE.md) §"Crate Structure".
+Crate layout and what each crate carries: [`ARCHITECTURE.md`](prose/canon/ARCHITECTURE.md) §"Crate Structure".
 
 Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
 
@@ -15,6 +15,6 @@ Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs f
 
 - `cargo test --workspace`: the working loop, run freely.
 - Binding surfaces compile in minutes and PR CI runs both on every push. Build one locally only to reproduce a red CI job, or when the change is in that binding's own code and no Rust test reaches it.
-- WASM: `./scripts/build-wasm.sh --ci && cd crates/bindings/wasm && npm test`. `--ci` is the fast-compile profile; bare `build-wasm.sh` is the publish build (opt-level=z, fat LTO).
+- WASM: `./scripts/build-wasm.sh --ci && cd crates/bindings/wasm && npm test`. `--ci` is the fast-compile profile; bare `build-wasm.sh` is the publish build.
 - Python: `cd crates/bindings/python && uv venv && source .venv/bin/activate && uv pip install maturin pytest && maturin develop && pytest`. `maturin develop` builds debug.
 - `uv run` in that directory syncs the project first, and the sync is maturin's PEP 517 backend building release: `uv run maturin --version` compiles the extension to print a version string. `--release` and `pip install -e .` reach the same build by hand. The flow above is CI's (`.github/workflows/ci.yml`) and never syncs.


### PR DESCRIPTION
Promote the prime directive to "wrong is worse than missing": a claim is
verified against the code or left unsaid, and the same bar guards cuts.

Relax the em-dash ban to a preference for new prose; an existing em-dash
is never worth an editing pass, so the em-dash-as-data scope row goes.

Apply the directive to the always-loaded prose: the line-budget numbers
now live only in prose/README.md (dense-prose and maintain-canon point),
and CLAUDE.md sheds its hand-kept crate list and copied build flags for
pointers to their homes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BtsYmmogEYPTCCjj4unaEa