### PR TITLE
Every type nests at every depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+- feat: **every type nests at every depth**. A property or an element is an
+  ordinary field, so it carries whatever a card-level field carries, itself
+  included: `object<array<string>>`, `array<array<integer>>`, a typed table whose
+  row holds a typed dictionary, and a variant cell holding either.
+  `quill::nested_object_not_supported` and `quill::nested_array_not_supported`
+  are gone, and `ShapePosition`'s three positions collapse to the one question
+  the walk still asks — is this card level, where `variants:` and `ui.group` are
+  the two keys that live. A widening: every quill that loaded before loads
+  unchanged.
+  The depth budget was what the flat address tables existed for.
+  `SchemaMeta` carried six name-keyed tables (`array_fields`, `object_fields`
+  and their card twins) so the helper's `_qm-known-path` could enumerate two
+  suffix steps rather than derive a grammar; they are replaced by one address
+  tree — the schema pruned to the steps it offers — that the helper and the span
+  scan both walk, converging on the unbounded descent `pdfform::bind` always
+  had. Three components deriving an address become one walk each side of the
+  seam, and `quillmark/tests/address_grammar.rs` pins the two against the deep
+  shapes as well as the shallow ones.
+  `variants:` stays card-level, now on its own reasoning rather than by
+  inheriting the depth ban: a variant's shape is a function of the schema *and*
+  the discriminant, and the union projection, the once-bound form, the plate's
+  single branch and `validation::out_of_variant` each hold because that gap is
+  one level deep ([SCHEMAS.md](prose/canon/SCHEMAS.md) §"Enum variants"). An
+  array-valued variant cell used to report `nested_array_not_supported`, whose
+  message named array elements and object properties — neither the situation;
+  the shape is now legal and `quill::variant_placement` is left saying only what
+  it means.
+- fix: `blueprint()` expands a container at every depth. `build_property_mapping`
+  spent each property through the scalar builder, so a nested `object` or typed
+  table rendered as `key: null # object` — its own properties, their markers and
+  their annotations absent — where the same shape one level up expanded. It now
+  recurses, and the card-level and nested paths are one implementation, so a
+  `default:` covers its subtree identically wherever it is declared. No
+  document changes shape: the shapes this fixes could not be declared before.
 - fix: a content leaf's `default:` reaches the plate from **every** position it
   can be declared in, not only card level. The load pass that imports each
   richtext/plaintext literal into its companion cache walked the card's field

--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -401,15 +401,7 @@ enum DateKind {
 /// The schema address tables `_qm-known-path` validates `form-field` paths
 /// against.
 fn meta_literal(meta: &SchemaMeta) -> String {
-    let tables = serde_json::json!({
-        "fields": meta.fields,
-        "card_fields": meta.card_fields,
-        "array_fields": meta.array_fields,
-        "card_array_fields": meta.card_array_fields,
-        "object_fields": meta.object_fields,
-        "card_object_fields": meta.card_object_fields,
-    });
-    lit(&tables)
+    lit(&meta.address_json())
 }
 
 /// Each present date's `_qm_dN` closure keyed by schema address, backing the
@@ -526,7 +518,6 @@ entrypoint = "lib.typ"
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
     use crate::emit::escape_markup;
     use crate::emit::EscapeCtx;
@@ -823,11 +814,12 @@ mod tests {
         }));
         let (lib, _) = generate_lib_typ(&serde_json::json!({}), &meta).unwrap();
         assert!(lib.contains("#let _qm-meta = ("));
-        assert!(lib.contains("\"fields\": ("));
-        assert!(lib.contains("\"subject\""));
-        // A primitive-element array maps to the empty row: the index step is
-        // all it admits.
-        assert!(lib.contains("\"array_fields\": (\"refs\": (),)"), "{lib}");
+        // A scalar is a leaf, and a primitive-element array offers its index
+        // step onto one: neither carries a `props` entry.
+        assert!(
+            lib.contains("\"props\": (\"refs\": (\"item\": (:),), \"subject\": (:),)"),
+            "{lib}"
+        );
     }
 
     /// `array_fields` and `object_fields` are one shape, so one predicate reads
@@ -843,12 +835,18 @@ mod tests {
                 }}},
             }
         }));
+        // A primitive-element array offers the index step and nothing past it.
+        let tags = meta.root.resolve("tags.0").expect("tags.0");
+        assert!(tags.props.is_empty() && tags.item.is_none());
         assert_eq!(
-            meta.array_fields,
-            BTreeMap::from([
-                ("tags".to_string(), vec![]),
-                ("refs".to_string(), vec!["org".to_string(), "num".to_string()]),
-            ]),
+            meta.root
+                .resolve("refs.0")
+                .expect("refs.0")
+                .props
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["num".to_string(), "org".to_string()],
         );
     }
 
@@ -874,28 +872,17 @@ mod tests {
                 "origin": { "type": "object", "properties": { "office": { "type": "string" } } },
             }}}
         }));
-        assert_eq!(
-            meta.object_fields,
-            BTreeMap::from([
-                ("address".to_string(), vec!["city".to_string()]),
-                (
-                    "classification".to_string(),
-                    vec!["value".to_string(), "poc".to_string()],
-                ),
-            ]),
-        );
-        assert_eq!(
-            meta.card_object_fields,
-            BTreeMap::from([(
-                "note".to_string(),
-                BTreeMap::from([("origin".to_string(), vec!["office".to_string()])]),
-            )]),
-        );
+        assert!(meta.root.resolve("address.city").is_some());
+        assert!(meta.root.resolve("classification.value").is_some());
+        assert!(meta.root.resolve("classification.poc").is_some());
+        // A scalar and a richtext field each offer no step.
+        assert!(meta.root.resolve("subject.anything").is_none());
+        assert!(meta.root.resolve("body.text").is_none());
+        assert!(meta.cards["note"].resolve("origin.office").is_some());
 
         let (lib, _) = generate_lib_typ(&serde_json::json!({}), &meta).unwrap();
-        assert!(lib.contains("\"object_fields\": ("), "{lib}");
         assert!(
-            lib.contains("\"card_object_fields\": (\"note\": (\"origin\": (\"office\",),),)"),
+            lib.contains("\"cards\": (\"note\": (\"props\": (\"origin\": (\"props\": (\"office\": (:),),),),),)"),
             "{lib}"
         );
     }

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -421,12 +421,7 @@ impl Backend for TypstBackend {
                 .source(main_id)
                 .ok()
                 .map(|src| {
-                    overlay::scalar_windows(
-                        &src,
-                        &schema_meta.fields,
-                        &schema_meta.object_fields,
-                        &schema_meta.array_fields,
-                    )
+                    overlay::scalar_windows(&src, &schema_meta.root)
                     .into_iter()
                     .map(|(path, range)| overlay::FieldWindow {
                         path,
@@ -508,118 +503,125 @@ fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
     )
 }
 
-/// Property names a container node declares, in declaration order.
-fn property_names(node: &serde_json::Value) -> Vec<String> {
-    node.get("properties")
-        .and_then(|v| v.as_object())
-        .map(|props| props.keys().cloned().collect())
-        .unwrap_or_default()
-}
-
-/// The fields addressable by index suffix (`refs.0`), each mapped to the
-/// property names its *row* offers (`refs.0.org`). A primitive-element array
-/// maps to the empty list: the index step is all it admits.
+/// The steps a schema address may take out of one node, and nothing else: the
+/// schema pruned to its address grammar.
 ///
-/// The property step's twin, and the same shape, so one predicate reads both.
-/// The nesting contract caps the suffix at a row property, so neither recurses.
-fn array_field_names(
-    properties: &serde_json::Map<String, serde_json::Value>,
-) -> BTreeMap<String, Vec<String>> {
-    properties
-        .iter()
-        .filter(|(_, fs)| fs.get("type").and_then(|v| v.as_str()) == Some("array"))
-        .map(|(name, fs)| {
-            let row = fs.get("items").map(property_names).unwrap_or_default();
-            (name.clone(), row)
-        })
-        .collect()
-}
-
-/// The fields addressable by one property step (`address.city`,
-/// `classification.poc`), each mapped to the property names it declares.
-///
+/// A node offers a property step (`props`), an index step (`item`), or neither.
 /// A typed dictionary and a variant container both project as `type: object`
 /// carrying `properties` — the container's own `value` among them — so one
-/// predicate spans both. A richtext field is `type: object` too but declares no
-/// `properties`; unlike an array, which always offers its index step, an
-/// object with no properties offers no step at all and so is left out.
-fn object_field_names(
-    properties: &serde_json::Map<String, serde_json::Value>,
-) -> BTreeMap<String, Vec<String>> {
-    properties
-        .iter()
-        .filter(|(_, fs)| fs.get("type").and_then(|v| v.as_str()) == Some("object"))
-        .map(|(name, fs)| (name.clone(), property_names(fs)))
-        .filter(|(_, names)| !names.is_empty())
-        .collect()
+/// shape spans both, and a richtext field, an `object` declaring no
+/// `properties`, offers no step at all. An array always offers its index step,
+/// whatever its element.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct AddressNode {
+    pub(crate) props: BTreeMap<String, AddressNode>,
+    pub(crate) item: Option<Box<AddressNode>>,
 }
 
-/// The transform schema plus the address tables derived from it, kept apart
-/// because they answer different questions at different depths. Lowering reads
-/// the schema node ([`helper::lowering`]) and is depth-invariant; the tables
-/// answer which *names* a plate may write, and are bounded by the address
-/// grammar. A table can only ever answer the second.
+impl AddressNode {
+    pub(crate) fn from_schema(node: &serde_json::Value) -> Self {
+        let props = node
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .map(|props| {
+                props
+                    .iter()
+                    .map(|(name, child)| (name.clone(), Self::from_schema(child)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let item = (node.get("type").and_then(|v| v.as_str()) == Some("array")).then(|| {
+            Box::new(
+                node.get("items")
+                    .map(Self::from_schema)
+                    .unwrap_or_default(),
+            )
+        });
+        Self { props, item }
+    }
+
+    /// The node `path` addresses, or `None` where it takes a step the schema
+    /// does not offer. A digit segment is the index step; any other is a
+    /// property step.
+    pub(crate) fn resolve(&self, path: &str) -> Option<&Self> {
+        path.split('.').try_fold(self, |node, seg| {
+            match seg.bytes().all(|b| b.is_ascii_digit()) && !seg.is_empty() {
+                true => node.item.as_deref(),
+                false => node.props.get(seg),
+            }
+        })
+    }
+
+    /// The generated `_qm-meta` shape: absent keys are absent steps, so a leaf
+    /// serializes as the empty dict.
+    fn to_json(&self) -> serde_json::Value {
+        let mut out = serde_json::Map::new();
+        if !self.props.is_empty() {
+            out.insert(
+                "props".to_string(),
+                serde_json::Value::Object(
+                    self.props
+                        .iter()
+                        .map(|(name, child)| (name.clone(), child.to_json()))
+                        .collect(),
+                ),
+            );
+        }
+        if let Some(item) = &self.item {
+            out.insert("item".to_string(), item.to_json());
+        }
+        serde_json::Value::Object(out)
+    }
+}
+
+/// The transform schema plus the address tree derived from it, kept apart
+/// because they answer different questions. Lowering reads the schema node
+/// ([`helper::lowering`]); the tree answers which *addresses* a plate may
+/// write, which is the same walk with everything but the steps pruned away.
 #[derive(Default)]
 pub(crate) struct SchemaMeta {
     /// The walk's cursor source: the same recursive projection
     /// `build_transform_schema` produced, kept whole rather than flattened.
     schema: serde_json::Value,
-    pub(crate) fields: Vec<String>,
-    /// Array field → its row's property names, gating `field.0` and
-    /// `field.0.prop`.
-    pub(crate) array_fields: BTreeMap<String, Vec<String>>,
-    /// Container field → its property names, gating `field.sub`. Native rather
-    /// than JSON: the span scan reads it on the AST walk, and `meta_literal`
-    /// serializes it either way.
-    pub(crate) object_fields: BTreeMap<String, Vec<String>>,
-    pub(crate) card_fields: BTreeMap<String, Vec<String>>,
-    pub(crate) card_array_fields: BTreeMap<String, BTreeMap<String, Vec<String>>>,
-    pub(crate) card_object_fields: BTreeMap<String, BTreeMap<String, Vec<String>>>,
+    /// Native rather than JSON: the span scan reads it on the AST walk, and
+    /// [`AddressNode::to_json`] serializes it for the helper either way.
+    pub(crate) root: AddressNode,
+    pub(crate) cards: BTreeMap<String, AddressNode>,
 }
 
 impl SchemaMeta {
-    /// A schema with no top-level `properties` yields empty tables and a walk
+    /// A schema with no top-level `properties` yields an empty tree and a walk
     /// that lowers every value literally: `build_transform_schema` always emits
     /// `properties`, so that only arises for hand-built schemas in tests.
     pub(crate) fn from_schema_json(schema_json: &serde_json::Value) -> Self {
-        let empty = serde_json::Map::new();
-        let properties_obj = schema_json
-            .get("properties")
-            .and_then(|v| v.as_object())
-            .unwrap_or(&empty);
-
-        let mut card_fields = BTreeMap::new();
-        let mut card_array_fields = BTreeMap::new();
-        let mut card_object_fields = BTreeMap::new();
+        let mut cards = BTreeMap::new();
         if let Some(defs) = schema_json.get("$defs").and_then(|v| v.as_object()) {
             for (def_name, def_schema) in defs {
                 let Some(kind) = def_name.strip_suffix("_card") else {
                     continue;
                 };
-                let Some(props) = def_schema.get("properties").and_then(|v| v.as_object()) else {
-                    continue;
-                };
-                card_fields.insert(kind.to_string(), props.keys().cloned().collect());
-                let arrays = array_field_names(props);
-                if !arrays.is_empty() {
-                    card_array_fields.insert(kind.to_string(), arrays);
-                }
-                let objects = object_field_names(props);
-                if !objects.is_empty() {
-                    card_object_fields.insert(kind.to_string(), objects);
-                }
+                cards.insert(kind.to_string(), AddressNode::from_schema(def_schema));
             }
         }
 
         Self {
-            fields: properties_obj.keys().cloned().collect(),
-            array_fields: array_field_names(properties_obj),
-            object_fields: object_field_names(properties_obj),
-            card_fields,
-            card_array_fields,
-            card_object_fields,
+            root: AddressNode::from_schema(schema_json),
+            cards,
             schema: schema_json.clone(),
         }
+    }
+
+    /// The address tables the helper's `_qm-known-path` validates against.
+    pub(crate) fn address_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "fields": self.root.to_json(),
+            "cards": serde_json::Value::Object(
+                self.cards
+                    .iter()
+                    .map(|(kind, node)| (kind.clone(), node.to_json()))
+                    .collect(),
+            ),
+        })
     }
 
     /// The schema node declaring a top-level field.
@@ -856,15 +858,15 @@ mod tests {
 
         let meta = SchemaMeta::from_schema_json(schema.as_json());
 
-        assert!(meta.array_fields.contains_key("sections"));
-        assert!(meta.array_fields.contains_key("signature_block"));
-        assert!(!meta.array_fields.contains_key("subject"));
-        // A richtext element declares no `properties`, so the row is empty and
-        // `sections.0.anything` stays unaddressable.
-        assert!(meta.array_fields["sections"].is_empty());
+        assert!(meta.root.resolve("sections.0").is_some());
+        assert!(meta.root.resolve("signature_block.0").is_some());
+        // A scalar offers no element for an index to resolve to.
+        assert!(meta.root.resolve("subject.0").is_none());
+        // A richtext element declares no `properties`, so `sections.0.anything`
+        // stays unaddressable.
+        assert!(meta.root.resolve("sections.0.anything").is_none());
 
-        let card_arrays = meta.card_array_fields.get("indorsement").unwrap();
-        assert_eq!(card_arrays["refs"], vec!["org".to_string()]);
+        assert!(meta.cards["indorsement"].resolve("refs.0.org").is_some());
     }
 
     #[test]

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -36,8 +36,7 @@
   let fields = _qm-meta.at("fields", default: (:))
   let cards = _qm-meta.at("cards", default: (:))
   let is-index(s) = s.match(regex("^[0-9]+$")) != none
-  // Every step out of a node, walked against the tree the schema declares: a
-  // digit takes the array element, any other segment a declared property. A
+  // A digit takes the array element, any other segment a declared property. A
   // node offering neither ends the walk, so a step past a leaf is rejected.
   let steps-ok(node, steps) = {
     for step in steps {

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -10,63 +10,57 @@
 // `_qm-known-path` (path validation, reading the generated `_qm-meta`), and
 // `display` (a date field's content projection, reading `_qm-display`).
 
-/// Backend-generated schema address tables (`fields`, `card_fields`,
-/// `array_fields`, `card_array_fields`, `object_fields`, `card_object_fields`)
-/// that validate `form-field` paths. A generated literal: never parsed from
-/// document data.
+/// Backend-generated schema address tree (`fields` for the main card, `cards`
+/// keyed by kind) that validates `form-field` paths: the schema pruned to the
+/// steps it offers, each node carrying `props` and `item` where it admits a
+/// property or an index step. A generated literal: never parsed from document
+/// data.
 #let _qm-meta = {meta_literal}
 
-/// Whether `path` parses against the schema address tables: a top-level field
-/// (`subject`), an array element (`refs.2`), a typed-table row property
-/// (`refs.2.org`), a container property (`classification.poc`), or a card
-/// address (`$cards.<kind>.<n>.<field>` with any of those suffixes). A suffix is
-/// gated on the step the field actually offers, not on the broader
-/// `fields`/`card_fields` name tables: `array_fields`/`card_array_fields` admit
-/// the index step and name what may follow it, `object_fields`/
-/// `card_object_fields` the property step, so `subject.0` and `subject.poc` are
-/// both rejected on a scalar `subject` even though the name itself is known — a
-/// scalar has neither an element nor a property for the address to resolve to.
-/// A container's properties are those its schema declares, so a variant
-/// container admits its `value` discriminant and every world's cells, and a
-/// typed dictionary its own keys. This is the pdfform resolver's grammar
-/// (`bind.rs`), so one schema address binds on either backend. Distinct from
-/// present-with-empty tables (e.g. a body-disabled main with no other fields and
-/// no cards), which validates against the empty set and so rejects every
-/// address.
+/// Whether `path` parses against the schema address tree: a top-level field
+/// (`subject`), an array element (`refs.2`), a container property
+/// (`classification.poc`, `contact.address.city`), or a card address
+/// (`$cards.<kind>.<n>.<field>` with any of those suffixes).
+///
+/// Each step is gated on what the node it steps out of actually offers, so
+/// `subject.0` and `subject.poc` are both rejected on a scalar `subject` even
+/// though the name itself is known — a scalar has neither an element nor a
+/// property for the address to resolve to. A container's properties are those
+/// its schema declares, so a variant container admits its `value` discriminant
+/// and every world's cells, and a typed dictionary its own keys. This is the
+/// pdfform resolver's grammar (`bind.rs`), so one schema address binds on
+/// either backend. Distinct from a present-but-empty tree (e.g. a body-disabled
+/// main with no other fields and no cards), which offers no step and so rejects
+/// every address.
 #let _qm-known-path(path) = {
-  let fields = _qm-meta.at("fields", default: ())
-  let card-fields = _qm-meta.at("card_fields", default: (:))
-  let array-fields = _qm-meta.at("array_fields", default: (:))
-  let card-array-fields = _qm-meta.at("card_array_fields", default: (:))
-  let object-fields = _qm-meta.at("object_fields", default: (:))
-  let card-object-fields = _qm-meta.at("card_object_fields", default: (:))
+  let fields = _qm-meta.at("fields", default: (:))
+  let cards = _qm-meta.at("cards", default: (:))
   let is-index(s) = s.match(regex("^[0-9]+$")) != none
-  // The suffix rule, shared by the top-level and card branches. The schema's
-  // one-level nesting contract bounds it at two steps, so this enumerates them
-  // rather than deriving a grammar: an index, then that row's property.
-  let steps-ok(field, steps, arrays, objects) = {
-    if steps.len() == 0 { return true }
-    if field in arrays and is-index(steps.at(0)) {
-      if steps.len() == 1 { return true }
-      return steps.len() == 2 and steps.at(1) in arrays.at(field)
+  // Every step out of a node, walked against the tree the schema declares: a
+  // digit takes the array element, any other segment a declared property. A
+  // node offering neither ends the walk, so a step past a leaf is rejected.
+  let steps-ok(node, steps) = {
+    for step in steps {
+      if is-index(step) {
+        if not ("item" in node) { return false }
+        node = node.at("item")
+      } else {
+        let props = node.at("props", default: (:))
+        if not (step in props) { return false }
+        node = props.at(step)
+      }
     }
-    return steps.len() == 1 and steps.at(0) in objects.at(field, default: ())
+    true
   }
   let parts = path.split(".")
   if parts.at(0) == "$cards" {
     if parts.len() < 4 { return false }
     let kind = parts.at(1)
-    if not (kind in card-fields) { return false }
+    if not (kind in cards) { return false }
     if not is-index(parts.at(2)) { return false }
-    if not (parts.at(3) in card-fields.at(kind)) { return false }
-    return steps-ok(
-      parts.at(3), parts.slice(4),
-      card-array-fields.at(kind, default: (:)),
-      card-object-fields.at(kind, default: (:)),
-    )
+    return steps-ok(cards.at(kind), parts.slice(3))
   }
-  if not (parts.at(0) in fields) { return false }
-  steps-ok(parts.at(0), parts.slice(1), array-fields, object-fields)
+  steps-ok(fields, parts)
 }
 
 /// Emit an unsigned form field. PDF: a clickable AcroForm widget here (a text

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -930,7 +930,6 @@ impl Tables<'_> {
             .unwrap_or_default()
     }
 
-    /// Whether the address offers an index step.
     fn is_indexable(&self, path: &str) -> bool {
         self.root
             .resolve(path)
@@ -1451,8 +1450,8 @@ main:
         spans.iter().any(|(p, t)| p == path && t == text)
     }
 
-    /// A read anchors on the cell it reaches, however many steps that takes, and
-    /// a read that stops partway anchors where it stopped.
+    /// A read that stops partway anchors where it stopped, so naming a
+    /// container is its own address rather than the leaf's.
     #[test]
     fn scalar_windows_take_every_step_the_plate_takes() {
         let src = Source::detached(

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -42,7 +42,7 @@
 //! `typst_layout::introspect::discover_frame`, transforming all four corners of
 //! each item box (the stack may rotate or scale).
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::ops::Range;
 
 use typst::foundations::{Content, Label, Value};
@@ -58,6 +58,7 @@ use quillmark_core::{ContentHit, HitGranularity, RenderedRegion};
 
 use crate::emit::SegmentMap;
 use crate::world::QuillWorld;
+use crate::AddressNode;
 
 /// A tracked byte window in a compiled source: the schema field whose content
 /// resolves into `range` of `file`. Content fields point at their generated
@@ -878,15 +879,9 @@ fn forward_pos(helper: &Source, segmap: &SegmentMap, pos: usize) -> usize {
 /// still carries the binding's span and needs a `field-region` claim.
 pub(crate) fn scalar_windows(
     source: &Source,
-    fields: &[String],
-    objects: &BTreeMap<String, Vec<String>>,
-    arrays: &BTreeMap<String, Vec<String>>,
+    address_root: &AddressNode,
 ) -> Vec<(String, Range<usize>)> {
-    let tables = Tables {
-        fields,
-        objects,
-        arrays,
-    };
+    let tables = Tables { root: address_root };
     let root = LinkedNode::new(source.root());
     let aliases = alias_bindings(&root, &tables);
     let mut anchors: Vec<(String, Range<usize>, Range<usize>)> = Vec::new();
@@ -911,34 +906,35 @@ pub(crate) fn scalar_windows(
     out
 }
 
-/// The address tables the scan resolves a read against — the same ones
+/// The address tree the scan resolves a read against — the same one
 /// [`_qm-known-path`] validates a `form-field` / `field-region` path against, so
 /// a scanned region path is one a claim could bind.
 struct Tables<'a> {
-    fields: &'a [String],
-    objects: &'a BTreeMap<String, Vec<String>>,
-    arrays: &'a BTreeMap<String, Vec<String>>,
+    root: &'a AddressNode,
 }
 
 impl Tables<'_> {
-    /// The property names an address offers a step into: a container field's own
-    /// keys, or an indexed row's. An address the grammar already caps offers none.
+    fn field_names(&self) -> Vec<String> {
+        self.root.props.keys().cloned().collect()
+    }
+
+    /// The property names an address offers a step into.
     ///
     /// Keyed on the address rather than the anchor, so an alias to a row
     /// (`#let r = data.refs.at(0)`) reaches the cell the chain it names does: the
     /// index step may have been taken in the initializer.
-    fn property_keys(&self, path: &str) -> &[String] {
-        if let Some(keys) = self.objects.get(path) {
-            return keys;
-        }
-        match path.rsplit_once('.') {
-            Some((array, index))
-                if !index.is_empty() && index.bytes().all(|b| b.is_ascii_digit()) =>
-            {
-                self.arrays.get(array).map(Vec::as_slice).unwrap_or_default()
-            }
-            _ => &[],
-        }
+    fn property_keys(&self, path: &str) -> Vec<String> {
+        self.root
+            .resolve(path)
+            .map(|node| node.props.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Whether the address offers an index step.
+    fn is_indexable(&self, path: &str) -> bool {
+        self.root
+            .resolve(path)
+            .is_some_and(|node| node.item.is_some())
     }
 }
 
@@ -1148,7 +1144,7 @@ fn data_access<'a>(
             if target.as_str() != "data" {
                 return None;
             }
-            let (name, anchor) = selected(node, tables.fields)?;
+            let (name, anchor) = selected(node, &tables.field_names())?;
             Some(step_into(name, anchor, tables))
         }
         // Reads before the binding ends — its own pattern, its initializer —
@@ -1162,25 +1158,34 @@ fn data_access<'a>(
     }
 }
 
-/// The address the read reaches into `name`: an array index (`refs.0`), then one
-/// property step (`classification.poc`, `refs.0.org`), or `name` itself where the
-/// read takes neither.
+/// The address the read reaches into `name`: every index (`refs.0`) and property
+/// (`classification.poc`, `refs.0.org`) step the plate actually takes, or `name`
+/// itself where it takes none.
 ///
-/// Two steps is the grammar's ceiling ([`_qm-known-path`]'s `steps-ok`), not a
-/// recursion: a row property is a leaf. Each step is its own address, so a
-/// whole-row read anchors on the row rather than on the table.
+/// Each step is its own address, so a whole-row read anchors on the row rather
+/// than on the table, and a read that stops halfway anchors where it stopped.
 fn step_into<'a>(
     name: String,
     anchor: LinkedNode<'a>,
     tables: &Tables,
 ) -> (String, LinkedNode<'a>) {
-    let (name, anchor) = match tables.arrays.get(&name).and_then(|_| select_index(&anchor)) {
-        Some((index, row)) => (format!("{name}.{index}"), row),
-        None => (name, anchor),
-    };
-    match select_property(&anchor, tables.property_keys(&name)) {
-        Some((key, deeper)) => (format!("{name}.{key}"), deeper),
-        None => (name, anchor),
+    let mut name = name;
+    let mut anchor = anchor;
+    loop {
+        if tables.is_indexable(&name) {
+            if let Some((index, row)) = select_index(&anchor) {
+                name = format!("{name}.{index}");
+                anchor = row;
+                continue;
+            }
+        }
+        match select_property(&anchor, &tables.property_keys(&name)) {
+            Some((key, deeper)) => {
+                name = format!("{name}.{key}");
+                anchor = deeper;
+            }
+            None => return (name, anchor),
+        }
     }
 }
 
@@ -1412,16 +1417,31 @@ main:
 
     /// `(path, source text)` per window, over the fields the tests below address.
     fn probe_spans(src: &Source) -> Vec<(String, String)> {
-        let fields = ["subject", "refs", "tags", "other", "classification"].map(str::to_string);
-        let objects = BTreeMap::from([(
-            "classification".to_string(),
-            ["value", "poc", "controlled by"].map(str::to_string).into(),
-        )]);
-        let arrays = BTreeMap::from([
-            ("refs".to_string(), ["org", "num"].map(str::to_string).into()),
-            ("tags".to_string(), Vec::new()),
-        ]);
-        scalar_windows(src, &fields, &objects, &arrays)
+        let root = AddressNode::from_schema(&serde_json::json!({
+            "properties": {
+                "subject": { "type": "string" },
+                "other": { "type": "string" },
+                "tags": { "type": "array", "items": { "type": "string" } },
+                "refs": { "type": "array", "items": { "type": "object", "properties": {
+                    "org": { "type": "string" },
+                    "num": { "type": "string" },
+                }}},
+                "classification": { "type": "object", "properties": {
+                    "value": { "type": "string" },
+                    "poc": { "type": "string" },
+                    "controlled by": { "type": "string" },
+                }},
+                "contact": { "type": "object", "properties": {
+                    "address": { "type": "object", "properties": {
+                        "city": { "type": "string" },
+                    }},
+                    "log": { "type": "array", "items": { "type": "object", "properties": {
+                        "note": { "type": "string" },
+                    }}},
+                }},
+            }
+        }));
+        scalar_windows(src, &root)
             .into_iter()
             .map(|(path, r)| (path, src.text()[r].to_string()))
             .collect()
@@ -1429,6 +1449,37 @@ main:
 
     fn has(spans: &[(String, String)], path: &str, text: &str) -> bool {
         spans.iter().any(|(p, t)| p == path && t == text)
+    }
+
+    /// A read anchors on the cell it reaches, however many steps that takes, and
+    /// a read that stops partway anchors where it stopped.
+    #[test]
+    fn scalar_windows_take_every_step_the_plate_takes() {
+        let src = Source::detached(
+            r#"
+#import "@local/quillmark-helper:0.1.0": data
+#data.contact.address.city
+#data.contact.address
+#data.contact
+#data.contact.log.at(0).note
+#data.contact.address.city.oops
+#let a = data.contact.address
+#a.city
+"#,
+        );
+        let spans = probe_spans(&src);
+        for (path, text) in [
+            ("contact.address.city", "data.contact.address.city"),
+            ("contact.address", "data.contact.address"),
+            ("contact", "data.contact"),
+            ("contact.log.0.note", "data.contact.log.at(0).note"),
+            // An undeclared step past a leaf mints nothing of its own: the read
+            // anchors on the deepest declared cell it reached.
+            ("contact.address.city", "data.contact.address.city.oops"),
+            ("contact.address.city", "a.city"),
+        ] {
+            assert!(has(&spans, path, text), "{path} / {text}: {spans:?}");
+        }
     }
 
     /// Naming the container before stepping into it must keep the address the
@@ -1777,7 +1828,7 @@ main:
         let main_id = world.main();
         let src = world.source(main_id).expect("main source");
         windows.extend(
-            scalar_windows(&src, &meta.fields, &meta.object_fields, &meta.array_fields)
+            scalar_windows(&src, &meta.root)
                 .into_iter()
                 .map(|(path, range)| FieldWindow {
                     path,

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -193,7 +193,6 @@ fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     append_scalar(items, field);
 }
 
-/// The properties of a typed dictionary: an `object` carrying `properties`.
 fn typed_dict_props(field: &FieldSchema) -> Option<&IndexMap<String, Box<FieldSchema>>> {
     match field.r#type {
         FieldType::Object => field.properties.as_ref(),
@@ -201,8 +200,6 @@ fn typed_dict_props(field: &FieldSchema) -> Option<&IndexMap<String, Box<FieldSc
     }
 }
 
-/// The row properties of a typed table: an `array` whose element is an `object`
-/// carrying `properties`.
 fn typed_table_props(field: &FieldSchema) -> Option<&IndexMap<String, Box<FieldSchema>>> {
     match field.r#type {
         FieldType::Array => match field.items.as_deref() {
@@ -347,9 +344,8 @@ fn property_cell(
 /// carries, at `path` relative to the field value (`[]` at card level).
 ///
 /// A `default:` is shippable as-is, so it renders verbatim and its subtree
-/// carries neither marker nor annotation — the leaves are covered by the
-/// container's own answer. `default: {}` on a typed dictionary instead expands
-/// to the blank-filled shape, so every key is shown.
+/// carries neither marker nor annotation. `default: {}` on a typed dictionary
+/// instead expands to the blank-filled shape, so every key is shown.
 fn container_cell(
     field: &FieldSchema,
     path: &[PathSegment],
@@ -371,12 +367,11 @@ fn container_cell(
         unreachable!("container_cell is reached only for a typed dictionary or a typed table")
     });
     match field.default.as_ref().map(|d| d.as_json()) {
-        // Any default (including `[]`) is shippable as-is, rendered verbatim.
+        // `[]` included: an array default stays inline rather than expanding.
         Some(default) => (default.clone(), Vec::new(), Vec::new()),
         // A row type declaring no properties is schema-invalid in practice:
         // emit a type-valid empty array rather than a null synthetic row.
         None if row_props.is_empty() => (JsonValue::Array(Vec::new()), Vec::new(), Vec::new()),
-        // One synthetic row, its properties addressed under `[Index(0)]`.
         None => {
             let mut row_path = path.to_vec();
             row_path.push(PathSegment::Index(0));
@@ -616,8 +611,7 @@ main:
             "{t}"
         );
 
-        // A blueprint is a document: what it stamps at depth must survive the
-        // parse it is written to be fed to.
+        // A blueprint is written to be parsed back, markers at depth included.
         let doc1 = Document::parse(&t).expect("blueprint must parse").document;
         let doc2 = Document::parse(&doc1.to_markdown())
             .expect("re-emit must parse")
@@ -625,10 +619,8 @@ main:
         assert_eq!(doc1, doc2, "a deep blueprint must round-trip");
     }
 
-    /// A container's `default:` is shippable as-is, so its subtree renders
-    /// verbatim and carries no marker of its own.
     #[test]
-    fn a_nested_container_default_renders_verbatim() {
+    fn a_nested_container_default_renders_verbatim_and_covers_its_leaves() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -180,27 +180,37 @@ fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
         return;
     }
 
-    // Typed table: an array whose element is an object with properties.
-    if matches!(field.r#type, FieldType::Array) {
-        if let Some(elem) = &field.items {
-            if matches!(elem.r#type, FieldType::Object) {
-                if let Some(props) = &elem.properties {
-                    append_typed_table(items, field, props);
-                    return;
-                }
-            }
-        }
-    }
-
-    // Typed dictionary: standalone object with defined properties.
-    if matches!(field.r#type, FieldType::Object) {
-        if let Some(props) = &field.properties {
-            append_typed_dict(items, field, props);
-            return;
-        }
+    if typed_dict_props(field).is_some() || typed_table_props(field).is_some() {
+        // The container key itself is untagged: `!must_fill` is rejected on a
+        // mapping (`prose/references/markdown-spec.md` §3.4), so a container's
+        // own `must_fill:` is inert and the obligation lives on its leaves.
+        push_leading(items, field, true);
+        let (value, nested, fills) = container_cell(field, &[]);
+        push_container_field(items, &field.name, value, nested, fills, field);
+        return;
     }
 
     append_scalar(items, field);
+}
+
+/// The properties of a typed dictionary: an `object` carrying `properties`.
+fn typed_dict_props(field: &FieldSchema) -> Option<&IndexMap<String, Box<FieldSchema>>> {
+    match field.r#type {
+        FieldType::Object => field.properties.as_ref(),
+        _ => None,
+    }
+}
+
+/// The row properties of a typed table: an `array` whose element is an `object`
+/// carrying `properties`.
+fn typed_table_props(field: &FieldSchema) -> Option<&IndexMap<String, Box<FieldSchema>>> {
+    match field.r#type {
+        FieldType::Array => match field.items.as_deref() {
+            Some(elem) => typed_dict_props(elem),
+            None => None,
+        },
+        _ => None,
+    }
 }
 
 /// Push the leading prose comments for a *top-level* field: the description,
@@ -302,13 +312,12 @@ fn build_property_mapping(
                 });
             }
         }
-        let (json, fill) = scalar_cell(prop);
+        let mut path = prefix.to_vec();
+        path.push(PathSegment::Key(prop.name.clone()));
+        let (json, sub_nested, sub_fills) = property_cell(prop, &path);
         map.insert(prop.name.clone(), json);
-        if fill {
-            let mut path = prefix.to_vec();
-            path.push(PathSegment::Key(prop.name.clone()));
-            fills.push(path);
-        }
+        nested.extend(sub_nested);
+        fills.extend(sub_fills);
         nested.push(NestedComment {
             container_path: prefix.to_vec(),
             position: slot,
@@ -319,37 +328,66 @@ fn build_property_mapping(
     (map, nested, fills)
 }
 
-/// Append a typed-dictionary field (`object` with `properties`). With a
-/// `default:`: render the default mapping (`{}` expands to the blank-filled
-/// shape; a non-empty partial default is rendered verbatim, all unmarked).
-/// Without one: recurse per property with leaf-level markers and annotations;
-/// the container key itself is untagged, since `!must_fill` is rejected on a
-/// mapping (`prose/references/markdown-spec.md` §3.4). A typed dictionary's own
-/// `must_fill:` is therefore inert — the obligation lives on its leaves.
-fn append_typed_dict(
-    items: &mut Vec<PayloadItem>,
+/// One property's contribution to its parent's mapping: its value, and the
+/// nested comments and fill paths its own subtree carries. `path` is the
+/// property's address relative to the field value.
+fn property_cell(
+    prop: &FieldSchema,
+    path: &[PathSegment],
+) -> (JsonValue, Vec<NestedComment>, Vec<Vec<PathSegment>>) {
+    if typed_dict_props(prop).is_some() || typed_table_props(prop).is_some() {
+        return container_cell(prop, path);
+    }
+    let (json, fill) = scalar_cell(prop);
+    let fills = if fill { vec![path.to_vec()] } else { Vec::new() };
+    (json, Vec::new(), fills)
+}
+
+/// A container's value plus the nested comments and fill paths its subtree
+/// carries, at `path` relative to the field value (`[]` at card level).
+///
+/// A `default:` is shippable as-is, so it renders verbatim and its subtree
+/// carries neither marker nor annotation — the leaves are covered by the
+/// container's own answer. `default: {}` on a typed dictionary instead expands
+/// to the blank-filled shape, so every key is shown.
+fn container_cell(
     field: &FieldSchema,
-    props: &IndexMap<String, Box<FieldSchema>>,
-) {
-    push_leading(items, field, true);
+    path: &[PathSegment],
+) -> (JsonValue, Vec<NestedComment>, Vec<Vec<PathSegment>>) {
+    if let Some(props) = typed_dict_props(field) {
+        return match field.default.as_ref().map(|d| d.as_json()) {
+            Some(JsonValue::Object(map)) if map.is_empty() => {
+                (blank(field).into_json(), Vec::new(), Vec::new())
+            }
+            Some(default) => (default.clone(), Vec::new(), Vec::new()),
+            None => {
+                let (map, nested, fills) = build_property_mapping(props, path);
+                (JsonValue::Object(map), nested, fills)
+            }
+        };
+    }
 
-    let (value, nested, fills) = match field.default.as_ref().map(|d| d.as_json()) {
-        // `default: {}` → expand to the field's blank-filled shape so every key
-        // is shown; the container's default covers its leaves, so they are
-        // unmarked and unannotated (uniform with a concrete default).
-        Some(JsonValue::Object(map)) if map.is_empty() => {
-            (blank(field).into_json(), Vec::new(), Vec::new())
-        }
-        // Concrete default (object or otherwise) → rendered verbatim, unmarked.
+    let row_props = typed_table_props(field).unwrap_or_else(|| {
+        unreachable!("container_cell is reached only for a typed dictionary or a typed table")
+    });
+    match field.default.as_ref().map(|d| d.as_json()) {
+        // Any default (including `[]`) is shippable as-is, rendered verbatim.
         Some(default) => (default.clone(), Vec::new(), Vec::new()),
-        // No default → per-property recursion at the mapping root.
+        // A row type declaring no properties is schema-invalid in practice:
+        // emit a type-valid empty array rather than a null synthetic row.
+        None if row_props.is_empty() => (JsonValue::Array(Vec::new()), Vec::new(), Vec::new()),
+        // One synthetic row, its properties addressed under `[Index(0)]`.
         None => {
-            let (map, nested, fills) = build_property_mapping(props, &[]);
-            (JsonValue::Object(map), nested, fills)
+            let mut row_path = path.to_vec();
+            row_path.push(PathSegment::Index(0));
+            let (row, nested, fills) = build_property_mapping(row_props, &row_path);
+            (
+                JsonValue::Array(vec![JsonValue::Object(row)]),
+                nested,
+                fills,
+            )
         }
-    };
-
-    push_container_field(items, &field.name, value, nested, fills, field);
+    }
 }
 
 /// Append a variant-bearing enum: the container, its discriminant cell, and the
@@ -441,38 +479,6 @@ fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     );
 }
 
-/// Append a typed-table field (`array<object>`). With a `default:`: render the
-/// default rows verbatim (including `default: []`, which stays inline `[]`:
-/// arrays do not expand). Without one: emit one synthetic row carrying each
-/// property's leaf-level marker and annotation; the container key itself is
-/// untagged, so the field's own `must_fill:` is inert (as for a typed dict).
-fn append_typed_table(
-    items: &mut Vec<PayloadItem>,
-    field: &FieldSchema,
-    item_props: &IndexMap<String, Box<FieldSchema>>,
-) {
-    push_leading(items, field, true);
-
-    let (value, nested, fills) = match field.default.as_ref().map(|d| d.as_json()) {
-        // Any default (including `[]`) is shippable as-is, rendered verbatim.
-        Some(default) => (default.clone(), Vec::new(), Vec::new()),
-        // Row type declares no properties (schema-invalid in practice): emit a
-        // type-valid empty array rather than a null synthetic row.
-        None if item_props.is_empty() => (JsonValue::Array(Vec::new()), Vec::new(), Vec::new()),
-        // No default → one synthetic row, per-property markers at `[Index(0)]`.
-        None => {
-            let (row, nested, fills) = build_property_mapping(item_props, &[PathSegment::Index(0)]);
-            (
-                JsonValue::Array(vec![JsonValue::Object(row)]),
-                nested,
-                fills,
-            )
-        }
-    };
-
-    push_container_field(items, &field.name, value, nested, fills, field);
-}
-
 /// Push a typed-container field (value + nested comments + nested fills) and
 /// its trailing inline type annotation. The top-level `fill` flag is always
 /// `false`: typed containers are tagged on their leaves, never the container.
@@ -557,6 +563,94 @@ mod tests {
 
     fn cfg(yaml: &str) -> QuillConfig {
         QuillConfig::from_yaml(yaml).expect("valid yaml")
+    }
+
+    /// Marker, annotation and description reach a leaf at whatever depth it is
+    /// declared, and a `default:` still covers the subtree under it.
+    #[test]
+    fn a_container_expands_at_every_depth() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    contact:
+      type: object
+      properties:
+        tags: { type: array, items: { type: string } }
+        address:
+          type: object
+          properties:
+            city: { type: string, description: The city }
+            zip: { type: string, default: "00000" }
+    refs:
+      type: array
+      items:
+        type: object
+        properties:
+          org: { type: string }
+          lead:
+            type: object
+            properties:
+              email: { type: string }
+"#)
+        .blueprint();
+
+        assert!(
+            t.contains(concat!(
+                "contact: # object\n",
+                "  tags: !must_fill # array<string>\n",
+                "  address: # object\n",
+                "    # The city\n",
+                "    city: !must_fill # string\n",
+                "    zip: \"00000\" # string\n",
+            )),
+            "{t}"
+        );
+        assert!(
+            t.contains(concat!(
+                "refs: # array<object>\n",
+                "  - org: !must_fill # string\n",
+                "    lead: # object\n",
+                "      email: !must_fill # string\n",
+            )),
+            "{t}"
+        );
+
+        // A blueprint is a document: what it stamps at depth must survive the
+        // parse it is written to be fed to.
+        let doc1 = Document::parse(&t).expect("blueprint must parse").document;
+        let doc2 = Document::parse(&doc1.to_markdown())
+            .expect("re-emit must parse")
+            .document;
+        assert_eq!(doc1, doc2, "a deep blueprint must round-trip");
+    }
+
+    /// A container's `default:` is shippable as-is, so its subtree renders
+    /// verbatim and carries no marker of its own.
+    #[test]
+    fn a_nested_container_default_renders_verbatim() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    contact:
+      type: object
+      properties:
+        address:
+          type: object
+          default: { city: Reston, zip: "20190" }
+          properties:
+            city: { type: string }
+            zip: { type: string }
+"#)
+        .blueprint();
+        assert!(t.contains("  address: # object\n"), "{t}");
+        assert!(!t.contains("address: !must_fill"), "{t}");
+        assert!(t.contains("Reston"), "{t}");
+        assert!(
+            !t.contains("city: !must_fill"),
+            "a covered leaf asks for nothing: {t}"
+        );
     }
 
     #[test]

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -110,19 +110,6 @@ struct CardSchemaDef {
     pub body: Option<BodyCardSchema>,
 }
 
-/// Depth context for [`QuillConfig::validate_field_schema_shape`]. Encodes
-/// which shapes are legal at the current nesting level, so the one-level
-/// nesting contract is enforced by a single recursive walk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ShapePosition {
-    /// A field declared directly on a card: scalar, object, or array.
-    Top,
-    /// An array's `items`: scalar or object (typed-table row), not an array.
-    ArrayItem,
-    /// An object's property: scalar only.
-    Leaf,
-}
-
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CoercionError {
@@ -903,19 +890,9 @@ impl QuillConfig {
         Ok(QuillValue::from_json(serde_json::Value::Object(out)))
     }
 
-    /// Recursively validate a field's structural shape, enforcing the
-    /// one-level nesting contract in a single pass. The `position` records
-    /// what shapes are legal at the current depth:
-    ///
-    /// - [`ShapePosition::Top`], a field declared directly on a card: scalar,
-    ///   `object` (typed dictionary), or `array` (primitive list or typed
-    ///   table).
-    /// - [`ShapePosition::ArrayItem`], an array's `items`: a scalar or an
-    ///   `object` (the typed-table row), but **not** another array.
-    /// - [`ShapePosition::Leaf`], an object's property (whether a top-level
-    ///   typed dictionary or a typed-table row): scalar only. No deeper
-    ///   containers, so `array<object<array>>` and `object<array>` are
-    ///   rejected here.
+    /// Recursively validate a field's structural shape. Every type nests at
+    /// every depth; `at_card_level` gates the two keys that do not,
+    /// `variants:` and `ui.group`.
     ///
     /// Returns the first violation as a ready-to-push [`Diagnostic`] whose
     /// message names `owner` (the field-name path, e.g. `rows[].tags`), or
@@ -923,7 +900,7 @@ impl QuillConfig {
     fn validate_field_schema_shape(
         schema: &FieldSchema,
         owner: &str,
-        position: ShapePosition,
+        at_card_level: bool,
     ) -> Option<Diagnostic> {
         let err = |code: &str, message: String| {
             Some(Diagnostic::new(Severity::Error, message).with_code(code.to_string()))
@@ -947,9 +924,7 @@ impl QuillConfig {
         // pass never descends into object properties or array items, so a nested
         // `group` is an inert knob. Reject it rather than let it silently do
         // nothing, the same dead-knob class this walk exists to catch.
-        if position != ShapePosition::Top
-            && schema.ui.as_ref().and_then(|u| u.group.as_ref()).is_some()
-        {
+        if !at_card_level && schema.ui.as_ref().and_then(|u| u.group.as_ref()).is_some() {
             return err(
                 "quill::nested_group_not_supported",
                 format!(
@@ -961,11 +936,13 @@ impl QuillConfig {
         }
 
         if let Some(variants) = &schema.variants {
-            // A variant set is a *card-level* shape: it turns its field into a
-            // container, and a container may not sit inside one (the same
-            // one-level rule `nested_object_not_supported` states from the
-            // object side).
-            if position != ShapePosition::Top {
+            // Every other container's shape is a function of the schema alone.
+            // A variant's is a function of the schema *and* the discriminant:
+            // the transform schema can only project the union of the worlds,
+            // and the wire carries whichever one the document selects. That gap
+            // is sound one level deep — a cell is unconditionally addressable
+            // and conditionally live — and compounds into a chain at two.
+            if !at_card_level {
                 return err(
                     "quill::variant_placement",
                     format!(
@@ -1041,13 +1018,13 @@ impl QuillConfig {
                             ),
                         );
                     }
-                    // A variant's fields are leaves, exactly as an object's
-                    // properties are: scalars only, no `ui.group` (they inherit
-                    // the discriminant's), no container one level down.
+                    // A variant's cells sit below card level, exactly as an
+                    // object's properties do: no `variants:` of their own, and
+                    // no `ui.group` (they inherit the discriminant's).
                     if let Some(diag) = Self::validate_field_schema_shape(
                         field,
                         &format!("{member_owner}.{name}"),
-                        ShapePosition::Leaf,
+                        false,
                     ) {
                         return Some(diag);
                     }
@@ -1078,17 +1055,6 @@ impl QuillConfig {
 
         match schema.r#type {
             FieldType::Object => {
-                // An object nested inside another object (a Leaf position) is
-                // the classic "nested type: object" rejection.
-                if position == ShapePosition::Leaf {
-                    return err(
-                        "quill::nested_object_not_supported",
-                        format!(
-                            "Field '{owner}' uses a nested type: object, which is not supported. \
-                             An object's properties may only be scalars."
-                        ),
-                    );
-                }
                 let Some(props) = &schema.properties else {
                     return err(
                         "quill::object_missing_properties",
@@ -1108,28 +1074,11 @@ impl QuillConfig {
                         ),
                     );
                 }
-                // Object properties are leaves: scalars only.
                 props.iter().find_map(|(name, prop)| {
-                    Self::validate_field_schema_shape(
-                        prop,
-                        &format!("{owner}.{name}"),
-                        ShapePosition::Leaf,
-                    )
+                    Self::validate_field_schema_shape(prop, &format!("{owner}.{name}"), false)
                 })
             }
             FieldType::Array => {
-                // An array may sit at the top level only; an array element may
-                // not itself be an array, and neither may an object property.
-                if position != ShapePosition::Top {
-                    return err(
-                        "quill::nested_array_not_supported",
-                        format!(
-                            "Field '{owner}' declares a nested array, which is not supported. \
-                             Array elements must be scalars or objects, and object properties \
-                             may only be scalars."
-                        ),
-                    );
-                }
                 if schema.properties.is_some() {
                     return err(
                         "quill::array_properties_not_supported",
@@ -1151,11 +1100,7 @@ impl QuillConfig {
                         ),
                     );
                 };
-                Self::validate_field_schema_shape(
-                    items,
-                    &format!("{owner}[]"),
-                    ShapePosition::ArrayItem,
-                )
+                Self::validate_field_schema_shape(items, &format!("{owner}[]"), false)
             }
             // Scalars are leaves; nothing further to validate.
             _ => None,
@@ -1530,10 +1475,10 @@ impl QuillConfig {
                 Ok(schema) => {
                     // One recursive pass enforces the whole shape contract:
                     // containers carry the right child schema (`object` →
-                    // `properties`, `array` → `items`), and nesting stops after
-                    // one structural level (a typed table is the deepest shape).
+                    // `properties`, `array` → `items`), and the card-level-only
+                    // keys appear only here.
                     if let Some(diag) =
-                        Self::validate_field_schema_shape(&schema, field_name, ShapePosition::Top)
+                        Self::validate_field_schema_shape(&schema, field_name, true)
                     {
                         errors.push(diag);
                         continue;

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -936,12 +936,10 @@ impl QuillConfig {
         }
 
         if let Some(variants) = &schema.variants {
-            // Every other container's shape is a function of the schema alone.
-            // A variant's is a function of the schema *and* the discriminant:
-            // the transform schema can only project the union of the worlds,
-            // and the wire carries whichever one the document selects. That gap
-            // is sound one level deep — a cell is unconditionally addressable
-            // and conditionally live — and compounds into a chain at two.
+            // A variant's shape is a function of the schema *and* the
+            // discriminant, so every projection downstream is the union of its
+            // worlds: sound one level deep, a chain at two (`SCHEMAS.md`
+            // §"Enum variants").
             if !at_card_level {
                 return err(
                     "quill::variant_placement",
@@ -1018,9 +1016,7 @@ impl QuillConfig {
                             ),
                         );
                     }
-                    // A variant's cells sit below card level, exactly as an
-                    // object's properties do: no `variants:` of their own, and
-                    // no `ui.group` (they inherit the discriminant's).
+                    // A cell inherits the discriminant's `ui.group`.
                     if let Some(diag) = Self::validate_field_schema_shape(
                         field,
                         &format!("{member_owner}.{name}"),
@@ -1475,8 +1471,7 @@ impl QuillConfig {
                 Ok(schema) => {
                     // One recursive pass enforces the whole shape contract:
                     // containers carry the right child schema (`object` →
-                    // `properties`, `array` → `items`), and the card-level-only
-                    // keys appear only here.
+                    // `properties`, `array` → `items`).
                     if let Some(diag) =
                         Self::validate_field_schema_shape(&schema, field_name, true)
                     {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1033,14 +1033,16 @@ main:
     }
 }
 
+/// A type means the same thing wherever it is declared, so a row property is
+/// an ordinary field carrying an ordinary container.
 #[test]
-fn test_nested_object_in_typed_table_rejected_with_error() {
+fn a_typed_table_row_carries_a_container_property() {
     let yaml_content = r#"
 quill:
   name: nested_obj_test
   version: "1.0"
   backend: typst
-  description: Test nested object in typed table rejection
+  description: Test nested object in typed table
 
 main:
   fields:
@@ -1058,15 +1060,13 @@ main:
                 type: string
 "#;
 
-    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
-
-    assert_eq!(err.len(), 1);
-    assert_eq!(err[0].severity, Severity::Error);
-    assert_eq!(
-        err[0].code.as_deref(),
-        Some("quill::nested_object_not_supported")
-    );
-    assert!(err[0].message.contains("rows"));
+    let config = QuillConfig::from_yaml_with_warnings(yaml_content)
+        .expect("loads")
+        .0;
+    let row = config.main.fields["rows"].items.as_ref().expect("items");
+    let nested = &row.properties.as_ref().expect("properties")["nested"];
+    assert_eq!(nested.r#type, FieldType::Object);
+    assert!(nested.properties.as_ref().expect("properties").contains_key("inner"));
 }
 
 #[test]
@@ -1546,7 +1546,7 @@ main:
 }
 
 #[test]
-fn test_nested_array_rejected() {
+fn an_array_element_is_itself_an_array() {
     let yaml_content = r#"
 quill:
   name: nested_array
@@ -1563,15 +1563,19 @@ main:
         items:
           type: integer
 "#;
-    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
-    assert!(err.iter().any(
-        |d| d.code.as_deref() == Some("quill::nested_array_not_supported")
-            && d.message.contains("grid")
-    ));
+    let config = QuillConfig::from_yaml_with_warnings(yaml_content)
+        .expect("loads")
+        .0;
+    let row = config.main.fields["grid"].items.as_ref().expect("items");
+    assert_eq!(row.r#type, FieldType::Array);
+    assert_eq!(
+        row.items.as_ref().expect("items").r#type,
+        FieldType::Integer
+    );
 }
 
 #[test]
-fn test_object_with_array_property_rejected() {
+fn a_typed_dictionary_carries_an_array_property() {
     let yaml_content = r#"
 quill:
   name: object_with_array
@@ -1589,11 +1593,15 @@ main:
           items:
             type: string
 "#;
-    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
-    assert!(err.iter().any(
-        |d| d.code.as_deref() == Some("quill::nested_array_not_supported")
-            && d.message.contains("address")
-    ));
+    let config = QuillConfig::from_yaml_with_warnings(yaml_content)
+        .expect("loads")
+        .0;
+    let lines = &config.main.fields["address"]
+        .properties
+        .as_ref()
+        .expect("properties")["lines"];
+    assert_eq!(lines.r#type, FieldType::Array);
+    assert_eq!(lines.items.as_ref().expect("items").r#type, FieldType::String);
 }
 
 #[test]

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -275,22 +275,36 @@ classification:
     assert_eq!(blank_plate, json!({ "value": "" }));
 }
 
+/// A variant cell carries any type a card field does, containers included. The
+/// two card-level keys are what it may not carry.
 #[test]
-fn a_variant_field_may_not_be_a_container_or_carry_a_group() {
-    assert!(load_error(
-        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: object, properties: { y: { type: string } } }\n"
-    )
-    .contains("quill::nested_object_not_supported"));
-    assert!(load_error(
-        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: array, items: { type: string } }\n"
-    )
-    .contains("quill::nested_array_not_supported"));
+fn a_variant_field_may_not_carry_variants_or_a_group() {
     // Variant fields inherit the discriminant's group; declaring one is the
     // same dead knob a nested `ui.group` always was.
     assert!(load_error(
         "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: string, ui: { group: g } }\n"
     )
     .contains("quill::nested_group_not_supported"));
+    assert!(load_error(
+        "    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          x: { type: enum, values: [P], variants: { P: { y: { type: string } } } }\n"
+    )
+    .contains("quill::variant_placement"));
+}
+
+/// The union projection is what stays one level deep; the shapes below it do
+/// not, so a cell holds a typed dictionary and a typed table like any field.
+#[test]
+fn a_variant_field_holds_a_container() {
+    for cell in [
+        "x: { type: object, properties: { y: { type: string } } }",
+        "x: { type: array, items: { type: string } }",
+        "x: { type: array, items: { type: object, properties: { y: { type: string } } } }",
+    ] {
+        let yaml = format!(
+            "quill:\n  name: ok\n  version: \"0.1.0\"\n  backend: typst\n  description: ok\n\ntypst:\n  plate_file: plate.typ\n\nmain:\n  fields:\n    c:\n      type: enum\n      values: [A]\n      variants:\n        A:\n          {cell}\n"
+        );
+        QuillConfig::from_yaml(&yaml).unwrap_or_else(|e| panic!("{cell}: {e:?}"));
+    }
 }
 
 /// Two spellings of one name would coerce a live value under the other world's

--- a/crates/quillmark/tests/address_grammar.rs
+++ b/crates/quillmark/tests/address_grammar.rs
@@ -1,8 +1,8 @@
 //! One schema address grammar, two implementations: pdfform's `bind` walks the
-//! `QuillConfig`, and the Typst helper's `_qm-known-path` reads the address
-//! tables `SchemaMeta` derives from the transform schema. `PLATE_DATA.md`
-//! promises a plate author that one address binds on either backend, and
-//! `GRAMMAR` is what holds the two to it.
+//! `QuillConfig`, and the Typst helper's `_qm-known-path` walks the address tree
+//! `SchemaMeta` derives from the transform schema. `PLATE_DATA.md` promises a
+//! plate author that one address binds on either backend, and `GRAMMAR` is what
+//! holds the two to it.
 //!
 //! A `$body` address is outside that table: a body is content rather than a
 //! bindable field, so pdfform's resolver roots none.
@@ -13,8 +13,9 @@ use quillmark::{Backend, FileTreeNode, Quill};
 use quillmark_typst::TypstBackend;
 use std::collections::HashMap;
 
-/// Every position the one-level nesting contract admits, declared on `main` and
-/// again on a card kind so each address has its card twin.
+/// Every position the schema admits, containers nested inside containers and a
+/// variant cell holding a typed table among them, declared on `main` and again
+/// on a card kind so each address has its card twin.
 const YAML: &str = r#"
 quill:
   name: address_grammar
@@ -38,11 +39,29 @@ main:
         properties:
           org: { type: string }
           num: { type: string }
+          lead:
+            type: object
+            properties:
+              email: { type: string }
     address:
       type: object
       properties:
         city: { type: string }
         street: { type: string }
+        geo:
+          type: object
+          properties:
+            lat: { type: number }
+        lines:
+          type: array
+          items:
+            type: string
+    grid:
+      type: array
+      items:
+        type: array
+        items:
+          type: integer
     classification:
       type: enum
       values: [UNCLASSIFIED, CUI]
@@ -50,6 +69,12 @@ main:
       variants:
         CUI:
           poc: { type: string }
+          history:
+            type: array
+            items:
+              type: object
+              properties:
+                when: { type: string }
 card_kinds:
   endorsement:
     fields:
@@ -71,6 +96,10 @@ card_kinds:
         properties:
           office: { type: string }
           city: { type: string }
+          geo:
+            type: object
+            properties:
+              lat: { type: number }
       level:
         type: enum
         values: [FIRST, SECOND]
@@ -92,11 +121,21 @@ const GRAMMAR: &[(&str, bool)] = &[
     ("refs.0", true),
     ("refs.9", true),
     ("refs.0.org", true),
+    ("refs.0.lead", true),
+    ("refs.0.lead.email", true),
     ("address", true),
     ("address.city", true),
+    ("address.geo.lat", true),
+    ("address.lines", true),
+    ("address.lines.0", true),
+    ("grid.0", true),
+    ("grid.0.0", true),
     ("classification", true),
     ("classification.value", true),
     ("classification.poc", true),
+    ("classification.history", true),
+    ("classification.history.0", true),
+    ("classification.history.0.when", true),
     ("$cards.endorsement.0.from", true),
     ("$cards.endorsement.9.from", true),
     ("$cards.endorsement.0.tags", true),
@@ -106,6 +145,7 @@ const GRAMMAR: &[(&str, bool)] = &[
     ("$cards.endorsement.0.refs.0.org", true),
     ("$cards.endorsement.0.origin", true),
     ("$cards.endorsement.0.origin.office", true),
+    ("$cards.endorsement.0.origin.geo.lat", true),
     ("$cards.endorsement.0.level", true),
     ("$cards.endorsement.0.level.value", true),
     ("$cards.endorsement.0.level.endorser", true),
@@ -118,9 +158,18 @@ const GRAMMAR: &[(&str, bool)] = &[
     ("address.9", false),
     ("address.zip", false),
     ("address.city.0", false),
+    ("address.geo.lon", false),
+    ("address.geo.lat.0", false),
+    ("address.lines.0.0", false),
+    ("refs.0.lead.phone", false),
+    ("refs.0.lead.email.0", false),
+    ("grid.0.0.0", false),
+    ("grid.0.x", false),
     ("classification.0", false),
     ("classification.undeclared", false),
     ("classification.value.oops", false),
+    ("classification.history.0.nosuch", false),
+    ("classification.history.x", false),
     ("$cards", false),
     ("$cards.endorsement", false),
     ("$cards.endorsement.0", false),
@@ -131,6 +180,7 @@ const GRAMMAR: &[(&str, bool)] = &[
     ("$cards.endorsement.0.from.0", false),
     ("$cards.endorsement.0.tags.0.org", false),
     ("$cards.endorsement.0.origin.office.0", false),
+    ("$cards.endorsement.0.origin.geo.lon", false),
 ];
 
 const PREAMBLE: &str = r#"#import "@local/quillmark-helper:0.1.0": field-region
@@ -154,15 +204,25 @@ fn data() -> serde_json::Value {
     serde_json::json!({
         "subject": "Widgets",
         "tags": ["urgent"],
-        "refs": [{ "org": "AFRL/RQ", "num": "2026-01" }],
-        "address": { "city": "Dayton", "street": "1864 Fourth St" },
-        "classification": { "value": "CUI", "poc": "Capt J. Smith" },
+        "refs": [{ "org": "AFRL/RQ", "num": "2026-01", "lead": { "email": "lead@example.mil" } }],
+        "address": {
+            "city": "Dayton",
+            "street": "1864 Fourth St",
+            "geo": { "lat": 39.78 },
+            "lines": ["Bldg 15", "Rm 200"],
+        },
+        "grid": [[1, 2], [3, 4]],
+        "classification": {
+            "value": "CUI",
+            "poc": "Capt J. Smith",
+            "history": [{ "when": "2026-01-02" }],
+        },
         "$cards": [{
             "$kind": "endorsement",
             "from": "SAF/AA",
             "tags": ["routine"],
             "refs": [{ "org": "AFRL/RQ", "num": "2026-02" }],
-            "origin": { "office": "SAF/AA", "city": "Dayton" },
+            "origin": { "office": "SAF/AA", "city": "Dayton", "geo": { "lat": 38.88 } },
             "level": { "value": "SECOND", "endorser": "Col K. Lee" },
         }],
     })

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -377,7 +377,7 @@ main:
           type: string
 ```
 
-Containers nest freely: a property or an element is an ordinary field, so it carries whatever type a card-level field carries, itself included. `object<array<string>>`, `array<array<integer>>` and a typed table whose row holds a typed dictionary are all declarable, and each leaf is addressable by the schema address its path spells (`contact.address.city`, `grid.0.0` — see [PLATE_DATA.md](../../prose/canon/PLATE_DATA.md#schema-addresses)).
+Containers nest freely: a property or an element is an ordinary field, so it carries whatever type a card-level field carries, itself included. `object<array<string>>`, `array<array<integer>>` and a typed table whose row holds a typed dictionary are all declarable, and each leaf is addressable by the schema address its path spells (`contact.address.city`, `grid.0.0` — see [PLATE_DATA.md](https://github.com/borb-sh/quillmark/blob/main/prose/canon/PLATE_DATA.md#schema-addresses)).
 
 Two keys are card-level regardless of depth: `ui.group` (grouping never descends) and `variants:` (see [Enum variants](#enum-variants)).
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -379,7 +379,7 @@ main:
 
 Containers nest freely: a property or an element is an ordinary field, so it carries whatever type a card-level field carries, itself included. `object<array<string>>`, `array<array<integer>>` and a typed table whose row holds a typed dictionary are all declarable, and each leaf is addressable by the schema address its path spells (`contact.address.city`, `grid.0.0` — see [PLATE_DATA.md](https://github.com/borb-sh/quillmark/blob/main/prose/canon/PLATE_DATA.md#schema-addresses)).
 
-Two keys are card-level regardless of depth: `ui.group` (grouping never descends) and `variants:` (see [Enum variants](#enum-variants)).
+Two keys are card-level regardless of depth: `ui.group` (grouping never descends) and `variants:` (see [Variants](#variants-fields-that-exist-only-for-one-choice)).
 
 ---
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -314,10 +314,9 @@ in a CUI block leaves those values in the document and warns
 (`validation::out_of_variant`); they simply stop rendering. Flip back and they
 are still there. Remove the field to drop the value for good.
 
-A variant holds any **leaf** type a card field may, prose and dates included:
-a `richtext` or `date` cell reaches the plate exactly as a card-level one does.
-What it cannot hold is another container — arrays and objects stay card-level,
-the same one-level nesting rule an object's properties obey. `variants:` itself
+A variant cell is an ordinary field: any type a card field may carry, prose,
+dates and containers included, reaching the plate exactly as a card-level one
+does. What it cannot carry is `variants:` of its own. `variants:` itself
 is valid only on a card-level `type: enum` field,
 keys only on declared members (never `""`, which owns no field set), and cannot
 declare a field named `value`. Variant fields inherit the discriminant's
@@ -378,7 +377,9 @@ main:
           type: string
 ```
 
-Nesting beyond one level is not supported: an array element may not itself be an array.
+Containers nest freely: a property or an element is an ordinary field, so it carries whatever type a card-level field carries, itself included. `object<array<string>>`, `array<array<integer>>` and a typed table whose row holds a typed dictionary are all declarable, and each leaf is addressable by the schema address its path spells (`contact.address.city`, `grid.0.0` — see [PLATE_DATA.md](../../prose/canon/PLATE_DATA.md#schema-addresses)).
+
+Two keys are card-level regardless of depth: `ui.group` (grouping never descends) and `variants:` (see [Enum variants](#enum-variants)).
 
 ---
 

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -115,7 +115,7 @@ Helper contents (generated in `backends/typst/helper.rs` from `lib.typ.template`
 ### Schema addresses
 
 `form-field(field:)` and `field-region(field)` name a schema field, and the
-generated `_qm-meta` address tables (`_qm-known-path`) validate that name at
+generated `_qm-meta` address tree (`_qm-known-path`) validates that name at
 compile time rather than leaving it silently unbound:
 
 | Address | Admitted by |
@@ -124,18 +124,18 @@ compile time rather than leaving it silently unbound:
 | `refs.2` | an array field — the element step |
 | `refs.2.org` | a typed table's row property, after the element step |
 | `classification.poc` | a container field — the property step |
+| `contact.address.city` | either step again, wherever the schema nests |
 | `$cards.<kind>.<n>.<field>` | a card field, `<n>` the per-kind ordinal |
 | `$cards.<kind>.<n>.<field>.<suffix>` | any of those suffixes, on a card field |
 
-A suffix is gated on the step the field actually offers, not on the name alone,
-so `subject.0` and `subject.poc` are both rejected on a scalar `subject`: a
-scalar has neither an element nor a property for the address to resolve to. A
-**container** is a typed dictionary or a variant container — both project as
-`type: object` carrying `properties`, so a variant's cells and its `value`
-discriminant are addressable exactly as a dictionary's keys are
-([SCHEMAS.md](SCHEMAS.md#enum-variants)). The row property is where the grammar
-stops, at two steps, matching the one-level nesting contract the schema itself
-holds to. This is the pdfform resolver's grammar
+Every step is gated on what the node it steps out of actually offers, not on the
+name alone, so `subject.0` and `subject.poc` are both rejected on a scalar
+`subject`: a scalar has neither an element nor a property for the address to
+resolve to. A **container** is a typed dictionary or a variant container — both
+project as `type: object` carrying `properties`, so a variant's cells and its
+`value` discriminant are addressable exactly as a dictionary's keys are
+([SCHEMAS.md](SCHEMAS.md#enum-variants)). The grammar stops where the schema
+does, at whatever depth that is. This is the pdfform resolver's grammar
 (`backends/pdfform/src/bind.rs`), so one address binds on either backend. The
 grammar is written twice, in two languages, and held to one table by
 `quillmark/tests/address_grammar.rs`.

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -104,7 +104,7 @@ Metadata resolution:
 - Unknown keys in the `quill:` section error with `quill::unknown_key` (typos like `platefile` are not silently captured).
 - Unknown top-level sections error with `quill::unknown_section` (typos like `card_kind:` are not silently ignored). Root-level `fields:` gets a targeted hint pointing to `main.fields:`.
 - Field schemas that fail to parse (e.g. a bare `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
-- `object` fields without a `properties` map error with `quill::object_missing_properties`; an empty `properties` map errors with `quill::object_empty_properties`; an object nested inside another object errors with `quill::nested_object_not_supported`.
+- `object` fields without a `properties` map error with `quill::object_missing_properties`; an empty `properties` map errors with `quill::object_empty_properties`.
 - Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
 - Malformed `main.body` / `card_kinds.<name>.body` blocks error with `quill::invalid_body`.
 - A `body.example` set together with `body.enabled: false` warns with `quill::body_example_unused` (the example has no effect).

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -96,9 +96,20 @@ The ceiling is deliberate and enforced at load rather than discovered at render:
 | a variant field named `value` | `quill::variant_reserved_field_name` |
 | a name two variants declare *differently* | `quill::variant_field_collision` |
 
-A variant carries any **leaf** type a card field may, prose and dates included. Every surface reaches a cell through the same dispatcher a card field uses — coercion through `conform_value`, validation through `validate_value`, the render floor through `resolve_value`, lowering through the schema-node walk ([PLATE_DATA.md](PLATE_DATA.md)) — so a `richtext` or `date` cell behaves as a card-level one does.
+A variant cell carries any type a card field may — prose, dates and containers included. Every surface reaches it through the same dispatcher a card field uses — coercion through `conform_value`, validation through `validate_value`, the render floor through `resolve_value`, lowering through the schema-node walk ([PLATE_DATA.md](PLATE_DATA.md)) — so it behaves as a card-level field of that type does. What a cell does not carry is `ui.group` (it inherits the discriminant's) or `variants:` of its own.
 
-Variant fields are leaves exactly as an object's properties are: no container one level down, and no `ui.group` (they inherit the discriminant's).
+**Why `variants:` alone stays card-level.** Every other container's shape is a
+function of the schema; a variant's is a function of the schema *and* the
+discriminant. The transform schema can only project the union of the worlds
+("at schema time there is no live world"), and the wire carries whichever one
+the document selects. Four things hold because that gap is exactly one level
+deep: `variant_field` resolves a name by a flat scan across the worlds, so
+`quill::variant_field_collision` can guarantee one name is one cell; a form
+binds once at open, so a cell is *unconditionally addressable* while only
+*conditionally live*; a plate branches once over `values ∪ blank` and needs no
+guard inside that branch; and `validation::out_of_variant` names one
+discriminant rather than a chain of them. Nesting spends all four, so the rule
+is its own, not the depth budget bottoming out.
 
 Two limits follow from the container shape and are accepted, not worked around:
 [`resolve()`](#the-resolved-value-view-resolve) reports **one** rung for the whole
@@ -363,7 +374,10 @@ order. The card body is a `body` sibling on the card, not a row in `fields`:
 present iff the kind enables a body (`enabled: false` undeclares it, so `body` is
 `null`), its source only ever `authored` (non-blank) or `blank` (blank).
 Source is one **top-level** rung per field; a nested blank-fill inside an authored
-dict or array is a projection detail of the value, not a per-subpath source.
+dict or array is a projection detail of the value, not a per-subpath source. The
+rung is therefore coarser the deeper a field nests, and a container authored at
+all reads `authored` however much of it the document left to the floor. Accepted:
+per-subpath provenance is a different view, and no consumer has asked for one.
 
 Value and provenance only. The view carries no diagnostics: completeness and
 errors stay `Quill::validate`'s, which a consumer merges with its own producers

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -100,16 +100,20 @@ A variant cell carries any type a card field may — prose, dates and containers
 
 **Why `variants:` alone stays card-level.** Every other container's shape is a
 function of the schema; a variant's is a function of the schema *and* the
-discriminant. The transform schema can only project the union of the worlds
-("at schema time there is no live world"), and the wire carries whichever one
-the document selects. Four things hold because that gap is exactly one level
-deep: `variant_field` resolves a name by a flat scan across the worlds, so
-`quill::variant_field_collision` can guarantee one name is one cell; a form
-binds once at open, so a cell is *unconditionally addressable* while only
-*conditionally live*; a plate branches once over `values ∪ blank` and needs no
-guard inside that branch; and `validation::out_of_variant` names one
-discriminant rather than a chain of them. Nesting spends all four, so the rule
-is its own, not the depth budget bottoming out.
+discriminant. The transform schema projects the union of the worlds — at schema
+time there is no live world — and the wire carries whichever one the document
+selects. Four things hold because that gap is exactly one level deep:
+
+- `variant_field` resolves a name by a flat scan across the worlds, which is
+  what lets `quill::variant_field_collision` guarantee one name is one cell.
+- A form binds once at open, so a cell is *unconditionally addressable* while
+  only *conditionally live*.
+- A plate branches once over `values ∪ blank` and needs no guard inside that
+  branch.
+- `validation::out_of_variant` names one discriminant rather than a chain.
+
+Nesting spends all four, so the restriction is a rule about `variants:` rather
+than about depth.
 
 Two limits follow from the container shape and are accepted, not worked around:
 [`resolve()`](#the-resolved-value-view-resolve) reports **one** rung for the whole


### PR DESCRIPTION
Closes the structural half of #1274. Disposition for #1287 is [commented there](https://github.com/borb-sh/quillmark/issues/1287#issuecomment-5318410308); nothing in this PR touches `ui`.

A property or an element is an ordinary field, so it carries whatever a card-level field carries, itself included: `object<array<string>>`, `array<array<integer>>`, a typed table whose row holds a typed dictionary, and a variant cell holding either. `quill::nested_object_not_supported` and `quill::nested_array_not_supported` are gone, and `ShapePosition`'s three positions collapse to the one question the walk still asks — is this card level, where `variants:` and `ui.group` are the two keys that live.

**This is a widening.** Every quill that loaded before loads unchanged, and no existing shape renders differently: for a depth-≤2 schema the new walks terminate exactly where the old enumerations did.

## Why the collapse rather than #1274(a)

The issue proposed lifting the ban for arrays of scalars first, then path-keying the lowering tables. Two things had changed under it:

- **Increment (b) had already shipped.** `3c3ff96` made lowering dispatch on the schema node beside each value, and `quill::variant_field_type` was already gone. What stayed name-keyed was the *address grammar*, which is the issue's item 2 — a different prerequisite that (b) had folded in.
- **(a) as scoped was a net add.** "Arrays of scalars at `Leaf`" narrows a rule rather than removing one: `ShapePosition` stays three-way, `nested_array_not_supported` stays, and a new check appears (at `Leaf`, an array's `items` must be scalar). It would also have shipped `contact.tags` addressable but `contact.tags.0` not — a fourth suffix form no implementation has, which is the positional inconsistency `3c3ff96` spent a breaking change removing from lowering, reintroduced one layer up.

## The address grammar was the depth cap's artifact

`SchemaMeta` carried six name-keyed tables (`array_fields`, `object_fields`, their card twins) so the helper's `_qm-known-path` could enumerate two suffix steps. The template said why: *"the one-level nesting contract bounds it at two steps, so this enumerates them rather than deriving a grammar."*

They are replaced by one `AddressNode` tree — the schema pruned to the steps it offers — walked by both the helper and the span scan, converging on the unbounded descent `pdfform::bind` already had. `span_scan::step_into`'s two-step ceiling becomes a loop. Three components deriving an address become one walk on each side of the seam, which is the drift class from `b810ee1` closed structurally rather than by re-syncing.

## `variants:` stays card-level, on its own reasoning

A variant's shape is a function of the schema *and* the discriminant, so the transform schema can only project the union of its worlds. Four things hold because that gap is one level deep: `variant_field`'s flat scan behind `variant_field_collision`; a form bound once at open, whose cells are unconditionally addressable and only conditionally live; a plate's single `values ∪ blank` branch needing no guard inside it; and `validation::out_of_variant` naming one discriminant rather than a chain.

Recorded in `SCHEMAS.md` so the exception carries a reason. Previously an array-valued variant cell reported `nested_array_not_supported`, whose message named array elements and object properties — neither the situation. That shape is now legal and `quill::variant_placement` is left saying only what it means.

## `blueprint()` expanded

`build_property_mapping` spent every property through the scalar builder, so a nested `object` or typed table would have rendered `key: null # object` — its properties, markers and annotations absent. Card-level and nested container rendering are now one implementation (`append_typed_dict` and `append_typed_table` fold into `container_cell`), so a `default:` covers its subtree identically wherever declared.

No document changes shape: the shapes this fixes could not be declared before.

## What needed nothing

Verified rather than assumed: `blank` (recurses `properties`, `Array → []`), `conform_value`, `validate_value`, `resolve_value`, `field_contains_content`, the content-`default:` import walk, `pdfform::bind` and `resolve::descend` (both already unbounded), and the `!must_fill` marker mechanism (`markdown-spec.md`: *"`key: !must_fill` at any depth"*).

## Testing

`cargo test --workspace` — 59 suites green. Three fewer clippy warnings than `main`; `check-canon` passes.

- `tests/address_grammar.rs` pins **both backends** against `contact.address.city`, `refs.0.lead.email`, `grid.0.0`, `classification.history.0.when` and each card twin, plus the rejects bounding every step (`address.geo.lat.0`, `grid.0.0.0`, `classification.history.x`, …). Its fixture data now carries deep values, so lowering is exercised end-to-end rather than address validation alone.
- Blueprint: nested expansion with markers, annotations and descriptions at each level, plus a parse round-trip; and a nested `default:` covering its leaves.
- Span scan: a four-step read (`data.contact.address.city`), a row-cell read (`data.contact.log.at(0).note`), partial reads anchoring where they stop, and an alias into a nested container.
- The four depth-ban tests became positive pins on the new behaviour rather than deletions.

## Two calls worth a second opinion

- **`resolve()` coarsening is accepted, not fixed.** Written into `SCHEMAS.md` as an explicit limit: the rung is coarser the deeper a field nests, and a container authored at all reads `authored` however much the document left to the floor. If that's not acceptable for the editor, it's separate work.
- **`variant_placement` kept at "not inside anything"** rather than the milder "not inside another variant". Relaxing later is additive; tightening would not be.

Production code nets −56 lines (`config.rs` −55, template −6, `helper.rs` −8; `lib.rs` and `span_scan.rs` roughly flat — the tree builder costs about what the six table builders did). Two error codes retired.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4vDjeVsZtJcxT3CBP7w6e)_