### PR TITLE
Pin the click sweep across a plaintext element

### DIFF
--- a/crates/quillmark/tests/plaintext_render_test.rs
+++ b/crates/quillmark/tests/plaintext_render_test.rs
@@ -154,3 +154,38 @@ fn a_plaintext_delimiter_is_one_addressable_cluster() {
         "a hit on `*` floors to the delimiter's own offset, never inside its escape"
     );
 }
+
+#[test]
+fn a_click_sweep_across_a_plaintext_element_walks_every_offset_once() {
+    let temp_dir = TempDir::new().unwrap();
+    let session = session(&temp_dir);
+    let region = session
+        .regions()
+        .into_iter()
+        .find(|r| r.field == "tags.0")
+        .expect("tags.0 region");
+
+    // Finer than the narrowest glyph at 11pt: a skipped offset is the
+    // inversion's, not the probe's.
+    const STEP: f32 = 0.25;
+    let y = region.rect[3] - 3.0;
+    let mut walk: Vec<usize> = Vec::new();
+    let mut x = region.rect[0];
+    while x <= region.rect[2] {
+        if let Some(hit) = session.position_at(region.page, x, y) {
+            assert_eq!(hit.field, "tags.0");
+            assert_eq!(hit.granularity, Some(HitGranularity::Cluster));
+            if walk.last() != Some(&hit.pos) {
+                walk.push(hit.pos);
+            }
+        }
+        x += STEP;
+    }
+
+    let expected: Vec<usize> = (0..STAR_TAG.chars().count()).collect();
+    assert_eq!(
+        walk, expected,
+        "one content offset per cluster: an escape resolving to its own interior \
+         would repeat, skip, or shift the tail"
+    );
+}


### PR DESCRIPTION
#1250 landed the substance of #1247: `plaintext_render_test.rs` pins scalar and `plaintext[]` element geometry at engine altitude (a region per element keyed `tags.<i>` carrying a span, `position_at` cluster-exact on the element address, `locate` round-tripping to a caret inside the region, `tags` itself keying nothing), and PREVIEW.md's producer list names `richtext` or `plaintext`, scalar or `[]` element. `region.rs`'s list had already stopped saying richtext.

One leg of the escape scan was left uncovered. Both existing `position_at` assertions land at or before the escaped `*` — offset 2 and the `*`'s own midpoint — and the monotone sweep beside them runs `locate`, the other direction. An inversion that resolved into an escape's interior would shift every offset past `\*` by one and pass all three.

So sweep the click direction across the whole element: left to right at 0.25pt, roughly a tenth of the narrowest glyph at 11pt, the deduped walk must be `0..18` exactly. A repeat, a skip, or a shifted tail fails; the per-probe assertions keep the hit on `tags.0` and cluster-exact throughout.

Nothing in what the engine returns changes. `field_boxes` answering `[]` for `tags` while answering for its elements stays as the issue scoped it.

`cargo test --workspace` green; `scripts/check-canon.mjs` OK. Tests only, so no changelog entry — same as #1250.

Closes #1247

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q84fgWCgpzpK9xFSRGZerg)_