### PR TITLE
Stop losing constructs between the content and the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+- feat(core,wasm): a quill declares, per body, the block constructs its plate
+  does not typeset (`main.body.unsupported`, `card_kinds.<k>.body.unsupported`;
+  names from `heading`, `rule`, `code`, `list`, `quote`, `table`, `image`).
+  A body holding one anyway draws the non-fatal `plate::unsupported_construct`,
+  a fifth warning family, on the pre-render walk `Quill::parse` runs beside
+  `conform`: one diagnostic per (body, construct) carrying the count in `args`
+  and the body's path, so occurrences collapse rather than scatter. The
+  declaration also rides `QuillConfig::schema()` to the editor, which is the
+  half a render-time warning could not serve: it answers before the gesture.
+  Nothing verifies a declaration — a plate that drops an undeclared construct
+  stays as silent as before. `usaf_memo` declares `rule`; empty everywhere
+  else, so no existing quill's schema or warnings change.
+- fix(fixtures): `usaf_memo`'s `render-body` drained its heading buffer in the
+  three shapes that used to discard it. A heading with nothing after it (the
+  buffer died with the loop, taking a list item's bullet with it), a heading
+  whose next element opened a *different* list item (its text was delivered
+  into that item), and a heading following a heading (the assignment overwrote
+  the earlier one) each lost their text with nothing in the render to say so.
+  The run-in style is unchanged where it was right: a heading joins the next
+  block of its own item, or the next paragraph at top level.
+- fix(content)!: `to_markdown` writes `***` for a thematic break, not `---`.
+  `- ` + `---` is four dashes separated by spaces, which re-imports as a
+  top-level break, so a rule as a bullet item's first block lost its item on
+  every markdown round-trip. The canonical spelling is now the one with the
+  fewest other readings (`---` is also a setext underline and the root-block
+  front-matter opener). Exported markdown changes for documents holding a
+  rule; the content model, wire data and rendered output do not.
+
 - refactor(core,pdfform,cli,wasm)!: the `enum:` modifier on `type: string`
   retires. `type: enum` with a `values:` list is the one spelling of a finite
   string domain; `enum:` on any type is now `quill::field_parse_error`, whose

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -44,12 +44,32 @@ export interface QuillCardUi {
     groups?: Record<string, QuillGroupUi>;
 }
 
+/** A block construct a body can hold. `paragraph` is absent on purpose: it is
+ * the floor and cannot be declined. */
+export type QuillBlockConstruct =
+    | "heading"
+    | "rule"
+    | "code"
+    | "list"
+    | "quote"
+    | "table"
+    | "image";
+
 /** Body namespace for a card (main or named card kind). */
 export interface QuillCardBody {
     /** When false, consumers must not accept or store body content for this card kind. Defaults to true. */
     enabled?: boolean;
     /** Example body content embedded verbatim in the blueprint body region. Fallback is "Write <card> body here." */
     example?: string;
+    /** Block constructs this quill's plate does not typeset in this body.
+     *
+     * Absent or empty means it declines nothing, which is the default. An
+     * editor reads this to decline a gesture before the author makes it; a body
+     * that holds one anyway draws a non-fatal `plate::unsupported_construct`
+     * warning carrying the construct and a count. It is the quill's claim about
+     * its own plate, and nothing verifies it: a construct absent from this list
+     * is not a promise that the plate typesets it. */
+    unsupported?: QuillBlockConstruct[];
 }
 
 /** Schema entry for a single field declared in a quill's `Quill.yaml`.

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -359,7 +359,14 @@ fn emit_leaf_block(ctx: &Ctx, range: std::ops::Range<usize>, out: &mut String) {
             let parts: Vec<String> = range.map(|i| render_inline(ctx, i, true)).collect();
             out.push_str(&parts.join("\\\n"));
         }
-        LineKind::Rule => out.push_str("---"),
+        // `***`, not `---`. All three break spellings import alike, so the
+        // canonical one is the spelling with the fewest other readings: `---`
+        // is also a setext underline, a front-matter fence, and — with the
+        // spaces a list prefix supplies — a bullet line, so `- ` + `---` is
+        // four dashes and re-imports as a top-level break, losing the item.
+        // A mixed-character line is never a break, so `***` survives every
+        // prefix a container can put in front of it.
+        LineKind::Rule => out.push_str("***"),
     }
 }
 
@@ -1202,7 +1209,7 @@ mod tests {
     /// a `document()` generator arm that `properties.rs` fuzzes; kept as a
     /// labeled table so a break localizes to the exact construct without a
     /// proptest seed. Constructs with NO generator coverage (nested_marks,
-    /// code_block, thematic_break, hard breaks) stay as their own tests below.
+    /// code_block, hard breaks) stay as their own tests below.
     #[test]
     fn single_constructs_round_trip() {
         for (label, md) in [
@@ -1214,6 +1221,9 @@ mod tests {
             ("bullet_list", "- a\n- b\n- c"),
             ("ordered_list", "3. a\n4. b"),
             ("multi_paragraph_item", "- first\n\n  second"),
+            ("heading_item", "- # Title\n\n  body text"),
+            ("rule_item", "* ---"),
+            ("thematic_break", "one\n\n***\n\ntwo"),
             ("blockquote", "> quoted text"),
             ("link", "see [our site](https://example.com) now"),
             ("table", "| a | b |\n| --- | --- |\n| 1 | 2 |"),
@@ -1235,19 +1245,35 @@ mod tests {
     }
 
     #[test]
-    fn thematic_break() {
-        round_trips("one\n\n***\n\ntwo");
-    }
-
-    #[test]
-    fn thematic_break_canonicalizes_to_dashes() {
-        // `***`/`___` and `---` all import to the same `Rule` line, so export
-        // re-emits the canonical `---` whatever the source delimiter was.
-        for src in ["***", "___", "- - -"] {
+    fn thematic_break_canonicalizes_to_stars() {
+        // `---`/`___` and `***` all import to the same `Rule` line, so export
+        // re-emits the canonical `***` whatever the source delimiter was.
+        for src in ["---", "___", "- - -"] {
             let rt = from_markdown(&format!("one\n\n{src}\n\ntwo")).unwrap();
             let md = to_markdown(&rt);
-            assert!(md.contains("\n\n---\n\n"), "source: {src}, got: {md:?}");
+            assert!(md.contains("\n\n***\n\n"), "source: {src}, got: {md:?}");
         }
+    }
+
+    /// A rule as a **bullet** item's first block. `- ` + `---` is four dashes
+    /// separated by spaces: a thematic break, and a break outranks a list item
+    /// wherever both readings fit, so the item was lost on re-import. The
+    /// ordered marker never collided (digits are not break characters) and a
+    /// rule as a *later* block is disambiguated by its indentation; both are
+    /// here so a regression localizes to the colliding shape.
+    #[test]
+    fn rule_opening_a_list_item_keeps_its_item() {
+        for md in ["* ---", "+ ---", "- ***", "- ___", "- - ***", "- > ***"] {
+            round_trips(md);
+        }
+        assert_eq!(to_markdown(&from_markdown("* ---").unwrap()), "- ***");
+        // The shapes that always survived, pinned against a fix that trades
+        // one collision for another: a bullet marker swapped to `*`/`+` would
+        // start a *new* list, resetting `ordinal` on this item and every one
+        // after it.
+        round_trips("1. ---");
+        round_trips("- one\n\n  ---");
+        round_trips("- a\n- ***\n- c");
     }
 
     #[test]

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -1255,22 +1255,21 @@ mod tests {
         }
     }
 
-    /// A rule as a **bullet** item's first block. `- ` + `---` is four dashes
-    /// separated by spaces: a thematic break, and a break outranks a list item
-    /// wherever both readings fit, so the item was lost on re-import. The
-    /// ordered marker never collided (digits are not break characters) and a
-    /// rule as a *later* block is disambiguated by its indentation; both are
-    /// here so a regression localizes to the colliding shape.
+    /// A rule as a **bullet** item's first block, the one shape where the
+    /// marker and the rule can spell one token: `- ` + `---` is four dashes
+    /// separated by spaces, a thematic break, and a break outranks a list item
+    /// wherever both readings fit. An ordered marker cannot collide (digits are
+    /// not break characters) and a rule as a *later* block is disambiguated by
+    /// its indentation; both sit here so a regression localizes.
     #[test]
     fn rule_opening_a_list_item_keeps_its_item() {
         for md in ["* ---", "+ ---", "- ***", "- ___", "- - ***", "- > ***"] {
             round_trips(md);
         }
         assert_eq!(to_markdown(&from_markdown("* ---").unwrap()), "- ***");
-        // The shapes that always survived, pinned against a fix that trades
-        // one collision for another: a bullet marker swapped to `*`/`+` would
-        // start a *new* list, resetting `ordinal` on this item and every one
-        // after it.
+        // The shapes that never collide, pinned against a fix that trades one
+        // collision for another: swapping the bullet marker to `*`/`+` starts a
+        // *new* list, resetting `ordinal` on this item and every one after it.
         round_trips("1. ---");
         round_trips("- one\n\n  ---");
         round_trips("- a\n- ***\n- c");

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -33,14 +33,13 @@ fn clean_word() -> impl Strategy<Value = String> {
 
 // `plain_word` carries inline-special and astral chars as *literal text*, so
 // escaping and USV bounds are exercised by the round-trip. The first char stays
-// alphanumeric, so a block marker never *leads* an item's content (`- >`, `- #`
-// would make pulldown build a nested block, not literal text, so the generated
-// source would not carry the prose this arm is generating); a block *as* an
-// item's block is a shape the editor does mint, and `block()` generates it
-// structurally. The tail carries `&` and the
-// block-marker chars (`# > - . +`), exercising `&`-entity escaping and a
-// trailing-`#` heading run through the round-trip, not just
-// the pinned `export::tests::*` unit tests.
+// alphanumeric, so a block marker never *leads* this token: `- >` and `- #`
+// make pulldown build a nested block rather than the literal text the arm is
+// generating. That bounds the token, not the suite — a block *as* a list item's
+// block is its own `block()` arm. The tail carries `&` and the block-marker
+// chars (`# > - . +`), exercising `&`-entity escaping and a trailing-`#`
+// heading run through the round-trip, not just the pinned
+// `export::tests::*` unit tests.
 fn plain_word() -> impl Strategy<Value = String> {
     r"[a-z0-9][a-z0-9*_~\\&#>.+😀你-]{0,5}"
 }

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -34,8 +34,10 @@ fn clean_word() -> impl Strategy<Value = String> {
 // `plain_word` carries inline-special and astral chars as *literal text*, so
 // escaping and USV bounds are exercised by the round-trip. The first char stays
 // alphanumeric, so a block marker never *leads* an item's content (`- >`, `- #`
-// would make pulldown build an empty nested block, not literal text: a
-// degenerate content no editor emits); but the tail carries `&` and the
+// would make pulldown build a nested block, not literal text, so the generated
+// source would not carry the prose this arm is generating); a block *as* an
+// item's block is a shape the editor does mint, and `block()` generates it
+// structurally. The tail carries `&` and the
 // block-marker chars (`# > - . +`), exercising `&`-entity escaping and a
 // trailing-`#` heading run through the round-trip, not just
 // the pinned `export::tests::*` unit tests.
@@ -118,6 +120,24 @@ fn block() -> impl Strategy<Value = String> {
             .join("\n")),
         // Nested bullet list (two container levels).
         (prose(), prose(), prose()).prop_map(|(a, b, c)| format!("- {a}\n  - {b}\n  - {c}")),
+        Just("***".to_string()),
+        // A block construct as a list item's own block, the shape the editor
+        // tier mints (`- ` then a rule or a heading) and no other arm reaches:
+        // every list arm above builds its items from `prose()` alone. Both
+        // marker families and both positions within the item, because only one
+        // combination collides — a rule as a *bullet* item's *first* block.
+        //
+        // The rule's source spelling here is `***`, not `---`: `- ---` is four
+        // dashes separated by spaces, which imports as a top-level break, so an
+        // arm written that way would generate the post-collision shape and
+        // assert the fixed point on it vacuously.
+        (1u8..=6, prose(), prose()).prop_map(|(lvl, h, p)| format!(
+            "- {} {h}\n\n  {p}",
+            "#".repeat(lvl as usize)
+        )),
+        prose().prop_map(|p| format!("- ***\n\n  {p}")),
+        prose().prop_map(|p| format!("1. ***\n\n   {p}")),
+        prose().prop_map(|p| format!("- {p}\n\n  ***")),
         prose().prop_map(|p| format!("> {p}")),
         prop::collection::vec(clean_word(), 1..4)
             .prop_map(|ls| format!("```\n{}\n```", ls.join("\n"))),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -828,6 +828,14 @@ mod args_canon {
             .args(),
         );
         add("validation::must_fill", BTreeMap::new());
+        // Built at the pre-render walk rather than from an error type: a quill
+        // declares the construct, so there is nothing to fail.
+        add("plate::unsupported_construct", {
+            let mut args = BTreeMap::new();
+            args.insert("construct".to_string(), "rule".into());
+            args.insert("count".to_string(), 3.into());
+            args
+        });
 
         out
     }

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -11,6 +11,7 @@ mod ignore;
 mod load;
 mod schema;
 mod schema_yaml;
+mod support;
 mod seed;
 mod tree;
 mod types;
@@ -24,11 +25,12 @@ pub use fill::zero_value;
 pub use formats::{parse_date, parse_datetime};
 pub use ignore::QuillIgnore;
 pub use schema::{build_transform_schema, QUILLMARK_INLINE_KEY, CONTENT_MEDIA_TYPE};
+pub use support::UNSUPPORTED_CONSTRUCT;
 pub use tree::FileTreeNode;
 pub use validation::ValidationError;
 pub use types::{
-    BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, GroupSchema, UiCardSchema,
-    UiFieldSchema,
+    BlockConstruct, BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, GroupSchema,
+    UiCardSchema, UiFieldSchema,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/conform.rs
+++ b/crates/core/src/quill/conform.rs
@@ -87,6 +87,7 @@ impl Quill {
             mut warnings,
         } = Document::parse(markdown)?;
         warnings.extend(self.conform(&mut document)?);
+        warnings.extend(self.unsupported_constructs(&document));
         Ok(Parsed { document, warnings })
     }
 

--- a/crates/core/src/quill/support.rs
+++ b/crates/core/src/quill/support.rs
@@ -1,0 +1,205 @@
+//! What a plate declines to typeset, and the warning a body draws for holding
+//! it anyway.
+//!
+//! A quill's plate is free to reinterpret a construct the content holds —
+//! absorb it into a neighbour, move its text elsewhere, typeset nothing at all
+//! — and the render says nothing, because only the quill knows it did. Core
+//! cannot detect it: the plate's output is ink, and the absence of ink where a
+//! construct used to be is not a signal any backend reports.
+//!
+//! So the quill declares it instead, per body, as data
+//! ([`BodyCardSchema::unsupported`]). That buys two things one diagnostic
+//! producer could not:
+//!
+//! - **An answer before the render.** An editor reads the declaration off the
+//!   schema and declines the gesture at the moment the author makes it. A
+//!   warning that arrives with the rendered page is too late to be the input
+//!   rule's answer, which is the question that raised this.
+//! - **A walk, not a scatter.** One traversal of the content sees every
+//!   occurrence at once, so a body holding forty rules draws one diagnostic
+//!   carrying `count: 40` rather than forty identical ones.
+//!
+//! What it does not buy is verification. A declaration is a claim about the
+//! plate that nothing checks, and a plate that drops a construct it never
+//! declared stays as silent as before. This is documentation with a diagnostic
+//! attached.
+//!
+//! The vocabulary is flat — one name per block kind, no `list_item > heading`
+//! contextual forms. Nothing in the bundled quills needs a contextual
+//! declaration, and the shape to reach for when one does is an open question
+//! better answered by the case that raises it.
+
+use std::collections::BTreeMap;
+
+use quillmark_content::{Content, KnownIslandType, LineKind};
+
+use crate::document::Document;
+use crate::path::DocPath;
+use crate::quill::types::BlockConstruct;
+use crate::{Diagnostic, Quill, Severity};
+
+use super::CardSchema;
+
+/// The diagnostic code every declined construct rides.
+pub const UNSUPPORTED_CONSTRUCT: &str = "plate::unsupported_construct";
+
+impl Quill {
+    /// One `plate::unsupported_construct` warning per (body, construct) this
+    /// quill declares it does not typeset and `doc` holds anyway.
+    ///
+    /// Pre-render and schema-level, alongside `conform::*`: [`Quill::parse`]
+    /// appends these to the `Parsed.warnings` it returns, and the walk is
+    /// stateless, so a repeat call re-emits the identical set. A quill that
+    /// declares nothing returns empty, which is every quill until one opts in.
+    ///
+    /// Non-fatal by construction. The content is representable, stores, and
+    /// round-trips; it is the page that will not carry it, and that is the
+    /// author's call to make once told.
+    pub fn unsupported_constructs(&self, doc: &Document) -> Vec<Diagnostic> {
+        let config = self.config();
+        let mut diags = Vec::new();
+        collect(
+            &config.main,
+            doc.main().body(),
+            &DocPath::main_body(),
+            &mut diags,
+        );
+        for (index, card) in doc.cards().iter().enumerate() {
+            let kind = card.kind().unwrap_or("");
+            // An unknown kind declares no body, so it declines nothing; the
+            // render gate passes it and so does this.
+            let Some(schema) = config.card_kind(kind) else {
+                continue;
+            };
+            let path = DocPath::card(Some(kind), index).body();
+            collect(schema, card.body(), &path, &mut diags);
+        }
+        diags
+    }
+}
+
+/// Append one diagnostic per declared construct `body` actually holds, in the
+/// declaration's own order so the set is stable across calls.
+fn collect(schema: &CardSchema, body: &Content, path: &DocPath, out: &mut Vec<Diagnostic>) {
+    let Some(declared) = schema.body.as_ref().map(|b| &b.unsupported) else {
+        return;
+    };
+    // No `is_blank` short-circuit: blankness is about text, and a rule carries
+    // none, so a body that is nothing but the construct being declined reads as
+    // blank and would skip the walk that exists to catch it.
+    if declared.is_empty() {
+        return;
+    }
+    let present = census(body);
+    for construct in declared {
+        let Some(&count) = present.get(construct) else {
+            continue;
+        };
+        let mut args = BTreeMap::new();
+        args.insert("construct".to_string(), construct.as_str().into());
+        args.insert("count".to_string(), count.into());
+        out.push(
+            Diagnostic::new(
+                Severity::Warning,
+                format!(
+                    "this quill does not typeset {}: {count} in this body will not reach the page",
+                    plural(*construct, count)
+                ),
+            )
+            .with_code(UNSUPPORTED_CONSTRUCT.to_string())
+            .with_path(path.to_string())
+            .with_args(args),
+        );
+    }
+}
+
+/// English enough for the engine's own sentence; a consumer wording this
+/// itself reads `construct` and `count` off `args` instead.
+fn plural(construct: BlockConstruct, count: usize) -> String {
+    let name = match construct {
+        BlockConstruct::Heading => "heading",
+        BlockConstruct::Rule => "horizontal rule",
+        BlockConstruct::Code => "code block",
+        BlockConstruct::List => "list",
+        BlockConstruct::Quote => "block quote",
+        BlockConstruct::Table => "table",
+        BlockConstruct::Image => "image",
+    };
+    if count == 1 {
+        format!("a {name}")
+    } else {
+        format!("{name}s")
+    }
+}
+
+/// How many of each block construct `body` holds.
+///
+/// A container counts once per contiguous **run**, not once per line or per
+/// item: a three-item list is one list, and a multi-paragraph quote is one
+/// quote. A run opens where the previous line carried no like container at that
+/// depth — like meaning same shape, so a sibling item (differing only by
+/// `ordinal`) continues its list rather than opening another. Two adjacent
+/// lists of identical shape therefore count as one, the same non-distinction
+/// the model itself documents for adjacent quotes.
+///
+/// A leaf block counts per block: a rule and a heading are one line each, and a
+/// code fence is counted at the line that opens it.
+///
+/// Islands are counted off `islands` rather than off the lines that hold them,
+/// so an image counts wherever it sits — alone on its line as a block island,
+/// or mid-sentence as an inline one. A quill that does not typeset images does
+/// not typeset either.
+fn census(body: &Content) -> BTreeMap<BlockConstruct, usize> {
+    use quillmark_content::model::Container;
+
+    /// A container's identity for run purposes: everything but which item.
+    fn shape(container: &Container) -> Option<(BlockConstruct, bool, u64)> {
+        match container {
+            Container::ListItem { ordered, start, .. } => {
+                Some((BlockConstruct::List, *ordered, *start))
+            }
+            Container::Quote => Some((BlockConstruct::Quote, false, 0)),
+            // The open set: a container this build does not know names no
+            // construct to decline.
+            _ => None,
+        }
+    }
+
+    let mut counts: BTreeMap<BlockConstruct, usize> = BTreeMap::new();
+    let mut prev: Vec<Option<(BlockConstruct, bool, u64)>> = Vec::new();
+
+    for island in &body.islands {
+        match KnownIslandType::parse(&island.island_type) {
+            Some(KnownIslandType::Table) => *counts.entry(BlockConstruct::Table).or_insert(0) += 1,
+            Some(KnownIslandType::Image) => *counts.entry(BlockConstruct::Image).or_insert(0) += 1,
+            // The open set: an island type this build does not know names no
+            // construct to decline.
+            None => {}
+        }
+    }
+
+    for line in &body.lines {
+        let here: Vec<_> = line.containers.iter().map(shape).collect();
+        for (depth, shape) in here.iter().enumerate() {
+            let Some((construct, _, _)) = shape else {
+                continue;
+            };
+            if prev.get(depth) != Some(shape) {
+                *counts.entry(*construct).or_insert(0) += 1;
+            }
+        }
+        prev = here;
+
+        // Islands are already counted; every other block kind counts here.
+        let construct = match &line.kind {
+            LineKind::Heading { .. } => Some(BlockConstruct::Heading),
+            LineKind::Rule => Some(BlockConstruct::Rule),
+            LineKind::Code { .. } if !line.continues => Some(BlockConstruct::Code),
+            _ => None,
+        };
+        if let Some(construct) = construct {
+            *counts.entry(construct).or_insert(0) += 1;
+        }
+    }
+    counts
+}

--- a/crates/core/src/quill/support.rs
+++ b/crates/core/src/quill/support.rs
@@ -3,31 +3,27 @@
 //!
 //! A quill's plate is free to reinterpret a construct the content holds —
 //! absorb it into a neighbour, move its text elsewhere, typeset nothing at all
-//! — and the render says nothing, because only the quill knows it did. Core
-//! cannot detect it: the plate's output is ink, and the absence of ink where a
-//! construct used to be is not a signal any backend reports.
+//! — and only the quill knows it did. Core cannot detect it: the plate's output
+//! is ink, and a construct that drew none is indistinguishable from one the
+//! content never held.
 //!
-//! So the quill declares it instead, per body, as data
-//! ([`BodyCardSchema::unsupported`]). That buys two things one diagnostic
-//! producer could not:
+//! So the quill declares it, per body, as data
+//! ([`BodyCardSchema::unsupported`]). Declaring rather than observing is what
+//! buys the two properties:
 //!
 //! - **An answer before the render.** An editor reads the declaration off the
-//!   schema and declines the gesture at the moment the author makes it. A
-//!   warning that arrives with the rendered page is too late to be the input
-//!   rule's answer, which is the question that raised this.
-//! - **A walk, not a scatter.** One traversal of the content sees every
-//!   occurrence at once, so a body holding forty rules draws one diagnostic
-//!   carrying `count: 40` rather than forty identical ones.
+//!   schema and declines the gesture as the author makes it. A warning arriving
+//!   with the rendered page is too late to be an input rule's answer.
+//! - **A walk, not a scatter.** One traversal sees every occurrence at once, so
+//!   a body holding forty rules draws one diagnostic carrying `count: 40`.
 //!
 //! What it does not buy is verification. A declaration is a claim about the
-//! plate that nothing checks, and a plate that drops a construct it never
-//! declared stays as silent as before. This is documentation with a diagnostic
-//! attached.
+//! plate that nothing checks: a construct absent from the list is not a promise
+//! the plate typesets it, and an undeclared drop stays silent. This is
+//! documentation with a diagnostic attached.
 //!
-//! The vocabulary is flat — one name per block kind, no `list_item > heading`
-//! contextual forms. Nothing in the bundled quills needs a contextual
-//! declaration, and the shape to reach for when one does is an open question
-//! better answered by the case that raises it.
+//! The vocabulary is flat: one name per block kind, no context-qualified forms.
+//! A heading is declined everywhere or nowhere.
 
 use std::collections::BTreeMap;
 

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for quill types and loading.
 
+mod support_tests;
+
 use super::*;
 use crate::{Diagnostic, Severity};
 use std::collections::HashMap;

--- a/crates/core/src/quill/tests/support_tests.rs
+++ b/crates/core/src/quill/tests/support_tests.rs
@@ -1,0 +1,184 @@
+//! `plate::unsupported_construct`: what a quill declares it does not typeset,
+//! and what a body holding it draws.
+
+use crate::quill::{quill_from_yaml, BlockConstruct, QuillConfig, UNSUPPORTED_CONSTRUCT};
+use crate::{Document, Quill, Severity};
+
+const YAML: &str = r#"
+quill:
+  name: decliner
+  version: 0.1.0
+  backend: typst
+  description: A quill that declines constructs
+main:
+  body:
+    unsupported: [rule, table]
+  fields: {}
+card_kinds:
+  note:
+    body: {}
+    fields: {}
+"#;
+
+fn quill() -> Quill {
+    quill_from_yaml(YAML)
+}
+
+/// `(code, path, construct, count)` for every warning `body` draws.
+fn warn(body: &str) -> Vec<(String, String, String, u64)> {
+    let markdown = format!("~~~card-yaml\n$quill: decliner\n~~~\n\n{body}\n");
+    let parsed = quill().parse(&markdown).expect("parses and conforms");
+    parsed
+        .warnings
+        .iter()
+        .filter(|d| d.code.as_deref() == Some(UNSUPPORTED_CONSTRUCT))
+        .map(|d| {
+            assert_eq!(d.severity, Severity::Warning, "never fatal: {d:?}");
+            (
+                d.code.clone().unwrap(),
+                d.path.clone().unwrap_or_default(),
+                d.args["construct"].as_str().unwrap().to_string(),
+                d.args["count"].as_u64().unwrap(),
+            )
+        })
+        .collect()
+}
+
+fn constructs(body: &str) -> Vec<(String, u64)> {
+    warn(body)
+        .into_iter()
+        .map(|(_, _, construct, count)| (construct, count))
+        .collect()
+}
+
+/// The warning names the construct, counts it, and anchors on the body's
+/// schema address: the path a consumer routes on.
+#[test]
+fn a_declined_construct_warns_against_its_body() {
+    assert_eq!(
+        warn("one\n\n***\n\ntwo"),
+        [(
+            UNSUPPORTED_CONSTRUCT.to_string(),
+            "main.body".to_string(),
+            "rule".to_string(),
+            1
+        )]
+    );
+}
+
+/// One warning per construct, not per occurrence: the walk sees the whole body
+/// at once, so a count rides `args` instead of forty identical diagnostics
+/// reaching an editor's surface.
+#[test]
+fn occurrences_collapse_into_one_count() {
+    assert_eq!(constructs("a\n\n***\n\nb\n\n***\n\nc\n\n***"), [("rule".to_string(), 3)]);
+    // At any depth, and the whole set is one diagnostic each.
+    assert_eq!(
+        constructs("- ***\n\n| a |\n| --- |\n| 1 |\n\n***"),
+        [("rule".to_string(), 2), ("table".to_string(), 1)]
+    );
+}
+
+/// A construct the quill never declined draws nothing, however much of it the
+/// body holds. Silence is the default and stays the default.
+#[test]
+fn an_undeclared_construct_is_silent() {
+    assert_eq!(constructs("# Title\n\n> quoted\n\n- a\n- b\n\n```\nx\n```"), []);
+    assert_eq!(constructs("just a paragraph"), []);
+    assert_eq!(constructs(""), []);
+}
+
+/// A card kind declaring an empty `unsupported` (the default) is silent even
+/// when the main card next to it is not.
+#[test]
+fn the_declaration_is_per_body() {
+    let markdown = "~~~card-yaml\n$quill: decliner\n~~~\n\n***\n\n~~~\n$kind: note\n~~~\n\n***\n";
+    let parsed = quill().parse(markdown).expect("parses");
+    let paths: Vec<_> = parsed
+        .warnings
+        .iter()
+        .filter(|d| d.code.as_deref() == Some(UNSUPPORTED_CONSTRUCT))
+        .map(|d| d.path.clone().unwrap_or_default())
+        .collect();
+    assert_eq!(paths, ["main.body"], "the note's body declines nothing");
+}
+
+/// The walk is stateless, so a second pass over the same document re-emits the
+/// identical set: the same contract `conform` holds.
+#[test]
+fn the_walk_is_idempotent() {
+    let markdown = "~~~card-yaml\n$quill: decliner\n~~~\n\n***\n";
+    let quill = quill();
+    let mut document = Document::parse(markdown).expect("parses").document;
+    quill.conform(&mut document).expect("conforms");
+    let first = quill.unsupported_constructs(&document);
+    assert_eq!(first, quill.unsupported_constructs(&document));
+    assert_eq!(first.len(), 1);
+}
+
+/// A misspelled construct is a load error, not a declaration that quietly
+/// matches nothing: the vocabulary is closed.
+#[test]
+fn an_unknown_construct_name_fails_the_load() {
+    let yaml = YAML.replace("[rule, table]", "[rules]");
+    assert!(
+        QuillConfig::from_yaml_with_warnings(&yaml).is_err(),
+        "`rules` is not a construct name"
+    );
+}
+
+/// A run counts once, not once per item or per line: the count is a count of
+/// constructs the author wrote.
+#[test]
+fn a_container_counts_once_per_run() {
+    let quill = quill_from_yaml(&YAML.replace("[rule, table]", "[list, quote]"));
+    let census = |body: &str| {
+        let markdown = format!("~~~card-yaml\n$quill: decliner\n~~~\n\n{body}\n");
+        let parsed = quill.parse(&markdown).expect("parses");
+        parsed
+            .warnings
+            .iter()
+            .filter(|d| d.code.as_deref() == Some(UNSUPPORTED_CONSTRUCT))
+            .map(|d| {
+                (
+                    d.args["construct"].as_str().unwrap().to_string(),
+                    d.args["count"].as_u64().unwrap(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    // Three items are one list; a multi-paragraph item does not re-open it.
+    assert_eq!(census("- a\n- b\n- c"), [("list".to_string(), 1)]);
+    assert_eq!(census("- a\n\n  still a"), [("list".to_string(), 1)]);
+    // A nested list is its own list, so two levels are two.
+    assert_eq!(census("- a\n  - b\n  - c"), [("list".to_string(), 2)]);
+    // Two lists with a paragraph between them are two.
+    assert_eq!(census("- a\n\nbetween\n\n- b"), [("list".to_string(), 2)]);
+    assert_eq!(census("> one\n>\n> two"), [("quote".to_string(), 1)]);
+}
+
+/// Every construct name in the vocabulary is reachable from content: a name
+/// nothing can hold would be a declaration that never fires.
+#[test]
+fn every_construct_name_is_reachable() {
+    for (construct, body) in [
+        (BlockConstruct::Heading, "# h"),
+        (BlockConstruct::Rule, "***"),
+        (BlockConstruct::Code, "```\nx\n```"),
+        (BlockConstruct::List, "- a"),
+        (BlockConstruct::Quote, "> q"),
+        (BlockConstruct::Table, "| a |\n| --- |\n| 1 |"),
+        (BlockConstruct::Image, "![alt](cat.png)"),
+    ] {
+        let quill = quill_from_yaml(&YAML.replace("[rule, table]", &format!("[{construct}]")));
+        let markdown = format!("~~~card-yaml\n$quill: decliner\n~~~\n\n{body}\n");
+        let parsed = quill.parse(&markdown).expect("parses");
+        let hits: Vec<_> = parsed
+            .warnings
+            .iter()
+            .filter(|d| d.code.as_deref() == Some(UNSUPPORTED_CONSTRUCT))
+            .collect();
+        assert_eq!(hits.len(), 1, "{construct} did not fire on {body:?}");
+        assert_eq!(hits[0].args["construct"].as_str().unwrap(), construct.as_str());
+    }
+}

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -61,6 +61,48 @@ impl<'de> Deserialize<'de> for UiFieldSchema {
     }
 }
 
+/// A block construct a body can hold: the block kinds the content model
+/// distinguishes, minus the paragraph, which is the floor and cannot be
+/// declined.
+///
+/// The vocabulary a quill declines constructs in
+/// ([`BodyCardSchema::unsupported`]). A closed set, so a misspelled construct
+/// is a load error rather than a declaration that matches nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BlockConstruct {
+    Heading,
+    Rule,
+    Code,
+    List,
+    Quote,
+    Table,
+    Image,
+}
+
+impl BlockConstruct {
+    /// The name this construct declares under, and the value that rides
+    /// `plate::unsupported_construct`'s `construct` arg.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Heading => "heading",
+            Self::Rule => "rule",
+            Self::Code => "code",
+            Self::List => "list",
+            Self::Quote => "quote",
+            Self::Table => "table",
+            Self::Image => "image",
+        }
+    }
+}
+
+impl std::fmt::Display for BlockConstruct {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Body namespace configuration for a card kind
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -82,6 +124,20 @@ pub struct BodyCardSchema {
     /// consumers fall back to importing `example`.
     #[serde(skip)]
     pub example_content: Option<QuillValue>,
+    /// The block constructs this quill's plate does not typeset in this body.
+    ///
+    /// A plate is free to reinterpret or drop a construct — absorb it into a
+    /// neighbour, move its text, typeset nothing at all — and only the quill
+    /// knows it did. This is where it says so, once, as data: an editor reads
+    /// it off the schema and declines the gesture before the author makes it,
+    /// and content that arrives by another door (an import, a repack, the CLI)
+    /// draws `plate::unsupported_construct` on the pre-render walk.
+    ///
+    /// Empty by default, so a quill that declares nothing keeps saying nothing.
+    /// A declaration is a claim about the plate that nothing verifies: it is
+    /// documentation with a diagnostic attached, not a proof.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unsupported: Vec<BlockConstruct>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -11,6 +11,10 @@ main:
   ui:
     groups: [addressing, letterhead, classification, additional]
   body:
+    # An AFH 33-337 memo has no dividers, so `render-body` typesets no
+    # horizontal rule at any depth. Everything else the content model carries
+    # reaches the page: a heading runs into the block it opens, as bold.
+    unsupported: [rule]
     example: |
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.
 

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -244,6 +244,8 @@ main:
       The first paragraph. Top-level paragraphs are auto-numbered; do not add manual numbering.
       
       - Nested bullets are automatically lettered.
+    unsupported:
+    - rule
 card_kinds:
   indorsement:
     description: >-

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/packages/tonguetoquill-usaf-memo/src/body.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/packages/tonguetoquill-usaf-memo/src/body.typ
@@ -233,7 +233,7 @@
       // a table (nest_level −1, so the level test alone excludes it), and
       // another heading all fail the test, and each would otherwise carry the
       // heading's text somewhere it was not authored. Those emit the heading
-      // on its own line, the treatment a heading before a table already got.
+      // on its own line, the treatment a heading before a table takes.
       if heading_buffer != none {
         let runs_in = (
           kind != "heading"

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/packages/tonguetoquill-usaf-memo/src/body.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/packages/tonguetoquill-usaf-memo/src/body.typ
@@ -199,6 +199,7 @@
   //   item.kind       — "par", "heading", "table", or "continuation"
   context {
     let heading_buffer = none
+    let heading_level = 0
     // Filter out zero-width paragraphs so that an empty body (e.g. empty
     // string from a KIND with no text) emits nothing and collapses to zero
     // vertical space. Tables are always kept regardless of measured width.
@@ -226,24 +227,36 @@
       let kind = item.kind
       let item_content = item.content
 
-      // Buffer headings for prepend to the next rendered element
-      if kind == "heading" {
-        heading_buffer = item_content
-        continue
+      // A buffered heading runs into this element only when the two belong to
+      // the same item: a later block of this list item ("continuation"), or,
+      // at top level, the next paragraph. The first block of the *next* item,
+      // a table (nest_level −1, so the level test alone excludes it), and
+      // another heading all fail the test, and each would otherwise carry the
+      // heading's text somewhere it was not authored. Those emit the heading
+      // on its own line, the treatment a heading before a table already got.
+      if heading_buffer != none {
+        let runs_in = (
+          kind != "heading"
+            and item.nest_level == heading_level
+            and (heading_level == 0 or kind == "continuation")
+        )
+        if runs_in {
+          item_content = [#strong[#heading_buffer.] #item_content]
+        } else {
+          if any_emitted { blank-line() }
+          strong[#heading_buffer.]
+          any_emitted = true
+        }
+        heading_buffer = none
       }
 
-      // Prepend buffered heading to the next non-heading element
-      if heading_buffer != none {
-        if kind == "table" {
-          // Tables cannot have inline text prepended; emit heading as
-          // a standalone bold line above the table
-          blank-line()
-          strong[#heading_buffer.]
-          heading_buffer = none
-        } else {
-          item_content = [#strong[#heading_buffer.] #item_content]
-          heading_buffer = none
-        }
+      // Buffer this heading for the next element to run into. The level it was
+      // captured at rides along: the run-in test needs it, and the buffer is
+      // read one iteration later, by which time `item` is the *next* element.
+      if kind == "heading" {
+        heading_buffer = item_content
+        heading_level = item.nest_level
+        continue
       }
 
       // Format based on element kind
@@ -335,6 +348,15 @@
         // `block.above` entirely and visibly compress the spacing.
         block[#final_par]
       }
+    }
+
+    // A heading with nothing after it never ran into anything, and the buffer
+    // dies with the loop unless it is drained here. Sticky for the same reason
+    // the last item is: a standalone heading is one line, so it keeps with the
+    // signature block rather than opening a page alone.
+    if heading_buffer != none {
+      if any_emitted { blank-line() }
+      block(sticky: true)[#strong[#heading_buffer.]]
     }
   }
 }

--- a/crates/quillmark/tests/usaf_memo_body_test.rs
+++ b/crates/quillmark/tests/usaf_memo_body_test.rs
@@ -24,7 +24,7 @@ fn body_regions(body: &str) -> Vec<([usize; 2], f32)> {
     let engine = Quillmark::new();
     let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");
     let parsed = Document::parse(&markdown).expect("parses").document;
-    let mut session = engine.open(&quill, &parsed).expect("opens");
+    let session = engine.open(&quill, &parsed).expect("opens");
     let mut regions: Vec<_> = session
         .regions()
         .iter()
@@ -107,4 +107,33 @@ fn the_seeded_memo_still_renders() {
     engine
         .render(&quill, &parsed, &RenderOptions::default())
         .expect("the seeded memo renders");
+}
+
+/// The memo declares the one construct it genuinely does not typeset. An
+/// AFH 33-337 memo has no dividers, and `render-body` typesets none at any
+/// depth — silently, until the body says so on the pre-render walk.
+#[test]
+fn a_rule_in_the_memo_body_warns() {
+    let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");
+    let markdown = "~~~card-yaml\n$quill: usaf_memo\n$kind: main\n~~~\n\none\n\n***\n\ntwo\n";
+    let warnings: Vec<_> = quill
+        .parse(markdown)
+        .expect("parses and conforms")
+        .warnings
+        .iter()
+        .filter(|d| d.code.as_deref() == Some(quillmark_core::quill::UNSUPPORTED_CONSTRUCT))
+        .map(|d| (d.path.clone(), d.args["construct"].as_str().unwrap().to_string()))
+        .collect();
+    assert_eq!(
+        warnings,
+        [(Some("main.body".to_string()), "rule".to_string())]
+    );
+    // Everything else the memo renders, so a body without a rule is silent.
+    let clean = "~~~card-yaml\n$quill: usaf_memo\n$kind: main\n~~~\n\n# H\n\n- a\n- b\n";
+    assert!(quill
+        .parse(clean)
+        .expect("parses")
+        .warnings
+        .iter()
+        .all(|d| d.code.as_deref() != Some(quillmark_core::quill::UNSUPPORTED_CONSTRUCT)));
 }

--- a/crates/quillmark/tests/usaf_memo_body_test.rs
+++ b/crates/quillmark/tests/usaf_memo_body_test.rs
@@ -1,0 +1,110 @@
+//! Heading survival through `usaf_memo`'s paragraph rebuild.
+//!
+//! The memo's `render-body` buffers a heading and prepends it to the next
+//! element as `strong[…]`: the AFH run-in style, deliberate. The buffer is one
+//! variable, so three shapes used to lose their heading with no trace in the
+//! render — a heading with nothing after it (the buffer died with the loop), a
+//! heading whose next element began a *different* list item (its text was
+//! delivered into that item), and a heading following a heading (the assignment
+//! overwrote the earlier one).
+//!
+//! The oracle is `regions()`, not output size: a region's `span` is the content
+//! range its glyphs came from, so text that never reached the page has no span
+//! covering it. Byte-length only says "something changed".
+
+#![cfg(feature = "typst")]
+
+use quillmark::{Document, Quillmark, RenderOptions};
+use quillmark_fixtures::quills_path;
+
+/// The `$body` regions for a memo whose body is `body`, as (content span, top
+/// edge) pairs sorted by content order.
+fn body_regions(body: &str) -> Vec<([usize; 2], f32)> {
+    let markdown = format!("~~~card-yaml\n$quill: usaf_memo\n$kind: main\n~~~\n\n{body}\n");
+    let engine = Quillmark::new();
+    let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");
+    let parsed = Document::parse(&markdown).expect("parses").document;
+    let mut session = engine.open(&quill, &parsed).expect("opens");
+    let mut regions: Vec<_> = session
+        .regions()
+        .iter()
+        .filter(|r| r.field == "$body")
+        .filter_map(|r| r.span.map(|s| (s, r.rect[1])))
+        .collect();
+    regions.sort_by_key(|(span, _)| *span);
+    regions
+}
+
+fn spans(body: &str) -> Vec<[usize; 2]> {
+    body_regions(body).into_iter().map(|(s, _)| s).collect()
+}
+
+/// A heading with nothing after it to run into. Both shapes ended the buffer
+/// holding content no later iteration consumed; the drop was total, taking the
+/// list item's bullet with it.
+#[test]
+fn a_trailing_heading_reaches_the_page() {
+    // "one" then "Trailing", the second on its own line.
+    assert_eq!(spans("one\n\n# Trailing"), [[0, 3], [4, 12]]);
+    assert_eq!(spans("- one\n- # Absorbed"), [[0, 3], [4, 12]]);
+    // The degenerate case: a body that is nothing but a heading.
+    assert_eq!(spans("# Only"), [[0, 4]]);
+}
+
+/// Two headings in a row. The buffer was assigned, not appended, so the first
+/// heading was destroyed by the second; only the second's run-in survived.
+#[test]
+fn consecutive_headings_both_reach_the_page() {
+    assert_eq!(spans("# First\n\n# Second\n\ntext"), [[0, 5], [6, 12], [13, 17]]);
+}
+
+/// Whether every `$body` region sits on one line. A run-in *is* the heading and
+/// the text it joined sharing a line, so this is the property to measure;
+/// coverage cannot see it (the text inks either way) and exact spans cannot
+/// either (a run-in surfaces as one merged region or two adjacent ones
+/// depending on the shape). The tolerance separates a bold/regular baseline
+/// difference (hundredths of a point) from a paragraph gap (tens).
+fn on_one_line(body: &str) -> bool {
+    let tops: Vec<f32> = body_regions(body).into_iter().map(|(_, y)| y).collect();
+    let (lo, hi) = tops.iter().fold((f32::MAX, f32::MIN), |(l, h), y| (l.min(*y), h.max(*y)));
+    hi - lo < 2.0
+}
+
+/// A heading whose next element opens a *different* list item. Coverage cannot
+/// see this one — the text inked either way — but its place could not be more
+/// wrong: the heading's text was prepended to the *next* item's own content, so
+/// the two shared a line.
+#[test]
+fn a_heading_does_not_cross_into_the_next_item() {
+    let regions = body_regions("- # Absorbed\n- second");
+    assert_eq!(
+        regions.iter().map(|(s, _)| *s).collect::<Vec<_>>(),
+        [[0, 8], [9, 15]],
+        "both texts ink"
+    );
+    assert!(
+        !on_one_line("- # Absorbed\n- second"),
+        "the heading holds its own line rather than joining the next item: {regions:?}"
+    );
+}
+
+/// The run-in itself is the point of the rebuild and is unchanged: a heading
+/// joins the next block *of its own item*, at top level and inside a list item
+/// alike.
+#[test]
+fn the_run_in_style_still_runs_in() {
+    assert!(on_one_line("- # Absorbed\n  item text"));
+    assert!(on_one_line("# Absorbed\n\nitem text"));
+}
+
+/// The seeded document still renders: the repair reuses the standalone-emit
+/// branch a heading before a table already took, so the common path is untouched.
+#[test]
+fn the_seeded_memo_still_renders() {
+    let engine = Quillmark::new();
+    let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");
+    let parsed = quill.seed_document();
+    engine
+        .render(&quill, &parsed, &RenderOptions::default())
+        .expect("the seeded memo renders");
+}

--- a/crates/quillmark/tests/usaf_memo_body_test.rs
+++ b/crates/quillmark/tests/usaf_memo_body_test.rs
@@ -1,15 +1,15 @@
 //! Heading survival through `usaf_memo`'s paragraph rebuild.
 //!
 //! The memo's `render-body` buffers a heading and prepends it to the next
-//! element as `strong[…]`: the AFH run-in style, deliberate. The buffer is one
-//! variable, so three shapes used to lose their heading with no trace in the
-//! render — a heading with nothing after it (the buffer died with the loop), a
-//! heading whose next element began a *different* list item (its text was
-//! delivered into that item), and a heading following a heading (the assignment
-//! overwrote the earlier one).
+//! element as `strong[…]`: the AFH run-in style, deliberate. The invariant the
+//! buffer must hold is that every heading reaches the page exactly once, in its
+//! own place. Three shapes press on it — a heading with nothing after it, a
+//! heading whose next element opens a *different* list item, and a heading
+//! following a heading — because each is a heading the next iteration does not
+//! consume.
 //!
 //! The oracle is `regions()`, not output size: a region's `span` is the content
-//! range its glyphs came from, so text that never reached the page has no span
+//! range its glyphs came from, so text that does not reach the page has no span
 //! covering it. Byte-length only says "something changed".
 
 #![cfg(feature = "typst")]
@@ -39,9 +39,9 @@ fn spans(body: &str) -> Vec<[usize; 2]> {
     body_regions(body).into_iter().map(|(s, _)| s).collect()
 }
 
-/// A heading with nothing after it to run into. Both shapes ended the buffer
-/// holding content no later iteration consumed; the drop was total, taking the
-/// list item's bullet with it.
+/// A heading with nothing after it to run into: the buffer holds content no
+/// later iteration consumes, so it must be drained after the loop rather than
+/// dying with it. Undrained, the loss is total, the list item's bullet included.
 #[test]
 fn a_trailing_heading_reaches_the_page() {
     // "one" then "Trailing", the second on its own line.
@@ -51,8 +51,8 @@ fn a_trailing_heading_reaches_the_page() {
     assert_eq!(spans("# Only"), [[0, 4]]);
 }
 
-/// Two headings in a row. The buffer was assigned, not appended, so the first
-/// heading was destroyed by the second; only the second's run-in survived.
+/// Two headings in a row. The buffer holds one heading, so the second must
+/// flush the first rather than overwrite it.
 #[test]
 fn consecutive_headings_both_reach_the_page() {
     assert_eq!(spans("# First\n\n# Second\n\ntext"), [[0, 5], [6, 12], [13, 17]]);
@@ -71,9 +71,9 @@ fn on_one_line(body: &str) -> bool {
 }
 
 /// A heading whose next element opens a *different* list item. Coverage cannot
-/// see this one — the text inked either way — but its place could not be more
-/// wrong: the heading's text was prepended to the *next* item's own content, so
-/// the two shared a line.
+/// see this one: the text inks whether or not it lands in the right item. Place
+/// is the tell — prepended to the next item's own content, a heading shares that
+/// item's line.
 #[test]
 fn a_heading_does_not_cross_into_the_next_item() {
     let regions = body_regions("- # Absorbed\n- second");
@@ -97,8 +97,8 @@ fn the_run_in_style_still_runs_in() {
     assert!(on_one_line("# Absorbed\n\nitem text"));
 }
 
-/// The seeded document still renders: the repair reuses the standalone-emit
-/// branch a heading before a table already took, so the common path is untouched.
+/// The common path is untouched: standalone emission is the branch a heading
+/// before a table already takes, and the seeded document renders through it.
 #[test]
 fn the_seeded_memo_still_renders() {
     let engine = Quillmark::new();
@@ -109,9 +109,9 @@ fn the_seeded_memo_still_renders() {
         .expect("the seeded memo renders");
 }
 
-/// The memo declares the one construct it genuinely does not typeset. An
-/// AFH 33-337 memo has no dividers, and `render-body` typesets none at any
-/// depth — silently, until the body says so on the pre-render walk.
+/// The memo declares the one construct it does not typeset. An AFH 33-337 memo
+/// has no dividers, and `render-body` draws none at any depth, so a rule leaves
+/// the page unmarked and the walk is the only place that says so.
 #[test]
 fn a_rule_in_the_memo_body_warns() {
     let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -453,6 +453,24 @@ card_kinds:
         type: string
 ```
 
+#### `body.unsupported`
+
+The block constructs your plate does not typeset in this body. Empty by default: declare nothing and nothing changes.
+
+A plate is free to reinterpret a construct — absorb it into a neighbour, move its text, typeset nothing at all — and only you know it did. Declaring it here says so once, as data, and buys two things: an editor reads it off the schema and can decline the gesture before the author makes it, and a body holding the construct anyway (from an import, a repack, the CLI) draws a `plate::unsupported_construct` warning on the pre-render walk. The warning is non-fatal and carries the body's path, the construct name, and how many the body holds.
+
+```yaml
+main:
+  body:
+    # This template has no dividers, at any depth.
+    unsupported: [rule]
+  fields: {}
+```
+
+Valid names: `heading`, `rule`, `code`, `list`, `quote`, `table`, `image`. The set is closed, so a misspelling is a load error rather than a declaration that quietly matches nothing. There is no paragraph name: a paragraph is the floor and cannot be declined, and there are no context-qualified forms (a heading is declined everywhere or nowhere).
+
+Nothing verifies a declaration against what your plate actually does. It is documentation with a diagnostic attached: declaring `rule` does not make rules disappear, and omitting a construct your plate drops keeps that drop as silent as before.
+
 ### Using Cards in Markdown
 
 Card kinds defined here are authored as `~~~` blocks (with a `$kind: <kind>` line) in the document body. See [card-yaml Blocks](../authoring/card-yaml.md#card-blocks) for the markdown syntax.

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -64,7 +64,7 @@ routing coercion-vs-undeclared is `edit::field_coercion_failed` vs.
 
 ## Warning flow
 
-Warnings travel the same `Diagnostic` currency as errors, on four producer
+Warnings travel the same `Diagnostic` currency as errors, on five producer
 families:
 
 - **Parse warnings**: the `warnings` on the `Parsed` that `Document::parse`
@@ -86,6 +86,18 @@ families:
   the `$seed` checks are the non-fatal ones. This is the editor-facing
   surface; the render pipeline zero-fills instead of warning on incomplete
   documents.
+- **`plate::unsupported_construct`: declined-construct warnings.** A quill
+  names, per body (`BodyCardSchema.unsupported`), the block constructs its
+  plate does not typeset; `Quill::unsupported_constructs` walks a document's
+  bodies against those declarations and `Quill::parse` appends the result to
+  `Parsed.warnings` beside the `conform::*` set. One diagnostic per (body,
+  construct) carrying `construct` and `count` in `args` and the body's schema
+  address in `path`: the walk sees the whole body, so occurrences collapse
+  rather than scattering. Stateless, so a repeat call re-emits the identical
+  set. Empty for every quill that declares nothing, which is the default.
+  Core cannot *detect* a plate dropping a construct — the absence of ink is
+  not a signal a backend reports — so this family is a declaration, not an
+  observation: nothing verifies it, and an undeclared drop stays silent.
 - **Compile warnings**: the Typst backend maps `typst::compile`'s non-fatal
   diagnostics (font fallback, overfull pages, …) through the same span
   resolution as errors. They are state of the session's current compile:
@@ -96,9 +108,12 @@ families:
   `open` → `render` path.
 
 Ordering in a merged `RenderResult.warnings` is pipeline order: parse
-warnings first, then compile warnings. No dedup: the families cannot
-overlap (parse warnings anchor `location` in the markdown source, compile
-warnings in Typst sources).
+warnings first, then compile warnings. No dedup *across* families: they
+cannot overlap (the pre-render families anchor `path` or a markdown
+`location`, compile warnings a `location` in Typst sources).
+`plate::unsupported_construct` dedups *within* itself, at the walk, for
+the reason the others need not: it is the one family whose producer sees
+every occurrence at once.
 
 ## Bindings Error Delegation
 
@@ -304,6 +319,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `parse::invalid_structure` | — | fallback |
 | `parse::missing_quill` | — | fallback |
 | `parse::body_import` | — | fallback |
+| `plate::unsupported_construct` | `construct`, `count` | structured |
 
 `parse::missing_quill` looks code-determined and is not: it picks one of three sentences by re-reading the source, and no field records which.
 


### PR DESCRIPTION
Closes #1241. Addresses #1240, splitting it: three of its cases are plate bugs and get fixed, one is a design decision and gets declared.

## The reframe

#1240 reads as one problem — a quill reinterprets or drops a construct and says nothing — and proposes one mechanism, a Typst-side `warn()` the backend collects. Measuring it against the code turns up four problems, and only one wants new machinery:

| | what it is | what it gets |
| --- | --- | --- |
| `- ---` on export (#1241) | codec bug | one line |
| trailing / cross-item / consecutive heading loss | **plate bugs** | a fix |
| `---` typesets nothing | deliberate non-support | a declaration |
| "heading absorbed into the following paragraph" | correct rendering | nothing |

Fix the plate and the reference quill's remaining honest warning is the `---` one, which is *static* — a property of the quill, constant across documents, knowable before any render. Nothing left is dynamic, so nothing here builds a runtime warning channel. See the last section for what that defers and when to revisit.

## 1. `to_markdown` writes `***` for a thematic break (#1241)

`- ` + `---` is four dashes separated by spaces: a thematic break, and a break outranks a list item wherever both readings fit. A rule as a bullet item's first block lost its item on every markdown round-trip — `* ---`, `+ ---`, `- ***`, `- ___` all import to `Rule` under a `ListItem` and exported to a top-level `Rule`.

The fix is unconditional rather than container-aware: **when a construct has several equivalent spellings, canonicalize to the one with the fewest alternative readings.** `---` is also a setext underline and the spec's root-block front-matter opener; `***` is a thematic break and nothing else, and a mixed-character line is never a break, so it survives any prefix a container puts in front of it at any depth. That keeps the rule arm context-free instead of threading container state through `emit_leaf_block` for one case.

`***` and `---` were checked to import identically in all six contexts a rule can be emitted into. The setext hazard is real and asymmetric — `a\n---` imports as an **h2 heading**, `a\n***` as a paragraph plus a rule — so this closes a second adjacency the blank-line separator was carrying alone.

⚠️ **Exported markdown changes** for documents holding a rule. The content model, wire data and rendered output do not.

#1241 offers a second option — swap the item's bullet marker to `*`/`+` — as interchangeable. It is not, and it is not taken: in CommonMark a changed bullet character starts a **new list**, resetting `ordinal`. Measured, `- a` + `- ***` (ordinals 0, 1) re-imports from `- a\n\n* ---` as ordinals 0, **0**; three items go 0,1,2 → 0,0,0. It trades one round-trip break for another and only looks right on the single-item case.

### Why the property suite missed it

`block()` had **no thematic-break arm at all**, and every list arm built its items from `prose()` alone, exactly as #1241 says. It now generates a rule and a heading as a list item's own block, both marker families, first block and later.

One trap worth naming: an arm emitting `- ---` as source tests nothing — that source already imports to a top-level rule, so the property would assert the fixed point on the post-collision shape and pass vacuously. The arms emit `***`.

## 2. The memo drains its heading buffer

`render-body` buffers a heading and prepends it to the next element as `strong[…]` — the AFH run-in style, deliberate. The buffer was one variable written with `=` and read only on the next iteration, so three shapes lost their heading:

- **a heading with nothing after it** — the buffer died with the loop. `one` + `# Trailing` inked exactly as much as `one` alone; in a list item the bullet went too. Not list-specific, as #1240 implies, and a document ending on a heading is ordinary.
- **a heading whose next element opened a different list item** — its text was delivered into that item, sharing its line.
- **a heading following a heading** — overwritten. `# First` + `# Second` + `text` inked exactly as much as `# Second` + `text`. **Not in #1240.**

The run-in now applies only when the heading and the element belong to the same item: a later block of this list item, or the next paragraph at top level. Everything else emits the heading on its own line — the branch a heading before a table already takes, so the repair generalizes an existing case rather than adding one (a table's `nest_level` of −1 now fails the level test instead of naming itself). No new state: the test reads `nest_level` and `kind`, both already recorded, so it stays clear of the layout convergence the `show enum.item` comment warns about.

**These are bugs, not reinterpretations.** A warning would have documented the defect as a feature — which is why #1240's "the reference quill's own three cases get the first three call sites" splits here into three fixes and one declaration.

## 3. A quill declares what its plate does not typeset

```yaml
main:
  body:
    unsupported: [rule]
```

Optional, empty by default, names from a closed set (`heading`, `rule`, `code`, `list`, `quote`, `table`, `image`) so a misspelling is a load error rather than a declaration matching nothing. `Quill::unsupported_constructs` walks a document's bodies against the declarations and `Quill::parse` appends the result beside the `conform::*` set — a fifth warning family, `plate::unsupported_construct`, non-fatal, carrying the construct, a count, and the body's schema address.

Declaring rather than observing is what buys the half a runtime warning could not: the declaration rides `QuillConfig::schema()` to the editor, which needs the answer **before** the gesture. That is the question quillmark-js#384 raised by removing the input-rule guards, and a post-render warning structurally cannot answer it. It is also why occurrences collapse — one walk sees the whole body, so forty rules are one diagnostic carrying `count: 40`.

What it does not buy is verification. Nothing checks a declaration against the plate: a construct absent from the list is not a promise the plate typesets it, and an undeclared drop stays as silent as before. Documentation with a diagnostic attached, and the docs say so.

Scoped to bodies — block constructs live in block content, and an `inline: true` richtext field cannot hold one. A non-inline richtext field wanting the same key is additive.

`usaf_memo` declares `rule`; the key is skipped when empty, so no other quill's schema bytes or warnings move.

## What is deliberately not built

No Typst-side `warn()`. Beyond having no surviving call site: Typst has no user-facing warning emission, so it cannot join `typst::compile`'s stream as #1240 describes — it would be a second channel (the `form-field` → `overlay/extract.rs` metadata query is the precedent, and it stays available). More importantly it is **silently defeatable**: Typst is pure, so the only emission route is content the plate must place, and the plate that drops a heading drops it by `continue`-ing past it — the same shape of code that would drop the `warn()` result.

On #1240's open questions, for whenever this is revisited:

- **`location` cannot anchor to markdown.** `resolve_span_to_location` resolves a span against its own file, so a `warn()` in `body.typ` yields a coordinate in the *package*. The `SegmentMap`s that could reach markdown are consumed only by `overlay/span_scan.rs` and map rendered glyph positions, not call spans — and a warning's position is where the plate *placed* it, which for an absorbed heading is the absorbing paragraph. `path` is the honest granularity, and §3 gives it.
- **Severity stays `Warning`.** ERROR.md pins the two-value ladder; families are distinguished by code namespace.
- **A question #1240 does not ask:** quill-authored free-text messages cannot ride the `code` + `args` discipline canon tabulates. §3 sidesteps it by keying on a closed vocabulary.

Revisit when loss is *content*-dependent rather than *construct*-dependent — something a static declaration cannot express.

## Verification

- `cargo test --workspace --features typst` — 52 test binaries green.
- WASM publish build + `vitest run` — 241 tests green, core size budget OK.
- `node scripts/check-canon.mjs` — OK. Clippy adds no warnings from the new files.
- The three plate tests were run against the **unfixed** plate and fail there; `the_run_in_style_still_runs_in` and `the_seeded_memo_still_renders` pass both ways, which is their job.
- The oracle for the plate is `regions()`, not output size: a region's `span` is the content range its glyphs came from, so text that does not reach the page has no span covering it.
- One golden moves: `usaf_memo`'s `schema.yaml` gains the two lines carrying `unsupported: [rule]` to the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4UUsUscdZUBNGLAsqvgaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4UUsUscdZUBNGLAsqvgaG)_