### PR TITLE
Anchor an undeclared property at the property, not at a bare name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- fix(core,wasm,python)!: `EditError::UnknownField` carries the in-field path
+  `FieldDecode` and `FieldNotContent` carry. A property an `object` field does
+  not declare — `get_content_at("address", [Key("zip")])` against an `address`
+  with no `zip` — reported `field 'zip' is not declared in the schema`, which
+  reads as a claim about a top-level field and collides outright when a real
+  top-level field shares the name. It now reports
+  `field 'address.zip' is not declared in the schema` and anchors the
+  diagnostic at `main.address.zip`, so the caller can tell an undeclared
+  property from an undeclared field. **Breaking**: the variant is a struct
+  variant, `UnknownField { field, at }`, matching the two siblings; `field`
+  stays a bare field name, and the `edit::unknown_field` code, its `field` arg
+  and the whole-field message are unchanged.
+
 ## v0.105.0 - 2026-08-14
 
 - feat(core,wasm,python)!: a `Content` nested inside a composite field is

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -72,11 +72,21 @@ pub enum EditError {
     InvalidFieldName(String),
 
     /// A typed write ([`TypedWriter::set`](crate::TypedWriter::set) /
-    /// [`CardWriter::set`](crate::CardWriter::set)) addressed a well-formed name
-    /// the bound schema does not declare (or a card whose `$kind` carries no
-    /// schema). Use [`Card::store_field`](Card::store_field) for opaque storage.
-    #[error("field '{0}' is not declared in the schema")]
-    UnknownField(String),
+    /// [`CardWriter::set`](crate::CardWriter::set)) or a schema-bound read
+    /// addressed a well-formed name the bound schema does not declare (or a card
+    /// whose `$kind` carries no schema). A property an `object` field does not
+    /// declare is the same error one level down, `at` naming it. Use
+    /// [`Card::store_field`](Card::store_field) for opaque storage.
+    #[error("field '{field}{}' is not declared in the schema", render_at(.at))]
+    UnknownField {
+        field: String,
+        /// The steps from the field to the undeclared name, its last segment
+        /// being that name: empty when the field itself is the undeclared one,
+        /// `[Key("zip")]` for an `address` object that declares no `zip`. Rides
+        /// the [`doc_path`](Self::doc_path) anchor as its own segments, so
+        /// `field` stays the field's name.
+        at: Vec<PathSegment>,
+    },
 
     #[error("invalid card kind '{0}': must match [a-z_][a-z0-9_]*")]
     InvalidKindName(String),
@@ -166,13 +176,20 @@ pub enum EditError {
 }
 
 impl EditError {
+    pub(crate) fn unknown_field(name: impl Into<String>) -> Self {
+        EditError::UnknownField {
+            field: name.into(),
+            at: Vec::new(),
+        }
+    }
+
     /// The namespaced diagnostic `code` (e.g. `"edit::invalid_field_name"`),
     /// one per variant and the variant's only stable discriminator. Consumers
     /// route on this, not on message text. Taxonomy: `prose/canon/ERROR.md`.
     pub fn code(&self) -> &'static str {
         match self {
             EditError::InvalidFieldName(_) => "edit::invalid_field_name",
-            EditError::UnknownField(_) => "edit::unknown_field",
+            EditError::UnknownField { .. } => "edit::unknown_field",
             EditError::InvalidKindName(_) => "edit::invalid_kind_name",
             EditError::ReservedKind => "edit::reserved_kind",
             EditError::IndexOutOfRange { .. } => "edit::index_out_of_range",
@@ -198,7 +215,7 @@ impl EditError {
     pub fn args(&self) -> BTreeMap<String, serde_json::Value> {
         match self {
             EditError::InvalidFieldName(field) => diag_args! { "field" => field },
-            EditError::UnknownField(field) => diag_args! { "field" => field },
+            EditError::UnknownField { field, at: _ } => diag_args! { "field" => field },
             EditError::InvalidKindName(kind) => diag_args! { "kind" => kind },
             EditError::ReservedKind => diag_args! {},
             EditError::IndexOutOfRange { index, len } => diag_args! {
@@ -255,11 +272,11 @@ impl EditError {
         use crate::path::DocPath;
         match self {
             EditError::FieldNotContent { field: f, at, .. }
-            | EditError::FieldDecode { field: f, at, .. } => {
+            | EditError::FieldDecode { field: f, at, .. }
+            | EditError::UnknownField { field: f, at } => {
                 Some(at.iter().fold(base.field(f), |p, seg| p.segment(seg)))
             }
             EditError::InvalidFieldName(f)
-            | EditError::UnknownField(f)
             | EditError::FieldNotInline { field: f, .. }
             | EditError::FieldCoercionFailed { field: f, .. } => Some(base.field(f)),
             EditError::IndexOutOfRange { index, .. } => Some(DocPath::card(None, *index)),
@@ -953,7 +970,7 @@ mod tests {
         );
         let card = DocPath::card(Some("indorsement"), 1);
         assert_eq!(
-            EditError::UnknownField("signature_block".into())
+            EditError::unknown_field("signature_block")
                 .doc_path(&card)
                 .unwrap()
                 .to_string(),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -601,7 +601,7 @@ mod args_canon {
 
         for e in [
             EditError::InvalidFieldName("9bad".into()),
-            EditError::UnknownField("nope".into()),
+            EditError::unknown_field("nope"),
             EditError::InvalidKindName("Bad".into()),
             EditError::ReservedKind,
             EditError::IndexOutOfRange { index: 3, len: 1 },

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -36,6 +36,9 @@ use crate::value::QuillValue;
 /// present, so it recurses rather than degrading to the bare `{}` that only a
 /// property-less object carries.
 pub fn blank(field: &FieldSchema) -> QuillValue {
+    // Keyed on the carrier rather than the `Enum` token, as every consumer of a
+    // finite domain is (`SCHEMAS.md` § "Type coercion"), so a serde-built schema
+    // whose type and carrier disagree still blanks to the reserved `""`.
     if field.enum_values.is_some() {
         return QuillValue::from_json(json!(""));
     }
@@ -119,6 +122,16 @@ properties:
                 "address": { "city": "", "tags": [] }
             })
         );
+    }
+
+    /// The carrier decides, so the answer survives a schema whose type and
+    /// carrier disagree — which the loader rejects (`values:` on a non-enum
+    /// type) and serde builds anyway.
+    #[test]
+    fn enum_values_on_a_non_enum_type_blanks_to_the_empty_string() {
+        let mut schema = FieldSchema::new("clearance".to_string(), FieldType::Integer, None);
+        schema.enum_values = Some(vec!["1".to_string(), "2".to_string()]);
+        assert_eq!(blank(&schema).into_json(), json!(""));
     }
 
     #[test]

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -117,7 +117,9 @@ impl<'a> TypedReader<'a> {
     /// count the caller holds.
     ///
     /// [`EditError::UnknownField`] for a name at any depth the schema does not
-    /// declare; [`EditError::FieldNotContent`] when `at` resolves to no content
+    /// declare, anchored at that name (`main.letterhead.nope`) rather than
+    /// reading as a claim about a top-level field;
+    /// [`EditError::FieldNotContent`] when `at` resolves to no content
     /// leaf, either through a step the schema cannot take or at a non-content
     /// terminal; [`EditError::FieldDecode`], anchored at the addressed path,
     /// when the value there decodes under neither encoding.
@@ -204,7 +206,7 @@ fn read_field(
 ) -> Result<Option<ReadValue>, EditError> {
     let schema = fields_schema
         .and_then(|m| m.get(name))
-        .ok_or_else(|| EditError::UnknownField(name.to_string()))?;
+        .ok_or_else(|| EditError::unknown_field(name))?;
     match schema.r#type {
         FieldType::RichText { .. } => project(
             card.field_markdown(name),
@@ -239,7 +241,7 @@ fn read_content(
 ) -> Result<Option<Content>, EditError> {
     let field = fields_schema
         .and_then(|m| m.get(name))
-        .ok_or_else(|| EditError::UnknownField(name.to_string()))?;
+        .ok_or_else(|| EditError::unknown_field(name))?;
     let leaf = schema_at(field, name, at)?;
     // The codec rides out of the dispatch: it is the declared type's, not the
     // stored shape's.
@@ -297,9 +299,12 @@ fn schema_at<'a>(
             (FieldType::Array, PathSegment::Index(_)) => cursor.items.as_deref().ok_or(blocked)?,
             (FieldType::Object, PathSegment::Key(key)) => match cursor.properties.as_ref() {
                 None => return Err(blocked),
-                Some(props) => props
-                    .get(key)
-                    .ok_or_else(|| EditError::UnknownField(key.clone()))?,
+                Some(props) => props.get(key).ok_or_else(|| EditError::UnknownField {
+                    field: name.to_string(),
+                    // Through the failed step, not up to it: the anchor names the
+                    // undeclared property, not the object holding it.
+                    at: at[..=depth].to_vec(),
+                })?,
             },
             _ => return Err(blocked),
         };
@@ -455,7 +460,7 @@ card_kinds:
         let view = TypedReader::new(&config, &doc);
         assert!(matches!(
             view.get("nope"),
-            Err(EditError::UnknownField(name)) if name == "nope"
+            Err(EditError::UnknownField { field, .. }) if field == "nope"
         ));
     }
 
@@ -541,7 +546,7 @@ card_kinds:
         assert_eq!(view.get_content("note").unwrap(), None);
         assert!(matches!(
             view.get_content("nope"),
-            Err(EditError::UnknownField(n)) if n == "nope"
+            Err(EditError::UnknownField { field, .. }) if field == "nope"
         ));
         // Answered from the schema, not the payload: `qty` holds 3.
         assert!(matches!(
@@ -709,10 +714,37 @@ card_kinds:
             view.get_content_at("recipients", &[]),
             Err(EditError::FieldNotContent { declared, .. }) if declared == "array"
         ));
-        assert!(matches!(
-            view.get_content_at("letterhead", &key("nope")),
-            Err(EditError::UnknownField(n)) if n == "nope"
-        ));
+    }
+
+    #[test]
+    fn unknown_property_anchors_at_the_property_it_names() {
+        let config = config();
+        let doc = blank_doc();
+        let view = TypedReader::new(&config, &doc);
+
+        let err = view.get_content_at("letterhead", &key("nope")).unwrap_err();
+        assert!(
+            matches!(&err, EditError::UnknownField { field, at }
+                if field == "letterhead" && at == &key("nope")),
+            "{err:?}"
+        );
+        assert_eq!(
+            err.to_string(),
+            "field 'letterhead.nope' is not declared in the schema",
+            "a property is not a claim about a top-level field of the same name"
+        );
+        assert_eq!(
+            err.doc_path(&crate::DocPath::main()).unwrap().to_string(),
+            "main.letterhead.nope"
+        );
+
+        let deep = view
+            .get_content_at("rows", &[PathSegment::Index(0), PathSegment::Key("nope".into())])
+            .unwrap_err();
+        assert_eq!(
+            deep.doc_path(&crate::DocPath::main()).unwrap().to_string(),
+            "main.rows[0].nope"
+        );
     }
 
     #[test]
@@ -769,7 +801,7 @@ card_kinds:
             card.get("body").unwrap(),
             Some(ReadValue::Markdown("a *card*".to_string()))
         );
-        assert!(matches!(card.get("nope"), Err(EditError::UnknownField(_))));
+        assert!(matches!(card.get("nope"), Err(EditError::UnknownField { .. })));
     }
 
     #[test]

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -55,7 +55,7 @@ impl<'a> TypedWriter<'a> {
         let config = self.config;
         match config.main.fields.get(name) {
             Some(schema) => self.doc.main_mut().commit_field(name, value, schema),
-            None => Err(EditError::UnknownField(name.to_string())),
+            None => Err(EditError::unknown_field(name)),
         }
     }
 
@@ -94,7 +94,7 @@ impl<'a> TypedWriter<'a> {
     pub fn revise_field(&mut self, name: &str, text: &str) -> Result<Delta, EditError> {
         match self.config.main.fields.get(name) {
             Some(schema) => self.doc.main_mut().revise_field_checked(name, text, schema),
-            None => Err(EditError::UnknownField(name.to_string())),
+            None => Err(EditError::unknown_field(name)),
         }
     }
 
@@ -177,7 +177,7 @@ impl CardWriter<'_> {
     pub fn set(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
         match self.schema.and_then(|s| s.fields.get(name)) {
             Some(schema) => self.card.commit_field(name, value, schema),
-            None => Err(EditError::UnknownField(name.to_string())),
+            None => Err(EditError::unknown_field(name)),
         }
     }
 
@@ -192,7 +192,7 @@ impl CardWriter<'_> {
     pub fn revise_field(&mut self, name: &str, text: &str) -> Result<Delta, EditError> {
         match self.schema.and_then(|s| s.fields.get(name)) {
             Some(schema) => self.card.revise_field_checked(name, text, schema),
-            None => Err(EditError::UnknownField(name.to_string())),
+            None => Err(EditError::unknown_field(name)),
         }
     }
 
@@ -235,7 +235,7 @@ where
                 Ok(stored) => resolved.push((name, stored)),
                 Err(e) => errors.push((name, e)),
             },
-            None => errors.push((name.clone(), EditError::UnknownField(name))),
+            None => errors.push((name.clone(), EditError::unknown_field(name))),
         }
     }
     if !errors.is_empty() {

--- a/crates/quillmark/tests/facade_surface.rs
+++ b/crates/quillmark/tests/facade_surface.rs
@@ -100,7 +100,7 @@ fn typed_read_spells_through_the_facade() {
     );
 
     let typo: Result<Option<ReadValue>, EditError> = reader.get("nope");
-    assert!(matches!(typo, Err(EditError::UnknownField(_))), "{typo:?}");
+    assert!(matches!(typo, Err(EditError::UnknownField { .. })), "{typo:?}");
 
     let card: CardReader = reader.card(0).expect("the note card resolves its schema");
     assert_eq!(card.kind(), Some("note"));


### PR DESCRIPTION
Closes #1263. Both nits were warranted; both are a few lines.

## 1. `EditError::UnknownField` carries the in-field path

`schema_at` can fail three ways, and 0.105 gave two of them an `at` path so a nested diagnostic anchors where it happened. The third kept reporting a bare name: `get_content_at("address", [Key("zip")])` against an `address` declaring no `zip` said `field 'zip' is not declared in the schema`, which reads as a claim about a top-level field and collides outright when a real top-level field is named `zip`.

Took the issue's first option — the smaller one, matching the shape 0.105 already chose. `UnknownField(String)` becomes `UnknownField { field, at: Vec<PathSegment> }`, filled with `at[..=depth]`: *through* the failed step rather than up to it as the `blocked` sibling is, so `field` stays the bare field name and `at` ends at the name nothing declares. The pair render `main.letterhead.nope` in the message and in the anchor; `rows[0].nope` anchors a level deeper.

- `doc_path` folds `at` into the anchor by joining the existing `FieldDecode` / `FieldNotContent` arm.
- `edit::unknown_field` and its `field` arg are unchanged, so the `ERROR.md` args table and the `args_canon` contract test don't move, and the whole-field message is byte-identical.
- The eight construction sites route through a new crate-private `EditError::unknown_field(name)`. Breaking only for a Rust matcher on the tuple variant: bindings construct `IndexOutOfRange` alone and convert generically through code/args/path, so they pick up the better anchor with no binding-code change.

## 2. `blank()`'s enum early return keeps its spelling, and gains a test

Kept rather than deleted: the `""` is keyed on the `enum_values` carrier, which is what every consumer of a finite domain keys on (`SCHEMAS.md` § "Type coercion"). `enum_values_on_a_non_enum_type_blanks_to_the_empty_string` is the case where the fallthrough would answer differently — a serde-built `FieldType::Integer` carrying `enum_values`, which the loader rejects and serde builds anyway. Verified it fails (`0` vs `""`) with the early return deleted, so the branch is no longer silently removable.

## Tests

- New `unknown_property_anchors_at_the_property_it_names` pins the message and both anchors.
- New `enum_values_on_a_non_enum_type_blanks_to_the_empty_string` pins the early return.
- `cargo test --workspace` green; `node scripts/check-canon.mjs` passes.

## Notes

CHANGELOG gains an `## Unreleased` section with the breaking `fix(core,wasm,python)!` entry, so it rides whatever release next breaks `EditError`. No migration-guide entry — those are written at release time against the real version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVFAtLAcERwDCvw13sqeqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVFAtLAcERwDCvw13sqeqN)_