### PR TITLE
fix(core)!: parse geometry addresses segment-wise (#1223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+- fix(core)!: geometry addresses parse segment-wise, so `locate` and
+  `fieldBoxes` answer for an address deeper than one segment. The translation
+  boundary folded a plate address's whole tail into one `Field`, so
+  `references.0` minted `main.references.0` — a string that reparses as a field
+  literally named `0`, and that the reverse direction refused outright. Both
+  spellings returned `None`, leaving caret placement and whole-field highlight
+  dead for **every** `array<richtext>` element (the flagship memo's
+  `references` among them) and for every nested key a pdfform widget binds
+  (`address.city`). `region.rs` now reads and renders a plate tail one segment
+  at a time: an all-digit segment is an array index, `$body` the body terminal,
+  anything else a field or map key.
+- change(wasm, python)!: `RenderedRegion.field`, `FieldRegion.field` and
+  `ContentHit.field` spell an array element bracketed — `main.references.0`
+  becomes `main.references[0]` — on `regions()`, `fieldAt`, `positionAt` and
+  `RenderResult.regions`. This is the spelling schema validation already emits,
+  so a `Diagnostic.path` and the geometry address for one place are now the same
+  string. A consumer finding an address's children by prefix (`startsWith(`${field}.`)`)
+  needs the `[` opener too, and any heuristic reading a trailing all-digit field
+  name as a lost index is dead.
+
 ## v0.103.0 - 2026-08-09
 
 - docs: `docs/integration/operations.md`, carrying what the other integration

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -230,8 +230,8 @@ describe('LiveSession canvas preview', () => {
   it('addresses an array element as a bracketed DocPath index, both directions', () => {
     // The backend keys each `array<richtext>` element `references.<i>` in plate
     // space. The boundary translates that segment-wise, so a consumer sees the
-    // one spelling `Diagnostic.path` also uses — and the `field`-taking verbs
-    // accept it back. Whole-tail-as-one-field left both dead for every element.
+    // one spelling `Diagnostic.path` also uses, and the `field`-taking verbs
+    // accept it back.
     const session = arrayElementSession()
 
     const region = session.regions().find((r) => r.field === 'main.references[0]')

--- a/crates/bindings/wasm/canvas.test.js
+++ b/crates/bindings/wasm/canvas.test.js
@@ -116,6 +116,48 @@ function openSession() {
   return engine.open(quill, Document.fromMarkdown(TEST_MARKDOWN))
 }
 
+// An `array<richtext(inline)>` field: the backend regions each element on its
+// own plate-space address (`references.<i>`), the shape whose translation the
+// `arrayElementSession` test below pins.
+const ARRAY_QUILL_YAML = `quill:
+  name: array_quill
+  version: "1.0.0"
+  backend: typst
+  description: Array-element addressing
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+    references:
+      type: array
+      items:
+        type: richtext
+        inline: true
+`
+
+const ARRAY_PLATE = `#import "@local/quillmark-helper:0.1.0": data
+#for r in data.references [ #r \\ ]
+`
+
+const ARRAY_MARKDOWN = `~~~card-yaml
+$quill: array_quill
+$kind: main
+references:
+  - First reference line.
+  - Second reference line.
+~~~
+`
+
+function arrayElementSession() {
+  const engine = new Quillmark()
+  const quill = Quill.fromTree(
+    makeQuill({ name: 'array_quill', plate: ARRAY_PLATE, quillYaml: ARRAY_QUILL_YAML }),
+  )
+  return engine.open(quill, Document.fromMarkdown(ARRAY_MARKDOWN))
+}
+
 /** Asserts a captured `putImageData` call's RGBA buffer carries both visible
  * ink (non-white, opaque pixels) and opaque background: catches a rasterizer
  * regression that wrote zeros, swapped channels, or skipped demultiply.
@@ -183,6 +225,37 @@ describe('LiveSession canvas preview', () => {
 
     // A click far off any ink resolves to nothing.
     expect(session.positionAt(bodyRegion.page, 2, 2)).toBeFalsy()
+  })
+
+  it('addresses an array element as a bracketed DocPath index, both directions', () => {
+    // The backend keys each `array<richtext>` element `references.<i>` in plate
+    // space. The boundary translates that segment-wise, so a consumer sees the
+    // one spelling `Diagnostic.path` also uses — and the `field`-taking verbs
+    // accept it back. Whole-tail-as-one-field left both dead for every element.
+    const session = arrayElementSession()
+
+    const region = session.regions().find((r) => r.field === 'main.references[0]')
+    expect(region, 'the first `references` element regions on a bracketed index').toBeTruthy()
+
+    // The reverse leg: `fieldBoxes` and `locate` take that same string.
+    const boxes = session.fieldBoxes('main.references[0]')
+    expect(boxes.length, 'fieldBoxes answers on the element address').toBeGreaterThan(0)
+    expect(boxes[0].field).toBe('main.references[0]')
+
+    const caret = session.locate('main.references[0]', 0)
+    expect(caret, 'locate answers on the element address').toBeTruthy()
+    expect(caret.field).toBe('main.references[0]')
+
+    // And the forward direction agrees: a point on the element's ink resolves
+    // to the same string, so positionAt → locate composes.
+    const [x0, y0, x1, y1] = region.rect
+    const cy = (y0 + y1) / 2
+    let hit = null
+    for (let f = 0.1; f <= 0.9 && !hit; f += 0.1) {
+      hit = session.positionAt(region.page, x0 + (x1 - x0) * f, cy)
+    }
+    expect(hit, 'positionAt resolves a point on the element ink').toBeTruthy()
+    expect(hit.field).toBe('main.references[0]')
   })
 
   it('paint sizes the canvas backing store and returns layout + pixel dimensions', () => {

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -398,7 +398,10 @@ export interface FieldRegion {
 	 * The field's canonical `DocPath` address (`parseDocPath`-routable), not a
 	 * backend widget name: `main.signature_block` for a main field,
 	 * `cards.<kind>[<i>].signature_block` for a card field (`cards[<i>].…` when the
-	 * card's kind is unknown).
+	 * card's kind is unknown). Nested addresses spell out in full, an array
+	 * element bracketed and a key dotted — `main.references[0]`,
+	 * `cards.<kind>[<i>].addr.city` — the same spelling `Diagnostic.path` uses,
+	 * so the two join on string equality.
 	 */
 	field: string;
 	/** 0-based page index. */

--- a/crates/core/src/path.rs
+++ b/crates/core/src/path.rs
@@ -22,13 +22,12 @@
 //!
 //! A field name is what the document carries, not an identifier: a nested YAML
 //! map key is unconstrained, so `!must_fill` collection mints `main.m.0` and
-//! `main.m.a-b`. The property the grammar rests on is narrower and is what
-//! `Display` → `FromStr` needs — a name excludes `.`, `[`, `]`, the three
-//! characters the serializer spends. One consequence is load-bearing
-//! elsewhere: **an all-digit name reads back as a name, never an index**
-//! (`main.m.0` is `Field{"0"}`), which is why the plate-space `.N` index
-//! spelling is translated at the geometry boundary (`region.rs`) rather than
-//! taught to this parser.
+//! `main.m.a-b`. All `Display` → `FromStr` needs is the narrower property that
+//! a name excludes `.`, `[`, `]`, the three characters the serializer spends.
+//! One consequence is load-bearing elsewhere: **an all-digit name reads back as
+//! a name, never an index** (`main.m.0` is `Field{"0"}`), so the plate-space
+//! `.N` index spelling is translated at the geometry boundary (`region.rs`)
+//! rather than here.
 //!
 //! Every document-model path is **rooted**: a main field is `main.<field>`
 //! (`main.title`, `main.recipients[0].name`), the main body `main.body`. A card
@@ -371,11 +370,10 @@ mod tests {
         round_trip(DocPath::main_body(), "main.body");
     }
 
-    /// A digit map key is a field, not an index. `!must_fill` collection mints
-    /// this shape by folding a nested value-tree path onto its field path
-    /// (`compose::collect_fill_diags`), so the reading is live on the wire; the
-    /// plate-space `.N` index spelling is translated at the geometry boundary
-    /// (`region.rs`) precisely so it never reaches this parser.
+    /// A digit map key is a field, not an index. `collect_fill_diags` mints
+    /// this shape by folding a nested value-tree path onto its field path, so
+    /// the reading is live on the wire, and `region.rs` translates the
+    /// plate-space `.N` index spelling rather than let it reach this parser.
     #[test]
     fn digit_field_name_is_a_key_not_an_index() {
         round_trip(DocPath::main().field("m").field("0"), "main.m.0");

--- a/crates/core/src/path.rs
+++ b/crates/core/src/path.rs
@@ -17,16 +17,25 @@
 //!         | "cards" "[" index "]"            // unknown-kind card (the only bare-index root)
 //! segment:= "." field | "[" index "]" | ".body"
 //! kind   := [a-z_][a-z0-9_]*
-//! field  := [A-Za-z_][A-Za-z0-9_]*
+//! field  := any run excluding "." "[" "]"
 //! ```
+//!
+//! A field name is what the document carries, not an identifier: a nested YAML
+//! map key is unconstrained, so `!must_fill` collection mints `main.m.0` and
+//! `main.m.a-b`. The property the grammar rests on is narrower and is what
+//! `Display` → `FromStr` needs — a name excludes `.`, `[`, `]`, the three
+//! characters the serializer spends. One consequence is load-bearing
+//! elsewhere: **an all-digit name reads back as a name, never an index**
+//! (`main.m.0` is `Field{"0"}`), which is why the plate-space `.N` index
+//! spelling is translated at the geometry boundary (`region.rs`) rather than
+//! taught to this parser.
 //!
 //! Every document-model path is **rooted**: a main field is `main.<field>`
 //! (`main.title`, `main.recipients[0].name`), the main body `main.body`. A card
 //! field is kind-qualified (`cards.<kind>[<i>].<field>`) so a consumer
 //! receives kind and array index without a second lookup; a card whose `$kind`
 //! has no schema (absent, or present but not a declared card kind) stays
-//! `cards[<i>]`. Field names and card kinds exclude `.`, `[`, `]`, so the
-//! rendered form round-trips.
+//! `cards[<i>]`.
 //!
 //! Rooting makes the grammar total against a field named for a root: a main
 //! field literally named `cards` or `main` is `main.cards` / `main.main`, which
@@ -360,6 +369,22 @@ mod tests {
     #[test]
     fn main_body() {
         round_trip(DocPath::main_body(), "main.body");
+    }
+
+    /// A digit map key is a field, not an index. `!must_fill` collection mints
+    /// this shape by folding a nested value-tree path onto its field path
+    /// (`compose::collect_fill_diags`), so the reading is live on the wire; the
+    /// plate-space `.N` index spelling is translated at the geometry boundary
+    /// (`region.rs`) precisely so it never reaches this parser.
+    #[test]
+    fn digit_field_name_is_a_key_not_an_index() {
+        round_trip(DocPath::main().field("m").field("0"), "main.m.0");
+        assert_eq!(
+            "main.m.0".parse::<DocPath>().unwrap().segs()[2],
+            DocSeg::Field {
+                name: "0".to_string()
+            }
+        );
     }
 
     #[test]

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -95,13 +95,14 @@
 #[non_exhaustive]
 pub struct RenderedRegion {
     /// The field's plate-space schema address as the backend keys it:
-    /// `"signature_block"` or `"$cards.<kind>.<ordinal>.<field>"` (a per-kind
-    /// ordinal). This is the backend-native form; a binding that owns the
-    /// document's card kinds translates it to a canonical
+    /// `"signature_block"`, `"references.0"` (an array element, `.`-separated
+    /// with a numeric segment per index) or `"$cards.<kind>.<ordinal>.<tail>"`
+    /// (a per-kind ordinal). This is the backend-native form; a binding that
+    /// owns the document's card kinds translates it to a canonical
     /// [`DocPath`] at its boundary
     /// ([`plate_addr_to_doc_path`]), so its consumers see one absolute-index
-    /// grammar. A core consumer reading `RenderedRegion` directly sees the
-    /// plate-space form.
+    /// grammar and one index spelling (`main.references[0]`). A core consumer
+    /// reading `RenderedRegion` directly sees the plate-space form.
     pub field: String,
     /// 0-based page index.
     pub page: usize,
@@ -208,6 +209,25 @@ pub fn field_boxes(regions: &[RenderedRegion], field: &str) -> Vec<RenderedRegio
 // to the document-array absolute index (and back) against the ordered card
 // kinds of the current compile, so `regions` / `fieldAt` / `positionAt` /
 // `locate` speak `DocPath`, never `$cards.` ordinals.
+//
+// **The plate-space tail** is a `.`-separated segment run, parsed and rendered
+// segment-wise by [`plate_tail_to_segs`] / [`plate_tail`]. A segment of all
+// ASCII digits is an array index, `$body` is the body terminal, anything else
+// is a field or map key. A tail's first segment is never an index (neither
+// `main` nor a card is an array), `$body` is never non-final, and no other
+// `$`-token appears. Whole-tail-as-one-field would mint a `DocPath` whose
+// rendered form reparses to different segments (`references.0` →
+// `main.references.0` → `[Main, Field{"references"}, Field{"0"}]`), and the
+// string leg is the one a binding crosses.
+//
+// `.N` reads as an index **here and not in [`DocPath::from_str`]**: plate
+// addresses are schema-derived, so no plate address carries a digit map key (a
+// field name and a card kind open with a lowercase ASCII letter, pdfform's
+// `descend` reads any numeric segment as an array index, and the Typst helper's
+// `_qm-known-path` accepts a dotted suffix only under an array-typed parent).
+// `DocPath` space is different: a nested YAML map key is unconstrained, and
+// `collect_fill_diags` mints `main.m.0` as `Field{"0"}`. That reading is why
+// the fix lives at this boundary rather than in the parser.
 
 use crate::path::{DocPath, DocSeg};
 
@@ -254,29 +274,62 @@ pub fn regions_to_doc_path(
     regions
 }
 
+/// Extend `base` by a plate-space tail's segments, per the tail grammar in the
+/// translation banner. `None` for a tail outside it: an empty piece, a leading
+/// index, a non-final `$body`, or any other `$`-token.
+fn plate_tail_to_segs(base: DocPath, tail: &str) -> Option<DocPath> {
+    let mut path = base;
+    let mut it = tail.split('.').peekable();
+    let mut first = true;
+    while let Some(piece) = it.next() {
+        let last = it.peek().is_none();
+        if piece.is_empty() {
+            return None;
+        }
+        path = if piece.bytes().all(|b| b.is_ascii_digit()) {
+            // Neither `main` nor a card is an array, so a tail never opens on
+            // an index.
+            if first {
+                return None;
+            }
+            path.index(piece.parse().ok()?)
+        } else if piece == "$body" {
+            if !last {
+                return None;
+            }
+            path.body()
+        } else if piece.starts_with('$') {
+            return None;
+        } else {
+            path.field(piece)
+        };
+        first = false;
+    }
+    Some(path)
+}
+
 /// Translate a backend plate-space geometry address into a canonical
 /// [`DocPath`], resolving the per-kind ordinal to the absolute card index via
 /// `card_kinds`. The grammar handled is exactly what geometry emits: `$body`
-/// (main body), a bare `<field>` (main field), `$cards.<kind>.<ord>.<field>`
-/// (card field), and `$cards.<kind>.<ord>.$body` (card body). `None` for an
-/// address outside that grammar or one naming a card the kind list cannot
-/// place: the caller keeps the original string.
+/// (main body), `<tail>` (main), and `$cards.<kind>.<ord>.<tail>` (card), where
+/// a tail is the segment run the translation banner states — so an array
+/// element (`references.0`) and a nested key (`address.city`) each become their
+/// own segments, not one field. `None` for an address outside that grammar or
+/// one naming a card the kind list cannot place: the caller keeps the original
+/// string.
 pub fn plate_addr_to_doc_path(addr: &str, card_kinds: &[Option<&str>]) -> Option<DocPath> {
     if addr == "$body" {
         return Some(DocPath::main_body());
     }
     if let Some(rest) = addr.strip_prefix("$cards.") {
+        // The whole tail reaches the tail parser: only kind and ordinal are
+        // split off here.
         let mut it = rest.splitn(3, '.');
         let kind = it.next()?;
         let ord: usize = it.next()?.parse().ok()?;
         let tail = it.next()?;
         let abs = abs_card_index(card_kinds, kind, ord)?;
-        let card = DocPath::card(Some(kind), abs);
-        return Some(if tail == "$body" {
-            card.body()
-        } else {
-            card.field(tail)
-        });
+        return plate_tail_to_segs(DocPath::card(Some(kind), abs), tail);
     }
     // A plate-space bare main field (`subject`) roots at `main` in `DocPath`
     // space (`main.subject`), so a consumer always receives a parsed, rooted
@@ -284,34 +337,80 @@ pub fn plate_addr_to_doc_path(addr: &str, card_kinds: &[Option<&str>]) -> Option
     if addr.starts_with('$') {
         return None;
     }
-    Some(DocPath::main().field(addr))
+    plate_tail_to_segs(DocPath::main(), addr)
+}
+
+/// Render a [`DocPath`] tail in plate space, joining segments with `.`. `None`
+/// for a tail plate space cannot spell: a leading [`Index`], a non-final
+/// [`Body`], a [`Card`] mid-path, or a field name that is empty, all ASCII
+/// digits, `$`-leading, or carries `.` / `[` / `]` — the first two because they
+/// would read back as an index or a body terminal, the rest because they would
+/// reparse as different segments. `None` is the honest answer there: geometry
+/// placed no such thing.
+///
+/// [`Index`]: DocSeg::Index
+/// [`Body`]: DocSeg::Body
+/// [`Card`]: DocSeg::Card
+fn plate_tail(tail: &[DocSeg]) -> Option<String> {
+    let mut out = String::new();
+    for (i, seg) in tail.iter().enumerate() {
+        if i > 0 {
+            out.push('.');
+        }
+        match seg {
+            DocSeg::Index { index } => {
+                if i == 0 {
+                    return None;
+                }
+                out.push_str(&index.to_string());
+            }
+            DocSeg::Body => {
+                if i + 1 != tail.len() {
+                    return None;
+                }
+                out.push_str("$body");
+            }
+            DocSeg::Field { name } => {
+                if name.is_empty()
+                    || name.bytes().all(|b| b.is_ascii_digit())
+                    || name.starts_with('$')
+                    || name.contains(['.', '[', ']'])
+                {
+                    return None;
+                }
+                out.push_str(name);
+            }
+            DocSeg::Main | DocSeg::Card { .. } => return None,
+        }
+    }
+    Some(out)
 }
 
 /// Translate a canonical [`DocPath`] geometry address back to the backend
-/// plate-space form (`main.body` → `$body`, `cards.<kind>[<abs>].<field>` →
-/// `$cards.<kind>.<ord>.<field>`), resolving the absolute card index to its
-/// per-kind ordinal via `card_kinds`. `None` when the path is not a geometry
-/// address (a document-model shape geometry never keys) or names a card the
-/// kind list cannot place. The inverse of [`plate_addr_to_doc_path`], for the
-/// `field`-taking queries (`locate`, `fieldBoxes`).
+/// plate-space form (`main.body` → `$body`, `main.references[0]` →
+/// `references.0`, `cards.<kind>[<abs>].<tail>` → `$cards.<kind>.<ord>.<tail>`),
+/// resolving the absolute card index to its per-kind ordinal via `card_kinds`.
+/// `None` when the path is not a geometry address (a document-model shape
+/// geometry never keys, or one plate space cannot spell — see [`plate_tail`]) or
+/// names a card the kind list cannot place. The inverse of
+/// [`plate_addr_to_doc_path`], for the `field`-taking queries (`locate`,
+/// `fieldBoxes`).
 pub fn doc_path_to_plate_addr(path: &DocPath, card_kinds: &[Option<&str>]) -> Option<String> {
     match path.segs() {
         [DocSeg::Main, DocSeg::Body] => Some("$body".to_string()),
-        [DocSeg::Main, DocSeg::Field { name }] => Some(name.clone()),
+        [DocSeg::Main, tail @ ..] if !tail.is_empty() => plate_tail(tail),
         [DocSeg::Card {
             kind: Some(kind),
             index,
-        }, rest @ ..] => {
+        }, tail @ ..]
+            if !tail.is_empty() =>
+        {
             // The path must actually name the card that sits at `index`.
             if card_kinds.get(*index).copied().flatten() != Some(kind.as_str()) {
                 return None;
             }
             let ord = per_kind_ordinal(card_kinds, *index)?;
-            match rest {
-                [DocSeg::Field { name }] => Some(format!("$cards.{kind}.{ord}.{name}")),
-                [DocSeg::Body] => Some(format!("$cards.{kind}.{ord}.$body")),
-                _ => None,
-            }
+            Some(format!("$cards.{kind}.{ord}.{}", plate_tail(tail)?))
         }
         _ => None,
     }
@@ -545,18 +644,68 @@ mod tests {
         assert_eq!(to_doc("signature_block").as_deref(), Some("main.signature_block"));
     }
 
+    /// A plate tail is parsed segment-wise: a numeric segment is an array
+    /// index, a key segment a field. The defect this pins folded the whole tail
+    /// into one `Field`, minting a path whose rendered form reparsed to
+    /// different segments.
+    #[test]
+    fn plate_to_docpath_parses_the_tail_segment_wise() {
+        // An `array<richtext>` element: the backend keys `<field>.<i>`.
+        assert_eq!(to_doc("references.0").as_deref(), Some("main.references[0]"));
+        // A nested key (pdfform binds these) is not an index.
+        assert_eq!(to_doc("address.city").as_deref(), Some("main.address.city"));
+        // Both at once, on a card: ordinal 1 of `note` is absolute 2.
+        assert_eq!(
+            to_doc("$cards.note.1.refs.0").as_deref(),
+            Some("cards.note[2].refs[0]")
+        );
+        assert_eq!(
+            to_doc("$cards.note.0.addr.city").as_deref(),
+            Some("cards.note[0].addr.city")
+        );
+    }
+
+    /// The three legs of the inverse guarantee over the whole geometry grammar.
+    /// The **string leg** is the one a binding crosses (`docpath_to_plate`
+    /// parses a consumer's string) and the one the defect broke, so a
+    /// round-trip that compares `DocPath` values alone would have passed while
+    /// `locate` answered nothing.
     #[test]
     fn docpath_to_plate_is_the_inverse() {
         for plate in [
             "$body",
             "signature_block",
+            "references.0",
+            "address.city",
+            "a.b.c.0.d",
             "$cards.note.0.on",
             "$cards.note.1.on",
             "$cards.annotation.0.text",
             "$cards.note.1.$body",
+            "$cards.note.1.refs.0",
+            "$cards.note.0.addr.city",
         ] {
-            let doc = to_doc(plate).unwrap();
-            assert_eq!(to_plate(&doc).as_deref(), Some(plate), "round-trip {plate}");
+            let doc = plate_addr_to_doc_path(plate, KINDS).unwrap();
+            // The string leg: the minted path survives Display → FromStr.
+            let rendered = doc.to_string();
+            assert_eq!(
+                rendered.parse::<DocPath>().ok(),
+                Some(doc.clone()),
+                "string leg {plate}"
+            );
+            // Plate → DocPath → plate.
+            assert_eq!(
+                doc_path_to_plate_addr(&doc, KINDS).as_deref(),
+                Some(plate),
+                "plate round-trip {plate}"
+            );
+            // DocPath → plate → DocPath, from the rendered string a consumer sends.
+            assert_eq!(to_plate(&rendered).as_deref(), Some(plate), "via string {plate}");
+            assert_eq!(
+                plate_addr_to_doc_path(&doc_path_to_plate_addr(&doc, KINDS).unwrap(), KINDS),
+                Some(doc),
+                "docpath round-trip {plate}"
+            );
         }
     }
 
@@ -572,6 +721,45 @@ mod tests {
         // A document-model shape geometry never keys (nested main field).
         assert_eq!(
             doc_path_to_plate_addr(&"recipients[0].name".parse().unwrap(), KINDS),
+            None
+        );
+        // A bare card head, and an empty or `$`-token tail piece.
+        assert_eq!(to_doc("$cards.note.1"), None);
+        assert_eq!(to_doc("references."), None);
+        assert_eq!(to_doc("refs.$seed"), None);
+        // `$body` is terminal.
+        assert_eq!(to_doc("a.$body.b"), None);
+        // A tail never opens on an index: neither `main` nor a card is an array.
+        assert_eq!(to_doc("0.x"), None);
+    }
+
+    /// `DocPath` values plate space cannot spell. `None`, not a guess: geometry
+    /// placed no such thing, and the caller keeps its original string.
+    #[test]
+    fn docpath_to_plate_rejects_unspellable_paths() {
+        for doc in [
+            // A digit map key (`collect_fill_diags` mints these) is a `Field`,
+            // not an index: spelling it `m.0` would read back as an index.
+            "main.m.0",
+            // A tail opening on an index.
+            "main[0].x",
+            // An unknown-kind card root.
+            "cards[0].x",
+            // A bare root, no tail.
+            "main",
+            "cards.note[0]",
+        ] {
+            assert_eq!(
+                doc_path_to_plate_addr(&doc.parse().unwrap(), KINDS),
+                None,
+                "unspellable {doc}"
+            );
+        }
+        // A non-final `Body`. Not reachable through the parser (a non-terminal
+        // `.body` reads as a field literally named `body`), so it is built
+        // segment-wise.
+        assert_eq!(
+            doc_path_to_plate_addr(&DocPath::main().body().field("x"), KINDS),
             None
         );
     }

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -215,10 +215,10 @@ pub fn field_boxes(regions: &[RenderedRegion], field: &str) -> Vec<RenderedRegio
 // ASCII digits is an array index, `$body` is the body terminal, anything else
 // is a field or map key. A tail's first segment is never an index (neither
 // `main` nor a card is an array), `$body` is never non-final, and no other
-// `$`-token appears. Whole-tail-as-one-field would mint a `DocPath` whose
-// rendered form reparses to different segments (`references.0` →
-// `main.references.0` → `[Main, Field{"references"}, Field{"0"}]`), and the
-// string leg is the one a binding crosses.
+// `$`-token appears. Segment-wise is what keeps the minted `DocPath` stable
+// across `Display` → `FromStr`, the leg a binding crosses: a tail carried whole
+// into one `Field` renders `main.references.0`, which reparses as a field named
+// `"0"`.
 //
 // `.N` reads as an index **here and not in [`DocPath::from_str`]**: plate
 // addresses are schema-derived, so no plate address carries a digit map key (a
@@ -226,8 +226,8 @@ pub fn field_boxes(regions: &[RenderedRegion], field: &str) -> Vec<RenderedRegio
 // `descend` reads any numeric segment as an array index, and the Typst helper's
 // `_qm-known-path` accepts a dotted suffix only under an array-typed parent).
 // `DocPath` space is different: a nested YAML map key is unconstrained, and
-// `collect_fill_diags` mints `main.m.0` as `Field{"0"}`. That reading is why
-// the fix lives at this boundary rather than in the parser.
+// `collect_fill_diags` mints `main.m.0` as `Field{"0"}`. Teaching the parser
+// `.N` would cost that reading, so the two spellings meet here instead.
 
 use crate::path::{DocPath, DocSeg};
 
@@ -279,9 +279,8 @@ pub fn regions_to_doc_path(
 /// index, a non-final `$body`, or any other `$`-token.
 fn plate_tail_to_segs(base: DocPath, tail: &str) -> Option<DocPath> {
     let mut path = base;
-    let mut it = tail.split('.').peekable();
-    let mut first = true;
-    while let Some(piece) = it.next() {
+    let mut it = tail.split('.').enumerate().peekable();
+    while let Some((i, piece)) = it.next() {
         let last = it.peek().is_none();
         if piece.is_empty() {
             return None;
@@ -289,7 +288,7 @@ fn plate_tail_to_segs(base: DocPath, tail: &str) -> Option<DocPath> {
         path = if piece.bytes().all(|b| b.is_ascii_digit()) {
             // Neither `main` nor a card is an array, so a tail never opens on
             // an index.
-            if first {
+            if i == 0 {
                 return None;
             }
             path.index(piece.parse().ok()?)
@@ -303,7 +302,6 @@ fn plate_tail_to_segs(base: DocPath, tail: &str) -> Option<DocPath> {
         } else {
             path.field(piece)
         };
-        first = false;
     }
     Some(path)
 }
@@ -645,9 +643,8 @@ mod tests {
     }
 
     /// A plate tail is parsed segment-wise: a numeric segment is an array
-    /// index, a key segment a field. The defect this pins folded the whole tail
-    /// into one `Field`, minting a path whose rendered form reparsed to
-    /// different segments.
+    /// index, a key segment a field. A tail carried whole into one `Field`
+    /// would mint a path that reparses to different segments.
     #[test]
     fn plate_to_docpath_parses_the_tail_segment_wise() {
         // An `array<richtext>` element: the backend keys `<field>.<i>`.
@@ -665,11 +662,10 @@ mod tests {
         );
     }
 
-    /// The three legs of the inverse guarantee over the whole geometry grammar.
-    /// The **string leg** is the one a binding crosses (`docpath_to_plate`
-    /// parses a consumer's string) and the one the defect broke, so a
-    /// round-trip that compares `DocPath` values alone would have passed while
-    /// `locate` answered nothing.
+    /// The inverse guarantee over the whole geometry grammar, including the
+    /// **string leg**: a round-trip comparing `DocPath` values alone holds even
+    /// when the rendered form reparses to different segments, and the rendered
+    /// form is what a binding hands `docpath_to_plate`.
     #[test]
     fn docpath_to_plate_is_the_inverse() {
         for plate in [
@@ -688,24 +684,10 @@ mod tests {
             let doc = plate_addr_to_doc_path(plate, KINDS).unwrap();
             // The string leg: the minted path survives Display → FromStr.
             let rendered = doc.to_string();
-            assert_eq!(
-                rendered.parse::<DocPath>().ok(),
-                Some(doc.clone()),
-                "string leg {plate}"
-            );
-            // Plate → DocPath → plate.
-            assert_eq!(
-                doc_path_to_plate_addr(&doc, KINDS).as_deref(),
-                Some(plate),
-                "plate round-trip {plate}"
-            );
-            // DocPath → plate → DocPath, from the rendered string a consumer sends.
-            assert_eq!(to_plate(&rendered).as_deref(), Some(plate), "via string {plate}");
-            assert_eq!(
-                plate_addr_to_doc_path(&doc_path_to_plate_addr(&doc, KINDS).unwrap(), KINDS),
-                Some(doc),
-                "docpath round-trip {plate}"
-            );
+            assert_eq!(rendered.parse::<DocPath>().ok(), Some(doc), "string leg {plate}");
+            // Plate → DocPath → plate, from the rendered string a consumer
+            // sends: `to_plate` parses it exactly as a binding does.
+            assert_eq!(to_plate(&rendered).as_deref(), Some(plate), "round-trip {plate}");
         }
     }
 

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -388,11 +388,12 @@ fn plate_tail(tail: &[DocSeg]) -> Option<String> {
 /// plate-space form (`main.body` → `$body`, `main.references[0]` →
 /// `references.0`, `cards.<kind>[<abs>].<tail>` → `$cards.<kind>.<ord>.<tail>`),
 /// resolving the absolute card index to its per-kind ordinal via `card_kinds`.
-/// `None` when the path is not a geometry address (a document-model shape
-/// geometry never keys, or one plate space cannot spell — see [`plate_tail`]) or
-/// names a card the kind list cannot place. The inverse of
-/// [`plate_addr_to_doc_path`], for the `field`-taking queries (`locate`,
-/// `fieldBoxes`).
+/// `None` when the path is not a geometry address: a document-model shape
+/// geometry never keys, one naming a card the kind list cannot place, or one
+/// plate space cannot spell — a leading index, a non-final body, or a field
+/// name that is empty, all ASCII digits, `$`-leading, or carries `.` / `[` /
+/// `]`. The inverse of [`plate_addr_to_doc_path`], for the `field`-taking
+/// queries (`locate`, `fieldBoxes`).
 pub fn doc_path_to_plate_addr(path: &DocPath, card_kinds: &[Option<&str>]) -> Option<String> {
     match path.segs() {
         [DocSeg::Main, DocSeg::Body] => Some("$body".to_string()),

--- a/crates/quillmark/tests/usaf_memo_regions_test.rs
+++ b/crates/quillmark/tests/usaf_memo_regions_test.rs
@@ -52,6 +52,24 @@ fn usaf_memo_regions_cover_body_signature_and_cards() {
         "an empty card body draws nothing and surfaces no region: {fields:?}"
     );
 
+    // An `array<richtext(inline)>` element regions per element, keyed
+    // `<field>.<i>` in plate space, and translates to the bracketed `DocPath`
+    // index a binding hands out — the same string schema validation spells.
+    assert!(
+        fields.contains("references.0"),
+        "each `references` element regions on its own address: {fields:?}"
+    );
+    let kinds: Vec<Option<&str>> = parsed.cards().iter().map(|c| c.kind()).collect();
+    let translated: HashSet<String> =
+        quillmark_core::regions_to_doc_path(regions.clone(), &kinds)
+            .into_iter()
+            .map(|r| r.field)
+            .collect();
+    assert!(
+        translated.contains("main.references[0]"),
+        "the element address crosses as a bracketed DocPath index: {translated:?}"
+    );
+
     // The forward direction survives the rebuild too: a point inside the
     // surfaced `$body` region resolves back to `$body`.
     let body = regions

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -214,19 +214,24 @@ only `Diagnostic.path`. Mutator (`edit::*`) diagnostics carry it (a field error
 at `main.<field>` or `cards.<kind>[<i>].<field>`, a structural out-of-range op at
 `cards[<i>]`);
 and `LiveSession` geometry (`regions` / `fieldAt` / `positionAt` / `locate`)
-keys on it: the session translates the backend's plate-space
-`$cards.<kind>.<ordinal>` form to the `DocPath` absolute index at the boundary,
-so one parser routes diagnostics and geometry alike.
+keys on it: the session translates the backend's plate-space form to `DocPath`
+at the boundary, segment by segment — the `$cards.<kind>.<ordinal>` head to the
+absolute index, a numeric tail segment to a bracketed array index
+(`references.0` → `main.references[0]`) — so one parser routes diagnostics and
+geometry alike, and a geometry address and the validation diagnostic on the
+same place are the same string.
 
 **Three grammars, one that crosses.** Only `DocPath` reaches a consumer. The
 other two stay backend/template-internal and are named here so they are not
 confused with it:
 
 - **Plate JSON**: the sigiled `data.$cards` a template author composes
-  ([CARDS.md](CARDS.md)), and the plate-space `$cards.<kind>.<ordinal>.<field>`
-  geometry address a plate's `$path` mints. A template-author contract, so it
-  keeps its own spelling (renaming it is a blast radius) and translates to
-  `DocPath` before it crosses.
+  ([CARDS.md](CARDS.md)), and the plate-space geometry address a plate's `$path`
+  mints: a `.`-separated run under an optional `$cards.<kind>.<ordinal>` head,
+  where an all-digit segment is an array index (`references.0`) and `$body` the
+  body terminal. A template-author contract (`form-field(field: "refs.2")`,
+  `plaintext(..)`, every published `form.json`), so it keeps its own spelling
+  (renaming it is a blast radius) and translates to `DocPath` before it crosses.
 - **Schema-space coercion anchors**: `CoercionError` keeps its own
   `card_kinds.<kind>.<field>` / bare-field anchors, a schema-declaration
   namespace, not a document path. Where a coercion becomes an


### PR DESCRIPTION
Fixes #1223.

`plate_addr_to_doc_path` folded a plate address's whole tail into one `Field`, so `references.0` minted `main.references.0` — a string that reparses as `[Main, Field{"references"}, Field{"0"}]`, a different address than the one minted. `doc_path_to_plate_addr` matched a single-`Field` tail only, so no multi-segment address translated back.

Both spellings returned `None` from `docpath_to_plate`, so `locate` and `fieldBoxes` were dead for every `array<richtext>` element — the flagship memo's `references` among them — and for every nested key a pdfform widget binds.

## The fix

`region.rs` reads and renders a plate tail one segment at a time. Two private helpers carry the grammar:

- `plate_tail_to_segs` extends a `DocPath` base: an all-digit segment is an array index, `$body` (final only) the body terminal, anything else a field or map key. `None` for an empty piece, a leading index, or any other `$`-token.
- `plate_tail` renders the reverse, `None` for a `DocPath` plate space cannot spell — a leading `Index`, a non-final `Body`, or a field name that is empty, all-digits, `$`-leading, or carries `.` `[` `]`.

`DocPath`'s grammar, its parser, and the plate-space `.N` spelling all stay put. `DocPath::from_str` keeps reading `.N` as a map key, the shape `!must_fill` collection mints as `main.m.0`; a plate address never carries one, which is why `.N` is an index at this boundary and not in the parser.

`path.rs`'s grammar block claimed `field := [A-Za-z_][A-Za-z0-9_]*`, which overstates what the parser holds — restated as the property that carries.

## Compatibility

`RenderedRegion.field`, `FieldRegion.field` and `ContentHit.field` spell an array element bracketed (`main.references.0` → `main.references[0]`) on `regions()`, `fieldAt`, `positionAt` and `RenderResult.regions`, in both WASM and Python. That is the spelling schema validation already emits, so a `Diagnostic.path` and the geometry address for one place are now the same string.

Downstream, a consumer finding an address's children by prefix (``startsWith(`${field}.`)``) needs the `[` opener too, and any heuristic reading a trailing all-digit field name as a lost index is dead.

Backends, the Python binding, the WASM call sites and `Diagnostic.path` are unchanged.

## Verification

- `cargo test --workspace`: green, 51 test binaries, zero failures.
- WASM: 234/234 vitest cases, including a new end-to-end one on a `references` element.
- The `region.rs` round-trip table asserts all three legs including the **string leg** (`Display` → `FromStr`) — the leg the defect broke and the one WASM crosses. A round-trip pair comparing `DocPath` values alone would have passed while `locate` answered nothing.

The defect was confirmed live before the fix rather than assumed: the flagship memo really emits `references.0` and `references.1` regions, and `docpath_to_plate` returned `None` for both spellings of that address. That check is now a permanent assertion in `usaf_memo_regions_test.rs`.

## Notes on the issue's spec

- It called for `splitn(4, '.')` on the card head. The existing code strips `$cards.` first, so `splitn(3)` already delivers the whole tail — kept, same effect.
- It listed `main.body.x` as a non-final-`Body` rejection case. That string doesn't parse to a non-final `Body` (a non-terminal `.body` reads as a field named `body`), so the case is built segment-wise instead.
- `_qm-known-path` caps main addresses at two segments, so the deeper nested-key tails the parser now accepts are reachable only through pdfform. That matches the issue's "backends unchanged" scope, and it is why the end-to-end teeth are on a `references` element rather than a nested key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcZLwporR6R9LNVoWjYe5f)_