### PR TITLE
docs: state the backend seam's scope and reserve its namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo add quillmark
 ```rust
 use quillmark::{quill_from_path, OutputFormat, Quillmark, RenderOptions};
 
-// A `Quill` is portable, declarative data.
+// A `Quill` is declarative data: no engine needed to load it.
 let quill = quill_from_path("path/to/quill")?;
 let engine = Quillmark::new();
 

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -5,11 +5,12 @@
 ## TL;DR
 
 Quillmark is a schema-driven document engine: it turns Markdown with card-yaml
-blocks into a fully typeset document (PDF, SVG, PNG). A `Quill` is portable,
-declarative data whose schema drives validation and scaffolding (parse /
-validate / schema / seed / blueprint / compile). The `Quillmark` engine is the
-thin-but-mandatory core every render routes through: a backend registry +
-render dispatcher. Backends do the heavy compilation.
+blocks into a fully typeset document (PDF, SVG, PNG). A `Quill` is declarative
+data: no backend, engine, or filesystem needed to construct or read it. Its
+schema drives validation and scaffolding (parse / validate / schema / seed /
+blueprint / compile). The `Quillmark` engine is the thin-but-mandatory core
+every render routes through: a backend registry + render dispatcher. Backends
+do the heavy compilation.
 
 ## Data Flow
 
@@ -91,7 +92,7 @@ coercion.
 ## Core Interfaces
 
 - **`Quillmark`**, Engine: a backend registry + render dispatcher. Auto-registers one backend per enabled feature (`TypstBackend` under `typst`, `PdfformBackend` under `pdfform`; both are default). Resolves a quill's declared backend at render time (erroring `engine::backend_not_found` on no match) and owns the backend-dependent surface: `render`, `open`, `supported_formats(&quill)`, `supports_canvas(&quill)`. It does not construct quills.
-- **`Quill`**, The single quill type in `quillmark-core`: portable, declarative data (file bundle + config + metadata, tagged with a declared backend id), held by value and carrying the pure config-read operations (`validate`, `schema`, `blueprint`, `seed_*`, `compile_data`, `dry_run`). Construct with `Quill::from_tree` or `quillmark::quill_from_path`; see [QUILL.md](QUILL.md)
+- **`Quill`**, The single quill type in `quillmark-core`: declarative data (file bundle + config + metadata, tagged with a declared backend id), held by value and carrying the pure config-read operations (`validate`, `schema`, `blueprint`, `seed_*`, `compile_data`, `dry_run`). Construct with `Quill::from_tree` or `quillmark::quill_from_path`; see [QUILL.md](QUILL.md)
 - **`Backend`**, Trait for output formats (`Send + Sync`): `id()`, `supported_formats()`, `open(&Quill, json)`. There is no universal template input: a backend reads whatever static inputs it needs (a Typst plate, a `form.pdf`) from the quill's own files. No canvas-capability method: capability is derived (`LiveSession::supports_canvas()` from the session seam; `formats_support_canvas()` as a pre-session hint)
 - **`LiveSession`**, Opaque live session returned by `Backend::open()`: a persistent compiler whose reads serve its current compile and whose `update(&Document)` recompiles in place, transactionally, returning a `ChangeSet` of dirty pages. Born bound to the `QuillConfig` it was opened against, so the edit verb checks the `$quill` pairing and compiles through the same door as the first compile (`QuillConfig::compile_checked`) rather than trusting a caller to have done both. The canvas seam lives on `SessionHandle` (`page_size_pt`/`render_rgba`), so a canvas backend overrides two methods and the WASM painter dispatches generically; see [PREVIEW.md](PREVIEW.md)
 - **`Document`**: Typed in-memory representation of a Quillmark Markdown file (root block, body, cards). Serializes via `serde` to a versioned JSON envelope (`StoredDocument`) for database persistence, decoupled from the evolving Markdown syntax; see [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md)
@@ -107,6 +108,18 @@ coercion.
 See [PLATE_DATA.md](PLATE_DATA.md) for the Typst helper package.
 
 ## Backend Implementation
+
+Backends are an in-workspace seam, not an extension point. `Backend` and
+`SessionHandle` are sealed and `#[doc(hidden)]`, outside the crate
+compatibility promise ([COMPATIBILITY.md](COMPATIBILITY.md)), so a new trait
+method lands in a minor release. What the seal withholds is the promise, not
+the ability: a crate willing to name the hidden module implements both and
+registers through `Quillmark::register_backend`, against items no release holds
+stable.
+
+A quill declares one backend and renders through that one, so rendering a schema
+two ways is two quills, with no mechanism keeping their field definitions in
+agreement.
 
 Implement the `Backend` trait and return a `LiveSession` wrapping a
 `SessionHandle` that does the format-specific rendering; to paint to a canvas,

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -112,14 +112,14 @@ See [PLATE_DATA.md](PLATE_DATA.md) for the Typst helper package.
 Backends are an in-workspace seam, not an extension point. `Backend` and
 `SessionHandle` are sealed and `#[doc(hidden)]`, outside the crate
 compatibility promise ([COMPATIBILITY.md](COMPATIBILITY.md)), so a new trait
-method lands in a minor release. What the seal withholds is the promise, not
-the ability: a crate willing to name the hidden module implements both and
-registers through `Quillmark::register_backend`, against items no release holds
-stable.
+method lands in a minor release. The seal withholds the promise, not the
+ability: a crate willing to name the hidden module implements both and
+registers through `Quillmark::register_backend`. Nothing it writes against is
+held stable.
 
-A quill declares one backend and renders through that one, so rendering a schema
-two ways is two quills, with no mechanism keeping their field definitions in
-agreement.
+A quill declares one backend and renders through that one. Rendering a schema
+two ways is therefore two quills, with nothing keeping their field definitions
+in agreement.
 
 Implement the `Backend` trait and return a `LiveSession` wrapping a
 `SessionHandle` that does the format-specific rendering; to paint to a canvas,

--- a/prose/canon/COMPATIBILITY.md
+++ b/prose/canon/COMPATIBILITY.md
@@ -27,9 +27,9 @@ own rustdoc:
 | `Backend` + `SessionHandle` | Sealed and `#[doc(hidden)]`; an out-of-workspace backend writes against items this crate does not hold stable. |
 | `quillmark_typst::emit` | `pub` only so `quillmark-fuzz` can drive the escapers directly. |
 
-Dropping a row promises the seam, and retracting a promise costs a major;
-publishing a stable contract later costs nothing. The rows therefore outlive
-any release that has not deliberately chosen to publish one.
+Deleting a row promises the seam. Publishing a contract later is additive and
+retracting a published one is a major, so a row stays until a release
+deliberately publishes that seam.
 
 ## `#[non_exhaustive]`
 

--- a/prose/canon/COMPATIBILITY.md
+++ b/prose/canon/COMPATIBILITY.md
@@ -27,6 +27,10 @@ own rustdoc:
 | `Backend` + `SessionHandle` | Sealed and `#[doc(hidden)]`; an out-of-workspace backend writes against items this crate does not hold stable. |
 | `quillmark_typst::emit` | `pub` only so `quillmark-fuzz` can drive the escapers directly. |
 
+Dropping a row promises the seam, and retracting a promise costs a major;
+publishing a stable contract later costs nothing. The rows therefore outlive
+any release that has not deliberately chosen to publish one.
+
 ## `#[non_exhaustive]`
 
 The attribute is narrower than it reads, and the two halves cost different

--- a/prose/canon/INDEX.md
+++ b/prose/canon/INDEX.md
@@ -9,7 +9,7 @@
 
 - **[../references/markdown-spec.md](../references/markdown-spec.md)** - Quillmark Markdown specification (superset of CommonMark)
 - **[DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md)** - Versioned JSON serialization of `Document` for database persistence
-- **[QUILL.md](QUILL.md)** - Quill resource file structure and the portable, declarative `Quill` data type
+- **[QUILL.md](QUILL.md)** - Quill resource file structure and the declarative `Quill` data type
 - **[VERSIONING.md](VERSIONING.md)** - Quill version format and `$quill` reference syntax (selector parsed, not runtime-resolved)
 - **[SCHEMAS.md](SCHEMAS.md)** - `QuillConfig` schema model, native validation, and emission overview
 - **[BLUEPRINT.md](BLUEPRINT.md)** - Annotated Markdown blueprint for LLM/MCP authoring

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -13,9 +13,9 @@ engine's job.
 
 ## The `Quill` type
 
-One type models a loaded quill: **`Quill`** (in `quillmark-core`), portable,
-declarative data. It is the authored input (file bundle, parsed config, metadata)
-tagged with its *declared* backend id, and it carries the pure config-read
+One type models a loaded quill: **`Quill`** (in `quillmark-core`), declarative
+data. It is the authored input (file bundle, parsed config, metadata) tagged
+with its *declared* backend id, and it carries the pure config-read
 operations (`validate`, `schema`, `metadata`, `blueprint`, `seed_*`,
 `compile_data`, `dry_run`). It holds **no backend** and needs **no engine** to
 construct or use; rendering is the engine's job (see
@@ -75,7 +75,10 @@ missing or malformed template surfaces as a render-time error, not a load error.
 
 One required top-level section, `quill` (bundle metadata); optional `main`
 (document fields), `card_kinds` (card kind definitions), and a backend-named
-section (`typst`). Every key, type, and UI property is documented in the
+section (`typst`). Top-level keys naming a backend are a reserved namespace, and
+the engine reads exactly one of them: the section named by `quill.backend`. A
+section named for any other backend is `quill::unknown_section`, the same
+refusal a typo gets. Every key, type, and UI property is documented in the
 [Quill.yaml reference](../../docs/quills/quill-yaml-reference.md); what follows
 is what the engine enforces.
 

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -75,10 +75,10 @@ missing or malformed template surfaces as a render-time error, not a load error.
 
 One required top-level section, `quill` (bundle metadata); optional `main`
 (document fields), `card_kinds` (card kind definitions), and a backend-named
-section (`typst`). Top-level keys naming a backend are a reserved namespace, and
-the engine reads exactly one of them: the section named by `quill.backend`. A
-section named for any other backend is `quill::unknown_section`, the same
-refusal a typo gets. Every key, type, and UI property is documented in the
+section (`typst`). Top-level keys naming a backend are reserved, and the engine
+reads exactly one: the section named by `quill.backend`. A section named for any
+other backend is `quill::unknown_section`, the same refusal a typo gets. Every
+key, type, and UI property is documented in the
 [Quill.yaml reference](../../docs/quills/quill-yaml-reference.md); what follows
 is what the engine enforces.
 

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -39,6 +39,8 @@ No registry consumes the selector: there is no collection of installed versions 
 
 A quill mismatch is distinct from a validation failure (a malformed document): here the document is well-formed but paired with the wrong Quill, so the remedy is to render with the referenced Quill or amend `$quill`. A bare name or `@latest` matches any version, so correctly-targeted documents never trip either check.
 
+`$quill` is a **pairing assertion**, not a render target and not a schema declaration: the caller chooses which Quill renders, and the reference only confirms the document was authored against it.
+
 ## Error Handling
 
 Three distinct failure paths, and the parser owns one of them outright:

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -39,7 +39,7 @@ No registry consumes the selector: there is no collection of installed versions 
 
 A quill mismatch is distinct from a validation failure (a malformed document): here the document is well-formed but paired with the wrong Quill, so the remedy is to render with the referenced Quill or amend `$quill`. A bare name or `@latest` matches any version, so correctly-targeted documents never trip either check.
 
-`$quill` is a **pairing assertion**, not a render target and not a schema declaration: the caller chooses which Quill renders, and the reference only confirms the document was authored against it.
+`$quill` is a **pairing assertion**, not a render target or a schema declaration. The caller chooses which Quill renders; the reference only confirms the document was authored against it.
 
 ## Error Handling
 


### PR DESCRIPTION
Closes #1203, as a canon change with no code change.

## What the review found

#1203 scores backend neutrality 2.5/5 across three problems. Auditing them against the code, one is factually overstated, one has the right symptom and the wrong decomposition, and one is correct.

**Problem 1 ("the extension point is sealed") is overstated.** `crates/quillmark/tests/backend_registration_test.rs` implements a working backend from an out-of-crate position in ~50 lines, using only `pub` items: `impl sealed::Sealed for X {}`, `Backend`, `SessionHandle`, `LiveSession::new`, and `Quillmark::register_backend` (`crates/quillmark/src/orchestration/engine.rs:45`, public, no exemption). `crates/core/src/backend.rs:26` already says so: the seal "is a declaration, not a barrier." What is withheld is the promise, not the ability — and that asymmetry runs the other way from how the issue reads it. Promising stability later is additive; retracting a promise is a major. Keeping the seal is what preserves the option.

**Problem 2 collapses three separable things.** The schema *type system* is already backend-neutral — `crates/backends/pdfform/src/bind.rs:290` binds every `SchemaType`, degrading richtext to text and refusing object/nested-array as `Unbindable`. What is missing is schema sharing between bundles (no `extends`/`include` in `config.rs`), and the actual mechanical blocker the issue does not name: `$quill: name@selector` binds a document to a bundle name, and `quill::name_mismatch` is a hard error.

**Problem 3 is correct.** "Portable" was carrying two senses — portable as a value (earned: `from_tree`, `Send + Sync`, pure config-read ops) and portable across implementations (not delivered).

## Changes

| File | Change |
|---|---|
| `ARCHITECTURE.md` | §Backend Implementation states the stance: in-workspace seam, not an extension point; the seal withholds the promise, not the ability; one quill declares one backend, so rendering a schema two ways is two quills with nothing keeping them in agreement |
| `ARCHITECTURE.md`, `INDEX.md`, `README.md` | Bare "portable" dropped at the four sites a reader hits without the definition. `QUILL.md:22` keeps the qualified reading it already had and is now the single home for the term |
| `QUILL.md` | Top-level keys naming a backend are reserved; the engine reads exactly one, the section named by `quill.backend` |
| `VERSIONING.md` | `$quill` is a pairing assertion, not a render target or a schema declaration |
| `COMPATIBILITY.md` | The asymmetry that keeps the exemption rows through a release: publishing later is additive, retracting is a major |

Two commits: the content change, then a dense-prose pass over the added prose.

## What this deliberately does not do

No stable `Backend` contract, no schema `extends`, no cross-backend rendering of one document. Those serve third-party backends, which are deferred. Checked for irreversibility, and none of them binds: widening `backend:` to a list, relaxing `quill::unknown_section`, unsealing the trait, and adding a document-level key are all additive. Strict parsing and the seal have already reserved the namespaces. This PR writes down the stance so the direction stays defined.

One item is out of reach of a doc change: the `Backend` + `SessionHandle` row in COMPATIBILITY.md's exemption table has to still be there at the 1.0 tag, or the seam is implicitly promised. The added note makes the stake legible in the release diff, but it remains a human check.

## Verification

`cargo test --workspace` — 0 failures. `node scripts/check-canon.mjs` — canon spine OK. No test parses canon prose; the only references are in comments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHA6W4xug3YqVwU7dPgWGz)_