### PR TITLE
chore(repo): union-merge CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,23 @@
 # serialiser still emits \n), so the tree is pinned to LF everywhere instead.
 * text=auto eol=lf
 
+# Every branch appends its release note under the changelog's `## Unreleased`
+# heading, at the same line, so this was the one merge conflict most branches
+# had and never an interesting one. `union` takes both sides of a conflicting
+# hunk instead of writing markers, so two branches each adding an entry merge to
+# both entries.
+#
+# It resolves silently: two branches editing the *same* entry merge to the union
+# of both, with nothing to flag it. Tolerable for prose no build step parses,
+# which is why it stays scoped to the changelog — a union-merged Cargo.lock is
+# duplicate `[[package]]` entries and a file cargo cannot read.
+#
+# Real git applies it: a local merge, a rebase, a CI runner. GitHub's merge
+# machinery reads its own attributes rather than this file, so a PR page can
+# still report the conflict that a local `git merge origin/main` resolves by
+# itself.
+CHANGELOG.md merge=union
+
 # Vendored upstream assets, byte-identical to what their projects ship.
 *.ttf binary
 *.otf binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Crate layout and what each crate carries: [`ARCHITECTURE.md`](prose/canon/ARCHIT
 Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
 
 - The `Cargo.toml` version is the last *released* one; CI bumps it on release.
+- A `CHANGELOG.md` conflict resolves itself: `.gitattributes` marks it `merge=union`, so merge `main` with local git rather than pressing "Update branch", which does not read it.
 - Commit early and often; CI gates every push.
 - Don't run `cargo fmt`.
 


### PR DESCRIPTION
Every branch appends its release note under `## Unreleased`, at the same line, so the changelog was the one merge conflict most branches had and never an interesting one. `.gitattributes` now marks it `merge=union`: git takes both sides of a conflicting hunk instead of writing markers, so two branches each adding an entry merge to both entries.

```
CHANGELOG.md merge=union
```

That is the whole change, plus the comment above it and one line in `CLAUDE.md`. No new directory, no script, no CI step, no change to the release workflow.

## Verified

Against the real `CHANGELOG.md`, with two branches each inserting a multi-paragraph entry at the same anchor — the case where hunk boundaries could have interleaved them:

- **Merges clean, entries intact.** Exit 0, no markers, both entries whole and un-interleaved, ours-then-theirs.
- **Control**: the identical merge without the attribute conflicts. The driver is what resolves it, not luck in how the hunks fell.

## Accepted costs

**It resolves silently.** Two branches editing the *same* entry merge to the union of both, with nothing to flag it — demonstrated:

```
- existing entry, reworded by Y
- existing entry, clarified by X
```

Tolerable for prose no build step parses, and the reason the attribute stays scoped to the changelog. A union-merged `Cargo.lock` would be duplicate `[[package]]` entries and a file cargo cannot read, with no conflict to catch it.

**GitHub does not read it.** The "Update branch" button and the mergeability check use GitHub's own attributes, not this file ([community#9288](https://github.com/orgs/community/discussions/9288) — staff response 2017, still unimplemented). A PR page can therefore still show the changelog conflict; a local `git merge origin/main` resolves it with no intervention. `CLAUDE.md` carries that note, since agent sessions are what merge these branches.

This supersedes the `changelog.d/` fragment approach previously on this branch, which is fully reverted — `release-prepare.yml`, `ci.yml`, and `CONTRIBUTING.md` are byte-identical with `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaRcH7L8j1KV4yMDNQ48b8