### PR TITLE
Enum variants: fields that exist only for one enum value

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -80,6 +80,11 @@ export interface QuillFieldSchema {
     /** The closed set of allowed values. Required on `type: "enum"`, and valid
      *  nowhere else. */
     values?: string[];
+    /** Per-member field sets on a card-level `type: "enum"` field, keyed by
+     *  member: the fields that exist only where the discriminant holds that
+     *  member. Declaring it makes the field rest as a container,
+     *  `{value: <member>, …that member's fields}`, rather than a bare string. */
+    variants?: Record<string, Record<string, QuillFieldSchema>>;
     /** Whether a human must author the field. Absent, it derives from
      *  `default`: a defaulted field is unobliged, a defaultless one obliged. */
     must_fill?: boolean;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -712,6 +712,12 @@ mod args_canon {
             "both `validation::must_fill` triggers must carry one key set"
         );
         add("validation::must_fill", marker.args);
+        // Built at the variant walk rather than from an error type: a stranded
+        // value is well-formed, so there is nothing to fail.
+        add(
+            "validation::out_of_variant",
+            crate::quill::compose::out_of_variant_warning(&path, "CUI", "UNCLASSIFIED").args,
+        );
         // Built at the pre-render walk rather than from an error type: a quill
         // declares the construct, so there is nothing to fail.
         add("plate::unsupported_construct", {

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -24,13 +24,15 @@ pub use resolved::{FieldSource, Resolved, ResolvedCard, ResolvedField, ResolvedM
 pub use fill::blank;
 pub use formats::{parse_date, parse_datetime};
 pub use ignore::QuillIgnore;
-pub use schema::{build_transform_schema, QUILLMARK_INLINE_KEY, CONTENT_MEDIA_TYPE};
+pub use schema::{
+    build_transform_schema, CONTENT_MEDIA_TYPE, QUILLMARK_INLINE_KEY, QUILLMARK_VARIANT_OF_KEY,
+};
 pub use support::UNSUPPORTED_CONSTRUCT;
 pub use tree::FileTreeNode;
 pub use validation::ValidationError;
 pub use types::{
     BlockConstruct, BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, GroupSchema,
-    UiCardSchema, UiFieldSchema,
+    UiCardSchema, UiFieldSchema, VariantFields, VARIANT_DISCRIMINANT_KEY,
 };
 
 use std::collections::HashMap;

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -7,7 +7,7 @@
 
 use indexmap::IndexMap;
 
-use super::{blank, CardSchema, FieldSchema, FieldType, QuillConfig};
+use super::{blank, CardSchema, FieldSchema, FieldType, QuillConfig, VARIANT_DISCRIMINANT_KEY};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::document::prescan::NestedComment;
 use crate::document::{Card, Document, Payload, PayloadItem};
@@ -174,6 +174,12 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 /// typed dictionaries (`object` with `properties`) to their per-property
 /// builders; everything else is a scalar/array cell.
 fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+    // Variant-bearing enum: a container whose live world the discriminant picks.
+    if field.is_variant_bearing() {
+        append_variant(items, field);
+        return;
+    }
+
     // Typed table: an array whose element is an object with properties.
     if matches!(field.r#type, FieldType::Array) {
         if let Some(elem) = &field.items {
@@ -344,6 +350,95 @@ fn append_typed_dict(
     };
 
     push_container_field(items, &field.name, value, nested, fills, field);
+}
+
+/// Append a variant-bearing enum: the container, its discriminant cell, and the
+/// fields of the world that discriminant selects.
+///
+/// A blueprint **is** a document, so it can only show one world — the one its own
+/// discriminant names (`default:` › `example:` › blank). The worlds it cannot
+/// show are named instead, one `# when <MEMBER>: <fields>` line each, so a reader
+/// filling the form learns that choosing a different member brings different
+/// cells. Every world is listed, the shown one included: the lines are the map,
+/// the cells are the position.
+///
+/// The discriminant carries the container's `!must_fill` marker (a mapping
+/// cannot hold one) and no inline annotation of its own — the container line
+/// already carries `enum<…>`, and `value` is that enum.
+fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+    push_leading(items, field, field.default.is_some());
+    if let Some(variants) = &field.variants {
+        for (member, fields) in variants {
+            let names: Vec<&str> = fields.keys().map(String::as_str).collect();
+            items.push(PayloadItem::comment(format!(
+                "when {member}: {}",
+                names.join(", ")
+            )));
+        }
+    }
+
+    let member = scalar_value(field);
+    let mut map = JsonMap::new();
+    let mut nested = Vec::new();
+    let mut fills = Vec::new();
+    map.insert(
+        VARIANT_DISCRIMINANT_KEY.to_string(),
+        match &member {
+            // A null discriminant would read as "no cell"; the blank is the
+            // enum's own spelling of an unanswered choice, and it round-trips.
+            JsonValue::Null => JsonValue::String(String::new()),
+            other => other.clone(),
+        },
+    );
+    if field.must_fill() {
+        fills.push(vec![PathSegment::Key(VARIANT_DISCRIMINANT_KEY.to_string())]);
+    }
+
+    let live = member.as_str().and_then(|m| field.variant_fields(m));
+    if let Some(fields) = live {
+        for (slot, prop) in fields.values().map(|b| b.as_ref()).enumerate() {
+            // Slot 0 is the discriminant, so every variant field sits one past it.
+            let position = slot + 1;
+            if let Some(desc) = collapse_opt(&prop.description) {
+                nested.push(NestedComment {
+                    container_path: Vec::new(),
+                    position,
+                    text: desc,
+                    inline: false,
+                });
+            }
+            if prop.default.is_some() {
+                if let Some(eg) = prop.example.as_ref() {
+                    nested.push(NestedComment {
+                        container_path: Vec::new(),
+                        position,
+                        text: format!("e.g. {}", eg_hint(eg)),
+                        inline: false,
+                    });
+                }
+            }
+            let (json, fill) = scalar_cell(prop);
+            map.insert(prop.name.clone(), json);
+            if fill {
+                fills.push(vec![PathSegment::Key(prop.name.clone())]);
+            }
+            nested.push(NestedComment {
+                container_path: Vec::new(),
+                position,
+                text: type_expression(prop),
+                inline: true,
+            });
+        }
+    }
+
+    push_container_field(
+        items,
+        &field.name,
+        JsonValue::Object(map),
+        nested,
+        fills,
+        field,
+    );
 }
 
 /// Append a typed-table field (`array<object>`). With a `default:`: render the

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -7,7 +7,10 @@ use std::str::FromStr;
 use indexmap::IndexMap;
 
 use super::resolved::FieldSource;
-use super::{seed, CardSchema, CoercionError, FieldSchema, FieldType, Leniency, Quill, QuillConfig};
+use super::{
+    seed, CardSchema, CoercionError, FieldSchema, FieldType, Leniency, Quill, QuillConfig,
+    VARIANT_DISCRIMINANT_KEY,
+};
 use crate::normalize::{normalize_document, normalize_field_name};
 use crate::quill::blank;
 use crate::path::DocPath;
@@ -242,6 +245,7 @@ impl Quill {
                 .into_iter()
                 .filter(|d| !claimed.contains(&d.path)),
         );
+        diags.extend(validate_variants(self.config(), doc));
         diags.extend(self.validate_seed(doc));
         diags
     }
@@ -506,6 +510,9 @@ pub(crate) fn resolve_value_sourced(
     value: Option<&QuillValue>,
     field: &FieldSchema,
 ) -> (QuillValue, FieldSource) {
+    if field.is_variant_bearing() {
+        return resolve_variant_sourced(value, field);
+    }
     let present = value.filter(|v| !v.as_json().is_null());
     let Some(v) = present else {
         // A content-bearing field (`richtext` or its literal sibling
@@ -570,6 +577,75 @@ pub(crate) fn resolve_value_sourced(
         _ => v.clone(),
     };
     (resolved, FieldSource::Authored)
+}
+
+/// Resolve a variant-bearing enum into the container the plate receives:
+/// `{value: <member>}` plus, when that member owns a field set, exactly that
+/// set — each cell blank-filled by the ordinary ladder.
+///
+/// **The container is a closed shape.** Only the live world's fields cross, so a
+/// value stranded by a discriminant flip and a key belonging to another variant
+/// are both dropped here rather than shipped alongside a tag that disowns them.
+/// That is what makes the plate contract total *per world*: inside the branch a
+/// plate is already obliged to write over `values ∪ blank`
+/// (`prose/canon/SCHEMAS.md` § "Blank-filled render"), every declared field of
+/// that world is present, so no guarded access is needed; outside it, none is.
+///
+/// The discriminant cuts the same ladder as any enum (authored › `default:` ›
+/// blank) and its rung is the container's: a member nobody chose leaves the
+/// whole cell at the rung that supplied it.
+fn resolve_variant_sourced(
+    value: Option<&QuillValue>,
+    field: &FieldSchema,
+) -> (QuillValue, FieldSource) {
+    let present = value.filter(|v| !v.as_json().is_null());
+    let authored = present.map(|v| v.as_json());
+    // Coercion normalizes to the container, so the authored discriminant is the
+    // `value` key. A bare scalar that bypassed coercion (a serde-built payload)
+    // still reads, keeping this total.
+    let authored_member = authored.and_then(|json| match json {
+        serde_json::Value::Object(o) => o.get(VARIANT_DISCRIMINANT_KEY),
+        other => Some(other),
+    });
+    let authored_member = authored_member
+        .filter(|v| !v.is_null())
+        .and_then(|v| v.as_str());
+
+    let (member, source) = match authored_member {
+        Some(member) => (member.to_string(), FieldSource::Authored),
+        None => match field.default.as_ref().and_then(|d| d.as_str()) {
+            Some(default) => (default.to_string(), FieldSource::Default),
+            None => (String::new(), FieldSource::Blank),
+        },
+    };
+    // A present container with no discriminant is still authored: the author
+    // wrote the cell, and the ladder filled the tag they left out.
+    let source = match (present.is_some(), source) {
+        (true, FieldSource::Blank) => FieldSource::Authored,
+        (_, s) => s,
+    };
+
+    let mut out = serde_json::Map::new();
+    out.insert(
+        VARIANT_DISCRIMINANT_KEY.to_string(),
+        serde_json::Value::String(member.clone()),
+    );
+    if let Some(fields) = field.variant_fields(&member) {
+        let object = authored.and_then(|j| j.as_object());
+        for (name, schema) in fields {
+            let cell = object
+                .and_then(|o| o.get(name))
+                .map(|j| QuillValue::from_json(j.clone()));
+            out.insert(
+                name.clone(),
+                resolve_value(cell.as_ref(), schema).into_json(),
+            );
+        }
+    }
+    (
+        QuillValue::from_json(serde_json::Value::Object(out)),
+        source,
+    )
 }
 
 /// Build a [`Payload`] from a coerced/defaulted field map, re-attaching `$quill`
@@ -694,6 +770,49 @@ fn collect_unauthored_field(
     path: &DocPath,
     out: &mut Vec<Diagnostic>,
 ) {
+    // A variant container is not itself a cell, for the reason a typed dictionary
+    // is not: `!must_fill` is rejected on a mapping. Its cells are the
+    // discriminant and — *only in the world the discriminant selects* — that
+    // world's fields. This is where obligation becomes conditional: a `poc` with
+    // no `default:` is obliged on a CUI memo and silent on every other one, which
+    // is the thing `must_fill` alone could not say (#1202).
+    if field.is_variant_bearing() {
+        let json = value.map(|v| v.as_json());
+        let object = json.and_then(|j| j.as_object());
+        // Pre-coercion the cell may still be the bare scalar; read either.
+        let authored = match json {
+            Some(serde_json::Value::Object(o)) => o.get(VARIANT_DISCRIMINANT_KEY),
+            other => other,
+        }
+        .filter(|v| !v.is_null());
+
+        let discriminant = path.field(VARIANT_DISCRIMINANT_KEY);
+        if authored.is_none() && field.must_fill() {
+            out.push(unauthored_warning(&discriminant));
+        }
+        let member = authored
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                field
+                    .default
+                    .as_ref()
+                    .and_then(|d| d.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_default();
+
+        if let Some(fields) = field.variant_fields(&member) {
+            for (name, schema) in fields {
+                let cell = object
+                    .and_then(|o| o.get(name))
+                    .map(|j| QuillValue::from_json(j.clone()));
+                collect_unauthored_field(schema, cell.as_ref(), &path.field(name), out);
+            }
+        }
+        return;
+    }
+
     if let (FieldType::Object, Some(props)) = (&field.r#type, &field.properties) {
         let obj = value.and_then(|v| v.as_json().as_object());
         for (name, prop) in props {
@@ -718,6 +837,104 @@ fn collect_unauthored_field(
             collect_unauthored_field(items, Some(&element), &path.index(index), out);
         }
     }
+}
+
+/// Report every authored cell that belongs to a variant the discriminant does
+/// not select, across the main card and every composable card.
+///
+/// **Carried, not dropped.** The value stays in the document and the diagnostic
+/// is non-fatal, because the alternative punishes the ordinary editor gesture:
+/// choose CUI, fill the block, flip to UNCLASSIFIED to compare, flip back. A
+/// coercion-time drop would spend the author's answers on that flip; gating
+/// render would hand them an undraftable document. So the wire stays honest —
+/// the render floor emits only the live world — and the document keeps what a
+/// human typed until a human clears it.
+fn validate_variants(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    collect_variant_diags(&config.main, doc.main(), &DocPath::main(), &mut diags);
+    for (index, card) in doc.cards().iter().enumerate() {
+        let Some(schema) = card.kind().and_then(|k| config.card_kind(k)) else {
+            continue;
+        };
+        collect_variant_diags(schema, card, &DocPath::card(card.kind(), index), &mut diags);
+    }
+    diags
+}
+
+fn collect_variant_diags(
+    schema: &CardSchema,
+    card: &Card,
+    base: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    let payload = card.payload();
+    for (name, field) in &schema.fields {
+        if !field.is_variant_bearing() {
+            continue;
+        }
+        let Some(object) = payload.get(name).and_then(|v| v.as_json().as_object().cloned()) else {
+            continue;
+        };
+        let member = object
+            .get(VARIANT_DISCRIMINANT_KEY)
+            .filter(|v| !v.is_null())
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                field
+                    .default
+                    .as_ref()
+                    .and_then(|d| d.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_default();
+        let live = field.variant_fields(&member);
+        for key in object.keys() {
+            if key == VARIANT_DISCRIMINANT_KEY || live.is_some_and(|f| f.contains_key(key)) {
+                continue;
+            }
+            // A key no variant declares is an undeclared field, which every
+            // other surface carries without comment; only a key some *other*
+            // world owns is the stranded case worth naming.
+            let Some(owner) = field.variants.as_ref().and_then(|variants| {
+                variants
+                    .iter()
+                    .find(|(_, set)| set.contains_key(key))
+                    .map(|(member, _)| member.clone())
+            }) else {
+                continue;
+            };
+            out.push(out_of_variant_warning(
+                &base.field(name).field(key),
+                &owner,
+                &member,
+            ));
+        }
+    }
+}
+
+pub(crate) fn out_of_variant_warning(path: &DocPath, owner: &str, member: &str) -> Diagnostic {
+    let path = path.to_string();
+    let selected = if member.is_empty() {
+        "left blank".to_string()
+    } else {
+        format!("`{member}`")
+    };
+    Diagnostic::new(
+        Severity::Warning,
+        format!(
+            "Field `{path}` belongs to the `{owner}` variant, but the discriminant is {selected}: \
+             the value is kept and will not render."
+        ),
+    )
+    .with_code("validation::out_of_variant".to_string())
+    .with_path(path)
+    .with_arg("variant", owner.into())
+    .with_arg("selected", member.into())
+    .with_hint(format!(
+        "Select `{owner}` to bring the field back into play, or remove the field to drop the \
+         value."
+    ))
 }
 
 pub(crate) fn unauthored_warning(path: &DocPath) -> Diagnostic {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Diagnostic, Severity, diag_args};
 use crate::value::QuillValue;
 
-use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG};
+use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG, VARIANT_DISCRIMINANT_KEY};
 use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
@@ -319,6 +319,15 @@ impl QuillConfig {
         // is never part of the JSON projection).
         if json_value.is_null() {
             return Ok(value.clone());
+        }
+
+        // A variant-bearing enum rests as a container, so it normalizes here and
+        // every surface downstream sees one shape. The bare scalar
+        // (`classification: CUI`) is the hand-authored spelling of a world with
+        // nothing filled in, and it is adopted rather than rejected: a document
+        // only needs the map once it has a variant field to carry.
+        if field_schema.is_variant_bearing() {
+            return Self::conform_variant(json_value, field_schema, path, mode);
         }
 
         match field_schema.r#type {
@@ -794,6 +803,118 @@ impl QuillConfig {
         Ok(out)
     }
 
+    /// Coerce a variant-bearing enum to its container form, `{value: <member>,
+    /// …}`. Two authored shapes reach here and both normalize to one:
+    ///
+    /// - a **bare scalar** (`classification: CUI`), the hand-authored spelling of
+    ///   a world carrying no variant answers, wrapped as `{value: "CUI"}`;
+    /// - a **map**, whose `value` coerces as the enum's string and whose other
+    ///   keys coerce against whichever variant declares them.
+    ///
+    /// A key no variant declares carries through verbatim, as an undeclared key
+    /// on a typed dictionary does: the schema is a floor here too. A key declared
+    /// by a *non-active* variant is coerced by that variant's schema and kept, so
+    /// flipping the discriminant in an editor and flipping back does not cost the
+    /// author their answers; `validation::out_of_variant` reports it, and the
+    /// render floor drops it from the plate.
+    ///
+    /// Names may repeat across variants (only one world is ever live), so the
+    /// lookup takes the first variant declaring the name: an ambiguity only
+    /// reachable for a stranded value, whose type nothing downstream reads.
+    fn conform_variant(
+        json_value: &serde_json::Value,
+        field_schema: &super::FieldSchema,
+        path: &str,
+        mode: Leniency,
+    ) -> Result<QuillValue, CoercionError> {
+        let discriminant = |v: &serde_json::Value| -> Option<String> {
+            v.as_str()
+                .map(str::to_string)
+                .or_else(|| scalar_as_string(v))
+        };
+
+        let Some(object) = json_value.as_object() else {
+            return match discriminant(json_value) {
+                Some(member) => {
+                    let mut out = serde_json::Map::new();
+                    out.insert(
+                        VARIANT_DISCRIMINANT_KEY.to_string(),
+                        serde_json::Value::String(member),
+                    );
+                    Ok(QuillValue::from_json(serde_json::Value::Object(out)))
+                }
+                // A shape that is neither a member nor a container: the render
+                // floor defers to validation, a strict write fails now.
+                None => match mode {
+                    Leniency::Render => Ok(QuillValue::from_json(json_value.clone())),
+                    Leniency::Write => Err(CoercionError::Uncoercible {
+                        path: path.to_string(),
+                        value: json_value.to_string(),
+                        target: "enum".to_string(),
+                        reason: "value is neither a member nor a variant container".to_string(),
+                    }),
+                },
+            };
+        };
+
+        let mut out = serde_json::Map::new();
+        for (key, value) in object {
+            if key == VARIANT_DISCRIMINANT_KEY {
+                // Null ≡ absent: leave the key out so the ladder fills it.
+                if value.is_null() {
+                    continue;
+                }
+                match discriminant(value) {
+                    Some(member) => {
+                        out.insert(key.clone(), serde_json::Value::String(member));
+                    }
+                    None => match mode {
+                        Leniency::Render => {
+                            out.insert(key.clone(), value.clone());
+                        }
+                        Leniency::Write => {
+                            return Err(CoercionError::Uncoercible {
+                                path: format!("{path}.{key}"),
+                                value: value.to_string(),
+                                target: "enum".to_string(),
+                                reason: "value is not a string".to_string(),
+                            });
+                        }
+                    },
+                }
+                continue;
+            }
+            match Self::variant_field_schema(field_schema, key) {
+                Some(schema) => {
+                    let coerced = Self::conform_value(
+                        &QuillValue::from_json(value.clone()),
+                        schema,
+                        &format!("{path}.{key}"),
+                        mode,
+                    )?;
+                    out.insert(key.clone(), coerced.into_json());
+                }
+                None => {
+                    out.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        Ok(QuillValue::from_json(serde_json::Value::Object(out)))
+    }
+
+    /// The schema for `name` under any of `field`'s variants, active or not.
+    pub(crate) fn variant_field_schema<'a>(
+        field: &'a super::FieldSchema,
+        name: &str,
+    ) -> Option<&'a super::FieldSchema> {
+        field
+            .variants
+            .as_ref()?
+            .values()
+            .find_map(|set| set.get(name))
+            .map(|boxed| boxed.as_ref())
+    }
+
     /// Recursively validate a field's structural shape, enforcing the
     /// one-level nesting contract in a single pass. The `position` records
     /// what shapes are legal at the current depth:
@@ -849,6 +970,124 @@ impl QuillConfig {
                      join a group."
                 ),
             );
+        }
+
+        if let Some(variants) = &schema.variants {
+            // A variant set is a *card-level* shape: it turns its field into a
+            // container, and a container may not sit inside one (the same
+            // one-level rule `nested_object_not_supported` states from the
+            // object side).
+            if position != ShapePosition::Top {
+                return err(
+                    "quill::variant_placement",
+                    format!(
+                        "Field '{owner}' declares 'variants' in a nested position. \
+                         Variants apply only to card-level enum fields; an object \
+                         property, an array item, and another variant's field cannot \
+                         carry one."
+                    ),
+                );
+            }
+            let Some(values) = &schema.enum_values else {
+                return err(
+                    "quill::variants_on_non_enum",
+                    format!(
+                        "Field '{owner}' declares 'variants' but is not type: enum. \
+                         A variant names one member of a closed domain, so declare \
+                         type: enum with a values: list."
+                    ),
+                );
+            };
+            if variants.is_empty() {
+                return err(
+                    "quill::variant_empty",
+                    format!(
+                        "Field '{owner}' has an empty 'variants' map. Declare at least \
+                         one member's field set, or remove the key entirely."
+                    ),
+                );
+            }
+            for (member, fields) in variants {
+                let member_owner = format!("{owner}.variants.{member}");
+                if !values.iter().any(|v| v == member) {
+                    // The blank lands here too, and its message is the pointed
+                    // one: it is not a member, so it owns no field set.
+                    return err(
+                        "quill::variant_unknown_value",
+                        format!(
+                            "Field '{owner}' declares a variant for '{member}', which is \
+                             not one of its 'values'. A variant keys on a declared member; \
+                             the blank (\"\") is not one and owns no field set."
+                        ),
+                    );
+                }
+                if fields.is_empty() {
+                    return err(
+                        "quill::variant_empty",
+                        format!(
+                            "Field '{member_owner}' declares no fields. A variant exists to \
+                             bring a field set into play; drop the member's entry if it \
+                             brings none."
+                        ),
+                    );
+                }
+                for (name, field) in fields {
+                    if name == VARIANT_DISCRIMINANT_KEY {
+                        return err(
+                            "quill::variant_reserved_field_name",
+                            format!(
+                                "Field '{member_owner}' declares a field named \
+                                 '{VARIANT_DISCRIMINANT_KEY}', which carries the \
+                                 discriminant itself. Rename the field."
+                            ),
+                        );
+                    }
+                    if !Self::is_snake_case_identifier(name) {
+                        return err(
+                            "quill::invalid_field_name",
+                            format!(
+                                "Invalid variant field key '{name}' on '{member_owner}': \
+                                 field keys must be snake_case (lowercase letters, digits, \
+                                 and underscores only), and capitalized field keys are \
+                                 reserved."
+                            ),
+                        );
+                    }
+                    // A variant's fields are leaves, exactly as an object's
+                    // properties are: scalars only, no `ui.group` (they inherit
+                    // the discriminant's), no container one level down.
+                    if let Some(diag) = Self::validate_field_schema_shape(
+                        field,
+                        &format!("{member_owner}.{name}"),
+                        ShapePosition::Leaf,
+                    ) {
+                        return Some(diag);
+                    }
+                    // Content and dates lower to Typst through *top-level* name
+                    // tables (`content_field_names`, the date tables), which do
+                    // not descend into a container. Declaring one here would
+                    // load clean and reach the plate as a raw dict, so the
+                    // ceiling is enforced rather than discovered at render.
+                    if matches!(
+                        field.r#type,
+                        FieldType::RichText { .. }
+                            | FieldType::PlainText { .. }
+                            | FieldType::Date
+                            | FieldType::DateTime
+                    ) {
+                        return err(
+                            "quill::variant_field_type",
+                            format!(
+                                "Field '{member_owner}.{name}' is type: {}, which a variant \
+                                 cannot carry. A variant holds plain data: string, enum, \
+                                 number, integer, or boolean. Declare prose and dates as \
+                                 card-level fields.",
+                                field.r#type.as_str()
+                            ),
+                        );
+                    }
+                }
+            }
         }
 
         match schema.r#type {
@@ -1031,6 +1270,14 @@ impl QuillConfig {
             for (name, prop) in props {
                 let nested = format!("{}.{}", owner_label, name);
                 Self::validate_field_blueprint_constraints(prop, &nested, errors);
+            }
+        }
+        if let Some(variants) = &schema.variants {
+            for (member, fields) in variants {
+                for (name, field) in fields {
+                    let nested = format!("{owner_label}.variants.{member}.{name}");
+                    Self::validate_field_blueprint_constraints(field, &nested, errors);
+                }
             }
         }
         if let Some(items) = &schema.items {
@@ -1927,6 +2174,8 @@ pub(crate) fn field_contains_content(field: &FieldSchema) -> bool {
             .properties
             .as_ref()
             .is_some_and(|p| p.values().any(|f| field_contains_content(f))),
+        // A variant carries plain data only (`quill::variant_field_type`), so no
+        // content leaf can sit inside one and the container never bears content.
         _ => false,
     }
 }

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -3,7 +3,7 @@
 
 use serde_json::json;
 
-use super::{FieldSchema, FieldType};
+use super::{FieldSchema, FieldType, VARIANT_DISCRIMINANT_KEY};
 use crate::value::QuillValue;
 
 /// The **blank** for `field`: the leanest value satisfying its declared type,
@@ -18,6 +18,7 @@ use crate::value::QuillValue;
 /// | `object` | every property at its own blank, recursively |
 /// | `integer`, `number` | `0` |
 /// | `boolean` | `false` |
+/// | `enum` with `variants:` | `{value: ""}` — the container holding the blank |
 ///
 /// A field's blank is a property of the *field*, not a member of the type's
 /// value domain: an `enum`'s blank sits outside `values:` rather than claiming
@@ -36,6 +37,15 @@ use crate::value::QuillValue;
 /// present, so it recurses rather than degrading to the bare `{}` that only a
 /// property-less object carries.
 pub fn blank(field: &FieldSchema) -> QuillValue {
+    // A variant-bearing enum rests as a container, so its blank is the container
+    // holding the blank discriminant. The blank activates no variant, so the
+    // object carries nothing else: the field set a member would bring is exactly
+    // what nobody has chosen.
+    if field.is_variant_bearing() {
+        let mut obj = serde_json::Map::new();
+        obj.insert(VARIANT_DISCRIMINANT_KEY.to_string(), json!(""));
+        return QuillValue::from_json(serde_json::Value::Object(obj));
+    }
     // Keyed on the carrier rather than the `Enum` token, as every consumer of a
     // finite domain is (`SCHEMAS.md` § "Type coercion"), so a serde-built schema
     // whose type and carrier disagree still blanks to the reserved `""`.

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -2,7 +2,7 @@
 //! [`QuillValue`]. Backend-agnostic: backends consume it to drive per-field
 //! transforms such as markdown to backend markup.
 
-use super::{FieldSchema, FieldType, QuillConfig};
+use super::{FieldSchema, FieldType, QuillConfig, VARIANT_DISCRIMINANT_KEY};
 use crate::value::QuillValue;
 
 /// The `contentMediaType` marking a richtext field in the transform schema. The
@@ -36,6 +36,13 @@ pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 /// and enforcement — if a consumer wants any — is that consumer's policy.
 pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
 
+/// Transform-schema keyword naming the enum member that brings a field into
+/// play. It sits on each property of a variant-bearing enum's container except
+/// the discriminant itself, and is the signal a UI needs to show or retire a
+/// cell as the discriminant changes — the fact the flat `cui_`-prefix convention
+/// could only carry in prose.
+pub const QUILLMARK_VARIANT_OF_KEY: &str = "quillmark:variant_of";
+
 /// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
 ///
 /// The descriptor marks richtext fields with `contentMediaType:
@@ -48,6 +55,39 @@ pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
 /// tables so `form-field(field:)` rejects `$body` addresses on that
 /// kind at compile time, matching `Quill::validate`'s hard error on authored
 /// body content for the same kind.
+/// The discriminant cell of a variant-bearing enum: the same
+/// `{type: string, enum: ["", …]}` a plain enum projects to, carrying the
+/// container's obligation. The container is a mapping and therefore not a cell
+/// (`!must_fill` is rejected on one), so this is where "a human must choose"
+/// lands.
+fn discriminant_schema(field: &FieldSchema) -> serde_json::Value {
+    let mut schema = serde_json::Map::new();
+    schema.insert(
+        QUILLMARK_MUST_FILL_KEY.to_string(),
+        serde_json::Value::Bool(field.must_fill()),
+    );
+    schema.insert(
+        "type".to_string(),
+        serde_json::Value::String("string".to_string()),
+    );
+    schema.insert(
+        "enum".to_string(),
+        serde_json::Value::Array(
+            std::iter::once(String::new())
+                .chain(field.enum_values.iter().flatten().cloned())
+                .map(serde_json::Value::String)
+                .collect(),
+        ),
+    );
+    if let Some(blank_title) = field.ui.as_ref().and_then(|u| u.blank_title.as_ref()) {
+        schema.insert(
+            QUILLMARK_BLANK_TITLE_KEY.to_string(),
+            serde_json::Value::String(blank_title.clone()),
+        );
+    }
+    serde_json::Value::Object(schema)
+}
+
 pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     fn field_to_schema(field: &FieldSchema) -> serde_json::Value {
         let mut schema = serde_json::Map::new();
@@ -64,6 +104,42 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
         // today (a plain string), plus the domain. Keyed on the domain, as the
         // render floor, the pdfform widget and the blueprint annotation all are,
         // so a `FieldSchema` built outside the loader projects its domain too.
+        // A variant-bearing enum crosses as the container it rests as: the
+        // discriminant under `value`, and every world's fields beside it, each
+        // tagged with the member that brings it into play. The union — not the
+        // live world — is what a *contract* describes: a pdfform binding and an
+        // editor form are built once, against a schema, and must address a field
+        // whose world today's document has not selected.
+        if let Some(variants) = &field.variants {
+            let mut properties = serde_json::Map::new();
+            properties.insert(
+                VARIANT_DISCRIMINANT_KEY.to_string(),
+                discriminant_schema(field),
+            );
+            for (member, fields) in variants {
+                for (name, variant_field) in fields {
+                    // Names may repeat across worlds; the first declaration wins,
+                    // as only one world is ever live.
+                    if properties.contains_key(name) {
+                        continue;
+                    }
+                    let mut child = field_to_schema(variant_field);
+                    if let Some(object) = child.as_object_mut() {
+                        object.insert(
+                            QUILLMARK_VARIANT_OF_KEY.to_string(),
+                            serde_json::Value::String(member.clone()),
+                        );
+                    }
+                    properties.insert(name.clone(), child);
+                }
+            }
+            schema.insert(
+                "type".to_string(),
+                serde_json::Value::String("object".to_string()),
+            );
+            schema.insert("properties".to_string(), properties.into());
+            return serde_json::Value::Object(schema);
+        }
         if let Some(values) = &field.enum_values {
             schema.insert(
                 "type".to_string(),

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -7,7 +7,7 @@
 use quillmark_content::Content;
 
 use super::Quill;
-use crate::quill::CardSchema;
+use crate::quill::{CardSchema, VARIANT_DISCRIMINANT_KEY};
 use crate::document::PayloadItem;
 use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 
@@ -40,6 +40,12 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     let mut items: Vec<PayloadItem> = Vec::new();
     for (name, field) in &schema.fields {
         let overlaid = overlay.and_then(|o| o.fields.get(name));
+        if field.is_variant_bearing() {
+            if let Some(item) = seed_variant(name, field, overlaid) {
+                items.push(item);
+            }
+            continue;
+        }
         let Some(value) = overlaid
             .or(field.example_content.as_ref())
             .or(field.example.as_ref())
@@ -79,6 +85,80 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     };
 
     (Payload::from_items(items), body)
+}
+
+/// Seed one variant-bearing enum, or `None` where neither the overlay nor any
+/// `example:` in the selected world has anything to commit (the field stays
+/// absent and the render floor supplies the container, as for every other type).
+///
+/// **The discriminant resolves first.** Which world is live decides which fields
+/// are even candidates, so an overlay that names the discriminant must be read
+/// before the field set is walked — otherwise the seed commits one world's tag
+/// beside another world's answers.
+///
+/// Per cell the precedence is the ordinary `overlay › example: › absent`, and
+/// the `!must_fill` marker rides a committed `example` exactly as elsewhere: an
+/// example documents shape, so it is not an answer. An overlay value is exempt —
+/// supplying one is a template author deciding.
+fn seed_variant(
+    name: &str,
+    field: &crate::quill::FieldSchema,
+    overlaid: Option<&QuillValue>,
+) -> Option<PayloadItem> {
+    let overlay_json = overlaid.map(|v| v.as_json());
+    let overlay_object = overlay_json.and_then(|j| j.as_object());
+    let overlay_member = match overlay_json {
+        Some(serde_json::Value::Object(o)) => o.get(VARIANT_DISCRIMINANT_KEY),
+        other => other,
+    }
+    .filter(|v| !v.is_null())
+    .and_then(|v| v.as_str());
+
+    let member = overlay_member
+        .map(str::to_string)
+        .or_else(|| {
+            field
+                .example
+                .as_ref()
+                .and_then(|e| e.as_str())
+                .map(str::to_string)
+        })?;
+
+    let mut map = serde_json::Map::new();
+    map.insert(
+        VARIANT_DISCRIMINANT_KEY.to_string(),
+        serde_json::Value::String(member.clone()),
+    );
+    let mut fills: Vec<String> = Vec::new();
+    if overlay_member.is_none() && field.must_fill() {
+        fills.push(VARIANT_DISCRIMINANT_KEY.to_string());
+    }
+
+    if let Some(fields) = field.variant_fields(&member) {
+        for (key, schema) in fields {
+            let overlaid_cell = overlay_object.and_then(|o| o.get(key));
+            let Some(value) = overlaid_cell.or(schema.example.as_ref().map(|e| e.as_json())) else {
+                continue;
+            };
+            map.insert(key.clone(), value.clone());
+            if overlaid_cell.is_none() && schema.must_fill() {
+                fills.push(key.clone());
+            }
+        }
+    }
+
+    let mut value = QuillValue::from_json(serde_json::Value::Object(map));
+    for key in &fills {
+        value.set_fill_at(&[crate::value::PathSegment::Key(key.clone())]);
+    }
+    Some(PayloadItem::Field {
+        key: name.to_string(),
+        value,
+        // A mapping never carries the root marker: the obligation sits on the
+        // discriminant cell inside it.
+        fill: false,
+        nested_comments: Vec::new(),
+    })
 }
 
 /// The form a seeded value commits at: the strict write's, for a field whose

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1,4 +1,5 @@
 mod support_tests;
+mod variant_tests;
 
 use super::*;
 use crate::{Diagnostic, Severity};

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -1,0 +1,498 @@
+//! Enum variants: fields that exist only for one enum value.
+//!
+//! The axis has four surfaces that must agree on one answer — load, the render
+//! floor, validation, and the authoring projections — and the shape of bug it
+//! invites is a disagreement between them. Each test below pins one surface to
+//! the same reading of the same schema.
+
+use crate::document::Document;
+use crate::quill::{blank, build_transform_schema, quill_from_yaml, FieldSchema, Quill, QuillConfig};
+use crate::value::QuillValue;
+use serde_json::json;
+
+/// A quill whose `classification` enum brings a `CUI` field set into play:
+/// `controlled_by` obliged in that world (no `default:`), `category` optional.
+fn quill_yaml() -> &'static str {
+    r#"
+quill:
+  name: variant_probe
+  version: "0.1.0"
+  backend: typst
+  description: Enum variant probe
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI, SECRET]
+      default: ""
+      variants:
+        CUI:
+          controlled_by: { type: string }
+          category: { type: string, default: "" }
+        SECRET:
+          declassify_on: { type: string }
+    title:
+      type: string
+      default: ""
+"#
+}
+
+fn config() -> QuillConfig {
+    QuillConfig::from_yaml(quill_yaml()).expect("variant probe loads")
+}
+
+fn quill() -> Quill {
+    quill_from_yaml(quill_yaml())
+}
+
+fn doc(fields: &str) -> Document {
+    let markdown =
+        format!("~~~\n$quill: variant_probe@0.1.0\n$kind: main\n{fields}~~~\n");
+    Document::parse(&markdown).expect("document parses").document
+}
+
+fn plate(document: &Document) -> serde_json::Value {
+    config()
+        .compile_data(document)
+        .expect("compile_data succeeds")["classification"]
+        .clone()
+}
+
+fn codes(document: &Document) -> Vec<(String, String)> {
+    quill()
+        .validate(document)
+        .into_iter()
+        .map(|d| {
+            (
+                d.code.unwrap_or_default(),
+                d.path.unwrap_or_default(),
+            )
+        })
+        .collect()
+}
+
+fn field(yaml: &str) -> FieldSchema {
+    let value = QuillValue::from_yaml_str(yaml).unwrap();
+    FieldSchema::from_quill_value("classification".to_string(), &value).unwrap()
+}
+
+fn load_error(fields: &str) -> String {
+    let yaml = format!(
+        r#"
+quill:
+  name: bad
+  version: "0.1.0"
+  backend: typst
+  description: bad
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+{fields}
+"#
+    );
+    let err = QuillConfig::from_yaml(&yaml).expect_err("expected a load error");
+    format!("{err:?}")
+}
+
+// ---------------------------------------------------------------- load errors
+
+#[test]
+fn variants_on_a_non_enum_field_is_a_load_error() {
+    assert!(load_error(
+        "    name:\n      type: string\n      variants:\n        A:\n          x: { type: string }\n"
+    )
+    .contains("quill::variants_on_non_enum"));
+}
+
+#[test]
+fn a_variant_keyed_by_a_non_member_is_a_load_error() {
+    let err = load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        B:\n          x: { type: string }\n",
+    );
+    assert!(err.contains("quill::variant_unknown_value"));
+}
+
+/// The blank is not a member, so it owns no field set: the same rule
+/// `quill::enum_blank_member` states from the `values:` side.
+#[test]
+fn a_variant_keyed_by_the_blank_is_a_load_error() {
+    let err = load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        \"\":\n          x: { type: string }\n",
+    );
+    assert!(err.contains("quill::variant_unknown_value"));
+}
+
+#[test]
+fn a_variant_field_named_value_collides_with_the_discriminant() {
+    let err = load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          value: { type: string }\n",
+    );
+    assert!(err.contains("quill::variant_reserved_field_name"));
+}
+
+/// A hoisted field earns the flat path's key gate: without it a variant could
+/// declare `$kind` and forge document metadata.
+#[test]
+fn a_variant_field_key_obeys_the_field_name_gate() {
+    let err = load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          $kind: { type: string }\n",
+    );
+    assert!(err.contains("quill::invalid_field_name"));
+}
+
+#[test]
+fn an_empty_variant_and_an_empty_variants_map_are_load_errors() {
+    assert!(load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A: {}\n"
+    )
+    .contains("quill::variant_empty"));
+    assert!(
+        load_error("    c:\n      type: enum\n      values: [A]\n      variants: {}\n")
+            .contains("quill::variant_empty")
+    );
+}
+
+/// Content and dates lower to Typst through top-level name tables that do not
+/// descend into a container, so declaring one inside a variant would load clean
+/// and reach the plate as a raw dict. The ceiling is enforced, not discovered.
+#[test]
+fn a_variant_carries_plain_data_only() {
+    for ty in ["richtext", "plaintext", "date", "datetime"] {
+        let err = load_error(&format!(
+            "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: {{ type: {ty} }}\n"
+        ));
+        assert!(
+            err.contains("quill::variant_field_type"),
+            "type: {ty} should be refused inside a variant, got {err}"
+        );
+    }
+}
+
+#[test]
+fn a_variant_field_may_not_be_a_container_or_carry_a_group() {
+    assert!(load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: object, properties: { y: { type: string } } }\n"
+    )
+    .contains("quill::nested_object_not_supported"));
+    assert!(load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: array, items: { type: string } }\n"
+    )
+    .contains("quill::nested_array_not_supported"));
+    // Variant fields inherit the discriminant's group; declaring one is the
+    // same dead knob a nested `ui.group` always was.
+    assert!(load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: string, ui: { group: g } }\n"
+    )
+    .contains("quill::nested_group_not_supported"));
+}
+
+/// A variant turns its field into a container, and a container may not sit
+/// inside one.
+#[test]
+fn variants_below_card_level_is_a_load_error() {
+    let err = load_error(
+        "    o:\n      type: object\n      properties:\n        c:\n          type: enum\n          values: [A]\n          variants:\n            A:\n              x: { type: string }\n",
+    );
+    assert!(err.contains("quill::variant_placement"));
+}
+
+// ----------------------------------------------------------------- the blank
+
+/// The blank activates no variant, so the container carries nothing but the
+/// unanswered discriminant.
+#[test]
+fn the_blank_of_a_variant_bearing_enum_is_the_container_holding_the_blank() {
+    let schema = field(
+        "type: enum\nvalues: [A]\nvariants:\n  A:\n    x: { type: string }\n",
+    );
+    assert_eq!(blank(&schema).into_json(), json!({ "value": "" }));
+}
+
+/// A plain enum is untouched: `variants:` is the one thing that changes the
+/// resting shape.
+#[test]
+fn a_variantless_enum_still_blanks_to_the_bare_string() {
+    let schema = field("type: enum\nvalues: [A]\n");
+    assert_eq!(blank(&schema).into_json(), json!(""));
+}
+
+// ------------------------------------------------------- the wire (per-world)
+
+#[test]
+fn an_empty_document_renders_the_container_with_no_variant_fields() {
+    assert_eq!(plate(&doc("")), json!({ "value": "" }));
+}
+
+/// Inside the world a plate branches into, every declared field is present —
+/// that is what makes an unguarded read total there.
+#[test]
+fn the_live_world_arrives_complete_and_blank_filled() {
+    assert_eq!(
+        plate(&doc("classification:\n  value: CUI\n")),
+        json!({ "value": "CUI", "controlled_by": "", "category": "" })
+    );
+}
+
+/// The container is a closed shape: a value belonging to a world nobody selected
+/// never reaches the plate, so a payload cannot arrive under a tag that disowns
+/// it.
+#[test]
+fn a_dormant_worlds_fields_never_reach_the_plate() {
+    assert_eq!(
+        plate(&doc(
+            "classification:\n  value: UNCLASSIFIED\n  controlled_by: SAF/AA\n"
+        )),
+        json!({ "value": "UNCLASSIFIED" })
+    );
+}
+
+/// The hand-authored spelling of a world with nothing filled in.
+#[test]
+fn a_bare_scalar_is_adopted_as_the_discriminant() {
+    assert_eq!(
+        plate(&doc("classification: SECRET\n")),
+        json!({ "value": "SECRET", "declassify_on": "" })
+    );
+}
+
+#[test]
+fn the_discriminant_falls_to_the_default_and_carries_its_world() {
+    let yaml = quill_yaml().replace("      default: \"\"\n      variants:", "      default: CUI\n      variants:");
+    let config = QuillConfig::from_yaml(&yaml).unwrap();
+    let data = config.compile_data(&doc("")).unwrap();
+    assert_eq!(
+        data["classification"],
+        json!({ "value": "CUI", "controlled_by": "", "category": "" })
+    );
+}
+
+/// Null ≡ absent holds through the container: a present-null discriminant
+/// blank-fills exactly as an omitted one does.
+#[test]
+fn a_null_discriminant_blank_fills() {
+    assert_eq!(
+        plate(&doc("classification:\n  value:\n")),
+        json!({ "value": "" })
+    );
+}
+
+// -------------------------------------------------------------- resolve() parity
+
+/// `resolve()`'s contract is byte-parity with the plate, and the container is
+/// one cell carrying one rung (as a typed dictionary is).
+#[test]
+fn resolve_reports_the_container_as_one_cell_matching_the_plate() {
+    let quill = quill();
+    let document = doc("classification:\n  value: CUI\n  controlled_by: SAF/AA\n");
+    let resolved = quill.resolve(&document);
+    let row = resolved
+        .main
+        .fields
+        .iter()
+        .find(|f| f.name == "classification")
+        .expect("classification row");
+    assert_eq!(row.value.as_json(), &plate(&document));
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Authored);
+
+    // An unanswered container reports the rung that supplied its discriminant:
+    // here the schema's `default: ""`, exactly as a plain enum would.
+    let blank_doc = doc("");
+    let resolved = quill.resolve(&blank_doc);
+    let row = resolved
+        .main
+        .fields
+        .iter()
+        .find(|f| f.name == "classification")
+        .unwrap();
+    assert_eq!(row.value.as_json(), &plate(&blank_doc));
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Default);
+}
+
+// ------------------------------------------------------------------ validation
+
+/// The conditional-obligation payoff: a field with no `default:` is obliged in
+/// its own world and silent everywhere else — the thing `must_fill` alone could
+/// not say (#1202).
+#[test]
+fn obligation_follows_the_selected_world() {
+    let obliged = codes(&doc("classification:\n  value: CUI\n"));
+    assert!(obliged.contains(&(
+        "validation::must_fill".to_string(),
+        "main.classification.controlled_by".to_string()
+    )));
+    // `category` declares a `default:`, so it stays skippable in the same world.
+    assert!(!obliged
+        .iter()
+        .any(|(_, path)| path == "main.classification.category"));
+
+    // The identical schema obliges nothing once another world is selected.
+    let quiet = codes(&doc("classification:\n  value: UNCLASSIFIED\n"));
+    assert!(!quiet
+        .iter()
+        .any(|(_, path)| path.starts_with("main.classification.")));
+}
+
+/// Flipping a discriminant in an editor must not cost the author their answers,
+/// and must not hand them a document that refuses to render.
+#[test]
+fn a_stranded_value_is_kept_and_warned_never_gated() {
+    let document = doc("classification:\n  value: UNCLASSIFIED\n  controlled_by: SAF/AA\n");
+    let diags = quill().validate(&document);
+    let stranded = diags
+        .iter()
+        .find(|d| d.code.as_deref() == Some("validation::out_of_variant"))
+        .expect("out_of_variant warning");
+    assert_eq!(stranded.severity, crate::Severity::Warning);
+    assert_eq!(
+        stranded.path.as_deref(),
+        Some("main.classification.controlled_by")
+    );
+    assert_eq!(stranded.args["variant"], json!("CUI"));
+    // Kept in the document…
+    assert_eq!(
+        document.main().payload().get("classification").unwrap().as_json()["controlled_by"],
+        json!("SAF/AA")
+    );
+    // …and dropped from the wire.
+    assert_eq!(plate(&document), json!({ "value": "UNCLASSIFIED" }));
+}
+
+/// A key no variant declares is an undeclared field, which every other surface
+/// carries without comment; only a key some *other* world owns is the stranded
+/// case worth naming.
+#[test]
+fn an_undeclared_key_draws_no_variant_warning() {
+    let document = doc("classification:\n  value: CUI\n  note: hello\n");
+    assert!(!quill()
+        .validate(&document)
+        .iter()
+        .any(|d| d.code.as_deref() == Some("validation::out_of_variant")));
+}
+
+#[test]
+fn the_domain_check_lands_on_the_discriminant_path() {
+    let found = codes(&doc("classification:\n  value: NATO\n"));
+    assert!(found.contains(&(
+        "validation::enum_violation".to_string(),
+        "main.classification.value".to_string()
+    )));
+}
+
+/// The live world's fields still type-check; a dormant world's do not, since
+/// nothing downstream reads them.
+#[test]
+fn only_the_live_worlds_fields_are_type_checked() {
+    let bad_live = codes(&doc("classification:\n  value: CUI\n  controlled_by: [1, 2]\n"));
+    assert!(bad_live
+        .iter()
+        .any(|(code, path)| code == "validation::type_mismatch"
+            && path == "main.classification.controlled_by"));
+
+    let bad_dormant = codes(&doc(
+        "classification:\n  value: UNCLASSIFIED\n  controlled_by: [1, 2]\n",
+    ));
+    assert!(!bad_dormant
+        .iter()
+        .any(|(code, _)| code == "validation::type_mismatch"));
+}
+
+// --------------------------------------------------------- authoring surfaces
+
+/// A blueprint is a document, so it shows one world and *names* the rest.
+#[test]
+fn the_blueprint_shows_one_world_and_names_the_others() {
+    let bp = config().blueprint();
+    assert!(bp.contains("# when CUI: controlled_by, category"));
+    assert!(bp.contains("# when SECRET: declassify_on"));
+    assert!(bp.contains("classification: # enum<UNCLASSIFIED | CUI | SECRET>"));
+    assert!(bp.contains("value: \"\""));
+    // The blank world owns no field set, so no variant cell is emitted.
+    assert!(!bp.contains("controlled_by:"));
+}
+
+#[test]
+fn the_blueprint_emits_the_default_worlds_cells_and_round_trips() {
+    let yaml = quill_yaml().replace("      default: \"\"\n      variants:", "      default: CUI\n      variants:");
+    let config = QuillConfig::from_yaml(&yaml).unwrap();
+    let bp = config.blueprint();
+    assert!(bp.contains("value: CUI"));
+    assert!(bp.contains("controlled_by:"));
+    // The blueprint round-trips through the parser by construction, and the
+    // container survives it as the container: the shape an author edits is the
+    // shape the parser reads back.
+    let reparsed = Document::parse(&bp).expect("blueprint round-trips").document;
+    let value = reparsed
+        .main()
+        .payload()
+        .get("classification")
+        .expect("classification survives the round trip")
+        .as_json()
+        .clone();
+    assert_eq!(value["value"], json!("CUI"));
+    assert!(value.get("controlled_by").is_some());
+}
+
+/// Which world is live decides which fields are even candidates, so the
+/// discriminant must resolve before the field set is walked.
+#[test]
+fn seeding_resolves_the_discriminant_before_walking_the_field_set() {
+    let yaml = quill_yaml()
+        .replace("      default: \"\"\n", "      example: CUI\n")
+        .replace(
+            "          controlled_by: { type: string }",
+            "          controlled_by: { type: string, example: SAF/AA }",
+        );
+    let quill = quill_from_yaml(&yaml);
+    let seeded = quill.seed_document();
+    let value = seeded
+        .main()
+        .payload()
+        .get("classification")
+        .expect("seeded classification")
+        .as_json()
+        .clone();
+    assert_eq!(value["value"], json!("CUI"));
+    assert_eq!(value["controlled_by"], json!("SAF/AA"));
+    // `declassify_on` belongs to a world the seed did not select.
+    assert!(value.get("declassify_on").is_none());
+}
+
+/// A contract describes every world: a pdfform binding and an editor form are
+/// built once, against the schema, and must address a field whose world today's
+/// document has not selected.
+#[test]
+fn the_transform_schema_carries_every_world_tagged_by_member() {
+    let schema = build_transform_schema(&config());
+    let json = schema.as_json();
+    let cls = &json["properties"]["classification"];
+    assert_eq!(cls["type"], json!("object"));
+    assert_eq!(
+        cls["properties"]["value"]["enum"],
+        json!(["", "UNCLASSIFIED", "CUI", "SECRET"])
+    );
+    assert_eq!(
+        cls["properties"]["controlled_by"]["quillmark:variant_of"],
+        json!("CUI")
+    );
+    assert_eq!(
+        cls["properties"]["declassify_on"]["quillmark:variant_of"],
+        json!("SECRET")
+    );
+}
+
+/// `schema()` is the declaration view and emits what the author wrote, so a
+/// round-trip through it re-loads.
+#[test]
+fn the_declaration_schema_round_trips_through_a_reload() {
+    let emitted = config().schema();
+    let variants = &emitted["main"]["fields"]["classification"]["variants"];
+    assert_eq!(variants["CUI"]["controlled_by"]["type"], json!("string"));
+    assert_eq!(variants["SECRET"]["declassify_on"]["type"], json!("string"));
+}

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -447,6 +447,16 @@ impl<'de> Deserialize<'de> for FieldType {
     }
 }
 
+/// The field set one enum member brings into play, in declaration order.
+pub type VariantFields = IndexMap<String, Box<FieldSchema>>;
+
+/// The key carrying the discriminant inside a variant-bearing enum's value.
+///
+/// Reserved: a variant may not declare a field under this name
+/// (`quill::variant_reserved_field_name`). Named for the date value-object's
+/// `.value`, the sibling idiom for "the scalar inside the wrapper".
+pub const VARIANT_DISCRIMINANT_KEY: &str = "value";
+
 /// Schema definition for a template field.
 ///
 /// `default` and `example` are both type-valid values with opposite intent:
@@ -495,6 +505,15 @@ pub struct FieldSchema {
     pub ui: Option<UiFieldSchema>,
     /// Restricts valid values on string fields. Serializes as `enum`.
     pub enum_values: Option<Vec<String>>,
+    /// Per-member field sets on an `enum` field: the fields that exist only in
+    /// the world where the discriminant holds that member. Keyed by member (a
+    /// subset of [`enum_values`](Self::enum_values); the blank owns no set).
+    ///
+    /// Declaring it is what turns the field into a **container**: a
+    /// variant-bearing enum rests as `{value: <member>, …the member's fields}`
+    /// rather than a bare string, at every projection. A member absent from this
+    /// map is a world with no fields of its own, spelled `{value: <member>}`.
+    pub variants: Option<IndexMap<String, VariantFields>>,
     /// Nested field schemas for `object` types (the typed dictionary's
     /// properties). Ordered: declaration order is display order at every
     /// nesting level, carried by the map itself.
@@ -535,6 +554,9 @@ struct FieldSchemaDef {
     /// The domain of a `type: enum` field, and the only spelling of one.
     /// Lands in [`FieldSchema::enum_values`].
     pub values: Option<Vec<String>>,
+    /// Per-member field sets, keyed by member. Lands in
+    /// [`FieldSchema::variants`].
+    pub variants: Option<serde_json::Map<String, serde_json::Value>>,
     // Nested schema support
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
     // Element schema for arrays.
@@ -553,11 +575,26 @@ impl FieldSchema {
             must_fill: None,
             ui: None,
             enum_values: None,
+            variants: None,
             properties: None,
             items: None,
             default_content: None,
             example_content: None,
         }
+    }
+
+    /// The fields `member` brings into play, or `None` where the field declares
+    /// no variants, the member owns no set, or `member` is the blank (which
+    /// activates nothing).
+    pub fn variant_fields(&self, member: &str) -> Option<&VariantFields> {
+        self.variants.as_ref()?.get(member)
+    }
+
+    /// Whether this field rests as a variant container (`{value: …, …}`) rather
+    /// than a bare scalar. Keyed on `variants:`, the one thing that changes the
+    /// resting shape: a plain `enum` stays a string everywhere.
+    pub fn is_variant_bearing(&self) -> bool {
+        self.variants.is_some()
     }
 
     /// Whether a human must author this cell, deriving from `default:` when
@@ -593,6 +630,30 @@ impl FieldSchema {
             must_fill: def.must_fill,
             ui: def.ui,
             enum_values,
+            variants: match def.variants {
+                Some(variants) => {
+                    let mut out = IndexMap::new();
+                    for (member, body) in variants {
+                        let fields = body.as_object().ok_or_else(|| {
+                            format!(
+                                "variant '{member}' must be a map of field schemas, \
+                                 written as it would be under `fields:`"
+                            )
+                        })?;
+                        let mut set = VariantFields::new();
+                        for (key, value) in fields {
+                            let field = FieldSchema::from_quill_value(
+                                key.clone(),
+                                &QuillValue::from_json(value.clone()),
+                            )?;
+                            set.insert(key.clone(), Box::new(field));
+                        }
+                        out.insert(member, set);
+                    }
+                    Some(out)
+                }
+                None => None,
+            },
             properties: if let Some(props) = def.properties {
                 // Declaration order (preserved by serde_json's `preserve_order`)
                 // carries straight into the `IndexMap`, so nested properties
@@ -697,6 +758,7 @@ impl Serialize for FieldSchema {
             + self.must_fill.is_some() as usize
             + self.ui.is_some() as usize
             + self.enum_values.is_some() as usize
+            + self.variants.is_some() as usize
             + self.properties.is_some() as usize
             + self.items.is_some() as usize;
         // Field order matches the struct declaration (what a derived impl
@@ -724,6 +786,9 @@ impl Serialize for FieldSchema {
         }
         if let Some(v) = &self.enum_values {
             map.serialize_entry("values", v)?;
+        }
+        if let Some(v) = &self.variants {
+            map.serialize_entry("variants", v)?;
         }
         if let Some(v) = &self.properties {
             map.serialize_entry("properties", v)?;

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -6,7 +6,7 @@ use crate::document::Document;
 use crate::error::{Diagnostic, Severity, diag_args};
 use crate::path::DocPath;
 use crate::quill::formats::{is_valid_date, is_valid_datetime};
-use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
+use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig, VARIANT_DISCRIMINANT_KEY};
 use crate::value::QuillValue;
 
 /// Validation error with a structured field path.
@@ -444,6 +444,10 @@ fn validate_value(
         return vec![];
     }
 
+    if field.is_variant_bearing() {
+        return validate_variant(field, value, path, ctx);
+    }
+
     let mut errors = Vec::new();
 
     let type_valid = match field.r#type {
@@ -629,6 +633,114 @@ fn validate_value(
                     value: actual.to_string(),
                     allowed: allowed.clone(),
                 });
+            }
+        }
+    }
+
+    errors
+}
+
+/// Validate a variant-bearing enum. The discriminant answers the domain check
+/// at `<path>.value`, and only the **live** world's fields are checked: a key a
+/// non-active variant declares is not this layer's to type-check, since nothing
+/// downstream reads it (`Quill::validate` reports it as
+/// `validation::out_of_variant`, a warning).
+///
+/// Both authored shapes reach here, because validation runs before coercion: the
+/// bare scalar (`classification: CUI`) and the container. The scalar is checked
+/// as the discriminant it stands for, at the container's own path — the path an
+/// author who wrote a scalar can act on.
+fn validate_variant(
+    field: &FieldSchema,
+    value: &QuillValue,
+    path: &DocPath,
+    ctx: ValueContext,
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    let json = value.as_json();
+
+    let check_member = |member: &str, at: &DocPath, errors: &mut Vec<ValidationError>| {
+        if let Some(allowed) = &field.enum_values {
+            if !member.is_empty() && !allowed.contains(&member.to_string()) {
+                errors.push(ValidationError::EnumViolation {
+                    path: at.to_string(),
+                    value: member.to_string(),
+                    allowed: allowed.clone(),
+                });
+            }
+        }
+    };
+
+    let Some(object) = json.as_object() else {
+        // The bare scalar spelling. Anything that is not a member-shaped scalar
+        // is a type error against the container.
+        let scalar = value
+            .as_str()
+            .map(str::to_string)
+            .or_else(|| super::config::scalar_as_string(json));
+        match scalar {
+            Some(member) => check_member(&member, path, &mut errors),
+            None => errors.push(ValidationError::TypeMismatch {
+                path: path.to_string(),
+                expected: "enum".to_string(),
+                actual: yaml_scalar_type(json).to_string(),
+                source_token: verbatim_yaml_scalar(json),
+                default: match ctx {
+                    ValueContext::Document => field
+                        .default
+                        .as_ref()
+                        .map(|d| verbatim_yaml_scalar(d.as_json())),
+                    ValueContext::SchemaLiteral => None,
+                },
+            }),
+        }
+        return errors;
+    };
+
+    let discriminant_path = path.field(VARIANT_DISCRIMINANT_KEY);
+    let authored = object
+        .get(VARIANT_DISCRIMINANT_KEY)
+        .filter(|v| !v.is_null());
+    let member = match authored {
+        Some(v) => match v
+            .as_str()
+            .map(str::to_string)
+            .or_else(|| super::config::scalar_as_string(v))
+        {
+            Some(member) => {
+                check_member(&member, &discriminant_path, &mut errors);
+                member
+            }
+            None => {
+                errors.push(ValidationError::TypeMismatch {
+                    path: discriminant_path.to_string(),
+                    expected: "enum".to_string(),
+                    actual: yaml_scalar_type(v).to_string(),
+                    source_token: verbatim_yaml_scalar(v),
+                    default: None,
+                });
+                String::new()
+            }
+        },
+        // An absent discriminant blank-fills from the ladder, exactly as an
+        // absent scalar enum does; the world it selects is the default's.
+        None => field
+            .default
+            .as_ref()
+            .and_then(|d| d.as_str())
+            .unwrap_or_default()
+            .to_string(),
+    };
+
+    if let Some(fields) = field.variant_fields(&member) {
+        for (name, schema) in fields {
+            if let Some(cell) = object.get(name) {
+                errors.extend(validate_value(
+                    schema,
+                    &QuillValue::from_json(cell.clone()),
+                    &path.field(name),
+                    ctx,
+                ));
             }
         }
     }

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/Quill.yaml
@@ -122,6 +122,24 @@ main:
         group: classification
         compact: true
       description: "Select the classification marking shown in the header and footer banner. Unclassified documents typically omit this banner entirely, leave blank unless the document is CUI or classified. Mark per DAFI 16-1404 (DoDM 5200.48 for CUI) and applicable DoD guidance."
+      variants:
+        CUI:
+          controlled_by:
+            type: string
+            example: SAF/AA
+            description: "Office or organization that designated this information as CUI. Required by DoDM 5200.48."
+          poc:
+            type: string
+            example: "Capt J. Smith, DSN 555-1234, john.smith@us.af.mil"
+            description: "Point of contact for CUI questions. Required by DoDM 5200.48."
+          category:
+            type: string
+            default: ""
+            description: "CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY'). Leave blank to omit."
+          limited_dissemination:
+            type: string
+            default: ""
+            description: "Limited dissemination control shown in the indicator block (e.g., 'FEDONLY', 'NOFORN'). Independent from the banner suffix."
 
     dissemination:
       type: string
@@ -130,38 +148,6 @@ main:
         group: classification
         compact: true
       description: "Banner dissemination suffix appended after double slash (e.g. 'NF' renders as CUI//NF in the header/footer). Leave blank for no suffix."
-
-    cui_controlled_by:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "Office or organization that designated this information as CUI (e.g., 'SAF/AA'). Required by DoDM 5200.48 when classification is CUI."
-
-    cui_category:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY'). Leave blank to omit."
-
-    cui_limited_dissemination:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "Limited dissemination control shown in the indicator block (e.g., 'FEDONLY', 'NOFORN'). Independent from the banner suffix above."
-
-    cui_poc:
-      type: string
-      default: ""
-      ui:
-        group: classification
-        compact: true
-      description: "Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234, john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI."
 
     references:
       type: array

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/__golden__/schema.yaml
@@ -111,47 +111,35 @@ main:
       - CONFIDENTIAL
       - SECRET
       - TOP SECRET
+      variants:
+        CUI:
+          controlled_by:
+            type: string
+            description: >-
+              Office or organization that designated this information as CUI. Required by
+              DoDM 5200.48.
+            example: SAF/AA
+          poc:
+            type: string
+            description: Point of contact for CUI questions. Required by DoDM 5200.48.
+            example: Capt J. Smith, DSN 555-1234, john.smith@us.af.mil
+          category:
+            type: string
+            description: >-
+              CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY').
+              Leave blank to omit.
+            default: ""
+          limited_dissemination:
+            type: string
+            description: >-
+              Limited dissemination control shown in the indicator block (e.g., 'FEDONLY',
+              'NOFORN'). Independent from the banner suffix.
+            default: ""
     dissemination:
       type: string
       description: >-
         Banner dissemination suffix appended after double slash (e.g. 'NF' renders as
         CUI//NF in the header/footer). Leave blank for no suffix.
-      default: ""
-      ui:
-        group: classification
-        compact: true
-    cui_controlled_by:
-      type: string
-      description: >-
-        Office or organization that designated this information as CUI (e.g.,
-        'SAF/AA'). Required by DoDM 5200.48 when classification is CUI.
-      default: ""
-      ui:
-        group: classification
-        compact: true
-    cui_category:
-      type: string
-      description: >-
-        CUI category from the DoD CUI Registry (e.g., 'Privacy/MED', 'CTI', 'PRVCY').
-        Leave blank to omit.
-      default: ""
-      ui:
-        group: classification
-        compact: true
-    cui_limited_dissemination:
-      type: string
-      description: >-
-        Limited dissemination control shown in the indicator block (e.g., 'FEDONLY',
-        'NOFORN'). Independent from the banner suffix above.
-      default: ""
-      ui:
-        group: classification
-        compact: true
-    cui_poc:
-      type: string
-      description: >-
-        Point of contact for CUI questions (e.g., 'Capt J. Smith, DSN 555-1234,
-        john.smith@us.af.mil'). Required by DoDM 5200.48 when classification is CUI.
       default: ""
       ui:
         group: classification

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
@@ -35,14 +35,22 @@
 
   references: data.references,
   footer_tag_line: data.tag_line,
-  classification_level: data.classification,
+  classification_level: data.classification.value,
   dissemination: data.dissemination,
 
-  // CUI designation indicator block fields (DoDM 5200.48)
-  cui_controlled_by: data.cui_controlled_by,
-  cui_category: data.cui_category,
-  cui_limited_dissemination: data.cui_limited_dissemination,
-  cui_poc: data.cui_poc,
+  // CUI designation indicator block fields (DoDM 5200.48). `classification`
+  // declares a `CUI` variant, so these four exist only where the discriminant
+  // reads CUI and the branch is what makes reading them total: inside it every
+  // declared field of that world is present, outside it none is. The package's
+  // own `cui_*: none` defaults cover the worlds that omit them.
+  ..if data.classification.value == "CUI" {
+    (
+      cui_controlled_by: data.classification.controlled_by,
+      cui_category: data.classification.category,
+      cui_limited_dissemination: data.classification.limited_dissemination,
+      cui_poc: data.classification.poc,
+    )
+  },
 
   // USAF vs DAF memorandum style (date format, body indentation). A memo has no
   // "no style" state, so the blank takes the package's default; `frontmatter`

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -253,6 +253,77 @@ your `values:` list stays clean.
 > `data.at(key, default: X)` is not a guard — every declared key is always
 > present at render, so its `default:` never fires and the blank flows through.
 
+#### Variants: fields that exist only for one choice
+
+Some fields belong to one choice and are meaningless beside any other. Declare
+them under `variants:`, keyed by the member that brings them into play:
+
+```yaml
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET]
+      default: ""
+      variants:
+        CUI:
+          controlled_by: { type: string }        # obliged, but only on a CUI memo
+          poc:           { type: string }
+          category:      { type: string, default: "" }
+```
+
+The field then holds a **container** instead of a bare string, and a document
+writes the choice under `value` with that world's answers beside it:
+
+```yaml
+classification:
+  value: CUI
+  controlled_by: SAF/AA
+  poc: Capt J. Smith, DSN 555-1234
+```
+
+A world with nothing to fill in still writes plainly — `classification:
+UNCLASSIFIED` is accepted and means the same as `{value: UNCLASSIFIED}`.
+
+Three things follow, and they are the reason to reach for this over a
+`cui_`-prefixed row of flat fields:
+
+- **The names shorten.** The prefix was hand-written namespacing; nesting
+  supplies it structurally, so `cui_poc` becomes `poc`.
+- **`must_fill` becomes conditional.** `controlled_by` declares no `default:`,
+  so it is obliged — but only where `classification` reads `CUI`. On every other
+  memo the same schema asks for nothing. That is the one cross-field rule the
+  engine checks rather than describes in `description:` prose.
+- **Editors know.** The schema says which cells are out of play, so a form
+  retires them instead of showing a CUI block on an unclassified memo.
+
+**Writing a plate against variants.** The live world's fields arrive only inside
+the branch that selects it, which is the branch you already owe every enum:
+
+```typst
+..if data.classification.value == "CUI" {
+  (controlled_by: data.classification.controlled_by, poc: data.classification.poc)
+},
+```
+
+Inside that branch every declared field of the world is present and blank-filled,
+so no guarded access is needed. Outside it there is nothing to read: an
+unanswered `classification` renders `{value: ""}`, and the blank brings no field
+set at all.
+
+**Flipping the choice keeps the answers.** Selecting `UNCLASSIFIED` after filling
+in a CUI block leaves those values in the document and warns
+(`validation::out_of_variant`); they simply stop rendering. Flip back and they
+are still there. Remove the field to drop the value for good.
+
+What a variant can hold is deliberately narrow — `string`, `enum`, `number`,
+`integer`, `boolean`. Prose and dates (`richtext`, `plaintext`, `date`,
+`datetime`) stay card-level fields (`quill::variant_field_type`), as do arrays
+and objects. `variants:` itself is valid only on a card-level `type: enum` field,
+keys only on declared members (never `""`, which owns no field set), and cannot
+declare a field named `value`. Variant fields inherit the discriminant's
+`ui.group`; declaring one inside a variant is an error. A field set shared by
+several members is repeated or shared with a YAML anchor — a variant keys on one
+member.
+
 ### Primitive Arrays, Typed Tables, and Typed Dictionaries
 
 Every array declares its element type under `items:`. For a **primitive list**, give `items` a scalar type, coercion and validation then apply element-wise (e.g. each element of an `integer[]` is coerced to an integer, and a bad element fails at its indexed path like `counts[1]`):

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -208,6 +208,35 @@ speak about the same cells (`SCHEMAS.md` § "Native validation").
 | `richtext` | On the field (bare; no block scalar) | `bio: !must_fill # richtext<markdown>` |
 | `object` (typed dict) | Per-property recursion | leaves carry `!must_fill` |
 | `array<object>` (typed table) | Per-property recursion in one synthetic row | leaves carry `!must_fill` |
+| `enum` with `variants:` | On the `value` cell, plus per-field recursion in the live world | `value: !must_fill` |
+
+### Enum variants
+
+A variant-bearing `enum` emits its container: the discriminant under `value`,
+then the fields of the world that discriminant names (`default:` › `example:` ›
+blank). A blueprint **is** a document, so it can show only one world; the others
+are named instead, one `# when <MEMBER>: <fields>` leading line each. Every world
+is listed, the shown one included — the lines are the map, the cells are the
+position.
+
+```
+# Select the classification marking shown in the header and footer banner.
+# when CUI: controlled_by, poc, category, limited_dissemination
+classification: # enum<UNCLASSIFIED | CUI | CONFIDENTIAL | SECRET | TOP SECRET>
+  value: ""
+```
+
+The container line carries the `enum<…>` annotation and `value` carries none:
+`value` *is* that enum, so a second annotation would restate it. The marker sits
+on `value` rather than the container, since `!must_fill` is rejected on a
+mapping.
+
+This is the one place the `unauthored` cell set is **value-dependent**: which
+cells the schema-side predicate addresses follows from the discriminant a
+document authored, so the blueprint and that document speak about the same cells
+only once both are in the same world. That is the point of the feature rather
+than a seam in it — an obligation that ignored the discriminant is exactly the
+unconditional `must_fill` variants exist to refine.
 
 ### Richtext fields
 
@@ -453,6 +482,12 @@ degrades gracefully on every type-valid input shape. The contract requires:
   render every declared key is always present, so its `default:` is dead code
   and the blank flows through. Where a package asserts membership, that is a
   failed compile rather than a quiet mis-render.
+- **A template reads a variant field only inside the branch that selects its
+  world.** A variant-bearing enum arrives as `{value: …}` carrying exactly the
+  live world's fields, so `data.c.value == "CUI"` is what makes `data.c.poc`
+  total; reading it outside that branch is a missing-key error on every other
+  document. The exhaustive branch above is therefore not just an obligation here
+  but the access path (`SCHEMAS.md` § "Enum variants").
 - No template asserts that a must-fill field is *non-empty*. The schema
   guarantees *presence*, not non-emptiness; the `!must_fill` marker
   is an authoring signal, not a render-time precondition.

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -307,6 +307,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `validation::body_disabled` | `card` | structured |
 | `validation::coercion_failed` | `value`, `target` | structured, coarser |
 | `validation::must_fill` | `trigger` | structured |
+| `validation::out_of_variant` | `variant`, `selected` | structured |
 | `validation::not_inline` | — | code-determined |
 | `validation::not_plain` | — | code-determined |
 | `edit::invalid_field_name` | `field` | structured |

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -30,6 +30,88 @@ Supported field types:
 | `plaintext` | Navigable **unformatted** prose over the same canonical content (`Content`) as `richtext` (same media type, nav, and regions) but a **literal** codec (`from_plaintext`/`to_plaintext`): delimiters stay literal, no markup, verbatim round-trip. Declare `inline: true` for the single-line variant. Constrained mark-/island-free (`Content::is_plain`); a formatted wire content is rejected (`validation::not_plain`), not stripped. **Rests as the literal string** |
 | `richtext` | Rich **formatted** prose over a canonical content (`Content`); markdown is a projection of it. Declare `inline: true` for the single-line variant (exactly one `Para` line, no container, no islands). The pre-richtext `markdown` spelling and the retired `type: richtext(inline)` token are schema load errors (`quill::field_parse_error`). **Rests as the canonical content object** |
 
+### Enum variants
+
+An `enum` may declare `variants:`, a per-member field set that exists only in the
+world where the discriminant holds that member:
+
+```yaml
+classification:
+  type: enum
+  values: [UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET]
+  variants:
+    CUI:
+      controlled_by: { type: string }
+      poc:           { type: string }
+      category:      { type: string, default: "" }
+```
+
+`variants:` is the one key that changes a field's **resting shape**: the field
+rests as `{value: <member>, …the member's fields}` at every projection, where a
+variantless enum rests as a bare string. A document authors it as the container,
+and the bare scalar (`classification: CUI`) is accepted as the spelling of a
+world carrying no variant answers — coercion normalizes both, so one shape
+reaches every surface downstream. `value` is reserved
+(`quill::variant_reserved_field_name`); it is the date value-object's `.value`,
+the sibling idiom for the scalar inside a wrapper.
+
+This is the DSL's only cross-field shape, and it buys three things the flat map
+could not say:
+
+- **Existence.** A `cui_`-style name prefix is hand-written namespacing that only
+  prose can scope. Nesting supplies the namespace structurally, and the names
+  shorten to what they mean.
+- **Obligation, conditionally.** `must_fill` inside a variant keeps its ordinary
+  `default:`-presence derivation, so it reads *"required in this world"*: `poc`
+  is obliged on a CUI memo and silent on every other one. This is the one
+  cross-field constraint the engine checks rather than describes.
+- **A UI signal.** `quillmark:variant_of` on the transform schema names the
+  member that brings each cell into play, so an editor retires cells that are out
+  of play instead of hard-coding the rule.
+
+**The wire carries exactly the live world, and totality is per-world.** The
+render floor emits `value` plus the selected member's fields — blank-filled as
+usual — and nothing else: the container is a *closed* shape, so a payload never
+reaches a plate under a tag that disowns it. A plate is already obliged to branch
+over `values ∪ blank` ([Blank-filled render](#blank-filled-render)); inside that
+branch every declared field of that world is present, so the access needs no
+guard, and outside it there is nothing to guard. The blank owns no field set, so
+an unanswered discriminant renders `{value: ""}` and the empty-document contract
+is untouched.
+
+**A stranded value is carried, not dropped.** An authored cell whose variant is
+out of play stays in the document and draws the non-fatal
+`validation::out_of_variant`; the render floor omits it. Dropping it at coercion
+would spend the author's answers on the ordinary editor gesture — choose CUI,
+fill the block, flip to UNCLASSIFIED to compare, flip back — and gating render
+would hand them an undraftable document. Only the wire is strict.
+
+The ceiling is deliberate and enforced at load rather than discovered at render:
+
+| Rule | Code |
+|---|---|
+| `variants:` on a non-enum field | `quill::variants_on_non_enum` |
+| a key outside `values:` (the blank owns no variant) | `quill::variant_unknown_value` |
+| `variants:` below card level, or inside another variant | `quill::variant_placement` |
+| an empty `variants:` map, or an empty variant | `quill::variant_empty` |
+| a variant field named `value` | `quill::variant_reserved_field_name` |
+| a `richtext`, `plaintext`, `date`, or `datetime` variant field | `quill::variant_field_type` |
+
+The last is the load-bearing one: content and dates lower to Typst through
+*top-level* name tables that do not descend into a container
+([PLATE_DATA.md](PLATE_DATA.md)), so such a field would load clean and reach the
+plate as a raw dict. **A variant carries plain data** — `string`, `enum`,
+`number`, `integer`, `boolean` — and prose and dates stay card-level fields.
+Variant fields are otherwise leaves exactly as an object's properties are: no
+container one level down, and no `ui.group` (they inherit the discriminant's).
+
+Three limits follow from the container shape and are accepted, not worked around:
+[`resolve()`](#the-resolved-value-view-resolve) reports **one** rung for the whole
+container, as it does for a typed dictionary; a variant field cannot host a
+Typst `form-field` widget or click-to-edit region, whose address grammar is flat
+plus one index; and a field set **shared** across several members is spelled by
+repeating it or sharing a YAML anchor, since a variant keys on one member.
+
 The text-ish types form a **data vs content** × **open/plain vs closed/formatted**
 2×2: `enum` (closed data), `string` (open data), `plaintext` (plain content),
 `richtext` (formatted content). Navigation/regions are a property of the content
@@ -327,6 +409,7 @@ domain.** It is both the render floor and the value a reader recognizes as
 | `object` | every property at its own blank, recursively |
 | `integer`, `number` | `0` |
 | `boolean` | `false` |
+| `enum` with `variants:` | `{value: ""}` — the container holding the blank |
 
 Nothing forces an enum's blank to sit inside `values:`, and putting it there
 destroys it: the floor would return a real choice nobody made, and a cosmetic
@@ -361,7 +444,9 @@ seeded documents alike (see [BLUEPRINT.md](BLUEPRINT.md)).
 present input, so an `else` fallback re-opens exactly the fabrication the blank
 closes: the cell renders a variant nobody chose, and the plate cannot tell the
 two apart. This is a retrofit obligation on existing plates, not only guidance
-for new ones.
+for new ones. Where the enum declares `variants:` the obligation also earns
+something: the branch is what makes the world's fields readable without a guard
+(see [Enum variants](#enum-variants)).
 
 ## Document seeding
 
@@ -472,11 +557,15 @@ Top-level schema keys: `main`, optional `card_kinds` (map keyed by card name).
 `main` and each entry in `card_kinds` share the same `CardSchema` shape:
 `fields` (map keyed by field name), optional `description`, optional `ui`,
 optional `body`. Each `FieldSchema` includes `type`, optional
-`description`/`default`/`example`/`enum`/`values`/`inline`/`properties`/`items`/`ui`.
+`description`/`default`/`example`/`enum`/`values`/`variants`/`inline`/`properties`/`items`/`ui`.
 The type-gated keys:
 
 - `inline`: valid only on the prose types (`richtext`, `plaintext`).
 - `values`: declares an `enum` field's domain, required there.
+- `variants`: per-member field sets on an `enum` field, valid only there and only
+  at card level (see [Enum variants](#enum-variants)). `schema()` emits it as
+  authored; the transform schema instead projects the container, flattening every
+  world's fields under `properties` and tagging each `quillmark:variant_of`.
 - `items`: the element schema, itself a `FieldSchema`; required on `array`
   fields and rejected elsewhere.
 - `properties`: used by `object` fields, and by an array's `object`-typed


### PR DESCRIPTION
Closes #1268.

An `enum` field may declare `variants:` — a per-member field set that exists only in the world where the discriminant holds that member.

```yaml
classification:
  type: enum
  values: [UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET]
  variants:
    CUI:
      controlled_by: { type: string }
      poc:           { type: string }
      category:      { type: string, default: "" }
```

`variants:` is the one key that changes a field's **resting shape**: the field holds `{value: <member>, …that member's fields}` at every projection, where a variantless enum stays a bare string. The bare scalar (`classification: CUI`) is accepted as the spelling of a world carrying no answers, and coercion normalizes both, so one shape reaches every surface downstream. `value` is reserved — it is the date value-object's `.value`, the sibling idiom for the scalar inside a wrapper.

## Totality is per-world, and the plate's existing obligation is the mechanism

The open question in the issue was how a plate survives a field that may not exist. This does **not** take the `variant()`-accessor route.

The render floor emits `value` plus the selected member's fields, blank-filled as usual, and **nothing else** — the container is a *closed* shape, so a payload never reaches a plate under a tag that disowns it. A plate is already obliged to branch over `values ∪ blank`; inside that branch every declared field of the world is present, so the access needs no guard, and outside it there is nothing to guard. The obligation stops being a tax and becomes the access path:

```typst
..if data.classification.value == "CUI" {
  (cui_poc: data.classification.poc, cui_controlled_by: data.classification.controlled_by)
},
```

The blank owns no field set, so an unanswered discriminant renders `{value: ""}` and the empty-document contract is untouched.

## Conditional obligation, with no new axis

`must_fill` inside a variant keeps its ordinary `default:`-presence derivation, so it reads *"required in this world"*. On the migrated fixture, `classification: CUI` now warns at `main.classification.controlled_by`; an unclassified memo warns at nothing. That is the CUI half of #1202 — a machine-checkable predicate the machine now checks, rather than `description:` prose.

## Stranded values are carried, not dropped

An authored cell whose variant is out of play stays in the document and draws the new non-fatal `validation::out_of_variant`; only the wire drops it. Dropping at coercion would spend the author's answers on the ordinary editor gesture — choose CUI, fill the block, flip to UNCLASSIFIED to compare, flip back — and gating render would hand them an undraftable document.

## Load errors

| Condition | Code |
|---|---|
| `variants:` on a non-enum field | `quill::variants_on_non_enum` |
| a key outside `values:` (the blank owns no variant) | `quill::variant_unknown_value` |
| `variants:` below card level, or inside another variant | `quill::variant_placement` |
| an empty `variants:` map, or an empty variant | `quill::variant_empty` |
| a variant field named `value` | `quill::variant_reserved_field_name` |
| a `richtext`, `plaintext`, `date`, or `datetime` variant field | `quill::variant_field_type` |

The last is the load-bearing one. Content and dates lower to Typst through *top-level* name tables that do not descend into a container, so such a field would load clean and reach the plate as a raw dict. Objects carry that hole today; this declines to widen it. **A variant carries plain data** — `string`, `enum`, `number`, `integer`, `boolean` — and prose and dates stay card-level fields. Variant fields are otherwise leaves exactly as an object's properties are, and a variant field key earns the flat path's `invalid_field_name` gate (without it a variant could declare `$kind`).

## Accepted ceilings

Documented rather than worked around: `resolve()` reports **one** rung for the whole container, as it does for a typed dictionary; a variant field cannot host a Typst `form-field` widget or click-to-edit region, whose address grammar is flat plus one index; and a field set shared across several members is repeated or shared with a YAML anchor.

One judgment call worth a reviewer's eye: the blueprint makes the `unauthored` cell set **value-dependent** for the first time — which cells the schema-side predicate addresses now follows from the discriminant a document authored. This treats that as the feature rather than a seam (an obligation that ignored the discriminant is the unconditional `must_fill` variants exist to refine) and says so in `BLUEPRINT.md`.

## Authoring surfaces

A blueprint *is* a document, so it shows one world and names the rest:

```
# Select the classification marking shown in the header and footer banner.
# when CUI: controlled_by, poc, category, limited_dissemination
classification: # enum<UNCLASSIFIED | CUI | CONFIDENTIAL | SECRET | TOP SECRET>
  value: ""
```

`schema()` emits `variants:` as authored; the transform schema instead projects the container, flattening every world's fields under `properties` and tagging each `quillmark:variant_of` — a contract describes every world, since a pdfform binding and an editor form are built once and must address a field whose world today's document has not selected. Seeding resolves the discriminant *before* walking the field set, so a `$seed` overlay naming the discriminant cannot commit one world's tag beside another's answers.

## Fixture migration

`usaf_memo` 0.2.0 in place: the four `cui_*` fields move under `classification.variants.CUI` and shorten to `controlled_by` / `poc` / `category` / `limited_dissemination` — the prefix was hand-written namespacing, and nesting supplies it structurally. `controlled_by` and `poc` drop the `default: ""` that made them unaskable, and the "Required by DoDM 5200.48 when classification is CUI" prose comes out of their descriptions now that the scoping is structural. `plate.typ` reads them inside the branch it already owed.

## Verification

- `cargo test --workspace` green: 40 test binaries, zero failures, including `every_quill_in_quiver_renders` and `every_quill_blueprint_round_trips_and_renders` over the migrated fixture.
- 28 new tests. The axis has four surfaces that must agree on one answer — load, the render floor, validation, and the authoring projections — and a disagreement between them is the shape of bug this design invites, so each test pins one surface to the same reading of the same schema.
- `node scripts/check-canon.mjs` passes; `diagnostic_args_match_canon` covers the new code; clippy unchanged at its 55-warning baseline.
- `cargo check -p quillmark-wasm` clean. The full `build-wasm.sh` and the `wasm32-unknown-unknown` target could not run in this container (its `wasm-bindgen-cli` is 0.2.122 against the lock's 0.2.118; the target is not installed). CI covers both; the only binding change is a `variants?` field on the `QuillFieldSchema` TS declaration.

## Docs

`SCHEMAS.md` gains an "Enum variants" section and the blank-table row; `BLUEPRINT.md` the `# when` line, a marker-position row, and a plate-contract clause; `ERROR.md` registers `validation::out_of_variant` in the args table; `docs/quills/quill-yaml-reference.md` gets an author-facing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAuKmKLoWs3FviGsqmQT57

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAuKmKLoWs3FviGsqmQT57)_