### PR TITLE
Bump minimum Node.js version to 24

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,7 +7,7 @@
       "username": "vscode",
       "installZsh": false
     },
-    "ghcr.io/devcontainers/features/node:1": { "version": "22" },
+    "ghcr.io/devcontainers/features/node:1": { "version": "24" },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     },
     "ghcr.io/astral-sh/uv:1": {},
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "lts"
+      "version": "24"
     }
   },
   "customizations": {

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -604,11 +604,11 @@ call returns: `try { return engine.render(quill, doc); } finally
 { doc.free(); }`: is safe even on the first render, while the backend
 binary is still loading.
 
-The package floor is Node 22+ (`engines: { node: ">=22" }`) and current
+The package floor is Node 24+ (`engines: { node: ">=24" }`) and current
 evergreen browsers; `--weak-refs` itself only needs Node 14.6+. The `using`
-sugar ([explicit resource management][erm]) needs Node 24 and is optional.
-Where it hasn't landed, an explicit `try` / `finally` runs on the Node 22
-floor:
+sugar ([explicit resource management][erm]) is on that floor and optional;
+an explicit `try` / `finally` is the equivalent, and the form that also runs
+in a browser that hasn't shipped it:
 
 ```ts
 const session = await engine.open(quill, doc);

--- a/crates/bindings/wasm/package.template.json
+++ b/crates/bindings/wasm/package.template.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "repository": {
     "type": "git",

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -122,7 +122,7 @@ Every Python verb is identical to its core/WASM twin or names its one difference
 
 ## WebAssembly: `bindings/quillmark-wasm`
 
-wasm-bindgen bindings published as `@quillmark/wasm`. Builds with `--target web` and `--weak-refs` so wasm-bindgen handles are reclaimed by `FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires Node 22+ / current evergreen browsers.
+wasm-bindgen bindings published as `@quillmark/wasm`. Builds with `--target web` and `--weak-refs` so wasm-bindgen handles are reclaimed by `FinalizationRegistry`; `.free()` remains as the eager teardown hook. Requires Node 24+ / current evergreen browsers.
 
 **The runtime owns instantiation.** `--target web` emits no `.wasm` ESM import and no top-level await, so nothing in the package graph forces a bundler plugin and a static import of `@quillmark/wasm` is safe anywhere, SSR included. The cost is that instantiation becomes explicit: `const { Quill, Document } = await init()` before the sync surface is touched.
 


### PR DESCRIPTION
Updates the minimum supported Node.js version from 22 to 24 across the project.

**Changes:**
- Updated `package.template.json` to require Node 24+ in the `engines` field
- Updated devcontainer configurations to use Node 24 instead of 22/lts
- Updated documentation in `README.md` and `BINDINGS.md` to reflect the new minimum version
- Clarified that explicit resource management (`using` syntax) is now on the floor and optional, with `try`/`finally` as the equivalent fallback for environments that haven't shipped it

This aligns the project's baseline with Node 24's LTS status and simplifies the documented feature support story.

https://claude.ai/code/session_0152rpwLqAMTFSXZW6zRmGxV