### PR TITLE
docs: give the text-type choice a decision procedure

### DIFF
--- a/docs/quills/creating-quills.md
+++ b/docs/quills/creating-quills.md
@@ -55,9 +55,9 @@ Four types hold text, and two questions pick one:
 | **open / literal** | `string` | `plaintext`: `*text*` stays literal |
 | **closed / formatted** | `enum`: a `values:` domain | `richtext`: `*text*` becomes emphasis |
 
-The letter above needs no content field: its prose is the document body, which is already rich text. Reach for `plaintext` or `richtext` when prose belongs in a *named field* — an abstract, a summary, a signature block note. Content fields carry navigation, regions, and click-to-edit in editor consumers; `string` and `enum` do not.
+The letter above needs no content field: its prose is the document body, which is already rich text. `plaintext` and `richtext` are for prose in a *named* field — an abstract, a summary. Such a field carries navigation, regions, and click-to-edit in editor consumers; `string` and `enum` carry none of that.
 
-Changing a declared type reinterprets every value already stored in that field, and data → content is lossy: markdown delimiters in the stored string are consumed as structure and the literal characters are gone. Pick before a corpus exists, or ship the change as a new quill version.
+Pick before a corpus exists. Changing a declared type reinterprets every value already stored in that field, and data → content is lossy: see [Choosing among `string`, `enum`, `plaintext`, and `richtext`](quill-yaml-reference.md#choosing-among-string-enum-plaintext-and-richtext).
 
 ## 3. Write `plate.typ`
 

--- a/docs/quills/creating-quills.md
+++ b/docs/quills/creating-quills.md
@@ -43,6 +43,22 @@ main:
 
 Use `default` for the value most authors will accept as-is (the field becomes optional, filled in when omitted). Use `example` to document the expected shape without supplying a default. Fields with neither are flagged in the blueprint with a `!must_fill` marker. See the [Quill.yaml Reference](quill-yaml-reference.md) for details.
 
+### Picking a text type
+
+Four types hold text, and two questions pick one:
+
+1. **Does the author write prose here, or does the plate compute with the value?** A name, URL, path, or reference key is data. A bio, an abstract, or a cover letter is content.
+2. Then, for data: **is the set of allowed values closed?** For content: **should `*text*` render as emphasis, or stay literal?**
+
+| | data — the plate computes with it | content — the author writes prose |
+|---|---|---|
+| **open / literal** | `string` | `plaintext`: `*text*` stays literal |
+| **closed / formatted** | `enum`: a `values:` domain | `richtext`: `*text*` becomes emphasis |
+
+The letter above needs no content field: its prose is the document body, which is already rich text. Reach for `plaintext` or `richtext` when prose belongs in a *named field* — an abstract, a summary, a signature block note. Content fields carry navigation, regions, and click-to-edit in editor consumers; `string` and `enum` do not.
+
+Changing a declared type reinterprets every value already stored in that field, and data → content is lossy: markdown delimiters in the stored string are consumed as structure and the literal characters are gone. Pick before a corpus exists, or ship the change as a new quill version.
+
 ## 3. Write `plate.typ`
 
 Your first plate template:

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -111,7 +111,7 @@ main:
 
 #### Choosing among `string`, `enum`, `plaintext`, and `richtext`
 
-The four text-ish types form a 2×2 of **data vs content** and **open/plain vs closed/formatted**. Two questions resolve it:
+The four text-ish types form a 2×2 of **data vs content** × **open/plain vs closed/formatted**, and two questions resolve it:
 
 1. Does the author write prose here, or does the plate compute with the value? Prose is content; a name, URL, path, identifier, or reference key is data.
 2. Then: is the domain closed (`enum` over `string`), or should markdown delimiters format the text rather than stay literal (`richtext` over `plaintext`)?
@@ -121,7 +121,7 @@ The four text-ish types form a 2×2 of **data vs content** and **open/plain vs c
 | **open / literal** | `string` | `plaintext`: `*text*` stays literal |
 | **closed / formatted** | `enum`: a `values:` domain | `richtext`: `*text*` becomes emphasis |
 
-The halves differ in what the field carries, not just how it renders. A content field rides the canonical content model, so it carries navigation, regions, and click-to-edit in editor consumers; `string` and `enum` carry none of that. `plaintext` and `richtext` share that entire stack and the same backend lowering, so they are indistinguishable in an editor and diverge only at emit, where the codec decides whether a delimiter is markup or a character.
+A content field rides the canonical content model, so it carries navigation, regions, and click-to-edit in editor consumers; `string` and `enum` carry none of that. `plaintext` and `richtext` share that entire stack and the same backend lowering, so they are indistinguishable in an editor and diverge only at emit, where the codec decides whether a delimiter is markup or a character.
 
 Changing a declared type reinterprets every stored value in that field at the next bound load, with no diagnostic, and data → content is the lossy direction: the stored string enters the codec's import and its delimiters are consumed as structure, leaving the literal characters unrecoverable. A declared type change is a new quill version ([Quill Versioning](versioning.md)); audit the corpus before publishing one, as under [Date and Datetime Grammars](#date-and-datetime-grammars).
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -109,11 +109,21 @@ main:
 | `richtext` | Rich, **formatted** prose over a canonical content; backends lower it to the target format. Markdown is its import/export projection. Add `inline: true` for the single-paragraph variant |
 | `object`   | Structured map; requires a `properties:` map |
 
-The four text-ish types form a 2×2 of **data vs content** and **open/plain vs
-closed/formatted**: `enum` (closed data), `string` (open data), `plaintext`
-(plain content), `richtext` (formatted content). Reach for `string` when the
-value is computed with, `plaintext`/`richtext` when it is prose the author
-navigates.
+#### Choosing among `string`, `enum`, `plaintext`, and `richtext`
+
+The four text-ish types form a 2×2 of **data vs content** and **open/plain vs closed/formatted**. Two questions resolve it:
+
+1. Does the author write prose here, or does the plate compute with the value? Prose is content; a name, URL, path, identifier, or reference key is data.
+2. Then: is the domain closed (`enum` over `string`), or should markdown delimiters format the text rather than stay literal (`richtext` over `plaintext`)?
+
+| | data — the plate computes with it | content — the author writes and navigates prose |
+|---|---|---|
+| **open / literal** | `string` | `plaintext`: `*text*` stays literal |
+| **closed / formatted** | `enum`: a `values:` domain | `richtext`: `*text*` becomes emphasis |
+
+The halves differ in what the field carries, not just how it renders. A content field rides the canonical content model, so it carries navigation, regions, and click-to-edit in editor consumers; `string` and `enum` carry none of that. `plaintext` and `richtext` share that entire stack and the same backend lowering, so they are indistinguishable in an editor and diverge only at emit, where the codec decides whether a delimiter is markup or a character.
+
+Changing a declared type reinterprets every stored value in that field at the next bound load, with no diagnostic, and data → content is the lossy direction: the stored string enters the codec's import and its delimiters are consumed as structure, leaving the literal characters unrecoverable. A declared type change is a new quill version ([Quill Versioning](versioning.md)); audit the corpus before publishing one, as under [Date and Datetime Grammars](#date-and-datetime-grammars).
 
 ### Date and Datetime Grammars
 


### PR DESCRIPTION
Closes #1231.

## Why

`string` / `enum` / `plaintext` / `richtext` is forced at an author's first text field, and neither doc gave a test for picking one. `creating-quills.md` never mentioned the choice at all — it declares three `string` fields and a `date` and moves on. `quill-yaml-reference.md` named the 2×2's axes without saying which side a given field falls on ("reach for `string` when the value is computed with" restates the axis rather than resolving it), and neither doc said what a wrong guess costs.

## What

Both docs now carry the same two questions and the same table:

| | data — the plate computes with it | content — the author writes prose |
|---|---|---|
| **open / literal** | `string` | `plaintext`: `*text*` stays literal |
| **closed / formatted** | `enum`: a `values:` domain | `richtext`: `*text*` becomes emphasis |

Axis names match `SCHEMAS.md` § "Quill.yaml DSL" so the user-facing table and canon read as one vocabulary.

- **`creating-quills.md`** gains a "Picking a text type" section after the `default`/`example` paragraph. It also names why the tutorial's own letter needs no content field — its prose is the document body — since that is otherwise the first thing a reader is confused about when told prose has its own types.
- **`quill-yaml-reference.md`** replaces the axis-naming paragraph with a "Choosing among…" subsection: the same questions and table, plus what the halves *carry* (a content field rides the canonical content model and gets nav/regions/click-to-edit; `string` and `enum` get none of it, so `plaintext` and `richtext` are indistinguishable in an editor and diverge only at emit), plus the cost of a wrong guess, cross-referenced to the parallel corpus-audit note under Date and Datetime Grammars.

The type-change cost lives in the reference; the tutorial states the rule and links, rather than restating the mechanism in both places.

## Scope

Docs only — no code, no fixtures, no goldens. Two things the issue records as deliberately out of scope: the versioning hole behind the lossy type change (`check_quill_reference` compares only name and selector, so an in-place type edit at the same version reinterprets a corpus with no diagnostic — already noted as unenforced at `SCHEMAS.md:76`), and the seven shipped quills declaring enums in the deprecated `enum:`-on-`string` dialect, which would move `usaf_memo`'s golden `schema.yaml` and is therefore a compat call rather than a docs cleanup.

## Verification

`node scripts/check-canon.mjs` passes. Nothing embeds these files — the only reference from code is a `see docs/quills/quill-yaml-reference.md` pointer in `crates/core/src/quill/types.rs:92` — so no test surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UFxnB4kZX1Ttx6qu66xQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_019UFxnB4kZX1Ttx6qu66xQ9)_