### PR TITLE
fix: the variant container joins its cells' rungs, as every namespace does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@
   wrote any of it, else `default` when a cell below resolved to one, else the
   floor. An absent container over defaulted cells read `blank` while rendering
   those defaults, which is the fact an editor ghosts from. Nothing inside a
-  container the document did not author reads `authored`.
+  container the document did not author reads `authored`. A variant container
+  counts its live world's cells the same way, so writing one of them lifts a
+  container whose discriminant fell to the schema's `default:`.
 
 - chore(deps): the Typst floor moves to 0.15.1. The workspace already resolved
   there under the 0.15.0 caret; the pin now names the version the tree is built

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -474,11 +474,9 @@ fn plate_fields(
 }
 
 /// The value half of [`resolve_value_sourced`], discarding the rung tag: the
-/// nested-recursion helper for a typed dictionary's properties and a typed
-/// array's elements, where the source of an inner cell is not surfaced (a
-/// present dict/array is [`Authored`](FieldSource::Authored) as a whole). Both
-/// canon projections cut the sourced ladder through [`resolve_card_sourced`];
-/// this is the inner value-only cut beneath it.
+/// nested cut for a typed array's elements, whose rungs no projection surfaces —
+/// an `array` is a cell, since arity is a fact no leaf carries, so its own rung
+/// is the one its seed supplied.
 fn resolve_value(value: Option<&QuillValue>, field: &FieldSchema) -> QuillValue {
     resolve_value_sourced(value, field).0
 }
@@ -554,33 +552,18 @@ fn seed_default(field: &FieldSchema) -> Option<QuillValue> {
 /// undeclared `note:` on a typed dict reaches the plate instead of being
 /// silently dropped.
 ///
-/// `outer` is the container's own rung, which **ceilings** its cells': nothing
-/// inside a container the document did not author may read
-/// [`Authored`](FieldSource::Authored). [`resolve_value_sourced`] cannot tell a
-/// seeded value from a written one, so without the ceiling a cell fed from a
-/// container `default:` would report itself authored.
+/// `seed_rung` is the rung that supplied `seed`, and it ceilings the cells'
+/// ([`compose_members`]).
 fn compose(
     seed: Option<&QuillValue>,
     field: &FieldSchema,
-    outer: FieldSource,
+    seed_rung: FieldSource,
 ) -> (QuillValue, FieldSource) {
-    let ceiling = match outer {
-        FieldSource::Authored => FieldSource::Authored,
-        _ => FieldSource::Default,
-    };
     match (&field.r#type, &field.properties, &field.items) {
         (FieldType::Object, Some(props), _) => {
             let obj = seed.and_then(|v| v.as_json().as_object());
             let mut out = serde_json::Map::new();
-            let mut rung = FieldSource::Blank;
-            for (pname, pschema) in props {
-                let pv = obj
-                    .and_then(|o| o.get(pname))
-                    .map(|j| QuillValue::from_json(j.clone()));
-                let (value, source) = resolve_value_sourced(pv.as_ref(), pschema);
-                rung = rung.join(source.min(ceiling));
-                out.insert(pname.clone(), value.into_json());
-            }
+            let rung = compose_members(obj, props, seed_rung, &mut out);
             // Preserve undeclared keys verbatim; only rebuild the ones the
             // schema names. Skips keys already emitted above so a declared
             // property keeps its resolved (blank-filled) value.
@@ -613,6 +596,40 @@ fn compose(
     }
 }
 
+/// Resolve every declared member of a namespace over its slice of `seed` into
+/// `out`, reporting the strongest rung any of them contributed. The two
+/// namespaces a schema can spell — a typed dictionary's `properties` and the
+/// live world of a variant container — compose identically; only the seed and
+/// the discriminant differ.
+///
+/// `seed_rung` is where the seed itself came from, and it **ceilings** its
+/// members': a value the document did not write may not read
+/// [`Authored`](FieldSource::Authored) one level down.
+/// [`resolve_value_sourced`] cannot tell a seeded value from a written one, so
+/// without the ceiling a cell fed from a container `default:` would report
+/// itself authored.
+fn compose_members(
+    seed: Option<&serde_json::Map<String, serde_json::Value>>,
+    members: &IndexMap<String, Box<FieldSchema>>,
+    seed_rung: FieldSource,
+    out: &mut serde_json::Map<String, serde_json::Value>,
+) -> FieldSource {
+    let ceiling = match seed_rung {
+        FieldSource::Authored => FieldSource::Authored,
+        _ => FieldSource::Default,
+    };
+    let mut rung = FieldSource::Blank;
+    for (name, schema) in members {
+        let cell = seed
+            .and_then(|o| o.get(name))
+            .map(|j| QuillValue::from_json(j.clone()));
+        let (value, source) = resolve_value_sourced(cell.as_ref(), schema);
+        rung = rung.join(source.capped_at(ceiling));
+        out.insert(name.clone(), value.into_json());
+    }
+    rung
+}
+
 /// Resolve a variant-bearing enum into the container the plate receives:
 /// `{value: <member>}` plus, when that member owns a field set, exactly that
 /// set — each cell blank-filled by the ordinary ladder.
@@ -626,8 +643,8 @@ fn compose(
 /// that world is present, so no guarded access is needed; outside it, none is.
 ///
 /// The discriminant cuts the same ladder as any enum (authored › `default:` ›
-/// blank) and its rung is the container's: a member nobody chose leaves the
-/// whole cell at the rung that supplied it.
+/// blank), and the container reports it joined with what its live world's cells
+/// contributed ([`compose_members`]) — the rule every namespace follows.
 fn resolve_variant_sourced(
     value: Option<&QuillValue>,
     field: &FieldSchema,
@@ -664,21 +681,26 @@ fn resolve_variant_sourced(
         VARIANT_DISCRIMINANT_KEY.to_string(),
         serde_json::Value::String(member.clone()),
     );
-    if let Some(fields) = field.variant_fields(&member) {
-        let object = authored.and_then(|j| j.as_object());
-        for (name, schema) in fields {
-            let cell = object
-                .and_then(|o| o.get(name))
-                .map(|j| QuillValue::from_json(j.clone()));
-            out.insert(
-                name.clone(),
-                resolve_value(cell.as_ref(), schema).into_json(),
-            );
-        }
-    }
+    // The cells are seeded from the authored container, never from the
+    // discriminant's `default:` — a member the schema chose brings no values
+    // with it — so their ceiling is whether the document wrote the container,
+    // not which rung supplied the tag.
+    let seed_rung = match present {
+        Some(_) => FieldSource::Authored,
+        None => FieldSource::Blank,
+    };
+    let cells = match field.variant_fields(&member) {
+        Some(fields) => compose_members(
+            authored.and_then(|j| j.as_object()),
+            fields,
+            seed_rung,
+            &mut out,
+        ),
+        None => FieldSource::Blank,
+    };
     (
         QuillValue::from_json(serde_json::Value::Object(out)),
-        source,
+        source.join(cells),
     )
 }
 

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -14,24 +14,31 @@ use crate::{Card, Document, QuillValue};
 
 /// The rung of the commitment ladder that produced a [`ResolvedField::value`].
 /// Serializes lowercase (`"authored" | "default" | "blank"`).
-///
-/// Variants are declared floor-first, so `Ord` ranks by *commitment*: how
-/// strongly the value claims to be the real answer. Reordering them reorders the
-/// ladder.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum FieldSource {
+    /// The authored value: the document's own content.
+    Authored,
+    /// The schema `default:` (or its content form for a content field).
+    Default,
     /// The field's [`blank`](crate::quill::blank): its spelling of
     /// "explicitly nothing", and the render floor.
     Blank,
-    /// The schema `default:` (or its content form for a content field).
-    Default,
-    /// The authored value: the document's own content.
-    Authored,
 }
 
 impl FieldSource {
+    /// Height on the ladder: how strongly the value claims to be the real
+    /// answer. Private, so the two operations below are the ladder's only
+    /// order — a consumer reads a rung, it never compares two.
+    fn commitment(self) -> u8 {
+        match self {
+            Self::Blank => 0,
+            Self::Default => 1,
+            Self::Authored => 2,
+        }
+    }
+
     /// The more committed of two rungs.
     ///
     /// A container has no rung of its own — it is a namespace, and its value is
@@ -39,7 +46,20 @@ impl FieldSource {
     /// contributed to it: authored if the document wrote any of it, else
     /// `default` if any cell below resolved to one, else the floor.
     pub(crate) fn join(self, other: Self) -> Self {
-        self.max(other)
+        if other.commitment() > self.commitment() {
+            other
+        } else {
+            self
+        }
+    }
+
+    /// This rung, held down to `ceiling`.
+    pub(crate) fn capped_at(self, ceiling: Self) -> Self {
+        if self.commitment() > ceiling.commitment() {
+            ceiling
+        } else {
+            self
+        }
     }
 }
 

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -459,6 +459,31 @@ fn resolve_reports_the_container_as_one_cell_matching_the_plate() {
     assert_eq!(row.source, crate::quill::resolved::FieldSource::Default);
 }
 
+/// The container is a namespace like any other: its rung is the strongest that
+/// contributed, so a cell the document wrote lifts a container whose
+/// discriminant came from the schema.
+#[test]
+fn an_authored_cell_lifts_a_defaulted_discriminant() {
+    let yaml = quill_yaml().replace(
+        "      default: \"\"\n      variants:",
+        "      default: CUI\n      variants:",
+    );
+    let quill = quill_from_yaml(&yaml);
+    let document = doc("classification:\n  controlled_by: SAF/AA\n");
+    let row = quill
+        .resolve(&document)
+        .main
+        .fields
+        .into_iter()
+        .find(|f| f.name == "classification")
+        .expect("classification row");
+    assert_eq!(
+        row.value.as_json(),
+        &json!({ "value": "CUI", "controlled_by": "SAF/AA", "category": "" })
+    );
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Authored);
+}
+
 // ------------------------------------------------------------------ validation
 
 /// The conditional-obligation payoff: a field with no `default:` is obliged in


### PR DESCRIPTION
Closes #1317.

#1315 made a namespace report the strongest rung any cell below contributed and documented it as universal — in `FieldSource::join`, in `RESOLVED_TS`, and in SCHEMAS.md, whose "Cells and namespaces" table already lists *a variant's field set* as a namespace. `resolve_variant_sourced` did not do it: it reported the discriminant's rung alone and resolved each cell through the unsourced cut, so nothing below could lift the container off the rung the tag supplied.

## The gap is observable

The issue scopes this as a code-and-doc symmetry gap with no constructible divergence. Measured, there is one.

Coercion never injects the default discriminant (`coerce_variant` copies the `value` key when the document wrote one and otherwise leaves it out), so a container the document *did* write, without a `value:` key, arrives present with its member taken from the schema's `default:`:

```yaml
classification:
  controlled_by: SAF/AA     # authored cell, no `value:`
```

| | container rung |
|---|---|
| before | `default` |
| after | `authored` |

The plate was already correct — `{"value":"CUI","controlled_by":"SAF/AA","category":""}` either way. Only the rung lied, and it is the fact an editor ghosts from.

Verified by reverting the fix under the new test: `left: Default, right: Authored`.

## What changed

**One composition for both namespaces** (`compose.rs`). The typed dictionary's cell loop and the variant's were the same loop; the variant's was missing the join. They are now one `compose_members` — declared members over their slice of the seed, each cell's rung joined under the seed's ceiling — called from `compose`'s object branch and from `resolve_variant_sourced`. The shape that could drift is gone rather than corrected in two places.

**The ceiling is the cells' seed, not the discriminant.** A member the schema chose brings no values with it: the variant's cells are seeded from the authored container or from nothing. Passing the discriminant's rung would have capped the case above back to `default` — the ceiling asks whether the document wrote the container, which for the object branch is the same question its seed rung already answers.

**`FieldSource` drops `Ord`** (`resolved.rs`). The derive made a `#[non_exhaustive]` enum's variant order load-bearing and handed consumers the comparison the ladder is defined by while `join` stayed `pub(crate)` — the second half of #1317. The order is now a private `commitment()`, and the two operations over it (`join`, `capped_at`) are the ladder's only order. The declaration returns to strongest-first, so #1315's public delta on this type is now nil. Adding `Ord` or a public `join` stays additive for a consumer that names the call site.

Docs are unchanged: all three sites state the general rule, and the code is what was out of step. The CHANGELOG entry #1315 added is still `Unreleased`, so it gains a clause rather than a second bullet.

## Scope and risk

`cargo test --workspace`: **1147 passing, 0 failing**, goldens included; `cargo clippy --workspace --all-targets` reports nothing on either touched file. No in-tree quill declares a variant `default:`, so no render output moves — the change is confined to what `resolve()` reports.

Behavior relative to 0.107: a variant container whose discriminant fell to the schema's `default:` now reads `authored` when the document wrote one of its cells. That is the rung meaning #1315 already shipped for a typed dictionary, applied to the one container it missed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vNqZkuVtQ9pGCS7aHzmYA)_