### PR TITLE
fix(typst): anchor a `let` alias only where the name is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,14 @@
   name a second `let`, a closure parameter, a loop pattern, an import, or an
   assignment could rebind is dropped rather than risk attributing another
   value's ink to the field, and a wildcard import disqualifies every alias.
+  Which name is followed is half the rule; which *occurrence* is the other half,
+  since a schema field name collides freely with the parameter names of a callee
+  the plate never defines (`date`, `title`, `caption`, `align`, `subject`). Only
+  an occurrence that reads the binding anchors: an identifier spelling the alias
+  as a named argument (`#text(size: 12pt)`), a dict key, another value's field
+  (`#styles.subject`) or an imported item's path draws no ink off the field, and
+  a window minted over one would carry a *wrong* address rather than a missing
+  one.
   Laundering past that — a function parameter, a destructured binding, a
   per-card loop variable — is unchanged and still needs a `field-region` claim,
   now stated for plate authors under "Which Reads Get Regions" in the Typst

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -996,15 +996,20 @@ fn collect_binders(node: &LinkedNode, tables: &Tables, out: &mut Binders) {
                     bind(ident.as_str(), out);
                 }
                 for param in closure.params().children() {
-                    let pattern = match param {
-                        ast::Param::Pos(pattern) => Some(pattern),
-                        ast::Param::Named(named) => Some(ast::Pattern::Normal(named.expr())),
-                        ast::Param::Spread(spread) => spread.sink_ident().map(|i| {
-                            ast::Pattern::Normal(ast::Expr::Ident(i))
-                        }),
-                    };
-                    for ident in pattern.map(ast::Pattern::bindings).unwrap_or_default() {
-                        bind(ident.as_str(), out);
+                    match param {
+                        ast::Param::Pos(pattern) => {
+                            for ident in pattern.bindings() {
+                                bind(ident.as_str(), out);
+                            }
+                        }
+                        // The name is the parameter; the default beside it binds
+                        // nothing.
+                        ast::Param::Named(named) => bind(named.name().as_str(), out),
+                        ast::Param::Spread(spread) => {
+                            if let Some(ident) = spread.sink_ident() {
+                                bind(ident.as_str(), out);
+                            }
+                        }
                     }
                 }
             }
@@ -1150,10 +1155,37 @@ fn data_access<'a>(
         // are not reads of the field.
         SyntaxKind::Ident => {
             let alias = aliases.get(node.cast::<ast::Ident>()?.as_str())?;
-            (node.range().start >= alias.bound_at)
+            (node.range().start >= alias.bound_at && reads_its_binding(node))
                 .then(|| step_into(alias.path.clone(), node.clone(), tables))
         }
         _ => None,
+    }
+}
+
+/// Whether the identifier reads what the name holds, rather than spelling a name
+/// of its own: a key selected off another value (`styles.subject`), a named
+/// argument or dict key (`text(subject: 12pt)`, `(subject: [Ink])`), an item
+/// named inside an import.
+///
+/// [`alias_bindings`] bounds which *name* an anchor may follow, this which
+/// *occurrence*. Both are needed: a schema field name collides freely with the
+/// parameter names of a callee the plate never defines (`date`, `caption`,
+/// `align`, `subject`), and a window over one would carry a wrong address over
+/// ink the field never drew. [`select_property`] tests the mirror of this for
+/// the step it takes.
+fn reads_its_binding(node: &LinkedNode) -> bool {
+    let Some(parent) = node.parent() else {
+        return true;
+    };
+    match parent.kind() {
+        SyntaxKind::FieldAccess => parent
+            .cast::<ast::FieldAccess>()
+            .is_some_and(|access| access.target().to_untyped() == node.get()),
+        SyntaxKind::Named => parent
+            .cast::<ast::Named>()
+            .is_some_and(|named| named.expr().to_untyped() == node.get()),
+        SyntaxKind::ImportItemPath | SyntaxKind::RenamedImportItem => false,
+        _ => true,
     }
 }
 
@@ -1534,6 +1566,7 @@ main:
         for plate in [
             "#let c = data.classification\n#let c = \"other\"\n#c.poc",
             "#let c = data.classification\n#let f(c) = [#c.poc]\n#f(1)",
+            "#let c = data.classification\n#let f(c: 1) = [#c.poc]\n#f()",
             "#let c = data.classification\n#for c in (1, 2) [#c.poc]",
             "#let c = data.classification\n#{ c = \"other\" }\n#c.poc",
             "#let c = data.classification\n#import \"x.typ\": *\n#c.poc",
@@ -1546,6 +1579,64 @@ main:
                 rebound(plate).is_empty(),
                 "alias survived a rebind in {plate:?}: {:?}",
                 rebound(plate)
+            );
+        }
+    }
+
+    /// An occurrence spelling the alias as a *name* reads nothing off the field,
+    /// so it anchors nothing: attributing a callee's argument to the field is a
+    /// wrong address, worse than the missing one dropping the alias would leave.
+    #[test]
+    fn scalar_windows_anchor_an_alias_only_where_the_name_is_read() {
+        let named = |plate: &str| {
+            let src = Source::detached(&format!(
+                "#import \"@local/quillmark-helper:0.1.0\": data\n{plate}\n"
+            ));
+            probe_spans(&src)
+                .into_iter()
+                .filter(|(_, t)| !t.starts_with("data"))
+                .collect::<Vec<_>>()
+        };
+        for plate in [
+            "#let other = data.other\n#text(other: 12pt)[Hello]",
+            "#let other = data.other\n#figure(caption: [Cap], other: 1)[Body]",
+            "#let other = data.other\n#let d = (other: [Inner])",
+            "#let other = data.other\n#set text(other: 1)",
+            "#let subject = data.subject\n#box[#mydict.subject]",
+            // The bound name is the path's last segment, so an earlier segment
+            // survives the name rule while naming a module, not a value.
+            "#let other = data.other\n#import \"x.typ\": other.deeper",
+        ] {
+            assert!(
+                named(plate).is_empty(),
+                "a name position anchored in {plate:?}: {:?}",
+                named(plate)
+            );
+        }
+    }
+
+    /// The collision is between a name and an occurrence, so the genuine read
+    /// still carries the address while the key beside it carries none.
+    #[test]
+    fn scalar_windows_keep_the_genuine_read_beside_a_colliding_key() {
+        let src = Source::detached(
+            r#"
+#import "@local/quillmark-helper:0.1.0": data
+#let subject = data.subject
+#let styles = (subject: [UNRELATED INK])
+#styles.subject
+#subject
+#upper(subject)
+"#,
+        );
+        let spans = probe_spans(&src);
+        for text in ["subject", "upper(subject)"] {
+            assert!(has(&spans, "subject", text), "missing {text}: {spans:?}");
+        }
+        for text in ["subject: [UNRELATED INK]", "styles.subject"] {
+            assert!(
+                !spans.iter().any(|(_, t)| t == text),
+                "{text:?} is no read of the field: {spans:?}"
             );
         }
     }

--- a/crates/backends/typst/tests/container_address.rs
+++ b/crates/backends/typst/tests/container_address.rs
@@ -184,6 +184,45 @@ fn a_rebound_alias_surfaces_no_region() {
     );
 }
 
+/// An identifier spelling the alias in a *name* position draws no ink off the
+/// field, so a click there must not route to it: a wrong address is worse than a
+/// missing one. The genuine read beside it keeps its region.
+#[test]
+fn a_key_spelling_an_alias_claims_none_of_its_ink() {
+    let plate = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 400pt, height: 200pt, margin: 40pt)
+#let subject = data.subject
+#let styles = (subject: [UNRELATED INK])
+#styles.subject
+#subject
+"#;
+    let session = open(plate);
+    let regions: Vec<_> = session
+        .regions()
+        .into_iter()
+        .filter(|r| r.field == "subject")
+        .collect();
+    let [region] = regions.as_slice() else {
+        panic!("only the read of the field regions on it: {regions:?}");
+    };
+    let (cx, cy) = (
+        (region.rect[0] + region.rect[2]) / 2.0,
+        (region.rect[1] + region.rect[3]) / 2.0,
+    );
+    assert_eq!(
+        session.field_at(region.page, cx, cy).as_deref(),
+        Some("subject"),
+        "the surviving region is the read, and a click on it routes to the field"
+    );
+    // The dict's ink shares the line, starting at the 40pt margin.
+    assert_eq!(
+        session.field_at(region.page, 60.0, cy),
+        None,
+        "a click on the dict's ink routes nowhere: {region:?}"
+    );
+}
+
 /// The container read whole is still one region: the step is what narrows it.
 #[test]
 fn the_container_read_whole_still_regions_on_the_container() {

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -197,7 +197,11 @@ whole-row read (`data.refs.at(0)`) names the row.
 A read through a `let` alias tracks where the chain it names would, so naming a
 container or a row before stepping into it costs no address. The alias holds only where
 the plate binds the name exactly once to one whole chain: a name a second binder
-could rebind would attribute another value's ink to the field.
+could rebind would attribute another value's ink to the field. Only the
+occurrences that *read* the name track: an identifier spelling it as a named
+argument (`#text(size: 12pt)` under `#let size = data.size`), a dict key, or
+another value's field reads nothing off the field, and schema field names
+collide freely with the parameter names of callees the plate never defines.
 Not tracked: expressions mixing several fields (`data.from + ", " + rank` has
 no single owner), a value laundered past what the alias pass follows (a
 function parameter, a destructured binding), and card scalars read from the


### PR DESCRIPTION
Closes #1300.

The alias lane carried one half of a two-part rule. `alias_bindings` decides **which name** an anchor may follow — bound exactly once, to one whole `data` chain. Nothing decided **which occurrence**, so every identifier token spelling that name anchored whatever its syntactic role, minting a window over ink the field never drew.

## The gate

`reads_its_binding` is the missing half, and `data_access`'s `Ident` arm now tests it beside `bound_at`. It rejects an identifier that spells a *name* rather than reading one:

| position | example |
|---|---|
| a `FieldAccess`'s `field()` | `#styles.subject` |
| a `Named`'s `name()` | `#text(other: 12pt)`, `(other: [Inner])`, `#set text(..)`, a destructuring key |
| an `ImportItemPath` / `RenamedImportItem` segment | `#import "x.typ": other.deeper` |

Both `FieldAccess` and `Named` are tested *positively* — is this node the `target()` / the `expr()` — mirroring what `select_property` already tests for the step it takes, rather than enumerating what to reject. A malformed tree yields a placeholder node that is never pointer-equal, so it falls to "not a read".

One side effect worth naming: `#let subject = data.subject` also made every later `data.subject` anchor *twice*, once via the chain and once via the field ident. That pushed `inside` to 2 and suppressed the legitimate enclosing-expression window for `#upper(data.subject)`. Gone with the same gate.

## Beyond the issue's scope: closure named parameters

The issue's reasoning rests on "a plate-local closure parameter would bump `counts` and drop the alias." It did not. `collect_binders` read `ast::Param::Named`'s **default expression** as a binding pattern instead of the parameter name, so:

- `#let f(subject: 1) = [#subject]` left the alias standing over the parameter's ink — the same wrong-address failure through a different door;
- `#let f(x: subject) = ..` bound `subject` from the default, dropping an alias it should have kept.

It now binds the parameter name, and the sweep in `scalar_windows_drop_an_alias_any_second_binder_could_rebind` gains the plate that pins it.

## Tests

Three, each verified to fail with the gate reverted:

- `scalar_windows_anchor_an_alias_only_where_the_name_is_read` — the role table from the issue, plus `#set` and an import path segment.
- `scalar_windows_keep_the_genuine_read_beside_a_colliding_key` — the key mints nothing while `#subject` and `#upper(subject)` keep their windows.
- `container_address::a_key_spelling_an_alias_claims_none_of_its_ink` — the issue's measured reproduction end to end through `Backend::open` / `LiveSession`: exactly one `subject` region, `field_at` at its centre is `Some("subject")`, and `field_at` over the dict's ink is `None`.

`cargo test --workspace` is green with no new warnings.

## Docs

`PREVIEW.md` and the changelog both state the occurrence rule. It is folded into the existing `feat(typst)` alias-lane entry rather than added as its own `fix`, since #1290 is itself unreleased — no shipped version ever had the defect.

## Adjacent, deliberately left alone

`#let data = (subject: "x")` shadows the helper import, and the `FieldAccess` lane does not consult the binder counts, so it would still anchor. That is a plate breaking its own import contract, it predates the alias lane, and it is not this issue's failure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mjb4LFxHHfXRfP1JEDy9NX)_