### PR TITLE
fix: the value ladder is cut per cell, so the plate is total at every depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+- fix: **the value ladder is cut per cell, so the plate is total at every
+  depth.** An absent container returned a value instead of descending, and
+  everything below it was decided by that one branch: an absent `contact` never
+  reached `contact.email`'s own `default:`, and a container `default: {name: A}`
+  crossed whole, so a declared property it omitted was **missing from the
+  plate** — a direct Typst read of it a compile error, on an address
+  `form-field` still binds. Two spellings of the same state disagreed:
+  authoring `contact: {}` rendered the leaf defaults that leaving `contact` out
+  did not, and `default: {}` — documented as expanding to the blank-filled
+  shape — emitted `{}` with no declared key at all. Resolution is now a descent:
+  a rung supplies a *seed*, and the same composition runs over it whichever rung
+  it came from, so absence is inherited rather than terminal and each cell cuts
+  its own ladder. A partial element inside an `array` `default:` is completed
+  against `items` as an authored element is. The variant container already
+  worked this way and stops being the special case.
+- **breaking** a `default:`/`example:` on an `object` with `properties` is a
+  load error (`quill::default_on_namespace`, `quill::example_on_namespace`),
+  naming the properties that hold it. A quill declaring one loaded before, so
+  the upgrade reads as a quill that stopped loading rather than as a fix; no
+  in-tree quill declares one. A typed dictionary is a namespace, not a cell:
+  the container literal was a second declaration of a value the property
+  already holds, and the two axes read different ones — `default: {name: A}`
+  rendered `A` while `must_fill` derives per property and still reported `name`
+  unauthored. It was also unchecked, so `default: {nope: 1}` loaded and crossed
+  an undeclared key to the plate. This is the variant container's rule
+  (`quill::default_type_mismatch`) generalized; an `array` keeps its literal,
+  since `items:` fixes the element type but never the arity.
+- fix: **seeding descends into a container's `example:`.** A dictionary with no
+  `example:` of its own seeded nothing, so a property's `example:` was
+  unreachable at every projection — the render floor never emits an example, and
+  the blueprint is a different document. A seed is now composed from whatever
+  its cells commit, sparse at every depth, and stays absent when none of them
+  commit anything. Markers ride the cell they belong to.
+- fix: `resolve()`'s rung is honest for a container. It has no rung of its own,
+  so it reports the strongest that contributed: `authored` when the document
+  wrote any of it, else `default` when a cell below resolved to one, else the
+  floor. An absent container over defaulted cells read `blank` while rendering
+  those defaults, which is the fact an editor ghosts from. Nothing inside a
+  container the document did not author reads `authored`.
+
 - chore(deps): the Typst floor moves to 0.15.1. The workspace already resolved
   there under the 0.15.0 caret; the pin now names the version the tree is built
   and tested against. `pdf-writer` stays at 0.15.0, still the version

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2037,7 +2037,14 @@ export type DocPathSeg =
 
 #[wasm_bindgen(typescript_custom_section)]
 const RESOLVED_TS: &'static str = r#"
-/** The commitment-ladder rung that produced a `ResolvedField.value`. */
+/**
+ * The commitment-ladder rung that produced a `ResolvedField.value`.
+ *
+ * A container has no rung of its own — it is a namespace, and its value is the
+ * composition of its cells' — so it reports the strongest rung that contributed:
+ * `authored` if the document wrote any of it, else `default` if any cell below
+ * resolved to one, else `blank`.
+ */
 export type FieldSource = "authored" | "default" | "blank";
 
 /**

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -344,12 +344,9 @@ fn property_cell(
 /// carries, at `path` relative to the field value (`[]` at card level).
 ///
 /// An **array** `default:` is shippable as-is, so it renders verbatim and its
-/// subtree carries neither marker nor annotation. A **typed dictionary** has no
-/// `default:` to render — it is a namespace, and a literal on it is a load error
-/// (`quill::default_on_namespace`) — so it always expands per property, each cell
-/// showing its own `default:` › `example:` › blank. That expansion is what the
-/// render floor now produces for an absent container, so the blueprint's cells
-/// and the plate's agree cell by cell.
+/// subtree carries neither marker nor annotation. A **typed dictionary** holds no
+/// literal to render (`quill::default_on_namespace`), so it always expands per
+/// property — the cells the render floor fills from those same declarations.
 fn container_cell(
     field: &FieldSchema,
     path: &[PathSegment],
@@ -615,9 +612,8 @@ main:
         assert_eq!(doc1, doc2, "a deep blueprint must round-trip");
     }
 
-    /// A nested container's cells carry their own defaults, and each covered
-    /// leaf asks for nothing — the same cells the render floor now fills from
-    /// the same declarations.
+    /// A nested container's cells carry their own defaults, and a covered leaf
+    /// asks for nothing.
     #[test]
     fn a_nested_containers_leaf_defaults_cover_their_own_cells() {
         let t = cfg(r#"
@@ -1018,9 +1014,8 @@ main:
     }
 
     #[test]
-    /// The "wholly skippable dictionary" is spelled as a type-empty `default:`
-    /// on each property — the spelling `default: {}` on the container used to
-    /// approximate, and the only one whose cells the render floor can reach.
+    /// A wholly skippable dictionary is spelled as a type-empty `default:` on
+    /// each property.
     fn typed_dict_with_type_empty_property_defaults_asks_for_nothing() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
@@ -1062,9 +1057,6 @@ main:
         assert!(t.contains("  zip: \"\" # string\n"));
     }
 
-    /// A typed dictionary always expands per property, each cell showing its
-    /// own `default:` — the cells the render floor fills from the same
-    /// declarations, so the two projections agree cell by cell.
     #[test]
     fn typed_dict_endorsed_per_property_renders_block_mapping() {
         let t = cfg(r#"
@@ -1090,8 +1082,6 @@ main:
         );
     }
 
-    /// A property's `example:` surfaces as its own `# e.g.` hint beside its
-    /// cell, since the container has no literal to hold one for it.
     #[test]
     fn typed_dict_property_example_keeps_its_own_eg_line() {
         let t = cfg(r#"

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -7,7 +7,7 @@
 
 use indexmap::IndexMap;
 
-use super::{blank, CardSchema, FieldSchema, FieldType, QuillConfig, VARIANT_DISCRIMINANT_KEY};
+use super::{CardSchema, FieldSchema, FieldType, QuillConfig, VARIANT_DISCRIMINANT_KEY};
 use crate::document::emit::{saphyr_emit_flow, saphyr_emit_scalar};
 use crate::document::prescan::NestedComment;
 use crate::document::{Card, Document, Payload, PayloadItem};
@@ -343,24 +343,20 @@ fn property_cell(
 /// A container's value plus the nested comments and fill paths its subtree
 /// carries, at `path` relative to the field value (`[]` at card level).
 ///
-/// A `default:` is shippable as-is, so it renders verbatim and its subtree
-/// carries neither marker nor annotation. `default: {}` on a typed dictionary
-/// instead expands to the blank-filled shape, so every key is shown.
+/// An **array** `default:` is shippable as-is, so it renders verbatim and its
+/// subtree carries neither marker nor annotation. A **typed dictionary** has no
+/// `default:` to render — it is a namespace, and a literal on it is a load error
+/// (`quill::default_on_namespace`) — so it always expands per property, each cell
+/// showing its own `default:` › `example:` › blank. That expansion is what the
+/// render floor now produces for an absent container, so the blueprint's cells
+/// and the plate's agree cell by cell.
 fn container_cell(
     field: &FieldSchema,
     path: &[PathSegment],
 ) -> (JsonValue, Vec<NestedComment>, Vec<Vec<PathSegment>>) {
     if let Some(props) = typed_dict_props(field) {
-        return match field.default.as_ref().map(|d| d.as_json()) {
-            Some(JsonValue::Object(map)) if map.is_empty() => {
-                (blank(field).into_json(), Vec::new(), Vec::new())
-            }
-            Some(default) => (default.clone(), Vec::new(), Vec::new()),
-            None => {
-                let (map, nested, fills) = build_property_mapping(props, path);
-                (JsonValue::Object(map), nested, fills)
-            }
-        };
+        let (map, nested, fills) = build_property_mapping(props, path);
+        return (JsonValue::Object(map), nested, fills);
     }
 
     let row_props = typed_table_props(field).unwrap_or_else(|| {
@@ -619,8 +615,11 @@ main:
         assert_eq!(doc1, doc2, "a deep blueprint must round-trip");
     }
 
+    /// A nested container's cells carry their own defaults, and each covered
+    /// leaf asks for nothing — the same cells the render floor now fills from
+    /// the same declarations.
     #[test]
-    fn a_nested_container_default_renders_verbatim_and_covers_its_leaves() {
+    fn a_nested_containers_leaf_defaults_cover_their_own_cells() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
@@ -630,10 +629,9 @@ main:
       properties:
         address:
           type: object
-          default: { city: Reston, zip: "20190" }
           properties:
-            city: { type: string }
-            zip: { type: string }
+            city: { type: string, default: Reston }
+            zip: { type: string, default: "20190" }
 "#)
         .blueprint();
         assert!(t.contains("  address: # object\n"), "{t}");
@@ -1020,26 +1018,27 @@ main:
     }
 
     #[test]
-    fn typed_dict_with_empty_default_expands_to_blank_filled() {
+    /// The "wholly skippable dictionary" is spelled as a type-empty `default:`
+    /// on each property — the spelling `default: {}` on the container used to
+    /// approximate, and the only one whose cells the render floor can reach.
+    fn typed_dict_with_type_empty_property_defaults_asks_for_nothing() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     address:
       type: object
-      default: {}
       properties:
-        street: { type: string }
-        zip:    { type: integer }
+        street: { type: string, default: "" }
+        zip:    { type: integer, default: 0 }
 "#)
         .blueprint();
         assert!(
-            t.contains("address: # object\n  street: \"\"\n  zip: 0\n"),
+            t.contains("address: # object\n  street: \"\" # string\n  zip: 0 # integer\n"),
             "wrong rendering: {t}"
         );
         assert!(!t.contains("{}"), "no bare empty object expected: {t}");
         assert!(!t.contains("!must_fill"), "no markers expected: {t}");
-        assert!(!t.contains("# string"), "no leaf annotations expected: {t}");
     }
 
     #[test]
@@ -1063,50 +1062,83 @@ main:
         assert!(t.contains("  zip: \"\" # string\n"));
     }
 
+    /// A typed dictionary always expands per property, each cell showing its
+    /// own `default:` — the cells the render floor fills from the same
+    /// declarations, so the two projections agree cell by cell.
     #[test]
-    fn typed_dict_endorsed_renders_block_mapping() {
+    fn typed_dict_endorsed_per_property_renders_block_mapping() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     address:
       type: object
-      default: { street: "5000 Forbes Ave", city: Pittsburgh }
       properties:
-        street: { type: string }
-        city:   { type: string }
+        street: { type: string, default: "5000 Forbes Ave" }
+        city:   { type: string, default: Pittsburgh }
 "#)
         .blueprint();
         assert!(t.contains("address: # object\n"));
         assert!(
-            t.contains("  street: 5000 Forbes Ave\n")
-                || t.contains("  street: \"5000 Forbes Ave\"\n")
+            t.contains("  street: 5000 Forbes Ave # string\n")
+                || t.contains("  street: \"5000 Forbes Ave\" # string\n")
         );
-        assert!(t.contains("  city: Pittsburgh\n"));
-        assert!(!t.contains("# string"));
+        assert!(t.contains("  city: Pittsburgh # string\n"));
+        assert!(
+            !t.contains("street: !must_fill"),
+            "a defaulted leaf asks for nothing: {t}"
+        );
     }
 
+    /// A property's `example:` surfaces as its own `# e.g.` hint beside its
+    /// cell, since the container has no literal to hold one for it.
     #[test]
-    fn typed_dict_with_example_keeps_eg_line_and_per_property() {
+    fn typed_dict_property_example_keeps_its_own_eg_line() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
     address:
       type: object
-      example: { street: "1 Infinite Loop", city: Cupertino }
       properties:
         street: { type: string }
-        city:   { type: string, default: "" }
+        city:   { type: string, default: "", example: Cupertino }
 "#)
         .blueprint();
         assert!(t.contains("address: # object\n"));
-        assert!(
-            t.contains("# e.g. {street: 1 Infinite Loop, city: Cupertino}\n")
-                || t.contains("# e.g. {city: Cupertino, street: 1 Infinite Loop}\n")
-        );
+        assert!(t.contains("# e.g. Cupertino\n"), "{t}");
         assert!(t.contains("  street: !must_fill # string\n"));
         assert!(t.contains("  city: \"\" # string\n"));
+    }
+
+    /// A typed dictionary is a namespace, not a cell: a literal on the
+    /// container is refused at load, naming the properties that hold it.
+    #[test]
+    fn a_literal_on_a_typed_dictionary_is_a_load_error() {
+        for (slot, code) in [
+            ("default", "quill::default_on_namespace"),
+            ("example", "quill::example_on_namespace"),
+        ] {
+            let yaml = format!(
+                r#"
+quill: {{ name: x, version: 1.0.0, backend: typst, description: x }}
+main:
+  fields:
+    address:
+      type: object
+      {slot}: {{ street: "5000 Forbes Ave" }}
+      properties:
+        street: {{ type: string }}
+        city:   {{ type: string }}
+"#
+            );
+            let err = QuillConfig::from_yaml(&yaml).expect_err("must refuse");
+            assert!(err.contains(code), "expected {code}; got {err}");
+            assert!(
+                err.contains("street") && err.contains("city"),
+                "the hint names the properties that hold the {slot}: {err}"
+            );
+        }
     }
 
     const LETTER_QUILL: &str = r#"

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -485,27 +485,31 @@ fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue 
 
 /// Resolve one (possibly absent or null) value against its field schema,
 /// reporting the [`FieldSource`] rung that produced it, and applying null ≡
-/// absent recursively so no bare null reaches the plate:
+/// absent recursively so no bare null reaches the plate.
 ///
-/// - A null or absent value becomes the schema `default:`
-///   ([`Default`](FieldSource::Default)), else the field's [`blank`]
-///   ([`Blank`](FieldSource::Blank)).
-/// - A present **typed dictionary** is rebuilt from its declared properties so a
-///   null/absent property blank-fills and the projection matches the schema shape.
-///   Source keys the schema does not declare pass through verbatim, matching
-///   `config::coerce_object_props`'s coercion-time behavior: the schema is a
-///   floor, not an allowlist, so an undeclared `note:` on a typed dict reaches
-///   the plate instead of being silently dropped.
-/// - A present **typed array** resolves each element against the item schema, so
-///   a null element blank-fills in place.
-/// - Any other present value is returned unchanged.
+/// **The ladder is per cell, and resolution is a descent rather than a return.**
+/// A cell is a leaf, an `array` (arity is a fact no leaf carries), or a variant
+/// discriminant; an `object` is a *namespace*, whose value is the composition of
+/// its cells'. So this picks a **seed** — the authored value, else the schema
+/// `default:` — and then hands it to [`compose`], which rebuilds a container from
+/// its declared members whichever rung the seed came from, and floors a leaf at
+/// its [`blank`]. Absence is *inherited*, not terminal: an absent container makes
+/// every cell below it absent, and each cell then cuts its own ladder.
 ///
-/// Every present shape is [`Authored`](FieldSource::Authored) (the nested
-/// blank-fill inside a dict/array is a projection detail, not a source change).
-/// The source is the byproduct of the same branch that computes the value, so
-/// the render projection ([`resolve_value`]) and the field-state view cut the
-/// one commitment ladder rather than each re-deriving precedence
-/// (`prose/canon/SCHEMAS.md` § "Value sources and projections").
+/// This is what makes the plate total at every depth: a declared address is
+/// present however much of its container the document left out
+/// (`prose/canon/PLATE_DATA.md`). Resolving through one composition also keeps
+/// the rungs from disagreeing with the obligation surface, which has always
+/// addressed cells through absence ([`collect_unauthored_field`]).
+///
+/// The rung is the seed's, and for a namespace it is the strongest rung
+/// contributing to the value: a container the document authored reads
+/// [`Authored`](FieldSource::Authored), an absent one reads
+/// [`Default`](FieldSource::Default) when any cell below took a `default:`, else
+/// [`Blank`](FieldSource::Blank). The source is the byproduct of the same walk
+/// that computes the value, so the render projection ([`resolve_value`]) and the
+/// resolved-value view cut the one commitment ladder rather than each re-deriving
+/// precedence (`prose/canon/SCHEMAS.md` § "Value sources and projections").
 pub(crate) fn resolve_value_sourced(
     value: Option<&QuillValue>,
     field: &FieldSchema,
@@ -513,36 +517,80 @@ pub(crate) fn resolve_value_sourced(
     if field.is_variant_bearing() {
         return resolve_variant_sourced(value, field);
     }
-    let present = value.filter(|v| !v.as_json().is_null());
-    let Some(v) = present else {
-        // `default_content` holds the imported form of `default:`, cached at
-        // load wherever the type tree bears a content leaf. The ladder injects
-        // a default without re-coercing it, so the cache is the only safe
-        // source: a raw `default` would cross to the plate as unimported
-        // markdown.
-        if let Some(content) = field.default_content.clone() {
-            return (content, FieldSource::Default);
-        }
-        if crate::quill::config::field_contains_content(field) {
-            return (blank(field), FieldSource::Blank);
-        }
-        return match field.default.clone() {
-            Some(default) => (default, FieldSource::Default),
-            None => (blank(field), FieldSource::Blank),
-        };
+    let (seed, source) = match value.filter(|v| !v.as_json().is_null()) {
+        Some(v) => (Some(v.clone()), FieldSource::Authored),
+        None => match seed_default(field) {
+            Some(default) => (Some(default), FieldSource::Default),
+            None => (None, FieldSource::Blank),
+        },
     };
-    let resolved = match (&field.r#type, &field.properties, &field.items) {
+    let (resolved, composed) = compose(seed.as_ref(), field, source);
+    (resolved, source.join(composed))
+}
+
+/// The `default:` a cell enters the descent with, in the form the plate takes it.
+///
+/// `default_content` holds the imported form, cached at load wherever the type
+/// tree bears a content leaf. The ladder injects a default without re-coercing
+/// it, so the cache is the only safe source: a raw `default` would cross to the
+/// plate as unimported markdown. A content-bearing tree whose companion is
+/// absent therefore has *no* seed rather than falling through to the raw
+/// literal — the gate `populate_field_content` is written against.
+fn seed_default(field: &FieldSchema) -> Option<QuillValue> {
+    if let Some(content) = field.default_content.clone() {
+        return Some(content);
+    }
+    if crate::quill::config::field_contains_content(field) {
+        return None;
+    }
+    field.default.clone()
+}
+
+/// Build `field`'s value from `seed`, the value its own rung supplied (`None`
+/// where no rung above the floor had one), and report the strongest rung any
+/// cell below contributed.
+///
+/// - A **typed dictionary** is rebuilt from its declared properties, each cell
+///   cutting its own ladder over its slice of the seed, so an absent or
+///   null property resolves to *its* `default:` and only then to its blank, and
+///   the projection matches the schema shape. Seed keys the schema does not
+///   declare pass through verbatim, matching `config::coerce_object_props`'s
+///   coercion-time behavior: the schema is a floor, not an allowlist, so an
+///   undeclared `note:` on a typed dict reaches the plate instead of being
+///   silently dropped.
+/// - A **typed array** resolves each element against the item schema, so a null
+///   element blank-fills in place and a partial element from an array `default:`
+///   is completed exactly as an authored one is.
+/// - Every other type is a leaf: the seed, else the field's [`blank`].
+///
+/// Terminates because each recursion descends strictly into the schema tree.
+///
+/// `outer` is the container's own rung, which **ceilings** its cells': nothing
+/// inside a container the document did not author can read
+/// [`Authored`](FieldSource::Authored), however the seed reached it. Without the
+/// ceiling a cell fed from a container `default:` would report itself authored,
+/// since [`resolve_value_sourced`] cannot tell a seeded value from a written one.
+fn compose(
+    seed: Option<&QuillValue>,
+    field: &FieldSchema,
+    outer: FieldSource,
+) -> (QuillValue, FieldSource) {
+    let ceiling = match outer {
+        FieldSource::Authored => FieldSource::Authored,
+        _ => FieldSource::Default,
+    };
+    match (&field.r#type, &field.properties, &field.items) {
         (FieldType::Object, Some(props), _) => {
-            let obj = v.as_json().as_object();
+            let obj = seed.and_then(|v| v.as_json().as_object());
             let mut out = serde_json::Map::new();
+            let mut rung = FieldSource::Blank;
             for (pname, pschema) in props {
                 let pv = obj
                     .and_then(|o| o.get(pname))
                     .map(|j| QuillValue::from_json(j.clone()));
-                out.insert(
-                    pname.clone(),
-                    resolve_value(pv.as_ref(), pschema).into_json(),
-                );
+                let (value, source) = resolve_value_sourced(pv.as_ref(), pschema);
+                rung = rung.join(source.min(ceiling));
+                out.insert(pname.clone(), value.into_json());
             }
             // Preserve undeclared keys verbatim; only rebuild the ones the
             // schema names. Skips keys already emitted above so a declared
@@ -554,19 +602,26 @@ pub(crate) fn resolve_value_sourced(
                     }
                 }
             }
-            QuillValue::from_json(serde_json::Value::Object(out))
+            (QuillValue::from_json(serde_json::Value::Object(out)), rung)
         }
         (FieldType::Array, _, Some(items)) => {
-            let arr = v.as_json().as_array().cloned().unwrap_or_default();
+            let arr = seed
+                .and_then(|v| v.as_json().as_array().cloned())
+                .unwrap_or_default();
             let out: Vec<serde_json::Value> = arr
                 .into_iter()
                 .map(|e| resolve_value(Some(&QuillValue::from_json(e)), items).into_json())
                 .collect();
-            QuillValue::from_json(serde_json::Value::Array(out))
+            (
+                QuillValue::from_json(serde_json::Value::Array(out)),
+                FieldSource::Blank,
+            )
         }
-        _ => v.clone(),
-    };
-    (resolved, FieldSource::Authored)
+        _ => match seed {
+            Some(v) => (v.clone(), FieldSource::Blank),
+            None => (blank(field), FieldSource::Blank),
+        },
+    }
 }
 
 /// Resolve a variant-bearing enum into the container the plate receives:
@@ -1182,6 +1237,152 @@ main:
         assert_eq!(
             plate["seal"], "",
             "an authored blank outranks the default and is not a gate error; got {plate}"
+        );
+    }
+
+    /// The ladder is per cell: an absent container reaches every leaf's own
+    /// `default:`, so a declared address is present *and* carries its author's
+    /// answer however much of the container the document left out.
+    #[test]
+    fn an_absent_container_reaches_every_leaf_default() {
+        const YAML: &str = r#"
+quill: { name: ac, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    contact:
+      type: object
+      properties:
+        name: { type: string }
+        email: { type: string, default: "hi@example.com" }
+        addr:
+          type: object
+          properties:
+            city: { type: string, default: Pgh }
+"#;
+        let absent = plate_of(YAML, "~~~card-yaml\n$quill: ac@1.0.0\n$kind: main\n~~~\n");
+        assert_eq!(
+            absent["contact"],
+            json!({ "name": "", "email": "hi@example.com", "addr": { "city": "Pgh" } }),
+            "an absent container cuts each cell's own ladder, at every depth; got {absent}"
+        );
+        // Authoring the empty map is a no-op: the same cells, the same rungs.
+        let authored = plate_of(
+            YAML,
+            "~~~card-yaml\n$quill: ac@1.0.0\n$kind: main\ncontact: {}\n~~~\n",
+        );
+        assert_eq!(
+            absent["contact"], authored["contact"],
+            "writing `contact: {{}}` must not change what renders; got {authored}"
+        );
+    }
+
+    /// The blueprint's cells and the plate's cells are cut from the same
+    /// declarations, so a value the blueprint shows is the value that renders
+    /// when the author leaves that line alone — the "shippable as-is"
+    /// affordance, which held only at card level while an absent container
+    /// short-circuited the ladder.
+    #[test]
+    fn the_blueprint_and_the_plate_agree_cell_by_cell() {
+        const YAML: &str = r#"
+quill: { name: bp, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    contact:
+      type: object
+      properties:
+        email: { type: string, default: "hi@example.com" }
+        when: { type: date, default: "2026-01-01" }
+        addr:
+          type: object
+          properties:
+            city: { type: string, default: Pgh }
+"#;
+        let blueprint = QuillConfig::from_yaml(YAML).expect("valid quill").blueprint();
+        let plate = plate_of(YAML, "~~~card-yaml\n$quill: bp@1.0.0\n$kind: main\n~~~\n");
+        for shown in ["hi@example.com", "2026-01-01", "Pgh"] {
+            assert!(
+                blueprint.contains(shown),
+                "the blueprint shows {shown}: {blueprint}"
+            );
+        }
+        assert_eq!(
+            plate["contact"],
+            json!({ "email": "hi@example.com", "when": "2026-01-01", "addr": { "city": "Pgh" } }),
+            "and the plate renders exactly those cells; got {plate}"
+        );
+    }
+
+    /// An `array` is a cell — arity is a fact no element declaration carries —
+    /// so it keeps its own `default:`, and each element it supplies is completed
+    /// against `items` exactly as an authored element is.
+    #[test]
+    fn an_array_default_completes_its_elements_against_items() {
+        const YAML: &str = r#"
+quill: { name: ad, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    rows:
+      type: array
+      default: [{ who: A }]
+      items:
+        type: object
+        properties:
+          who: { type: string }
+          role: { type: string, default: lead }
+"#;
+        let defaulted = plate_of(YAML, "~~~card-yaml\n$quill: ad@1.0.0\n$kind: main\n~~~\n");
+        assert_eq!(
+            defaulted["rows"],
+            json!([{ "who": "A", "role": "lead" }]),
+            "a partial default element blank-fills against `items`; got {defaulted}"
+        );
+        let authored = plate_of(
+            YAML,
+            "~~~card-yaml\n$quill: ad@1.0.0\n$kind: main\nrows:\n  - who: A\n~~~\n",
+        );
+        assert_eq!(
+            defaulted["rows"], authored["rows"],
+            "which rung supplied the row does not change its shape; got {authored}"
+        );
+    }
+
+    /// A container has no rung of its own: it reports the strongest rung that
+    /// contributed to it, so an absent container whose cells took defaults reads
+    /// `default` rather than claiming the floor.
+    #[test]
+    fn a_containers_rung_is_the_strongest_its_cells_contributed() {
+        let defaulted = field(
+            r#"
+type: object
+properties:
+  name: { type: string }
+  email: { type: string, default: "hi@example.com" }
+"#,
+        );
+        assert_eq!(
+            resolve_value_sourced(None, &defaulted).1,
+            FieldSource::Default,
+            "a cell below took its `default:`, so the container is not at the floor"
+        );
+
+        let floored = field(
+            r#"
+type: object
+properties:
+  name: { type: string }
+"#,
+        );
+        assert_eq!(
+            resolve_value_sourced(None, &floored).1,
+            FieldSource::Blank,
+            "nothing below the floor contributed, so the container reports it"
+        );
+
+        let authored = QuillValue::from_json(json!({}));
+        assert_eq!(
+            resolve_value_sourced(Some(&authored), &floored).1,
+            FieldSource::Authored,
+            "a container the document wrote is authored, however little it holds"
         );
     }
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -498,16 +498,12 @@ fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue 
 ///
 /// This is what makes the plate total at every depth: a declared address is
 /// present however much of its container the document left out
-/// (`prose/canon/PLATE_DATA.md`). Resolving through one composition also keeps
-/// the rungs from disagreeing with the obligation surface, which has always
-/// addressed cells through absence ([`collect_unauthored_field`]).
+/// (`prose/canon/PLATE_DATA.md`), which is what lets a plate read one directly
+/// rather than through a guarded accessor.
 ///
-/// The rung is the seed's, and for a namespace it is the strongest rung
-/// contributing to the value: a container the document authored reads
-/// [`Authored`](FieldSource::Authored), an absent one reads
-/// [`Default`](FieldSource::Default) when any cell below took a `default:`, else
-/// [`Blank`](FieldSource::Blank). The source is the byproduct of the same walk
-/// that computes the value, so the render projection ([`resolve_value`]) and the
+/// The rung is the seed's, joined with what the descent found
+/// ([`FieldSource::join`]). It is the byproduct of the same walk that computes
+/// the value, so the render projection ([`resolve_value`]) and the
 /// resolved-value view cut the one commitment ladder rather than each re-deriving
 /// precedence (`prose/canon/SCHEMAS.md` § "Value sources and projections").
 pub(crate) fn resolve_value_sourced(
@@ -532,10 +528,10 @@ pub(crate) fn resolve_value_sourced(
 ///
 /// `default_content` holds the imported form, cached at load wherever the type
 /// tree bears a content leaf. The ladder injects a default without re-coercing
-/// it, so the cache is the only safe source: a raw `default` would cross to the
-/// plate as unimported markdown. A content-bearing tree whose companion is
-/// absent therefore has *no* seed rather than falling through to the raw
-/// literal — the gate `populate_field_content` is written against.
+/// it, so the cache is the only safe source: a raw `default` would cross as
+/// unimported markdown. A content-bearing tree whose companion is absent
+/// therefore has *no* seed — the gate `populate_field_content` is written
+/// against.
 fn seed_default(field: &FieldSchema) -> Option<QuillValue> {
     if let Some(content) = field.default_content.clone() {
         return Some(content);
@@ -548,28 +544,21 @@ fn seed_default(field: &FieldSchema) -> Option<QuillValue> {
 
 /// Build `field`'s value from `seed`, the value its own rung supplied (`None`
 /// where no rung above the floor had one), and report the strongest rung any
-/// cell below contributed.
+/// cell below contributed. Terminates because each recursion descends strictly
+/// into the schema tree.
 ///
-/// - A **typed dictionary** is rebuilt from its declared properties, each cell
-///   cutting its own ladder over its slice of the seed, so an absent or
-///   null property resolves to *its* `default:` and only then to its blank, and
-///   the projection matches the schema shape. Seed keys the schema does not
-///   declare pass through verbatim, matching `config::coerce_object_props`'s
-///   coercion-time behavior: the schema is a floor, not an allowlist, so an
-///   undeclared `note:` on a typed dict reaches the plate instead of being
-///   silently dropped.
-/// - A **typed array** resolves each element against the item schema, so a null
-///   element blank-fills in place and a partial element from an array `default:`
-///   is completed exactly as an authored one is.
-/// - Every other type is a leaf: the seed, else the field's [`blank`].
-///
-/// Terminates because each recursion descends strictly into the schema tree.
+/// A typed dictionary's cells each cut their own ladder over their slice of the
+/// seed, so an absent property resolves to *its* `default:` before its blank. A
+/// seed key the schema does not declare passes through verbatim, matching
+/// `config::coerce_object_props`: the schema is a floor, not an allowlist, so an
+/// undeclared `note:` on a typed dict reaches the plate instead of being
+/// silently dropped.
 ///
 /// `outer` is the container's own rung, which **ceilings** its cells': nothing
-/// inside a container the document did not author can read
-/// [`Authored`](FieldSource::Authored), however the seed reached it. Without the
-/// ceiling a cell fed from a container `default:` would report itself authored,
-/// since [`resolve_value_sourced`] cannot tell a seeded value from a written one.
+/// inside a container the document did not author may read
+/// [`Authored`](FieldSource::Authored). [`resolve_value_sourced`] cannot tell a
+/// seeded value from a written one, so without the ceiling a cell fed from a
+/// container `default:` would report itself authored.
 fn compose(
     seed: Option<&QuillValue>,
     field: &FieldSchema,
@@ -1240,9 +1229,6 @@ main:
         );
     }
 
-    /// The ladder is per cell: an absent container reaches every leaf's own
-    /// `default:`, so a declared address is present *and* carries its author's
-    /// answer however much of the container the document left out.
     #[test]
     fn an_absent_container_reaches_every_leaf_default() {
         const YAML: &str = r#"
@@ -1276,11 +1262,8 @@ main:
         );
     }
 
-    /// The blueprint's cells and the plate's cells are cut from the same
-    /// declarations, so a value the blueprint shows is the value that renders
-    /// when the author leaves that line alone — the "shippable as-is"
-    /// affordance, which held only at card level while an absent container
-    /// short-circuited the ladder.
+    /// A value the blueprint shows is the value that renders when the author
+    /// leaves that line alone: the "shippable as-is" affordance, at any depth.
     #[test]
     fn the_blueprint_and_the_plate_agree_cell_by_cell() {
         const YAML: &str = r#"
@@ -1312,9 +1295,8 @@ main:
         );
     }
 
-    /// An `array` is a cell — arity is a fact no element declaration carries —
-    /// so it keeps its own `default:`, and each element it supplies is completed
-    /// against `items` exactly as an authored element is.
+    /// An `array` is a cell: `items:` fixes the element type but never the
+    /// arity, so it keeps its own `default:`.
     #[test]
     fn an_array_default_completes_its_elements_against_items() {
         const YAML: &str = r#"
@@ -1346,9 +1328,6 @@ main:
         );
     }
 
-    /// A container has no rung of its own: it reports the strongest rung that
-    /// contributed to it, so an absent container whose cells took defaults reads
-    /// `default` rather than claiming the floor.
     #[test]
     fn a_containers_rung_is_the_strongest_its_cells_contributed() {
         let defaulted = field(

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1313,18 +1313,14 @@ impl QuillConfig {
     }
 
     /// Refuse a `default:` / `example:` declared on a **typed dictionary**, which
-    /// is a namespace rather than a cell: its value is the composition of its
-    /// properties', so a literal on the container is a second declaration of a
-    /// fact the properties already carry, and the two disagree. The value axis
-    /// would read the container while the obligation axis reads the leaf — a
-    /// `default: {name: A}` renders `A` and still warns that nobody authored
-    /// `name`, since `must_fill` derives per property.
+    /// is a namespace rather than a cell: a literal on the container is a second
+    /// declaration of a fact its properties already carry, and the two axes read
+    /// different ones — `default: {name: A}` renders `A` while `must_fill`
+    /// derives per property and still reports `name` unauthored.
     ///
     /// The variant container refuses the same shape for the same reason
-    /// (`quill::{default,example}_type_mismatch`, its `is_variant_bearing` hint),
-    /// and schema literals are strict where document payloads are lenient
-    /// (`prose/canon/SCHEMAS.md` § "Type coercion"). An `array` keeps its literal:
-    /// arity is a fact no element declaration carries, so it *is* a cell.
+    /// (`quill::{default,example}_type_mismatch`). An `array` keeps its literal:
+    /// `items:` fixes the element type but never the arity, so it *is* a cell.
     fn reject_namespace_literal(
         slot: &str,
         schema: &FieldSchema,

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1187,6 +1187,12 @@ impl QuillConfig {
     ) {
         Self::validate_description_singleline(schema.description.as_deref(), owner_label, errors);
         Self::validate_enum_literals(schema, owner_label, errors);
+        if schema.example.is_some() {
+            Self::reject_namespace_literal("example", schema, owner_label, errors);
+        }
+        if schema.default.is_some() {
+            Self::reject_namespace_literal("default", schema, owner_label, errors);
+        }
         if let Some(v) = &schema.example {
             Self::validate_schema_slot("example", v, schema, owner_label, errors);
         }
@@ -1304,6 +1310,50 @@ impl QuillConfig {
                 }
             }
         }
+    }
+
+    /// Refuse a `default:` / `example:` declared on a **typed dictionary**, which
+    /// is a namespace rather than a cell: its value is the composition of its
+    /// properties', so a literal on the container is a second declaration of a
+    /// fact the properties already carry, and the two disagree. The value axis
+    /// would read the container while the obligation axis reads the leaf — a
+    /// `default: {name: A}` renders `A` and still warns that nobody authored
+    /// `name`, since `must_fill` derives per property.
+    ///
+    /// The variant container refuses the same shape for the same reason
+    /// (`quill::{default,example}_type_mismatch`, its `is_variant_bearing` hint),
+    /// and schema literals are strict where document payloads are lenient
+    /// (`prose/canon/SCHEMAS.md` § "Type coercion"). An `array` keeps its literal:
+    /// arity is a fact no element declaration carries, so it *is* a cell.
+    fn reject_namespace_literal(
+        slot: &str,
+        schema: &FieldSchema,
+        owner_label: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) {
+        let Some(props) = schema
+            .properties
+            .as_ref()
+            .filter(|_| matches!(schema.r#type, FieldType::Object))
+        else {
+            return;
+        };
+        let names: Vec<&str> = props.keys().map(String::as_str).collect();
+        errors.push(
+            Diagnostic::new(
+                Severity::Error,
+                format!(
+                    "{owner_label} declares type 'object' but carries a {slot}. A typed \
+                     dictionary is a namespace, not a cell: each property holds its own {slot}."
+                ),
+            )
+            .with_code(format!("quill::{slot}_on_namespace"))
+            .with_hint(format!(
+                "Move each value onto the property that holds it ({}), and remove the \
+                 container's {slot}.",
+                names.join(", ")
+            )),
+        );
     }
 
     /// Validate a single `example:` or `default:` literal against the declared

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -12,12 +12,12 @@ use super::compose::resolve_card_sourced;
 use super::{CardSchema, Quill, QuillConfig};
 use crate::{Card, Document, QuillValue};
 
-/// The rung of the commitment ladder that produced a [`ResolvedField::value`],
-/// ordered by *commitment*: how strongly the value claims to be the real answer.
+/// The rung of the commitment ladder that produced a [`ResolvedField::value`].
 /// Serializes lowercase (`"authored" | "default" | "blank"`).
 ///
-/// The declaration order **is** the ordering, floor first, so `Ord` ranks a rung
-/// against another and [`join`](Self::join) picks the more committed of two.
+/// Variants are declared floor-first, so `Ord` ranks by *commitment*: how
+/// strongly the value claims to be the real answer. Reordering them reorders the
+/// ladder.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -12,19 +12,35 @@ use super::compose::resolve_card_sourced;
 use super::{CardSchema, Quill, QuillConfig};
 use crate::{Card, Document, QuillValue};
 
-/// The rung of the commitment ladder that produced a [`ResolvedField::value`].
+/// The rung of the commitment ladder that produced a [`ResolvedField::value`],
+/// ordered by *commitment*: how strongly the value claims to be the real answer.
 /// Serializes lowercase (`"authored" | "default" | "blank"`).
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+///
+/// The declaration order **is** the ordering, floor first, so `Ord` ranks a rung
+/// against another and [`join`](Self::join) picks the more committed of two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum FieldSource {
-    /// The authored value: the document's own content.
-    Authored,
-    /// The schema `default:` (or its content form for a content field).
-    Default,
     /// The field's [`blank`](crate::quill::blank): its spelling of
     /// "explicitly nothing", and the render floor.
     Blank,
+    /// The schema `default:` (or its content form for a content field).
+    Default,
+    /// The authored value: the document's own content.
+    Authored,
+}
+
+impl FieldSource {
+    /// The more committed of two rungs.
+    ///
+    /// A container has no rung of its own — it is a namespace, and its value is
+    /// the composition of its cells' — so it reports the strongest rung that
+    /// contributed to it: authored if the document wrote any of it, else
+    /// `default` if any cell below resolved to one, else the floor.
+    pub(crate) fn join(self, other: Self) -> Self {
+        self.max(other)
+    }
 }
 
 /// One resolved row: its `name`, the value the render projection would use, and

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -31,12 +31,8 @@ use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 /// a hash on a seed → store → load → conform cycle nobody edited.
 fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, Content) {
     // Drive by `schema.fields` (declaration order), so the result is in
-    // declaration order natively: no merge-then-sort. Per field the precedence
-    // is `overlay › example_content › example › absent`: a richtext-bearing field
-    // seeds from its pre-validated content companion, every other from its raw
-    // `example`, and the overlay overrides either (and can supply a value for a
-    // `default`-only field the base omits). An overlay key naming no schema
-    // field is skipped: it is never iterated here.
+    // declaration order natively: no merge-then-sort. An overlay key naming no
+    // schema field is skipped: it is never iterated here.
     let mut items: Vec<PayloadItem> = Vec::new();
     for (name, field) in &schema.fields {
         let overlaid = overlay.and_then(|o| o.fields.get(name));
@@ -97,18 +93,17 @@ struct Seeded {
 /// The `example:` a field commits, descending a typed dictionary to reach the
 /// examples its properties declare.
 ///
-/// **A namespace has no example of its own** — a typed dictionary carries no
-/// `default:`/`example:` (`quill::example_on_namespace`) — so the seed composes
-/// one from whatever its cells commit, and stays absent when none of them commit
-/// anything. Without the descent a property's `example:` would be unreachable at
-/// every projection: the render floor never emits an example, and the blueprint
-/// is a different document. The commit is *sparse*, exactly as at card level:
-/// only the cells with an example appear, and the rest defer to the render floor.
+/// A typed dictionary carries no `example:` of its own
+/// (`quill::example_on_namespace`), so its seed composes from whatever its cells
+/// commit and stays `None` when none of them commit anything. Nothing else
+/// reaches a nested `example:`: the render floor never emits one, and the
+/// blueprint is a different document. The commit is *sparse*, as at card level —
+/// only the cells with an example appear, the rest deferring to the render floor.
 ///
-/// Per cell the precedence is the ordinary `overlay › example_content › example ›
-/// absent`, the content companion first so a content field seeds its resting
-/// form. An overlay applies to the whole field, cells included: `$seed` is a
-/// template author deciding, so it also lifts the marker.
+/// The content companion is read before the raw `example:` so a content field
+/// seeds its resting form. An overlay covers the whole field, cells included, and
+/// lifts the marker: `$seed` is a template author deciding, which is the act the
+/// marker asks for.
 fn seed_field(field: &crate::quill::FieldSchema, overlaid: Option<&QuillValue>) -> Option<Seeded> {
     if let Some(value) = overlaid {
         return Some(Seeded {
@@ -206,8 +201,7 @@ fn seed_variant(
     if let Some(fields) = field.variant_fields(&member) {
         for (key, schema) in fields {
             // A cell carries any type a card field may, so it seeds through the
-            // same descent: a cell that is itself a typed dictionary composes
-            // from its properties' examples rather than needing one of its own.
+            // same descent.
             let overlaid_cell = overlay_object
                 .and_then(|o| o.get(key))
                 .map(|j| QuillValue::from_json(j.clone()));

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -7,7 +7,7 @@
 use quillmark_content::Content;
 
 use super::Quill;
-use crate::quill::{CardSchema, VARIANT_DISCRIMINANT_KEY};
+use crate::quill::{CardSchema, FieldType, VARIANT_DISCRIMINANT_KEY};
 use crate::document::PayloadItem;
 use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 
@@ -46,21 +46,20 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
             }
             continue;
         }
-        let Some(value) = overlaid
-            .or(field.example_content.as_ref())
-            .or(field.example.as_ref())
-        else {
+        let Some(Seeded { value, fills }) = seed_field(field, overlaid) else {
             continue;
         };
+        let mut value = seeded_rest(name, &value, field);
+        for path in fills.iter().filter(|p| !p.is_empty()) {
+            value.set_fill_at(path);
+        }
         items.push(PayloadItem::Field {
             key: name.clone(),
-            value: seeded_rest(name, value, field),
-            // An `example` on a must-fill field is shape documentation, not
-            // the answer, so it commits *carrying the marker*: that is what
-            // lands a seed on the same cells the blueprint stamps. An overlay
-            // value is exempt — `$seed` is a template author deciding, which is
-            // the act the marker asks for.
-            fill: overlaid.is_none() && field.must_fill(),
+            value,
+            // The root marker, where the field itself is the marked cell. A
+            // mapping never carries one: its obligation sits on the leaves
+            // inside it, which `fills` addresses by path.
+            fill: fills.iter().any(Vec::is_empty),
             nested_comments: Vec::new(),
         });
     }
@@ -85,6 +84,74 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     };
 
     (Payload::from_items(items), body)
+}
+
+/// What one field contributes to a seed: the value to commit, and the paths
+/// inside it that carry a `!must_fill` marker (the empty path being the value's
+/// own root).
+struct Seeded {
+    value: QuillValue,
+    fills: Vec<Vec<crate::value::PathSegment>>,
+}
+
+/// The `example:` a field commits, descending a typed dictionary to reach the
+/// examples its properties declare.
+///
+/// **A namespace has no example of its own** — a typed dictionary carries no
+/// `default:`/`example:` (`quill::example_on_namespace`) — so the seed composes
+/// one from whatever its cells commit, and stays absent when none of them commit
+/// anything. Without the descent a property's `example:` would be unreachable at
+/// every projection: the render floor never emits an example, and the blueprint
+/// is a different document. The commit is *sparse*, exactly as at card level:
+/// only the cells with an example appear, and the rest defer to the render floor.
+///
+/// Per cell the precedence is the ordinary `overlay › example_content › example ›
+/// absent`, the content companion first so a content field seeds its resting
+/// form. An overlay applies to the whole field, cells included: `$seed` is a
+/// template author deciding, so it also lifts the marker.
+fn seed_field(field: &crate::quill::FieldSchema, overlaid: Option<&QuillValue>) -> Option<Seeded> {
+    if let Some(value) = overlaid {
+        return Some(Seeded {
+            value: value.clone(),
+            fills: Vec::new(),
+        });
+    }
+    if let (FieldType::Object, Some(props)) = (&field.r#type, &field.properties) {
+        let mut map = serde_json::Map::new();
+        let mut fills = Vec::new();
+        for (name, prop) in props {
+            let Some(seeded) = seed_field(prop, None) else {
+                continue;
+            };
+            for path in seeded.fills {
+                let mut rebased = vec![crate::value::PathSegment::Key(name.clone())];
+                rebased.extend(path);
+                fills.push(rebased);
+            }
+            map.insert(name.clone(), seeded.value.into_json());
+        }
+        if map.is_empty() {
+            return None;
+        }
+        return Some(Seeded {
+            value: QuillValue::from_json(serde_json::Value::Object(map)),
+            fills,
+        });
+    }
+    let value = field
+        .example_content
+        .as_ref()
+        .or(field.example.as_ref())?
+        .clone();
+    // An `example` on a must-fill field is shape documentation, not the answer,
+    // so it commits *carrying the marker*: that is what lands a seed on the same
+    // cells the blueprint stamps.
+    let fills = if field.must_fill() {
+        vec![Vec::new()]
+    } else {
+        Vec::new()
+    };
+    Some(Seeded { value, fills })
 }
 
 /// Seed one variant-bearing enum, or `None` where neither the overlay nor any
@@ -129,27 +196,36 @@ fn seed_variant(
         VARIANT_DISCRIMINANT_KEY.to_string(),
         serde_json::Value::String(member.clone()),
     );
-    let mut fills: Vec<String> = Vec::new();
+    let mut fills: Vec<Vec<crate::value::PathSegment>> = Vec::new();
     if overlay_member.is_none() && field.must_fill() {
-        fills.push(VARIANT_DISCRIMINANT_KEY.to_string());
+        fills.push(vec![crate::value::PathSegment::Key(
+            VARIANT_DISCRIMINANT_KEY.to_string(),
+        )]);
     }
 
     if let Some(fields) = field.variant_fields(&member) {
         for (key, schema) in fields {
-            let overlaid_cell = overlay_object.and_then(|o| o.get(key));
-            let Some(value) = overlaid_cell.or(schema.example.as_ref().map(|e| e.as_json())) else {
+            // A cell carries any type a card field may, so it seeds through the
+            // same descent: a cell that is itself a typed dictionary composes
+            // from its properties' examples rather than needing one of its own.
+            let overlaid_cell = overlay_object
+                .and_then(|o| o.get(key))
+                .map(|j| QuillValue::from_json(j.clone()));
+            let Some(seeded) = seed_field(schema, overlaid_cell.as_ref()) else {
                 continue;
             };
-            map.insert(key.clone(), value.clone());
-            if overlaid_cell.is_none() && schema.must_fill() {
-                fills.push(key.clone());
+            for path in seeded.fills {
+                let mut rebased = vec![crate::value::PathSegment::Key(key.clone())];
+                rebased.extend(path);
+                fills.push(rebased);
             }
+            map.insert(key.clone(), seeded.value.into_json());
         }
     }
 
     let mut value = QuillValue::from_json(serde_json::Value::Object(map));
-    for key in &fills {
-        value.set_fill_at(&[crate::value::PathSegment::Key(key.clone())]);
+    for path in &fills {
+        value.set_fill_at(path);
     }
     Some(PayloadItem::Field {
         key: name.to_string(),

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -308,10 +308,8 @@ fn well_formed_seed_overlay_yields_no_seed_diagnostics() {
     );
 }
 
-/// A typed dictionary carries no `example:` of its own — it is a namespace —
-/// so the seed composes one from the examples its properties declare, and stays
-/// absent when none of them declare any. Without the descent a nested `example:`
-/// would be unreachable at every projection: the render floor never emits one.
+/// A typed dictionary's seed composes from the examples its properties declare,
+/// and stays absent when none of them declare any.
 #[test]
 fn a_dictionarys_seed_is_composed_from_its_properties_examples() {
     let quill = quill_from_yaml(

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -307,3 +307,49 @@ fn well_formed_seed_overlay_yields_no_seed_diagnostics() {
         "a well-formed overlay should produce no seed diagnostics: {diags:?}",
     );
 }
+
+/// A typed dictionary carries no `example:` of its own — it is a namespace —
+/// so the seed composes one from the examples its properties declare, and stays
+/// absent when none of them declare any. Without the descent a nested `example:`
+/// would be unreachable at every projection: the render floor never emits one.
+#[test]
+fn a_dictionarys_seed_is_composed_from_its_properties_examples() {
+    let quill = quill_from_yaml(
+        r#"
+quill: { name: sd, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    contact:
+      type: object
+      properties:
+        name: { type: string, example: Ada }
+        email: { type: string, default: "hi@example.com" }
+        note: { type: string }
+    empty:
+      type: object
+      properties:
+        tag: { type: string, default: t }
+"#,
+    );
+    let seeded = quill.seed_document();
+    let payload = seeded.main().payload();
+
+    assert_eq!(
+        payload.get("contact").map(|v| v.as_json().clone()),
+        Some(serde_json::json!({ "name": "Ada" })),
+        "the commit is sparse: only the cells with an example, the rest deferred"
+    );
+    assert!(
+        payload.get("empty").is_none(),
+        "a dictionary whose cells commit nothing stays absent, as any field does"
+    );
+    // The marker rides a committed example on a must-fill cell, at its own path.
+    assert!(
+        payload
+            .get("contact")
+            .expect("contact seeded")
+            .nonroot_fill_paths()
+            .any(|p| p == vec![crate::value::PathSegment::Key("name".to_string())]),
+        "a must-fill cell's marker rides at the cell, not the container"
+    );
+}

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2500,11 +2500,11 @@ main:
     assert_eq!(literal["marks"], serde_json::json!([]));
 }
 
-/// The sibling position: a `default:` on the **container**. It commits the same
-/// imported content a leaf's does — which declaration carries the literal does
-/// not change what crosses.
+/// The sibling position: a `default:` reached *through* an absent container. A
+/// cell's literal commits the same imported content whatever sits above it, and
+/// an `array` — the one container that is itself a cell — commits its own.
 #[test]
-fn a_containers_own_content_default_reaches_the_plate_as_content() {
+fn a_content_default_inside_an_absent_container_reaches_the_plate_as_content() {
     const YAML: &str = r#"
 quill:
   name: container_default
@@ -2515,10 +2515,10 @@ main:
   fields:
     dict:
       type: object
-      default: { note: "A **dict** note" }
       properties:
         note:
           type: richtext
+          default: "A **dict** note"
     rows:
       type: array
       default: ["A **row** note"]
@@ -2526,10 +2526,10 @@ main:
         type: richtext
     plain:
       type: object
-      default: { tag: bare }
       properties:
         tag:
           type: string
+          default: bare
 "#;
     let config = QuillConfig::from_yaml(YAML).expect("container defaults load");
     let document = Document::parse(concat!(
@@ -2556,8 +2556,8 @@ main:
             "{path} keeps the default's marks: {plate}"
         );
     }
-    // A container bearing no content leaf has no companion to read, and its
-    // `default:` still crosses verbatim.
+    // A cell bearing no content has no companion to read, and its `default:`
+    // still crosses verbatim through the absent container above it.
     assert_eq!(plate["plain"]["tag"], serde_json::json!("bare"));
 }
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -84,8 +84,8 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | matches `type`    | no       | The value the **majority of authors want**. When the field is omitted, the default is filled in, and the blueprint renders that concrete value with a type-only annotation, shippable as-is. Declaring it also flips the derived `must_fill` to `false` (see below). |
-| `example`     | matches `type`    | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only, never rendered as the value: it takes the blueprint cell when no `default` holds it, and surfaces in the `# e.g.` line otherwise. |
+| `default`     | matches `type`    | no       | The value the **majority of authors want**. When the cell is omitted, the default is filled in — at any depth, whether or not the container above it was authored — and the blueprint renders that concrete value with a type-only annotation, shippable as-is. Declaring it also flips the derived `must_fill` to `false` (see below). Declared on a **cell**: a leaf or an `array`. On an `object` it is a load error (`quill::default_on_namespace`), since its properties hold their own. |
+| `example`     | matches `type`    | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only, never rendered as the value: it takes the blueprint cell when no `default` holds it, and surfaces in the `# e.g.` line otherwise. Declared on a **cell**, as `default` is (`quill::example_on_namespace`). |
 | `must_fill`   | boolean           | no       | Whether a human must author this cell (see [Obligation: `must_fill`](#obligation-must_fill)). Defaults to `!default.is_some()`. |
 | `values`      | array of strings  | for `enum` | The closed set of allowed string values: the **choices**. Required on every `enum` field. Declaring `""` is a load error — every enum also accepts its [blank](#the-blank-values-is-for-choices-not-for-the-absence-of-one), which the engine supplies. |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
@@ -383,6 +383,29 @@ main:
 ```
 
 Containers nest freely: a property or an element is an ordinary field, so it carries whatever type a card-level field carries, itself included. `object<array<string>>`, `array<array<integer>>` and a typed table whose row holds a typed dictionary are all declarable, and each leaf is addressable by the schema address its path spells (`contact.address.city`, `grid.0.0` — see [PLATE_DATA.md](https://github.com/borb-sh/quillmark/blob/main/prose/canon/PLATE_DATA.md#schema-addresses)).
+
+**A dictionary holds no `default:` or `example:` of its own** — its properties do:
+
+```yaml
+address:
+  type: object
+  # default: { street: "5000 Forbes Ave" }   # quill::default_on_namespace
+  properties:
+    street: { type: string, default: "5000 Forbes Ave" }
+    city:   { type: string, default: "" }    # type-empty: a skippable cell
+```
+
+The container spelling would be a second declaration of a value the property
+already holds, and the two disagree: `must_fill` derives per property, so a
+container default renders a value *and* still reports the cell unauthored. Each
+property's `default:` is reached whether or not a document authors the container
+above it, so writing `address: {}` changes nothing — which also makes a whole
+dictionary skippable by giving each property a type-empty default.
+
+An `array` **does** keep its own `default:` / `example:`: `items:` fixes the
+element type but never the arity, so `default: []` and `default: [{…}]` say
+something no property declaration can. Each element it supplies is completed
+against `items` exactly as an authored element is.
 
 Two keys are card-level regardless of depth: `ui.group` (grouping never descends) and `variants:` (see [Variants](#variants-fields-that-exist-only-for-one-choice)).
 

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -185,9 +185,10 @@ two axes"). Reading them off separately gives the full grid:
 An `example` takes the cell only when no `default:` holds it, and surfaces in
 the `# e.g.` leading line otherwise. That gate is a *value*-axis question:
 `must_fill` never moves an example between the cell and the hint. The rule holds
-uniformly for scalars, arrays, typed tables, and typed dictionaries: **except
-`richtext`**, which never inlines its example as a value at all; its `example:`
-always surfaces as the `# e.g.` line (see "Richtext fields").
+uniformly for scalars, arrays and typed tables, and for each **property** of a
+typed dictionary (which holds no cell of its own): **except `richtext`**, which
+never inlines its example as a value at all; its `example:` always surfaces as
+the `# e.g.` line (see "Richtext fields").
 
 All fields render as **live YAML**: no commented-out fields. The `!must_fill`
 marker is the sole "must fill" signal on this surface: a reader's mental model
@@ -326,23 +327,24 @@ sequence, e.g. `# e.g. [{org: ACME, year: 2020}]`.
 
 ## Typed dictionaries
 
-A field of `type: object` with a `properties` map follows the uniform
-cell cascade: `default:` (any default, including `{}`) is shippable as-is;
-without one:
+A field of `type: object` with a `properties` map carries **no cell of its own**:
+it is a namespace, and a `default:`/`example:` on it is a load error
+([SCHEMAS.md](SCHEMAS.md) § "Cells and namespaces"). So it always expands, and
+there is no container-level cascade to choose between:
 
-- A non-empty `default:` renders as a concrete block mapping (property
-  values only, no annotations). Only the keys present in the default are
-  shown: a *partial* default is a deliberate "already handled, ignore the
-  rest" signal and is rendered verbatim. The outer key carries `# object`.
-- `default: {}` **expands** to the field's blank-filled shape: every property
-  shown with its type-empty value (`""`, `0`, `false`, `[]`, …), all
-  unmarked and unannotated (uniform with a concrete default, the container
-  being defaulted either way). The bare `{}` is never emitted: an empty
-  defaulted object shows its structure. The outer key carries `# object`.
-- Without a `default:`, each property is emitted with its own
-  description, inline annotation, and the `!must_fill` marker on its leaf
-  value. The container key itself is untagged: you tag the leaves, not the
-  container (per [markdown-spec.md](../references/markdown-spec.md) §3.4).
+- Each property is emitted with its own description, inline annotation, and
+  its own cell cascade — `default:` › `example:` › blank under the derived
+  `!must_fill` marker — exactly as a card-level field of that type. A property
+  carrying a `default:` therefore renders that concrete value unmarked, and a
+  wholly skippable dictionary is spelled by each property carrying a type-empty
+  one.
+- The container key itself is untagged: you tag the leaves, not the
+  container (per [markdown-spec.md](../references/markdown-spec.md) §3.4). The
+  outer key carries `# object`.
+
+The cells the blueprint shows are the cells the render floor fills, from the same
+declarations: an author who deletes a defaulted line gets that default back at
+render, which is what the "shippable as-is" affordance promises.
   The outer key carries `# object`.
 
 The `{}` expansion (and not partial defaults, and not arrays) makes the object

--- a/prose/canon/PLATE_DATA.md
+++ b/prose/canon/PLATE_DATA.md
@@ -142,6 +142,13 @@ does, at whatever depth that is. This is the pdfform resolver's grammar
 grammar is written twice, in two languages, and held to one table by
 `quillmark/tests/address_grammar.rs`.
 
+**An address the grammar admits is a key the plate carries.** The blank-fill is
+total at every depth ([SCHEMAS.md](SCHEMAS.md#blank-filled-render)), so a
+declared address resolves however much of its container the document left out:
+`data.contact.address.city` is a direct read, never a guarded one. This is the
+converse of the `$`-metadata rule above — those keys are read with a total
+accessor *because* they may be absent, and a declared field may not be.
+
 Cards carry their canonical prefix as `$path`, so a plate composes a card
 address without reimplementing the kind+ordinal grammar:
 `field-region(card.at("$path") + "$body")`. A body is content rather than a

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -117,7 +117,8 @@ than about depth.
 
 Two limits follow from the container shape and are accepted, not worked around:
 [`resolve()`](#the-resolved-value-view-resolve) reports **one** rung for the whole
-container, as it does for a typed dictionary; and a field set **shared** across
+container — the strongest that contributed — as it does for a typed dictionary;
+and a field set **shared** across
 several members is spelled by repeating it or sharing a YAML anchor, since a
 variant keys on one member.
 
@@ -324,6 +325,12 @@ Every field value comes from one of a small set of **sources**, ordered by
 *commitment*: how strongly the value claims to be the real answer. This is the
 **commitment ladder**:
 
+The ladder is cut per **cell**, not per field. A cell is any leaf, an `array`
+(arity is a fact no element declaration carries), and a variant discriminant. An
+`object` and a variant's world are **namespaces**: they hold no value of their
+own, and theirs is the composition of their cells'. See
+[Cells and namespaces](#cells-and-namespaces).
+
 | Rung | Source | Persisted into a `Document`? | Renders? |
 |---|---|---|---|
 | top | authored value | yes: it *is* the document content | yes |
@@ -354,6 +361,47 @@ field maps rather than a sort key):
 | add-card (into a document) | `$seed` overlay › `example:` › absent | (deferred to render floor) | a new composable `Card`: [Document seeding](#document-seeding) |
 | editor (consumer-side) | authored › `default:` › blank, resolved per field and **tagged with its source rung** | blank | the engine's [`resolve()`](#the-resolved-value-view-resolve) resolved-value view: value and source rung per field |
 
+### Cells and namespaces
+
+A **cell** holds a value and cuts the ladder for it. A **namespace** holds cells,
+and its value is what they compose to. The split decides where a literal may be
+declared and how absence travels:
+
+| Shape | Kind | Why |
+|---|---|---|
+| every leaf | cell | it is the value |
+| `array` | cell | `items` fixes the element type, never the **arity**: `default: []` and `default: [{…}]` say what no element declaration can |
+| `enum` discriminant | cell | the member is a leaf choice |
+| `object` with `properties` | namespace | the schema fixes the keys, so nothing in the value is absent from its cells |
+| a variant's field set | namespace | same, once the discriminant selects the world |
+
+Two rules follow, and between them the plate is total at every depth:
+
+- **A literal is declared where its cell is.** A `default:` / `example:` on a
+  typed dictionary is a load error (`quill::{default,example}_on_namespace`)
+  naming the properties that hold it, as a container-shaped literal on a
+  variant-bearing enum already is
+  (`quill::{default,example}_type_mismatch`). The container spelling is a
+  *second* declaration of a fact the cells already carry, and the two axes read
+  different ones: `default: {name: A}` renders `A` while `must_fill` derives per
+  property and still warns that nobody authored `name`. Schema literals are
+  strict where document payloads are lenient ([Type coercion](#type-coercion)),
+  so this is the same strictness, not a new kind.
+- **Absence is inherited, not terminal.** An absent namespace makes every cell
+  below it absent, and each cell then cuts its own ladder — so a property's
+  `default:` is reached whether or not the document authored the container above
+  it, at any depth. Resolution is therefore a **descent**: the rung supplies a
+  *seed*, and the same composition runs over it whichever rung it came from. A
+  partial element inside an `array` `default:` is completed against `items`
+  exactly as an authored element is, and writing `contact: {}` is a no-op rather
+  than an edit that changes the render.
+
+A namespace has no rung of its own, so [`resolve()`](#the-resolved-value-view-resolve)
+reports the strongest rung that contributed: `authored` if the document wrote any
+of it, else `default` if any cell below resolved to one, else the floor. Nothing
+inside a container the document did not author can read `authored`, however the
+seed reached it.
+
 The consumer-side `Document`-payload × schema join is a **non-goal**:
 [`resolve()`](#the-resolved-value-view-resolve) supersedes it. The
 editor reads value and source rung from one engine call rather than re-cutting
@@ -381,11 +429,14 @@ value, source }` rows in declaration order: order is structural, not object-key
 order. The card body is a `body` sibling on the card, not a row in `fields`:
 present iff the kind enables a body (`enabled: false` undeclares it, so `body` is
 `null`), its source only ever `authored` (non-blank) or `blank` (blank).
-Source is one **top-level** rung per field; a nested blank-fill inside an authored
-dict or array is a projection detail of the value, not a per-subpath source. The
-rung is therefore coarser the deeper a field nests, and a container authored at
-all reads `authored` however much of it the document left to the floor. Accepted:
-per-subpath provenance is a different view, and no consumer has asked for one.
+Source is one rung per **field**, and a container's is the strongest rung that
+contributed to it ([Cells and namespaces](#cells-and-namespaces)): a container
+authored at all reads `authored` however much of it the document left to the
+floor, and an absent one reads `default` when any cell below took a `default:`.
+So the rung answers *"does anything here come from the schema"* at any depth,
+but not *which cell*. Per-subpath rows are a further view: the descent computes
+each cell's rung already, so exposing them is additive to this shape rather than
+a second resolver, and waits on a consumer naming the call site.
 
 Value and provenance only. The view carries no diagnostics: completeness and
 errors stay `Quill::validate`'s, which a consumer merges with its own producers
@@ -406,10 +457,19 @@ surfaces as a diagnostic beyond the non-fatal `validation::must_fill` warning
 Rendering and the *completeness verdict* are orthogonal. The render path
 (`QuillConfig::compile_data` and the ladder it cuts, `ladder_sourced`, both in
 core's `quill::compose`; the engine calls it) uses **blank-filled render**:
-every absent schema field is resolved by precedence: an authored value, else
+every absent schema **cell** is resolved by precedence: an authored value, else
 the `default:`, else the field's blank (`blank`, defined below): in the
 plate-JSON projection that feeds the backend **only, never in the persisted
 document**.
+
+The fill is **total at every depth**, which is what lets a plate read a declared
+address directly rather than through a guarded accessor
+([PLATE_DATA.md](PLATE_DATA.md)). Totality does not depend on which rung supplied
+a value, or on how much of a container the document authored: absence is
+inherited and each cell cuts its own ladder
+([Cells and namespaces](#cells-and-namespaces)), so a declared address is present
+whether its container was written, left out, or seeded from an `array`
+`default:`.
 
 - **Incomplete is renderable.** A document that merely omits a field (or
   leaves it present-null) renders fine: the field is blank-filled in the
@@ -481,11 +541,19 @@ something: the branch is what makes the world's fields readable without a guard
 ## Document seeding
 
 **Seeding** builds a starter `Document` from the schema for editor consumers
-("new document"): each field that declares an `example:` is committed, and
-**every other field is left absent**. The seeding cascade is therefore
-`example: → absent`: absent fields are never written; they are interpolated at
+("new document"): each **cell** that declares an `example:` is committed, and
+**every other cell is left absent**. The seeding cascade is therefore
+`example: → absent`: absent cells are never written; they are interpolated at
 the compilation layer by [blank-filled render](#blank-filled-render) (`default:`,
 else the field's blank), exactly as for any authored document.
+
+Seeding descends a namespace for the same reason the render floor does: a typed
+dictionary carries no `example:` of its own, so its seed is composed from
+whatever its properties commit, and it stays absent when none of them commit
+anything. The commit is **sparse** at every depth — only the cells with an
+`example:` appear, and the rest defer to the render floor — so a nested
+`example:` is reachable at all. It otherwise would not be: the render floor never
+emits an `example`, and the blueprint is a different document.
 
 **Seed-commits-rest.** A seeded content field commits its codec's resting form
 (a richtext field and the body the canonical content, a plaintext field its
@@ -625,7 +693,9 @@ encode opposite author intents:
   authored value always wins: `ladder_sourced` in core's
   `quill::compose`). The blueprint renders that concrete default value with a
   type-only annotation. Type-empty defaults (`default: ""`, `[]`, `false`, `0`)
-  are the canonical way to mark a "skippable" cell.
+  are the canonical way to mark a "skippable" cell; a *dictionary* is skippable
+  by its properties each carrying one, since the container holds no literal
+  ([Cells and namespaces](#cells-and-namespaces)).
 - **`example`** matches the semantic and type *shape* of the desired
   value but is *not* the value most authors want. It documents shape, not
   the choice, so it never becomes the rendered value; it takes the cell in the

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -325,11 +325,9 @@ Every field value comes from one of a small set of **sources**, ordered by
 *commitment*: how strongly the value claims to be the real answer. This is the
 **commitment ladder**:
 
-The ladder is cut per **cell**, not per field. A cell is any leaf, an `array`
-(arity is a fact no element declaration carries), and a variant discriminant. An
-`object` and a variant's world are **namespaces**: they hold no value of their
-own, and theirs is the composition of their cells'. See
-[Cells and namespaces](#cells-and-namespaces).
+The ladder is cut per **cell**, not per field: see
+[Cells and namespaces](#cells-and-namespaces) for which shapes are which, and
+what follows for literals and for absence.
 
 | Rung | Source | Persisted into a `Document`? | Renders? |
 |---|---|---|---|
@@ -396,11 +394,9 @@ Two rules follow, and between them the plate is total at every depth:
   exactly as an authored element is, and writing `contact: {}` is a no-op rather
   than an edit that changes the render.
 
-A namespace has no rung of its own, so [`resolve()`](#the-resolved-value-view-resolve)
-reports the strongest rung that contributed: `authored` if the document wrote any
-of it, else `default` if any cell below resolved to one, else the floor. Nothing
-inside a container the document did not author can read `authored`, however the
-seed reached it.
+A namespace has no rung of its own, so what
+[`resolve()`](#the-resolved-value-view-resolve) reports for one is derived: see
+that section.
 
 The consumer-side `Document`-payload × schema join is a **non-goal**:
 [`resolve()`](#the-resolved-value-view-resolve) supersedes it. The
@@ -429,14 +425,15 @@ value, source }` rows in declaration order: order is structural, not object-key
 order. The card body is a `body` sibling on the card, not a row in `fields`:
 present iff the kind enables a body (`enabled: false` undeclares it, so `body` is
 `null`), its source only ever `authored` (non-blank) or `blank` (blank).
-Source is one rung per **field**, and a container's is the strongest rung that
-contributed to it ([Cells and namespaces](#cells-and-namespaces)): a container
-authored at all reads `authored` however much of it the document left to the
-floor, and an absent one reads `default` when any cell below took a `default:`.
-So the rung answers *"does anything here come from the schema"* at any depth,
-but not *which cell*. Per-subpath rows are a further view: the descent computes
-each cell's rung already, so exposing them is additive to this shape rather than
-a second resolver, and waits on a consumer naming the call site.
+Source is one rung per **field**. A namespace holds no rung of its own
+([Cells and namespaces](#cells-and-namespaces)), so it reports the strongest that
+contributed: `authored` when the document wrote any of it, else `default` when a
+cell below resolved to one, else the floor. Nothing inside a container the
+document did not author reads `authored`, however the seed reached it. So the
+rung answers *"does anything here come from the schema"* at any depth, but not
+*which cell*. Per-subpath rows are a further view: the descent computes each
+cell's rung already, so exposing them is additive to this shape rather than a
+second resolver, and waits on a consumer naming the call site.
 
 Value and provenance only. The view carries no diagnostics: completeness and
 errors stay `Quill::validate`'s, which a consumer merges with its own producers


### PR DESCRIPTION
Closes #1313, which scopes the defect to a container's own `default:`. Measured, it is larger: the issue's row 1 — certified there as the correct baseline, *"the blank floor is total"* — is broken the same way.

## Measured before

`compile_data`, document authoring nothing unless stated. Schema: `contact: object` with `name`, `email {default: hi@example.com}`, `when: date {default: 2026-01-01}`, `addr: object { city {default: Pgh} }`.

| container `default:` | document | plate for `contact` |
|---|---|---|
| none | unset | `{"name":"","email":"","when":"","addr":{"city":""}}` |
| none | `contact: {}` | `{"name":"","email":"hi@example.com","when":"2026-01-01","addr":{"city":""}}` |
| `{}` | unset | `{}` |
| `{name: A}` | unset | `{"name":"A"}` |

Four consequences, each verified rather than inferred:

- **An absent container skipped every leaf `default:` inside it**, at every depth. Typing `contact: {}` — a no-op edit — changed the render.
- **`default: {}` emitted a plate with no declared key.** BLUEPRINT.md documents it as expanding to the blank-filled shape, and the blueprint does; the two contradicted each other on a documented case.
- **The blueprint disagreed on row 1 too**: it printed `hi@example.com`, `2026-01-01`, `Pgh` where the render printed `""`, `""`, `""` — so "shippable as-is (delete the line to fall back to the default)" was false for any cell inside a container.
- **The value and obligation axes disagreed about one cell**: `default: {name: A}` rendered `A` *and* raised `validation::must_fill` at `main.c.name`, since `must_fill` derives per property.

Downstream, `_qm-meta` is built from the schema while `emit_value` walks the data, so `form-field(field: "contact.email")` compiled against an address whose key the plate did not carry, and a direct `data.contact.email` read was a compile error.

## What changed

**Resolution is a descent, never a return** (`compose.rs`). `resolve_value_sourced` picks a *seed* (`default_content` › `default` › nothing) and hands it to a new `compose`, which rebuilds a container from its declared members whichever rung the seed came from. Absence is inherited rather than terminal, so each cell cuts its own ladder at any depth. Terminates by strict schema descent. The variant container already worked this way and stops being the special case.

**A literal is declared where its cell is** (`config.rs`) — **breaking**. `default:`/`example:` on an `object` with `properties` is a load error, `quill::default_on_namespace` / `quill::example_on_namespace`, hinting the properties that hold it. This is the variant container's existing rule (`quill::default_type_mismatch`) generalized. An `array` keeps its literal: `items:` fixes the element type but never the arity. The container literal was also unchecked — `default: {nope: 1}` loaded and crossed an undeclared key.

**Seeding descends** (`seed.rs`). A dictionary with no `example:` of its own seeded nothing, so a property's `example:` was unreachable at every projection — the render floor never emits an example, and the blueprint is a different document. Required for the load error above to be non-lossy.

**The container rung is honest** (`resolved.rs`). `FieldSource` is `Ord` (floor first) with a `join`; a namespace reports the strongest rung that contributed. A `ceiling` in `compose` stops a cell fed from a container default from claiming `authored`.

## Measured after

Rows 1 and 2 both yield `{"name":"","email":"hi@example.com","when":"2026-01-01","addr":{"city":"Pgh"}}` — `contact: {}` is a true no-op. Row 3 is a load error; per-property type-empty defaults are the spelling that reaches the plate. `default: [{who: A}]` yields `[{"who":"A","role":"lead"}]`, identical to authoring that row.

## Scope and risk

`cargo test --workspace`: **1146 passing, 0 failing**, goldens included; no new clippy warnings. Prototyping the descent alone against the pre-existing suite produced zero failures, so no in-tree quill's output moves. Five tests asserted the shape the load error removes and were rewritten to assert the new rule; one new test pins that the blueprint's cells and the plate's cells agree, the invariant `default: {}` was violating in both directions.

External quills declaring an object-level literal will fail to load — loud and one line to fix per site, and a schema change is a new quill version under VERSIONING regardless. No in-tree quill declares one; array literals (`usaf_memo`, `sample_form`, `classic_resume`) are unaffected.

**On `resolve()`**: this ships the rung's *meaning*, not a per-cell tree. `ResolvedField` is `#[non_exhaustive]`, so nested rows stay additive later; what 1.0 would freeze is the existing field's semantics, and that is what is corrected here. The full tree has real design tension — an `array` is both a cell and a namespace — worth deciding deliberately rather than in this PR.

No migration guide: those land at release time in this repo (`d50a76b` for 0.106→0.107), so the four CHANGELOG `Unreleased` entries are the artifact.

Docs: `SCHEMAS.md` gains a "Cells and namespaces" section and restates the ladder per cell; `BLUEPRINT.md` loses the typed-dictionary `default:` cascade; `PLATE_DATA.md`'s totality claim is now true; `quill-yaml-reference.md` documents where a literal may be declared.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1v9Axrd1kYW8UkigLJEQV)_