### PR TITLE
Pin the render floor's two type-domain edges and the seeded fill tag

### DIFF
--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -825,4 +825,90 @@ card_kinds:
             "a body-enabled kind keeps its $body content object"
         );
     }
+
+    // ── The render floor's two type-domain edges. Every shipped quill declares
+    //    a `default:` on every enum and never authors an empty `date`, so the
+    //    fixture suite reaches neither path; these pin the behavior a plate
+    //    actually receives (issue 1234, breaking changes 1 and 2).
+
+    /// A defaultless `enum` floors to the first declared variant: `zero_value`
+    /// returns an in-domain value, and `values.first()` is the only one
+    /// available. The plate cannot distinguish it from an authored choice.
+    #[test]
+    fn absent_defaultless_enum_floors_to_the_first_variant() {
+        let plate = plate_of(
+            r#"
+quill: { name: ev, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI, SECRET]
+"#,
+            "~~~card-yaml\n$quill: ev@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+        );
+        assert_eq!(
+            plate["classification"], "UNCLASSIFIED",
+            "declaration order picks the value; got {plate}"
+        );
+    }
+
+    /// The same floor inside a typed dictionary: `zero_value` recurses per
+    /// property, so a nested defaultless enum takes the first variant even when
+    /// the dictionary itself is absent.
+    #[test]
+    fn nested_defaultless_enum_floors_to_the_first_variant() {
+        let plate = plate_of(
+            r#"
+quill: { name: env, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string }
+    marking:
+      type: object
+      properties:
+        level:
+          type: enum
+          values: [UNCLASSIFIED, CUI]
+        note: { type: string }
+"#,
+            "~~~card-yaml\n$quill: env@1.0.0\n$kind: main\ntitle: T\n~~~\n",
+        );
+        assert_eq!(
+            plate["marking"],
+            json!({ "level": "UNCLASSIFIED", "note": "" }),
+            "the recursive floor fills each property; got {plate}"
+        );
+    }
+
+    /// An authored empty `date` coerces to null before the ladder runs
+    /// (`config::conform_value`), so it reads as absent and the `default:`
+    /// fills. The same literal on a `string` outranks the default: presence,
+    /// not truthiness, is what the ladder keys on.
+    #[test]
+    fn authored_empty_date_coerces_to_absent_and_takes_the_default() {
+        let plate = plate_of(
+            r#"
+quill: { name: dz, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    signed_on:
+      type: date
+      default: "2026-01-01"
+    subtitle:
+      type: string
+      default: "a default"
+"#,
+            "~~~card-yaml\n$quill: dz@1.0.0\n$kind: main\nsigned_on: \"\"\nsubtitle: \"\"\n~~~\n",
+        );
+        assert_eq!(
+            plate["signed_on"], "2026-01-01",
+            "the empty date nulls in coercion, so the default fills; got {plate}"
+        );
+        assert_eq!(
+            plate["subtitle"], "",
+            "the empty string survives coercion and outranks the default"
+        );
+    }
 }

--- a/crates/core/src/quill/conform/tests.rs
+++ b/crates/core/src/quill/conform/tests.rs
@@ -300,6 +300,59 @@ fn conform_is_a_no_op_on_seeds() {
     assert_eq!(bytes(&doc2), before2, "seed_card is already at rest");
 }
 
+/// A `!must_fill` tag on a seeded `example` cell rides the payload *item*, not
+/// the value, so it crosses the storage seam without touching either byte
+/// discipline: seed → store → load → conform is a byte no-op with the tag
+/// present, and the cell keeps its resting form (a `plaintext` literal string, a
+/// `richtext` canonical content object). The shape a seeder that stamped its
+/// must-fill cells would persist (issue 1234, open question 2).
+///
+/// The resting form here is the *seeder's* doing, not conform's: a tagged field
+/// is skipped outright (`fill_marked_fields_are_skipped`), so it never reaches
+/// the strict write. Seed-commits-rest is what makes the two agree, which a
+/// stamping seeder would promote from a nicety to a prerequisite — a tag on a
+/// cell written off-rest would pin it there.
+#[test]
+fn a_fill_tag_on_a_seeded_cell_survives_store_load_conform() {
+    let quill = quill();
+    let mut doc = quill.seed_document();
+
+    // Tag in place, keeping each seeded value: `insert_item` preserves an
+    // existing key's position, so the payload order is still declaration order.
+    for key in ["subject", "note"] {
+        let seeded = doc.main().payload().get(key).expect("seeded").clone();
+        doc.main_mut().store_fill(key, seeded).unwrap();
+    }
+    let tagged = bytes(&doc);
+
+    let mut loaded = Document::try_from(
+        serde_json::from_str::<StoredDocument>(&tagged).expect("the tagged seed loads"),
+    )
+    .expect("and converts to a document");
+    let diags = quill.conform(&mut loaded).expect("the quill matches");
+
+    assert!(diags.is_empty(), "{diags:?}");
+    assert_eq!(bytes(&loaded), tagged, "the cycle moves no bytes");
+    assert!(
+        loaded.main().payload().is_fill("subject") && loaded.main().payload().is_fill("note"),
+        "both tags survive the round trip"
+    );
+    assert_eq!(
+        loaded.main().payload().get("note").unwrap().as_json(),
+        &json!("a *literal* line"),
+        "the tagged plaintext cell keeps its resting form"
+    );
+    assert!(
+        loaded.main().payload().get("subject").unwrap().as_json().is_object(),
+        "and the tagged richtext cell keeps its canonical content object"
+    );
+
+    // The tag is the only difference from the untagged seed: same values, same
+    // order, so a consumer's cache key moves once when the tag lands and holds.
+    let untagged = bytes(&quill.seed_document());
+    assert_ne!(tagged, untagged, "the tag is stored, not inferred");
+}
+
 /// The plate is the render floor's shape and does not move: `plaintext` reaches
 /// the backend as a content object whichever form was committed.
 #[test]


### PR DESCRIPTION
Tests only; no behavior change. Groundwork for #1234, which names two breaking changes the fixture suite structurally cannot catch and one open question a round trip can answer.

## The render floor's two type-domain edges (`quill/compose.rs`)

All seven shipped quills declare a `default:` on every enum, and none authors an empty `date`, so nothing in the suite reaches either floor path. #1234 flags this explicitly: *"No shipped quill exercises this path (all seven declare defaults), so the fixture suite will not catch it."* Three characterization tests take the plate through them:

- `absent_defaultless_enum_floors_to_the_first_variant` — an absent, defaultless enum reaches the plate as `values[0]`.
- `nested_defaultless_enum_floors_to_the_first_variant` — the same floor one level down. `zero_value` recurses per property, so an enum inside a typed dictionary switches too; #1234 asserts this and it holds.
- `authored_empty_date_coerces_to_absent_and_takes_the_default` — an authored `date: ""` nulls in coercion and the `default:` fills, with the `string` case asserted alongside so the asymmetry between the two types reads off a single test.

All three pass against current behavior, which is the point: rules 1 and 3 of #1234 turn them red, with the expected values stated inline, so the flip arrives as a test failure rather than as silent output movement on documents nobody re-rendered.

## The seeded fill tag across the storage seam (`quill/conform/tests.rs`)

`a_fill_tag_on_a_seeded_cell_survives_store_load_conform` carries `!must_fill` on two example-seeded cells — a `plaintext` resting as a literal string and a `richtext` resting as the canonical content object — through seed → store → load → conform. Byte-equal, both tags intact, both resting forms held. That answers #1234's open question about `DOCUMENT_STORAGE.md` byte-stability: the tag rides the payload item, so neither byte discipline is touched.

The test comment records the mechanism, which is not the obvious one: `conform` skips any fill-tagged field outright, so a stamped cell never reaches the strict write. The resting form survives because seed-commits-rest already wrote it correctly, which makes that property a prerequisite for a stamping seeder rather than a convenience.

## Verification

`cargo test --workspace` — 20 test binaries, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm3UybXaJSu8S5sitEBw1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm3UybXaJSu8S5sitEBw1G)_