### PR TITLE
Retire `must_fill:`: obligation is a reading of `default:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,36 @@
   an undeclared key to the plate. This is the variant container's rule
   (`quill::default_type_mismatch`) generalized; an `array` keeps its literal,
   since `items:` fixes the element type but never the arity.
+- **breaking** `must_fill:` is retired: obligation is a reading of `default:`,
+  never a declaration of its own. Declaring the key is a load error
+  (`quill::field_parse_error`) naming the migration that field's shape takes,
+  `FieldSchema::must_fill()` is `default.is_none()`, and the raw
+  `FieldSchema.must_fill` field is gone. Four of the five legacy declarations
+  restate the derivation and migrate by **deletion**: `must_fill:` on a typed
+  dictionary (a namespace carries no obligation — its leaves do), `must_fill:
+  true` with no `default:`, and `must_fill: false` beside one. `must_fill:
+  false` with no `default:` becomes `default: <the type's blank>` (`""`, `[]`,
+  `0`, `false`) — already the corpus's most common `default:`. The fifth,
+  `must_fill: true` beside a `default:`, is the one behavior deleted and the
+  one judgment call: keep the `default:` to render the value unasked, or move
+  it to `example:` to keep the ask. An example fills the blueprint cell the
+  default vacated, seeds *carrying* the `!must_fill` marker where a
+  `default:`-only field seeds nothing, and never renders — so an untouched
+  document renders the blank rather than asserting a value nobody chose. For a
+  `string` or `enum` the blueprint bytes are identical either way; three shapes
+  are not. A `richtext` example never inlines, so its cell becomes a bare
+  marker and the value survives only as the `# e.g.` hint. An
+  `integer`/`number`/`boolean` blank is indistinguishable at the plate from an
+  authored zero. On a variant container the two targets select different
+  worlds: `default: CUI` renders the CUI world and obliges its cells, while
+  `example: CUI` leaves the discriminant blank. Also removed:
+  `quillmark:must_fill` from the transform schema, which is the wire *validity*
+  contract, and an unauthored must-fill cell is wire-valid by design; the
+  declaration view carries `default:` for a consumer that wants to derive.
+  No in-tree quill declared the key and the declaration view emits only what an
+  author wrote, so no emitted JSON changes for any real quill — the WASM
+  `QuillFieldSchema` TS interface loses `must_fill?: boolean`, a compile-time
+  break for editors typed against it.
 - fix: **seeding descends into a container's `example:`.** A dictionary with no
   `example:` of its own seeded nothing, so a property's `example:` was
   unreachable at every projection — the render floor never emits an example, and

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -185,8 +185,8 @@ value under a type-only `# <type>` annotation and the render path uses it when
 the document omits the field. Without one, an `example` takes the cell as a
 suggested value, and an absent field blank-fills.
 
-**Obligation** — whether a human must author the field, declared by
-`must_fill:` and deriving from `default:`'s absence when left unset. An obliged
+**Obligation** — whether a human must author the field, read off `default:`'s
+absence: a defaulted field asks nobody, a defaultless one asks. An obliged
 field carries the `!must_fill` marker in the blueprint, and validation emits the
 non-fatal `validation::must_fill` warning while the document leaves it
 unauthored — from either of two triggers, named by the diagnostic's `trigger`

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -396,8 +396,8 @@ that value under a type-only `# <type>` annotation and the render path uses it
 when the document omits the field. Without one, an `example` takes the cell as
 a suggested value, and an absent field blank-fills.
 
-**Obligation** — whether a human must author the field, declared by
-`must_fill:` and deriving from `default:`'s absence when left unset. An obliged
+**Obligation** — whether a human must author the field, read off `default:`'s
+absence: a defaulted field asks nobody, a defaultless one asks. An obliged
 field carries the `!must_fill` marker in `quill.blueprint`, and
 `quill.validate(doc)` emits the non-fatal `validation::must_fill` warning while
 the document leaves it unauthored — from either of two triggers, named by the

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -65,12 +65,11 @@ export interface QuillCardBody {
 
 /** Schema entry for a single field declared in a quill's `Quill.yaml`.
  *
- * Two independent axes, and no separate `required` one. `default` and
- * `example` say what the cell holds; `must_fill` says whether a human must
- * author it, deriving from `default`'s absence when left unset. An obliged
- * field carries a `!must_fill` marker in the blueprint and warns
- * `validation::must_fill` while the document leaves it unauthored. Neither
- * axis gates render: an absent field blank-fills.
+ * One declared dial, and no `required` key. `default` and `example` say what
+ * the cell holds, and `default`'s absence is also the obligation: a field
+ * nobody declared a value for carries a `!must_fill` marker in the blueprint
+ * and warns `validation::must_fill` while the document leaves it unauthored.
+ * Neither gates render: an absent field blank-fills.
  */
 export interface QuillFieldSchema {
     type: "string" | "number" | "integer" | "boolean" | "array" | "object" | "date" | "datetime" | "richtext" | "plaintext" | "enum";
@@ -85,9 +84,6 @@ export interface QuillFieldSchema {
      *  member. Declaring it makes the field rest as a container,
      *  `{value: <member>, …that member's fields}`, rather than a bare string. */
     variants?: Record<string, Record<string, QuillFieldSchema>>;
-    /** Whether a human must author the field. Absent, it derives from
-     *  `default`: a defaulted field is unobliged, a defaultless one obliged. */
-    must_fill?: boolean;
     ui?: QuillFieldUi;
     properties?: Record<string, QuillFieldSchema>;
     items?: QuillFieldSchema;

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -65,11 +65,11 @@ export interface QuillCardBody {
 
 /** Schema entry for a single field declared in a quill's `Quill.yaml`.
  *
- * One declared dial, and no `required` key. `default` and `example` say what
- * the cell holds, and `default`'s absence is also the obligation: a field
- * nobody declared a value for carries a `!must_fill` marker in the blueprint
- * and warns `validation::must_fill` while the document leaves it unauthored.
- * Neither gates render: an absent field blank-fills.
+ * One declaration, and no `required` key. `default` and `example` say what the
+ * cell holds, and `default`'s absence is the obligation: a field nobody
+ * declared a value for carries a `!must_fill` marker in the blueprint and warns
+ * `validation::must_fill` while the document leaves it unauthored. Neither
+ * gates render: an absent field blank-fills.
  */
 export interface QuillFieldSchema {
     type: "string" | "number" | "integer" | "boolean" | "array" | "object" | "date" | "datetime" | "richtext" | "plaintext" | "enum";

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -228,9 +228,8 @@ fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool
 }
 
 /// The cell's `(value, fill)` for a scalar/array/richtext leaf. The value is
-/// `default:` › `example:` › bare null; the marker is the field's derived
-/// `must_fill`. Both read `default:`: a defaulted cell shows its value unmarked,
-/// a defaultless one carries the marker over whatever `example:` suggests.
+/// `default:` › `example:` › bare null; the marker is `default:`'s absence, so
+/// an `example` always arrives under it.
 fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
     (scalar_value(field), field.must_fill())
 }
@@ -675,7 +674,6 @@ main:
     note: { type: string, default: "" }
 "#)
         .blueprint();
-        // The type's blank is how a quill says "optional, nothing to suggest".
         assert!(t.contains("\nnote: \"\" # string\n"), "{t}");
         assert!(!t.contains("!must_fill"), "{t}");
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -182,8 +182,8 @@ fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
 
     if typed_dict_props(field).is_some() || typed_table_props(field).is_some() {
         // The container key itself is untagged: `!must_fill` is rejected on a
-        // mapping (`prose/references/markdown-spec.md` §3.4), so a container's
-        // own `must_fill:` is inert and the obligation lives on its leaves.
+        // mapping (`prose/references/markdown-spec.md` §3.4), so the obligation
+        // lives on the leaves.
         push_leading(items, field, true);
         let (value, nested, fills) = container_cell(field, &[]);
         push_container_field(items, &field.name, value, nested, fills, field);
@@ -227,13 +227,10 @@ fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool
     }
 }
 
-/// The cell's `(value, fill)` for a scalar/array/richtext leaf: the two axes
-/// read independently. The value is `default:` › `example:` › bare null; the
-/// marker is the field's derived `must_fill`. A field carrying both a default
-/// and `must_fill: true` therefore shows the default *and* asks for
-/// confirmation, and an explicitly optional field with nothing to suggest emits
-/// a bare unmarked cell (the type annotation alone tells the reader what goes
-/// there).
+/// The cell's `(value, fill)` for a scalar/array/richtext leaf. The value is
+/// `default:` › `example:` › bare null; the marker is the field's derived
+/// `must_fill`. Both read `default:`: a defaulted cell shows its value unmarked,
+/// a defaultless one carries the marker over whatever `example:` suggests.
 fn scalar_cell(field: &FieldSchema) -> (JsonValue, bool) {
     (scalar_value(field), field.must_fill())
 }
@@ -651,50 +648,39 @@ main:
         assert!(t.contains("# e.g. Hello world\nbio: !must_fill # richtext<markdown>\n"));
     }
 
+    /// A suggested value a human must still confirm: the example takes the cell
+    /// no `default:` holds, and the derived obligation marks it there.
     #[test]
-    fn a_default_and_an_explicit_must_fill_show_both() {
+    fn an_example_takes_the_cell_it_suggests_under_the_marker() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    classification: { type: enum, values: [UNCLASSIFIED, CUI], default: UNCLASSIFIED, must_fill: true }
+    classification: { type: enum, values: [UNCLASSIFIED, CUI], example: UNCLASSIFIED }
 "#)
         .blueprint();
         assert!(
             t.contains("classification: !must_fill UNCLASSIFIED # enum<UNCLASSIFIED | CUI>\n"),
             "{t}"
         );
+        assert!(!t.contains("e.g."), "the example is the cell, not a hint: {t}");
     }
 
     #[test]
-    fn an_opted_out_field_with_nothing_to_suggest_emits_a_bare_unmarked_cell() {
+    fn a_blank_default_emits_an_unmarked_cell() {
         let t = cfg(r#"
 quill: { name: x, version: 1.0.0, backend: typst, description: x }
 main:
   fields:
-    note: { type: string, must_fill: false }
+    note: { type: string, default: "" }
 "#)
         .blueprint();
-        // `null` is the emitter's spelling of an empty unmarked cell; it parses
-        // back to the state a missing key would.
-        assert!(t.contains("\nnote: null # string\n"), "{t}");
+        // The type's blank is how a quill says "optional, nothing to suggest".
+        assert!(t.contains("\nnote: \"\" # string\n"), "{t}");
         assert!(!t.contains("!must_fill"), "{t}");
 
-        let doc = Document::parse(&t).expect("the bare cell parses").document;
+        let doc = Document::parse(&t).expect("the blank cell parses").document;
         assert_eq!(doc, Document::parse(&doc.to_markdown()).expect("re-emit").document);
-    }
-
-    #[test]
-    fn an_opted_out_field_keeps_its_example_as_the_cell_value() {
-        let t = cfg(r#"
-quill: { name: x, version: 1.0.0, backend: typst, description: x }
-main:
-  fields:
-    note: { type: string, example: A note, must_fill: false }
-"#)
-        .blueprint();
-        assert!(t.contains("note: A note # string\n"), "{t}");
-        assert!(!t.contains("e.g."), "the example is the cell, not a hint: {t}");
     }
 
     #[test]

--- a/crates/core/src/quill/compose/must_fill_tests.rs
+++ b/crates/core/src/quill/compose/must_fill_tests.rs
@@ -1,4 +1,4 @@
-//! The obligation axis: `must_fill:` and the unauthored-cell predicate.
+//! The obligation axis: `default:`'s absence and the unauthored-cell predicate.
 
 use crate::quill::quill_from_yaml;
 use crate::quill::resolved::FieldSource;
@@ -32,8 +32,8 @@ main:
     subject:    { type: string }
     severity:   { type: enum, values: [low, high] }
     status:     { type: string, default: draft }
-    confirmed:  { type: string, default: draft, must_fill: true }
-    optional:   { type: string, must_fill: false }
+    confirmed:  { type: string, example: draft }
+    optional:   { type: string, default: "" }
 "#;
 
 fn md(fields: &str) -> String {

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -305,7 +305,7 @@ mod tests {
     }
 
     /// The projection is the wire *validity* contract, and obligation is not a
-    /// validity fact: an unauthored must-fill cell is wire-valid by design, so a
+    /// validity fact: an unauthored must-fill cell is wire-valid by design. A
     /// `required`-shaped flag here would read as the gate `SCHEMAS.md` forbids.
     #[test]
     fn obligation_does_not_cross_into_the_transform_schema() {

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -27,18 +27,6 @@ pub const QUILLMARK_PLAIN_KEY: &str = "quillmark:plain";
 /// conventional label.
 pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 
-/// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
-///
-/// The descriptor marks richtext fields with `contentMediaType:
-/// application/quillmark-content+json` (see [`CONTENT_MEDIA_TYPE`]) and
-/// date/date-time fields with the corresponding JSON Schema `format`.
-///
-/// `$body` is injected into a kind's `properties` only when that kind's
-/// `body.enabled` is not `false`. A body-disabled kind's `$body` is absent,
-/// not present-and-empty: absence cascades through the `__meta__` address
-/// tables so `form-field(field:)` rejects `$body` addresses on that
-/// kind at compile time, matching `Quill::validate`'s hard error on authored
-/// body content for the same kind.
 /// The discriminant cell of a variant-bearing enum: the same
 /// `{type: string, enum: ["", …]}` a plain enum projects to. The container is a
 /// mapping and therefore not a cell, so this is where the choice lands.
@@ -66,6 +54,18 @@ fn discriminant_schema(field: &FieldSchema) -> serde_json::Value {
     serde_json::Value::Object(schema)
 }
 
+/// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
+///
+/// The descriptor marks richtext fields with `contentMediaType:
+/// application/quillmark-content+json` (see [`CONTENT_MEDIA_TYPE`]) and
+/// date/date-time fields with the corresponding JSON Schema `format`.
+///
+/// `$body` is injected into a kind's `properties` only when that kind's
+/// `body.enabled` is not `false`. A body-disabled kind's `$body` is absent,
+/// not present-and-empty: absence cascades through the `__meta__` address
+/// tables so `form-field(field:)` rejects `$body` addresses on that
+/// kind at compile time, matching `Quill::validate`'s hard error on authored
+/// body content for the same kind.
 pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     fn field_to_schema(field: &FieldSchema) -> serde_json::Value {
         let mut schema = serde_json::Map::new();

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -27,15 +27,6 @@ pub const QUILLMARK_PLAIN_KEY: &str = "quillmark:plain";
 /// conventional label.
 pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 
-/// Transform-schema keyword carrying whether a human must author the field
-/// ([`FieldSchema::must_fill`](crate::quill::FieldSchema::must_fill)). Emitted
-/// on every field, always resolved: the obligation is not derivable from this
-/// projection, which carries no `default:`.
-///
-/// It is an authoring affordance, not a submit gate. An unfilled field renders,
-/// and enforcement — if a consumer wants any — is that consumer's policy.
-pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
-
 /// Build a JSON-Schema-shaped descriptor of a [`QuillConfig`]'s main + card fields.
 ///
 /// The descriptor marks richtext fields with `contentMediaType:
@@ -49,16 +40,10 @@ pub const QUILLMARK_MUST_FILL_KEY: &str = "quillmark:must_fill";
 /// kind at compile time, matching `Quill::validate`'s hard error on authored
 /// body content for the same kind.
 /// The discriminant cell of a variant-bearing enum: the same
-/// `{type: string, enum: ["", …]}` a plain enum projects to, carrying the
-/// container's obligation. The container is a mapping and therefore not a cell
-/// (`!must_fill` is rejected on one), so this is where "a human must choose"
-/// lands.
+/// `{type: string, enum: ["", …]}` a plain enum projects to. The container is a
+/// mapping and therefore not a cell, so this is where the choice lands.
 fn discriminant_schema(field: &FieldSchema) -> serde_json::Value {
     let mut schema = serde_json::Map::new();
-    schema.insert(
-        QUILLMARK_MUST_FILL_KEY.to_string(),
-        serde_json::Value::Bool(field.must_fill()),
-    );
     schema.insert(
         "type".to_string(),
         serde_json::Value::String("string".to_string()),
@@ -84,14 +69,6 @@ fn discriminant_schema(field: &FieldSchema) -> serde_json::Value {
 pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
     fn field_to_schema(field: &FieldSchema) -> serde_json::Value {
         let mut schema = serde_json::Map::new();
-        // In the prelude, not a type arm: the enum arm returns early below, and
-        // an enum is the type an obligation matters most for. The *derived*
-        // answer crosses, not the raw `Option` — a consumer reading this
-        // projection should never have to re-run the `default:` derivation.
-        schema.insert(
-            QUILLMARK_MUST_FILL_KEY.to_string(),
-            serde_json::Value::Bool(field.must_fill()),
-        );
         // A finite domain projects to the idiomatic JSON-Schema spelling
         // `{type: string, enum: [...]}`: exactly what a backend dispatches on
         // today (a plain string), plus the domain. Keyed on the domain, as the
@@ -327,8 +304,11 @@ mod tests {
         build_transform_schema(&config)
     }
 
+    /// The projection is the wire *validity* contract, and obligation is not a
+    /// validity fact: an unauthored must-fill cell is wire-valid by design, so a
+    /// `required`-shaped flag here would read as the gate `SCHEMAS.md` forbids.
     #[test]
-    fn must_fill_is_resolved_and_reaches_every_type() {
+    fn obligation_does_not_cross_into_the_transform_schema() {
         let yaml = r#"
 quill:
   name: x
@@ -339,20 +319,11 @@ main:
   fields:
     severity:   { type: enum, values: [low, high] }
     status:     { type: string, default: draft }
-    confirmed:  { type: string, default: draft, must_fill: true }
-    optional:   { type: string, must_fill: false }
 "#;
         let json = build_from_yaml(yaml).as_json().clone();
-        let flag = |name: &str| json["properties"][name][QUILLMARK_MUST_FILL_KEY].clone();
 
-        // The enum arm returns before the type match, so a key placed in a type
-        // arm would miss the one type an obligation matters most for.
-        assert_eq!(flag("severity"), serde_json::json!(true));
-        // Derived, not raw: a consumer reading this projection sees no
-        // `default:` and so cannot re-run the derivation itself.
-        assert_eq!(flag("status"), serde_json::json!(false));
-        assert_eq!(flag("confirmed"), serde_json::json!(true));
-        assert_eq!(flag("optional"), serde_json::json!(false));
+        assert!(!json.to_string().contains("must_fill"), "{json}");
+        assert_eq!(json["properties"]["status"], serde_json::json!({"type": "string"}));
     }
 
     #[test]
@@ -384,7 +355,6 @@ main:
         let domain = serde_json::json!({
             "type": "string",
             "enum": ["", "UNCLASSIFIED", "CUI"],
-            QUILLMARK_MUST_FILL_KEY: true,
         });
         assert_eq!(json["properties"]["classification"], domain);
         // The domain survives the recursion into an array's element object: a
@@ -394,7 +364,6 @@ main:
             serde_json::json!({
                 "type": "string",
                 "enum": ["", "approve", "disapprove"],
-                QUILLMARK_MUST_FILL_KEY: true,
             })
         );
     }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2801,6 +2801,70 @@ fn the_enum_modifier_is_a_load_error_on_every_type() {
     }
 }
 
+/// Every legacy declaration fails load, and the message names the one migration
+/// that shape takes: four are a deletion, and the fifth is the judgment call.
+#[test]
+fn the_must_fill_key_is_a_load_error_naming_its_migration() {
+    for (field, route) in [
+        (
+            "    s:\n      type: string\n      must_fill: true\n",
+            "obliged already",
+        ),
+        (
+            "    s:\n      type: string\n      default: draft\n      must_fill: false\n",
+            "unobliged already",
+        ),
+        (
+            "    s:\n      type: string\n      must_fill: false\n",
+            "write `default: \"\"`",
+        ),
+        (
+            "    n:\n      type: integer\n      must_fill: false\n",
+            "write `default: 0`",
+        ),
+        (
+            "    tags:\n      type: array\n      items: { type: string }\n      must_fill: false\n",
+            "write `default: []`",
+        ),
+        (
+            "    s:\n      type: string\n      default: draft\n      must_fill: true\n",
+            "move it to `example: \"draft\"`",
+        ),
+        (
+            "    c:\n      type: object\n      properties: { name: { type: string } }\n      \
+             must_fill: false\n",
+            "each property carries its own obligation",
+        ),
+    ] {
+        let err = quill_with_field(field).unwrap_err();
+        assert!(
+            err.iter()
+                .any(|d| d.code.as_deref() == Some("quill::field_parse_error")
+                    && d.message.contains("must_fill: is retired")
+                    && d.message.contains(route)),
+            "must_fill: should fail load routing to `{route}`, got: {err:?}"
+        );
+    }
+}
+
+/// The key is rejected wherever a field schema is, not only at card level.
+#[test]
+fn the_must_fill_key_is_rejected_at_every_depth() {
+    for field in [
+        "    c:\n      type: object\n      properties: { name: { type: string, must_fill: true } }\n",
+        "    tags:\n      type: array\n      items: { type: string, must_fill: true }\n",
+        "    c:\n      type: enum\n      values: [a]\n      variants: { a: { poc: { type: string, must_fill: true } } }\n",
+    ] {
+        let err = quill_with_field(field).unwrap_err();
+        assert!(
+            err.iter()
+                .any(|d| d.code.as_deref() == Some("quill::field_parse_error")
+                    && d.message.contains("must_fill: is retired")),
+            "a nested must_fill: should fail load, got: {err:?}"
+        );
+    }
+}
+
 #[test]
 fn values_on_a_non_enum_type_is_a_load_error() {
     let err = quill_with_field("    s:\n      type: string\n      values: [a, b]\n").unwrap_err();

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -463,8 +463,8 @@ pub const VARIANT_DISCRIMINANT_KEY: &str = "value";
 /// omitted), while `example` matches the desired type and shape but is not
 /// the value most authors want (it documents shape only, never rendering).
 ///
-/// `default:` is the one dial an author turns, and it answers both questions a
-/// field raises. The **value** axis is `default:` › `example:` › the field's
+/// `default:` is the only declaration, and it answers both questions a field
+/// raises. The **value** axis is `default:` › `example:` › the field's
 /// [`blank`](crate::quill::blank), and decides what a cell holds. The
 /// **obligation** axis, [`must_fill()`](Self::must_fill), is a reading of the
 /// same declaration: a field nobody supplied a value for is one a human must
@@ -564,8 +564,8 @@ struct FieldSchemaDef {
     pub inline: Option<bool>,
 }
 
-/// A schema literal spelled as `Quill.yaml` would carry it: JSON is a YAML
-/// subset, so the JSON form pastes back into the file it came from.
+/// A schema literal as `Quill.yaml` would spell it. JSON is a YAML subset, so
+/// the JSON form quotes straight back into the file.
 fn literal(value: &QuillValue) -> String {
     serde_json::to_string(value.as_json()).unwrap_or_else(|_| "null".to_string())
 }
@@ -614,10 +614,8 @@ impl FieldSchema {
         self.variants.is_some()
     }
 
-    /// Whether a human must author this cell: a field the quill author declared
-    /// no value for asks for one, a defaulted field does not. Keyed on
-    /// `default`'s *presence*, so a `default: ""` stays a skippable cell rather
-    /// than becoming a marker.
+    /// Whether a human must author this cell. Keyed on `default`'s *presence*,
+    /// so a `default: ""` stays a skippable cell rather than becoming a marker.
     ///
     /// The blueprint's marker, the seeding stamp and the `Quill::validate`
     /// predicate are one answer, and it is this one.
@@ -697,16 +695,15 @@ impl FieldSchema {
             example_content: None,
         };
         // Last, so the rejection reads the resolved field: the migration it
-        // names turns on the type and the `default:`.
+        // names turns on the type and `default:`.
         match def.must_fill {
             Some(declared) => Err(Self::retired_must_fill(declared, &schema)),
             None => Ok(schema),
         }
     }
 
-    /// The migration for a declared `must_fill:`. Which one the field takes
-    /// turns on the rest of its declaration, which an author cannot read off the
-    /// retired key alone.
+    /// The migration for a declared `must_fill:`, classified by the rest of the
+    /// declaration: the key alone does not say which one the field takes.
     fn retired_must_fill(declared: bool, schema: &FieldSchema) -> String {
         let head = "must_fill: is retired; obligation derives from default:'s absence";
         let namespace = matches!(schema.r#type, FieldType::Object) && schema.properties.is_some();

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -463,16 +463,18 @@ pub const VARIANT_DISCRIMINANT_KEY: &str = "value";
 /// omitted), while `example` matches the desired type and shape but is not
 /// the value most authors want (it documents shape only, never rendering).
 ///
-/// A field carries two independent axes. The **value** axis is `default:` ›
-/// `example:` › the field's [`blank`](crate::quill::blank), and decides what a
-/// cell holds. The **obligation** axis is [`must_fill()`](Self::must_fill), and
-/// decides whether a human must author it. Neither implies the other: a
-/// `default:` can still demand confirmation (`must_fill: true`), and a field
-/// with nothing to suggest can be genuinely optional (`must_fill: false`).
+/// `default:` is the one dial an author turns, and it answers both questions a
+/// field raises. The **value** axis is `default:` › `example:` › the field's
+/// [`blank`](crate::quill::blank), and decides what a cell holds. The
+/// **obligation** axis, [`must_fill()`](Self::must_fill), is a reading of the
+/// same declaration: a field nobody supplied a value for is one a human must
+/// answer.
 ///
 /// Obligation is a warning, never a gate: an unauthored must-fill field
 /// blank-fills and renders, and the only signal is the non-fatal
-/// `validation::must_fill` warning. There is no separate `required:` axis.
+/// `validation::must_fill` warning. There is no separate `required:` axis, and
+/// no `must_fill:` key — [`from_quill_value`](Self::from_quill_value) rejects
+/// one, routing the declaration back to `default:`.
 ///
 /// The richtext single-line constraint has **one** carrier: the
 /// `FieldType::RichText { inline }` enum. The wire's sibling `inline:` key folds
@@ -492,15 +494,11 @@ pub struct FieldSchema {
     pub r#type: FieldType,
     pub description: Option<String>,
     /// The value most authors want; interpolated when the field is omitted.
-    /// Its presence is what an unset `must_fill:` derives from.
+    /// Its presence is the whole of [`must_fill()`](Self::must_fill).
     pub default: Option<QuillValue>,
     /// A value matching the desired type and shape but not the value most
     /// authors want; documents shape only and never renders as the value.
     pub example: Option<QuillValue>,
-    /// Whether a human must author this cell. Read through
-    /// [`must_fill()`](Self::must_fill), never directly: `None` derives from
-    /// `default`.
-    pub must_fill: Option<bool>,
     pub ui: Option<UiFieldSchema>,
     /// Restricts valid values on string fields. Serializes as `enum`.
     pub enum_values: Option<Vec<String>>,
@@ -543,6 +541,9 @@ struct FieldSchemaDef {
     pub description: Option<String>,
     pub default: Option<QuillValue>,
     pub example: Option<QuillValue>,
+    /// The retired `must_fill:` key, parsed only to reject it by name and route
+    /// the author to `default:`
+    /// ([`FieldSchema::retired_must_fill`](FieldSchema::retired_must_fill)).
     pub must_fill: Option<bool>,
     pub ui: Option<UiFieldSchema>,
     /// The retired `enum:` modifier, parsed only to reject it by name: under
@@ -563,6 +564,12 @@ struct FieldSchemaDef {
     pub inline: Option<bool>,
 }
 
+/// A schema literal spelled as `Quill.yaml` would carry it: JSON is a YAML
+/// subset, so the JSON form pastes back into the file it came from.
+fn literal(value: &QuillValue) -> String {
+    serde_json::to_string(value.as_json()).unwrap_or_else(|_| "null".to_string())
+}
+
 impl FieldSchema {
     pub fn new(name: String, r#type: FieldType, description: Option<String>) -> Self {
         Self {
@@ -571,7 +578,6 @@ impl FieldSchema {
             description,
             default: None,
             example: None,
-            must_fill: None,
             ui: None,
             enum_values: None,
             variants: None,
@@ -608,18 +614,15 @@ impl FieldSchema {
         self.variants.is_some()
     }
 
-    /// Whether a human must author this cell, deriving from `default:` when
-    /// `must_fill:` is unset: a field the quill author declared no value for
-    /// asks for one, a defaulted field does not. The derivation is keyed on
+    /// Whether a human must author this cell: a field the quill author declared
+    /// no value for asks for one, a defaulted field does not. Keyed on
     /// `default`'s *presence*, so a `default: ""` stays a skippable cell rather
     /// than becoming a marker.
     ///
-    /// Read this rather than the raw [`must_fill`](Self::must_fill) field: the
-    /// blueprint's marker, the seeding stamp, the `Quill::validate` predicate,
-    /// and the transform schema's `quillmark:must_fill` are one answer, and it
-    /// is this one.
+    /// The blueprint's marker, the seeding stamp and the `Quill::validate`
+    /// predicate are one answer, and it is this one.
     pub fn must_fill(&self) -> bool {
-        self.must_fill.unwrap_or(self.default.is_none())
+        self.default.is_none()
     }
 
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
@@ -632,13 +635,12 @@ impl FieldSchema {
         // `type: enum` requires `values:`; `values:` on any other type, and
         // `enum:` on any type at all, is a hard error.
         let enum_values = Self::resolve_enum_values(&r#type, def.enum_key, def.values)?;
-        Ok(Self {
+        let schema = Self {
             name: key.clone(),
             r#type,
             description: def.description,
             default: def.default,
             example: def.example,
-            must_fill: def.must_fill,
             ui: def.ui,
             enum_values,
             variants: match def.variants {
@@ -693,7 +695,58 @@ impl FieldSchema {
             // them empty.
             default_content: None,
             example_content: None,
-        })
+        };
+        // Last, so the rejection reads the resolved field: the migration it
+        // names turns on the type and the `default:`.
+        match def.must_fill {
+            Some(declared) => Err(Self::retired_must_fill(declared, &schema)),
+            None => Ok(schema),
+        }
+    }
+
+    /// The migration for a declared `must_fill:`. Which one the field takes
+    /// turns on the rest of its declaration, which an author cannot read off the
+    /// retired key alone.
+    fn retired_must_fill(declared: bool, schema: &FieldSchema) -> String {
+        let head = "must_fill: is retired; obligation derives from default:'s absence";
+        let namespace = matches!(schema.r#type, FieldType::Object) && schema.properties.is_some();
+        let route = match (namespace, declared, schema.default.is_some()) {
+            (true, _, _) => "remove it — a typed dictionary is a namespace, and each property \
+                             carries its own obligation"
+                .to_string(),
+            (_, true, false) => {
+                "remove it — a field with no default: is obliged already".to_string()
+            }
+            (_, false, true) => {
+                "remove it — a field with a default: is unobliged already".to_string()
+            }
+            (_, false, false) => format!(
+                "write `default: {}` instead — a defaulted cell is the skippable one",
+                Self::blank_literal(schema)
+            ),
+            (_, true, true) => format!(
+                "keep the default: to render {value} unasked, or move it to `example: {value}` to \
+                 ask — an example seeds under the !must_fill marker and never renders, so an \
+                 untouched document renders {blank}",
+                value = literal(schema.default.as_ref().expect("default is present")),
+                blank = Self::blank_literal(schema),
+            ),
+        };
+        format!("{head}, so {route}")
+    }
+
+    /// The blank as an author writes it into `default:`. Not
+    /// [`blank`](crate::quill::blank), which builds the *resting* form: a prose
+    /// field's is `""` rather than the empty content, and a variant container's
+    /// is the blank discriminant rather than the container.
+    fn blank_literal(schema: &FieldSchema) -> &'static str {
+        match schema.r#type {
+            FieldType::Array => "[]",
+            FieldType::Integer | FieldType::Number => "0",
+            FieldType::Boolean => "false",
+            FieldType::Object => "{}",
+            _ => "\"\"",
+        }
     }
 
     /// Fold the sibling `inline:` key into a prose type's enum payload. Both
@@ -766,7 +819,6 @@ impl Serialize for FieldSchema {
             + self.description.is_some() as usize
             + self.default.is_some() as usize
             + self.example.is_some() as usize
-            + self.must_fill.is_some() as usize
             + self.ui.is_some() as usize
             + self.enum_values.is_some() as usize
             + self.variants.is_some() as usize
@@ -785,12 +837,6 @@ impl Serialize for FieldSchema {
         }
         if let Some(v) = &self.example {
             map.serialize_entry("example", v)?;
-        }
-        // The raw `Option`, not the derived answer: the schema wire is what the
-        // author wrote, and re-emitting the derivation would pin every field's
-        // obligation the first time a quill round-tripped through it.
-        if let Some(v) = &self.must_fill {
-            map.serialize_entry("must_fill", v)?;
         }
         if let Some(v) = &self.ui {
             map.serialize_entry("ui", v)?;

--- a/docs/integration/error-handling.md
+++ b/docs/integration/error-handling.md
@@ -58,7 +58,7 @@ Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed
 Fatality is a two-value ladder: `Error` blocks the stage that emits it; `Warning` never does. There is no lint-level configuration and no warning-to-error promotion. Warnings ride the same `Diagnostic` currency on non-fatal channels:
 
 - **Parse warnings** (e.g. a `~~~` opener missing its blank line) carried on the parsed document (`doc.warnings`) and spliced into a render's warnings.
-- **Validation warnings**: `quill.validate(doc)` returns every diagnostic; `validation::must_fill` and the `$seed` checks are the non-fatal ones. `validation::must_fill` fires on two triggers, named by its `trigger` arg: `marker`, an outstanding `!must_fill` tag in the document, and `unauthored`, a cell the schema obliges (`must_fill:`) that nobody has authored. At most one per path; the marker wins where both apply. The render path never gates on either: an absent field blank-fills.
+- **Validation warnings**: `quill.validate(doc)` returns every diagnostic; `validation::must_fill` and the `$seed` checks are the non-fatal ones. `validation::must_fill` fires on two triggers, named by its `trigger` arg: `marker`, an outstanding `!must_fill` tag in the document, and `unauthored`, a cell the schema obliges (one with no `default:`) that nobody has authored. At most one per path; the marker wins where both apply. The render path never gates on either: an absent field blank-fills.
 - **Compile warnings**: a backend's non-fatal diagnostics (font fallback, overfull pages), carried on `result.warnings`.
 
 A successful render returns artifacts **and** a `warnings` list, so inspect it even on success.

--- a/docs/quills/blueprint.md
+++ b/docs/quills/blueprint.md
@@ -24,7 +24,7 @@ Write main body here.
 
 Two annotation slots, disjoint by purpose: **leading `# …` lines** carry prose (a description, an `# e.g.` example); the **inline `# …`** at the end of a value line carries structure, the field's `# <type>[<format>]`.
 
-The reader's one rule: a **`!must_fill`** marker present → replace it before shipping; a concrete value present → shippable as-is. The cell's *value* is `default:` › `example:` › bare; the *marker* is the field's `must_fill:`, which defaults to "obliged unless a `default:` says otherwise". The two are independent, so a cell can carry a concrete default **and** a marker asking a human to confirm it. A surviving marker never blocks render: it raises only the non-fatal `validation::must_fill` warning; a strict consumer (an LLM authoring loop) treats any outstanding marker as "not done."
+The reader's one rule: a **`!must_fill`** marker present → replace it before shipping; a concrete value present → shippable as-is. The cell's *value* is `default:` › `example:` › bare; the *marker* is `default:`'s absence, so a cell can carry a suggested `example` **and** a marker asking a human to confirm it. A surviving marker never blocks render: it raises only the non-fatal `validation::must_fill` warning; a strict consumer (an LLM authoring loop) treats any outstanding marker as "not done."
 
 ## Seeding: the filled-out twin
 

--- a/docs/quills/creating-quills.md
+++ b/docs/quills/creating-quills.md
@@ -41,7 +41,7 @@ main:
 
 `name`, `backend`, `version`, and `description` are all required. `name` must be `snake_case`. Define your document's expected root-block fields under `main.fields`. Each field has a `type`, optional `default`, `description`, and validation constraints. Use `integer` for whole numbers only and `number` for values that may include decimals. For the full list of field types, UI hints, typed arrays, and enum constraints, see the [Quill.yaml Reference](quill-yaml-reference.md).
 
-Use `default` for the value most authors will accept as-is (filled in when the field is omitted). Use `example` to document the expected shape without supplying a default. A field with neither is one nobody has answered: the blueprint flags it with a `!must_fill` marker and `Quill::validate` warns while it stays unauthored. Set `must_fill:` explicitly where you want a default a human must still confirm, or an optional field with nothing to suggest — it is a warning either way, never a gate. See the [Quill.yaml Reference](quill-yaml-reference.md#obligation-must_fill) for details.
+Use `default` for the value most authors will accept as-is (filled in when the field is omitted); the type's blank (`""`, `[]`, `0`, `false`) is how you declare "nothing" as that value, and it makes the field optional. Use `example` to document the expected shape without supplying a default. A field with no `default` is one nobody has answered: the blueprint flags it with a `!must_fill` marker — over the `example`, where there is one — and `Quill::validate` warns while it stays unauthored. It is a warning, never a gate. See the [Quill.yaml Reference](quill-yaml-reference.md#obligation) for details.
 
 ### Picking a text type
 

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -84,37 +84,35 @@ main:
 |---------------|-------------------|----------|-------------|
 | `type`        | string            | yes      | Data type (see [Field Types](#field-types)) |
 | `description` | string            | no       | Detailed help text |
-| `default`     | matches `type`    | no       | The value the **majority of authors want**. When the cell is omitted, the default is filled in — at any depth, whether or not the container above it was authored — and the blueprint renders that concrete value with a type-only annotation, shippable as-is. Declaring it also flips the derived `must_fill` to `false` (see below). Declared on a **cell**: a leaf or an `array`. On an `object` it is a load error (`quill::default_on_namespace`), since its properties hold their own. |
+| `default`     | matches `type`    | no       | The value the **majority of authors want**. When the cell is omitted, the default is filled in — at any depth, whether or not the container above it was authored — and the blueprint renders that concrete value with a type-only annotation, shippable as-is. Declaring it also makes the field unobliged (see [Obligation](#obligation)). Declared on a **cell**: a leaf or an `array`. On an `object` it is a load error (`quill::default_on_namespace`), since its properties hold their own. |
 | `example`     | matches `type`    | no       | A value matching the **type and shape** of what the author wants, but **not** the value desired most of the time. Documents shape only, never rendered as the value: it takes the blueprint cell when no `default` holds it, and surfaces in the `# e.g.` line otherwise. Declared on a **cell**, as `default` is (`quill::example_on_namespace`). |
-| `must_fill`   | boolean           | no       | Whether a human must author this cell (see [Obligation: `must_fill`](#obligation-must_fill)). Defaults to `!default.is_some()`. |
 | `values`      | array of strings  | for `enum` | The closed set of allowed string values: the **choices**. Required on every `enum` field. Declaring `""` is a load error — every enum also accepts its [blank](#the-blank-values-is-for-choices-not-for-the-absence-of-one), which the engine supplies. |
 | `ui`          | object            | no       | UI rendering hints (see [UI Properties](#ui-properties)) |
 | `items`       | object            | for `array` | Element schema for an `array` field (a nested field schema). Required on every array. |
 | `properties`  | object            | for `object` | Nested field schemas for an `object` typed dictionary (or an array's `object`-typed `items`). Required on every `object` field. |
 | `inline`      | boolean           | no       | For `richtext` and `plaintext` only: constrain the content to a single paragraph/line (a one-line editor surface). |
 
-### Obligation: `must_fill`
+### Obligation
 
-A field says two separate things. `default` and `example` say **what a cell
-holds**; `must_fill` says **whether a human must author it**. Leave it out and
-it derives from `default`: a defaulted field is not obliged, a defaultless one
-is.
-
-Write it when you want a combination the derivation cannot reach:
+One question per field: **does it have a value when nobody types anything?**
+`default` is the answer, and its absence is what obliges a human.
 
 ```yaml
-# A safe value renders, and a human must still confirm it.
+# Optional, with nothing to suggest: the type's blank is the answer "nothing".
+internal_note:
+  type: string
+  default: ""
+
+# A suggested marking a human must still confirm: no default, so the cell is
+# obliged, and the example fills it under the marker.
 classification:
   type: enum
   values: [UNCLASSIFIED, CUI]
-  default: UNCLASSIFIED
-  must_fill: true
-
-# Genuinely optional, with nothing to suggest.
-internal_note:
-  type: string
-  must_fill: false
+  example: UNCLASSIFIED
 ```
+
+There is no `must_fill:` key: declaring one is a load error naming the `default:`
+or `example:` to write instead.
 
 An obliged field is one that carries the `!must_fill` marker in the blueprint,
 is stamped when seeding commits its `example`, and raises the non-fatal

--- a/prose/canon/BLUEPRINT.md
+++ b/prose/canon/BLUEPRINT.md
@@ -154,8 +154,7 @@ Examples:
 | `count: 0 # integer` | defaulted integer (type-empty default, shippable as-is) |
 | `active: false # boolean` | defaulted boolean (type-empty default, shippable as-is) |
 | `notes: "" # string` | defaulted empty string (the "skippable" cell) |
-| `classification: !must_fill UNCLASSIFIED # enum<UNCLASSIFIED \| CUI>` | a default **and** `must_fill: true`: renders safely, still asks a human to confirm |
-| `note: null # string` | `must_fill: false` with nothing to suggest: explicitly optional, nothing to say |
+| `classification: !must_fill UNCLASSIFIED # enum<UNCLASSIFIED \| CUI>` | an `example` on a defaultless enum: the suggested marking fills the cell, still asking a human to confirm it |
 | `bio: !must_fill # richtext<markdown>` | must-fill richtext: bare marker (see "Richtext fields") |
 | `recipient: !must_fill # array<string>` | must-fill array of strings |
 | `date: !must_fill # date<YYYY-MM-DD>` | must-fill date |
@@ -165,26 +164,23 @@ Examples:
 
 ## Placeholder value precedence
 
-The blueprint emits along **two orthogonal axes**. The *value axis* decides
-what data the cell carries; the *marker axis* decides whether the cell is
-stamped `!must_fill`. They are independent: the marker never changes the
-value, and the value never implies the marker.
+The blueprint emits along **two axes**, and one declaration answers both. The
+*value axis* decides what data the cell carries; the *marker axis* decides
+whether the cell is stamped `!must_fill`.
 
 **Value** is `default:` › `example:` › bare (null for scalars, empty for a
-container). **Marker** is the field's derived `must_fill` (`SCHEMAS.md` § "The
-two axes"). Reading them off separately gives the full grid:
+container). **Marker** is the field's derived `must_fill` (`SCHEMAS.md` § "Value
+and obligation"), which is `default:`'s absence. The full grid:
 
 | Field state | Value rendered | Marker |
 |---|---|---|
 | `default` | the default | none |
-| `default` + `must_fill: true` | the default | `!must_fill` |
 | no `default`, has `example` | the `example` | `!must_fill` |
 | no `default`, no `example` | bare null/empty | `!must_fill` |
-| no `default`, `must_fill: false` | the `example` else bare null | none |
 
 An `example` takes the cell only when no `default:` holds it, and surfaces in
-the `# e.g.` leading line otherwise. That gate is a *value*-axis question:
-`must_fill` never moves an example between the cell and the hint. The rule holds
+the `# e.g.` leading line otherwise. The `default:` that vacates the cell is the
+one that marks it, so a suggested value arrives under its marker. The rule holds
 uniformly for scalars, arrays and typed tables, and for each **property** of a
 typed dictionary (which holds no cell of its own): **except `richtext`**, which
 never inlines its example as a value at all; its `example:` always surfaces as

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -699,49 +699,56 @@ encode opposite author intents:
   blueprint only when no `default:` holds it, and surfaces as a `# e.g.` line
   otherwise.
 
-### The two axes: value and obligation
+### Value and obligation: one declaration
 
-A field declares two independent things, and neither implies the other.
+A field asks one question, and `default:` is the whole answer: *does this field
+have a value when nobody types anything?*
 
 - The **value** axis is `default:` › `example:` › the field's blank. It decides
   what a cell holds.
-- The **obligation** axis is `must_fill:`. It decides whether a human must
-  author that cell.
+- The **obligation** axis is `default:`'s **absence**. It decides whether a human
+  must author that cell.
 
-`must_fill:` is `true` / `false`, and when unset it **derives** from the value
-axis: a field with a `default:` is not obliged, a field without one is. So a
-quill that never writes the key gets the whole obligation surface off `default:`
-alone. The derivation reads `default`'s *presence*, so a `default: ""` stays a
-skippable cell rather than becoming a marker. The key lives on the field schema,
-so it applies at every nesting level.
+Declare a `default:` and the document renders with it, unasked; the type's blank
+(`""`, `[]`, `0`, `false`) is how a field declares the answer "nothing". Leave it
+off and the field is the engine's to ask about. The derivation reads
+`default`'s *presence*, so a
+`default: ""` stays a skippable cell rather than becoming a marker. It lives on
+the field schema, so it applies at every nesting level.
 
-Declaring it reaches two cells the derivation cannot:
+`example:` is commentary either way: it shows what goes there, seeds new
+documents, and never renders. On a defaultless field it takes the blueprint cell
+*under* the marker and seeds carrying it, which is how a quill suggests a value a
+human must still confirm — a classification marking, an effective date. Until
+somebody accepts the suggestion the document renders the blank rather than
+asserting a value nobody chose.
 
-- `must_fill: true` beside a `default:` — a safe value renders, **and** a human
-  must still confirm it. Classification markings and effective dates are the
-  cases it exists for: the document is never wrong out of the box, and nobody
-  ships one nobody looked at. An editor's *confirm* discharges it by writing the
-  default's value as authored content: no new state, at the cost that the cell
-  then holds that value rather than tracking a later `default:` change.
-- `must_fill: false` with no `default:` — genuinely optional, with nothing to
-  suggest.
+There is no `must_fill:` key and no `required:` one. Declaring `must_fill:` is a
+load error (`quill::field_parse_error`), and the message names the `default:` or
+`example:` that field carries in its place.
 
 Obligation is a **warning, never a gate**: an unauthored must-fill field
 blank-fills and renders, and the signal is the non-fatal
 `validation::must_fill` (see [Native validation](#native-validation)). There is
-no `required:` axis and no severity knob on this one — severity already *is* the
-render-gate signal, so an `Error` that renders fine would break every consumer
-routing Error ≡ won't-render. An editor's "can't submit" is consumer policy over
-the warning: *a strict consumer treats any outstanding marker as not done*.
-A quill author arriving from web forms has the right prior for the affordance
-and the wrong one for the enforcement.
+no severity knob on this one — severity already *is* the render-gate signal, so
+an `Error` that renders fine would break every consumer routing Error ≡
+won't-render. An editor's "can't submit" is consumer policy over the warning: *a
+strict consumer treats any outstanding marker as not done*. A quill author
+arriving from web forms has the right prior for the affordance and the wrong one
+for the enforcement.
 
-On a typed dictionary the container's own `must_fill:` is **inert**: `!must_fill`
-is rejected on a mapping, so the obligation lives on the leaves and the
+Obligation belongs to a **cell**. A namespace holds none of its own: `!must_fill`
+is rejected on a mapping, so the obligation lives on the leaves, and the
 blueprint and the predicate both address them there. An array is its own cell,
 including an array of objects.
 
-See [BLUEPRINT.md](BLUEPRINT.md) for how the two axes render into cells.
+The transform schema carries no obligation at all. That projection is the wire
+*validity* contract, and an unauthored must-fill cell is wire-valid by design —
+the blank leads every emitted `enum` domain precisely so a generated validator
+accepts it. The declaration view carries `default:`, so a consumer wanting the
+obligation reads it there.
+
+See [BLUEPRINT.md](BLUEPRINT.md) for how value and obligation render into cells.
 
 Identity fields (`name`, `version`, `backend`, `author`, `description`) live on the parent metadata object (Wasm: `Quill.metadata` getter; Python: `Quill.metadata`). Both bindings also expose `backend_id`/`backendId` directly; Python additionally exposes `quill_ref`, a derived `name@version` string.
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -713,14 +713,14 @@ Declare a `default:` and the document renders with it, unasked; the type's blank
 (`""`, `[]`, `0`, `false`) is how a field declares the answer "nothing". Leave it
 off and the field is the engine's to ask about. The derivation reads
 `default`'s *presence*, so a
-`default: ""` stays a skippable cell rather than becoming a marker. It lives on
-the field schema, so it applies at every nesting level.
+`default: ""` stays a skippable cell rather than becoming a marker. The
+derivation lives on the field schema, so it applies at every nesting level.
 
 `example:` is commentary either way: it shows what goes there, seeds new
 documents, and never renders. On a defaultless field it takes the blueprint cell
-*under* the marker and seeds carrying it, which is how a quill suggests a value a
-human must still confirm — a classification marking, an effective date. Until
-somebody accepts the suggestion the document renders the blank rather than
+*under* the marker, and seeds carrying it. That is how a quill suggests a value a
+human must still confirm — a classification marking, an effective date — and
+until somebody accepts the suggestion the document renders the blank rather than
 asserting a value nobody chose.
 
 There is no `must_fill:` key and no `required:` one. Declaring `must_fill:` is a


### PR DESCRIPTION
Closes #1319. Closes #1316 by removing the axis rather than aligning it.

`FieldSchema::must_fill()` is `self.default.is_none()` and stays the single site of the derivation. One question per field — *does it have a value when nobody types anything?* — with `default:` as the whole answer, and the type's blank (`""`, `[]`, `0`, `false`) as the way to write "nothing".

## The load error classifies itself

Declaring the key is `quill::field_parse_error`, riding the retired `enum:` key's route with no new code. The rejection runs last in `from_quill_value`, so it reads the resolved field and names the migration that shape takes:

```
Failed to parse field schema 's': must_fill: is retired; obligation derives from
default:'s absence, so keep the default: to render "draft" unasked, or move it to
`example: "draft"` to ask — an example seeds under the !must_fill marker and never
renders, so an untouched document renders ""
```

Four of the five shapes are a deletion — any `must_fill:` on a namespace (checked first; a typed dictionary's obligation lives on its leaves), `must_fill: true` with no `default:`, `must_fill: false` beside one — and `must_fill: false` with no `default:` becomes `default: <the type's blank>`, naming the concrete literal. `blank_literal` spells the *declared* blank rather than `blank()`'s resting form: a prose field's is `""`, not the empty content, and a variant container's is the blank discriminant, not the container.

Recursion through `properties`, `items` and `variants` comes free, since each goes through `from_quill_value`.

## The one behavior deleted

A value that renders unattended **and** asks a human to confirm it. `example:` is the replacement: it fills the blueprint cell the absent `default:` vacated, seeds *carrying* the `!must_fill` marker where a `default:`-only field seeds nothing, and never renders. For a `string` or `enum` the blueprint is byte-identical — `{default: UNCLASSIFIED, must_fill: true}` and `{example: UNCLASSIFIED}` both emit `classification: !must_fill UNCLASSIFIED # enum<UNCLASSIFIED | CUI>`, measured. Three shapes are not, and the CHANGELOG carries each: a `richtext` example never inlines, so its cell becomes a bare marker; an `integer`/`number`/`boolean` blank is indistinguishable at the plate from an authored zero; and on a variant container `default: CUI` renders the CUI world and obliges its cells while `example: CUI` leaves the discriminant blank.

The render floor moves from the default to the blank for a migrated field, which for a classification marking is arguably the safer failure — but it is a behavior change for any external quill that used the combination. No in-tree quill declares the key (0 of 77 fields across the seven fixtures).

## Transform schema

`quillmark:must_fill` and both emission sites are gone. Not forced by the rule — that projection strips `default:` and so cannot re-derive the bit — but obligation is not a *validity* fact: an unauthored must-fill cell is wire-valid by design, the blank leading every emitted `enum` domain precisely so a generated validator accepts it. A `required`-shaped flag there invites the one misreading `SCHEMAS.md` forbids. The declaration view carries `default:` for a consumer that wants to derive, and re-emitting a derived key later is additive.

## Surfaces

- **Model** — the struct field, its `new()` initializer, and its arm + `len` term in the hand-written `Serialize`. `FieldSchemaDef.must_fill` stays as a rejection-only binding, mirroring `enum_key`.
- **Bindings** — the WASM `QuillFieldSchema` TS interface loses `must_fill?: boolean`, a compile-time break for editors typed against it. `Serialize` emitted the raw `Option`, so no emitted JSON changes for any real quill. Python needs no code change.
- **Tests** — five declaration sites migrated; `an_opted_out_field_keeps_its_example_as_the_cell_value` deleted (it pinned the one behavior with no survivor — `{example: A note}` alone now marks the cell, and `{default: "", example: A note}` demotes the example to a hint; its "the example is the cell, not a hint" assertion moved onto the surviving `example:` test). Two new tests cover all seven message routes and rejection at every depth. The existing `a_dictionarys_seed_is_composed_from_its_properties_examples` already pins the flagged `seed_parts` concern — `seed_field`'s object branch returns before `field.must_fill()`, so a namespace cannot stamp a marker on a mapping.
- **Docs** — `SCHEMAS.md` § collapses to "Value and obligation: one declaration"; `BLUEPRINT.md`'s grid drops to three rows; `quill-yaml-reference.md`, `creating-quills.md`, `docs/quills/blueprint.md`, `error-handling.md`, both binding READMEs, and a breaking `Unreleased` CHANGELOG entry carrying every migration case. No migration file — those land at release time in this repo (`d50a76b`).

## Unchanged

The `!must_fill` **marker**: document state, the YAML tag, `storeFill`/`isFill`/`nestedFills`, and the marker trigger of `validation::must_fill`. Also `validate_unauthored`, the seeding stamp, `ERROR.md`'s two-trigger contract, and `compile_data`. `CHANGELOG.md`'s 0.105 entry and `docs/migrations/0.104-to-0.105.md` are history and stay accurate about 0.105.

## Verification

`cargo test --workspace` green with no warnings; `cargo check -p quillmark-wasm` clean; `scripts/check-canon.mjs` passes.

One pre-existing defect left alone, adjacent to the diff: in `schema.rs` the doc block for `build_transform_schema` is physically attached to the private `discriminant_schema` below it, so the public function is undocumented. Happy to move it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWkWFtQWETAgzHbXeZtsS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWkWFtQWETAgzHbXeZtsS9)_