### PR TITLE
Review fixes for v0.106.0: variant name-collision gate, release notes, prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+- feat(core,wasm)!: an `enum` may declare `variants:`, a per-member field set
+  that exists only in the world where the discriminant holds that member. This
+  is the DSL's first cross-field shape, and it replaces the `cui_`-prefix
+  convention with one the engine checks: `must_fill` inside a variant keeps its
+  ordinary `default:`-presence derivation, so it reads *required in this world* —
+  a `poc` obliged on a CUI memo and silent on every other one, the thing
+  `must_fill` alone could not say. **Breaking**: declaring `variants:` changes
+  the field's resting shape at every projection, from a bare string to a
+  container, `{value: <member>, …that member's fields}`; the bare scalar
+  (`classification: CUI`) is still accepted as the spelling of a world carrying
+  no answers, and coercion normalizes both. The wire carries exactly the live
+  world, so a plate reads a variant field inside the `values ∪ blank` branch it
+  already owes the enum, and inside that branch every declared field is present
+  and needs no guard. A value stranded by a discriminant flip is kept and warned
+  (`validation::out_of_variant`), never dropped at coercion or gated at render.
+  The ceiling is enforced at load, not discovered at render: a variant carries
+  plain data only, sits at card level only, and cannot declare `value`. The
+  transform schema projects the container with every world's fields tagged
+  `quillmark:variant_of`, since a binding built once against a schema must
+  address a field today's document has not selected. `FieldSchema` gains
+  `variants`; `VariantFields`, `VARIANT_DISCRIMINANT_KEY` and
+  `QUILLMARK_VARIANT_OF_KEY` are new.
+- feat(fixtures)!: `usaf_memo`'s four `cui_*` fields move under
+  `classification`'s `CUI` variant as `controlled_by`, `poc`, `category`, and
+  `limited_dissemination`. `controlled_by` and `poc` drop their `default: ""`
+  and are therefore obliged — on a CUI memo only, which is what DoDM 5200.48
+  actually requires and what the flat spelling could state only in
+  `description:` prose. A document writes `classification: {value: CUI, …}` and
+  a plate reads `data.classification.value`.
+- feat(typst): `field-region(field, body)` claims the ink `body` draws for a
+  schema field, so a plate can tie content it *composes* — a banner keyed on a
+  field, a package-built block, a computed table — to `session.regions()` and
+  `session.fieldAt(..)`. Layout-neutral: `body` is returned untouched between two
+  invisible `metadata` markers. It is a **fallback** claim, never an override:
+  ink already tracked to a field keeps that field, so wrapping is purely
+  additive and cannot retarget. Each *call* claims independently, so a wrapper
+  invoked once per card yields one region per card — the way a card's scalar
+  fields get regions at all, reading as they do from a loop variable that carries
+  no per-instance identity.
 - feat(typst,pdf): `form-field` takes `font`, `size`, and `align`, so an
   injected widget's value can be set to match the type around it. A widget was
   fixed at Helvetica, auto-size, left: auto-size makes the rendered size a
@@ -35,7 +74,16 @@
   rather than `date-placeholder-line`: the widget carries the date, and a rule
   under a widget wider than it underlines only the fraction of the value narrow
   enough to sit over it. It is package-internal, not exported from `lib.typ`.
-
+- fix(core): a name two variants declare *differently* is a load error,
+  `quill::variant_field_collision`. The name is one cell of the container
+  whichever world brings it into play — neither the coercion lookup nor the
+  transform schema consults the discriminant to fill it — so two readings of it
+  coerced a live value under the other world's type: a document selecting a
+  world whose `note` is `integer` had its `42` coerced to `"42"` by a sibling
+  world's `string` and then failed `validation::type_mismatch`, undraftable and
+  blamed for a string it never wrote. Identical declarations, which is what
+  repeating a shared field set or sharing a YAML anchor produces, collapse to
+  that one cell without loss and stay legal.
 - fix(core,wasm,python)!: `EditError::UnknownField` carries the in-field path
   `FieldDecode` and `FieldNotContent` carry. A property an `object` field does
   not declare — `get_content_at("address", [Key("zip")])` against an `address`

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -359,8 +359,9 @@ fn append_typed_dict(
 /// discriminant names (`default:` › `example:` › blank). The worlds it cannot
 /// show are named instead, one `# when <MEMBER>: <fields>` line each, so a reader
 /// filling the form learns that choosing a different member brings different
-/// cells. Every world is listed, the shown one included: the lines are the map,
-/// the cells are the position.
+/// cells. Every member owning a field set is listed, the shown one included if it
+/// owns one; a member that brings no cells has nothing to announce. The lines are
+/// the map, the cells are the position.
 ///
 /// The discriminant carries the container's `!must_fill` marker (a mapping
 /// cannot hold one) and no inline annotation of its own — the container line

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -359,9 +359,8 @@ fn append_typed_dict(
 /// discriminant names (`default:` › `example:` › blank). The worlds it cannot
 /// show are named instead, one `# when <MEMBER>: <fields>` line each, so a reader
 /// filling the form learns that choosing a different member brings different
-/// cells. Every member owning a field set is listed, the shown one included if it
-/// owns one; a member that brings no cells has nothing to announce. The lines are
-/// the map, the cells are the position.
+/// cells. A member owning a field set gets a line, the shown one included; one
+/// bringing no cells gets none. The lines are the map, the cells are the position.
 ///
 /// The discriminant carries the container's `!must_fill` marker (a mapping
 /// cannot hold one) and no inline annotation of its own — the container line

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -775,7 +775,7 @@ fn collect_unauthored_field(
     // discriminant and — *only in the world the discriminant selects* — that
     // world's fields. This is where obligation becomes conditional: a `poc` with
     // no `default:` is obliged on a CUI memo and silent on every other one, which
-    // is the thing `must_fill` alone could not say (#1202).
+    // is the thing `must_fill` alone cannot say.
     if field.is_variant_bearing() {
         let json = value.map(|v| v.as_json());
         let object = json.and_then(|j| j.as_object());

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -818,9 +818,11 @@ impl QuillConfig {
     /// author their answers; `validation::out_of_variant` reports it, and the
     /// render floor drops it from the plate.
     ///
-    /// Names may repeat across variants (only one world is ever live), so the
-    /// lookup takes the first variant declaring the name: an ambiguity only
-    /// reachable for a stranded value, whose type nothing downstream reads.
+    /// Names may repeat across variants, and the lookup takes the first variant
+    /// declaring one without consulting the discriminant. That is total because
+    /// `quill::variant_field_collision` rejects a name two worlds declare
+    /// *differently* at load: whichever world is live, the one slot the name
+    /// resolves to carries the one declaration every world gave it.
     fn conform_variant(
         json_value: &serde_json::Value,
         field_schema: &super::FieldSchema,
@@ -1083,6 +1085,32 @@ impl QuillConfig {
                                  number, integer, or boolean. Declare prose and dates as \
                                  card-level fields.",
                                 field.r#type.as_str()
+                            ),
+                        );
+                    }
+                    // A name several worlds declare resolves to one slot: the
+                    // coercion lookup and the transform schema both key on the
+                    // name alone, so two spellings of it would coerce a live
+                    // value under the wrong world's type and describe it to a
+                    // consumer under the wrong one. Identical declarations —
+                    // what repeating a shared field set or sharing a YAML anchor
+                    // produces — collapse to that one slot without loss, so the
+                    // gate is disagreement, not repetition.
+                    if let Some((first, _)) = variants
+                        .iter()
+                        .take_while(|(m, _)| *m != member)
+                        .find_map(|(m, set)| set.get(name).map(|f| (m, f)))
+                        .filter(|(_, first)| first.as_ref() != field.as_ref())
+                    {
+                        return err(
+                            "quill::variant_field_collision",
+                            format!(
+                                "Field '{owner}' declares '{name}' differently under \
+                                 '{first}' and '{member}'. A name is one cell of the \
+                                 container whichever world brings it into play, so every \
+                                 variant declaring it must declare it identically; give \
+                                 the two readings separate names, or share one declaration \
+                                 with a YAML anchor."
                             ),
                         );
                     }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -821,8 +821,7 @@ impl QuillConfig {
     /// Names may repeat across variants, and the lookup takes the first variant
     /// declaring one without consulting the discriminant. That is total because
     /// `quill::variant_field_collision` rejects a name two worlds declare
-    /// *differently* at load: whichever world is live, the one slot the name
-    /// resolves to carries the one declaration every world gave it.
+    /// *differently*, so every repetition is the same declaration.
     fn conform_variant(
         json_value: &serde_json::Value,
         field_schema: &super::FieldSchema,
@@ -1088,14 +1087,9 @@ impl QuillConfig {
                             ),
                         );
                     }
-                    // A name several worlds declare resolves to one slot: the
-                    // coercion lookup and the transform schema both key on the
-                    // name alone, so two spellings of it would coerce a live
-                    // value under the wrong world's type and describe it to a
-                    // consumer under the wrong one. Identical declarations —
-                    // what repeating a shared field set or sharing a YAML anchor
-                    // produces — collapse to that one slot without loss, so the
-                    // gate is disagreement, not repetition.
+                    // The coercion lookup and the transform schema both key on
+                    // the name alone, never the discriminant, so a name resolves
+                    // to one slot however many worlds declare it.
                     if let Some((first, _)) = variants
                         .iter()
                         .take_while(|(m, _)| *m != member)

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -118,8 +118,11 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             );
             for (member, fields) in variants {
                 for (name, variant_field) in fields {
-                    // Names may repeat across worlds; the first declaration wins,
-                    // as only one world is ever live.
+                    // Names may repeat across worlds, and every repetition is
+                    // the same declaration (`quill::variant_field_collision`),
+                    // so the first fills the one slot the name gets. Its
+                    // `variant_of` names only that first world, which understates
+                    // a shared cell's reach.
                     if properties.contains_key(name) {
                         continue;
                     }

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -118,11 +118,10 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             );
             for (member, fields) in variants {
                 for (name, variant_field) in fields {
-                    // Names may repeat across worlds, and every repetition is
-                    // the same declaration (`quill::variant_field_collision`),
-                    // so the first fills the one slot the name gets. Its
-                    // `variant_of` names only that first world, which understates
-                    // a shared cell's reach.
+                    // Every repetition of a name is the same declaration
+                    // (`quill::variant_field_collision`), so the first fills the
+                    // one slot it gets. `variant_of` then names only that first
+                    // world, understating a shared cell's reach.
                     if properties.contains_key(name) {
                         continue;
                     }

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -193,6 +193,38 @@ fn a_variant_field_may_not_be_a_container_or_carry_a_group() {
     .contains("quill::nested_group_not_supported"));
 }
 
+/// A name resolves to one slot of the container, and neither the coercion
+/// lookup nor the transform schema consults the discriminant to fill it. Two
+/// worlds spelling it differently would coerce a live value under the other
+/// world's type — a hard `validation::type_mismatch` on a document that is
+/// valid against the world it selected.
+#[test]
+fn a_name_two_worlds_declare_differently_is_a_load_error() {
+    let err = load_error(
+        "    c:\n      type: enum\n      values: [A, B]\n      variants:\n        A:\n          note: { type: string }\n        B:\n          note: { type: integer }\n",
+    );
+    assert!(err.contains("quill::variant_field_collision"), "{err}");
+    assert!(err.contains("'A'") && err.contains("'B'"), "{err}");
+}
+
+/// Repetition is how a shared field set is spelled, so identical declarations
+/// collapse to the one slot without loss and stay legal.
+#[test]
+fn a_name_two_worlds_declare_identically_loads() {
+    let config = QuillConfig::from_yaml(&quill_yaml().replace(
+        "        SECRET:\n          declassify_on: { type: string }",
+        "        SECRET:\n          declassify_on: { type: string }\n          controlled_by: { type: string }",
+    ))
+    .expect("an identically-repeated variant field loads");
+    let doc = Document::parse(
+        "~~~\n$quill: variant_probe@0.1.0\n$kind: main\nclassification:\n  value: SECRET\n  controlled_by: SAF/AA\n  declassify_on: 20301231\n~~~\n",
+    )
+    .expect("parses")
+    .document;
+    let data = config.compile_data(&doc).expect("compile_data succeeds");
+    assert_eq!(data["classification"]["controlled_by"], json!("SAF/AA"));
+}
+
 /// A variant turns its field into a container, and a container may not sit
 /// inside one.
 #[test]

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -193,11 +193,9 @@ fn a_variant_field_may_not_be_a_container_or_carry_a_group() {
     .contains("quill::nested_group_not_supported"));
 }
 
-/// A name resolves to one slot of the container, and neither the coercion
-/// lookup nor the transform schema consults the discriminant to fill it. Two
-/// worlds spelling it differently would coerce a live value under the other
-/// world's type — a hard `validation::type_mismatch` on a document that is
-/// valid against the world it selected.
+/// Two spellings of one name would coerce a live value under the other world's
+/// type, failing `validation::type_mismatch` on a document valid against the
+/// world it selected.
 #[test]
 fn a_name_two_worlds_declare_differently_is_a_load_error() {
     let err = load_error(
@@ -207,8 +205,8 @@ fn a_name_two_worlds_declare_differently_is_a_load_error() {
     assert!(err.contains("'A'") && err.contains("'B'"), "{err}");
 }
 
-/// Repetition is how a shared field set is spelled, so identical declarations
-/// collapse to the one slot without loss and stay legal.
+/// Repetition is how a shared field set is spelled, so the gate is disagreement
+/// rather than repetition.
 #[test]
 fn a_name_two_worlds_declare_identically_loads() {
     let config = QuillConfig::from_yaml(&quill_yaml().replace(
@@ -350,8 +348,8 @@ fn resolve_reports_the_container_as_one_cell_matching_the_plate() {
 // ------------------------------------------------------------------ validation
 
 /// The conditional-obligation payoff: a field with no `default:` is obliged in
-/// its own world and silent everywhere else — the thing `must_fill` alone could
-/// not say (#1202).
+/// its own world and silent everywhere else — the thing `must_fill` alone cannot
+/// say.
 #[test]
 fn obligation_follows_the_selected_world() {
     let obliged = codes(&doc("classification:\n  value: CUI\n"));

--- a/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
+++ b/crates/fixtures/resources/quills/usaf_memo/0.2.0/plate.typ
@@ -116,7 +116,7 @@
     // Sized in multiples of that face's own size rather than inches, because
     // `font_size` is a document field with no declared ceiling: an inch width
     // would stay put while the text inside it grew, and a fixed size clips
-    // where auto-size used to shrink. The longest date either memo style
+    // where auto-size would shrink. The longest date either memo style
     // produces sets just over 8em in Times ("September 28, 2026", the DAF
     // ordering, at 8.03em; USAF's "28 September 2026" is 7.78em), so 10em
     // clears the worst case at any body size. Wider than `date-placeholder`'s

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -45,10 +45,20 @@ const DEFAULT_APPEARANCE: &[u8] = b"/Helv 0 Tf 0 g";
 /// One widget's `/DA`: its face and size over the house black fill. `f32`'s
 /// `Display` drops the trailing `.0`, so a whole-point size writes `12`, and an
 /// absent size writes the `0 Tf` that defers to the viewer's auto-size.
+///
+/// A size that is not a positive finite number falls back to that same `0 Tf`:
+/// `font_size` is a public field, and `NaN`/`inf` would reach the `/DA` as a
+/// token no PDF number grammar admits, while a negative one is `0 Tf` said
+/// obscurely. The Typst helper rejects all three at the call site; this keeps a
+/// direct spine consumer from writing a file no viewer can parse.
 fn field_appearance(spec: &FieldSpec) -> Vec<u8> {
+    let size = spec
+        .font_size
+        .filter(|s| s.is_finite() && *s > 0.0)
+        .unwrap_or(0.0);
     let mut da = b"/".to_vec();
     da.extend_from_slice(spec.font.resource_name());
-    da.extend_from_slice(format!(" {} Tf 0 g", spec.font_size.unwrap_or(0.0)).as_bytes());
+    da.extend_from_slice(format!(" {size} Tf 0 g").as_bytes());
     da
 }
 

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -46,11 +46,10 @@ const DEFAULT_APPEARANCE: &[u8] = b"/Helv 0 Tf 0 g";
 /// `Display` drops the trailing `.0`, so a whole-point size writes `12`, and an
 /// absent size writes the `0 Tf` that defers to the viewer's auto-size.
 ///
-/// A size that is not a positive finite number falls back to that same `0 Tf`:
-/// `font_size` is a public field, and `NaN`/`inf` would reach the `/DA` as a
-/// token no PDF number grammar admits, while a negative one is `0 Tf` said
-/// obscurely. The Typst helper rejects all three at the call site; this keeps a
-/// direct spine consumer from writing a file no viewer can parse.
+/// A size that is not positive and finite falls back to that same `0 Tf`:
+/// `font_size` is public, so the Typst helper's call-site asserts do not cover
+/// every caller, and `NaN`/`inf` reach the `/DA` as a token no PDF number
+/// grammar admits.
 fn field_appearance(spec: &FieldSpec) -> Vec<u8> {
     let size = spec
         .font_size

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -538,3 +538,30 @@ fn xref_emits_multiple_subsections_when_ids_have_gaps() {
         "expected multiple xref subsections, found {headers}"
     );
 }
+
+/// `font_size` is a public field, so the spine cannot assume the Typst helper's
+/// call-site asserts ran. A `/DA` reading `NaN Tf` parses as no PDF number, and
+/// the file a viewer cannot open is worse than the auto-size it asked for.
+#[test]
+fn a_nonsense_font_size_falls_back_to_auto_rather_than_forging_a_da() {
+    let base = build_base_pdf(1);
+    let mut fields = vec![FieldSpec::new(
+        "Date".into(),
+        0,
+        [180.0, 700.0, 520.0, 720.0],
+        FieldType::Text { multiline: false },
+    )];
+    for bad in [f32::NAN, f32::INFINITY, -12.0] {
+        fields[0].font_size = Some(bad);
+        let out = stamp(base.clone(), &fields, &StampOptions::default())
+            .unwrap_or_else(|e| panic!("{bad} should stamp: {}", e.message));
+        let text = String::from_utf8_lossy(&out);
+        assert!(
+            text.contains("/Helv 0 Tf 0 g"),
+            "{bad} should write the auto-size /DA"
+        );
+        for token in ["NaN", "inf", "-12 Tf"] {
+            assert!(!text.contains(token), "{bad} leaked {token:?} into the PDF");
+        }
+    }
+}

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -539,9 +539,8 @@ fn xref_emits_multiple_subsections_when_ids_have_gaps() {
     );
 }
 
-/// `font_size` is a public field, so the spine cannot assume the Typst helper's
-/// call-site asserts ran. A `/DA` reading `NaN Tf` parses as no PDF number, and
-/// the file a viewer cannot open is worse than the auto-size it asked for.
+/// `font_size` is public, so the spine cannot assume the Typst helper's asserts
+/// ran, and a `/DA` reading `NaN Tf` parses as no PDF number.
 #[test]
 fn a_nonsense_font_size_falls_back_to_auto_rather_than_forging_a_da() {
     let base = build_base_pdf(1);

--- a/crates/quillmark/tests/usaf_memo_date_field_test.rs
+++ b/crates/quillmark/tests/usaf_memo_date_field_test.rs
@@ -1,9 +1,9 @@
 //! Styling and placement of the USAF memo's injected indorsement-date widget.
 //!
 //! An indorsement is dated when the endorser signs it, so the date is normally
-//! blank at compile time and prints as a fill-in rule. The widget seated on that
-//! rule stands in for a date the memo would otherwise typeset, so it has to be
-//! set like one: AFH 33-337's 12 point Times body face, ending at the same right
+//! blank at compile time and the widget is the only thing occupying its slot.
+//! It stands in for a date the memo would otherwise typeset, so it has to be set
+//! like one: AFH 33-337's 12 point Times body face, ending at the same right
 //! margin `display-date` would have ended at.
 
 #![cfg(feature = "typst")]

--- a/crates/quillmark/tests/usaf_memo_regions_test.rs
+++ b/crates/quillmark/tests/usaf_memo_regions_test.rs
@@ -147,9 +147,9 @@ fn usaf_memo_date_region_rides_the_vendored_display() {
     );
 }
 
-/// An indorsement whose date is blank prints a bare rule, so the only thing
-/// carrying that address is the widget seated on it. Without it the endorser's
-/// date is the one memo field a preview cannot route a click to.
+/// An indorsement whose date is blank draws nothing at all, so the widget seated
+/// in its reserved space is the only thing carrying that address. Without it the
+/// endorser's date is the one memo field a preview cannot route a click to.
 #[test]
 fn a_blank_indorsement_date_regions_through_its_fill_in_widget() {
     let engine = Quillmark::new();
@@ -173,7 +173,7 @@ fn a_blank_indorsement_date_regions_through_its_fill_in_widget() {
     assert_eq!(
         session.field_at(date.page, cx, cy).as_deref(),
         Some("$cards.indorsement.0.date"),
-        "a click on the fill-in rule routes to the card's date"
+        "a click on the fill-in widget routes to the card's date"
     );
 
     let pdf = engine

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -322,7 +322,9 @@ keys only on declared members (never `""`, which owns no field set), and cannot
 declare a field named `value`. Variant fields inherit the discriminant's
 `ui.group`; declaring one inside a variant is an error. A field set shared by
 several members is repeated or shared with a YAML anchor — a variant keys on one
-member.
+member — but every variant declaring a given name must declare it *identically*,
+since the name is one cell of the container whichever world brings it into play
+(`quill::variant_field_collision`).
 
 ### Primitive Arrays, Typed Tables, and Typed Dictionaries
 

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -215,9 +215,11 @@ speak about the same cells (`SCHEMAS.md` § "Native validation").
 A variant-bearing `enum` emits its container: the discriminant under `value`,
 then the fields of the world that discriminant names (`default:` › `example:` ›
 blank). A blueprint **is** a document, so it can show only one world; the others
-are named instead, one `# when <MEMBER>: <fields>` leading line each. Every world
-is listed, the shown one included — the lines are the map, the cells are the
-position.
+are named instead, one `# when <MEMBER>: <fields>` leading line each. Every member
+owning a field set gets a line, the shown one included if it owns one — a member
+that brings no cells has nothing to announce, which is why the example below,
+sitting in the blank world, carries only `CUI`'s. The lines are the map, the cells
+are the position.
 
 ```
 # Select the classification marking shown in the header and footer banner.

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -113,13 +113,13 @@ Typst `form-field` widget or click-to-edit region, whose address grammar is flat
 plus one index; and a field set **shared** across several members is spelled by
 repeating it or sharing a YAML anchor, since a variant keys on one member.
 
-A repeated name is one **cell** of the container, not one per world: both the
-coercion lookup and the transform schema key on the name alone. So every variant
-declaring a name must declare it identically — `quill::variant_field_collision`
-rejects disagreement at load, rather than letting a live value coerce under
-another world's type. (A YAML anchor satisfies this by construction; hand-copying
-does not.) The projection still tags that cell `quillmark:variant_of` with the
-*first* declaring member, which understates a shared cell's reach.
+A repeated name is one **cell** of the container, not one per world: the coercion
+lookup and the transform schema both key on the name alone, never the
+discriminant. So every variant declaring a name must declare it identically —
+`quill::variant_field_collision` rejects disagreement at load, rather than letting
+a live value coerce under another world's type. The projection tags that cell
+`quillmark:variant_of` with the *first* declaring member, understating a shared
+cell's reach.
 
 The text-ish types form a **data vs content** × **open/plain vs closed/formatted**
 2×2: `enum` (closed data), `string` (open data), `plaintext` (plain content),

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -96,6 +96,7 @@ The ceiling is deliberate and enforced at load rather than discovered at render:
 | an empty `variants:` map, or an empty variant | `quill::variant_empty` |
 | a variant field named `value` | `quill::variant_reserved_field_name` |
 | a `richtext`, `plaintext`, `date`, or `datetime` variant field | `quill::variant_field_type` |
+| a name two variants declare *differently* | `quill::variant_field_collision` |
 
 The last is the load-bearing one: content and dates lower to Typst through
 *top-level* name tables that do not descend into a container
@@ -111,6 +112,14 @@ container, as it does for a typed dictionary; a variant field cannot host a
 Typst `form-field` widget or click-to-edit region, whose address grammar is flat
 plus one index; and a field set **shared** across several members is spelled by
 repeating it or sharing a YAML anchor, since a variant keys on one member.
+
+A repeated name is one **cell** of the container, not one per world: both the
+coercion lookup and the transform schema key on the name alone. So every variant
+declaring a name must declare it identically — `quill::variant_field_collision`
+rejects disagreement at load, rather than letting a live value coerce under
+another world's type. (A YAML anchor satisfies this by construction; hand-copying
+does not.) The projection still tags that cell `quillmark:variant_of` with the
+*first* declaring member, which understates a shared cell's reach.
 
 The text-ish types form a **data vs content** × **open/plain vs closed/formatted**
 2×2: `enum` (closed data), `string` (open data), `plaintext` (plain content),


### PR DESCRIPTION
Findings from a critical review of #1275 (`v0.105.0..release/v0.106.0`), limited to the ones cheap enough to fix. The rest is filed as #1276, #1277, #1278.

Based on `main`, carrying no version bump — the changelog entries sit under `## Unreleased`, which is where the release job seeds the version section from.

## The correctness bug

Cross-variant name collisions were unvalidated, and `variant_field_schema` resolves a name by first-declaring variant without consulting the discriminant. `conform_variant` uses it for every key, so the **live** world's own value took the wrong world's schema:

```yaml
level:
  type: enum
  values: [A, B]
  variants:
    A: { note: { type: string } }
    B: { note: { type: integer } }
```

`level: {value: B, note: 42}` — valid against world B — coerced `42` through A's `string` to `"42"`, then failed validation (which correctly uses B):

```
validation::type_mismatch — Field `main.level.note` got string `"42"`, schema declares `integer`
```

An undraftable document, blaming the author for a string they never wrote.

`quill::variant_field_collision` now rejects a name two variants declare *differently*, at load. A load-time gate rather than a discriminant-aware lookup, because it makes first-wins correct by construction on **both** surfaces that use it — coercion and `build_transform_schema` — and matches the ceiling-enforced-at-load discipline the rest of the axis already follows. Identical declarations still load, so the documented "repeat it or share a YAML anchor" spelling of a shared field set is untouched.

The two comments asserting this ambiguity was unreachable ("only reachable for a stranded value, whose type nothing downstream reads") now state the invariant that actually makes first-wins total.

## Changelog

The curated section covered `form-field` styling, the fixture date widget, `UnknownField`, and the Python fix — but neither **enum variants** nor **`field-region`**, the two feature commits and most of the diff. #1275's generated section inherits that gap, and its own seed comment lists both as uncovered. Entries added for both, plus the collision fix.

## `field_appearance` guard

`FieldSpec::font_size` is a public field on a published crate, and `NaN`/`inf` reached the `/DA` as `NaN Tf` — a token no PDF number grammar admits. The Typst helper's call-site asserts don't cover a direct spine consumer. Non-positive and non-finite sizes now fall back to the same `0 Tf` an absent size writes.

## Prose

- `Every world is listed, the shown one included` was false in `append_variant` and `BLUEPRINT.md`: only members *owning a field set* get a `# when` line, as that section's own example (sitting in the blank world, showing one line) demonstrates.
- Three comments still described the fill-in rule `d6efa1b2` deleted — including one whose reasoning inverted, since nothing is drawn there at all now.
- A `dense-prose` pass over the new comments: cut what restated the error message beside it, two `(#1202)` status markers, and one `used to` framing in the memo plate.

## Verification

`cargo test --workspace`: 1095 passed, 0 failed. `node scripts/check-canon.mjs`: canon spine OK.

Four new tests — the collision gate rejecting and the identical-declaration case still loading and rendering; the `font_size` guard across `NaN`/`inf`/negative.

## Not fixed here

`quillmark:variant_of` still names only the first declaring member, so a genuinely shared cell is understated to a UI. The gate guarantees the slot's *type* is right; only its reach is wrong. That changes a wire shape and wanted a decision rather than a drive-by — #1277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBq4KX47SortFbBMiZyDez