### PR TITLE
ci: drop the tagger GitHub App from the release workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,3 +1,11 @@
+# Cut a release: bump the workspace version, seed the changelog section, push the
+# release branch, and open the PR. Merging that PR is what tags and publishes
+# (release.yml).
+#
+# Opening it needs Settings → Actions → "Allow GitHub Actions to create and approve
+# pull requests", which no `permissions:` block grants. A PR opened by `GITHUB_TOKEN`
+# gets no `pull_request` run, so the same step dispatches ci.yml at the branch: the
+# release PR is the one change that must not merge unchecked.
 name: Prepare Release
 
 on:
@@ -27,20 +35,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # The ci.yml dispatch.
+      actions: write
     steps:
-      # App token is required so CI runs on the bot-opened PR.
-      # PRs opened with the default GITHUB_TOKEN do not trigger workflow events.
-      - name: Generate token
-        id: app
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.TAGGER_APP_ID }}
-          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
-
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ steps.app.outputs.token }}
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -152,7 +152,7 @@ jobs:
 
       - name: Push branch and open PR
         env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.next }}"
           BRANCH="release/v${VERSION}"
@@ -170,6 +170,13 @@ jobs:
 
           **Before merging:** review and edit the \`v${VERSION}\` section at the top of \`CHANGELOG.md\` on this branch, seeded from the curated \`## Unreleased\` section when one exists (raw commits ride in an HTML comment as a coverage check), else from the raw commit list. The final section becomes the GitHub Release notes.
 
-          Merging this PR will tag and publish the release." \
+          Merging this PR will tag and publish the release.
+
+          The checks here come from a dispatched \`CI\` run at the branch head: a PR opened by \`GITHUB_TOKEN\` gets no \`pull_request\` run." \
             --base main \
             --head "$BRANCH"
+
+          # The checks, dispatched rather than triggered. Only this first commit
+          # needs it; a later push to the branch is a human's and fires
+          # `synchronize`.
+          gh workflow run ci.yml --ref "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,19 @@ on:
     types: [closed]
     branches: [main]
 
+# One release at a time per HEAD BRANCH, which is every closed PR's own branch:
+# this workflow starts a run for each of them and the `if:` below is what sorts
+# them out, so a group any wider than the branch puts ordinary merges in the
+# release's queue. A group holds one pending run, and the arrival of a third
+# cancels the second before its first step, so a shared group would let an
+# unrelated merge evict a queued release, which then publishes nothing and
+# notifies nobody. Per branch, a re-run of one release supersedes its own
+# predecessor and nothing else reaches it. `cancel-in-progress: false` because a
+# release cancelled partway through has published some crates and not others.
+concurrency:
+  group: release-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -30,7 +43,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: main
+          # The merge commit this event names rather than `main`, which is whatever
+          # landed while this run queued. One commit gates, is tagged, is built and
+          # is published, so the tag names the bytes.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Read workspace version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,23 +20,17 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     permissions:
+      # The tag and the GitHub Release, and the whole of what either needs. A tag
+      # ruleset that restricts creations has to admit github-actions[bot], or the
+      # tag push below is rejected.
       contents: write
     outputs:
       version: ${{ steps.version.outputs.next }}
     steps:
-      # App token is required because the tag-creation ruleset blocks GITHUB_TOKEN.
-      - name: Generate token
-        id: app
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.TAGGER_APP_ID }}
-          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
-
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ steps.app.outputs.token }}
 
       - name: Read workspace version
         id: version
@@ -76,7 +70,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.next }}"
           if [[ "$VERSION" == *-* ]]; then


### PR DESCRIPTION
Both uses of the app token have a GITHUB_TOKEN equivalent, the one
quillmark-js runs on:

- The bot-opened release PR gets no `pull_request` run, so the same step
  dispatches ci.yml at the branch head. ci.yml already carries
  `workflow_dispatch` and conditions no job on the event, so a dispatched
  run is the same suite.
- The tag and the GitHub Release need `contents: write` and nothing else.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V6GLajYRFBwjLyKRLoMXPR