### PR TITLE
refactor: dedup the container-address and variant-cell paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@
   under `properties`, since a binding built once against a schema must address a
   field today's document has not selected; member scoping stays on the
   declaration view, where `schema()` emits `variants:` keyed by member.
-  `FieldSchema` gains `variants`; `VariantFields` and `VARIANT_DISCRIMINANT_KEY`
-  are new.
+  `FieldSchema` gains `variants` and `variant_field` (the cell a name declares
+  under any world); `VariantFields` and `VARIANT_DISCRIMINANT_KEY` are new.
 - feat(fixtures)!: `usaf_memo`'s four `cui_*` fields move under
   `classification`'s `CUI` variant as `controlled_by`, `poc`, `category`, and
   `limited_dissemination`. `controlled_by` and `poc` drop their `default: ""`

--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -206,20 +206,19 @@ pub fn bind<'a>(
         config.main.fields.get(root).ok_or_else(|| dangling(root))?
     };
 
-    // The discriminant is the container's own enum, so the step selects a value
-    // rather than a child schema and nothing may follow it.
-    let mut at_discriminant = false;
-    for seg in parts {
-        if at_discriminant {
-            return Err(dangling(seg));
-        }
+    for seg in parts.by_ref() {
+        // The discriminant is the container's own enum, so the step selects a
+        // value rather than a child schema: the walk stops on it, and the
+        // trailing check below rejects anything that follows.
         if cur.is_variant_bearing() && seg == VARIANT_DISCRIMINANT_KEY {
-            at_discriminant = true;
-            continue;
+            break;
         }
         cur = descend(cur, seg).ok_or_else(|| dangling(seg))?;
     }
-    Ok(cur)
+    match parts.next() {
+        Some(seg) => Err(dangling(seg)),
+        None => Ok(cur),
+    }
 }
 
 fn descend<'a>(cur: &'a FieldSchema, seg: &str) -> Option<&'a FieldSchema> {
@@ -230,15 +229,7 @@ fn descend<'a>(cur: &'a FieldSchema, seg: &str) -> Option<&'a FieldSchema> {
         },
         Err(_) => match cur.r#type {
             SchemaType::Object => cur.properties.as_ref()?.get(seg).map(Box::as_ref),
-            // A name several worlds declare is one cell
-            // (`quill::variant_field_collision`), so the first match is the
-            // declaration.
-            _ => cur
-                .variants
-                .as_ref()?
-                .values()
-                .find_map(|set| set.get(seg))
-                .map(Box::as_ref),
+            _ => cur.variant_field(seg),
         },
     }
 }

--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -504,9 +504,10 @@ entrypoint = "lib.typ"
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
     use crate::emit::escape_markup;
     use crate::emit::EscapeCtx;
-    use std::collections::BTreeMap;
     use quillmark_core::quill::CONTENT_MEDIA_TYPE;
 
     fn meta_from(schema: serde_json::Value) -> SchemaMeta {

--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -506,6 +506,7 @@ mod tests {
     use super::*;
     use crate::emit::escape_markup;
     use crate::emit::EscapeCtx;
+    use std::collections::BTreeMap;
     use quillmark_core::quill::CONTENT_MEDIA_TYPE;
 
     fn meta_from(schema: serde_json::Value) -> SchemaMeta {
@@ -802,7 +803,7 @@ mod tests {
                 }},
                 "classification": { "type": "object", "properties": {
                     "value": { "type": "string", "enum": ["", "CUI"] },
-                    "poc": { "type": "string", "quillmark:variant_of": "CUI" },
+                    "poc": { "type": "string" },
                 }},
             },
             "$defs": { "note_card": { "properties": {
@@ -811,20 +812,20 @@ mod tests {
         }));
         assert_eq!(
             meta.object_fields,
-            serde_json::json!({
-                "address": ["city"],
-                "classification": ["value", "poc"],
-            })
-            .as_object()
-            .unwrap()
-            .clone(),
+            BTreeMap::from([
+                ("address".to_string(), vec!["city".to_string()]),
+                (
+                    "classification".to_string(),
+                    vec!["value".to_string(), "poc".to_string()],
+                ),
+            ]),
         );
         assert_eq!(
             meta.card_object_fields,
-            serde_json::json!({ "note": { "origin": ["office"] } })
-                .as_object()
-                .unwrap()
-                .clone(),
+            BTreeMap::from([(
+                "note".to_string(),
+                BTreeMap::from([("origin".to_string(), vec!["office".to_string()])]),
+            )]),
         );
 
         let (lib, _) = generate_lib_typ(&serde_json::json!({}), &meta).unwrap();

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -21,6 +21,7 @@ mod overlay;
 mod world;
 
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 use quillmark_core::{
     quill::{build_transform_schema, QUILLMARK_INLINE_KEY, CONTENT_MEDIA_TYPE},
@@ -669,14 +670,14 @@ fn array_field_names(properties: &serde_json::Map<String, serde_json::Value>) ->
 /// `properties`, so it contributes no step.
 fn object_field_names(
     properties: &serde_json::Map<String, serde_json::Value>,
-) -> serde_json::Map<String, serde_json::Value> {
+) -> BTreeMap<String, Vec<String>> {
     properties
         .iter()
         .filter(|(_, fs)| fs.get("type").and_then(|v| v.as_str()) == Some("object"))
         .filter_map(|(name, fs)| {
             let props = fs.get("properties")?.as_object()?;
             let names: Vec<String> = props.keys().cloned().collect();
-            (!names.is_empty()).then(|| (name.clone(), names.into()))
+            (!names.is_empty()).then(|| (name.clone(), names))
         })
         .collect()
 }
@@ -692,7 +693,9 @@ pub(crate) struct SchemaMeta {
     pub(crate) datetime_fields: Vec<String>,
     pub(crate) array_fields: Vec<String>,
     /// Container field → its property names, gating the `field.sub` step.
-    pub(crate) object_fields: serde_json::Map<String, serde_json::Value>,
+    /// Native rather than JSON like the card tables: the span scan reads it on
+    /// the AST walk, and `meta_literal` serializes it either way.
+    pub(crate) object_fields: BTreeMap<String, Vec<String>>,
     /// A subset of `content_fields`, driving the pure-inline lowering.
     pub(crate) inline_fields: Vec<String>,
     pub(crate) card_content_fields: serde_json::Map<String, serde_json::Value>,
@@ -701,7 +704,7 @@ pub(crate) struct SchemaMeta {
     pub(crate) card_field_names: serde_json::Map<String, serde_json::Value>,
     pub(crate) card_array_fields: serde_json::Map<String, serde_json::Value>,
     /// The card twin of `object_fields`, keyed kind → field → property names.
-    pub(crate) card_object_fields: serde_json::Map<String, serde_json::Value>,
+    pub(crate) card_object_fields: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     pub(crate) card_inline_fields: serde_json::Map<String, serde_json::Value>,
     pub(crate) fields: Vec<String>,
 }
@@ -725,7 +728,7 @@ impl SchemaMeta {
         let mut card_datetime_fields = serde_json::Map::new();
         let mut card_field_names = serde_json::Map::new();
         let mut card_array_fields = serde_json::Map::new();
-        let mut card_object_fields = serde_json::Map::new();
+        let mut card_object_fields = BTreeMap::new();
         let mut card_inline_fields = serde_json::Map::new();
         fn insert_names(
             table: &mut serde_json::Map<String, serde_json::Value>,
@@ -768,7 +771,7 @@ impl SchemaMeta {
                     );
                     let objects = card_props.map(object_field_names).unwrap_or_default();
                     if !objects.is_empty() {
-                        card_object_fields.insert(card_kind.to_string(), objects.into());
+                        card_object_fields.insert(card_kind.to_string(), objects);
                     }
                     insert_names(
                         &mut card_inline_fields,

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -40,6 +40,10 @@
   let object-fields = _qm-meta.at("object_fields", default: (:))
   let card-object-fields = _qm-meta.at("card_object_fields", default: (:))
   let is-index(s) = s.match(regex("^[0-9]+$")) != none
+  // The one-step suffix rule, shared by the top-level and card branches.
+  let step-ok(field, step, arrays, objects) = (
+    (field in arrays and is-index(step)) or step in objects.at(field, default: ())
+  )
   let parts = path.split(".")
   if parts.at(0) == "$cards" {
     if parts.len() < 4 or parts.len() > 5 { return false }
@@ -48,17 +52,17 @@
     if not is-index(parts.at(2)) { return false }
     let field = parts.at(3)
     if parts.len() == 5 {
-      let step = parts.at(4)
-      if field in card-array-fields.at(kind, default: ()) and is-index(step) { return true }
-      return step in card-object-fields.at(kind, default: (:)).at(field, default: ())
+      return step-ok(
+        field, parts.at(4),
+        card-array-fields.at(kind, default: ()),
+        card-object-fields.at(kind, default: (:)),
+      )
     }
     return field in card-fields.at(kind)
   }
   if parts.len() == 1 { return path in fields }
   if parts.len() == 2 {
-    let (field, step) = (parts.at(0), parts.at(1))
-    if field in array-fields and is-index(step) { return true }
-    return step in object-fields.at(field, default: ())
+    return step-ok(parts.at(0), parts.at(1), array-fields, object-fields)
   }
   false
 }

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -42,7 +42,7 @@
 //! `typst_layout::introspect::discover_frame`, transforming all four corners of
 //! each item box (the stack may rotate or scale).
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Range;
 
 use typst::foundations::{Content, Label, Value};
@@ -876,7 +876,7 @@ fn forward_pos(helper: &Source, segmap: &SegmentMap, pos: usize) -> usize {
 pub(crate) fn scalar_windows(
     source: &Source,
     fields: &[String],
-    containers: &serde_json::Map<String, serde_json::Value>,
+    containers: &BTreeMap<String, Vec<String>>,
 ) -> Vec<(String, Range<usize>)> {
     let mut anchors: Vec<(String, Range<usize>, Range<usize>)> = Vec::new();
     collect_anchors(
@@ -910,7 +910,7 @@ pub(crate) fn scalar_windows(
 fn collect_anchors(
     node: &LinkedNode,
     fields: &[String],
-    containers: &serde_json::Map<String, serde_json::Value>,
+    containers: &BTreeMap<String, Vec<String>>,
     out: &mut Vec<(String, Range<usize>, Range<usize>)>,
 ) {
     if let Some((path, anchor)) = data_access(node, fields, containers) {
@@ -952,28 +952,20 @@ fn collect_anchors(
 fn data_access<'a>(
     node: &LinkedNode<'a>,
     fields: &[String],
-    containers: &serde_json::Map<String, serde_json::Value>,
+    containers: &BTreeMap<String, Vec<String>>,
 ) -> Option<(String, LinkedNode<'a>)> {
     if node.kind() != SyntaxKind::FieldAccess {
         return None;
     }
-    let access = node.cast::<ast::FieldAccess>()?;
-    let ast::Expr::Ident(target) = access.target() else {
+    let ast::Expr::Ident(target) = node.cast::<ast::FieldAccess>()?.target() else {
         return None;
     };
     if target.as_str() != "data" {
         return None;
     }
-    let field = access.field();
-    let (name, anchor) = if fields.iter().any(|f| f == field.as_str()) {
-        (field.as_str().to_string(), node.clone())
-    } else if field.as_str() == "at" {
-        select_by_at(node, fields)?
-    } else {
-        return None;
-    };
-    let keys = crate::helper::names_at(containers, &name);
-    match select_property(&anchor, &keys) {
+    let (name, anchor) = selected(node, fields)?;
+    let keys = containers.get(&name).map(Vec::as_slice).unwrap_or_default();
+    match select_property(&anchor, keys) {
         Some((key, deeper)) => Some((format!("{name}.{key}"), deeper)),
         None => Some((name, anchor)),
     }
@@ -985,22 +977,24 @@ fn select_property<'a>(
     node: &LinkedNode<'a>,
     keys: &[String],
 ) -> Option<(String, LinkedNode<'a>)> {
-    if keys.is_empty() {
-        return None;
-    }
     let parent = node.parent()?;
-    let access = parent.cast::<ast::FieldAccess>()?;
-    if access.target().to_untyped() != node.get() {
+    if parent.cast::<ast::FieldAccess>()?.target().to_untyped() != node.get() {
         return None;
     }
-    let field = access.field();
+    selected(parent, keys)
+}
+
+/// The key `access` selects out of `keys` and the node the selection widens to.
+/// One grammar, two spellings: `.<key>` names it directly, `.at("<key>")`
+/// reaches the keys an identifier cannot spell.
+fn selected<'a>(access: &LinkedNode<'a>, keys: &[String]) -> Option<(String, LinkedNode<'a>)> {
+    let field = access.cast::<ast::FieldAccess>()?.field();
     if keys.iter().any(|k| k == field.as_str()) {
-        return Some((field.as_str().to_string(), parent.clone()));
+        return Some((field.as_str().to_string(), access.clone()));
     }
-    if field.as_str() == "at" {
-        return select_by_at(parent, keys);
-    }
-    None
+    (field.as_str() == "at")
+        .then(|| select_by_at(access, keys))
+        .flatten()
 }
 
 /// The `.at("<key>")` spelling: `access` is the `<expr>.at` field access, and
@@ -1179,11 +1173,10 @@ main:
     /// the tests below address.
     fn probe_spans(src: &Source) -> Vec<(String, String)> {
         let fields = ["subject", "refs", "other", "classification"].map(str::to_string);
-        let mut containers = serde_json::Map::new();
-        containers.insert(
+        let containers = BTreeMap::from([(
             "classification".to_string(),
-            serde_json::json!(["value", "poc", "controlled by"]),
-        );
+            ["value", "poc", "controlled by"].map(str::to_string).into(),
+        )]);
         scalar_windows(src, &fields, &containers)
             .into_iter()
             .map(|(path, r)| (path, src.text()[r].to_string()))
@@ -1386,8 +1379,16 @@ main:
       description: a scalar the plate interpolates
 "#;
 
-    /// Mirrors `open`'s window assembly, so a probe reads what a session would.
-    fn probe_regions(plate: &str, data: serde_json::Value) -> Vec<RenderedRegion> {
+    /// A compiled plate with the inputs both queries take. Mirrors `open`'s
+    /// window assembly, so a probe reads what a session would.
+    struct Probe {
+        world: QuillWorld,
+        doc: PagedDocument,
+        helper: Source,
+        windows: Vec<FieldWindow>,
+    }
+
+    fn probe(plate: &str, data: serde_json::Value) -> Probe {
         let q = quill(REGION_YAML, plate);
         let plate_src = crate::read_plate(&q).expect("plate");
         let schema = quillmark_core::quill::build_transform_schema(q.config());
@@ -1413,8 +1414,42 @@ main:
         let helper = world
             .source(QuillWorld::helper_fid("lib.typ"))
             .expect("helper source");
-        let unclosed: Vec<usize> = unclosed_claims(&doc).into_iter().map(|(c, _)| c).collect();
-        scan_content_regions(&doc, &world, &helper, &windows, &unclosed)
+        Probe {
+            world,
+            doc,
+            helper,
+            windows,
+        }
+    }
+
+    impl Probe {
+        /// What `open` stores on the session: the claims left open at the end
+        /// of the walk, by index.
+        fn unclosed(&self) -> Vec<usize> {
+            unclosed_claims(&self.doc).into_iter().map(|(c, _)| c).collect()
+        }
+
+        fn regions(&self, unclosed: &[usize]) -> Vec<RenderedRegion> {
+            scan_content_regions(&self.doc, &self.world, &self.helper, &self.windows, unclosed)
+        }
+
+        fn field_at(&self, unclosed: &[usize], page: usize, x: f32, y: f32) -> Option<String> {
+            field_at(
+                &self.doc,
+                &self.world,
+                &self.helper,
+                &self.windows,
+                unclosed,
+                page,
+                x,
+                y,
+            )
+        }
+    }
+
+    fn probe_regions(plate: &str, data: serde_json::Value) -> Vec<RenderedRegion> {
+        let p = probe(plate, data);
+        p.regions(&p.unclosed())
     }
 
     fn body(markdown: &str) -> serde_json::Value {
@@ -1542,19 +1577,9 @@ Interleaved plate chrome.
 
     #[test]
     fn an_open_marker_whose_close_never_lands_is_reported_unclosed() {
-        let q = quill(REGION_YAML, STRANDED_OPEN);
-        let plate = crate::read_plate(&q).expect("plate");
-        let schema = quillmark_core::quill::build_transform_schema(q.config());
-        let meta = crate::SchemaMeta::from_schema_json(schema.as_json());
-        let data = body("Body text.");
-        let transformed = crate::transformed_data(&meta, &data).expect("transform");
-        let mut world = QuillWorld::new(&q, &plate).expect("world");
-        world
-            .inject_helper_package(transformed.as_ref(), &meta)
-            .expect("inject");
-        let (doc, _) = compile_document(&world).expect("compile");
+        let p = probe(STRANDED_OPEN, body("Body text."));
         assert_eq!(
-            unclosed_claims(&doc),
+            unclosed_claims(&p.doc),
             vec![(0, "classification".to_string())],
             "the stranded open is named, so a plate author can act on it"
         );
@@ -1586,25 +1611,12 @@ Interleaved plate chrome.
     /// that it is threaded through.
     #[test]
     fn an_unclosed_claim_does_not_capture_clicks_on_later_pages() {
-        let q = quill(REGION_YAML, STRANDED_OPEN);
-        let plate = crate::read_plate(&q).expect("plate");
-        let schema = quillmark_core::quill::build_transform_schema(q.config());
-        let meta = crate::SchemaMeta::from_schema_json(schema.as_json());
-        let data = body(&"A long paragraph of body text. ".repeat(60));
-        let transformed = crate::transformed_data(&meta, &data).expect("transform");
-        let mut world = QuillWorld::new(&q, &plate).expect("world");
-        let windows = world
-            .inject_helper_package(transformed.as_ref(), &meta)
-            .expect("inject");
-        let (doc, _) = compile_document(&world).expect("compile");
-        let helper = world
-            .source(QuillWorld::helper_fid("lib.typ"))
-            .expect("helper source");
-        let unclosed: Vec<usize> = unclosed_claims(&doc).into_iter().map(|(c, _)| c).collect();
-        assert!(doc.pages().len() > 1, "the runaway needs a later page");
+        let p = probe(STRANDED_OPEN, body(&"A long paragraph of body text. ".repeat(60)));
+        assert!(p.doc.pages().len() > 1, "the runaway needs a later page");
 
-        let last = doc.pages().len() - 1;
-        let runaway = scan_content_regions(&doc, &world, &helper, &windows, &[])
+        let last = p.doc.pages().len() - 1;
+        let runaway = p
+            .regions(&[])
             .into_iter()
             .find(|r| r.field == "classification" && r.page == last)
             .expect("unsuppressed, the claim reaches the last page");
@@ -1613,12 +1625,12 @@ Interleaved plate chrome.
             (runaway.rect[1] + runaway.rect[3]) / 2.0,
         );
         assert_eq!(
-            field_at(&doc, &world, &helper, &windows, &[], last, cx, cy),
+            p.field_at(&[], last, cx, cy),
             Some("classification".to_string()),
             "sanity: unsuppressed, that ink routes to the stranded claim"
         );
         assert_eq!(
-            field_at(&doc, &world, &helper, &windows, &unclosed, last, cx, cy),
+            p.field_at(&p.unclosed(), last, cx, cy),
             None,
             "suppressed, page chrome under a runaway claim answers to no field"
         );

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -885,7 +885,7 @@ impl QuillConfig {
                 }
                 continue;
             }
-            match Self::variant_field_schema(field_schema, key) {
+            match field_schema.variant_field(key) {
                 Some(schema) => {
                     let coerced = Self::conform_value(
                         &QuillValue::from_json(value.clone()),
@@ -901,19 +901,6 @@ impl QuillConfig {
             }
         }
         Ok(QuillValue::from_json(serde_json::Value::Object(out)))
-    }
-
-    /// The schema for `name` under any of `field`'s variants, active or not.
-    pub(crate) fn variant_field_schema<'a>(
-        field: &'a super::FieldSchema,
-        name: &str,
-    ) -> Option<&'a super::FieldSchema> {
-        field
-            .variants
-            .as_ref()?
-            .values()
-            .find_map(|set| set.get(name))
-            .map(|boxed| boxed.as_ref())
     }
 
     /// Recursively validate a field's structural shape, enforcing the

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -590,6 +590,18 @@ impl FieldSchema {
         self.variants.as_ref()?.get(member)
     }
 
+    /// The declaration of the cell `name` under *any* of this field's variants,
+    /// active world or not. A name several worlds declare is one cell
+    /// (`quill::variant_field_collision` rejects disagreement at load), so the
+    /// first match is the declaration.
+    pub fn variant_field(&self, name: &str) -> Option<&FieldSchema> {
+        self.variants
+            .as_ref()?
+            .values()
+            .find_map(|set| set.get(name))
+            .map(Box::as_ref)
+    }
+
     /// Whether this field rests as a variant container (`{value: …, …}`) rather
     /// than a bare scalar. Keyed on `variants:`, the one thing that changes the
     /// resting shape: a plain `enum` stays a string everywhere.


### PR DESCRIPTION
Cleanup over the three fixes for #1276, #1277 and #1278, from a review of how those decisions compose. No behavior change; the address grammar, the suppression set and the projection all answer exactly what they answered before.

## What the review found

The three land on one coherent position — addresses get one property step, everything else stays whole-container — but they left the same rule written in several places, because each PR touched the seam from its own side.

**One home for the variant-cell lookup.** pdfform's `descend` re-implemented core's `variant_field_schema` byte for byte, so "a name several worlds declare is one cell" lived in two crates, tied together only by `quill::variant_field_collision` and a comment. Now `FieldSchema::variant_field`, beside the `variant_fields`/`is_variant_bearing` accessors the same cycle added.

**One home for each grammar.** `data_access` and `select_property` both spelled the `.key` / `.at("key")` dispatch — now shared through `selected`. `_qm-known-path`'s card and top-level branches both spelled the index-or-property rule — now one `step-ok` closure. A new spelling lands once instead of twice.

**Native address tables.** `object_fields` and `card_object_fields` were `serde_json::Map`, so the span scan re-parsed JSON into a fresh `Vec<String>` for every data reference on the AST walk, reaching sideways into the source-generation module for `names_at` to do it. They are `BTreeMap` now; the overlay reads them directly.

**Smaller.** The binder's `at_discriminant` flag — set on one loop turn, read on the next — is a `break` plus a trailing check. The two unclosed-claim tests build their document through `probe` instead of re-spelling the compile pipeline; one had drifted, omitting the scalar-window extension `probe_regions` documents itself as mirroring. And a `quillmark:variant_of` key left in a test schema by the projection that deleted it, the last occurrence in the tree, is gone.

## Verification

`cargo test --workspace` passes, including under CI's `--all-features --locked`. Clippy on `quillmark-typst` is unchanged at its prior warning count.

Two independent reviews audited the diff hunk by hunk against `f1919b3`, with differential probes run on both revisions:

- **The address grammar is unchanged.** A 35-path truth table through `_qm-known-path` and a 30-spelling window probe through `scalar_windows` are byte-identical across the two revisions — including a field named `at` and a container key named `at`, where the resolution is quirky on both sides alike.
- **The binder is unchanged.** 44 paths over two schemas give identical `Ok`/`Err` and identical `Dangling` segment names, covering `classification.value.oops`, a non-variant object carrying a `value` property, and the card forms.
- **The generated `_qm-meta` literal is byte-identical.** `preserve_order` is on, so the old maps iterated in declaration order and the new ones sort — but `lit` sorts object keys recursively and leaves arrays alone, so both collapse to the same text. Confirmed against a schema with containers, card kinds and inner properties all declared out of order. (The surrounding `lib.typ` does change, in the hand-written `step-ok` region.)

## Still open, not addressed here

Two seams the review surfaced that are changes in their own right, not cleanups:

- **Read granularity now exceeds write granularity.** A click resolves to `classification.poc` and crosses to `main.classification.poc`, but `TypedWriter::set` is keyed on a top-level name, and `resolve()` reports one rung for the whole container. Option 3 of #1276 (`set_at`) was never taken, and the whole-container read-modify-write is documented nowhere.
- **The `usaf_memo` regression that motivated #1276 is not pinned.** The plate reads `data.classification.poc`, so granularity is restored end to end, but the tests covering it are on a synthetic plate; `usaf_memo_regions_test.rs` asserts nothing about `classification.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsC1J37FnTGQ1eShUyEy2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsC1J37FnTGQ1eShUyEy2f)_