### PR TITLE
fix: an empty mapping emits as `{}` rather than losing its key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+- fix: **an empty mapping emits as `{}` rather than losing its key.** `emit_field`
+  dropped an empty-object field entirely, which composes with the block form of
+  its parent into markdown no parser accepts: a `$ext` whose every namespace
+  emptied wrote `$ext:` with no children, and re-parsed as null. That is the
+  `parse::invalid_structure` a `@quillmark/svelte` host hit on save, once a
+  tips-card dismissal had cleared `$ext.editor.tips`. One level down the same
+  rule ran silent: `$ext` is the only slot type-checked, so an inner mapping
+  turned null and the document parsed clean, handing a consumer back a type it
+  never wrote. Plain user fields carried that loss too — `cfg: {opts: {}}`
+  re-parsed as `cfg: null`, and the second emit then differed from the first.
+  Empty mappings now emit `key: {}` at every depth. That is the spelling a
+  sequence item (`- {}`) and a wholly empty `$ext: {}` already used, so an
+  emptied container survives the round-trip as the value a consumer stored.
+
 ## v0.108.1 - 2026-08-19
 
 - fix: **a content cell under `variants:` is readable at its codec.**

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -54,16 +54,16 @@ impl Document {
     /// - Multi-line strings: emitted as inline double-quoted scalars with
     ///   `\n` escapes; no `|` / `>` block forms.
     ///
-    /// - **Empty containers.** An empty object omits its key entirely; an empty
-    ///   array emits as `key: []\n`.
+    /// - **Empty containers.** An empty object emits as `key: {}\n`; an empty
+    ///   array emits as `key: []\n`. Neither collapses to a bare `key:`, which
+    ///   reads back as null.
     ///
     /// # What is preserved
     ///
     /// - **YAML comments**: own-line and inline trailing comments round-trip
     ///   at their source position. Comments whose host disappears at emit time
-    ///   (empty-mapping omission, programmatic field removal) degrade to
-    ///   own-line comments at the same indent so the comment text is preserved
-    ///   even when its position shifts.
+    ///   (programmatic field removal) degrade to own-line comments at the same
+    ///   indent so the comment text is preserved even when its position shifts.
     /// - **`!must_fill` tags**: round-trip via the `fill` flag on `PayloadItem::Field`.
     ///
     /// # What is lost
@@ -119,10 +119,8 @@ fn emit_meta_line(out: &mut String, key: &str, value: &str, trailer: Option<&str
     out.push('\n');
 }
 
-/// Emit an out-of-band meta block (`$ext` / `$seed`). An empty map emits inline
-/// as `<key>: {}` so the declaration survives the round-trip. `nested` carries
-/// comments at paths relative to the value tree. Meta maps never carry
-/// `!must_fill`.
+/// Emit an out-of-band meta block (`$ext` / `$seed`). `nested` carries comments
+/// at paths relative to the value tree. Meta maps never carry `!must_fill`.
 fn emit_meta_block(
     out: &mut String,
     key: &str,
@@ -344,8 +342,7 @@ fn push_trailer(out: &mut String, trailer: Option<&str>) {
 /// Emit a `key: <value>\n` pair at `indent` spaces.
 ///
 /// `path` is the container path for nested-comment interleaving. Empty objects
-/// are omitted; their inline trailer degrades to an own-line comment to
-/// preserve the text. Empty arrays emit `key: []\n`. When `fill` is `true`:
+/// emit `key: {}\n`, empty arrays `key: []\n`. When `fill` is `true`:
 /// scalars → `key: !must_fill <value>`, empty seqs → `key: !must_fill []`, null →
 /// `key: !must_fill`, non-empty seqs → `key: !must_fill\n  - …`. Mappings with `fill`
 /// are rejected at parse and never reach this path.
@@ -398,12 +395,11 @@ fn emit_field(
     }
     match value {
         JsonValue::Object(map) if map.is_empty() => {
-            if let Some(t) = inline_trailer {
-                push_indent(out, indent);
-                out.push_str("# ");
-                out.push_str(t);
-                out.push('\n');
-            }
+            push_indent(out, indent);
+            emit_key_at(out, key, indent);
+            out.push_str(": {}");
+            push_trailer(out, inline_trailer);
+            out.push('\n');
         }
         JsonValue::Object(map) => {
             push_indent(out, indent);
@@ -905,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_object_omitted() {
+    fn empty_object_emitted() {
         let value = QuillValue::from_json(serde_json::json!({}));
         let mut out = String::new();
         emit_field(
@@ -919,11 +915,11 @@ mod tests {
             &[],
             None,
         );
-        assert_eq!(out, "");
+        assert_eq!(out, "empty_map: {}\n");
     }
 
     #[test]
-    fn empty_object_with_inline_trailer_degrades() {
+    fn empty_object_keeps_inline_trailer() {
         let value = QuillValue::from_json(serde_json::json!({}));
         let mut out = String::new();
         emit_field(
@@ -937,7 +933,7 @@ mod tests {
             &[],
             Some("orphan"),
         );
-        assert_eq!(out, "# orphan\n");
+        assert_eq!(out, "empty_map: {} # orphan\n");
     }
 
     #[test]

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -196,7 +196,7 @@ fn round_trip_quill_version_selectors() {
 }
 
 #[test]
-fn empty_map_omitted_from_emit() {
+fn empty_map_emits_inline_braces() {
     use crate::value::QuillValue;
     use indexmap::IndexMap;
 
@@ -219,13 +219,19 @@ fn empty_map_omitted_from_emit() {
 
     let md = doc.to_markdown();
     assert!(
-        !md.contains("empty_obj"),
-        "empty object should be omitted from emit, got:\n{}",
+        md.contains("empty_obj: {}\n"),
+        "empty object should emit as inline braces, got:\n{}",
         md
     );
     assert!(
         md.contains("real_field: hello"),
         "real field should appear in emit, got:\n{}",
+        md
+    );
+    assert_eq!(
+        doc,
+        crate::document::Document::parse(&md).unwrap().document,
+        "empty object must survive the round-trip, got:\n{}",
         md
     );
 }

--- a/crates/core/src/document/tests/ext_tests.rs
+++ b/crates/core/src/document/tests/ext_tests.rs
@@ -142,6 +142,61 @@ $ext: {}
 }
 
 #[test]
+fn emptied_ext_namespace_round_trips() {
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+$ext:
+  editor:
+    tips:
+      - a tip
+title: Body
+~~~
+
+Body content.
+";
+    let mut doc = parse(src);
+    doc.main_mut()
+        .store_ext_namespace("editor", json!({}))
+        .expect("store empty namespace");
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$ext:\n  editor: {}\n"),
+        "emptied namespace must keep its key, got:\n{emitted}",
+    );
+    assert_eq!(doc, parse(&emitted));
+}
+
+/// `$ext` is the only slot type-checked, so an inner mapping reading back as
+/// null raises nothing.
+#[test]
+fn empty_mapping_inside_ext_namespace_round_trips() {
+    let src = "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+title: Body
+~~~
+";
+    let mut doc = parse(src);
+    doc.main_mut()
+        .store_ext_namespace("editor", json!({ "tips": {} }))
+        .expect("store nested empty mapping");
+
+    let emitted = doc.to_markdown();
+    let reparsed = parse(&emitted);
+    assert_eq!(
+        reparsed.main().ext().expect("ext present")["editor"]["tips"],
+        json!({}),
+        "a nested empty mapping must not read back as null, got:\n{emitted}",
+    );
+    assert_eq!(doc, reparsed);
+    assert_eq!(emitted, reparsed.to_markdown());
+}
+
+#[test]
 fn set_ext_inserts_after_kind_and_before_user_fields() {
     let mut doc = parse(
         "\

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -519,35 +519,37 @@ fn orphan_inline_after_remove_degrades_to_own_line() {
 }
 
 #[test]
-fn inline_on_empty_mapping_degrades_to_own_line() {
-    use crate::QuillValue;
-
-    // Construct programmatically since `key: {}` doesn't appear in source.
-    let src = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n";
-    let mut doc = Document::parse(src).unwrap().document;
-    let _ = doc
-        .main_mut()
-        .payload_mut()
-        .insert("empty", QuillValue::from_json(serde_json::json!({})));
-    {
-        let fm = doc.main_mut().payload_mut();
-        let items = fm.items().to_vec();
-        let mut new_items = items;
-        new_items.push(crate::PayloadItem::comment_inline("notes about empty"));
-        *fm = crate::document::Payload::from_items(new_items);
-    }
+fn inline_on_empty_mapping_rides_on_the_braces() {
+    let src = "~~~card-yaml\n$quill: q\n$kind: main\nempty: {} # notes about empty\n~~~\n";
+    let doc = Document::parse(src).unwrap().document;
 
     let emitted = doc.to_markdown();
     assert!(
-        !emitted.contains("empty:"),
-        "empty mapping must be omitted\nGot:\n{}",
+        emitted.contains("empty: {} # notes about empty\n"),
+        "empty mapping keeps its key and its inline trailer\nGot:\n{}",
         emitted
     );
-    assert!(
-        emitted.contains("# notes about empty"),
-        "inline trailer for an omitted host must degrade to own-line\nGot:\n{}",
-        emitted
+
+    let doc2 = Document::parse(&emitted).unwrap().document;
+    assert_eq!(doc, doc2, "empty mapping must survive the round-trip");
+    assert_eq!(emitted, doc2.to_markdown(), "round-trip must be idempotent");
+}
+
+#[test]
+fn nested_empty_mapping_survives_round_trip() {
+    use crate::QuillValue;
+
+    let src = "~~~card-yaml\n$quill: q\n$kind: main\n~~~\n";
+    let mut doc = Document::parse(src).unwrap().document;
+    let _ = doc.main_mut().payload_mut().insert(
+        "cfg",
+        QuillValue::from_json(serde_json::json!({ "opts": {} })),
     );
+
+    let emitted = doc.to_markdown();
+    let doc2 = Document::parse(&emitted).unwrap().document;
+    assert_eq!(doc, doc2, "nested empty mapping must not become null\nGot:\n{emitted}");
+    assert_eq!(emitted, doc2.to_markdown(), "round-trip must be idempotent");
 }
 
 /// `- key: !must_fill` puts the marker on the dash line, where prescan must

--- a/crates/core/src/document/tests/seed_tests.rs
+++ b/crates/core/src/document/tests/seed_tests.rs
@@ -233,6 +233,28 @@ $kind: main
 }
 
 #[test]
+fn empty_seed_overlay_round_trips() {
+    let mut doc = parse(
+        "\
+~~~card-yaml
+$quill: q@1.0
+$kind: main
+~~~
+",
+    );
+    doc.main_mut()
+        .store_seed_overlay("indorsement", json!({}))
+        .unwrap();
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$seed:\n  indorsement: {}\n"),
+        "empty overlay must keep its key, got:\n{emitted}",
+    );
+    assert_eq!(doc, parse(&emitted));
+}
+
+#[test]
 fn store_seed_overlay_rejects_invalid_and_reserved_kinds() {
     // `$seed` is keyed by composable card-kind, so the writer must reject
     // names that could never name a composable card (unlike free-form `$ext`).

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -473,6 +473,10 @@ alias and the `---`-fenced root alias (§3.2.1) both re-emit as bare `~~~`.
 (own-line and inline, including those adjacent to `$` lines) survive the
 round-trip.
 
+**Empty containers.** An empty mapping emits as `key: {}` and an empty
+sequence as `key: []`, at every nesting level and under `$ext` / `$seed`
+alike. Neither collapses to a bare `key:`, which reads back as null.
+
 Programmatically constructed metadata that does not have a source-order
 emits in the canonical key order `$quill`, `$kind`, `$ext`, `$seed`: the
 typed mutators (`set_quill` / `set_kind` / `set_ext` / `set_seed`)


### PR DESCRIPTION
Closes #1325.

## The diagnosis

The chain in the issue holds; each link reproduces. Two corrections, both widening it:

**The user-field path carries the identical silent bug.** The issue argues the omit rule "earns its place for schema'd user fields, where an empty mapping carries nothing." It does not. `cfg: {"opts": {}}` emits `cfg:` and re-parses as `cfg: null` — the same mapping-to-null substitution, no error raised, no `$ext` involved. The proposed meta-only fix leaves this live, and by the issue's own reading ("this is the worse of the two") it is the half most worth closing.

**Idempotence breaks, not only fidelity.** The first emit writes `cfg:`, the second `cfg: null`. Spec §9.1 holds that one round-trip canonicalises and further ones are no-ops; that is violated today on a document that raises nothing.

## The fix

An empty mapping emits `key: {}` at every depth, rather than a `meta` flag threaded through `emit_mapping_children` → `emit_field`.

`emit_field` was the outlier among the empty-object emit sites. The other two already write braces — `emit_field_inline` for a seq-item's first key, `emit_sequence_item` for `- {}` — as does `emit_meta_block` for a wholly empty `$ext: {}`. So this applies the existing rule at the site that skipped it, and needs no new parameter.

Removing the omit rule cost nothing: the workspace suite produced exactly four failures, every one a test asserting the rule itself. Nothing else depended on it.

## Changes

- `crates/core/src/document/emit.rs` — the empty-object arm of `emit_field`, and the rustdoc carrying the old rule.
- Regression tests: the issue's repro and its nested variant (`ext_tests`), the `$seed` twin (`seed_tests`), the nested user field (`lossiness_tests`).
- An inline trailer on an empty mapping now rides on the braces rather than degrading to an own-line comment. The degradation path remains for programmatic field removal, covered by `orphan_inline_after_remove_degrades_to_own_line`.
- `prose/references/markdown-spec.md` §9 states the rule. Its absence there is what let the emit rules drift: the spec pinned `$ext: {}` but never said what an empty container emits generally.

## Verification

`cargo test --workspace` passes, 59 targets. Clippy clean on the touched file.

WASM and Python bindings not built locally: the change is core-only and reached by Rust tests, and no binding test asserts anything about empty-object emission. CI covers both.

## Note for the consumer fix

The JS-side change described in the issue — dropping an emptied namespace rather than storing `{}` — is still worth keeping, but becomes a preference rather than a workaround. A stored `{}` anywhere under `$ext` now round-trips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn56emq1AZYt4MMdKcS3Yn)_