### PR TITLE
The obligation axis: `must_fill:` on the schema, and the unauthored-cell predicate

### DIFF
--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -653,12 +653,19 @@ def test_typed_set_clears_must_fill_marker():
     doc = Document.from_markdown(
         "~~~card-yaml\n$quill: taro@0.1.0\n$kind: main\ntitle: !must_fill\n~~~\n"
     )
-    codes = [d.get("code") for d in quill.validate(doc)]
-    assert "validation::must_fill" in codes
+    def fills(path):
+        return [
+            d
+            for d in quill.validate(doc)
+            if d.get("code") == "validation::must_fill" and d.get("path") == path
+        ]
+
+    # Scoped to `main.title`: the other defaultless fields this quill declares
+    # are obliged too, and stay so until someone authors them.
+    assert [d.get("args", {}).get("trigger") for d in fills("main.title")] == ["marker"]
 
     quill.writer(doc).set("title", "Real Title")
-    codes_after = [d.get("code") for d in quill.validate(doc)]
-    assert "validation::must_fill" not in codes_after
+    assert fills("main.title") == []
     assert field(doc.main, "title") == "Real Title"
 
 

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -660,8 +660,8 @@ def test_typed_set_clears_must_fill_marker():
             if d.get("code") == "validation::must_fill" and d.get("path") == path
         ]
 
-    # Scoped to `main.title`: the other defaultless fields this quill declares
-    # are obliged too, and stay so until someone authors them.
+    # Scoped to `main.title`: this quill's other defaultless field is obliged
+    # too, and stays so.
     assert [d.get("args", {}).get("trigger") for d in fills("main.title")] == ["marker"]
 
     quill.writer(doc).set("title", "Real Title")

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -164,15 +164,12 @@ def test_render_tolerates_must_fill_marker(engine, tmp_path):
         f"validation::must_fill must be a non-fatal warning; got: {fill}"
     )
 
-    # There is no separate completeness code: obligation, from either trigger,
-    # travels as `validation::must_fill`.
     codes = [d.get("code") for d in diags]
     assert "validation::field_absent" not in codes, (
         f"field_absent is removed and must not be surfaced; got: {codes}"
     )
 
-    # The `trigger` arg crosses the binding boundary, which is what lets a
-    # consumer route "drop the stale marker" apart from "nobody filled this in".
+    # `trigger` is what a consumer routes on, so pin it crossing the boundary.
     by_path = {d.get("path"): d.get("args", {}).get("trigger") for d in fill}
     assert by_path.get("main.title") == "marker", f"got: {fill}"
     assert by_path.get("main.count") is None, "an authored cell is discharged"

--- a/crates/bindings/python/tests/test_schema.py
+++ b/crates/bindings/python/tests/test_schema.py
@@ -164,12 +164,18 @@ def test_render_tolerates_must_fill_marker(engine, tmp_path):
         f"validation::must_fill must be a non-fatal warning; got: {fill}"
     )
 
-    # The removed `validation::field_absent` completeness code never surfaces:
-    # absent Unendorsed fields zero-fill silently.
+    # There is no separate completeness code: obligation, from either trigger,
+    # travels as `validation::must_fill`.
     codes = [d.get("code") for d in diags]
     assert "validation::field_absent" not in codes, (
         f"field_absent is removed and must not be surfaced; got: {codes}"
     )
+
+    # The `trigger` arg crosses the binding boundary, which is what lets a
+    # consumer route "drop the stale marker" apart from "nobody filled this in".
+    by_path = {d.get("path"): d.get("args", {}).get("trigger") for d in fill}
+    assert by_path.get("main.title") == "marker", f"got: {fill}"
+    assert by_path.get("main.count") is None, "an authored cell is discharged"
 
 
 def test_render_succeeds_when_unendorsed_supplied(engine, tmp_path):

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1822,8 +1822,7 @@ title: !must_fill
   it('validate surfaces the same code for a cell the schema obliges and nobody authored', () => {
     const { quill } = buildQuill()
 
-    // No marker anywhere: this document never saw a blueprint. The obligation
-    // is read off the schema, which is the whole point of the second trigger.
+    // No marker anywhere: this document never saw a blueprint.
     const md = `~~~card-yaml
 $quill: schema_test
 $kind: main
@@ -1835,8 +1834,7 @@ $kind: main
     )
     expect(title).toBeDefined()
     expect(title.severity).toBe('warning')
-    // The `trigger` arg is how a consumer tells the two apart; it crosses as
-    // an ordinary diagnostic arg.
+    // `trigger` is what a consumer routes on, so pin it crossing the boundary.
     expect(title.args.trigger).toBe('unauthored')
   })
 })

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1818,6 +1818,27 @@ title: !must_fill
       ),
     ).toBe(true)
   })
+
+  it('validate surfaces the same code for a cell the schema obliges and nobody authored', () => {
+    const { quill } = buildQuill()
+
+    // No marker anywhere: this document never saw a blueprint. The obligation
+    // is read off the schema, which is the whole point of the second trigger.
+    const md = `~~~card-yaml
+$quill: schema_test
+$kind: main
+~~~
+`
+    const diags = quill.validate(Document.fromMarkdown(md))
+    const title = diags.find(
+      (d) => d.code === 'validation::must_fill' && d.path === 'main.title',
+    )
+    expect(title).toBeDefined()
+    expect(title.severity).toBe('warning')
+    // The `trigger` arg is how a consumer tells the two apart; it crosses as
+    // an ordinary diagnostic arg.
+    expect(title.args.trigger).toBe('unauthored')
+  })
 })
 
 describe('nested !must_fill', () => {

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -822,9 +822,9 @@ mod tests {
     #[test]
     fn a_marked_content_cell_emits_its_markdown_projection() {
         // Seeding stamps `!must_fill` on an example-seeded must-fill field, so a
-        // content object and a marker now meet on one cell. The raw object has
-        // no card-yaml spelling: emitted unprojected it lands as a nested
-        // mapping that will not re-parse, and drops the marker on the way.
+        // content object and a marker meet on one cell. The raw object has no
+        // card-yaml spelling: emitted unprojected it lands as a nested mapping
+        // that will not re-parse, and drops the marker on the way.
         let mut payload = crate::document::Payload::new();
         payload.set_quill("q@1.0.0".parse().expect("reference"));
         payload.set_kind("main");

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -188,25 +188,25 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                 nested_comments,
             } => {
                 // card-yaml is the human-authored surface, so a stored content
-                // object projects back to markdown here. Such a field is never
-                // `!must_fill` and carries no nested comments, so the projected
-                // scalar takes the plain string path.
-                if !*fill {
-                    if let Some(markdown) = project_content_field(value.as_json()) {
-                        emit_field(
-                            out,
-                            key,
-                            &JsonValue::String(markdown),
-                            0,
-                            false,
-                            &[],
-                            &[],
-                            &[],
-                            trailer,
-                        );
-                        i += if consumed_trailer { 2 } else { 1 };
-                        continue;
-                    }
+                // object projects back to markdown here. The projection runs
+                // marker or no marker: a seeded `example` on a must-fill content
+                // field carries one, and the raw object has no card-yaml
+                // spelling. Once projected the cell is a scalar, which is the
+                // shape `!must_fill` emits against.
+                if let Some(markdown) = project_content_field(value.as_json()) {
+                    emit_field(
+                        out,
+                        key,
+                        &JsonValue::String(markdown),
+                        0,
+                        *fill,
+                        &[],
+                        &[],
+                        &[],
+                        trailer,
+                    );
+                    i += if consumed_trailer { 2 } else { 1 };
+                    continue;
                 }
                 let path: Vec<CommentPathSegment> = Vec::new();
                 // Nested fill markers; the top-level one rides on `*fill`.
@@ -816,6 +816,39 @@ mod tests {
             parsed, &value,
             "scalar round-trip mismatch for {:?}: emitted as {:?}",
             value, yaml
+        );
+    }
+
+    #[test]
+    fn a_marked_content_cell_emits_its_markdown_projection() {
+        // Seeding stamps `!must_fill` on an example-seeded must-fill field, so a
+        // content object and a marker now meet on one cell. The raw object has
+        // no card-yaml spelling: emitted unprojected it lands as a nested
+        // mapping that will not re-parse, and drops the marker on the way.
+        let mut payload = crate::document::Payload::new();
+        payload.set_quill("q@1.0.0".parse().expect("reference"));
+        payload.set_kind("main");
+        let mut card = crate::document::Card::from_parts(
+            payload,
+            quillmark_content::Content::empty(),
+        );
+        let content = quillmark_content::import::from_markdown("Q3 results").expect("content");
+        card.store_fill(
+            "subject",
+            QuillValue::from_json(quillmark_content::serial::to_canonical_value(&content)),
+        )
+        .expect("stored");
+
+        let md = crate::document::Document::from_main_and_cards(card, Vec::new()).to_markdown();
+
+        assert!(
+            md.contains("subject: !must_fill Q3 results\n"),
+            "the cell projects to markdown under its marker: {md}"
+        );
+        let reparsed = crate::document::Document::parse(&md).expect("re-parses").document;
+        assert!(
+            reparsed.main().payload().is_fill("subject"),
+            "and the marker survives: {md}"
         );
     }
 

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -821,10 +821,9 @@ mod tests {
 
     #[test]
     fn a_marked_content_cell_emits_its_markdown_projection() {
-        // Seeding stamps `!must_fill` on an example-seeded must-fill field, so a
-        // content object and a marker meet on one cell. The raw object has no
-        // card-yaml spelling: emitted unprojected it lands as a nested mapping
-        // that will not re-parse, and drops the marker on the way.
+        // A canonical content object has no card-yaml spelling: emitted
+        // unprojected it lands as a nested mapping that will not re-parse, and
+        // drops the marker on the way.
         let mut payload = crate::document::Payload::new();
         payload.set_quill("q@1.0.0".parse().expect("reference"));
         payload.set_kind("main");

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -246,6 +246,13 @@ impl Diagnostic {
         self
     }
 
+    /// Attach one substitution fact, for a code minted inline rather than from
+    /// an error enum's `args()`. See [`Self::args`].
+    pub fn with_arg(mut self, key: &str, value: serde_json::Value) -> Self {
+        self.args.insert(key.to_string(), value);
+        self
+    }
+
     /// Walk `source`'s cause chain eagerly into [`Self::source_chain`].
     pub fn with_source(mut self, source: &(dyn std::error::Error + 'static)) -> Self {
         let mut current: Option<&(dyn std::error::Error + 'static)> = Some(source);
@@ -694,7 +701,17 @@ mod args_canon {
             }
             .args(),
         );
-        add("validation::must_fill", BTreeMap::new());
+        // Two constructors, one code: sampling one and pinning the other against
+        // it is what stops the pair from drifting into two key sets.
+        let path = crate::path::DocPath::main().field("subject");
+        let marker = crate::quill::compose::fill_warning(&path);
+        let unauthored = crate::quill::compose::unauthored_warning(&path);
+        assert_eq!(
+            marker.args.keys().collect::<Vec<_>>(),
+            unauthored.args.keys().collect::<Vec<_>>(),
+            "both `validation::must_fill` triggers must carry one key set"
+        );
+        add("validation::must_fill", marker.args);
         // Built at the pre-render walk rather than from an error type: a quill
         // declares the construct, so there is nothing to fail.
         add("plate::unsupported_construct", {

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -1,7 +1,7 @@
 //! The `Quill` type: portable, validated quill data.
 
 mod blueprint;
-mod compose;
+pub(crate) mod compose;
 mod config;
 pub(crate) mod conform;
 mod resolved;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -16,8 +16,8 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 
 impl QuillConfig {
     /// Generate the canonical annotated Markdown blueprint for this quill:
-    /// the authoring surface handed to LLMs and humans, with Unendorsed cells
-    /// carrying the `!must_fill` marker. See module docs for the annotation
+    /// the authoring surface handed to LLMs and humans, with every must-fill
+    /// cell carrying the `!must_fill` marker. See module docs for the annotation
     /// grammar; the function is total over any valid `QuillConfig`.
     ///
     /// The "filled-out" twin of the blueprint is **seeding**
@@ -198,9 +198,11 @@ fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
 }
 
 /// Push the leading prose comments for a *top-level* field: the description,
-/// then the `# e.g.` hint. `eg_when` gates the hint: scalars surface it only
-/// when Endorsed (an Unendorsed example inlines as the marker value instead),
-/// while typed containers always surface it (their example never inlines).
+/// then the `# e.g.` hint. `eg_when` gates the hint: a scalar surfaces it only
+/// when a `default:` already occupies the cell (otherwise the example *is* the
+/// cell's value), while typed containers always surface it (their example never
+/// inlines). The gate is a value-axis question and stays keyed on `default`:
+/// `must_fill` never moves an example between the cell and the hint.
 fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool) {
     if let Some(desc) = collapse_opt(&field.description) {
         items.push(PayloadItem::comment(desc));
@@ -212,21 +214,30 @@ fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool
     }
 }
 
-/// The cell's `(value, fill)` for a scalar/array/richtext leaf, per the value
-/// cascade. Endorsed → the default, no marker. Unendorsed → the `example` (when
-/// present) carried by the marker, else a bare null marker. A richtext leaf never
-/// inlines an example: an Unendorsed richtext leaf is always a bare marker, but
-/// its `example:` still surfaces as a `# e.g.` hint (see `append_scalar`).
+/// The cell's `(value, fill)` for a scalar/array/richtext leaf: the two axes
+/// read independently. The value is `default:` › `example:` › bare null; the
+/// marker is the field's derived `must_fill`. A field carrying both a default
+/// and `must_fill: true` therefore shows the default *and* asks for
+/// confirmation, and an explicitly optional field with nothing to suggest emits
+/// a bare unmarked cell (the type annotation alone tells the reader what goes
+/// there).
 fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
+    (scalar_value(field), field.must_fill())
+}
+
+/// The value half. A richtext leaf never inlines an example: its `example:`
+/// surfaces as a `# e.g.` hint instead (see `append_scalar`), so its
+/// defaultless cell is always bare.
+fn scalar_value(field: &FieldSchema) -> JsonValue {
     if let Some(default) = &field.default {
-        return (default.as_json().clone(), false);
+        return default.as_json().clone();
     }
     if matches!(field.r#type, FieldType::RichText { .. }) {
-        return (JsonValue::Null, true);
+        return JsonValue::Null;
     }
     match field.example.as_ref() {
-        Some(eg) => (eg.as_json().clone(), true),
-        None => (JsonValue::Null, true),
+        Some(eg) => eg.as_json().clone(),
+        None => JsonValue::Null,
     }
 }
 
@@ -248,7 +259,7 @@ fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     items.push(PayloadItem::comment_inline(type_expression(field)));
 }
 
-/// Build the per-property body of an Unendorsed typed container: the value
+/// Build the per-property body of a defaultless typed container: the value
 /// mapping (each property at its own cell, in declaration order), the nested
 /// comments (description + `# e.g.` + inline type annotation, addressed by
 /// `container_path`/slot), and the nested fill paths. `prefix` is the container
@@ -274,7 +285,7 @@ fn build_property_mapping(
                 inline: false,
             });
         }
-        // `# e.g.` only when Endorsed (see `push_leading`).
+        // `# e.g.` only when a `default:` holds the cell (see `push_leading`).
         if prop.default.is_some() {
             if let Some(eg) = prop.example.as_ref() {
                 nested.push(NestedComment {
@@ -302,11 +313,13 @@ fn build_property_mapping(
     (map, nested, fills)
 }
 
-/// Append a typed-dictionary field (`object` with `properties`). Endorsed:
-/// render the default mapping (`{}` expands to the zero-filled shape; a
-/// non-empty partial default is rendered verbatim, all unmarked). Unendorsed:
-/// recurse per property with leaf-level markers and annotations; the container
-/// key itself is untagged.
+/// Append a typed-dictionary field (`object` with `properties`). With a
+/// `default:`: render the default mapping (`{}` expands to the blank-filled
+/// shape; a non-empty partial default is rendered verbatim, all unmarked).
+/// Without one: recurse per property with leaf-level markers and annotations;
+/// the container key itself is untagged, since `!must_fill` is rejected on a
+/// mapping (`prose/references/markdown-spec.md` §3.4). A typed dictionary's own
+/// `must_fill:` is therefore inert — the obligation lives on its leaves.
 fn append_typed_dict(
     items: &mut Vec<PayloadItem>,
     field: &FieldSchema,
@@ -333,10 +346,11 @@ fn append_typed_dict(
     push_container_field(items, &field.name, value, nested, fills, field);
 }
 
-/// Append a typed-table field (`array<object>`). Endorsed: render the default
-/// rows verbatim (including `default: []`, which stays inline `[]`: arrays do
-/// not expand). Unendorsed: emit one synthetic row carrying each property's
-/// leaf-level marker and annotation; the container key itself is untagged.
+/// Append a typed-table field (`array<object>`). With a `default:`: render the
+/// default rows verbatim (including `default: []`, which stays inline `[]`:
+/// arrays do not expand). Without one: emit one synthetic row carrying each
+/// property's leaf-level marker and annotation; the container key itself is
+/// untagged, so the field's own `must_fill:` is inert (as for a typed dict).
 fn append_typed_table(
     items: &mut Vec<PayloadItem>,
     field: &FieldSchema,
@@ -460,6 +474,61 @@ main:
 "#)
         .blueprint();
         assert!(t.contains("# e.g. Hello world\nbio: !must_fill # richtext<markdown>\n"));
+    }
+
+    #[test]
+    fn a_default_and_an_explicit_must_fill_show_both() {
+        // The two axes are independent: the value cell carries the default (so
+        // the document renders something safe) and the marker still asks a human
+        // to confirm it. This cell had no spelling while `default:` carried both.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    classification: { type: enum, values: [UNCLASSIFIED, CUI], default: UNCLASSIFIED, must_fill: true }
+"#)
+        .blueprint();
+        assert!(
+            t.contains("classification: !must_fill UNCLASSIFIED # enum<UNCLASSIFIED | CUI>\n"),
+            "{t}"
+        );
+    }
+
+    #[test]
+    fn an_opted_out_field_with_nothing_to_suggest_emits_a_bare_unmarked_cell() {
+        // The cell shape the emitter never had to produce: no default, no
+        // example, no obligation. It stays in the blueprint rather than being
+        // omitted — the blueprint is the document's full shape, and the type
+        // annotation is exactly what a reader needs to fill it if they want to.
+        // The explicit `null` is the emitter's spelling of an empty unmarked
+        // cell; it parses back to the same state a missing key would.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    note: { type: string, must_fill: false }
+"#)
+        .blueprint();
+        assert!(t.contains("\nnote: null # string\n"), "{t}");
+        assert!(!t.contains("!must_fill"), "{t}");
+
+        let doc = Document::parse(&t).expect("the bare cell parses").document;
+        assert_eq!(doc, Document::parse(&doc.to_markdown()).expect("re-emit").document);
+    }
+
+    #[test]
+    fn an_opted_out_field_keeps_its_example_as_the_cell_value() {
+        // The value axis is untouched by the marker axis: `example:` still
+        // inlines when no `default:` holds the cell, marker or no marker.
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    note: { type: string, example: A note, must_fill: false }
+"#)
+        .blueprint();
+        assert!(t.contains("note: A note # string\n"), "{t}");
+        assert!(!t.contains("e.g."), "the example is the cell, not a hint: {t}");
     }
 
     #[test]

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -245,7 +245,7 @@ fn scalar_value(field: &FieldSchema) -> JsonValue {
 /// plus its trailing inline type annotation.
 fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     // A richtext field never inlines its `example:` as the marker value, so
-    // (unlike other Unendorsed scalars) the example would vanish entirely.
+    // (unlike other defaultless scalars) the example would vanish entirely.
     // Surface it as a `# e.g.` hint instead (no-ops when no `example:` is set).
     let eg_when = field.default.is_some() || matches!(field.r#type, FieldType::RichText { .. });
     push_leading(items, field, eg_when);
@@ -328,15 +328,15 @@ fn append_typed_dict(
     push_leading(items, field, true);
 
     let (value, nested, fills) = match field.default.as_ref().map(|d| d.as_json()) {
-        // `default: {}` → expand to the field's zero-filled shape so every key
-        // is shown; all leaves are Endorsed-by-the-container, hence unmarked
-        // and unannotated (uniform with a concrete default).
+        // `default: {}` → expand to the field's blank-filled shape so every key
+        // is shown; the container's default covers its leaves, so they are
+        // unmarked and unannotated (uniform with a concrete default).
         Some(JsonValue::Object(map)) if map.is_empty() => {
             (blank(field).into_json(), Vec::new(), Vec::new())
         }
         // Concrete default (object or otherwise) → rendered verbatim, unmarked.
         Some(default) => (default.clone(), Vec::new(), Vec::new()),
-        // Unendorsed → per-property recursion at the mapping root.
+        // No default → per-property recursion at the mapping root.
         None => {
             let (map, nested, fills) = build_property_mapping(props, &[]);
             (JsonValue::Object(map), nested, fills)
@@ -364,7 +364,7 @@ fn append_typed_table(
         // Row type declares no properties (schema-invalid in practice): emit a
         // type-valid empty array rather than a null synthetic row.
         None if item_props.is_empty() => (JsonValue::Array(Vec::new()), Vec::new(), Vec::new()),
-        // Unendorsed → one synthetic row, per-property markers at `[Index(0)]`.
+        // No default → one synthetic row, per-property markers at `[Index(0)]`.
         None => {
             let (row, nested, fills) = build_property_mapping(item_props, &[PathSegment::Index(0)]);
             (
@@ -478,9 +478,6 @@ main:
 
     #[test]
     fn a_default_and_an_explicit_must_fill_show_both() {
-        // The two axes are independent: the value cell carries the default (so
-        // the document renders something safe) and the marker still asks a human
-        // to confirm it. This cell had no spelling while `default:` carried both.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -496,12 +493,6 @@ main:
 
     #[test]
     fn an_opted_out_field_with_nothing_to_suggest_emits_a_bare_unmarked_cell() {
-        // The cell shape the emitter never had to produce: no default, no
-        // example, no obligation. It stays in the blueprint rather than being
-        // omitted — the blueprint is the document's full shape, and the type
-        // annotation is exactly what a reader needs to fill it if they want to.
-        // The explicit `null` is the emitter's spelling of an empty unmarked
-        // cell; it parses back to the same state a missing key would.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -509,6 +500,8 @@ main:
     note: { type: string, must_fill: false }
 "#)
         .blueprint();
+        // `null` is the emitter's spelling of an empty unmarked cell; it parses
+        // back to the state a missing key would.
         assert!(t.contains("\nnote: null # string\n"), "{t}");
         assert!(!t.contains("!must_fill"), "{t}");
 
@@ -518,8 +511,6 @@ main:
 
     #[test]
     fn an_opted_out_field_keeps_its_example_as_the_cell_value() {
-        // The value axis is untouched by the marker axis: `example:` still
-        // inlines when no `default:` holds the cell, marker or no marker.
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -218,8 +218,8 @@ impl Quill {
     ///
     /// `validation::must_fill` has **two triggers**, covering disjoint failures
     /// under one code: a `!must_fill` marker the document carries
-    /// ([`validate_fills`]), and a schema-side must-fill cell nobody authored
-    /// ([`validate_unauthored`]). Neither subsumes the other — a document that
+    /// (`validate_fills`), and a schema-side must-fill cell nobody authored
+    /// (`validate_unauthored`). Neither subsumes the other — a document that
     /// never saw a blueprint carries no marker, and a seeded `example` is
     /// present, in-domain, and structurally indistinguishable from authored
     /// content — so both run, and the `trigger` arg tells a consumer which

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -1,6 +1,7 @@
 //! Consumer-facing operations on a [`Quill`]: validation, seeding, and the
 //! zero-filled compile to backend wire JSON. Pure reads of the config.
 
+use std::collections::HashSet;
 use std::str::FromStr;
 
 use indexmap::IndexMap;
@@ -213,7 +214,17 @@ impl Quill {
     /// consumers route on the code without parsing message text: type
     /// mismatches, unknown card kinds, body-on-disabled-body, and the non-fatal
     /// `validation::must_fill` warning, the only non-fatal one; the rest are
-    /// blockers. Field absence is not surfaced (it blank-fills at render).
+    /// blockers.
+    ///
+    /// `validation::must_fill` has **two triggers**, covering disjoint failures
+    /// under one code: a `!must_fill` marker the document carries
+    /// ([`validate_fills`]), and a schema-side must-fill cell nobody authored
+    /// ([`validate_unauthored`]). Neither subsumes the other — a document that
+    /// never saw a blueprint carries no marker, and a seeded `example` is
+    /// present, in-domain, and structurally indistinguishable from authored
+    /// content — so both run, and the `trigger` arg tells a consumer which
+    /// fired. Where both would fire on one path (a bare marker on an unauthored
+    /// cell) the marker wins: its hint is the actionable one.
     ///
     /// Field values, defaults, and presentation order are not part of this
     /// surface: read them from the [`Document`] payload and the quill schema
@@ -223,7 +234,14 @@ impl Quill {
             Ok(()) => Vec::new(),
             Err(errors) => errors.iter().map(|e| e.to_diagnostic()).collect(),
         };
-        diags.extend(validate_fills(self.config(), doc));
+        let marked = validate_fills(self.config(), doc);
+        let claimed: HashSet<Option<String>> = marked.iter().map(|d| d.path.clone()).collect();
+        diags.extend(marked);
+        diags.extend(
+            validate_unauthored(self.config(), doc)
+                .into_iter()
+                .filter(|d| !claimed.contains(&d.path)),
+        );
         diags.extend(self.validate_seed(doc));
         diags
     }
@@ -604,7 +622,7 @@ fn collect_fill_diags(card: &Card, base: &DocPath, out: &mut Vec<Diagnostic>) {
     }
 }
 
-fn fill_warning(path: &DocPath) -> Diagnostic {
+pub(crate) fn fill_warning(path: &DocPath) -> Diagnostic {
     let path = path.to_string();
     Diagnostic::new(
         Severity::Warning,
@@ -612,12 +630,122 @@ fn fill_warning(path: &DocPath) -> Diagnostic {
     )
     .with_code("validation::must_fill".to_string())
     .with_path(path)
+    .with_arg("trigger", "marker".into())
     .with_hint(
         "Replace the value and drop the `!must_fill` marker, or remove the marker if the \
          current value is intended."
             .to_string(),
     )
 }
+
+/// Surface every schema-side must-fill cell the document leaves **unauthored**
+/// as a non-fatal warning, across the main card and every composable card.
+///
+/// The marker half ([`validate_fills`]) can only see documents that carry one.
+/// This half consults the schema, so a hand-written, programmatically built, or
+/// pre-field document gets the same completeness signal a blueprint-derived one
+/// does.
+///
+/// **Unauthored is absent-or-null**, not [`FieldSource`]. The two agree at top
+/// level, but `FieldSource` is one rung per top-level field by design
+/// ([`resolve_value_sourced`] reports a present typed dict `Authored` as a
+/// whole), so a source-keyed check would go silent on a must-fill property
+/// inside a touched container. Authoring the field's **blank** discharges the
+/// warning: the human made the call, and blank is a legitimate rendered state.
+fn validate_unauthored(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    collect_unauthored_diags(&config.main, doc.main(), &DocPath::main(), &mut diags);
+    for (index, card) in doc.cards().iter().enumerate() {
+        let Some(schema) = card.kind().and_then(|k| config.card_kind(k)) else {
+            continue;
+        };
+        collect_unauthored_diags(
+            schema,
+            card,
+            &DocPath::card(card.kind(), index),
+            &mut diags,
+        );
+    }
+    diags
+}
+
+fn collect_unauthored_diags(
+    schema: &CardSchema,
+    card: &Card,
+    base: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    let payload = card.payload();
+    for (name, field) in &schema.fields {
+        collect_unauthored_field(field, payload.get(name), &base.field(name), out);
+    }
+}
+
+/// Walk one declared field, warning at each **cell** the schema obliges and the
+/// document leaves unauthored. The cell set is exactly the set of paths the
+/// blueprint would stamp `!must_fill`, so the two triggers agree on where an
+/// obligation lives and a fresh seed converges with a hand-written document:
+///
+/// - A **typed dictionary** is never itself a cell (`!must_fill` is rejected on
+///   a mapping, `prose/references/markdown-spec.md` §3.4, and the blueprint
+///   marks its leaves). Recursion runs whether or not the container is present,
+///   so an absent `address` warns at `address.street` — a path an editor can
+///   resolve and a marker can occupy — rather than at a container path that can
+///   be neither.
+/// - Every **other** type is the cell, the array included: an absent array is
+///   one unauthored cell, and `[]` is an authored answer that discharges it.
+///   Once present, elements resolve against the item schema, so a null element
+///   warns at its own index.
+fn collect_unauthored_field(
+    field: &FieldSchema,
+    value: Option<&QuillValue>,
+    path: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    if let (FieldType::Object, Some(props)) = (&field.r#type, &field.properties) {
+        let obj = value.and_then(|v| v.as_json().as_object());
+        for (name, prop) in props {
+            let pv = obj
+                .and_then(|o| o.get(name))
+                .map(|j| QuillValue::from_json(j.clone()));
+            collect_unauthored_field(prop, pv.as_ref(), &path.field(name), out);
+        }
+        return;
+    }
+
+    let Some(present) = value.filter(|v| !v.as_json().is_null()) else {
+        if field.must_fill() {
+            out.push(unauthored_warning(path));
+        }
+        return;
+    };
+
+    if let (FieldType::Array, Some(items)) = (&field.r#type, &field.items) {
+        for (index, element) in present.as_json().as_array().into_iter().flatten().enumerate() {
+            let element = QuillValue::from_json(element.clone());
+            collect_unauthored_field(items, Some(&element), &path.index(index), out);
+        }
+    }
+}
+
+pub(crate) fn unauthored_warning(path: &DocPath) -> Diagnostic {
+    let path = path.to_string();
+    Diagnostic::new(
+        Severity::Warning,
+        format!("Field `{path}` must be filled in: nobody has authored a value."),
+    )
+    .with_code("validation::must_fill".to_string())
+    .with_path(path)
+    .with_arg("trigger", "unauthored".into())
+    .with_hint(
+        "Author a value. To record that empty is the intended answer, write the field's \
+         blank explicitly rather than leaving it out."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod must_fill_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -682,9 +682,10 @@ fn collect_unauthored_diags(
 }
 
 /// Walk one declared field, warning at each **cell** the schema obliges and the
-/// document leaves unauthored. The cell set is exactly the set of paths the
-/// blueprint would stamp `!must_fill`, so the two triggers agree on where an
-/// obligation lives and a fresh seed converges with a hand-written document:
+/// document leaves unauthored. Cells sit where the blueprint stamps its markers
+/// (`prose/canon/BLUEPRINT.md` § "Placeholder value precedence"), so the two
+/// triggers agree on where an obligation lives and a fresh seed converges with a
+/// hand-written document:
 ///
 /// - A **typed dictionary** is never itself a cell (`!must_fill` is rejected on
 ///   a mapping, `prose/references/markdown-spec.md` §3.4, and the blueprint
@@ -695,7 +696,9 @@ fn collect_unauthored_diags(
 /// - Every **other** type is the cell, the array included: an absent array is
 ///   one unauthored cell, and `[]` is an authored answer that discharges it.
 ///   Once present, elements resolve against the item schema, so a null element
-///   warns at its own index.
+///   warns at its own index. The blueprint's synthetic row indexes a table the
+///   document has yet to have rows for, which is why the absent case anchors on
+///   the container here and on `[0]`'s leaves there.
 fn collect_unauthored_field(
     field: &FieldSchema,
     value: Option<&QuillValue>,

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -639,19 +639,14 @@ pub(crate) fn fill_warning(path: &DocPath) -> Diagnostic {
 }
 
 /// Surface every schema-side must-fill cell the document leaves **unauthored**
-/// as a non-fatal warning, across the main card and every composable card.
+/// as a non-fatal warning, across the main card and every composable card. The
+/// schema half of `validation::must_fill`, reaching documents that carry no
+/// marker to read.
 ///
-/// The marker half ([`validate_fills`]) can only see documents that carry one.
-/// This half consults the schema, so a hand-written, programmatically built, or
-/// pre-field document gets the same completeness signal a blueprint-derived one
-/// does.
-///
-/// **Unauthored is absent-or-null**, not [`FieldSource`]. The two agree at top
-/// level, but `FieldSource` is one rung per top-level field by design
-/// ([`resolve_value_sourced`] reports a present typed dict `Authored` as a
-/// whole), so a source-keyed check would go silent on a must-fill property
-/// inside a touched container. Authoring the field's **blank** discharges the
-/// warning: the human made the call, and blank is a legitimate rendered state.
+/// Unauthored is **absent-or-null**, never [`FieldSource`]: the rung is one per
+/// top-level field, so a present typed dict reports `Authored` as a whole
+/// ([`resolve_value_sourced`]) and a source-keyed check goes silent on a
+/// must-fill property inside it.
 fn validate_unauthored(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
     collect_unauthored_diags(&config.main, doc.main(), &DocPath::main(), &mut diags);
@@ -681,24 +676,18 @@ fn collect_unauthored_diags(
     }
 }
 
-/// Walk one declared field, warning at each **cell** the schema obliges and the
-/// document leaves unauthored. Cells sit where the blueprint stamps its markers
-/// (`prose/canon/BLUEPRINT.md` § "Placeholder value precedence"), so the two
-/// triggers agree on where an obligation lives and a fresh seed converges with a
-/// hand-written document:
+/// Warn at each **cell** the schema obliges and the document leaves unauthored.
+/// Cells sit where the blueprint stamps its markers (`prose/canon/BLUEPRINT.md`
+/// § "Placeholder value precedence"), so the two triggers speak about the same
+/// paths:
 ///
-/// - A **typed dictionary** is never itself a cell (`!must_fill` is rejected on
-///   a mapping, `prose/references/markdown-spec.md` §3.4, and the blueprint
-///   marks its leaves). Recursion runs whether or not the container is present,
-///   so an absent `address` warns at `address.street` — a path an editor can
-///   resolve and a marker can occupy — rather than at a container path that can
-///   be neither.
-/// - Every **other** type is the cell, the array included: an absent array is
-///   one unauthored cell, and `[]` is an authored answer that discharges it.
-///   Once present, elements resolve against the item schema, so a null element
-///   warns at its own index. The blueprint's synthetic row indexes a table the
-///   document has yet to have rows for, which is why the absent case anchors on
-///   the container here and on `[0]`'s leaves there.
+/// - A **typed dictionary** is never itself a cell: `!must_fill` is rejected on
+///   a mapping (`prose/references/markdown-spec.md` §3.4). Recursion runs
+///   present or absent, so an absent `address` warns at `address.street`, a path
+///   an editor can resolve and a marker can occupy.
+/// - Every **other** type is the cell, the array included, so `[]` is an
+///   authored answer. A present array resolves its elements against the item
+///   schema; an absent one has no index to anchor on and warns at the container.
 fn collect_unauthored_field(
     field: &FieldSchema,
     value: Option<&QuillValue>,

--- a/crates/core/src/quill/compose/must_fill_tests.rs
+++ b/crates/core/src/quill/compose/must_fill_tests.rs
@@ -1,0 +1,330 @@
+//! The obligation axis: `must_fill:` on the schema and the unauthored-cell
+//! predicate that reads it.
+
+use crate::quill::quill_from_yaml;
+use crate::quill::resolved::FieldSource;
+use crate::{Document, Quill};
+
+/// Every `validation::must_fill` path, with its `trigger` arg, sorted.
+fn obligations(quill: &Quill, md: &str) -> Vec<(String, String)> {
+    let doc = Document::parse(md).expect("parse").document;
+    let mut out: Vec<(String, String)> = quill
+        .validate(&doc)
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::must_fill"))
+        .map(|d| {
+            (
+                d.path.clone().expect("every must_fill anchors at a path"),
+                d.args["trigger"].as_str().expect("trigger arg").to_string(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn paths(quill: &Quill, md: &str) -> Vec<String> {
+    obligations(quill, md).into_iter().map(|(p, _)| p).collect()
+}
+
+const SCALARS: &str = r#"
+quill: { name: ob, version: 1.0.0, backend: typst, description: obligations }
+main:
+  fields:
+    subject:    { type: string }
+    severity:   { type: enum, values: [low, high] }
+    status:     { type: string, default: draft }
+    confirmed:  { type: string, default: draft, must_fill: true }
+    optional:   { type: string, must_fill: false }
+"#;
+
+fn md(fields: &str) -> String {
+    format!("~~~card-yaml\n$quill: ob@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+#[test]
+fn a_defaultless_field_is_obliged_and_a_defaulted_one_is_not() {
+    let quill = quill_from_yaml(SCALARS);
+
+    // Rows (a) and (b): nothing authored. `subject`/`severity` derive the
+    // obligation from having no `default:`; `confirmed` declares it despite
+    // carrying one. `status` (defaulted) and `optional` (opted out) stay quiet.
+    assert_eq!(
+        paths(&quill, &md("")),
+        ["main.confirmed", "main.severity", "main.subject"]
+    );
+}
+
+#[test]
+fn authoring_a_value_or_the_blank_discharges_the_obligation() {
+    let quill = quill_from_yaml(SCALARS);
+
+    // Row (c): a value. Row (d): the blank literal — the human said "nothing",
+    // which is an answer. An `enum`'s blank is `""`, outside `values:`, which is
+    // what makes the obligation dischargeable for a finite domain at all.
+    assert_eq!(
+        paths(
+            &quill,
+            &md("subject: Q3 results\nseverity: \"\"\nconfirmed: draft\n")
+        ),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn null_does_not_discharge_but_the_blank_does() {
+    let quill = quill_from_yaml(SCALARS);
+
+    // The one place null and the blank part company. On the value ladder they
+    // are still identical (both blank-fill); on the obligation surface, writing
+    // the blank is an act and clearing the key is not.
+    let rest = "severity: low\nconfirmed: draft\n";
+    assert_eq!(
+        paths(&quill, &md(&format!("subject: null\n{rest}"))),
+        ["main.subject"]
+    );
+    assert!(paths(&quill, &md(&format!("subject: \"\"\n{rest}"))).is_empty());
+}
+
+const CONTAINERS: &str = r#"
+quill: { name: cn, version: 1.0.0, backend: typst, description: containers }
+main:
+  fields:
+    address:
+      type: object
+      properties:
+        street: { type: string }
+        city:   { type: string }
+        zip:    { type: string, default: "" }
+    recipients:
+      type: array
+      items: { type: string }
+"#;
+
+fn cn(fields: &str) -> String {
+    format!("~~~card-yaml\n$quill: cn@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+#[test]
+fn a_typed_dict_is_obliged_at_its_leaves_present_or_absent() {
+    let quill = quill_from_yaml(CONTAINERS);
+
+    // A mapping cannot carry `!must_fill` (markdown-spec §3.4) and the blueprint
+    // marks its leaves, so the predicate does too — at the same paths, whether
+    // or not the container is present. No 1-vs-N jump on the first keystroke
+    // into the container, and every path an editor can resolve.
+    let absent = paths(&quill, &cn("recipients: []\n"));
+    let touched = paths(&quill, &cn("recipients: []\naddress:\n  city: Pittsburgh\n"));
+    assert_eq!(absent, ["main.address.city", "main.address.street"]);
+    assert_eq!(touched, ["main.address.street"]);
+}
+
+#[test]
+fn a_touched_container_does_not_silence_its_unauthored_leaves() {
+    let quill = quill_from_yaml(CONTAINERS);
+
+    // The reason the predicate keys on cell presence rather than `FieldSource`:
+    // `resolve_value_sourced` reports a present typed dict `Authored` as a
+    // whole, so a source-keyed check would report nothing here.
+    let doc = Document::parse(&cn("address:\n  city: Pittsburgh\n"))
+        .expect("parse")
+        .document;
+    let (_, source) = super::resolve_value_sourced(
+        doc.main().payload().get("address"),
+        &crate::quill::QuillConfig::from_yaml(CONTAINERS).unwrap().main.fields["address"],
+    );
+    assert_eq!(source, FieldSource::Authored, "the view sees one authored dict");
+    assert!(paths(&quill, &cn("address:\n  city: Pittsburgh\n"))
+        .contains(&"main.address.street".to_string()));
+}
+
+#[test]
+fn an_array_is_one_cell_and_the_empty_array_answers_it() {
+    let quill = quill_from_yaml(CONTAINERS);
+
+    // An array *is* its cell: absent, it is one unauthored answer, not N at
+    // indices nobody can point at. `[]` is a real answer — "no recipients" —
+    // so it discharges, exactly as the blank does for a scalar.
+    assert!(paths(&quill, &cn("")).contains(&"main.recipients".to_string()));
+    assert!(!paths(&quill, &cn("recipients: []\n")).contains(&"main.recipients".to_string()));
+
+    // Present, its elements resolve against the item schema, so a hole in the
+    // list warns at its own index rather than silently blank-filling.
+    assert!(paths(&quill, &cn("recipients: [Ada, null]\n"))
+        .contains(&"main.recipients[1]".to_string()));
+}
+
+const CARDS: &str = r#"
+quill: { name: cd, version: 1.0.0, backend: typst, description: cards }
+main:
+  fields:
+    title: { type: string }
+card_kinds:
+  indorsement:
+    fields:
+      from: { type: string }
+"#;
+
+#[test]
+fn a_card_kind_is_obliged_once_per_instance() {
+    let quill = quill_from_yaml(CARDS);
+    let root = "~~~card-yaml\n$quill: cd@1.0.0\n$kind: main\ntitle: T\n~~~\n";
+    let card = "\n~~~card-yaml\n$kind: indorsement\n~~~\n";
+
+    // A card kind obliges nothing until the document carries an instance: a
+    // schema cannot demand a card exist. So the count scales with the document,
+    // not with the schema's field total.
+    assert!(paths(&quill, root).is_empty());
+    assert_eq!(
+        paths(&quill, &format!("{root}{card}")),
+        ["cards.indorsement[0].from"]
+    );
+    assert_eq!(
+        paths(&quill, &format!("{root}{card}{card}")),
+        [
+            "cards.indorsement[0].from",
+            "cards.indorsement[1].from"
+        ]
+    );
+}
+
+#[test]
+fn the_marker_wins_where_both_triggers_fire() {
+    let quill = quill_from_yaml(SCALARS);
+
+    // A bare marker is both: a tag the document carries and a cell nobody
+    // authored. One code, one diagnostic per path, and the marker's hint is the
+    // actionable one ("drop the marker").
+    assert_eq!(
+        obligations(&quill, &md("subject: !must_fill\nseverity: \"\"\nconfirmed: x\n")),
+        [("main.subject".to_string(), "marker".to_string())]
+    );
+
+    // A marker riding a suggested value is the case the schema predicate is
+    // structurally blind to: present, in-domain, indistinguishable from
+    // authored content. Only the tag catches it.
+    assert_eq!(
+        obligations(&quill, &md("subject: !must_fill Draft\nseverity: low\nconfirmed: x\n")),
+        [("main.subject".to_string(), "marker".to_string())]
+    );
+}
+
+#[test]
+fn a_hand_written_tag_fires_on_an_unobliged_field() {
+    let quill = quill_from_yaml(SCALARS);
+
+    // The tag is document-sovereign: it does not consult `must_fill:`.
+    assert_eq!(
+        obligations(
+            &quill,
+            &md("subject: S\nseverity: low\nconfirmed: x\noptional: !must_fill later\n")
+        ),
+        [("main.optional".to_string(), "marker".to_string())]
+    );
+}
+
+#[test]
+fn an_unauthored_obligation_never_gates_render() {
+    let quill = quill_from_yaml(SCALARS);
+    let doc = Document::parse(&md("")).expect("parse").document;
+
+    // The whole point of the axis: obligation is a warning, not a gate. The
+    // predicate lives beside `validate_fills` on the editor surface, never in
+    // `validate_document`, whose non-empty error list becomes a `RenderError`.
+    assert_eq!(paths(&quill, &md("")).len(), 3, "the document is incomplete");
+    let plate = quill.compile_data(&doc).expect("and renders anyway");
+    assert_eq!(plate["subject"], "", "the unauthored cell blank-fills");
+}
+
+#[test]
+fn a_fresh_seed_and_a_blank_document_report_the_same_cells() {
+    // Rule 8's claim, made checkable: seeding stamps every example it commits on
+    // a must-fill field, so the blueprint's filled-out twin reads as incomplete
+    // in exactly the cells a hand-written document does. The triggers differ;
+    // the cell set does not.
+    let quill = quill_from_yaml(
+        r#"
+quill: { name: sd, version: 1.0.0, backend: typst, description: seed }
+main:
+  fields:
+    subject:  { type: string, example: Q3 results }
+    memo_for: { type: array, items: { type: string }, example: [Ada] }
+    status:   { type: string, default: draft, example: final }
+"#,
+    );
+
+    let seeded = quill.seed_document();
+    let mut from_seed: Vec<(String, String)> = quill
+        .validate(&seeded)
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::must_fill"))
+        .map(|d| {
+            (
+                d.path.clone().unwrap(),
+                d.args["trigger"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    from_seed.sort();
+
+    let blank = obligations(
+        &quill_from_yaml(
+            r#"
+quill: { name: sd, version: 1.0.0, backend: typst, description: seed }
+main:
+  fields:
+    subject:  { type: string, example: Q3 results }
+    memo_for: { type: array, items: { type: string }, example: [Ada] }
+    status:   { type: string, default: draft, example: final }
+"#,
+        ),
+        "~~~card-yaml\n$quill: sd@1.0.0\n$kind: main\n~~~\n",
+    );
+
+    assert_eq!(
+        from_seed.iter().map(|(p, _)| p).collect::<Vec<_>>(),
+        blank.iter().map(|(p, _)| p).collect::<Vec<_>>(),
+        "seed and blank document agree on the cells"
+    );
+    assert_eq!(
+        from_seed,
+        [
+            ("main.memo_for".to_string(), "marker".to_string()),
+            ("main.subject".to_string(), "marker".to_string())
+        ],
+        "the seed's signal rides the committed marker"
+    );
+    assert!(
+        blank.iter().all(|(_, t)| t == "unauthored"),
+        "the blank document's rides the schema: {blank:?}"
+    );
+}
+
+#[test]
+fn a_seed_overlay_value_commits_unmarked() {
+    // `$seed` is a template author deciding, which is the act the marker asks
+    // for; an `example` is documentation of shape and is not.
+    let quill = quill_from_yaml(
+        r#"
+quill: { name: ov, version: 1.0.0, backend: typst, description: overlay }
+main:
+  fields:
+    title: { type: string }
+card_kinds:
+  note:
+    fields:
+      label: { type: string, example: A label }
+"#,
+    );
+
+    let bare = quill.seed_card("note", None).expect("declared kind");
+    assert!(bare.payload().is_fill("label"), "an example stays a placeholder");
+
+    let overlay = crate::SeedOverlay::from_json(&serde_json::json!({ "label": "Enclosure" }))
+        .expect("valid overlay");
+    let chosen = quill.seed_card("note", Some(&overlay)).expect("declared kind");
+    assert!(
+        !chosen.payload().is_fill("label"),
+        "an overlay value is a decision, not a placeholder"
+    );
+}

--- a/crates/core/src/quill/compose/must_fill_tests.rs
+++ b/crates/core/src/quill/compose/must_fill_tests.rs
@@ -1,11 +1,9 @@
-//! The obligation axis: `must_fill:` on the schema and the unauthored-cell
-//! predicate that reads it.
+//! The obligation axis: `must_fill:` and the unauthored-cell predicate.
 
 use crate::quill::quill_from_yaml;
 use crate::quill::resolved::FieldSource;
 use crate::{Document, Quill};
 
-/// Every `validation::must_fill` path, with its `trigger` arg, sorted.
 fn obligations(quill: &Quill, md: &str) -> Vec<(String, String)> {
     let doc = Document::parse(md).expect("parse").document;
     let mut out: Vec<(String, String)> = quill
@@ -46,9 +44,6 @@ fn md(fields: &str) -> String {
 fn a_defaultless_field_is_obliged_and_a_defaulted_one_is_not() {
     let quill = quill_from_yaml(SCALARS);
 
-    // Rows (a) and (b): nothing authored. `subject`/`severity` derive the
-    // obligation from having no `default:`; `confirmed` declares it despite
-    // carrying one. `status` (defaulted) and `optional` (opted out) stay quiet.
     assert_eq!(
         paths(&quill, &md("")),
         ["main.confirmed", "main.severity", "main.subject"]
@@ -59,9 +54,6 @@ fn a_defaultless_field_is_obliged_and_a_defaulted_one_is_not() {
 fn authoring_a_value_or_the_blank_discharges_the_obligation() {
     let quill = quill_from_yaml(SCALARS);
 
-    // Row (c): a value. Row (d): the blank literal — the human said "nothing",
-    // which is an answer. An `enum`'s blank is `""`, outside `values:`, which is
-    // what makes the obligation dischargeable for a finite domain at all.
     assert_eq!(
         paths(
             &quill,
@@ -75,9 +67,6 @@ fn authoring_a_value_or_the_blank_discharges_the_obligation() {
 fn null_does_not_discharge_but_the_blank_does() {
     let quill = quill_from_yaml(SCALARS);
 
-    // The one place null and the blank part company. On the value ladder they
-    // are still identical (both blank-fill); on the obligation surface, writing
-    // the blank is an act and clearing the key is not.
     let rest = "severity: low\nconfirmed: draft\n";
     assert_eq!(
         paths(&quill, &md(&format!("subject: null\n{rest}"))),
@@ -109,10 +98,6 @@ fn cn(fields: &str) -> String {
 fn a_typed_dict_is_obliged_at_its_leaves_present_or_absent() {
     let quill = quill_from_yaml(CONTAINERS);
 
-    // A mapping cannot carry `!must_fill` (markdown-spec §3.4) and the blueprint
-    // marks its leaves, so the predicate does too — at the same paths, whether
-    // or not the container is present. No 1-vs-N jump on the first keystroke
-    // into the container, and every path an editor can resolve.
     let absent = paths(&quill, &cn("recipients: []\n"));
     let touched = paths(&quill, &cn("recipients: []\naddress:\n  city: Pittsburgh\n"));
     assert_eq!(absent, ["main.address.city", "main.address.street"]);
@@ -123,9 +108,8 @@ fn a_typed_dict_is_obliged_at_its_leaves_present_or_absent() {
 fn a_touched_container_does_not_silence_its_unauthored_leaves() {
     let quill = quill_from_yaml(CONTAINERS);
 
-    // The reason the predicate keys on cell presence rather than `FieldSource`:
-    // `resolve_value_sourced` reports a present typed dict `Authored` as a
-    // whole, so a source-keyed check would report nothing here.
+    // The source rung is asserted alongside to show what a `FieldSource`-keyed
+    // check would see instead: one authored dict, and no leaf.
     let doc = Document::parse(&cn("address:\n  city: Pittsburgh\n"))
         .expect("parse")
         .document;
@@ -142,14 +126,9 @@ fn a_touched_container_does_not_silence_its_unauthored_leaves() {
 fn an_array_is_one_cell_and_the_empty_array_answers_it() {
     let quill = quill_from_yaml(CONTAINERS);
 
-    // An array *is* its cell: absent, it is one unauthored answer, not N at
-    // indices nobody can point at. `[]` is a real answer — "no recipients" —
-    // so it discharges, exactly as the blank does for a scalar.
     assert!(paths(&quill, &cn("")).contains(&"main.recipients".to_string()));
     assert!(!paths(&quill, &cn("recipients: []\n")).contains(&"main.recipients".to_string()));
 
-    // Present, its elements resolve against the item schema, so a hole in the
-    // list warns at its own index rather than silently blank-filling.
     assert!(paths(&quill, &cn("recipients: [Ada, null]\n"))
         .contains(&"main.recipients[1]".to_string()));
 }
@@ -171,9 +150,6 @@ fn a_card_kind_is_obliged_once_per_instance() {
     let root = "~~~card-yaml\n$quill: cd@1.0.0\n$kind: main\ntitle: T\n~~~\n";
     let card = "\n~~~card-yaml\n$kind: indorsement\n~~~\n";
 
-    // A card kind obliges nothing until the document carries an instance: a
-    // schema cannot demand a card exist. So the count scales with the document,
-    // not with the schema's field total.
     assert!(paths(&quill, root).is_empty());
     assert_eq!(
         paths(&quill, &format!("{root}{card}")),
@@ -192,17 +168,13 @@ fn a_card_kind_is_obliged_once_per_instance() {
 fn the_marker_wins_where_both_triggers_fire() {
     let quill = quill_from_yaml(SCALARS);
 
-    // A bare marker is both: a tag the document carries and a cell nobody
-    // authored. One code, one diagnostic per path, and the marker's hint is the
-    // actionable one ("drop the marker").
     assert_eq!(
         obligations(&quill, &md("subject: !must_fill\nseverity: \"\"\nconfirmed: x\n")),
         [("main.subject".to_string(), "marker".to_string())]
     );
 
-    // A marker riding a suggested value is the case the schema predicate is
-    // structurally blind to: present, in-domain, indistinguishable from
-    // authored content. Only the tag catches it.
+    // Present, in-domain, indistinguishable from authored content: the schema
+    // predicate is structurally blind to this one, so only the tag catches it.
     assert_eq!(
         obligations(&quill, &md("subject: !must_fill Draft\nseverity: low\nconfirmed: x\n")),
         [("main.subject".to_string(), "marker".to_string())]
@@ -213,7 +185,6 @@ fn the_marker_wins_where_both_triggers_fire() {
 fn a_hand_written_tag_fires_on_an_unobliged_field() {
     let quill = quill_from_yaml(SCALARS);
 
-    // The tag is document-sovereign: it does not consult `must_fill:`.
     assert_eq!(
         obligations(
             &quill,
@@ -228,30 +199,23 @@ fn an_unauthored_obligation_never_gates_render() {
     let quill = quill_from_yaml(SCALARS);
     let doc = Document::parse(&md("")).expect("parse").document;
 
-    // The whole point of the axis: obligation is a warning, not a gate. The
-    // predicate lives beside `validate_fills` on the editor surface, never in
-    // `validate_document`, whose non-empty error list becomes a `RenderError`.
     assert_eq!(paths(&quill, &md("")).len(), 3, "the document is incomplete");
     let plate = quill.compile_data(&doc).expect("and renders anyway");
     assert_eq!(plate["subject"], "", "the unauthored cell blank-fills");
 }
 
-#[test]
-fn a_fresh_seed_and_a_blank_document_report_the_same_cells() {
-    // Rule 8's claim, made checkable: seeding stamps every example it commits on
-    // a must-fill field, so the blueprint's filled-out twin reads as incomplete
-    // in exactly the cells a hand-written document does. The triggers differ;
-    // the cell set does not.
-    let quill = quill_from_yaml(
-        r#"
+const SEEDED: &str = r#"
 quill: { name: sd, version: 1.0.0, backend: typst, description: seed }
 main:
   fields:
     subject:  { type: string, example: Q3 results }
     memo_for: { type: array, items: { type: string }, example: [Ada] }
     status:   { type: string, default: draft, example: final }
-"#,
-    );
+"#;
+
+#[test]
+fn a_fresh_seed_and_a_blank_document_report_the_same_cells() {
+    let quill = quill_from_yaml(SEEDED);
 
     let seeded = quill.seed_document();
     let mut from_seed: Vec<(String, String)> = quill
@@ -268,16 +232,7 @@ main:
     from_seed.sort();
 
     let blank = obligations(
-        &quill_from_yaml(
-            r#"
-quill: { name: sd, version: 1.0.0, backend: typst, description: seed }
-main:
-  fields:
-    subject:  { type: string, example: Q3 results }
-    memo_for: { type: array, items: { type: string }, example: [Ada] }
-    status:   { type: string, default: draft, example: final }
-"#,
-        ),
+        &quill_from_yaml(SEEDED),
         "~~~card-yaml\n$quill: sd@1.0.0\n$kind: main\n~~~\n",
     );
 
@@ -302,8 +257,6 @@ main:
 
 #[test]
 fn a_seed_overlay_value_commits_unmarked() {
-    // `$seed` is a template author deciding, which is the act the marker asks
-    // for; an `example` is documentation of shape and is not.
     let quill = quill_from_yaml(
         r#"
 quill: { name: ov, version: 1.0.0, backend: typst, description: overlay }

--- a/crates/core/src/quill/conform/tests.rs
+++ b/crates/core/src/quill/conform/tests.rs
@@ -278,12 +278,9 @@ fn conform_is_a_no_op_on_seeds() {
 #[test]
 fn a_fill_tag_on_a_seeded_cell_survives_store_load_conform() {
     let quill = quill();
-    let mut doc = quill.seed_document();
-
-    for key in ["subject", "note"] {
-        let seeded = doc.main().payload().get(key).expect("seeded").clone();
-        doc.main_mut().store_fill(key, seeded).unwrap();
-    }
+    let doc = quill.seed_document();
+    // Seeding stamps them: an `example` on a must-fill field is shape
+    // documentation, not the answer.
     let tagged = bytes(&doc);
 
     let mut loaded = Document::try_from(
@@ -308,8 +305,23 @@ fn a_fill_tag_on_a_seeded_cell_survives_store_load_conform() {
         "and the tagged richtext cell keeps its canonical content object"
     );
 
-    let untagged = bytes(&quill.seed_document());
+    // The flag rides the payload item; nothing recomputes it from the schema at
+    // load. Dropped from a document whose schema still says must-fill, it stays
+    // dropped — the document is sovereign over its own markers.
+    let mut cleared = quill.seed_document();
+    for key in ["subject", "note"] {
+        let seeded = cleared.main().payload().get(key).expect("seeded").clone();
+        cleared.main_mut().store_field(key, seeded).unwrap();
+    }
+    let untagged = bytes(&cleared);
     assert_ne!(tagged, untagged, "the tag is stored, not inferred");
+
+    let mut reloaded = Document::try_from(
+        serde_json::from_str::<StoredDocument>(&untagged).expect("the untagged seed loads"),
+    )
+    .expect("and converts to a document");
+    quill.conform(&mut reloaded).expect("the quill matches");
+    assert_eq!(bytes(&reloaded), untagged, "and no cycle re-stamps it");
 }
 
 #[test]

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -27,6 +27,15 @@ pub const QUILLMARK_PLAIN_KEY: &str = "quillmark:plain";
 /// conventional label.
 pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 
+/// Transform-schema keyword carrying whether a human must author the field
+/// ([`FieldSchema::must_fill`](crate::quill::FieldSchema::must_fill)). Emitted
+/// on every field, always resolved: the obligation is not derivable from this
+/// projection, which carries no `default:`.
+///
+/// It is an authoring affordance, not a submit gate. An unfilled field renders,
+/// and enforcement — if a consumer wants any — is that consumer's policy.
+pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
+
 /// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
 ///
 /// The descriptor marks richtext fields with `contentMediaType:
@@ -42,6 +51,14 @@ pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     fn field_to_schema(field: &FieldSchema) -> serde_json::Value {
         let mut schema = serde_json::Map::new();
+        // In the prelude, not a type arm: the enum arm returns early below, and
+        // an enum is the type an obligation matters most for. The *derived*
+        // answer crosses, not the raw `Option` — a consumer reading this
+        // projection should never have to re-run the `default:` derivation.
+        schema.insert(
+            QUILLMARK_MUST_FILL_KEY.to_string(),
+            serde_json::Value::Bool(field.must_fill()),
+        );
         // A finite domain projects to the idiomatic JSON-Schema spelling
         // `{type: string, enum: [...]}`: exactly what a backend dispatches on
         // today (a plain string), plus the domain. Keyed on the domain, as the
@@ -249,6 +266,34 @@ mod tests {
     }
 
     #[test]
+    fn must_fill_is_resolved_and_reaches_every_type() {
+        let yaml = r#"
+quill:
+  name: x
+  version: 1.0.0
+  backend: typst
+  description: x
+main:
+  fields:
+    severity:   { type: enum, values: [low, high] }
+    status:     { type: string, default: draft }
+    confirmed:  { type: string, default: draft, must_fill: true }
+    optional:   { type: string, must_fill: false }
+"#;
+        let json = build_from_yaml(yaml).as_json().clone();
+        let flag = |name: &str| json["properties"][name][QUILLMARK_MUST_FILL_KEY].clone();
+
+        // The enum arm returns before the type match, so a key placed in a type
+        // arm would miss the one type an obligation matters most for.
+        assert_eq!(flag("severity"), serde_json::json!(true));
+        // Derived, not raw: a consumer reading this projection sees no
+        // `default:` and so cannot re-run the derivation itself.
+        assert_eq!(flag("status"), serde_json::json!(false));
+        assert_eq!(flag("confirmed"), serde_json::json!(true));
+        assert_eq!(flag("optional"), serde_json::json!(false));
+    }
+
+    #[test]
     fn enum_carries_its_domain_at_every_depth() {
         let yaml = r#"
 quill:
@@ -274,13 +319,21 @@ main:
         let json = schema.as_json();
         // The blank leads the domain: the projection describes what is
         // wire-valid, and every enum accepts its blank.
-        let domain = serde_json::json!({ "type": "string", "enum": ["", "UNCLASSIFIED", "CUI"] });
+        let domain = serde_json::json!({
+            "type": "string",
+            "enum": ["", "UNCLASSIFIED", "CUI"],
+            QUILLMARK_MUST_FILL_KEY: true,
+        });
         assert_eq!(json["properties"]["classification"], domain);
         // The domain survives the recursion into an array's element object: a
         // consumer building a validator sees it, blank and all, at the leaf too.
         assert_eq!(
             json["properties"]["endorsements"]["items"]["properties"]["action"],
-            serde_json::json!({ "type": "string", "enum": ["", "approve", "disapprove"] })
+            serde_json::json!({
+                "type": "string",
+                "enum": ["", "approve", "disapprove"],
+                QUILLMARK_MUST_FILL_KEY: true,
+            })
         );
     }
 

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -1,12 +1,14 @@
 //! Document seeding from a quill schema: commit each field's `example` and
 //! leave every other field absent, so the render layer still supplies
-//! `default`/zero and the absence-based completeness signal survives.
+//! `default`/blank. A committed `example` on a must-fill field carries the
+//! `!must_fill` marker, so seeding and the blueprint stamp the same cells and a
+//! fresh seed reads as incomplete exactly where a blank document does.
 
-use indexmap::IndexMap;
 use quillmark_content::Content;
 
 use super::Quill;
 use crate::quill::CardSchema;
+use crate::document::PayloadItem;
 use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 
 /// Build the seeded `(payload, body)` for one card schema, layering an optional
@@ -35,15 +37,26 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     // `example`, and the overlay overrides either (and can supply a value for a
     // `default`-only field the base omits). An overlay key naming no schema
     // field is skipped: it is never iterated here.
-    let mut fields: IndexMap<String, QuillValue> = IndexMap::new();
+    let mut items: Vec<PayloadItem> = Vec::new();
     for (name, field) in &schema.fields {
-        let value = overlay
-            .and_then(|o| o.fields.get(name))
+        let overlaid = overlay.and_then(|o| o.fields.get(name));
+        let Some(value) = overlaid
             .or(field.example_content.as_ref())
-            .or(field.example.as_ref());
-        if let Some(value) = value {
-            fields.insert(name.clone(), seeded_rest(name, value, field));
-        }
+            .or(field.example.as_ref())
+        else {
+            continue;
+        };
+        items.push(PayloadItem::Field {
+            key: name.clone(),
+            value: seeded_rest(name, value, field),
+            // An `example` on a must-fill field is shape documentation, not the
+            // answer, so it commits *carrying the marker*: a seeded cell that
+            // read as done was the one hole between the blueprint and its
+            // filled-out twin. An overlay value is exempt — `$seed` is a
+            // template author deciding, which is the act the marker asks for.
+            fill: overlaid.is_none() && field.must_fill(),
+            nested_comments: Vec::new(),
+        });
     }
 
     // Body region as a content: an overlay body (authored markdown) is imported;
@@ -65,7 +78,7 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
         Content::empty()
     };
 
-    (Payload::from_index_map(fields), body)
+    (Payload::from_items(items), body)
 }
 
 /// The form a seeded value commits at: the strict write's, for a field whose

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -49,11 +49,11 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
         items.push(PayloadItem::Field {
             key: name.clone(),
             value: seeded_rest(name, value, field),
-            // An `example` on a must-fill field is shape documentation, not the
-            // answer, so it commits *carrying the marker*: a seeded cell that
-            // read as done was the one hole between the blueprint and its
-            // filled-out twin. An overlay value is exempt — `$seed` is a
-            // template author deciding, which is the act the marker asks for.
+            // An `example` on a must-fill field is shape documentation, not
+            // the answer, so it commits *carrying the marker*: that is what
+            // lands a seed on the same cells the blueprint stamps. An overlay
+            // value is exempt — `$seed` is a template author deciding, which is
+            // the act the marker asks for.
             fill: overlaid.is_none() && field.must_fill(),
             nested_comments: Vec::new(),
         });

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -454,12 +454,15 @@ impl<'de> Deserialize<'de> for FieldType {
 /// omitted), while `example` matches the desired type and shape but is not
 /// the value most authors want (it documents shape only, never rendering).
 ///
-/// A field's *cell* is determined by `default`: a field with a `default:`
-/// is **Endorsed** (the rendered value is shippable as-is), while a field
-/// without a `default:` is **Unendorsed** (the author endorsed no value, so
-/// the blueprint carries a `!must_fill` placeholder to ask for one). Absence is
-/// not a requirement: a missing or null Unendorsed field zero-fills at
-/// render. A surviving `!must_fill` placeholder is surfaced as the non-fatal
+/// A field carries two independent axes. The **value** axis is `default:` ›
+/// `example:` › the field's [`blank`](crate::quill::blank), and decides what a
+/// cell holds. The **obligation** axis is [`must_fill()`](Self::must_fill), and
+/// decides whether a human must author it. Neither implies the other: a
+/// `default:` can still demand confirmation (`must_fill: true`), and a field
+/// with nothing to suggest can be genuinely optional (`must_fill: false`).
+///
+/// Obligation is a warning, never a gate: an unauthored must-fill field
+/// blank-fills and renders, and the only signal is the non-fatal
 /// `validation::must_fill` warning. There is no separate `required:` axis.
 ///
 /// The richtext single-line constraint has **one** carrier: the
@@ -485,6 +488,10 @@ pub struct FieldSchema {
     /// A value matching the desired type and shape but not the value most
     /// authors want; documents shape only and never renders as the value.
     pub example: Option<QuillValue>,
+    /// Whether a human must author this cell. Read through
+    /// [`must_fill()`](Self::must_fill), never directly: `None` derives from
+    /// `default`.
+    pub must_fill: Option<bool>,
     pub ui: Option<UiFieldSchema>,
     /// Restricts valid values on string fields. Serializes as `enum`.
     pub enum_values: Option<Vec<String>>,
@@ -518,6 +525,7 @@ struct FieldSchemaDef {
     pub description: Option<String>,
     pub default: Option<QuillValue>,
     pub example: Option<QuillValue>,
+    pub must_fill: Option<bool>,
     pub ui: Option<UiFieldSchema>,
     /// The retired `enum:` modifier, parsed only to reject it by name: under
     /// `deny_unknown_fields` an absent binding reports "unknown field `enum`"
@@ -542,6 +550,7 @@ impl FieldSchema {
             description,
             default: None,
             example: None,
+            must_fill: None,
             ui: None,
             enum_values: None,
             properties: None,
@@ -549,6 +558,20 @@ impl FieldSchema {
             default_content: None,
             example_content: None,
         }
+    }
+
+    /// Whether a human must author this cell, deriving from `default:` when
+    /// `must_fill:` is unset: a field the quill author endorsed no value for
+    /// asks for one, a defaulted field does not. The derivation is keyed on
+    /// `default`'s *presence*, so a `default: ""` stays a skippable cell rather
+    /// than becoming a marker.
+    ///
+    /// Read this rather than the raw [`must_fill`](Self::must_fill) field: the
+    /// blueprint's marker, the seeding stamp, the `Quill::validate` predicate,
+    /// and the transform schema's `quillmark:must_fill` are one answer, and it
+    /// is this one.
+    pub fn must_fill(&self) -> bool {
+        self.must_fill.unwrap_or(self.default.is_none())
     }
 
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
@@ -567,6 +590,7 @@ impl FieldSchema {
             description: def.description,
             default: def.default,
             example: def.example,
+            must_fill: def.must_fill,
             ui: def.ui,
             enum_values,
             properties: if let Some(props) = def.properties {
@@ -670,6 +694,7 @@ impl Serialize for FieldSchema {
             + self.description.is_some() as usize
             + self.default.is_some() as usize
             + self.example.is_some() as usize
+            + self.must_fill.is_some() as usize
             + self.ui.is_some() as usize
             + self.enum_values.is_some() as usize
             + self.properties.is_some() as usize
@@ -687,6 +712,12 @@ impl Serialize for FieldSchema {
         }
         if let Some(v) = &self.example {
             map.serialize_entry("example", v)?;
+        }
+        // The raw `Option`, not the derived answer: the schema wire is what the
+        // author wrote, and re-emitting the derivation would pin every field's
+        // obligation the first time a quill round-tripped through it.
+        if let Some(v) = &self.must_fill {
+            map.serialize_entry("must_fill", v)?;
         }
         if let Some(v) = &self.ui {
             map.serialize_entry("ui", v)?;

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -483,7 +483,7 @@ pub struct FieldSchema {
     pub r#type: FieldType,
     pub description: Option<String>,
     /// The value most authors want; interpolated when the field is omitted.
-    /// Its presence makes the field Endorsed.
+    /// Its presence is what an unset `must_fill:` derives from.
     pub default: Option<QuillValue>,
     /// A value matching the desired type and shape but not the value most
     /// authors want; documents shape only and never renders as the value.

--- a/docs/integration/error-handling.md
+++ b/docs/integration/error-handling.md
@@ -58,7 +58,7 @@ Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed
 Fatality is a two-value ladder: `Error` blocks the stage that emits it; `Warning` never does. There is no lint-level configuration and no warning-to-error promotion. Warnings ride the same `Diagnostic` currency on non-fatal channels:
 
 - **Parse warnings** (e.g. a `~~~` opener missing its blank line) carried on the parsed document (`doc.warnings`) and spliced into a render's warnings.
-- **Validation warnings**: `quill.validate(doc)` returns every diagnostic; `validation::must_fill` (an outstanding `!must_fill` marker) and the `$seed` checks are the non-fatal ones. The render path never gates on incompleteness: an absent field blank-fills.
+- **Validation warnings**: `quill.validate(doc)` returns every diagnostic; `validation::must_fill` and the `$seed` checks are the non-fatal ones. `validation::must_fill` fires on two triggers, named by its `trigger` arg: `marker`, an outstanding `!must_fill` tag in the document, and `unauthored`, a cell the schema obliges (`must_fill:`) that nobody has authored. At most one per path; the marker wins where both apply. The render path never gates on either: an absent field blank-fills.
 - **Compile warnings**: a backend's non-fatal diagnostics (font fallback, overfull pages), carried on `result.warnings`.
 
 A successful render returns artifacts **and** a `warnings` list, so inspect it even on success.

--- a/docs/quills/blueprint.md
+++ b/docs/quills/blueprint.md
@@ -24,7 +24,7 @@ Write main body here.
 
 Two annotation slots, disjoint by purpose: **leading `# …` lines** carry prose (a description, an `# e.g.` example); the **inline `# …`** at the end of a value line carries structure, the field's `# <type>[<format>]`.
 
-The reader's one rule: a **`!must_fill`** marker present → replace it before shipping; a concrete value present → shippable as-is. A field with a `default:` is **Endorsed** and renders that default (keep or override); a field without one is **Unendorsed** and carries the marker, its value the field's `example:` when present (a suggested value), else bare. A surviving marker never blocks render: it raises only the non-fatal `validation::must_fill` warning; a strict consumer (an LLM authoring loop) treats any outstanding marker as "not done."
+The reader's one rule: a **`!must_fill`** marker present → replace it before shipping; a concrete value present → shippable as-is. The cell's *value* is `default:` › `example:` › bare; the *marker* is the field's `must_fill:`, which defaults to "obliged unless a `default:` says otherwise". The two are independent, so a cell can carry a concrete default **and** a marker asking a human to confirm it. A surviving marker never blocks render: it raises only the non-fatal `validation::must_fill` warning; a strict consumer (an LLM authoring loop) treats any outstanding marker as "not done."
 
 ## Seeding: the filled-out twin
 

--- a/docs/quills/creating-quills.md
+++ b/docs/quills/creating-quills.md
@@ -41,7 +41,7 @@ main:
 
 `name`, `backend`, `version`, and `description` are all required. `name` must be `snake_case`. Define your document's expected root-block fields under `main.fields`. Each field has a `type`, optional `default`, `description`, and validation constraints. Use `integer` for whole numbers only and `number` for values that may include decimals. For the full list of field types, UI hints, typed arrays, and enum constraints, see the [Quill.yaml Reference](quill-yaml-reference.md).
 
-Use `default` for the value most authors will accept as-is (the field becomes optional, filled in when omitted). Use `example` to document the expected shape without supplying a default. Fields with neither are flagged in the blueprint with a `!must_fill` marker. See the [Quill.yaml Reference](quill-yaml-reference.md) for details.
+Use `default` for the value most authors will accept as-is (filled in when the field is omitted). Use `example` to document the expected shape without supplying a default. A field with neither is one nobody has answered: the blueprint flags it with a `!must_fill` marker and `Quill::validate` warns while it stays unauthored. Set `must_fill:` explicitly where you want a default a human must still confirm, or an optional field with nothing to suggest — it is a warning either way, never a gate. See the [Quill.yaml Reference](quill-yaml-reference.md#obligation-must_fill) for details.
 
 ### Picking a text type
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -84,13 +84,57 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | matches `type`    | no       | The value the **majority of authors want**. When the field is omitted, the default is filled in. **Declaring `default` makes the field Endorsed**: the blueprint renders the concrete default value with a type-only annotation (no marker), shippable as-is. Omitting `default` makes the field **Unendorsed**: the blueprint stamps the `!must_fill` marker (carrying the field's `example` as a suggested value when present, else bare). A surviving marker raises the non-fatal `validation::must_fill` warning: it never gates render, since an absent or present-null field blank-fills. |
-| `example`     | matches `type`    | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only: surfaced in the [blueprint](https://github.com/borb-sh/quillmark/blob/main/prose/canon/BLUEPRINT.md)'s `# e.g.` line for documentation and LLM authoring, never rendered as the value. |
+| `default`     | matches `type`    | no       | The value the **majority of authors want**. When the field is omitted, the default is filled in, and the blueprint renders that concrete value with a type-only annotation, shippable as-is. Declaring it also flips the derived `must_fill` to `false` (see below). |
+| `example`     | matches `type`    | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only, never rendered as the value: it takes the blueprint cell when no `default` holds it, and surfaces in the `# e.g.` line otherwise. |
+| `must_fill`   | boolean           | no       | Whether a human must author this cell (see [Obligation: `must_fill`](#obligation-must_fill)). Defaults to `!default.is_some()`. |
 | `values`      | array of strings  | for `enum` | The closed set of allowed string values: the **choices**. Required on every `enum` field. Declaring `""` is a load error — every enum also accepts its [blank](#the-blank-values-is-for-choices-not-for-the-absence-of-one), which the engine supplies. |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
 | `items`       | object            | for `array` | Element schema for an `array` field (a nested field schema). Required on every array. |
 | `properties`  | object            | for `object` | Nested field schemas for an `object` typed dictionary (or an array's `object`-typed `items`). Required on every `object` field. |
 | `inline`      | boolean           | no       | For `richtext` and `plaintext` only: constrain the content to a single paragraph/line (a one-line editor surface). |
+
+### Obligation: `must_fill`
+
+A field says two separate things. `default` and `example` say **what a cell
+holds**; `must_fill` says **whether a human must author it**. Leave it out and
+it derives from `default` — a defaulted field is not obliged, a defaultless one
+is — which is what every quill written before the key already means.
+
+Write it when you want a combination the derivation cannot reach:
+
+```yaml
+# A safe value renders, and a human must still confirm it.
+classification:
+  type: enum
+  values: [UNCLASSIFIED, CUI]
+  default: UNCLASSIFIED
+  must_fill: true
+
+# Genuinely optional, with nothing to suggest.
+internal_note:
+  type: string
+  must_fill: false
+```
+
+An obliged field is one that carries the `!must_fill` marker in the blueprint,
+is stamped when seeding commits its `example`, and raises the non-fatal
+`validation::must_fill` warning from `Quill::validate` while the document leaves
+it unauthored. Three things discharge it: authoring a value, authoring the
+field's [blank](#the-blank-values-is-for-choices-not-for-the-absence-of-one)
+(deliberately nothing is an answer), or dropping the marker by hand.
+
+**It is an affordance, not a submit gate.** If you arrive from web forms, the
+familiar half transfers — the editor knows which fields to mark — and the
+enforcement half does not. An unfilled must-fill field **renders**; nothing
+refuses it. "Must pick" is this warning plus whatever policy a consumer layers
+on top, canonically *a strict consumer treats any outstanding marker as not
+done*. There is deliberately no `required:` and no severity knob: on this
+surface `Severity::Error` already means "won't render".
+
+On a **typed dictionary** the key is inert on the container — the obligation
+lives on its leaves, which is where the blueprint marks and the warning
+anchors. An **array** is its own cell, so `[]` is an authored answer that
+discharges it.
 
 ### Field Types
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -97,8 +97,8 @@ main:
 
 A field says two separate things. `default` and `example` say **what a cell
 holds**; `must_fill` says **whether a human must author it**. Leave it out and
-it derives from `default` — a defaulted field is not obliged, a defaultless one
-is — which is what every quill written before the key already means.
+it derives from `default`: a defaulted field is not obliged, a defaultless one
+is.
 
 Write it when you want a combination the derivation cannot reach:
 
@@ -128,8 +128,8 @@ familiar half transfers — the editor knows which fields to mark — and the
 enforcement half does not. An unfilled must-fill field **renders**; nothing
 refuses it. "Must pick" is this warning plus whatever policy a consumer layers
 on top, canonically *a strict consumer treats any outstanding marker as not
-done*. There is deliberately no `required:` and no severity knob: on this
-surface `Severity::Error` already means "won't render".
+done*. There is no `required:` and no severity knob: on this surface
+`Severity::Error` already means "won't render".
 
 On a **typed dictionary** the key is inert on the container — the obligation
 lives on its leaves, which is where the blueprint marks and the warning

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -24,7 +24,7 @@ $kind: main
 # <field description>
 field: !must_fill # <type>
   - <example item>
-endorsed: value # <type>[<format>]
+settled: value # <type>[<format>]
 ~~~
 
 Write main body here.
@@ -81,15 +81,14 @@ Per field, in order:
 1. `# <description>`: `description:` from `Quill.yaml`,
    whitespace-collapsed. **Single line only**; multi-line descriptions are
    rejected at `Quill.yaml` parse time.
-2. `# e.g. <value>`: emitted on an **Endorsed** field whenever `example:`
-   is configured. Independent of type. On an Endorsed field the example
-   never becomes the rendered value, so it surfaces as a hint. On an
-   **Unendorsed** field there is normally no `# e.g.` line: the example inlines
-   directly as the `!must_fill` marker's suggested value (see "Placeholder
-   value precedence"), so a separate hint would be redundant. The one exception
-   is `richtext`, which never inlines its example as the value: an Unendorsed
-   richtext field with an `example:` therefore keeps the `# e.g.` line (see
-   "Richtext fields").
+2. `# e.g. <value>`: emitted whenever `example:` is configured **and a
+   `default:` already holds the cell**. Independent of type. There the example
+   never becomes the rendered value, so it surfaces as a hint; where no
+   `default:` holds the cell the example inlines *as* the value (see
+   "Placeholder value precedence") and a separate hint would be redundant. The
+   one exception is `richtext`, which never inlines its example as the value: a
+   defaultless richtext field with an `example:` therefore keeps the `# e.g.`
+   line (see "Richtext fields").
 
 That's it. There is no leading `# required`, `# enum:`, `# default:`, or
 `# type:`: those collapse into the inline.
@@ -119,13 +118,10 @@ Form: **`# <type>[<format>]`**
     (nothing meaningful to refine).
 
 The inline annotation is **purely structural**: it carries the type (and
-optional format), nothing else. Shippability is conveyed by the **value cell**,
-not by the annotation: an Endorsed field (one with a `default:`) renders its
-concrete default value, which is shippable as-is: keep or override; an
-Unendorsed field (no `default:`) carries the `!must_fill` marker on its value
-instead. The reader's single rule is: a `!must_fill` marker present → fill it;
-a concrete value present → shippable as-is (delete or blank the line to fall
-back to the default).
+optional format), nothing else. What a reader must *do* is carried by the cell:
+a `!must_fill` marker asks for a value, and its absence says the cell is
+shippable as-is (delete or blank the line to fall back to the default). The two
+can co-occur — a marked cell may still carry a concrete value to review.
 
 The `$`-prefixed system-metadata keys (`$quill`, `$kind`, …) carry no
 inline type annotation: they are not user-defined data fields, so there
@@ -152,16 +148,18 @@ Examples:
 
 | Line | Reading |
 |---|---|
-| `name: !must_fill # string` | Unendorsed string, no example: bare marker, replace before shipping |
-| `name: !must_fill Jane Doe # string` | Unendorsed string with an `example`: the example is the suggested value, still marked |
-| `title: "Curriculum Vitae" # string` | Endorsed string: concrete value, shippable as-is (keep or override) |
-| `count: 0 # integer` | Endorsed integer (type-empty default, shippable as-is) |
-| `active: false # boolean` | Endorsed boolean (type-empty default, shippable as-is) |
-| `notes: "" # string` | Endorsed empty string (the "skippable" cell) |
-| `bio: !must_fill # richtext<markdown>` | Unendorsed richtext: bare marker (see "Richtext fields") |
-| `recipient: !must_fill # array<string>` | Unendorsed array of strings |
-| `date: !must_fill # date<YYYY-MM-DD>` | Unendorsed date |
-| `severity: !must_fill # enum<low \| medium \| high>` | Unendorsed enum |
+| `name: !must_fill # string` | must-fill string, no example: bare marker, replace before shipping |
+| `name: !must_fill Jane Doe # string` | must-fill string with an `example`: the example is the suggested value, still marked |
+| `title: "Curriculum Vitae" # string` | defaulted string: concrete value, shippable as-is (keep or override) |
+| `count: 0 # integer` | defaulted integer (type-empty default, shippable as-is) |
+| `active: false # boolean` | defaulted boolean (type-empty default, shippable as-is) |
+| `notes: "" # string` | defaulted empty string (the "skippable" cell) |
+| `classification: !must_fill UNCLASSIFIED # enum<UNCLASSIFIED \| CUI>` | a default **and** `must_fill: true`: renders safely, still asks a human to confirm |
+| `note: null # string` | `must_fill: false` with nothing to suggest: explicitly optional, nothing to say |
+| `bio: !must_fill # richtext<markdown>` | must-fill richtext: bare marker (see "Richtext fields") |
+| `recipient: !must_fill # array<string>` | must-fill array of strings |
+| `date: !must_fill # date<YYYY-MM-DD>` | must-fill date |
+| `severity: !must_fill # enum<low \| medium \| high>` | must-fill enum |
 | `$quill: cmu_letter@0.1.0 # keep verbatim` | quill binding metadata, emitted verbatim; the inline reminder guards against dropping the line |
 | `$kind: skill` followed by `# composable (0..N)` | repeat the entire `~~~` … `~~~` block per instance |
 
@@ -172,33 +170,36 @@ what data the cell carries; the *marker axis* decides whether the cell is
 stamped `!must_fill`. They are independent: the marker never changes the
 value, and the value never implies the marker.
 
+**Value** is `default:` › `example:` › bare (null for scalars, empty for a
+container). **Marker** is the field's derived `must_fill` (`SCHEMAS.md` § "The
+two axes"). Reading them off separately gives the full grid:
+
 | Field state | Value rendered | Marker |
 |---|---|---|
-| Has `default` (Endorsed) | the default | none |
-| No `default`, no `example` (Unendorsed) | none (bare null/empty) | `!must_fill` |
-| No `default`, has `example` (Unendorsed) | the `example` | `!must_fill` |
+| `default` | the default | none |
+| `default` + `must_fill: true` | the default | `!must_fill` |
+| no `default`, has `example` | the `example` | `!must_fill` |
+| no `default`, no `example` | bare null/empty | `!must_fill` |
+| no `default`, `must_fill: false` | the `example` else bare null | none |
 
-So an Unendorsed field is always stamped `!must_fill`; its *value* is the
-field's `example` when one exists (a reviewable suggested value), else bare
-(null for scalars, empty for the marked container). An Endorsed field renders
-its default with **no marker**: the concrete value cell is the shippability
-signal on its own.
-
-An `example` on an **Endorsed** field never becomes the rendered value: it
-surfaces in the `# e.g.` leading line instead. Only **Unendorsed** fields
-inline the example as the marker's suggested value. This holds uniformly for
-scalars, arrays, typed tables, and typed dictionaries: **except `richtext`**,
-which never inlines its example as a value in either endorsement state; its
-`example:` always surfaces as the `# e.g.` line (see "Richtext fields").
+An `example` takes the cell only when no `default:` holds it, and surfaces in
+the `# e.g.` leading line otherwise. That gate is a *value*-axis question:
+`must_fill` never moves an example between the cell and the hint. The rule holds
+uniformly for scalars, arrays, typed tables, and typed dictionaries: **except
+`richtext`**, which never inlines its example as a value at all; its `example:`
+always surfaces as the `# e.g.` line (see "Richtext fields").
 
 All fields render as **live YAML**: no commented-out fields. The `!must_fill`
-marker is the sole "must fill" signal: a reader's mental model is one rule,
-**`!must_fill` on a field → replace before shipping; otherwise the value cell
-is shippable as-is**. A marked document still renders (the cell blank-fills, or
-uses its suggested value); the marker only drives the non-fatal
+marker is the sole "must fill" signal on this surface: a reader's mental model
+is one rule, **`!must_fill` on a field → replace before shipping; otherwise the
+value cell is shippable as-is**. A marked document still renders (the cell
+blank-fills, or uses its suggested value); the marker only drives the non-fatal
 `validation::must_fill` warning (see "Guarantees").
 
-The marker is stamped where the LLM types the value:
+The marker is stamped where the LLM types the value. This table is also the
+**cell set the `unauthored` trigger addresses**: the schema-side predicate warns
+at exactly these paths, so the blueprint and a document that never saw one
+speak about the same cells (`SCHEMAS.md` § "Native validation").
 
 | Type | Marker position | Example |
 |---|---|---|
@@ -214,7 +215,7 @@ A richtext field's value cell is markdown: the surface projection of the
 content model, which `to_markdown` re-emits: carried under a `# richtext<markdown>`
 annotation.
 
-An **Unendorsed** `richtext` field renders as a bare marker on the field:
+A defaultless `richtext` field renders as a bare marker on the field:
 no block scalar:
 
 ```
@@ -233,7 +234,7 @@ from real content). Instead the `example:` surfaces as a `# e.g.` leading hint:
 bio: !must_fill # richtext<markdown>
 ```
 
-When a `default:` is configured, the field is **Endorsed** and renders its
+When a `default:` is configured, the field renders its
 default as an **inline double-quoted scalar** with `\n` escapes: the canonical
 `to_markdown` string form (no `|`/`>` block scalars):
 
@@ -246,7 +247,7 @@ If the default is empty (`default: ""`), the cell is the inline empty string
 
 ### Multi-element example arrays
 
-The `example` of an Unendorsed array field rides the `!must_fill` marker as a
+The `example` of a defaultless array field rides the `!must_fill` marker as a
 **block-style sequence**: the canonical `to_markdown` form at every nesting
 level:
 
@@ -273,15 +274,15 @@ fallback; authors needing these characters must reshape their values.
 ## Typed tables
 
 A field of `type: array` with a `properties` map follows the uniform
-cell cascade: `default:` (any default, including `[]`) is Endorsed and
-shippable as-is; no `default:` is Unendorsed:
+cell cascade: `default:` (any default, including `[]`) is shippable as-is;
+without one:
 
 - A non-empty `default:` renders as actual rows (no per-property
   annotations on each row). The outer key carries `# array<object>`.
 - `default: []` renders inline as `[]` with `# array<object>`:
   shippable empty. Inline row shape is not surfaced under an empty
   default; use `example:` to document row shape.
-- No `default:` is Unendorsed: one synthetic row is emitted with each
+- Without a `default:`, one synthetic row is emitted with each
   property carrying its own description, inline annotation, and the
   `!must_fill` marker on its leaf value. The container key itself is
   untagged: you tag the leaves, not the container (per
@@ -295,8 +296,8 @@ sequence, e.g. `# e.g. [{org: ACME, year: 2020}]`.
 ## Typed dictionaries
 
 A field of `type: object` with a `properties` map follows the uniform
-cell cascade: `default:` (any default, including `{}`) is Endorsed and
-shippable as-is; no `default:` is Unendorsed:
+cell cascade: `default:` (any default, including `{}`) is shippable as-is;
+without one:
 
 - A non-empty `default:` renders as a concrete block mapping (property
   values only, no annotations). Only the keys present in the default are
@@ -304,10 +305,10 @@ shippable as-is; no `default:` is Unendorsed:
   rest" signal and is rendered verbatim. The outer key carries `# object`.
 - `default: {}` **expands** to the field's blank-filled shape: every property
   shown with its type-empty value (`""`, `0`, `false`, `[]`, …), all
-  unmarked and unannotated (uniform with a concrete default, since the
-  container is Endorsed). The bare `{}` is never emitted: an empty endorsed
-  object shows its structure. The outer key carries `# object`.
-- No `default:` is Unendorsed: each property is emitted with its own
+  unmarked and unannotated (uniform with a concrete default, the container
+  being defaulted either way). The bare `{}` is never emitted: an empty
+  defaulted object shows its structure. The outer key carries `# object`.
+- Without a `default:`, each property is emitted with its own
   description, inline annotation, and the `!must_fill` marker on its leaf
   value. The container key itself is untagged: you tag the leaves, not the
   container (per [markdown-spec.md](../references/markdown-spec.md) §3.4).
@@ -417,8 +418,8 @@ Write main body here.
 `blueprint()` guarantees the emitted document is **parseable** *and*
 **renders**: every field key is present, every value is YAML-valid, the
 document round-trips through `Document::parse` and back, and every
-cell is type-valid. Endorsed cells coerce and validate against their default;
-Unendorsed cells carry the `!must_fill` marker on a value that is either the
+cell is type-valid. A defaulted cell coerces and validates against its default;
+a defaultless cell carries the `!must_fill` marker on a value that is either the
 field's `example` (a real, type-valid suggested value) or bare null/empty:
 and because **null ≡ absent** (a present-null cell blank-fills at render, just
 like an omitted field), even a bare-marked cell renders cleanly. A surviving
@@ -452,7 +453,7 @@ degrades gracefully on every type-valid input shape. The contract requires:
   render every declared key is always present, so its `default:` is dead code
   and the blank flows through. Where a package asserts membership, that is a
   failed compile rather than a quiet mis-render.
-- No template asserts that an Unendorsed field is *non-empty*. The schema
+- No template asserts that a must-fill field is *non-empty*. The schema
   guarantees *presence*, not non-emptiness; the `!must_fill` marker
   is an authoring signal, not a render-time precondition.
 - "Renders successfully" means "compiles without error," not "produces
@@ -474,7 +475,7 @@ content, not prose.
 
 | Projection | Intent | Value precedence | Output | Markers? |
 |---|---|---|---|---|
-| `blueprint` | *"give me the form to fill"* | Endorsed: `default:`; Unendorsed: `example:` else bare | annotated string | yes (`!must_fill`) |
+| `blueprint` | *"give me the form to fill"* | value: `default:` › `example:` › bare; marker: the derived `must_fill` | annotated string | yes (`!must_fill`) |
 | seeding | *"give me a filled-out one"* | `example:` › absent | committed `Document` | no |
 
 The **blueprint** column is this doc's contract (above). The **seeding**

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -174,26 +174,40 @@ Either quote the value (`build_number: "42"`) or change the schema's
 `type:` to `integer`.
 ```
 
+`validation::must_fill` has two triggers, distinguished by its `trigger` arg
+and by nothing else — one code, one anchor grammar, one severity. The messages
+differ because the two name different situations:
+
 ```
 Field `name` is marked `!must_fill`: a placeholder awaiting a value.
 ```
 
-with the hint *"Replace the value and drop the `!must_fill` marker, or remove
-the marker if the current value is intended."* It is a warning, not an error:
-the field still renders (the marked cell blank-fills or uses its suggested
-value).
+(`trigger: marker`) with the hint *"Replace the value and drop the `!must_fill`
+marker, or remove the marker if the current value is intended."*
 
-A present-null value (`subtitle:`, `subtitle: null`, `subtitle: ~`) is
-treated exactly like an omitted field: null ≡ absent. It validates clean
-and blank-fills at render (authored › `default:` › blank), so it produces
-no diagnostic. Field absence is likewise not surfaced as a diagnostic (see
-[SCHEMAS.md](SCHEMAS.md) § "Native validation"), so a merely incomplete
-document also produces no field-level diagnostic.
+```
+Field `name` must be filled in: nobody has authored a value.
+```
+
+(`trigger: unauthored`) with the hint *"Author a value. To record that empty is
+the intended answer, write the field's blank explicitly rather than leaving it
+out."* Either way it is a warning, not an error: the field still renders (the
+cell blank-fills or uses its suggested value). At most one is emitted per path;
+where both apply the marker wins, its hint being the actionable one.
+
+A present-null value (`subtitle:`, `subtitle: null`, `subtitle: ~`) is treated
+exactly like an omitted field on the **value** ladder: null ≡ absent, it
+coerces and validates clean, and it blank-fills at render (authored ›
+`default:` › blank). On the obligation surface the two are together on the
+other side: neither is an authored answer, so both trigger `unauthored` where
+the schema obliges the cell (see [SCHEMAS.md](SCHEMAS.md) § "Native
+validation"). An incomplete document therefore produces no *fatal* field-level
+diagnostic, and warns exactly where a human has yet to make a call.
 
 Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and
-`crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning`, for
-`validation::must_fill`).
+`crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning` and
+`validate_unauthored`/`unauthored_warning`, for `validation::must_fill`).
 
 ## Document-model paths
 

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -292,7 +292,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `validation::unknown_card` | `card` | structured |
 | `validation::body_disabled` | `card` | structured |
 | `validation::coercion_failed` | `value`, `target` | structured, coarser |
-| `validation::must_fill` | — | code-determined |
+| `validation::must_fill` | `trigger` | structured |
 | `validation::not_inline` | — | code-determined |
 | `validation::not_plain` | — | code-determined |
 | `edit::invalid_field_name` | `field` | structured |

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -169,19 +169,42 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   rarely-authored distinction, breaks YAML round-trip sanity (a loaded-then-
   saved document must not sprout `field: null` lines), and buys nothing the
   ladder does not already give. The simpler model is the contract.
-- **`!must_fill` marker → non-fatal warning.** For every `!must_fill` marker
-  present (root or nested, main card or composable card)
-  `Quill::validate` emits `validation::must_fill` at **`Severity::Warning`**,
-  regardless of whether the marker carries a value. It **never gates render**:
-  a marked document renders fine (the cell blank-fills, or uses its suggested
-  value). A strict consumer (e.g. an LLM authoring loop) treats any
-  outstanding marker as "not done."
+- **Null ≡ absent holds on the value ladder; the obligation surface splits
+  them.** The identification above is about *values*, and it is unqualified:
+  null and absent blank-fill identically, forever. But `must_fill` asks whether
+  a human made a call, and writing the field's blank is such a call while
+  clearing the key is not — so `field: ""` discharges the warning and
+  `field: null` does not. Two verbs that are interchangeable today part company
+  here: `removeField` and writing the blank stop being the same act, and a UI
+  rendering both as an empty box shows nothing of the difference. This is the
+  cost of letting a human answer "deliberately nothing" at all; the alternative
+  (keying on the resolved source rung) cannot see a must-fill leaf inside a
+  container the author has touched, and leaves the deliberate blank with no
+  spelling.
+- **`validation::must_fill` → non-fatal warning, from two triggers.**
+  `Quill::validate` emits it at **`Severity::Warning`** when either holds, with a
+  `trigger` arg naming which:
+  - `marker` — a `!must_fill` marker is present (root or nested, main card or
+    composable card), whether or not it carries a value. The marker is
+    document-sovereign: it fires without consulting the schema, and a human
+    dropping it is a decision nothing re-derives.
+  - `unauthored` — the schema obliges the cell and the document leaves it
+    absent or present-null.
+
+  Neither subsumes the other. A hand-written or programmatically built document
+  carries no marker; a seeded `example` is present, in-domain, and structurally
+  indistinguishable from authored content. Where both would fire on one path
+  (a bare marker on an unauthored cell) one diagnostic is emitted and the marker
+  wins: its hint is the actionable one. It **never gates render**: the cell
+  blank-fills, or uses its suggested value. A strict consumer (e.g. an LLM
+  authoring loop) treats any outstanding warning as "not done."
 - **Absence semantics**: a missing (or present-null) field with a `default:`
   accepts the default; without a `default:` it blank-fills. Either way it
-  validates clean. Field absence is **not surfaced as a diagnostic**:
-  `Quill::validate` raises no completeness/`field_absent` code, so a merely
-  incomplete (or present-null) document validates clean. The only authoring
-  signal it raises is the non-fatal `validation::must_fill` warning.
+  coerces and validates clean — absence is never *malformed*, and there is no
+  `field_absent` code. On the editor surface it is surfaced where the schema
+  obliges it: an unauthored must-fill cell warns. So `Quill::validate` on an
+  incomplete document is not clean, and the count is per *document* — a card
+  kind obliges nothing until an instance of it exists.
 
 Field-level type and presence errors render under a uniform shape:
 field path, verbatim source token, schema declaration, and both exits
@@ -218,8 +241,8 @@ field maps rather than a sort key):
 | Projection | Per-field precedence | Floor | Output |
 |---|---|---|---|
 | render (fidelity) | authored › `default:` › blank | blank | plate JSON: [Blank-filled render](#blank-filled-render) |
-| `blueprint` document | Endorsed: `default:`; Unendorsed: `example:` else blank, stamped `!must_fill` | blank (under the marker) | annotated string, [BLUEPRINT.md](BLUEPRINT.md) |
-| seeding | `example:` › absent | (deferred to render floor) | committed `Document`: [Document seeding](#document-seeding) |
+| `blueprint` document | value: `default:` › `example:` › blank; marker: the derived `must_fill` | blank (under the marker) | annotated string, [BLUEPRINT.md](BLUEPRINT.md) |
+| seeding | `example:` › absent, stamped `!must_fill` where the schema obliges | (deferred to render floor) | committed `Document`: [Document seeding](#document-seeding) |
 | add-card (into a document) | `$seed` overlay › `example:` › absent | (deferred to render floor) | a new composable `Card`: [Document seeding](#document-seeding) |
 | editor (consumer-side) | authored › `default:` › blank, resolved per field and **tagged with its source rung** | blank | the engine's [`resolve()`](#the-resolved-value-view-resolve) resolved-value view: value and source rung per field |
 
@@ -231,9 +254,9 @@ the ladder in consumer code. Completeness and errors stay `Quill::validate`'s
 guidance (`example:`, labels, groups) reads from `Quill::schema`.
 
 Two seams are deliberate, not uniform: on `blueprint` the floor still
-blank-fills like every other projection (an Unendorsed cell with no `example`
+blank-fills like every other projection (a must-fill cell with no `example`
 carries bare null/empty under its marker), but the projection additionally
-**stamps the `!must_fill` marker** on every Unendorsed field: the marker
+**stamps the `!must_fill` marker** on every must-fill field: the marker
 rides *alongside* the value rather than replacing it; and `blank` is a property
 of the field rather than a member of the type's domain — an `enum`'s blank is
 `""`, outside `values:`
@@ -277,9 +300,10 @@ the `default:`, else the field's blank (`blank`, defined below): in the
 plate-JSON projection that feeds the backend **only, never in the persisted
 document**.
 
-- **Incomplete is renderable.** A document that merely omits an Unendorsed
-  field (or leaves it present-null) renders fine: the field is blank-filled
-  in the projection, and validates clean.
+- **Incomplete is renderable.** A document that merely omits a field (or
+  leaves it present-null) renders fine: the field is blank-filled in the
+  projection, and coercion/validation pass. A must-fill field it leaves
+  unauthored warns on the editor surface and still renders.
 - **Malformed is fatal.** The only malformed case is a value that cannot
   coerce to (or validate against) its declared type. Placeholders and null
   are *not* malformed: a `!must_fill` marker renders, using its suggested
@@ -388,15 +412,21 @@ path's "`default:` wins" rule applies to authored and blank documents, where no
   fills the body when bodies are enabled.
 - **The main card** carries `$quill` and `$kind: main`, so a seed round-trips
   through Markdown like an authored document.
-- **Provenance is untracked in the persisted document.** A seeded `example` is
-  committed as ordinary authored content, indistinguishable from hand-authored
-  input. Carrying no `!must_fill` marker, it reads as done: an Unendorsed field
-  seeded with an `example` raises no `validation::must_fill` warning. Whether a
-  field's value came from seeding or later authoring is not recorded; correctness
-  and renderability do not depend on the distinction. The commitment *rung* is a
-  separate axis and is reported on read: the
+- **A seeded `example` on a must-fill field commits carrying its marker.** An
+  `example` documents *shape*, so a seeded one reading as done was the single
+  hole between the blueprint and its filled-out twin: the two now stamp the same
+  cells, and a fresh seed reports incomplete in exactly the cells a hand-written
+  document does. A `$seed` overlay value is exempt — supplying one is a template
+  author deciding, which is the act the marker asks for.
+- **Provenance is otherwise untracked in the persisted document.** A seeded
+  value is committed as ordinary authored content, indistinguishable from
+  hand-authored input; whether it came from seeding or later authoring is not
+  recorded, and correctness and renderability do not depend on the distinction.
+  The marker is not provenance — a human may drop it without changing the value,
+  and nothing re-derives it (see [Native validation](#native-validation)). The
+  commitment *rung* is a separate axis, reported on read: the
   [`resolve()`](#the-resolved-value-view-resolve) projection tags each
-  field `authored` / `default` / `zero`: a seeded and a hand-authored value both
+  field `authored` / `default` / `blank`: a seeded and a hand-authored value both
   read as `authored`, both being document content.
 
 Seeding is the **filled-out twin of the blueprint**
@@ -463,32 +493,58 @@ encode opposite author intents:
   authors want it, the field can be omitted entirely: at render time the
   default fills any field the document leaves out (an
   authored value always wins: `ladder_sourced` in core's
-  `quill::compose`). A field with a `default:` is **Endorsed**: the
-  rendered value is shippable as-is, and the blueprint renders that concrete
-  default value with a type-only annotation (no marker). Type-empty defaults
-  (`default: ""`, `[]`, `false`, `0`) are the canonical way to mark a
-  "skippable" cell.
+  `quill::compose`). The blueprint renders that concrete default value with a
+  type-only annotation. Type-empty defaults (`default: ""`, `[]`, `false`, `0`)
+  are the canonical way to mark a "skippable" cell.
 - **`example`** matches the semantic and type *shape* of the desired
   value but is *not* the value most authors want. It documents shape, not
-  the choice, so it never becomes the rendered value; it only surfaces in
-  the blueprint's `# e.g.` line.
+  the choice, so it never becomes the rendered value; it takes the cell in the
+  blueprint only when no `default:` holds it, and surfaces as a `# e.g.` line
+  otherwise.
 
-### Unendorsed vs. Endorsed fields
+### The two axes: value and obligation
 
-A field is **Unendorsed** when no `default:` is declared: the quill author
-has endorsed no value, so the blueprint stamps the `!must_fill` marker to
-ask an LLM or author to supply one. That is a *communication device on the
-blueprint surface*, not a requirement: a missing (or present-null) Unendorsed
-field blank-fills silently at render, and a surviving marker raises only the
-non-fatal warning. "Must-fill" therefore lives solely on the blueprint/marker
-surface; the schema axis is endorsement, not obligation.
+A field declares two independent things, and neither implies the other.
 
-A field is **Endorsed** when `default:` is declared; the rendered default
-is shippable as-is (the author can keep or override it).
+- The **value** axis is `default:` › `example:` › the field's blank. It decides
+  what a cell holds.
+- The **obligation** axis is `must_fill:`. It decides whether a human must
+  author that cell.
 
-There is no separate `required:` axis; the presence or absence of
-`default:` is the sole author choice per field. See
-[BLUEPRINT.md](BLUEPRINT.md) for how the two cells render.
+`must_fill:` is `true` / `false`, and when unset it **derives** from the value
+axis: a field with a `default:` is not obliged, a field without one is. Every
+quill that never writes the key therefore behaves exactly as before, and the
+derivation is keyed on `default`'s *presence*, so a `default: ""` stays a
+skippable cell rather than becoming a marker. Because the key lives on the field
+schema it applies at every nesting level.
+
+Declaring it reaches two cells the derivation cannot:
+
+- `must_fill: true` beside a `default:` — a safe value renders, **and** a human
+  must still confirm it. Classification markings and effective dates are the
+  motivating cases: the document is never wrong out of the box, and nobody ships
+  one nobody looked at. An editor's *confirm* discharges this by writing the
+  default's value as authored content — no new state, at the stated cost that
+  the cell stops tracking a later `default:` change.
+- `must_fill: false` with no `default:` — genuinely optional, with nothing to
+  suggest.
+
+Obligation is a **warning, never a gate**: an unauthored must-fill field
+blank-fills and renders, and the signal is the non-fatal
+`validation::must_fill` (see [Native validation](#native-validation)). There is
+no `required:` axis and no severity knob on this one — severity already *is* the
+render-gate signal, so an `Error` that renders fine would break every consumer
+routing Error ≡ won't-render. An editor's "can't submit" is consumer policy over
+the warning: *a strict consumer treats any outstanding marker as not done*.
+A quill author arriving from web forms has the right prior for the affordance
+and the wrong one for the enforcement.
+
+On a typed dictionary the container's own `must_fill:` is **inert**: `!must_fill`
+is rejected on a mapping, so the obligation lives on the leaves and the
+blueprint and the predicate both address them there. An array is its own cell,
+including an array of objects.
+
+See [BLUEPRINT.md](BLUEPRINT.md) for how the two axes render into cells.
 
 Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata` getter; Python: `Quill.metadata`). Both bindings also expose `backend_id`/`backendId` directly; Python additionally exposes `quill_ref`, a derived `name@version` string.
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -174,9 +174,10 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   null and absent blank-fill identically, forever. But `must_fill` asks whether
   a human made a call, and writing the field's blank is such a call while
   clearing the key is not — so `field: ""` discharges the warning and
-  `field: null` does not. Two verbs that are interchangeable today part company
-  here: `removeField` and writing the blank stop being the same act, and a UI
-  rendering both as an empty box shows nothing of the difference. This is the
+  `field: null` does not. So two verbs part company here: `removeField` (drop
+  the key) and writing the blank are the same act on the value ladder and
+  different acts on this surface, and a UI rendering both as an empty box shows
+  nothing of the difference. This is the
   cost of letting a human answer "deliberately nothing" at all; the alternative
   (keying on the resolved source rung) cannot see a must-fill leaf inside a
   container the author has touched, and leaves the deliberate blank with no
@@ -413,10 +414,9 @@ path's "`default:` wins" rule applies to authored and blank documents, where no
 - **The main card** carries `$quill` and `$kind: main`, so a seed round-trips
   through Markdown like an authored document.
 - **A seeded `example` on a must-fill field commits carrying its marker.** An
-  `example` documents *shape*, so a seeded one reading as done was the single
-  hole between the blueprint and its filled-out twin: the two now stamp the same
-  cells, and a fresh seed reports incomplete in exactly the cells a hand-written
-  document does. A `$seed` overlay value is exempt — supplying one is a template
+  `example` documents *shape*, so a seeded one is not an answer. Stamping it is
+  what makes the blueprint and its filled-out twin stamp the same cells: a fresh
+  seed reports incomplete in exactly the cells a hand-written document does. A `$seed` overlay value is exempt — supplying one is a template
   author deciding, which is the act the marker asks for.
 - **Provenance is otherwise untracked in the persisted document.** A seeded
   value is committed as ordinary authored content, indistinguishable from

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -170,18 +170,16 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   saved document must not sprout `field: null` lines), and buys nothing the
   ladder does not already give. The simpler model is the contract.
 - **Null ≡ absent holds on the value ladder; the obligation surface splits
-  them.** The identification above is about *values*, and it is unqualified:
-  null and absent blank-fill identically, forever. But `must_fill` asks whether
-  a human made a call, and writing the field's blank is such a call while
-  clearing the key is not — so `field: ""` discharges the warning and
-  `field: null` does not. So two verbs part company here: `removeField` (drop
-  the key) and writing the blank are the same act on the value ladder and
-  different acts on this surface, and a UI rendering both as an empty box shows
-  nothing of the difference. This is the
-  cost of letting a human answer "deliberately nothing" at all; the alternative
-  (keying on the resolved source rung) cannot see a must-fill leaf inside a
-  container the author has touched, and leaves the deliberate blank with no
-  spelling.
+  them.** The identification above is about *values*, and it stays unqualified:
+  null and absent blank-fill identically. `must_fill` asks a different question
+  — did a human make a call — and writing the field's blank is one while
+  clearing the key is not, so `field: ""` discharges the warning and
+  `field: null` does not. Two verbs therefore part company: `removeField` and
+  writing the blank are one act on the value ladder and two here, and a UI
+  rendering both as an empty box shows nothing of the difference. That is the
+  price of letting a human answer "deliberately nothing" at all: keying the
+  obligation on the resolved source rung instead would leave the deliberate
+  blank unspellable and go blind to a must-fill leaf inside a touched container.
 - **`validation::must_fill` → non-fatal warning, from two triggers.**
   `Quill::validate` emits it at **`Severity::Warning`** when either holds, with a
   `trigger` arg naming which:
@@ -512,20 +510,20 @@ A field declares two independent things, and neither implies the other.
   author that cell.
 
 `must_fill:` is `true` / `false`, and when unset it **derives** from the value
-axis: a field with a `default:` is not obliged, a field without one is. Every
-quill that never writes the key therefore behaves exactly as before, and the
-derivation is keyed on `default`'s *presence*, so a `default: ""` stays a
-skippable cell rather than becoming a marker. Because the key lives on the field
-schema it applies at every nesting level.
+axis: a field with a `default:` is not obliged, a field without one is. So a
+quill that never writes the key gets the whole obligation surface off `default:`
+alone. The derivation reads `default`'s *presence*, so a `default: ""` stays a
+skippable cell rather than becoming a marker. The key lives on the field schema,
+so it applies at every nesting level.
 
 Declaring it reaches two cells the derivation cannot:
 
 - `must_fill: true` beside a `default:` — a safe value renders, **and** a human
   must still confirm it. Classification markings and effective dates are the
-  motivating cases: the document is never wrong out of the box, and nobody ships
-  one nobody looked at. An editor's *confirm* discharges this by writing the
-  default's value as authored content — no new state, at the stated cost that
-  the cell stops tracking a later `default:` change.
+  cases it exists for: the document is never wrong out of the box, and nobody
+  ships one nobody looked at. An editor's *confirm* discharges it by writing the
+  default's value as authored content: no new state, at the cost that the cell
+  then holds that value rather than tracking a later `default:` change.
 - `must_fill: false` with no `default:` — genuinely optional, with nothing to
   suggest.
 


### PR DESCRIPTION
Implements the obligation axis of #1234 — rules 5–8, the `quillmark:must_fill` half of rule 9, and rule 10 — closing #1255. Depends on the value axis, which landed in #1258.

## The gap

`default:` carried the fill value and the obligation signal on one bit, so only the diagonal of a 2×2 was reachable. "A safe value renders, **but** a human must still confirm it" had no spelling, and neither did "optional, with nothing to suggest."

Worse, the obligation was unobservable where it mattered. `validate_fills` walks the document payload and never consults the schema, so a hand-written, programmatically built, or pre-field document received zero completeness signal regardless of what `Quill.yaml` said.

## What landed

`must_fill: Option<bool>` on `FieldSchema`, derived `unwrap_or(default.is_none())` so every existing quill keeps its exact behavior, and `Quill::validate` gains a second trigger: a schema-side predicate warning where the schema obliges a cell and the document leaves it unauthored. The two triggers share one code and carry a `trigger: marker | unauthored` arg; where both fire on a path, one diagnostic is emitted and the marker wins.

Seeding stamps the marker on example-seeded must-fill cells, which is what makes a fresh seed and a blank document report the identical cell set. `quillmark:must_fill` rides the transform schema in the prelude, before the enum arm's early return. The blueprint's two axes now read independently.

## Divergence from the issue: the container boundary

The issue asks for "the container is the cell when absent, per-leaf recursion once present." That rule has a 1→N warning cliff on the first keystroke into a container, and it emits a diagnostic at a path that can never carry a marker — `!must_fill` is rejected on a mapping (`markdown-spec.md` §3.4).

Implemented instead: **cells sit where the blueprint stamps its markers.**

- A **typed dict** is never itself a cell; recursion runs present or absent, so an absent `address` warns at `address.street` — a path an editor can resolve and a marker can occupy.
- Every **other** type is the cell, arrays included. `[]` is an authored answer that discharges. A present array resolves elements against the item schema; an absent one has no index to anchor on and warns at the container.

No absent/present special case, no count cliff, and rule 8's convergence becomes structural rather than a coincidence of which fields `usaf_memo` happens to declare.

## Corrections to the issue's claims

**The convergence number is wrong.** Three of the seven cited fields (`indorsement.{from, for, signature_block}`) are card-kind fields, not nested object properties, and a card kind obliges nothing until an instance exists. Measured on the flagship:

| document | warnings | trigger |
|---|---|---|
| `usaf_memo`, main card only | 4 | `unauthored` |
| + 1 indorsement card | 7 | `unauthored` |
| fresh seed (main + 1 indorsement) | 7 | `marker` |

The last two are the **same seven paths** — the convergence rule 8 claims is real, but per *card*. Breaking change 4 is `N = 4 + 3 per indorsement card`, not `N = 7`.

**`ERROR.md` § "Diagnostic args" is missing from the issue's work list, and it is tested** (`diagnostic_args_match_canon`). Adding `trigger` without the canon row is a red test. The sample is now taken from the real constructors, with both triggers pinned to one key set so the pair cannot drift.

Two smaller imprecisions: `schema.rs` does have a shared tail (the enum arm early-returns before it, so the prelude guidance stands), and `conform.rs:152`'s fill-skip sits behind `field_contains_content`, which narrows rule 8's hazard to content fields rather than negating it.

## A bug rule 8 exposed

The markdown emitter gated its content projection on the field being unmarked — `// Such a field is never !must_fill`, true until seeding started stamping. A seeded richtext `example` carrying a marker emitted its raw canonical object, producing YAML that does not re-parse and silently dropping the marker. Caught by `usaf_memo_rejects_a_kindless_card`; fixed and regression-tested.

## Discretionary calls

- **Rule 10's undefined cell shape** → emit `note: null # string`. The blueprint stays a complete field inventory; omitting the field would break that for no gain.
- **Rule 8 exempts `$seed` overlay values.** An `example` documents shape; an overlay is a template author *deciding*, which is the act the marker asks for.

## Breaking changes

1. `Quill::validate` on an incomplete document goes from clean to N warnings, amending `SCHEMAS.md`'s "Field absence is not surfaced as a diagnostic."
2. `SCHEMAS.md` § "Document seeding" reverses: a seeded `example` on a must-fill field no longer reads as done.
3. Null and the blank literal become behaviorally distinct on the obligation surface. Null ≡ absent still holds on the value ladder, unqualified.
4. Every field on the transform schema gains `quillmark:must_fill` (additive).

## Testing

`cargo test --workspace`, `node scripts/check-canon.mjs`, WASM (247) and Python (106) suites all pass locally.

Two existing tests needed correcting rather than accommodating. `a_fill_tag_on_a_seeded_cell_survives_store_load_conform` asserted the tag is stored-not-inferred by comparing against an unstamped seed; it now proves the same invariant from the negative direction (a dropped tag stays dropped through a cycle). `test_typed_set_clears_must_fill_marker` asserted globally what it means locally — taro declares two defaultless fields — and is now scoped to the path whose lifecycle it tests.

Closes #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162zbPdSofGEqdH8a8bekoq

---
_Generated by [Claude Code](https://claude.ai/code/session_0162zbPdSofGEqdH8a8bekoq)_