### PR TITLE
Rewrite dense-prose as a project-agnostic skill, and trim CLAUDE.md

### DIFF
--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -1,55 +1,43 @@
 ---
 name: dense-prose
-description: Comment and doc policy — delete by default, prose only where the reader cannot get the fact from the code. Use when writing or reviewing code comments, prose/canon/, or any doc, and when a comment restates code, narrates change ("used to", "no longer", "as of 0.x"), or carries a list that will rot.
+description: Comment and doc policy — write none by default, keep only what a reader cannot get faster from the code. Use when writing or reviewing comments, docstrings, READMEs, or design docs, and when prose restates its own code, sells, or narrates how the code got here ("used to", "no longer", "as of 0.x", "tracked in #123").
 ---
 
-## Default: no comment
+## Default: none
 
-Code is the documentation. A comment is an admission the code failed to carry the fact, and it bills forever: read on every visit, rotted by every edit. Start at none and add back only what a reader demonstrably cannot get from the code.
+Code is the documentation. A comment is a second copy of a fact — read on every visit, rotted by every edit — so the honest default is zero, and one comes back only where a reader cannot get the fact faster from the code itself.
 
-Wrong is worse than missing. An unsaid fact costs a lookup; a wrong one is believed. Bloat and rot are one failure — a claim nobody re-checked. Verify against the code or say nothing.
+Wrong is worse than missing. A missing fact costs a lookup; a wrong one is believed. Bloat and rot are the same failure, a claim nobody re-checked: verify against the code or write nothing. The bar cuts both ways — a cut that drops a fact is dilution, not compression.
 
-## What earns prose
+## What earns words
 
 | Surface | Budget |
 |---|---|
-| `pub` API of a published crate, TypeScript declarations, `.pyi` stubs, READMEs | A tight paragraph: the contract, the argument and return meaning the type does not carry, errors, panics. One example, and only where the call shape is not obvious. |
-| The non-obvious why | One line: workaround, upstream bug, ordering constraint, spec citation, wire-format fact. |
-| `SAFETY:` on `unsafe`, `#[allow]` and `cfg` rationale | Keep. |
-| Anything private or `pub(crate)` | Nothing, unless it states an invariant the reader would otherwise violate. Then one line. |
-| Load-bearing legacy (versioned wire schemas in `crates/core/src/document/dto.rs`) | Keep the fact: the old-format description *is* current reader behavior. |
+| Public API: what a caller depends on without reading the body | The contract — argument and return meaning the types do not carry, errors, and the invariants a caller can violate. One example, where the call shape is not obvious. |
+| A non-obvious why | One line: the ordering constraint, the upstream bug, the spec citation, the workaround that looks arbitrary and is not. |
+| A hazard the compiler cannot see | Keep. Preconditions on unsafe code, suppressed warnings, deliberate deviation from the obvious. |
+| A test | Its name. One line only where the assertion is unreadable without it; a regression test states the invariant guarded, never the bug's history. |
+| Anything internal | Nothing, unless it states an invariant the reader would otherwise break. Then one line. |
 
 ## Delete on sight
 
-- **Echoes.** `// increment i`; `/// The name` on `name`; a doc re-narrating the body. A better identifier beats the comment.
-- **Rot-prone lists.** Never enumerate a module's items, features, or behaviors: rustdoc lists items and the hand-list drifts. Name the module's job in one line, or say nothing.
-- **History.** "used to", "no longer", "previously", "formerly", "as of 0.x", "removed in", "renamed", "we switched" — assert the present instead. Current behavior in a historical costume keeps the fact and drops the framing: "the legacy `~~~card-yaml` opener is still accepted but no longer canonical" → "`~~~card-yaml` is also accepted as a non-canonical alias." (`used to` often means "used **in order to**"; read before cutting.)
-- **Deliberation.** "we considered", "spike", "deferred", "for now", "eventually", rejected-alternative essays. Keep the resulting fact and the rationale for the present choice; drop the when and the who.
-- **Status markers.** `(#970)`, "tracked in #736" say only that work is in motion, and they date the sentence around them. Keep only where the issue is the subject, in a CI or release doc.
-- **Sell.** *powerful, seamless, battle-tested, simply, easily*. Keep *just / simply / only* when load-bearing ("just sugar for the `raw` element").
-- **Banners and throat-clearing.** `// ---- helpers ----`, "Note that", a first line restating its own heading.
+- **Echoes.** Prose restating the line beneath it, or a field's own name. A better identifier beats the comment.
+- **Hand-kept lists.** A header enumerating a module's exports, cases, or features: the tooling lists them already and the copy drifts. Name the module's job in one line, or say nothing.
+- **Process instead of state.** "used to", "no longer", "previously", "as of 0.x", "renamed", "we switched", "we considered", "deferred", "for now", "tracked in #123" — each narrates how the code got here or that work is in motion, and each dates the sentence around it. Assert the present.
+- **Sell.** *powerful, seamless, battle-tested, effortless*, and *simply / easily* where they only flatter. Keep *just / only* where load-bearing.
+- **Throat-clearing.** "Note that", banner rules, a first line restating its own heading.
+
+Reframe rather than delete where the past is load-bearing for the present: an accepted alias, a tolerated input, a stored old format is current behavior in a historical costume. Read before cutting, since `used to` often means "used **in order to**".
 
 ## Compress what survives
 
-Cut any sentence whose removal costs no fact. Length tracks surprise: the unobvious invariant gets the words, the obvious call gets none. One claim per sentence — fold a qualifier into the clause it qualifies, and split a sentence carrying seven clauses, because the reader decompresses it to reach the one fact they came for. A bullet needing three clauses is three bullets or a table row; per-case rules (per type, per format, per backend) are a table.
+Cut any sentence whose removal costs no fact. Length tracks surprise: the unobvious invariant gets the words, the obvious call gets none. Lead with the contract, then the mechanism. Fold a qualifier into the clause it qualifies rather than appending a sentence, name the specific noun and the measured number, and reuse the term the code already uses instead of minting a synonym.
 
-Present tense. Lead with the contract, then the mechanism. Name the specific noun and the measured number. Reuse the terms of art (*card-yaml block, plate, quill, backend, seam*).
-
-A paragraph is one line: never hard-wrap prose at a column. A line break means a new paragraph, list item, or table row. Comments wrap to the code's line budget.
-
-## Tests
-
-A test's name is its documentation. Delete test comments; keep one line only where the assertion is unreadable without it. A regression test states the invariant guarded ("X must not happen; would cause Y"), never the bug's history.
+Compression is not density: one claim per sentence. A sentence carrying seven clauses is maximally compressed and unreadable, because the reader decompresses it to reach the one fact they came for. A bullet needing three clauses is three bullets; per-case rules are a table, and a table row is a record, not a sentence.
 
 ## Limits
 
-- `docs/migrations/**`, `CHANGELOG.md`, and era-stamped records: **repair only**. They are accurate to their moment — fix what was wrong when written, leave what was right in its era's vocabulary.
-- `prose/references/`, `prose/proposals/`, `prose/plans/`: strip the sell only. Discussing other or future states is their job.
+- Era-stamped records — changelogs, applied migrations, incident notes — are **repair only**. They are accurate to their moment: fix what was wrong when written, leave what was right in its era's vocabulary.
 - Never rename identifiers. Out of scope, pure churn.
-- Edits are surgical: touch a line only when it breaks a rule. A cut that drops a fact is dilution, not compression.
-
-Canon *structure* (Title → Implementation anchor → TL;DR, one concept per page) belongs to **`maintain-canon`**.
-
-## Done when
-
-Nothing restates code, no header carries a rotting list, no prose narrates history or deliberation, and every surviving sentence states a verified fact the reader could not get faster from the code. Verify: build and tests pass, no doctest broken, `node scripts/check-canon.mjs` passes.
+- Edits are surgical. Touch a line only when it breaks a rule, and match the file's existing formatting rather than reflowing around the change.
+- Run the project's own checks before finishing. A doc example is compiled code, and a test may assert the wording being changed.

--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -1,43 +1,41 @@
 ---
 name: dense-prose
-description: Comment and doc policy — write none by default, keep only what a reader cannot get faster from the code. Use when writing or reviewing comments, docstrings, READMEs, or design docs, and when prose restates its own code, sells, or narrates how the code got here ("used to", "no longer", "as of 0.x", "tracked in #123").
+description: Comment and doc policy — write none by default, keep only what a reader cannot get faster from the code. Use when writing or reviewing comments, docstrings, or any doc, and when prose restates its own code, sells, or narrates how the code got here ("used to", "no longer", "as of 0.x", "tracked in #123").
 ---
 
 ## Default: none
 
-Code is the documentation. A comment is a second copy of a fact — read on every visit, rotted by every edit — so the honest default is zero, and one comes back only where a reader cannot get the fact faster from the code itself.
+Code is the documentation. A comment is a second copy of a fact, read on every visit and rotted by every edit. The default is none; one comes back only where a reader cannot get the fact faster from the code itself.
 
-Wrong is worse than missing. A missing fact costs a lookup; a wrong one is believed. Bloat and rot are the same failure, a claim nobody re-checked: verify against the code or write nothing. The bar cuts both ways — a cut that drops a fact is dilution, not compression.
+Wrong is worse than missing. A missing fact costs a lookup; a wrong one is believed. Bloat and rot are the same failure, a claim nobody re-checked: verify against the code or write nothing. The bar cuts both ways: a cut that drops a fact is dilution, not compression. A comment contradicting the code gets fixed, not deleted.
 
 ## What earns words
 
 | Surface | Budget |
 |---|---|
-| Public API: what a caller depends on without reading the body | The contract — argument and return meaning the types do not carry, errors, and the invariants a caller can violate. One example, where the call shape is not obvious. |
-| A non-obvious why | One line: the ordering constraint, the upstream bug, the spec citation, the workaround that looks arbitrary and is not. |
-| A hazard the compiler cannot see | Keep. Preconditions on unsafe code, suppressed warnings, deliberate deviation from the obvious. |
-| A test | Its name. One line only where the assertion is unreadable without it; a regression test states the invariant guarded, never the bug's history. |
-| Anything internal | Nothing, unless it states an invariant the reader would otherwise break. Then one line. |
+| Public API: what a caller depends on without reading the body | The contract — argument and return meaning the types do not carry, the errors, the invariants a caller can violate. One example, where the call shape is not obvious. |
+| A reason not visible from the code | One line: the ordering constraint, the upstream bug, the spec citation, the choice that looks arbitrary and is not. |
+| A hazard the tooling will not show | Keep. An unsafe precondition, a suppressed warning or lint, a deliberate deviation from the obvious. |
+| A test | Its name. A regression test states the invariant guarded, never the bug's history. |
+| Everything else | Nothing, unless a reader would otherwise break an invariant. Then one line. |
 
 ## Delete on sight
 
-- **Echoes.** Prose restating the line beneath it, or a field's own name. A better identifier beats the comment.
+- **Echoes.** Prose restating the line beneath it, or a field's own name.
 - **Hand-kept lists.** A header enumerating a module's exports, cases, or features: the tooling lists them already and the copy drifts. Name the module's job in one line, or say nothing.
-- **Process instead of state.** "used to", "no longer", "previously", "as of 0.x", "renamed", "we switched", "we considered", "deferred", "for now", "tracked in #123" — each narrates how the code got here or that work is in motion, and each dates the sentence around it. Assert the present.
-- **Sell.** *powerful, seamless, battle-tested, effortless*, and *simply / easily* where they only flatter. Keep *just / only* where load-bearing.
-- **Throat-clearing.** "Note that", banner rules, a first line restating its own heading.
+- **Process instead of state.** "used to", "no longer", "as of 0.x", "we switched", "we considered", "deferred", "for now", "tracked in #123" — the story of how the code got here, or that work is in motion. State what is, in the present tense: not what the code will do, not how it came to do it. The reason for a choice survives; the account of reaching it does not.
+- **Sell.** *powerful, seamless, battle-tested, effortless*, and *simply / easily* where they only flatter. Keep *just / simply / only* where load-bearing.
+- **Throat-clearing.** "Note that", a banner comment (`// ---- helpers ----`), a first line restating its own heading.
 
 Reframe rather than delete where the past is load-bearing for the present: an accepted alias, a tolerated input, a stored old format is current behavior in a historical costume. Read before cutting, since `used to` often means "used **in order to**".
 
 ## Compress what survives
 
-Cut any sentence whose removal costs no fact. Length tracks surprise: the unobvious invariant gets the words, the obvious call gets none. Lead with the contract, then the mechanism. Fold a qualifier into the clause it qualifies rather than appending a sentence, name the specific noun and the measured number, and reuse the term the code already uses instead of minting a synonym.
+Cut any sentence whose removal costs no fact. Length tracks surprise: the unobvious invariant gets the words, the obvious call gets none. Name the specific noun and the measured number. Reuse the term the code already uses rather than minting a synonym.
 
-Compression is not density: one claim per sentence. A sentence carrying seven clauses is maximally compressed and unreadable, because the reader decompresses it to reach the one fact they came for. A bullet needing three clauses is three bullets; per-case rules are a table, and a table row is a record, not a sentence.
+Compression is not density: one claim per sentence. A sentence carrying seven clauses is maximally compressed and unreadable, because the reader decompresses it to reach the one fact they came for. A bullet needing three clauses is three bullets; per-case rules are a table.
 
 ## Limits
 
-- Era-stamped records — changelogs, applied migrations, incident notes — are **repair only**. They are accurate to their moment: fix what was wrong when written, leave what was right in its era's vocabulary.
-- Never rename identifiers. Out of scope, pure churn.
-- Edits are surgical. Touch a line only when it breaks a rule.
-- A comment-only change can break the build: doc examples compile, and a test may assert the wording being changed.
+- A doc about another moment keeps it. A changelog, an applied migration, or an incident note is **repair only**: fix what was wrong when written, leave what was right in its era's vocabulary. A proposal argues a future state, and flattening it into what is destroys the document.
+- Touch a line only when it breaks a rule.

--- a/.claude/skills/dense-prose/SKILL.md
+++ b/.claude/skills/dense-prose/SKILL.md
@@ -39,5 +39,5 @@ Compression is not density: one claim per sentence. A sentence carrying seven cl
 
 - Era-stamped records — changelogs, applied migrations, incident notes — are **repair only**. They are accurate to their moment: fix what was wrong when written, leave what was right in its era's vocabulary.
 - Never rename identifiers. Out of scope, pure churn.
-- Edits are surgical. Touch a line only when it breaks a rule, and match the file's existing formatting rather than reflowing around the change.
-- Run the project's own checks before finishing. A doc example is compiled code, and a test may assert the wording being changed.
+- Edits are surgical. Touch a line only when it breaks a rule.
+- A comment-only change can break the build: doc examples compile, and a test may assert the wording being changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Crate layout and what each crate carries: [`ARCHITECTURE.md`](prose/canon/ARCHIT
 
 Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md).
 
+Comments default to none, and one earns its place only where the code cannot carry the fact itself. What survives states what is: present tense, unsold, no history. The `dense-prose` skill is the whole policy.
+
 - The `Cargo.toml` version is the last *released* one; CI bumps it on release.
 - A `CHANGELOG.md` conflict resolves itself: `.gitattributes` marks it `merge=union`, so merge `main` with local git rather than pressing "Update branch", which does not read it.
 - Don't run `cargo fmt`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,10 @@ Schema-driven document engine: Markdown + YAML card metadata → rendered PDF/SV
 
 Crate layout and what each crate carries: [`ARCHITECTURE.md`](prose/canon/ARCHITECTURE.md) §"Crate Structure".
 
-Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md). Comments and docs follow the `dense-prose` skill.
+Design docs: [`prose/canon/INDEX.md`](prose/canon/INDEX.md).
 
 - The `Cargo.toml` version is the last *released* one; CI bumps it on release.
 - A `CHANGELOG.md` conflict resolves itself: `.gitattributes` marks it `merge=union`, so merge `main` with local git rather than pressing "Update branch", which does not read it.
-- Commit early and often; CI gates every push.
 - Don't run `cargo fmt`.
 
 ## Tests


### PR DESCRIPTION
Two changes on one principle: a line earns its place only by counteracting a default, and anything the assistant already does unprompted is an echo.

# 1. `.claude/skills/dense-prose/SKILL.md`

Replaced with a greenfield version: 41 lines / 3,764 bytes, against 55/4,986 here before, 65/5,788 in `quillmark-js`, and 92/10,898 in `web-app`.

## Two cuts drove the size

**Three rules collapsed into one.** History markers, deliberation markers, and issue numbers were separate rules in every prior version, but they state a single idea — prose narrating *process* where it should assert *state*. The `Workflow` and `Done when` sections went with them: both re-listed rules stated earlier, and duplication is what the skill forbids.

**Rules that steer toward defaults were dropped.** That retired "match the file's existing formatting", "run the project's checks before finishing", and — via a cascade — "never rename identifiers", which existed only to guard against an invitation this skill was issuing itself in "a better identifier beats the comment". Cutting the invitation retires the guard and resolves the deadlock between them: an echo comment on a badly-named symbol previously had no legal action.

## Portability

No path, command, sibling skill, or term of art survives, so the file carries nothing that rots against a repo it does not read, and drops into `quillmark-js` and `web-app` unchanged. Casualties: the `dto.rs` example, the `check-canon.mjs` verification step, and the `maintain-canon` hand-off.

The `prose/proposals/` and `prose/plans/` carve-out was restated generally rather than dropped — a proposal argues a future state, and flattening it into what-is destroys the document. It now shares a bullet with changelogs and migrations, which are the same shape: a doc whose subject is another moment.

## Behavior changes worth review

- The one-line-paragraph rule is **gone**. It is a formatting convention rather than a density principle, and no portable skill can know a project's wrap width. Worth noting it was unmet anyway: 14 of 16 pages in `prose/canon/` are hard-wrapped at ~80 columns, so the rule described an intent rather than the corpus. This is the most contestable cut here.
- The rationale-preservation rule now lives *inside* the process bullet ("the reason for a choice survives; the account of reaching it does not") rather than as a separate exception, which is what made it droppable.
- The hazard row no longer assumes a compiled language, so suppressed lints and `# type: ignore` rationale are covered alongside `unsafe` preconditions.

## Verification

Audited against its own rules, by grep and by an independent adversarial read. The read caught three defects grep structurally could not: three directives packed into one sentence two lines above "one claim per sentence"; *simply* condemned in the sell rule and absent from its keep-list; and a dead label restating the sentence beneath it. All three are fixed.

# 2. `CLAUDE.md`

20 lines → 21. CLAUDE.md is charged against *every* session, including the majority where a given line is irrelevant, so the bar is higher than a skill's: bespoke to this repo, non-derivable, and better than the unprompted default.

**Cut:** "Commit early and often; CI gates every push" — a principle rather than a fact about this repo, and committing at coherent points is not worse.

**Replaced:** "Comments and docs follow the `dense-prose` skill" was a bare pointer, and a skill only loads when its description triggers. Most comments are written mid-implementation, on tasks that never trip a prose-shaped trigger, where the assistant reverts to commenting liberally and selling. Three sentences now carry the standing default — none by default, present tense, unsold, no history — and route to the skill for everything past that. The same three sentences go into `quillmark-js` and `web-app` verbatim, since the voice is shared even though every other line in these files is repo-specific.

Everything expensive to rediscover stays untouched: `cargo fmt`, the version being the last *released* one, the `merge=union` / "Update branch" trap, the don't-build-bindings-locally guidance, and the `uv run` sync that compiles a release build to print a version string.

## Verification

`node scripts/check-canon.mjs` passes. No code or prose outside these two files is touched.