### PR TITLE
fix(python): declare license-files so the sdist ships its LICENSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   variant, `UnknownField { field, at }`, matching the two siblings; `field`
   stays a bare field name, and the `edit::unknown_field` code, its `field` arg
   and the whole-field message are unchanged.
+- fix(python): declaring `license-files` ships the `LICENSE` the sdist metadata
+  names, which PyPI rejected the sdist for lacking. v0.104.0 and v0.105.0 are
+  wheels only.
 
 ## v0.105.0 - 2026-08-14
 

--- a/crates/bindings/python/pyproject.toml
+++ b/crates/bindings/python/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["maturin>=1.7,<2.0"]
+# >=1.9.3 puts declared `license-files` at the sdist root, where `License-File` points.
+requires = ["maturin>=1.9.3,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -8,12 +9,12 @@ dynamic = ["version"]
 description = "Python bindings for Quillmark - a schema-driven document engine"
 authors = [{ name = "Quillmark Contributors" }]
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -32,7 +33,7 @@ Changelog = "https://github.com/borb-sh/quillmark/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "maturin>=1.7,<2.0",
+    "maturin>=1.9.3,<2.0",
 ]
 
 [tool.maturin]

--- a/crates/bindings/python/uv.lock
+++ b/crates/bindings/python/uv.lock
@@ -113,7 +113,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
+    { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.9.3,<2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
The `publish-python` job has failed the last two releases. Not credentials, artifacts, or the action — all four wheels uploaded 200 OK and the sdist then got:

```
400 License-File LICENSE does not exist in distribution file
    quillmark-0.105.0.tar.gz at quillmark-0.105.0/LICENSE
```

`crates/bindings/python/LICENSE` is a symlink to the workspace copy. maturin auto-detects it into `License-File: LICENSE`, but only an explicitly declared `license-files` puts that file at the sdist root the field names — the workspace sdist held it at `crates/bindings/python/LICENSE`. PyPI validates the field against the archive and rejects the mismatch.

## Change

`crates/bindings/python/pyproject.toml`, plus the one `uv.lock` line and a CHANGELOG entry:

- `license-files = ["LICENSE"]` — the fix.
- `license = "Apache-2.0"` — PEP 639 SPDX expression, which retires the license classifier PEP 639 deprecates.
- `maturin>=1.9.3` — the release that fixed the sdist half ("Fix adding `project.license-files` to source distributions").

## Verification

Reproduced locally with maturin 1.14.1: byte-identical failure before, and after the change `LICENSE` sits at the sdist root and at `.dist-info/licenses/LICENSE` in the wheel, both under `License-Expression: Apache-2.0` with no deprecated `License:` beside it. `py.typed`, `_quillmark.pyi` and the extension still ship; 106 Python tests pass against a wheel built from the new config.

Worth knowing: `twine check --strict` passes the broken sdist, and the publish action already runs it via `verify-metadata`. This class of rejection is only reachable from warehouse itself.

v0.104.0 and v0.105.0 are permanently sdist-less on PyPI — their wheels published and the version numbers cannot be reused, so `pip install --no-binary` and unlisted-platform builds cannot use those two. The next release will be complete. The trusted-publisher configuration needs no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDVTXADwHi9U7zbk3Y8spK
