### PR TITLE
Pin the schema address grammar across both backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- test: one table pins the schema address grammar on both backends
+  (`quillmark/tests/address_grammar.rs`), covering every position the nesting
+  contract admits, each position's card twin, and the rejects that bound each
+  step. `PLATE_DATA.md` promises a plate author that one address binds on
+  either backend, and the grammar is written twice to keep it — an unbounded
+  schema walk in `pdfform::bind`, an enumeration of the suffix forms in the
+  Typst helper's `_qm-known-path` — reading two different projections of the
+  same `QuillConfig`, so either side can move alone. `pdfform` exports
+  `resolves_schema_address` (`#[doc(hidden)]`) so the pin can ask both the same
+  question. A body address is the plate grammar's alone and is pinned as such.
+
 - **breaking** typst: lowering dispatches on the schema node beside each value
   rather than on tables of top-level field names, so a declared type means the
   same thing wherever it is declared. A `date`, `richtext` or `plaintext`

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -108,11 +108,9 @@ impl Backend for PdfformBackend {
 
 /// Whether `path` resolves against `config` as a schema address.
 ///
-/// Binding a widget needs more than this — the resolved field must also project
-/// to a widget shape — but the grammar alone is what the Typst helper's
-/// `_qm-known-path` states a second time, so the drift pin
-/// (`quillmark/tests/address_grammar.rs`) compares the two at exactly this
-/// question. Not part of the rendering seam.
+/// Binding a widget needs more: the resolved field must also project to a widget
+/// shape. The grammar alone is what the Typst helper's `_qm-known-path` states a
+/// second time, so `quillmark/tests/address_grammar.rs` compares the two here.
 #[doc(hidden)]
 pub fn resolves_schema_address(config: &QuillConfig, path: &str) -> bool {
     bind::bind(config, "", path).is_ok()

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -15,6 +15,7 @@ mod typography;
 use bind::BoundWidget;
 use flatten::flatten as flatten_to_pdf;
 use form::FormSpec;
+use quillmark_core::quill::QuillConfig;
 use quillmark_core::session::SessionHandle;
 use quillmark_core::{
     Artifact, Backend, ChangeSet, Diagnostic, LiveSession, OutputFormat, Quill, RenderError,
@@ -103,6 +104,18 @@ impl Backend for PdfformBackend {
             source.config().clone(),
         ))
     }
+}
+
+/// Whether `path` resolves against `config` as a schema address.
+///
+/// Binding a widget needs more than this — the resolved field must also project
+/// to a widget shape — but the grammar alone is what the Typst helper's
+/// `_qm-known-path` states a second time, so the drift pin
+/// (`quillmark/tests/address_grammar.rs`) compares the two at exactly this
+/// question. Not part of the rendering seam.
+#[doc(hidden)]
+pub fn resolves_schema_address(config: &QuillConfig, path: &str) -> bool {
+    bind::bind(config, "", path).is_ok()
 }
 
 fn resolve_field_specs(bound: &[BoundWidget], json_data: &serde_json::Value) -> Vec<FieldSpec> {

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -2,8 +2,8 @@
 //! the public `Backend`/`LiveSession` path, and the address a region carries for
 //! a plate that reads one property.
 //!
-//! Which addresses the grammar admits is `quillmark/tests/address_grammar.rs`,
-//! stated once there against both backends.
+//! The addresses the grammar admits are stated once, against both backends, in
+//! `quillmark/tests/address_grammar.rs`.
 
 use quillmark_core::Backend;
 use quillmark_typst::TypstBackend;
@@ -336,8 +336,8 @@ fn a_variant_cell_lowers_its_declared_type() {
     );
 }
 
-/// The two helpers carrying the grammar assert on the same table, so an address
-/// the shared pin refuses is refused at the widget seam too.
+/// The shared pin drives `field-region`; `form-field` carries its own copy of
+/// the assert.
 #[test]
 fn a_widget_binds_the_same_grammar_a_claim_does() {
     let err = rejects(

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -1,7 +1,9 @@
 //! The container property step (`classification.poc`, `address.city`) through
-//! the public `Backend`/`LiveSession` path: what the address grammar accepts,
-//! what it still rejects, and the address a region carries for a plate that
-//! reads one property.
+//! the public `Backend`/`LiveSession` path, and the address a region carries for
+//! a plate that reads one property.
+//!
+//! Which addresses the grammar admits is `quillmark/tests/address_grammar.rs`,
+//! stated once there against both backends.
 
 use quillmark_core::Backend;
 use quillmark_typst::TypstBackend;
@@ -266,12 +268,8 @@ card_kinds:
     );
 }
 
-/// The step is gated on what the field offers, so a scalar admits neither an
-/// index nor a property, and a container admits only its declared keys.
-/// A typed table's row property is one address on both backends. pdfform's
-/// `bind` descends unboundedly and has always resolved `refs.0.org`; the Typst
-/// grammar capped at one suffix step, so the shape `ShapePosition::ArrayItem`
-/// admits was writable on one backend only.
+/// A typed table's row property claims ink of its own, through an explicit
+/// claim and through a widget alike.
 #[test]
 fn a_typed_table_row_property_is_addressable() {
     let session = open(
@@ -338,28 +336,15 @@ fn a_variant_cell_lowers_its_declared_type() {
     );
 }
 
+/// The two helpers carrying the grammar assert on the same table, so an address
+/// the shared pin refuses is refused at the widget seam too.
 #[test]
-fn the_step_is_gated_on_the_declared_shape() {
-    for (address, plate_field) in [
-        ("subject.poc", "a scalar has no property"),
-        ("classification.undeclared", "an undeclared key is no cell"),
-        ("classification.0", "a container has no element"),
-        ("address.9", "a typed dictionary has no element"),
-        ("refs.0.undeclared", "an undeclared row key is no cell"),
-        ("tags.0.org", "a primitive element has no property"),
-        ("address.city.0", "the grammar stops at the declared depth"),
-        ("refs.org", "a row property needs its index"),
-    ] {
-        let plate = format!(
-            r#"
-#import "@local/quillmark-helper:0.1.0": field-region
-#field-region("{address}")[x]
-"#
-        );
-        let err = rejects(&plate);
-        assert!(
-            err.contains("not a schema field address"),
-            "{plate_field} ({address:?}): {err}"
-        );
-    }
+fn a_widget_binds_the_same_grammar_a_claim_does() {
+    let err = rejects(
+        r#"
+#import "@local/quillmark-helper:0.1.0": form-field
+#form-field("Bad", field: "address.city.0", value: "x")
+"#,
+    );
+    assert!(err.contains("not a schema field address"), "{err}");
 }

--- a/crates/quillmark/tests/address_grammar.rs
+++ b/crates/quillmark/tests/address_grammar.rs
@@ -1,12 +1,11 @@
-//! One schema address grammar, two implementations. pdfform's `bind` walks the
-//! `QuillConfig`; the Typst helper's `_qm-known-path` reads the address tables
-//! `SchemaMeta` derives from the transform schema. `PLATE_DATA.md` promises a
-//! plate author that one address binds on either backend, and [`GRAMMAR`] is
-//! what holds the two to it — neither side can move alone.
+//! One schema address grammar, two implementations: pdfform's `bind` walks the
+//! `QuillConfig`, and the Typst helper's `_qm-known-path` reads the address
+//! tables `SchemaMeta` derives from the transform schema. `PLATE_DATA.md`
+//! promises a plate author that one address binds on either backend, and
+//! `GRAMMAR` is what holds the two to it.
 //!
-//! The two content addresses sit outside that promise:
-//! [`a_body_address_is_typst_only`] pins them so the asymmetry reads as declared
-//! rather than as drift.
+//! A `$body` address is outside that table: a body is content rather than a
+//! bindable field, so pdfform's resolver roots none.
 
 #![cfg(all(feature = "typst", feature = "pdfform"))]
 
@@ -14,8 +13,8 @@ use quillmark::{Backend, FileTreeNode, Quill};
 use quillmark_typst::TypstBackend;
 use std::collections::HashMap;
 
-/// Every position the one-level nesting contract admits, declared once at card
-/// level and once inside a card kind so each address has its card twin.
+/// Every position the one-level nesting contract admits, declared on `main` and
+/// again on a card kind so each address has its card twin.
 const YAML: &str = r#"
 quill:
   name: address_grammar
@@ -83,9 +82,8 @@ card_kinds:
 
 /// Every address both backends must resolve, and every one both must refuse.
 ///
-/// An index is not bounds-checked at address time on either side — `refs.9` and
-/// the ninth endorsement resolve against a document carrying one of each — so
-/// the grammar is a question about the schema alone.
+/// An index is not bounds-checked: `refs.9` resolves against a document carrying
+/// one ref, because the grammar asks about the schema alone.
 const GRAMMAR: &[(&str, bool)] = &[
     ("subject", true),
     ("tags", true),
@@ -170,7 +168,6 @@ fn data() -> serde_json::Value {
     })
 }
 
-/// A plate claiming each of `addresses`, so one compile answers a whole column.
 fn claims(addresses: impl IntoIterator<Item = &'static str>) -> String {
     addresses
         .into_iter()
@@ -216,9 +213,6 @@ fn typst_refuses_every_address_the_grammar_refuses() {
     }
 }
 
-/// A body is content rather than a widget-bindable field, so the promise
-/// [`GRAMMAR`] pins stops at the two body addresses: a plate writes them and
-/// pdfform's resolver roots neither.
 #[test]
 fn a_body_address_is_typst_only() {
     let bodies = ["$body", "$cards.endorsement.0.$body"];

--- a/crates/quillmark/tests/address_grammar.rs
+++ b/crates/quillmark/tests/address_grammar.rs
@@ -1,0 +1,235 @@
+//! One schema address grammar, two implementations. pdfform's `bind` walks the
+//! `QuillConfig`; the Typst helper's `_qm-known-path` reads the address tables
+//! `SchemaMeta` derives from the transform schema. `PLATE_DATA.md` promises a
+//! plate author that one address binds on either backend, and [`GRAMMAR`] is
+//! what holds the two to it — neither side can move alone.
+//!
+//! The two content addresses sit outside that promise:
+//! [`a_body_address_is_typst_only`] pins them so the asymmetry reads as declared
+//! rather than as drift.
+
+#![cfg(all(feature = "typst", feature = "pdfform"))]
+
+use quillmark::{Backend, FileTreeNode, Quill};
+use quillmark_typst::TypstBackend;
+use std::collections::HashMap;
+
+/// Every position the one-level nesting contract admits, declared once at card
+/// level and once inside a card kind so each address has its card twin.
+const YAML: &str = r#"
+quill:
+  name: address_grammar
+  version: 0.1.0
+  backend: typst
+  description: every position the nesting contract admits
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    subject:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+    refs:
+      type: array
+      items:
+        type: object
+        properties:
+          org: { type: string }
+          num: { type: string }
+    address:
+      type: object
+      properties:
+        city: { type: string }
+        street: { type: string }
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      default: ""
+      variants:
+        CUI:
+          poc: { type: string }
+card_kinds:
+  endorsement:
+    fields:
+      from:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+      refs:
+        type: array
+        items:
+          type: object
+          properties:
+            org: { type: string }
+            num: { type: string }
+      origin:
+        type: object
+        properties:
+          office: { type: string }
+          city: { type: string }
+      level:
+        type: enum
+        values: [FIRST, SECOND]
+        default: ""
+        variants:
+          SECOND:
+            endorser: { type: string }
+"#;
+
+/// Every address both backends must resolve, and every one both must refuse.
+///
+/// An index is not bounds-checked at address time on either side — `refs.9` and
+/// the ninth endorsement resolve against a document carrying one of each — so
+/// the grammar is a question about the schema alone.
+const GRAMMAR: &[(&str, bool)] = &[
+    ("subject", true),
+    ("tags", true),
+    ("tags.0", true),
+    ("refs", true),
+    ("refs.0", true),
+    ("refs.9", true),
+    ("refs.0.org", true),
+    ("address", true),
+    ("address.city", true),
+    ("classification", true),
+    ("classification.value", true),
+    ("classification.poc", true),
+    ("$cards.endorsement.0.from", true),
+    ("$cards.endorsement.9.from", true),
+    ("$cards.endorsement.0.tags", true),
+    ("$cards.endorsement.0.tags.0", true),
+    ("$cards.endorsement.0.refs", true),
+    ("$cards.endorsement.0.refs.0", true),
+    ("$cards.endorsement.0.refs.0.org", true),
+    ("$cards.endorsement.0.origin", true),
+    ("$cards.endorsement.0.origin.office", true),
+    ("$cards.endorsement.0.level", true),
+    ("$cards.endorsement.0.level.value", true),
+    ("$cards.endorsement.0.level.endorser", true),
+    ("nonesuch", false),
+    ("subject.0", false),
+    ("subject.poc", false),
+    ("tags.0.org", false),
+    ("refs.org", false),
+    ("refs.0.undeclared", false),
+    ("address.9", false),
+    ("address.zip", false),
+    ("address.city.0", false),
+    ("classification.0", false),
+    ("classification.undeclared", false),
+    ("classification.value.oops", false),
+    ("$cards", false),
+    ("$cards.endorsement", false),
+    ("$cards.endorsement.0", false),
+    ("$cards.0.from", false),
+    ("$cards.nosuch.0.from", false),
+    ("$cards.endorsement.x.from", false),
+    ("$cards.endorsement.0.nosuch", false),
+    ("$cards.endorsement.0.from.0", false),
+    ("$cards.endorsement.0.tags.0.org", false),
+    ("$cards.endorsement.0.origin.office.0", false),
+];
+
+const PREAMBLE: &str = r#"#import "@local/quillmark-helper:0.1.0": field-region
+#set page(width: 400pt, height: 1200pt, margin: 20pt)
+"#;
+
+fn quill(plate: &str) -> Quill {
+    let mut files = HashMap::new();
+    for (name, contents) in [("Quill.yaml", YAML), ("plate.typ", plate)] {
+        files.insert(
+            name.to_string(),
+            FileTreeNode::File {
+                contents: contents.as_bytes().to_vec(),
+            },
+        );
+    }
+    Quill::from_tree(FileTreeNode::Directory { files }).expect("load quill")
+}
+
+fn data() -> serde_json::Value {
+    serde_json::json!({
+        "subject": "Widgets",
+        "tags": ["urgent"],
+        "refs": [{ "org": "AFRL/RQ", "num": "2026-01" }],
+        "address": { "city": "Dayton", "street": "1864 Fourth St" },
+        "classification": { "value": "CUI", "poc": "Capt J. Smith" },
+        "$cards": [{
+            "$kind": "endorsement",
+            "from": "SAF/AA",
+            "tags": ["routine"],
+            "refs": [{ "org": "AFRL/RQ", "num": "2026-02" }],
+            "origin": { "office": "SAF/AA", "city": "Dayton" },
+            "level": { "value": "SECOND", "endorser": "Col K. Lee" },
+        }],
+    })
+}
+
+/// A plate claiming each of `addresses`, so one compile answers a whole column.
+fn claims(addresses: impl IntoIterator<Item = &'static str>) -> String {
+    addresses
+        .into_iter()
+        .fold(PREAMBLE.to_string(), |mut plate, address| {
+            plate.push_str(&format!("#field-region(\"{address}\")[x]\n"));
+            plate
+        })
+}
+
+fn compile(plate: &str) -> Result<quillmark::LiveSession, String> {
+    TypstBackend
+        .open(&quill(plate), &data())
+        .map_err(|e| format!("{e}"))
+}
+
+#[test]
+fn pdfform_resolves_exactly_the_shared_grammar() {
+    let quill = quill("");
+    for (address, resolves) in GRAMMAR {
+        assert_eq!(
+            quillmark_pdfform::resolves_schema_address(quill.config(), address),
+            *resolves,
+            "{address:?}"
+        );
+    }
+}
+
+#[test]
+fn typst_admits_every_address_the_grammar_resolves() {
+    let accepted = GRAMMAR.iter().filter(|(_, ok)| *ok).map(|(a, _)| *a);
+    if let Err(err) = compile(&claims(accepted)) {
+        panic!("every resolving address must compile: {err}");
+    }
+}
+
+#[test]
+fn typst_refuses_every_address_the_grammar_refuses() {
+    for (address, _) in GRAMMAR.iter().filter(|(_, ok)| !*ok) {
+        let Err(err) = compile(&claims([*address])) else {
+            panic!("{address:?} must not compile");
+        };
+        assert!(err.contains("not a schema field address"), "{address:?}: {err}");
+    }
+}
+
+/// A body is content rather than a widget-bindable field, so the promise
+/// [`GRAMMAR`] pins stops at the two body addresses: a plate writes them and
+/// pdfform's resolver roots neither.
+#[test]
+fn a_body_address_is_typst_only() {
+    let bodies = ["$body", "$cards.endorsement.0.$body"];
+    let quill = quill("");
+    for address in bodies {
+        assert!(
+            !quillmark_pdfform::resolves_schema_address(quill.config(), address),
+            "{address:?}"
+        );
+    }
+    if let Err(err) = compile(&claims(bodies)) {
+        panic!("a plate claims a body address: {err}");
+    }
+}

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -133,11 +133,15 @@ resolve to. A **container** is a typed dictionary or a variant container — bot
 project as `type: object` carrying `properties`, so a variant's cells and its
 `value` discriminant are addressable exactly as a dictionary's keys are
 ([SCHEMAS.md](SCHEMAS.md#enum-variants)). This is the pdfform resolver's grammar
-(`backends/pdfform/src/bind.rs`), so one address binds on either backend.
+(`backends/pdfform/src/bind.rs`), so one address binds on either backend. The two
+are written twice, in two languages, and held to one table by
+`quillmark/tests/address_grammar.rs`.
 
 Cards carry their canonical prefix as `$path`, so a plate composes a card
 address without reimplementing the kind+ordinal grammar:
-`field-region(card.at("$path") + "$body")`.
+`field-region(card.at("$path") + "$body")`. A body is content rather than a
+bindable field, so that one address is the plate grammar's alone: pdfform's
+resolver roots no `$body`.
 
 The same addresses key the preview's region sidecar
 ([PREVIEW.md](PREVIEW.md)), so a plate that reads one container property

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -133,15 +133,15 @@ resolve to. A **container** is a typed dictionary or a variant container — bot
 project as `type: object` carrying `properties`, so a variant's cells and its
 `value` discriminant are addressable exactly as a dictionary's keys are
 ([SCHEMAS.md](SCHEMAS.md#enum-variants)). This is the pdfform resolver's grammar
-(`backends/pdfform/src/bind.rs`), so one address binds on either backend. The two
-are written twice, in two languages, and held to one table by
+(`backends/pdfform/src/bind.rs`), so one address binds on either backend. The
+grammar is written twice, in two languages, and held to one table by
 `quillmark/tests/address_grammar.rs`.
 
 Cards carry their canonical prefix as `$path`, so a plate composes a card
 address without reimplementing the kind+ordinal grammar:
 `field-region(card.at("$path") + "$body")`. A body is content rather than a
-bindable field, so that one address is the plate grammar's alone: pdfform's
-resolver roots no `$body`.
+bindable field, so a `$body` address is the plate grammar's alone: pdfform's
+resolver roots none.
 
 The same addresses key the preview's region sidecar
 ([PREVIEW.md](PREVIEW.md)), so a plate that reads one container property


### PR DESCRIPTION
Closes #1295.

`PLATE_DATA.md` promises a plate author that one schema address binds on either backend. The grammar is written twice to keep that promise — an unbounded schema walk over `QuillConfig` in `pdfform::bind`, an enumeration of the suffix forms over the generated address tables in the Typst helper's `_qm-known-path` — and the two read *different* projections of the same config, so either side can move alone. #1292 closed one such divergence by hand on both sides with nothing to catch the next.

One table now states the promise, and both sides answer to it.

## What's here

**`crates/quillmark/tests/address_grammar.rs`** — a 45-row `GRAMMAR` table (address → resolves), driven three ways:

| test | what it asks |
|---|---|
| `pdfform_resolves_exactly_the_shared_grammar` | the resolver, called directly |
| `typst_admits_every_address_the_grammar_resolves` | all 24 accepts claimed in one plate, one compile |
| `typst_refuses_every_address_the_grammar_refuses` | one compile per reject, each asserting the seam's own message |

Rows cover every position the nesting contract admits — scalar, primitive list, array element, typed table, row, row property, typed dictionary, dictionary property, variant container, discriminant, variant cell — each one's card twin, and the rejects that bound each step. The whole file runs in 0.43s.

**`crates/backends/pdfform/src/lib.rs`** — `resolves_schema_address(&QuillConfig, &str) -> bool` behind `#[doc(hidden)]`. Three lines, the grammar question only: binding a widget also demands a widget shape, and that half does not cross.

**`crates/backends/typst/tests/container_address.rs`** — hands over its accept/reject table and keeps what is its own (the regions a container read carries), plus `a_widget_binds_the_same_grammar_a_claim_does` so `form-field`'s copy of the assert stays covered.

**`prose/canon/PLATE_DATA.md`** — the claim names what enforces it.

## The pin bites

Reverting `steps-ok` to its one-suffix-step cap fails `typst_admits_…` alone, naming the address:

```
every resolving address must compile: assertion failed: field-region: "refs.0.org"
is not a schema field address; ...
```

## One asymmetry found and pinned

`$body` already diverges. The Typst root table carries it and `PLATE_DATA.md` documents `field-region(card.at("$path") + "$body")`, while pdfform's resolver roots only `main.fields` / `$cards` and returns `Dangling`. Defensible — a body is content, not a bindable field — but it means the promise was never literal. `a_body_address_is_typst_only` pins it in both directions, so teaching pdfform to root `$body` fails the test and forces the canon claim to move with it. No behavior changed.

## Not done

- **The fixture-quill option** (a `form.pdf` + `form.json` + plate to reach `bind` through `Backend::open`) — pdfform already covers that seam with PDF fixtures, and grammar parity is a pure function of the schema, so the fixture buys re-coverage at the price of a binary artifact to maintain.
- **Deriving one grammar from a shared source** — as #1291 decided. `_qm-known-path` runs inside Typst at plate-compile time over author-written strings with unbounded indices, so it can neither call Rust nor be a precomputed accept-set. The duplication is structural; the table is the remedy.

## Verification

`cargo test --workspace`: 0 failures. `node scripts/check-canon.mjs`: OK. No new clippy warnings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRSaR277eGV1EnB8BvXwXP)_