### PR TITLE
feat(typst): follow a single-assignment `let` alias to its schema address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- feat(typst): a scalar read through a `let` alias regions on the address the
+  chain it names would carry, so `#let c = data.classification` … `#c.poc`
+  surfaces `classification.poc` where it surfaced nothing at all — not the
+  container's address, absent. 0.106 made a container property addressable,
+  which makes stepping into one worth writing, and binding the container once
+  before stepping into it three times is the refactor that follows; it cost the
+  address, silently, with the document still rendering correctly. An alias is
+  followed only where the plate binds the name exactly once to one whole `data`
+  chain: a name a second `let`, a closure parameter, a loop pattern, an import,
+  or an assignment could rebind is dropped rather than risk attributing another
+  value's ink to the field, and a wildcard import disqualifies every alias. What
+  the pass cannot follow — a function parameter, a destructured binding, a
+  per-card loop variable — is unchanged and still needs a `field-region` claim,
+  now stated for plate authors under "Which Reads Get Regions" in the Typst
+  backend guide. Content and date fields were never affected: their ink is born
+  in generated code.
+
 - feat(wasm): `VARIANT_DISCRIMINANT_KEY` joins the runtime's static exports,
   beside `MAIN_CARD_ADDR`. v0.106.0 announced the constant as new API but shipped
   it to Rust only, leaving a JS consumer reading or writing a variant container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,18 @@
 - feat(typst): a scalar read through a `let` alias regions on the address the
   chain it names would carry, so `#let c = data.classification` … `#c.poc`
   surfaces `classification.poc` where it surfaced nothing at all — not the
-  container's address, absent. 0.106 made a container property addressable,
-  which makes stepping into one worth writing, and binding the container once
-  before stepping into it three times is the refactor that follows; it cost the
-  address, silently, with the document still rendering correctly. An alias is
-  followed only where the plate binds the name exactly once to one whole `data`
-  chain: a name a second `let`, a closure parameter, a loop pattern, an import,
-  or an assignment could rebind is dropped rather than risk attributing another
-  value's ink to the field, and a wildcard import disqualifies every alias. What
-  the pass cannot follow — a function parameter, a destructured binding, a
+  container's address, absent. Binding a container once and stepping into it
+  three times is the refactor 0.106's property addressing invites, and it cost
+  the address silently, the document still rendering correctly. An alias holds
+  only where the plate binds the name exactly once to one whole `data` chain: a
+  name a second `let`, a closure parameter, a loop pattern, an import, or an
+  assignment could rebind is dropped rather than risk attributing another
+  value's ink to the field, and a wildcard import disqualifies every alias.
+  Laundering past that — a function parameter, a destructured binding, a
   per-card loop variable — is unchanged and still needs a `field-region` claim,
   now stated for plate authors under "Which Reads Get Regions" in the Typst
-  backend guide. Content and date fields were never affected: their ink is born
-  in generated code.
+  backend guide. Content and date fields are unaffected: their ink is born in
+  generated code.
 
 - feat(wasm): `VARIANT_DISCRIMINANT_KEY` joins the runtime's static exports,
   beside `MAIN_CARD_ADDR`. v0.106.0 announced the constant as new API but shipped

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -907,9 +907,8 @@ pub(crate) fn scalar_windows(
     out
 }
 
-/// What one `let` alias names: the schema path its initializer resolved to, and
-/// the byte the binding ends at. A read before that byte reads whatever else
-/// held the name, so the position bounds the alias the way lexical order does.
+/// A read before `bound_at` reads whatever else held the name, so the position
+/// bounds the alias the way lexical order does.
 struct Alias {
     path: String,
     bound_at: usize,
@@ -941,9 +940,8 @@ fn alias_bindings(
         .collect()
 }
 
-/// What one walk of the plate finds: how many binding positions each name has,
-/// the alias candidates among them, and whether a wildcard import bound names
-/// the walk cannot see at all.
+/// A wildcard import binds names in another file, so it disqualifies every
+/// alias no matter which side of a binding it sits on.
 #[derive(Default)]
 struct Binders {
     counts: HashMap<String, usize>,
@@ -1040,8 +1038,6 @@ fn collect_binders(
     }
 }
 
-/// The `(name, alias)` a `#let <ident> = <data chain>` names, if its
-/// initializer is one whole chain resolving to a schema path.
 fn alias_candidate(
     node: &LinkedNode,
     binding: ast::LetBinding,
@@ -1156,7 +1152,6 @@ fn step_property<'a>(
         None => (name, anchor),
     }
 }
-
 
 /// The declared key `node`'s parent selects off it — `.<key>` or
 /// `.at("<key>")` — and the node that selection widens to.
@@ -1374,8 +1369,8 @@ main:
         spans.iter().any(|(p, t)| p == path && t == text)
     }
 
-    /// The refactor #1284 reports: naming the container before stepping into it
-    /// must keep the address the direct chain carries.
+    /// Naming the container before stepping into it must keep the address the
+    /// direct chain carries.
     #[test]
     fn scalar_windows_follow_a_single_assignment_let_alias() {
         let src = Source::detached(

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -865,26 +865,28 @@ fn forward_pos(helper: &Source, segmap: &SegmentMap, pos: usize) -> usize {
 ///   one reference sits inside it: `data.a + data.b` has no single owner.
 ///
 /// Chain windows sort first, so ink resolving to the reference itself is never
-/// claimed by a wider window. A value laundered through `#let s = data.x` is not
-/// chased: it carries the binding's span.
+/// claimed by a wider window.
 ///
 /// A reference that steps into a declared container (`data.classification.poc`)
 /// anchors on the property, so the region carries the address the plate actually
 /// read rather than the container's. `containers` is the `object_fields` table
 /// [`_qm-known-path`] validates against, so a region path is one a
 /// `form-field`/`field-region` could bind.
+///
+/// A read through a single-assignment `let` alias ([`alias_bindings`]) is a
+/// reference site like the chain it names, so naming a container before
+/// stepping into it keeps the address. Laundering the tracker cannot follow —
+/// a function parameter, a destructured binding, a per-card loop variable —
+/// still carries the binding's span and needs a `field-region` claim.
 pub(crate) fn scalar_windows(
     source: &Source,
     fields: &[String],
     containers: &BTreeMap<String, Vec<String>>,
 ) -> Vec<(String, Range<usize>)> {
+    let root = LinkedNode::new(source.root());
+    let aliases = alias_bindings(&root, fields, containers);
     let mut anchors: Vec<(String, Range<usize>, Range<usize>)> = Vec::new();
-    collect_anchors(
-        &LinkedNode::new(source.root()),
-        fields,
-        containers,
-        &mut anchors,
-    );
+    collect_anchors(&root, fields, containers, &aliases, &mut anchors);
 
     let mut out: Vec<(String, Range<usize>)> = anchors
         .iter()
@@ -905,15 +907,172 @@ pub(crate) fn scalar_windows(
     out
 }
 
+/// What one `let` alias names: the schema path its initializer resolved to, and
+/// the byte the binding ends at. A read before that byte reads whatever else
+/// held the name, so the position bounds the alias the way lexical order does.
+struct Alias {
+    path: String,
+    bound_at: usize,
+}
+
+/// Each identifier the plate binds exactly once, to exactly one `data` chain.
+///
+/// The single-binder rule is what makes an alias safe to follow: a name a
+/// second `let`, a closure parameter, a loop pattern, an import, or an
+/// assignment could rebind is dropped, so no window is ever minted over ink
+/// belonging to another value. An initializer must be the chain and nothing
+/// else — `#let x = upper(data.subject)` and `#let x = data.a + data.b` both
+/// yield no alias, the first because the chain is not the whole expression and
+/// the second because no single field owns it.
+fn alias_bindings(
+    root: &LinkedNode,
+    fields: &[String],
+    containers: &BTreeMap<String, Vec<String>>,
+) -> HashMap<String, Alias> {
+    let mut candidates: Vec<(String, Alias)> = Vec::new();
+    let mut binders: HashMap<String, usize> = HashMap::new();
+    collect_binders(root, fields, containers, &mut candidates, &mut binders);
+    candidates
+        .into_iter()
+        .filter(|(name, _)| binders.get(name) == Some(&1))
+        .collect()
+}
+
+/// Counts every binding position by name, and collects the alias candidates
+/// among them. A wildcard import binds names this walk cannot see, so one
+/// anywhere in the plate disqualifies every alias.
+fn collect_binders(
+    node: &LinkedNode,
+    fields: &[String],
+    containers: &BTreeMap<String, Vec<String>>,
+    candidates: &mut Vec<(String, Alias)>,
+    binders: &mut HashMap<String, usize>,
+) {
+    let bind = |name: &str, binders: &mut HashMap<String, usize>| {
+        *binders.entry(name.to_string()).or_default() += 1;
+    };
+    match node.kind() {
+        SyntaxKind::LetBinding => {
+            if let Some(binding) = node.cast::<ast::LetBinding>() {
+                for ident in binding.kind().bindings() {
+                    bind(ident.as_str(), binders);
+                }
+                if let Some((name, alias)) = alias_candidate(node, binding, fields, containers) {
+                    candidates.push((name, alias));
+                }
+            }
+        }
+        SyntaxKind::Closure => {
+            if let Some(closure) = node.cast::<ast::Closure>() {
+                for ident in closure.name().into_iter() {
+                    bind(ident.as_str(), binders);
+                }
+                for param in closure.params().children() {
+                    let pattern = match param {
+                        ast::Param::Pos(pattern) => Some(pattern),
+                        ast::Param::Named(named) => Some(ast::Pattern::Normal(named.expr())),
+                        ast::Param::Spread(spread) => spread.sink_ident().map(|i| {
+                            ast::Pattern::Normal(ast::Expr::Ident(i))
+                        }),
+                    };
+                    for ident in pattern.map(ast::Pattern::bindings).unwrap_or_default() {
+                        bind(ident.as_str(), binders);
+                    }
+                }
+            }
+        }
+        SyntaxKind::ForLoop => {
+            if let Some(loop_) = node.cast::<ast::ForLoop>() {
+                for ident in loop_.pattern().bindings() {
+                    bind(ident.as_str(), binders);
+                }
+            }
+        }
+        SyntaxKind::DestructAssignment => {
+            if let Some(assign) = node.cast::<ast::DestructAssignment>() {
+                for ident in assign.pattern().bindings() {
+                    bind(ident.as_str(), binders);
+                }
+            }
+        }
+        SyntaxKind::ModuleImport => {
+            if let Some(import) = node.cast::<ast::ModuleImport>() {
+                match import.imports() {
+                    // The bound names are in another file; disqualify every
+                    // alias by binding a name no read can resolve to.
+                    Some(ast::Imports::Wildcard) => binders.values_mut().for_each(|c| *c += 1),
+                    Some(ast::Imports::Items(items)) => {
+                        for item in items.iter() {
+                            bind(item.bound_name().as_str(), binders);
+                        }
+                    }
+                    None => {}
+                }
+            }
+        }
+        SyntaxKind::Binary => {
+            if let Some(binary) = node.cast::<ast::Binary>() {
+                if matches!(
+                    binary.op(),
+                    ast::BinOp::Assign
+                        | ast::BinOp::AddAssign
+                        | ast::BinOp::SubAssign
+                        | ast::BinOp::MulAssign
+                        | ast::BinOp::DivAssign
+                ) {
+                    if let ast::Expr::Ident(ident) = binary.lhs() {
+                        bind(ident.as_str(), binders);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    for child in node.children() {
+        collect_binders(&child, fields, containers, candidates, binders);
+    }
+}
+
+/// The `(name, alias)` a `#let <ident> = <data chain>` names, if its
+/// initializer is one whole chain resolving to a schema path.
+fn alias_candidate(
+    node: &LinkedNode,
+    binding: ast::LetBinding,
+    fields: &[String],
+    containers: &BTreeMap<String, Vec<String>>,
+) -> Option<(String, Alias)> {
+    let ast::LetBindingKind::Normal(ast::Pattern::Normal(ast::Expr::Ident(name))) = binding.kind()
+    else {
+        return None;
+    };
+    let init = binding.init()?.to_untyped();
+    let init = node.children().find(|c| c.get() == init)?;
+    let mut inner = Vec::new();
+    collect_anchors(&init, fields, containers, &HashMap::new(), &mut inner);
+    let [(path, chain, _)] = inner.as_slice() else {
+        return None;
+    };
+    (*chain == init.range()).then(|| {
+        (
+            name.as_str().to_string(),
+            Alias {
+                path: path.clone(),
+                bound_at: node.range().end,
+            },
+        )
+    })
+}
+
 /// Recursion continues into matched subtrees: a reference nested in another
 /// chain's arguments is its own site.
 fn collect_anchors(
     node: &LinkedNode,
     fields: &[String],
     containers: &BTreeMap<String, Vec<String>>,
+    aliases: &HashMap<String, Alias>,
     out: &mut Vec<(String, Range<usize>, Range<usize>)>,
 ) {
-    if let Some((path, anchor)) = data_access(node, fields, containers) {
+    if let Some((path, anchor)) = data_access(node, fields, containers, aliases) {
         // Chain: the outermost postfix chain headed by this access.
         let mut chain = anchor.clone();
         while let Some(parent) = chain.parent() {
@@ -941,35 +1100,56 @@ fn collect_anchors(
         out.push((path, chain.range(), wide.range()));
     }
     for child in node.children() {
-        collect_anchors(&child, fields, containers, out);
+        collect_anchors(&child, fields, containers, aliases, out);
     }
 }
 
-/// If `node` is a `data.<field>` access or a `data.at("<field>")` call head
-/// with a declared field, its schema path and the node to widen from — stepped
-/// one property deeper where the field is a container and the plate selected
-/// one of its declared keys.
+/// The schema path `node` reads and the node to widen from, for the two shapes
+/// that name a field: a `data.<field>` / `data.at("<field>")` access, and a
+/// read through a `let` alias. Either steps one property deeper where the field
+/// is a container and the plate selected one of its declared keys.
 fn data_access<'a>(
     node: &LinkedNode<'a>,
     fields: &[String],
     containers: &BTreeMap<String, Vec<String>>,
+    aliases: &HashMap<String, Alias>,
 ) -> Option<(String, LinkedNode<'a>)> {
-    if node.kind() != SyntaxKind::FieldAccess {
-        return None;
-    }
-    let ast::Expr::Ident(target) = node.cast::<ast::FieldAccess>()?.target() else {
-        return None;
-    };
-    if target.as_str() != "data" {
-        return None;
-    }
-    let (name, anchor) = selected(node, fields)?;
-    let keys = containers.get(&name).map(Vec::as_slice).unwrap_or_default();
-    match select_property(&anchor, keys) {
-        Some((key, deeper)) => Some((format!("{name}.{key}"), deeper)),
-        None => Some((name, anchor)),
+    match node.kind() {
+        SyntaxKind::FieldAccess => {
+            let ast::Expr::Ident(target) = node.cast::<ast::FieldAccess>()?.target() else {
+                return None;
+            };
+            if target.as_str() != "data" {
+                return None;
+            }
+            let (name, anchor) = selected(node, fields)?;
+            Some(step_property(name, anchor, containers))
+        }
+        // Reads before the binding ends — its own pattern, its initializer —
+        // are not reads of the field.
+        SyntaxKind::Ident => {
+            let alias = aliases.get(node.cast::<ast::Ident>()?.as_str())?;
+            (node.range().start >= alias.bound_at)
+                .then(|| step_property(alias.path.clone(), node.clone(), containers))
+        }
+        _ => None,
     }
 }
+
+/// One property step where `name` is a container and the read selected a
+/// declared key, else the field itself.
+fn step_property<'a>(
+    name: String,
+    anchor: LinkedNode<'a>,
+    containers: &BTreeMap<String, Vec<String>>,
+) -> (String, LinkedNode<'a>) {
+    let keys = containers.get(&name).map(Vec::as_slice).unwrap_or_default();
+    match select_property(&anchor, keys) {
+        Some((key, deeper)) => (format!("{name}.{key}"), deeper),
+        None => (name, anchor),
+    }
+}
+
 
 /// The declared key `node`'s parent selects off it — `.<key>` or
 /// `.at("<key>")` — and the node that selection widens to.
@@ -1185,6 +1365,93 @@ main:
 
     fn has(spans: &[(String, String)], path: &str, text: &str) -> bool {
         spans.iter().any(|(p, t)| p == path && t == text)
+    }
+
+    /// The refactor #1284 reports: naming the container before stepping into it
+    /// must keep the address the direct chain carries.
+    #[test]
+    fn scalar_windows_follow_a_single_assignment_let_alias() {
+        let src = Source::detached(
+            r#"
+#import "@local/quillmark-helper:0.1.0": data
+#let c = data.classification
+#c.poc
+#c.at("controlled by")
+#c
+#c.undeclared
+#let s = data.subject
+#s
+#upper(s)
+#let a = data.at("classification", default: (:))
+#a.poc
+"#,
+        );
+        let spans = probe_spans(&src);
+        for (path, text) in [
+            ("classification.poc", "c.poc"),
+            ("classification.controlled by", "c.at(\"controlled by\")"),
+            ("classification", "c"),
+            ("subject", "s"),
+            ("subject", "upper(s)"),
+            ("classification.poc", "a.poc"),
+        ] {
+            assert!(has(&spans, path, text), "missing {path}/{text}: {spans:?}");
+        }
+        assert!(
+            has(&spans, "classification", "c.undeclared"),
+            "an undeclared key falls back to the container: {spans:?}"
+        );
+    }
+
+    /// A name a second binder could rebind carries no alias: attributing
+    /// another value's ink to the field is worse than surfacing no region.
+    #[test]
+    fn scalar_windows_drop_an_alias_any_second_binder_could_rebind() {
+        let rebound = |plate: &str| {
+            let src = Source::detached(&format!(
+                "#import \"@local/quillmark-helper:0.1.0\": data\n{plate}\n"
+            ));
+            probe_spans(&src)
+                .into_iter()
+                .filter(|(p, _)| p.starts_with("classification"))
+                .filter(|(_, t)| !t.starts_with("data"))
+                .collect::<Vec<_>>()
+        };
+        for plate in [
+            "#let c = data.classification\n#let c = \"other\"\n#c.poc",
+            "#let c = data.classification\n#let f(c) = [#c.poc]\n#f(1)",
+            "#let c = data.classification\n#for c in (1, 2) [#c.poc]",
+            "#let c = data.classification\n#{ c = \"other\" }\n#c.poc",
+            "#let c = data.classification\n#import \"x.typ\": *\n#c.poc",
+            "#let (c, d) = (data.classification, 1)\n#c.poc",
+        ] {
+            assert!(
+                rebound(plate).is_empty(),
+                "alias survived a rebind in {plate:?}: {:?}",
+                rebound(plate)
+            );
+        }
+    }
+
+    /// An initializer that is not one whole chain names no single field.
+    #[test]
+    fn scalar_windows_alias_only_a_whole_data_chain() {
+        let src = Source::detached(
+            r#"
+#import "@local/quillmark-helper:0.1.0": data
+#let w = upper(data.subject)
+#w
+#let m = data.subject + data.other
+#m
+"#,
+        );
+        let spans = probe_spans(&src);
+        for text in ["w", "m"] {
+            assert!(
+                !spans.iter().any(|(_, t)| t == text),
+                "{text:?} is no alias: {spans:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -929,43 +929,52 @@ fn alias_bindings(
     fields: &[String],
     containers: &BTreeMap<String, Vec<String>>,
 ) -> HashMap<String, Alias> {
-    let mut candidates: Vec<(String, Alias)> = Vec::new();
-    let mut binders: HashMap<String, usize> = HashMap::new();
-    collect_binders(root, fields, containers, &mut candidates, &mut binders);
-    candidates
+    let mut found = Binders::default();
+    collect_binders(root, fields, containers, &mut found);
+    if found.wildcard_import {
+        return HashMap::new();
+    }
+    found
+        .candidates
         .into_iter()
-        .filter(|(name, _)| binders.get(name) == Some(&1))
+        .filter(|(name, _)| found.counts.get(name) == Some(&1))
         .collect()
 }
 
-/// Counts every binding position by name, and collects the alias candidates
-/// among them. A wildcard import binds names this walk cannot see, so one
-/// anywhere in the plate disqualifies every alias.
+/// What one walk of the plate finds: how many binding positions each name has,
+/// the alias candidates among them, and whether a wildcard import bound names
+/// the walk cannot see at all.
+#[derive(Default)]
+struct Binders {
+    counts: HashMap<String, usize>,
+    candidates: Vec<(String, Alias)>,
+    wildcard_import: bool,
+}
+
 fn collect_binders(
     node: &LinkedNode,
     fields: &[String],
     containers: &BTreeMap<String, Vec<String>>,
-    candidates: &mut Vec<(String, Alias)>,
-    binders: &mut HashMap<String, usize>,
+    out: &mut Binders,
 ) {
-    let bind = |name: &str, binders: &mut HashMap<String, usize>| {
-        *binders.entry(name.to_string()).or_default() += 1;
+    let bind = |name: &str, out: &mut Binders| {
+        *out.counts.entry(name.to_string()).or_default() += 1;
     };
     match node.kind() {
         SyntaxKind::LetBinding => {
             if let Some(binding) = node.cast::<ast::LetBinding>() {
                 for ident in binding.kind().bindings() {
-                    bind(ident.as_str(), binders);
+                    bind(ident.as_str(), out);
                 }
                 if let Some((name, alias)) = alias_candidate(node, binding, fields, containers) {
-                    candidates.push((name, alias));
+                    out.candidates.push((name, alias));
                 }
             }
         }
         SyntaxKind::Closure => {
             if let Some(closure) = node.cast::<ast::Closure>() {
                 for ident in closure.name().into_iter() {
-                    bind(ident.as_str(), binders);
+                    bind(ident.as_str(), out);
                 }
                 for param in closure.params().children() {
                     let pattern = match param {
@@ -976,7 +985,7 @@ fn collect_binders(
                         }),
                     };
                     for ident in pattern.map(ast::Pattern::bindings).unwrap_or_default() {
-                        bind(ident.as_str(), binders);
+                        bind(ident.as_str(), out);
                     }
                 }
             }
@@ -984,26 +993,24 @@ fn collect_binders(
         SyntaxKind::ForLoop => {
             if let Some(loop_) = node.cast::<ast::ForLoop>() {
                 for ident in loop_.pattern().bindings() {
-                    bind(ident.as_str(), binders);
+                    bind(ident.as_str(), out);
                 }
             }
         }
         SyntaxKind::DestructAssignment => {
             if let Some(assign) = node.cast::<ast::DestructAssignment>() {
                 for ident in assign.pattern().bindings() {
-                    bind(ident.as_str(), binders);
+                    bind(ident.as_str(), out);
                 }
             }
         }
         SyntaxKind::ModuleImport => {
             if let Some(import) = node.cast::<ast::ModuleImport>() {
                 match import.imports() {
-                    // The bound names are in another file; disqualify every
-                    // alias by binding a name no read can resolve to.
-                    Some(ast::Imports::Wildcard) => binders.values_mut().for_each(|c| *c += 1),
+                    Some(ast::Imports::Wildcard) => out.wildcard_import = true,
                     Some(ast::Imports::Items(items)) => {
                         for item in items.iter() {
-                            bind(item.bound_name().as_str(), binders);
+                            bind(item.bound_name().as_str(), out);
                         }
                     }
                     None => {}
@@ -1021,7 +1028,7 @@ fn collect_binders(
                         | ast::BinOp::DivAssign
                 ) {
                     if let ast::Expr::Ident(ident) = binary.lhs() {
-                        bind(ident.as_str(), binders);
+                        bind(ident.as_str(), out);
                     }
                 }
             }
@@ -1029,7 +1036,7 @@ fn collect_binders(
         _ => {}
     }
     for child in node.children() {
-        collect_binders(&child, fields, containers, candidates, binders);
+        collect_binders(&child, fields, containers, out);
     }
 }
 
@@ -1046,7 +1053,7 @@ fn alias_candidate(
         return None;
     };
     let init = binding.init()?.to_untyped();
-    let init = node.children().find(|c| c.get() == init)?;
+    let init = node.children().find(|c| std::ptr::eq(c.get(), init))?;
     let mut inner = Vec::new();
     collect_anchors(&init, fields, containers, &HashMap::new(), &mut inner);
     let [(path, chain, _)] = inner.as_slice() else {
@@ -1423,6 +1430,9 @@ main:
             "#let c = data.classification\n#for c in (1, 2) [#c.poc]",
             "#let c = data.classification\n#{ c = \"other\" }\n#c.poc",
             "#let c = data.classification\n#import \"x.typ\": *\n#c.poc",
+            // The wildcard binds names this walk never sees, whichever side of
+            // the binding it sits on.
+            "#import \"x.typ\": *\n#let c = data.classification\n#c.poc",
             "#let (c, d) = (data.classification, 1)\n#c.poc",
         ] {
             assert!(

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -102,6 +102,60 @@ fn a_property_read_regions_on_the_property() {
     );
 }
 
+/// Naming the container before stepping into it is the refactor a plate author
+/// reaches for once a container is worth reading, and it must cost no address:
+/// the region a bound read surfaces is the one the direct chain surfaces.
+#[test]
+fn a_property_read_through_a_let_alias_keeps_the_property_address() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#let c = data.classification
+#let a = data.at("address", default: (:))
+#c.poc #c.at("controlled_by") #a.city
+"#;
+    let session = open(plate);
+    let regions = session.regions();
+    for field in ["classification.poc", "classification.controlled_by", "address.city"] {
+        assert!(
+            regions.iter().any(|r| r.field == field),
+            "{field:?} regions through the alias: {regions:?}"
+        );
+    }
+
+    let poc = regions
+        .iter()
+        .find(|r| r.field == "classification.poc")
+        .expect("the property region surfaces");
+    let (cx, cy) = (
+        (poc.rect[0] + poc.rect[2]) / 2.0,
+        (poc.rect[1] + poc.rect[3]) / 2.0,
+    );
+    assert_eq!(
+        session.field_at(poc.page, cx, cy).as_deref(),
+        Some("classification.poc"),
+        "a click on a bound read routes to the cell it read"
+    );
+}
+
+/// A name the plate could rebind is not followed, so a stale alias never
+/// attributes another value's ink to the field.
+#[test]
+fn a_rebound_alias_surfaces_no_region() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#let c = data.classification
+#let c = (poc: "someone else")
+#c.poc
+"#;
+    let regions = open(plate).regions();
+    assert!(
+        !regions.iter().any(|r| r.field.starts_with("classification")),
+        "a rebound name carries no address: {regions:?}"
+    );
+}
+
 /// The container read whole is still one region: the step is what narrows it.
 #[test]
 fn the_container_read_whole_still_regions_on_the_container() {

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -102,9 +102,8 @@ fn a_property_read_regions_on_the_property() {
     );
 }
 
-/// Naming the container before stepping into it is the refactor a plate author
-/// reaches for once a container is worth reading, and it must cost no address:
-/// the region a bound read surfaces is the one the direct chain surfaces.
+/// A bound read surfaces the region the direct chain surfaces, so naming a
+/// container before stepping into it costs no address.
 #[test]
 fn a_property_read_through_a_let_alias_keeps_the_property_address() {
     let plate = r#"

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -17,10 +17,11 @@
 //!   twice. `#upper(data.subject)` attributes the whole expression as long as
 //!   it holds one reference, and a read stepping into a declared container
 //!   (`data.classification.poc`) attributes the property rather than the
-//!   container. Not tracked: an expression mixing several fields,
-//!   a value laundered through an intermediate binding, and card scalars read
-//!   from the per-card loop variable (one site shared by every instance —
-//!   bind a widget for those).
+//!   container. A read through a `let` alias bound exactly once to one whole
+//!   chain tracks where that chain would. Not tracked: an expression mixing
+//!   several fields, a value laundered past the alias (a function parameter, a
+//!   destructured binding), and card scalars read from the per-card loop
+//!   variable (one site shared by every instance — bind a widget for those).
 //! - **Form-field widgets** carry a schema path explicitly. A widget that
 //!   binds none produces no region: only schema-addressable fields surface.
 //!

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -296,7 +296,7 @@ Rebind that name anywhere in the plate — a second `let`, a closure parameter, 
 | a destructured binding (`#let (poc, ..) = data.classification`) | the pattern names no chain |
 | a per-card loop variable (`#for card in data.at("$cards")`) | one shared expression site carries no per-instance identity |
 
-In each of those the document still renders correctly and only the click target is missing, so nothing fails to tell you — reach for a `field-region` claim below.
+Each of those still renders correctly and loses only the click target, which is why nothing announces it. Wrap the read in a `field-region` claim to get the region back.
 
 **Content and date fields need none of this.** A `richtext` value's ink is born in generated code, so it keeps its address through a function, a loop, or a package that rebuilds it; a `date` field's `(.display)(..)` closure is tracked the same way.
 

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -279,6 +279,27 @@ These affect the PDF only. SVG and PNG reserve the same invisible layout space r
 
 The label `<__qm_field__>` and metadata `kind: "__qm_field__"` are reserved for this hand-off: the same `query(metadata)` caveat noted for `signature-field` applies.
 
+## Which Reads Get Regions
+
+A **scalar** is tracked at the expression that draws it, so where you write the read decides whether it surfaces in `session.regions()`. Naming the value first is fine: a `let` bound once to one whole `data` chain is followed, and stepping into a container through that name keeps the cell's address.
+
+```typst
+#let c = data.classification
+#c.poc                       // regions as `classification.poc`, same as #data.classification.poc
+```
+
+Rebind that name anywhere in the plate — a second `let`, a closure parameter, a loop pattern, an assignment — and it stops being followed, because a read can no longer be tied to one value. Three shapes are past what the tracker follows at all:
+
+| Shape | Why |
+|---|---|
+| a value handed to a function (`#let f(c) = [#c.poc]`) | the parameter is a fresh name bound per call |
+| a destructured binding (`#let (poc, ..) = data.classification`) | the pattern names no chain |
+| a per-card loop variable (`#for card in data.at("$cards")`) | one shared expression site carries no per-instance identity |
+
+In each of those the document still renders correctly and only the click target is missing, so nothing fails to tell you — reach for a `field-region` claim below.
+
+**Content and date fields need none of this.** A `richtext` value's ink is born in generated code, so it keeps its address through a function, a loop, or a package that rebuilds it; a `date` field's `(.display)(..)` closure is tracked the same way.
+
 ## Tying Composed Content to a Field
 
 A live preview routes a click back to the schema field that produced the ink under it, and it finds that field automatically for content it generated: a `richtext` field's markup, a `#data.subject` reference in your plate. Content your plate *composes* — a banner keyed off `data.classification`, an address block a vendored package lays out, a computed table — draws ink Quillmark cannot attribute to anything. `field-region` claims it:

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -191,9 +191,9 @@ A read that steps into a declared container (`data.classification.poc`,
 cell the plate read rather than the container holding it; a key the container
 does not declare is no address, and the read falls back to the container.
 A read through a `let` alias tracks where the chain it names would, so naming a
-container before stepping into it costs no address; the alias must be bound
-exactly once to one whole chain, since a name a second binder could rebind
-would attribute another value's ink to the field.
+container before stepping into it costs no address. The alias holds only where
+the plate binds the name exactly once to one whole chain: a name a second binder
+could rebind would attribute another value's ink to the field.
 Not tracked: expressions mixing several fields (`data.from + ", " + rank` has
 no single owner), a value laundered past what the alias pass follows (a
 function parameter, a destructured binding), and card scalars read from the

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -190,10 +190,15 @@ A read that steps into a declared container (`data.classification.poc`,
 `data.address.at("city")`) tracks on the **property**, so the region names the
 cell the plate read rather than the container holding it; a key the container
 does not declare is no address, and the read falls back to the container.
+A read through a `let` alias tracks where the chain it names would, so naming a
+container before stepping into it costs no address; the alias must be bound
+exactly once to one whole chain, since a name a second binder could rebind
+would attribute another value's ink to the field.
 Not tracked: expressions mixing several fields (`data.from + ", " + rank` has
-no single owner), values laundered through intermediate bindings, and card
-scalars read from the per-card loop variable (one shared expression site
-carries no per-instance identity: bind a widget or wrap a claim for those).
+no single owner), a value laundered past what the alias pass follows (a
+function parameter, a destructured binding), and card scalars read from the
+per-card loop variable (one shared expression site carries no per-instance
+identity: bind a widget or wrap a claim for those).
 **Marker claims** cover the ink a plate *composes* rather than reads off a
 field: a banner keyed on `data.classification`, a package-built address block, a
 computed table. The helper's `field-region(field, body)` brackets `body` with


### PR DESCRIPTION
Closes #1284.

A scalar read through a binding surfaced no region at all — not the container's address, absent. The two spellings differ by a refactor no plate author would think twice about: name the container once, step into it three times. The document renders correctly either way, so only the interaction surface goes missing and nothing says so.

## The fix

Tracking is **source-level, not value-level**: a window is a byte range and the classifier only asks whether a glyph's span falls inside it. So the alias resolves syntactically, with no classifier change and no data-seam change — `alias_bindings` collects each identifier the plate binds exactly once to exactly one whole `data` chain, and a read through that name anchors where the chain would, reusing `select_property`/`selected` verbatim.

Measured through `Backend::open` → `regions()`, against a declared `contact` object:

| spelling in the plate | before | after |
|---|---|---|
| `#data.contact.name` | `contact.name` | `contact.name` |
| `#let p = data.at("contact", default: (:))` … `#p.name` | *(none)* | `contact.name` |
| `#let q = data.contact` … `#q.name` | *(none)* | `contact.name` |
| bind once, use three times | *(none)* | `contact.name`, `contact.email`, `contact.listed` |
| `#let s = data.subject` … `#s` | *(none)* | `subject` |

## What makes it safe

The single-binder rule. A name a second `let`, a closure parameter, a loop pattern, an import, or an assignment could rebind is dropped rather than risk minting a window over another value's ink — a wrong region routes a click to the wrong field, which is worse than surfacing none. A wildcard import binds names the walk cannot see and disqualifies every alias. An initializer must be one whole chain: `#let x = upper(data.subject)` and `#let x = data.a + data.b` both yield no alias.

Laundering the pass cannot follow — a function parameter, a destructured binding, a per-card loop variable — is unchanged and still needs a `field-region` claim.

## Worth a reviewer's attention

- **The strictness is deliberate but quiet.** A plate that rebinds a name anywhere, even in an unrelated scope, silently drops back to no region. I chose that over risking a wrong address; it does mean the fix is less uniform than the behavior it replaces.
- **`d2f8295` fixes two defects in my own guard**, both caught on review rather than by the first test pass: the wildcard disqualifier only raised counts for names already recorded, so an import placed *before* the binding left the alias intact (verified the new case fails against the old logic); and the initializer lookup used structural equality, which `#let x = x` would resolve to the pattern instead of the init.

## Docs

The tracking contract stated the binding case as a flat non-guarantee in `PREVIEW.md` and the `regions` rustdoc, both updated. The plate-author guide — the one surface an author actually reads — never stated it at all: it documented the sibling case (the per-card loop variable) and its remedy, so the rule was discoverable only from the instance that happened to be written down. New "Which Reads Get Regions" section states the whole rule there, including that content and date fields are exempt because their ink is born in generated code.

`docs/migrations/0.105-to-0.106.md` is left alone — it describes 0.106 accurately, and this ships in the next minor.

## Not in scope

While tracing this I found that a `date` or `richtext` declared inside a **typed dictionary** degrades to a raw literal, because `quill::variant_field_type` has no `object` twin. That is filed separately as #1289. The two are cleanly separable: restoring an address through a binding gives a container property the same string-grade region a direct read gives it today, and cannot restore the date object, which is decided at codegen before any span tracking runs.

## Verification

`cargo test --workspace` green across all 58 test binaries; `node scripts/check-canon.mjs` passes. New coverage: three unit tests on `scalar_windows` (alias resolution, every rebinding shape, initializer shape) and two acceptance tests through the public `Backend`/`LiveSession` path in `container_address.rs`, one of which asserts `field_at` routes a click on a bound read to the cell it read.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137WcoKM8khhVCA1WBTms7C)_