### PR TITLE
fix: a container's own `default:` crosses as content, or is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- fix: **a container's own `default:` reaches the plate as content.** The render
+  floor read `default_content` only for a `richtext`/`plaintext` leaf. An
+  `object` or `array` carrying its `default:` on the container fell through to
+  the raw literal instead, crossing as unimported markdown where every other
+  content position delivers a canonical content object. The companion was
+  already cached and never read. The floor now keys off the cache — present is
+  the form to commit, absent over a content-bearing tree blank-fills — which
+  covers leaf and container alike and drops the type test. `usaf_memo`'s
+  `references` (`array<richtext(inline)>`, `default: []`) carried the same
+  defect, invisible only because the list was empty.
+- fix: **a container-shaped `default:`/`example:` on a variant-bearing enum is a
+  load error** (`quill::default_type_mismatch`, `quill::example_type_mismatch`).
+  The container is the shape a *document* writes. As a schema literal it cached
+  no content form and yielded no discriminant, so the field blank-filled in
+  silence as if nothing were declared. The diagnostic names the discriminant
+  spelling instead, which is where a world's cells carry their own literals.
+  Scalar literals are unaffected.
+
 - feat: **every type nests at every depth**. A property or an element is an
   ordinary field, so it carries whatever a card-level field carries, itself
   included: `object<array<string>>`, `array<array<integer>>`, a typed table whose

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -515,28 +515,17 @@ pub(crate) fn resolve_value_sourced(
     }
     let present = value.filter(|v| !v.as_json().is_null());
     let Some(v) = present else {
-        // A content-bearing field (`richtext` or its literal sibling
-        // `plaintext`) commits the *content* form of its default
-        // (`default_content`, cached at load by `from_yaml_with_warnings` for every
-        // content leaf at every declaration depth), so the seam carries canonical
-        // Content-JSON the backend can classify. It
-        // must NOT fall through to the raw `default`: the ladder injects this
-        // default without re-coercing it (coercion touched only authored
-        // values), so a bare authored string here would reach the plate
-        // uncoerced and be misread. A content field with no cached
-        // `default_content` (only reachable via a serde-built `QuillConfig`,
-        // never the loader) blank-fills to the empty content.
-        if matches!(
-            field.r#type,
-            FieldType::RichText { .. } | FieldType::PlainText { .. }
-        ) {
-            return match field.default_content.clone() {
-                Some(content) => (content, FieldSource::Default),
-                None => (blank(field), FieldSource::Blank),
-            };
+        // `default_content` holds the imported form of `default:`, cached at
+        // load wherever the type tree bears a content leaf. The ladder injects
+        // a default without re-coercing it, so the cache is the only safe
+        // source: a raw `default` would cross to the plate as unimported
+        // markdown.
+        if let Some(content) = field.default_content.clone() {
+            return (content, FieldSource::Default);
         }
-        // Non-content: `default_content` is always `None`, so use the raw
-        // `default`, then the field's blank.
+        if crate::quill::config::field_contains_content(field) {
+            return (blank(field), FieldSource::Blank);
+        }
         return match field.default.clone() {
             Some(default) => (default, FieldSource::Default),
             None => (blank(field), FieldSource::Blank),

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1355,7 +1355,18 @@ impl QuillConfig {
                     } else {
                         Self::truncate_preview(source_token)
                     };
-                    let hint = if actual == "number" || actual == "integer" {
+                    let hint = if schema.is_variant_bearing() && actual == "object" {
+                        let member = schema
+                            .enum_values
+                            .as_ref()
+                            .and_then(|v| v.first())
+                            .map(String::as_str)
+                            .unwrap_or("<member>");
+                        format!(
+                            "Write the {slot} as the discriminant alone ({slot}: {member}); \
+                             a variant's own field carries its {slot} on that field."
+                        )
+                    } else if actual == "number" || actual == "integer" {
                         let schema_type = if actual == "integer" {
                             "integer"
                         } else {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2500,6 +2500,67 @@ main:
     assert_eq!(literal["marks"], serde_json::json!([]));
 }
 
+/// The sibling position: a `default:` on the **container**. It commits the same
+/// imported content a leaf's does — which declaration carries the literal does
+/// not change what crosses.
+#[test]
+fn a_containers_own_content_default_reaches_the_plate_as_content() {
+    const YAML: &str = r#"
+quill:
+  name: container_default
+  version: "1.0"
+  backend: typst
+  description: container content default probe
+main:
+  fields:
+    dict:
+      type: object
+      default: { note: "A **dict** note" }
+      properties:
+        note:
+          type: richtext
+    rows:
+      type: array
+      default: ["A **row** note"]
+      items:
+        type: richtext
+    plain:
+      type: object
+      default: { tag: bare }
+      properties:
+        tag:
+          type: string
+"#;
+    let config = QuillConfig::from_yaml(YAML).expect("container defaults load");
+    let document = Document::parse(concat!(
+        "~~~\n",
+        "$quill: container_default@1.0\n",
+        "$kind: main\n",
+        "~~~\n",
+    ))
+    .expect("parses")
+    .document;
+    let plate = config.compile_data(&document).expect("compiles");
+
+    for (path, cell, text) in [
+        ("dict.note", &plate["dict"]["note"], "A dict note"),
+        ("rows.0", &plate["rows"][0], "A row note"),
+    ] {
+        assert_eq!(
+            cell["text"].as_str(),
+            Some(text),
+            "{path} is canonical content, not the raw markdown: {plate}"
+        );
+        assert_eq!(
+            cell["marks"][0]["type"], "strong",
+            "{path} keeps the default's marks: {plate}"
+        );
+    }
+    // A container bearing no content leaf has no companion to read, and its
+    // `default:` still crosses verbatim.
+    assert_eq!(plate["plain"]["tag"], serde_json::json!("bare"));
+}
+
 /// Importing a literal is what checks it, so the nested gate is the companion walk
 /// reaching the leaf rather than a validation pass of its own. The diagnostic must
 /// name the leaf's declaration path: the card field holding it is not the mistake.

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -649,3 +649,52 @@ fn the_declaration_schema_round_trips_through_a_reload() {
     assert_eq!(variants["CUI"]["controlled_by"]["type"], json!("string"));
     assert_eq!(variants["SECRET"]["declassify_on"]["type"], json!("string"));
 }
+
+/// A container-shaped schema literal is refused at load, in either slot, and the
+/// diagnostic names the discriminant spelling that works.
+#[test]
+fn a_container_shaped_schema_literal_is_a_load_error() {
+    for slot in ["default", "example"] {
+        let yaml = format!(
+            concat!(
+                "quill:\n",
+                "  name: variant_literal\n",
+                "  version: \"0.1.0\"\n",
+                "  backend: typst\n",
+                "  description: probe\n",
+                "main:\n",
+                "  fields:\n",
+                "    classification:\n",
+                "      type: enum\n",
+                "      values: [UNCLASSIFIED, CUI]\n",
+                "      {slot}: {{ value: CUI, note: \"A **bold** note\" }}\n",
+                "      variants:\n",
+                "        CUI:\n",
+                "          note: {{ type: richtext }}\n",
+            ),
+            slot = slot,
+        );
+        let err = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+        let diag = err
+            .iter()
+            .find(|d| d.code.as_deref() == Some(&format!("quill::{slot}_type_mismatch")))
+            .unwrap_or_else(|| panic!("a container-shaped `{slot}:` is a load error, got: {err:?}"));
+        assert!(
+            diag.hint
+                .as_deref()
+                .is_some_and(|h| h.contains(&format!("{slot}: UNCLASSIFIED"))),
+            "the hint names the discriminant spelling, got: {:?}",
+            diag.hint
+        );
+    }
+}
+
+/// `usaf_memo` ships a blank `default:` on a variant-bearing enum, so the scalar
+/// spelling is load-bearing rather than merely tolerated.
+#[test]
+fn a_scalar_schema_literal_stays_legal_on_a_variant_bearing_enum() {
+    let plate = config()
+        .compile_data(&doc(""))
+        .expect("a blank scalar `default:` loads and compiles");
+    assert_eq!(plate["classification"]["value"], json!(""));
+}

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -697,6 +697,21 @@ fn validate_variant(
         return errors;
     };
 
+    // The container is a document spelling. A schema literal names the
+    // discriminant alone, each world's cells carrying their own; the container
+    // caches no content and yields no discriminant, so accepting it would
+    // blank-fill the field in silence.
+    if ctx == ValueContext::SchemaLiteral {
+        errors.push(ValidationError::TypeMismatch {
+            path: path.to_string(),
+            expected: "enum".to_string(),
+            actual: yaml_scalar_type(json).to_string(),
+            source_token: verbatim_yaml_scalar(json),
+            default: None,
+        });
+        return errors;
+    }
+
     let discriminant_path = path.field(VARIANT_DISCRIMINANT_KEY);
     let authored = object
         .get(VARIANT_DISCRIMINANT_KEY)

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -283,6 +283,11 @@ classification:
 A world with nothing to fill in still writes plainly — `classification:
 UNCLASSIFIED` is accepted and means the same as `{value: UNCLASSIFIED}`.
 
+The container is a *document* shape. The schema's own `default:` and `example:`
+name the discriminant alone (`default: ""`, `example: CUI`); a container-shaped
+one is a load error, because each cell in a world carries its literal on its own
+declaration.
+
 Three things follow, and they are the reason to reach for this over a
 `cui_`-prefixed row of flat fields:
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -245,7 +245,11 @@ Coercion rules per type:
   token as its markdown source. The leniency is scoped to
   *document* payloads via the shared `scalar_as_string` predicate; a quill
   author's own `default:`/`example:` literals stay strict, so the blueprint
-  keeps quoting ambiguous string literals
+  keeps quoting ambiguous string literals. The same strictness rejects a
+  container-shaped literal on a variant-bearing enum
+  (`quill::{default,example}_type_mismatch`): the container is a *document*
+  spelling, and a schema literal names the discriminant alone; the cells inside
+  a world carry their literals on their own declarations
 
 ## Native validation
 
@@ -500,7 +504,18 @@ seed's commit takes the extra step to the field's rest. The authored markdown li
 untouched: it is the source of truth the schema emits and the blueprint prints;
 the content is a derived projection of it.
 
-The load pass walks the **schema**, not the card's field map, so a leaf's companions are populated wherever it is declared — an object property, a typed table's row property, a variant cell. The render floor reads the companion off whichever leaf it resolves, so covering every position is what makes an absent companion mean "no literal" rather than "not reached"; a gap blank-fills and drops the author's `default:` silently. Importing is also checking, so a nested `richtext(inline)` violation is a load error there, in a `default:` or an `example:`.
+The load pass walks the **schema**, not the card's field map, so companions are
+populated at every declaration whose type tree bears a content leaf
+(`field_contains_content`) — the leaf wherever it sits, and the container above
+it carrying a literal of its own.
+
+The render floor reads the companion off whichever declaration it resolves, so
+covering every position is what makes an absent companion mean "no literal"
+rather than "not reached"; a gap blank-fills and drops the author's `default:`
+silently. The cache is also the gate: a content-bearing tree with no companion
+blank-fills rather than falling through to the raw literal, which would cross as
+unimported markdown. Importing is also checking, so a nested `richtext(inline)`
+violation is a load error there, in a `default:` or an `example:`.
 
 Committing *only* `example` is the whole design. The render ladder already
 produces `default` and the blank at compile time but **never `example`** (example


### PR DESCRIPTION
Closes #1304, taking the narrow option for each row rather than the one that closes both.

## Row three — the render floor never read the companion it had

`resolve_value_sourced` gated the `default_content` lookup on the field's own type, so an `object` or `array` carrying its `default:` on the container failed the `matches!` and fell through to the raw literal. The plate received markdown as a `str` where every other content position delivers a canonical content object — the raw-wire-value failure #1292 removed everywhere else.

The companion was already cached: `literal_content`'s `Object` and `Array` arms recurse and convert. Nothing read it.

The floor now keys off the cache, which makes the type test unnecessary — `cache_literal_content` only caches where `field_contains_content` holds, so a present companion is the form to commit and its absence over a content-bearing tree blank-fills. Net −2 lines and one fewer branch.

The guard on the blank-fill path is `field_contains_content`, not the old `RichText | PlainText` test. That is the invariant that actually governs: a raw `default` is unsafe to inject when the *tree* bears a content leaf, not only when the field is one. It also stops a content-bearing tree with a null `default:` from putting a bare null on the plate, which `resolve_value_sourced`'s own doc comment already promises it doesn't.

**This is not object-only.** `usaf_memo`'s `references` (`Quill.yaml:153`) is `array<richtext(inline)>` with a container-level `default: []` and has the identical defect today — invisible only because the list is empty. A non-empty default there ships raw markdown.

## Row two — a container-shaped schema literal is refused at load

`literal_content` has no `Enum` arm, so a variant container caches nothing, and `resolve_variant_sourced` reads the default through `.as_str()`, so an object-shaped one yields no discriminant either. The whole `default:` vanished and the field blank-filled as if nothing were declared, with no diagnostic.

Rather than build the `Enum` arm for an authoring position nothing uses, the load rejects the shape. No in-tree quill declares one, and the reference docs only ever show the scalar form.

No new error code. `validate_schema_literal` already routes variant-bearing fields to `validate_variant`, which must accept the container because it is the same primitive that validates *document* values, where the container is the coerced normal form. The guard is `ctx == SchemaLiteral` inside that function, reusing `ValidationError::TypeMismatch`, so the existing `quill::{default,example}_type_mismatch` conversion carries it. One branch in the `config.rs` hint chain names the discriminant spelling instead of the generic "make it match the type". `example:` is covered for free — both slots route through the same function.

With this in place, the recursion asymmetry #1303 flagged between `field_contains_content` and `literal_content` becomes the rule rather than a gap: `literal_content` does not recurse into a variant container because a variant container has no literal of its own.

## Verification

Three tests. Both new behaviors were run against the unfixed source first and fail there; the row-three failure prints the defect directly:

```
{"dict":{"note":"A **dict** note"},"rows":["A **row** note"],…}
```

- `a_containers_own_content_default_reaches_the_plate_as_content` — object and array containers deliver canonical content; a container with no content leaf still passes its `default:` verbatim.
- `a_container_shaped_schema_literal_is_a_load_error` — both slots, asserting the hint names the discriminant.
- `a_scalar_schema_literal_stays_legal_on_a_variant_bearing_enum` — pins the spelling `usaf_memo` ships.

`cargo test --workspace` green (59 suites, 0 failures). Clippy at 46 warnings before and after — none new.

## Docs

`SCHEMAS.md:503` said the floor reads the companion "off whichever **leaf** it resolves", which this makes stale; that paragraph and the schema-literal-strictness bullet are updated, and `check-canon.mjs` passes. The Variants section of the YAML reference states that the container is a document shape and a container-shaped literal is a load error.

## Not included

The `Enum` arm for `literal_content` plus render-floor support (the issue's option 1) would make row two work. It is machinery for a position with no author, so it is skipped deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds1D2TKkPZzNTzAETV8nKk)_