### PR TITLE
feat(typst,pdfform): address one property step into a declared container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- feat(typst,pdfform): a schema address may step one property into a declared
+  container, so `form-field(field: "classification.poc")` and
+  `field-region("address.city")` name a cell rather than the container holding
+  it. Two generated address tables gate the step the way `array_fields` gates
+  the index step, and a typed dictionary and a variant container reach both
+  alike: `classification.value` addresses the discriminant, `classification.poc`
+  a variant cell in any world. The pdfform binder descends a variant container
+  to match, so one address binds on either backend where `address.city` bound
+  only on pdfform and asserted on Typst. **Region addresses shift** for a plate
+  that reads a container property directly: `#data.classification.poc` regions
+  as `classification.poc` where it regioned as `classification`, and `fieldAt`
+  answers the same. A container read whole is unchanged, as is a read of a key
+  the container does not declare.
 - feat(core,wasm)!: an `enum` may declare `variants:`, a per-member field set
   that exists only in the world where the discriminant holds that member. This
   is the DSL's first cross-field shape, and it replaces the `cui_`-prefix

--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -3,7 +3,9 @@
 //! layer. Pure in the quill, so it runs once at open: a widget bound to a
 //! nonexistent field or an out-of-range page is a load error, not a silent blank.
 
-use quillmark_core::quill::{FieldSchema, FieldType as SchemaType, QuillConfig};
+use quillmark_core::quill::{
+    FieldSchema, FieldType as SchemaType, QuillConfig, VARIANT_DISCRIMINANT_KEY,
+};
 use quillmark_pdf::FieldType as WidgetType;
 
 use crate::form::{BoundField, FormSpec, Rect, UnboundWidget, WidgetKind};
@@ -168,6 +170,13 @@ fn flip_rect(r: Rect, media_box: [f32; 4]) -> [f32; 4] {
 /// index, selected at value time. Absolute-index addressing (`$cards.<i>.…`) is
 /// rejected — the widget kind must be statically derivable, and only kind+index
 /// identifies the schema field.
+///
+/// A variant container is addressed through its resting shape rather than as a
+/// whole: `classification.value` is the discriminant and `classification.<cell>`
+/// a variant field, active world or not, since a form binds against the schema
+/// once and the document selects its world later. The container itself resolves
+/// but binds nothing — its value is the container object, which no widget
+/// coerces — so a plate wanting the level binds `.value`.
 pub fn bind<'a>(
     config: &'a QuillConfig,
     name: &str,
@@ -197,7 +206,17 @@ pub fn bind<'a>(
         config.main.fields.get(root).ok_or_else(|| dangling(root))?
     };
 
+    // The discriminant is the container's own enum, so the step selects a value
+    // rather than a child schema and nothing may follow it.
+    let mut at_discriminant = false;
     for seg in parts {
+        if at_discriminant {
+            return Err(dangling(seg));
+        }
+        if cur.is_variant_bearing() && seg == VARIANT_DISCRIMINANT_KEY {
+            at_discriminant = true;
+            continue;
+        }
         cur = descend(cur, seg).ok_or_else(|| dangling(seg))?;
     }
     Ok(cur)
@@ -211,7 +230,15 @@ fn descend<'a>(cur: &'a FieldSchema, seg: &str) -> Option<&'a FieldSchema> {
         },
         Err(_) => match cur.r#type {
             SchemaType::Object => cur.properties.as_ref()?.get(seg).map(Box::as_ref),
-            _ => None,
+            // A name several worlds declare is one cell
+            // (`quill::variant_field_collision`), so the first match is the
+            // declaration.
+            _ => cur
+                .variants
+                .as_ref()?
+                .values()
+                .find_map(|set| set.get(seg))
+                .map(Box::as_ref),
         },
     }
 }
@@ -352,6 +379,14 @@ main:
         type: object
         properties:
           org: { type: string }
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      default: ""
+      variants:
+        CUI:
+          poc: { type: string }
+          urgent: { type: boolean }
 card_kinds:
   indorsement:
     fields:
@@ -414,6 +449,25 @@ card_kinds:
         assert_eq!(kind("address.street").unwrap(), WidgetType::Text { multiline: false });
     }
 
+    /// A variant container is bound through its resting shape: the discriminant
+    /// under `value`, each world's cells beside it. Binding is against the
+    /// *schema*, so a cell binds whether or not today's document selects its
+    /// world — the form is built once and the document picks a world later.
+    #[test]
+    fn variant_container_binds_through_its_resting_shape() {
+        assert_eq!(
+            kind("classification.value").unwrap(),
+            WidgetType::Choice {
+                options: vec!["".into(), "UNCLASSIFIED".into(), "CUI".into()]
+            }
+        );
+        assert_eq!(
+            kind("classification.poc").unwrap(),
+            WidgetType::Text { multiline: false }
+        );
+        assert_eq!(kind("classification.urgent").unwrap(), WidgetType::Checkbox);
+    }
+
     #[test]
     fn object_and_object_array_are_unbindable() {
         // `array<array>` never reaches `bind`: the schema loader rejects it
@@ -436,6 +490,9 @@ card_kinds:
             ("full_name.0", "0"),
             ("address.zip", "zip"),
             ("comments.oops", "oops"),
+            ("classification.nosuch", "nosuch"),
+            // The discriminant is a value, not a schema to descend further.
+            ("classification.value.oops", "oops"),
         ] {
             let c = config();
             match bind(&c, "W", path) {

--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -273,10 +273,10 @@ impl<'m> Codegen<'m> {
         kind: &str,
         prefix: &str,
     ) -> String {
-        let content = card_names(&self.meta.card_content_fields, kind);
-        let dates = card_names(&self.meta.card_date_fields, kind);
-        let datetimes = card_names(&self.meta.card_datetime_fields, kind);
-        let inlines = card_names(&self.meta.card_inline_fields, kind);
+        let content = names_at(&self.meta.card_content_fields, kind);
+        let dates = names_at(&self.meta.card_date_fields, kind);
+        let datetimes = names_at(&self.meta.card_datetime_fields, kind);
+        let inlines = names_at(&self.meta.card_inline_fields, kind);
         let mut items = Vec::with_capacity(obj.len() + 1);
         // The canonical address prefix, so plates compose schema-field addresses
         // without reimplementing the kind+ordinal grammar.
@@ -359,7 +359,7 @@ enum DateKind {
     DateTime,
 }
 
-pub(crate) fn card_names(
+pub(crate) fn names_at(
     table: &serde_json::Map<String, serde_json::Value>,
     kind: &str,
 ) -> Vec<String> {
@@ -382,6 +382,8 @@ fn meta_literal(meta: &SchemaMeta) -> String {
         "card_fields": meta.card_field_names,
         "array_fields": meta.array_fields,
         "card_array_fields": meta.card_array_fields,
+        "object_fields": meta.object_fields,
+        "card_object_fields": meta.card_object_fields,
     });
     lit(&tables)
 }
@@ -783,6 +785,54 @@ mod tests {
         assert!(lib.contains("\"fields\": ("));
         assert!(lib.contains("\"subject\""));
         assert!(lib.contains("\"array_fields\": (\"refs\",)"));
+    }
+
+    /// A typed dictionary and a variant container reach the same table: both
+    /// project as `type: object` carrying `properties`, the container's `value`
+    /// discriminant among them. A richtext field is `type: object` too and must
+    /// stay out of it, offering no property step.
+    #[test]
+    fn object_fields_table_carries_every_declared_container() {
+        let meta = meta_from(serde_json::json!({
+            "properties": {
+                "subject": { "type": "string" },
+                "body": richtext_field(),
+                "address": { "type": "object", "properties": {
+                    "city": { "type": "string" },
+                }},
+                "classification": { "type": "object", "properties": {
+                    "value": { "type": "string", "enum": ["", "CUI"] },
+                    "poc": { "type": "string", "quillmark:variant_of": "CUI" },
+                }},
+            },
+            "$defs": { "note_card": { "properties": {
+                "origin": { "type": "object", "properties": { "office": { "type": "string" } } },
+            }}}
+        }));
+        assert_eq!(
+            meta.object_fields,
+            serde_json::json!({
+                "address": ["city"],
+                "classification": ["value", "poc"],
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        );
+        assert_eq!(
+            meta.card_object_fields,
+            serde_json::json!({ "note": { "origin": ["office"] } })
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+
+        let (lib, _) = generate_lib_typ(&serde_json::json!({}), &meta).unwrap();
+        assert!(lib.contains("\"object_fields\": ("), "{lib}");
+        assert!(
+            lib.contains("\"card_object_fields\": (\"note\": (\"origin\": (\"office\",),),)"),
+            "{lib}"
+        );
     }
 
     /// Slots are located in the raw template only.

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -229,8 +229,8 @@ fn validate_date_fields(
                 continue;
             };
             let prefix = format!("$cards.{kind}.");
-            let dates = helper::card_names(&meta.card_date_fields, kind);
-            let datetimes = helper::card_names(&meta.card_datetime_fields, kind);
+            let dates = helper::names_at(&meta.card_date_fields, kind);
+            let datetimes = helper::names_at(&meta.card_datetime_fields, kind);
             check(&dates, card_obj, &prefix, false)?;
             check(&datetimes, card_obj, &prefix, true)?;
         }
@@ -461,7 +461,7 @@ impl Backend for TypstBackend {
                 .source(main_id)
                 .ok()
                 .map(|src| {
-                    overlay::scalar_windows(&src, &schema_meta.fields)
+                    overlay::scalar_windows(&src, &schema_meta.fields, &schema_meta.object_fields)
                         .into_iter()
                         .map(|(path, range)| overlay::FieldWindow {
                             path,
@@ -632,6 +632,28 @@ fn array_field_names(properties: &serde_json::Map<String, serde_json::Value>) ->
     })
 }
 
+/// The fields addressable by one property step (`address.city`,
+/// `classification.poc`), each mapped to the property names it declares. The
+/// index step's twin: `array_fields` gates `field.0`, this gates `field.sub`.
+///
+/// A typed dictionary and a variant container both project as `type: object`
+/// carrying `properties` — the container's own `value` among them — so one
+/// predicate spans both. A richtext field is `type: object` too but declares no
+/// `properties`, so it contributes no step.
+fn object_field_names(
+    properties: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    properties
+        .iter()
+        .filter(|(_, fs)| fs.get("type").and_then(|v| v.as_str()) == Some("object"))
+        .filter_map(|(name, fs)| {
+            let props = fs.get("properties")?.as_object()?;
+            let names: Vec<String> = props.keys().cloned().collect();
+            (!names.is_empty()).then(|| (name.clone(), names.into()))
+        })
+        .collect()
+}
+
 /// Schema-derived tables backing `form-field` path validation and the helper's
 /// content/date classification. A schema with no top-level `properties` yields
 /// all-empty tables: `build_transform_schema` always emits `properties`, so
@@ -642,6 +664,8 @@ pub(crate) struct SchemaMeta {
     pub(crate) date_fields: Vec<String>,
     pub(crate) datetime_fields: Vec<String>,
     pub(crate) array_fields: Vec<String>,
+    /// Container field → its property names, gating the `field.sub` step.
+    pub(crate) object_fields: serde_json::Map<String, serde_json::Value>,
     /// A subset of `content_fields`, driving the pure-inline lowering.
     pub(crate) inline_fields: Vec<String>,
     pub(crate) card_content_fields: serde_json::Map<String, serde_json::Value>,
@@ -649,6 +673,8 @@ pub(crate) struct SchemaMeta {
     pub(crate) card_datetime_fields: serde_json::Map<String, serde_json::Value>,
     pub(crate) card_field_names: serde_json::Map<String, serde_json::Value>,
     pub(crate) card_array_fields: serde_json::Map<String, serde_json::Value>,
+    /// The card twin of `object_fields`, keyed kind → field → property names.
+    pub(crate) card_object_fields: serde_json::Map<String, serde_json::Value>,
     pub(crate) card_inline_fields: serde_json::Map<String, serde_json::Value>,
     pub(crate) fields: Vec<String>,
 }
@@ -663,6 +689,7 @@ impl SchemaMeta {
         let date_fields = date_field_names(properties_obj);
         let datetime_fields = datetime_field_names(properties_obj);
         let array_fields = array_field_names(properties_obj);
+        let object_fields = object_field_names(properties_obj);
         let inline_fields = inline_field_names(properties_obj);
         let fields = properties_obj.keys().cloned().collect();
 
@@ -671,6 +698,7 @@ impl SchemaMeta {
         let mut card_datetime_fields = serde_json::Map::new();
         let mut card_field_names = serde_json::Map::new();
         let mut card_array_fields = serde_json::Map::new();
+        let mut card_object_fields = serde_json::Map::new();
         let mut card_inline_fields = serde_json::Map::new();
         fn insert_names(
             table: &mut serde_json::Map<String, serde_json::Value>,
@@ -711,6 +739,10 @@ impl SchemaMeta {
                         card_kind,
                         card_props.map(array_field_names).unwrap_or_default(),
                     );
+                    let objects = card_props.map(object_field_names).unwrap_or_default();
+                    if !objects.is_empty() {
+                        card_object_fields.insert(card_kind.to_string(), objects.into());
+                    }
                     insert_names(
                         &mut card_inline_fields,
                         card_kind,
@@ -725,12 +757,14 @@ impl SchemaMeta {
             date_fields,
             datetime_fields,
             array_fields,
+            object_fields,
             inline_fields,
             card_content_fields,
             card_date_fields,
             card_datetime_fields,
             card_field_names,
             card_array_fields,
+            card_object_fields,
             card_inline_fields,
             fields,
         }

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -11,26 +11,34 @@
 // `plaintext` (a content field's string projection, reading `_qm-plaintext`).
 
 /// Backend-generated schema address tables (`fields`, `card_fields`,
-/// `array_fields`, `card_array_fields`) that validate `form-field` paths.
-/// A generated literal: never parsed from document data.
+/// `array_fields`, `card_array_fields`, `object_fields`, `card_object_fields`)
+/// that validate `form-field` paths. A generated literal: never parsed from
+/// document data.
 #let _qm-meta = {meta_literal}
 
 /// Whether `path` parses against the schema address tables: a top-level field
-/// (`subject`), an array element (`refs.2`), or a card address
-/// (`$cards.<kind>.<n>.<field>`, optional `.<i>` element suffix). An indexed
-/// suffix (`field.N`) is only a real address for an array-typed field (any
-/// array, matching the pdfform resolver's grammar) so it validates against
-/// `array_fields`/`card_array_fields`, not the broader `fields`/`card_fields`
-/// name tables, rejecting `subject.0` on a scalar `subject` even though the
-/// name itself is known: a scalar has no element for the address to resolve
-/// to. Distinct from present-with-empty tables (e.g. a body-disabled main with
-/// no other fields and no cards), which validates against the empty set and so
-/// rejects every address.
+/// (`subject`), an array element (`refs.2`), a container property
+/// (`classification.poc`), or a card address (`$cards.<kind>.<n>.<field>`, with
+/// either suffix). A one-step suffix is gated on the step the field actually
+/// offers, not on the broader `fields`/`card_fields` name tables:
+/// `array_fields`/`card_array_fields` admit the index step, and
+/// `object_fields`/`card_object_fields` the property step, so `subject.0` and
+/// `subject.poc` are both rejected on a scalar `subject` even though the name
+/// itself is known — a scalar has neither an element nor a property for the
+/// address to resolve to. A container's properties are those its schema
+/// declares, so a variant container admits its `value` discriminant and every
+/// world's cells, and a typed dictionary its own keys. This is the pdfform
+/// resolver's grammar (`bind.rs`), so one schema address binds on either
+/// backend. Distinct from present-with-empty tables (e.g. a body-disabled main
+/// with no other fields and no cards), which validates against the empty set
+/// and so rejects every address.
 #let _qm-known-path(path) = {
   let fields = _qm-meta.at("fields", default: ())
   let card-fields = _qm-meta.at("card_fields", default: (:))
   let array-fields = _qm-meta.at("array_fields", default: ())
   let card-array-fields = _qm-meta.at("card_array_fields", default: (:))
+  let object-fields = _qm-meta.at("object_fields", default: (:))
+  let card-object-fields = _qm-meta.at("card_object_fields", default: (:))
   let is-index(s) = s.match(regex("^[0-9]+$")) != none
   let parts = path.split(".")
   if parts.at(0) == "$cards" {
@@ -40,12 +48,18 @@
     if not is-index(parts.at(2)) { return false }
     let field = parts.at(3)
     if parts.len() == 5 {
-      return field in card-array-fields.at(kind, default: ()) and is-index(parts.at(4))
+      let step = parts.at(4)
+      if field in card-array-fields.at(kind, default: ()) and is-index(step) { return true }
+      return step in card-object-fields.at(kind, default: (:)).at(field, default: ())
     }
     return field in card-fields.at(kind)
   }
   if parts.len() == 1 { return path in fields }
-  if parts.len() == 2 { return parts.at(0) in array-fields and is-index(parts.at(1)) }
+  if parts.len() == 2 {
+    let (field, step) = (parts.at(0), parts.at(1))
+    if field in array-fields and is-index(step) { return true }
+    return step in object-fields.at(field, default: ())
+  }
   false
 }
 
@@ -114,7 +128,7 @@
   assert(field == none or std.type(field) == str,
     message: "form-field: field must be a string or none, got " + repr(std.type(field)))
   assert(field == none or _qm-known-path(field),
-    message: "form-field: " + repr(field) + " is not a schema field address; expected a field name, an array element like \"refs.2\", or a card path composed from the card's $path prefix")
+    message: "form-field: " + repr(field) + " is not a schema field address; expected a field name, an array element like \"refs.2\", a container property like \"classification.poc\", or a card path composed from the card's $path prefix")
   assert(font in ("helvetica", "times", "courier"),
     message: "form-field: font must be one of helvetica/times/courier, got " + repr(font))
   assert(align in ("left", "center", "right"),
@@ -187,7 +201,7 @@
   assert(std.type(field) == str,
     message: "field-region: field must be a string, got " + repr(std.type(field)))
   assert(_qm-known-path(field),
-    message: "field-region: " + repr(field) + " is not a schema field address; expected a field name, an array element like \"refs.2\", or a card path composed from the card's $path prefix")
+    message: "field-region: " + repr(field) + " is not a schema field address; expected a field name, an array element like \"refs.2\", a container property like \"classification.poc\", or a card path composed from the card's $path prefix")
   [#metadata((kind: "__qm_region__", field: field, close: false)) <__qm_region__>]
   body
   [#metadata((kind: "__qm_region__", field: field, close: true)) <__qm_region__>]

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -819,9 +819,24 @@ fn forward_pos(helper: &Source, segmap: &SegmentMap, pos: usize) -> usize {
 /// Chain windows sort first, so ink resolving to the reference itself is never
 /// claimed by a wider window. A value laundered through `#let s = data.x` is not
 /// chased: it carries the binding's span.
-pub(crate) fn scalar_windows(source: &Source, fields: &[String]) -> Vec<(String, Range<usize>)> {
+///
+/// A reference that steps into a declared container (`data.classification.poc`)
+/// anchors on the property, so the region carries the address the plate actually
+/// read rather than the container's. `containers` is the `object_fields` table
+/// [`_qm-known-path`] validates against, so a region path is one a
+/// `form-field`/`field-region` could bind.
+pub(crate) fn scalar_windows(
+    source: &Source,
+    fields: &[String],
+    containers: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<(String, Range<usize>)> {
     let mut anchors: Vec<(String, Range<usize>, Range<usize>)> = Vec::new();
-    collect_anchors(&LinkedNode::new(source.root()), fields, &mut anchors);
+    collect_anchors(
+        &LinkedNode::new(source.root()),
+        fields,
+        containers,
+        &mut anchors,
+    );
 
     let mut out: Vec<(String, Range<usize>)> = anchors
         .iter()
@@ -847,9 +862,10 @@ pub(crate) fn scalar_windows(source: &Source, fields: &[String]) -> Vec<(String,
 fn collect_anchors(
     node: &LinkedNode,
     fields: &[String],
+    containers: &serde_json::Map<String, serde_json::Value>,
     out: &mut Vec<(String, Range<usize>, Range<usize>)>,
 ) {
-    if let Some((path, anchor)) = data_access(node, fields) {
+    if let Some((path, anchor)) = data_access(node, fields, containers) {
         // Chain: the outermost postfix chain headed by this access.
         let mut chain = anchor.clone();
         while let Some(parent) = chain.parent() {
@@ -877,13 +893,19 @@ fn collect_anchors(
         out.push((path, chain.range(), wide.range()));
     }
     for child in node.children() {
-        collect_anchors(&child, fields, out);
+        collect_anchors(&child, fields, containers, out);
     }
 }
 
 /// If `node` is a `data.<field>` access or a `data.at("<field>")` call head
-/// with a declared field, its schema path and the node to widen from.
-fn data_access<'a>(node: &LinkedNode<'a>, fields: &[String]) -> Option<(String, LinkedNode<'a>)> {
+/// with a declared field, its schema path and the node to widen from — stepped
+/// one property deeper where the field is a container and the plate selected
+/// one of its declared keys.
+fn data_access<'a>(
+    node: &LinkedNode<'a>,
+    fields: &[String],
+    containers: &serde_json::Map<String, serde_json::Value>,
+) -> Option<(String, LinkedNode<'a>)> {
     if node.kind() != SyntaxKind::FieldAccess {
         return None;
     }
@@ -895,29 +917,64 @@ fn data_access<'a>(node: &LinkedNode<'a>, fields: &[String]) -> Option<(String, 
         return None;
     }
     let field = access.field();
-    if fields.iter().any(|f| f == field.as_str()) {
-        return Some((field.as_str().to_string(), node.clone()));
+    let (name, anchor) = if fields.iter().any(|f| f == field.as_str()) {
+        (field.as_str().to_string(), node.clone())
+    } else if field.as_str() == "at" {
+        select_by_at(node, fields)?
+    } else {
+        return None;
+    };
+    let keys = crate::helper::names_at(containers, &name);
+    match select_property(&anchor, &keys) {
+        Some((key, deeper)) => Some((format!("{name}.{key}"), deeper)),
+        None => Some((name, anchor)),
     }
-    // `data.at("field")`: the parent call carries the field name as its first
-    // positional string argument.
+}
+
+/// The declared key `node`'s parent selects off it — `.<key>` or
+/// `.at("<key>")` — and the node that selection widens to.
+fn select_property<'a>(
+    node: &LinkedNode<'a>,
+    keys: &[String],
+) -> Option<(String, LinkedNode<'a>)> {
+    if keys.is_empty() {
+        return None;
+    }
+    let parent = node.parent()?;
+    let access = parent.cast::<ast::FieldAccess>()?;
+    if access.target().to_untyped() != node.get() {
+        return None;
+    }
+    let field = access.field();
+    if keys.iter().any(|k| k == field.as_str()) {
+        return Some((field.as_str().to_string(), parent.clone()));
+    }
     if field.as_str() == "at" {
-        let parent = node.parent()?;
-        let call = parent.cast::<ast::FuncCall>()?;
-        let ast::Expr::FieldAccess(callee) = call.callee() else {
-            return None;
-        };
-        if callee.to_untyped() != node.get() {
-            return None;
-        }
-        let first = call.args().items().find_map(|arg| match arg {
-            ast::Arg::Pos(ast::Expr::Str(s)) => Some(s.get().to_string()),
-            _ => None,
-        })?;
-        if fields.contains(&first) {
-            return Some((first, parent.clone()));
-        }
+        return select_by_at(parent, keys);
     }
     None
+}
+
+/// The `.at("<key>")` spelling: `access` is the `<expr>.at` field access, and
+/// its parent call carries the key as its first positional string argument.
+/// Reaches the keys an identifier cannot spell.
+fn select_by_at<'a>(
+    access: &LinkedNode<'a>,
+    keys: &[String],
+) -> Option<(String, LinkedNode<'a>)> {
+    let parent = access.parent()?;
+    let call = parent.cast::<ast::FuncCall>()?;
+    let ast::Expr::FieldAccess(callee) = call.callee() else {
+        return None;
+    };
+    if callee.to_untyped() != access.get() {
+        return None;
+    }
+    let first = call.args().items().find_map(|arg| match arg {
+        ast::Arg::Pos(ast::Expr::Str(s)) => Some(s.get().to_string()),
+        _ => None,
+    })?;
+    keys.contains(&first).then(|| (first, parent.clone()))
 }
 
 #[cfg(test)]
@@ -1070,6 +1127,25 @@ main:
         }
     }
 
+    /// `(path, source text)` per window, over the fields and the one container
+    /// the tests below address.
+    fn probe_spans(src: &Source) -> Vec<(String, String)> {
+        let fields = ["subject", "refs", "other", "classification"].map(str::to_string);
+        let mut containers = serde_json::Map::new();
+        containers.insert(
+            "classification".to_string(),
+            serde_json::json!(["value", "poc", "controlled by"]),
+        );
+        scalar_windows(src, &fields, &containers)
+            .into_iter()
+            .map(|(path, r)| (path, src.text()[r].to_string()))
+            .collect()
+    }
+
+    fn has(spans: &[(String, String)], path: &str, text: &str) -> bool {
+        spans.iter().any(|(p, t)| p == path && t == text)
+    }
+
     #[test]
     fn scalar_windows_track_chains_and_single_owner_enclosing_expressions() {
         let src = Source::detached(
@@ -1083,25 +1159,15 @@ main:
 #let s = data.other
 "#,
         );
-        let fields = vec![
-            "subject".to_string(),
-            "refs".to_string(),
-            "other".to_string(),
-        ];
-        let wins = scalar_windows(&src, &fields);
-        let text = src.text();
-        let spans: Vec<(&str, &str)> = wins
-            .iter()
-            .map(|(p, r)| (p.as_str(), &text[r.clone()]))
-            .collect();
-        for expected in [
+        let spans = probe_spans(&src);
+        for (path, text) in [
             ("subject", "data.subject"),
             ("subject", "data.at(\"subject\")"),
             ("refs", "data.refs.at(0)"),
             ("other", "data.other"),
             ("subject", "upper(data.subject)"),
         ] {
-            assert!(spans.contains(&expected), "missing {expected:?}: {spans:?}");
+            assert!(has(&spans, path, text), "missing {path}/{text}: {spans:?}");
         }
         assert!(
             !spans
@@ -1109,15 +1175,59 @@ main:
                 .any(|(_, t)| t.contains("data.subject + data.other")),
             "multi-reference expressions are not attributed: {spans:?}"
         );
-        let chain_pos = spans
-            .iter()
-            .position(|s| *s == ("subject", "data.subject"))
-            .unwrap();
-        let wide_pos = spans
-            .iter()
-            .position(|s| *s == ("subject", "upper(data.subject)"))
-            .unwrap();
-        assert!(chain_pos < wide_pos, "chains sort before wides: {spans:?}");
+        let at = |text: &str| {
+            spans
+                .iter()
+                .position(|(p, t)| p == "subject" && t == text)
+                .unwrap()
+        };
+        assert!(
+            at("data.subject") < at("upper(data.subject)"),
+            "chains sort before wides: {spans:?}"
+        );
+    }
+
+    /// The container step: a property read anchors on the property, so the
+    /// region carries an address `_qm-known-path` would accept, while the
+    /// container read whole still anchors on the container.
+    #[test]
+    fn scalar_windows_step_into_a_declared_container_property() {
+        let src = Source::detached(
+            r#"
+#import "@local/quillmark-helper:0.1.0": data
+#data.classification.value
+#data.classification.poc
+#data.classification.at("controlled by")
+#data.at("classification").poc
+#data.classification
+#data.classification.undeclared
+#upper(data.classification.poc)
+"#,
+        );
+        let spans = probe_spans(&src);
+        for (path, text) in [
+            ("classification.value", "data.classification.value"),
+            ("classification.poc", "data.classification.poc"),
+            (
+                "classification.controlled by",
+                "data.classification.at(\"controlled by\")",
+            ),
+            ("classification.poc", "data.at(\"classification\").poc"),
+            ("classification", "data.classification"),
+            ("classification.poc", "upper(data.classification.poc)"),
+        ] {
+            assert!(has(&spans, path, text), "missing {path}/{text}: {spans:?}");
+        }
+        // An undeclared key is no address, so the read falls back to the
+        // container rather than minting `classification.undeclared`.
+        assert!(
+            !spans.iter().any(|(p, _)| p.ends_with(".undeclared")),
+            "an undeclared key mints no address: {spans:?}"
+        );
+        assert!(
+            has(&spans, "classification", "data.classification.undeclared"),
+            "the undeclared read still anchors on the container: {spans:?}"
+        );
     }
 
     fn collect_spans(frame: &Frame, out: &mut Vec<Span>) {
@@ -1242,7 +1352,7 @@ main:
         let main_id = world.main();
         let src = world.source(main_id).expect("main source");
         windows.extend(
-            scalar_windows(&src, &meta.fields)
+            scalar_windows(&src, &meta.fields, &meta.object_fields)
                 .into_iter()
                 .map(|(path, range)| FieldWindow {
                     path,

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -1,0 +1,211 @@
+//! The container property step (`classification.poc`, `address.city`) through
+//! the public `Backend`/`LiveSession` path: what the address grammar accepts,
+//! what it still rejects, and the address a region carries for a plate that
+//! reads one property.
+
+use quillmark_core::Backend;
+use quillmark_typst::TypstBackend;
+
+mod common;
+
+const YAML: &str = r#"
+quill:
+  name: container_address
+  version: 0.1.0
+  backend: typst
+  description: container property addressing
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    subject:
+      type: string
+      description: a scalar, which offers no step at all
+    address:
+      type: object
+      description: a typed dictionary
+      properties:
+        city:
+          type: string
+        street:
+          type: string
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      default: ""
+      description: a variant container
+      variants:
+        CUI:
+          poc:
+            type: string
+          controlled_by:
+            type: string
+"#;
+
+fn data() -> serde_json::Value {
+    serde_json::json!({
+        "subject": "Widgets",
+        "address": { "city": "Dayton", "street": "1864 Fourth St" },
+        "classification": { "value": "CUI", "poc": "Capt J. Smith", "controlled_by": "SAF/AA" },
+    })
+}
+
+fn open(plate: &str) -> quillmark_core::LiveSession {
+    TypstBackend
+        .open(&common::quill_with_plate(YAML, plate), &data())
+        .expect("open")
+}
+
+fn rejects(plate: &str) -> String {
+    let source = common::quill_with_plate(YAML, plate);
+    let Err(err) = TypstBackend.open(&source, &data()) else {
+        panic!("the address must not compile");
+    };
+    format!("{err}")
+}
+
+/// A property read anchors on the property, so the region names the cell the
+/// plate read rather than the container holding it.
+#[test]
+fn a_property_read_regions_on_the_property() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#data.classification.poc
+#data.address.city
+"#;
+    let session = open(plate);
+    let regions = session.regions();
+    for field in ["classification.poc", "address.city"] {
+        assert!(
+            regions.iter().any(|r| r.field == field),
+            "{field:?} regions on its own address: {regions:?}"
+        );
+    }
+    assert!(
+        !regions.iter().any(|r| r.field == "classification"),
+        "the container does not also claim the property's ink: {regions:?}"
+    );
+
+    let poc = regions
+        .iter()
+        .find(|r| r.field == "classification.poc")
+        .expect("the property region surfaces");
+    let (cx, cy) = (
+        (poc.rect[0] + poc.rect[2]) / 2.0,
+        (poc.rect[1] + poc.rect[3]) / 2.0,
+    );
+    assert_eq!(
+        session.field_at(poc.page, cx, cy).as_deref(),
+        Some("classification.poc"),
+        "a click on the cell routes to the cell, not the container"
+    );
+}
+
+/// The container read whole is still one region: the step is what narrows it.
+#[test]
+fn the_container_read_whole_still_regions_on_the_container() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#data.classification.value
+#repr(data.address)
+"#;
+    let regions = open(plate).regions();
+    for field in ["classification.value", "address"] {
+        assert!(
+            regions.iter().any(|r| r.field == field),
+            "{field:?} regions: {regions:?}"
+        );
+    }
+}
+
+/// The whole point of the tables: a widget and a claim can now name a cell.
+#[test]
+fn a_widget_and_a_claim_bind_a_container_property() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data, field-region, form-field
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#form-field("Poc", type: "text", value: data.classification.poc, field: "classification.poc")
+#field-region("address.city")[#box(stroke: 1pt, inset: 4pt)[#upper(data.address.city)]]
+"#;
+    let regions = open(plate).regions();
+    for field in ["classification.poc", "address.city"] {
+        assert!(
+            regions.iter().any(|r| r.field == field),
+            "{field:?} surfaces: {regions:?}"
+        );
+    }
+}
+
+/// A card's container fields ride the same table, keyed through the card's
+/// `$path` prefix.
+#[test]
+fn a_card_container_property_is_addressable() {
+    const CARD_YAML: &str = r#"
+quill:
+  name: card_container_address
+  version: 0.1.0
+  backend: typst
+  description: card container addressing
+typst:
+  plate_file: plate.typ
+main:
+  body:
+    enabled: false
+card_kinds:
+  endorsement:
+    fields:
+      origin:
+        type: object
+        properties:
+          office:
+            type: string
+"#;
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data, field-region
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#for card in data.at("$cards") {
+  field-region(card.at("$path") + "origin.office")[#card.origin.office]
+}
+"#;
+    let session = TypstBackend
+        .open(
+            &common::quill_with_plate(CARD_YAML, plate),
+            &serde_json::json!({
+                "$cards": [ { "$kind": "endorsement", "origin": { "office": "SAF/AA" } } ]
+            }),
+        )
+        .expect("open");
+    let regions = session.regions();
+    assert!(
+        regions
+            .iter()
+            .any(|r| r.field == "$cards.endorsement.0.origin.office"),
+        "the card's container property claims its ink: {regions:?}"
+    );
+}
+
+/// The step is gated on what the field offers, so a scalar admits neither an
+/// index nor a property, and a container admits only its declared keys.
+#[test]
+fn the_step_is_gated_on_the_declared_shape() {
+    for (address, plate_field) in [
+        ("subject.poc", "a scalar has no property"),
+        ("classification.undeclared", "an undeclared key is no cell"),
+        ("classification.0", "a container has no element"),
+        ("address.9", "a typed dictionary has no element"),
+    ] {
+        let plate = format!(
+            r#"
+#import "@local/quillmark-helper:0.1.0": field-region
+#field-region("{address}")[x]
+"#
+        );
+        let err = rejects(&plate);
+        assert!(
+            err.contains("not a schema field address"),
+            "{plate_field} ({address:?}): {err}"
+        );
+    }
+}

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -15,7 +15,9 @@
 //! - **Direct scalar references** — each `data.<field>` expression in the
 //!   plate is its own site, so a scalar in both header and footer surfaces
 //!   twice. `#upper(data.subject)` attributes the whole expression as long as
-//!   it holds one reference. Not tracked: an expression mixing several fields,
+//!   it holds one reference, and a read stepping into a declared container
+//!   (`data.classification.poc`) attributes the property rather than the
+//!   container. Not tracked: an expression mixing several fields,
 //!   a value laundered through an intermediate binding, and card scalars read
 //!   from the per-card loop variable (one site shared by every instance —
 //!   bind a widget for those).
@@ -53,7 +55,8 @@
 pub struct RenderedRegion {
     /// The field's plate-space schema address as the backend keys it:
     /// `"signature_block"`, `"references.0"` (a numeric segment per array
-    /// index) or `"$cards.<kind>.<ordinal>.<tail>"` (a per-kind ordinal).
+    /// index), `"classification.poc"` (a container property) or
+    /// `"$cards.<kind>.<ordinal>.<tail>"` (a per-kind ordinal).
     /// [`plate_addr_to_doc_path`] translates it to a canonical [`DocPath`];
     /// a core consumer reading `RenderedRegion` directly sees this form.
     pub field: String,

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -250,7 +250,9 @@ By default a widget's only identity is its `/T` name. Pass `field:` to additiona
 #form-field("Signature", type: "signature", field: "signature_block")
 ```
 
-`field:` is **region-only**: the `/T` widget name stays `name`; only the sidecar entry keys on `field:`. The address must be a real schema field: a bare field name, an array element like `"refs.2"`, or a card path built from the card's `$path` prefix (a bad address raises a Typst assert). Omit `field:` and the widget exposes no region: a click has no schema field to route to.
+`field:` is **region-only**: the `/T` widget name stays `name`; only the sidecar entry keys on `field:`. The address must be a real schema field: a bare field name, an array element like `"refs.2"`, a container property like `"classification.poc"`, or a card path built from the card's `$path` prefix (a bad address raises a Typst assert). Omit `field:` and the widget exposes no region: a click has no schema field to route to.
+
+A one-step suffix is checked against what the field actually offers, so `"refs.2"` needs an `array` and `"classification.poc"` a container — an `object` field, or an `enum` declaring `variants:`, whose cells and `value` discriminant address alike. `"subject.0"` and `"subject.poc"` are both rejected on a scalar `subject`.
 
 ### Styling the value text
 

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -131,3 +131,34 @@ Helper contents (generated in `backends/typst/helper.rs` from `lib.typ.template`
   Note the name collision: this Typst helper is distinct from the `plaintext`
   **field type**. The helper projects *any* content to a `str`; the field type
   declares a field's content plain from the start.
+
+### Schema addresses
+
+`form-field(field:)` and `field-region(field)` name a schema field, and the
+generated `_qm-meta` address tables (`_qm-known-path`) validate that name at
+compile time rather than leaving it silently unbound:
+
+| Address | Admitted by |
+|---|---|
+| `subject` | any declared field |
+| `refs.2` | an array field — the element step |
+| `classification.poc` | a container field — the property step |
+| `$cards.<kind>.<n>.<field>` | a card field, `<n>` the per-kind ordinal |
+| `$cards.<kind>.<n>.<field>.<step>` | either step, on a card field |
+
+A one-step suffix is gated on the step the field actually offers, not on the
+name alone, so `subject.0` and `subject.poc` are both rejected on a scalar
+`subject`: a scalar has neither an element nor a property for the address to
+resolve to. A **container** is a typed dictionary or a variant container — both
+project as `type: object` carrying `properties`, so a variant's cells and its
+`value` discriminant are addressable exactly as a dictionary's keys are
+([SCHEMAS.md](SCHEMAS.md#enum-variants)). This is the pdfform resolver's grammar
+(`backends/pdfform/src/bind.rs`), so one address binds on either backend.
+
+Cards carry their canonical prefix as `$path`, so a plate composes a card
+address without reimplementing the kind+ordinal grammar:
+`field-region(card.at("$path") + "$body")`.
+
+The same addresses key the preview's region sidecar
+([PREVIEW.md](PREVIEW.md)), so a plate that reads one container property
+surfaces a region a consumer can route back to that property.

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -186,6 +186,10 @@ glyph, not a marker a rebuild could drop. **Direct scalar references**: each
 tracked site; a scalar shown in header and footer surfaces both sites, and a
 reference wrapped in an expression (`#upper(data.subject)`) attributes the
 whole expression's ink to the field when it is the only reference inside it.
+A read that steps into a declared container (`data.classification.poc`,
+`data.address.at("city")`) tracks on the **property**, so the region names the
+cell the plate read rather than the container holding it; a key the container
+does not declare is no address, and the read falls back to the container.
 Not tracked: expressions mixing several fields (`data.from + ", " + rank` has
 no single owner), values laundered through intermediate bindings, and card
 scalars read from the per-card loop variable (one shared expression site
@@ -201,12 +205,10 @@ region. Each *call* claims separately,
 so a wrapper invoked once per card with a `$path`-composed address is one
 region per card. Ink attributable to no source position at all (list bullets,
 underline rules) stays unclaimed here as everywhere.
-**Form-field widgets** carry the path explicitly
-(pdfform from the form mapping, a Typst `form-field` from its `field:`
-argument, validated against schema address tables baked into the generated
-helper: cards carry their canonical prefix as `$path`, so plates compose
-card addresses without reimplementing the kind+ordinal grammar) and surface a
-region only when they bind one: a widget with no schema field is a backend
+**Form-field widgets** carry the path explicitly — pdfform from the form
+mapping, a Typst `form-field` from its `field:` argument, both against the one
+address grammar ([PLATE_DATA.md](PLATE_DATA.md#schema-addresses)) — and surface
+a region only when they bind one: a widget with no schema field is a backend
 artifact, not a routable field.
 
 ### Segments and the striped union

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -99,9 +99,9 @@ The ceiling is deliberate and enforced at load rather than discovered at render:
 | a name two variants declare *differently* | `quill::variant_field_collision` |
 
 The last is the load-bearing one: content and dates lower to Typst through
-*top-level* name tables that do not descend into a container
-([PLATE_DATA.md](PLATE_DATA.md)), so such a field would load clean and reach the
-plate as a raw dict. **A variant carries plain data** — `string`, `enum`,
+*top-level* content and date name tables that do not descend into a container
+([PLATE_DATA.md](PLATE_DATA.md)) — unlike the address tables, which do — so such
+a field would load clean and reach the plate as a raw dict. **A variant carries plain data** — `string`, `enum`,
 `number`, `integer`, `boolean` — and prose and dates stay card-level fields.
 Variant fields are otherwise leaves exactly as an object's properties are: no
 container one level down, and no `ui.group` (they inherit the discriminant's).

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -106,12 +106,19 @@ plate as a raw dict. **A variant carries plain data** — `string`, `enum`,
 Variant fields are otherwise leaves exactly as an object's properties are: no
 container one level down, and no `ui.group` (they inherit the discriminant's).
 
-Three limits follow from the container shape and are accepted, not worked around:
+Two limits follow from the container shape and are accepted, not worked around:
 [`resolve()`](#the-resolved-value-view-resolve) reports **one** rung for the whole
-container, as it does for a typed dictionary; a variant field cannot host a
-Typst `form-field` widget or click-to-edit region, whose address grammar is flat
-plus one index; and a field set **shared** across several members is spelled by
-repeating it or sharing a YAML anchor, since a variant keys on one member.
+container, as it does for a typed dictionary; and a field set **shared** across
+several members is spelled by repeating it or sharing a YAML anchor, since a
+variant keys on one member.
+
+A cell is addressable one step down, exactly as a typed dictionary's property is
+([PLATE_DATA.md](PLATE_DATA.md#schema-addresses)): `classification.poc` binds a
+`form-field` widget or a `field-region` claim on either backend, and
+`classification.value` the discriminant. Addressing is against the *schema*, so a
+cell is bindable in every world — a form is built once and the document selects
+its world later. The whole container is not bindable: its value is the container
+object, which no widget coerces.
 
 A repeated name is one **cell** of the container, not one per world: the coercion
 lookup and the transform schema both key on the name alone, never the


### PR DESCRIPTION
Closes #1276, taking option (1) + (2) from the issue: extend the address grammar, and attribute regions to the property. `set_at` (option 3) is left out as a separable change.

## The gap

`_qm-known-path` admitted a top-level field, an array element, or a card path. A container's own cells were unreachable, so neither `form-field(field:)` nor `field-region` could name one. Meanwhile the pdfform binder already descended a typed dictionary, so `address.city` bound on one backend and asserted on the other — while `lib.typ`'s comment claimed the two grammars matched.

## What changed

**The property step.** Two generated address tables — `object_fields`, `card_object_fields` — gate `field.sub` the way `array_fields` already gates `field.0`. A typed dictionary and a variant container both project as `type: object` carrying `properties`, so one predicate spans both and the container's `value` discriminant comes along free. The step is gated on what the field actually offers, so `subject.0` and `subject.poc` are both still rejected on a scalar.

**Region attribution.** `scalar_windows` anchors a property read on the property, so `#data.classification.poc` regions as `classification.poc` and `fieldAt` answers the same. The `.at("key")` spelling steps too, reaching keys an identifier cannot spell (`data.address.at("controlled by")`). A key the container does not declare is no address, and the read falls back to the container.

**Backend parity.** pdfform's `bind::descend` walks a variant container, and treats the discriminant as a value rather than a schema, so nothing may follow it (`classification.value.oops` stays dangling). One address now binds on either backend.

Worth noting: a variant-bearing enum bound *whole* on pdfform resolves but can never carry a value — its value is the container object, which no widget coerces. `classification.value` is the bindable address for the discriminant.

## Behavior change

Region addresses shift for a plate that reads a container property **directly**: `#data.classification.poc` regions as `classification.poc` where it regioned as `classification`. A container read whole is unchanged, as is a read of an undeclared key. `regions_to_doc_path` already walked arbitrary tails, so `classification.poc` crosses to `main.classification.poc` with no core change and no binding change.

## A correction to the issue's premise

Issue §2 states the migration made "all four CUI cells plus the banner surface as regions labelled `classification`". They do not — on `usaf_memo` those cells surface **no region at all**, before or after this PR. Verified by opening a session with the CUI world live:

```
DOC classification = {"value":"CUI","poc":"Capt J. Smith",…}
REGION $body   $cards.indorsement.0.date   $cards.indorsement.0.signature_block
REGION references.0   references.1   signature_block   subject
```

The cause is in the vendored package: `frontmatter.typ` builds each line as `lines.push([Controlled By: #cui_controlled_by.trim()])`. `.trim()` yields a new string whose glyphs carry the *package's* span, so the ink never resolves to the plate's window. `subject` regions because the package places it verbatim. The pre-migration `data.cui_poc` would have been laundered identically, so this is a `.trim()` effect rather than variant fallout.

The grammar gap and the backend asymmetry were both real and are closed; this PR does not restore `usaf_memo`'s granularity, because there was none to restore. That claim is deliberately absent from the CHANGELOG.

## Docs

The address grammar had no canonical home — SCHEMAS.md pointed at PLATE_DATA.md for it, and PLATE_DATA.md did not carry it. It is now a table in PLATE_DATA.md § Schema addresses, with SCHEMAS.md and PREVIEW.md linking rather than restating. SCHEMAS.md's variants ceiling drops from three limits to two: the address-grammar limit is retracted.

## Tests

- `crates/backends/typst/tests/container_address.rs` (new, 5 tests): property regions, `field_at` routing to the cell, widget + claim binding, the card container path, and the gating rejections.
- `span_scan.rs`: a unit test over the container step covering `.at("…")`, the enclosing-expression widening, and the undeclared-key fallback.
- `helper.rs`: the two tables, pinning that a richtext field (also `type: object`) stays out of them.
- `bind.rs`: variant container binding through its resting shape, plus two new dangling cases.

`cargo test --workspace` green (58 test binaries, 0 failures); `node scripts/check-canon.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jsy4Vof3JHaEMmnepofJTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jsy4Vof3JHaEMmnepofJTe)_