### PR TITLE
Retire the `enum:` modifier; project a field's domain by capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- refactor(core,pdfform,cli,wasm)!: the `enum:` modifier on `type: string`
+  retires. `type: enum` with a `values:` list is the one spelling of a finite
+  string domain; `enum:` on any type is now `quill::field_parse_error`, whose
+  message names the replacement — it is the only diagnostic a quill written
+  against the modifier ever received, since the deprecation shipped in 0.94
+  with no warning code behind it. `QuillConfig::schema()` re-emits every
+  domain as `values:`, so a consumer reading `enum:` off the schema echo (the
+  wasm `QuillFieldSchema.enum`, dropped here) reads `values:` instead. The
+  `usaf_memo` and `sample_form` fixtures migrate; wire data and rendered
+  output are unchanged, the projections being domain-keyed already.
+- fix(core): `build_transform_schema` keys a field's finite domain on the
+  domain itself rather than the `Enum` token, joining the render floor, the
+  pdfform widget kind and the blueprint annotation. Under the retired
+  spelling every `usaf_memo` enum — `classification`, `format`, `action` —
+  projected as a bare `{"type":"string"}`, so a consumer building a
+  JSON-Schema validator from the transform schema accepted
+  `classification: "banana"` while pdfform drew the six-option dropdown for
+  the same field and `QuillConfig` rejected the value at coercion (#1237)
 - fix(core)!: geometry addresses parse segment-wise, so `locate` and
   `fieldBoxes` answer for an address deeper than one segment. The translation
   boundary folded a plate address's whole tail into one `Field`, so

--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -266,17 +266,15 @@ fn descend<'a>(cur: &'a FieldSchema, seg: &str) -> Option<&'a FieldSchema> {
 }
 
 /// Project a resolved [`FieldSchema`] to its widget kind. Keyed on the field's
-/// *capability*, not its `type` token: crucially, choice keys on
-/// `enum_values.is_some()`, so both `type: enum` and the deprecated `string` +
-/// `enum:` modifier project to a dropdown (keying on the `Enum` variant would
-/// silently demote the latter to a text box). Total or a load error: an
-/// `object`, or an array of objects/arrays, has no widget shape.
+/// *capability*, not its `type` token: choice keys on `enum_values.is_some()`,
+/// so any field carrying a finite domain is a dropdown. Total or a load error:
+/// an `object`, or an array of objects/arrays, has no widget shape.
 pub fn project_kind(
     field: &FieldSchema,
     name: &str,
     path: &str,
 ) -> Result<WidgetType, BindError> {
-    // A finite string domain, however spelled, is a dropdown.
+    // A finite string domain is a dropdown.
     if let Some(values) = &field.enum_values {
         return Ok(WidgetType::Choice {
             options: values.clone(),
@@ -387,11 +385,8 @@ main:
     agree:
       type: boolean
     favorite_color:
-      type: string
-      enum: [red, green, blue]
-    promoted_color:
       type: enum
-      values: [cyan, magenta]
+      values: [red, green, blue]
     count:
       type: integer
     when:
@@ -442,19 +437,11 @@ card_kinds:
     }
 
     #[test]
-    fn both_enum_spellings_project_to_choice() {
-        // Deprecated `string` + `enum:` and promoted `type: enum` both key on
-        // `enum_values.is_some()`.
+    fn enum_projects_to_choice() {
         assert_eq!(
             kind("favorite_color").unwrap(),
             WidgetType::Choice {
                 options: vec!["red".into(), "green".into(), "blue".into()]
-            }
-        );
-        assert_eq!(
-            kind("promoted_color").unwrap(),
-            WidgetType::Choice {
-                options: vec!["cyan".into(), "magenta".into()]
             }
         );
     }

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -173,22 +173,14 @@ fn validate_file_references(
 /// Type/enum/format errors on `example:` and `default:` literals are caught
 /// authoritatively at parse time (`QuillConfig::from_yaml_with_warnings`, Step 1)
 /// via the shared `validate_schema_literal` core and reported there with full
-/// diagnostics. This pass only adds the advisory checks the parser does not:
-/// empty enum constraints and missing field descriptions.
+/// diagnostics. This pass only adds the advisory check the parser does not: a
+/// missing field description.
 fn validate_field_schemas(
     fields: &IndexMap<String, FieldSchema>,
     result: &mut ValidationResult,
     context: &str,
 ) {
     for (field_name, field_schema) in fields {
-        if let Some(ref enum_values) = field_schema.enum_values {
-            if enum_values.is_empty() {
-                result.add_warning(
-                    format!("{context} '{field_name}': enum constraint is empty"),
-                    "cli::empty_enum",
-                );
-            }
-        }
         if field_schema
             .description
             .as_deref()

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -66,11 +66,8 @@ export interface QuillFieldSchema {
     description?: string;
     default?: unknown;
     example?: unknown;
-    /** Closed value domain. On `type: "enum"` declared as `values`; the
-     *  deprecated `enum` modifier on `type: "string"` is accepted for one
-     *  release. Both round-trip through this field. */
-    enum?: string[];
-    /** Required on `type: "enum"`: the closed set of allowed string values. */
+    /** Required on `type: "enum"`, and valid nowhere else: the closed set of
+     *  allowed string values. */
     values?: string[];
     ui?: QuillFieldUi;
     properties?: Record<string, QuillFieldSchema>;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -556,7 +556,7 @@ main:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    format: { type: string, enum: [standard, informal], default: standard }
+    format: { type: enum, values: [standard, informal], default: standard }
 "#)
         .blueprint();
         assert!(t.contains("format: standard # enum<standard | informal>\n"));
@@ -571,7 +571,7 @@ main:
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    severity: { type: string, enum: [low, medium, high] }
+    severity: { type: enum, values: [low, medium, high] }
 "#)
         .blueprint();
         assert!(t.contains("severity: !must_fill # enum<low | medium | high>\n"));
@@ -1018,8 +1018,8 @@ main:
     date:
       type: datetime
     priority:
-      type: string
-      enum: [normal, urgent]
+      type: enum
+      values: [normal, urgent]
       default: normal
     attachments:
       type: array

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -40,6 +40,27 @@ pub const QUILLMARK_PLAIN_KEY: &str = "quillmark:plain";
 pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     fn field_to_schema(field: &FieldSchema) -> serde_json::Value {
         let mut schema = serde_json::Map::new();
+        // A finite domain projects to the idiomatic JSON-Schema spelling
+        // `{type: string, enum: [...]}`: exactly what a backend dispatches on
+        // today (a plain string), plus the domain. Keyed on the domain, as the
+        // render floor, the pdfform widget and the blueprint annotation all are,
+        // so a `FieldSchema` built outside the loader projects its domain too.
+        if let Some(values) = &field.enum_values {
+            schema.insert(
+                "type".to_string(),
+                serde_json::Value::String("string".to_string()),
+            );
+            schema.insert(
+                "enum".to_string(),
+                serde_json::Value::Array(
+                    values
+                        .iter()
+                        .map(|v| serde_json::Value::String(v.clone()))
+                        .collect(),
+                ),
+            );
+            return serde_json::Value::Object(schema);
+        }
         match field.r#type {
             FieldType::String => {
                 schema.insert(
@@ -87,25 +108,13 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                     );
                 }
             }
+            // A loaded `enum` always carries `values:`, so the domain branch
+            // above claims it; this arm is the domain-less residue.
             FieldType::Enum => {
-                // The promoted token projects to the idiomatic JSON-Schema
-                // spelling `{type: string, enum: [...]}`: exactly what a backend
-                // dispatches on today (a plain string), plus the finite domain.
                 schema.insert(
                     "type".to_string(),
                     serde_json::Value::String("string".to_string()),
                 );
-                if let Some(values) = &field.enum_values {
-                    schema.insert(
-                        "enum".to_string(),
-                        serde_json::Value::Array(
-                            values
-                                .iter()
-                                .map(|v| serde_json::Value::String(v.clone()))
-                                .collect(),
-                        ),
-                    );
-                }
             }
             FieldType::Number => {
                 schema.insert(
@@ -225,6 +234,40 @@ mod tests {
     fn build_from_yaml(yaml: &str) -> QuillValue {
         let config = QuillConfig::from_yaml(yaml).expect("yaml parses");
         build_transform_schema(&config)
+    }
+
+    #[test]
+    fn enum_carries_its_domain_at_every_depth() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+    endorsements:
+      type: array
+      items:
+        type: object
+        properties:
+          action:
+            type: enum
+            values: [approve, disapprove]
+"#;
+        let schema = build_from_yaml(yaml);
+        let json = schema.as_json();
+        let domain = serde_json::json!({ "type": "string", "enum": ["UNCLASSIFIED", "CUI"] });
+        assert_eq!(json["properties"]["classification"], domain);
+        // The domain survives the recursion into an array's element object: a
+        // consumer building a validator sees it at the leaf too.
+        assert_eq!(
+            json["properties"]["endorsements"]["items"]["properties"]["action"],
+            serde_json::json!({ "type": "string", "enum": ["approve", "disapprove"] })
+        );
     }
 
     #[test]

--- a/crates/core/src/quill/schema_yaml.rs
+++ b/crates/core/src/quill/schema_yaml.rs
@@ -24,8 +24,8 @@ quill:
 main:
   fields:
     status:
-      type: string
-      enum: [draft, final]
+      type: enum
+      values: [draft, final]
       default: draft
       ui:
         group: Meta
@@ -42,7 +42,7 @@ card_kinds:
     fn schema_includes_ui() {
         let config = cfg(FULL);
         let yaml = config.schema_yaml().unwrap();
-        assert!(yaml.contains("enum:") && yaml.contains("type: integer"));
+        assert!(yaml.contains("values:") && yaml.contains("type: integer"));
         assert!(yaml.contains("card_kinds:") && yaml.contains("indorsement:"));
         assert!(yaml.contains("ui:") && yaml.contains("group: Meta"));
     }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2864,7 +2864,7 @@ fn example_string_type_accepts_quoted_decimal_example() {
 #[test]
 fn example_not_in_enum_is_rejected() {
     let yaml = example_default_yaml(
-        "    color:\n      type: string\n      enum: [a, b]\n      example: c\n",
+        "    color:\n      type: enum\n      values: [a, b]\n      example: c\n",
     );
     let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
     let diag = errors
@@ -2879,7 +2879,7 @@ fn example_not_in_enum_is_rejected() {
 #[test]
 fn example_in_enum_loads_successfully() {
     let yaml = example_default_yaml(
-        "    color:\n      type: string\n      enum: [a, b]\n      example: a\n",
+        "    color:\n      type: enum\n      values: [a, b]\n      example: a\n",
     );
     QuillConfig::from_yaml(&yaml).expect("enum-member example should load");
 }
@@ -3250,7 +3250,7 @@ fn plaintext_transform_schema_carries_media_type_and_plain_annotation() {
 }
 
 // ---------------------------------------------------------------------------
-// enum: the promoted `type: enum` token
+// enum: `type: enum` + `values:`, the one spelling of a finite string domain
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -3307,27 +3307,27 @@ fn enum_membership_is_validated_on_a_document_value() {
 }
 
 #[test]
-fn legacy_enum_modifier_on_string_is_still_accepted() {
-    // The deprecated spelling loads and populates the same store.
-    let config = quill_with_field("    color:\n      type: string\n      enum: [a, b]\n")
-        .expect("legacy enum: on string still loads");
-    let field = config.main.fields.get("color").unwrap();
-    assert_eq!(field.r#type, FieldType::String);
-    assert_eq!(
-        field.enum_values.as_deref(),
-        Some(["a".to_string(), "b".to_string()].as_slice())
-    );
+fn the_enum_modifier_is_a_load_error_on_every_type() {
+    // The modifier is retired on the type that used to accept it, and the
+    // message routes to `type: enum` rather than reporting an unknown key.
+    for field in [
+        "    color:\n      type: string\n      enum: [a, b]\n",
+        "    color:\n      type: enum\n      enum: [a, b]\n",
+        "    n:\n      type: integer\n      enum: [a, b]\n",
+    ] {
+        let err = quill_with_field(field).unwrap_err();
+        assert!(
+            err.iter()
+                .any(|d| d.code.as_deref() == Some("quill::field_parse_error")
+                    && d.message.contains("enum: is retired")
+                    && d.message.contains("values:")),
+            "enum: should fail load with a migration message, got: {err:?}"
+        );
+    }
 }
 
 #[test]
-fn enum_or_values_on_a_non_enum_type_is_a_load_error() {
-    // enum:/values: on a non-string, non-enum type fails to load.
-    let err = quill_with_field("    n:\n      type: integer\n      enum: [1, 2]\n").unwrap_err();
-    assert!(
-        err.iter()
-            .any(|d| d.code.as_deref() == Some("quill::field_parse_error")),
-        "enum: on an integer field should fail to load, got: {err:?}"
-    );
+fn values_on_a_non_enum_type_is_a_load_error() {
     let err = quill_with_field("    s:\n      type: string\n      values: [a, b]\n").unwrap_err();
     assert!(
         err.iter()

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -326,12 +326,11 @@ pub enum FieldType {
     },
     /// A closed finite domain of string values: the "branch on this" data type.
     /// Surfaced as `type: enum` with a required `values:` list (carried in
-    /// [`FieldSchema::enum_values`], the single storage shared with the
-    /// deprecated `enum:` modifier on `string`). Projects to the idiomatic
-    /// JSON-Schema `{type: string, enum: [...]}`: exactly the shape backends
-    /// already consume, so promoting the token costs zero backend edits. Scoped
-    /// to string-valued members: an enum is a branching key, and numeric
-    /// domains are range constraints on `number`, not enums.
+    /// [`FieldSchema::enum_values`]), the sole spelling of a finite domain.
+    /// Projects to the idiomatic JSON-Schema `{type: string, enum: [...]}`:
+    /// exactly the shape backends already consume, so the token costs zero
+    /// backend edits. Scoped to string-valued members: an enum is a branching
+    /// key, and numeric domains are range constraints on `number`, not enums.
     Enum,
 }
 
@@ -469,13 +468,13 @@ struct FieldSchemaDef {
     pub default: Option<QuillValue>,
     pub example: Option<QuillValue>,
     pub ui: Option<UiFieldSchema>,
-    /// The deprecated `enum:` modifier on `type: string`, accepted alongside
-    /// the promoted `type: enum` + `values:` spelling; both land in
-    /// [`FieldSchema::enum_values`].
+    /// The retired `enum:` modifier, parsed only to reject it by name: under
+    /// `deny_unknown_fields` an absent binding reports "unknown field `enum`"
+    /// with no route to `values:`.
     #[serde(rename = "enum")]
-    pub enum_values: Option<Vec<String>>,
-    /// The `values:` list required by the promoted `type: enum`. Merged with
-    /// `enum_values` into the one carrier at load.
+    pub enum_key: Option<Vec<String>>,
+    /// The domain of a `type: enum` field, and the only spelling of one.
+    /// Lands in [`FieldSchema::enum_values`].
     pub values: Option<Vec<String>>,
     // Nested schema support
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
@@ -508,11 +507,9 @@ impl FieldSchema {
         // here, so `FieldType::RichText { inline }` (and its `PlainText` sibling)
         // is the one carrier thereafter.
         let r#type = Self::resolve_prose_inline(def.r#type, def.inline)?;
-        // Fold the two enum spellings into the one carrier: the promoted
-        // `type: enum` requires `values:`; the deprecated `enum:` modifier is
-        // accepted only on `string`. On any other type an `enum:`/`values:` key
-        // is a hard error.
-        let enum_values = Self::resolve_enum_values(&r#type, def.enum_values, def.values)?;
+        // `type: enum` requires `values:`; `values:` on any other type, and
+        // `enum:` on any type at all, is a hard error.
+        let enum_values = Self::resolve_enum_values(&r#type, def.enum_key, def.values)?;
         Ok(Self {
             name: key.clone(),
             r#type,
@@ -575,43 +572,32 @@ impl FieldSchema {
         }
     }
 
-    /// Reconcile the two enum spellings into [`FieldSchema::enum_values`]:
-    /// the promoted `type: enum` requires a non-empty `values:` list; `type:
-    /// string` accepts the deprecated `enum:` modifier; any other type carrying
-    /// either key is an error.
+    /// Resolve the domain into [`FieldSchema::enum_values`]. `type: enum`
+    /// requires a non-empty `values:` list and is the one spelling of a finite
+    /// domain; `values:` elsewhere, and `enum:` anywhere, is an error. The
+    /// `enum:` message is a migration instruction: it is the only diagnostic a
+    /// quill written against the modifier ever receives.
     fn resolve_enum_values(
         r#type: &FieldType,
         enum_key: Option<Vec<String>>,
         values_key: Option<Vec<String>>,
     ) -> Result<Option<Vec<String>>, String> {
+        if enum_key.is_some() {
+            return Err(
+                "enum: is retired; declare a finite string domain as type: enum with a \
+                 values: list"
+                    .to_string(),
+            );
+        }
         match r#type {
-            FieldType::Enum => {
-                if enum_key.is_some() {
-                    return Err(
-                        "type: enum declares its domain with values:, not enum:; rename the key"
-                            .to_string(),
-                    );
-                }
-                match values_key {
-                    Some(v) if !v.is_empty() => Ok(Some(v)),
-                    _ => Err("type: enum requires a non-empty values: list".to_string()),
-                }
-            }
-            FieldType::String => {
-                if values_key.is_some() {
-                    return Err(
-                        "values: is only valid on type: enum; on a string use the enum: modifier \
-                         (deprecated) or declare type: enum"
-                            .to_string(),
-                    );
-                }
-                Ok(enum_key)
-            }
+            FieldType::Enum => match values_key {
+                Some(v) if !v.is_empty() => Ok(Some(v)),
+                _ => Err("type: enum requires a non-empty values: list".to_string()),
+            },
             other => {
-                if enum_key.is_some() || values_key.is_some() {
+                if values_key.is_some() {
                     return Err(format!(
-                        "enum:/values: is only valid on type: enum (or the deprecated enum: on \
-                         type: string), not on type: {}",
+                        "values: is only valid on type: enum, not on type: {}",
                         other.as_str()
                     ));
                 }
@@ -655,14 +641,7 @@ impl Serialize for FieldSchema {
             map.serialize_entry("ui", v)?;
         }
         if let Some(v) = &self.enum_values {
-            // The promoted type re-emits its domain as `values:`; the deprecated
-            // modifier on `string` re-emits as `enum:`, so each spelling round-trips.
-            let key = if matches!(self.r#type, FieldType::Enum) {
-                "values"
-            } else {
-                "enum"
-            };
-            map.serialize_entry(key, v)?;
+            map.serialize_entry("values", v)?;
         }
         if let Some(v) = &self.properties {
             map.serialize_entry("properties", v)?;

--- a/crates/fixtures/resources/quills/sample_form/0.1.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/sample_form/0.1.0/Quill.yaml
@@ -32,8 +32,8 @@ main:
       description: Whether the applicant agrees to the terms. Binds the Agree checkbox.
 
     favorite_color:
-      type: string
-      enum:
+      type: enum
+      values:
         - red
         - green
         - blue

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -78,8 +78,8 @@ main:
       description: The full organization name of your unit.
 
     letterhead_seal:
-      type: string
-      enum:
+      type: enum
+      values:
         - dow
         - dod
       default: dow
@@ -106,8 +106,8 @@ main:
       description: "Organizational motto at the bottom of the page. Supports Markdown emphasis (e.g. *italics*, **bold**)."
 
     classification:
-      type: string
-      enum:
+      type: enum
+      values:
         - ""
         - UNCLASSIFIED
         - CUI
@@ -208,8 +208,8 @@ main:
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
     memo_style:
-      type: string
-      enum:
+      type: enum
+      values:
         - usaf
         - daf
       default: usaf
@@ -264,8 +264,8 @@ card_kinds:
           group: addressing
         description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title."
       format:
-        type: string
-        enum:
+        type: enum
+        values:
           - standard
           - informal
           - separate_page
@@ -275,8 +275,8 @@ card_kinds:
           compact: true
         description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
       action:
-        type: string
-        enum:
+        type: enum
+        values:
           - ""
           - undecided
           - approve

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -66,7 +66,7 @@ main:
       items:
         type: string
     letterhead_seal:
-      type: string
+      type: enum
       description: >-
         Department of War (DoW) or Department of Defense (DoD) seal shown in the
         letterhead.
@@ -74,7 +74,7 @@ main:
       ui:
         group: letterhead
         compact: true
-      enum:
+      values:
       - dow
       - dod
     letterhead_seal_subtitle:
@@ -95,7 +95,7 @@ main:
         compact: true
       inline: true
     classification:
-      type: string
+      type: enum
       description: >-
         Select the classification marking shown in the header and footer banner.
         Unclassified documents typically omit this banner entirely, leave blank unless the
@@ -105,7 +105,7 @@ main:
       ui:
         group: classification
         compact: true
-      enum:
+      values:
       - ""
       - UNCLASSIFIED
       - CUI
@@ -208,7 +208,7 @@ main:
       items:
         type: string
     memo_style:
-      type: string
+      type: enum
       description: >-
         USAF memorandum or DAF headquarters memorandum; DAF changes date format and
         body paragraph layout per AFH 33-337.
@@ -216,7 +216,7 @@ main:
       ui:
         group: additional
         compact: true
-      enum:
+      values:
       - usaf
       - daf
     font_size:
@@ -273,18 +273,18 @@ card_kinds:
         items:
           type: string
       format:
-        type: string
+        type: enum
         description: "'standard' (formal, same page), 'informal' (less formal routing), or 'separate_page' (begins on a new page)."
         default: standard
         ui:
           group: additional
           compact: true
-        enum:
+        values:
         - standard
         - informal
         - separate_page
       action:
-        type: string
+        type: enum
         description: >-
           Action taken by the endorser. Leave blank to hide the Approve/Disapprove line
           entirely, 'undecided' to display the line with neither option circled, 'approve'
@@ -293,7 +293,7 @@ card_kinds:
         ui:
           group: additional
           compact: true
-        enum:
+        values:
         - ""
         - undecided
         - approve

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -59,8 +59,8 @@ main:
       description: Whether the applicant agrees to the terms. Binds the Agree checkbox.
 
     favorite_color:
-      type: string
-      enum:
+      type: enum
+      values:
         - red
         - green
         - blue
@@ -161,11 +161,11 @@ An unbound widget has no `schema_field`, so it cannot inherit a kind: it declare
 
 ### Widget-kind projection
 
-A bound field's kind is derived from the **capability of the resolved schema field**, not its `type` token, so both `type: enum` and the deprecated `string` + `enum:` modifier project to a dropdown. The projection is total, or the quill fails to load:
+A bound field's kind is derived from the **capability of the resolved schema field**, not its `type` token. The projection is total, or the quill fails to load:
 
 | Resolved schema field | Widget kind |
 |---|---|
-| has `enum` values (any spelling) | **choice**, options = the enum values |
+| has `enum` values | **choice**, options = the enum values |
 | `boolean` | **checkbox** |
 | `string`, `number`, `integer`, `date`, `datetime`, `richtext`, `plaintext` | **text** |
 | array of the above (scalar or prose) | **text**: elements joined with newlines |

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -87,7 +87,6 @@ main:
 | `default`     | matches `type`    | no       | The value the **majority of authors want**. When the field is omitted, the default is filled in. **Declaring `default` makes the field Endorsed**: the blueprint renders the concrete default value with a type-only annotation (no marker), shippable as-is. Omitting `default` makes the field **Unendorsed**: the blueprint stamps the `!must_fill` marker (carrying the field's `example` as a suggested value when present, else bare). A surviving marker raises the non-fatal `validation::must_fill` warning: it never gates render, since an absent or present-null field zero-fills. |
 | `example`     | matches `type`    | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only: surfaced in the [blueprint](https://github.com/borb-sh/quillmark/blob/main/prose/canon/BLUEPRINT.md)'s `# e.g.` line for documentation and LLM authoring, never rendered as the value. |
 | `values`      | array of strings  | for `enum` | The closed set of allowed string values. Required on every `enum` field. |
-| `enum`        | array of strings  | no       | **Deprecated** alias of `values`, accepted on `type: string` for one release. Prefer `type: enum` with `values:`. |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
 | `items`       | object            | for `array` | Element schema for an `array` field (a nested field schema). Required on every array. |
 | `properties`  | object            | for `object` | Nested field schemas for an `object` typed dictionary (or an array's `object`-typed `items`). Required on every `object` field. |
@@ -161,8 +160,8 @@ main:
       description: "Format style for the endorsement."
 ```
 
-The `enum:` modifier on `type: string` is a deprecated alias, accepted for one
-release. `enum:`/`values:` on any other type is a load error.
+`values:` on any other type is a load error, as is the retired `enum:`
+modifier on any type.
 
 ### Primitive Arrays, Typed Tables, and Typed Dictionaries
 
@@ -349,8 +348,8 @@ card_kinds:
         ui:
           group: Addressing
       format:
-        type: string
-        enum: [standard, informal, separate_page]
+        type: enum
+        values: [standard, informal, separate_page]
         default: standard
 ```
 
@@ -514,8 +513,8 @@ main:
         group: Header
 
     status:
-      type: string
-      enum: [on_track, at_risk, blocked]
+      type: enum
+      values: [on_track, at_risk, blocked]
       ui:
         group: Header
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -19,7 +19,7 @@ Supported field types:
 | Quill.yaml Type | Meaning |
 |---|---|
 | `string` | Open scalar UTF-8 text: a value the template computes with (URL, path, identifier, reference key), not prose it lays out |
-| `enum` | Closed string domain; requires a `values:` list. Projects to JSON-Schema `{type: string, enum: […]}`. The `enum:` modifier on `string` is a deprecated alias; `enum:`/`values:` on any other type is a load error |
+| `enum` | Closed string domain; requires a `values:` list. Projects to JSON-Schema `{type: string, enum: […]}`. `values:` on any other type, and `enum:` on any type at all, is a load error |
 | `number` | Numeric value (integers and decimals) |
 | `integer` | Integer-only numeric value |
 | `boolean` | `true` / `false` |
@@ -118,7 +118,7 @@ Coercion rules per type:
   caches (`default_content`/`example_content`) and the render-floor zero (the
   empty content) cover `plaintext` exactly as `richtext`: both are content
   leaves (`field_contains_content`)
-- **`enum` domain validation.** An `enum` field (or the deprecated `enum:` modifier on `string`) coerces as a string; domain membership is a *value* check (`validation::enum_violation`), not a type check, so an out-of-domain string is well-typed but invalid. `type: enum` requires a non-empty `values:` list; `enum:`/`values:` on any type other than `string`/`enum` is a load error (`quill::field_parse_error`). Both spellings populate one carrier (`FieldSchema::enum_values`) and project identically to `{type: string, enum: […]}`
+- **`enum` domain validation.** An `enum` field coerces as a string; domain membership is a *value* check (`validation::enum_violation`), not a type check, so an out-of-domain string is well-typed but invalid. `type: enum` requires a non-empty `values:` list; `values:` on any other type is a load error (`quill::field_parse_error`), as is `enum:` on any type. The domain rides one carrier (`FieldSchema::enum_values`), and every consumer keys on that carrier rather than on the `Enum` token: the render floor, the pdfform widget kind, the blueprint annotation, and the transform-schema projection to `{type: string, enum: […]}`
 - **Null short-circuits coercion.** A null value (`field:`, `field: null`,
   `field: ~`) passes coercion unchanged for *every* type: null ≡ absent, so
   it carries no data to coerce. The value reaches the render floor and
@@ -397,7 +397,6 @@ The type-gated keys:
 
 - `inline`: valid only on the prose types (`richtext`, `plaintext`).
 - `values`: declares an `enum` field's domain, required there.
-- `enum`: a deprecated alias for `values` on `string`.
 - `items`: the element schema, itself a `FieldSchema`; required on `array`
   fields and rejected elsewhere.
 - `properties`: used by `object` fields, and by an array's `object`-typed


### PR DESCRIPTION
Closes #1237.

## The bug

`build_transform_schema` matched on `field.r#type`, so a field spelling its domain the deprecated way (`type: string` + `enum:`) fell into the bare `String` arm and its domain was dropped. Reproduced before touching anything:

```
PROMOTED   {"type":"string","enum":["A","B"]}
DEPRECATED {"type":"string"}
ECHO       {...,"deprecated":{"type":"string","enum":["A","B"]}}
```

`usaf_memo@0.2.0` used the deprecated spelling for all five of its enums, so on the flagship quill `classification`, `format` and `action` projected as unconstrained strings. A consumer building a JSON-Schema validator from the transform schema accepted `classification: "banana"` while `pdfform` drew the six-option dropdown for the same field and `QuillConfig` rejected the value at coercion.

Four of the five consumers already keyed on the capability (`enum_values.is_some()`): the render floor (`fill.rs:29`), the pdfform widget (`bind.rs:280`), domain validation (`validation.rs:621`), and the blueprint annotation (`blueprint.rs:434`). Only the transform schema keyed on the token.

## What changed

**The `enum:` modifier retires.** `type: enum` with a `values:` list is the one spelling of a finite string domain; `enum:` on any type is now `quill::field_parse_error`. The key is still parsed, only to reject it by name — under `deny_unknown_fields` a removed binding reports "unknown field `enum`" with no route to `values:`, and this message is the *only* diagnostic such a quill has ever received: the 0.94 deprecation shipped with no warning code behind it. `FieldSchema` serialization emits `values:` unconditionally, the two-spelling round-trip fork being gone.

Retirement makes #1237 structural rather than fixed-per-site: no loaded field can carry a domain without the `Enum` token, so the defect cannot recur at a new consumer.

**`build_transform_schema` keys on the domain anyway,** hoisted ahead of the type match, mirroring `project_kind`. All five consumers now key identically, and a `FieldSchema` built outside the loader (the struct's fields are `pub`) projects its domain too.

`cli::empty_enum` is deleted — an empty domain is unreachable once `type: enum` requires a non-empty list.

## Interaction with #1234

Rule 9 specifies `enum: ["", …values]` at `schema.rs:98`, which is the `Enum` arm. Implemented there against the old keying it would have injected the blank into promoted enums only, leaving `usaf_memo`'s enums unconstrained — the failure inverting rather than resolving. Rule 9 now lands on one code path.

## Migration

`usaf_memo@0.2.0` and `sample_form@0.1.0` migrate to `type: enum` + `values:`; docs and canon follow. Wire data, rendered output, coercion, validation, widget projection and blueprint annotation are all unchanged — the projections were domain-keyed already. The consumer-visible change is `QuillConfig::schema()`, which re-emits every domain as `values:` where it emitted `enum:` (the wasm `QuillFieldSchema.enum` field is dropped to match).

**One judgment call worth review:** `usaf_memo@0.2.0`'s bytes are edited in place rather than cut as 0.3.0. `letterhead_seal` did go `type: string` → `type: enum`, and `SCHEMAS.md:76` says a declared type change is a new quill version — but the field's behavior is byte-identical and only the schema echo's spelling moves. Repo practice cuts the same way (the 0.95 `datetime` split migrated these same fixtures in place), so I followed it. Cutting 0.3.0 instead is a separate and much larger change.

## Testing

`cargo test --workspace` green (the `usaf_memo` schema golden regenerates). Clippy warnings unchanged at 58; `check-canon` OK. New coverage: the transform schema carries a domain at top level and at an array-element object leaf; `enum:` is a load error on `string`, `enum` and `integer` alike, with a message routing to `values:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuNBinMDw3ZHP4SffUGExh

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuNBinMDw3ZHP4SffUGExh)_