### PR TITLE
fix(typst): bound and report an unclosed field-region claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,15 +41,14 @@
   invoked once per card yields one region per card — the way a card's scalar
   fields get regions at all, reading as they do from a loop variable that carries
   no per-instance identity. The marker stack persists across pages so a claim can
-  span a page break, so a claim whose closing marker never reaches a frame is
-  bounded by nothing and would take every unattributed piece of ink to the end of
-  the document. Those are found before the scan and suppressed in both the region
-  and point queries — an unbounded claim yields nothing rather than everything —
-  and reported as a `typst::unclosed_field_region` warning naming the field,
-  since only the plate author can act on it. Typst does not separate the two
-  markers on its own (they are siblings in content flow, and clipping, overflow,
-  floats, footnotes and marginals all keep them together); a plate emitting the
-  call's return value in parts can.
+  span a page break, which leaves a claim whose closing marker never reaches a
+  frame bounded by nothing: it would take every unattributed piece of ink to the
+  end of the document. Those are found before the scan and suppressed in both the
+  region and point queries — an unbounded claim yields nothing rather than
+  everything — and reported as a `typst::unclosed_field_region` warning naming
+  the field, since only the plate author can act on it. Typst does not separate
+  the two markers on its own — they are siblings in content flow — but a plate
+  emitting the call's return value in parts can.
 - feat(typst,pdf): `form-field` takes `font`, `size`, and `align`, so an
   injected widget's value can be set to match the type around it. A widget was
   fixed at Helvetica, auto-size, left: auto-size makes the rendered size a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,16 @@
   additive and cannot retarget. Each *call* claims independently, so a wrapper
   invoked once per card yields one region per card — the way a card's scalar
   fields get regions at all, reading as they do from a loop variable that carries
-  no per-instance identity.
+  no per-instance identity. The marker stack persists across pages so a claim can
+  span a page break, so a claim whose closing marker never reaches a frame is
+  bounded by nothing and would take every unattributed piece of ink to the end of
+  the document. Those are found before the scan and suppressed in both the region
+  and point queries — an unbounded claim yields nothing rather than everything —
+  and reported as a `typst::unclosed_field_region` warning naming the field,
+  since only the plate author can act on it. Typst does not separate the two
+  markers on its own (they are siblings in content flow, and clipping, overflow,
+  floats, footnotes and marginals all keep them together); a plate emitting the
+  call's return value in parts can.
 - feat(typst,pdf): `form-field` takes `font`, `size`, and `align`, so an
   injected widget's value can be set to match the type around it. A widget was
   fixed at Helvetica, auto-size, left: auto-size makes the rendered size a

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -65,13 +65,34 @@ struct TypstSession {
     /// What [`session_warnings`] built for the live compile. The compile half
     /// swaps on each committed `apply`; the load half rides along unchanged.
     warnings: Vec<Diagnostic>,
+    /// [`overlay::unclosed_claims`] for the live document, suppressed by every
+    /// region and point query. Computed with the compile rather than per query:
+    /// `field_at` cannot derive it from the page prefix it walks.
+    unclosed_claims: Vec<usize>,
 }
 
-/// The quill's load warnings, then this compile's own. One order, built in one
-/// place, so an `apply` that swaps only what it recompiled keeps the load half.
-fn session_warnings(world: &world::QuillWorld, compile: Vec<Diagnostic>) -> Vec<Diagnostic> {
+/// The quill's load warnings, then this compile's own, then one per runaway
+/// `field-region`. One order, built in one place, so an `apply` that swaps only
+/// what it recompiled keeps the load half.
+fn session_warnings(
+    world: &world::QuillWorld,
+    compile: Vec<Diagnostic>,
+    unclosed: &[(usize, String)],
+) -> Vec<Diagnostic> {
     let mut all = world.load_warnings().to_vec();
     all.extend(compile);
+    all.extend(unclosed.iter().map(|(_, field)| {
+        Diagnostic::new(
+            Severity::Warning,
+            format!("`field-region(\"{field}\")` never closed; its claim was dropped"),
+        )
+        .with_code("typst::unclosed_field_region".to_string())
+        .with_hint(
+            "both markers must reach the frame together, so emit the call's \
+             return value whole rather than in parts"
+                .to_string(),
+        )
+    }));
     all
 }
 
@@ -279,6 +300,7 @@ impl SessionHandle for TypstSession {
         let helper_source = helper_source(&self.world)?;
         let field_placements = overlay::extract(&document)?;
         let new_hashes = page_hashes(&document);
+        let unclosed = overlay::unclosed_claims(&document);
 
         let dirty_pages = (0..new_hashes.len())
             .filter(|&i| self.page_hashes.get(i) != Some(&new_hashes[i]))
@@ -290,7 +312,8 @@ impl SessionHandle for TypstSession {
         self.helper_source = helper_source;
         self.page_count = new_hashes.len();
         self.page_hashes = new_hashes;
-        self.warnings = session_warnings(&self.world, compile_warnings);
+        self.warnings = session_warnings(&self.world, compile_warnings, &unclosed);
+        self.unclosed_claims = unclosed.into_iter().map(|(claim, _)| claim).collect();
 
         Ok(ChangeSet::new(self.page_count, dirty_pages))
     }
@@ -342,6 +365,7 @@ impl SessionHandle for TypstSession {
             &self.world,
             &self.helper_source,
             &self.windows,
+            &self.unclosed_claims,
         ));
         regions
     }
@@ -362,6 +386,7 @@ impl SessionHandle for TypstSession {
                     &self.world,
                     &self.helper_source,
                     &self.windows,
+                    &self.unclosed_claims,
                     page,
                     x,
                     y,
@@ -475,7 +500,8 @@ impl Backend for TypstBackend {
         };
         windows.extend(scalar_windows.iter().cloned());
         let (document, compile_warnings) = compile::compile_document(&world)?;
-        let warnings = session_warnings(&world, compile_warnings);
+        let unclosed = overlay::unclosed_claims(&document);
+        let warnings = session_warnings(&world, compile_warnings, &unclosed);
         let helper_src = helper_source(&world)?;
         let page_count = document.pages().len();
         let field_placements = overlay::extract(&document)?;
@@ -491,6 +517,7 @@ impl Backend for TypstBackend {
             helper_source: helper_src,
             page_hashes: hashes,
             warnings,
+            unclosed_claims: unclosed.into_iter().map(|(claim, _)| claim).collect(),
         };
         Ok(LiveSession::new(
             Box::new(session),

--- a/crates/backends/typst/src/overlay/mod.rs
+++ b/crates/backends/typst/src/overlay/mod.rs
@@ -11,7 +11,8 @@ mod span_scan;
 
 pub(crate) use extract::extract;
 pub(crate) use span_scan::{
-    field_at, locate, position_at, scalar_windows, scan_content_regions, FieldWindow,
+    field_at, locate, position_at, scalar_windows, scan_content_regions, unclosed_claims,
+    FieldWindow,
 };
 
 /// Mirrors the spine's [`FieldType`] but carries the *resolved* Typst value.

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -23,6 +23,12 @@
 //! innermost open marker instead of counting as foreign. Each *call* is its own
 //! claim, so a wrapper invoked per card yields one region per card.
 //!
+//! The stack persists across pages so a claim can span a page break, which means
+//! an open marker whose close never reaches the frame would claim every
+//! unattributed hit to the end of the document. [`unclosed_claims`] names those
+//! ahead of the scan and both queries suppress them, so an unbounded claim
+//! yields nothing rather than everything.
+//!
 //! **First placement only.** Each span-window key's region is its first maximal
 //! run of consecutive matching frame items. Span data cannot distinguish
 //! "package chrome between two placements" from "a second placement" (both are a
@@ -202,16 +208,36 @@ const REGION_LABEL: &str = "__qm_region__";
 struct Markers {
     claims: Vec<String>,
     stack: Vec<usize>,
+    /// Claim indices [`unclosed_claims`] found still open at the end of the
+    /// document. Keeping them off `stack` leaves their ink foreign, exactly as
+    /// if the plate had emitted no marker at all.
+    suppressed: Vec<usize>,
 }
 
 impl Markers {
+    fn suppressing(suppressed: &[usize]) -> Self {
+        Self {
+            suppressed: suppressed.to_vec(),
+            ..Self::default()
+        }
+    }
+
     /// A close unwinds to the innermost open claim on `path`; one whose open
     /// never reached the frame (content Typst laid out elsewhere) is dropped
-    /// rather than popping an unrelated claim.
+    /// rather than popping an unrelated claim. An open still on the stack when
+    /// the walk ends is the mirror case, handled by [`unclosed_claims`]: it
+    /// cannot be detected here, where the rest of the document is still ahead.
+    ///
+    /// `claims` grows on every open, suppressed or not, so an index addresses
+    /// the same call in any walk of one document — including the page prefix
+    /// [`field_at`] walks.
     fn edge(&mut self, path: &str, close: bool) {
         if !close {
             self.claims.push(path.to_string());
-            self.stack.push(self.claims.len() - 1);
+            let claim = self.claims.len() - 1;
+            if !self.suppressed.contains(&claim) {
+                self.stack.push(claim);
+            }
         } else if let Some(i) = self.stack.iter().rposition(|&c| self.claims[c] == path) {
             self.stack.truncate(i);
         }
@@ -220,6 +246,24 @@ impl Markers {
     fn current(&self) -> Option<usize> {
         self.stack.last().copied()
     }
+}
+
+/// The `(claim, field)` of every `field-region` whose open marker reached a
+/// frame but whose close never did, over the whole document. A claim an
+/// enclosing close unwound past counts as closed: its extent was bounded, so
+/// nothing ran away.
+///
+/// Marker-only, so the cost is frame items rather than glyphs.
+pub(crate) fn unclosed_claims(doc: &PagedDocument) -> Vec<(usize, String)> {
+    let mut markers = Markers::default();
+    for page in doc.pages() {
+        scan_markers(&page.frame, &mut markers);
+    }
+    markers
+        .stack
+        .iter()
+        .map(|&c| (c, markers.claims[c].clone()))
+        .collect()
 }
 
 /// `(field, is-close)` if `elem` is one of `field-region`'s markers.
@@ -461,15 +505,17 @@ enum Run {
 
 /// Each span window's **first placement** and each `field-region` call's whole
 /// claim: one [`RenderedRegion`] per page a run touches, PDF bottom-left rects,
-/// sorted (page, field, key order).
+/// sorted (page, field, key order). A claim in `unclosed` accrues nothing and so
+/// surfaces no region.
 pub(crate) fn scan_content_regions(
     doc: &PagedDocument,
     world: &QuillWorld,
     helper: &Source,
     windows: &[FieldWindow],
+    unclosed: &[usize],
 ) -> Vec<RenderedRegion> {
     let mut cls = Classifier::new(world, helper, windows);
-    let mut markers = Markers::default();
+    let mut markers = Markers::suppressing(unclosed);
     let mut hits = Vec::new();
     for (page, p) in doc.pages().iter().enumerate() {
         collect_page_hits(&p.frame, page, &mut cls, &mut markers, &mut hits);
@@ -597,12 +643,16 @@ fn accrue(boxes: &mut Vec<(usize, Aabb)>, hit: &Hit) {
 /// tracked ink the later-painted item wins; untracked ink never occludes.
 ///
 /// Earlier pages are walked for their markers alone, so a `field-region` that
-/// opened on a previous page still claims this page's ink.
+/// opened on a previous page still claims this page's ink. That lookbehind is
+/// also why `unclosed` has to be supplied rather than derived here: whether a
+/// claim open at `page` ever closes is only knowable from the pages after it,
+/// which this walk never reaches.
 pub(crate) fn field_at(
     doc: &PagedDocument,
     world: &QuillWorld,
     helper: &Source,
     windows: &[FieldWindow],
+    unclosed: &[usize],
     page: usize,
     x: f32,
     y: f32,
@@ -612,7 +662,7 @@ pub(crate) fn field_at(
     let (x, y) = (x as f64, page_h - y as f64);
 
     let mut cls = Classifier::new(world, helper, windows);
-    let mut markers = Markers::default();
+    let mut markers = Markers::suppressing(unclosed);
     let mut hits = Vec::new();
     for earlier in doc.pages().iter().take(page) {
         scan_markers(&earlier.frame, &mut markers);
@@ -1047,7 +1097,7 @@ main:
             let helper = world
                 .source(QuillWorld::helper_fid("lib.typ"))
                 .expect("helper source");
-            let regions = scan_content_regions(&doc, &world, &helper, &windows);
+            let regions = scan_content_regions(&doc, &world, &helper, &windows, &[]);
             regions
                 .iter()
                 .filter(|r| r.field == "body")
@@ -1255,7 +1305,8 @@ main:
         let helper = world
             .source(QuillWorld::helper_fid("lib.typ"))
             .expect("helper source");
-        scan_content_regions(&doc, &world, &helper, &windows)
+        let unclosed: Vec<usize> = unclosed_claims(&doc).into_iter().map(|(c, _)| c).collect();
+        scan_content_regions(&doc, &world, &helper, &windows, &unclosed)
     }
 
     fn body(markdown: &str) -> serde_json::Value {
@@ -1368,6 +1419,144 @@ Interleaved plate chrome.
              text: claim {:?} vs body {:?}",
             claim.rect,
             body_box.rect
+        );
+    }
+
+    /// Typst never separates the two markers on its own — every overflow, clip,
+    /// float and marginal case keeps them together — so the reachable way to
+    /// strand an open is a plate emitting the call's return value in parts.
+    const STRANDED_OPEN: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, field-region
+#set page(width: 300pt, height: 200pt, margin: 20pt, header: [PAGE CHROME])
+#let r = field-region("classification")[#box(stroke: 1pt)[X]]
+#r.children.at(0)
+#data.body
+"#;
+
+    #[test]
+    fn an_open_marker_whose_close_never_lands_is_reported_unclosed() {
+        let q = quill(REGION_YAML, STRANDED_OPEN);
+        let plate = crate::read_plate(&q).expect("plate");
+        let schema = quillmark_core::quill::build_transform_schema(q.config());
+        let meta = crate::SchemaMeta::from_schema_json(schema.as_json());
+        let data = body("Body text.");
+        let transformed = crate::transformed_data(&meta, &data).expect("transform");
+        let mut world = QuillWorld::new(&q, &plate).expect("world");
+        world
+            .inject_helper_package(transformed.as_ref(), &meta)
+            .expect("inject");
+        let (doc, _) = compile_document(&world).expect("compile");
+        assert_eq!(
+            unclosed_claims(&doc),
+            vec![(0, "classification".to_string())],
+            "the stranded open is named, so a plate author can act on it"
+        );
+    }
+
+    /// The runaway: a claim left open owns every unattributed hit to the end of
+    /// the document, page chrome included.
+    #[test]
+    fn an_unclosed_claim_surfaces_no_region_at_all() {
+        let long = body(&"A long paragraph of body text. ".repeat(60));
+        let regions = probe_regions(STRANDED_OPEN, long.clone());
+        assert!(
+            regions.iter().any(|r| r.field == "body"),
+            "the fields that do resolve are untouched: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| r.field == "classification"),
+            "the unbounded claim yields nothing rather than every page's chrome: \
+             {:?}",
+            regions
+                .iter()
+                .filter(|r| r.field == "classification")
+                .map(|r| r.page)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// The point query is the symptom users see: chrome on a later page routing
+    /// clicks to whatever field was wrapped somewhere above. It cannot derive
+    /// the suppression set itself, so this guards that it is threaded through.
+    #[test]
+    fn an_unclosed_claim_does_not_capture_clicks_on_later_pages() {
+        let q = quill(REGION_YAML, STRANDED_OPEN);
+        let plate = crate::read_plate(&q).expect("plate");
+        let schema = quillmark_core::quill::build_transform_schema(q.config());
+        let meta = crate::SchemaMeta::from_schema_json(schema.as_json());
+        let data = body(&"A long paragraph of body text. ".repeat(60));
+        let transformed = crate::transformed_data(&meta, &data).expect("transform");
+        let mut world = QuillWorld::new(&q, &plate).expect("world");
+        let windows = world
+            .inject_helper_package(transformed.as_ref(), &meta)
+            .expect("inject");
+        let (doc, _) = compile_document(&world).expect("compile");
+        let helper = world
+            .source(QuillWorld::helper_fid("lib.typ"))
+            .expect("helper source");
+        let unclosed: Vec<usize> = unclosed_claims(&doc).into_iter().map(|(c, _)| c).collect();
+        assert!(doc.pages().len() > 1, "the runaway needs a later page");
+
+        // Aim at ink the unsuppressed claim demonstrably swallows on a page it
+        // has no business reaching, rather than guessing where chrome sits.
+        let last = doc.pages().len() - 1;
+        let runaway = scan_content_regions(&doc, &world, &helper, &windows, &[])
+            .into_iter()
+            .find(|r| r.field == "classification" && r.page == last)
+            .expect("unsuppressed, the claim reaches the last page");
+        let (cx, cy) = (
+            (runaway.rect[0] + runaway.rect[2]) / 2.0,
+            (runaway.rect[1] + runaway.rect[3]) / 2.0,
+        );
+        assert_eq!(
+            field_at(&doc, &world, &helper, &windows, &[], last, cx, cy),
+            Some("classification".to_string()),
+            "sanity: unsuppressed, that ink routes to the stranded claim"
+        );
+        assert_eq!(
+            field_at(&doc, &world, &helper, &windows, &unclosed, last, cx, cy),
+            None,
+            "suppressed, page chrome under a runaway claim answers to no field"
+        );
+    }
+
+    /// Suppression is per claim, not per field name: a second, well-formed call
+    /// on the same field keeps its region.
+    #[test]
+    fn a_balanced_claim_beside_an_unclosed_one_still_surfaces() {
+        const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, field-region
+#set page(width: 300pt, height: 200pt, margin: 20pt)
+#let r = field-region("classification")[#box(stroke: 1pt)[X]]
+#r.children.at(0)
+#field-region("classification")[#box(stroke: 1pt)[OK]]
+"#;
+        let regions = probe_regions(PLATE, body("Body."));
+        assert_eq!(
+            regions
+                .iter()
+                .filter(|r| r.field == "classification")
+                .count(),
+            1,
+            "only the balanced call claims: {regions:?}"
+        );
+    }
+
+    /// A claim an enclosing close unwound past is bounded, so it is not a
+    /// runaway and keeps its region.
+    #[test]
+    fn an_inner_claim_closed_by_its_enclosing_one_is_not_suppressed() {
+        const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data, field-region
+#set page(width: 300pt, height: 200pt, margin: 20pt)
+#let inner = field-region("body")[#box(stroke: 1pt)[I]]
+#field-region("classification")[#inner.children.at(0) #box(stroke: 1pt)[C]]
+#data.body
+"#;
+        let regions = probe_regions(PLATE, body("Text."));
+        assert!(
+            regions.iter().any(|r| r.field == "body"),
+            "the inner claim is bounded by the outer close: {regions:?}"
         );
     }
 

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -252,8 +252,6 @@ impl Markers {
 /// frame but whose close never did, over the whole document. A claim an
 /// enclosing close unwound past counts as closed: its extent was bounded, so
 /// nothing ran away.
-///
-/// Marker-only, so the cost is frame items rather than glyphs.
 pub(crate) fn unclosed_claims(doc: &PagedDocument) -> Vec<(usize, String)> {
     let mut markers = Markers::default();
     for page in doc.pages() {
@@ -643,10 +641,10 @@ fn accrue(boxes: &mut Vec<(usize, Aabb)>, hit: &Hit) {
 /// tracked ink the later-painted item wins; untracked ink never occludes.
 ///
 /// Earlier pages are walked for their markers alone, so a `field-region` that
-/// opened on a previous page still claims this page's ink. That lookbehind is
-/// also why `unclosed` has to be supplied rather than derived here: whether a
-/// claim open at `page` ever closes is only knowable from the pages after it,
-/// which this walk never reaches.
+/// opened on a previous page still claims this page's ink. `unclosed` is
+/// supplied rather than derived here because whether a claim open at `page` ever
+/// closes is knowable only from the pages after it, which this walk never
+/// reaches.
 pub(crate) fn field_at(
     doc: &PagedDocument,
     world: &QuillWorld,
@@ -1422,9 +1420,8 @@ Interleaved plate chrome.
         );
     }
 
-    /// Typst never separates the two markers on its own — every overflow, clip,
-    /// float and marginal case keeps them together — so the reachable way to
-    /// strand an open is a plate emitting the call's return value in parts.
+    /// Typst never separates the two markers on its own, so the way to strand an
+    /// open is a plate emitting the call's return value in parts.
     const STRANDED_OPEN: &str = r#"
 #import "@local/quillmark-helper:0.1.0": data, field-region
 #set page(width: 300pt, height: 200pt, margin: 20pt, header: [PAGE CHROME])
@@ -1453,8 +1450,8 @@ Interleaved plate chrome.
         );
     }
 
-    /// The runaway: a claim left open owns every unattributed hit to the end of
-    /// the document, page chrome included.
+    /// A claim left open would own every unattributed hit to the end of the
+    /// document, page chrome included.
     #[test]
     fn an_unclosed_claim_surfaces_no_region_at_all() {
         let long = body(&"A long paragraph of body text. ".repeat(60));
@@ -1475,9 +1472,8 @@ Interleaved plate chrome.
         );
     }
 
-    /// The point query is the symptom users see: chrome on a later page routing
-    /// clicks to whatever field was wrapped somewhere above. It cannot derive
-    /// the suppression set itself, so this guards that it is threaded through.
+    /// The point query cannot derive the suppression set itself, so this guards
+    /// that it is threaded through.
     #[test]
     fn an_unclosed_claim_does_not_capture_clicks_on_later_pages() {
         let q = quill(REGION_YAML, STRANDED_OPEN);
@@ -1497,8 +1493,6 @@ Interleaved plate chrome.
         let unclosed: Vec<usize> = unclosed_claims(&doc).into_iter().map(|(c, _)| c).collect();
         assert!(doc.pages().len() > 1, "the runaway needs a later page");
 
-        // Aim at ink the unsuppressed claim demonstrably swallows on a page it
-        // has no business reaching, rather than guessing where chrome sits.
         let last = doc.pages().len() - 1;
         let runaway = scan_content_regions(&doc, &world, &helper, &windows, &[])
             .into_iter()
@@ -1542,8 +1536,6 @@ Interleaved plate chrome.
         );
     }
 
-    /// A claim an enclosing close unwound past is bounded, so it is not a
-    /// runaway and keeps its region.
     #[test]
     fn an_inner_claim_closed_by_its_enclosing_one_is_not_suppressed() {
         const PLATE: &str = r#"

--- a/crates/backends/typst/tests/field_region.rs
+++ b/crates/backends/typst/tests/field_region.rs
@@ -77,9 +77,8 @@ fn a_claim_does_not_displace_a_nested_scalar_site() {
     }
 }
 
-/// Silence is the worst outcome for a runaway claim: the plate author is the
-/// only one who can fix it, and the symptom (chrome routing clicks to a field)
-/// does not point at its cause.
+/// The symptom — chrome routing clicks to a field — does not point at its
+/// cause, and only the plate author can fix it.
 #[test]
 fn an_unclosed_claim_warns_and_claims_nothing() {
     let plate = r#"

--- a/crates/backends/typst/tests/field_region.rs
+++ b/crates/backends/typst/tests/field_region.rs
@@ -77,6 +77,41 @@ fn a_claim_does_not_displace_a_nested_scalar_site() {
     }
 }
 
+/// Silence is the worst outcome for a runaway claim: the plate author is the
+/// only one who can fix it, and the symptom (chrome routing clicks to a field)
+/// does not point at its cause.
+#[test]
+fn an_unclosed_claim_warns_and_claims_nothing() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data, field-region
+#set page(width: 300pt, height: 200pt, margin: 20pt, header: [PAGE CHROME])
+#let r = field-region("classification")[#box(stroke: 1pt)[X]]
+#r.children.at(0)
+#lorem(300)
+"#;
+    let session = open(plate);
+    assert!(
+        session.page_count() > 1,
+        "the runaway needs a page after the stranded open"
+    );
+
+    let warning = session
+        .warnings()
+        .iter()
+        .find(|d| d.code.as_deref() == Some("typst::unclosed_field_region"))
+        .expect("the unclosed claim is reported");
+    assert!(
+        warning.message.contains("classification"),
+        "the warning names the field the author must fix: {}",
+        warning.message
+    );
+
+    assert!(
+        !session.regions().iter().any(|r| r.field == "classification"),
+        "and the claim surfaces nothing rather than every page's chrome"
+    );
+}
+
 #[test]
 fn an_unknown_field_address_fails_the_compile() {
     let plate = r#"

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -326,6 +326,7 @@ That is the way to give a card's *scalar* fields regions: read from the loop var
 
 - A `field` that is not a known schema address, or is not a string, raises a Typst assert pointing at `field-region`.
 - A claim whose content Typst lays out somewhere else entirely (`#place`, a float) claims whatever ink lands between its markers instead; wrap the placed content rather than the `place` call.
+- Emit the call's return value whole. Splitting it — passing `.children` through separately, say — can land the opening marker in a frame without its closing one, and a claim with no end would otherwise take every unattributed piece of ink to the end of the document. Such a claim is dropped entirely and reported as a `typst::unclosed_field_region` warning naming the field.
 
 The label `<__qm_region__>` and metadata `kind: "__qm_region__"` are reserved for this hand-off: the same `query(metadata)` caveat applies.
 

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -326,7 +326,7 @@ That is the way to give a card's *scalar* fields regions: read from the loop var
 
 - A `field` that is not a known schema address, or is not a string, raises a Typst assert pointing at `field-region`.
 - A claim whose content Typst lays out somewhere else entirely (`#place`, a float) claims whatever ink lands between its markers instead; wrap the placed content rather than the `place` call.
-- Emit the call's return value whole. Splitting it — passing `.children` through separately, say — can land the opening marker in a frame without its closing one, and a claim with no end would otherwise take every unattributed piece of ink to the end of the document. Such a claim is dropped entirely and reported as a `typst::unclosed_field_region` warning naming the field.
+- Emit the call's return value whole. Splitting it — passing `.children` through separately, say — can land the opening marker in a frame without its closing one. Such a claim is bounded by nothing, so rather than let it take every unattributed piece of ink to the end of the document it is dropped entirely and reported as a `typst::unclosed_field_region` warning naming the field.
 
 The label `<__qm_region__>` and metadata `kind: "__qm_region__"` are reserved for this hand-off: the same `query(metadata)` caveat applies.
 

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -201,10 +201,10 @@ region. Each *call* claims separately,
 so a wrapper invoked once per card with a `$path`-composed address is one
 region per card. Ink attributable to no source position at all (list bullets,
 underline rules) stays unclaimed here as everywhere. The marker stack persists
-across pages so a claim can span a page break, so a claim whose close marker
-never reaches a frame would run to the end of the document: those are found
-before the scan, suppressed in both the region and point queries, and reported
-as a `typst::unclosed_field_region` warning naming the field.
+across pages so a claim can span a page break, which leaves a claim whose close
+marker never reaches a frame bounded by nothing: those are found before the
+scan, suppressed in both the region and point queries, and reported as a
+`typst::unclosed_field_region` warning naming the field.
 **Form-field widgets** carry the path explicitly
 (pdfform from the form mapping, a Typst `form-field` from its `field:`
 argument, validated against schema address tables baked into the generated

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -200,7 +200,11 @@ claim, not an override: content blocks, scalar sites, and nested
 region. Each *call* claims separately,
 so a wrapper invoked once per card with a `$path`-composed address is one
 region per card. Ink attributable to no source position at all (list bullets,
-underline rules) stays unclaimed here as everywhere.
+underline rules) stays unclaimed here as everywhere. The marker stack persists
+across pages so a claim can span a page break, so a claim whose close marker
+never reaches a frame would run to the end of the document: those are found
+before the scan, suppressed in both the region and point queries, and reported
+as a `typst::unclosed_field_region` warning naming the field.
 **Form-field widgets** carry the path explicitly
 (pdfform from the form mapping, a Typst `form-field` from its `field:`
 argument, validated against schema address tables baked into the generated


### PR DESCRIPTION
Closes #1278.

## The defect

The marker stack persists across pages so a claim can span a page break. That leaves an open marker whose close never reaches a frame bounded by nothing: it takes every unattributed hit to the end of the document — page chrome included — and silently, so the symptom is unrelated chrome routing clicks to whatever field was wrapped somewhere above.

`Markers::edge` handled the mirror case carefully (a close whose open never landed is dropped rather than popping an unrelated claim) and had no counterpart for this one, because at the point of the walk where an open arrives the rest of the document is still ahead. Three things compounded the blast radius: a `Key::Marker` run never goes `Done`, so the one mechanism that bounds a span-window run doesn't apply; the claim is a *fallback*, so its appetite is exactly "all ink no field owns"; and `field_at`'s marker lookbehind faithfully reconstructs it on every point query.

## The fix

`unclosed_claims(doc)` names them in one marker-only pass over the finished document. A claim an enclosing close unwound past counts as closed — its extent was bounded, so nothing ran away.

Both queries then suppress them. A suppressed open never enters `Markers::stack`, so its ink stays `Foreign` exactly as if the plate had emitted no marker at all, and the runaway yields nothing rather than everything. Suppressing at the stack rather than filtering at region-emit time matters: the latter would leave the runaway still contaminating the run scan as `current`, suspending other fields' runs.

The set is computed with the compile rather than per query because **`field_at` cannot derive it** — whether a claim open at its page ever closes is only knowable from the pages *after* it, which its lookbehind never reaches. One precomputed set can serve both entry points because claim indices are assigned in walk order and `claims` grows on every open, suppressed or not, so index N addresses the same call in the full walk and in `field_at`'s page prefix alike.

Each dropped claim also raises a `typst::unclosed_field_region` warning naming the field, since only the plate author can act on it and silence is the worst outcome here.

## On reachability, which changed the tests rather than the fix

The issue proposed that overflowed or clipped content could lose the trailing tag while keeping the leading one. It can't. Compiling 17 plates through the real backend and counting `__qm_region__` tags in the final frames, every one balanced — clipped fixed-height blocks, zero-height clipped boxes, overflow with and without `clip`, `hide`, `place` off-page, `place(float: true)`, footnote bodies, fixed-height table cells, unbreakable blocks that don't fit, `columns`, rotate/scale groups, header marginals, `context`/`state` re-layout, and `#show <__qm_region__>: none`. Typst's `clip` is a group property; the tags are still there, and tags aren't content elements subject to show rules.

So the regression test the issue suggested ("compile a plate whose `field-region` body overflows the page") would have passed against the unfixed code. What does strand an open is a plate emitting the call's return value in parts — `#r.children.at(0)` — which is what the tests use. Measured on a 4-page document before the fix: the claim covered pages `[0,1,2,3]` and `field_at` returned `classification` for header chrome on every one; the balanced control covered page `[0]` only.

This makes the change a robustness fix rather than a user-facing preview bug, and the warning half correspondingly more valuable: if the only way in is a plate doing something unusual with the return value, a diagnostic naming the field is exactly what tells that author they've broken the contract.

## Tests

Five new, each verified to go red with the suppression disabled or to pin a property the fix could plausibly break:

- `an_open_marker_whose_close_never_lands_is_reported_unclosed` — the detector names the field.
- `an_unclosed_claim_surfaces_no_region_at_all` — the runaway claims nothing; fields that do resolve are untouched.
- `an_unclosed_claim_does_not_capture_clicks_on_later_pages` — the point query, aimed at ink derived from the unsuppressed claim's own geometry rather than a guessed coordinate, with a sanity assertion that the unsuppressed path *does* route that ink to the stranded claim so the test can't degrade into asserting `None == None`.
- `a_balanced_claim_beside_an_unclosed_one_still_surfaces` — suppression is per claim, not per field name. This is the case that would break if index stability didn't hold.
- `an_inner_claim_closed_by_its_enclosing_one_is_not_suppressed` — a bounded claim is not a runaway.
- Acceptance: `an_unclosed_claim_warns_and_claims_nothing` through the public `Backend`/`LiveSession` path.

`cargo test --workspace` is green: 57 test binaries, zero failures. One new clippy warning (`field_at` at 8 args), left alone — `ci.yml` documents a deliberate decision not to gate on clippy.

## Docs

Changelog folded into the existing `field-region` entry rather than added as a `fix:` — that feature is still unreleased (last tag 0.105.0), so this bug never shipped. `prose/canon/PREVIEW.md` carries the invariant; `docs/quills/typst-backend.md` states the "emit the return value whole" contract next to the existing `#place` caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3gLKyNGKHffhSizAx8Rfg)_