### PR TITLE
docs(migration): a span guide for 0.92 → 0.102

### DIFF
--- a/docs/migrations/0.92-to-0.102.md
+++ b/docs/migrations/0.92-to-0.102.md
@@ -1,0 +1,65 @@
+# 0.92 → 0.102 — ten steps in one page
+
+Ordered by what a build reports rather than by version. Two breaks in the range compile clean and surface at runtime, with nothing in the diff to warn you; the other twenty are a table, each row pointing at the step that owns it. Each step guide states its own step in full — this page is the route across them. Crossing a single step, read that step's guide instead.
+
+## The two a type checker does not report
+
+### `await init()` — 0.101 → 0.102
+
+`@quillmark/wasm` ships wasm-bindgen's web target. `init()` returns a `Promise<void>`, and every export throws `runtime::not_initialized` until it resolves.
+
+```js
+const wasm = await import('@quillmark/wasm');
+wasm.init();                    // type-checks; floating
+this.Document = wasm.Document;  // throws, or does not, by load order
+```
+
+A floating promise is an ESLint rule (`@typescript-eslint/no-floating-promises`), not a `tsc` diagnostic, so the signature is the whole of the compiler's signal. Load order decides the rest: an entry point that awaits something slower first reaches an initialized runtime and passes, in dev and in the test that covers it.
+
+The throw names its cause and carries the fix as `Diagnostic.hint`, so a call site that does reach it is one read from fixed. Await at every entry point rather than trusting one to run first — `init` is idempotent, and repeated awaits share one instantiation.
+
+### `insertCard` argument order — 0.94 → 0.95
+
+```
+0.94    doc.insertCard(2, card)
+0.95    doc.insertCard(card, 2)     // `at` absent appends; `pushCard` is gone
+```
+
+Both parameters moved and changed type, so a typed call site fails to compile. An untyped one does not: plain JS, or a `card` typed `any` off a JSON round-trip.
+
+It is not silent at runtime. `insertCard` coerces its first argument through one door, which rejects a number with `card must be a Card object` and a flat `{ kind, fields }` with an unknown-field error naming `fields`. The exposure is a call site no test covers failing on first use, not a document written wrong.
+
+## The rest, by step
+
+The breaks a JS consumer meets, one row each. The step guides carry the Rust and Python surfaces this table omits, and state every break in full.
+
+| Break | Step | Action |
+|---|---|---|
+| `RenderSession` → `LiveSession` | [0.92 → 0.93](0.92-to-0.93.md) | Rename at use sites |
+| `Severity` drops `note`, leaving `error` and `warning` | [0.92 → 0.93](0.92-to-0.93.md) | Drop the arm; `"note"` fails to deserialize |
+| `RenderError` becomes a struct carrying `Diagnostic`s | [0.92 → 0.93](0.92-to-0.93.md) | Route on each diagnostic's namespaced `code` |
+| The `<must-fill>` string sentinel becomes the `!must_fill` tag | [0.92 → 0.93](0.92-to-0.93.md) | Retag; a bare null falls back to default or zero |
+| `type: richtext(inline)` → `inline: true`; `ui.order` is removed | [0.93 → 0.94](0.93-to-0.94.md) | Retag; declaration order is the ordering contract |
+| Read `card.body` is a `Content`, not a string | [0.93 → 0.94](0.93-to-0.94.md), [0.94 → 0.95](0.94-to-0.95.md) | `exportMarkdown(card.body)`, or read through `quill.reader(doc)` |
+| `setField` / `setFields` / `setFill` / `setExt` → `store*` | [0.94 → 0.95](0.94-to-0.95.md) | Rename; **store** is the verbatim lane, **set** the typed writer |
+| The card verb twins fold onto one `Addr` | [0.94 → 0.95](0.94-to-0.95.md) | `setCardField(2, n, v)` → `storeField({ card: 2, field: n }, v)`; a bare string is `{ field }` |
+| `setExtNamespace(ns, v)` → `storeExtNamespace(addr, ns, v)` | [0.94 → 0.95](0.94-to-0.95.md) | Add the address; `{}` is main |
+| `doc.main.seed?.[kind]` → `doc.seedOverlay(kind)` | [0.94 → 0.95](0.94-to-0.95.md) | Read the overlay without serializing the main card |
+| `datetime` splits into strict `date` and `datetime` | [0.94 → 0.95](0.94-to-0.95.md) | **Audit the corpus first**: the grammars are disjoint, so a stored value outside the type you rename to strands at render |
+| `view()` → `reader()`; mutator failures gain `edit::*` codes | [0.95 → 0.96](0.95-to-0.96.md) | Rename; route on `code` |
+| One address grammar (`DocPath`) on every boundary | [0.95 → 0.96](0.95-to-0.96.md) | Parse with `parseDocPath`, build with `formatDocPath` |
+| The transport read becomes `Document.getStored` | [0.96 → 0.97](0.96-to-0.97.md) | Rename; distinct from `reader.get` and `reader.getContent` |
+| `OutputFormat::Txt` retires; the block vocabulary opens | [0.97 → 0.98](0.97-to-0.98.md) | Drop the format; an unknown line kind round-trips opaque rather than failing the load |
+| A handle from a second copy of `@quillmark/wasm` is refused | [0.98 → 0.99](0.98-to-0.99.md) | One wasm per process; dedupe the install |
+| Card `$id`, `cardIndexById` and `find_card` are removed | [0.99 → 0.100](0.99-to-0.100.md) | Per-card keys move to `$ext` under a namespace you own, with no uniqueness guarantee |
+| `applyChange` takes one `ChangeBundle` | [0.100 → 0.101](0.100-to-0.101.md) | Fold the three positional op arguments; the `islandOps` channel is additive |
+| `install*` → `overwrite*`, writer `setBody` → `reviseBody` (returning the `Delta`), `LiveSession.apply` → `update`, `getMarkdown` and reader `getBody` → `bodyMarkdown`, `store` / `removeSeedNamespace` → `*SeedOverlay`, `schemaVersionOf` → `storageVersionOf` | [0.101 → 0.102](0.101-to-0.102.md) | Rename sweep; the storage wire key stays `"schema"` |
+| The content-field `edit::*` codes rename and gain a `codec` arg | [0.101 → 0.102](0.101-to-0.102.md) | Re-key routing; read `codec` for the lane that ran |
+
+## Storage crosses the range
+
+A blob tagged `@0.92.0` opens at 0.102. It is the oldest wire format read, migrating one hop to `@0.93.0`, and that hop is the only one that can fail: it cold-imports the stored markdown `body` through the parse path, so a pathologically over-nested body is rejected as `StorageError::Malformed` rather than truncated. Tags older than `@0.92.0` have no reader.
+
+## The other half of a JS upgrade
+
+`@quillmark/wasm` is not the whole of a JS consumer's pin. The loader and the Svelte binding version independently, in `borb-sh/quillmark-js`, and their changelogs are the record for that half: `packages/quiver/CHANGELOG.md` and `packages/svelte/CHANGELOG.md`. `Quiver#resolve` becoming sync, and the removal of `warm`, `fromPackage` and `buildPackage`, are quiver 0.17.0. The removals surface at a call site as a runtime `TypeError` naming nothing about a version; an already-awaited `resolve` is unaffected by the sync change.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -6,7 +6,9 @@ the old form stops parsing or compiling — so the guide is the path forward, no
 an optional read.
 
 Each guide covers one step. To cross several versions, work through them in
-order; each states its own breaks in full.
+order; each states its own breaks in full. One span guide sits above them:
+[0.92 → 0.102](0.92-to-0.102.md) routes a consumer across that range and leads
+with the two breaks a type checker does not report.
 
 !!! note "0.93 was never separately published"
 
@@ -18,6 +20,7 @@ order; each states its own breaks in full.
 
 | Step | What changes |
 |---|---|
+| [0.92 → 0.102](0.92-to-0.102.md) | **Span guide.** The ten steps in one page, leading with the two breaks a type checker does not report: `await init()` and the `insertCard(card, at?)` reorder. The other twenty are a table, each row pointing at the step that owns it. |
 | [0.101 → 0.102](0.101-to-0.102.md) | The pre-1.0 vocabulary reset. `install*` → `overwrite*`, writer `setBody` → `reviseBody` (now returning the receipt), `LiveSession.apply` → `update`, `getMarkdown` / reader `getBody` → `bodyMarkdown`, `store/removeSeedNamespace` → `*SeedOverlay`, `schemaVersionOf` → `storageVersionOf`. The `edit::*` codes for content-field failures rename and gain a `codec` arg, so one code covers both codecs; `richtext::not_inline` becomes `validation::not_inline`. Documents and stored blobs are unaffected. Separately, island-id minting splits by case: restoring a deleted island re-lands the id it was deleted under, and the island channel states two contracts it previously left to the implementation. `@quillmark/wasm` ships `--target web`: `await init()` is required before first use, and the bundler plugins the package used to demand are gone. |
 | [0.100 → 0.101](0.100-to-0.101.md) | Two Rust constructors leave the published surface: `Document::from_main_and_cards` becomes crate-internal (its invariants were `debug_assert`s feeding a release-build panic), and `QuillConfig::from_yaml` is removed for `from_yaml_with_warnings`, which keeps the structured diagnostics the boxed string destroyed. The change-bundle verbs take one `ChangeBundle` struct in place of three positional op arguments, because the bundle gains an island channel: `IslandOp` edits an island's payload or inserts one with its slot, so a table or image edit keeps the field's identity anchors instead of falling back to a whole-field `install`. On the bindings the channel is additive (`applyChange`'s new optional `islandOps`); documents and stored blobs are unaffected. |
 | [0.99 → 0.100](0.99-to-0.100.md) | Card `$id` is removed: the reserved key, `find_card` / `set_card_id` / `remove_card_id`, the collision errors, and `cardIndexById` / `card_index_by_id` plus the projected `id` on both bindings. Per-card consumer keys move to `$ext` under a namespace you own, with no uniqueness guarantee. `Content`, `Line`, `Mark`, and `Island` take `#[non_exhaustive]`, the four the 0.99 sweep missed, so their literals give way to `new` plus `with_*` setters. A string-valued `plaintext` field reads through the literal codec instead of markdown, and `reader.getContent` returns a content field's corpus whichever lane built the document. Load conforms content fields to one resting form per codec (`Quill::parse` / `Quill::conform`, the bound door), and `Diagnostic.args` carries the facts a message interpolates. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ not_in_nav: |
   /migrations/0.99-to-0.100.md
   /migrations/0.100-to-0.101.md
   /migrations/0.101-to-0.102.md
+  /migrations/0.92-to-0.102.md
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
Answers borb-sh/quillmark-js#310, which reports two breaks that a consumer's type checker did not catch on a 0.92.1 → 0.102.0 upgrade.

## What the investigation found

Every change the issue lists is already documented — `await init()` in `0.101-to-0.102.md`, the `insertCard` reorder in `0.94-to-0.95.md` with a literal before/after, and so on down the list. Nothing is missing.

The gap is the cross-version path. `index.md` states the design: *"Each guide covers one step. To cross several versions, work through them in order."* For this range that is ten guides — 4,008 lines, ~28,800 words — with no aggregate and no ordering by what a build will actually report.

## The change

**New `docs/migrations/0.92-to-0.102.md`**, a span guide sitting above the step guides:

- **The two a type checker does not report.** `await init()` and the `insertCard(card, at?)` reorder, each with the mechanism — a floating promise is a lint rule rather than a `tsc` diagnostic; the reorder is invisible only where the call site is untyped.
- **The rest, by step** — 20 rows, each pointing at the guide that owns it, bounded to the surface a JS consumer meets. The step guides keep the Rust and Python surfaces.
- **Storage across the range** — a `@0.92.0` blob still opens; the one hop that can fail, and how.
- **The other half of a JS upgrade** — the quiver and svelte changelogs downstream.

`index.md` gains the span row and a line in the cross-version paragraph. `mkdocs.yml` gains the `not_in_nav` entry, so the guide publishes without adding to the nav the overview already carries.

## Corrections to the issue's account

Three of its claims did not survive checking against the code, so the guide states the checked version:

- **The `insertCard` reorder is not silent at runtime.** `js_to_card` (`crates/bindings/wasm/src/engine.rs:2459`) rejects a number with `card must be a Card object`, and the unknown-field guard above it rejects a flat `{ kind, fields }`. It is checker-invisible, not silent — the exposure is a call site no test covers, not a document written wrong.
- **`Card.body` spans two steps**, not one: the read becomes `RichText` in 0.93 → 0.94, and `RichText` renames to `Content` in 0.94 → 0.95. That row carries both links.
- **`quiver.resolve` going sync raises no `TypeError`** — an already-awaited call is unaffected. Only the removals do.

## Notes

Docs only; no code changes. `scripts/check-canon.mjs` passes. `mkdocs build` was not run — mkdocs is not installed in this environment — but the links are relative within `docs/migrations/` and follow the existing pattern.

Written in the house voice per the `dense-prose` skill, run as an explicit pass. The existing step guides were left untouched: they are era-stamped records, which that skill scopes as repair-only.

The related quillmark-js work is borb-sh/quillmark-js#315, and #1209 covers the one architectural gap a note cannot close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQv6nsJxGYwJstSkuFwDQr