### PR TITLE
Two shallow walks reach their leaves: nested content defaults, and the span scan's index step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- fix: a content leaf's `default:` reaches the plate from **every** position it
+  can be declared in, not only card level. The load pass that imports each
+  richtext/plaintext literal into its companion cache walked the card's field
+  map, so an `object` property, a typed-table row property and a variant cell
+  each kept their authored `default:` and cached nothing; the render floor read
+  the leaf's empty companion and blank-filled. A document authoring only the
+  container (`dict: {}`, `rows: [{}]`, `c: {value: CUI}`) rendered correctly
+  with the author's default missing, and nothing upstream had anything to
+  report. The walk now recurses `properties` / `items` / `variants`, the shapes
+  `field_contains_content` already descended. Importing a literal is also what
+  checks it, so a nested `richtext(inline)` violation — in a `default:` or an
+  `example:` — now fails load as a card-level one always has, naming the leaf's
+  declaration path. Nested `example:` *surfacing* was never broken: the
+  blueprint prints the raw literal at every depth.
 - **breaking** typst: lowering dispatches on the schema node beside each value
   rather than on tables of top-level field names, so a declared type means the
   same thing wherever it is declared. A `date`, `richtext` or `plaintext`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@
   `example:` — now fails load as a card-level one always has, naming the leaf's
   declaration path. Nested `example:` *surfacing* was never broken: the
   blueprint prints the raw literal at every depth.
+- **breaking** typst: a plate's direct read of a typed-table row cell regions on
+  the cell (`refs.0.org`), where it regioned on the whole array before — a
+  *wrong* address, not a missing one, routing a click on the org cell to the
+  entire table. The span scan was the third component deriving a schema address
+  and the one left at the one-level ceiling: 0.106 lifted the lowering walk and
+  `_qm-known-path` to the row property, so the three no longer agreed, and the
+  scan is the one that decides what a *read* is attributed to. It now takes the
+  index step (`.at(n)`, the only spelling Typst has for an array index) and then
+  the row property, gated on the `array_fields` table. Each step is its own
+  address, so a whole-row read names the row (`refs.0`) and a primitive
+  element's read names the element (`tags.0`); a negative index and an
+  undeclared row key mint nothing and fall back as before. Consumers keying on
+  the array's address for element ink see the narrower address instead. Explicit
+  `field-region` / `form-field` claims are unchanged, and the alias lane keeps
+  parity: `#let row = data.refs.at(0)` … `#row.org` regions on `refs.0.org`.
 - **breaking** typst: lowering dispatches on the schema node beside each value
   rather than on tables of top-level field names, so a declared type means the
   same thing wherever it is declared. A `date`, `richtext` or `plaintext`

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -421,15 +421,20 @@ impl Backend for TypstBackend {
                 .source(main_id)
                 .ok()
                 .map(|src| {
-                    overlay::scalar_windows(&src, &schema_meta.fields, &schema_meta.object_fields)
-                        .into_iter()
-                        .map(|(path, range)| overlay::FieldWindow {
-                            path,
-                            file: main_id,
-                            range,
-                            segments: Vec::new(),
-                        })
-                        .collect()
+                    overlay::scalar_windows(
+                        &src,
+                        &schema_meta.fields,
+                        &schema_meta.object_fields,
+                        &schema_meta.array_fields,
+                    )
+                    .into_iter()
+                    .map(|(path, range)| overlay::FieldWindow {
+                        path,
+                        file: main_id,
+                        range,
+                        segments: Vec::new(),
+                    })
+                    .collect()
                 })
                 .unwrap_or_default()
         };

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -867,11 +867,9 @@ fn forward_pos(helper: &Source, segmap: &SegmentMap, pos: usize) -> usize {
 /// Chain windows sort first, so ink resolving to the reference itself is never
 /// claimed by a wider window.
 ///
-/// A reference that steps into a declared container (`data.classification.poc`)
-/// anchors on the property, so the region carries the address the plate actually
-/// read rather than the container's. `containers` is the `object_fields` table
-/// [`_qm-known-path`] validates against, so a region path is one a
-/// `form-field`/`field-region` could bind.
+/// A reference that steps into a declared container (`data.classification.poc`,
+/// `data.refs.at(0).org`) anchors on the cell, so the region carries the address
+/// the plate actually read rather than the container's.
 ///
 /// A read through a single-assignment `let` alias ([`alias_bindings`]) is a
 /// reference site like the chain it names, so naming a container before
@@ -881,12 +879,18 @@ fn forward_pos(helper: &Source, segmap: &SegmentMap, pos: usize) -> usize {
 pub(crate) fn scalar_windows(
     source: &Source,
     fields: &[String],
-    containers: &BTreeMap<String, Vec<String>>,
+    objects: &BTreeMap<String, Vec<String>>,
+    arrays: &BTreeMap<String, Vec<String>>,
 ) -> Vec<(String, Range<usize>)> {
+    let tables = Tables {
+        fields,
+        objects,
+        arrays,
+    };
     let root = LinkedNode::new(source.root());
-    let aliases = alias_bindings(&root, fields, containers);
+    let aliases = alias_bindings(&root, &tables);
     let mut anchors: Vec<(String, Range<usize>, Range<usize>)> = Vec::new();
-    collect_anchors(&root, fields, containers, &aliases, &mut anchors);
+    collect_anchors(&root, &tables, &aliases, &mut anchors);
 
     let mut out: Vec<(String, Range<usize>)> = anchors
         .iter()
@@ -907,6 +911,40 @@ pub(crate) fn scalar_windows(
     out
 }
 
+/// The address tables the scan resolves a read against: the top-level field
+/// names, and the step each container field offers — `object_fields` the property
+/// step, `array_fields` the index step and the row properties that may follow it.
+/// The same tables [`_qm-known-path`] validates a `form-field` / `field-region`
+/// path against, so a scanned region path is one a claim could bind.
+struct Tables<'a> {
+    fields: &'a [String],
+    objects: &'a BTreeMap<String, Vec<String>>,
+    arrays: &'a BTreeMap<String, Vec<String>>,
+}
+
+impl Tables<'_> {
+    /// The property names an address offers a step into: a container field's own
+    /// keys, or the row properties left by an index step. Everything the grammar
+    /// caps — a scalar, a row property, a primitive element — offers none.
+    ///
+    /// Keying on the address rather than on the anchor is what puts an alias to a
+    /// row (`#let r = data.refs.at(0)`) at parity with the chain it names: the
+    /// index step may have been taken in the initializer.
+    fn property_keys(&self, path: &str) -> &[String] {
+        if let Some(keys) = self.objects.get(path) {
+            return keys;
+        }
+        match path.rsplit_once('.') {
+            Some((array, index))
+                if !index.is_empty() && index.bytes().all(|b| b.is_ascii_digit()) =>
+            {
+                self.arrays.get(array).map(Vec::as_slice).unwrap_or_default()
+            }
+            _ => &[],
+        }
+    }
+}
+
 /// A read before `bound_at` reads whatever else held the name, so the position
 /// bounds the alias the way lexical order does.
 struct Alias {
@@ -923,13 +961,9 @@ struct Alias {
 /// else — `#let x = upper(data.subject)` and `#let x = data.a + data.b` both
 /// yield no alias, the first because the chain is not the whole expression and
 /// the second because no single field owns it.
-fn alias_bindings(
-    root: &LinkedNode,
-    fields: &[String],
-    containers: &BTreeMap<String, Vec<String>>,
-) -> HashMap<String, Alias> {
+fn alias_bindings(root: &LinkedNode, tables: &Tables) -> HashMap<String, Alias> {
     let mut found = Binders::default();
-    collect_binders(root, fields, containers, &mut found);
+    collect_binders(root, tables, &mut found);
     if found.wildcard_import {
         return HashMap::new();
     }
@@ -949,12 +983,7 @@ struct Binders {
     wildcard_import: bool,
 }
 
-fn collect_binders(
-    node: &LinkedNode,
-    fields: &[String],
-    containers: &BTreeMap<String, Vec<String>>,
-    out: &mut Binders,
-) {
+fn collect_binders(node: &LinkedNode, tables: &Tables, out: &mut Binders) {
     let bind = |name: &str, out: &mut Binders| {
         *out.counts.entry(name.to_string()).or_default() += 1;
     };
@@ -964,7 +993,7 @@ fn collect_binders(
                 for ident in binding.kind().bindings() {
                     bind(ident.as_str(), out);
                 }
-                if let Some((name, alias)) = alias_candidate(node, binding, fields, containers) {
+                if let Some((name, alias)) = alias_candidate(node, binding, tables) {
                     out.candidates.push((name, alias));
                 }
             }
@@ -1034,15 +1063,14 @@ fn collect_binders(
         _ => {}
     }
     for child in node.children() {
-        collect_binders(&child, fields, containers, out);
+        collect_binders(&child, tables, out);
     }
 }
 
 fn alias_candidate(
     node: &LinkedNode,
     binding: ast::LetBinding,
-    fields: &[String],
-    containers: &BTreeMap<String, Vec<String>>,
+    tables: &Tables,
 ) -> Option<(String, Alias)> {
     let ast::LetBindingKind::Normal(ast::Pattern::Normal(ast::Expr::Ident(name))) = binding.kind()
     else {
@@ -1051,7 +1079,7 @@ fn alias_candidate(
     let init = binding.init()?.to_untyped();
     let init = node.children().find(|c| std::ptr::eq(c.get(), init))?;
     let mut inner = Vec::new();
-    collect_anchors(&init, fields, containers, &HashMap::new(), &mut inner);
+    collect_anchors(&init, tables, &HashMap::new(), &mut inner);
     let [(path, chain, _)] = inner.as_slice() else {
         return None;
     };
@@ -1070,12 +1098,11 @@ fn alias_candidate(
 /// chain's arguments is its own site.
 fn collect_anchors(
     node: &LinkedNode,
-    fields: &[String],
-    containers: &BTreeMap<String, Vec<String>>,
+    tables: &Tables,
     aliases: &HashMap<String, Alias>,
     out: &mut Vec<(String, Range<usize>, Range<usize>)>,
 ) {
-    if let Some((path, anchor)) = data_access(node, fields, containers, aliases) {
+    if let Some((path, anchor)) = data_access(node, tables, aliases) {
         // Chain: the outermost postfix chain headed by this access.
         let mut chain = anchor.clone();
         while let Some(parent) = chain.parent() {
@@ -1103,18 +1130,17 @@ fn collect_anchors(
         out.push((path, chain.range(), wide.range()));
     }
     for child in node.children() {
-        collect_anchors(&child, fields, containers, aliases, out);
+        collect_anchors(&child, tables, aliases, out);
     }
 }
 
 /// The schema path `node` reads and the node to widen from, for the two shapes
 /// that name a field: a `data.<field>` / `data.at("<field>")` access, and a
-/// read through a `let` alias. Either steps one property deeper where the field
-/// is a container and the plate selected one of its declared keys.
+/// read through a `let` alias. Either steps deeper where the field is a
+/// container and the plate selected into it ([`step_into`]).
 fn data_access<'a>(
     node: &LinkedNode<'a>,
-    fields: &[String],
-    containers: &BTreeMap<String, Vec<String>>,
+    tables: &Tables,
     aliases: &HashMap<String, Alias>,
 ) -> Option<(String, LinkedNode<'a>)> {
     match node.kind() {
@@ -1125,29 +1151,38 @@ fn data_access<'a>(
             if target.as_str() != "data" {
                 return None;
             }
-            let (name, anchor) = selected(node, fields)?;
-            Some(step_property(name, anchor, containers))
+            let (name, anchor) = selected(node, tables.fields)?;
+            Some(step_into(name, anchor, tables))
         }
         // Reads before the binding ends — its own pattern, its initializer —
         // are not reads of the field.
         SyntaxKind::Ident => {
             let alias = aliases.get(node.cast::<ast::Ident>()?.as_str())?;
             (node.range().start >= alias.bound_at)
-                .then(|| step_property(alias.path.clone(), node.clone(), containers))
+                .then(|| step_into(alias.path.clone(), node.clone(), tables))
         }
         _ => None,
     }
 }
 
-/// One property step where `name` is a container and the read selected a
-/// declared key, else the field itself.
-fn step_property<'a>(
+/// The steps the read takes into `name`, or the field itself where it takes
+/// none: an array index (`refs.0`), then one property off whatever that leaves —
+/// a container field's own keys (`classification.poc`) or an indexed row's
+/// (`refs.0.org`).
+///
+/// Two steps is the address grammar's ceiling ([`_qm-known-path`]'s `steps-ok`),
+/// not a recursion: a row property is a leaf. Each step is its own address, so a
+/// whole-row read anchors on the row rather than on the table.
+fn step_into<'a>(
     name: String,
     anchor: LinkedNode<'a>,
-    containers: &BTreeMap<String, Vec<String>>,
+    tables: &Tables,
 ) -> (String, LinkedNode<'a>) {
-    let keys = containers.get(&name).map(Vec::as_slice).unwrap_or_default();
-    match select_property(&anchor, keys) {
+    let (name, anchor) = match tables.arrays.get(&name).and_then(|_| select_index(&anchor)) {
+        Some((index, row)) => (format!("{name}.{index}"), row),
+        None => (name, anchor),
+    };
+    match select_property(&anchor, tables.property_keys(&name)) {
         Some((key, deeper)) => (format!("{name}.{key}"), deeper),
         None => (name, anchor),
     }
@@ -1179,26 +1214,55 @@ fn selected<'a>(access: &LinkedNode<'a>, keys: &[String]) -> Option<(String, Lin
         .flatten()
 }
 
-/// The `.at("<key>")` spelling: `access` is the `<expr>.at` field access, and
-/// its parent call carries the key as its first positional string argument.
-/// Reaches the keys an identifier cannot spell.
+/// The array index `node`'s parent selects off it, and the node that selection
+/// widens to. `.at(n)` is the only spelling — Typst has no `.0` field access for
+/// an array element — and the grammar takes any non-negative literal, matching
+/// [`_qm-known-path`]'s digit test: a negative index lexes as unary minus over
+/// the magnitude and so never matches an `Int` argument.
+fn select_index<'a>(node: &LinkedNode<'a>) -> Option<(i64, LinkedNode<'a>)> {
+    let parent = node.parent()?;
+    let access = parent.cast::<ast::FieldAccess>()?;
+    if access.target().to_untyped() != node.get() || access.field().as_str() != "at" {
+        return None;
+    }
+    let (ast::Expr::Int(index), call) = at_selector(parent)? else {
+        return None;
+    };
+    Some((index.get(), call))
+}
+
+/// The `.at("<key>")` spelling of a property step. Reaches the keys an
+/// identifier cannot spell.
 fn select_by_at<'a>(
     access: &LinkedNode<'a>,
     keys: &[String],
 ) -> Option<(String, LinkedNode<'a>)> {
+    let (ast::Expr::Str(key), call) = at_selector(access)? else {
+        return None;
+    };
+    let key = key.get().to_string();
+    keys.contains(&key).then_some((key, call))
+}
+
+/// The selector argument of the `<expr>.at(..)` call `access` heads, and the call
+/// node the selection widens to: the spine both `.at` steps share, a string key
+/// and an integer index. `access` is the `<expr>.at` field access.
+fn at_selector<'a>(access: &LinkedNode<'a>) -> Option<(ast::Expr<'a>, LinkedNode<'a>)> {
     let parent = access.parent()?;
-    let call = parent.cast::<ast::FuncCall>()?;
+    // Cast off the underlying node, whose lifetime is the tree's: casting off the
+    // `LinkedNode` would tie the returned expression to this borrow of `access`.
+    let call: ast::FuncCall = parent.get().cast()?;
     let ast::Expr::FieldAccess(callee) = call.callee() else {
         return None;
     };
     if callee.to_untyped() != access.get() {
         return None;
     }
-    let first = call.args().items().find_map(|arg| match arg {
-        ast::Arg::Pos(ast::Expr::Str(s)) => Some(s.get().to_string()),
+    let selector = call.args().items().find_map(|arg| match arg {
+        ast::Arg::Pos(expr) => Some(expr),
         _ => None,
     })?;
-    keys.contains(&first).then(|| (first, parent.clone()))
+    Some((selector, parent.clone()))
 }
 
 #[cfg(test)]
@@ -1351,15 +1415,19 @@ main:
         }
     }
 
-    /// `(path, source text)` per window, over the fields and the one container
-    /// the tests below address.
+    /// `(path, source text)` per window, over the fields and the two containers
+    /// the tests below address: a variant container and a typed table.
     fn probe_spans(src: &Source) -> Vec<(String, String)> {
-        let fields = ["subject", "refs", "other", "classification"].map(str::to_string);
-        let containers = BTreeMap::from([(
+        let fields = ["subject", "refs", "tags", "other", "classification"].map(str::to_string);
+        let objects = BTreeMap::from([(
             "classification".to_string(),
             ["value", "poc", "controlled by"].map(str::to_string).into(),
         )]);
-        scalar_windows(src, &fields, &containers)
+        let arrays = BTreeMap::from([
+            ("refs".to_string(), ["org", "num"].map(str::to_string).into()),
+            ("tags".to_string(), Vec::new()),
+        ]);
+        scalar_windows(src, &fields, &objects, &arrays)
             .into_iter()
             .map(|(path, r)| (path, src.text()[r].to_string()))
             .collect()
@@ -1476,7 +1544,7 @@ main:
         for (path, text) in [
             ("subject", "data.subject"),
             ("subject", "data.at(\"subject\")"),
-            ("refs", "data.refs.at(0)"),
+            ("refs.0", "data.refs.at(0)"),
             ("other", "data.other"),
             ("subject", "upper(data.subject)"),
         ] {
@@ -1540,6 +1608,50 @@ main:
         assert!(
             has(&spans, "classification", "data.classification.undeclared"),
             "the undeclared read still anchors on the container: {spans:?}"
+        );
+    }
+
+    /// The index step and the row property it opens: `.at(n)` is the only spelling
+    /// of an array index, and what may follow it is the row's declared keys.
+    #[test]
+    fn scalar_windows_step_into_a_typed_table_row() {
+        let src = Source::detached(
+            r#"
+#import "@local/quillmark-helper:0.1.0": data
+#data.refs.at(0).org
+#data.refs.at(12).at("num")
+#data.at("refs").at(0).org
+#let row = data.refs.at(0)
+#row.org
+#data.refs.at(0)
+#data.tags.at(3)
+#data.refs
+#data.refs.at(0).undeclared
+#data.refs.at(-1)
+#data.tags.at(0).org
+"#,
+        );
+        let spans = probe_spans(&src);
+        for (path, text) in [
+            ("refs.0.org", "data.refs.at(0).org"),
+            ("refs.12.num", "data.refs.at(12).at(\"num\")"),
+            ("refs.0.org", "data.at(\"refs\").at(0).org"),
+            ("refs.0.org", "row.org"),
+            ("refs.0", "data.refs.at(0)"),
+            ("tags.3", "data.tags.at(3)"),
+            ("refs", "data.refs"),
+            // An undeclared row key is no address, so the read falls back to the
+            // row; a primitive element offers no property at all.
+            ("refs.0", "data.refs.at(0).undeclared"),
+            ("tags.0", "data.tags.at(0).org"),
+        ] {
+            assert!(has(&spans, path, text), "missing {path}/{text}: {spans:?}");
+        }
+        // A negative index lexes as unary minus over the magnitude, so it never
+        // matches the integer arm and the read stays on the table.
+        assert!(
+            has(&spans, "refs", "data.refs.at(-1)"),
+            "a negative index mints no address: {spans:?}"
         );
     }
 
@@ -1673,7 +1785,7 @@ main:
         let main_id = world.main();
         let src = world.source(main_id).expect("main source");
         windows.extend(
-            scalar_windows(&src, &meta.fields, &meta.object_fields)
+            scalar_windows(&src, &meta.fields, &meta.object_fields, &meta.array_fields)
                 .into_iter()
                 .map(|(path, range)| FieldWindow {
                     path,

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -911,11 +911,9 @@ pub(crate) fn scalar_windows(
     out
 }
 
-/// The address tables the scan resolves a read against: the top-level field
-/// names, and the step each container field offers — `object_fields` the property
-/// step, `array_fields` the index step and the row properties that may follow it.
-/// The same tables [`_qm-known-path`] validates a `form-field` / `field-region`
-/// path against, so a scanned region path is one a claim could bind.
+/// The address tables the scan resolves a read against — the same ones
+/// [`_qm-known-path`] validates a `form-field` / `field-region` path against, so
+/// a scanned region path is one a claim could bind.
 struct Tables<'a> {
     fields: &'a [String],
     objects: &'a BTreeMap<String, Vec<String>>,
@@ -924,11 +922,10 @@ struct Tables<'a> {
 
 impl Tables<'_> {
     /// The property names an address offers a step into: a container field's own
-    /// keys, or the row properties left by an index step. Everything the grammar
-    /// caps — a scalar, a row property, a primitive element — offers none.
+    /// keys, or an indexed row's. An address the grammar already caps offers none.
     ///
-    /// Keying on the address rather than on the anchor is what puts an alias to a
-    /// row (`#let r = data.refs.at(0)`) at parity with the chain it names: the
+    /// Keyed on the address rather than the anchor, so an alias to a row
+    /// (`#let r = data.refs.at(0)`) reaches the cell the chain it names does: the
     /// index step may have been taken in the initializer.
     fn property_keys(&self, path: &str) -> &[String] {
         if let Some(keys) = self.objects.get(path) {
@@ -1165,13 +1162,12 @@ fn data_access<'a>(
     }
 }
 
-/// The steps the read takes into `name`, or the field itself where it takes
-/// none: an array index (`refs.0`), then one property off whatever that leaves —
-/// a container field's own keys (`classification.poc`) or an indexed row's
-/// (`refs.0.org`).
+/// The address the read reaches into `name`: an array index (`refs.0`), then one
+/// property step (`classification.poc`, `refs.0.org`), or `name` itself where the
+/// read takes neither.
 ///
-/// Two steps is the address grammar's ceiling ([`_qm-known-path`]'s `steps-ok`),
-/// not a recursion: a row property is a leaf. Each step is its own address, so a
+/// Two steps is the grammar's ceiling ([`_qm-known-path`]'s `steps-ok`), not a
+/// recursion: a row property is a leaf. Each step is its own address, so a
 /// whole-row read anchors on the row rather than on the table.
 fn step_into<'a>(
     name: String,
@@ -1215,10 +1211,10 @@ fn selected<'a>(access: &LinkedNode<'a>, keys: &[String]) -> Option<(String, Lin
 }
 
 /// The array index `node`'s parent selects off it, and the node that selection
-/// widens to. `.at(n)` is the only spelling — Typst has no `.0` field access for
-/// an array element — and the grammar takes any non-negative literal, matching
-/// [`_qm-known-path`]'s digit test: a negative index lexes as unary minus over
-/// the magnitude and so never matches an `Int` argument.
+/// widens to. `.at(n)` is the only spelling: Typst has no `.0` field access for an
+/// array element. Any non-negative literal is admitted, matching
+/// [`_qm-known-path`]'s digit test — a negative index lexes as unary minus over
+/// the magnitude, so it never reaches the `Int` arm and needs no sign check.
 fn select_index<'a>(node: &LinkedNode<'a>) -> Option<(i64, LinkedNode<'a>)> {
     let parent = node.parent()?;
     let access = parent.cast::<ast::FieldAccess>()?;
@@ -1245,8 +1241,7 @@ fn select_by_at<'a>(
 }
 
 /// The selector argument of the `<expr>.at(..)` call `access` heads, and the call
-/// node the selection widens to: the spine both `.at` steps share, a string key
-/// and an integer index. `access` is the `<expr>.at` field access.
+/// node the selection widens to. `access` is the `<expr>.at` field access.
 fn at_selector<'a>(access: &LinkedNode<'a>) -> Option<(ast::Expr<'a>, LinkedNode<'a>)> {
     let parent = access.parent()?;
     // Cast off the underlying node, whose lifetime is the tree's: casting off the
@@ -1415,8 +1410,7 @@ main:
         }
     }
 
-    /// `(path, source text)` per window, over the fields and the two containers
-    /// the tests below address: a variant container and a typed table.
+    /// `(path, source text)` per window, over the fields the tests below address.
     fn probe_spans(src: &Source) -> Vec<(String, String)> {
         let fields = ["subject", "refs", "tags", "other", "classification"].map(str::to_string);
         let objects = BTreeMap::from([(
@@ -1611,8 +1605,6 @@ main:
         );
     }
 
-    /// The index step and the row property it opens: `.at(n)` is the only spelling
-    /// of an array index, and what may follow it is the row's declared keys.
     #[test]
     fn scalar_windows_step_into_a_typed_table_row() {
         let src = Source::detached(

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -292,10 +292,9 @@ fn a_typed_table_row_property_is_addressable() {
     );
 }
 
-/// A direct read of a row cell anchors on the cell: the scan takes the index step
-/// and then the row property, so the region carries the address the lowering and
-/// `_qm-known-path` already agree on and a click on the org cell routes there
-/// rather than to the whole table.
+/// The address the scan reports must be the one the lowering and `_qm-known-path`
+/// already agree on: anchoring on the array routes a click on the org cell to the
+/// whole table.
 #[test]
 fn a_direct_row_cell_read_anchors_on_the_row_property() {
     let session = open(
@@ -328,9 +327,6 @@ fn a_direct_row_cell_read_anchors_on_the_row_property() {
     );
 }
 
-/// Each step is its own address, so a read that stops short of the row property
-/// anchors on the row, and one that never indexes at all still anchors on the
-/// table.
 #[test]
 fn a_read_that_stops_short_anchors_on_the_step_it_took() {
     let session = open(
@@ -348,9 +344,8 @@ fn a_read_that_stops_short_anchors_on_the_step_it_took() {
     }
 }
 
-/// Naming a row before stepping into it costs no address, so the alias lane
-/// reaches the same cell the direct chain does even though the index step was
-/// taken in the initializer.
+/// The alias lane reaches the cell even though the index step was taken in the
+/// initializer, so the address is not the one the anchor alone would offer.
 #[test]
 fn a_row_cell_read_through_a_let_alias_keeps_the_cell_address() {
     let session = open(

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -292,23 +292,80 @@ fn a_typed_table_row_property_is_addressable() {
     );
 }
 
-/// `collect_anchors` steps one *property* into a declared container and has no
-/// index step, so a direct read of a row cell anchors on the array: a click on
-/// the org cell routes to the whole table. The address grammar and the lowering
-/// both reach `refs.0.org`, so this is a wrong address rather than a missing
-/// one. Pinned here so widening the scan is a deliberate change with its own
-/// sweep over every plate that reads an array element.
+/// A direct read of a row cell anchors on the cell: the scan takes the index step
+/// and then the row property, so the region carries the address the lowering and
+/// `_qm-known-path` already agree on and a click on the org cell routes there
+/// rather than to the whole table.
 #[test]
-fn a_direct_row_cell_read_still_anchors_on_the_array() {
+fn a_direct_row_cell_read_anchors_on_the_row_property() {
     let session = open(
         r#"
 #import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
 #data.refs.at(0).org
 "#,
     );
+    let regions = session.regions();
+    let fields: Vec<&str> = regions.iter().map(|r| r.field.as_str()).collect();
+    assert!(fields.contains(&"refs.0.org"), "{fields:?}");
+    assert!(
+        !fields.contains(&"refs"),
+        "the table does not also claim the cell's ink: {fields:?}"
+    );
+
+    let cell = regions
+        .iter()
+        .find(|r| r.field == "refs.0.org")
+        .expect("the row property region surfaces");
+    let (cx, cy) = (
+        (cell.rect[0] + cell.rect[2]) / 2.0,
+        (cell.rect[1] + cell.rect[3]) / 2.0,
+    );
+    assert_eq!(
+        session.field_at(cell.page, cx, cy).as_deref(),
+        Some("refs.0.org"),
+        "a click on the cell routes to the cell, not the table"
+    );
+}
+
+/// Each step is its own address, so a read that stops short of the row property
+/// anchors on the row, and one that never indexes at all still anchors on the
+/// table.
+#[test]
+fn a_read_that_stops_short_anchors_on_the_step_it_took() {
+    let session = open(
+        r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#repr(data.refs.at(0))
+#data.tags.at(0)
+#repr(data.refs)
+"#,
+    );
     let fields: Vec<String> = session.regions().into_iter().map(|r| r.field).collect();
-    assert!(fields.iter().any(|f| f == "refs"), "{fields:?}");
-    assert!(!fields.iter().any(|f| f == "refs.0.org"), "{fields:?}");
+    for field in ["refs.0", "tags.0", "refs"] {
+        assert!(fields.iter().any(|f| f == field), "{field:?}: {fields:?}");
+    }
+}
+
+/// Naming a row before stepping into it costs no address, so the alias lane
+/// reaches the same cell the direct chain does even though the index step was
+/// taken in the initializer.
+#[test]
+fn a_row_cell_read_through_a_let_alias_keeps_the_cell_address() {
+    let session = open(
+        r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#let row = data.refs.at(0)
+#let table = data.refs
+#row.org #row.at("num") #table.at(0).org
+"#,
+    );
+    let fields: Vec<String> = session.regions().into_iter().map(|r| r.field).collect();
+    for field in ["refs.0.org", "refs.0.num"] {
+        assert!(fields.iter().any(|f| f == field), "{field:?}: {fields:?}");
+    }
 }
 
 /// A variant cell of a rich type lowers exactly as a card-level one does: the

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -517,9 +517,9 @@ pub(crate) fn resolve_value_sourced(
     let Some(v) = present else {
         // A content-bearing field (`richtext` or its literal sibling
         // `plaintext`) commits the *content* form of its default
-        // (`default_content`, cached at load by `from_yaml_with_warnings` for
-        // every content leaf at every declaration depth), so
-        // the seam carries canonical Content-JSON the backend can classify. It
+        // (`default_content`, cached at load by `from_yaml_with_warnings` for every
+        // content leaf at every declaration depth), so the seam carries canonical
+        // Content-JSON the backend can classify. It
         // must NOT fall through to the raw `default`: the ladder injects this
         // default without re-coercing it (coercion touched only authored
         // values), so a bare authored string here would reach the plate

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -517,7 +517,8 @@ pub(crate) fn resolve_value_sourced(
     let Some(v) = present else {
         // A content-bearing field (`richtext` or its literal sibling
         // `plaintext`) commits the *content* form of its default
-        // (`default_content`, cached at load by `from_yaml_with_warnings`), so
+        // (`default_content`, cached at load by `from_yaml_with_warnings` for
+        // every content leaf at every declaration depth), so
         // the seam carries canonical Content-JSON the backend can classify. It
         // must NOT fall through to the raw `default`: the ladder injects this
         // default without re-coercing it (coercion touched only authored

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -2179,12 +2179,11 @@ pub(crate) fn field_contains_content(field: &FieldSchema) -> bool {
 /// a failed import or a `richtext(inline)` violation is appended to `errors` as a
 /// load diagnostic.
 ///
-/// **The walk is over the schema, not the card's field map.** A content leaf's
-/// `default:` is its own wherever it is declared, and the render floor reads the
-/// companion off whichever leaf it resolves, so an unpopulated position
-/// blank-fills and drops the author's default silently. Covering every one is
-/// what makes the floor's `None` mean "no literal to cache" rather than "not
-/// walked to".
+/// **The walk is over the schema, not the card's field map.** The render floor
+/// reads the companion off whichever leaf it resolves, so covering every
+/// declaration position is what makes its `None` mean "no literal to cache"
+/// rather than "not walked to"; a position left out blank-fills and drops the
+/// author's `default:` silently.
 ///
 /// `card` labels the owning card and `path` the field's declaration path
 /// (`dict.note`, `rows[].note`, `c.variants.CUI.note`), the spelling

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -2174,12 +2174,32 @@ pub(crate) fn field_contains_content(field: &FieldSchema) -> bool {
 }
 
 /// Populate a field's `default_content` / `example_content` companion caches from
-/// its markdown literals. No-op for a non-richtext field; a failed import or a
-/// `richtext(inline)` violation is appended to `errors` as a load diagnostic.
-fn populate_field_content(field: &mut FieldSchema, owner: &str, errors: &mut Vec<Diagnostic>) {
+/// its markdown literals, and every nested declaration's from its own. No-op
+/// where the type tree bears no content leaf, since nothing below it does either;
+/// a failed import or a `richtext(inline)` violation is appended to `errors` as a
+/// load diagnostic.
+///
+/// **The walk is over the schema, not the card's field map.** A content leaf's
+/// `default:` is its own wherever it is declared, and the render floor reads the
+/// companion off whichever leaf it resolves, so an unpopulated position
+/// blank-fills and drops the author's default silently. Covering every one is
+/// what makes the floor's `None` mean "no literal to cache" rather than "not
+/// walked to".
+///
+/// `card` labels the owning card and `path` the field's declaration path
+/// (`dict.note`, `rows[].note`, `c.variants.CUI.note`), the spelling
+/// `validate_field_blueprint_constraints` uses, so the two load passes anchor a
+/// diagnostic the same way.
+fn populate_field_content(
+    field: &mut FieldSchema,
+    card: &str,
+    path: &str,
+    errors: &mut Vec<Diagnostic>,
+) {
     if !field_contains_content(field) {
         return;
     }
+    let owner = format!("{card} field `{path}`");
     if let Some(default) = field.default.clone() {
         match literal_content(&default, field, &format!("{owner} `default`")) {
             Ok(content) => field.default_content = content,
@@ -2192,15 +2212,31 @@ fn populate_field_content(field: &mut FieldSchema, owner: &str, errors: &mut Vec
             Err(d) => errors.push(d),
         }
     }
+    if let Some(props) = field.properties.as_mut() {
+        for (name, prop) in props.iter_mut() {
+            populate_field_content(prop, card, &format!("{path}.{name}"), errors);
+        }
+    }
+    if let Some(variants) = field.variants.as_mut() {
+        for (member, set) in variants.iter_mut() {
+            for (name, cell) in set.iter_mut() {
+                let nested = format!("{path}.variants.{member}.{name}");
+                populate_field_content(cell, card, &nested, errors);
+            }
+        }
+    }
+    if let Some(items) = field.items.as_mut() {
+        populate_field_content(items, card, &format!("{path}[]"), errors);
+    }
 }
 
 /// Populate every content companion on a card: each field's
-/// `default`/`example`, and the card's `body.example` (block richtext, no
-/// inline constraint; skipped when the body is disabled, since its example is
-/// inert).
+/// `default`/`example` and each nested declaration's, plus the card's
+/// `body.example` (block richtext, no inline constraint; skipped when the body is
+/// disabled, since its example is inert).
 fn populate_card_content(card: &mut CardSchema, label: &str, errors: &mut Vec<Diagnostic>) {
     for (name, field) in card.fields.iter_mut() {
-        populate_field_content(field, &format!("{label} field `{name}`"), errors);
+        populate_field_content(field, label, name, errors);
     }
     let body_enabled = card.body.as_ref().is_none_or(|b| b.enabled != Some(false));
     if body_enabled {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2409,10 +2409,9 @@ fn block_richtext_default_caches_content() {
     );
 }
 
-/// A content leaf's `default:` reaches the plate wherever the leaf is declared.
-/// The four positions are one test because the failure shape is a companion walk
-/// that stops at one of them, and a document authoring only the containers is what
-/// makes each cell fall to the render floor.
+/// The four positions ride one test because the failure shape is a companion walk
+/// that stops at one of them. Authoring only the containers is what drops each
+/// cell to the render floor, where a missing companion blank-fills.
 #[test]
 fn a_nested_content_defaults_literal_reaches_the_plate_at_every_position() {
     const YAML: &str = r#"
@@ -2493,9 +2492,9 @@ main:
     assert_eq!(literal["marks"], serde_json::json!([]));
 }
 
-/// Importing a literal is what checks it, so reaching a nested leaf puts its
-/// literal in front of the same `richtext(inline)` gate a card-level one faces.
-/// The diagnostic names the leaf's declaration path, not the card field holding it.
+/// Importing a literal is what checks it, so the nested gate is the companion walk
+/// reaching the leaf rather than a validation pass of its own. The diagnostic must
+/// name the leaf's declaration path: the card field holding it is not the mistake.
 #[test]
 fn a_nested_inline_richtext_default_over_one_para_is_a_load_error() {
     let err = quill_with_field(concat!(

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2,7 +2,7 @@ mod support_tests;
 mod variant_tests;
 
 use super::*;
-use crate::{Diagnostic, Severity};
+use crate::{Diagnostic, Document, Severity};
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fs;
@@ -2406,6 +2406,114 @@ fn block_richtext_default_caches_content() {
     assert!(
         content.as_json().is_object(),
         "cached default is a content object"
+    );
+}
+
+/// A content leaf's `default:` reaches the plate wherever the leaf is declared.
+/// The four positions are one test because the failure shape is a companion walk
+/// that stops at one of them, and a document authoring only the containers is what
+/// makes each cell fall to the render floor.
+#[test]
+fn a_nested_content_defaults_literal_reaches_the_plate_at_every_position() {
+    const YAML: &str = r#"
+quill:
+  name: nested_default
+  version: "1.0"
+  backend: typst
+  description: nested content default probe
+main:
+  fields:
+    top:
+      type: richtext
+      default: "A **top** note"
+    dict:
+      type: object
+      properties:
+        note:
+          type: richtext
+          default: "A **dict** note"
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          note:
+            type: richtext
+            default: "A **row** note"
+    literal:
+      type: array
+      items:
+        type: plaintext
+        default: "A *literal* line"
+    c:
+      type: enum
+      values: [CUI]
+      default: ""
+      variants:
+        CUI:
+          note:
+            type: richtext
+            default: "A **variant** note"
+"#;
+    let config = QuillConfig::from_yaml(YAML).expect("nested defaults load");
+    let document = Document::parse(concat!(
+        "~~~\n",
+        "$quill: nested_default@1.0\n",
+        "$kind: main\n",
+        "dict: {}\n",
+        "rows:\n  - {}\n",
+        "literal: [null]\n",
+        "c:\n  value: CUI\n",
+        "~~~\n",
+    ))
+    .expect("parses")
+    .document;
+    let plate = config.compile_data(&document).expect("compiles");
+
+    for (path, cell, text) in [
+        ("top", &plate["top"], "A top note"),
+        ("dict.note", &plate["dict"]["note"], "A dict note"),
+        ("rows.0.note", &plate["rows"][0]["note"], "A row note"),
+        ("c.note", &plate["c"]["note"], "A variant note"),
+    ] {
+        assert_eq!(
+            cell["text"].as_str(),
+            Some(text),
+            "{path} carries its own default: {plate}"
+        );
+        assert_eq!(
+            cell["marks"][0]["type"], "strong",
+            "{path} keeps the default's marks: {plate}"
+        );
+    }
+    // A `plaintext` leaf is the other content codec, and its literal imports
+    // verbatim: the asterisks are text, not emphasis.
+    let literal = &plate["literal"][0];
+    assert_eq!(literal["text"].as_str(), Some("A *literal* line"));
+    assert_eq!(literal["marks"], serde_json::json!([]));
+}
+
+/// Importing a literal is what checks it, so reaching a nested leaf puts its
+/// literal in front of the same `richtext(inline)` gate a card-level one faces.
+/// The diagnostic names the leaf's declaration path, not the card field holding it.
+#[test]
+fn a_nested_inline_richtext_default_over_one_para_is_a_load_error() {
+    let err = quill_with_field(concat!(
+        "    dict:\n",
+        "      type: object\n",
+        "      properties:\n",
+        "        tag:\n",
+        "          type: richtext\n",
+        "          inline: true\n",
+        "          default: \"one\\n\\ntwo\"\n",
+    ))
+    .unwrap_err();
+    assert!(
+        err.iter().any(|d| {
+            d.code.as_deref() == Some("validation::not_inline")
+                && d.message.contains("`dict.tag`")
+        }),
+        "the nested literal fails load, naming the leaf: {err:?}"
     );
 }
 

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -290,6 +290,16 @@ A **scalar** is tracked at the expression that draws it, so where you write the 
 #c.poc                       // regions as `classification.poc`, same as #data.classification.poc
 ```
 
+A read into a typed table works the same way, one step further: the index and
+then the row property, the addresses `form-field(field:)` takes.
+
+```typst
+#data.refs.at(0).org         // regions as `refs.0.org`
+#data.refs.at(0)             // regions as `refs.0` — each step is its own address
+#let row = data.refs.at(0)
+#row.org                     // regions as `refs.0.org` too
+```
+
 Rebind that name anywhere in the plate — a second `let`, a closure parameter, a loop pattern, an assignment — and it stops being followed, because a read can no longer be tied to one value. Three shapes are past what the tracker follows at all:
 
 | Shape | Why |

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -134,8 +134,8 @@ scalar has neither an element nor a property for the address to resolve to. A
 `type: object` carrying `properties`, so a variant's cells and its `value`
 discriminant are addressable exactly as a dictionary's keys are
 ([SCHEMAS.md](SCHEMAS.md#enum-variants)). The row property is where the grammar
-stops: two steps, enumerated rather than derived, matching the one-level nesting
-contract the schema itself holds to. This is the pdfform resolver's grammar
+stops, at two steps, matching the one-level nesting contract the schema itself
+holds to. This is the pdfform resolver's grammar
 (`backends/pdfform/src/bind.rs`), so one address binds on either backend.
 
 Cards carry their canonical prefix as `$path`, so a plate composes a card

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -122,17 +122,20 @@ compile time rather than leaving it silently unbound:
 |---|---|
 | `subject` | any declared field |
 | `refs.2` | an array field — the element step |
+| `refs.2.org` | a typed table's row property, after the element step |
 | `classification.poc` | a container field — the property step |
 | `$cards.<kind>.<n>.<field>` | a card field, `<n>` the per-kind ordinal |
-| `$cards.<kind>.<n>.<field>.<step>` | either step, on a card field |
+| `$cards.<kind>.<n>.<field>.<suffix>` | any of those suffixes, on a card field |
 
-A one-step suffix is gated on the step the field actually offers, not on the
-name alone, so `subject.0` and `subject.poc` are both rejected on a scalar
-`subject`: a scalar has neither an element nor a property for the address to
-resolve to. A **container** is a typed dictionary or a variant container — both
-project as `type: object` carrying `properties`, so a variant's cells and its
-`value` discriminant are addressable exactly as a dictionary's keys are
-([SCHEMAS.md](SCHEMAS.md#enum-variants)). This is the pdfform resolver's grammar
+A suffix is gated on the step the field actually offers, not on the name alone,
+so `subject.0` and `subject.poc` are both rejected on a scalar `subject`: a
+scalar has neither an element nor a property for the address to resolve to. A
+**container** is a typed dictionary or a variant container — both project as
+`type: object` carrying `properties`, so a variant's cells and its `value`
+discriminant are addressable exactly as a dictionary's keys are
+([SCHEMAS.md](SCHEMAS.md#enum-variants)). The row property is where the grammar
+stops: two steps, enumerated rather than derived, matching the one-level nesting
+contract the schema itself holds to. This is the pdfform resolver's grammar
 (`backends/pdfform/src/bind.rs`), so one address binds on either backend.
 
 Cards carry their canonical prefix as `$path`, so a plate composes a card
@@ -140,5 +143,5 @@ address without reimplementing the kind+ordinal grammar:
 `field-region(card.at("$path") + "$body")`.
 
 The same addresses key the preview's region sidecar
-([PREVIEW.md](PREVIEW.md)), so a plate that reads one container property
-surfaces a region a consumer can route back to that property.
+([PREVIEW.md](PREVIEW.md)), so a plate that reads one container property or one
+row cell surfaces a region a consumer can route back to it.

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -192,8 +192,7 @@ region names what the plate read rather than the container holding it; a key the
 container does not declare is no address, and the read falls back to the
 container. The steps are the address grammar's
 ([PLATE_DATA.md](PLATE_DATA.md#schema-addresses)), so a scanned region is a
-name a `field-region` could claim: one property off a container, or an array
-index and then that row's property. Each step is its own address, so a
+name a `field-region` could claim, and each step is its own address: a
 whole-row read (`data.refs.at(0)`) names the row.
 A read through a `let` alias tracks where the chain it names would, so naming a
 container or a row before stepping into it costs no address. The alias holds only where

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -187,11 +187,16 @@ tracked site; a scalar shown in header and footer surfaces both sites, and a
 reference wrapped in an expression (`#upper(data.subject)`) attributes the
 whole expression's ink to the field when it is the only reference inside it.
 A read that steps into a declared container (`data.classification.poc`,
-`data.address.at("city")`) tracks on the **property**, so the region names the
-cell the plate read rather than the container holding it; a key the container
-does not declare is no address, and the read falls back to the container.
+`data.address.at("city")`, `data.refs.at(0).org`) tracks on the **cell**, so the
+region names what the plate read rather than the container holding it; a key the
+container does not declare is no address, and the read falls back to the
+container. The steps are the address grammar's
+([PLATE_DATA.md](PLATE_DATA.md#schema-addresses)), so a scanned region is a
+name a `field-region` could claim: one property off a container, or an array
+index and then that row's property. Each step is its own address, so a
+whole-row read (`data.refs.at(0)`) names the row.
 A read through a `let` alias tracks where the chain it names would, so naming a
-container before stepping into it costs no address. The alias holds only where
+container or a row before stepping into it costs no address. The alias holds only where
 the plate binds the name exactly once to one whole chain: a name a second binder
 could rebind would attribute another value's ink to the field.
 Not tracked: expressions mixing several fields (`data.from + ", " + rank` has

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -482,6 +482,8 @@ seed's commit takes the extra step to the field's rest. The authored markdown li
 untouched: it is the source of truth the schema emits and the blueprint prints;
 the content is a derived projection of it.
 
+The load pass walks the **schema**, not the card's field map, so a leaf's companions are populated wherever it is declared — an object property, a typed table's row property, a variant cell. A leaf's `default:` is its own, and the render floor reads the companion off whichever leaf it resolves, so an unpopulated position blank-fills and drops the author's default silently: covering every one is what makes an absent companion mean "no literal" rather than "not reached". Importing is also checking, so a nested `richtext(inline)` violation is a load error there, in a `default:` or an `example:`.
+
 Committing *only* `example` is the whole design. The render ladder already
 produces `default` and the blank at compile time but **never `example`** (example
 is excluded from the render path; see [BLUEPRINT.md](BLUEPRINT.md)), so

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -482,7 +482,7 @@ seed's commit takes the extra step to the field's rest. The authored markdown li
 untouched: it is the source of truth the schema emits and the blueprint prints;
 the content is a derived projection of it.
 
-The load pass walks the **schema**, not the card's field map, so a leaf's companions are populated wherever it is declared — an object property, a typed table's row property, a variant cell. A leaf's `default:` is its own, and the render floor reads the companion off whichever leaf it resolves, so an unpopulated position blank-fills and drops the author's default silently: covering every one is what makes an absent companion mean "no literal" rather than "not reached". Importing is also checking, so a nested `richtext(inline)` violation is a load error there, in a `default:` or an `example:`.
+The load pass walks the **schema**, not the card's field map, so a leaf's companions are populated wherever it is declared — an object property, a typed table's row property, a variant cell. The render floor reads the companion off whichever leaf it resolves, so covering every position is what makes an absent companion mean "no literal" rather than "not reached"; a gap blank-fills and drops the author's `default:` silently. Importing is also checking, so a nested `richtext(inline)` violation is a load error there, in a `default:` or an `example:`.
 
 Committing *only* `example` is the whole design. The render ladder already
 produces `default` and the blank at compile time but **never `example`** (example


### PR DESCRIPTION
Closes #1293. Closes #1294.

Both issues are the same shape as #1291's lowering tables — a walk that stops where the schema keeps going — on the two remaining components that were still shallow. They are independent, one commit each.

## #1293 — a content leaf's `default:` is dropped at every nested position

`populate_field_content` imports each richtext/plaintext literal into its companion cache, but `populate_card_content` only ever called it on the card's own fields. Every nested leaf kept its authored `default:` and cached nothing, so `resolve_value_sourced` read `default_content: None` and blank-filled.

Measured before touching anything, on one quill with the same `default:` on each leaf and a document authoring only the containers:

| declaration | before | after |
|---|---|---|
| card-level `richtext` | `"A top note"`, `strong` intact | unchanged |
| `object` → `richtext` property | `""` | `"A dict note"`, `strong` intact |
| `array` row → `richtext` property | `""` | `"A row note"`, `strong` intact |
| variant cell → `richtext` | `""` | `"A variant note"`, `strong` intact |

The walk now recurses `properties` / `items` / `variants`, the shapes `field_contains_content` already descended. Diagnostic labels use `validate_field_blueprint_constraints`'s existing path spelling (`dict.note`, `rows[].note`, `c.variants.CUI.note`), so both load passes anchor the same way.

**Two consequences worth a reviewer's attention:**

- **Importing a literal is what checks it.** A nested `richtext(inline)` violation — in `default:` *or* `example:` — is now a load error where it previously passed unexamined. Correct and consistent with card level, pinned by a test, but it is a behavior change for any quill carrying such a literal. No fixture quill does.
- Nested `example_content` is now cached too, though nothing reads it yet (seeding reads only card-level examples). The issue's note that `example:` "behaves correctly at all nesting levels" holds for *surfacing* — the blueprint reads the raw literal at any depth.

The regression test fails on the pre-fix tree and passes after; both directions verified.

## #1294 — a direct read of a row cell anchors on the array

`collect_anchors` / `step_property` took one *property* step and had no index step, so `#data.refs.at(0).org` regioned as `refs` and a click on the org cell routed to the whole table. A wrong address, not a missing one. `_qm-known-path` and the lowering walk both reached `refs.0.org` after #1292, so the three components disagreed — and the scan is the one that decides what a *read* is attributed to.

`step_into` (renamed from `step_property`) now takes the index step then one property step, gated on `array_fields`. `.at(n)` is the only form to match: Typst has no `.0` field access for an array index, so `select_by_at`'s spine is shared with a new integer arm.

| read | region |
|---|---|
| `data.refs.at(0).org` | `refs.0.org` |
| `data.refs.at(0)` | `refs.0` |
| `data.tags.at(0)` | `tags.0` |
| `data.refs` | `refs` |
| `data.refs.at(0).undeclared` | `refs.0` |
| `data.refs.at(-1)` | `refs` |

**Two judgment calls beyond the issue's stated shape:**

- The property step is keyed on the **address** rather than the anchor, which keeps the alias lane at parity: `#let row = data.refs.at(0)` … `#row.org` reaches `refs.0.org`. Without it the alias stalls at `refs.0` — an ancestor, not the cell, which is the same class of wrong address the issue is about.
- The four tables now ride one `Tables` struct rather than threading a fourth parameter through five signatures.

**On the retargeting sweep the issue asked for:** no fixture plate reads an array by `.at(<int>)` — `usaf_memo` reads arrays whole (`data.references`, `data.cc`, `data.signature_block`) and hands them to packages — so no fixture region moves. `$cards` is not in the transform schema's top-level `properties`, so there was no risk of minting an invalid `$cards.0`. The one pinned assertion (`a_direct_row_cell_read_still_anchors_on_the_array`) is replaced by its inverse plus coverage for the stop-short and alias cases. Consumers keying on the array's address for element ink see the narrower address instead: that is the breaking half.

Also repaired `PLATE_DATA.md`'s address table, stale since #1292 — it was missing the `refs.2.org` row and still claimed a "one-step suffix" after `steps-ok` widened to two.

## Verification

- `cargo test --workspace --all-features` — clean, 58 suites
- `cargo doc --no-deps --workspace` with `RUSTDOCFLAGS=-Dwarnings` — clean
- `node scripts/check-canon.mjs` — OK
- `cargo clippy` warning count identical to `main` (47 across the two crates) — no new lint debt

Not built: the WASM and Python binding surfaces. Neither has a test touching array region addresses, and both changes are confined to Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ccu4KzzZ3Xm27BSmfMTWRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ccu4KzzZ3Xm27BSmfMTWRP)_