### PR TITLE
Enum variants: fields that exist only for one enum value

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -89,6 +89,16 @@ export interface QuillFieldSchema {
     /** `true` on a `richtext` or `plaintext` field declared `inline`: the
      *  single-paragraph, container-free, island-free constraint. */
     inline?: boolean;
+    /** Present on a field that exists only where a sibling `enum` holds one
+     *  value: the quill declared it under that enum's `variants:`, and the
+     *  schema emits it flat, in display position, scoped by this.
+     *
+     *  A hide/show signal, not a validity constraint. The field is declared and
+     *  blank-filled whatever the discriminant reads, so it renders either way;
+     *  an authored value while the discriminant names another value warns
+     *  `validation::out_of_variant` and is kept. `must_fill` stays the
+     *  unconditional answer, and this scopes it: "must fill, in this world". */
+    variant_of?: { field: string; value: string };
 }
 
 /** Schema entry for the main card or a named card kind. */

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -712,6 +712,16 @@ mod args_canon {
             "both `validation::must_fill` triggers must carry one key set"
         );
         add("validation::must_fill", marker.args);
+        add(
+            "validation::out_of_variant",
+            crate::quill::compose::out_of_variant_warning(
+                &path,
+                "classification",
+                "UNCLASSIFIED",
+                "CUI",
+            )
+            .args,
+        );
         // Built at the pre-render walk rather than from an error type: a quill
         // declares the construct, so there is nothing to fail.
         add("plate::unsupported_construct", {

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -16,6 +16,7 @@ mod seed;
 mod tree;
 mod types;
 pub(crate) mod validation;
+pub(crate) mod variant;
 
 pub use config::{CoercionError, QuillConfig};
 pub(crate) use config::Leniency;
@@ -30,7 +31,7 @@ pub use tree::FileTreeNode;
 pub use validation::ValidationError;
 pub use types::{
     BlockConstruct, BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, GroupSchema,
-    UiCardSchema, UiFieldSchema,
+    UiCardSchema, UiFieldSchema, VariantFields, VariantOf,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -134,11 +134,8 @@ fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
         .map(|r| r.0.iter().map(|g| g.id.as_str()).collect());
     let variants = variant::index(card);
     for field in group_fields(card.fields.values(), registry.as_deref()) {
-        // The blueprint is one static form, so it shows the one world its own
-        // discriminant cell names. A skipped variant's fields are named on the
-        // discriminant instead (`when_lines`): an author who changes that cell
-        // learns which fields come into play, and re-validating then reports
-        // them unauthored.
+        // One static form shows the one world its own discriminant cell names;
+        // `when_lines` names the fields of every world it does not.
         if !variant::in_play(field, |d| variant::blueprint_value(card, d)) {
             continue;
         }
@@ -146,12 +143,9 @@ fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
     }
 }
 
-/// `when <VALUE>: <field>, <field>` for each of this discriminant's variants
-/// the blueprint is not showing, in declaration order. Empty for every field
-/// that is not a discriminant with skipped variants.
-///
-/// Field names are snake_case, so the line cannot collide with the inline
-/// annotation grammar's reserved characters.
+/// `when <VALUE>: <field>, <field>` per variant the blueprint is not showing,
+/// in declaration order. Field names are snake_case, so the line cannot collide
+/// with the reserved characters of the inline annotation grammar.
 fn when_lines(
     card: &CardSchema,
     variants: &IndexMap<&str, IndexMap<&str, Vec<&str>>>,

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -7,7 +7,7 @@
 
 use indexmap::IndexMap;
 
-use super::{blank, CardSchema, FieldSchema, FieldType, QuillConfig};
+use super::{blank, variant, CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::document::prescan::NestedComment;
 use crate::document::{Card, Document, Payload, PayloadItem};
@@ -132,9 +132,40 @@ fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
         .as_ref()
         .and_then(|u| u.groups.as_ref())
         .map(|r| r.0.iter().map(|g| g.id.as_str()).collect());
+    let variants = variant::index(card);
     for field in group_fields(card.fields.values(), registry.as_deref()) {
-        append_field(items, field);
+        // The blueprint is one static form, so it shows the one world its own
+        // discriminant cell names. A skipped variant's fields are named on the
+        // discriminant instead (`when_lines`): an author who changes that cell
+        // learns which fields come into play, and re-validating then reports
+        // them unauthored.
+        if !variant::in_play(field, |d| variant::blueprint_value(card, d)) {
+            continue;
+        }
+        append_field(items, field, &when_lines(card, &variants, &field.name));
     }
+}
+
+/// `when <VALUE>: <field>, <field>` for each of this discriminant's variants
+/// the blueprint is not showing, in declaration order. Empty for every field
+/// that is not a discriminant with skipped variants.
+///
+/// Field names are snake_case, so the line cannot collide with the inline
+/// annotation grammar's reserved characters.
+fn when_lines(
+    card: &CardSchema,
+    variants: &IndexMap<&str, IndexMap<&str, Vec<&str>>>,
+    name: &str,
+) -> Vec<String> {
+    let Some(values) = variants.get(name) else {
+        return Vec::new();
+    };
+    let shown = variant::blueprint_value(card, name);
+    values
+        .iter()
+        .filter(|(value, _)| **value != shown)
+        .map(|(value, fields)| format!("when {}: {}", value, fields.join(", ")))
+        .collect()
 }
 
 /// Order fields by `ui.group` (ungrouped lead, then grouped clusters),
@@ -173,7 +204,7 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 /// Append one top-level field. Dispatches typed tables (`array<object>`) and
 /// typed dictionaries (`object` with `properties`) to their per-property
 /// builders; everything else is a scalar/array cell.
-fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema, when: &[String]) {
     // Typed table: an array whose element is an object with properties.
     if matches!(field.r#type, FieldType::Array) {
         if let Some(elem) = &field.items {
@@ -194,18 +225,23 @@ fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
         }
     }
 
-    append_scalar(items, field);
+    append_scalar(items, field, when);
 }
 
 /// Push the leading prose comments for a *top-level* field: the description,
-/// then the `# e.g.` hint. `eg_when` gates the hint: a scalar surfaces it only
-/// when a `default:` already occupies the cell (otherwise the example *is* the
-/// cell's value), while typed containers always surface it (their example never
-/// inlines). The gate is a value-axis question and stays keyed on `default`:
-/// `must_fill` never moves an example between the cell and the hint.
-fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool) {
+/// the `when <VALUE>: …` lines a discriminant carries for the variants this
+/// blueprint is not showing, then the `# e.g.` hint. `eg_when` gates the hint: a
+/// scalar surfaces it only when a `default:` already occupies the cell
+/// (otherwise the example *is* the cell's value), while typed containers always
+/// surface it (their example never inlines). The gate is a value-axis question
+/// and stays keyed on `default`: `must_fill` never moves an example between the
+/// cell and the hint.
+fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool, when: &[String]) {
     if let Some(desc) = collapse_opt(&field.description) {
         items.push(PayloadItem::comment(desc));
+    }
+    for line in when {
+        items.push(PayloadItem::comment(line.clone()));
     }
     if eg_when {
         if let Some(eg) = field.example.as_ref() {
@@ -243,12 +279,12 @@ fn scalar_value(field: &FieldSchema) -> JsonValue {
 
 /// Append a scalar / scalar-array / richtext field as a single payload field
 /// plus its trailing inline type annotation.
-fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema, when: &[String]) {
     // A richtext field never inlines its `example:` as the marker value, so
     // (unlike other defaultless scalars) the example would vanish entirely.
     // Surface it as a `# e.g.` hint instead (no-ops when no `example:` is set).
     let eg_when = field.default.is_some() || matches!(field.r#type, FieldType::RichText { .. });
-    push_leading(items, field, eg_when);
+    push_leading(items, field, eg_when, when);
     let (json, fill) = scalar_cell(field);
     items.push(PayloadItem::Field {
         key: field.name.clone(),
@@ -325,7 +361,7 @@ fn append_typed_dict(
     field: &FieldSchema,
     props: &IndexMap<String, Box<FieldSchema>>,
 ) {
-    push_leading(items, field, true);
+    push_leading(items, field, true, &[]);
 
     let (value, nested, fills) = match field.default.as_ref().map(|d| d.as_json()) {
         // `default: {}` → expand to the field's blank-filled shape so every key
@@ -356,7 +392,7 @@ fn append_typed_table(
     field: &FieldSchema,
     item_props: &IndexMap<String, Box<FieldSchema>>,
 ) {
-    push_leading(items, field, true);
+    push_leading(items, field, true, &[]);
 
     let (value, nested, fills) = match field.default.as_ref().map(|d| d.as_json()) {
         // Any default (including `[]`) is shippable as-is, rendered verbatim.

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -674,10 +674,9 @@ fn collect_unauthored_diags(
 ) {
     let payload = card.payload();
     for (name, field) in &schema.fields {
-        // An out-of-play variant field obliges nothing: the world it belongs to
-        // is not the one this document is in. Its `must_fill` is unchanged and
-        // applies the moment the discriminant names its variant, which is what
-        // makes a discriminant flip tell a strict consumer "not done".
+        // An out-of-play variant field obliges nothing. Its `must_fill` is
+        // unchanged and applies the moment the discriminant names its variant,
+        // which is how a flip tells a strict consumer "not done".
         if !variant::in_play(field, |d| {
             variant::document_value(schema, d, payload.get(d))
         }) {
@@ -689,13 +688,9 @@ fn collect_unauthored_diags(
 
 /// Warn at each authored, non-blank value sitting in a field whose variant is
 /// not in play: a `cui_poc` on a memo whose `classification` reads
-/// `UNCLASSIFIED`.
-///
-/// A warning, never a gate, and the value is carried rather than dropped. An
-/// editor flipping a discriminant strands the old world's answers, and deleting
-/// them to recover would be the form-toggle trap; the render floor keeps
-/// projecting them, so nothing is lost and the plate — which reads a variant
-/// field unconditionally — stays total.
+/// `UNCLASSIFIED`. The value is carried, not dropped — the render floor keeps
+/// projecting it, so flipping a discriminant strands an answer without
+/// destroying it.
 ///
 /// Blank-ness is the field's own [`blank`], so the `integer`/`number`/`boolean`
 /// seam applies here too: an authored `0` in an out-of-play numeric field is
@@ -732,8 +727,7 @@ fn collect_out_of_variant(
         if resolved == variant.value {
             continue;
         }
-        // Absent, null, and the field's own blank all say "nobody answered
-        // here", which is exactly what an out-of-play field should hold.
+        // Absent, null, and the blank are what an out-of-play field should hold.
         let Some(value) = payload.get(name).filter(|v| !v.as_json().is_null()) else {
             continue;
         };

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use indexmap::IndexMap;
 
 use super::resolved::FieldSource;
+use super::variant;
 use super::{seed, CardSchema, CoercionError, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
 use crate::normalize::{normalize_document, normalize_field_name};
 use crate::quill::blank;
@@ -212,9 +213,9 @@ impl Quill {
     /// The editor-facing validation surface. Forwards the canonical
     /// `validation::*` diagnostics verbatim (same code, `path`, `hint`) so
     /// consumers route on the code without parsing message text: type
-    /// mismatches, unknown card kinds, body-on-disabled-body, and the non-fatal
-    /// `validation::must_fill` warning, the only non-fatal one; the rest are
-    /// blockers.
+    /// mismatches, unknown card kinds, body-on-disabled-body, and the two
+    /// non-fatal warnings — `validation::must_fill` and
+    /// `validation::out_of_variant`; the rest are blockers.
     ///
     /// `validation::must_fill` has **two triggers**, covering disjoint failures
     /// under one code: a `!must_fill` marker the document carries
@@ -242,6 +243,7 @@ impl Quill {
                 .into_iter()
                 .filter(|d| !claimed.contains(&d.path)),
         );
+        diags.extend(validate_out_of_variant(self.config(), doc));
         diags.extend(self.validate_seed(doc));
         diags
     }
@@ -672,8 +674,109 @@ fn collect_unauthored_diags(
 ) {
     let payload = card.payload();
     for (name, field) in &schema.fields {
+        // An out-of-play variant field obliges nothing: the world it belongs to
+        // is not the one this document is in. Its `must_fill` is unchanged and
+        // applies the moment the discriminant names its variant, which is what
+        // makes a discriminant flip tell a strict consumer "not done".
+        if !variant::in_play(field, |d| {
+            variant::document_value(schema, d, payload.get(d))
+        }) {
+            continue;
+        }
         collect_unauthored_field(field, payload.get(name), &base.field(name), out);
     }
+}
+
+/// Warn at each authored, non-blank value sitting in a field whose variant is
+/// not in play: a `cui_poc` on a memo whose `classification` reads
+/// `UNCLASSIFIED`.
+///
+/// A warning, never a gate, and the value is carried rather than dropped. An
+/// editor flipping a discriminant strands the old world's answers, and deleting
+/// them to recover would be the form-toggle trap; the render floor keeps
+/// projecting them, so nothing is lost and the plate — which reads a variant
+/// field unconditionally — stays total.
+///
+/// Blank-ness is the field's own [`blank`], so the `integer`/`number`/`boolean`
+/// seam applies here too: an authored `0` in an out-of-play numeric field is
+/// indistinguishable from its blank and never warns.
+fn validate_out_of_variant(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    collect_out_of_variant(&config.main, doc.main(), &DocPath::main(), &mut diags);
+    for (index, card) in doc.cards().iter().enumerate() {
+        let Some(schema) = card.kind().and_then(|k| config.card_kind(k)) else {
+            continue;
+        };
+        collect_out_of_variant(
+            schema,
+            card,
+            &DocPath::card(card.kind(), index),
+            &mut diags,
+        );
+    }
+    diags
+}
+
+fn collect_out_of_variant(
+    schema: &CardSchema,
+    card: &Card,
+    base: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    let payload = card.payload();
+    for (name, field) in &schema.fields {
+        let Some(variant) = &field.variant_of else {
+            continue;
+        };
+        let resolved = variant::document_value(schema, &variant.field, payload.get(&variant.field));
+        if resolved == variant.value {
+            continue;
+        }
+        // Absent, null, and the field's own blank all say "nobody answered
+        // here", which is exactly what an out-of-play field should hold.
+        let Some(value) = payload.get(name).filter(|v| !v.as_json().is_null()) else {
+            continue;
+        };
+        if value.as_json() == blank(field).as_json() {
+            continue;
+        }
+        out.push(out_of_variant_warning(
+            &base.field(name),
+            &variant.field,
+            &resolved,
+            &variant.value,
+        ));
+    }
+}
+
+pub(crate) fn out_of_variant_warning(
+    path: &DocPath,
+    discriminant: &str,
+    resolved: &str,
+    owner: &str,
+) -> Diagnostic {
+    let path = path.to_string();
+    let reading = if resolved.is_empty() {
+        "is blank".to_string()
+    } else {
+        format!("reads `{resolved}`")
+    };
+    Diagnostic::new(
+        Severity::Warning,
+        format!(
+            "Field `{path}` exists only where `{discriminant}` is `{owner}`, but \
+             `{discriminant}` {reading}."
+        ),
+    )
+    .with_code("validation::out_of_variant".to_string())
+    .with_path(path)
+    .with_arg("discriminant", discriminant.into())
+    .with_arg("resolved", resolved.into())
+    .with_arg("variant", owner.into())
+    .with_hint(format!(
+        "Either set `{discriminant}` to `{owner}`, or clear the field. The value is kept and \
+         still renders."
+    ))
 }
 
 /// Warn at each **cell** the schema obliges and the document leaves unauthored.

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -727,11 +727,7 @@ fn collect_out_of_variant(
         if resolved == variant.value {
             continue;
         }
-        // Absent, null, and the blank are what an out-of-play field should hold.
-        let Some(value) = payload.get(name).filter(|v| !v.as_json().is_null()) else {
-            continue;
-        };
-        if value.as_json() == blank(field).as_json() {
+        if payload.get(name).is_none_or(|v| unanswered(field, v)) {
             continue;
         }
         out.push(out_of_variant_warning(
@@ -740,6 +736,24 @@ fn collect_out_of_variant(
             &resolved,
             &variant.value,
         ));
+    }
+}
+
+/// Whether `value` says "nobody answered here", the state an out-of-play field
+/// should be in. Null and the field's [`blank`] are that; so is an authored
+/// empty scalar or container, because `Quill::validate` reads the payload
+/// *before* coercion and a content leaf rests at `""` rather than at the empty
+/// content the blank compares as.
+fn unanswered(field: &FieldSchema, value: &QuillValue) -> bool {
+    let json = value.as_json();
+    if json.is_null() || *json == *blank(field).as_json() {
+        return true;
+    }
+    match json {
+        serde_json::Value::String(text) => text.is_empty(),
+        serde_json::Value::Object(map) => map.is_empty(),
+        serde_json::Value::Array(items) => items.is_empty(),
+        _ => false,
     }
 }
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -8,8 +8,10 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Diagnostic, Severity, diag_args};
 use crate::value::QuillValue;
 
-use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG};
-use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
+use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG, VARIANT_OF_AUTHORED_MSG};
+use super::{
+    BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema, VariantOf,
+};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
 /// string: a boolean (`true`/`false`) or number (`47`, `1.0`). `None` for
@@ -937,6 +939,183 @@ impl QuillConfig {
         }
     }
 
+    /// Lift every `variants:` field set into the card's flat field map, each
+    /// lifted field stamped with the discriminant and value it exists under.
+    ///
+    /// The hoist is the whole variant mechanism. After it runs there is no
+    /// nested structure left: `CardSchema::fields` carries every field a card
+    /// declares, so coercion, the render ladder, `conform`, and `resolve()` see
+    /// ordinary fields and need no variant knowledge. A lifted field lands
+    /// immediately after its discriminant, variants in declaration order and
+    /// fields in declaration order within each, so hoisted position *is* display
+    /// and blueprint position.
+    ///
+    /// Runs before group validation and the content-cache import, so a lifted
+    /// field earns the same `ui.group` reference check and the same
+    /// `default`/`example` content cache as a flatly-declared one.
+    fn hoist_variants(card: &mut CardSchema, context: &str, errors: &mut Vec<Diagnostic>) {
+        for (name, field) in &card.fields {
+            Self::reject_nested_variants(field, &format!("{context} '{name}'"), errors);
+        }
+        if card.fields.values().all(|f| f.variants.is_none()) {
+            return;
+        }
+
+        // Flat names are unique (they are map keys), so every duplicate here is
+        // a variant field colliding with a flat field or with another variant's.
+        // Counted across the whole card before anything is lifted: the effective
+        // type map is the flat union, and a name that resolved to two schemas
+        // would make a field's type depend on the discriminant's value, which is
+        // the one thing that would force coercion to consult another field.
+        let mut counts: IndexMap<&str, usize> = IndexMap::new();
+        for (name, field) in &card.fields {
+            *counts.entry(name.as_str()).or_default() += 1;
+            for fields in field.variants.iter().flat_map(|v| v.values()) {
+                for variant_field in fields.keys() {
+                    *counts.entry(variant_field.as_str()).or_default() += 1;
+                }
+            }
+        }
+        let collisions: HashSet<String> = counts
+            .iter()
+            .filter(|(_, count)| **count > 1)
+            .map(|(name, _)| (*name).to_string())
+            .collect();
+        for name in &collisions {
+            errors.push(
+                Diagnostic::new(
+                    Severity::Error,
+                    format!(
+                        "{context} '{name}' is declared more than once on this card. A card's \
+                         field names are one namespace: a variant's fields share it with the \
+                         card's flat fields and with every other variant's."
+                    ),
+                )
+                .with_code("quill::variant_field_collision".to_string())
+                .with_hint(format!(
+                    "Rename one of the '{name}' declarations. A field that belongs to more than \
+                     one world is declared flat, outside `variants:`."
+                )),
+            );
+        }
+
+        let mut hoisted: IndexMap<String, FieldSchema> = IndexMap::new();
+        for (name, mut field) in std::mem::take(&mut card.fields) {
+            let variants = field.variants.take();
+            let owner = format!("{context} '{name}'");
+            let enum_values = field.enum_values.clone();
+            hoisted.insert(name.clone(), field);
+
+            let Some(variants) = variants else {
+                continue;
+            };
+            let Some(enum_values) = enum_values else {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "{owner} declares `variants:` but is not `type: enum`. Variants hang \
+                             off an enum's `values:`: only a closed domain can discriminate."
+                        ),
+                    )
+                    .with_code("quill::variants_on_non_enum".to_string())
+                    .with_hint(
+                        "Declare the field as `type: enum` with a `values:` list, or move the \
+                         variant's fields out to the card's own `fields:`."
+                            .to_string(),
+                    ),
+                );
+                continue;
+            };
+
+            for (value, fields) in variants {
+                if !enum_values.contains(&value) {
+                    errors.push(
+                        Diagnostic::new(
+                            Severity::Error,
+                            format!(
+                                "{owner} declares a variant for '{value}', which is not one of \
+                                 its `values:` ({}).",
+                                enum_values.join(", ")
+                            ),
+                        )
+                        .with_code("quill::variant_unknown_value".to_string())
+                        .with_hint(if value.is_empty() {
+                            "The blank is not a member and activates no variant. Declare a real \
+                             member (`undecided`, `n_a`) where the empty state owns fields."
+                                .to_string()
+                        } else {
+                            format!("Add '{value}' to `values:`, or correct the variant key.")
+                        }),
+                    );
+                    continue;
+                }
+                for (field_name, schema) in fields {
+                    if collisions.contains(&field_name) {
+                        continue;
+                    }
+                    let mut schema = *schema;
+                    schema.variant_of = Some(VariantOf {
+                        field: name.clone(),
+                        value: value.clone(),
+                    });
+                    let owner = format!("{context} '{field_name}'");
+                    if let Some(diag) = Self::validate_field_schema_shape(
+                        &schema,
+                        &field_name,
+                        ShapePosition::Top,
+                    ) {
+                        errors.push(diag);
+                        continue;
+                    }
+                    Self::validate_field_blueprint_constraints(&schema, &owner, errors);
+                    hoisted.insert(field_name, schema);
+                }
+            }
+        }
+        card.fields = hoisted;
+    }
+
+    /// Reject `variants:` anywhere below a card's own field map: inside an
+    /// `object`'s properties, an `array`'s element schema, or on a variant field
+    /// itself. A variant's discriminant is a sibling field on the card, so a
+    /// nested declaration has nothing to discriminate on, and variants do not
+    /// recurse.
+    fn reject_nested_variants(field: &FieldSchema, owner: &str, errors: &mut Vec<Diagnostic>) {
+        let mut nested: Vec<(&FieldSchema, String)> = Vec::new();
+        for (name, prop) in field.properties.iter().flatten() {
+            nested.push((prop, format!("{owner}.{name}")));
+        }
+        if let Some(items) = &field.items {
+            nested.push((items, format!("{owner}[]")));
+        }
+        for fields in field.variants.iter().flat_map(|v| v.values()) {
+            for (name, variant_field) in fields {
+                nested.push((variant_field, format!("{owner} variant field '{name}'")));
+            }
+        }
+        for (schema, label) in nested {
+            if schema.variants.is_some() {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "{label} declares `variants:`, which is valid only on a card's own \
+                             `enum` field. A discriminant is a sibling field on the card, and \
+                             variants do not nest."
+                        ),
+                    )
+                    .with_code("quill::variant_placement".to_string())
+                    .with_hint(
+                        "Move the enum and its `variants:` up to the card's `fields:`."
+                            .to_string(),
+                    ),
+                );
+            }
+            Self::reject_nested_variants(schema, &label, errors);
+        }
+    }
+
     /// Reject multi-line descriptions. Single-line is required so the leading
     /// `# <description>` blueprint slot stays one line and the field-comment
     /// stack remains parseable for LLM consumers.
@@ -1345,6 +1524,9 @@ impl QuillConfig {
             }
             if obj.get("type").and_then(|v| v.as_str()) == Some("richtext(inline)") {
                 return Some(format!("{RICHTEXT_INLINE_TOKEN_MSG}."));
+            }
+            if obj.contains_key("variant_of") {
+                return Some(format!("{VARIANT_OF_AUTHORED_MSG}."));
             }
             if obj.get("type").and_then(|v| v.as_str()) == Some("markdown") {
                 return Some(
@@ -1785,6 +1967,15 @@ impl QuillConfig {
                     }
                 }
             }
+        }
+
+        // Lift every enum's `variants:` into its card's flat field map before
+        // any pass that iterates fields: group references, content caches, and
+        // every later consumer then see one field list with no variant knowledge.
+        Self::hoist_variants(&mut main, "field schema", &mut errors);
+        for card in &mut card_kinds {
+            let context = format!("card_kind '{}' field", card.name);
+            Self::hoist_variants(card, &context, &mut errors);
         }
 
         // Warn when `body.example` is set together with `body.enabled: false`:

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1048,6 +1048,24 @@ impl QuillConfig {
                     if collisions.contains(&field_name) {
                         continue;
                     }
+                    // A hoisted field is a card field, so it earns the flat
+                    // path's key gate. Without it a variant could name a `$`
+                    // key or a non-identifier, and the blueprint would emit a
+                    // document that does not parse.
+                    if !Self::is_snake_case_identifier(&field_name) {
+                        errors.push(
+                            Diagnostic::new(
+                                Severity::Error,
+                                format!(
+                                    "Invalid {context} '{field_name}': field keys must be \
+                                     snake_case (lowercase letters, digits, and underscores \
+                                     only), and capitalized field keys are reserved."
+                                ),
+                            )
+                            .with_code("quill::invalid_field_name".to_string()),
+                        );
+                        continue;
+                    }
                     let mut schema = *schema;
                     schema.variant_of = Some(VariantOf {
                         field: name.clone(),

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -942,17 +942,12 @@ impl QuillConfig {
     /// Lift every `variants:` field set into the card's flat field map, each
     /// lifted field stamped with the discriminant and value it exists under.
     ///
-    /// The hoist is the whole variant mechanism. After it runs there is no
-    /// nested structure left: `CardSchema::fields` carries every field a card
-    /// declares, so coercion, the render ladder, `conform`, and `resolve()` see
-    /// ordinary fields and need no variant knowledge. A lifted field lands
-    /// immediately after its discriminant, variants in declaration order and
-    /// fields in declaration order within each, so hoisted position *is* display
-    /// and blueprint position.
-    ///
-    /// Runs before group validation and the content-cache import, so a lifted
-    /// field earns the same `ui.group` reference check and the same
-    /// `default`/`example` content cache as a flatly-declared one.
+    /// After it runs there is no nested structure left: `CardSchema::fields`
+    /// carries every field a card declares, so coercion, the render ladder,
+    /// `conform`, and `resolve()` see ordinary fields and need no variant
+    /// knowledge. A lifted field lands immediately after its discriminant,
+    /// variants in declaration order and fields in declaration order within
+    /// each, so hoisted position *is* display and blueprint position.
     fn hoist_variants(card: &mut CardSchema, context: &str, errors: &mut Vec<Diagnostic>) {
         for (name, field) in &card.fields {
             Self::reject_nested_variants(field, &format!("{context} '{name}'"), errors);
@@ -961,12 +956,11 @@ impl QuillConfig {
             return;
         }
 
-        // Flat names are unique (they are map keys), so every duplicate here is
-        // a variant field colliding with a flat field or with another variant's.
-        // Counted across the whole card before anything is lifted: the effective
-        // type map is the flat union, and a name that resolved to two schemas
-        // would make a field's type depend on the discriminant's value, which is
-        // the one thing that would force coercion to consult another field.
+        // Flat names are map keys, so every duplicate here involves a variant
+        // field. Counted across the whole card before anything is lifted: a name
+        // resolving to two schemas would make a field's type depend on the
+        // discriminant's value, the one thing that would force coercion to
+        // consult another field.
         let mut counts: IndexMap<&str, usize> = IndexMap::new();
         for (name, field) in &card.fields {
             *counts.entry(name.as_str()).or_default() += 1;
@@ -1969,9 +1963,9 @@ impl QuillConfig {
             }
         }
 
-        // Lift every enum's `variants:` into its card's flat field map before
-        // any pass that iterates fields: group references, content caches, and
-        // every later consumer then see one field list with no variant knowledge.
+        // Before every pass that iterates fields, so a hoisted field earns the
+        // same `ui.group` reference check and `default`/`example` content cache
+        // as a flatly-declared one.
         Self::hoist_variants(&mut main, "field schema", &mut errors);
         for card in &mut card_kinds {
             let context = format!("card_kind '{}' field", card.name);

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -69,15 +69,11 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             QUILLMARK_MUST_FILL_KEY.to_string(),
             serde_json::Value::Bool(field.must_fill()),
         );
-        // Beside `must_fill`, and in the prelude for the same reason: the enum
-        // arm returns early, and a discriminant's own variant fields are enums
-        // often enough. The pair reads "must fill, in this world" — `must_fill`
-        // stays the unconditional derived answer and this scopes it.
-        //
-        // No `if`/`then` companion: an out-of-variant value is wire-valid by
-        // design (it coerces, and the render floor projects it), so a standard
-        // validator accepting it agrees with the engine. Diagnosing it is
-        // `Quill::validate`'s (`validation::out_of_variant`).
+        // In the prelude beside `must_fill`, for the reason stated there. The
+        // pair reads "must fill, in this world": `must_fill` stays the
+        // unconditional answer and this scopes it. No `if`/`then` companion — an
+        // out-of-variant value is wire-valid (it coerces, and the floor projects
+        // it), so a standard validator accepting it agrees with the engine.
         if let Some(variant) = &field.variant_of {
             schema.insert(
                 QUILLMARK_VARIANT_OF_KEY.to_string(),

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -36,6 +36,16 @@ pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 /// and enforcement — if a consumer wants any — is that consumer's policy.
 pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
 
+/// Transform-schema keyword scoping a field to one value of a sibling `enum`
+/// ([`FieldSchema::variant_of`](crate::quill::FieldSchema::variant_of)), as
+/// `{field, value}`. Emitted only on a field hoisted out of an enum's
+/// `variants:`; an unconditional field carries nothing.
+///
+/// A hide/show signal for editors, not a validity constraint: the field is
+/// declared and blank-filled regardless of the discriminant, so a backend
+/// reads it unconditionally.
+pub const QUILLMARK_VARIANT_OF_KEY: &str = "quillmark:variant_of";
+
 /// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
 ///
 /// The descriptor marks richtext fields with `contentMediaType:
@@ -59,6 +69,21 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             QUILLMARK_MUST_FILL_KEY.to_string(),
             serde_json::Value::Bool(field.must_fill()),
         );
+        // Beside `must_fill`, and in the prelude for the same reason: the enum
+        // arm returns early, and a discriminant's own variant fields are enums
+        // often enough. The pair reads "must fill, in this world" — `must_fill`
+        // stays the unconditional derived answer and this scopes it.
+        //
+        // No `if`/`then` companion: an out-of-variant value is wire-valid by
+        // design (it coerces, and the render floor projects it), so a standard
+        // validator accepting it agrees with the engine. Diagnosing it is
+        // `Quill::validate`'s (`validation::out_of_variant`).
+        if let Some(variant) = &field.variant_of {
+            schema.insert(
+                QUILLMARK_VARIANT_OF_KEY.to_string(),
+                serde_json::json!({ "field": variant.field, "value": variant.value }),
+            );
+        }
         // A finite domain projects to the idiomatic JSON-Schema spelling
         // `{type: string, enum: [...]}`: exactly what a backend dispatches on
         // today (a plain string), plus the domain. Keyed on the domain, as the

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -39,6 +39,12 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     // field is skipped: it is never iterated here.
     let mut items: Vec<PayloadItem> = Vec::new();
     for (name, field) in &schema.fields {
+        // A variant field seeds only in the world the seed itself lands in,
+        // resolved from the discriminant's own seeded value (`example:` ›
+        // `default:` › blank).
+        if !crate::quill::variant::in_play(field, |d| crate::quill::variant::seed_value(schema, d)) {
+            continue;
+        }
         let overlaid = overlay.and_then(|o| o.fields.get(name));
         let Some(value) = overlaid
             .or(field.example_content.as_ref())

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -39,9 +39,7 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     // field is skipped: it is never iterated here.
     let mut items: Vec<PayloadItem> = Vec::new();
     for (name, field) in &schema.fields {
-        // A variant field seeds only in the world the seed itself lands in,
-        // resolved from the discriminant's own seeded value (`example:` ›
-        // `default:` › blank).
+        // A variant field seeds only in the world the seed itself lands in.
         if !crate::quill::variant::in_play(field, |d| crate::quill::variant::seed_value(schema, d)) {
             continue;
         }

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -39,8 +39,11 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     // field is skipped: it is never iterated here.
     let mut items: Vec<PayloadItem> = Vec::new();
     for (name, field) in &schema.fields {
-        // A variant field seeds only in the world the seed itself lands in.
-        if !crate::quill::variant::in_play(field, |d| crate::quill::variant::seed_value(schema, d)) {
+        // A variant field seeds only in the world the seed itself lands in,
+        // overlay included: `$seed` may name the discriminant.
+        if !crate::quill::variant::in_play(field, |d| {
+            crate::quill::variant::seed_value(schema, d, overlay)
+        }) {
             continue;
         }
         let overlaid = overlay.and_then(|o| o.fields.get(name));

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -307,3 +307,42 @@ fn well_formed_seed_overlay_yields_no_seed_diagnostics() {
         "a well-formed overlay should produce no seed diagnostics: {diags:?}",
     );
 }
+
+/// The overlay leads the variant axis as it leads every other field: supplying
+/// one is a template author deciding. Resolving the discriminant from the
+/// schema alone commits a card whose own `action` names a world its fields were
+/// drawn from another, silently dropping the overlay's answer.
+#[test]
+fn a_seed_overlay_naming_a_discriminant_seeds_that_variant() {
+    const VARIANT_QUILL: &str = r#"
+quill: { name: seed_variant, version: "1.0", backend: typst, description: Seed variant test }
+main:
+  fields:
+    title: { type: string, default: "" }
+card_kinds:
+  indorsement:
+    fields:
+      action:
+        type: enum
+        values: [approve, disapprove]
+        default: approve
+        variants:
+          disapprove:
+            reason: { type: string, default: "" }
+"#;
+    let quill = quill_from_yaml(VARIANT_QUILL);
+
+    let card = quill
+        .seed_card(
+            "indorsement",
+            Some(&overlay(json!({"action": "disapprove", "reason": "not in my lane"}))),
+        )
+        .expect("known kind");
+    let fields = card.payload().to_index_map();
+    assert_eq!(fields["action"].as_str(), Some("disapprove"));
+    assert_eq!(fields["reason"].as_str(), Some("not in my lane"));
+
+    // With no overlay the schema default holds, and the other world stays out.
+    let plain = quill.seed_card("indorsement", None).expect("known kind");
+    assert!(plain.payload().to_index_map().get("reason").is_none());
+}

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -267,6 +267,32 @@ impl Serialize for GroupRegistry {
     }
 }
 
+/// The enum value a variant field exists under: the back-reference the loader's
+/// hoist leaves on every field lifted out of an [`enum`](FieldType::Enum)
+/// field's `variants:` map.
+///
+/// A field carrying one is *in play* only where its discriminant resolves to
+/// `value`; out of play it is skipped by the blueprint, the seeder, and the
+/// must-fill predicate, and an authored non-blank value in it draws
+/// `validation::out_of_variant`. It stays declared, typed, and blank-filled at
+/// the render floor regardless: conditional existence is an authoring and
+/// validation fact, never a wire one, so a plate reads a variant field
+/// unconditionally.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct VariantOf {
+    /// The discriminant: a sibling `enum` field on the same card.
+    pub field: String,
+    /// The discriminant value this field exists under; a member of that enum's
+    /// `values:`, never the blank (which activates nothing).
+    pub value: String,
+}
+
+/// Per-value field sets authored under an `enum` field's `variants:`, keyed by
+/// enum value then by field name. Both levels keep declaration order, which the
+/// hoist turns into position in the card's field map.
+pub type VariantFields = IndexMap<String, IndexMap<String, Box<FieldSchema>>>;
+
 /// Schema definition for a card kind (composable content blocks)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -516,6 +542,17 @@ pub struct FieldSchema {
     /// commits this so a seeded field is content from birth. `None` under the same
     /// conditions as [`default_content`](Self::default_content).
     pub example_content: Option<QuillValue>,
+    /// Per-value field sets authored under this `enum` field's `variants:`.
+    ///
+    /// The parse landing zone only: the loader's hoist drains it into the card's
+    /// flat field map, stamping each lifted field's
+    /// [`variant_of`](Self::variant_of), so a loaded schema always reads `None`
+    /// here and `CardSchema::fields` is the one carrier thereafter. Never
+    /// serialized — `schema()` emits the hoisted form.
+    pub variants: Option<VariantFields>,
+    /// Set by the hoist on a field lifted out of an enum's `variants:`: the
+    /// discriminant and value it exists under. See [`VariantOf`].
+    pub variant_of: Option<VariantOf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -540,7 +577,19 @@ struct FieldSchemaDef {
     // Element schema for arrays.
     pub items: Option<serde_json::Value>,
     pub inline: Option<bool>,
+    /// Per-value field sets on an `enum` field, keyed by enum value.
+    pub variants: Option<serde_json::Map<String, serde_json::Value>>,
+    /// Parsed only to reject it by name: `variant_of` is emitted by `schema()`,
+    /// never authored. Under `deny_unknown_fields` an absent binding reports
+    /// "unknown field `variant_of`" with no route to `variants:`.
+    pub variant_of: Option<serde_json::Value>,
 }
+
+/// Shared by this deserializer's error and `QuillConfig::field_parse_hint`'s
+/// hint text, so the two can't drift.
+pub(crate) const VARIANT_OF_AUTHORED_MSG: &str =
+    "variant_of is emitted by the schema projection, never authored; declare the field \
+     under its discriminant enum's variants: map";
 
 impl FieldSchema {
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {
@@ -557,6 +606,8 @@ impl FieldSchema {
             items: None,
             default_content: None,
             example_content: None,
+            variants: None,
+            variant_of: None,
         }
     }
 
@@ -584,6 +635,33 @@ impl FieldSchema {
         // `type: enum` requires `values:`; `values:` on any other type, and
         // `enum:` on any type at all, is a hard error.
         let enum_values = Self::resolve_enum_values(&r#type, def.enum_key, def.values)?;
+        if def.variant_of.is_some() {
+            return Err(VARIANT_OF_AUTHORED_MSG.to_string());
+        }
+        // Membership, collision, and placement are the hoist's checks (they need
+        // the whole card); this only builds the tree it will drain.
+        let variants = match def.variants {
+            None => None,
+            Some(variants) => {
+                let mut out: VariantFields = IndexMap::new();
+                for (value, fields) in variants {
+                    let fields = fields.as_object().cloned().ok_or_else(|| {
+                        format!("variants.{value} must be a map of field name to field schema")
+                    })?;
+                    let mut parsed = IndexMap::new();
+                    for (name, schema) in fields {
+                        let field = FieldSchema::from_quill_value(
+                            name.clone(),
+                            &QuillValue::from_json(schema),
+                        )
+                        .map_err(|e| format!("variants.{value}.{name}: {e}"))?;
+                        parsed.insert(name, Box::new(field));
+                    }
+                    out.insert(value, parsed);
+                }
+                Some(out)
+            }
+        };
         Ok(Self {
             name: key.clone(),
             r#type,
@@ -621,6 +699,9 @@ impl FieldSchema {
             // them empty.
             default_content: None,
             example_content: None,
+            variants,
+            // Stamped by the loader's hoist, which alone knows the discriminant.
+            variant_of: None,
         })
     }
 
@@ -687,10 +768,12 @@ impl Serialize for FieldSchema {
         use serde::ser::SerializeMap;
         // `inline: true` is projected back out of the enum (the flag's single
         // carrier) so the wire round-trips. `name` rides the map key; the
-        // `*_content` caches are load-time derivations, never serialized.
+        // `*_content` caches are load-time derivations, never serialized, as is
+        // `variants`, which the hoist drains into the emitted flat field map.
         let inline = matches!(self.r#type, FieldType::RichText { inline: true }).then_some(true);
         let len = 1
             + inline.is_some() as usize
+            + self.variant_of.is_some() as usize
             + self.description.is_some() as usize
             + self.default.is_some() as usize
             + self.example.is_some() as usize
@@ -733,6 +816,13 @@ impl Serialize for FieldSchema {
         }
         if let Some(v) = inline {
             map.serialize_entry("inline", &v)?;
+        }
+        // The hoisted form: a variant field is emitted flat, in hoisted
+        // position, annotated with the world it belongs to. Consumers read one
+        // ordered field list and key hide/show on this, rather than
+        // re-implementing the hoist to match what `resolve()` returns.
+        if let Some(v) = &self.variant_of {
+            map.serialize_entry("variant_of", v)?;
         }
         map.end()
     }

--- a/crates/core/src/quill/variant.rs
+++ b/crates/core/src/quill/variant.rs
@@ -1,0 +1,96 @@
+//! The variant axis: which enum-discriminated fields are in play.
+//!
+//! A field hoisted out of an enum's `variants:` carries a
+//! [`VariantOf`](super::VariantOf) back-reference and exists only where its
+//! discriminant resolves to that value. Every projection asks the same question
+//! and resolves the discriminant differently — the render ladder for a document,
+//! the blueprint's value axis for the form, the seed cascade for a seed — so the
+//! predicate takes the resolution as a closure rather than owning one.
+
+use indexmap::IndexMap;
+
+use super::{CardSchema, FieldSchema};
+use crate::value::QuillValue;
+
+/// Whether `field` is in play when each discriminant resolves through
+/// `resolve`. A field with no `variant_of` is unconditional and always in play;
+/// a variant field is in play exactly where its discriminant reads its value,
+/// so the blank (which is no member) activates nothing.
+pub(crate) fn in_play(field: &FieldSchema, resolve: impl Fn(&str) -> String) -> bool {
+    match &field.variant_of {
+        None => true,
+        Some(variant) => resolve(&variant.field) == variant.value,
+    }
+}
+
+/// The discriminant value a *document* holds: authored non-null › `default:` ›
+/// blank. The render ladder, minus `example:`, which never enters it.
+pub(crate) fn document_value(
+    card: &CardSchema,
+    name: &str,
+    authored: Option<&QuillValue>,
+) -> String {
+    // Null ≡ absent, so only those two fall through to the schema rung: an
+    // authored blank is an answer, and it activates nothing.
+    if let Some(value) = authored.filter(|v| !v.as_json().is_null()) {
+        return value.as_str().unwrap_or_default().to_string();
+    }
+    card.fields
+        .get(name)
+        .and_then(|field| field.default.as_ref())
+        .and_then(|d| d.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// The discriminant value the **blueprint** shows: its cell's value axis,
+/// `default:` › `example:` › the blank. The form's own answer decides which
+/// variant the form shows.
+pub(crate) fn blueprint_value(card: &CardSchema, name: &str) -> String {
+    let Some(field) = card.fields.get(name) else {
+        return String::new();
+    };
+    field
+        .default
+        .as_ref()
+        .or(field.example.as_ref())
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// The discriminant value a **seed** renders: `example:` (the one source seeding
+/// commits) › `default:` › blank.
+pub(crate) fn seed_value(card: &CardSchema, name: &str) -> String {
+    let Some(field) = card.fields.get(name) else {
+        return String::new();
+    };
+    field
+        .example
+        .as_ref()
+        .or(field.default.as_ref())
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Field names per discriminant value, for every field hoisted out of that
+/// discriminant's `variants:`, in hoisted order. The inverse of the hoist,
+/// rebuilt from the flat field map so `variant_of` stays the one carrier.
+pub(crate) fn index(card: &CardSchema) -> IndexMap<&str, IndexMap<&str, Vec<&str>>> {
+    let mut out: IndexMap<&str, IndexMap<&str, Vec<&str>>> = IndexMap::new();
+    for (name, field) in &card.fields {
+        let Some(variant) = &field.variant_of else {
+            continue;
+        };
+        out.entry(variant.field.as_str())
+            .or_default()
+            .entry(variant.value.as_str())
+            .or_default()
+            .push(name.as_str());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/quill/variant.rs
+++ b/crates/core/src/quill/variant.rs
@@ -9,6 +9,19 @@ use indexmap::IndexMap;
 
 use super::{CardSchema, FieldSchema};
 use crate::value::QuillValue;
+use crate::SeedOverlay;
+
+/// A discriminant's authored text, canonicalizing the bare scalars a `string`/
+/// `enum` field adopts at coercion (`true`, `47`). Without it the variant axis
+/// and coercion disagree: the plate lowers `flag: true` to `"true"` and puts the
+/// variant in play while the axis reads the blank and calls it out.
+fn authored_text(value: &QuillValue) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| super::config::scalar_as_string(value.as_json()))
+        .unwrap_or_default()
+}
 
 /// Whether `field` is in play when each discriminant resolves through
 /// `resolve`. The blank is no member, so it activates nothing.
@@ -29,7 +42,7 @@ pub(crate) fn document_value(
     // Null ≡ absent, so only those two fall through to the schema rung: an
     // authored blank is an answer, and it activates nothing.
     if let Some(value) = authored.filter(|v| !v.as_json().is_null()) {
-        return value.as_str().unwrap_or_default().to_string();
+        return authored_text(value);
     }
     card.fields
         .get(name)
@@ -55,9 +68,15 @@ pub(crate) fn blueprint_value(card: &CardSchema, name: &str) -> String {
         .to_string()
 }
 
-/// The discriminant value a **seed** renders: `example:` (the one source seeding
-/// commits) › `default:` › blank.
-pub(crate) fn seed_value(card: &CardSchema, name: &str) -> String {
+/// The discriminant value a **seed** renders: `$seed` overlay › `example:` (the
+/// one source seeding commits) › `default:` › blank. The overlay leads for the
+/// same reason it leads on every other field — supplying one is a template
+/// author deciding — and a seed that skipped it would commit a card whose own
+/// discriminant names a world its fields were drawn from another.
+pub(crate) fn seed_value(card: &CardSchema, name: &str, overlay: Option<&SeedOverlay>) -> String {
+    if let Some(value) = overlay.and_then(|o| o.fields.get(name)) {
+        return authored_text(value);
+    }
     let Some(field) = card.fields.get(name) else {
         return String::new();
     };

--- a/crates/core/src/quill/variant.rs
+++ b/crates/core/src/quill/variant.rs
@@ -2,10 +2,8 @@
 //!
 //! A field hoisted out of an enum's `variants:` carries a
 //! [`VariantOf`](super::VariantOf) back-reference and exists only where its
-//! discriminant resolves to that value. Every projection asks the same question
-//! and resolves the discriminant differently — the render ladder for a document,
-//! the blueprint's value axis for the form, the seed cascade for a seed — so the
-//! predicate takes the resolution as a closure rather than owning one.
+//! discriminant resolves to that value. Each projection cuts a different ladder
+//! to resolve it, so the predicate takes the resolution as a closure.
 
 use indexmap::IndexMap;
 
@@ -13,9 +11,7 @@ use super::{CardSchema, FieldSchema};
 use crate::value::QuillValue;
 
 /// Whether `field` is in play when each discriminant resolves through
-/// `resolve`. A field with no `variant_of` is unconditional and always in play;
-/// a variant field is in play exactly where its discriminant reads its value,
-/// so the blank (which is no member) activates nothing.
+/// `resolve`. The blank is no member, so it activates nothing.
 pub(crate) fn in_play(field: &FieldSchema, resolve: impl Fn(&str) -> String) -> bool {
     match &field.variant_of {
         None => true,
@@ -74,9 +70,8 @@ pub(crate) fn seed_value(card: &CardSchema, name: &str) -> String {
         .to_string()
 }
 
-/// Field names per discriminant value, for every field hoisted out of that
-/// discriminant's `variants:`, in hoisted order. The inverse of the hoist,
-/// rebuilt from the flat field map so `variant_of` stays the one carrier.
+/// Discriminant → value → the fields hoisted out of it, in hoisted order.
+/// Rebuilt from the flat field map, so `variant_of` stays the one carrier.
 pub(crate) fn index(card: &CardSchema) -> IndexMap<&str, IndexMap<&str, Vec<&str>>> {
     let mut out: IndexMap<&str, IndexMap<&str, Vec<&str>>> = IndexMap::new();
     for (name, field) in &card.fields {

--- a/crates/core/src/quill/variant/tests.rs
+++ b/crates/core/src/quill/variant/tests.rs
@@ -1,0 +1,453 @@
+//! The variant axis: the load-time hoist, and the projections that read it.
+
+use crate::quill::schema::{QUILLMARK_MUST_FILL_KEY, QUILLMARK_VARIANT_OF_KEY};
+use crate::quill::{blank, build_transform_schema, quill_from_yaml, QuillConfig};
+use crate::{Document, Quill};
+
+const CLASSIFICATION: &str = r#"
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI, SECRET]
+      default: ""
+      variants:
+        CUI:
+          cui_controlled_by: { type: string }
+          cui_category: { type: string, default: "" }
+        SECRET:
+          declassify_on: { type: date }
+"#;
+
+fn yaml(fields: &str) -> String {
+    format!(
+        "quill: {{ name: vf, version: 1.0.0, backend: typst, description: variants }}\nmain:\n  fields:\n{fields}"
+    )
+}
+
+fn config(fields: &str) -> QuillConfig {
+    QuillConfig::from_yaml_with_warnings(&yaml(fields))
+        .map(|(config, _)| config)
+        .unwrap_or_else(|e| panic!("schema should load: {e:?}"))
+}
+
+fn load_err(fields: &str) -> Vec<String> {
+    QuillConfig::from_yaml_with_warnings(&yaml(fields))
+        .err()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|d| d.code.clone())
+        .collect()
+}
+
+fn md(fields: &str) -> String {
+    format!("~~~\n$quill: vf@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+fn doc(fields: &str) -> Document {
+    Document::parse(&md(fields)).expect("document parses").document
+}
+
+/// Every diagnostic as `(code, path)`, sorted so assertions read as sets.
+fn diags(quill: &Quill, doc: &Document) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = quill
+        .validate(doc)
+        .iter()
+        .map(|d| {
+            (
+                d.code.clone().unwrap_or_default(),
+                d.path.clone().unwrap_or_default(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn hoist_lands_variant_fields_after_their_discriminant() {
+    let config = config(&format!("{CLASSIFICATION}    trailing:\n      type: string\n"));
+    let names: Vec<&str> = config.main.fields.keys().map(String::as_str).collect();
+    assert_eq!(
+        names,
+        [
+            "classification",
+            "cui_controlled_by",
+            "cui_category",
+            "declassify_on",
+            "trailing",
+        ],
+        "variants hoist in declaration order, immediately after the discriminant"
+    );
+    let stamp = |name: &str| {
+        config.main.fields[name]
+            .variant_of
+            .as_ref()
+            .map(|v| (v.field.as_str(), v.value.as_str()))
+    };
+    assert_eq!(stamp("cui_controlled_by"), Some(("classification", "CUI")));
+    assert_eq!(stamp("declassify_on"), Some(("classification", "SECRET")));
+    assert_eq!(stamp("trailing"), None);
+    assert!(
+        config.main.fields["classification"].variants.is_none(),
+        "the hoist drains `variants:`: the flat field map is the one carrier"
+    );
+}
+
+/// `must_fill` derives from `default:` presence exactly as for a flat field:
+/// the variant scopes the obligation rather than introducing a second axis.
+#[test]
+fn a_variant_field_keeps_its_own_type_and_obligation() {
+    let config = config(CLASSIFICATION);
+    assert!(config.main.fields["cui_controlled_by"].must_fill());
+    assert!(!config.main.fields["cui_category"].must_fill());
+}
+
+#[test]
+fn variants_on_a_non_enum_field_is_a_load_error() {
+    let codes = load_err(
+        "    note:\n      type: string\n      variants:\n        CUI:\n          x: { type: string }\n",
+    );
+    assert!(codes.contains(&"quill::variants_on_non_enum".to_string()), "{codes:?}");
+}
+
+#[test]
+fn a_variant_key_outside_the_domain_is_a_load_error() {
+    let codes = load_err(
+        "    level:\n      type: enum\n      values: [a, b]\n      variants:\n        c:\n          x: { type: string }\n",
+    );
+    assert!(codes.contains(&"quill::variant_unknown_value".to_string()), "{codes:?}");
+}
+
+/// The blank is never a member, so it owns no variant: it is the absence of a
+/// choice, and a field existing under it would exist under "nobody answered".
+#[test]
+fn the_blank_owns_no_variant() {
+    let codes = load_err(
+        "    level:\n      type: enum\n      values: [a, b]\n      variants:\n        \"\":\n          x: { type: string }\n",
+    );
+    assert!(codes.contains(&"quill::variant_unknown_value".to_string()), "{codes:?}");
+}
+
+/// One namespace per card. A name resolving to two schemas would make a field's
+/// type depend on the discriminant's value, the one thing that would force
+/// coercion to consult another field.
+#[test]
+fn a_variant_field_colliding_with_a_flat_field_is_a_load_error() {
+    let codes = load_err(
+        "    level:\n      type: enum\n      values: [a, b]\n      variants:\n        a:\n          note: { type: integer }\n    note:\n      type: string\n",
+    );
+    assert!(codes.contains(&"quill::variant_field_collision".to_string()), "{codes:?}");
+}
+
+#[test]
+fn two_variants_declaring_one_name_is_a_load_error() {
+    let codes = load_err(
+        "    level:\n      type: enum\n      values: [a, b]\n      variants:\n        a:\n          note: { type: string }\n        b:\n          note: { type: integer }\n",
+    );
+    assert!(codes.contains(&"quill::variant_field_collision".to_string()), "{codes:?}");
+}
+
+#[test]
+fn variants_below_card_level_is_a_load_error() {
+    let codes = load_err(
+        "    row:\n      type: object\n      properties:\n        level:\n          type: enum\n          values: [a]\n          variants:\n            a:\n              x: { type: string }\n",
+    );
+    assert!(codes.contains(&"quill::variant_placement".to_string()), "{codes:?}");
+}
+
+#[test]
+fn variants_do_not_nest() {
+    let codes = load_err(
+        "    level:\n      type: enum\n      values: [a]\n      variants:\n        a:\n          inner:\n            type: enum\n            values: [x]\n            variants:\n              x:\n                deep: { type: string }\n",
+    );
+    assert!(codes.contains(&"quill::variant_placement".to_string()), "{codes:?}");
+}
+
+/// `variant_of` is emission-only: `schema()` prints the hoisted form, and the
+/// authoring spelling stays nested.
+#[test]
+fn authoring_variant_of_directly_is_a_load_error() {
+    let codes = load_err(
+        "    note:\n      type: string\n      variant_of:\n        field: level\n        value: a\n",
+    );
+    assert!(codes.contains(&"quill::field_parse_error".to_string()), "{codes:?}");
+}
+
+#[test]
+fn schema_emits_the_hoisted_form_with_variant_of() {
+    let schema = config(CLASSIFICATION).schema();
+    let field = &schema["main"]["fields"]["cui_controlled_by"];
+    assert_eq!(field["variant_of"]["field"], "classification");
+    assert_eq!(field["variant_of"]["value"], "CUI");
+    assert!(
+        schema["main"]["fields"]["classification"]
+            .get("variants")
+            .is_none(),
+        "the declaration nests, the emission hoists: one shape reaches consumers"
+    );
+}
+
+#[test]
+fn transform_schema_scopes_must_fill_with_variant_of() {
+    let wire = build_transform_schema(&config(CLASSIFICATION));
+    let json = wire.as_json();
+    let field = &json["properties"]["cui_controlled_by"];
+    assert_eq!(field[QUILLMARK_VARIANT_OF_KEY]["value"], "CUI");
+    // Unconditional and scoped are separate answers: the field must be filled,
+    // in the world it belongs to.
+    assert_eq!(field[QUILLMARK_MUST_FILL_KEY], serde_json::json!(true));
+    assert!(
+        json["properties"]["classification"]
+            .get(QUILLMARK_VARIANT_OF_KEY)
+            .is_none(),
+        "an unconditional field carries no scope"
+    );
+}
+
+/// The plate reads a variant field unconditionally, so the floor stays total:
+/// conditional existence is an authoring fact, never a wire one.
+#[test]
+fn an_out_of_play_field_is_still_blank_filled_at_the_floor() {
+    let plate = config(CLASSIFICATION)
+        .compile_data(&doc("classification: UNCLASSIFIED\n"))
+        .expect("blank-filled render is total over every declared field");
+    // Each at its own blank, across two variants neither of which is in play.
+    assert_eq!(plate["cui_controlled_by"], "");
+    assert_eq!(plate["declassify_on"], "");
+}
+
+#[test]
+fn an_unauthored_obligation_waits_for_its_variant() {
+    let quill = quill_from_yaml(&yaml(CLASSIFICATION));
+
+    let unclassified = diags(&quill, &doc("classification: UNCLASSIFIED\n"));
+    assert!(
+        !unclassified
+            .iter()
+            .any(|(_, path)| path == "main.cui_controlled_by"),
+        "an out-of-play cell obliges nothing: {unclassified:?}"
+    );
+
+    // The discriminant flip is the point: the same document, one cell changed,
+    // now reports the cells a strict authoring loop must fill.
+    let cui = diags(&quill, &doc("classification: CUI\n"));
+    assert!(
+        cui.contains(&(
+            "validation::must_fill".to_string(),
+            "main.cui_controlled_by".to_string()
+        )),
+        "an in-play must-fill cell warns unauthored: {cui:?}"
+    );
+    assert!(
+        !cui.iter().any(|(_, path)| path == "main.cui_category"),
+        "a defaulted variant field stays skippable: {cui:?}"
+    );
+}
+
+#[test]
+fn an_authored_value_outside_its_variant_warns() {
+    let quill = quill_from_yaml(&yaml(CLASSIFICATION));
+    let found = diags(
+        &quill,
+        &doc("classification: UNCLASSIFIED\ncui_controlled_by: SAF/AA\n"),
+    );
+    assert!(
+        found.contains(&(
+            "validation::out_of_variant".to_string(),
+            "main.cui_controlled_by".to_string()
+        )),
+        "{found:?}"
+    );
+}
+
+#[test]
+fn out_of_variant_never_gates_render() {
+    let document = doc("classification: UNCLASSIFIED\ncui_controlled_by: SAF/AA\n");
+    let severities: Vec<_> = quill_from_yaml(&yaml(CLASSIFICATION))
+        .validate(&document)
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::out_of_variant"))
+        .map(|d| d.severity)
+        .collect();
+    assert_eq!(severities, [crate::Severity::Warning]);
+    // The stranded value is carried, not dropped: flipping a discriminant back
+    // must not have cost the author their answer.
+    let plate = config(CLASSIFICATION)
+        .compile_data(&document)
+        .expect("still renders");
+    assert_eq!(plate["cui_controlled_by"], "SAF/AA");
+}
+
+/// Absent, null, and the field's own blank all read as "nobody answered here",
+/// which is exactly what an out-of-play field should hold.
+#[test]
+fn a_blank_or_absent_out_of_play_field_is_silent() {
+    let quill = quill_from_yaml(&yaml(CLASSIFICATION));
+    for fields in [
+        "classification: UNCLASSIFIED\n",
+        "classification: UNCLASSIFIED\ncui_controlled_by: \"\"\n",
+        "classification: UNCLASSIFIED\ncui_controlled_by: null\n",
+    ] {
+        let found = diags(&quill, &doc(fields));
+        assert!(
+            !found
+                .iter()
+                .any(|(code, _)| code == "validation::out_of_variant"),
+            "{fields:?} should be silent: {found:?}"
+        );
+    }
+}
+
+/// The marker is document-sovereign: a human dropping `!must_fill` is a
+/// decision nothing re-derives, so the schema never suppresses it.
+#[test]
+fn a_marker_on_an_out_of_play_field_still_warns() {
+    let quill = quill_from_yaml(&yaml(CLASSIFICATION));
+    let found = diags(
+        &quill,
+        &doc("classification: UNCLASSIFIED\ncui_controlled_by: !must_fill\n"),
+    );
+    assert!(
+        found.contains(&(
+            "validation::must_fill".to_string(),
+            "main.cui_controlled_by".to_string()
+        )),
+        "{found:?}"
+    );
+}
+
+#[test]
+fn the_blueprint_shows_one_world_and_names_the_others() {
+    // Blank default: no variant is active, so every variant field is skipped
+    // and each is named on the discriminant.
+    let blueprint = config(CLASSIFICATION).blueprint();
+    assert!(!blueprint.contains("cui_controlled_by:"), "{blueprint}");
+    assert!(
+        blueprint.contains("# when CUI: cui_controlled_by, cui_category"),
+        "{blueprint}"
+    );
+    assert!(
+        blueprint.contains("# when SECRET: declassify_on"),
+        "{blueprint}"
+    );
+}
+
+#[test]
+fn the_blueprint_emits_the_variant_its_own_cell_names() {
+    let blueprint = config(&CLASSIFICATION.replace(r#"default: """#, "default: CUI")).blueprint();
+    assert!(
+        blueprint.contains("cui_controlled_by: !must_fill"),
+        "{blueprint}"
+    );
+    assert!(
+        !blueprint.contains("# when CUI:"),
+        "the shown world needs no when line: {blueprint}"
+    );
+    assert!(
+        blueprint.contains("# when SECRET: declassify_on"),
+        "{blueprint}"
+    );
+    assert!(!blueprint.contains("declassify_on:"), "{blueprint}");
+}
+
+#[test]
+fn a_blueprint_carrying_variants_still_round_trips() {
+    let config = config(CLASSIFICATION);
+    let blueprint = config.blueprint();
+    let parsed = Document::parse(&blueprint).expect("blueprint parses").document;
+    assert_eq!(parsed.to_markdown(), blueprint, "blueprint round-trips");
+    config.compile_data(&parsed).expect("every blueprint renders");
+}
+
+#[test]
+fn seeding_commits_only_the_active_variant() {
+    let active = CLASSIFICATION
+        .replace(r#"default: """#, "default: CUI")
+        .replace(
+            "cui_controlled_by: { type: string }",
+            "cui_controlled_by: { type: string, example: SAF/AA }",
+        )
+        .replace(
+            "declassify_on: { type: date }",
+            "declassify_on: { type: date, example: 2030-01-01 }",
+        );
+    let seeded = quill_from_yaml(&yaml(&active)).seed_document();
+    let payload = seeded.main().payload();
+    assert!(payload.get("cui_controlled_by").is_some());
+    assert!(
+        payload.get("declassify_on").is_none(),
+        "an out-of-play example never seeds"
+    );
+}
+
+/// Variants are a per-card shape: a card kind carries its own discriminant, and
+/// the hoist runs on every card the same way.
+#[test]
+fn variants_work_on_a_card_kind() {
+    let config = QuillConfig::from_yaml_with_warnings(
+        r#"
+quill: { name: vf, version: 1.0.0, backend: typst, description: variants }
+main:
+  fields:
+    title: { type: string, default: "" }
+card_kinds:
+  indorsement:
+    fields:
+      action:
+        type: enum
+        values: [approve, disapprove]
+        default: approve
+        variants:
+          disapprove:
+            reason: { type: string }
+"#,
+    )
+    .map(|(config, _)| config)
+    .expect("loads");
+    let card = config.card_kind("indorsement").unwrap();
+    let names: Vec<&str> = card.fields.keys().map(String::as_str).collect();
+    assert_eq!(names, ["action", "reason"]);
+    assert_eq!(
+        card.fields["reason"]
+            .variant_of
+            .as_ref()
+            .map(|v| v.value.as_str()),
+        Some("disapprove")
+    );
+}
+
+/// Two discriminants on one card are independent axes: each variant field
+/// resolves against its own, and the hoist keeps each block with its owner.
+#[test]
+fn two_discriminants_on_one_card_stay_independent() {
+    let two = "    kind:\n      type: enum\n      values: [letter, memo]\n      default: letter\n      variants:\n        memo:\n          memo_for: { type: string }\n    urgency:\n      type: enum\n      values: [routine, flash]\n      default: flash\n      variants:\n        flash:\n          callback: { type: string }\n";
+    let config = config(two);
+    assert_eq!(
+        config.main.fields.keys().map(String::as_str).collect::<Vec<_>>(),
+        ["kind", "memo_for", "urgency", "callback"]
+    );
+
+    // `kind` reads its default `letter`, so `memo_for` is out of play, while
+    // `urgency` reads `flash` and brings `callback` in.
+    let quill = quill_from_yaml(&yaml(two));
+    let found = diags(&quill, &doc(""));
+    assert!(
+        !found.iter().any(|(_, path)| path == "main.memo_for"),
+        "the out-of-play axis obliges nothing: {found:?}"
+    );
+    assert!(
+        found.contains(&(
+            "validation::must_fill".to_string(),
+            "main.callback".to_string()
+        )),
+        "the in-play axis obliges its own field: {found:?}"
+    );
+}
+
+#[test]
+fn blank_is_unchanged_by_the_variant_axis() {
+    let config = config(CLASSIFICATION);
+    assert_eq!(
+        blank(&config.main.fields["cui_controlled_by"]).into_json(),
+        serde_json::json!("")
+    );
+}

--- a/crates/core/src/quill/variant/tests.rs
+++ b/crates/core/src/quill/variant/tests.rs
@@ -426,6 +426,70 @@ fn two_discriminants_on_one_card_stay_independent() {
     );
 }
 
+/// A hoisted field is a card field, so it earns the flat path's key gate.
+/// Without it a variant could name a `$` key and the blueprint would emit a
+/// document with a duplicate mapping key, breaking its parseability guarantee.
+#[test]
+fn a_variant_field_name_must_be_a_valid_field_key() {
+    for bad in ["$kind", "$quill", "$body", "Foo", "bad-name", "9x", "a b"] {
+        let codes = load_err(&format!(
+            "    level:\n      type: enum\n      values: [a]\n      default: a\n      variants:\n        a:\n          \"{bad}\": {{ type: string, default: \"\" }}\n"
+        ));
+        assert!(
+            codes.contains(&"quill::invalid_field_name".to_string()),
+            "{bad:?} must be rejected: {codes:?}"
+        );
+    }
+}
+
+/// The variant axis and coercion must read one discriminant. Coercion adopts a
+/// bare scalar's canonical text, so an axis reading `as_str()` alone would call
+/// the field out of play while the plate puts it in.
+#[test]
+fn a_bare_scalar_discriminant_reads_as_its_coerced_text() {
+    let bare = "    flag:\n      type: enum\n      values: [\"true\", \"false\"]\n      default: \"false\"\n      variants:\n        \"true\":\n          why: { type: string }\n";
+    let quill = quill_from_yaml(&yaml(bare));
+
+    let authored = doc("flag: true\nwhy: because\n");
+    assert!(
+        !diags(&quill, &authored)
+            .iter()
+            .any(|(code, _)| code == "validation::out_of_variant"),
+        "the field is in play: the plate lowers `flag: true` to `\"true\"`"
+    );
+    assert_eq!(
+        config(bare).compile_data(&authored).expect("renders")["why"],
+        "because"
+    );
+    // The converse leak: an in-play obligation must not go silent either.
+    assert!(
+        diags(&quill, &doc("flag: true\n")).contains(&(
+            "validation::must_fill".to_string(),
+            "main.why".to_string()
+        )),
+        "an in-play must-fill cell still warns under a bare-scalar discriminant"
+    );
+}
+
+/// `Quill::validate` reads the payload before coercion, so a content leaf rests
+/// at `""` and a typed dict at `{}` rather than at the coerced blank. Comparing
+/// against the blank alone would warn at an already-clear field, with no edit
+/// that resolves it.
+#[test]
+fn an_uncoerced_blank_out_of_play_field_is_silent() {
+    let shapes = "    level:\n      type: enum\n      values: [p, q]\n      default: p\n      variants:\n        q:\n          rt: { type: richtext }\n          obj: { type: object, properties: { a: { type: string } } }\n          arr: { type: array, items: { type: string } }\n";
+    let found = diags(
+        &quill_from_yaml(&yaml(shapes)),
+        &doc("level: p\nrt: \"\"\nobj: {}\narr: []\n"),
+    );
+    assert!(
+        !found
+            .iter()
+            .any(|(code, _)| code == "validation::out_of_variant"),
+        "{found:?}"
+    );
+}
+
 #[test]
 fn blank_is_unchanged_by_the_variant_axis() {
     let config = config(CLASSIFICATION);

--- a/crates/core/src/quill/variant/tests.rs
+++ b/crates/core/src/quill/variant/tests.rs
@@ -92,8 +92,7 @@ fn hoist_lands_variant_fields_after_their_discriminant() {
     );
 }
 
-/// `must_fill` derives from `default:` presence exactly as for a flat field:
-/// the variant scopes the obligation rather than introducing a second axis.
+/// The variant scopes the obligation; it does not add a second axis.
 #[test]
 fn a_variant_field_keeps_its_own_type_and_obligation() {
     let config = config(CLASSIFICATION);
@@ -117,8 +116,7 @@ fn a_variant_key_outside_the_domain_is_a_load_error() {
     assert!(codes.contains(&"quill::variant_unknown_value".to_string()), "{codes:?}");
 }
 
-/// The blank is never a member, so it owns no variant: it is the absence of a
-/// choice, and a field existing under it would exist under "nobody answered".
+/// The blank is no member, so a field under it would exist under "nobody chose".
 #[test]
 fn the_blank_owns_no_variant() {
     let codes = load_err(
@@ -127,9 +125,8 @@ fn the_blank_owns_no_variant() {
     assert!(codes.contains(&"quill::variant_unknown_value".to_string()), "{codes:?}");
 }
 
-/// One namespace per card. A name resolving to two schemas would make a field's
-/// type depend on the discriminant's value, the one thing that would force
-/// coercion to consult another field.
+/// One namespace per card: a name resolving to two schemas would make a field's
+/// type depend on the discriminant's value.
 #[test]
 fn a_variant_field_colliding_with_a_flat_field_is_a_load_error() {
     let codes = load_err(
@@ -162,8 +159,7 @@ fn variants_do_not_nest() {
     assert!(codes.contains(&"quill::variant_placement".to_string()), "{codes:?}");
 }
 
-/// `variant_of` is emission-only: `schema()` prints the hoisted form, and the
-/// authoring spelling stays nested.
+/// `variant_of` is emission-only; the authoring spelling stays nested.
 #[test]
 fn authoring_variant_of_directly_is_a_load_error() {
     let codes = load_err(
@@ -192,8 +188,7 @@ fn transform_schema_scopes_must_fill_with_variant_of() {
     let json = wire.as_json();
     let field = &json["properties"]["cui_controlled_by"];
     assert_eq!(field[QUILLMARK_VARIANT_OF_KEY]["value"], "CUI");
-    // Unconditional and scoped are separate answers: the field must be filled,
-    // in the world it belongs to.
+    // Separate answers: must be filled, in the world it belongs to.
     assert_eq!(field[QUILLMARK_MUST_FILL_KEY], serde_json::json!(true));
     assert!(
         json["properties"]["classification"]
@@ -203,14 +198,12 @@ fn transform_schema_scopes_must_fill_with_variant_of() {
     );
 }
 
-/// The plate reads a variant field unconditionally, so the floor stays total:
-/// conditional existence is an authoring fact, never a wire one.
+/// The plate reads a variant field unconditionally, so the floor stays total.
 #[test]
 fn an_out_of_play_field_is_still_blank_filled_at_the_floor() {
     let plate = config(CLASSIFICATION)
         .compile_data(&doc("classification: UNCLASSIFIED\n"))
         .expect("blank-filled render is total over every declared field");
-    // Each at its own blank, across two variants neither of which is in play.
     assert_eq!(plate["cui_controlled_by"], "");
     assert_eq!(plate["declassify_on"], "");
 }
@@ -227,8 +220,7 @@ fn an_unauthored_obligation_waits_for_its_variant() {
         "an out-of-play cell obliges nothing: {unclassified:?}"
     );
 
-    // The discriminant flip is the point: the same document, one cell changed,
-    // now reports the cells a strict authoring loop must fill.
+    // One cell changed, and the cells a strict loop must fill are now reported.
     let cui = diags(&quill, &doc("classification: CUI\n"));
     assert!(
         cui.contains(&(
@@ -269,16 +261,13 @@ fn out_of_variant_never_gates_render() {
         .map(|d| d.severity)
         .collect();
     assert_eq!(severities, [crate::Severity::Warning]);
-    // The stranded value is carried, not dropped: flipping a discriminant back
-    // must not have cost the author their answer.
+    // Carried, not dropped: a flip must not cost the author their answer.
     let plate = config(CLASSIFICATION)
         .compile_data(&document)
         .expect("still renders");
     assert_eq!(plate["cui_controlled_by"], "SAF/AA");
 }
 
-/// Absent, null, and the field's own blank all read as "nobody answered here",
-/// which is exactly what an out-of-play field should hold.
 #[test]
 fn a_blank_or_absent_out_of_play_field_is_silent() {
     let quill = quill_from_yaml(&yaml(CLASSIFICATION));
@@ -297,8 +286,7 @@ fn a_blank_or_absent_out_of_play_field_is_silent() {
     }
 }
 
-/// The marker is document-sovereign: a human dropping `!must_fill` is a
-/// decision nothing re-derives, so the schema never suppresses it.
+/// The marker is document-sovereign: the schema never suppresses one.
 #[test]
 fn a_marker_on_an_out_of_play_field_still_warns() {
     let quill = quill_from_yaml(&yaml(CLASSIFICATION));
@@ -317,8 +305,7 @@ fn a_marker_on_an_out_of_play_field_still_warns() {
 
 #[test]
 fn the_blueprint_shows_one_world_and_names_the_others() {
-    // Blank default: no variant is active, so every variant field is skipped
-    // and each is named on the discriminant.
+    // Blank default: no variant is active, so every one of them is skipped.
     let blueprint = config(CLASSIFICATION).blueprint();
     assert!(!blueprint.contains("cui_controlled_by:"), "{blueprint}");
     assert!(
@@ -379,8 +366,6 @@ fn seeding_commits_only_the_active_variant() {
     );
 }
 
-/// Variants are a per-card shape: a card kind carries its own discriminant, and
-/// the hoist runs on every card the same way.
 #[test]
 fn variants_work_on_a_card_kind() {
     let config = QuillConfig::from_yaml_with_warnings(
@@ -415,8 +400,6 @@ card_kinds:
     );
 }
 
-/// Two discriminants on one card are independent axes: each variant field
-/// resolves against its own, and the hoist keeps each block with its owner.
 #[test]
 fn two_discriminants_on_one_card_stay_independent() {
     let two = "    kind:\n      type: enum\n      values: [letter, memo]\n      default: letter\n      variants:\n        memo:\n          memo_for: { type: string }\n    urgency:\n      type: enum\n      values: [routine, flash]\n      default: flash\n      variants:\n        flash:\n          callback: { type: string }\n";

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -122,6 +122,37 @@ main:
         group: classification
         compact: true
       description: "Select the classification marking shown in the header and footer banner. Unclassified documents typically omit this banner entirely, leave blank unless the document is CUI or classified. Mark per DAFI 16-1404 (DoDM 5200.48 for CUI) and applicable DoD guidance."
+      variants:
+        CUI:
+          cui_controlled_by:
+            type: string
+            ui:
+              group: classification
+              compact: true
+            description: "Office or organization that designated this information as CUI (e.g., 'SAF/AA')."
+
+          cui_poc:
+            type: string
+            ui:
+              group: classification
+              compact: true
+            description: "Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234, john.smith@us.af.mil')."
+
+          cui_category:
+            type: string
+            default: ""
+            ui:
+              group: classification
+              compact: true
+            description: "CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY'). Leave blank to omit."
+
+          cui_limited_dissemination:
+            type: string
+            default: ""
+            ui:
+              group: classification
+              compact: true
+            description: "Limited dissemination control shown in the indicator block (e.g., 'FEDONLY', 'NOFORN'). Independent from the banner suffix above."
 
     dissemination:
       type: string
@@ -130,38 +161,6 @@ main:
         group: classification
         compact: true
       description: "Banner dissemination suffix appended after double slash (e.g. 'NF' renders as CUI//NF in the header/footer). Leave blank for no suffix."
-
-    cui_controlled_by:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "Office or organization that designated this information as CUI (e.g., 'SAF/AA'). Required by DoDM 5200.48 when classification is CUI."
-
-    cui_category:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY'). Leave blank to omit."
-
-    cui_limited_dissemination:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "Limited dissemination control shown in the indicator block (e.g., 'FEDONLY', 'NOFORN'). Independent from the banner suffix above."
-
-    cui_poc:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234, john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI."
 
     references:
       type: array

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -111,24 +111,26 @@ main:
       - CONFIDENTIAL
       - SECRET
       - TOP SECRET
-    dissemination:
-      type: string
-      description: >-
-        Banner dissemination suffix appended after double slash (e.g. 'NF' renders as
-        CUI//NF in the header/footer). Leave blank for no suffix.
-      default: ""
-      ui:
-        group: classification
-        compact: true
     cui_controlled_by:
       type: string
-      description: >-
-        Office or organization that designated this information as CUI (e.g.,
-        'SAF/AA'). Required by DoDM 5200.48 when classification is CUI.
-      default: ""
+      description: Office or organization that designated this information as CUI (e.g., 'SAF/AA').
       ui:
         group: classification
         compact: true
+      variant_of:
+        field: classification
+        value: CUI
+    cui_poc:
+      type: string
+      description: >-
+        Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234,
+        john.smith@us.af.mil').
+      ui:
+        group: classification
+        compact: true
+      variant_of:
+        field: classification
+        value: CUI
     cui_category:
       type: string
       description: >-
@@ -138,6 +140,9 @@ main:
       ui:
         group: classification
         compact: true
+      variant_of:
+        field: classification
+        value: CUI
     cui_limited_dissemination:
       type: string
       description: >-
@@ -147,11 +152,14 @@ main:
       ui:
         group: classification
         compact: true
-    cui_poc:
+      variant_of:
+        field: classification
+        value: CUI
+    dissemination:
       type: string
       description: >-
-        Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234,
-        john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI.
+        Banner dissemination suffix appended after double slash (e.g. 'NF' renders as
+        CUI//NF in the header/footer). Leave blank for no suffix.
       default: ""
       ui:
         group: classification

--- a/crates/quillmark/tests/usaf_memo_variant_test.rs
+++ b/crates/quillmark/tests/usaf_memo_variant_test.rs
@@ -1,0 +1,127 @@
+//! `usaf_memo`'s CUI block as an enum variant of `classification`.
+//!
+//! The migration moved four flat fields under `classification.variants.CUI` and
+//! dropped the `default: ""` that made `cui_controlled_by` and `cui_poc`
+//! unaskable. Both halves of the contract are asserted here: the plate still
+//! receives every CUI field unconditionally (`plate.typ` reads `data.cui_*`
+//! with no guard), and the obligation the statute states — DoDM 5200.48 —
+//! now fires as a diagnostic instead of living in `description:` prose.
+
+use quillmark_fixtures::quills_path;
+
+fn memo(classification: &str, extra: &str) -> String {
+    format!(
+        "~~~card-yaml
+$quill: usaf_memo@0.2.0
+$kind: main
+letterhead_title: DEPARTMENT OF THE AIR FORCE
+letterhead_caption: [123D EXAMPLE WING]
+memo_for: [SOME/CC]
+subject: A memo
+classification: {classification}
+{extra}signature_block: [A. AUTHOR, Captain, USAF, Flight Commander]
+~~~
+
+Body prose.
+"
+    )
+}
+
+fn quill() -> quillmark::Quill {
+    quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load")
+}
+
+fn must_fill_paths(quill: &quillmark::Quill, md: &str) -> Vec<String> {
+    let doc = quillmark::Document::parse(md).expect("parse").document;
+    let mut paths: Vec<String> = quill
+        .validate(&doc)
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::must_fill"))
+        .filter_map(|d| d.path.clone())
+        .filter(|p| p.starts_with("main.cui_"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// The floor stays total: a variant field is declared, blank-filled, and
+/// present in the plate projection whatever the discriminant reads. `plate.typ`
+/// reads `data.cui_controlled_by` unguarded, so anything less fails the compile.
+#[test]
+fn every_cui_field_reaches_the_plate_whatever_the_classification() {
+    let quill = quill();
+    for classification in ["\"\"", "UNCLASSIFIED", "CUI", "SECRET"] {
+        let doc = quillmark::Document::parse(&memo(classification, ""))
+            .expect("parse")
+            .document;
+        let plate = quill.compile_data(&doc).expect("blank-filled render is total");
+        for field in [
+            "cui_controlled_by",
+            "cui_poc",
+            "cui_category",
+            "cui_limited_dissemination",
+        ] {
+            assert_eq!(
+                plate[field], "",
+                "{field} must reach the plate under classification {classification}"
+            );
+        }
+    }
+}
+
+/// The statutory obligation, as a diagnostic. Unclassified asks for nothing;
+/// flipping the one cell to CUI asks for exactly the two fields DoDM 5200.48
+/// requires, and leaves the two optional ones alone.
+#[test]
+fn cui_obliges_controlled_by_and_poc_only_under_cui() {
+    let quill = quill();
+
+    assert!(
+        must_fill_paths(&quill, &memo("UNCLASSIFIED", "")).is_empty(),
+        "an unclassified memo owes no CUI answer"
+    );
+    assert_eq!(
+        must_fill_paths(&quill, &memo("CUI", "")),
+        ["main.cui_controlled_by", "main.cui_poc"],
+        "CUI obliges the two fields the statute names, and only those"
+    );
+    assert!(
+        must_fill_paths(
+            &quill,
+            &memo("CUI", "cui_controlled_by: SAF/AA\ncui_poc: Capt J. Smith, DSN 555-1234\n")
+        )
+        .is_empty(),
+        "authoring both discharges the obligation"
+    );
+}
+
+/// Stranded data warns and survives. An editor flipping the discriminant back
+/// to UNCLASSIFIED must not lose the author's answers, and must not be handed
+/// an invalid document either.
+#[test]
+fn a_cui_answer_on_an_unclassified_memo_warns_without_blocking() {
+    let quill = quill();
+    let md = memo("UNCLASSIFIED", "cui_poc: Capt J. Smith, DSN 555-1234\n");
+    let doc = quillmark::Document::parse(&md).expect("parse").document;
+
+    let diags = quill.validate(&doc);
+    let stranded: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::out_of_variant"))
+        .collect();
+    assert_eq!(stranded.len(), 1, "got: {diags:?}");
+    assert_eq!(stranded[0].path.as_deref(), Some("main.cui_poc"));
+    assert_eq!(stranded[0].severity, quillmark::Severity::Warning);
+
+    assert!(
+        diags
+            .iter()
+            .all(|d| d.severity != quillmark::Severity::Error),
+        "stranded data is never a blocker: {diags:?}"
+    );
+    let plate = quill.compile_data(&doc).expect("still renders");
+    assert_eq!(
+        plate["cui_poc"], "Capt J. Smith, DSN 555-1234",
+        "the value is carried, not dropped"
+    );
+}

--- a/crates/quillmark/tests/usaf_memo_variant_test.rs
+++ b/crates/quillmark/tests/usaf_memo_variant_test.rs
@@ -1,11 +1,10 @@
 //! `usaf_memo`'s CUI block as an enum variant of `classification`.
 //!
-//! The migration moved four flat fields under `classification.variants.CUI` and
-//! dropped the `default: ""` that made `cui_controlled_by` and `cui_poc`
-//! unaskable. Both halves of the contract are asserted here: the plate still
+//! Four fields live under `classification.variants.CUI`, two of them
+//! defaultless. Both halves of that contract are asserted here: the plate
 //! receives every CUI field unconditionally (`plate.typ` reads `data.cui_*`
-//! with no guard), and the obligation the statute states — DoDM 5200.48 —
-//! now fires as a diagnostic instead of living in `description:` prose.
+//! with no guard), and DoDM 5200.48's obligation fires as a diagnostic rather
+//! than sitting in `description:` prose.
 
 use quillmark_fixtures::quills_path;
 
@@ -44,9 +43,8 @@ fn must_fill_paths(quill: &quillmark::Quill, md: &str) -> Vec<String> {
     paths
 }
 
-/// The floor stays total: a variant field is declared, blank-filled, and
-/// present in the plate projection whatever the discriminant reads. `plate.typ`
-/// reads `data.cui_controlled_by` unguarded, so anything less fails the compile.
+/// The floor stays total whatever the discriminant reads. `plate.typ` reads
+/// `data.cui_controlled_by` unguarded, so anything less fails the compile.
 #[test]
 fn every_cui_field_reaches_the_plate_whatever_the_classification() {
     let quill = quill();
@@ -69,9 +67,8 @@ fn every_cui_field_reaches_the_plate_whatever_the_classification() {
     }
 }
 
-/// The statutory obligation, as a diagnostic. Unclassified asks for nothing;
-/// flipping the one cell to CUI asks for exactly the two fields DoDM 5200.48
-/// requires, and leaves the two optional ones alone.
+/// The statutory obligation, as a diagnostic: flipping the one cell to CUI asks
+/// for exactly the two fields DoDM 5200.48 requires.
 #[test]
 fn cui_obliges_controlled_by_and_poc_only_under_cui() {
     let quill = quill();
@@ -95,9 +92,8 @@ fn cui_obliges_controlled_by_and_poc_only_under_cui() {
     );
 }
 
-/// Stranded data warns and survives. An editor flipping the discriminant back
-/// to UNCLASSIFIED must not lose the author's answers, and must not be handed
-/// an invalid document either.
+/// Stranded data warns and survives: an editor flipping the discriminant back
+/// loses neither the author's answers nor a valid document.
 #[test]
 fn a_cui_answer_on_an_unclassified_memo_warns_without_blocking() {
     let quill = quill();

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -253,6 +253,74 @@ your `values:` list stays clean.
 > `data.at(key, default: X)` is not a guard — every declared key is always
 > present at render, so its `default:` never fires and the blank flows through.
 
+#### Variants: fields that exist only for one value
+
+Some fields only make sense under one choice. A CUI memo needs a controlling
+office and a point of contact; an unclassified one has nowhere to put them.
+Declare them under that value with `variants:`:
+
+```yaml
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI, SECRET]
+      default: ""
+      variants:
+        CUI:
+          cui_controlled_by: { type: string }
+          cui_poc:           { type: string }
+          cui_category:      { type: string, default: "" }
+```
+
+Three things follow, and the third is the one that surprises people.
+
+**Authors write them flat.** A variant field is an ordinary top-level field in
+the document — `cui_poc: Capt Smith`, never nested under `classification`.
+`variants:` groups the *declaration*, not the data.
+
+**Obligation becomes conditional, with no new key.** `must_fill` works exactly
+as it does anywhere: `cui_controlled_by` has no `default:`, so it must be
+filled — but only once `classification` is `CUI`. On an unclassified memo it
+asks for nothing. This is the whole reason to reach for `variants:`: before it,
+marking such a field required meant demanding it on every document.
+
+**Your plate still reads every variant field, always.** Variants scope the
+*authoring* surface — editors hide out-of-play fields, the blueprint omits them,
+seeding skips them. They do not change the render projection: every declared
+field is present and blank-filled at render, whatever the discriminant says. So
+write `data.cui_poc` unguarded, and key a CUI block on `classification`, never on
+whether `cui_poc` is non-empty.
+
+An author who fills in `cui_poc` and then switches `classification` back to
+`UNCLASSIFIED` keeps their text — it is not deleted — and gets a warning
+(`validation::out_of_variant`) saying it is out of play. Nothing blocks; nothing
+is lost.
+
+Rules worth knowing up front:
+
+- `variants:` is valid only on `type: enum`, and only on a card's own fields
+  (not inside `properties:` or `items:`, and not nested inside another variant).
+- Every key must be a member of `values:`. The blank owns no variant: it means
+  nobody chose, so nothing exists under it.
+- **Field names are one namespace per card.** A variant's field may not share a
+  name with a card field or with another variant's field. A field belonging to
+  more than one world is declared flat, outside `variants:`.
+- Each value gets its own block. Several values sharing one field set means
+  repeating it (or a YAML anchor) for now.
+
+`quillmark schema` shows the result **flat**, each variant field annotated with
+the world it belongs to, in the position it will be displayed:
+
+```yaml
+    cui_poc:
+      type: string
+      variant_of:
+        field: classification
+        value: CUI
+```
+
+That is emission only — write `variants:` in your `Quill.yaml`; `variant_of:`
+there is an error.
+
 ### Primitive Arrays, Typed Tables, and Typed Dictionaries
 
 Every array declares its element type under `items:`. For a **primitive list**, give `items` a scalar type, coercion and validation then apply element-wise (e.g. each element of an `integer[]` is coerced to an integer, and a bad element fails at its indexed path like `counts[1]`):

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -304,8 +304,8 @@ Rules worth knowing up front:
 - **Field names are one namespace per card.** A variant's field may not share a
   name with a card field or with another variant's field. A field belonging to
   more than one world is declared flat, outside `variants:`.
-- Each value gets its own block. Several values sharing one field set means
-  repeating it (or a YAML anchor) for now.
+- Each value gets its own block. Several values sharing one field set repeat it,
+  or share a YAML anchor.
 
 `quillmark schema` shows the result **flat**, each variant field annotated with
 the world it belongs to, in the position it will be displayed:

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -239,8 +239,8 @@ cannot collide with the reserved characters of the format slot.
 Discovery of those fields' types and descriptions is the **validate loop's**,
 not this line's: an author who writes `classification: CUI` and re-validates
 receives `validation::must_fill` (`trigger: unauthored`) at exactly the cells
-that came into play. That is the loop's whole point — a relational omission the
-DSL could not previously state now reaches a strict consumer as "not done."
+that came into play. That is the loop's whole point: it is how a relational
+omission reaches a strict consumer as "not done."
 
 The blueprint guarantee is unaffected: fewer fields and more comments, both of
 which parse, round-trip, and render.

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -81,7 +81,10 @@ Per field, in order:
 1. `# <description>`: `description:` from `Quill.yaml`,
    whitespace-collapsed. **Single line only**; multi-line descriptions are
    rejected at `Quill.yaml` parse time.
-2. `# e.g. <value>`: emitted whenever `example:` is configured **and a
+2. `# when <VALUE>: <field>, <field>`: one line per variant an `enum`
+   discriminant declares and the blueprint is **not** showing (see "Enum
+   variants"). Absent on every other field.
+3. `# e.g. <value>`: emitted whenever `example:` is configured **and a
    `default:` already holds the cell**. Independent of type. There the example
    never becomes the rendered value, so it surfaces as a hint; where no
    `default:` holds the cell the example inlines *as* the value (see
@@ -208,6 +211,39 @@ speak about the same cells (`SCHEMAS.md` § "Native validation").
 | `richtext` | On the field (bare; no block scalar) | `bio: !must_fill # richtext<markdown>` |
 | `object` (typed dict) | Per-property recursion | leaves carry `!must_fill` |
 | `array<object>` (typed table) | Per-property recursion in one synthetic row | leaves carry `!must_fill` |
+
+### Enum variants
+
+A blueprint is one static document, but an enum's `variants:` make the field set
+a function of an answer given *while filling the form*
+([SCHEMAS.md](SCHEMAS.md) § "Enum variants"). The blueprint shows the **one
+world its own discriminant cell names**: the cell carries its value-axis answer
+(`default:` › `example:` › the blank), and only that variant's fields are
+emitted. Fields of every other variant are omitted entirely — not commented out,
+which the all-live-YAML rule forbids and which would collide with the leading-
+annotation grammar besides.
+
+What is omitted is still named. The discriminant carries one leading line per
+skipped variant:
+
+```
+# Select the classification marking shown in the header and footer banner.
+# when CUI: cui_controlled_by, cui_poc, cui_category
+classification: "" # enum<UNCLASSIFIED | CUI | SECRET>
+```
+
+So the form stays honest about what it is not showing, and the reader learns
+which cells an answer brings into play. Field names are snake_case, so the line
+cannot collide with the reserved characters of the format slot.
+
+Discovery of those fields' types and descriptions is the **validate loop's**,
+not this line's: an author who writes `classification: CUI` and re-validates
+receives `validation::must_fill` (`trigger: unauthored`) at exactly the cells
+that came into play. That is the loop's whole point — a relational omission the
+DSL could not previously state now reaches a strict consumer as "not done."
+
+The blueprint guarantee is unaffected: fewer fields and more comments, both of
+which parse, round-trip, and render.
 
 ### Richtext fields
 
@@ -456,6 +492,12 @@ degrades gracefully on every type-valid input shape. The contract requires:
 - No template asserts that a must-fill field is *non-empty*. The schema
   guarantees *presence*, not non-emptiness; the `!must_fill` marker
   is an authoring signal, not a render-time precondition.
+- **A template keys a variant's block on the discriminant, never on its variant
+  fields' non-emptiness.** Every variant field is declared and blank-filled
+  whatever the discriminant reads ([SCHEMAS.md](SCHEMAS.md) § "Enum variants"),
+  so the plate reads it unconditionally; and a stranded out-of-variant value
+  still reaches the plate, where it must stay inert rather than switching a
+  block on.
 - "Renders successfully" means "compiles without error," not "produces
   meaningful output." An empty-string title is a blank title: that is
   acceptable.

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -82,10 +82,10 @@ families:
   no content leaf never enters the walk, so a scalar the strict write would
   refuse raises no `conform::*` warning and reaches `validation::*` instead.
 - **Validation warnings**: `Quill::validate(doc)` returns every
-  `validation::*` diagnostic, mixing severities; `validation::must_fill` and
-  the `$seed` checks are the non-fatal ones. This is the editor-facing
-  surface; the render pipeline blank-fills instead of warning on incomplete
-  documents.
+  `validation::*` diagnostic, mixing severities; `validation::must_fill`,
+  `validation::out_of_variant`, and the `$seed` checks are the non-fatal ones.
+  This is the editor-facing surface; the render pipeline blank-fills instead of
+  warning on incomplete documents.
 - **`plate::unsupported_construct`: declined-construct warnings.** A quill
   names, per body (`BodyCardSchema.unsupported`), the block constructs its
   plate does not typeset; `Quill::unsupported_constructs` walks a document's
@@ -204,10 +204,27 @@ the schema obliges the cell (see [SCHEMAS.md](SCHEMAS.md) § "Native
 validation"). An incomplete document therefore produces no *fatal* field-level
 diagnostic, and warns exactly where a human has yet to make a call.
 
+`validation::out_of_variant` (non-fatal, `Severity::Warning`) is the same
+shape one axis over: an authored, non-blank value sitting in a field whose
+variant is not in play ([SCHEMAS.md](SCHEMAS.md) § "Enum variants").
+
+```
+Field `main.cui_poc` exists only where `classification` is `CUI`, but
+`classification` reads `UNCLASSIFIED`.
+```
+
+with the hint *"Either set `classification` to `CUI`, or clear the field. The
+value is kept and still renders."* Both exits, as above, and the second clause
+is the contract rather than reassurance: the value stays authored and keeps
+reaching the plate, so flipping a discriminant strands data without destroying
+it.
+
 Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and
 `crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning` and
-`validate_unauthored`/`unauthored_warning`, for `validation::must_fill`).
+`validate_unauthored`/`unauthored_warning` for `validation::must_fill`,
+`validate_out_of_variant`/`out_of_variant_warning` for
+`validation::out_of_variant`).
 
 ## Document-model paths
 
@@ -307,6 +324,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `validation::body_disabled` | `card` | structured |
 | `validation::coercion_failed` | `value`, `target` | structured, coarser |
 | `validation::must_fill` | `trigger` | structured |
+| `validation::out_of_variant` | `discriminant`, `resolved`, `variant` | structured |
 | `validation::not_inline` | — | code-determined |
 | `validation::not_plain` | — | code-determined |
 | `edit::invalid_field_name` | `field` | structured |

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -38,6 +38,95 @@ stack and the same backend lowering (both carry `contentMediaType:
 application/quillmark-content+json`); `plaintext` additionally carries
 `quillmark:plain: true`, an editor-only annotation backends ignore.
 
+### Enum variants
+
+An `enum` field may declare `variants:`, a per-value field set that exists only
+in the world where the discriminant holds that value. It is the one cross-field
+shape the DSL carries.
+
+```yaml
+classification:
+  type: enum
+  values: [UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET]
+  variants:
+    CUI:
+      cui_controlled_by: { type: string }
+      cui_poc:           { type: string }
+      cui_category:      { type: string, default: "" }
+```
+
+Each variant's fields use the full field grammar (`ui:`, `default:`,
+`example:`, `must_fill:`, nested `items:` / `properties:`).
+
+**The document stays flat.** A variant field is authored at the card's top level
+like any other (`cui_poc: …`, never nested under `classification:`), so the
+syntax borrows the tagged-union shape while the document remains a flat map with
+a predicate over it. The weakening is the design: nesting would break every
+existing document and the hand-authorability of the frontmatter.
+
+**Conditional existence is an authoring fact, not a wire one.** Three surfaces
+read it — the blueprint skips an out-of-play field, seeding does not commit one,
+and the must-fill predicate does not oblige one — and the render floor does not:
+a variant field is declared, blank-filled, and present in the plate projection
+whatever the discriminant reads. A plate therefore reads a variant field
+unconditionally, and the empty-document contract
+([BLUEPRINT.md](BLUEPRINT.md) § "Guarantees") is untouched.
+
+**Obligation costs no new axis.** `must_fill` inside a variant keeps the
+ordinary derivation, so `must_fill: true` (or a defaultless field) means
+"required *in this world*" with nothing added to the two axes below.
+
+#### The hoist
+
+At load the whole `variants:` map is **lifted into the card's flat field map**,
+each lifted field stamped with the discriminant and value it exists under
+(`FieldSchema::variant_of`). A lifted field lands immediately after its
+discriminant, variants in declaration order and fields in declaration order
+within each, so hoisted position *is* display and blueprint position.
+
+After the hoist there is no nested structure left: `CardSchema::fields` carries
+every field a card declares, so coercion, the render ladder, `conform`, and
+[`resolve()`](#the-resolved-value-view-resolve) see ordinary fields and need no
+variant knowledge. This is what keeps the feature to one load-time pass.
+
+The hoist runs before group validation and the content-cache import, so a
+lifted field earns the same `ui.group` reference check and the same
+`default`/`example` content cache as a flatly-declared one.
+
+| Condition | Load error |
+|---|---|
+| `variants:` on a non-enum field | `quill::variants_on_non_enum` |
+| a `variants:` key outside `values:` (the blank falls out here: it is never a member, so it owns no variant) | `quill::variant_unknown_value` |
+| a variant field name colliding with any other field on the card — flat fields and every variant of every enum, one namespace | `quill::variant_field_collision` |
+| `variants:` below card level (inside `items:` / `properties:`) or on a variant field itself | `quill::variant_placement` |
+
+The one-namespace rule is what keeps coercion value-independent: the effective
+type map is the flat union, so a name resolving to two schemas — which would
+make a field's type a function of the discriminant's *value* — is
+unrepresentable rather than handled.
+
+#### Stranded values
+
+An authored, non-blank value in a field whose variant is not in play raises
+`validation::out_of_variant` at `Severity::Warning`, and the value is **carried,
+not dropped**: it coerces, it stays authored, and the render floor keeps
+projecting it. An editor flipping a discriminant therefore strands the old
+world's answers without destroying them, which is the behavior every real form
+has; refusing the document instead would force deleting those answers to
+recover. Blank-ness is the field's own [blank](#blank-filled-render), so the
+`integer` / `number` / `boolean` seam applies here too: an authored `0` in an
+out-of-play numeric field is indistinguishable from its blank and never warns.
+
+#### Emission
+
+`variants:` is the **authoring** spelling and the only one: `variant_of:`
+written in `Quill.yaml` is a load error (`quill::field_parse_error`).
+`QuillConfig::schema()` emits the **hoisted** form — every field flat, in
+hoisted order, a variant field carrying `variant_of: {field, value}` — so a
+consumer reads one ordered field list and keys hide/show on the annotation
+instead of re-implementing the hoist to match what `resolve()` returns. The
+transform schema carries the same fact as `quillmark:variant_of`.
+
 ### Content fields rest per codec
 
 A content field's **resting form** is the shape it is stored in once anything
@@ -197,6 +286,18 @@ Validation is implemented by a native walker over `QuillConfig` in `quill/valida
   wins: its hint is the actionable one. It **never gates render**: the cell
   blank-fills, or uses its suggested value. A strict consumer (e.g. an LLM
   authoring loop) treats any outstanding warning as "not done."
+
+  The `unauthored` trigger skips an **out-of-play variant field**
+  ([Enum variants](#enum-variants)): the world it belongs to is not the one the
+  document is in, so it obliges nothing. Its obligation is unchanged and applies
+  the moment the discriminant names its variant, which is what lets the strict
+  loop above be told "not done" for a relational omission: authoring
+  `classification: CUI` brings `cui_poc` into play, and the next `validate`
+  reports it. The `marker` trigger is document-sovereign and fires regardless —
+  a human dropping a `!must_fill` is a decision the schema does not overrule.
+- **`validation::out_of_variant` → non-fatal warning.** An authored, non-blank
+  value in an out-of-play variant field. Never a gate, and the value is carried:
+  see [Stranded values](#stranded-values).
 - **Absence semantics**: a missing (or present-null) field with a `default:`
   accepts the default; without a `default:` it blank-fills. Either way it
   coerces and validates clean — absence is never *malformed*, and there is no
@@ -472,11 +573,14 @@ Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name).
 `main` and each entry in `card_kinds` share the same `CardSchema` shape:
 `fields` (map keyed by field name), optional `description`, optional `ui`,
 optional `body`. Each `FieldSchema` includes `type`, optional
-`description`/`default`/`example`/`enum`/`values`/`inline`/`properties`/`items`/`ui`.
+`description`/`default`/`example`/`enum`/`values`/`inline`/`properties`/`items`/`ui`/`variant_of`.
 The type-gated keys:
 
 - `inline`: valid only on the prose types (`richtext`, `plaintext`).
 - `values`: declares an `enum` field's domain, required there.
+- `variants`: valid only on `enum`, and authoring-only — it never appears in
+  the emission, which carries the hoisted `variant_of` instead
+  ([Enum variants](#enum-variants)).
 - `items`: the element schema, itself a `FieldSchema`; required on `array`
   fields and rejected elsewhere.
 - `properties`: used by `object` fields, and by an array's `object`-typed

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -66,7 +66,10 @@ existing document and the hand-authorability of the frontmatter.
 
 **Conditional existence is an authoring fact, not a wire one.** Three surfaces
 read it — the blueprint skips an out-of-play field, seeding does not commit one,
-and the must-fill predicate does not oblige one — and the render floor does not:
+and the must-fill predicate does not oblige one — and each resolves the
+discriminant by cutting its own ladder: the render ladder for a document, the
+blueprint's value axis for the form, and the seed cascade (`$seed` overlay
+included) for a seed. The render floor does not read it at all:
 a variant field is declared, blank-filled, and present in the plate projection
 whatever the discriminant reads. A plate therefore reads a variant field
 unconditionally, and the empty-document contract
@@ -99,6 +102,7 @@ lifted field earns the same `ui.group` reference check and the same
 | a `variants:` key outside `values:` (the blank falls out here: it is never a member, so it owns no variant) | `quill::variant_unknown_value` |
 | a variant field name colliding with any other field on the card — flat fields and every variant of every enum, one namespace | `quill::variant_field_collision` |
 | `variants:` below card level (inside `items:` / `properties:`) or on a variant field itself | `quill::variant_placement` |
+| a variant field name that is not a valid field key — a hoisted field is a card field and earns the same gate | `quill::invalid_field_name` |
 
 The one-namespace rule is what keeps coercion value-independent: the effective
 type map is the flat union, so a name resolving to two schemas — which would
@@ -113,9 +117,20 @@ not dropped**: it coerces, it stays authored, and the render floor keeps
 projecting it. An editor flipping a discriminant therefore strands the old
 world's answers without destroying them, which is the behavior every real form
 has; refusing the document instead would force deleting those answers to
-recover. Blank-ness is the field's own [blank](#blank-filled-render), so the
-`integer` / `number` / `boolean` seam applies here too: an authored `0` in an
-out-of-play numeric field is indistinguishable from its blank and never warns.
+recover.
+
+Blank-ness is the field's own [blank](#blank-filled-render), widened by the
+authored shorthands: `Quill::validate` reads the payload *before* coercion, so a
+content leaf rests at `""` and a typed dictionary at `{}` rather than at the
+coerced blank they compare as, and an empty scalar or container is unanswered
+whatever the field's type. The `integer` / `number` / `boolean` seam applies
+here too: an authored `0` in an out-of-play numeric field is indistinguishable
+from its blank and never warns.
+
+The discriminant resolves through the same canonicalization coercion applies, so
+a bare scalar in a `string`-domain enum (`flag: true` where `values:` holds
+`"true"`) puts its variant in play rather than reading as the blank. The axis
+and the plate never disagree about which world a document is in.
 
 #### Emission
 

--- a/prose/proposals/enum-variants.md
+++ b/prose/proposals/enum-variants.md
@@ -77,9 +77,9 @@ Two consumers in `validation.rs`:
 
 ## Fixture migration
 
-`usaf_memo` 0.2.0, edited in place: no type changes, no stored-value reinterpretation, and plate JSON stays byte-identical, so the VERSIONING ref-immutability rule (which targets type changes that rewrite stored values) is not tripped; the only behavioral delta is new warnings.
+`usaf_memo` 0.2.0, edited in place: no type changes and no stored-value reinterpretation, so the VERSIONING ref-immutability rule (which targets type changes that rewrite stored values) is not tripped. Every plate key and value is unchanged across the classification × CUI-authoring matrix; plate *key order* moves, since the hoist repositions the `cui_*` block ahead of `dissemination`, which no plate reads (`plate.typ` addresses fields by name). The behavioral deltas are new warnings and that order.
 
-- Move `cui_controlled_by`, `cui_poc`, `cui_category`, `cui_limited_dissemination` under `classification.variants.CUI`, keeping each field's `ui.group: classification`.
+- Move `cui_controlled_by`, `cui_poc`, `cui_category`, `cui_limited_dissemination` under `classification.variants.CUI`, keeping each field's `ui.group: classification`. The two obliged fields lead, so the block reads obligation-first.
 - Drop `default: ""` from `cui_controlled_by` and `cui_poc`: the derivation then obliges them when CUI is active, matching DoDM 5200.48. `cui_category` and `cui_limited_dissemination` keep `default: ""` (skippable).
 - Trim the "Required … when classification is CUI" clauses from descriptions: the scoping is structural now.
 - Hoist order places the `cui_*` fields between `classification` and `dissemination`; regenerate `__golden__/schema.yaml`. An omitted `cui_controlled_by`/`cui_poc` moves from the `default` rung to the `blank` rung in `resolve()` output (same `""` bytes); regenerate any golden that captures source tags.
@@ -98,7 +98,7 @@ Two consumers in `validation.rs`:
 - Validation: `out_of_variant` fires on authored non-blank out-of-play, not on blank/null/in-play, and resolves the discriminant through `default:`; `unauthored` skips out-of-play and fires in-play; marker sovereignty on an out-of-play field.
 - Blueprint: skip plus `# when` line with a blank-defaulted discriminant; live variant fields when the default names the variant; existing quiver round-trip/render tests cover the migrated fixture.
 - Seeding: out-of-play examples not committed.
-- Render: migrated `usaf_memo` plate JSON byte-identical to pre-migration.
+- Render: migrated `usaf_memo` reaches the plate with every `cui_*` field present and blank under every classification.
 
 ## Deferred
 

--- a/prose/proposals/enum-variants.md
+++ b/prose/proposals/enum-variants.md
@@ -1,0 +1,105 @@
+# Enum Variants
+
+> **Issue**: borb-sh/quillmark#1268
+> **Touches**: `crates/core/src/quill/`, `crates/fixtures/resources/quills/usaf_memo/`, `prose/canon/SCHEMAS.md`, `prose/canon/BLUEPRINT.md`
+
+## TL;DR
+
+An enum field may declare `variants:`: per-value field sets that exist only when the discriminant holds that value. The document stays a flat map, the render floor stays total, and out-of-variant authored values warn rather than gate. Implementation is a load-time hoist: variant fields become ordinary entries in the card's field map carrying a `variant_of` back-reference, so coercion, compose, conform, resolve, and both backends need zero changes; only load, validation, blueprint, and seeding read the reference.
+
+## The model
+
+The syntax borrows the tagged-union shape; the semantics are deliberately weaker, and the weakening is the design:
+
+- **Flat document.** Variant fields are authored at the card's top level like any field (`cui_poc: …`, never nested under `classification:`). Existing documents parse unchanged.
+- **Union-typed.** Every variant field has one unconditional type. Coercion never consults another field's value. This is enforced by a load-time name-uniqueness rule, not by runtime dispatch.
+- **Total floor.** Variant fields are always present in the plate projection, blank-filled by the ordinary ladder. `plate.typ` reads `data.cui_poc` unconditionally today and continues to; the empty-document render contract holds untouched.
+- **Warning, never a gate.** An authored non-blank value in an inactive variant's field draws `validation::out_of_variant` at `Severity::Warning`. The value still coerces (malformed stays fatal), still flows to the plate per the ladder, and the document still renders. Flipping the discriminant in an editor strands data as a warning, not an invalid document.
+
+So "conditional existence" is a fact of the authoring, validation, and UI surfaces, and deliberately not a fact of the wire. What the DSL gains: the schema names which fields belong to which world, `must_fill` becomes "required in this world", a UI gets a machine-readable hide/show signal, and the LLM authoring loop gets told "not done" when a discriminant flip brings obliged cells into play.
+
+## Syntax and load rules
+
+```yaml
+classification:
+  type: enum
+  values: [UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET]
+  variants:
+    CUI:
+      cui_controlled_by: { type: string }
+      cui_poc:           { type: string }
+      cui_category:      { type: string, default: "" }
+```
+
+`variants:` is a map from enum value to a `fields:`-shaped map; each value schema uses the full existing field grammar (`ui:`, `default:`, `example:`, `must_fill:`, nested `items:`/`properties:`).
+
+Load errors, per-cause codes following the `quill::enum_blank_member` precedent:
+
+| Condition | Code |
+|---|---|
+| `variants:` on a non-enum field | `quill::variants_on_non_enum` |
+| a `variants:` key not in `values:` (the blank `""` falls out here: it is never a member) | `quill::variant_unknown_value` |
+| a variant field name colliding with any other field in the card — flat fields and every variant of every enum, one namespace | `quill::variant_field_collision` |
+| `variants:` below card level (inside `items:` or `properties:`) or on a variant field itself (no recursion) | `quill::variant_placement` |
+
+The one-namespace rule is what keeps coercion value-independent: the effective type map is the flat union, and the collision that would make a field's type depend on the discriminant is unrepresentable.
+
+## Implementation: hoist at load
+
+The whole cut rides one load-time pass, and its cheapness is the argument for this shape.
+
+**Parse.** `FieldSchemaDef` gains `variants: Option<serde_json::Map<String, serde_json::Value>>`; `FieldSchema::from_quill_value` parses it into a transient `variants: Option<IndexMap<String, IndexMap<String, Box<FieldSchema>>>>` on `FieldSchema` (never serialized; order preserved).
+
+**Hoist.** The loader post-pass (`QuillConfig::from_yaml_with_warnings`, beside the content-cache import) drains each card's `variants` maps: after the membership, placement, and collision checks, every variant field is spliced into `CardSchema.fields` immediately after its discriminant, variants in declaration order, fields in declaration order within each. Each hoisted `FieldSchema` is stamped `variant_of: Option<VariantOf { field: String, value: String }>`.
+
+**Everything downstream is free.** Coercion, `compile_data` and the ladder, `conform`, `resolve()`, the pdfform widget walk, and the Typst `_qm-meta` address tables all iterate `CardSchema.fields` and see ordinary fields. `resolve()` keeps its byte-for-byte-with-the-plate contract with no edit. Declaration order stays the one ordering carrier: hoist position *is* display and blueprint position.
+
+**Serialization.** The hand-written `FieldSchema` serializer emits `variant_of: { field: …, value: … }` as the last key (after `inline`). `QuillConfig::schema()` therefore emits the union flat with per-field annotations rather than mirroring the authored nesting. That is the better consumer contract: an editor renders one ordered field list and keys hide/show on the annotation, instead of re-implementing the hoist and inventing an ordering for variant fields. `FieldSchemaDef` rejects a wire `variant_of:` with a directive message (the `ui.order` / `enum:` parse-to-reject precedent): the authoring spelling stays nested-only.
+
+## Validation
+
+One shared helper: resolve each discriminant per card as authored-non-null › `default:` › blank (the render ladder minus `example`, which never enters it), and derive an active-variant predicate `field is in play ⇔ variant_of is None, or its (field, value) matches the resolved discriminant`. The blank discriminant activates nothing.
+
+Two consumers in `validation.rs`:
+
+- **`unauthored` must-fill trigger**: skips out-of-play fields. In-play variant fields keep the ordinary derivation (`must_fill:` unset derives from `default:` presence), which is the whole conditional-obligation story — no new axis. The `marker` trigger stays document-sovereign and fires regardless: a human's `!must_fill` is not the schema's to suppress.
+- **`validation::out_of_variant`** (new, `Severity::Warning`): an authored, non-blank value in an out-of-play field. Blank-ness compares against the field's `blank` producer (empty content for prose types); the `0`/`false` seam from the blank table applies here too — a numeric variant field's authored `0` reads as blank and never warns, accepted as the same permanent seam. Message per the ERROR.md contract: field path, the discriminant's name and resolved value, the owning variant value, and both exits (set the discriminant, or clear the field).
+
+## Projections
+
+**Transform schema** (`build_transform_schema`): emit `quillmark:variant_of: { field, value }` in the prelude beside `quillmark:must_fill` (before the enum early-return). `quillmark:must_fill` keeps its unconditional derived answer; `variant_of` scopes it — the pair reads "must fill, in this world". No `if`/`then` emission: an out-of-variant value is wire-valid by design (it coerces and renders), so a standard validator accepting it is correct, and the engine's `validate` remains the authority on the warning.
+
+**Blueprint**: the blueprint-active variant per discriminant is derived from its cell value (`default:` › `example:` › bare blank). In-play variant fields emit as live YAML with the ordinary per-field treatment; out-of-play variant fields are skipped entirely — no commented-out fields, per the existing rule. Each discriminant gains one leading `# when <VALUE>: <field>, <field>, …` line per skipped variant, after the description line and before `# e.g.`. Field names are snake_case, so the line cannot collide with the reserved-character grammar. Discovery of the skipped fields' types and descriptions is the validate loop's job: an agent that writes `classification: CUI` and re-validates receives `unauthored` warnings naming the newly obliged cells. The parse/round-trip/render guarantee holds trivially (fewer fields, plus comments, which round-trip).
+
+**Seeding**: the seed-active variant per discriminant is `example:` (committed) › `default:` › blank. Example-bearing in-play variant fields commit as usual, marker stamping unchanged; out-of-play variant fields never seed.
+
+**Plate contract addendum** (BLUEPRINT.md guarantees section): a plate keys a variant's block on the discriminant, never on the variant fields' non-emptiness — an out-of-variant value reaches the plate and must stay inert there.
+
+## Fixture migration
+
+`usaf_memo` 0.2.0, edited in place: no type changes, no stored-value reinterpretation, and plate JSON stays byte-identical, so the VERSIONING ref-immutability rule (which targets type changes that rewrite stored values) is not tripped; the only behavioral delta is new warnings.
+
+- Move `cui_controlled_by`, `cui_poc`, `cui_category`, `cui_limited_dissemination` under `classification.variants.CUI`, keeping each field's `ui.group: classification`.
+- Drop `default: ""` from `cui_controlled_by` and `cui_poc`: the derivation then obliges them when CUI is active, matching DoDM 5200.48. `cui_category` and `cui_limited_dissemination` keep `default: ""` (skippable).
+- Trim the "Required … when classification is CUI" clauses from descriptions: the scoping is structural now.
+- Hoist order places the `cui_*` fields between `classification` and `dissemination`; regenerate `__golden__/schema.yaml`. An omitted `cui_controlled_by`/`cui_poc` moves from the `default` rung to the `blank` rung in `resolve()` output (same `""` bytes); regenerate any golden that captures source tags.
+
+## Canon and docs
+
+- `SCHEMAS.md`: a "Variants" subsection in the DSL section (syntax, load errors, hoist/`variant_of`, the flat-document/total-floor/warning triad), plus the `out_of_variant` entry and the `unauthored`-trigger scoping under Native validation.
+- `BLUEPRINT.md`: the `# when` leading line and the in-play emission rule; the plate contract addendum.
+- `ERROR.md`: register the new codes.
+- `docs/quills/quill-yaml-reference.md`: author-facing `variants:` entry.
+
+## Tests
+
+- Load: parse happy path; each error code; hoist order and `variant_of` stamps; two variant-bearing enums in one card.
+- Emission: `schema()` flat-plus-annotation (golden); transform schema `quillmark:variant_of`.
+- Validation: `out_of_variant` fires on authored non-blank out-of-play, not on blank/null/in-play, and resolves the discriminant through `default:`; `unauthored` skips out-of-play and fires in-play; marker sovereignty on an out-of-play field.
+- Blueprint: skip plus `# when` line with a blank-defaulted discriminant; live variant fields when the default names the variant; existing quiver round-trip/render tests cover the migrated fixture.
+- Seeding: out-of-play examples not committed.
+- Render: migrated `usaf_memo` plate JSON byte-identical to pre-migration.
+
+## Deferred
+
+Out of the initial cut, each a compatible later extension: multi-value variant keys (the CONFIDENTIAL/SECRET/TOP SECRET shared block — the accepted ceiling; YAML anchors are the interim spelling), floor suppression of out-of-variant values (would demote the authored rung; needs its own case), in-play tagging on `resolve()` rows (consumers already hold `variant_of` and the discriminant row), `variants:` below card level, JSON-Schema `if`/`then` on the transform wire, and non-enum discriminants (#1202's `SEE DISTRIBUTION` shape remains open there).


### PR DESCRIPTION
Closes #1268.

An `enum` field may declare `variants:` — a per-value field set that exists only where the discriminant holds that value. It is the one cross-field shape the schema DSL carries.

```yaml
classification:
  type: enum
  values: [UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET]
  variants:
    CUI:
      cui_controlled_by: { type: string }
      cui_poc:           { type: string }
      cui_category:      { type: string, default: "" }
```

## The mechanism is a load-time hoist

Each variant's fields are lifted into the card's flat field map, stamped with a `variant_of: {field, value}` back-reference, and placed immediately after their discriminant. After that there is no nested structure left, so **coercion, the render ladder, `conform`, `resolve()`, and both backends see ordinary fields and needed no changes**. Four surfaces read the back-reference: load, validation, blueprint, seeding.

## Three properties bound what conditional existence means

The issue frames this as a tagged union. The syntax borrows that shape; the semantics deliberately do not, and each retreat is what keeps the change small.

- **The document stays flat.** A variant field is authored at the card's top level, so existing documents parse unchanged and the frontmatter stays hand-authorable. A card's field names are **one namespace** — a name resolving to two schemas would make a field's type depend on another field's *value*, the one thing that would force coercion to consult siblings. `quill::variant_field_collision` makes that unrepresentable.
- **The render floor stays total.** A variant field is declared and blank-filled whatever the discriminant reads, so plates address it unconditionally and the empty-document contract is untouched. Conditional existence is an authoring/validation fact, never a wire one.
- **Stranded values warn, never gate.** An authored value whose variant is out of play draws the new non-fatal `validation::out_of_variant` and is **carried, not dropped**. Flipping a discriminant in an editor must not cost the author their answers, and must not hand them an invalid document — the form-toggle trap.

## Conditional obligation costs no new axis

`must_fill` inside a variant keeps its ordinary `default:`-presence derivation, so it reads *"required in this world"*. This closes the CUI half of #1202: writing `classification: CUI` brings `cui_controlled_by` and `cui_poc` into play, and the next `validate` reports them — the "not done" signal a strict LLM authoring loop needs for a relational omission it previously could not be told about.

## Authoring surfaces

The blueprint shows the one world its own discriminant cell names, and names each skipped variant's fields on that cell:

```
# Select the classification marking shown in the header and footer banner.
# when CUI: cui_controlled_by, cui_poc, cui_category, cui_limited_dissemination
classification: "" # enum<UNCLASSIFIED | CUI | CONFIDENTIAL | SECRET | TOP SECRET>
```

`variants:` is the authoring spelling; `schema()` emits the **hoisted** form (flat, annotated `variant_of`, in display position) so an editor reads one ordered field list instead of re-implementing the hoist to match `resolve()`. Authoring `variant_of:` directly is a load error. The transform schema carries the same fact as `quillmark:variant_of`.

## Load errors

| Condition | Code |
|---|---|
| `variants:` on a non-enum field | `quill::variants_on_non_enum` |
| a key outside `values:` (the blank owns no variant) | `quill::variant_unknown_value` |
| a name colliding with any other field on the card | `quill::variant_field_collision` |
| `variants:` below card level, or nested in another variant | `quill::variant_placement` |
| a name that is not a valid field key — a hoisted field earns the flat path's gate | `quill::invalid_field_name` |

## Fixture migration

`usaf_memo` 0.2.0 in place: the four `cui_*` fields move under `classification.variants.CUI`, `cui_controlled_by`/`cui_poc` drop the `default: ""` that made them unaskable, and the "Required … when classification is CUI" prose comes out of the descriptions now that the scoping is structural. No type changes and no stored-value reinterpretation, so the ref-immutability rule is not tripped.

Every plate key and value is unchanged across the classification × CUI-authoring matrix (verified against the pre-migration schema). Plate *key order* moves, since the hoist repositions the `cui_*` block ahead of `dissemination` — no plate reads key order, and `plate.typ` addresses fields by name.

## Review pass

An adversarial correctness review over the diff found four real defects, each reproduced before the fix and now covered by a regression test:

| Defect | Symptom |
|---|---|
| Variant field names bypassed the flat path's key gate | A variant could declare `$kind`; the quill loaded clean and `blueprint()` emitted a duplicate mapping key, breaking its parseability guarantee |
| Seeding ignored a `$seed` overlay that names the discriminant | `seed_card` committed a card whose own `action` read `disapprove` while that variant's fields were skipped, dropping the overlay's answer |
| The blank test compared an uncoerced value against the coerced blank | `validate` runs before coercion, so an empty `richtext` (`""`) or typed dict (`{}`) falsely warned "clear the field" with no edit that resolved it |
| The discriminant ladder read `as_str()` while coercion adopts bare scalars | For an enum with scalar-looking members, `flag: true` reached the plate in play but validated as out-of-variant, and an in-play `must_fill` went silent |

Three of the four are cross-surface disagreements — the variant axis reading a different ladder than coercion, the seed, or the flat load path. They are the shape of bug this design invites, so the regression tests pin each surface to one answer.

## Verification

- `cargo test --workspace --all-features --locked` and `cargo test -p quillmark --no-default-features --locked` green; 32 new tests.
- `every_quill_in_quiver_renders` and `every_quill_blueprint_round_trips_and_renders` cover the migrated fixture.
- `node scripts/check-canon.mjs` passes; clippy unchanged at its 26-warning baseline.
- Prose follows the repo's `dense-prose` policy.
- `cargo check -p quillmark-wasm --target wasm32-unknown-unknown` clean (the TS declaration gained `variant_of`). The full `build-wasm.sh` could not run in this container: its `wasm-bindgen-cli` is 0.2.122 against the lock's 0.2.118. CI pins the right one.

## Docs

`SCHEMAS.md` gains an "Enum variants" section; `BLUEPRINT.md` the `# when` line and a plate-contract clause; `ERROR.md` registers the new code in the args table (enforced by `diagnostic_args_match_canon`); `docs/quills/quill-yaml-reference.md` gets an author-facing section.

`prose/proposals/enum-variants.md` carries the design and the deferred list — multi-value variant keys (the accepted ceiling; YAML anchors interim), floor suppression, `resolve()` in-play tagging, nested variants, and non-enum discriminants (#1202's `SEE DISTRIBUTION` shape stays open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WnRozq2zXTqbJCBSRnVAM

---
_Generated by [Claude Code](https://claude.ai/code/session_019WnRozq2zXTqbJCBSRnVAM)_