### PR TITLE
refactor(core)!: drop quillmark:variant_of from the transform schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@
   (`validation::out_of_variant`), never dropped at coercion or gated at render.
   The ceiling is enforced at load, not discovered at render: a variant carries
   plain data only, sits at card level only, and cannot declare `value`. The
-  transform schema projects the container with every world's fields tagged
-  `quillmark:variant_of`, since a binding built once against a schema must
-  address a field today's document has not selected. `FieldSchema` gains
-  `variants`; `VariantFields`, `VARIANT_DISCRIMINANT_KEY` and
-  `QUILLMARK_VARIANT_OF_KEY` are new.
+  transform schema projects the container with every world's fields flattened
+  under `properties`, since a binding built once against a schema must address a
+  field today's document has not selected; member scoping stays on the
+  declaration view, where `schema()` emits `variants:` keyed by member.
+  `FieldSchema` gains `variants`; `VariantFields` and `VARIANT_DISCRIMINANT_KEY`
+  are new.
 - feat(fixtures)!: `usaf_memo`'s four `cui_*` fields move under
   `classification`'s `CUI` variant as `controlled_by`, `poc`, `category`, and
   `limited_dissemination`. `controlled_by` and `poc` drop their `default: ""`

--- a/crates/core/src/quill.rs
+++ b/crates/core/src/quill.rs
@@ -24,9 +24,7 @@ pub use resolved::{FieldSource, Resolved, ResolvedCard, ResolvedField, ResolvedM
 pub use fill::blank;
 pub use formats::{parse_date, parse_datetime};
 pub use ignore::QuillIgnore;
-pub use schema::{
-    build_transform_schema, CONTENT_MEDIA_TYPE, QUILLMARK_INLINE_KEY, QUILLMARK_VARIANT_OF_KEY,
-};
+pub use schema::{build_transform_schema, CONTENT_MEDIA_TYPE, QUILLMARK_INLINE_KEY};
 pub use support::UNSUPPORTED_CONSTRUCT;
 pub use tree::FileTreeNode;
 pub use validation::ValidationError;

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -36,13 +36,6 @@ pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 /// and enforcement — if a consumer wants any — is that consumer's policy.
 pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
 
-/// Transform-schema keyword naming the enum member that brings a field into
-/// play. It sits on each property of a variant-bearing enum's container except
-/// the discriminant itself, and is the signal a UI needs to show or retire a
-/// cell as the discriminant changes — the fact the flat `cui_`-prefix convention
-/// could only carry in prose.
-pub const QUILLMARK_VARIANT_OF_KEY: &str = "quillmark:variant_of";
-
 /// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
 ///
 /// The descriptor marks richtext fields with `contentMediaType:
@@ -105,34 +98,25 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
         // render floor, the pdfform widget and the blueprint annotation all are,
         // so a `FieldSchema` built outside the loader projects its domain too.
         // A variant-bearing enum crosses as the container it rests as: the
-        // discriminant under `value`, and every world's fields beside it, each
-        // tagged with the member that brings it into play. The union — not the
-        // live world — is what a *contract* describes: a pdfform binding and an
-        // editor form are built once, against a schema, and must address a field
-        // whose world today's document has not selected.
+        // discriminant under `value`, and every world's fields flattened beside
+        // it. The schema describes resting shapes, and at schema time there is
+        // no live world, so the union is the only projection available. Which
+        // member owns a cell is not restated here: `variants:` on the
+        // declaration view (`QuillConfig::schema`) carries that, keyed by member.
         if let Some(variants) = &field.variants {
             let mut properties = serde_json::Map::new();
             properties.insert(
                 VARIANT_DISCRIMINANT_KEY.to_string(),
                 discriminant_schema(field),
             );
-            for (member, fields) in variants {
+            for fields in variants.values() {
                 for (name, variant_field) in fields {
-                    // Every repetition of a name is the same declaration
-                    // (`quill::variant_field_collision`), so the first fills the
-                    // one slot it gets. `variant_of` then names only that first
-                    // world, understating a shared cell's reach.
+                    // One slot per name: every repetition is the same
+                    // declaration (`quill::variant_field_collision`).
                     if properties.contains_key(name) {
                         continue;
                     }
-                    let mut child = field_to_schema(variant_field);
-                    if let Some(object) = child.as_object_mut() {
-                        object.insert(
-                            QUILLMARK_VARIANT_OF_KEY.to_string(),
-                            serde_json::Value::String(member.clone()),
-                        );
-                    }
-                    properties.insert(name.clone(), child);
+                    properties.insert(name.clone(), field_to_schema(variant_field));
                 }
             }
             schema.insert(

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -494,11 +494,8 @@ fn seeding_resolves_the_discriminant_before_walking_the_field_set() {
     assert!(value.get("declassify_on").is_none());
 }
 
-/// A contract describes every world: a pdfform binding and an editor form are
-/// built once, against the schema, and must address a field whose world today's
-/// document has not selected.
 #[test]
-fn the_transform_schema_carries_every_world_tagged_by_member() {
+fn the_transform_schema_flattens_every_world_into_one_container() {
     let schema = build_transform_schema(&config());
     let json = schema.as_json();
     let cls = &json["properties"]["classification"];
@@ -507,14 +504,26 @@ fn the_transform_schema_carries_every_world_tagged_by_member() {
         cls["properties"]["value"]["enum"],
         json!(["", "UNCLASSIFIED", "CUI", "SECRET"])
     );
-    assert_eq!(
-        cls["properties"]["controlled_by"]["quillmark:variant_of"],
-        json!("CUI")
-    );
-    assert_eq!(
-        cls["properties"]["declassify_on"]["quillmark:variant_of"],
-        json!("SECRET")
-    );
+    assert_eq!(cls["properties"]["controlled_by"]["type"], json!("string"));
+    assert_eq!(cls["properties"]["declassify_on"]["type"], json!("string"));
+}
+
+/// `variants:` on the declaration view states it instead, keyed by member.
+#[test]
+fn the_transform_schema_does_not_restate_which_member_owns_a_cell() {
+    let schema = build_transform_schema(&config());
+    let cls = &schema.as_json()["properties"]["classification"];
+    for name in ["controlled_by", "category", "declassify_on"] {
+        assert_eq!(
+            cls["properties"][name]
+                .as_object()
+                .expect("variant cell projects as an object")
+                .keys()
+                .filter(|k| k.starts_with("quillmark:variant"))
+                .count(),
+            0
+        );
+    }
 }
 
 /// `schema()` is the declaration view and emits what the author wrote, so a

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -65,9 +65,9 @@ could not say:
   `default:`-presence derivation, so it reads *"required in this world"*: `poc`
   is obliged on a CUI memo and silent on every other one. This is the one
   cross-field constraint the engine checks rather than describes.
-- **A UI signal.** `quillmark:variant_of` on the transform schema names the
-  member that brings each cell into play, so an editor retires cells that are out
-  of play instead of hard-coding the rule.
+- **A UI signal.** `variants:` is keyed by member on the declaration view
+  ([`Quill::schema`](#schema-emission)), so an editor shows and retires
+  cells as the discriminant changes instead of hard-coding the rule.
 
 **The wire carries exactly the live world, and totality is per-world.** The
 render floor emits `value` plus the selected member's fields — blank-filled as
@@ -117,9 +117,7 @@ A repeated name is one **cell** of the container, not one per world: the coercio
 lookup and the transform schema both key on the name alone, never the
 discriminant. So every variant declaring a name must declare it identically —
 `quill::variant_field_collision` rejects disagreement at load, rather than letting
-a live value coerce under another world's type. The projection tags that cell
-`quillmark:variant_of` with the *first* declaring member, understating a shared
-cell's reach.
+a live value coerce under another world's type.
 
 The text-ish types form a **data vs content** × **open/plain vs closed/formatted**
 2×2: `enum` (closed data), `string` (open data), `plaintext` (plain content),
@@ -573,8 +571,8 @@ The type-gated keys:
 - `values`: declares an `enum` field's domain, required there.
 - `variants`: per-member field sets on an `enum` field, valid only there and only
   at card level (see [Enum variants](#enum-variants)). `schema()` emits it as
-  authored; the transform schema instead projects the container, flattening every
-  world's fields under `properties` and tagging each `quillmark:variant_of`.
+  authored, keyed by member; the transform schema instead projects the container,
+  flattening every world's fields under `properties` with no member scoping.
 - `items`: the element schema, itself a `FieldSchema`; required on `array`
   fields and rejected elsewhere.
 - `properties`: used by `object` fields, and by an array's `object`-typed


### PR DESCRIPTION
Closes #1277 — by deleting the key rather than reshaping it.

## Why deletion

The transform schema is a backend wire contract. Its only reader anywhere is the Typst backend's `SchemaMeta` (`crates/backends/typst/src/lib.rs:657`), which builds top-level name tables and never descends into a variant container. It cannot need to: `quill::variant_field_type` restricts a variant to plain data *precisely because* content and dates lower through those tables. The pdfform backend doesn't consume the projection at all, and canon already rules out the widget case — "a variant field cannot host a Typst `form-field` widget or click-to-edit region." No binding surfaces the projection either: `Quill.schema` in wasm and Python both return `QuillConfig::schema()`.

The editor named in #1277 is on that other projection, and has to be — the transform schema emits no `description`, `example`, or `ui.group`. The declaration view carries `variants` as `IndexMap<member, VariantFields>`, which answers *is this a container*, *which member owns this cell*, and *what is in play for `CUI`* exactly. Restating a lossy version of that here bought nothing and cost accuracy: one slot per name meant a field shared across members carried only its first declarer.

## The trade

#1277's item 2 (understated reach) is removed with the key. Item 1 gets **worse**: a container is now genuinely indistinguishable from a typed dictionary whose properties include a string-enum `value`, where before it was recoverable by scanning children for `variant_of`. Deliberate — nothing in this projection needs the distinction, and a future consumer can specify the shape it wants instead of us guessing. Item 3 is left alone: the container and its `value` child both emit the same `field.must_fill()` call on the same field, so they cannot disagree.

## Changes

- `schema.rs`: const, emit block, and `member` binding gone; the union-flattening comment rewritten — it cited "a pdfform binding and an editor form," neither of which reads this projection. It now rests on the claim that holds: the schema describes resting shapes, and at schema time there is no live world.
- `quill.rs`: dropped from the `pub use`.
- `SCHEMAS.md`: the "A UI signal" bullet **kept**, repointed at the declaration view — the fact survives, only its carrier changed. The first-declarer paragraph and the type-gated-keys mention are gone.
- `variant_tests.rs`: split in two — one pins the union, one pins that member scoping is not restated, so a future re-add is deliberate.
- `CHANGELOG.md`: the pending entry amended in place.

## Note on the version claim

#1277 says the key is "one release old," added in v0.106.0. It never shipped — `variants:` is still under `## Unreleased` and v0.105.0 is the latest release. So this breaks no released API; the `!` is conservative, matching the pending `feat(core,wasm)!` entry it amends.

## Verification

`cargo test --workspace` green (57 suites, 0 failures), `cargo clippy --workspace --all-targets` clean on the touched file, `node scripts/check-canon.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCGNRJgdLnFLwesxnacp12

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCGNRJgdLnFLwesxnacp12)_