### PR TITLE
chore(deps): move the Typst floor to 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- chore(deps): the Typst floor moves to 0.15.1. The workspace already resolved
+  there under the 0.15.0 caret; the pin now names the version the tree is built
+  and tested against. `pdf-writer` stays at 0.15.0, still the version
+  `typst-pdf` → `krilla` forces and the newest published.
+
 ## v0.107.0 - 2026-08-17
 
 - fix(typst): `display(field, ..)` validates its address against the schema, the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,11 @@ time = { version = "0.3.44", features = ["formatting", "parsing"] }
 # Pinned to the version the Typst toolchain (typst-pdf → krilla) already forces,
 # so the workspace links a single copy of the PDF writer.
 pdf-writer = "0.15.0"
-typst = "0.15.0"
-typst-layout = "0.15.0"
-typst-pdf = "0.15.0"
-typst-render = "0.15.0"
-typst-svg = "0.15.0"
+typst = "0.15.1"
+typst-layout = "0.15.1"
+typst-pdf = "0.15.1"
+typst-render = "0.15.1"
+typst-svg = "0.15.1"
 
 # Intra-project dependencies
 quillmark-core = { version = "0.107.0", path = "crates/core" }


### PR DESCRIPTION
The workspace pins for `typst`, `typst-layout`, `typst-pdf`, `typst-render`, and `typst-svg` move from `0.15.0` to `0.15.1`.

`Cargo.lock` does not change. The `0.15.0` caret already resolved to `typst 0.15.1` — along with `typst-assets`, `typst-eval`, `typst-syntax`, `typst-utils` and the rest of the toolchain — so the tree was already compiling against 0.15.1. The pin now names the version it is built and tested against rather than a floor a release behind what is linked.

`pdf-writer` stays at `0.15.0`: there is no `0.15.1`, and `0.15.0` remains the version `typst-pdf` → `krilla 0.8.2` forces, which is what its pin comment is about. `comemo` is likewise already at its newest (`0.5.1`) under the existing `"0.5"` requirement.

`cargo test --workspace` passes — 59 test targets green.